### PR TITLE
fix: improve --save-auth UX with better error messages and auth handling

### DIFF
--- a/bin/adcp-config.js
+++ b/bin/adcp-config.js
@@ -163,13 +163,15 @@ async function promptSecure(prompt, hidden = true) {
  * @param {string} protocol Protocol (optional)
  * @param {string} authToken Auth token (optional)
  * @param {boolean} nonInteractive Skip prompts if all required args provided
+ * @param {boolean} noAuth Explicitly skip auth (--no-auth flag)
  */
-async function interactiveSetup(alias, url = null, protocol = null, authToken = null, nonInteractive = false) {
-  // Non-interactive mode: if URL is provided, just save it
+async function interactiveSetup(alias, url = null, protocol = null, authToken = null, nonInteractive = false, noAuth = false) {
+  // Non-interactive mode: save immediately without prompts
   if (nonInteractive && url) {
     const agentConfig = { url };
     if (protocol) agentConfig.protocol = protocol;
     if (authToken) agentConfig.auth_token = authToken;
+    // noAuth flag means explicitly don't save auth
 
     saveAgent(alias, agentConfig);
     console.log(`\n✅ Agent '${alias}' saved to ${CONFIG_FILE}`);
@@ -190,9 +192,10 @@ async function interactiveSetup(alias, url = null, protocol = null, authToken = 
     protocol = protocolInput || null;
   }
 
-  // Get auth token if not provided
-  if (!authToken) {
-    authToken = await promptSecure('Auth token (leave blank if not needed): ', true);
+  // Get auth token if not provided and not explicitly disabled
+  if (!authToken && !noAuth) {
+    process.stdout.write('Auth token (leave blank if not needed): ');
+    authToken = await promptSecure('', true);
     authToken = authToken || null;
   }
 


### PR DESCRIPTION
## Problem

**Issue 1: URL without alias causes hang**
When running `adcp --save-auth https://url`, the CLI treated the URL as the alias and entered interactive mode. The password prompt for auth token was hidden, making it appear to hang with no visible feedback.

**Issue 2: Auth token silently skipped**
When providing a URL on the command line, the auth token was silently skipped with no way to provide it non-interactively.

## Solution

### 1. Clear Error Messages
- Detect when URL is provided without alias
- Show helpful error message with correct usage example

### 2. New Auth Flags
- `--auth <token>` - Provide auth token for non-interactive mode
- `--no-auth` - Explicitly skip auth for non-interactive mode
- Interactive mode now always prompts for auth (can be left blank)

### 3. Improved Prompts
- Password prompt now more visible (prints prompt text before hidden input)
- Updated help text with clearer examples

## New Behavior

```bash
# Non-interactive with auth
adcp --save-auth myagent https://url --auth token

# Non-interactive without auth
adcp --save-auth myagent https://url --no-auth

# Interactive (asks for protocol & auth)
adcp --save-auth myagent https://url

# Interactive (asks for URL, protocol & auth)
adcp --save-auth myagent
```

## Test Plan
- [x] Test error message when URL provided without alias
- [x] Test non-interactive mode with `--auth`
- [x] Test non-interactive mode with `--no-auth`
- [x] Test interactive mode still prompts for auth
- [x] Test error when both `--auth` and `--no-auth` provided
- [x] Verify help text is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)