### PR TITLE
chore: add missing changesets for #347 and #343

### DIFF
--- a/.changeset/fix-audience-targeting-flag.md
+++ b/.changeset/fix-audience-targeting-flag.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix `audienceManagement` capability flag never being detected. The Zod schema and wire format define the feature flag as `audience_targeting`, but `parseCapabilitiesResponse` was reading `audience_management`. Renamed the internal `MediaBuyFeatures` property to match schema naming and updated `TASK_FEATURE_MAP` so `sync_audiences` correctly requires the flag.

--- a/.changeset/fix-get-products-validation.md
+++ b/.changeset/fix-get-products-validation.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix `get_products` responses with non-array `products` field crashing downstream consumers. Added Zod schema validation for `get_products` responses in the response unwrapper and updated `normalizeGetProductsResponse` to convert malformed responses to AdCP error responses instead of silently passing through.


### PR DESCRIPTION
## Summary
- Add patch changeset for #347: fix `audienceManagement` capability flag never being detected (renamed to `audienceTargeting` to match schema)
- Add patch changeset for #343: fix `get_products` responses with non-array `products` field crashing downstream consumers

These PRs merged without changesets, so version 4.11.0 was published without their entries. Once merged, the changesets automation will create a release PR to publish 4.12.0 with these fixes included in the changelog.

## Test plan
- [ ] Verify changeset check passes in CI
- [ ] After merge, confirm release PR is auto-created with correct 4.11.1 version bump