### PR TITLE
fix: allow cross-origin OAuth resource URLs for proxied MCP servers

### DIFF
--- a/.changeset/fix-oauth-resource-check.md
+++ b/.changeset/fix-oauth-resource-check.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix OAuth protected resource validation for servers behind reverse proxies or DNS aliases. The MCP SDK's default same-origin check rejected servers that advertise a canonical resource URL different from the connection URL. The client now accepts cross-origin resource URLs while enforcing HTTPS.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 **/*.generated.ts
 schemas/cache/
+docs/

--- a/src/lib/auth/oauth/MCPOAuthProvider.ts
+++ b/src/lib/auth/oauth/MCPOAuthProvider.ts
@@ -97,6 +97,29 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   /**
+   * Validate the protected resource URL from server metadata (RFC 9728).
+   *
+   * Servers behind reverse proxies or DNS aliases may advertise a canonical
+   * resource URL (RFC 8707) that differs from the URL the client connected to.
+   * We allow cross-origin resource URLs because agent configs are pre-configured
+   * by the user, not discovered from untrusted sources. The authorization server
+   * remains the final gatekeeper for token audience validation.
+   */
+  async validateResourceURL(serverUrl: string | URL, resource?: string): Promise<URL | undefined> {
+    if (!resource) {
+      return undefined;
+    }
+
+    const resourceURL = new URL(resource);
+
+    if (resourceURL.protocol !== 'https:') {
+      throw new Error(`Server at ${serverUrl} advertised non-HTTPS resource URL: ${resource}`);
+    }
+
+    return resourceURL;
+  }
+
+  /**
    * Generate OAuth state parameter
    */
   async state(): Promise<string> {

--- a/test/lib/oauth.test.js
+++ b/test/lib/oauth.test.js
@@ -523,6 +523,68 @@ describe('MCPOAuthProvider', () => {
     assert.strictEqual(provider.hasRefreshToken(), true);
   });
 
+  test('validateResourceURL returns server resource when present', async () => {
+    const provider = new MCPOAuthProvider({
+      agent,
+      flowHandler: mockFlowHandler,
+      clientMetadata: {
+        ...DEFAULT_CLIENT_METADATA,
+        redirect_uris: ['http://localhost:8766/callback'],
+      },
+    });
+
+    // Server advertises a different domain (e.g., canonical domain behind proxy)
+    const result = await provider.validateResourceURL(
+      'https://test-agent.example.org/mcp',
+      'https://canonical.example.com/mcp'
+    );
+    assert.ok(result instanceof URL);
+    assert.strictEqual(result.toString(), 'https://canonical.example.com/mcp');
+  });
+
+  test('validateResourceURL returns undefined when no resource', async () => {
+    const provider = new MCPOAuthProvider({
+      agent,
+      flowHandler: mockFlowHandler,
+      clientMetadata: {
+        ...DEFAULT_CLIENT_METADATA,
+        redirect_uris: ['http://localhost:8766/callback'],
+      },
+    });
+
+    const result = await provider.validateResourceURL('https://example.com/mcp');
+    assert.strictEqual(result, undefined);
+  });
+
+  test('validateResourceURL rejects non-HTTPS resource URLs', async () => {
+    const provider = new MCPOAuthProvider({
+      agent,
+      flowHandler: mockFlowHandler,
+      clientMetadata: {
+        ...DEFAULT_CLIENT_METADATA,
+        redirect_uris: ['http://localhost:8766/callback'],
+      },
+    });
+
+    await assert.rejects(
+      () => provider.validateResourceURL('https://example.com/mcp', 'http://insecure.example.com/mcp'),
+      { message: /non-HTTPS resource URL/ }
+    );
+  });
+
+  test('validateResourceURL rejects invalid URL strings', async () => {
+    const provider = new MCPOAuthProvider({
+      agent,
+      flowHandler: mockFlowHandler,
+      clientMetadata: {
+        ...DEFAULT_CLIENT_METADATA,
+        redirect_uris: ['http://localhost:8766/callback'],
+      },
+    });
+
+    await assert.rejects(() => provider.validateResourceURL('https://example.com/mcp', 'not-a-url'));
+  });
+
   test('calls storage when provided', async () => {
     let savedAgent = null;
     const mockStorage = {


### PR DESCRIPTION
## Summary
- Override `validateResourceURL` in `MCPOAuthProvider` to accept cross-origin resource URLs while enforcing HTTPS
- Fixes CLI error: `Protected resource https://agenticadvertising.org/mcp does not match expected https://test-agent.adcontextprotocol.org/mcp`
- MCP servers behind reverse proxies or DNS aliases can advertise a canonical resource URL (RFC 8707/9728) that differs from the connection URL

## Test plan
- [x] All 1121 tests pass (2 skipped)
- [x] New tests for: cross-origin resource acceptance, undefined resource, non-HTTPS rejection, invalid URL rejection
- [x] Verified live OAuth flow against `https://test-agent.adcontextprotocol.org/mcp` connects successfully
- [x] Code review and security review completed — HTTPS enforcement added per reviewer feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)