### PR TITLE
fix: prevent zero budget in media buy creation

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -2490,7 +2490,7 @@
                 <div class="param-group">
                     <label>Budget (required):</label>
                     <div style="display: flex; gap: 10px; align-items: center;">
-                        <input type="number" id="campaign-budget" placeholder="10000" min="0" required>
+                        <input type="number" id="campaign-budget" placeholder="10000" min="0.01" step="0.01" required>
                         <select id="budget-currency" required>
                             <option value="USD">USD</option>
                             <option value="EUR">EUR</option>
@@ -5012,7 +5012,8 @@
             const buyerRef = document.getElementById('buyer-ref').value;
             const poNumber = document.getElementById('po-number').value;
             const brandManifest = document.getElementById('promoted-offering').value;
-            const budget = parseFloat(document.getElementById('campaign-budget').value) || 0;
+            const budgetInput = document.getElementById('campaign-budget').value;
+            const budget = parseFloat(budgetInput);
             const currency = document.getElementById('budget-currency').value || 'USD';
             const dailyCap = document.getElementById('daily-cap').value;
             const pacing = document.getElementById('budget-pacing').value || 'even';
@@ -5044,9 +5045,9 @@
                 alert('Advertiser/Offering Description is required');
                 return;
             }
-            if (!budget || budget <= 0) {
-                logEvent('error', 'Valid budget is required');
-                alert('Valid budget is required');
+            if (!budgetInput || isNaN(budget) || budget <= 0) {
+                logEvent('error', 'Budget must be a positive number greater than 0');
+                alert('Budget must be a positive number greater than 0');
                 return;
             }
             


### PR DESCRIPTION
## Summary
Fixed validation issue where the budget field could accept 0, causing server-side validation error "Invalid budget: 0.0. Budget must be positive."

## Changes
- Updated budget input field: `min="0.01"` (was `"0"`) and added `step="0.01"`
- Improved validation logic to explicitly check for NaN and zero values
- Removed fallback to 0 in parseFloat to properly detect invalid input
- Enhanced error message to be more specific: "Budget must be a positive number greater than 0"

## Test plan
- [x] Verify HTML5 validation prevents entering 0 or negative values
- [x] Verify JavaScript validation catches invalid inputs
- [x] Confirm error message is clear and helpful
- [x] Build succeeds without errors
- [x] Existing tests continue to pass

## Notes
The issue was that HTML5 validation was accepting 0 as valid (since `min="0"`), and the fallback logic `parseFloat(...) || 0` was converting empty/invalid inputs to 0. This fix prevents zero from being accepted at both the HTML5 and JavaScript validation layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)