### PR TITLE
fix: treat working/input-required as valid intermediate states

### DIFF
--- a/.changeset/fix-webhook-and-intermediate-states.md
+++ b/.changeset/fix-webhook-and-intermediate-states.md
@@ -1,0 +1,12 @@
+---
+"@adcp/client": minor
+---
+
+fix: treat working/input-required as valid intermediate states and extract A2A webhook payloads
+
+- `working` status now returns immediately with `status: 'working'` instead of polling and timing out
+- `input-required` status returns valid result instead of throwing `InputRequiredError` when no handler provided
+- Made `success=true` consistent for all intermediate states (working, submitted, input-required, deferred)
+- Added `taskType` parameter to `handleWebhook` for all client classes (SingleAgentClient, AgentClient, ADCPMultiAgentClient)
+- `handleWebhook` now extracts ADCP response from raw A2A task payloads (artifacts[0].parts[].data where kind === 'data')
+- Handlers now receive unwrapped ADCP responses instead of raw A2A protocol structure

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "3.1.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "3.1.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",
@@ -1310,23 +1310,6 @@
         }
       }
     },
-    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -2628,24 +2611,28 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
+      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
         "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -4744,9 +4731,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4754,6 +4741,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -6606,23 +6597,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/rc": {

--- a/src/lib/core/ADCPMultiAgentClient.ts
+++ b/src/lib/core/ADCPMultiAgentClient.ts
@@ -939,7 +939,12 @@ export class ADCPMultiAgentClient {
    * });
    * ```
    */
-  async handleWebhook(payload: any, signature?: string, timestamp?: string | number): Promise<boolean> {
+  async handleWebhook(
+    payload: any,
+    signature?: string,
+    timestamp?: string | number,
+    taskType?: string
+  ): Promise<boolean> {
     // Extract agent ID from payload
     // Webhook payloads include agent_id or we can infer from operation_id pattern
     const agentId = payload.agent_id || this.inferAgentIdFromPayload(payload);
@@ -949,7 +954,7 @@ export class ADCPMultiAgentClient {
     }
 
     const agent = this.getAgent(agentId);
-    return agent.handleWebhook(payload, signature, timestamp);
+    return agent.handleWebhook(payload, signature, timestamp, taskType);
   }
 
   /**

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -74,10 +74,16 @@ export class AgentClient {
    * @param payload - Webhook payload from agent
    * @param signature - Optional signature for verification (X-ADCP-Signature)
    * @param timestamp - Optional timestamp for verification (X-ADCP-Timestamp)
+   * @param taskType - Task type from URL path (e.g., 'create_media_buy')
    * @returns Whether webhook was handled successfully
    */
-  async handleWebhook(payload: any, signature?: string, timestamp?: string | number): Promise<boolean> {
-    return this.client.handleWebhook(payload, signature, timestamp);
+  async handleWebhook(
+    payload: any,
+    signature?: string,
+    timestamp?: string | number,
+    taskType?: string
+  ): Promise<boolean> {
+    return this.client.handleWebhook(payload, signature, timestamp, taskType);
   }
 
   /**

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -107,7 +107,9 @@ export interface ConversationContext {
 export type TaskStatus =
   | 'pending'
   | 'running'
+  | 'working'
   | 'needs_input'
+  | 'input-required'
   | 'completed'
   | 'failed'
   | 'deferred'
@@ -214,10 +216,10 @@ export interface SubmittedContinuation<T> {
  * Result of a task execution
  */
 export interface TaskResult<T = any> {
-  /** Whether the task completed successfully */
+  /** Whether the task is progressing without errors (true for all intermediate states and successful completion) */
   success: boolean;
   /** Task execution status */
-  status: 'completed' | 'deferred' | 'submitted';
+  status: 'completed' | 'deferred' | 'submitted' | 'input-required' | 'working';
   /** Task result data (if successful) */
   data?: T;
   /** Error message (if failed) */
@@ -243,6 +245,8 @@ export interface TaskResult<T = any> {
     clarificationRounds: number;
     /** Final status */
     status: TaskStatus;
+    /** Input request details (for input-required status) */
+    inputRequest?: InputRequest;
   };
   /** Full conversation history */
   conversation?: Message[];


### PR DESCRIPTION
## Summary
- `working` status now returns immediately instead of polling/timing out
- `input-required` status returns valid result instead of throwing `InputRequiredError`
- Both are valid HITL (human-in-the-loop) intermediate states, not errors
- Made `success=true` consistent for all intermediate states (working, submitted, input-required, deferred)
- Updated JSDoc to clarify `success` means "progressing without errors"

## Problem
When agents like Yahoo return `working` or `input-required` status, the client would:
1. For `working`: Poll and eventually throw `TaskTimeoutError`
2. For `input-required`: Throw `InputRequiredError` if no handler provided

These are valid intermediate states for HITL workflows and should NOT throw errors.

## Solution
Return proper `TaskResult` objects with the intermediate status, allowing callers to handle them appropriately (e.g., set up webhooks, poll later, or display to user).

## Test plan
- [x] Verify `working` status returns `{ success: true, status: 'working', ... }`
- [x] Verify `input-required` status returns `{ success: true, status: 'input-required', ... }`
- [x] Verify `submitted` status returns `{ success: true, status: 'submitted', ... }`
- [x] Verify `deferred` status returns `{ success: true, status: 'deferred', ... }`
- [x] Verify `completed` status still works correctly
- [x] Build passes