### PR TITLE
feat: add @adcp/client/auth export path

### DIFF
--- a/.changeset/oauth-exports.md
+++ b/.changeset/oauth-exports.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": minor
+---
+
+Add `@adcp/client/auth` export path for OAuth and authentication utilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
       "import": "./dist/lib/testing/index.js",
       "require": "./dist/lib/testing/index.js",
       "types": "./dist/lib/testing/index.d.ts"
+    },
+    "./auth": {
+      "import": "./dist/lib/auth/index.js",
+      "require": "./dist/lib/auth/index.js",
+      "types": "./dist/lib/auth/index.d.ts"
     }
   },
   "bin": {


### PR DESCRIPTION
## Summary
- Add `./auth` export path to package.json for OAuth and authentication utilities
- Enables importing from `@adcp/client/auth` for OAuth flows

## Usage
```typescript
import { 
  discoverOAuthMetadata, 
  supportsOAuth, 
  MCPOAuthProvider,
  CLIFlowHandler,
  createCLIOAuthProvider 
} from '@adcp/client/auth';
```

## Test plan
- [x] Library builds successfully
- [x] Export path resolves correctly in dist
- [x] Types file exists at dist/lib/auth/index.d.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)