### PR TITLE
feat: add brand identity blocks to all test kits

### DIFF
--- a/.changeset/brand-identity-test-kits.md
+++ b/.changeset/brand-identity-test-kits.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": minor
+---
+
+Add full brand identity blocks (logos, colors, fonts, tone) and creative assets to all test kit YAMLs. New test kits for Bistro Oranje, Summit Foods, and Osei Natural. Enables loading all sandbox brands from @adcp/client instead of hardcoding them.

--- a/storyboards/fictional-entities.yaml
+++ b/storyboards/fictional-entities.yaml
@@ -57,6 +57,7 @@ advertisers:
     domain: "bistro-oranje.example"
     industry: hospitality
     sandbox_brand: true
+    test_kit: "test-kits/bistro-oranje.yaml"
     description: >
       Dutch restaurant chain. Used in rights licensing scenarios where
       Carlos manages programmatic rights for ad campaigns.
@@ -68,6 +69,7 @@ advertisers:
     domain: "summitfoods.example"
     industry: cpg
     sandbox_brand: true
+    test_kit: "test-kits/summit-foods.yaml"
     description: >
       Organic food / CPG brand. Buys retail media inventory on ShopGrid
       in commerce media scenarios.
@@ -78,6 +80,7 @@ advertisers:
     domain: "oseinatural.example"
     industry: beauty
     sandbox_brand: true
+    test_kit: "test-kits/osei-natural.yaml"
     description: >
       8-person natural skincare company based in Nairobi. Represents the
       small business that advertising should serve but currently doesn't.

--- a/storyboards/test-kits/bistro-oranje.yaml
+++ b/storyboards/test-kits/bistro-oranje.yaml
@@ -1,0 +1,121 @@
+# Bistro Oranje — Hospitality Advertiser Test Kit
+#
+# Entity definition: fictional-entities.yaml → advertisers[bistro_oranje]
+#
+# Dutch restaurant chain used in rights licensing scenarios.
+#
+# This brand is registered as a sandbox brand in AgenticAdvertising.org (AAO).
+# Agents resolve bistro-oranje.example via the standard AAO brand resolution path.
+# AAO returns the brand.json below but excludes sandbox brands from production
+# brand discovery results.
+
+id: bistro_oranje
+name: "Bistro Oranje"
+description: "Dutch restaurant chain for rights licensing storyboard testing"
+sandbox: true
+
+brand:
+  house:
+    domain: "bistro-oranje.example"
+    name: "Bistro Oranje"
+  brand_id: "bistro_oranje"
+  names:
+    - en: "Bistro Oranje"
+    - nl: "Bistro Oranje"
+  description: "Modern Dutch dining — seasonal menus inspired by the Netherlands, served with warmth."
+  industry: "hospitality"
+  keller_type: "master"
+  logos:
+    - url: "https://test-assets.adcontextprotocol.org/bistro-oranje/logo-primary.png"
+      orientation: "horizontal"
+      background: "light-bg"
+      variant: "primary"
+      width: 400
+      height: 100
+    - url: "https://test-assets.adcontextprotocol.org/bistro-oranje/logo-icon.png"
+      orientation: "square"
+      background: "transparent-bg"
+      variant: "icon"
+      width: 200
+      height: 200
+  colors:
+    primary: "#E65100"
+    secondary: "#1B5E20"
+    accent: "#FFC107"
+    background: "#FFF8E1"
+    text: "#212121"
+  fonts:
+    heading:
+      family: "Playfair Display"
+      weight: 700
+      url: "https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700"
+    body:
+      family: "Source Sans Pro"
+      weight: 400
+      url: "https://fonts.googleapis.com/css2?family=Source+Sans+Pro"
+  tone:
+    voice: "Warm and inviting, with understated confidence. We let the food speak — no excess, no pretension."
+    attributes:
+      - "welcoming"
+      - "seasonal"
+      - "unpretentious"
+    dos:
+      - "Mention seasonal ingredients by name"
+      - "Reference Dutch culinary traditions"
+      - "Keep descriptions sensory and specific"
+    donts:
+      - "Use fine-dining jargon"
+      - "Overuse superlatives"
+      - "Promise exclusivity — Bistro Oranje is for everyone"
+
+assets:
+  images:
+    - id: "hero_300x250"
+      url: "https://test-assets.adcontextprotocol.org/bistro-oranje/hero-300x250.jpg"
+      width: 300
+      height: 250
+      mime_type: "image/jpeg"
+      description: "Medium rectangle hero — seasonal dish on rustic table"
+
+    - id: "hero_728x90"
+      url: "https://test-assets.adcontextprotocol.org/bistro-oranje/hero-728x90.jpg"
+      width: 728
+      height: 90
+      mime_type: "image/jpeg"
+      description: "Leaderboard hero — bistro exterior with canal backdrop"
+
+    - id: "hero_320x50"
+      url: "https://test-assets.adcontextprotocol.org/bistro-oranje/hero-320x50.jpg"
+      width: 320
+      height: 50
+      mime_type: "image/jpeg"
+      description: "Mobile banner hero — close-up of signature stamppot"
+
+    - id: "hero_160x600"
+      url: "https://test-assets.adcontextprotocol.org/bistro-oranje/hero-160x600.jpg"
+      width: 160
+      height: 600
+      mime_type: "image/jpeg"
+      description: "Wide skyscraper hero — vertical dining room scene"
+
+    - id: "hero_master"
+      url: "https://test-assets.adcontextprotocol.org/bistro-oranje/hero-master.jpg"
+      width: 1200
+      height: 628
+      mime_type: "image/jpeg"
+      description: "Master hero image — high-res chef plating seasonal dish"
+
+  text:
+    headlines:
+      - "Taste the Season at Bistro Oranje"
+      - "Dutch Comfort, Modern Kitchen"
+      - "Reserve Your Table Tonight"
+    descriptions:
+      - "Seasonal menus inspired by Dutch tradition, made with ingredients sourced within 50km. Bistro Oranje — Amsterdam, Rotterdam, Utrecht."
+      - "From stamppot to stroopwafel, every dish tells a story. Book your table at Bistro Oranje."
+    cta:
+      - "Reserve a Table"
+      - "View the Menu"
+      - "Find a Location"
+
+  click_url: "https://bistro-oranje.example/reservations"

--- a/storyboards/test-kits/nova-motors.yaml
+++ b/storyboards/test-kits/nova-motors.yaml
@@ -25,6 +25,49 @@ brand:
     - en: "Nova Motors"
   description: "Electric vehicles for the next generation. The Volta EV — performance meets sustainability."
   industry: "automotive"
+  keller_type: "master"
+  logos:
+    - url: "https://test-assets.adcontextprotocol.org/nova-motors/logo-primary.png"
+      orientation: "horizontal"
+      background: "light-bg"
+      variant: "primary"
+      width: 400
+      height: 100
+    - url: "https://test-assets.adcontextprotocol.org/nova-motors/logo-icon.png"
+      orientation: "square"
+      background: "transparent-bg"
+      variant: "icon"
+      width: 200
+      height: 200
+  colors:
+    primary: "#0D47A1"
+    secondary: "#00BFA5"
+    accent: "#FF6D00"
+    background: "#F5F5F5"
+    text: "#1A1A1A"
+  fonts:
+    heading:
+      family: "Inter"
+      weight: 700
+      url: "https://fonts.googleapis.com/css2?family=Inter:wght@700"
+    body:
+      family: "Inter"
+      weight: 400
+      url: "https://fonts.googleapis.com/css2?family=Inter"
+  tone:
+    voice: "Forward-thinking and precise. We speak to drivers who care about engineering and the planet — no greenwashing, no hype."
+    attributes:
+      - "innovative"
+      - "precise"
+      - "optimistic"
+    dos:
+      - "Lead with performance specs"
+      - "Reference sustainability with evidence"
+      - "Use clean, modern language"
+    donts:
+      - "Greenwash or overstate environmental claims"
+      - "Use legacy automotive clichés"
+      - "Condescend about range anxiety"
 
 campaign:
   brand: "Nova Motors"
@@ -141,6 +184,58 @@ signals:
           percent: 12
           max_cpm: 3.00
           currency: "USD"
+
+assets:
+  images:
+    - id: "hero_300x250"
+      url: "https://test-assets.adcontextprotocol.org/nova-motors/hero-300x250.jpg"
+      width: 300
+      height: 250
+      mime_type: "image/jpeg"
+      description: "Medium rectangle hero — Volta EV on coastal highway"
+
+    - id: "hero_728x90"
+      url: "https://test-assets.adcontextprotocol.org/nova-motors/hero-728x90.jpg"
+      width: 728
+      height: 90
+      mime_type: "image/jpeg"
+      description: "Leaderboard hero — Volta EV front profile with charging station"
+
+    - id: "hero_320x50"
+      url: "https://test-assets.adcontextprotocol.org/nova-motors/hero-320x50.jpg"
+      width: 320
+      height: 50
+      mime_type: "image/jpeg"
+      description: "Mobile banner hero — Volta EV dashboard detail"
+
+    - id: "hero_160x600"
+      url: "https://test-assets.adcontextprotocol.org/nova-motors/hero-160x600.jpg"
+      width: 160
+      height: 600
+      mime_type: "image/jpeg"
+      description: "Wide skyscraper hero — vertical Volta EV silhouette"
+
+    - id: "hero_master"
+      url: "https://test-assets.adcontextprotocol.org/nova-motors/hero-master.jpg"
+      width: 1200
+      height: 628
+      mime_type: "image/jpeg"
+      description: "Master hero image — high-res Volta EV in motion"
+
+  text:
+    headlines:
+      - "The Volta EV — 0 to 60 in 3.2s"
+      - "Performance Meets Sustainability"
+      - "Drive Electric. Drive Nova."
+    descriptions:
+      - "340 miles of range. 15-minute fast charge. The Volta EV is engineered for drivers who refuse to compromise."
+      - "Zero emissions, zero compromises. Test drive the Volta EV at your nearest Nova Motors dealer."
+    cta:
+      - "Reserve Yours"
+      - "Schedule a Test Drive"
+      - "Explore the Volta"
+
+  click_url: "https://novamotors.example/volta-ev"
 
 destinations:
   platforms:

--- a/storyboards/test-kits/osei-natural.yaml
+++ b/storyboards/test-kits/osei-natural.yaml
@@ -1,0 +1,121 @@
+# Osei Natural — Beauty Advertiser Test Kit
+#
+# Entity definition: fictional-entities.yaml → advertisers[osei_natural]
+#
+# 8-person natural skincare company based in Nairobi. Represents the small
+# business that advertising should serve but currently doesn't.
+#
+# This brand is registered as a sandbox brand in AgenticAdvertising.org (AAO).
+# Agents resolve oseinatural.example via the standard AAO brand resolution path.
+# AAO returns the brand.json below but excludes sandbox brands from production
+# brand discovery results.
+
+id: osei_natural
+name: "Osei Natural"
+description: "Natural skincare brand for small-business advertiser storyboard testing"
+sandbox: true
+
+brand:
+  house:
+    domain: "oseinatural.example"
+    name: "Osei Natural"
+  brand_id: "osei_natural"
+  names:
+    - en: "Osei Natural"
+  description: "Natural skincare rooted in East African botanicals. Small-batch, founder-led, and unapologetically simple."
+  industry: "beauty"
+  keller_type: "master"
+  logos:
+    - url: "https://test-assets.adcontextprotocol.org/osei-natural/logo-primary.png"
+      orientation: "horizontal"
+      background: "light-bg"
+      variant: "primary"
+      width: 400
+      height: 100
+    - url: "https://test-assets.adcontextprotocol.org/osei-natural/logo-icon.png"
+      orientation: "square"
+      background: "transparent-bg"
+      variant: "icon"
+      width: 200
+      height: 200
+  colors:
+    primary: "#5D4037"
+    secondary: "#C8E6C9"
+    accent: "#FF8F00"
+    background: "#FBF7F4"
+    text: "#2E2E2E"
+  fonts:
+    heading:
+      family: "Cormorant Garamond"
+      weight: 600
+      url: "https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@600"
+    body:
+      family: "Lato"
+      weight: 400
+      url: "https://fonts.googleapis.com/css2?family=Lato"
+  tone:
+    voice: "Calm, grounded, and personal. Amara speaks directly to customers like a trusted friend sharing what works."
+    attributes:
+      - "authentic"
+      - "gentle"
+      - "personal"
+    dos:
+      - "Name specific botanicals and their origins"
+      - "Use first-person when appropriate — the founder is the brand"
+      - "Keep it warm and conversational"
+    donts:
+      - "Use clinical or pharmaceutical language"
+      - "Make anti-aging claims — Osei Natural is about care, not correction"
+      - "Erase the brand's Kenyan identity — it's a feature, not a detail"
+
+assets:
+  images:
+    - id: "hero_300x250"
+      url: "https://test-assets.adcontextprotocol.org/osei-natural/hero-300x250.jpg"
+      width: 300
+      height: 250
+      mime_type: "image/jpeg"
+      description: "Medium rectangle hero — product jars with botanical ingredients"
+
+    - id: "hero_728x90"
+      url: "https://test-assets.adcontextprotocol.org/osei-natural/hero-728x90.jpg"
+      width: 728
+      height: 90
+      mime_type: "image/jpeg"
+      description: "Leaderboard hero — Amara in workshop with shea butter"
+
+    - id: "hero_320x50"
+      url: "https://test-assets.adcontextprotocol.org/osei-natural/hero-320x50.jpg"
+      width: 320
+      height: 50
+      mime_type: "image/jpeg"
+      description: "Mobile banner hero — close-up of baobab oil serum"
+
+    - id: "hero_160x600"
+      url: "https://test-assets.adcontextprotocol.org/osei-natural/hero-160x600.jpg"
+      width: 160
+      height: 600
+      mime_type: "image/jpeg"
+      description: "Wide skyscraper hero — vertical product lineup on linen"
+
+    - id: "hero_master"
+      url: "https://test-assets.adcontextprotocol.org/osei-natural/hero-master.jpg"
+      width: 1200
+      height: 628
+      mime_type: "image/jpeg"
+      description: "Master hero image — high-res flat lay of full product range"
+
+  text:
+    headlines:
+      - "Your Skin Deserves Better Ingredients"
+      - "Small-Batch Skincare from Nairobi"
+      - "Rooted in East African Botanicals"
+    descriptions:
+      - "Shea butter, baobab oil, and aloe — sourced from East African growers, blended by hand in Nairobi. Osei Natural."
+      - "Eight people, twelve products, zero compromises. Natural skincare that actually works."
+    cta:
+      - "Shop the Collection"
+      - "Meet the Founder"
+      - "Try a Sample Kit"
+
+  click_url: "https://oseinatural.example/shop"

--- a/storyboards/test-kits/summit-foods.yaml
+++ b/storyboards/test-kits/summit-foods.yaml
@@ -1,0 +1,120 @@
+# Summit Foods — CPG Advertiser Test Kit
+#
+# Entity definition: fictional-entities.yaml → advertisers[summit_foods]
+#
+# Organic food / CPG brand that buys retail media inventory on ShopGrid.
+#
+# This brand is registered as a sandbox brand in AgenticAdvertising.org (AAO).
+# Agents resolve summitfoods.example via the standard AAO brand resolution path.
+# AAO returns the brand.json below but excludes sandbox brands from production
+# brand discovery results.
+
+id: summit_foods
+name: "Summit Foods"
+description: "Organic food CPG brand for retail media storyboard testing"
+sandbox: true
+
+brand:
+  house:
+    domain: "summitfoods.example"
+    name: "Summit Foods"
+  brand_id: "summit_foods"
+  names:
+    - en: "Summit Foods"
+  description: "Organic pantry staples made from ingredients you can pronounce. From farm to shelf, nothing artificial."
+  industry: "cpg"
+  keller_type: "master"
+  logos:
+    - url: "https://test-assets.adcontextprotocol.org/summit-foods/logo-primary.png"
+      orientation: "horizontal"
+      background: "light-bg"
+      variant: "primary"
+      width: 400
+      height: 100
+    - url: "https://test-assets.adcontextprotocol.org/summit-foods/logo-icon.png"
+      orientation: "square"
+      background: "transparent-bg"
+      variant: "icon"
+      width: 200
+      height: 200
+  colors:
+    primary: "#33691E"
+    secondary: "#F9A825"
+    accent: "#BF360C"
+    background: "#FAFAF5"
+    text: "#1B1B1B"
+  fonts:
+    heading:
+      family: "Nunito"
+      weight: 700
+      url: "https://fonts.googleapis.com/css2?family=Nunito:wght@700"
+    body:
+      family: "Nunito"
+      weight: 400
+      url: "https://fonts.googleapis.com/css2?family=Nunito"
+  tone:
+    voice: "Honest and approachable. We talk like a farmer at a market stall — proud of the product, plain about what's in it."
+    attributes:
+      - "transparent"
+      - "approachable"
+      - "earthy"
+    dos:
+      - "Name specific ingredients and sourcing"
+      - "Use plain language over marketing speak"
+      - "Emphasize taste alongside health"
+    donts:
+      - "Use 'clean eating' or diet-culture language"
+      - "Make unsubstantiated health claims"
+      - "Position as premium or exclusive — Summit Foods is everyday food"
+
+assets:
+  images:
+    - id: "hero_300x250"
+      url: "https://test-assets.adcontextprotocol.org/summit-foods/hero-300x250.jpg"
+      width: 300
+      height: 250
+      mime_type: "image/jpeg"
+      description: "Medium rectangle hero — product lineup on kitchen counter"
+
+    - id: "hero_728x90"
+      url: "https://test-assets.adcontextprotocol.org/summit-foods/hero-728x90.jpg"
+      width: 728
+      height: 90
+      mime_type: "image/jpeg"
+      description: "Leaderboard hero — harvest field with Summit Foods packaging"
+
+    - id: "hero_320x50"
+      url: "https://test-assets.adcontextprotocol.org/summit-foods/hero-320x50.jpg"
+      width: 320
+      height: 50
+      mime_type: "image/jpeg"
+      description: "Mobile banner hero — close-up of organic granola bar"
+
+    - id: "hero_160x600"
+      url: "https://test-assets.adcontextprotocol.org/summit-foods/hero-160x600.jpg"
+      width: 160
+      height: 600
+      mime_type: "image/jpeg"
+      description: "Wide skyscraper hero — vertical pantry shelf with Summit products"
+
+    - id: "hero_master"
+      url: "https://test-assets.adcontextprotocol.org/summit-foods/hero-master.jpg"
+      width: 1200
+      height: 628
+      mime_type: "image/jpeg"
+      description: "Master hero image — high-res breakfast spread with Summit products"
+
+  text:
+    headlines:
+      - "Organic. Honest. Delicious."
+      - "Ingredients You Can Pronounce"
+      - "From Our Farm to Your Shelf"
+    descriptions:
+      - "Organic pantry staples made with five ingredients or fewer. Summit Foods — real food for real kitchens."
+      - "No fillers, no artificial anything. Just honest food that tastes like food should."
+    cta:
+      - "Shop Now"
+      - "Find in Store"
+      - "Try the Sampler"
+
+  click_url: "https://summitfoods.example/shop"


### PR DESCRIPTION
## Summary

- Add full brand identity (logos, colors, fonts, tone) and creative assets to `nova-motors.yaml`
- Create new test kits for **Bistro Oranje** (hospitality), **Summit Foods** (CPG), and **Osei Natural** (beauty) with complete brand blocks and assets
- Update `fictional-entities.yaml` with `test_kit` references for the three new brands

All five sandbox advertisers now have complete test kits, enabling adcp-1 to load all fictional brands directly from `@adcp/client` instead of hardcoding them.

Closes #513

## Test plan

- [x] All 5 YAML files parse correctly through `sandbox-entities.ts` loader
- [x] Structural consistency verified across all test kits (same fields, same nesting)
- [x] Domain references match between test kits and `fictional-entities.yaml`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)