### PR TITLE
fix: revert library version to 2.0.2 for proper changeset bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/client",
-  "version": "2.1.0",
+  "version": "2.0.2",
   "description": "AdCP client library with protocol support for MCP and A2A, includes testing framework",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '2.1.0';
+export const LIBRARY_VERSION = '2.0.2';
 
 /**
  * AdCP specification version this library is compatible with
@@ -15,7 +15,7 @@ export const ADCP_VERSION = '2.1.0';
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '2.1.0',
+  library: '2.0.2',
   adcp: '2.1.0',
   compatible: true,
   generatedAt: '2025-10-19T20:49:59.528Z'


### PR DESCRIPTION
## Problem

PR #51 manually bumped package.json to 2.1.0 to match AdCP schema version. This caused changesets to calculate: 2.1.0 + minor bump = 2.2.0 (wrong!)

## Solution

Revert LIBRARY_VERSION to 2.0.2 while keeping ADCP_VERSION at 2.1.0. This allows changesets to properly calculate: 2.0.2 + minor bump = 2.1.0 (correct!)

## Result

After merging this PR, the changeset workflow will create a new Release PR that correctly bumps from 2.0.2 to 2.1.0.