### PR TITLE
fix: get_signals passes signal_ids, activate_signal drops hardcoded fallback

### DIFF
--- a/.changeset/fix-request-builder-signals.md
+++ b/.changeset/fix-request-builder-signals.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+fix: get_signals builder passes through signal_ids from sample_request, activate_signal removes hardcoded platform destination fallback

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -330,24 +330,27 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Signals ────────────────────────────────────────────
 
-  get_signals(_step, _context, options) {
-    return options.brief ? { signal_spec: options.brief } : {};
+  get_signals(step, context, options) {
+    if (options.brief) return { signal_spec: options.brief };
+    if (step.sample_request?.signal_ids) {
+      return injectContext({ signal_ids: step.sample_request.signal_ids }, context);
+    }
+    return {};
   },
 
   activate_signal(step, context, _options) {
     const signal = selectSignal(context);
-    // Use step-specific destinations when the storyboard defines them (e.g., agent vs platform)
-    const destinations = step.sample_request?.destinations ?? [
-      { type: 'platform', platform: 'dv360', account: 'test-dv360-account' },
-      { type: 'platform', platform: 'trade-desk', account: 'test-ttd-account' },
-    ];
-    return {
+    const destinations = step.sample_request?.destinations as Array<Record<string, unknown>> | undefined;
+    const request: Record<string, unknown> = {
       signal_agent_segment_id: signal?.signal_agent_segment_id ?? context.signal_id ?? 'test-signal',
       pricing_option_id:
         (signal?.pricing_options as Array<Record<string, unknown>> | undefined)?.[0]?.pricing_option_id ??
         context.pricing_option_id,
-      destinations,
     };
+    if (destinations) {
+      request.destinations = (injectContext({ destinations }, context) as Record<string, unknown>).destinations;
+    }
+    return request;
   },
 
   // ── Capabilities ───────────────────────────────────────

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -157,6 +157,117 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('get_signals', () => {
+    test('uses brief from options as signal_spec', () => {
+      const options = { ...DEFAULT_OPTIONS, brief: 'EV buyers near dealerships' };
+      const result = buildRequest(step('get_signals'), {}, options);
+      assert.strictEqual(result.signal_spec, 'EV buyers near dealerships');
+    });
+
+    test('includes signal_ids from sample_request', () => {
+      const s = step('get_signals', {
+        sample_request: {
+          signal_ids: [
+            { source: 'catalog', data_provider_domain: 'tridentauto.example', id: 'likely_ev_buyers' },
+          ],
+        },
+      });
+      const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.signal_ids, [
+        { source: 'catalog', data_provider_domain: 'tridentauto.example', id: 'likely_ev_buyers' },
+      ]);
+      assert.strictEqual(result.signal_spec, undefined);
+    });
+
+    test('brief takes priority over signal_ids', () => {
+      const s = step('get_signals', {
+        sample_request: {
+          signal_ids: [{ source: 'catalog', data_provider_domain: 'x.example', id: 'seg1' }],
+        },
+      });
+      const options = { ...DEFAULT_OPTIONS, brief: 'override brief' };
+      const result = buildRequest(s, {}, options);
+      assert.strictEqual(result.signal_spec, 'override brief');
+      assert.strictEqual(result.signal_ids, undefined);
+    });
+
+    test('returns empty object when no brief and no signal_ids', () => {
+      const result = buildRequest(step('get_signals'), {}, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result, {});
+    });
+
+    test('injects context placeholders in signal_ids', () => {
+      const s = step('get_signals', {
+        sample_request: {
+          signal_ids: [
+            { source: 'catalog', data_provider_domain: '$context.provider_domain', id: 'seg1' },
+          ],
+        },
+      });
+      const context = { provider_domain: 'resolved.example' };
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.signal_ids[0].data_provider_domain, 'resolved.example');
+    });
+  });
+
+  describe('activate_signal', () => {
+    test('uses agent destinations from sample_request', () => {
+      const s = step('activate_signal', {
+        sample_request: {
+          destinations: [{ type: 'agent', agent_url: 'https://sa.example' }],
+        },
+      });
+      const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.destinations, [
+        { type: 'agent', agent_url: 'https://sa.example' },
+      ]);
+    });
+
+    test('uses platform destinations from sample_request', () => {
+      const s = step('activate_signal', {
+        sample_request: {
+          destinations: [{ type: 'platform', platform: 'the-trade-desk', account: 'ttd-123' }],
+        },
+      });
+      const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.destinations, [
+        { type: 'platform', platform: 'the-trade-desk', account: 'ttd-123' },
+      ]);
+    });
+
+    test('omits destinations when sample_request has none', () => {
+      const result = buildRequest(step('activate_signal'), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.destinations, undefined);
+    });
+
+    test('uses signal from context', () => {
+      const context = {
+        signals: [
+          {
+            signal_agent_segment_id: 'seg-1',
+            pricing_options: [{ pricing_option_id: 'po-1' }],
+          },
+        ],
+      };
+      const result = buildRequest(step('activate_signal'), context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.signal_agent_segment_id, 'seg-1');
+      assert.strictEqual(result.pricing_option_id, 'po-1');
+    });
+
+    test('injects context placeholders in destinations', () => {
+      const s = step('activate_signal', {
+        sample_request: {
+          destinations: [{ type: 'agent', agent_url: '$context.seller_url' }],
+        },
+      });
+      const context = { seller_url: 'https://resolved.example' };
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.destinations, [
+        { type: 'agent', agent_url: 'https://resolved.example' },
+      ]);
+    });
+  });
+
   describe('hasRequestBuilder', () => {
     test('returns true for tasks with builders', () => {
       const tasks = [
@@ -170,6 +281,8 @@ describe('Request Builder', () => {
         'sync_event_sources',
         'log_event',
         'comply_test_controller',
+        'get_signals',
+        'activate_signal',
       ];
       for (const task of tasks) {
         assert.ok(hasRequestBuilder(task), `should have builder for ${task}`);

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -167,9 +167,7 @@ describe('Request Builder', () => {
     test('includes signal_ids from sample_request', () => {
       const s = step('get_signals', {
         sample_request: {
-          signal_ids: [
-            { source: 'catalog', data_provider_domain: 'tridentauto.example', id: 'likely_ev_buyers' },
-          ],
+          signal_ids: [{ source: 'catalog', data_provider_domain: 'tridentauto.example', id: 'likely_ev_buyers' }],
         },
       });
       const result = buildRequest(s, {}, DEFAULT_OPTIONS);
@@ -199,9 +197,7 @@ describe('Request Builder', () => {
     test('injects context placeholders in signal_ids', () => {
       const s = step('get_signals', {
         sample_request: {
-          signal_ids: [
-            { source: 'catalog', data_provider_domain: '$context.provider_domain', id: 'seg1' },
-          ],
+          signal_ids: [{ source: 'catalog', data_provider_domain: '$context.provider_domain', id: 'seg1' }],
         },
       });
       const context = { provider_domain: 'resolved.example' };
@@ -218,9 +214,7 @@ describe('Request Builder', () => {
         },
       });
       const result = buildRequest(s, {}, DEFAULT_OPTIONS);
-      assert.deepStrictEqual(result.destinations, [
-        { type: 'agent', agent_url: 'https://sa.example' },
-      ]);
+      assert.deepStrictEqual(result.destinations, [{ type: 'agent', agent_url: 'https://sa.example' }]);
     });
 
     test('uses platform destinations from sample_request', () => {
@@ -262,9 +256,7 @@ describe('Request Builder', () => {
       });
       const context = { seller_url: 'https://resolved.example' };
       const result = buildRequest(s, context, DEFAULT_OPTIONS);
-      assert.deepStrictEqual(result.destinations, [
-        { type: 'agent', agent_url: 'https://resolved.example' },
-      ]);
+      assert.deepStrictEqual(result.destinations, [{ type: 'agent', agent_url: 'https://resolved.example' }]);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #484 (upstream: adcontextprotocol/adcp#2054)

- **`get_signals`**: Builder now checks `step.sample_request.signal_ids` when `options.brief` is not set, with context injection. Fixes false negatives for `search_by_ids` and `verify_provenance_metadata` storyboard steps that pass `signal_ids` instead of `signal_spec`.
- **`activate_signal`**: Removed hardcoded `type: "platform"` destination fallback. Destinations are read exclusively from `step.sample_request.destinations` with context injection. When no destinations are defined, the field is omitted rather than fabricating incorrect platform destinations.

## Test plan

- [x] 10 new test cases covering both builders (28 total, all passing)
- [x] `signal_ids` passthrough from sample_request
- [x] Brief priority over signal_ids
- [x] `$context.*` placeholder substitution in signal_ids and destinations
- [x] Agent vs platform destination types from sample_request
- [x] Missing destinations omits field (no fabrication)
- [x] Signal context extraction for segment ID and pricing
- [x] `hasRequestBuilder` list updated to include both tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)