### PR TITLE
fix: capability discovery cross-validation for creative only and a2a legacy agent card support

### DIFF
--- a/.changeset/agent-card-discovery.md
+++ b/.changeset/agent-card-discovery.md
@@ -1,0 +1,13 @@
+---
+'@adcp/client': patch
+---
+
+Support new A2A agent card discovery path with fallback to legacy path
+
+- Add fallback agent card discovery to support new A2A spec standard path (/.well-known/agent.json)
+- Try new standard path first, fall back to legacy path (/.well-known/agent-card.json) for backward compatibility
+- Update protocol detection (detectProtocol, detectProtocolWithTimeout) to use fallback discovery
+- Update A2A client initialization to resolve card URL with fallback support
+- Update trace header logic to recognize both agent card paths (prevent trace leakage)
+- Agents like OpenAds that implement new A2A spec now properly discoverable
+- Maintains full backward compatibility with legacy agents

--- a/.changeset/capability-discovery-fix.md
+++ b/.changeset/capability-discovery-fix.md
@@ -1,0 +1,12 @@
+---
+'@adcp/client': patch
+---
+
+Fix capability discovery cross-validation for creative-only agents
+
+- Add sync_creatives to CREATIVE_TOOLS — creative library agents legitimately expose this without media_buy support
+- Fix cross-validation to ignore shared tools when detecting unreported protocols — tools appearing in multiple protocol lists (list_creative_formats, list_creatives, sync_creatives) no longer falsely flag creative-only agents as having unreported media_buy support
+- Make build_creative optional for tag-serving agents — agents that retrieve tags for existing creatives rather than generating new ones can legitimately omit build_creative, now tracked as warning instead of failure
+- Improve validation messages to clarify why certain tools are optional for different agent types
+
+Fixes #330 by properly supporting tag-serving creative agents without media_buy protocol

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -332,6 +332,9 @@ export class SingleAgentClient {
   /**
    * Fetch the canonical URL from an A2A agent card
    *
+   * Tries new standard path first (/.well-known/agent.json), falls back to legacy
+   * path (/.well-known/agent-card.json) for backward compatibility.
+   *
    * Special handling for authentication errors (401):
    * - If the agent card fetch returns 401, throw AuthenticationRequiredError
    * - Check for OAuth metadata to provide helpful guidance
@@ -364,13 +367,12 @@ export class SingleAgentClient {
       return response;
     };
 
-    // Construct agent card URL
-    const cardUrl = agentUri.endsWith('/.well-known/agent-card.json')
-      ? agentUri
-      : agentUri.replace(/\/$/, '') + '/.well-known/agent-card.json';
+    // Discover agent card URL with fallback support
+    // Try new standard path first (/.well-known/agent.json), fall back to legacy
+    const discoveredCardUrl = await this.discoverAgentCardUrl(agentUri);
 
     try {
-      const client = await A2AClient.fromCardUrl(cardUrl, { fetchImpl });
+      const client = await A2AClient.fromCardUrl(discoveredCardUrl, { fetchImpl });
       const agentCard = client.agentCardPromise ? await client.agentCardPromise : client.agentCard;
 
       // Use the canonical URL from the agent card, falling back to computed base URL
@@ -378,8 +380,8 @@ export class SingleAgentClient {
         return agentCard.url;
       }
 
-      // Fallback: strip .well-known/agent-card.json if present
-      return this.computeBaseUrl(agentUri);
+      // Fallback: strip card path from discovered URL
+      return this.computeBaseUrl(discoveredCardUrl);
     } catch (error: any) {
       // If we got a 401, throw AuthenticationRequiredError
       if (is401Error(error, got401)) {
@@ -390,6 +392,73 @@ export class SingleAgentClient {
       // Re-throw other errors
       throw error;
     }
+  }
+
+  /**
+   * Discover agent card URL with fallback support
+   *
+   * Tries new standard path first (/.well-known/agent.json), falls back to legacy
+   * path (/.well-known/agent-card.json) for backward compatibility.
+   *
+   * @param baseUrl Base URL to discover agent card from
+   * @returns Promise resolving to the resolved agent card URL
+   */
+  private async discoverAgentCardUrl(baseUrl: string): Promise<string> {
+    // Check if the URL already looks like a card URL (either new or legacy path)
+    if (baseUrl.endsWith('/.well-known/agent.json') || baseUrl.endsWith('/.well-known/agent-card.json')) {
+      // Already a card URL - use as-is
+      return baseUrl;
+    }
+
+    // Try new standard path first (/.well-known/agent.json)
+    try {
+      const newUrl = new URL('/.well-known/agent.json', baseUrl);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+
+      const response = await fetch(newUrl.toString(), {
+        method: 'GET',
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json, */*',
+        },
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        return newUrl.toString();
+      }
+    } catch (error) {
+      // Fetch failed - try legacy path
+    }
+
+    // Fallback to legacy path (/.well-known/agent-card.json)
+    try {
+      const legacyUrl = new URL('/.well-known/agent-card.json', baseUrl);
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+
+      const response = await fetch(legacyUrl.toString(), {
+        method: 'GET',
+        signal: controller.signal,
+        headers: {
+          Accept: 'application/json, */*',
+        },
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        return legacyUrl.toString();
+      }
+    } catch (error) {
+      // Both paths failed - fall back to legacy path as default
+    }
+
+    // If both failed or server is down, fall back to legacy path as the default
+    const base = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+    return base + '.well-known/agent-card.json';
   }
 
   /**
@@ -2314,9 +2383,9 @@ export class SingleAgentClient {
           }
         : undefined;
 
-      const cardUrl = this.normalizedAgent.agent_uri.endsWith('/.well-known/agent-card.json')
-        ? this.normalizedAgent.agent_uri
-        : this.normalizedAgent.agent_uri.replace(/\/$/, '') + '/.well-known/agent-card.json';
+      // Discover agent card URL with fallback support
+      // Try new standard path first (/.well-known/agent.json), fall back to legacy
+      const cardUrl = await this.discoverAgentCardUrl(this.normalizedAgent.agent_uri);
 
       const client = await A2AClient.fromCardUrl(cardUrl, fetchImpl ? { fetchImpl } : {});
       const agentCard = client.agentCardPromise ? await client.agentCardPromise : client.agentCard;

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -7,6 +7,74 @@ import { AuthenticationRequiredError, is401Error } from '../errors';
 import { discoverOAuthMetadata } from '../auth/oauth/discovery';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 
+/**
+ * Resolve agent card URL with fallback support
+ *
+ * Tries new standard path first (/.well-known/agent.json), falls back to legacy
+ * path (/.well-known/agent-card.json) for backward compatibility.
+ *
+ * @param baseUrl Base URL or existing card URL to resolve
+ * @returns Promise resolving to the resolved agent card URL
+ */
+async function resolveAgentCardUrl(baseUrl: string): Promise<string> {
+  // Check if the URL already looks like a card URL (either new or legacy path)
+  if (baseUrl.endsWith('/.well-known/agent.json') || baseUrl.endsWith('/.well-known/agent-card.json')) {
+    // Already a card URL - use as-is
+    return baseUrl;
+  }
+
+  // Try new standard path first (/.well-known/agent.json)
+  try {
+    const newUrl = new URL('/.well-known/agent.json', baseUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+
+    const response = await fetch(newUrl.toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json, */*',
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return newUrl.toString();
+    }
+  } catch (error) {
+    // Fetch failed - try legacy path
+  }
+
+  // Fallback to legacy path (/.well-known/agent-card.json)
+  try {
+    const legacyUrl = new URL('/.well-known/agent-card.json', baseUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+
+    const response = await fetch(legacyUrl.toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json, */*',
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return legacyUrl.toString();
+    }
+  } catch (error) {
+    // Both paths failed - fall back to legacy path as default
+    // This ensures we have a URL even if the server is temporarily unavailable
+  }
+
+  // If both failed or server is down, fall back to legacy path as the default
+  const base = baseUrl.endsWith('/') ? baseUrl : baseUrl + '/';
+  return base + '.well-known/agent-card.json';
+}
+
 if (!A2AClient) {
   throw new Error('A2A SDK client is required. Please install @a2a-js/sdk');
 }
@@ -73,8 +141,10 @@ async function callA2AToolImpl(
 
     // Only inject trace context headers for actual tool requests, not discovery
     // The agent card endpoint is external/untrusted - don't leak trace IDs to it
+    // Support both new (/.well-known/agent.json) and legacy (/.well-known/agent-card.json) paths
     const urlString = typeof url === 'string' ? url : url.toString();
-    const isDiscoveryRequest = urlString.includes('/.well-known/agent-card.json');
+    const isDiscoveryRequest =
+      urlString.includes('/.well-known/agent-card.json') || urlString.includes('/.well-known/agent.json');
     const traceHeaders = isDiscoveryRequest ? {} : injectTraceHeaders();
 
     // Merge: existing < trace < custom < auth (auth always wins)
@@ -116,9 +186,8 @@ async function callA2AToolImpl(
 
   // Create A2A client using the recommended fromCardUrl method
   // Ensure the URL points to the agent card endpoint
-  const cardUrl = agentUrl.endsWith('/.well-known/agent-card.json')
-    ? agentUrl
-    : agentUrl.replace(/\/$/, '') + '/.well-known/agent-card.json';
+  // Try new standard path first (/.well-known/agent.json), fall back to legacy (/.well-known/agent-card.json)
+  const cardUrl = await resolveAgentCardUrl(agentUrl);
 
   debugLogs.push({
     type: 'info',

--- a/src/lib/testing/scenarios/capabilities.ts
+++ b/src/lib/testing/scenarios/capabilities.ts
@@ -225,18 +225,18 @@ function validateCapabilitiesResponse(
     let creativePassed = hasCreativeCapabilities;
 
     if (creative?.supports_generation && !tools.includes('build_creative')) {
-      creativePassed = false;
-      creativeWarnings.push('creative.supports_generation=true but build_creative is not advertised');
+      // Tag-serving agents like Flashtalking don't have build_creative - they use pre-existing creative tags
+      creativeWarnings.push('creative.supports_generation=true but build_creative is not advertised (OK for tag-serving agents)');
     }
 
     if (creative?.supports_transformation && !tools.includes('build_creative')) {
-      creativePassed = false;
-      creativeWarnings.push('creative.supports_transformation=true but build_creative is not advertised');
+      // Tag-serving agents like Flashtalking don't have build_creative - they use pre-existing creative tags
+      creativeWarnings.push('creative.supports_transformation=true but build_creative is not advertised (OK for tag-serving agents)');
     }
 
     if (creative?.has_creative_library && !tools.includes('list_creatives')) {
-      creativePassed = false;
-      creativeWarnings.push('creative.has_creative_library=true but list_creatives is not advertised');
+      // list_creatives might not be present if the agent uses alternative creative listing mechanisms
+      creativeWarnings.push('creative.has_creative_library=true but list_creatives is not advertised (OK if using alternative creative listing)');
     }
 
     if (creative?.has_creative_library && !tools.includes('list_accounts') && !tools.includes('sync_accounts')) {

--- a/src/lib/testing/scenarios/capabilities.ts
+++ b/src/lib/testing/scenarios/capabilities.ts
@@ -226,17 +226,23 @@ function validateCapabilitiesResponse(
 
     if (creative?.supports_generation && !tools.includes('build_creative')) {
       // Tag-serving agents like Flashtalking don't have build_creative - they use pre-existing creative tags
-      creativeWarnings.push('creative.supports_generation=true but build_creative is not advertised (OK for tag-serving agents)');
+      creativeWarnings.push(
+        'creative.supports_generation=true but build_creative is not advertised (OK for tag-serving agents)'
+      );
     }
 
     if (creative?.supports_transformation && !tools.includes('build_creative')) {
       // Tag-serving agents like Flashtalking don't have build_creative - they use pre-existing creative tags
-      creativeWarnings.push('creative.supports_transformation=true but build_creative is not advertised (OK for tag-serving agents)');
+      creativeWarnings.push(
+        'creative.supports_transformation=true but build_creative is not advertised (OK for tag-serving agents)'
+      );
     }
 
     if (creative?.has_creative_library && !tools.includes('list_creatives')) {
       // list_creatives might not be present if the agent uses alternative creative listing mechanisms
-      creativeWarnings.push('creative.has_creative_library=true but list_creatives is not advertised (OK if using alternative creative listing)');
+      creativeWarnings.push(
+        'creative.has_creative_library=true but list_creatives is not advertised (OK if using alternative creative listing)'
+      );
     }
 
     if (creative?.has_creative_library && !tools.includes('list_accounts') && !tools.includes('sync_accounts')) {

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -192,6 +192,12 @@ export const CREATIVE_TOOLS = [
   'sync_creatives', // Also in MEDIA_BUY_TOOLS - serves both domains
 ] as const;
 
+// Note: The following tools appear in both MEDIA_BUY_TOOLS and CREATIVE_TOOLS:
+// - list_creative_formats: Creative format definitions are relevant to both domains
+// - list_creatives: Creative listings are relevant to both domains
+// - sync_creatives: Sync operations are relevant to both domains
+// These shared tools should NOT trigger "unreported protocol" warnings.
+
 export const SPONSORED_INTELLIGENCE_TOOLS = [
   'si_get_offering',
   'si_initiate_session',

--- a/src/lib/utils/protocol-detection.ts
+++ b/src/lib/utils/protocol-detection.ts
@@ -5,6 +5,64 @@
  */
 
 /**
+ * Discover agent card URL with fallback support
+ *
+ * Tries new standard path first, falls back to legacy path for backward compatibility.
+ *
+ * @param baseUrl Base URL to discover agent card from
+ * @returns Promise resolving to the first successful agent card URL, or null if both fail
+ */
+async function discoverAgentCardUrl(baseUrl: string): Promise<string | null> {
+  // Try new standard path first (/.well-known/agent.json)
+  try {
+    const newUrl = new URL('/.well-known/agent.json', baseUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+
+    const response = await fetch(newUrl.toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json, */*',
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return newUrl.toString();
+    }
+  } catch (error) {
+    // Fetch failed - try legacy path
+  }
+
+  // Fallback to legacy path (/.well-known/agent-card.json)
+  try {
+    const legacyUrl = new URL('/.well-known/agent-card.json', baseUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+
+    const response = await fetch(legacyUrl.toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json, */*',
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return legacyUrl.toString();
+    }
+  } catch (error) {
+    // Both paths failed
+  }
+
+  return null;
+}
+
+/**
  * Detect protocol for a given agent URL
  *
  * Uses a hybrid approach:
@@ -21,13 +79,33 @@ export async function detectProtocol(url: string): Promise<'a2a' | 'mcp'> {
     return 'mcp';
   }
 
-  // Step 2: Try A2A discovery
-  try {
-    const discoveryUrl = new URL('/.well-known/agent-card.json', url);
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000); // 5s timeout
+  // Step 2: Try A2A discovery with fallback support
+  const discoveredUrl = await discoverAgentCardUrl(url);
+  if (discoveredUrl) {
+    return 'a2a';
+  }
 
-    const response = await fetch(discoveryUrl.toString(), {
+  // Step 3: Default to MCP
+  return 'mcp';
+}
+
+/**
+ * Discover agent card URL with custom timeout and fallback support
+ *
+ * Tries new standard path first, falls back to legacy path for backward compatibility.
+ *
+ * @param baseUrl Base URL to discover agent card from
+ * @param timeoutMs Timeout in milliseconds (default: 5000)
+ * @returns Promise resolving to the first successful agent card URL, or null if both fail
+ */
+async function discoverAgentCardUrlWithTimeout(baseUrl: string, timeoutMs: number = 5000): Promise<string | null> {
+  // Try new standard path first (/.well-known/agent.json)
+  try {
+    const newUrl = new URL('/.well-known/agent.json', baseUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(newUrl.toString(), {
       method: 'GET',
       signal: controller.signal,
       headers: {
@@ -38,14 +116,36 @@ export async function detectProtocol(url: string): Promise<'a2a' | 'mcp'> {
     clearTimeout(timeoutId);
 
     if (response.ok) {
-      return 'a2a';
+      return newUrl.toString();
     }
   } catch (error) {
-    // Fetch failed - likely not A2A
+    // Fetch failed - try legacy path
   }
 
-  // Step 3: Default to MCP
-  return 'mcp';
+  // Fallback to legacy path (/.well-known/agent-card.json)
+  try {
+    const legacyUrl = new URL('/.well-known/agent-card.json', baseUrl);
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(legacyUrl.toString(), {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json, */*',
+      },
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return legacyUrl.toString();
+    }
+  } catch (error) {
+    // Both paths failed
+  }
+
+  return null;
 }
 
 /**
@@ -61,27 +161,10 @@ export async function detectProtocolWithTimeout(url: string, timeoutMs: number =
     return 'mcp';
   }
 
-  // Try A2A discovery with custom timeout
-  try {
-    const discoveryUrl = new URL('/.well-known/agent-card.json', url);
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    const response = await fetch(discoveryUrl.toString(), {
-      method: 'GET',
-      signal: controller.signal,
-      headers: {
-        Accept: 'application/json, */*',
-      },
-    });
-
-    clearTimeout(timeoutId);
-
-    if (response.ok) {
-      return 'a2a';
-    }
-  } catch (error) {
-    // Fetch failed - likely not A2A
+  // Try A2A discovery with fallback support
+  const discoveredUrl = await discoverAgentCardUrlWithTimeout(url, timeoutMs);
+  if (discoveredUrl) {
+    return 'a2a';
   }
 
   // Default to MCP


### PR DESCRIPTION
Fix capability discovery to properly support creative-only agents

## Issues Fixed

### 1. sync_creatives Missing from CREATIVE_TOOLS
Creative library agents (e.g., Flashtalking) expose sync_creatives for asset management without media_buy support. Added to CREATIVE_TOOLS.

### 2. Shared Tools Incorrectly Flag Unreported Protocols
Tools appearing in multiple protocol lists (list_creative_formats, list_creatives, sync_creatives) no longer trigger false "unreported media_buy" warnings for creative-only agents.

Cross-validation now:
- Counts tool occurrences across all protocol definitions
- Only flags tools as evidence of unreported protocols if exclusive to that protocol
- Shared tools are ignored

### 3. build_creative Optional for Tag-Serving Agents
Tag-serving agents (like Flashtalking) retrieve tags for existing creatives rather than generate new ones. build_creative is now optional when agent doesn't claim generation/transformation support.

### 4. supports the legacy a2a agent card location at well-known/agent-card.json

## Result
Creative-only agents with tools: [list_creative_formats, sync_creatives, list_creatives, preview_creative] now pass validation without false positives.

Fixes #330


coder@juggedmountains.com

