### PR TITLE
fix: strip adcp_major_version from v2 seller tool calls

### DIFF
--- a/.changeset/fix-v2-adcp-major-version.md
+++ b/.changeset/fix-v2-adcp-major-version.md
@@ -1,0 +1,9 @@
+---
+"@adcp/client": patch
+---
+
+Fix adcp_major_version breaking v2 seller tool calls
+
+- Stop injecting adcp_major_version into tool args for v2 sellers (strict Pydantic schemas reject it)
+- Make ProtocolClient version-aware via serverVersion parameter
+- Strip adcp_major_version in all v2 request adapters as belt-and-suspenders

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -979,9 +979,10 @@ export class SingleAgentClient {
     const agent = await this.ensureEndpointDiscovered();
 
     // Adapt request for v2 servers if needed
+    const serverVersion = await this.detectServerVersion();
     const adaptedParams = await this.adaptRequestForServerVersion(taskType, normalizedParams);
 
-    const result = await this.executor.executeTask<T>(agent, taskType, adaptedParams, inputHandler, options);
+    const result = await this.executor.executeTask<T>(agent, taskType, adaptedParams, inputHandler, options, serverVersion);
 
     // Normalize response to v3 format
     if (result.success && result.data) {
@@ -1897,9 +1898,10 @@ export class SingleAgentClient {
 
     // Adapt request for the server's protocol version (e.g. strip v3-only
     // fields like buying_mode when talking to v2 agents).
+    const serverVersion = await this.detectServerVersion();
     const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams);
 
-    const result = await this.executor.executeTask<T>(agent, taskName, adaptedParams, inputHandler, options);
+    const result = await this.executor.executeTask<T>(agent, taskName, adaptedParams, inputHandler, options, serverVersion);
 
     // Normalize response to v3 format for consistent API surface
     if (result.success && result.data) {

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -982,7 +982,14 @@ export class SingleAgentClient {
     const serverVersion = await this.detectServerVersion();
     const adaptedParams = await this.adaptRequestForServerVersion(taskType, normalizedParams);
 
-    const result = await this.executor.executeTask<T>(agent, taskType, adaptedParams, inputHandler, options, serverVersion);
+    const result = await this.executor.executeTask<T>(
+      agent,
+      taskType,
+      adaptedParams,
+      inputHandler,
+      options,
+      serverVersion
+    );
 
     // Normalize response to v3 format
     if (result.success && result.data) {
@@ -1901,7 +1908,14 @@ export class SingleAgentClient {
     const serverVersion = await this.detectServerVersion();
     const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams);
 
-    const result = await this.executor.executeTask<T>(agent, taskName, adaptedParams, inputHandler, options, serverVersion);
+    const result = await this.executor.executeTask<T>(
+      agent,
+      taskName,
+      adaptedParams,
+      inputHandler,
+      options,
+      serverVersion
+    );
 
     // Normalize response to v3 format for consistent API surface
     if (result.success && result.data) {

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -90,6 +90,7 @@ export class TaskExecutor {
   private activeTasks = new Map<string, TaskState>();
   private conversationStorage?: Map<string, Message[]>;
   private governanceMiddleware?: GovernanceMiddleware;
+  private lastKnownServerVersion?: 'v2' | 'v3';
 
   constructor(
     private config: {
@@ -160,8 +161,10 @@ export class TaskExecutor {
     taskName: string,
     params: any,
     inputHandler?: InputHandler,
-    options: TaskOptions = {}
+    options: TaskOptions = {},
+    serverVersion?: 'v2' | 'v3'
   ): Promise<TaskResult<T>> {
+    if (serverVersion) this.lastKnownServerVersion = serverVersion;
     const taskId = options.contextId || randomUUID();
     const startTime = Date.now();
     const workingTimeout = this.config.workingTimeout || 120000; // 120s max per PR #78
@@ -287,7 +290,9 @@ export class TaskExecutor {
         effectiveParams,
         debugLogs,
         webhookUrl,
-        this.config.webhookSecret
+        this.config.webhookSecret,
+        undefined,
+        serverVersion
       );
 
       // Emit protocol_response activity
@@ -921,7 +926,7 @@ export class TaskExecutor {
         // Fall through to tool call if protocol method is not supported
       }
     }
-    const response = (await ProtocolClient.callTool(agent, 'tasks/list', {})) as Record<string, unknown>;
+    const response = (await ProtocolClient.callTool(agent, 'tasks/list', {}, [], undefined, undefined, undefined, this.lastKnownServerVersion)) as Record<string, unknown>;
     return (response.tasks as TaskInfo[]) || [];
   }
 
@@ -948,7 +953,7 @@ export class TaskExecutor {
         // Fall through to tool call if protocol method is not supported
       }
     }
-    const response = (await ProtocolClient.callTool(agent, 'tasks/get', { taskId })) as Record<string, unknown>;
+    const response = (await ProtocolClient.callTool(agent, 'tasks/get', { taskId }, [], undefined, undefined, undefined, this.lastKnownServerVersion)) as Record<string, unknown>;
     return (response.task as TaskInfo) || (response as unknown as TaskInfo);
   }
 
@@ -1044,7 +1049,11 @@ export class TaskExecutor {
         contextId,
         input,
       },
-      debugLogs
+      debugLogs,
+      undefined,
+      undefined,
+      undefined,
+      this.lastKnownServerVersion
     );
 
     // Add response message

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -926,7 +926,16 @@ export class TaskExecutor {
         // Fall through to tool call if protocol method is not supported
       }
     }
-    const response = (await ProtocolClient.callTool(agent, 'tasks/list', {}, [], undefined, undefined, undefined, this.lastKnownServerVersion)) as Record<string, unknown>;
+    const response = (await ProtocolClient.callTool(
+      agent,
+      'tasks/list',
+      {},
+      [],
+      undefined,
+      undefined,
+      undefined,
+      this.lastKnownServerVersion
+    )) as Record<string, unknown>;
     return (response.tasks as TaskInfo[]) || [];
   }
 
@@ -953,7 +962,16 @@ export class TaskExecutor {
         // Fall through to tool call if protocol method is not supported
       }
     }
-    const response = (await ProtocolClient.callTool(agent, 'tasks/get', { taskId }, [], undefined, undefined, undefined, this.lastKnownServerVersion)) as Record<string, unknown>;
+    const response = (await ProtocolClient.callTool(
+      agent,
+      'tasks/get',
+      { taskId },
+      [],
+      undefined,
+      undefined,
+      undefined,
+      this.lastKnownServerVersion
+    )) as Record<string, unknown>;
     return (response.task as TaskInfo) || (response as unknown as TaskInfo);
   }
 

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -46,7 +46,8 @@ export class ProtocolClient {
     debugLogs: DebugLogEntry[] = [],
     webhookUrl?: string,
     webhookSecret?: string,
-    webhookToken?: string
+    webhookToken?: string,
+    serverVersion?: 'v2' | 'v3'
   ): Promise<unknown> {
     return withSpan(
       `adcp.${agent.protocol}.call_tool`,
@@ -61,8 +62,10 @@ export class ProtocolClient {
 
         const authToken = getAuthToken(agent);
 
-        // Declare AdCP major version on every request so sellers can validate compatibility
-        const argsWithVersion = { adcp_major_version: ADCP_MAJOR_VERSION, ...args };
+        // Declare AdCP major version on every request so sellers can validate compatibility.
+        // Skip for v2 servers — they don't recognise the field and strict-schema agents reject it.
+        const argsWithVersion =
+          serverVersion === 'v2' ? args : { adcp_major_version: ADCP_MAJOR_VERSION, ...args };
 
         // Build push_notification_config for ASYNC TASK STATUS notifications
         // (NOT for reporting_webhook - that stays in args)
@@ -108,24 +111,24 @@ export class ProtocolClient {
 /**
  * Simple factory functions for protocol-specific clients
  */
-export const createMCPClient = (agentUrl: string, authToken?: string, headers?: Record<string, string>) => ({
+export const createMCPClient = (agentUrl: string, authToken?: string, headers?: Record<string, string>, serverVersion?: 'v2' | 'v3') => ({
   callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
     callMCPToolWithTasks(
       agentUrl,
       toolName,
-      { adcp_major_version: ADCP_MAJOR_VERSION, ...args },
+      serverVersion === 'v2' ? args : { adcp_major_version: ADCP_MAJOR_VERSION, ...args },
       authToken,
       debugLogs,
       headers
     ),
 });
 
-export const createA2AClient = (agentUrl: string, authToken?: string, headers?: Record<string, string>) => ({
+export const createA2AClient = (agentUrl: string, authToken?: string, headers?: Record<string, string>, serverVersion?: 'v2' | 'v3') => ({
   callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
     callA2ATool(
       agentUrl,
       toolName,
-      { adcp_major_version: ADCP_MAJOR_VERSION, ...parameters },
+      serverVersion === 'v2' ? parameters : { adcp_major_version: ADCP_MAJOR_VERSION, ...parameters },
       authToken,
       debugLogs,
       undefined,

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -64,8 +64,7 @@ export class ProtocolClient {
 
         // Declare AdCP major version on every request so sellers can validate compatibility.
         // Skip for v2 servers — they don't recognise the field and strict-schema agents reject it.
-        const argsWithVersion =
-          serverVersion === 'v2' ? args : { adcp_major_version: ADCP_MAJOR_VERSION, ...args };
+        const argsWithVersion = serverVersion === 'v2' ? args : { adcp_major_version: ADCP_MAJOR_VERSION, ...args };
 
         // Build push_notification_config for ASYNC TASK STATUS notifications
         // (NOT for reporting_webhook - that stays in args)
@@ -111,7 +110,12 @@ export class ProtocolClient {
 /**
  * Simple factory functions for protocol-specific clients
  */
-export const createMCPClient = (agentUrl: string, authToken?: string, headers?: Record<string, string>, serverVersion?: 'v2' | 'v3') => ({
+export const createMCPClient = (
+  agentUrl: string,
+  authToken?: string,
+  headers?: Record<string, string>,
+  serverVersion?: 'v2' | 'v3'
+) => ({
   callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
     callMCPToolWithTasks(
       agentUrl,
@@ -123,7 +127,12 @@ export const createMCPClient = (agentUrl: string, authToken?: string, headers?: 
     ),
 });
 
-export const createA2AClient = (agentUrl: string, authToken?: string, headers?: Record<string, string>, serverVersion?: 'v2' | 'v3') => ({
+export const createA2AClient = (
+  agentUrl: string,
+  authToken?: string,
+  headers?: Record<string, string>,
+  serverVersion?: 'v2' | 'v3'
+) => ({
   callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
     callA2ATool(
       agentUrl,

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-11T18:10:06.605Z
+// Generated at: 2026-04-13T17:42:26.496Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -87,6 +87,7 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
     artifact_webhook,
     brand,
     brand_manifest: inputManifest,
+    adcp_major_version,
     ...rest
   } = request;
 
@@ -124,7 +125,7 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
  * Strips v3-only top-level fields and adapts packages.
  */
 export function adaptUpdateMediaBuyRequestForV2(request: any): any {
-  const { reporting_webhook, ...rest } = request;
+  const { reporting_webhook, adcp_major_version, ...rest } = request;
 
   return {
     ...rest,

--- a/src/lib/utils/pricing-adapter.ts
+++ b/src/lib/utils/pricing-adapter.ts
@@ -317,6 +317,7 @@ export function adaptGetProductsRequestForV2(request: any): any {
   delete adapted.property_list;
   delete adapted.account;
   delete adapted.pagination;
+  delete adapted.adcp_major_version;
 
   return adapted;
 }

--- a/src/lib/utils/sync-creatives-adapter.ts
+++ b/src/lib/utils/sync-creatives-adapter.ts
@@ -36,7 +36,7 @@ function adaptCreativeAssetForV2(creative: any): any {
  * Strips v3-only top-level fields and adapts each creative asset.
  */
 export function adaptSyncCreativesRequestForV2(request: any): any {
-  const { account, ...rest } = request;
+  const { account, adcp_major_version, ...rest } = request;
 
   return {
     ...rest,


### PR DESCRIPTION
## Summary

- Make `ProtocolClient` version-aware so `adcp_major_version` is **never** sent to v2 sellers
- Pass detected server version from `SingleAgentClient` through `TaskExecutor` to `ProtocolClient` on all call paths (`executeTask`, `tasks/list`, `tasks/get`, `continue_task`)
- Strip `adcp_major_version` in all 4 v2 adapters (`get_products`, `create_media_buy`, `update_media_buy`, `sync_creatives`) as belt-and-suspenders

## Problem

`ProtocolClient.callTool()` unconditionally injected `adcp_major_version: 3` into every tool call's arguments. V2 sellers with strict Pydantic schemas (e.g. Magnite Sales) reject unknown keyword arguments, causing `get_products` and all other calls to fail with:

```
Unexpected keyword argument [type=unexpected_keyword_argument, input_value=3, input_type=int]
```

The injection happened at the protocol layer **below** the v2 adaptation layer, so the existing field-stripping adapters never had a chance to remove it.

## Test plan

- [ ] Verify `npm run build` passes
- [ ] Verify `npm test` passes (2633/2633)
- [ ] Verify `adcp_major_version` is sent to v3 sellers
- [ ] Verify `adcp_major_version` is NOT sent to v2 sellers on any code path
- [ ] Test against Magnite Sales agent (v2) — `get_products` should succeed