### PR TITLE
chore: release package 3.3.1

### DIFF
--- a/.changeset/fix-null-validation.md
+++ b/.changeset/fix-null-validation.md
@@ -1,5 +1,0 @@
----
-"@adcp/client": patch
----
-
-Fix Zod schema validation to accept null values for all optional fields. Updated the schema generator to apply `.nullish()` globally to all optional schema fields, allowing both `null` and `undefined` values where TypeScript types permit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.3.1
+
+### Patch Changes
+
+- ec50aae: Fix Zod schema validation to accept null values for all optional fields. Updated the schema generator to apply `.nullish()` globally to all optional schema fields, allowing both `null` and `undefined` values where TypeScript types permit.
+
 ## 3.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/client",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "AdCP client library with protocol support for MCP and A2A, includes testing framework",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps version from 3.3.0 to 3.3.1
- Updates CHANGELOG.md with release notes
- Removes consumed changeset file

## Changes
- **patch**: Fix Zod schema validation to accept null values for all optional fields. Updated the schema generator to apply `.nullish()` globally to all optional schema fields, allowing both `null` and `undefined` values where TypeScript types permit.

## Test plan
- [ ] CI passes
- [ ] Version bump is correct (3.3.0 → 3.3.1)
- [ ] CHANGELOG.md contains release notes
- [ ] Changeset file has been removed