### PR TITLE
feat: replace dry_run with sandbox as protocol safety mechanism

### DIFF
--- a/.changeset/remove-dry-run-protocol.md
+++ b/.changeset/remove-dry-run-protocol.md
@@ -1,0 +1,11 @@
+---
+"@adcp/client": minor
+---
+
+Remove dry_run as a protocol concept in favor of sandbox
+
+- Removed X-Dry-Run HTTP header from test client
+- Removed dry_run from TestOptions, TestResult, SuiteResult, StoryboardResult, ComplianceResult
+- Made sandbox: true the default for all test runs (comply, testAgent, testAllScenarios)
+- Changed CLI --dry-run to preview mode (shows steps without executing, opt-in)
+- Replaced --no-dry-run flag with --dry-run (default is now to execute)

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -235,7 +235,7 @@ async function handleTestCommand(args) {
     const descriptions = {
       health_check: 'Basic connectivity check - verify agent responds',
       discovery: 'Test get_products, list_creative_formats, list_authorized_properties',
-      create_media_buy: 'Discovery + create a test media buy (dry-run by default)',
+      create_media_buy: 'Discovery + create a test media buy (sandbox)',
       full_sales_flow: 'Full lifecycle: discovery → create → update → delivery',
       creative_sync: 'Test sync_creatives flow',
       creative_inline: 'Test inline creatives in create_media_buy',
@@ -304,7 +304,7 @@ async function handleTestCommand(args) {
 
   const jsonOutput = args.includes('--json');
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
-  const dryRun = !args.includes('--no-dry-run');
+  const dryRun = args.includes('--dry-run');
   const useOAuth = args.includes('--oauth');
 
   // Filter out flag arguments to find positional arguments
@@ -413,7 +413,6 @@ async function handleTestCommand(args) {
   // Build test options
   const testOptions = {
     protocol,
-    dry_run: dryRun,
     brief,
     ...(finalAuthToken && { auth: { type: 'bearer', token: finalAuthToken } }),
   };
@@ -421,7 +420,6 @@ async function handleTestCommand(args) {
   if (!jsonOutput) {
     console.log(`\n🧪 Running '${scenario}' tests against ${agentUrl}`);
     console.log(`   Protocol: ${protocol.toUpperCase()}`);
-    console.log(`   Dry Run: ${dryRun ? 'Yes (safe mode)' : 'No (real operations)'}`);
     console.log(`   Auth: ${oauthTokens ? 'oauth' : finalAuthToken ? 'configured' : 'none'}\n`);
   }
 
@@ -599,7 +597,7 @@ function parseAgentOptions(args) {
 
   const jsonOutput = args.includes('--json');
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
-  const dryRun = !args.includes('--no-dry-run');
+  const dryRun = args.includes('--dry-run');
 
   // Filter out flags and their values to find positional args
   const flagValues = [
@@ -782,7 +780,7 @@ OPTIONS:
   --json                JSON output (recommended for LLM consumption)
   --auth TOKEN          Authentication token
   --protocol PROTO      Force protocol: mcp or a2a
-  --no-dry-run          Execute real operations (default: dry-run)
+  --dry-run             Preview steps without executing
   --debug               Debug output
 
 EXAMPLES:
@@ -968,16 +966,44 @@ async function handleStoryboardRun(args) {
     authToken: resolvedAuth,
   } = await resolveAgent(agentArg, authToken, protocolFlag, jsonOutput);
 
+  const stepCount = storyboard.phases.reduce((sum, p) => sum + p.steps.length, 0);
+
   if (!jsonOutput) {
     console.error(`Running storyboard: ${storyboard.title}`);
     console.error(`Agent: ${agentUrl} (${protocol})`);
-    console.error(`Steps: ${storyboard.phases.reduce((sum, p) => sum + p.steps.length, 0)}`);
-    console.error(`Dry run: ${dryRun}\n`);
+    console.error(`Steps: ${stepCount}\n`);
+  }
+
+  // --dry-run: preview mode — show the plan without executing
+  if (dryRun) {
+    if (jsonOutput) {
+      console.log(JSON.stringify({
+        storyboard_id: storyboard.id,
+        storyboard_title: storyboard.title,
+        agent_url: agentUrl,
+        protocol,
+        preview: true,
+        phases: storyboard.phases.map(p => ({
+          phase: p.title,
+          steps: p.steps.map(s => ({ id: s.id, title: s.title, task: s.task })),
+        })),
+      }, null, 2));
+    } else {
+      console.log(`\n${storyboard.title} (${storyboard.id})`);
+      console.log('═'.repeat(50));
+      for (const phase of storyboard.phases) {
+        console.log(`\n── Phase: ${phase.title} ──`);
+        for (const step of phase.steps) {
+          console.log(`  ${step.id}: ${step.title} → ${step.task}`);
+        }
+      }
+      console.log(`\n${stepCount} step(s) would be executed. Use without --dry-run to run.`);
+    }
+    return;
   }
 
   const options = {
     protocol,
-    dry_run: dryRun,
     ...(resolvedAuth ? { auth: { type: 'bearer', token: resolvedAuth } } : {}),
   };
 
@@ -1103,7 +1129,6 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 
   const testOptions = {
     protocol,
-    dry_run: opts.dryRun,
     brief: opts.brief,
     tracks,
     storyboards,
@@ -1116,7 +1141,6 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
   if (!opts.jsonOutput) {
     console.log(`\nRunning storyboard assessment against ${agentUrl}`);
     console.log(`   Protocol: ${protocol.toUpperCase()}`);
-    console.log(`   Mode: ${opts.dryRun ? 'Dry Run' : 'Live'}`);
     if (storyboards) console.log(`   Storyboards: ${storyboards.join(', ')}`);
     if (platform_type) console.log(`   Platform: ${platform_type}`);
     console.log(`   Timeout: ${timeoutMs / 1000}s`);
@@ -1151,7 +1175,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 
 async function handleStoryboardStepCmd(args) {
   const { getStoryboardById, runStoryboardStep } = await import('../dist/lib/testing/storyboard/index.js');
-  const { authToken, protocolFlag, jsonOutput, debug, dryRun, positionalArgs } = parseAgentOptions(args);
+  const { authToken, protocolFlag, jsonOutput, debug, positionalArgs } = parseAgentOptions(args);
 
   const agentArg = positionalArgs[0];
   const storyboardId = positionalArgs[1];
@@ -1188,7 +1212,6 @@ async function handleStoryboardStepCmd(args) {
 
   const options = {
     protocol,
-    dry_run: dryRun,
     context,
     request,
     ...(resolvedAuth ? { auth: { type: 'bearer', token: resolvedAuth } } : {}),

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -977,17 +977,23 @@ async function handleStoryboardRun(args) {
   // --dry-run: preview mode — show the plan without executing
   if (dryRun) {
     if (jsonOutput) {
-      console.log(JSON.stringify({
-        storyboard_id: storyboard.id,
-        storyboard_title: storyboard.title,
-        agent_url: agentUrl,
-        protocol,
-        preview: true,
-        phases: storyboard.phases.map(p => ({
-          phase: p.title,
-          steps: p.steps.map(s => ({ id: s.id, title: s.title, task: s.task })),
-        })),
-      }, null, 2));
+      console.log(
+        JSON.stringify(
+          {
+            storyboard_id: storyboard.id,
+            storyboard_title: storyboard.title,
+            agent_url: agentUrl,
+            protocol,
+            preview: true,
+            phases: storyboard.phases.map(p => ({
+              phase: p.title,
+              steps: p.steps.map(s => ({ id: s.id, title: s.title, task: s.task })),
+            })),
+          },
+          null,
+          2
+        )
+      );
     } else {
       console.log(`\n${storyboard.title} (${storyboard.id})`);
       console.log('═'.repeat(50));

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -277,7 +277,7 @@ Useful flags:
 - `--list-platform-types`: Show all available platform types
 - `--tracks core,products,...`: Restrict the run to specific tracks
 - `--brief TEXT`: Override the default sample discovery brief
-- `--no-dry-run`: Use live mode instead of dry-run mode
+- `--dry-run`: Preview steps without executing
 - `--json`: Emit machine-readable output for automation
 
 ## Environment Variables

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -563,7 +563,7 @@ Run compliance tests with `adcp test <agent> <scenario>`. 24 built-in scenarios:
 |----------|---------------|
 | `health_check` | Basic connectivity check - verify agent responds |
 | `discovery` | Test get_products, list_creative_formats, list_authorized_properties |
-| `create_media_buy` | Discovery + create a test media buy (dry-run by default) |
+| `create_media_buy` | Discovery + create a test media buy (sandbox) |
 | `full_sales_flow` | Full lifecycle: discovery → create → update → delivery |
 | `creative_sync` | Test sync_creatives flow |
 | `creative_inline` | Test inline creatives in create_media_buy |

--- a/skills/adcp/SKILL.md
+++ b/skills/adcp/SKILL.md
@@ -124,7 +124,7 @@ When `--platform-type` and `--tracks` are both set, `--tracks` controls which st
 - `--tracks TRACKS` — Comma-separated tracks to test
 - `--list-platform-types` — Show available platform types
 - `--debug` — Verbose logging
-- `--no-dry-run` — Execute real operations (default is dry-run)
+- `--dry-run` — Preview steps without executing
 
 ### JSON output structure
 
@@ -203,7 +203,7 @@ Run `adcp test --list-scenarios` for all 24 with descriptions.
 - `--json` — Machine-readable output for CI
 - `--debug` — Verbose logging
 - `--protocol mcp|a2a` — Force protocol
-- `--no-dry-run` — Execute real operations (default is dry-run)
+- `--dry-run` — Preview steps without executing
 - `--brief "text"` — Custom brief for product discovery tests
 
 ## Registry

--- a/src/lib/testing/agent-tester.ts
+++ b/src/lib/testing/agent-tester.ts
@@ -5,7 +5,7 @@
  *
  * Features:
  * - Channel-aware testing (only tests features the agent supports)
- * - Optional dry-run mode (real testing requires actual media buys)
+ * - Sandbox mode for safe testing (real testing requires actual media buys)
  * - Comprehensive scenario coverage based on AdCP spec
  * - Schema validation via @adcp/client
  *
@@ -112,10 +112,9 @@ export async function testAgent(
   let profile: AgentProfile | undefined;
   const logger = getLogger();
 
-  // Default dry_run to true for safety
   const effectiveOptions: TestOptions = {
     ...options,
-    dry_run: options.dry_run !== false,
+    sandbox: options.sandbox !== false,
     test_session_id: options.test_session_id || `addie-test-${Date.now()}`,
   };
 
@@ -463,7 +462,6 @@ export async function testAgent(
     total_duration_ms: totalDuration,
     tested_at: new Date().toISOString(),
     agent_profile: profile,
-    dry_run: effectiveOptions.dry_run !== false,
   };
 
   logger.info({ agentUrl, scenario, overallPassed, passedCount, failedCount, totalDuration }, 'Agent test completed');

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -85,11 +85,6 @@ export function getLogger(): Logger {
 export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mcp', options: TestOptions = {}) {
   const headers: Record<string, string> = {};
 
-  // Dry-run is true by default for safety
-  if (options.dry_run !== false) {
-    headers['X-Dry-Run'] = 'true';
-  }
-
   if (options.test_session_id) {
     headers['X-Test-Session-ID'] = options.test_session_id;
   }

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -176,7 +176,7 @@ function collectObservations(
               track,
               message:
                 'Agent does not confirm sandbox mode in get_media_buys response. ' +
-                'Include sandbox: true so buyers can verify the agent honored dry_run mode.',
+                'Include sandbox: true so buyers can verify the agent honored sandbox mode.',
             });
           }
 
@@ -634,7 +634,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
   try {
     const effectiveOptions: TestOptions = {
       ...testOptions,
-      dry_run: testOptions.dry_run !== false,
+      sandbox: testOptions.sandbox !== false,
       test_session_id: testOptions.test_session_id || `comply-${Date.now()}`,
     };
 
@@ -796,7 +796,6 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       controller_scenarios: controllerDetection.detected ? controllerDetection.scenarios : undefined,
       tested_at: new Date().toISOString(),
       total_duration_ms: Date.now() - start,
-      dry_run: effectiveOptions.dry_run !== false,
     };
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId);
@@ -885,7 +884,6 @@ async function buildUnreachableResult(
     storyboards_executed: [],
     tested_at: new Date().toISOString(),
     total_duration_ms: Date.now() - start,
-    dry_run: effectiveOptions.dry_run !== false,
   };
 }
 
@@ -952,7 +950,7 @@ export function formatComplianceResults(result: ComplianceResult): string {
   output += `Agent:    ${result.agent_url}\n`;
   output += `Name:     ${result.agent_profile.name}\n`;
   output += `Tools:    ${result.agent_profile.tools.length}\n`;
-  output += `Mode:     ${result.dry_run ? 'Dry Run' : 'Live'}\n`;
+  output += `Mode:     Sandbox\n`;
   if (result.platform_coherence) {
     output += `Platform: ${result.platform_coherence.label}\n`;
   }

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -70,7 +70,6 @@ export function mapStoryboardResultsToTrackResult(
           : `${phase.phase_title}: ${steps.filter(s => !s.passed).length} step(s) failed`,
         total_duration_ms: phase.duration_ms,
         tested_at: sbResult.tested_at,
-        dry_run: sbResult.dry_run,
       };
 
       scenarios.push(testResult);

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -95,7 +95,6 @@ export interface ComplianceResult {
   controller_scenarios?: string[];
   tested_at: string;
   total_duration_ms: number;
-  dry_run: boolean;
 }
 
 export interface ComplianceSummary {

--- a/src/lib/testing/formatter.ts
+++ b/src/lib/testing/formatter.ts
@@ -13,7 +13,6 @@ export function formatTestResults(result: TestResult): string {
   output += `**Agent:** ${result.agent_url}\n`;
   output += `**Scenario:** ${result.scenario}\n`;
   output += `**Duration:** ${result.total_duration_ms}ms\n`;
-  output += `**Mode:** ${result.dry_run ? '🧪 Dry Run' : '🔴 Live'}\n`;
   output += `**Result:** ${result.summary}\n\n`;
 
   // Show agent profile if discovered

--- a/src/lib/testing/orchestrator.ts
+++ b/src/lib/testing/orchestrator.ts
@@ -182,7 +182,7 @@ export function getApplicableScenarios(tools: string[], filter?: readonly TestSc
  * Run all applicable test scenarios against an agent and return aggregated results.
  *
  * Scenarios are run sequentially. Each scenario re-uses the same TestOptions
- * (including auth, dry_run, brand, etc.). The total duration includes the
+ * (including auth, brand, etc.). The total duration includes the
  * initial capability discovery call.
  *
  * Note: testAllScenarios creates a client for capability discovery, then each
@@ -199,7 +199,7 @@ export async function testAllScenarios(agentUrl: string, options: OrchestratorOp
 
   const effectiveOptions: TestOptions = {
     ...testOptions,
-    dry_run: testOptions.dry_run !== false,
+    sandbox: testOptions.sandbox !== false,
     test_session_id: testOptions.test_session_id || `addie-suite-${Date.now()}`,
   };
 
@@ -223,7 +223,6 @@ export async function testAllScenarios(agentUrl: string, options: OrchestratorOp
       failed_count: 0,
       total_duration_ms: Date.now() - start,
       tested_at: new Date().toISOString(),
-      dry_run: effectiveOptions.dry_run !== false,
     };
   }
 
@@ -252,7 +251,6 @@ export async function testAllScenarios(agentUrl: string, options: OrchestratorOp
     failed_count: failedCount,
     total_duration_ms: Date.now() - start,
     tested_at: new Date().toISOString(),
-    dry_run: effectiveOptions.dry_run !== false,
   };
 }
 
@@ -265,7 +263,6 @@ export function formatSuiteResults(suite: SuiteResult): string {
   output += `**Agent:** ${suite.agent_url}\n`;
   output += `**Agent Name:** ${suite.agent_profile.name}\n`;
   output += `**Duration:** ${suite.total_duration_ms}ms\n`;
-  output += `**Mode:** ${suite.dry_run ? '🧪 Dry Run' : '🔴 Live'}\n`;
   if (suite.scenarios_run.length === 0) {
     output += `**Result:** No applicable scenarios found for this agent.\n\n`;
   } else {

--- a/src/lib/testing/scenarios/brand-rights.ts
+++ b/src/lib/testing/scenarios/brand-rights.ts
@@ -136,7 +136,6 @@ export async function testBrandRightsFlow(
           brand_domain: options.brand?.domain ?? 'example.com',
           brand_id: options.brand?.brand_id,
           rights_type: 'usage',
-          dry_run: options.dry_run !== false,
         }) as Promise<TaskResult>
     );
 
@@ -148,7 +147,6 @@ export async function testBrandRightsFlow(
           request_id: data['request_id'],
           status: data['status'],
           rights_id: data['rights_id'],
-          dry_run: data['dry_run'],
         },
         null,
         2
@@ -317,7 +315,6 @@ export async function testCreativeApproval(
             },
           ],
         },
-        dry_run: options.dry_run !== false,
       }) as Promise<TaskResult>
   );
 

--- a/src/lib/testing/scenarios/error-compliance.ts
+++ b/src/lib/testing/scenarios/error-compliance.ts
@@ -113,7 +113,6 @@ export async function testErrorCodes(
 
   const authToken = options.auth?.type === 'bearer' ? options.auth.token : undefined;
   const headers: Record<string, string> = {};
-  if (options.dry_run !== false) headers['X-Dry-Run'] = 'true';
 
   let correctCodes = 0;
   let totalChecked = 0;
@@ -247,7 +246,6 @@ export async function testErrorStructure(
 
   const authToken = options.auth?.type === 'bearer' ? options.auth.token : undefined;
   const headers: Record<string, string> = {};
-  if (options.dry_run !== false) headers['X-Dry-Run'] = 'true';
 
   const start = Date.now();
   // Use first provocation to get an error response
@@ -350,7 +348,6 @@ export async function testErrorTransport(
 
   const authToken = options.auth?.type === 'bearer' ? options.auth.token : undefined;
   const headers: Record<string, string> = {};
-  if (options.dry_run !== false) headers['X-Dry-Run'] = 'true';
 
   const start = Date.now();
   const provocation = createProvocations()[0]!;

--- a/src/lib/testing/scenarios/governance.ts
+++ b/src/lib/testing/scenarios/governance.ts
@@ -260,7 +260,7 @@ export async function testGovernancePropertyLists(
   }
 
   // Test: delete_property_list
-  if (profile.tools.includes('delete_property_list') && createdListId && options.dry_run === false) {
+  if (profile.tools.includes('delete_property_list') && createdListId) {
     const { result, step } = await runStep<TaskResult>(
       'Delete property list',
       'delete_property_list',
@@ -308,14 +308,6 @@ export async function testGovernancePropertyLists(
       }
       steps.push(errorStep);
     }
-  } else if (profile.tools.includes('delete_property_list') && createdListId) {
-    steps.push({
-      step: 'Delete property list',
-      task: 'delete_property_list',
-      passed: true,
-      duration_ms: 0,
-      details: 'Skipped in dry-run mode',
-    });
   }
 
   return { steps, profile };
@@ -749,8 +741,8 @@ export async function testPropertyListFilters(
   }
   steps.push(getStep);
 
-  // Cleanup: delete if not dry-run
-  if (options.dry_run === false && profile.tools.includes('delete_property_list')) {
+  // Cleanup
+  if (profile.tools.includes('delete_property_list')) {
     const { result: delResult, step: delStep } = await runStep<TaskResult>(
       'Delete test property list (cleanup)',
       'delete_property_list',

--- a/src/lib/testing/scenarios/signals.ts
+++ b/src/lib/testing/scenarios/signals.ts
@@ -158,7 +158,7 @@ export async function testSignalsFlow(
         } else if (result && !result.success) {
           // Check if this is an expected failure (e.g., destination not supported)
           const error = result.error || '';
-          if (error.includes('not supported') || error.includes('invalid destination') || error.includes('dry_run')) {
+          if (error.includes('not supported') || error.includes('invalid destination')) {
             step.passed = true;
             step.details = `Expected rejection: ${error}`;
           } else {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -122,7 +122,6 @@ export async function runStoryboard(
     failed_count: failedCount,
     skipped_count: skippedCount,
     tested_at: new Date().toISOString(),
-    dry_run: options.dry_run !== false,
   };
 
   // Close MCP connections when the runner created its own client

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -185,5 +185,4 @@ export interface StoryboardResult {
   failed_count: number;
   skipped_count: number;
   tested_at: string;
-  dry_run: boolean;
 }

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -84,8 +84,6 @@ export interface TestOptions {
   format_ids?: string[];
   // Test session ID for isolation
   test_session_id?: string;
-  // Whether to use dry-run mode (default: true for safety)
-  dry_run?: boolean;
   // Channels to focus on (if not specified, tests all agent supports)
   channels?: string[];
   // Specific pricing models to test
@@ -208,8 +206,6 @@ export interface TestResult {
   tested_at: string;
   // Agent profile discovered during testing
   agent_profile?: AgentProfile;
-  // Was this run in dry-run mode?
-  dry_run: boolean;
 }
 
 export interface SuiteResult {
@@ -230,7 +226,6 @@ export interface SuiteResult {
   /** Wall-clock time including capability discovery and all scenario runs */
   total_duration_ms: number;
   tested_at: string;
-  dry_run: boolean;
 }
 
 // Generic task result from executeTask

--- a/test/lib/compliance.test.js
+++ b/test/lib/compliance.test.js
@@ -373,7 +373,6 @@ describe('formatComplianceResults', () => {
             steps: [],
             summary: 'Passed',
             total_duration_ms: 100,
-
           },
         ],
         skipped_scenarios: [],
@@ -391,7 +390,6 @@ describe('formatComplianceResults', () => {
             steps: [{ step: 'Check pricing', passed: false, duration_ms: 50, error: 'No pricing options' }],
             summary: 'Failed',
             total_duration_ms: 50,
-
           },
         ],
         skipped_scenarios: [],

--- a/test/lib/compliance.test.js
+++ b/test/lib/compliance.test.js
@@ -373,7 +373,7 @@ describe('formatComplianceResults', () => {
             steps: [],
             summary: 'Passed',
             total_duration_ms: 100,
-            dry_run: true,
+
           },
         ],
         skipped_scenarios: [],
@@ -391,7 +391,7 @@ describe('formatComplianceResults', () => {
             steps: [{ step: 'Check pricing', passed: false, duration_ms: 50, error: 'No pricing options' }],
             summary: 'Failed',
             total_duration_ms: 50,
-            dry_run: true,
+
           },
         ],
         skipped_scenarios: [],
@@ -442,7 +442,6 @@ describe('formatComplianceResults', () => {
     storyboards_executed: ['capability_discovery', 'schema_validation'],
     tested_at: new Date().toISOString(),
     total_duration_ms: 150,
-    dry_run: true,
   };
 
   test('includes agent name and URL', () => {

--- a/test/lib/format-suite-failure-details.test.js
+++ b/test/lib/format-suite-failure-details.test.js
@@ -42,7 +42,7 @@ describe('formatSuiteResults includes step-level failure details', () => {
       failed_count: 1,
       total_duration_ms: 2513,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -88,7 +88,7 @@ describe('formatSuiteResults includes step-level failure details', () => {
       failed_count: 0,
       total_duration_ms: 500,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -118,7 +118,7 @@ describe('formatSuiteResults includes step-level failure details', () => {
       failed_count: 1,
       total_duration_ms: 100,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);

--- a/test/lib/format-suite-failure-details.test.js
+++ b/test/lib/format-suite-failure-details.test.js
@@ -42,7 +42,6 @@ describe('formatSuiteResults includes step-level failure details', () => {
       failed_count: 1,
       total_duration_ms: 2513,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -88,7 +87,6 @@ describe('formatSuiteResults includes step-level failure details', () => {
       failed_count: 0,
       total_duration_ms: 500,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -118,7 +116,6 @@ describe('formatSuiteResults includes step-level failure details', () => {
       failed_count: 1,
       total_duration_ms: 100,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);

--- a/test/lib/storyboard-observations.test.js
+++ b/test/lib/storyboard-observations.test.js
@@ -39,7 +39,7 @@ function storyboardResult(overrides = {}) {
     failed_count: 0,
     skipped_count: 0,
     tested_at: '2026-01-01T00:00:00.000Z',
-    dry_run: true,
+
     ...overrides,
   };
 }

--- a/test/lib/storyboard-skip-counting.test.js
+++ b/test/lib/storyboard-skip-counting.test.js
@@ -39,7 +39,7 @@ function storyboardResult(overrides = {}) {
     failed_count: 0,
     skipped_count: 0,
     tested_at: '2026-01-01T00:00:00.000Z',
-    dry_run: true,
+
     ...overrides,
   };
 }

--- a/test/lib/test-orchestrator.test.js
+++ b/test/lib/test-orchestrator.test.js
@@ -270,7 +270,6 @@ describe('formatSuiteResults', () => {
       failed_count: 0,
       total_duration_ms: 300,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -294,7 +293,6 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -333,7 +331,6 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -360,7 +357,6 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     // Should not throw even without steps
@@ -389,7 +385,6 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -409,7 +404,6 @@ describe('formatSuiteResults', () => {
       failed_count: 0,
       total_duration_ms: 100,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
 
     const output = formatSuiteResults(suite);
@@ -435,7 +429,6 @@ describe('formatSuiteResultsJSON', () => {
       failed_count: 0,
       total_duration_ms: 0,
       tested_at: '2025-01-01T00:00:00.000Z',
-
     };
     const json = formatSuiteResultsJSON(suite);
     const parsed = JSON.parse(json);

--- a/test/lib/test-orchestrator.test.js
+++ b/test/lib/test-orchestrator.test.js
@@ -270,7 +270,7 @@ describe('formatSuiteResults', () => {
       failed_count: 0,
       total_duration_ms: 300,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -280,7 +280,6 @@ describe('formatSuiteResults', () => {
     assert.ok(output.includes('2 passed'), 'should show pass count');
     assert.ok(output.includes('create_media_buy'), 'should list skipped scenarios');
     assert.ok(output.includes('health_check'), 'should list run scenarios');
-    assert.ok(output.includes('Dry Run'), 'should indicate dry run mode');
   });
 
   test('formats a failed suite correctly', () => {
@@ -295,7 +294,7 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -334,7 +333,7 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -361,7 +360,7 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     // Should not throw even without steps
@@ -390,7 +389,7 @@ describe('formatSuiteResults', () => {
       failed_count: 1,
       total_duration_ms: 50,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -410,7 +409,7 @@ describe('formatSuiteResults', () => {
       failed_count: 0,
       total_duration_ms: 100,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
 
     const output = formatSuiteResults(suite);
@@ -436,7 +435,7 @@ describe('formatSuiteResultsJSON', () => {
       failed_count: 0,
       total_duration_ms: 0,
       tested_at: '2025-01-01T00:00:00.000Z',
-      dry_run: true,
+
     };
     const json = formatSuiteResultsJSON(suite);
     const parsed = JSON.parse(json);

--- a/test/lib/testing-deprecation.test.js
+++ b/test/lib/testing-deprecation.test.js
@@ -85,7 +85,7 @@ describe('Testing Framework Deprecation Warnings', () => {
       scenario: 'creative_flow',
       overall_passed: true,
       total_duration_ms: 1000,
-      dry_run: true,
+
       steps: [
         { step: 'Step 1', passed: true, duration_ms: 100 },
         {
@@ -111,7 +111,7 @@ describe('Testing Framework Deprecation Warnings', () => {
       scenario: 'creative_flow',
       overall_passed: true,
       total_duration_ms: 1000,
-      dry_run: true,
+
       summary: '3/3 passed',
       steps: [
         {

--- a/test/lib/user-agent-config.test.js
+++ b/test/lib/user-agent-config.test.js
@@ -250,7 +250,6 @@ describe('userAgent config', () => {
       // We verify by checking the agent config it was constructed with
       const client = createTestClient('https://agent.example.com/mcp', 'mcp', {
         userAgent: 'AAO-ComplianceCheck/1.0',
-        dry_run: true,
       });
 
       // The client's getAgent() should reflect the injected User-Agent
@@ -265,12 +264,9 @@ describe('userAgent config', () => {
     test('does not inject User-Agent when userAgent option is not set', () => {
       const { createTestClient } = require('../../dist/lib/testing/client.js');
 
-      const client = createTestClient('https://agent.example.com/mcp', 'mcp', {
-        dry_run: true,
-      });
+      const client = createTestClient('https://agent.example.com/mcp', 'mcp', {});
 
       const agent = client.getAgent();
-      // Headers may have X-Dry-Run but should not have User-Agent
       assert.strictEqual(
         agent.headers?.['User-Agent'],
         undefined,


### PR DESCRIPTION
## Summary

- **Removed `X-Dry-Run` header** from the test client — `dry_run` is no longer a protocol concept
- **Removed `dry_run`** from `TestOptions`, `TestResult`, `SuiteResult`, `StoryboardResult`, `ComplianceResult`
- **Made `sandbox: true` the default** for all test entry points (`comply`, `testAgent`, `testAllScenarios`)
- **Changed CLI `--dry-run`** to preview mode: shows storyboard steps without executing (opt-in, not default)
- **Replaced `--no-dry-run`** with `--dry-run` (execute is now the default behavior)
- **Cleaned up** governance scenarios that gated cleanup on dry_run — sandbox protects, always clean up
- Updated docs, skills, and tests

### Why

`dry_run` was overloaded across three layers:
1. CLI: "don't execute anything"
2. Protocol header (`X-Dry-Run`): "call the agent but don't persist"
3. Agent behavior: overlapped with `sandbox` semantics

Now there are two clean concepts:
- **`sandbox: true`** = protocol-level safety (always on for testing)
- **`--dry-run`** = CLI preview only ("show me what you'd do")

### Protocol issue

adcontextprotocol/adcp#2087 tracks deprecation of `X-Dry-Run` in the spec.

## Test plan

- [x] Build passes (`tsc`)
- [x] All 2626 tests pass, 0 failures
- [x] CLI `--dry-run` preview mode works (human-readable + JSON)
- [x] CLI real execution works against test-mcp agent with sandbox default
- [x] Code review: all Should Fix items addressed
- [x] Security review: no Must Fix or Should Fix findings for our changes


🤖 Generated with [Claude Code](https://claude.com/claude-code)