### PR TITLE
feat: add configurable log levels to PropertyCrawler

### DIFF
--- a/.changeset/quiet-crawler-logs.md
+++ b/.changeset/quiet-crawler-logs.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Add configurable log levels to PropertyCrawler to reduce noise from expected failures. The PropertyCrawler now accepts a `logLevel` option ('error' | 'warn' | 'info' | 'debug' | 'silent') that controls logging verbosity. Expected failures (404s, HTML responses, missing .well-known/adagents.json files) are now logged at debug level instead of error/warn level, while unexpected failures remain at error level. This prevents log pollution when domains don't have adagents.json files, which is a common and expected scenario.


### PR DESCRIPTION
## Summary
Adds configurable log levels to PropertyCrawler to reduce noise from expected failures.

## Problem
PropertyCrawler was logging full error stack traces when failing to fetch `.well-known/adagents.json` from domains. This is an expected scenario (many domains won't have this file), but it polluted logs with noise and made it hard to spot actual errors.

## Solution
- Added `PropertyCrawlerConfig` interface with `logLevel` option
- Integrated existing `Logger` utility with proper context (`[PropertyCrawler]`)
- Implemented intelligent error classification:
  - **Expected failures** (404s, HTML responses, missing files) → `debug` level
  - **Unexpected failures** (network errors, timeouts) → `error` level  
  - **Success metrics** → `info` level
- All errors still captured in `CrawlResult.errors` array for programmatic access

## Changes
- Added `EXPECTED_FAILURE_PATTERNS` constant with refined regex patterns
- Added comprehensive JSDoc documentation
- Backwards compatible: defaults to `'warn'` level

## Usage Examples
```typescript
// Silent mode - no console output
const crawler = new PropertyCrawler({ logLevel: 'silent' });

// Default - warnings and errors only
const crawler = new PropertyCrawler({ logLevel: 'warn' });

// Debug - see all attempts including expected failures  
const crawler = new PropertyCrawler({ logLevel: 'debug' });
```

## Testing
- ✅ TypeScript compilation passes
- ✅ Build succeeds
- ✅ Pre-push validation passes
- ✅ Changeset created for automated release

## Code Review
Reviewed by code-reviewer agent - approved with refinements applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)