### PR TITLE
fix: retry StreamableHTTP on session errors instead of SSE fallback

### DIFF
--- a/.changeset/quick-terms-occur.md
+++ b/.changeset/quick-terms-occur.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix: retry StreamableHTTP on session errors instead of falling back to SSE. When a server returns 404 "Session not found", the client now retries with a fresh StreamableHTTP connection rather than incorrectly falling back to SSE transport.


### PR DESCRIPTION
## Summary

- When a StreamableHTTP `connect()` fails with a 404 "Session not found" error, `callMCPTool()` now retries with a fresh StreamableHTTP connection instead of incorrectly falling back to SSE transport
- SSE fallback is reserved for errors that genuinely indicate the server doesn't support StreamableHTTP
- Fixes the issue where the real session error was masked by a subsequent SSE 401 failure

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Verify against an MCP agent that returns "Session not found" — should retry StreamableHTTP, not fall back to SSE
- [ ] Verify against an agent that only supports SSE — should still fall back correctly