### PR TITLE
Fix creative format field name and structure

### DIFF
--- a/.changeset/fix-creative-format-field.md
+++ b/.changeset/fix-creative-format-field.md
@@ -1,0 +1,14 @@
+---
+"@adcp/client": patch
+---
+
+Fix creative sync validation errors by correcting format field name and structure
+
+Multiple locations in the codebase were incorrectly using `format` instead of `format_id` when creating creative assets for sync_creatives calls. This caused the AdCP agent to reject creatives with validation errors: "Input should be a valid dictionary or instance of FormatId".
+
+**Fixed locations:**
+- `src/public/index.html:8611` - Creative upload form
+- `src/public/index.html:5137` - Sample creative generation
+- `scripts/manual-testing/full-wonderstruck-test.ts:284` - Test script (also fixed to use proper FormatID object structure)
+
+All creatives are now properly formatted according to the AdCP specification with the correct `format_id` field containing a FormatID object with `agent_url` and `id` properties.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.2.2"

--- a/scripts/manual-testing/full-wonderstruck-test.ts
+++ b/scripts/manual-testing/full-wonderstruck-test.ts
@@ -281,7 +281,11 @@ async function fullWonderstruckTest() {
       {
         creative_id: creativeId,
         name: `${brandCard.brand_name} - ${width}x${height} Display`,
-        format: `display_${width}x${height}`,
+        format_id: {
+          agent_url: 'https://creatives.adcontextprotocol.org',
+          id: `display_${width}x${height}`
+        },
+        assets: {},
         media_url: displayAsset.url,
         click_url: brandCard.website,
         width: displayAsset.dimensions.width,

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -5134,7 +5134,7 @@
             const creative = {
                 creative_id: `${namePrefix}_${format.format_id}_${Date.now()}`,
                 name: `${namePrefix} - ${format.name || format.format_id}`,
-                format: format.format_id,
+                format_id: format.format_id,
                 media_url: null,
                 package_assignments: [] // Will be filled by caller
             };
@@ -8608,7 +8608,7 @@ ${JSON.stringify(result, null, 2)}
 
                     const asset = {
                         name: creativeName,
-                        format: format.format_id,
+                        format_id: format.format_id,
                         status: 'active'
                     };
 


### PR DESCRIPTION
## Background
Creative assets were being created with an incorrect `format` field instead of the required `format_id` field. This led to AdCP agent validation errors.

## Changes
- **`.changeset/fix-creative-format-field.md`**: New changeset file detailing the patch.
- **`package-lock.json`**: Updated version to 2.3.0.
- **`scripts/manual-testing/full-wonderstruck-test.ts`**: Corrected the `format` field to `format_id` and ensured it's a `FormatID` object with `agent_url` and `id` properties.
- **`src/public/index.html`**:
    - At line 8611, changed `format` to `format_id` for creative asset creation.
    - At line 5137, changed `format` to `format_id` for sample creative generation.

## Testing
- [ ] Verify creative sync passes with the AdCP agent.
- [ ] Test manual creative uploads through the UI.
- [ ] Run the `full-wonderstruck-test.ts` script to ensure it completes without errors.
