### PR TITLE
Add NPM publishing documentation to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -387,8 +387,48 @@ Should show:
 - Real agent mode should only be enabled in production
 - Never commit actual auth tokens to version control
 
+## NPM Publishing & Release Management
+
+### 🚨 CRITICAL: GitHub Release vs Git Tag 🚨
+
+**IMPORTANT**: This project uses GitHub Actions for automatic npm publishing. The workflow is triggered by **GitHub Releases**, NOT git tags.
+
+#### Correct Release Process:
+1. **Create GitHub Release** (not just a git tag)
+   - Use `gh release create v0.x.x` command
+   - Or create release via GitHub web interface
+   - This triggers the CI/CD workflow automatically
+
+2. **Workflow Trigger**: 
+   - The publish job runs on `github.event_name == 'release' && github.event.action == 'published'`
+   - Located in `.github/workflows/ci.yml` lines 154-186
+
+#### Common Mistake:
+- ❌ **Wrong**: `git tag v0.x.x && git push origin v0.x.x` (only creates tag)
+- ✅ **Correct**: `gh release create v0.x.x` (creates tag AND release)
+
+#### Release Commands:
+```bash
+# Create release (this will trigger npm publish automatically)
+gh release create v0.2.3 --title "v0.2.3" --notes "Release v0.2.3"
+
+# Check if release triggered the workflow
+gh run list --event=release
+
+# Monitor workflow progress
+gh run watch
+```
+
+#### Verification:
+After creating a GitHub release, verify:
+- [ ] GitHub Actions workflow runs automatically
+- [ ] Package is published to npm registry
+- [ ] Version appears at https://npmjs.com/package/@adcp/client
+
+**Remember**: Always use GitHub releases for triggering npm publishing, not just git tags.
+
 ---
 
-*Last updated: 2025-09-11 (Added Fly.io deployment requirements and unit tests)*
+*Last updated: 2025-09-26 (Added NPM publishing and release management section)*
 *Project: AdCP Testing Framework*
 *Environment: Fly.io Production*


### PR DESCRIPTION
## Summary
- Add comprehensive NPM publishing and release management documentation to CLAUDE.md
- Clarify critical difference between git tags and GitHub releases for npm publishing
- Document correct release process using `gh release create` command
- Add verification steps and common pitfall prevention

## Changes Made
- Added new section "NPM Publishing & Release Management" to CLAUDE.md
- Documented workflow trigger requirements (`github.event_name == 'release'`)
- Provided step-by-step release commands and verification checklist
- Emphasized that GitHub releases (not just git tags) are required to trigger npm publishing

## Context
Previously created a git tag for v0.2.3 which didn't trigger the npm publishing workflow. The workflow requires a GitHub release event, not just a tag push. This documentation prevents future confusion and ensures proper release process.

## Test Plan
- [x] Updated documentation is clear and actionable
- [x] Release process successfully triggered npm publish for v0.2.3
- [x] Package @adcp/client@0.2.3 is now available on npm registry

🤖 Generated with [Claude Code](https://claude.ai/code)