### PR TITLE
perf: optimize pre-push hook from 5min to 2s

### DIFF
--- a/.changeset/faster-pre-push-hook.md
+++ b/.changeset/faster-pre-push-hook.md
@@ -1,0 +1,11 @@
+---
+"@adcp/client": patch
+---
+
+Optimize pre-push git hook for faster development workflow
+
+- Reduced pre-push hook execution time from 5+ minutes to ~2-5 seconds
+- Now only runs essential fast checks: TypeScript typecheck + library build
+- Removed slow operations: schema sync, full test suite
+- Full validation (tests, schemas) still runs in GitHub Actions CI
+- Makes git push much faster while catching TypeScript and build errors early


### PR DESCRIPTION
## Problem

The pre-push git hook was running comprehensive validation including:
- Schema download from network (~30s)
- Full test suite including slow tests (~4+ minutes)
- Schema validation
- Build

This made `git push` take **5+ minutes**, which is frustrating for development.

## Solution

Optimized the pre-push hook to only run essential fast checks:
- ✅ TypeScript typecheck (catches syntax/type errors)
- ✅ Library build (ensures code compiles)
- ❌ Schema sync (moved to CI only)
- ❌ Test suite (moved to CI only)

## Results

**Before:**
```
$ git push
🔍 Running pre-push validation...
📥 Downloading schemas...
🧪 Running all tests...
⏱️  Total: 5+ minutes
```

**After:**
```
$ git push
🔍 Running pre-push validation...
📝 Checking TypeScript types...
🔨 Building library...
✅ Pre-push validation passed! (~5s)
💡 Full validation (tests, schemas) will run in GitHub Actions CI
⏱️  Total: 2-5 seconds
```

## Testing

- [x] Tested hook execution time: **2.4 seconds**
- [x] Hook still catches TypeScript errors
- [x] Hook still catches build failures
- [x] CI will still run full validation

## Notes

- Existing users will get the new fast hook automatically on next `npm install`
- CI remains the source of truth for full validation
- This follows best practices: pre-push should be fast, CI should be comprehensive

## Impact

This will significantly improve developer experience by making `git push` nearly instant instead of a 5-minute wait.