### PR TITLE
fix: improve comply runner signal-to-noise against real agents

### DIFF
--- a/.changeset/comply-runner-improvements.md
+++ b/.changeset/comply-runner-improvements.md
@@ -1,0 +1,14 @@
+---
+"@adcp/client": minor
+---
+
+Improve comply runner signal-to-noise ratio against real agents
+
+- Skip storyboard steps when agent doesn't implement the tool (new `missing_tool` skip reason)
+- Detect unresolved `$context` placeholders and skip with `dependency_failed` instead of sending invalid requests
+- Catch "Unknown tool" errors from agents and convert to skips
+- Add rate limit retry with exponential backoff and jitter (3 retries, 2s/4s/8s base)
+- Fix `sync_creatives` request builder to send creatives for all discovered formats, not just the first (#482)
+- Fix `mapStepToTestStep` to preserve runner's skip semantics (skips no longer counted as failures)
+- Fix `extractErrorData` to handle nested JSON in error messages
+- Truncate agent error messages to 2000 chars to prevent report bloat

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -108,7 +108,7 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
   return {
     step: stepResult.title,
     task: stepResult.task,
-    passed: stepResult.skipped ? false : stepResult.passed,
+    passed: stepResult.passed,
     duration_ms: stepResult.duration_ms,
     error: stepResult.error,
     details: validationDetails || undefined,
@@ -118,6 +118,7 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
           (
             {
               missing_test_harness: 'Not testable: requires comply_test_controller harness',
+              missing_tool: 'Skipped: agent does not implement this tool',
               not_testable: 'Not testable: agent lacks required tool',
               dependency_failed: 'Skipped: prior stateful step failed',
             } as Record<string, string>

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -287,29 +287,38 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   sync_creatives(_step, context, options) {
-    const format = selectFormat(context);
-    const formatId = format?.format_id ?? context.format_id ?? { agent_url: 'unknown', id: 'unknown' };
+    const formats = (context.formats as Array<Record<string, unknown>> | undefined) ?? [];
+    const now = Date.now();
 
-    // Build assets as a record (not array) — keyed by asset role
-    const assets: Record<string, unknown> = {
-      primary: {
-        url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg',
-        width: 1200,
-        height: 628,
-        format: 'image/jpeg',
-      },
-    };
+    // Send one creative per discovered format so downstream steps
+    // (e.g., build_video_tag) can find creatives in every format.
+    const creatives =
+      formats.length > 0
+        ? formats.map((fmt, i) => ({
+            creative_id: `test-creative-${now}-${i}`,
+            name: `E2E Test Creative ${i + 1}`,
+            format_id: fmt.format_id ?? context.format_id ?? { agent_url: 'unknown', id: 'unknown' },
+            assets: buildAssetsForFormat(fmt),
+          }))
+        : [
+            {
+              creative_id: `test-creative-${now}`,
+              name: 'E2E Test Creative',
+              format_id: context.format_id ?? { agent_url: 'unknown', id: 'unknown' },
+              assets: {
+                primary: {
+                  url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg',
+                  width: 1200,
+                  height: 628,
+                  format: 'image/jpeg',
+                },
+              },
+            },
+          ];
 
     return {
       account: context.account ?? resolveAccount(options),
-      creatives: [
-        {
-          creative_id: `test-creative-${Date.now()}`,
-          name: 'E2E Test Creative',
-          format_id: formatId,
-          assets,
-        },
-      ],
+      creatives,
     };
   },
 
@@ -689,4 +698,47 @@ function selectSignal(context: StoryboardContext): Record<string, unknown> | und
   const signals = context.signals as Array<Record<string, unknown>> | undefined;
   if (!signals?.length) return undefined;
   return signals[0];
+}
+
+/**
+ * Build placeholder assets appropriate for a format's type.
+ * Uses the format name to guess whether it's video, native, or display.
+ */
+function buildAssetsForFormat(format: Record<string, unknown>): Record<string, unknown> {
+  const name = String(format.name ?? format.format_id ?? '').toLowerCase();
+  const type = String(format.type ?? '').toLowerCase();
+
+  if (type === 'video' || name.includes('video') || name.includes('vast')) {
+    return {
+      video: {
+        url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/trail-pro-30s.mp4',
+        duration: 30,
+        format: 'video/mp4',
+      },
+    };
+  }
+
+  if (type === 'native' || name.includes('native')) {
+    return {
+      image: {
+        url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg',
+        width: 1200,
+        height: 628,
+        format: 'image/jpeg',
+      },
+      headline: {
+        content: 'Trail Pro 3000 — Built for the Summit',
+      },
+    };
+  }
+
+  // Default: display image
+  return {
+    primary: {
+      url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/hero-master.jpg',
+      width: 1200,
+      height: 628,
+      format: 'image/jpeg',
+    },
+  };
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -208,6 +208,27 @@ async function executeStep(
     };
   }
 
+  // Skip if agent doesn't implement the tool this step calls.
+  if (
+    options.agentTools &&
+    !options.agentTools.includes(step.task)
+  ) {
+    const next = getNextStepPreview(step.id, allSteps, context);
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: true,
+      skipped: true,
+      skip_reason: 'missing_tool',
+      duration_ms: 0,
+      validations: [],
+      context,
+      next,
+    };
+  }
+
   // Build request — priority:
   // 1. User-provided --request override
   // 2. For expect_error steps: use sample_request directly (preserves intentionally invalid input)
@@ -231,13 +252,36 @@ async function executeStep(
     request = applyContextInputs(request, step.context_inputs, context);
   }
 
+  // Detect unresolved $context placeholders — a prior step likely failed
+  // and didn't produce the expected output. Skip rather than sending garbage.
+  const unresolvedVars = findUnresolvedContextVars(request);
+  if (unresolvedVars.length > 0 && !step.expect_error) {
+    const next = getNextStepPreview(step.id, allSteps, context);
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: false,
+      skipped: true,
+      skip_reason: 'dependency_failed',
+      duration_ms: 0,
+      validations: [],
+      context,
+      error: `Skipped: unresolved context variables: ${unresolvedVars.join(', ')}`,
+      next,
+    };
+  }
+
   // Execute the task
   let { result: taskResult, step: stepResult } = await runStep(step.title, step.task, () =>
     executeStoryboardTask(client, step.task, request)
   );
 
-  // Feature-unsupported errors → treat as not testable (skip)
-  if (!taskResult && stepResult.error?.includes('does not support:')) {
+  // Feature-unsupported or unknown-tool errors → treat as skip
+  const isUnsupported = stepResult.error?.includes('does not support:');
+  const isUnknownTool = stepResult.error && /Unknown tool[:\s]/i.test(stepResult.error);
+  if (!taskResult && (isUnsupported || isUnknownTool)) {
     const next = getNextStepPreview(step.id, allSteps, context);
     return {
       step_id: step.id,
@@ -246,7 +290,7 @@ async function executeStep(
       task: step.task,
       passed: true,
       skipped: true,
-      skip_reason: 'not_testable',
+      skip_reason: isUnknownTool ? 'missing_tool' : 'not_testable',
       duration_ms: stepResult.duration_ms,
       validations: [],
       context,
@@ -315,7 +359,7 @@ async function executeStep(
     response: taskResult?.data,
     validations,
     context: updatedContext,
-    error: step.expect_error ? undefined : stepResult.error || taskResult?.error || undefined,
+    error: step.expect_error ? undefined : truncateError(stepResult.error || taskResult?.error),
     next,
   };
 }
@@ -324,10 +368,36 @@ async function executeStep(
 // Helpers
 // ────────────────────────────────────────────────────────────
 
+const MAX_ERROR_LENGTH = 2000;
+
+function truncateError(error: string | undefined): string | undefined {
+  if (!error) return undefined;
+  return error.length > MAX_ERROR_LENGTH ? error.slice(0, MAX_ERROR_LENGTH) + '...[truncated]' : error;
+}
+
 interface FlatStep {
   step: StoryboardStep;
   phaseId: string;
   globalIndex: number;
+}
+
+/**
+ * Find any "$context.xxx" strings that weren't resolved during injection.
+ */
+function findUnresolvedContextVars(obj: unknown): string[] {
+  const vars: string[] = [];
+  const walk = (val: unknown) => {
+    if (typeof val === 'string') {
+      const match = val.match(/^\$context\.(\w+)$/);
+      if (match?.[1]) vars.push(match[1]);
+    } else if (Array.isArray(val)) {
+      val.forEach(walk);
+    } else if (val !== null && typeof val === 'object') {
+      Object.values(val as Record<string, unknown>).forEach(walk);
+    }
+  };
+  walk(obj);
+  return vars;
 }
 
 function flattenSteps(storyboard: Storyboard): FlatStep[] {
@@ -375,14 +445,15 @@ function getNextStepPreview(
  * expect_error step validations can check error fields.
  */
 function extractErrorData(errorMessage: string): Record<string, unknown> | null {
-  // Try to find JSON containing adcp_error in the error message
-  const jsonMatch = errorMessage.match(/\{[\s\S]*?"adcp_error"[\s\S]*?\}/);
-  if (jsonMatch) {
-    try {
-      const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
-      if (parsed.adcp_error) return parsed;
-    } catch {
-      // Not valid JSON
+  // Find a JSON object containing adcp_error by trying JSON.parse from each '{'
+  if (errorMessage.includes('"adcp_error"')) {
+    for (let i = errorMessage.indexOf('{'); i !== -1; i = errorMessage.indexOf('{', i + 1)) {
+      try {
+        const parsed = JSON.parse(errorMessage.slice(i)) as Record<string, unknown>;
+        if (parsed.adcp_error) return parsed;
+      } catch {
+        // Not valid JSON from this position, keep looking
+      }
     }
   }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -209,10 +209,7 @@ async function executeStep(
   }
 
   // Skip if agent doesn't implement the tool this step calls.
-  if (
-    options.agentTools &&
-    !options.agentTools.includes(step.task)
-  ) {
+  if (options.agentTools && !options.agentTools.includes(step.task)) {
     const next = getNextStepPreview(step.id, allSteps, context);
     return {
       step_id: step.id,

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -101,8 +101,7 @@ export async function executeStoryboardTask(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       const isRateLimit =
-        /rate limit/i.test(msg) ||
-        (/"code":\s*-32000/.test(msg) && /rate.?limit|too many|throttl/i.test(msg));
+        /rate limit/i.test(msg) || (/"code":\s*-32000/.test(msg) && /rate.?limit|too many|throttl/i.test(msg));
       if (isRateLimit && attempt < MAX_RETRIES) {
         const jitter = Math.random() * 1000;
         const delay = BASE_DELAY_MS * 2 ** attempt + jitter;

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -84,12 +84,33 @@ export async function executeStoryboardTask(
   const methodName = Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined;
 
   let result;
-  if (methodName && typeof client[methodName] === 'function') {
-    result = await client[methodName](params);
-  } else {
-    // Fall back to generic executeTask for tasks without dedicated methods
-    // (e.g., sync_governance, future tasks)
-    result = await client.executeTask(taskName, params);
+  const invoke = async () => {
+    if (methodName && typeof client[methodName] === 'function') {
+      return client[methodName](params);
+    }
+    return client.executeTask(taskName, params);
+  };
+
+  // Retry with exponential backoff on rate limit errors
+  const MAX_RETRIES = 3;
+  const BASE_DELAY_MS = 2000;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      result = await invoke();
+      break;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isRateLimit =
+        /rate limit/i.test(msg) ||
+        (/"code":\s*-32000/.test(msg) && /rate.?limit|too many|throttl/i.test(msg));
+      if (isRateLimit && attempt < MAX_RETRIES) {
+        const jitter = Math.random() * 1000;
+        const delay = BASE_DELAY_MS * 2 ** attempt + jitter;
+        await new Promise(resolve => setTimeout(resolve, delay));
+        continue;
+      }
+      throw err;
+    }
   }
 
   // If the agent returned an async status but included data in the initial

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -151,7 +151,7 @@ export interface StoryboardStepResult {
   /** True when the step was not executed */
   skipped?: boolean;
   /** Why the step was skipped */
-  skip_reason?: 'not_testable' | 'dependency_failed' | 'missing_test_harness';
+  skip_reason?: 'not_testable' | 'dependency_failed' | 'missing_test_harness' | 'missing_tool';
   /** True when the step expected an error (inverted pass/fail) */
   expect_error?: boolean;
   duration_ms: number;


### PR DESCRIPTION
## Summary

- Skip storyboard steps when agent doesn't implement the tool (`missing_tool` skip reason) instead of counting as failures
- Detect unresolved `$context` placeholders and skip with `dependency_failed` instead of sending garbage to agents
- Catch "Unknown tool" errors from agents as a fallback and convert to skips
- Add rate limit retry with exponential backoff + jitter (3 retries, 2s/4s/8s base)
- Fix `sync_creatives` request builder to send creatives for all discovered formats, not just the first (#482)
- Fix `mapStepToTestStep` to preserve runner's skip semantics (skips no longer incorrectly counted as failures)
- Fix `extractErrorData` to handle nested JSON in error messages
- Truncate agent error messages to 2000 chars to prevent report bloat

### Real-agent validation results (before → after)

| Agent | Failures Before | Failures After | Notes |
|-------|----------------|---------------|-------|
| **creative** | 11 | **0** | Fully passing (2 tracks pass, 8 correctly skipped) |
| **moloco** | 48 | **23** | All 26 "unknown tool" now skipped; remaining are agent compliance issues |
| **openads** | timeout/unclear | **4 real failures** | Clean signal: `publisher_domains`, `status` enum, `brief` validation |
| **test-mcp** | 83 | **74** | Remaining are agent-side (task polling, rate limits) |

Closes #482

## Test plan

- [x] `npm test` passes (2558 tests, 0 failures)
- [x] Code review: 2 Must Fix addressed, 4 Should Fix addressed
- [x] Security review: 2 Should Fix addressed, 0 Must Fix
- [x] Validated against 4 real agents (test-mcp, creative, openads, moloco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)