### PR TITLE
fix: rename audienceManagement to audienceTargeting

### DIFF
--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -186,7 +186,7 @@ export interface SingleAgentClientConfig extends ConversationConfig {
   /**
    * Validate that the seller supports required features before each task call.
    * When true, tasks like syncAudiences will fail fast with FeatureUnsupportedError
-   * if the seller hasn't declared audience_management support.
+   * if the seller hasn't declared audience_targeting support.
    *
    * @default true
    */

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -29,7 +29,7 @@ export interface MediaBuyFeatures {
   /** Agent supports conversion event tracking (sync_event_sources, log_event) */
   conversionTracking?: boolean;
   /** Agent supports first-party CRM audience management (sync_audiences) */
-  audienceManagement?: boolean;
+  audienceTargeting?: boolean;
 }
 
 /**
@@ -250,8 +250,8 @@ export function buildSyntheticCapabilities(tools: ToolInfo[]): AdcpCapabilities 
     contentStandards: false,
     // Conversion tracking if event tracking tools are available
     conversionTracking: EVENT_TRACKING_TOOLS.some(t => toolNames.has(t)),
-    // Audience management if sync_audiences is available
-    audienceManagement: toolNames.has('sync_audiences'),
+    // Audience targeting if sync_audiences is available
+    audienceTargeting: toolNames.has('sync_audiences'),
   };
 
   return {
@@ -278,7 +278,7 @@ export function parseCapabilitiesResponse(response: any): AdcpCapabilities {
     propertyListFiltering: response.media_buy?.features?.property_list_filtering ?? false,
     contentStandards: response.media_buy?.features?.content_standards ?? false,
     conversionTracking: response.media_buy?.features?.conversion_tracking ?? false,
-    audienceManagement: response.media_buy?.features?.audience_management ?? false,
+    audienceTargeting: response.media_buy?.features?.audience_targeting ?? false,
   };
 
   let account: AccountCapabilities | undefined;
@@ -400,7 +400,7 @@ export const TASK_FEATURE_MAP: Record<string, FeatureName[]> = {
   // list_creatives intentionally omitted — serves both media-buy and creative domains
 
   // Audience management
-  sync_audiences: ['media_buy', 'audience_management'],
+  sync_audiences: ['media_buy', 'audience_targeting'],
 
   // Event tracking / conversion
   sync_event_sources: ['media_buy', 'conversion_tracking'],
@@ -452,8 +452,8 @@ const FEATURE_KEY_MAP: Record<string, keyof MediaBuyFeatures> = {
   property_list_filtering: 'propertyListFiltering',
   content_standards: 'contentStandards',
   conversion_tracking: 'conversionTracking',
-  audience_targeting: 'audienceManagement',
-  audience_management: 'audienceManagement',
+  audience_targeting: 'audienceTargeting',
+  audience_management: 'audienceTargeting', // legacy alias
 };
 
 /**

--- a/test/lib/feature-capability-validation.test.js
+++ b/test/lib/feature-capability-validation.test.js
@@ -26,7 +26,7 @@ function makeCapabilities(overrides = {}) {
       propertyListFiltering: false,
       contentStandards: false,
       conversionTracking: true,
-      audienceManagement: false,
+      audienceTargeting: false,
     },
     extensions: ['scope3'],
     _synthetic: false,
@@ -197,8 +197,8 @@ describe('TASK_FEATURE_MAP', () => {
     }
   });
 
-  test('maps sync_audiences to audience_management', () => {
-    assert.ok(TASK_FEATURE_MAP.sync_audiences.includes('audience_management'));
+  test('maps sync_audiences to audience_targeting', () => {
+    assert.ok(TASK_FEATURE_MAP.sync_audiences.includes('audience_targeting'));
     assert.ok(TASK_FEATURE_MAP.sync_audiences.includes('media_buy'));
   });
 

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -623,7 +623,7 @@ describe('v3 partial-schema field stripping', () => {
       features: {
         inlineCreativeManagement: false,
         conversionTracking: false,
-        audienceManagement: false,
+        audienceTargeting: false,
         propertyListFiltering: false,
         contentStandards: false,
       },
@@ -686,7 +686,7 @@ describe('v3 partial-schema field stripping', () => {
       features: {
         inlineCreativeManagement: false,
         conversionTracking: false,
-        audienceManagement: false,
+        audienceTargeting: false,
         propertyListFiltering: false,
         contentStandards: false,
       },


### PR DESCRIPTION
## Summary
- The Zod schema and wire format define the feature flag as `audience_targeting`, but `parseCapabilitiesResponse` was reading `audience_management` — so the flag was never picked up from capabilities responses
- Renamed the internal `MediaBuyFeatures` property from `audienceManagement` to `audienceTargeting` to match the schema naming
- Updated `TASK_FEATURE_MAP` so `sync_audiences` correctly requires `audience_targeting`

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [x] Lint passes (0 errors)
- [x] Build passes
- [ ] CI passes
- [ ] Verify `parseCapabilitiesResponse` correctly reads `audience_targeting` from a capabilities response with the flag set to `true`