### PR TITLE
fix: preserve ext field for v2 servers

### DIFF
--- a/.changeset/fix-ext-v2-preservation.md
+++ b/.changeset/fix-ext-v2-preservation.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix ext field being incorrectly stripped from v2 server requests. ext is a protocol-level extension field valid in all AdCP versions and should always be preserved.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-14
-> @adcp/client v4.29.0
+> @adcp/client v4.30.1
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 
@@ -189,6 +189,7 @@ Each tool is called as `agent.<methodName>(params)` and returns `TaskResult<Resp
   invoice_recipient: Business Entity
   io_acceptance: object
   po_number: string
+  agency_estimate_number: string
   push_notification_config: Push Notification Config
   reporting_webhook: Reporting Webhook
   artifact_webhook: object

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-14
-> Library: @adcp/client v4.29.0
+> Library: @adcp/client v4.30.1
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 
@@ -123,7 +123,7 @@ Optional: `format_ids: object[]`, `asset_types: object[]`, `max_width: integer`,
 Request parameters for creating a media buy.
 
 Required: `account: Account Ref`, `brand: Brand Ref`, `start_time: Start Timing`, `end_time: string`
-Optional: `idempotency_key: string`, `plan_id: string`, `proposal_id: string`, `total_budget: object`, `packages: object[]`, `advertiser_industry: Advertiser Industry`, `invoice_recipient: Business Entity`, `io_acceptance: object`, +5 more
+Optional: `idempotency_key: string`, `plan_id: string`, `proposal_id: string`, `total_budget: object`, `packages: object[]`, `advertiser_industry: Advertiser Industry`, `invoice_recipient: Business Entity`, `io_acceptance: object`, +6 more
 
 #### `update_media_buy`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "4.29.0",
+  "version": "4.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "4.29.0",
+      "version": "4.30.1",
       "license": "Apache-2.0",
       "dependencies": {
         "yaml": "^2.7.1"

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1051,7 +1051,7 @@ export class SingleAgentClient {
 
     // Strip any top-level fields not declared in the agent's tool schema.
     // This handles partial implementations (agents that omit some fields)
-    // and prevents unknown fields like idempotency_key/ext from causing
+    // and prevents unknown fields like idempotency_key from causing
     // validation errors on the remote server.
     // Fails open when no schema is cached — better to send unknown fields and
     // let the agent respond than to silently drop data that might be required.
@@ -1062,7 +1062,7 @@ export class SingleAgentClient {
     const declaredFields = new Set(Object.keys(toolSchema));
     // Protocol envelope fields are always preserved — they live at the
     // protocol layer, not in individual tool schemas.
-    const envelopeFields = new Set(['governance_context', 'push_notification_config', 'context_id']);
+    const envelopeFields = new Set(['governance_context', 'push_notification_config', 'context_id', 'ext']);
     const filtered: Record<string, unknown> = {};
     const stripped: string[] = [];
 

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-10T14:21:16.215Z
+// Generated at: 2026-04-14T15:19:02.167Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -643,6 +643,10 @@ export interface Package {
      */
     acknowledged_at?: string;
   };
+  /**
+   * Agency estimate or authorization number for this package. Echoed from the buyer's request. When present on the package, takes precedence over the media buy-level estimate number.
+   */
+  agency_estimate_number?: string;
   /**
    * ISO 8601 timestamp for creative upload or change deadline for this package. After this deadline, creative changes are rejected. When absent, the media buy's creative_deadline applies.
    */
@@ -1380,6 +1384,10 @@ export type CatalogAsset = Catalog;
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
 export type CreativeStatus = 'processing' | 'pending_review' | 'approved' | 'rejected' | 'archived';
+/**
+ * Industry-standard identifier types for advertising creatives. These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.
+ */
+export type CreativeIdentifierType = 'ad_id' | 'isci' | 'clearcast_clock';
 
 /**
  * Creative asset for upload to library - supports static assets, generative formats, and third-party snippets
@@ -1450,6 +1458,10 @@ export interface CreativeAsset {
    * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
    */
   placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
 }
 /**
@@ -2050,6 +2062,16 @@ export interface ReferenceAsset {
    * Human-readable description of the asset and how it should inform creative generation
    */
   description?: string;
+}
+/**
+ * An industry-standard identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number). These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.
+ */
+export interface IndustryIdentifier {
+  type: CreativeIdentifierType;
+  /**
+   * The identifier value (e.g., 'ABCD1234000H' for Ad-ID)
+   */
+  value: string;
 }
 /**
  * Selects properties from a publisher's adagents.json. Used for both product definitions and agent authorization. Supports three selection patterns: all properties, specific IDs, or by tags.
@@ -4669,6 +4691,10 @@ export interface CreativeManifest {
    * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
    */
   rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
   ext?: ExtensionObject;
 }

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-14T15:19:02.167Z
+// Generated at: 2026-04-14T15:58:16.683Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -1032,6 +1032,10 @@ export interface MeasurementTerms {
      * Maximum acceptable variance between the billing vendor's count and the other party's count before resolution is triggered (e.g., 10 means a 10% divergence triggers review).
      */
     max_variance_percent?: number;
+    /**
+     * Which measurement window the billing metric is reconciled against. References a window_id from the product's reporting_capabilities.measurement_windows. For broadcast TV, this is typically 'c7' (live + 7 days DVR). When absent, billing is based on the seller's standard reporting without windowed maturation.
+     */
+    measurement_window?: string;
   };
   /**
    * Remedies available when a performance standard or billing measurement variance is breached. Seller declares which remedy types they support. When a breach occurs, the seller proposes a remedy from this menu; the buyer accepts or disputes.
@@ -3249,6 +3253,10 @@ export interface ReportingCapabilities {
    * Whether delivery data can be filtered to arbitrary date ranges. 'date_range' means the platform supports start_date/end_date parameters. 'lifetime_only' means the platform returns campaign lifetime totals and date range parameters are not accepted.
    */
   date_range_support: 'date_range' | 'lifetime_only';
+  /**
+   * Measurement maturation windows available for this product. Used by broadcast and linear TV sellers where measurement accumulates over time (Live, C3, C7). Each window defines an accumulation period and expected data availability. When present, delivery reports reference a specific window_id. Digital-only sellers typically omit this.
+   */
+  measurement_windows?: MeasurementWindow[];
 }
 /**
  * Geographic breakdown support for this product. Declares which geo levels and systems are available for by_geo reporting within by_package.
@@ -3274,6 +3282,31 @@ export interface GeographicBreakdownSupport {
   postal_area?: {
     [k: string]: boolean | undefined;
   };
+}
+/**
+ * A measurement maturation window for broadcast and linear TV. Broadcast measurement is not delayed data — it matures over time as time-shifted (DVR) viewing accumulates. Each window represents a defined accumulation period after the live broadcast.
+ */
+export interface MeasurementWindow {
+  /**
+   * Identifier for this measurement window. Standard values: 'live' (real-time viewers only), 'c3' (live + 3 days time-shifted), 'c7' (live + 7 days time-shifted). Sellers may define custom windows for other accumulation periods.
+   */
+  window_id: string;
+  /**
+   * Human-readable description of what this window measures
+   */
+  description?: string;
+  /**
+   * Number of days after live broadcast included in this window. 0 = live only, 3 = live + 3 days DVR, 7 = live + 7 days DVR.
+   */
+  duration_days: number;
+  /**
+   * Expected number of days after broadcast before this window's data is available from the measurement vendor. For example, C7 window data from VideoAmp typically arrives ~22 days after broadcast (7-day accumulation + ~15-day processing).
+   */
+  expected_availability_days?: number;
+  /**
+   * Whether this window is the basis for delivery guarantees and reconciliation. A product typically has one guarantee basis window (e.g., C7 for most US broadcast). Buyers reconcile against the guarantee basis window's final numbers.
+   */
+  is_guarantee_basis?: boolean;
 }
 /**
  * Creative requirements and restrictions for a product
@@ -4368,6 +4401,10 @@ export interface MeasurementTerms1 {
      * Maximum acceptable variance between the billing vendor's count and the other party's count before resolution is triggered (e.g., 10 means a 10% divergence triggers review).
      */
     max_variance_percent?: number;
+    /**
+     * Which measurement window the billing metric is reconciled against. References a window_id from the product's reporting_capabilities.measurement_windows. For broadcast TV, this is typically 'c7' (live + 7 days DVR). When absent, billing is based on the seller's standard reporting without windowed maturation.
+     */
+    measurement_window?: string;
   };
   /**
    * Remedies available when a performance standard or billing measurement variance is breached. Seller declares which remedy types they support. When a breach occurs, the seller proposes a remedy from this menu; the buyer accepts or disputes.

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-14T12:45:16.111Z
+// Generated at: 2026-04-14T15:19:04.247Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -292,6 +292,8 @@ export const CatalogSchema = z.object({
 
 export const CreativeStatusSchema = z.union([z.literal("processing"), z.literal("pending_review"), z.literal("approved"), z.literal("rejected"), z.literal("archived")]);
 
+export const CreativeIdentifierTypeSchema = z.union([z.literal("ad_id"), z.literal("isci"), z.literal("clearcast_clock")]);
+
 export const ImageAssetSchema = z.object({
     url: z.string(),
     width: z.number(),
@@ -458,6 +460,11 @@ export const MarkdownAssetSchema = z.object({
 }).passthrough();
 
 export const CatalogAssetSchema = CatalogSchema;
+
+export const IndustryIdentifierSchema = z.object({
+    type: CreativeIdentifierTypeSchema,
+    value: z.string()
+}).passthrough();
 
 export const ReferenceAssetSchema = z.object({
     url: z.string(),
@@ -1570,6 +1577,7 @@ export const PackageSchema = z.object({
         reason: z.string().nullish(),
         acknowledged_at: z.string().nullish()
     }).passthrough().nullish(),
+    agency_estimate_number: z.string().nullish(),
     creative_deadline: z.string().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
@@ -1606,6 +1614,7 @@ export const CreativeAssetSchema = z.object({
     status: CreativeStatusSchema.nullish(),
     weight: z.number().nullish(),
     placement_ids: z.array(z.string()).nullish(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).nullish(),
     provenance: ProvenanceSchema.nullish()
 }).passthrough();
 
@@ -1997,6 +2006,7 @@ export const CreativeManifestSchema = z.object({
     format_id: FormatIDSchema,
     assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
     rights: z.array(RightsConstraintSchema).nullish(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).nullish(),
     provenance: ProvenanceSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 }).passthrough();
@@ -3922,7 +3932,7 @@ export const GetMediaBuysResponseSchema = z.object({
 }).passthrough();
 
 export const GetMediaBuyDeliveryResponseSchema = z.object({
-    notification_type: z.union([z.literal("scheduled"), z.literal("final"), z.literal("delayed"), z.literal("adjusted")]).nullish(),
+    notification_type: z.union([z.literal("scheduled"), z.literal("final"), z.literal("delayed"), z.literal("adjusted"), z.literal("window_update")]).nullish(),
     partial_data: z.boolean().nullish(),
     unavailable_count: z.number().nullish(),
     sequence_number: z.number().nullish(),
@@ -3967,6 +3977,9 @@ export const GetMediaBuyDeliveryResponseSchema = z.object({
             currency: z.string().nullish(),
             delivery_status: z.union([z.literal("delivering"), z.literal("completed"), z.literal("budget_exhausted"), z.literal("flight_ended"), z.literal("goal_met")]).nullish(),
             paused: z.boolean().nullish(),
+            is_final: z.boolean().nullish(),
+            measurement_window: z.string().nullish(),
+            supersedes_window: z.string().nullish(),
             by_catalog_item: z.array(DeliveryMetricsSchema.and(z.object({
                 content_id: z.string().nullish(),
                 content_id_type: ContentIDTypeSchema.nullish()
@@ -4561,6 +4574,7 @@ export const CreateMediaBuyRequestSchema = z.object({
         signature_id: z.string().nullish()
     }).passthrough().nullish(),
     po_number: z.string().nullish(),
+    agency_estimate_number: z.string().nullish(),
     start_time: StartTimingSchema,
     end_time: z.string(),
     push_notification_config: PushNotificationConfigSchema.nullish(),

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-14T15:19:04.247Z
+// Generated at: 2026-04-14T15:58:18.136Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -145,7 +145,8 @@ export const FormatIDSchema = z.object({
 export const MeasurementTermsSchema = z.object({
     billing_measurement: z.object({
         vendor: BrandReferenceSchema,
-        max_variance_percent: z.number().nullish()
+        max_variance_percent: z.number().nullish(),
+        measurement_window: z.string().nullish()
     }).passthrough().nullish(),
     makegood_policy: z.object({
         available_remedies: z.array(MakegoodRemedySchema)
@@ -734,6 +735,14 @@ export const GeographicBreakdownSupportSchema = z.object({
     postal_area: z.record(z.string(), z.boolean()).nullish()
 }).passthrough();
 
+export const MeasurementWindowSchema = z.object({
+    window_id: z.string(),
+    description: z.string().nullish(),
+    duration_days: z.number(),
+    expected_availability_days: z.number().nullish(),
+    is_guarantee_basis: z.boolean().nullish()
+}).passthrough();
+
 export const DiagnosticIssueSchema = z.object({
     severity: z.union([z.literal("error"), z.literal("warning"), z.literal("info")]),
     message: z.string()
@@ -1068,7 +1077,8 @@ export const AccountSchema = z.object({
 export const MeasurementTerms1Schema = z.object({
     billing_measurement: z.object({
         vendor: BrandReferenceSchema,
-        max_variance_percent: z.number().nullish()
+        max_variance_percent: z.number().nullish(),
+        measurement_window: z.string().nullish()
     }).passthrough().nullish(),
     makegood_policy: z.object({
         available_remedies: z.array(MakegoodRemedySchema)
@@ -1341,7 +1351,8 @@ export const ReportingCapabilitiesSchema = z.object({
     supports_device_platform_breakdown: z.boolean().nullish(),
     supports_audience_breakdown: z.boolean().nullish(),
     supports_placement_breakdown: z.boolean().nullish(),
-    date_range_support: z.union([z.literal("date_range"), z.literal("lifetime_only")])
+    date_range_support: z.union([z.literal("date_range"), z.literal("lifetime_only")]),
+    measurement_windows: z.array(MeasurementWindowSchema).nullish()
 }).passthrough();
 
 export const MeasurementReadinessSchema = z.object({
@@ -3848,6 +3859,7 @@ export const PackageRequestSchema = z.object({
     performance_standards: z.array(PerformanceStandardSchema).nullish(),
     creative_assignments: z.array(CreativeAssignmentSchema).nullish(),
     creatives: z.array(CreativeAssetSchema).nullish(),
+    agency_estimate_number: z.string().nullish(),
     context: ContextObjectSchema.nullish(),
     ext: ExtensionObjectSchema.nullish()
 }).passthrough();

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -1914,6 +1914,10 @@ export interface MeasurementTerms {
      * Maximum acceptable variance between the billing vendor's count and the other party's count before resolution is triggered (e.g., 10 means a 10% divergence triggers review).
      */
     max_variance_percent?: number;
+    /**
+     * Which measurement window the billing metric is reconciled against. References a window_id from the product's reporting_capabilities.measurement_windows. For broadcast TV, this is typically 'c7' (live + 7 days DVR). When absent, billing is based on the seller's standard reporting without windowed maturation.
+     */
+    measurement_window?: string;
   };
   /**
    * Remedies available when a performance standard or billing measurement variance is breached. Seller declares which remedy types they support. When a breach occurs, the seller proposes a remedy from this menu; the buyer accepts or disputes.
@@ -2001,6 +2005,10 @@ export interface ReportingCapabilities {
    * Whether delivery data can be filtered to arbitrary date ranges. 'date_range' means the platform supports start_date/end_date parameters. 'lifetime_only' means the platform returns campaign lifetime totals and date range parameters are not accepted.
    */
   date_range_support: 'date_range' | 'lifetime_only';
+  /**
+   * Measurement maturation windows available for this product. Used by broadcast and linear TV sellers where measurement accumulates over time (Live, C3, C7). Each window defines an accumulation period and expected data availability. When present, delivery reports reference a specific window_id. Digital-only sellers typically omit this.
+   */
+  measurement_windows?: MeasurementWindow[];
 }
 /**
  * Geographic breakdown support for this product. Declares which geo levels and systems are available for by_geo reporting within by_package.
@@ -2026,6 +2034,31 @@ export interface GeographicBreakdownSupport {
   postal_area?: {
     [k: string]: boolean | undefined;
   };
+}
+/**
+ * A measurement maturation window for broadcast and linear TV. Broadcast measurement is not delayed data — it matures over time as time-shifted (DVR) viewing accumulates. Each window represents a defined accumulation period after the live broadcast.
+ */
+export interface MeasurementWindow {
+  /**
+   * Identifier for this measurement window. Standard values: 'live' (real-time viewers only), 'c3' (live + 3 days time-shifted), 'c7' (live + 7 days time-shifted). Sellers may define custom windows for other accumulation periods.
+   */
+  window_id: string;
+  /**
+   * Human-readable description of what this window measures
+   */
+  description?: string;
+  /**
+   * Number of days after live broadcast included in this window. 0 = live only, 3 = live + 3 days DVR, 7 = live + 7 days DVR.
+   */
+  duration_days: number;
+  /**
+   * Expected number of days after broadcast before this window's data is available from the measurement vendor. For example, C7 window data from VideoAmp typically arrives ~22 days after broadcast (7-day accumulation + ~15-day processing).
+   */
+  expected_availability_days?: number;
+  /**
+   * Whether this window is the basis for delivery guarantees and reconciliation. A product typically has one guarantee basis window (e.g., C7 for most US broadcast). Buyers reconcile against the guarantee basis window's final numbers.
+   */
+  is_guarantee_basis?: boolean;
 }
 /**
  * Creative requirements and restrictions for a product
@@ -3699,6 +3732,10 @@ export interface PackageRequest {
    * Upload new creative assets and assign to this package (creatives will be added to library). Use creative_assignments instead for existing library creatives.
    */
   creatives?: CreativeAsset[];
+  /**
+   * Agency estimate or authorization number for this package. Overrides the media buy-level estimate number when different packages correspond to different agency estimates (e.g., different stations or flights within the same buy).
+   */
+  agency_estimate_number?: string;
   context?: ContextObject;
   ext?: ExtensionObject;
 }

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -3418,6 +3418,10 @@ export type CatalogAsset = Catalog;
  */
 export type CreativeStatus = 'processing' | 'pending_review' | 'approved' | 'rejected' | 'archived';
 /**
+ * Industry-standard identifier types for advertising creatives. These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.
+ */
+export type CreativeIdentifierType = 'ad_id' | 'isci' | 'clearcast_clock';
+/**
  * Industry classification for this specific campaign. A brand may operate across multiple industries (brand.json industries field), but each media buy targets one. For example, a consumer health company running a wellness campaign sends 'healthcare.wellness', not 'cpg'. Sellers map this to platform-native codes (e.g., Spotify ADV categories, LinkedIn industry IDs). When omitted, sellers may infer from the brand manifest's industries field.
  */
 export type AdvertiserIndustry =
@@ -3576,6 +3580,10 @@ export interface CreateMediaBuyRequest {
    * Purchase order number for tracking
    */
   po_number?: string;
+  /**
+   * Agency estimate or authorization number. Primary financial reference for broadcast buys — links the order to the agency's media plan and billing system. Travels with the order and Ad-IDs through the transaction lifecycle.
+   */
+  agency_estimate_number?: string;
   start_time: StartTiming;
   /**
    * Campaign end date/time in ISO 8601 format
@@ -3951,6 +3959,10 @@ export interface CreativeAsset {
    * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
    */
   placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
 }
 /**
@@ -4553,6 +4565,16 @@ export interface ReferenceAsset {
   description?: string;
 }
 /**
+ * An industry-standard identifier for an advertising creative (e.g., Ad-ID, ISCI, Clearcast clock number). These identifiers are managed by external registries and used across the supply chain to track and reference specific creative assets.
+ */
+export interface IndustryIdentifier {
+  type: CreativeIdentifierType;
+  /**
+   * The identifier value (e.g., 'ABCD1234000H' for Ad-ID)
+   */
+  value: string;
+}
+/**
  * Override the account's default billing entity for this specific buy. When provided, the seller invoices this entity instead. The seller MUST validate the invoice recipient is authorized for this account. When governance_agents are configured, the seller MUST include invoice_recipient in the check_governance request.
  */
 export interface BusinessEntity {
@@ -5010,6 +5032,10 @@ export interface Package {
      */
     acknowledged_at?: string;
   };
+  /**
+   * Agency estimate or authorization number for this package. Echoed from the buyer's request. When present on the package, takes precedence over the media buy-level estimate number.
+   */
+  agency_estimate_number?: string;
   /**
    * ISO 8601 timestamp for creative upload or change deadline for this package. After this deadline, creative changes are rejected. When absent, the media buy's creative_deadline applies.
    */
@@ -5750,9 +5776,9 @@ export type AudienceSource = 'synced' | 'platform' | 'third_party' | 'lookalike'
  */
 export interface GetMediaBuyDeliveryResponse {
   /**
-   * Type of webhook notification (only present in webhook deliveries): scheduled = regular periodic update, final = campaign completed, delayed = data not yet available, adjusted = resending period with updated data
+   * Type of webhook notification (only present in webhook deliveries): scheduled = regular periodic update, final = campaign completed, delayed = data not yet available, adjusted = resending period with corrected data (same window), window_update = resending period with a wider measurement window (e.g., C3 superseding live, C7 superseding C3)
    */
-  notification_type?: 'scheduled' | 'final' | 'delayed' | 'adjusted';
+  notification_type?: 'scheduled' | 'final' | 'delayed' | 'adjusted' | 'window_update';
   /**
    * Indicates if any media buys in this webhook have missing/delayed data (only present in webhook deliveries)
    */
@@ -5918,6 +5944,18 @@ export interface GetMediaBuyDeliveryResponse {
        * Whether this package is currently paused by the buyer
        */
       paused?: boolean;
+      /**
+       * Whether this delivery data is final for the reporting period. When false, the data may be updated as measurement matures (e.g., broadcast C7 window accumulating DVR playback) or as processing completes (e.g., IVT filtering, deduplication). When true, the seller considers this data closed — no further updates for this period. Absent means the seller does not distinguish provisional from final data.
+       */
+      is_final?: boolean;
+      /**
+       * Which measurement window this data represents, referencing a window_id from the product's reporting_capabilities.measurement_windows. For broadcast: 'live', 'c3', 'c7'. When absent, the data is not windowed (standard digital reporting). When present with is_final: false, a later report for the same period will provide a wider window or more complete data.
+       */
+      measurement_window?: string;
+      /**
+       * Which measurement window this data replaces. Present on window_update notifications to indicate progression (e.g., 'live' when reporting C3 data that supersedes live-only numbers). Absent on the first report for a period. Buyers should replace stored data for the superseded window with this report's data.
+       */
+      supersedes_window?: string;
       /**
        * Delivery by catalog item within this package. Available for catalog-driven packages when the seller supports item-level reporting.
        */
@@ -7342,6 +7380,10 @@ export interface CreativeManifest {
    * Rights constraints attached to this creative. Each entry represents constraints from a single rights holder. A creative may combine multiple rights constraints (e.g., talent likeness + music license). For v1, rights constraints are informational metadata — the buyer/orchestrator manages creative lifecycle against these terms.
    */
   rights?: RightsConstraint[];
+  /**
+   * Industry-standard identifiers for this specific manifest (e.g., Ad-ID, ISCI, Clearcast clock number). When present, overrides creative-level identifiers. Use when different format versions of the same source creative have distinct Ad-IDs (e.g., the :15 and :30 cuts).
+   */
+  industry_identifiers?: IndustryIdentifier[];
   provenance?: Provenance;
   ext?: ExtensionObject;
 }

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -89,7 +89,6 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
     brand_manifest: inputManifest,
     adcp_major_version,
     idempotency_key,
-    ext,
     ...rest
   } = request;
 
@@ -127,7 +126,7 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
  * Strips v3-only top-level fields and adapts packages.
  */
 export function adaptUpdateMediaBuyRequestForV2(request: any): any {
-  const { reporting_webhook, adcp_major_version, idempotency_key, ext, ...rest } = request;
+  const { reporting_webhook, adcp_major_version, idempotency_key, ...rest } = request;
 
   return {
     ...rest,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '4.29.0';
+export const LIBRARY_VERSION = '4.30.1';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '4.29.0',
+  library: '4.30.1',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-14T06:31:24.084Z',
+  generatedAt: '2026-04-14T15:19:01.481Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary
- **Fixes regression from PR #516** which incorrectly stripped `ext` from v2 server requests
- `ext` is a protocol-level extension field valid in **all** AdCP versions (v2 and v3)
- Removed `ext` from destructuring in `adaptCreateMediaBuyRequestForV2` and `adaptUpdateMediaBuyRequestForV2` so it passes through in `...rest`
- Added `ext` to the `envelopeFields` allowlist in `SingleAgentClient.ts` so schema-based stripping always preserves it

## Test plan
- [x] Build passes
- [x] Lint passes (0 errors)
- [x] All existing tests pass
- [ ] Verify `create_media_buy` with `ext` field against a v2 server
- [ ] Verify `update_media_buy` with `ext` field against a v2 server