### PR TITLE
fix: add governance context extractors for storyboard runner

### DIFF
--- a/.changeset/governance-extractors.md
+++ b/.changeset/governance-extractors.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Add check_governance and report_plan_outcome context extractors to storyboard runner

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -202,6 +202,22 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     // Governance registration — no IDs to extract, just confirmation
     return { governance_synced: true, governance_response: data };
   },
+
+  check_governance(data) {
+    const d = data as Record<string, unknown>;
+    const extracted: Record<string, unknown> = {};
+    if (d?.governance_context) extracted.governance_context = d.governance_context;
+    if (d?.check_id) extracted.check_id = d.check_id;
+    if (d?.status) extracted.governance_status = d.status;
+    return extracted;
+  },
+
+  report_plan_outcome(data) {
+    const d = data as Record<string, unknown>;
+    const extracted: Record<string, unknown> = {};
+    if (d?.status) extracted.outcome_status = d.status;
+    return extracted;
+  },
 };
 
 /**

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -204,17 +204,19 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
   },
 
   check_governance(data) {
-    const d = data as Record<string, unknown>;
+    const d = data as Record<string, unknown> | undefined;
     const extracted: Record<string, unknown> = {};
     if (d?.governance_context) extracted.governance_context = d.governance_context;
     if (d?.check_id) extracted.check_id = d.check_id;
+    if (d?.plan_id) extracted.plan_id = d.plan_id;
     if (d?.status) extracted.governance_status = d.status;
     return extracted;
   },
 
   report_plan_outcome(data) {
-    const d = data as Record<string, unknown>;
+    const d = data as Record<string, unknown> | undefined;
     const extracted: Record<string, unknown> = {};
+    if (d?.outcome_id) extracted.outcome_id = d.outcome_id;
     if (d?.status) extracted.outcome_status = d.status;
     return extracted;
   },

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -5,16 +5,18 @@ const { extractContext } = require('../../dist/lib/testing/storyboard/context.js
 
 describe('context extractors', () => {
   describe('check_governance', () => {
-    it('extracts governance_context, check_id, and status', () => {
+    it('extracts governance_context, check_id, plan_id, and status', () => {
       const data = {
         status: 'approved',
         check_id: 'chk_123',
-        governance_context: { plan_id: 'plan_1', rules: ['no-gambling'] },
+        plan_id: 'plan_1',
+        governance_context: 'opaque-ctx-abc123',
       };
       const result = extractContext('check_governance', data);
       assert.deepStrictEqual(result, {
-        governance_context: { plan_id: 'plan_1', rules: ['no-gambling'] },
+        governance_context: 'opaque-ctx-abc123',
         check_id: 'chk_123',
+        plan_id: 'plan_1',
         governance_status: 'approved',
       });
     });
@@ -31,10 +33,10 @@ describe('context extractors', () => {
   });
 
   describe('report_plan_outcome', () => {
-    it('extracts outcome_status from status', () => {
-      const data = { status: 'completed' };
+    it('extracts outcome_id and outcome_status', () => {
+      const data = { status: 'completed', outcome_id: 'out_456' };
       const result = extractContext('report_plan_outcome', data);
-      assert.deepStrictEqual(result, { outcome_status: 'completed' });
+      assert.deepStrictEqual(result, { outcome_id: 'out_456', outcome_status: 'completed' });
     });
 
     it('returns empty object when status is missing', () => {

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -1,0 +1,44 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { extractContext } = require('../../dist/lib/testing/storyboard/context.js');
+
+describe('context extractors', () => {
+  describe('check_governance', () => {
+    it('extracts governance_context, check_id, and status', () => {
+      const data = {
+        status: 'approved',
+        check_id: 'chk_123',
+        governance_context: { plan_id: 'plan_1', rules: ['no-gambling'] },
+      };
+      const result = extractContext('check_governance', data);
+      assert.deepStrictEqual(result, {
+        governance_context: { plan_id: 'plan_1', rules: ['no-gambling'] },
+        check_id: 'chk_123',
+        governance_status: 'approved',
+      });
+    });
+
+    it('extracts only present fields', () => {
+      const data = { status: 'denied' };
+      const result = extractContext('check_governance', data);
+      assert.deepStrictEqual(result, { governance_status: 'denied' });
+    });
+
+    it('returns empty object for empty data', () => {
+      assert.deepStrictEqual(extractContext('check_governance', {}), {});
+    });
+  });
+
+  describe('report_plan_outcome', () => {
+    it('extracts outcome_status from status', () => {
+      const data = { status: 'completed' };
+      const result = extractContext('report_plan_outcome', data);
+      assert.deepStrictEqual(result, { outcome_status: 'completed' });
+    });
+
+    it('returns empty object when status is missing', () => {
+      assert.deepStrictEqual(extractContext('report_plan_outcome', {}), {});
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `check_governance` context extractor — extracts `governance_context`, `check_id`, `plan_id`, and `governance_status`
- Add `report_plan_outcome` context extractor — extracts `outcome_id` and `outcome_status`
- Both follow existing extractor conventions (selective field extraction, `| undefined` cast)

Closes #487

## Test plan
- [x] Unit tests for both extractors (5 tests in `test/lib/context-extractors.test.js`)
- [x] Drift tests confirm both tasks have registered response schemas (200 tests pass)
- [x] Full test suite passes (2593 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)