### PR TITLE
chore: release package v3.14.1

### DIFF
--- a/.changeset/fix-fastify-plugins.md
+++ b/.changeset/fix-fastify-plugins.md
@@ -1,5 +1,0 @@
----
-'@adcp/client': patch
----
-
-Upgrade @fastify/cors and @fastify/static for Fastify 5 compatibility, fixing production server crash loop

--- a/.changeset/fix-oauth-discovery.md
+++ b/.changeset/fix-oauth-discovery.md
@@ -1,5 +1,0 @@
----
-'@adcp/client': patch
----
-
-Fix OAuth discovery to use RFC 8414 path-aware resolution, trying `{origin}/.well-known/oauth-authorization-server{path}` before falling back to root

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.14.1
+
+### Patch Changes
+
+- 45b1229: Upgrade @fastify/cors and @fastify/static for Fastify 5 compatibility, fixing production server crash loop
+- d22c3b2: Fix OAuth discovery to use RFC 8414 path-aware resolution, trying `{origin}/.well-known/oauth-authorization-server{path}` before falling back to root
+
 ## 3.14.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/client",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "AdCP client library with protocol support for MCP and A2A, includes testing framework",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version to 3.14.1
- Consume pending changesets for two patch fixes:
  - Upgrade @fastify/cors and @fastify/static for Fastify 5 compatibility, fixing production server crash loop
  - Fix OAuth discovery to use RFC 8414 path-aware resolution with fallback

## Test plan
- [ ] CI passes (lint, build, typecheck)
- [ ] Verify CHANGELOG.md is correct
- [ ] After merge, confirm npm publish workflow triggers and publishes 3.14.1