### PR TITLE
chore: add changeset for PR #70

### DIFF
--- a/.changeset/webhook-signature-fix.md
+++ b/.changeset/webhook-signature-fix.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix webhook HMAC verification by propagating X-ADCP-Timestamp header through AgentClient.handleWebhook() and server route. Update update_media_buy tool signature to remove push_notification_config (matches create_media_buy). Add auto-injection of reporting_webhook in createMediaBuy when webhookUrlTemplate is configured.


### PR DESCRIPTION
Adds missing changeset for PR #70 which fixed webhook HMAC verification by propagating X-ADCP-Timestamp header.

This changeset documents the following changes from PR #70:
- Fixed webhook HMAC verification by propagating `X-ADCP-Timestamp` through `AgentClient.handleWebhook()` and server route
- Updated `update_media_buy` tool signature to remove `push_notification_config` (matches `create_media_buy`)
- Added auto-injection of `reporting_webhook` in `createMediaBuy` when `webhookUrlTemplate` is configured

**Version:** This is a patch-level change.

Fixes the missing changeset issue noted in PR #70 review.