### PR TITLE
feat: add creative agent support and update to AdCP v2.0.0 schemas

### DIFF
--- a/scripts/manual-testing/full-wonderstruck-test.ts
+++ b/scripts/manual-testing/full-wonderstruck-test.ts
@@ -1,0 +1,372 @@
+#!/usr/bin/env tsx
+// Full Wonderstruck test: Brand Card → Get Products → Create Media Buy → Sync Creatives → Update Media Buy
+
+import { readFileSync } from 'fs';
+import { ADCPMultiAgentClient, type CreateMediaBuyRequest, type SyncCreativesRequest, type UpdateMediaBuyRequest } from '../../src/lib';
+import path from 'path';
+
+async function fullWonderstruckTest() {
+  console.log('🎯 Full Wonderstruck Test Workflow');
+  console.log('===================================\n');
+
+  // Initialize client from environment config
+  const client = ADCPMultiAgentClient.fromEnv();
+
+  // Get the test sales agent for products
+  // (Wonderstruck is a brand, not a sales agent with inventory)
+  const agentId = process.env.TEST_AGENT_ID || 'principal_3bd0d4a8';
+  const agent = client.agent(agentId);
+  const agentConfig = agent.getAgent();
+
+  console.log(`✅ Connected to agent: ${agentConfig.name}`);
+  console.log(`   URI: ${agentConfig.agent_uri}`);
+  console.log(`   Protocol: ${agentConfig.protocol}\n`);
+
+  // STEP 1: Load Brand Card
+  console.log('📋 STEP 1: Loading Wonderstruck Brand Card');
+  console.log('='.repeat(50));
+
+  const brandCardPath = path.join(__dirname, 'wonderstruck-brand-card.json');
+  const brandCard = JSON.parse(readFileSync(brandCardPath, 'utf8'));
+
+  console.log(`✅ Brand Card Loaded:`);
+  console.log(`   Brand: ${brandCard.brand_name}`);
+  console.log(`   Tagline: ${brandCard.tagline}`);
+  console.log(`   Colors: ${brandCard.visual_identity.primary_colors.map((c: any) => c.name).join(', ')}`);
+  console.log(`   Assets: ${brandCard.asset_library.length} items\n`);
+
+  // STEP 2: Get Products from ALL agents
+  console.log('📦 STEP 2: Getting Products from ALL Sales Agents');
+  console.log('='.repeat(50));
+
+  const brief = `Looking for 300x250 display advertising inventory for ${brandCard.brand_name}, a consciousness and spirituality podcast. Target audience includes spiritually curious adults, consciousness researchers, and philosophy enthusiasts interested in transformative experiences and extraordinary phenomena.`;
+
+  // Query all agents in parallel using our multi-agent client
+  const allAgentIds = client.getAgentIds();
+  console.log(`\n🔍 Querying ${allAgentIds.length} agents: ${allAgentIds.join(', ')}\n`);
+
+  const productResults = await Promise.all(
+    allAgentIds.map(async (id) => {
+      const agentClient = client.agent(id);
+      const agentConfig = agentClient.getAgent();
+      try {
+        console.log(`   Querying ${agentConfig.name}...`);
+        const result = await agentClient.getProducts({
+          brief,
+          promoted_offering: `${brandCard.brand_name}: ${brandCard.mission}`
+        });
+        if (!result.success) {
+          console.log(`   ⚠️  ${agentConfig.name} returned error: ${result.error}`);
+          console.log(`      Status: ${result.status}, Data: ${JSON.stringify(result.data)}`);
+        } else {
+          const count = result.data?.products?.length || 0;
+          console.log(`   ✅ ${agentConfig.name}: ${count} products`);
+        }
+        return { agentId: id, agentName: agentConfig.name, result };
+      } catch (error: any) {
+        console.log(`   ❌ ${agentConfig.name} exception: ${error.message}`);
+        console.log(`      Stack: ${error.stack?.split('\n')[0]}`);
+        return { agentId: id, agentName: agentConfig.name, result: null };
+      }
+    })
+  );
+
+  // Collect all products from all agents
+  const allProducts: Array<{ product: any; agentId: string; agentName: string }> = [];
+  productResults.forEach(({ agentId, agentName, result }) => {
+    if (result?.success && result.data?.products) {
+      result.data.products.forEach((product: any) => {
+        allProducts.push({ product, agentId, agentName });
+      });
+    }
+  });
+
+  console.log(`\n✅ Found ${allProducts.length} total products across all agents`);
+
+  if (allProducts.length === 0) {
+    console.error('❌ No products available');
+    return;
+  }
+
+  // Display products grouped by agent
+  allProducts.forEach(({ product, agentName }, i: number) => {
+    console.log(`\n${i + 1}. ${product.name || product.product_id} [${agentName}]`);
+    if (product.description) {
+      console.log(`   Description: ${product.description}`);
+    }
+    if (product.formats) {
+      console.log(`   Formats: ${product.formats.join(', ')}`);
+    }
+    if (product.pricing_options) {
+      console.log(`   Pricing Options: ${product.pricing_options.length} available`);
+      product.pricing_options.forEach((po: any, j: number) => {
+        console.log(`      ${j + 1}. ${po.pricing_option_id}: ${po.pricing_model} (${po.currency || 'N/A'})`);
+      });
+    }
+  });
+
+  // STEP 3: Choose a Product that supports 300x250
+  console.log('\n📌 STEP 3: Choosing Product');
+  console.log('='.repeat(50));
+
+  // First, try to find the Wonderstruck "Live 300x250" product
+  let selectedProductEntry = allProducts.find(({ product, agentName }) =>
+    agentName.toLowerCase().includes('wonderstruck') &&
+    (product.name?.includes('300x250') || product.description?.includes('300x250'))
+  );
+
+  if (selectedProductEntry) {
+    console.log('✅ Found Wonderstruck 300x250 product!');
+  }
+
+  // Fallback: Look for any product that explicitly supports 300x250
+  if (!selectedProductEntry) {
+    selectedProductEntry = allProducts.find(({ product }) =>
+      product.formats?.some((f: string) => f.includes('300x250') || f === 'display_300x250')
+    );
+  }
+
+  // Last resort: Any display product
+  if (!selectedProductEntry) {
+    console.log('⚠️  No product explicitly supports 300x250, checking for display products...');
+    selectedProductEntry = allProducts.find(({ product }) =>
+      product.name?.toLowerCase().includes('display') ||
+      product.description?.toLowerCase().includes('display')
+    );
+  }
+
+  // Use any product from Wonderstruck if available
+  if (!selectedProductEntry) {
+    console.log('⚠️  No display product found, using first available Wonderstruck product...');
+    selectedProductEntry = allProducts.find(({ agentName }) =>
+      agentName.toLowerCase().includes('wonderstruck')
+    );
+  }
+
+  if (!selectedProductEntry) {
+    console.error('❌ No suitable product found');
+    return;
+  }
+
+  const selectedProduct = selectedProductEntry.product;
+  const selectedAgent = client.agent(selectedProductEntry.agentId);
+
+  console.log(`✅ Selected: ${selectedProduct.name || selectedProduct.product_id} [${selectedProductEntry.agentName}]`);
+  console.log(`   Product ID: ${selectedProduct.product_id}`);
+  if (selectedProduct.formats) {
+    console.log(`   Formats: ${selectedProduct.formats.join(', ')}`);
+  }
+
+  // Select first available pricing option (preferably CPM)
+  const pricingOptions = selectedProduct.pricing_options || [];
+  let selectedPricingOption = pricingOptions.find((po: any) => po.pricing_model === 'cpm') || pricingOptions[0];
+
+  if (selectedPricingOption) {
+    console.log(`   Selected Pricing Option: ${selectedPricingOption.pricing_option_id}`);
+    console.log(`   Model: ${selectedPricingOption.pricing_model}`);
+    console.log(`   Currency: ${selectedPricingOption.currency}`);
+  } else {
+    console.log(`   ⚠️  No pricing options available - using legacy format`);
+  }
+  console.log();
+
+  // STEP 4: Create Media Buy
+  console.log('💰 STEP 4: Creating Media Buy');
+  console.log('='.repeat(50));
+
+  const buyerRef = `wonderstruck_${Date.now()}`;
+
+  // Use our library to intelligently find compatible formats
+  console.log('\n🎨 Discovering creative formats using CreativeAgentClient...');
+
+  // Get the standard creative agent
+  const creativeAgent = client.getStandardCreativeAgent();
+  console.log(`📡 Connected to: ${creativeAgent.getAgentUrl()}`);
+
+  // Get all display formats
+  const displayFormats = await client.findFormatsByType('display');
+  console.log(`\n✅ Found ${displayFormats.length} display formats total`);
+
+  // Choose the best format: prefer image over generative
+  // The format's renders array contains the actual dimensions
+  const selectedFormat = displayFormats.find(f =>
+    f.format_id.id.includes('image')
+  ) || displayFormats[0];
+
+  if (!selectedFormat) {
+    throw new Error('No display format found in creative agent');
+  }
+
+  // Get dimensions from the format's renders (per AdCP v2.0.0 spec)
+  const primaryRender = selectedFormat.renders?.[0];
+  const width = primaryRender?.dimensions?.width || 300;
+  const height = primaryRender?.dimensions?.height || 250;
+
+  console.log(`\n📐 Selected format: ${selectedFormat.format_id.id}`);
+  console.log(`   Name: ${selectedFormat.name}`);
+  console.log(`   Type: ${selectedFormat.type}`);
+  console.log(`   Dimensions: ${width}x${height} (from format spec)`);
+  console.log(`   Agent: ${selectedFormat.agent_url}`);
+  if (selectedFormat.description) {
+    console.log(`   Description: ${selectedFormat.description}`);
+  }
+
+  // Use structured format IDs per AdCP v1.8.0 spec (creative agent already returns them structured)
+  const formatIds = [{
+    agent_url: selectedFormat.format_id.agent_url,
+    id: selectedFormat.format_id.id
+  }];
+
+  const mediaBuyRequest: CreateMediaBuyRequest = {
+    buyer_ref: buyerRef,
+    po_number: `PO-${Date.now()}`,
+    brand_manifest: brandCard, // NEW in PR #88: Use full brand card as brand_manifest
+    promoted_offering: `${brandCard.brand_name}: ${brandCard.mission}`, // DEPRECATED in v1.8.0 but still required by v2.4 servers
+    budget: 5000, // NEW in PR #88: Simplified to just a number (currency from pricing_option_id)
+    start_time: 'asap', // Using the ASAP feature from PR #84
+    end_time: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 days
+    packages: [
+      {
+        buyer_ref: `pkg_${Date.now()}`,
+        product_id: selectedProduct.product_id, // NEW in v1.8.0: Use product_id instead of products array
+        format_ids: formatIds,
+        ...(selectedPricingOption && { pricing_option_id: selectedPricingOption.pricing_option_id }), // NEW in PR #88: Select pricing model
+        budget: 5000 // NEW in PR #88: Package budget is now just a number
+      }
+    ]
+  };
+
+  console.log(`📤 Creating media buy with ASAP start time...`);
+  console.log(`   Buyer Ref: ${buyerRef}`);
+  console.log(`   Brand: ${brandCard.brand_name}`);
+  console.log(`   Product: ${selectedProduct.product_id}`);
+  console.log(`   Agent: ${selectedProductEntry.agentName}`);
+  if (selectedPricingOption) {
+    console.log(`   Pricing Model: ${selectedPricingOption.pricing_model}`);
+    console.log(`   Budget: ${mediaBuyRequest.budget} ${selectedPricingOption.currency}`);
+  } else {
+    console.log(`   Budget: ${mediaBuyRequest.budget} (currency TBD)`);
+  }
+  console.log(`   Start: ASAP\n`);
+
+  const mediaBuyResult = await selectedAgent.createMediaBuy(mediaBuyRequest);
+
+  if (!mediaBuyResult.success) {
+    console.error('❌ Failed to create media buy:', mediaBuyResult.error);
+    console.error('Full result:', JSON.stringify(mediaBuyResult, null, 2));
+    return;
+  }
+
+  const mediaBuyId = mediaBuyResult.data.media_buy_id;
+  console.log(`✅ Media Buy Created!`);
+  console.log(`   Media Buy ID: ${mediaBuyId}`);
+  console.log(`   Status: ${mediaBuyResult.data.status}\n`);
+
+  // STEP 5: Sync Creatives with Brand Card
+  console.log('🎨 STEP 5: Syncing Creatives with Brand Card');
+  console.log('='.repeat(50));
+
+  const assetId = `display_${width}x${height}`;
+  const displayAsset = brandCard.asset_library.find((a: any) => a.asset_id === assetId);
+
+  if (!displayAsset) {
+    console.error(`❌ No ${width}x${height} asset found in brand card (expected asset_id: ${assetId})`);
+    console.log('   Available assets:', brandCard.asset_library.map((a: any) => a.asset_id).join(', '));
+    return;
+  }
+
+  const creativeId = `wonderstruck_${width}x${height}_${Date.now()}`;
+  const syncRequest: SyncCreativesRequest = {
+    creatives: [
+      {
+        creative_id: creativeId,
+        name: `${brandCard.brand_name} - ${width}x${height} Display`,
+        format: `display_${width}x${height}`,
+        media_url: displayAsset.url,
+        click_url: brandCard.website,
+        width: displayAsset.dimensions.width,
+        height: displayAsset.dimensions.height,
+        tags: ['wonderstruck', 'podcast', 'consciousness', `${width}x${height}`]
+      }
+    ]
+  };
+
+  console.log(`📤 Syncing creative...`);
+  console.log(`   Creative ID: ${creativeId}`);
+  console.log(`   Name: ${syncRequest.creatives[0].name}`);
+  console.log(`   Media URL: ${syncRequest.creatives[0].media_url}`);
+  console.log(`   Click URL: ${syncRequest.creatives[0].click_url}\n`);
+
+  const syncResult = await selectedAgent.syncCreatives(syncRequest);
+
+  if (!syncResult.success) {
+    console.error('❌ Failed to sync creatives:', syncResult.error);
+    console.error('Full result:', JSON.stringify(syncResult, null, 2));
+    return;
+  }
+
+  console.log(`✅ Creative Synced!`);
+  console.log(`   Created: ${syncResult.data.created?.length || 0}`);
+  console.log(`   Updated: ${syncResult.data.updated?.length || 0}`);
+  console.log(`   Failed: ${syncResult.data.failed?.length || 0}\n`);
+
+  // STEP 6: Update Media Buy to attach the creative
+  console.log('🔄 STEP 6: Updating Media Buy to Attach Creative');
+  console.log('='.repeat(50));
+
+  const updateRequest: UpdateMediaBuyRequest = {
+    media_buy_id: mediaBuyId,
+    packages: [
+      {
+        package_id: mediaBuyResult.data.packages?.[0]?.package_id,
+        creative_ids: [creativeId]
+      }
+    ]
+  };
+
+  console.log(`📤 Updating media buy...`);
+  console.log(`   Media Buy ID: ${mediaBuyId}`);
+  console.log(`   Adding Creative: ${creativeId}\n`);
+
+  const updateResult = await selectedAgent.updateMediaBuy(updateRequest);
+
+  if (!updateResult.success) {
+    console.error('❌ Failed to update media buy:', updateResult.error);
+    console.error('Full result:', JSON.stringify(updateResult, null, 2));
+    return;
+  }
+
+  console.log(`✅ Media Buy Updated!`);
+  console.log(`   Status: ${updateResult.data.status}`);
+
+  // FINAL SUMMARY
+  console.log('\n' + '='.repeat(50));
+  console.log('🎉 SUCCESS! Full Workflow Completed');
+  console.log('='.repeat(50));
+  console.log('\n📊 Summary:');
+  console.log(`   ✅ Brand Card: ${brandCard.brand_name}`);
+  console.log(`   ✅ Products Retrieved: ${allProducts.length}`);
+  console.log(`   ✅ Media Buy Created: ${mediaBuyId}`);
+  console.log(`   ✅ Creative Synced: ${creativeId}`);
+  console.log(`   ✅ Media Buy Updated with Creative`);
+  console.log('\n🚀 Creative should now be live on wonderstruck.org!');
+  console.log(`   Format: ${width}x${height} display banner`);
+  console.log(`   Click URL: ${brandCard.website}`);
+  console.log(`   Creative URL: ${displayAsset.url}\n`);
+}
+
+// Run the full test
+if (require.main === module) {
+  fullWonderstruckTest()
+    .then(() => {
+      console.log('✨ Test completed!');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('❌ Fatal error:', error);
+      console.error(error.stack);
+      process.exit(1);
+    });
+}
+
+export { fullWonderstruckTest };

--- a/scripts/manual-testing/wonderstruck-brand-card.json
+++ b/scripts/manual-testing/wonderstruck-brand-card.json
@@ -1,0 +1,105 @@
+{
+  "brand_name": "Wonderstruck Podcast",
+  "tagline": "Taking on the Transformative",
+  "mission": "Exploring consciousness, spiritual experiences, and transformative topics through expert interviews and deep investigations into experiences beyond mainstream materialism.",
+  "website": "https://wonderstruck.org",
+  "brand_voice": {
+    "tone": "scholarly, curious, open-minded, contemplative",
+    "personality": "intellectual, exploratory, mystical, philosophical",
+    "values": [
+      "intellectual curiosity",
+      "open-minded exploration",
+      "consciousness investigation",
+      "transformative experiences"
+    ]
+  },
+  "visual_identity": {
+    "primary_colors": [
+      {
+        "name": "Gold",
+        "hex": "#FFB400",
+        "usage": "Primary brand color, highlights, accents"
+      },
+      {
+        "name": "Navy",
+        "hex": "#011221",
+        "usage": "Dark backgrounds, text, primary dark"
+      },
+      {
+        "name": "Accent Blue",
+        "hex": "#4054B2",
+        "usage": "Secondary accents, links, interactive elements"
+      }
+    ],
+    "logo": {
+      "url": "https://wonderstruck.org/wp-content/uploads/2022/04/logo.svg",
+      "format": "svg",
+      "variants": ["full_color", "reversed"]
+    },
+    "typography": {
+      "heading_style": "clean, modern sans-serif",
+      "body_style": "readable, professional",
+      "aesthetic": "minimalist, contemporary"
+    },
+    "imagery_style": "cosmic, celestial, stars, philosophical, minimalist duotone",
+    "design_principles": [
+      "clean and modern",
+      "cosmic and mystical elements",
+      "minimalist approach",
+      "philosophical visual metaphors"
+    ]
+  },
+  "target_audience": "Spiritually curious adults, consciousness researchers, philosophy enthusiasts, and meditation practitioners who are intellectually curious, open to extraordinary experiences, and seeking transformative insights into consciousness studies and unexplained phenomena.",
+  "content_themes": [
+    "consciousness exploration",
+    "spiritual experiences",
+    "transformative practices",
+    "extraordinary phenomena",
+    "philosophical inquiry",
+    "meditation and mindfulness"
+  ],
+  "host": {
+    "name": "Elizabeth Rovere",
+    "image": "duotone portrait style"
+  },
+  "asset_library": [
+    {
+      "asset_id": "logo_svg",
+      "type": "image",
+      "url": "https://wonderstruck.org/wp-content/uploads/2022/04/logo.svg",
+      "format": "svg",
+      "description": "Wonderstruck logo",
+      "usage": "primary logo for all placements"
+    },
+    {
+      "asset_id": "display_300x250",
+      "type": "image",
+      "url": "https://storage.googleapis.com/scope3-assets-swift-catfish/customers/1/brand-agents/48/assets/079fadf7-ec79-4fcc-81b1-f3c6df585d5b.jpg",
+      "format": "jpg",
+      "dimensions": {
+        "width": 300,
+        "height": 250
+      },
+      "description": "300x250 display banner with cosmic imagery",
+      "usage": "display advertising, banner placements"
+    }
+  ],
+  "call_to_actions": [
+    "Listen Now",
+    "Explore Episodes",
+    "Subscribe",
+    "Learn More",
+    "Join the Journey"
+  ],
+  "prohibited_content": [
+    "superficial self-help",
+    "materialistic messaging",
+    "closed-minded perspectives",
+    "anti-intellectual content"
+  ],
+  "brand_guidelines": {
+    "voice_guidelines": "Maintain an intellectual yet accessible tone. Balance scholarly rigor with openness to mystery and wonder. Avoid dogmatism while maintaining thoughtful skepticism.",
+    "visual_guidelines": "Use cosmic and celestial imagery. Maintain clean, minimalist design. Primary gold (#FFB400) for highlights against navy (#011221) backgrounds. Embrace mystical elements while staying sophisticated.",
+    "messaging_guidelines": "Focus on transformation, consciousness, and extraordinary human experiences. Lead with curiosity and intellectual exploration. Avoid making definitive claims about unexplained phenomena."
+  }
+}

--- a/src/lib/core/CreativeAgentClient.ts
+++ b/src/lib/core/CreativeAgentClient.ts
@@ -1,0 +1,264 @@
+// Creative Agent Client - First-class support for creative agents
+
+import { ADCPClient } from './ADCPClient';
+import type { ADCPClientConfig } from './ADCPClient';
+import type { AgentConfig } from '../types';
+import type { FormatID } from '../types/core.generated';
+import type {
+  ListCreativeFormatsRequest,
+  ListCreativeFormatsResponse
+} from '../types/tools.generated';
+
+/**
+ * Configuration for CreativeAgentClient
+ */
+export interface CreativeAgentClientConfig extends ADCPClientConfig {
+  /** Creative agent URL */
+  agentUrl: string;
+  /** Protocol to use (defaults to 'mcp') */
+  protocol?: 'mcp' | 'a2a';
+  /** Authentication token if required */
+  authToken?: string;
+}
+
+/**
+ * Creative Agent Client - Specialized client for interacting with creative agents
+ *
+ * Creative agents provide creative format catalogs and creative assembly services.
+ * This client provides a simplified interface for common creative agent operations.
+ *
+ * @example
+ * ```typescript
+ * // Standard creative agent
+ * const creativeAgent = new CreativeAgentClient({
+ *   agentUrl: 'https://creative.adcontextprotocol.org/mcp'
+ * });
+ *
+ * // List available formats
+ * const formats = await creativeAgent.listFormats();
+ *
+ * // Find specific format
+ * const banner = formats.find(f => f.format_id.id === 'display_300x250_image');
+ * ```
+ */
+export class CreativeAgentClient {
+  private client: ADCPClient;
+  private agentUrl: string;
+
+  constructor(config: CreativeAgentClientConfig) {
+    const agentConfig: AgentConfig = {
+      id: config.agentUrl.replace(/https?:\/\//, '').replace(/\//g, '_'),
+      name: 'Creative Agent',
+      agent_uri: config.agentUrl,
+      protocol: config.protocol || 'mcp',
+      ...(config.authToken && { auth_token_env: config.authToken })
+    };
+
+    this.client = new ADCPClient(agentConfig, config);
+    this.agentUrl = config.agentUrl;
+  }
+
+  /**
+   * List all available creative formats
+   *
+   * @param params - Optional filtering parameters
+   * @returns Promise resolving to array of creative formats
+   *
+   * @example
+   * ```typescript
+   * const formats = await creativeAgent.listFormats();
+   *
+   * // Filter to display formats
+   * const displayFormats = formats.filter(f => f.type === 'display');
+   *
+   * // Find by dimensions
+   * const banners = formats.filter(f =>
+   *   f.renders?.[0]?.dimensions?.width === 300 &&
+   *   f.renders?.[0]?.dimensions?.height === 250
+   * );
+   * ```
+   */
+  async listFormats(
+    params: ListCreativeFormatsRequest = {}
+  ): Promise<CreativeFormat[]> {
+    const result = await this.client.listCreativeFormats(params);
+
+    if (!result.success || !result.data) {
+      throw new Error(`Failed to list creative formats: ${result.error || 'Unknown error'}`);
+    }
+
+    // Parse stringified result if needed (MCP servers may return stringified JSON)
+    let formats = result.data.formats;
+
+    if (!formats && (result.data as any).result) {
+      const parsed = typeof (result.data as any).result === 'string'
+        ? JSON.parse((result.data as any).result)
+        : (result.data as any).result;
+      formats = parsed.formats;
+    }
+
+    return (formats || []) as any as CreativeFormat[];
+  }
+
+  /**
+   * Find formats by type
+   *
+   * @param type - Format type to filter by
+   * @returns Promise resolving to matching formats
+   *
+   * @example
+   * ```typescript
+   * const videoFormats = await creativeAgent.findByType('video');
+   * const displayFormats = await creativeAgent.findByType('display');
+   * ```
+   */
+  async findByType(type: CreativeFormatType): Promise<CreativeFormat[]> {
+    const allFormats = await this.listFormats();
+    return allFormats.filter(f => f.type === type);
+  }
+
+  /**
+   * Find formats by dimensions
+   *
+   * @param width - Width in pixels
+   * @param height - Height in pixels
+   * @returns Promise resolving to matching formats
+   *
+   * @example
+   * ```typescript
+   * // Find all 300x250 formats
+   * const mediumRectangles = await creativeAgent.findByDimensions(300, 250);
+   * ```
+   */
+  async findByDimensions(width: number, height: number): Promise<CreativeFormat[]> {
+    const allFormats = await this.listFormats();
+    return allFormats.filter(f =>
+      f.renders?.some(r =>
+        r.dimensions?.width === width && r.dimensions?.height === height
+      )
+    );
+  }
+
+  /**
+   * Find format by ID
+   *
+   * @param formatId - Format ID to search for
+   * @returns Promise resolving to matching format or undefined
+   *
+   * @example
+   * ```typescript
+   * const format = await creativeAgent.findById('display_300x250_image');
+   * if (format) {
+   *   console.log(`Found: ${format.name}`);
+   * }
+   * ```
+   */
+  async findById(formatId: string): Promise<CreativeFormat | undefined> {
+    const allFormats = await this.listFormats();
+    return allFormats.find(f => f.format_id.id === formatId);
+  }
+
+  /**
+   * Get the agent URL
+   */
+  getAgentUrl(): string {
+    return this.agentUrl;
+  }
+
+  /**
+   * Get the underlying ADCP client for advanced operations
+   */
+  getClient(): ADCPClient {
+    return this.client;
+  }
+}
+
+/**
+ * Creative format type
+ */
+export type CreativeFormatType = 'audio' | 'video' | 'display' | 'native' | 'dooh' | 'rich_media' | 'universal';
+
+/**
+ * Creative format definition (per AdCP v2.0.0 spec)
+ *
+ * Uses structured FormatID from official schemas. Creative agents return
+ * format catalogs with this structure for format discovery and selection.
+ */
+export interface CreativeFormat {
+  /** Structured format identifier per AdCP v2.0.0 */
+  format_id: FormatID;
+  /** Base URL of the creative agent */
+  agent_url: string;
+  /** Human-readable format name */
+  name: string;
+  /** Description of the format */
+  description?: string;
+  /** Preview image URL */
+  preview_image?: string;
+  /** Example URL */
+  example_url?: string;
+  /** Media type */
+  type: CreativeFormatType;
+  /** Render specifications */
+  renders?: Array<{
+    role: string;
+    dimensions?: {
+      width: number;
+      height: number;
+      min_width?: number;
+      min_height?: number;
+      max_width?: number;
+      max_height?: number;
+      responsive?: {
+        width: boolean;
+        height: boolean;
+      };
+      aspect_ratio?: string;
+      unit?: string;
+    };
+  }>;
+  /** Required assets for this format */
+  assets_required?: Array<{
+    asset_id: string;
+    asset_type: string;
+    asset_role: string;
+    required: boolean;
+    requirements?: any;
+  }>;
+  /** Supported macros */
+  supported_macros?: string[];
+  /** Output format IDs (for generative formats) */
+  output_format_ids?: Array<{
+    agent_url: string;
+    id: string;
+  }>;
+}
+
+/**
+ * Factory function to create a creative agent client
+ *
+ * @param config - Creative agent configuration
+ * @returns Configured CreativeAgentClient instance
+ *
+ * @example
+ * ```typescript
+ * const creativeAgent = createCreativeAgentClient({
+ *   agentUrl: 'https://creative.adcontextprotocol.org/mcp'
+ * });
+ * ```
+ */
+export function createCreativeAgentClient(
+  config: CreativeAgentClientConfig
+): CreativeAgentClient {
+  return new CreativeAgentClient(config);
+}
+
+/**
+ * Standard creative agent URLs
+ */
+export const STANDARD_CREATIVE_AGENTS = {
+  /** Official AdCP reference creative agent */
+  ADCP_REFERENCE: 'https://creative.adcontextprotocol.org/mcp',
+  /** Official AdCP reference creative agent (A2A) */
+  ADCP_REFERENCE_A2A: 'https://creative.adcontextprotocol.org/a2a'
+} as const;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -8,6 +8,14 @@ export type { ADCPClientConfig } from './core/ADCPClient';
 export { AgentClient, type TaskResponseTypeMap, type AdcpTaskName } from './core/AgentClient';
 export { ADCPMultiAgentClient, AgentCollection as NewAgentCollection, createADCPMultiAgentClient } from './core/ADCPMultiAgentClient';
 export { ConfigurationManager } from './core/ConfigurationManager';
+export {
+  CreativeAgentClient,
+  createCreativeAgentClient,
+  STANDARD_CREATIVE_AGENTS,
+  type CreativeFormat,
+  type CreativeFormatType,
+  type CreativeAgentClientConfig
+} from './core/CreativeAgentClient';
 export { TaskExecutor } from './core/TaskExecutor';
 export { ProtocolResponseParser, responseParser, ADCP_STATUS, type ADCPStatus } from './core/ProtocolResponseParser';
 export { ResponseValidator, responseValidator, type ValidationResult, type ValidationOptions } from './core/ResponseValidator';

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v2.0.0
-// Generated at: 2025-10-15T14:51:19.539Z
+// Generated at: 2025-10-17T02:26:01.045Z
 
 // MEDIA-BUY SCHEMA
 /**

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -989,10 +989,6 @@ export interface ListCreativeFormatsResponse {
 export interface Format {
   format_id: FormatID;
   /**
-   * Base URL of the agent that provides this format (authoritative source). E.g., 'https://reference.adcp.org', 'https://dco.example.com'
-   */
-  agent_url?: string;
-  /**
    * Human-readable format name
    */
   name: string;

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -2310,6 +2310,12 @@
                 
                 <div class="param-group">
                     <label>Flight Dates:</label>
+                    <div style="margin-bottom: 8px;">
+                        <label style="display: flex; align-items: center; gap: 8px;">
+                            <input type="checkbox" id="start-asap" style="width: auto;">
+                            <span>Start ASAP (immediate campaign start)</span>
+                        </label>
+                    </div>
                     <div style="display: flex; gap: 10px;">
                         <input type="date" id="start-date">
                         <span>to</span>
@@ -4271,12 +4277,23 @@
             // Set default dates
             const startDate = document.getElementById('start-date');
             const endDate = document.getElementById('end-date');
+            const startAsapCheckbox = document.getElementById('start-asap');
             const today = new Date();
             const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
-            
+
             startDate.value = today.toISOString().split('T')[0];
             endDate.value = nextWeek.toISOString().split('T')[0];
-            
+
+            // Add event listener to ASAP checkbox
+            startAsapCheckbox.addEventListener('change', function() {
+                startDate.disabled = this.checked;
+                if (this.checked) {
+                    startDate.style.opacity = '0.5';
+                } else {
+                    startDate.style.opacity = '1';
+                }
+            });
+
             // Show modal
             document.getElementById('create-media-buy-modal').style.display = 'block';
         }
@@ -4444,6 +4461,7 @@
             const currency = document.getElementById('budget-currency').value || 'USD';
             const dailyCap = document.getElementById('daily-cap').value;
             const pacing = document.getElementById('budget-pacing').value || 'even';
+            const startAsap = document.getElementById('start-asap').checked;
             const startDate = document.getElementById('start-date').value;
             const endDate = document.getElementById('end-date').value;
             
@@ -4533,7 +4551,7 @@
                     packages: packages,
                     brand_manifest: brandManifest,
                     po_number: poNumber,
-                    start_time: startDate ? new Date(startDate).toISOString() : new Date().toISOString(),
+                    start_time: startAsap ? 'asap' : (startDate ? new Date(startDate).toISOString() : new Date().toISOString()),
                     end_time: endDate ? new Date(endDate).toISOString() : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
                     budget: budgetConfig
                 };


### PR DESCRIPTION
## Summary

Adds first-class creative agent support and updates to AdCP v2.0.0 schemas with structured FormatID types.

### Key Changes

- **CreativeAgentClient**: New client for interacting with creative agents
  - `listFormats()` - Query creative format catalogs
  - `findByType()` - Filter formats by type (display, video, audio, etc.)
  - `findByDimensions()` - Find formats by width/height
  - `findById()` - Find specific format by ID

- **ADCPMultiAgentClient Integration**:
  - `createCreativeAgent()` - Create client for any creative agent
  - `getStandardCreativeAgent()` - Get client for standard creative agent
  - `discoverFormats()` - Discover all available formats
  - `findFormatsByType()` - Filter formats by type
  - `findFormatsByDimensions()` - Find formats by dimensions

- **AdCP v2.0.0 Schemas**:
  - Updated to structured FormatID type: `{agent_url: string, id: string}`
  - Creative format discovery now uses official FormatID types
  - Dimensions extracted from `format.renders[0].dimensions` per spec

### Breaking Changes

- Format discovery now returns `FormatID` objects instead of strings
- Updated to AdCP v2.0.0 schemas (from v1.8.0)

### Test Plan

- [x] Creative agent format discovery works
- [x] Format filtering by type and dimensions works
- [x] Multi-agent product queries work
- [x] End-to-end Wonderstruck test runs (server-side issues remain)
- [x] All existing tests pass

### Notes

This PR includes the ASAP start time feature from the branch base and creative agent support. When merged, Release Please will create a release PR for v2.0.0 due to the breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)