### PR TITLE
fix: strip inferred buying_mode from get_products for partial v3 agents

### DIFF
--- a/.changeset/mcp-schema-filter.md
+++ b/.changeset/mcp-schema-filter.md
@@ -1,0 +1,11 @@
+---
+"@adcp/client": patch
+---
+
+Fix get_products failing with "Unexpected keyword argument: buying_mode" on partial v3 agents
+
+When calling `get_products`, the client infers and adds `buying_mode` to requests for backwards compatibility. For agents detected as v3 (have `get_adcp_capabilities`) but with an incomplete `get_products` implementation that doesn't declare `buying_mode` in its tool schema, this caused a pydantic validation error and the entire call to fail.
+
+The fix caches tool `inputSchema` data (already fetched via `listTools` during capability detection) and uses it in `adaptRequestForServerVersion` to strip `buying_mode` from `get_products` requests when the agent's schema doesn't declare the field. Fails open — if no schema is cached, the field is sent unchanged.
+
+This is targeted to `get_products` + `buying_mode` at the existing version-adaptation layer, rather than blanket schema filtering at the protocol layer.


### PR DESCRIPTION
## Problem

`get_products` calls to Planet Nine (and any agent with a partial v3 implementation) fail with:

```
1 validation error for call[get_products]
buying_mode
  Unexpected keyword argument
```

**Root cause**: The client infers and adds `buying_mode: 'brief'` to `get_products` requests for backwards compat with callers that don't supply it. For agents detected as v3 (they have `get_adcp_capabilities`) but with an incomplete `get_products` implementation that doesn't declare `buying_mode` in their tool schema, this field gets rejected.

**Why the existing v2/v3 adaptation didn't catch it**: `adaptRequestForServerVersion` already strips `buying_mode` for v2 agents via `adaptGetProductsRequestForV2`. But the detection is binary — Planet Nine is correctly detected as v3, so the v2 downgrade never runs. The binary check can't see partial v3 implementations.

## Fix

**Layer**: `SingleAgentClient.adaptRequestForServerVersion` — the existing layer for exactly this kind of version-compatibility adaptation.

**Approach**: Cache tool `inputSchema.properties` per tool when `getCapabilities()` runs (the data is already fetched via `getAgentInfo()` → `listTools`, so zero extra network calls). Add `toolDeclaresField()` helper that checks the cache. In the v3 branch of `adaptRequestForServerVersion`, strip `buying_mode` from `get_products` requests when the agent's schema doesn't declare the field.

Fails open — if no schema is cached, the field passes through unchanged.

## Changes

| File | Change |
|------|--------|
| `src/lib/core/SingleAgentClient.ts` | Add `cachedToolSchemas`, populate in `getCapabilities()`, add `toolDeclaresField()`, strip `buying_mode` in v3 branch of `adaptRequestForServerVersion` |
| `src/server/sales-agents-handlers.ts` | Fix pre-existing type error: `account_id` → `account: { account_id }` per `AccountReference` union type |
| `src/lib/types/tools.generated.ts` | Generated: `GetAccountFinancialsRequest/Response` types |
| `src/lib/types/schemas.generated.ts` | Generated: schema additions |
| `src/lib/types/core.generated.ts` | Generated: core type additions |
| `src/lib/agents/index.generated.ts` | Generated: `getAccountFinancials()` method |
| `.changeset/mcp-schema-filter.md` | Patch changeset |

## Call path (why this fixes the reported log)

1. `agentic-api` → `client.getProducts(...)` → `executeAndHandle`
2. `getCapabilities()` → `getAgentInfo()` → `listTools` → **`cachedToolSchemas` populated with Planet Nine's actual schemas**
3. `adaptRequestForServerVersion` detects v3 → `toolDeclaresField('get_products', 'buying_mode')` returns false → **`buying_mode` stripped** + `console.warn` logged
4. `get_products` called with just `{ brief: "..." }` → succeeds

## Test plan
- [ ] Call `get_products` on Planet Nine — should succeed, no more unexpected keyword argument error
- [ ] Console should show `[AdCP] Stripping inferred "buying_mode"...` warning for Planet Nine
- [ ] Fully spec-compliant v3 agents (schema declares `buying_mode`) — unaffected, field passes through
- [ ] v2 agents — unaffected, existing `adaptGetProductsRequestForV2` path still runs
- [ ] If `listTools` unavailable — fails open, field passes through unchanged