### PR TITLE
fix: normalize v2 pricing options before schema validation

### DIFF
--- a/.changeset/fix-v2-pricing-validation.md
+++ b/.changeset/fix-v2-pricing-validation.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": patch
+---
+
+Fix schema validation for v2 pricing options in get_products responses
+
+When servers return v2-style pricing options (rate, is_fixed, price_guidance.floor), schema validation now normalizes them to v3 format (fixed_price, floor_price) before validation. This ensures v2 server responses pass validation against v3 schemas.


### PR DESCRIPTION
## Summary

- Fix schema validation failures for v2 server responses
- Add normalization before validation in TaskExecutor
- V2 pricing fields (`rate`, `is_fixed`, `price_guidance.floor`) are now converted to v3 format (`fixed_price`, `floor_price`) before schema validation

## Problem

When calling `get_products` against v2 servers (like test-agent.adcontextprotocol.org), schema validation was failing with errors like:

```
Schema validation: products.0.pricing_options.0: Invalid input
```

The root cause was that validation ran BEFORE the v2→v3 normalization that happens in `SingleAgentClient.normalizeResponseToV3()`.

## Solution

Added `normalizeResponseForValidation()` method in `TaskExecutor` that normalizes responses before schema validation. This reuses the existing `normalizeGetProductsResponse()` utility from `pricing-adapter.ts`.

## Test plan

- [x] All 38 pricing adapter tests pass
- [x] All 27 response validator tests pass
- [x] Build succeeds
- [ ] Manual test against test-agent.adcontextprotocol.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)