### PR TITLE
fix: handle raw array formats response, add missing_test_harness skip reason

### DIFF
--- a/.changeset/fix-formats-array-skip-reason.md
+++ b/.changeset/fix-formats-array-skip-reason.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix normalizeFormatsResponse to handle raw array responses from creative agents, and distinguish missing test harness from not-testable skip reasons in storyboard runner

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1103,9 +1103,16 @@ async function handleStoryboardRun(args) {
     console.log('═'.repeat(50));
     for (const phase of result.phases) {
       console.log(`\n── Phase: ${phase.phase_title} ──────────────────────────────`);
+      const SKIP_ICONS = { missing_test_harness: '🔧', not_testable: '⏭️', dependency_failed: '⏭️' };
+      const SKIP_LABELS = {
+        missing_test_harness: ' [needs test harness]',
+        not_testable: ' [not testable]',
+        dependency_failed: ' [dependency failed]',
+      };
       for (const step of phase.steps) {
-        const icon = step.passed ? '✅' : '❌';
-        console.log(`\n${icon} ${step.title} (${step.duration_ms}ms)`);
+        const icon = step.skipped ? (SKIP_ICONS[step.skip_reason] ?? '⏭️') : step.passed ? '✅' : '❌';
+        const skipLabel = SKIP_LABELS[step.skip_reason] ?? '';
+        console.log(`\n${icon} ${step.title}${skipLabel} (${step.duration_ms}ms)`);
         console.log(`   Task: ${step.task}`);
         if (step.error) {
           console.log(`   Error: ${step.error}`);

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -115,11 +115,13 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
     observation_data: stepResult.response as Record<string, unknown> | undefined,
     warnings: stepResult.skipped
       ? [
-          stepResult.skip_reason === 'not_testable'
-            ? 'Not testable: agent lacks required tool'
-            : stepResult.skip_reason === 'dependency_failed'
-              ? 'Skipped: prior stateful step failed'
-              : 'Step skipped',
+          (
+            {
+              missing_test_harness: 'Not testable: requires comply_test_controller harness',
+              not_testable: 'Not testable: agent lacks required tool',
+              dependency_failed: 'Skipped: prior stateful step failed',
+            } as Record<string, string>
+          )[stepResult.skip_reason ?? ''] ?? 'Step skipped',
         ]
       : undefined,
   };

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -200,7 +200,7 @@ async function executeStep(
       task: step.task,
       passed: true,
       skipped: true,
-      skip_reason: 'not_testable',
+      skip_reason: step.requires_tool === 'comply_test_controller' ? 'missing_test_harness' : 'not_testable',
       duration_ms: 0,
       validations: [],
       context,

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -151,7 +151,7 @@ export interface StoryboardStepResult {
   /** True when the step was not executed */
   skipped?: boolean;
   /** Why the step was skipped */
-  skip_reason?: 'not_testable' | 'dependency_failed';
+  skip_reason?: 'not_testable' | 'dependency_failed' | 'missing_test_harness';
   /** True when the step expected an error (inverted pass/fail) */
   expect_error?: boolean;
   duration_ms: number;

--- a/src/lib/utils/format-renders.ts
+++ b/src/lib/utils/format-renders.ts
@@ -100,6 +100,11 @@ export function normalizeFormatRenders(format: FormatV2 | FormatV3): FormatV3 {
  * Normalize all formats in a list_creative_formats response
  */
 export function normalizeFormatsResponse(response: any): any {
+  // Handle raw array responses (agent omitted { formats: [...] } wrapper)
+  if (Array.isArray(response)) {
+    return { formats: response.map(normalizeFormatRenders) };
+  }
+
   if (!response.formats || !Array.isArray(response.formats)) {
     return response;
   }

--- a/test/lib/storyboard-skip-counting.test.js
+++ b/test/lib/storyboard-skip-counting.test.js
@@ -124,6 +124,40 @@ describe('storyboard skip counting', () => {
       assert.strictEqual(trackResult.status, 'fail', 'track with all-failed steps should have fail status');
     });
 
+    test('missing_test_harness skip_reason maps to test harness warning', () => {
+      const result = storyboardResult({
+        passed_count: 2,
+        failed_count: 0,
+        skipped_count: 1,
+        phases: [
+          {
+            phase_id: 'flow',
+            phase_title: 'Flow',
+            passed: true,
+            steps: [
+              stepResult({ duration_ms: 50 }),
+              stepResult({ step_id: 'step-2', duration_ms: 50 }),
+              stepResult({
+                step_id: 'step-3',
+                skipped: true,
+                skip_reason: 'missing_test_harness',
+                duration_ms: 0,
+              }),
+            ],
+            duration_ms: 100,
+          },
+        ],
+      });
+
+      const trackResult = mapStoryboardResultsToTrackResult('core', [result], dummyProfile);
+      const skippedStep = trackResult.scenarios[0].steps[2];
+      assert.ok(skippedStep.warnings, 'skipped step should have warnings');
+      assert.ok(
+        skippedStep.warnings[0].includes('comply_test_controller'),
+        'warning should mention test controller harness'
+      );
+    });
+
     test('track with mixed pass and fail reports partial status', () => {
       const result = storyboardResult({
         passed_count: 1,

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -651,6 +651,26 @@ describe('Format Renders Normalizer', () => {
       assert.ok(normalized.formats[0].renders);
       assert.ok(normalized.formats[1].renders);
     });
+
+    test('should wrap raw array response in { formats: [...] }', () => {
+      const response = [
+        { format_id: { id: 'format-1' }, width: 300, height: 250 },
+        { format_id: { id: 'format-2' }, renders: [{ role: 'primary' }] },
+      ];
+
+      const normalized = normalizeFormatsResponse(response);
+
+      assert.ok(normalized.formats, 'should have formats property');
+      assert.strictEqual(normalized.formats.length, 2);
+      assert.ok(normalized.formats[0].renders, 'v2 format should be normalized');
+      assert.ok(normalized.formats[1].renders, 'v3 format should be preserved');
+    });
+
+    test('should return response unchanged when formats is missing', () => {
+      const response = { other: 'data' };
+      const normalized = normalizeFormatsResponse(response);
+      assert.deepStrictEqual(normalized, response);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- **Fixes #458**: `normalizeFormatsResponse()` now handles raw array responses from creative agents by wrapping them in `{ formats: [...] }` before normalization
- **Fixes #459**: Steps requiring `comply_test_controller` get `skip_reason: 'missing_test_harness'` instead of generic `'not_testable'`, with distinct icons and labels in CLI output (`🔧 [needs test harness]` vs `⏭️ [not testable]`)

## Changes
- `src/lib/utils/format-renders.ts` — array detection in `normalizeFormatsResponse`
- `src/lib/testing/storyboard/types.ts` — added `'missing_test_harness'` to `skip_reason` union
- `src/lib/testing/storyboard/runner.ts` — special-case `comply_test_controller` in requires_tool check
- `src/lib/testing/compliance/storyboard-tracks.ts` — warning message for new skip reason (lookup table)
- `bin/adcp.js` — distinct icons and labels for skipped steps (lookup table)

## Test plan
- [x] New test: raw array wrapping in `normalizeFormatsResponse` (`v3-compatibility.test.js`)
- [x] New test: unchanged behavior when formats property is missing
- [x] New test: `missing_test_harness` warning in storyboard-tracks bridge (`storyboard-skip-counting.test.js`)
- [x] Full test suite passes (1794 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)