### PR TITLE
fix: add account to test harness create_media_buy requests

### DIFF
--- a/.changeset/fix-harness-account.md
+++ b/.changeset/fix-harness-account.md
@@ -1,0 +1,12 @@
+---
+"@adcp/client": patch
+---
+
+Fix test harness `create_media_buy` scenarios failing with `account: Invalid input`
+
+The `buildCreateMediaBuyRequest` helper was not including the required `account` field,
+causing client-side Zod validation to reject the request before it reached the agent.
+
+- Add `account: resolveAccount(options)` to `buildCreateMediaBuyRequest`
+- Add backwards-compatible `account` inference in `normalizeRequestParams` so callers
+  that pre-date the required `account` field keep working (derived from `brand`)

--- a/src/lib/testing/scenarios/media-buy.ts
+++ b/src/lib/testing/scenarios/media-buy.ts
@@ -102,6 +102,7 @@ export function buildCreateMediaBuyRequest(
 
   return {
     buyer_ref: `e2e-test-${Date.now()}`,
+    account: resolveAccount(options),
     brand: resolveBrand(options),
     start_time: startTime.toISOString(),
     end_time: endTime.toISOString(),

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -86,6 +86,16 @@ export function normalizeRequestParams(taskType: string, params: any): any {
     }
   }
 
+  // ── account inference (create_media_buy) ──
+  // Derive account from brand when not provided so callers that pre-date
+  // the required account field keep working.
+  if (taskType === 'create_media_buy' && !normalized.account && normalized.brand) {
+    normalized.account = {
+      brand: normalized.brand,
+      operator: normalized.brand.domain,
+    };
+  }
+
   // ── Package normalization (create_media_buy, update_media_buy) ──
   if ((taskType === 'create_media_buy' || taskType === 'update_media_buy') && Array.isArray(normalized.packages)) {
     normalized.packages = normalized.packages.map(normalizePackageParams);


### PR DESCRIPTION
## Summary

- `buildCreateMediaBuyRequest` was missing the required `account` field, causing client-side Zod validation to reject every `create_media_buy`, `full_sales_flow`, and `creative_inline` test scenario before the request reached the agent
- Added `account: resolveAccount(options)` to `buildCreateMediaBuyRequest`
- Added backwards-compatible `account` inference in `normalizeRequestParams` (derived from `brand`) so existing callers that pre-date the required `account` field keep working

Fixes adcontextprotocol/adcp#1539

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 1106 tests pass (0 failures)
- [ ] Run `test_adcp_agent` against the public test agent to confirm the 3 previously-failing scenarios now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)