### PR TITLE
feat: sync AdCP schema — sandbox mode + creative format filters

### DIFF
--- a/.changeset/sync-sandbox-schema.md
+++ b/.changeset/sync-sandbox-schema.md
@@ -1,0 +1,10 @@
+---
+"@adcp/client": minor
+---
+
+Sync upstream AdCP schema: sandbox mode support and creative format filters
+
+- Added `sandbox?: boolean` to `Account`, `MediaBuyFeatures`, and all task response types (`GetProductsResponse`, `CreateMediaBuySuccess`, `UpdateMediaBuySuccess`, `SyncCreativesSuccess`, `ListCreativesResponse`, `ListCreativeFormatsResponse`, `GetMediaBuyDeliveryResponse`, `ProvidePerformanceFeedbackSuccess`, `SyncEventSourcesSuccess`, `LogEventSuccess`, `SyncAudiencesSuccess`, `BuildCreativeSuccess`, `ActivateSignalSuccess`, `GetSignalsResponse`)
+- Added `sandbox?: boolean` filter to `ListAccountsRequest` and `SyncAccountsRequest`
+- Added `output_format_ids` and `input_format_ids` filter fields to `ListCreativeFormatsRequest`
+- Added `input_format_ids` to `Format`

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-02-19T11:49:54.677Z
+// Generated at: 2026-02-19T18:57:51.207Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -196,6 +196,10 @@ export interface Account {
     amount: number;
     currency: string;
   };
+  /**
+   * When true, this is a sandbox account. All requests using this account_id are treated as sandbox — no real platform calls, no real spend.
+   */
+  sandbox?: boolean;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
 }
@@ -2635,6 +2639,10 @@ export interface GetProductsResponse {
    */
   product_selectors_applied?: boolean;
   pagination?: PaginationResponse;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
@@ -2931,6 +2939,10 @@ export interface CreateMediaBuySuccess {
    * Array of created packages with complete state information
    */
   packages: Package[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
@@ -3017,6 +3029,10 @@ export interface UpdateMediaBuySuccess {
    * Array of packages that were modified with complete state information
    */
   affected_packages?: Package[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
@@ -3133,6 +3149,10 @@ export interface SyncCreativesSuccess {
     };
     [k: string]: unknown | undefined;
   }[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
@@ -3192,6 +3212,10 @@ export interface Account1 {
     amount: number;
     currency: string;
   };
+  /**
+   * When true, this is a sandbox account. All requests using this account_id are treated as sandbox — no real platform calls, no real spend.
+   */
+  sandbox?: boolean;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
 }

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-02-19T14:12:26.972Z
+// Generated at: 2026-02-19T18:57:52.307Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -48,6 +48,7 @@ export const AccountSchema = z.record(z.string(), z.union([z.unknown(), z.undefi
         amount: z.number(),
         currency: z.string()
     }).nullish(),
+    sandbox: z.boolean().nullish(),
     ext: ExtensionObjectSchema.nullish()
 }));
 
@@ -591,6 +592,7 @@ export const SyncCreativesSuccessSchema = z.object({
         assigned_to: z.array(z.string()).nullish(),
         assignment_errors: z.record(z.string(), z.string()).nullish()
     })),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -611,6 +613,7 @@ export const Account1Schema = z.record(z.string(), z.union([z.unknown(), z.undef
         amount: z.number(),
         currency: z.string()
     }).nullish(),
+    sandbox: z.boolean().nullish(),
     ext: ExtensionObjectSchema.nullish()
 }));
 
@@ -686,7 +689,8 @@ export const MediaBuyFeaturesSchema = z.record(z.string(), z.union([z.boolean(),
     property_list_filtering: z.boolean().nullish(),
     content_standards: z.boolean().nullish(),
     conversion_tracking: z.boolean().nullish(),
-    audience_targeting: z.boolean().nullish()
+    audience_targeting: z.boolean().nullish(),
+    sandbox: z.boolean().nullish()
 }));
 
 export const SignalTargetingSchema = z.union([z.record(z.string(), z.union([z.unknown(), z.undefined()])).and(z.object({
@@ -851,6 +855,8 @@ export const ListCreativeFormatsRequestSchema = z.object({
     is_responsive: z.boolean().nullish(),
     name_search: z.string().nullish(),
     wcag_level: WCAGLevelSchema.nullish(),
+    output_format_ids: z.array(FormatIDSchema).nullish(),
+    input_format_ids: z.array(FormatIDSchema).nullish(),
     pagination: PaginationRequestSchema.nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
@@ -1092,6 +1098,7 @@ export const ListCreativesResponseSchema = z.object({
         rejected: z.number().nullish(),
         archived: z.number().nullish()
     }).nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1116,6 +1123,7 @@ export const UpdateMediaBuySuccessSchema = z.object({
     buyer_ref: z.string(),
     implementation_date: z.string().nullish().nullable(),
     affected_packages: z.array(PackageSchema).nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1209,6 +1217,7 @@ export const FeedbackSourceSchema = z.union([z.literal("buyer_attribution"), z.l
 
 export const ProvidePerformanceFeedbackSuccessSchema = z.object({
     success: z.literal(true),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1248,6 +1257,7 @@ export const SyncEventSourcesSuccessSchema = z.object({
         action: z.union([z.literal("created"), z.literal("updated"), z.literal("unchanged"), z.literal("deleted"), z.literal("failed")]),
         errors: z.array(z.string()).nullish()
     })),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1306,6 +1316,7 @@ export const LogEventSuccessSchema = z.object({
     })).nullish(),
     warnings: z.array(z.string()).nullish(),
     match_quality: z.number().nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1357,6 +1368,7 @@ export const SyncAudiencesSuccessSchema = z.object({
         minimum_size: z.number().nullish(),
         errors: z.array(ErrorSchema).nullish()
     })),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1402,6 +1414,7 @@ export const ReferenceAssetSchema = z.record(z.string(), z.union([z.unknown(), z
 
 export const BuildCreativeSuccessSchema = z.object({
     creative_manifest: CreativeManifestSchema,
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -1674,6 +1687,7 @@ export const ActivateSignalRequestSchema = z.object({
 
 export const ActivateSignalSuccessSchema = z.object({
     deployments: z.array(DeploymentSchema),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -2414,6 +2428,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
 export const ListAccountsRequestSchema = z.object({
     status: z.union([z.literal("active"), z.literal("pending_approval"), z.literal("payment_required"), z.literal("suspended"), z.literal("closed")]).nullish(),
     pagination: PaginationRequestSchema.nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -2431,7 +2446,8 @@ export const SyncAccountsRequestSchema = z.object({
         house: z.string(),
         brand_id: z.string().nullish(),
         operator: z.string().nullish(),
-        billing: z.union([z.literal("brand"), z.literal("operator"), z.literal("agent")]).nullish()
+        billing: z.union([z.literal("brand"), z.literal("operator"), z.literal("agent")]).nullish(),
+        sandbox: z.boolean().nullish()
     })),
     delete_missing: z.boolean().nullish(),
     dry_run: z.boolean().nullish(),
@@ -2464,7 +2480,8 @@ export const SyncAccountsSuccessSchema = z.object({
             currency: z.string()
         }).nullish(),
         errors: z.array(ErrorSchema).nullish(),
-        warnings: z.array(z.string()).nullish()
+        warnings: z.array(z.string()).nullish(),
+        sandbox: z.boolean().nullish()
     })),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
@@ -2551,6 +2568,7 @@ export const CreateMediaBuySuccessSchema = z.object({
     account: AccountSchema.nullish(),
     creative_deadline: z.string().nullish(),
     packages: z.array(PackageSchema),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -2639,6 +2657,7 @@ export const FormatSchema = z.record(z.string(), z.union([z.unknown(), z.undefin
         })])).nullish(),
     delivery: z.record(z.string(), z.union([z.unknown(), z.undefined()])).nullish(),
     supported_macros: z.array(z.union([UniversalMacroSchema, z.string()])).nullish(),
+    input_format_ids: z.array(FormatID1Schema).nullish(),
     output_format_ids: z.array(FormatID1Schema).nullish(),
     format_card: z.record(z.string(), z.union([z.unknown(), z.undefined()])).and(z.object({
         format_id: FormatID2Schema,
@@ -2774,6 +2793,7 @@ export const GetMediaBuyDeliveryResponseSchema = z.object({
         })).nullish()
     })),
     errors: z.array(ErrorSchema).nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -2939,6 +2959,7 @@ export const GetSignalsResponseSchema = z.object({
     })),
     errors: z.array(ErrorSchema).nullish(),
     pagination: PaginationResponseSchema.nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -3038,6 +3059,7 @@ export const GetProductsResponseSchema = z.object({
     property_list_applied: z.boolean().nullish(),
     product_selectors_applied: z.boolean().nullish(),
     pagination: PaginationResponseSchema.nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });
@@ -3065,6 +3087,7 @@ export const ListCreativeFormatsResponseSchema = z.object({
     })).nullish(),
     errors: z.array(ErrorSchema).nullish(),
     pagination: PaginationResponseSchema.nullish(),
+    sandbox: z.boolean().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 });

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -418,6 +418,10 @@ export interface MediaBuyFeatures {
    * Supports sync_audiences task and audience_include/audience_exclude in targeting overlays for first-party CRM audience management
    */
   audience_targeting?: boolean;
+  /**
+   * Supports sandbox mode for operations without real platform calls or spend
+   */
+  sandbox?: boolean;
   [k: string]: boolean | undefined;
 }
 /**
@@ -717,6 +721,10 @@ export interface GetProductsResponse {
    */
   product_selectors_applied?: boolean;
   pagination?: PaginationResponse;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -1929,6 +1937,14 @@ export interface ListCreativeFormatsRequest {
    */
   name_search?: string;
   wcag_level?: WCAGLevel;
+  /**
+   * Filter to formats whose output_format_ids includes any of these format IDs. Returns formats that can produce these outputs — inspect each result's input_format_ids to see what inputs they accept.
+   */
+  output_format_ids?: FormatID[];
+  /**
+   * Filter to formats whose input_format_ids includes any of these format IDs. Returns formats that accept these creatives as input — inspect each result's output_format_ids to see what they can produce.
+   */
+  input_format_ids?: FormatID[];
   pagination?: PaginationRequest;
   context?: ContextObject;
   ext?: ExtensionObject;
@@ -2035,6 +2051,10 @@ export interface ListCreativeFormatsResponse {
    */
   errors?: Error[];
   pagination?: PaginationResponse;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -2130,7 +2150,11 @@ export interface Format {
    */
   supported_macros?: (UniversalMacro | string)[];
   /**
-   * For generative formats: array of format IDs that this format can generate. When a format accepts inputs like brand context and message, this specifies what concrete output formats can be produced (e.g., a generative banner format might output standard image banner formats).
+   * Array of format IDs this format accepts as input creative manifests. When present, indicates this format can take existing creatives in these formats as input. Omit for formats that work from raw assets (images, text, etc.) rather than existing creatives.
+   */
+  input_format_ids?: FormatID1[];
+  /**
+   * Array of format IDs that this format can produce as output. When present, indicates this format can build creatives in these output formats (e.g., a multi-publisher template format might produce standard display formats across many publishers). Omit for formats that produce a single fixed output (the format itself).
    */
   output_format_ids?: FormatID1[];
   /**
@@ -3441,6 +3465,10 @@ export interface CreateMediaBuySuccess {
    * Array of created packages with complete state information
    */
   packages: Package[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -3499,6 +3527,10 @@ export interface Account {
     amount: number;
     currency: string;
   };
+  /**
+   * When true, this is a sandbox account. All requests using this account_id are treated as sandbox — no real platform calls, no real spend.
+   */
+  sandbox?: boolean;
   ext?: ExtensionObject;
   [k: string]: unknown | undefined;
 }
@@ -3719,6 +3751,10 @@ export interface SyncCreativesSuccess {
       [k: string]: string;
     };
   }[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -4107,6 +4143,10 @@ export interface ListCreativesResponse {
      */
     archived?: number;
   };
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -4223,6 +4263,10 @@ export interface UpdateMediaBuySuccess {
    * Array of packages that were modified with complete state information
    */
   affected_packages?: Package[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -4499,6 +4543,10 @@ export interface GetMediaBuyDeliveryResponse {
    * Task-specific errors and warnings (e.g., missing delivery data, reporting platform issues)
    */
   errors?: Error[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -4820,6 +4868,10 @@ export interface ProvidePerformanceFeedbackSuccess {
    * Whether the performance feedback was successfully received
    */
   success: true;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -4939,6 +4991,10 @@ export interface SyncEventSourcesSuccess {
      */
     errors?: string[];
   }[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -5178,6 +5234,10 @@ export interface LogEventSuccess {
    * Overall match quality score for the batch (0.0 = no matches, 1.0 = all matched)
    */
   match_quality?: number;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -5340,6 +5400,10 @@ export interface SyncAudiencesSuccess {
      */
     errors?: Error[];
   }[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -5531,6 +5595,10 @@ export type BuildCreativeResponse = BuildCreativeSuccess | BuildCreativeError;
  */
 export interface BuildCreativeSuccess {
   creative_manifest: CreativeManifest;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -6671,6 +6739,10 @@ export interface GetSignalsResponse {
    */
   errors?: Error[];
   pagination?: PaginationResponse;
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -6711,6 +6783,10 @@ export interface ActivateSignalSuccess {
    * Array of deployment results for each deployment target
    */
   deployments: Deployment[];
+  /**
+   * When true, this response contains simulated data from sandbox mode.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -9426,6 +9502,10 @@ export interface ListAccountsRequest {
    */
   status?: 'active' | 'pending_approval' | 'payment_required' | 'suspended' | 'closed';
   pagination?: PaginationRequest;
+  /**
+   * Filter by sandbox status. true returns only sandbox accounts, false returns only production accounts. Omit to return all accounts.
+   */
+  sandbox?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -9481,6 +9561,10 @@ export interface SyncAccountsRequest {
      * Who should be invoiced. brand: seller invoices the brand directly. operator: seller invoices the operator (agency). agent: agent consolidates billing across brands. Omit to accept the seller's default.
      */
     billing?: 'brand' | 'operator' | 'agent';
+    /**
+     * When true, provision this as a sandbox account. No real platform calls or billing. Sandbox accounts are identified by account_id in subsequent requests.
+     */
+    sandbox?: boolean;
   }[];
   /**
    * When true, accounts previously synced by this agent but not included in this request will be deactivated. Scoped to the authenticated agent — does not affect accounts managed by other agents. Use with caution.
@@ -9589,6 +9673,10 @@ export interface SyncAccountsSuccess {
      * Non-fatal warnings about this account
      */
     warnings?: string[];
+    /**
+     * Whether this is a sandbox account, echoed from the request.
+     */
+    sandbox?: boolean;
   }[];
   context?: ContextObject;
   ext?: ExtensionObject;


### PR DESCRIPTION
## Summary

- Syncs generated types from upstream AdCP schema
- Adds `sandbox?: boolean` to `Account`, `MediaBuyFeatures`, and all task response types
- Adds `sandbox?: boolean` filter to `ListAccountsRequest` and `SyncAccountsRequest`
- Adds `output_format_ids` and `input_format_ids` filter fields to `ListCreativeFormatsRequest` and `Format`

## Test plan

- [ ] Generated types match upstream schemas
- [ ] Build passes (`npm run build:lib`)
- [ ] TypeScript types check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)