### PR TITLE
feat: add AXE segment fields to targeting overlay

### DIFF
--- a/.changeset/1762976327-targeting-overlay-axe-segments.md
+++ b/.changeset/1762976327-targeting-overlay-axe-segments.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Added axe_include_segment and axe_exclude_segment fields to TargetingOverlay type to support AXE (Agentic eXecution Engine) segment-based audience targeting capabilities. These fields were restored in the main adcp schema (PR #193) and are now available in the client library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "2.7.2",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "2.7.2",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v2.4.0
-// Generated at: 2025-11-08T15:37:51.053Z
+// Generated at: 2025-11-12T19:32:26.852Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -117,6 +117,14 @@ export interface TargetingOverlay {
    * Restrict delivery to specific postal/ZIP codes. Use for regulatory compliance or RCT testing.
    */
   geo_postal_code_any_of?: string[];
+  /**
+   * AXE segment ID to include for targeting
+   */
+  axe_include_segment?: string;
+  /**
+   * AXE segment ID to exclude from targeting
+   */
+  axe_exclude_segment?: string;
   frequency_cap?: FrequencyCap;
 }
 /**
@@ -1493,6 +1501,14 @@ export interface TargetingOverlay {
    * Restrict delivery to specific postal/ZIP codes. Use for regulatory compliance or RCT testing.
    */
   geo_postal_code_any_of?: string[];
+  /**
+   * AXE segment ID to include for targeting
+   */
+  axe_include_segment?: string;
+  /**
+   * AXE segment ID to exclude from targeting
+   */
+  axe_exclude_segment?: string;
   frequency_cap?: FrequencyCap;
 }
 /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2025-11-11T19:48:08.338Z
+// Generated at: 2025-11-12T19:32:27.885Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -334,6 +334,8 @@ export const TargetingOverlaySchema = z.object({
     geo_region_any_of: z.array(z.string()).optional(),
     geo_metro_any_of: z.array(z.string()).optional(),
     geo_postal_code_any_of: z.array(z.string()).optional(),
+    axe_include_segment: z.string().optional(),
+    axe_exclude_segment: z.string().optional(),
     frequency_cap: FrequencyCapSchema.optional()
 });
 

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -1608,6 +1608,14 @@ export interface TargetingOverlay {
    * Restrict delivery to specific postal/ZIP codes. Use for regulatory compliance or RCT testing.
    */
   geo_postal_code_any_of?: string[];
+  /**
+   * AXE segment ID to include for targeting
+   */
+  axe_include_segment?: string;
+  /**
+   * AXE segment ID to exclude from targeting
+   */
+  axe_exclude_segment?: string;
   frequency_cap?: FrequencyCap;
 }
 /**


### PR DESCRIPTION
## Summary
Added `axe_include_segment` and `axe_exclude_segment` fields to `TargetingOverlay` type to support AXE (Agentic eXecution Engine) segment-based audience targeting.

## Changes
- Synced schemas from adcontextprotocol.org (v2.4.0)
- Updated TypeScript type definitions in `src/lib/types/core.generated.ts`
- Updated Zod schema validation in `src/lib/types/schemas.generated.ts`
- Created changeset for patch release

## Related
- Upstream PR: https://github.com/adcontextprotocol/adcp/pull/193
- These fields were restored in the main adcp schema

## Test Plan
- [x] Synced latest schemas
- [x] Regenerated types successfully
- [x] Build passes
- [x] Library tests pass
- [x] Changeset created

🤖 Generated with [Claude Code](https://claude.com/claude-code)