### PR TITLE
fix: resolve 6 creative testing issues

### DIFF
--- a/.changeset/fix-creative-testing.md
+++ b/.changeset/fix-creative-testing.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': minor
+---
+
+Fix creative protocol testing issues and add creative_lifecycle scenario
+
+- Fix preview_creative test calls to use current schema (request_type: 'single' + creative_manifest)
+- Remove incorrect media_buy gate on sync_creatives (now dual-domain with creative protocol)
+- Fix cross-validation false positives from shared tools (list_creative_formats, list_creatives, sync_creatives)
+- Respect min_spend_per_package when building test media buy requests
+- Add creative_lifecycle scenario: format validation, bulk sync, snapshot testing, build/preview

--- a/src/lib/testing/agent-tester.ts
+++ b/src/lib/testing/agent-tester.ts
@@ -50,6 +50,7 @@ import {
   testCreativeInline,
   testCreativeReference,
   testCreativeFlow,
+  testCreativeLifecycle,
   testSignalsFlow,
   testErrorHandling,
   testValidation,
@@ -153,6 +154,12 @@ export async function testAgent(
 
       case 'creative_flow':
         result = await testCreativeFlow(agentUrl, effectiveOptions);
+        steps = result.steps;
+        profile = result.profile;
+        break;
+
+      case 'creative_lifecycle':
+        result = await testCreativeLifecycle(agentUrl, effectiveOptions);
         steps = result.steps;
         profile = result.profile;
         break;
@@ -353,6 +360,7 @@ export {
   testCreativeSync,
   testCreativeInline,
   testCreativeFlow,
+  testCreativeLifecycle,
   testSignalsFlow,
   testErrorHandling,
   testValidation,

--- a/src/lib/testing/orchestrator.ts
+++ b/src/lib/testing/orchestrator.ts
@@ -27,7 +27,7 @@ export const SCENARIO_REQUIREMENTS: Partial<Record<TestScenario, string[]>> = {
   creative_inline: ['get_products', 'create_media_buy'],
   creative_reference: ['get_products', 'create_media_buy', 'build_creative', 'sync_creatives'],
   temporal_validation: ['get_products', 'create_media_buy'],
-  creative_sync: ['get_products', 'create_media_buy', 'sync_creatives'],
+  creative_sync: ['sync_creatives'],
 
   // Requires get_products
   pricing_edge_cases: ['get_products'],
@@ -39,6 +39,7 @@ export const SCENARIO_REQUIREMENTS: Partial<Record<TestScenario, string[]>> = {
 
   // Requires creative agent tools
   creative_flow: ['build_creative'],
+  creative_lifecycle: ['list_creative_formats'],
 
   // Requires signals tools
   signals_flow: ['get_signals'],
@@ -87,6 +88,7 @@ export const DEFAULT_SCENARIOS: readonly TestScenario[] = [
   'behavior_analysis',
   'response_consistency',
   'creative_flow',
+  'creative_lifecycle',
   'signals_flow',
   'governance_property_lists',
   'governance_content_standards',

--- a/src/lib/testing/scenarios/capabilities.ts
+++ b/src/lib/testing/scenarios/capabilities.ts
@@ -337,17 +337,26 @@ function crossValidateProtocolsAndTools(capabilities: AdcpCapabilities, tools: s
     }
   }
 
-  // Check for tools that suggest protocols not reported
+  // Check for tools that suggest protocols not reported.
+  // Only consider tools exclusive to a protocol — shared tools (those appearing
+  // in multiple protocol tool lists) don't indicate a specific unreported protocol.
+  const allProtocolTools = Object.values(protocolToolMap).flat();
+  const toolProtocolCount = new Map<string, number>();
+  for (const tool of allProtocolTools) {
+    toolProtocolCount.set(tool, (toolProtocolCount.get(tool) || 0) + 1);
+  }
+
   const unreportedProtocols: string[] = [];
 
   for (const [protocol, expectedTools] of Object.entries(protocolToolMap)) {
     if (!capabilities.protocols.includes(protocol as AdcpProtocol)) {
-      const presentTools = expectedTools.filter(t => tools.includes(t));
-      if (presentTools.length > 0) {
+      // Only flag based on exclusive tools (not shared across protocols)
+      const exclusivePresent = expectedTools.filter(t => tools.includes(t) && toolProtocolCount.get(t) === 1);
+      if (exclusivePresent.length > 0) {
         unreportedProtocols.push(protocol);
         perProtocolDiffs[protocol] = {
           expected: [],
-          found: [...presentTools],
+          found: [...exclusivePresent],
           missing: [],
         };
       }

--- a/src/lib/testing/scenarios/creative.ts
+++ b/src/lib/testing/scenarios/creative.ts
@@ -95,7 +95,8 @@ export async function testCreativeFlow(
       'preview_creative',
       async () =>
         client.executeTask('preview_creative', {
-          creative: {
+          request_type: 'single',
+          creative_manifest: {
             format_id: formatsToTest[0]?.format_id || 'display_300x250',
             name: 'Minimal Test Creative',
             assets: [],
@@ -112,7 +113,8 @@ export async function testCreativeFlow(
         'preview_creative',
         async () =>
           client.executeTask('preview_creative', {
-            creative: {
+            request_type: 'single',
+            creative_manifest: {
               format_id: sampleFormat.format_id,
               name: 'Full Test Creative',
               assets: buildTestAssets(sampleFormat),
@@ -145,7 +147,8 @@ export async function testCreativeFlow(
       'preview_creative',
       async () =>
         client.executeTask('preview_creative', {
-          creative: {
+          request_type: 'single',
+          creative_manifest: {
             format_id: 'INVALID_FORMAT_ID_12345',
             name: 'Error Test Creative',
             assets: [],
@@ -162,6 +165,291 @@ export async function testCreativeFlow(
       errorStep.details = 'Correctly rejected invalid format_id';
     }
     steps.push(errorStep);
+  }
+
+  return { steps, profile };
+}
+
+/**
+ * Test: Creative Lifecycle
+ *
+ * Chains creative protocol operations end-to-end:
+ * 1. list_creative_formats → verify format schema
+ * 2. sync_creatives with multiple creatives → verify per-creative status
+ * 3. list_creatives (no snapshot) → verify basic fields
+ * 4. list_creatives (include_snapshot: true) → verify snapshot or snapshot_unavailable_reason
+ * 5. build_creative or preview_creative on synced creative → adapt to agent capabilities
+ */
+export async function testCreativeLifecycle(
+  agentUrl: string,
+  options: TestOptions
+): Promise<{ steps: TestStepResult[]; profile?: AgentProfile }> {
+  const steps: TestStepResult[] = [];
+  const client = createTestClient(agentUrl, options.protocol || 'mcp', options);
+
+  // Discover agent profile
+  const { profile, step: profileStep } = await discoverAgentProfile(client);
+  steps.push(profileStep);
+
+  if (!profileStep.passed) {
+    return { steps, profile };
+  }
+
+  // Step 1: Discover creative formats
+  const { formats, step: formatStep } = await discoverCreativeFormats(client, profile);
+  steps.push(formatStep);
+
+  if (!formatStep.passed || !formats || formats.length === 0) {
+    return { steps, profile };
+  }
+
+  profile.supported_formats = formats;
+
+  // Validate format schema: each format should have format_id, type, and required_assets
+  const formatSchemaIssues: string[] = [];
+  for (const format of formats) {
+    if (!format.format_id) formatSchemaIssues.push('Missing format_id');
+    if (!format.type) formatSchemaIssues.push(`Format ${format.format_id}: missing type`);
+  }
+
+  steps.push({
+    step: 'Validate format schema',
+    passed: formatSchemaIssues.length === 0,
+    duration_ms: 0,
+    details:
+      formatSchemaIssues.length === 0
+        ? `All ${formats.length} format(s) have required fields`
+        : formatSchemaIssues.join('; '),
+    warnings: formatSchemaIssues.length > 0 ? formatSchemaIssues : undefined,
+  });
+
+  // Step 2: Sync multiple creatives (image + video if formats allow)
+  if (profile.tools.includes('sync_creatives')) {
+    const imageFormat = formats.find(f => f.type === 'display' || f.type === 'image') || formats[0];
+    const videoFormat = formats.find(f => f.type === 'video');
+
+    const creativesToSync = [
+      {
+        creative_id: `lifecycle-img-${Date.now()}`,
+        name: 'Lifecycle Test Image Creative',
+        format_id: imageFormat.format_id,
+        assets: {
+          primary: {
+            url: 'https://via.placeholder.com/300x250.png?text=Lifecycle+Image',
+            width: 300,
+            height: 250,
+            format: 'png',
+          },
+        },
+      },
+    ];
+
+    if (videoFormat) {
+      creativesToSync.push({
+        creative_id: `lifecycle-vid-${Date.now()}`,
+        name: 'Lifecycle Test Video Creative',
+        format_id: videoFormat.format_id,
+        assets: {
+          primary: {
+            url: 'https://storage.googleapis.com/webfundamentals-assets/videos/chrome.mp4',
+            width: 1920,
+            height: 1080,
+            format: 'mp4',
+          },
+        },
+      });
+    }
+
+    const { result: syncResult, step: syncStep } = await runStep<TaskResult>(
+      `Sync ${creativesToSync.length} creative(s) to library`,
+      'sync_creatives',
+      async () =>
+        client.executeTask('sync_creatives', {
+          creatives: creativesToSync,
+        }) as Promise<TaskResult>
+    );
+
+    if (syncResult?.success && syncResult?.data) {
+      const data = syncResult.data as any;
+      const creatives = data.creatives || [];
+      const actions = creatives.map((c: any) => c.action);
+      const failed = creatives.filter((c: any) => c.action === 'failed');
+
+      syncStep.details = `Synced ${creatives.length} creative(s), actions: ${actions.join(', ')}`;
+      syncStep.response_preview = JSON.stringify(
+        {
+          synced_count: creatives.length,
+          actions,
+          creative_ids: creatives.map((c: any) => c.creative_id),
+          failed_count: failed.length,
+          failed_errors: failed.map((c: any) => ({ creative_id: c.creative_id, errors: c.errors })),
+        },
+        null,
+        2
+      );
+    } else if (syncResult && !syncResult.success) {
+      syncStep.passed = false;
+      syncStep.error = syncResult.error || 'sync_creatives returned unsuccessful result';
+    }
+    steps.push(syncStep);
+
+    // Step 3: list_creatives without snapshot
+    if (profile.tools.includes('list_creatives')) {
+      const { result: listResult, step: listStep } = await runStep<TaskResult>(
+        'List creatives (no snapshot)',
+        'list_creatives',
+        async () => client.executeTask('list_creatives', {}) as Promise<TaskResult>
+      );
+
+      if (listResult?.success && listResult?.data) {
+        const data = listResult.data as any;
+        const creatives = data.creatives || [];
+
+        // Validate basic fields on each creative
+        const fieldIssues: string[] = [];
+        for (const creative of creatives.slice(0, 5)) {
+          if (!creative.creative_id) fieldIssues.push('Creative missing creative_id');
+          if (!creative.name) fieldIssues.push(`Creative ${creative.creative_id}: missing name`);
+          if (!creative.format_id) fieldIssues.push(`Creative ${creative.creative_id}: missing format_id`);
+        }
+
+        // Verify snapshot is absent when not requested
+        const hasUnexpectedSnapshot = creatives.some((c: any) => c.snapshot !== undefined);
+
+        if (fieldIssues.length > 0) {
+          listStep.passed = false;
+          listStep.error = `Creative field validation: ${fieldIssues.join('; ')}`;
+        } else {
+          listStep.details = `Found ${creatives.length} creative(s) with valid fields`;
+        }
+
+        listStep.response_preview = JSON.stringify(
+          {
+            creatives_count: creatives.length,
+            statuses: Array.from(new Set(creatives.map((c: any) => c.status))),
+            has_unexpected_snapshot: hasUnexpectedSnapshot,
+            query_summary: data.query_summary,
+          },
+          null,
+          2
+        );
+
+        if (hasUnexpectedSnapshot) {
+          listStep.warnings = ['snapshot field present on creatives without include_snapshot=true'];
+        }
+      } else if (listResult && !listResult.success) {
+        listStep.passed = false;
+        listStep.error = listResult.error || 'list_creatives returned unsuccessful result';
+      }
+      steps.push(listStep);
+
+      // Step 4: list_creatives with include_snapshot: true
+      const { result: snapshotResult, step: snapshotStep } = await runStep<TaskResult>(
+        'List creatives (include_snapshot: true)',
+        'list_creatives',
+        async () => client.executeTask('list_creatives', { include_snapshot: true }) as Promise<TaskResult>
+      );
+
+      if (snapshotResult?.success && snapshotResult?.data) {
+        const data = snapshotResult.data as any;
+        const creatives = data.creatives || [];
+
+        // Each creative should have either snapshot data or snapshot_unavailable_reason
+        const invalidCreatives = creatives.filter((c: any) => {
+          if (c.snapshot) {
+            return !c.snapshot.as_of || c.snapshot.staleness_seconds === undefined;
+          }
+          return !c.snapshot_unavailable_reason;
+        });
+
+        if (invalidCreatives.length > 0) {
+          snapshotStep.passed = false;
+          snapshotStep.error = `${invalidCreatives.length} creative(s) missing both snapshot and snapshot_unavailable_reason`;
+        } else {
+          const withSnapshot = creatives.filter((c: any) => !!c.snapshot).length;
+          const withReason = creatives.filter((c: any) => !!c.snapshot_unavailable_reason).length;
+          snapshotStep.details = `${creatives.length} creative(s): ${withSnapshot} with snapshot, ${withReason} with unavailable_reason`;
+        }
+
+        snapshotStep.response_preview = JSON.stringify(
+          {
+            creatives_count: creatives.length,
+            with_snapshot: creatives.filter((c: any) => !!c.snapshot).length,
+            with_unavailable_reason: creatives.filter((c: any) => !!c.snapshot_unavailable_reason).length,
+            snapshot_reasons: Array.from(
+              new Set(creatives.map((c: any) => c.snapshot_unavailable_reason).filter(Boolean))
+            ),
+          },
+          null,
+          2
+        );
+      } else if (snapshotResult && !snapshotResult.success) {
+        snapshotStep.passed = false;
+        snapshotStep.error = snapshotResult.error || 'list_creatives with snapshot returned unsuccessful result';
+      }
+      steps.push(snapshotStep);
+    }
+  }
+
+  // Step 5: build_creative or preview_creative (adapt to agent capabilities)
+  if (profile.tools.includes('build_creative')) {
+    const targetFormat = formats[0];
+    const { result, step } = await runStep<TaskResult>(
+      `Build creative for lifecycle (${targetFormat.format_id})`,
+      'build_creative',
+      async () =>
+        client.executeTask('build_creative', {
+          target_format_id: targetFormat.format_id,
+          brand: resolveBrand(options),
+          message: `Create a ${targetFormat.type || 'display'} ad for lifecycle testing`,
+          quality: 'draft',
+          include_preview: true,
+        }) as Promise<TaskResult>
+    );
+
+    if (result?.success && result?.data) {
+      const data = result.data as any;
+      const manifest = data.creative_manifest || data.creative_manifests?.[0];
+      step.details = `Built creative manifest for format ${manifest?.format_id || targetFormat.format_id}`;
+      step.response_preview = JSON.stringify(
+        {
+          format_id: manifest?.format_id || targetFormat.format_id,
+          asset_keys: Object.keys(manifest?.assets || {}),
+          has_preview: !!data.preview,
+        },
+        null,
+        2
+      );
+    } else if (result && !result.success) {
+      step.passed = false;
+      step.error = result.error || 'build_creative failed';
+    }
+    steps.push(step);
+  } else if (profile.tools.includes('preview_creative')) {
+    // Tag-serving agents may only support preview, not build
+    const targetFormat = formats[0];
+    const { result, step } = await runStep<TaskResult>(
+      `Preview creative for lifecycle (${targetFormat.format_id})`,
+      'preview_creative',
+      async () =>
+        client.executeTask('preview_creative', {
+          request_type: 'single',
+          creative_manifest: {
+            format_id: targetFormat.format_id,
+            name: 'Lifecycle Test Preview',
+            assets: buildTestAssets(targetFormat),
+          },
+        }) as Promise<TaskResult>
+    );
+
+    if (result?.success && result?.data) {
+      const data = result.data as any;
+      step.details = `Generated preview with ${data.renders?.length || 0} render(s)`;
+    } else if (result && !result.success) {
+      step.passed = false;
+      step.error = result.error || 'preview_creative failed';
+    }
+    steps.push(step);
   }
 
   return { steps, profile };

--- a/src/lib/testing/scenarios/index.ts
+++ b/src/lib/testing/scenarios/index.ts
@@ -25,7 +25,7 @@ export {
 } from './media-buy';
 
 // Creative agent testing
-export { testCreativeFlow } from './creative';
+export { testCreativeFlow, testCreativeLifecycle } from './creative';
 
 // Signals agent testing
 export { testSignalsFlow } from './signals';

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -61,7 +61,8 @@ export function buildCreateMediaBuyRequest(
     creative_ids?: string[];
   } = {}
 ): any {
-  const budget = options.budget || 1000;
+  const minSpend = pricingOption.min_spend_per_package || 0;
+  const budget = options.budget || Math.max(1000, minSpend);
   const now = new Date();
   const startTime = new Date(now.getTime() + 24 * 60 * 60 * 1000); // Tomorrow
   const endTime = new Date(startTime.getTime() + 7 * 24 * 60 * 60 * 1000); // 7 days later

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -13,6 +13,7 @@ export type TestScenario =
   | 'creative_reference' // Build -> sync -> reference a creative via creative_ids
   | 'pricing_models' // Test different pricing models the agent supports
   | 'creative_flow' // Creative agent: list_formats -> build -> preview
+  | 'creative_lifecycle' // Creative agent: formats -> sync multiple -> list with/without snapshot -> build/preview
   | 'signals_flow' // Signals agent: get_signals -> activate
   // Edge case testing scenarios
   | 'error_handling' // Test agent returns proper error responses

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -189,6 +189,7 @@ export const CREATIVE_TOOLS = [
   'list_creative_formats',
   'preview_creative',
   'list_creatives',
+  'sync_creatives', // Also in MEDIA_BUY_TOOLS - serves both domains
 ] as const;
 
 export const SPONSORED_INTELLIGENCE_TOOLS = [
@@ -395,8 +396,7 @@ export const TASK_FEATURE_MAP: Record<string, FeatureName[]> = {
   get_media_buy_delivery: ['media_buy'],
   provide_performance_feedback: ['media_buy'],
 
-  // Creative management requires media_buy + inline_creative_management
-  sync_creatives: ['media_buy', 'inline_creative_management'],
+  // sync_creatives intentionally omitted — serves both media-buy and creative domains
   // list_creatives intentionally omitted — serves both media-buy and creative domains
 
   // Audience management

--- a/test/lib/feature-capability-validation.test.js
+++ b/test/lib/feature-capability-validation.test.js
@@ -208,14 +208,14 @@ describe('TASK_FEATURE_MAP', () => {
     }
   });
 
-  test('maps creative management tasks to inline_creative_management', () => {
-    // sync_creatives requires media_buy + inline_creative_management
-    assert.ok(
-      TASK_FEATURE_MAP.sync_creatives.includes('inline_creative_management'),
-      'sync_creatives should require inline_creative_management'
+  test('maps dual-domain creative tasks correctly', () => {
+    // sync_creatives, list_creatives, and list_creative_formats are intentionally
+    // omitted from TASK_FEATURE_MAP because they serve both media-buy and creative domains
+    assert.strictEqual(
+      TASK_FEATURE_MAP.sync_creatives,
+      undefined,
+      'sync_creatives should not be in TASK_FEATURE_MAP (dual-domain)'
     );
-    // list_creatives and list_creative_formats are intentionally omitted from
-    // TASK_FEATURE_MAP because they serve both media-buy and creative domains
     assert.strictEqual(
       TASK_FEATURE_MAP.list_creatives,
       undefined,


### PR DESCRIPTION
## Summary

Fixes 6 open testing issues affecting creative protocol testing:

- **#329**: `preview_creative` test calls used stale schema (`creative` field instead of `request_type: 'single'` + `creative_manifest`)
- **#328**: `sync_creatives` was incorrectly gated behind `media_buy` + `inline_creative_management`, blocking creative-only agents
- **#330/#311**: Cross-validation falsely flagged shared tools (`list_creative_formats`, `list_creatives`, `sync_creatives`) as evidence of unreported protocols. Now only exclusive tools trigger the check.
- **#310**: `buildCreateMediaBuyRequest` ignored `min_spend_per_package` from pricing options, causing test failures on agents with higher minimums
- **#331**: Added `creative_lifecycle` scenario covering format schema validation, multi-creative bulk sync, snapshot testing (`include_snapshot: true` with `as_of`/`staleness_seconds` validation), and build/preview

Closes #329, #328, #330, #311, #310, #331

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 1054 tests pass (0 failures)
- [x] Updated `feature-capability-validation.test.js` to reflect new dual-domain semantics for `sync_creatives`
- [ ] Run `adcp test <creative-only-agent> creative_lifecycle` to validate the new scenario end-to-end
- [ ] Run `adcp test <creative-only-agent> creative_sync` to verify sync_creatives no longer requires media_buy
- [ ] Run `adcp test <sales-agent> capability_discovery` to verify cross-validation no longer false-positives on shared tools
- [ ] Run `adcp test <high-minimum-agent> create_media_buy` to verify min_spend_per_package is respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)