### PR TITLE
feat: add 4 context extractors for storyboard  refs

### DIFF
--- a/.changeset/add-context-extractors.md
+++ b/.changeset/add-context-extractors.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Add context extractors for list_creatives, sync_catalogs, sync_audiences, and sync_event_sources so storyboards can use $context references instead of hardcoded IDs

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -116,6 +116,15 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     return { creative_results: results };
   },
 
+  list_creatives(data) {
+    const d = data as Record<string, unknown> | undefined;
+    const creatives = d?.creatives as Array<Record<string, unknown>> | undefined;
+    if (!creatives?.[0]) return {};
+    const extracted: Record<string, unknown> = { creatives };
+    if (creatives[0].creative_id) extracted.creative_id = creatives[0].creative_id;
+    return extracted;
+  },
+
   preview_creative(data) {
     const d = data as Record<string, unknown> | undefined;
     const previews = d?.previews as Array<Record<string, unknown>> | undefined;
@@ -141,6 +150,33 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     const extracted: Record<string, unknown> = { deployments };
     if (first.activation_key) extracted.activation_key = first.activation_key;
     if (first.type) extracted.deployment_type = first.type;
+    return extracted;
+  },
+
+  sync_catalogs(data) {
+    const d = data as Record<string, unknown> | undefined;
+    const catalogs = d?.catalogs as Array<Record<string, unknown>> | undefined;
+    if (!catalogs?.[0]) return {};
+    const extracted: Record<string, unknown> = { catalogs };
+    if (catalogs[0].catalog_id) extracted.catalog_id = catalogs[0].catalog_id;
+    return extracted;
+  },
+
+  sync_audiences(data) {
+    const d = data as Record<string, unknown> | undefined;
+    const audiences = d?.audiences as Array<Record<string, unknown>> | undefined;
+    if (!audiences?.[0]) return {};
+    const extracted: Record<string, unknown> = { audiences };
+    if (audiences[0].audience_id) extracted.audience_id = audiences[0].audience_id;
+    return extracted;
+  },
+
+  sync_event_sources(data) {
+    const d = data as Record<string, unknown> | undefined;
+    const sources = d?.event_sources as Array<Record<string, unknown>> | undefined;
+    if (!sources?.[0]) return {};
+    const extracted: Record<string, unknown> = { event_sources: sources };
+    if (sources[0].event_source_id) extracted.event_source_id = sources[0].event_source_id;
     return extracted;
   },
 

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -4,6 +4,92 @@ const assert = require('node:assert/strict');
 const { extractContext } = require('../../dist/lib/testing/storyboard/context.js');
 
 describe('context extractors', () => {
+  describe('list_creatives', () => {
+    it('extracts creative_id and creatives array', () => {
+      const data = {
+        creatives: [
+          { creative_id: 'cr_1', name: 'Banner A' },
+          { creative_id: 'cr_2', name: 'Banner B' },
+        ],
+      };
+      const result = extractContext('list_creatives', data);
+      assert.equal(result.creative_id, 'cr_1');
+      assert.deepStrictEqual(result.creatives, data.creatives);
+    });
+
+    it('returns empty object for empty creatives', () => {
+      assert.deepStrictEqual(extractContext('list_creatives', { creatives: [] }), {});
+    });
+
+    it('returns empty object for undefined data', () => {
+      assert.deepStrictEqual(extractContext('list_creatives', undefined), {});
+    });
+
+    it('extracts array when first item has no creative_id', () => {
+      const data = { creatives: [{ name: 'Banner A' }] };
+      const result = extractContext('list_creatives', data);
+      assert.deepStrictEqual(result.creatives, data.creatives);
+      assert.equal(result.creative_id, undefined);
+    });
+  });
+
+  describe('sync_catalogs', () => {
+    it('extracts catalog_id and catalogs array', () => {
+      const data = {
+        catalogs: [{ catalog_id: 'cat_menu', action: 'created', item_count: 3 }],
+      };
+      const result = extractContext('sync_catalogs', data);
+      assert.equal(result.catalog_id, 'cat_menu');
+      assert.deepStrictEqual(result.catalogs, data.catalogs);
+    });
+
+    it('returns empty object for empty catalogs', () => {
+      assert.deepStrictEqual(extractContext('sync_catalogs', { catalogs: [] }), {});
+    });
+
+    it('returns empty object for undefined data', () => {
+      assert.deepStrictEqual(extractContext('sync_catalogs', undefined), {});
+    });
+  });
+
+  describe('sync_audiences', () => {
+    it('extracts audience_id and audiences array', () => {
+      const data = {
+        audiences: [{ audience_id: 'aud_001', action: 'created', status: 'active' }],
+      };
+      const result = extractContext('sync_audiences', data);
+      assert.equal(result.audience_id, 'aud_001');
+      assert.deepStrictEqual(result.audiences, data.audiences);
+    });
+
+    it('returns empty object for empty audiences', () => {
+      assert.deepStrictEqual(extractContext('sync_audiences', { audiences: [] }), {});
+    });
+
+    it('returns empty object for undefined data', () => {
+      assert.deepStrictEqual(extractContext('sync_audiences', undefined), {});
+    });
+  });
+
+  describe('sync_event_sources', () => {
+    it('extracts event_source_id and event_sources array', () => {
+      const data = {
+        event_sources: [{ event_source_id: 'es_website', action: 'created' }],
+      };
+      const result = extractContext('sync_event_sources', data);
+      assert.equal(result.event_source_id, 'es_website');
+      assert.deepStrictEqual(result.event_sources, data.event_sources);
+    });
+
+    it('returns empty object for empty event_sources', () => {
+      assert.deepStrictEqual(extractContext('sync_event_sources', { event_sources: [] }), {});
+    });
+
+    it('returns empty object for undefined data', () => {
+      assert.deepStrictEqual(extractContext('sync_event_sources', undefined), {});
+    });
+  });
+
   describe('check_governance', () => {
     it('extracts governance_context, check_id, plan_id, and status', () => {
       const data = {


### PR DESCRIPTION
## Summary
- Add context extractors for `list_creatives`, `sync_catalogs`, `sync_audiences`, and `sync_event_sources`
- Enables storyboards to use `$context.creative_id`, `$context.catalog_id`, `$context.audience_id`, and `$context.event_source_id` instead of hardcoded IDs
- Follows existing extractor pattern: extract first item's ID + full array into context

## Test plan
- [x] 18 tests pass in `test/lib/context-extractors.test.js` (happy path, empty array, undefined data, missing ID)
- [x] 204 storyboard drift tests pass
- [x] Build succeeds
- [x] Code review: no Must Fix or Should Fix issues
- [x] Security review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)