### PR TITLE
chore: release v3.2.1

### DIFF
--- a/.changeset/fix-input-required-a2a-status.md
+++ b/.changeset/fix-input-required-a2a-status.md
@@ -1,5 +1,0 @@
----
-"@adcp/client": patch
----
-
-Fixed ProtocolResponseParser to correctly detect input-required status in A2A JSON-RPC wrapped responses. The parser now checks response.result.status.state for A2A responses before falling back to other status locations, preventing "Schema validation failed" errors when agents return input-required status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.1
+
+### Patch Changes
+
+- 918a91a: Fixed ProtocolResponseParser to correctly detect input-required status in A2A JSON-RPC wrapped responses. The parser now checks response.result.status.state for A2A responses before falling back to other status locations, preventing "Schema validation failed" errors when agents return input-required status.
+
 ## 3.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/client",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "AdCP client library with protocol support for MCP and A2A, includes testing framework",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## Release v3.2.1

This release includes a patch fix for input-required status detection in A2A protocol responses.

### Changes

- **Fixed**: ProtocolResponseParser to correctly detect input-required status in A2A JSON-RPC wrapped responses
- The parser now checks `response.result.status.state` for A2A responses before falling back to other status locations
- Prevents "Schema validation failed" errors when agents return input-required status

### Version

- Bumped from: **3.2.0**
- Bumped to: **3.2.1**

### Checklist

- [x] CHANGELOG.md updated
- [x] package.json version bumped
- [x] Changeset applied and removed
- [x] Pre-push validation passed (typecheck + build)

Once this PR is merged, GitHub Actions will automatically publish v3.2.1 to npm.

---

**Automated release process**: This release was prepared using Changesets. Merging this PR will trigger automatic publishing to npm.