### PR TITLE
feat: infer buying_mode from brief presence for backwards compatibility

### DIFF
--- a/.changeset/infer-buying-mode.md
+++ b/.changeset/infer-buying-mode.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": minor
+---
+
+Infer buying_mode from brief presence on get_products for backwards compatibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,24 @@ npm run test:all          # Full test suite
 - `test/e2e/` - Integration tests
 - `examples/` - Usage examples and demos
 
+## Backwards Compatibility
+
+**This is a published npm library. Callers on older versions must not break when we add new required fields.**
+
+When adding a new required field to a request schema:
+1. **Infer it from existing fields** in `SingleAgentClient.normalizeRequestParams()` so callers that don't send it still work
+2. **Update all internal callers** (testing scenarios, server handlers) to send the field explicitly
+3. **Add tests** verifying the inference works and that explicit values are preserved
+
+Example: `buying_mode` was added as required on `get_products`. The client infers it from `brief` presence — callers that only sent `{ brief: '...' }` keep working.
+
+The pattern:
+- `normalizeRequestParams()` runs before validation, filling in derivable fields
+- `validateRequest()` runs Zod schemas after normalization
+- `adaptRequestForServerVersion()` handles v3→v2 downgrades for older servers
+
+**Never add a required field without a backwards-compatible default or inference path.**
+
 ## Common Gotchas
 
 1. **Protocol clients**: Always use official `@a2a-js/sdk` and `@modelcontextprotocol/sdk`
@@ -242,6 +260,7 @@ npm run test:all          # Full test suite
 3. **Mock data**: Never inject fallback data when agents return empty responses
 4. **Version management**: Let changesets handle package.json, edit ADCP_VERSION separately
 5. **Debug logs**: UI expects specific format with separate request/response entries
+6. **Backwards compatibility**: New required schema fields need inference in `normalizeRequestParams()`
 
 ## Debug Log Format (DO NOT CHANGE)
 

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -174,6 +174,7 @@ export async function discoverAgentCapabilities(
 
   const brief = options.brief || 'Show me all available advertising products across all channels';
   const getProductsParams: Record<string, unknown> = {
+    buying_mode: 'brief',
     brief,
     brand: resolveBrand(options),
   };

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -131,6 +131,7 @@ export async function testCreateMediaBuy(
     'get_products',
     async () =>
       client.executeTask('get_products', {
+        buying_mode: 'brief',
         brief: options.brief || 'Looking for display advertising products',
         brand: resolveBrand(options),
       }) as Promise<TaskResult>
@@ -458,6 +459,7 @@ export async function testCreativeInline(
     'get_products',
     async () =>
       client.executeTask('get_products', {
+        buying_mode: 'brief',
         brief: options.brief || 'Looking for display advertising products',
         brand: resolveBrand(options),
       }) as Promise<TaskResult>

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -365,6 +365,11 @@ function buildToolArgs(toolName: string, brief?: string, promotedOffering?: stri
   const brandAcceptingTools = ['get_products', 'create_media_buy'];
 
   // Only add parameters that the tool accepts
+  // Note: SingleAgentClient.normalizeRequestParams() also infers buying_mode,
+  // but the server uses executeTaskOnAgent() which may bypass that path.
+  if (toolName === 'get_products') {
+    args.buying_mode = brief ? 'brief' : 'wholesale';
+  }
   if (briefAcceptingTools.includes(toolName) && brief) {
     args.brief = brief;
   }


### PR DESCRIPTION
## Summary

- When `buying_mode` is not provided on `get_products` requests, infer it from `brief` presence (`brief` → `'brief'`, no brief → `'wholesale'`). This ensures callers written before `buying_mode` became required keep working.
- Apply normalization in both `getProducts()` and generic `executeTask()` paths via `normalizeRequestParams()`
- Fix `buildToolArgs` in server.ts to include `buying_mode`
- Update testing scenarios to use `buying_mode` and `brand` (replacing deprecated `brand_manifest` references)
- Document backwards compatibility pattern in AGENTS.md

## Other compat gaps investigated

Audited all validated request schemas for other required fields that older callers might not send. `buying_mode` on `get_products` is the only gap — all other required fields either existed since the tool's introduction or are on newer tools where callers would already use current schemas.

## Test plan

- [x] 5 new tests for buying_mode inference (brief present, brief absent, explicit brief, explicit wholesale, extra fields)
- [x] All 847 existing tests pass
- [x] Build succeeds with no TypeScript errors
- [x] Changeset included (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)