### PR TITLE
fix: prevent injecting push notification config for unsupported tools

### DIFF
--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -8,6 +8,7 @@ import type { AgentConfig } from '../types';
 import type { PushNotificationConfig } from '../types/tools.generated';
 import { getAuthToken } from '../auth';
 import { validateAgentUrl } from '../validation';
+import { checkToolSupportsPushNotification } from '../utils/tool-support';
 
 /**
  * Universal protocol client - automatically routes to the correct protocol implementation
@@ -43,7 +44,9 @@ export class ProtocolClient {
     // Build push_notification_config for ASYNC TASK STATUS notifications
     // (NOT for reporting_webhook - that stays in args)
     // Schema: https://adcontextprotocol.org/schemas/v1/core/push-notification-config.json
-    const pushNotificationConfig: PushNotificationConfig | undefined = webhookUrl
+    // Only build for tools that support async task notifications
+    const shouldAddWebhook = checkToolSupportsPushNotification(toolName) && webhookUrl;
+    const pushNotificationConfig: PushNotificationConfig | undefined = shouldAddWebhook
       ? {
           url: webhookUrl,
           ...(webhookToken && { token: webhookToken }),

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -140,3 +140,6 @@ export type { AdCPResponse } from './response-unwrapper';
 
 // Re-export protocol detection utilities
 export { detectProtocol, detectProtocolWithTimeout } from './protocol-detection';
+
+// Re-export tool support utilities
+export { checkToolSupportsPushNotification } from './tool-support';

--- a/src/lib/utils/tool-support.ts
+++ b/src/lib/utils/tool-support.ts
@@ -1,0 +1,26 @@
+/**
+ * Tool Support Utilities
+ *
+ * Checks which tools support specific AdCP features
+ */
+
+/**
+ * Check if a tool supports push_notification_config for async task notifications
+ *
+ * @param toolName - Name of the tool to check
+ * @returns true if the tool supports push_notification_config, false otherwise
+ */
+export function checkToolSupportsPushNotification(toolName: string | undefined): boolean {
+  if (!toolName) {
+    return false;
+  }
+
+  // Tools that support async task notifications via push_notification_config
+  const supportedTools = new Set([
+    'sync_creatives',
+    'create_media_buy',
+    'update_media_buy',
+  ]);
+
+  return supportedTools.has(toolName.toLowerCase());
+}


### PR DESCRIPTION
- Some tools do not support push_notification_config. But we were injecting them always as long as the client has webhookTemplate configured. 
- This resulted in errors such as: `Fix get_media_buy_delivery failing with "Unexpected keyword argument: push_notification_config"`

This PR adds tool name check before auto injecting push_notification_config.