### PR TITLE
chore: release package v3.16.0

### DIFF
--- a/.changeset/full-registry-client.md
+++ b/.changeset/full-registry-client.md
@@ -1,7 +1,0 @@
----
-'@adcp/client': minor
----
-
-Add full AdCP Registry client with 28 SDK methods and 17 CLI commands
-
-Generates TypeScript types from the registry OpenAPI spec using openapi-typescript. Expands RegistryClient with methods for brand/property listing, agent discovery, authorization validation, search, and adagents tooling. Adds corresponding CLI commands including list-brands, list-properties, search, agents, publishers, stats, validate, lookup, discover, and check-auth.

--- a/.changeset/quick-terms-occur.md
+++ b/.changeset/quick-terms-occur.md
@@ -1,5 +1,0 @@
----
-"@adcp/client": patch
----
-
-Fix: retry StreamableHTTP on session errors instead of falling back to SSE. When a server returns 404 "Session not found", the client now retries with a fresh StreamableHTTP connection rather than incorrectly falling back to SSE transport.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.16.0
+
+### Minor Changes
+
+- 03d47c6: Add full AdCP Registry client with 28 SDK methods and 17 CLI commands
+
+  Generates TypeScript types from the registry OpenAPI spec using openapi-typescript. Expands RegistryClient with methods for brand/property listing, agent discovery, authorization validation, search, and adagents tooling. Adds corresponding CLI commands including list-brands, list-properties, search, agents, publishers, stats, validate, lookup, discover, and check-auth.
+
+### Patch Changes
+
+- 253c86b: Fix: retry StreamableHTTP on session errors instead of falling back to SSE. When a server returns 404 "Session not found", the client now retries with a fresh StreamableHTTP connection rather than incorrectly falling back to SSE transport.
+
 ## 3.15.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adcp/client",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "AdCP client library with protocol support for MCP and A2A, includes testing framework",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",


### PR DESCRIPTION
## Summary

- Bumps `@adcp/client` from 3.15.0 to **3.16.0**
- Consumes 2 pending changesets

### Minor Changes
- Add full AdCP Registry client with 28 SDK methods and 17 CLI commands

### Patch Changes
- Fix: retry StreamableHTTP on session errors instead of falling back to SSE

## Test plan

- [ ] CI passes
- [ ] Merging triggers automated npm publish via OIDC
- [ ] Verify on npm: `npm view @adcp/client version` returns `3.16.0`