### PR TITLE
fix: strip undeclared fields from tool args for all server versions

### DIFF
--- a/.changeset/strip-unknown-fields-all-versions.md
+++ b/.changeset/strip-unknown-fields-all-versions.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix schema-based field stripping to apply for all server versions, not just v3. Fields like idempotency_key and ext that are not declared in the remote server's tool schema are now stripped before sending, preventing validation errors on servers that don't accept them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "4.27.0",
+  "version": "4.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "4.27.0",
+      "version": "4.29.0",
       "license": "Apache-2.0",
       "dependencies": {
         "yaml": "^2.7.1"

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1026,58 +1026,61 @@ export class SingleAgentClient {
     // Get server version (cached after first call)
     const version = await this.detectServerVersion();
 
-    if (version === 'v3') {
-      // For v3 agents that have a cached inputSchema, strip any top-level fields
-      // not declared in the schema's properties. This handles partial v3
-      // implementations (agents that declare get_adcp_capabilities but omit some
-      // v3 fields like brand or buying_mode from their tool schema).
-      // Fails open when no schema is cached — better to send unknown fields and
-      // let the agent respond than to silently drop data that might be required.
-      // MCP-only in practice: A2A agents don't populate cachedToolSchemas.
-      const toolSchema = this.cachedToolSchemas?.get(taskType);
-      if (!toolSchema) return params;
+    let adapted = params;
 
-      const declaredFields = new Set(Object.keys(toolSchema));
-      // Protocol envelope fields are always preserved — they live at the
-      // protocol layer, not in individual tool schemas.
-      const envelopeFields = new Set(['governance_context', 'push_notification_config', 'context_id']);
-      const filtered: Record<string, unknown> = {};
-      const stripped: string[] = [];
+    if (version !== 'v3') {
+      // Adapt v3 requests for v2 servers
+      switch (taskType) {
+        case 'get_products':
+          adapted = adaptGetProductsRequestForV2(params);
+          break;
 
-      for (const [key, value] of Object.entries(params)) {
-        if (declaredFields.has(key) || envelopeFields.has(key)) {
-          filtered[key] = value;
-        } else {
-          stripped.push(key);
-        }
+        case 'create_media_buy':
+          adapted = adaptCreateMediaBuyRequestForV2(params);
+          break;
+
+        case 'update_media_buy':
+          adapted = adaptUpdateMediaBuyRequestForV2(params);
+          break;
+
+        case 'sync_creatives':
+          adapted = adaptSyncCreativesRequestForV2(params);
+          break;
       }
-
-      if (stripped.length > 0) {
-        console.warn(
-          `[AdCP] Stripping fields not declared in agent "${this.agent.id}" schema for ${taskType}: ${stripped.join(', ')}`
-        );
-      }
-
-      return filtered;
     }
 
-    // Adapt v3 requests for v2 servers
-    switch (taskType) {
-      case 'get_products':
-        return adaptGetProductsRequestForV2(params);
+    // Strip any top-level fields not declared in the agent's tool schema.
+    // This handles partial implementations (agents that omit some fields)
+    // and prevents unknown fields like idempotency_key/ext from causing
+    // validation errors on the remote server.
+    // Fails open when no schema is cached — better to send unknown fields and
+    // let the agent respond than to silently drop data that might be required.
+    // MCP-only in practice: A2A agents don't populate cachedToolSchemas.
+    const toolSchema = this.cachedToolSchemas?.get(taskType);
+    if (!toolSchema) return adapted;
 
-      case 'create_media_buy':
-        return adaptCreateMediaBuyRequestForV2(params);
+    const declaredFields = new Set(Object.keys(toolSchema));
+    // Protocol envelope fields are always preserved — they live at the
+    // protocol layer, not in individual tool schemas.
+    const envelopeFields = new Set(['governance_context', 'push_notification_config', 'context_id']);
+    const filtered: Record<string, unknown> = {};
+    const stripped: string[] = [];
 
-      case 'update_media_buy':
-        return adaptUpdateMediaBuyRequestForV2(params);
-
-      case 'sync_creatives':
-        return adaptSyncCreativesRequestForV2(params);
-
-      default:
-        return params;
+    for (const [key, value] of Object.entries(adapted)) {
+      if (declaredFields.has(key) || envelopeFields.has(key)) {
+        filtered[key] = value;
+      } else {
+        stripped.push(key);
+      }
     }
+
+    if (stripped.length > 0) {
+      console.warn(
+        `[AdCP] Stripping fields not declared in agent "${this.agent.id}" schema for ${taskType}: ${stripped.join(', ')}`
+      );
+    }
+
+    return filtered;
   }
 
   /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-14T06:31:39.008Z
+// Generated at: 2026-04-14T12:45:16.111Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -88,6 +88,8 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
     brand,
     brand_manifest: inputManifest,
     adcp_major_version,
+    idempotency_key,
+    ext,
     ...rest
   } = request;
 
@@ -125,7 +127,7 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
  * Strips v3-only top-level fields and adapts packages.
  */
 export function adaptUpdateMediaBuyRequestForV2(request: any): any {
-  const { reporting_webhook, adcp_major_version, ...rest } = request;
+  const { reporting_webhook, adcp_major_version, idempotency_key, ext, ...rest } = request;
 
   return {
     ...rest,


### PR DESCRIPTION
## Summary
- Schema-based field stripping was only running for v3 servers, allowing undeclared fields like `idempotency_key` and `ext` to pass through to v2 servers and cause validation errors
- Refactored `adaptRequestForServerVersion` so the schema-based stripping runs as a final pass **after** any v2 adaptation, for all server versions
- Also includes explicit destructuring of `idempotency_key`/`ext` in the v2 adapters as belt-and-suspenders

## Test plan
- [ ] Existing tests pass (no behavioral change for v3 path)
- [ ] Verify `create_media_buy` against a Magnite-style server that rejects unknown fields
- [ ] Confirm `console.warn` fires when fields are stripped