### PR TITLE
chore: add missing changeset for PR #298 v2.x backward compat fix

### DIFF
--- a/.changeset/fix-v2-backward-compat.md
+++ b/.changeset/fix-v2-backward-compat.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": patch
+---
+
+fix: make v3-required by_package fields optional for v2.x agent backward compatibility
+
+Real-world agents implementing v2.5/v2.6 of the AdCP spec were failing schema validation because v3 added new required fields (pricing_model, rate, currency, breakdown item IDs, total_budget, approval_status) that older agents don't send. Added a BACKWARD_COMPAT_OPTIONAL_FIELDS mechanism to generate-types.ts that removes specified fields from required arrays before TypeScript/Zod generation, without touching the canonical JSON schemas.


### PR DESCRIPTION
## Summary

- PR #298 was merged without a changeset, which means the fix won't be published to npm
- This adds the missing changeset so the release automation picks it up

## Changes

- Adds `.changeset/fix-v2-backward-compat.md` (patch bump) for the backward compatibility fix from PR #298 that made v3-required `by_package` fields optional for v2.x agents

## Test plan

- [ ] Verify CI changeset check passes
- [ ] Verify Release PR is auto-generated after merge with correct patch version bump