### PR TITLE
feat: add protocol-level webhook configuration support

### DIFF
--- a/test/webhook-signature-verification.test.js
+++ b/test/webhook-signature-verification.test.js
@@ -1,0 +1,135 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { ADCPClient } = require('../dist/lib/core/ADCPClient');
+const crypto = require('crypto');
+
+describe('Webhook Signature Verification (PR #86 Spec)', () => {
+  const agent = {
+    id: 'test_agent',
+    name: 'Test Agent',
+    agent_uri: 'https://test.example.com',
+    protocol: 'mcp',
+    requiresAuth: false
+  };
+
+  const webhookSecret = 'test-secret-key-minimum-32-characters-long';
+
+  test('should verify valid webhook signature per PR #86 spec', () => {
+    const client = new ADCPClient(agent, { webhookSecret });
+
+    const payload = {
+      event: 'creative.status_changed',
+      creative_id: 'creative_123',
+      status: 'approved',
+      timestamp: '2025-10-08T22:30:00Z'
+    };
+
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    // Generate signature per PR #86 spec: sha256=HMAC({timestamp}.{json_payload})
+    const message = `${timestamp}.${JSON.stringify(payload)}`;
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(message);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    // Verify signature
+    const isValid = client.verifyWebhookSignature(payload, signature, timestamp);
+    assert.strictEqual(isValid, true);
+  });
+
+  test('should reject webhook with invalid signature', () => {
+    const client = new ADCPClient(agent, { webhookSecret });
+
+    const payload = {
+      event: 'creative.status_changed',
+      creative_id: 'creative_123',
+      status: 'approved'
+    };
+
+    const timestamp = Math.floor(Date.now() / 1000);
+    const invalidSignature = 'sha256=invalid_signature_here';
+
+    const isValid = client.verifyWebhookSignature(payload, invalidSignature, timestamp);
+    assert.strictEqual(isValid, false);
+  });
+
+  test('should reject webhook with old timestamp (> 5 minutes)', () => {
+    const client = new ADCPClient(agent, { webhookSecret });
+
+    const payload = {
+      event: 'creative.status_changed',
+      creative_id: 'creative_123',
+      status: 'approved'
+    };
+
+    // Timestamp from 10 minutes ago
+    const oldTimestamp = Math.floor(Date.now() / 1000) - 600;
+
+    // Generate valid signature for old timestamp
+    const message = `${oldTimestamp}.${JSON.stringify(payload)}`;
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(message);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    // Should reject due to timestamp being too old
+    const isValid = client.verifyWebhookSignature(payload, signature, oldTimestamp);
+    assert.strictEqual(isValid, false);
+  });
+
+  test('should accept webhook within 5 minute window', () => {
+    const client = new ADCPClient(agent, { webhookSecret });
+
+    const payload = {
+      event: 'creative.status_changed',
+      creative_id: 'creative_123',
+      status: 'approved'
+    };
+
+    // Timestamp from 2 minutes ago (within 5 minute window)
+    const recentTimestamp = Math.floor(Date.now() / 1000) - 120;
+
+    // Generate valid signature
+    const message = `${recentTimestamp}.${JSON.stringify(payload)}`;
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(message);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    // Should accept
+    const isValid = client.verifyWebhookSignature(payload, signature, recentTimestamp);
+    assert.strictEqual(isValid, true);
+  });
+
+  test('should handle timestamp as string', () => {
+    const client = new ADCPClient(agent, { webhookSecret });
+
+    const payload = {
+      event: 'creative.status_changed',
+      creative_id: 'creative_123',
+      status: 'approved'
+    };
+
+    const timestamp = Math.floor(Date.now() / 1000);
+    const timestampStr = timestamp.toString();
+
+    // Generate valid signature
+    const message = `${timestamp}.${JSON.stringify(payload)}`;
+    const hmac = crypto.createHmac('sha256', webhookSecret);
+    hmac.update(message);
+    const signature = `sha256=${hmac.digest('hex')}`;
+
+    // Should accept string timestamp
+    const isValid = client.verifyWebhookSignature(payload, signature, timestampStr);
+    assert.strictEqual(isValid, true);
+  });
+
+  test('should return false when webhookSecret not configured', () => {
+    const client = new ADCPClient(agent, {}); // No webhookSecret
+
+    const payload = { event: 'test' };
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = 'sha256=anything';
+
+    const isValid = client.verifyWebhookSignature(payload, signature, timestamp);
+    assert.strictEqual(isValid, false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds AdCP-compliant webhook configuration support that works across both MCP and A2A protocols.

## Changes

### Library Enhancements
- **ADCPClient**: Added `webhookUrlTemplate` and `webhookSecret` configuration options
- **ADCPClient**: Updated `verifyWebhookSignature()` with timestamp validation per AdCP PR #86 spec
- **ADCPClient**: Added `createWebhookHandler()` helper for one-line webhook endpoint setup
- **TaskExecutor**: Generates webhook URLs with macro substitution (`{agent_id}`, `{task_type}`, `{operation_id}`)
- **ProtocolClient**: Injects `push_notification_config` into tool arguments automatically

### Testing
- Added `test/webhook-signature-verification.test.js` with 6 passing tests
- Validates HMAC-SHA256 signature generation and verification
- Tests timestamp freshness validation (5 minute window)
- Tested manually with sync_creatives, create_media_buy, and update_media_buy

## Implementation Details

### Webhook Configuration Format (AdCP-Compliant)
```javascript
{
  push_notification_config: {
    url: "https://myapp.com/webhook/{operation_id}",
    authentication: {
      schemes: ["HMAC-SHA256"],
      credentials: "your-webhook-secret"
    }
  }
}
```

### Usage Example
```typescript
const client = new ADCPClient(agent, {
  webhookUrlTemplate: 'https://myapp.com/webhook/{task_type}/{agent_id}/{operation_id}',
  webhookSecret: 'your-secret-key-min-32-chars',
  handlers: {
    onSyncCreativesStatusChange: async (result) => {
      console.log('Webhook received:', result);
    }
  }
});

// One-line webhook handler setup
app.post('/webhook', client.createWebhookHandler());
```

## Verification

Tested all three operations with local A2A agent:
- ✅ sync_creatives - Webhook config sent correctly
- ✅ create_media_buy - Webhook config sent correctly  
- ✅ update_media_buy - Webhook config sent correctly

All requests include proper `push_notification_config` structure matching AdCP specification.

## Related
- Implements AdCP webhook specification
- Follows AdCP PR #86 signature format: `sha256={hex}` with `{timestamp}.{json_payload}` message format
- Universal implementation works for both MCP and A2A protocols