### PR TITLE
fix: reconcile v2 brand adapter with schema filter for misdetected v3 servers

### DIFF
--- a/.changeset/fix-v2-brand-adapter.md
+++ b/.changeset/fix-v2-brand-adapter.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix brand field being silently stripped when a v3 server is misdetected as v2. The v2 adapter renames brand → brand_manifest, but the schema filter then drops brand_manifest when the tool schema declares brand. Added adapter alias reconciliation so brand_manifest maps back to brand when the schema expects it. Improved version detection logging to surface why get_adcp_capabilities failures cause v2 fallback.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ your context: `src/lib/types/*.generated.ts`, `src/lib/agents/index.generated.ts
 **Building a brand rights agent?** Read and follow `skills/build-brand-rights-agent/SKILL.md` — covers brand identity, rights licensing, creative approval.
 
 **Critical rules**:
+- ALWAYS create a changeset (`npm run changeset`) for ANY library/CLI code change before pushing a PR. This is mandatory — do not wait to be asked.
 - ALWAYS use official `@a2a-js/sdk` and `@modelcontextprotocol/sdk` clients — never custom HTTP or SSE parsing
 - NEVER inject mock/fallback data — return exactly what agents provide
 - NEVER hardcode API keys, tokens, or credentials — use environment variables

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1060,6 +1060,23 @@ export class SingleAgentClient {
     if (!toolSchema) return adapted;
 
     const declaredFields = new Set(Object.keys(toolSchema));
+
+    // The v2 adapter may rename fields (e.g. brand → brand_manifest) that a
+    // v3 server — misdetected as v2 — doesn't declare.  Reconcile known
+    // adapter mappings so the value isn't silently dropped.
+    const adapterAliases: [string, string][] = [['brand_manifest', 'brand']];
+    for (const [adapterField, schemaField] of adapterAliases) {
+      if (
+        adapted[adapterField] !== undefined &&
+        !declaredFields.has(adapterField) &&
+        declaredFields.has(schemaField) &&
+        adapted[schemaField] === undefined
+      ) {
+        adapted[schemaField] = adapted[adapterField];
+        delete adapted[adapterField];
+      }
+    }
+
     // Protocol envelope fields are always preserved — they live at the
     // protocol layer, not in individual tool schemas.
     const envelopeFields = new Set(['governance_context', 'push_notification_config', 'context_id', 'ext']);
@@ -2484,12 +2501,20 @@ export class SingleAgentClient {
           this.cachedCapabilities = augmentCapabilitiesFromTools(parseCapabilitiesResponse(result.data), tools);
           return this.cachedCapabilities;
         }
-        // Log when executeTask returns but success is false
-        console.warn(`[AdCP] get_adcp_capabilities returned non-success, falling back to synthetic capabilities`, {
-          success: result.success,
-          error: result.error,
-          hasData: !!result.data,
-        });
+        // Log when executeTask returns but success is false — this causes
+        // the server to be treated as v2 even though it advertises
+        // get_adcp_capabilities, which will trigger v2 field adapters.
+        console.warn(
+          `[AdCP] Agent "${this.agent.id}" advertises get_adcp_capabilities but the call ` +
+            `returned non-success — falling back to v2 synthetic capabilities. ` +
+            `This may cause v2 field adapters to run against a v3 server.`,
+          {
+            success: result.success,
+            error: result.error,
+            hasData: !!result.data,
+            data: result.data,
+          }
+        );
       } catch (error: unknown) {
         // Re-throw errors that indicate real infrastructure problems —
         // only fall through for tool-execution failures (the agent
@@ -2498,14 +2523,20 @@ export class SingleAgentClient {
           throw error;
         }
         console.warn(
-          `[AdCP] get_adcp_capabilities call failed, falling back to synthetic capabilities: ${
-            error instanceof Error ? error.message : String(error)
-          }`
+          `[AdCP] Agent "${this.agent.id}" advertises get_adcp_capabilities but the call ` +
+            `threw — falling back to v2 synthetic capabilities. ` +
+            `This may cause v2 field adapters to run against a v3 server. ` +
+            `Error: ${error instanceof Error ? error.message : String(error)}`
         );
       }
     }
 
     // Build synthetic capabilities from tool list (v2)
+    console.warn(
+      `[AdCP] Agent "${this.agent.id}" detected as v2` +
+        (hasCapabilitiesTool ? ' (has get_adcp_capabilities tool but call failed)' : '') +
+        `. Tools: [${tools.map(t => t.name).join(', ')}]`
+    );
     this.cachedCapabilities = buildSyntheticCapabilities(tools);
     return this.cachedCapabilities;
   }

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-14T15:58:16.683Z
+// Generated at: 2026-04-14T15:29:06.571Z
 
 // MEDIA-BUY SCHEMA
 /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-14T15:58:18.136Z
+// Generated at: 2026-04-14T15:29:08.528Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)


### PR DESCRIPTION
## Summary

- When a v3 server (e.g. Content Ignite) is misdetected as v2 because its `get_adcp_capabilities` call fails, the v2 adapter renames `brand` → `brand_manifest`. The schema filter then strips `brand_manifest` because the v3 tool schema declares `brand` — resulting in empty args and a `VALIDATION_ERROR`.
- Added adapter alias reconciliation in the schema filter: if `brand_manifest` is present but undeclared, and `brand` IS declared, maps the value back to `brand`.
- Improved logging when `get_adcp_capabilities` fails to surface why a server falls back to v2 detection, including agent ID, error details, and tool list.

## Test plan

- [ ] Verify existing tests pass (181/181 passing)
- [ ] Test against Content Ignite to confirm `brand` is no longer stripped
- [ ] Check warn logs to identify root cause of `get_adcp_capabilities` failure for Content Ignite