### PR TITLE
fix: update timeout tests to match TaskExecutor error result behavior

### DIFF
--- a/.changeset/fix-timeout-tests.md
+++ b/.changeset/fix-timeout-tests.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fixed timeout handling tests to match TaskExecutor behavior. Tests now correctly expect error results instead of thrown exceptions when timeouts occur.


### PR DESCRIPTION
## Summary
Fixed timeout handling tests in `error-scenarios.test.js` to correctly expect error results (`success: false`) instead of thrown exceptions.

## Background
The tests were expecting `TaskExecutor` to throw `TaskTimeoutError` exceptions, but the implementation actually catches all exceptions internally and returns standardized error results via the `TaskResult` interface.

**Why CI was passing:** These tests are marked as "slow tests" and skipped in CI via `skip: process.env.CI` (line 17 of the test file). The failures only occurred in local development.

## Changes
Updated 4 timeout-related tests:
- ✅ "should timeout on working status after configured limit" 
- ✅ "should handle polling timeout during working status"
- ✅ "should handle webhook timeout in submitted tasks" - Fixed async activity issue
- ✅ "should handle zero and negative timeout values"

## Test Results
All timeout tests now pass in local development:
```javascript
// Before (BROKEN):
await assert.rejects(executor.executeTask(...), TaskTimeoutError);

// After (CORRECT):
const result = await executor.executeTask(...);
assert.strictEqual(result.success, false);
assert(result.error.includes('timed out'));
```

## Architecture Verification
✅ Confirmed this is the correct protocol design:
- `TaskExecutor.ts` line 489: Throws `TaskTimeoutError` internally
- `TaskExecutor.ts` line 215: Catches all errors in public API
- `TaskExecutor.ts` line 766-788: Converts to `TaskResult` with `success: false`
- Follows Result pattern (not exception-based error handling)

## Related Issues
- These are pre-existing test failures (not related to PR #101)
- Note: Other slow test files may need similar updates (see code review)

## Changeset
- 📦 Patch version bump (test-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)