### PR TITLE
Fix Fly.io deployment health check configuration

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,28 +19,12 @@ primary_region = 'iad'
   auto_start_machines = true
   min_machines_running = 0
 
-[[services]]
-  protocol = 'tcp'
-  internal_port = 8080
-  processes = ['app']
-
-  [[services.ports]]
-    port = 80
-    handlers = ['http']
-    force_https = true
-
-  [[services.ports]]
-    port = 443
-    handlers = ['tls', 'http']
-
-  [[services.http_checks]]
-    interval = '15s'
-    timeout = '2s'
+  [[http_service.checks]]
     grace_period = '10s'
-    method = 'get'
+    interval = '15s'
+    timeout = '10s'
+    method = 'GET'
     path = '/health'
-    protocol = 'http'
-    tls_skip_verify = false
 
 [[vm]]
   cpu_kind = 'shared'


### PR DESCRIPTION
## Summary
- Fixed deployment failure caused by incompatible health check configuration in fly.toml
- Replaced legacy `[[services.http_checks]]` with modern `[[http_service.checks]]` format
- Increased health check timeout from 2s to 10s for better reliability

## Problem
The deployment was failing with health check timeouts due to using an outdated configuration format that Fly.io could no longer parse properly.

## Solution
1. **Removed legacy configuration**: Eliminated the `[[services]]` block with `[[services.http_checks]]`
2. **Updated to modern format**: Used `[[http_service.checks]]` which is the current recommended syntax
3. **Improved timeout**: Increased from 2s to 10s to handle potential network latency during health checks

## Test plan
- [x] Verified fly.toml configuration is valid (`fly deploy` validation passes)
- [x] Successful deployment completed without timeout errors
- [x] Health check endpoint `/health` responds correctly (< 1s response time)
- [x] Application is running and accessible at https://adcp-testing.fly.dev
- [x] Machine shows "1 total, 1 passing" health checks

🤖 Generated with [Claude Code](https://claude.ai/code)