### PR TITLE
fix: rename Authorized Properties section to AdCP Capabilities

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -2843,16 +2843,16 @@
         </div>
       </div>
 
-      <!-- Authorized Properties Section -->
+      <!-- AdCP Capabilities Section -->
       <div class="section">
         <h3>
-          🏢 Authorized Properties
+          ⚙️ AdCP Capabilities
           <span style="color: #666; font-size: 14px; font-weight: normal">- Auto-loaded with agent data</span>
         </h3>
 
         <div id="properties-content" style="min-height: 100px; padding: 15px; background: #f9f9f9; border-radius: 8px">
           <p style="color: #666; text-align: center">
-            Select an agent and click "Load Agent Data" to see authorized properties
+            Select an agent and click "Load Agent Data" to see AdCP capabilities
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Renamed the "Authorized Properties" section in the testing UI to "AdCP Capabilities"
- Updated the placeholder text to match
- The section was already displaying capabilities data, just had an outdated label

## Test plan
- [ ] Load the testing UI and verify the section is now labeled "AdCP Capabilities"
- [ ] Verify the placeholder text says "Select an agent and click 'Load Agent Data' to see AdCP capabilities"

🤖 Generated with [Claude Code](https://claude.com/claude-code)