### PR TITLE
chore: upgrade @modelcontextprotocol/sdk to 1.20.2

### DIFF
--- a/.changeset/upgrade-mcp-sdk.md
+++ b/.changeset/upgrade-mcp-sdk.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": patch
+---
+
+Upgraded @modelcontextprotocol/sdk to 1.20.2
+
+Updated the MCP SDK dependency from 1.19.1 to 1.20.2 to get the latest bug fixes and improvements.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.19.1.tgz",
-      "integrity": "sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ==",
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.2.tgz",
+      "integrity": "sha512-6rqTdFt67AAAzln3NOKsXRmv5ZzPkgbfaebKBqUbts7vK1GZudqnrun5a8d3M/h955cam9RHZ6Jb4Y1XhnmFPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Upgraded the Model Context Protocol SDK from 1.19.1 to 1.20.2 (latest version).

## Changes

- Updated `@modelcontextprotocol/sdk` from 1.19.1 → 1.20.2
- Added changeset for automated release

## What's New in 1.19.1 → 1.20.2

Based on the [TypeScript SDK releases](https://github.com/modelcontextprotocol/typescript-sdk/releases):

### Version 1.20.2 (Oct 24, 2025)
- Patch release with minor bug fixes

### Version 1.20.1 (Oct 16, 2025)
- **Fix**: Added Accept header to auth metadata request
- **Fix**: Allow empty string as valid URL in DCR workflow
- Documentation improvements

### Version 1.20.0 (Oct 9, 2025)
- **Improvement**: Enhanced README documentation with better quick start examples
- **Improvement**: Added `lint:fix` script
- **Fix**: Default to S256 code challenge if not specified in authorization server metadata

## Testing

✅ MCP custom fetch tests pass
✅ Build succeeds

## Why

Keeping dependencies up to date ensures we have the latest bug fixes and improvements from the MCP SDK, including the important Accept header fix in 1.20.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)