### PR TITLE
Fix Fly.io deployment timeout issues

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -33,10 +33,14 @@ primary_region = 'iad'
     port = 443
     handlers = ['tls', 'http']
 
-  [[services.tcp_checks]]
+  [[services.http_checks]]
     interval = '15s'
     timeout = '2s'
     grace_period = '10s'
+    method = 'get'
+    path = '/health'
+    protocol = 'http'
+    tls_skip_verify = false
 
 [[vm]]
   cpu_kind = 'shared'

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ const cors = require('cors');
 const { SalesAgentsHandlers } = require('./src/sales-agents-handlers-node');
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 8080;
 
 // Middleware
 app.use(cors({


### PR DESCRIPTION
## Summary
- Fix Fly.io deployment hanging on health checks
- Replace TCP health checks with HTTP health checks pointing to `/health` endpoint  
- Update Dockerfile to properly build TypeScript and use correct production files
- Fix port consistency (8080) across all configuration files

## Changes Made
- **fly.toml**: Changed from TCP checks to HTTP health checks at `/health`
- **Dockerfile**: Added TypeScript build step and proper file copying for production
- **server.js**: Fixed default port from 3000 to 8080 for consistency

## Test Plan  
- [x] Verify health check endpoint is accessible
- [ ] Deploy to Fly.io and confirm deployment succeeds without timeout
- [ ] Test application functionality after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)