### PR TITLE
fix the a2a sdk client import issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@a2a-js/sdk": "^0.3.3",
+        "@a2a-js/sdk": "^0.3.4",
         "@fastify/cors": "^9.0.1",
         "@fastify/static": "^7.0.0",
         "@modelcontextprotocol/sdk": "^0.4.0",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@a2a-js/sdk": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.3.tgz",
-      "integrity": "sha512-YdtyMDsUQxKn7XOmMUibMsETj0MtjRs1kBMAXqt9pBhXAITxte61i6w1b18FejnC9qSxuNCNTxKqbW5cyVbEWg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.4.tgz",
+      "integrity": "sha512-WXMk/UspvQFxesvb8hXyfPE8d3ibpiRie24Yw/5ruMqNJcdwxjfZ1G0gj6vYE/I9RAZD145CNzedpZA2cLV2JQ==",
       "dependencies": {
         "uuid": "^11.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@a2a-js/sdk": "^0.3.3",
+    "@a2a-js/sdk": "^0.3.4",
     "@fastify/cors": "^9.0.1",
     "@fastify/static": "^7.0.0",
     "@modelcontextprotocol/sdk": "^0.4.0",

--- a/src/protocols.ts
+++ b/src/protocols.ts
@@ -1,11 +1,23 @@
 // Official protocol clients
 // Note: MCP client is commented out for now since we're focusing on A2A
 // import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-// Import A2A client - need to check correct path based on package structure
-// import { A2AClient } from '@a2a-js/sdk';
 
-// For now, let's simulate A2A responses until we can resolve the import
-const A2AClient: any = null;
+// Import A2A client
+let A2AClient: any = null;
+try {
+  // Try to import the A2A client from the client module
+  const clientModule = require('@a2a-js/sdk/client');
+  A2AClient = clientModule.A2AClient;
+  if (A2AClient) {
+    console.log('✅ A2A SDK client imported successfully');
+  } else {
+    throw new Error('A2AClient not found in client module');
+  }
+} catch (error) {
+  console.warn('⚠️ A2A SDK import failed:', error instanceof Error ? error.message : String(error));
+  console.log('📄 Falling back to HTTP-based A2A implementation');
+  A2AClient = null;
+}
 import { AgentConfig, TestResult, CreativeFormat } from './types/adcp';
 
 // Production mode detection

--- a/src/sales-agents-handlers-node.js
+++ b/src/sales-agents-handlers-node.js
@@ -5,15 +5,20 @@
 
 // Use native fetch (available in Node.js 18+)
 
-// Mock A2A client for now since the SDK has import issues
-// We'll use your working HTTP fallback approach
+// Import A2A client with proper error handling
 let A2AClient = null;
 try {
-    // SDK imports commented out due to ES module compatibility issues
-    // We'll use the HTTP fallback approach which works reliably
-    A2AClient = null;
+    // Try to import the A2A client from the client module
+    const clientModule = require('@a2a-js/sdk/client');
+    A2AClient = clientModule.A2AClient;
+    if (A2AClient) {
+        console.log('✅ A2A SDK client imported successfully in handlers');
+    } else {
+        throw new Error('A2AClient not found in client module');
+    }
 } catch (error) {
-    console.log('A2A SDK not available, using HTTP fallback');
+    console.warn('⚠️ A2A SDK import failed in handlers:', error.message);
+    console.log('📄 Using HTTP fallback approach for A2A protocol');
     A2AClient = null;
 }
 


### PR DESCRIPTION
This pull request improves the integration of the A2A SDK client by updating the dependency version and implementing robust, error-tolerant imports in both the main protocol module and the sales agent handlers. If the SDK import fails, the code now logs a clear warning and gracefully falls back to an HTTP-based implementation.

**A2A SDK Integration Improvements:**

* Updated the `@a2a-js/sdk` dependency to version `^0.3.4` in `package.json` to ensure compatibility with the latest features and fixes.
* Modified `src/protocols.ts` to attempt importing the `A2AClient` from the SDK, with error handling that logs a warning and falls back to an HTTP-based implementation if the import fails.
* Updated `src/sales-agents-handlers-node.js` to similarly attempt importing the `A2AClient`, providing detailed logs for success or failure and defaulting to an HTTP fallback as needed.