### PR TITLE
fix: correct A2A discovery endpoint and Accept headers

### DIFF
--- a/.changeset/fix-accept-header.md
+++ b/.changeset/fix-accept-header.md
@@ -1,0 +1,9 @@
+---
+"@adcp/client": patch
+---
+
+Fixed A2A protocol discovery endpoint and Accept headers
+
+- Changed discovery endpoint from incorrect `/.well-known/a2a-server` to correct `/.well-known/agent-card.json` per A2A spec
+- Updated Accept header from `application/json` to `application/json, */*` for better compatibility with various server implementations
+- Updated protocol detection test to correctly expect A2A detection for test-agent.adcontextprotocol.org

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",

--- a/src/lib/utils/protocol-detection.ts
+++ b/src/lib/utils/protocol-detection.ts
@@ -23,7 +23,7 @@ export async function detectProtocol(url: string): Promise<'a2a' | 'mcp'> {
 
   // Step 2: Try A2A discovery
   try {
-    const discoveryUrl = new URL('/.well-known/a2a-server', url);
+    const discoveryUrl = new URL('/.well-known/agent-card.json', url);
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
 
@@ -31,7 +31,7 @@ export async function detectProtocol(url: string): Promise<'a2a' | 'mcp'> {
       method: 'GET',
       signal: controller.signal,
       headers: {
-        'Accept': 'application/json'
+        'Accept': 'application/json, */*'
       }
     });
 
@@ -66,7 +66,7 @@ export async function detectProtocolWithTimeout(
 
   // Try A2A discovery with custom timeout
   try {
-    const discoveryUrl = new URL('/.well-known/a2a-server', url);
+    const discoveryUrl = new URL('/.well-known/agent-card.json', url);
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -74,7 +74,7 @@ export async function detectProtocolWithTimeout(
       method: 'GET',
       signal: controller.signal,
       headers: {
-        'Accept': 'application/json'
+        'Accept': 'application/json, */*'
       }
     });
 

--- a/test/lib/protocol-detection.test.js
+++ b/test/lib/protocol-detection.test.js
@@ -19,9 +19,15 @@ test('Protocol Detection Tests', async (t) => {
     assert.strictEqual(protocol, 'mcp');
   });
 
-  await t.test('detects protocol for real test agent', async () => {
+  await t.test('detects A2A for real test agent (root URL)', async () => {
     const protocol = await detectProtocol('https://test-agent.adcontextprotocol.org');
-    // Should detect MCP (either via heuristic or discovery)
+    // Should detect A2A since the agent has /.well-known/agent-card.json endpoint
+    assert.strictEqual(protocol, 'a2a');
+  });
+
+  await t.test('detects MCP for real test agent (MCP endpoint)', async () => {
+    const protocol = await detectProtocol('https://test-agent.adcontextprotocol.org/mcp/');
+    // Should detect MCP from URL pattern
     assert.strictEqual(protocol, 'mcp');
   });
 


### PR DESCRIPTION
## Summary

Fixed critical bug in A2A protocol discovery that was using incorrect endpoint path and missing proper Accept headers.

## Changes

- **Discovery endpoint**: Changed from incorrect `/.well-known/a2a-server` to spec-compliant `/.well-known/agent-card.json`
- **Accept headers**: Updated from `application/json` to `application/json, */*` for better server compatibility
- **Tests**: Added test coverage for both A2A and MCP protocol detection on the same agent

## Details

### Bug
The @adcp/client v2.5.1 was using the wrong discovery endpoint path (`/.well-known/a2a-server`) and sending a restrictive Accept header (`application/json` only).

### Fix
According to the A2A protocol specification:
- The correct discovery endpoint is `/.well-known/agent-card.json` (following RFC 8615)
- Accept headers should be flexible to support various server implementations

### Test Coverage
- ✅ A2A detection: `https://test-agent.adcontextprotocol.org` → detects A2A (has agent-card.json)
- ✅ MCP detection: `https://test-agent.adcontextprotocol.org/mcp/` → detects MCP (URL pattern)
- ✅ All 8 protocol detection tests pass

## Test plan

- [x] Run protocol detection tests: `node --test test/lib/protocol-detection.test.js`
- [x] Verify build succeeds: `npm run build`
- [x] Verify A2A endpoint responds: `curl -I https://test-agent.adcontextprotocol.org/.well-known/agent-card.json`
- [x] Changeset created for automated release

🤖 Generated with [Claude Code](https://claude.com/claude-code)