### PR TITLE
fix: allow authToken reassignment from saved agent config

### DIFF
--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -307,7 +307,7 @@ async function main() {
 
   // Parse options first
   const authIndex = args.indexOf('--auth');
-  const authToken = authIndex !== -1 ? args[authIndex + 1] : process.env.ADCP_AUTH_TOKEN;
+  let authToken = authIndex !== -1 ? args[authIndex + 1] : process.env.ADCP_AUTH_TOKEN;
   const protocolIndex = args.indexOf('--protocol');
   const protocolFlag = protocolIndex !== -1 ? args[protocolIndex + 1] : null;
   const jsonOutput = args.includes('--json');


### PR DESCRIPTION
## Summary

Fixes FATAL ERROR when using saved agent aliases that have authentication configured.

**The Problem:**
The CLI was crashing with "FATAL ERROR: Assignment to constant variable" when calling saved agents with auth tokens configured.

**Root Cause:**
- Line 310: `authToken` was declared as `const`
- Line 360: The code tried to reassign `authToken = savedAgent.auth_token` when using an alias

**The Solution:**
Changed `authToken` from `const` to `let` to allow proper reassignment from saved agent configuration.

## Test Plan

- [x] Added test agent using `--save-auth` command
- [x] Verified agent appears in `--list-agents`
- [x] Called agent to list available tools (no FATAL ERROR)
- [x] Called specific tool with saved agent
- [x] Tested auth token loading from saved config
- [x] Tested --auth flag override priority
- [x] Cleaned up test agents

Auth token priority now works correctly:
1. `--auth` flag (highest priority)
2. Saved agent's `auth_token` (fallback)
3. `ADCP_AUTH_TOKEN` environment variable (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>