### PR TITLE
fix: coerce null array fields in media buy package responses

### DIFF
--- a/.changeset/fix-null-map-crash.md
+++ b/.changeset/fix-null-map-crash.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix crash when servers return explicit null for optional array fields (creative_assignments, creative_ids, products) on media buy packages

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -136,17 +136,31 @@ export function adaptUpdateMediaBuyRequestForV2(request: any): any {
 
 /**
  * Normalize a v2-style package response to v3.
- * Converts creative_ids to creative_assignments.
+ * Converts creative_ids to creative_assignments and coerces null array fields
+ * to undefined so downstream consumers can safely use optional chaining.
  */
 export function normalizePackageResponse(pkg: PackageResponseV2 | PackageResponseV3): PackageResponseV3 {
+  // Coerce null array fields to undefined — some servers (e.g. Magnite) return
+  // explicit nulls for optional array fields like creative_assignments,
+  // creative_ids, and products. Leaving them as null causes downstream .map()
+  // crashes since callers expect undefined (absent) or a real array.
+  const nullArrayFields = ['creative_assignments', 'creative_ids', 'products'] as const;
+  let cleaned: any = pkg;
+  for (const field of nullArrayFields) {
+    if (field in cleaned && cleaned[field] === null) {
+      const { [field]: _removed, ...rest } = cleaned;
+      cleaned = rest;
+    }
+  }
+
   // Already v3 format
-  if (pkg.creative_assignments) {
-    return pkg as PackageResponseV3;
+  if (cleaned.creative_assignments) {
+    return cleaned as PackageResponseV3;
   }
 
   // v2 format - convert creative_ids to creative_assignments
-  if ((pkg as PackageResponseV2).creative_ids) {
-    const { creative_ids, ...rest } = pkg as PackageResponseV2;
+  if ((cleaned as PackageResponseV2).creative_ids) {
+    const { creative_ids, ...rest } = cleaned as PackageResponseV2;
     return {
       ...rest,
       creative_assignments: creative_ids!.map(id => ({ creative_id: id })),
@@ -154,7 +168,7 @@ export function normalizePackageResponse(pkg: PackageResponseV2 | PackageRespons
   }
 
   // No creatives
-  return pkg as PackageResponseV3;
+  return cleaned as PackageResponseV3;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Magnite returns explicit `null` for optional array fields (`creative_assignments`, `creative_ids`, `products`) on media buy packages instead of omitting them
- `normalizePackageResponse` now strips null array fields before processing, so downstream `.map()` calls receive `undefined` (absent) instead of `null`
- Prevents `TypeError: Cannot read properties of null (reading 'map')` crash after successful media buy creation

## Test plan
- [ ] Verify `normalizePackageResponse` strips `creative_assignments: null` → field absent
- [ ] Verify `normalizePackageResponse` strips `creative_ids: null` → field absent
- [ ] Verify `normalizePackageResponse` strips `products: null` → field absent
- [ ] Verify non-null array fields are preserved unchanged
- [ ] Verify v2→v3 creative_ids conversion still works for real arrays