### PR TITLE
chore: add missing changeset for PR #84

### DIFF
--- a/.changeset/pr-84-ui-improvements.md
+++ b/.changeset/pr-84-ui-improvements.md
@@ -1,0 +1,17 @@
+---
+"@adcp/client": patch
+---
+
+UI formatting and error logging improvements
+
+- Fixed media buy packages to include format_ids array (was causing Pydantic validation errors)
+- Added error-level logging for failed media buy operations (create, update, get_delivery)
+- Fixed format objects display in products table (was showing [object Object])
+- Added runtime schema validation infrastructure with Zod
+- Added request validation to ADCPClient (fail fast on invalid requests)
+- Added configurable validation modes (strict/non-strict) via environment variables
+- Preserved trailing slashes in MCP endpoint discovery
+- Improved error display in UI debug panel with proper formatting
+- Added structured logger utility to replace console statements
+- **BREAKING**: Aligned budget handling with AdCP spec - MediaBuy.budget (object) is now MediaBuy.total_budget (number)
+- **BREAKING**: Removed budget field from CreateMediaBuyRequest (calculated from packages per spec)


### PR DESCRIPTION
Adds the missing changeset file for PR #84 which was merged without a changeset.

This will allow the automated release process to include PR #84's changes in the next release (2.5.2).

## Changes in PR #84
- Fixed media buy packages to include format_ids array
- Added error-level logging for failed media buy operations
- Fixed format objects display in products table
- Added runtime schema validation with Zod
- Added configurable validation modes
- Preserved trailing slashes in MCP endpoint discovery
- Improved error display in UI debug panel
- Added structured logger utility
- **BREAKING**: Aligned budget handling with AdCP spec
- **BREAKING**: Removed budget field from CreateMediaBuyRequest

## Related
- Fixes missing changeset from PR #84
- Will be automatically picked up by Release PR #87