### PR TITLE
feat: add filterInvalidArrayItems validation option

### DIFF
--- a/.changeset/filter-invalid-array-items.md
+++ b/.changeset/filter-invalid-array-items.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": minor
+---
+
+Add `validation.filterInvalidArrayItems` client option to return valid items from array responses instead of rejecting the entire response when some items fail schema validation

--- a/.changeset/filter-invalid-array-items.md
+++ b/.changeset/filter-invalid-array-items.md
@@ -2,4 +2,4 @@
 "@adcp/client": minor
 ---
 
-Add `validation.filterInvalidArrayItems` client option to return valid items from array responses instead of rejecting the entire response when some items fail schema validation
+Add `validation.filterInvalidProducts` client option to filter out invalid products from get_products responses instead of rejecting the entire response when some products fail schema validation

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -515,6 +515,68 @@ Each tool is called as `agent.<methodName>(params)` and returns `TaskResult<Resp
 }
 ```
 
+**`create_collection_list`** — Request parameters for creating a new collection list.
+
+```
+{
+  name: string  // required
+  description: string
+  base_collections: object[]
+  filters: Collection List Filters
+  brand: Brand Ref
+  idempotency_key: string
+  context: Context
+}
+```
+
+**`update_collection_list`** — Request parameters for updating an existing collection list.
+
+```
+{
+  list_id: string  // required
+  name: string
+  description: string
+  base_collections: object[]
+  filters: Collection List Filters
+  brand: Brand Ref
+  webhook_url: string
+  context: Context
+  idempotency_key: string
+}
+```
+
+**`get_collection_list`** — Request parameters for retrieving a collection list with resolved collections.
+
+```
+{
+  list_id: string  // required
+  resolve: boolean
+  pagination: object
+  context: Context
+}
+```
+
+**`list_collection_lists`** — Request parameters for listing collection lists.
+
+```
+{
+  principal: string
+  name_contains: string
+  pagination: Pagination Request
+  context: Context
+}
+```
+
+**`delete_collection_list`** — Request parameters for deleting a collection list.
+
+```
+{
+  list_id: string  // required
+  context: Context
+  idempotency_key: string
+}
+```
+
 **`list_content_standards`** — Request parameters for listing content standards configurations.
 
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -281,6 +281,40 @@ Request parameters for deleting a property list.
 Required: `list_id: string`
 Optional: `context: Context`, `idempotency_key: string`
 
+#### `create_collection_list`
+
+Request parameters for creating a new collection list.
+
+Required: `name: string`
+Optional: `description: string`, `base_collections: object[]`, `filters: Collection List Filters`, `brand: Brand Ref`, `idempotency_key: string`, `context: Context`
+
+#### `update_collection_list`
+
+Request parameters for updating an existing collection list.
+
+Required: `list_id: string`
+Optional: `name: string`, `description: string`, `base_collections: object[]`, `filters: Collection List Filters`, `brand: Brand Ref`, `webhook_url: string`, `context: Context`, `idempotency_key: string`
+
+#### `get_collection_list`
+
+Request parameters for retrieving a collection list with resolved collections.
+
+Required: `list_id: string`
+Optional: `resolve: boolean`, `pagination: object`, `context: Context`
+
+#### `list_collection_lists`
+
+Request parameters for listing collection lists.
+
+Optional: `principal: string`, `name_contains: string`, `pagination: Pagination Request`, `context: Context`
+
+#### `delete_collection_list`
+
+Request parameters for deleting a collection list.
+
+Required: `list_id: string`
+Optional: `context: Context`, `idempotency_key: string`
+
 #### `list_content_standards`
 
 Request parameters for listing content standards configurations.

--- a/src/lib/agents/index.generated.ts
+++ b/src/lib/agents/index.generated.ts
@@ -52,6 +52,16 @@ import type {
   ListPropertyListsResponse,
   DeletePropertyListRequest,
   DeletePropertyListResponse,
+  CreateCollectionListRequest,
+  CreateCollectionListResponse,
+  UpdateCollectionListRequest,
+  UpdateCollectionListResponse,
+  GetCollectionListRequest,
+  GetCollectionListResponse,
+  ListCollectionListsRequest,
+  ListCollectionListsResponse,
+  DeleteCollectionListRequest,
+  DeleteCollectionListResponse,
   ListContentStandardsRequest,
   ListContentStandardsResponse,
   GetContentStandardsRequest,
@@ -298,6 +308,41 @@ export class Agent {
    */
   async deletePropertyList(params: DeletePropertyListRequest): Promise<DeletePropertyListResponse> {
     return this.callTool<DeletePropertyListResponse>('delete_property_list', params);
+  }
+
+  /**
+   * Official AdCP create_collection_list tool schema
+   */
+  async createCollectionList(params: CreateCollectionListRequest): Promise<CreateCollectionListResponse> {
+    return this.callTool<CreateCollectionListResponse>('create_collection_list', params);
+  }
+
+  /**
+   * Official AdCP update_collection_list tool schema
+   */
+  async updateCollectionList(params: UpdateCollectionListRequest): Promise<UpdateCollectionListResponse> {
+    return this.callTool<UpdateCollectionListResponse>('update_collection_list', params);
+  }
+
+  /**
+   * Official AdCP get_collection_list tool schema
+   */
+  async getCollectionList(params: GetCollectionListRequest): Promise<GetCollectionListResponse> {
+    return this.callTool<GetCollectionListResponse>('get_collection_list', params);
+  }
+
+  /**
+   * Official AdCP list_collection_lists tool schema
+   */
+  async listCollectionLists(params: ListCollectionListsRequest): Promise<ListCollectionListsResponse> {
+    return this.callTool<ListCollectionListsResponse>('list_collection_lists', params);
+  }
+
+  /**
+   * Official AdCP delete_collection_list tool schema
+   */
+  async deleteCollectionList(params: DeleteCollectionListRequest): Promise<DeleteCollectionListResponse> {
+    return this.callTool<DeleteCollectionListResponse>('delete_collection_list', params);
   }
 
   /**
@@ -602,6 +647,41 @@ export class AgentCollection {
    */
   async listPropertyLists(params: ListPropertyListsRequest): Promise<ListPropertyListsResponse[]> {
     return this.callToolOnAll<ListPropertyListsResponse>('list_property_lists', params);
+  }
+
+  /**
+   * Official AdCP create_collection_list tool schema (across multiple agents)
+   */
+  async createCollectionList(params: CreateCollectionListRequest): Promise<CreateCollectionListResponse[]> {
+    return this.callToolOnAll<CreateCollectionListResponse>('create_collection_list', params);
+  }
+
+  /**
+   * Official AdCP update_collection_list tool schema (across multiple agents)
+   */
+  async updateCollectionList(params: UpdateCollectionListRequest): Promise<UpdateCollectionListResponse[]> {
+    return this.callToolOnAll<UpdateCollectionListResponse>('update_collection_list', params);
+  }
+
+  /**
+   * Official AdCP get_collection_list tool schema (across multiple agents)
+   */
+  async getCollectionList(params: GetCollectionListRequest): Promise<GetCollectionListResponse[]> {
+    return this.callToolOnAll<GetCollectionListResponse>('get_collection_list', params);
+  }
+
+  /**
+   * Official AdCP list_collection_lists tool schema (across multiple agents)
+   */
+  async listCollectionLists(params: ListCollectionListsRequest): Promise<ListCollectionListsResponse[]> {
+    return this.callToolOnAll<ListCollectionListsResponse>('list_collection_lists', params);
+  }
+
+  /**
+   * Official AdCP delete_collection_list tool schema (across multiple agents)
+   */
+  async deleteCollectionList(params: DeleteCollectionListRequest): Promise<DeleteCollectionListResponse[]> {
+    return this.callToolOnAll<DeleteCollectionListResponse>('delete_collection_list', params);
   }
 
   /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -224,6 +224,17 @@ export interface SingleAgentClientConfig extends ConversationConfig {
      * @default true
      */
     logSchemaViolations?: boolean;
+    /**
+     * Filter out invalid items from array fields instead of rejecting the entire response (default: false)
+     *
+     * When true: If a response contains array fields (e.g. products), each item is validated
+     * individually. Valid items are kept, invalid items are dropped, and the response is
+     * returned as long as at least one valid item remains.
+     * When false: The entire response is rejected if any array item fails validation.
+     *
+     * @default false
+     */
+    filterInvalidArrayItems?: boolean;
   };
   /** Governance configuration for buyer-side campaign governance */
   governance?: import('./GovernanceTypes').GovernanceConfig;
@@ -277,6 +288,7 @@ export class SingleAgentClient {
       webhookSecret: config.webhookSecret,
       strictSchemaValidation: config.validation?.strictSchemaValidation !== false, // Default: true
       logSchemaViolations: config.validation?.logSchemaViolations !== false, // Default: true
+      filterInvalidArrayItems: config.validation?.filterInvalidArrayItems === true, // Default: false
       onActivity: config.onActivity,
       governance: config.governance,
     });

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -225,16 +225,18 @@ export interface SingleAgentClientConfig extends ConversationConfig {
      */
     logSchemaViolations?: boolean;
     /**
-     * Filter out invalid items from array fields instead of rejecting the entire response (default: false)
+     * Filter out invalid products from get_products responses instead of rejecting the entire response (default: false)
      *
-     * When true: If a response contains array fields (e.g. products), each item is validated
-     * individually. Valid items are kept, invalid items are dropped, and the response is
-     * returned as long as at least one valid item remains.
-     * When false: The entire response is rejected if any array item fails validation.
+     * When true: Each product in a get_products response is validated individually.
+     * Valid products are kept, invalid products are dropped, and the response is
+     * returned as long as it passes full schema validation after filtering.
+     * When false: The entire response is rejected if any product fails validation.
+     *
+     * Only applies to get_products — all other tool responses use standard validation.
      *
      * @default false
      */
-    filterInvalidArrayItems?: boolean;
+    filterInvalidProducts?: boolean;
   };
   /** Governance configuration for buyer-side campaign governance */
   governance?: import('./GovernanceTypes').GovernanceConfig;
@@ -288,7 +290,7 @@ export class SingleAgentClient {
       webhookSecret: config.webhookSecret,
       strictSchemaValidation: config.validation?.strictSchemaValidation !== false, // Default: true
       logSchemaViolations: config.validation?.logSchemaViolations !== false, // Default: true
-      filterInvalidArrayItems: config.validation?.filterInvalidArrayItems === true, // Default: false
+      filterInvalidProducts: config.validation?.filterInvalidProducts === true, // Default: false
       onActivity: config.onActivity,
       governance: config.governance,
     });

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -116,6 +116,8 @@ export class TaskExecutor {
       strictSchemaValidation?: boolean;
       /** Log all schema validation violations to debug logs (default: true) */
       logSchemaViolations?: boolean;
+      /** Filter out invalid items from array fields instead of rejecting the entire response (default: false) */
+      filterInvalidArrayItems?: boolean;
       /** Global activity callback for observability */
       onActivity?: (activity: Activity) => void | Promise<void>;
       /** Governance configuration for buyer-side campaign governance */
@@ -603,7 +605,9 @@ export class TaskExecutor {
       }
 
       // Now unwrap the response
-      const unwrapped = unwrapProtocolResponse(response, toolName);
+      const unwrapped = unwrapProtocolResponse(response, toolName, undefined, {
+        filterInvalidArrayItems: this.config.filterInvalidArrayItems,
+      });
 
       // Log successful extraction with result details
       if (response?.structuredContent) {

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -116,8 +116,8 @@ export class TaskExecutor {
       strictSchemaValidation?: boolean;
       /** Log all schema validation violations to debug logs (default: true) */
       logSchemaViolations?: boolean;
-      /** Filter out invalid items from array fields instead of rejecting the entire response (default: false) */
-      filterInvalidArrayItems?: boolean;
+      /** Filter out invalid products from get_products responses instead of rejecting the entire response (default: false) */
+      filterInvalidProducts?: boolean;
       /** Global activity callback for observability */
       onActivity?: (activity: Activity) => void | Promise<void>;
       /** Governance configuration for buyer-side campaign governance */
@@ -606,7 +606,7 @@ export class TaskExecutor {
 
       // Now unwrap the response
       const unwrapped = unwrapProtocolResponse(response, toolName, undefined, {
-        filterInvalidArrayItems: this.config.filterInvalidArrayItems,
+        filterInvalidProducts: this.config.filterInvalidProducts,
       });
 
       // Log successful extraction with result details

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-14T15:29:06.571Z
+// Generated at: 2026-04-14T21:54:58.555Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -881,6 +881,8 @@ export interface TargetingOverlay {
   audience_exclude?: string[];
   frequency_cap?: FrequencyCap;
   property_list?: PropertyListReference;
+  collection_list?: CollectionListReference;
+  collection_list_exclude?: CollectionListReference;
   /**
    * Age restriction for compliance. Use for legal requirements (alcohol, gambling), not audience targeting.
    */
@@ -1012,6 +1014,23 @@ export interface PropertyListReference {
   agent_url: string;
   /**
    * Identifier for the property list within the agent
+   */
+  list_id: string;
+  /**
+   * JWT or other authorization token for accessing the list. Optional if the list is public or caller has implicit access.
+   */
+  auth_token?: string;
+}
+/**
+ * Reference to a collection list for including specific collections (programs, shows) within this product. The package runs on the intersection of matched collections and this list. Use for inclusion-based collection targeting. Seller must declare support in get_adcp_capabilities.
+ */
+export interface CollectionListReference {
+  /**
+   * URL of the agent managing the collection list
+   */
+  agent_url: string;
+  /**
+   * Identifier for the collection list within the agent
    */
   list_id: string;
   /**
@@ -2319,7 +2338,18 @@ export type InstallmentStatus = 'scheduled' | 'tentative' | 'live' | 'postponed'
 /**
  * Rating system used
  */
-export type ContentRatingSystem = 'tv_parental' | 'mpaa' | 'podcast' | 'esrb' | 'bbfc' | 'fsk' | 'acb' | 'custom';
+export type ContentRatingSystem =
+  | 'tv_parental'
+  | 'mpaa'
+  | 'podcast'
+  | 'esrb'
+  | 'bbfc'
+  | 'fsk'
+  | 'acb'
+  | 'chvrs'
+  | 'csa'
+  | 'pegi'
+  | 'custom';
 /**
  * Category of the event
  */
@@ -2417,7 +2447,7 @@ export interface Product {
    */
   performance_standards?: PerformanceStandard[];
   cancellation_policy?: CancellationPolicy;
-  reporting_capabilities?: ReportingCapabilities;
+  reporting_capabilities: ReportingCapabilities;
   creative_policy?: CreativePolicy;
   /**
    * Whether this is a custom product

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-14T15:29:08.528Z
+// Generated at: 2026-04-14T21:55:00.553Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -198,6 +198,12 @@ export const FrequencyCapSchema = z.object({
 }).passthrough();
 
 export const PropertyListReferenceSchema = z.object({
+    agent_url: z.string(),
+    list_id: z.string(),
+    auth_token: z.string().nullish()
+}).passthrough();
+
+export const CollectionListReferenceSchema = z.object({
     agent_url: z.string(),
     list_id: z.string(),
     auth_token: z.string().nullish()
@@ -524,7 +530,7 @@ export const ActionSourceSchema = z.union([z.literal("website"), z.literal("app"
 
 export const InstallmentStatusSchema = z.union([z.literal("scheduled"), z.literal("tentative"), z.literal("live"), z.literal("postponed"), z.literal("cancelled"), z.literal("aired"), z.literal("published")]);
 
-export const ContentRatingSystemSchema = z.union([z.literal("tv_parental"), z.literal("mpaa"), z.literal("podcast"), z.literal("esrb"), z.literal("bbfc"), z.literal("fsk"), z.literal("acb"), z.literal("custom")]);
+export const ContentRatingSystemSchema = z.union([z.literal("tv_parental"), z.literal("mpaa"), z.literal("podcast"), z.literal("esrb"), z.literal("bbfc"), z.literal("fsk"), z.literal("acb"), z.literal("chvrs"), z.literal("csa"), z.literal("pegi"), z.literal("custom")]);
 
 export const SpecialCategorySchema = z.union([z.literal("awards"), z.literal("championship"), z.literal("concert"), z.literal("conference"), z.literal("election"), z.literal("festival"), z.literal("gala"), z.literal("holiday"), z.literal("premiere"), z.literal("product_launch"), z.literal("reunion"), z.literal("tribute")]);
 
@@ -1285,9 +1291,6 @@ export const PaginationRequestSchema = z.object({
 export const MediaBuyFeaturesSchema = z.record(z.string(), z.boolean()).and(z.object({
     inline_creative_management: z.boolean().nullish(),
     property_list_filtering: z.boolean().nullish(),
-    content_standards: z.boolean().nullish(),
-    conversion_tracking: z.boolean().nullish(),
-    audience_targeting: z.boolean().nullish(),
     catalog_management: z.boolean().nullish()
 }).passthrough());
 
@@ -1533,6 +1536,8 @@ export const TargetingOverlaySchema = z.object({
     audience_exclude: z.array(z.string()).nullish(),
     frequency_cap: FrequencyCapSchema.nullish(),
     property_list: PropertyListReferenceSchema.nullish(),
+    collection_list: CollectionListReferenceSchema.nullish(),
+    collection_list_exclude: CollectionListReferenceSchema.nullish(),
     age_restriction: z.object({
         min: z.number(),
         verification_required: z.boolean().nullish(),
@@ -2415,6 +2420,143 @@ export const DeletePropertyListResponseSchema = z.object({
     ext: ExtensionObjectSchema.nullish()
 }).passthrough();
 
+export const PublisherCollectionsSourceSchema = z.object({
+    selection_type: z.literal("publisher_collections"),
+    publisher_domain: z.string(),
+    collection_ids: z.array(z.string())
+}).passthrough();
+
+export const DistributionIdentifierTypeSchema = z.union([z.literal("apple_podcast_id"), z.literal("spotify_collection_id"), z.literal("rss_url"), z.literal("podcast_guid"), z.literal("amazon_music_id"), z.literal("iheart_id"), z.literal("podcast_index_id"), z.literal("youtube_channel_id"), z.literal("youtube_playlist_id"), z.literal("amazon_title_id"), z.literal("roku_channel_id"), z.literal("pluto_channel_id"), z.literal("tubi_id"), z.literal("peacock_id"), z.literal("tiktok_id"), z.literal("twitch_channel"), z.literal("imdb_id"), z.literal("gracenote_id"), z.literal("eidr_id"), z.literal("domain"), z.literal("substack_id")]);
+
+export const GenreTaxonomySchema = z.union([z.literal("iab_content_3.0"), z.literal("iab_content_2.2"), z.literal("gracenote"), z.literal("eidr"), z.literal("apple_genres"), z.literal("google_genres"), z.literal("roku"), z.literal("amazon_genres"), z.literal("custom")]);
+
+export const ProductionQualitySchema = z.union([z.literal("professional"), z.literal("prosumer"), z.literal("ugc")]);
+
+export const CollectionListFiltersSchema = z.object({
+    content_ratings_exclude: z.array(ContentRatingSchema).nullish(),
+    content_ratings_include: z.array(ContentRatingSchema).nullish(),
+    genres_exclude: z.array(z.string()).nullish(),
+    genres_include: z.array(z.string()).nullish(),
+    genre_taxonomy: GenreTaxonomySchema.nullish(),
+    kinds: z.array(z.union([z.literal("series"), z.literal("publication"), z.literal("event_series"), z.literal("rotation")])).nullish(),
+    exclude_distribution_ids: z.array(z.object({
+        type: DistributionIdentifierTypeSchema,
+        value: z.string()
+    }).passthrough()).nullish(),
+    production_quality: z.array(ProductionQualitySchema).nullish()
+}).passthrough();
+
+export const DistributionIDsSourceSchema = z.object({
+    selection_type: z.literal("distribution_ids"),
+    identifiers: z.array(z.object({
+        type: DistributionIdentifierTypeSchema,
+        value: z.string()
+    }).passthrough())
+}).passthrough();
+
+export const PublisherGenresSourceSchema = z.object({
+    selection_type: z.literal("publisher_genres"),
+    publisher_domain: z.string(),
+    genres: z.array(z.string()),
+    genre_taxonomy: GenreTaxonomySchema
+}).passthrough();
+
+export const BaseCollectionSourceSchema = z.union([DistributionIDsSourceSchema, PublisherCollectionsSourceSchema, PublisherGenresSourceSchema]);
+
+export const UpdateCollectionListRequestSchema = z.object({
+    adcp_major_version: z.number().nullish(),
+    list_id: z.string(),
+    name: z.string().nullish(),
+    description: z.string().nullish(),
+    base_collections: z.array(BaseCollectionSourceSchema).nullish(),
+    filters: CollectionListFiltersSchema.nullish(),
+    brand: BrandReferenceSchema.nullish(),
+    webhook_url: z.string().nullish(),
+    context: ContextObjectSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish(),
+    idempotency_key: z.string().nullish()
+}).passthrough();
+
+export const CollectionListSchema = z.object({
+    list_id: z.string(),
+    name: z.string(),
+    description: z.string().nullish(),
+    principal: z.string().nullish(),
+    base_collections: z.array(BaseCollectionSourceSchema).nullish(),
+    filters: CollectionListFiltersSchema.nullish(),
+    brand: BrandReferenceSchema.nullish(),
+    webhook_url: z.string().nullish(),
+    cache_duration_hours: z.number().nullish(),
+    created_at: z.string().nullish(),
+    updated_at: z.string().nullish(),
+    collection_count: z.number().nullish()
+}).passthrough();
+
+export const GetCollectionListRequestSchema = z.object({
+    adcp_major_version: z.number().nullish(),
+    list_id: z.string(),
+    resolve: z.boolean().nullish(),
+    pagination: z.object({
+        max_results: z.number().nullish(),
+        cursor: z.string().nullish()
+    }).passthrough().nullish(),
+    context: ContextObjectSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const GetCollectionListResponseSchema = z.object({
+    list: CollectionListSchema,
+    collections: z.array(z.object({
+        collection_rid: z.string().nullish(),
+        name: z.string(),
+        distribution_ids: z.array(z.object({
+            type: DistributionIdentifierTypeSchema,
+            value: z.string()
+        }).passthrough()).nullish(),
+        content_rating: ContentRatingSchema.nullish(),
+        genre: z.array(z.string()).nullish(),
+        genre_taxonomy: GenreTaxonomySchema.nullish(),
+        kind: z.union([z.literal("series"), z.literal("publication"), z.literal("event_series"), z.literal("rotation")]).nullish()
+    }).passthrough()).nullish(),
+    pagination: PaginationResponseSchema.nullish(),
+    resolved_at: z.string().nullish(),
+    cache_valid_until: z.string().nullish(),
+    coverage_gaps: z.record(z.string(), z.array(z.object({
+            type: DistributionIdentifierTypeSchema,
+            value: z.string()
+        }).passthrough())).nullish(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const ListCollectionListsRequestSchema = z.object({
+    adcp_major_version: z.number().nullish(),
+    principal: z.string().nullish(),
+    name_contains: z.string().nullish(),
+    pagination: PaginationRequestSchema.nullish(),
+    context: ContextObjectSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const ListCollectionListsResponseSchema = z.object({
+    lists: z.array(CollectionListSchema),
+    pagination: PaginationResponseSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const DeleteCollectionListRequestSchema = z.object({
+    adcp_major_version: z.number().nullish(),
+    list_id: z.string(),
+    context: ContextObjectSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish(),
+    idempotency_key: z.string().nullish()
+}).passthrough();
+
+export const DeleteCollectionListResponseSchema = z.object({
+    deleted: z.boolean(),
+    list_id: z.string(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
 export const ListContentStandardsRequestSchema = z.object({
     adcp_major_version: z.number().nullish(),
     channels: z.array(MediaChannelSchema).nullish(),
@@ -3152,16 +3294,9 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
     }).passthrough().nullish(),
     media_buy: z.object({
         supported_pricing_models: z.array(PricingModelSchema).nullish(),
-        reporting: z.object({
-            supports_date_range: z.boolean().nullish(),
-            supports_daily_breakdown: z.boolean().nullish(),
-            supports_webhooks: z.boolean().nullish(),
-            available_dimensions: z.array(z.union([z.literal("geo"), z.literal("device_type"), z.literal("device_platform"), z.literal("audience"), z.literal("placement"), z.literal("creative"), z.literal("keyword"), z.literal("catalog_item")])).nullish()
-        }).passthrough().nullish(),
         features: MediaBuyFeaturesSchema.nullish(),
         execution: z.object({
             trusted_match: z.object({
-                supported: z.boolean().nullish(),
                 surfaces: z.array(z.union([z.literal("website"), z.literal("mobile_app"), z.literal("ctv_app"), z.literal("desktop_app"), z.literal("dooh"), z.literal("podcast"), z.literal("radio"), z.literal("streaming_audio"), z.literal("ai_assistant")])).nullish()
             }).passthrough().nullish(),
             axe_integrations: z.array(z.string()).nullish(),
@@ -3172,6 +3307,9 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
                 simid: z.boolean().nullish()
             }).passthrough().nullish(),
             targeting: z.object({
+                supported_geo_levels: z.array(z.union([z.literal("countries"), z.literal("regions"), z.literal("metros"), z.literal("postal_areas")])).nullish(),
+                supported_metro_systems: z.array(z.union([z.literal("nielsen_dma"), z.literal("uk_itl1"), z.literal("uk_itl2"), z.literal("eurostat_nuts2")])).nullish(),
+                supported_postal_systems: z.array(z.union([z.literal("us_zip"), z.literal("us_zip_plus_four"), z.literal("gb_outward"), z.literal("gb_full"), z.literal("ca_fsa"), z.literal("ca_full"), z.literal("de_plz"), z.literal("fr_code_postal"), z.literal("au_postcode"), z.literal("ch_plz"), z.literal("at_plz")])).nullish(),
                 geo_countries: z.boolean().nullish(),
                 geo_regions: z.boolean().nullish(),
                 geo_metros: z.object({
@@ -3197,11 +3335,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
                     supported: z.boolean().nullish(),
                     verification_methods: z.array(AgeVerificationMethodSchema).nullish()
                 }).passthrough().nullish(),
-                device_platform: z.boolean().nullish(),
-                device_type: z.boolean().nullish(),
                 language: z.boolean().nullish(),
-                audience_include: z.boolean().nullish(),
-                audience_exclude: z.boolean().nullish(),
                 keyword_targets: z.object({
                     supported_match_types: z.array(z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]))
                 }).passthrough().nullish(),
@@ -3238,7 +3372,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
                 post_view: z.array(DurationSchema).nullish()
             }).passthrough()).nullish()
         }).passthrough().nullish(),
-        content_standards_detail: z.object({
+        content_standards: z.object({
             supports_local_evaluation: z.boolean().nullish(),
             supported_channels: z.array(MediaChannelSchema).nullish(),
             supports_webhook_delivery: z.boolean().nullish()
@@ -3293,7 +3427,6 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
         brand_url: z.string().nullish()
     }).passthrough().nullish(),
     brand: z.object({
-        identity: z.boolean().nullish(),
         rights: z.boolean().nullish(),
         right_types: z.array(RightTypeSchema).nullish(),
         available_uses: z.array(RightUseSchema).nullish(),
@@ -3691,7 +3824,7 @@ export const ProductSchema = z.object({
     measurement_terms: MeasurementTermsSchema.nullish(),
     performance_standards: z.array(PerformanceStandardSchema).nullish(),
     cancellation_policy: CancellationPolicySchema.nullish(),
-    reporting_capabilities: ReportingCapabilitiesSchema.nullish(),
+    reporting_capabilities: ReportingCapabilitiesSchema,
     creative_policy: CreativePolicySchema.nullish(),
     is_custom: z.boolean().nullish(),
     property_targeting_allowed: z.boolean().nullish(),
@@ -4334,6 +4467,29 @@ export const GetPropertyListResponseSchema = z.object({
 export const ListPropertyListsResponseSchema = z.object({
     lists: z.array(PropertyListSchema),
     pagination: PaginationResponseSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const CreateCollectionListRequestSchema = z.object({
+    adcp_major_version: z.number().nullish(),
+    name: z.string(),
+    description: z.string().nullish(),
+    base_collections: z.array(BaseCollectionSourceSchema).nullish(),
+    filters: CollectionListFiltersSchema.nullish(),
+    brand: BrandReferenceSchema.nullish(),
+    idempotency_key: z.string().nullish(),
+    context: ContextObjectSchema.nullish(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const CreateCollectionListResponseSchema = z.object({
+    list: CollectionListSchema,
+    auth_token: z.string(),
+    ext: ExtensionObjectSchema.nullish()
+}).passthrough();
+
+export const UpdateCollectionListResponseSchema = z.object({
+    list: CollectionListSchema,
     ext: ExtensionObjectSchema.nullish()
 }).passthrough();
 

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -657,18 +657,6 @@ export interface MediaBuyFeatures {
    */
   property_list_filtering?: boolean;
   /**
-   * Full support for content_standards configuration including sampling rates and category filtering
-   */
-  content_standards?: boolean;
-  /**
-   * Supports sync_event_sources and log_event tasks for conversion event tracking
-   */
-  conversion_tracking?: boolean;
-  /**
-   * Supports sync_audiences task and audience_include/audience_exclude in targeting overlays for first-party CRM audience management
-   */
-  audience_targeting?: boolean;
-  /**
    * Supports sync_catalogs task for catalog feed management with platform review and approval
    */
   catalog_management?: boolean;
@@ -954,7 +942,18 @@ export type InstallmentStatus = 'scheduled' | 'tentative' | 'live' | 'postponed'
 /**
  * Rating system used
  */
-export type ContentRatingSystem = 'tv_parental' | 'mpaa' | 'podcast' | 'esrb' | 'bbfc' | 'fsk' | 'acb' | 'custom';
+export type ContentRatingSystem =
+  | 'tv_parental'
+  | 'mpaa'
+  | 'podcast'
+  | 'esrb'
+  | 'bbfc'
+  | 'fsk'
+  | 'acb'
+  | 'chvrs'
+  | 'csa'
+  | 'pegi'
+  | 'custom';
 /**
  * Category of the event
  */
@@ -1126,7 +1125,7 @@ export interface Product {
    */
   performance_standards?: PerformanceStandard[];
   cancellation_policy?: CancellationPolicy;
-  reporting_capabilities?: ReportingCapabilities;
+  reporting_capabilities: ReportingCapabilities;
   creative_policy?: CreativePolicy;
   /**
    * Whether this is a custom product
@@ -3823,6 +3822,8 @@ export interface TargetingOverlay {
   audience_exclude?: string[];
   frequency_cap?: FrequencyCap;
   property_list?: PropertyListReference;
+  collection_list?: CollectionListReference;
+  collection_list_exclude?: CollectionListReference;
   /**
    * Age restriction for compliance. Use for legal requirements (alcohol, gambling), not audience targeting.
    */
@@ -3909,6 +3910,23 @@ export interface TargetingOverlay {
      */
     match_type: 'broad' | 'phrase' | 'exact';
   }[];
+}
+/**
+ * Reference to a collection list for including specific collections (programs, shows) within this product. The package runs on the intersection of matched collections and this list. Use for inclusion-based collection targeting. Seller must declare support in get_adcp_capabilities.
+ */
+export interface CollectionListReference {
+  /**
+   * URL of the agent managing the collection list
+   */
+  agent_url: string;
+  /**
+   * Identifier for the collection list within the agent
+   */
+  list_id: string;
+  /**
+   * JWT or other authorization token for accessing the list. Optional if the list is public or caller has implicit access.
+   */
+  auth_token?: string;
 }
 /**
  * Assignment of a creative asset to a package with optional placement targeting. Used in create_media_buy and update_media_buy requests. Note: sync_creatives does not support placement_ids - use create/update_media_buy for placement-level targeting.
@@ -9526,6 +9544,454 @@ export interface DeletePropertyListResponse {
   ext?: ExtensionObject;
 }
 
+// create_collection_list parameters
+/**
+ * A source of collections for a collection list. Supports three selection patterns: distribution identifiers (cross-publisher), publisher-specific collection IDs, or publisher-specific genres.
+ */
+export type BaseCollectionSource = DistributionIDsSource | PublisherCollectionsSource | PublisherGenresSource;
+/**
+ * Type of distribution identifier
+ */
+export type DistributionIdentifierType =
+  | 'apple_podcast_id'
+  | 'spotify_collection_id'
+  | 'rss_url'
+  | 'podcast_guid'
+  | 'amazon_music_id'
+  | 'iheart_id'
+  | 'podcast_index_id'
+  | 'youtube_channel_id'
+  | 'youtube_playlist_id'
+  | 'amazon_title_id'
+  | 'roku_channel_id'
+  | 'pluto_channel_id'
+  | 'tubi_id'
+  | 'peacock_id'
+  | 'tiktok_id'
+  | 'twitch_channel'
+  | 'imdb_id'
+  | 'gracenote_id'
+  | 'eidr_id'
+  | 'domain'
+  | 'substack_id';
+/**
+ * Taxonomy for the genre values. Required so sellers can interpret genre strings unambiguously. Use 'custom' for free-form values negotiated out of band.
+ */
+export type GenreTaxonomy =
+  | 'iab_content_3.0'
+  | 'iab_content_2.2'
+  | 'gracenote'
+  | 'eidr'
+  | 'apple_genres'
+  | 'google_genres'
+  | 'roku'
+  | 'amazon_genres'
+  | 'custom';
+/**
+ * Production quality tier for collection content. Maps to OpenRTB content.prodq: professional=1, prosumer=2, ugc=3. Seller-declared — no external validation.
+ */
+export type ProductionQuality = 'professional' | 'prosumer' | 'ugc';
+/**
+ * Request parameters for creating a new collection list
+ */
+export interface CreateCollectionListRequest {
+  /**
+   * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   */
+  adcp_major_version?: number;
+  /**
+   * Human-readable name for the list
+   */
+  name: string;
+  /**
+   * Description of the list's purpose
+   */
+  description?: string;
+  /**
+   * Array of collection sources to evaluate. Each entry is a discriminated union: distribution_ids (platform-independent identifiers), publisher_collections (publisher_domain + collection_ids), or publisher_genres (publisher_domain + genres). If omitted, queries the agent's entire collection database.
+   */
+  base_collections?: BaseCollectionSource[];
+  filters?: CollectionListFilters;
+  brand?: BrandReference;
+  /**
+   * Client-generated unique key for this request. Prevents duplicate collection list creation on retries. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   */
+  idempotency_key?: string;
+  context?: ContextObject;
+  ext?: ExtensionObject;
+}
+/**
+ * Select collections by platform-independent distribution identifiers. The primary mechanism for cross-publisher collection matching.
+ */
+export interface DistributionIDsSource {
+  /**
+   * Discriminator indicating selection by platform-independent distribution identifiers
+   */
+  selection_type: 'distribution_ids';
+  /**
+   * Platform-independent identifiers (imdb_id, gracenote_id, eidr_id, etc.). Each identifier uniquely identifies a collection across all publishers.
+   */
+  identifiers: {
+    type: DistributionIdentifierType;
+    /**
+     * The identifier value
+     */
+    value: string;
+  }[];
+}
+/**
+ * Select specific collections within a publisher's adagents.json by collection ID
+ */
+export interface PublisherCollectionsSource {
+  /**
+   * Discriminator indicating selection by specific collection IDs within a publisher
+   */
+  selection_type: 'publisher_collections';
+  /**
+   * Domain where publisher's adagents.json is hosted
+   */
+  publisher_domain: string;
+  /**
+   * Specific collection IDs from the publisher's adagents.json
+   */
+  collection_ids: string[];
+}
+/**
+ * Select all collections from a publisher matching genre criteria. Use when excluding entire content categories from a specific publisher.
+ */
+export interface PublisherGenresSource {
+  /**
+   * Discriminator indicating selection by genre within a publisher
+   */
+  selection_type: 'publisher_genres';
+  /**
+   * Domain where publisher's adagents.json is hosted
+   */
+  publisher_domain: string;
+  /**
+   * Genre values to match against the publisher's collections
+   */
+  genres: string[];
+  genre_taxonomy: GenreTaxonomy;
+}
+/**
+ * Dynamic filters to apply when resolving the list
+ */
+export interface CollectionListFilters {
+  /**
+   * Exclude collections with any of these content ratings (OR logic). This is a metadata filter on the collection's declared content_rating field — it does not evaluate episode content.
+   */
+  content_ratings_exclude?: ContentRating[];
+  /**
+   * Include only collections with any of these content ratings (OR logic). Collections without a declared content_rating are excluded.
+   */
+  content_ratings_include?: ContentRating[];
+  /**
+   * Exclude collections tagged with any of these genres (OR logic). Values are interpreted against genre_taxonomy when present.
+   */
+  genres_exclude?: string[];
+  /**
+   * Include only collections with any of these genres (OR logic). Collections without genre metadata are excluded. Values are interpreted against genre_taxonomy when present.
+   */
+  genres_include?: string[];
+  genre_taxonomy?: GenreTaxonomy;
+  /**
+   * Filter to these collection kinds
+   */
+  kinds?: ('series' | 'publication' | 'event_series' | 'rotation')[];
+  /**
+   * Always exclude collections with these distribution identifiers
+   */
+  exclude_distribution_ids?: {
+    type: DistributionIdentifierType;
+    /**
+     * The identifier value
+     */
+    value: string;
+  }[];
+  /**
+   * Filter by production quality tier
+   */
+  production_quality?: ProductionQuality[];
+}
+
+// create_collection_list response
+/**
+ * Response payload for create_collection_list task
+ */
+export interface CreateCollectionListResponse {
+  list: CollectionList;
+  /**
+   * Token that can be shared with sellers to authorize fetching this list. Store this - it is only returned at creation time.
+   */
+  auth_token: string;
+  ext?: ExtensionObject;
+}
+/**
+ * The created collection list
+ */
+export interface CollectionList {
+  /**
+   * Unique identifier for this collection list
+   */
+  list_id: string;
+  /**
+   * Human-readable name for the list
+   */
+  name: string;
+  /**
+   * Description of the list's purpose
+   */
+  description?: string;
+  /**
+   * Principal identity that owns this list
+   */
+  principal?: string;
+  /**
+   * Array of collection sources to evaluate. Each entry is a discriminated union: distribution_ids (platform-independent identifiers), publisher_collections (publisher_domain + collection_ids), or publisher_genres (publisher_domain + genres). If omitted, queries the agent's entire collection database.
+   */
+  base_collections?: BaseCollectionSource[];
+  filters?: CollectionListFilters;
+  brand?: BrandReference;
+  /**
+   * URL to receive notifications when the resolved list changes
+   */
+  webhook_url?: string;
+  /**
+   * Recommended cache duration for resolved list. Consumers should re-fetch after this period. Defaults to 168 (one week) because collection metadata changes less frequently than property metadata.
+   */
+  cache_duration_hours?: number;
+  /**
+   * When the list was created
+   */
+  created_at?: string;
+  /**
+   * When the list was last modified
+   */
+  updated_at?: string;
+  /**
+   * Number of collections in the resolved list (at time of last resolution)
+   */
+  collection_count?: number;
+}
+
+// update_collection_list parameters
+/**
+ * Request parameters for updating an existing collection list
+ */
+export interface UpdateCollectionListRequest {
+  /**
+   * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   */
+  adcp_major_version?: number;
+  /**
+   * ID of the collection list to update
+   */
+  list_id: string;
+  /**
+   * New name for the list
+   */
+  name?: string;
+  /**
+   * New description
+   */
+  description?: string;
+  /**
+   * Complete replacement for the base collections list (not a patch). Each entry is a discriminated union: distribution_ids (platform-independent identifiers), publisher_collections (publisher_domain + collection_ids), or publisher_genres (publisher_domain + genres).
+   */
+  base_collections?: BaseCollectionSource[];
+  filters?: CollectionListFilters;
+  brand?: BrandReference;
+  /**
+   * Update the webhook URL for list change notifications (set to empty string to remove)
+   */
+  webhook_url?: string;
+  context?: ContextObject;
+  ext?: ExtensionObject;
+  /**
+   * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   */
+  idempotency_key?: string;
+}
+
+// update_collection_list response
+/**
+ * Response payload for update_collection_list task
+ */
+export interface UpdateCollectionListResponse {
+  list: CollectionList;
+  ext?: ExtensionObject;
+}
+
+// get_collection_list parameters
+/**
+ * Request parameters for retrieving a collection list with resolved collections
+ */
+export interface GetCollectionListRequest {
+  /**
+   * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   */
+  adcp_major_version?: number;
+  /**
+   * ID of the collection list to retrieve
+   */
+  list_id: string;
+  /**
+   * Whether to apply filters and return resolved collections (default: true)
+   */
+  resolve?: boolean;
+  /**
+   * Pagination parameters. Uses higher limits than standard pagination because collection lists can contain thousands of entries.
+   */
+  pagination?: {
+    /**
+     * Maximum number of collections to return per page
+     */
+    max_results?: number;
+    /**
+     * Opaque cursor from a previous response to fetch the next page
+     */
+    cursor?: string;
+  };
+  context?: ContextObject;
+  ext?: ExtensionObject;
+}
+
+// get_collection_list response
+/**
+ * Response payload for get_collection_list task. Returns resolved collection entries with identification and key metadata for matching. Consumers should cache the resolved collections and refresh based on cache_valid_until.
+ */
+export interface GetCollectionListResponse {
+  list: CollectionList;
+  /**
+   * Resolved collections that passed filters (if resolve=true). Each entry contains identification and key metadata for seller matching.
+   */
+  collections?: {
+    /**
+     * Registry-assigned stable identifier for this collection. Present when the collection has been registered in the collection registry.
+     */
+    collection_rid?: string;
+    /**
+     * Human-readable collection name
+     */
+    name: string;
+    /**
+     * Platform-independent identifiers for cross-publisher matching
+     */
+    distribution_ids?: {
+      type: DistributionIdentifierType;
+      /**
+       * The identifier value
+       */
+      value: string;
+    }[];
+    content_rating?: ContentRating;
+    /**
+     * Genre tags for this collection
+     */
+    genre?: string[];
+    genre_taxonomy?: GenreTaxonomy;
+    /**
+     * What kind of content program this is
+     */
+    kind?: 'series' | 'publication' | 'event_series' | 'rotation';
+  }[];
+  pagination?: PaginationResponse;
+  /**
+   * When the list was resolved
+   */
+  resolved_at?: string;
+  /**
+   * Cache expiration timestamp. Re-fetch the list after this time to get updated collections.
+   */
+  cache_valid_until?: string;
+  /**
+   * Collections included in the list despite missing metadata for a filtered dimension. Maps dimension name (e.g., 'genre', 'content_rating') to arrays of distribution identifiers for collections not covered. Only present when filters are applied and some collections lack the filtered metadata.
+   */
+  coverage_gaps?: {
+    [k: string]:
+      | {
+          type: DistributionIdentifierType;
+          /**
+           * The identifier value
+           */
+          value: string;
+        }[]
+      | undefined;
+  };
+  ext?: ExtensionObject;
+}
+/**
+ * Request parameters for listing collection lists
+ */
+export interface ListCollectionListsRequest {
+  /**
+   * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   */
+  adcp_major_version?: number;
+  /**
+   * Filter to lists owned by this principal
+   */
+  principal?: string;
+  /**
+   * Filter to lists whose name contains this string
+   */
+  name_contains?: string;
+  pagination?: PaginationRequest;
+  context?: ContextObject;
+  ext?: ExtensionObject;
+}
+
+// list_collection_lists response
+/**
+ * Response payload for list_collection_lists task
+ */
+export interface ListCollectionListsResponse {
+  /**
+   * Array of collection lists (metadata only, not resolved collections)
+   */
+  lists: CollectionList[];
+  pagination?: PaginationResponse;
+  ext?: ExtensionObject;
+}
+
+// delete_collection_list parameters
+/**
+ * Request parameters for deleting a collection list
+ */
+export interface DeleteCollectionListRequest {
+  /**
+   * The AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
+   */
+  adcp_major_version?: number;
+  /**
+   * ID of the collection list to delete
+   */
+  list_id: string;
+  context?: ContextObject;
+  ext?: ExtensionObject;
+  /**
+   * Client-generated unique key for at-most-once execution. If a request with the same key has already been processed, the server returns the original response without re-processing. MUST be unique per (seller, request) pair to prevent cross-seller correlation. Use a fresh UUID v4 for each request.
+   */
+  idempotency_key?: string;
+}
+
+// delete_collection_list response
+/**
+ * Response payload for delete_collection_list task
+ */
+export interface DeleteCollectionListResponse {
+  /**
+   * Whether the list was successfully deleted
+   */
+  deleted: boolean;
+  /**
+   * ID of the deleted list
+   */
+  list_id: string;
+  ext?: ExtensionObject;
+}
+
 // list_content_standards parameters
 /**
  * Request parameters for listing content standards configurations
@@ -12188,56 +12654,22 @@ export interface GetAdCPCapabilitiesResponse {
     sandbox?: boolean;
   };
   /**
-   * Media-buy protocol capabilities. Only present if media_buy is in supported_protocols.
+   * Media-buy protocol capabilities. Expected when media_buy is in supported_protocols. Sellers declaring media_buy should also include account with supported_billing.
    */
   media_buy?: {
     /**
      * Pricing models this seller supports across its product portfolio. Buyers can use this for pre-flight filtering before querying individual products. Individual products may support a subset of these models.
      */
     supported_pricing_models?: PricingModel[];
-    /**
-     * Seller-level reporting capabilities. Summarizes what reporting features are available across the seller's product portfolio. Individual products may vary — check product-level reporting_capabilities for specifics.
-     */
-    reporting?: {
-      /**
-       * Whether any products support date range filtering (date_range_support: 'date_range'). When false, all products return lifetime-only data.
-       */
-      supports_date_range?: boolean;
-      /**
-       * Whether delivery reporting includes daily_breakdown at the media buy and/or package level.
-       */
-      supports_daily_breakdown?: boolean;
-      /**
-       * Whether any products support webhook-based reporting notifications.
-       */
-      supports_webhooks?: boolean;
-      /**
-       * Reporting dimensions available across the seller's portfolio. Individual products may support a subset. Dimensions geo, device_type, device_platform, audience, and placement are opt-in via reporting_dimensions on the delivery request. Dimensions creative, keyword, and catalog_item are included automatically when the seller supports them (not controlled by reporting_dimensions).
-       */
-      available_dimensions?: (
-        | 'geo'
-        | 'device_type'
-        | 'device_platform'
-        | 'audience'
-        | 'placement'
-        | 'creative'
-        | 'keyword'
-        | 'catalog_item'
-      )[];
-    };
     features?: MediaBuyFeatures;
     /**
      * Technical execution capabilities for media buying
      */
     execution?: {
       /**
-       * Trusted Match Protocol (TMP) support. When present, this seller supports real-time contextual and/or identity matching. Check individual products via get_products for per-product TMP capabilities.
+       * Trusted Match Protocol (TMP) support. Presence of this object indicates the seller has TMP infrastructure deployed. Check individual products via get_products for per-product TMP capabilities.
        */
       trusted_match?: {
-        /**
-         * Whether this seller has TMP infrastructure deployed.
-         */
-        supported?: boolean;
         /**
          * Surface types this seller supports via TMP.
          */
@@ -12283,81 +12715,64 @@ export interface GetAdCPCapabilitiesResponse {
        */
       targeting?: {
         /**
-         * Supports country-level geo targeting using ISO 3166-1 alpha-2 codes (e.g., 'US', 'GB', 'DE')
+         * Geographic targeting levels this seller supports.
+         */
+        supported_geo_levels?: ('countries' | 'regions' | 'metros' | 'postal_areas')[];
+        /**
+         * Metro area classification systems this seller supports. Only meaningful when supported_geo_levels includes 'metros'.
+         */
+        supported_metro_systems?: ('nielsen_dma' | 'uk_itl1' | 'uk_itl2' | 'eurostat_nuts2')[];
+        /**
+         * Postal code systems this seller supports. Only meaningful when supported_geo_levels includes 'postal_areas'.
+         */
+        supported_postal_systems?: (
+          | 'us_zip'
+          | 'us_zip_plus_four'
+          | 'gb_outward'
+          | 'gb_full'
+          | 'ca_fsa'
+          | 'ca_full'
+          | 'de_plz'
+          | 'fr_code_postal'
+          | 'au_postcode'
+          | 'ch_plz'
+          | 'at_plz'
+        )[];
+        /**
+         * @deprecated
+         * Deprecated in 3.0, will be removed in 4.0. Use supported_geo_levels instead.
          */
         geo_countries?: boolean;
         /**
-         * Supports region/state-level geo targeting using ISO 3166-2 subdivision codes (e.g., 'US-NY', 'GB-SCT', 'DE-BY')
+         * @deprecated
+         * Deprecated in 3.0, will be removed in 4.0. Use supported_geo_levels instead.
          */
         geo_regions?: boolean;
         /**
-         * Metro area targeting support. Specifies which classification systems are supported.
+         * @deprecated
+         * Deprecated in 3.0, will be removed in 4.0. Use supported_metro_systems instead.
          */
         geo_metros?: {
-          /**
-           * Supports Nielsen DMA codes (US market, e.g., '501' for NYC)
-           */
           nielsen_dma?: boolean;
-          /**
-           * Supports UK ITL Level 1 regions
-           */
           uk_itl1?: boolean;
-          /**
-           * Supports UK ITL Level 2 regions
-           */
           uk_itl2?: boolean;
-          /**
-           * Supports Eurostat NUTS Level 2 regions (EU)
-           */
           eurostat_nuts2?: boolean;
         };
         /**
-         * Postal area targeting support. Specifies which postal code systems are supported. System names encode country and precision.
+         * @deprecated
+         * Deprecated in 3.0, will be removed in 4.0. Use supported_postal_systems instead.
          */
         geo_postal_areas?: {
-          /**
-           * US 5-digit ZIP codes (e.g., '10001')
-           */
           us_zip?: boolean;
-          /**
-           * US 9-digit ZIP+4 codes (e.g., '10001-1234')
-           */
           us_zip_plus_four?: boolean;
-          /**
-           * UK postcode district / outward code (e.g., 'SW1', 'EC1')
-           */
           gb_outward?: boolean;
-          /**
-           * UK full postcode (e.g., 'SW1A 1AA')
-           */
           gb_full?: boolean;
-          /**
-           * Canadian Forward Sortation Area (e.g., 'K1A')
-           */
           ca_fsa?: boolean;
-          /**
-           * Canadian full postal code (e.g., 'K1A 0B1')
-           */
           ca_full?: boolean;
-          /**
-           * German Postleitzahl, 5 digits (e.g., '10115')
-           */
           de_plz?: boolean;
-          /**
-           * French code postal, 5 digits (e.g., '75001')
-           */
           fr_code_postal?: boolean;
-          /**
-           * Australian postcode, 4 digits (e.g., '2000')
-           */
           au_postcode?: boolean;
-          /**
-           * Swiss Postleitzahl, 4 digits (e.g., '8000')
-           */
           ch_plz?: boolean;
-          /**
-           * Austrian Postleitzahl, 4 digits (e.g., '1010')
-           */
           at_plz?: boolean;
         };
         /**
@@ -12374,25 +12789,9 @@ export interface GetAdCPCapabilitiesResponse {
           verification_methods?: AgeVerificationMethod[];
         };
         /**
-         * Whether seller supports device platform targeting (Sec-CH-UA-Platform values)
-         */
-        device_platform?: boolean;
-        /**
-         * Whether seller supports device type targeting (form factor: desktop, mobile, tablet, ctv, dooh, unknown). When true, seller supports both device_type (include) and device_type_exclude (exclude) in targeting overlays.
-         */
-        device_type?: boolean;
-        /**
          * Whether seller supports language targeting (ISO 639-1 codes)
          */
         language?: boolean;
-        /**
-         * Whether seller supports audience_include in targeting overlays (requires features.audience_targeting)
-         */
-        audience_include?: boolean;
-        /**
-         * Whether seller supports audience_exclude in targeting overlays (requires features.audience_targeting)
-         */
-        audience_exclude?: boolean;
         /**
          * Keyword targeting capabilities. Presence indicates support for targeting_overlay.keyword_targets and keyword_targets_add/remove in update_media_buy.
          */
@@ -12435,7 +12834,7 @@ export interface GetAdCPCapabilitiesResponse {
       };
     };
     /**
-     * Audience targeting capabilities. Only present when features.audience_targeting is true.
+     * Audience targeting capabilities. Presence of this object indicates the seller supports audience targeting, including sync_audiences and audience_include/audience_exclude in targeting overlays.
      */
     audience_targeting?: {
       /**
@@ -12463,7 +12862,7 @@ export interface GetAdCPCapabilitiesResponse {
       };
     };
     /**
-     * Seller-level conversion tracking capabilities. Only present when features.conversion_tracking is true.
+     * Seller-level conversion tracking capabilities. Presence of this object indicates the seller supports sync_event_sources and log_event for conversion event tracking.
      */
     conversion_tracking?: {
       /**
@@ -12502,9 +12901,9 @@ export interface GetAdCPCapabilitiesResponse {
       }[];
     };
     /**
-     * Content standards implementation details. Only meaningful when features.content_standards is true. Gives buyers pre-buy visibility into local evaluation and artifact delivery capabilities.
+     * Content standards implementation details. Presence of this object indicates the seller supports content_standards configuration including sampling rates and category filtering. Gives buyers pre-buy visibility into local evaluation and artifact delivery capabilities.
      */
-    content_standards_detail?: {
+    content_standards?: {
       /**
        * Whether the seller runs a local evaluation model. When false, all artifacts will have local_verdict: 'unevaluated' and the failures_only filter on get_media_buy_artifacts is not useful.
        */
@@ -12519,7 +12918,7 @@ export interface GetAdCPCapabilitiesResponse {
       supports_webhook_delivery?: boolean;
     };
     /**
-     * Information about the seller's media inventory portfolio
+     * Information about the seller's media inventory portfolio. Expected for media_buy sellers — buyers use this to understand inventory coverage and verify authorization via adagents.json.
      */
     portfolio?: {
       /**
@@ -12680,10 +13079,6 @@ export interface GetAdCPCapabilitiesResponse {
    * Brand protocol capabilities. Only present if brand is in supported_protocols. Brand agents provide identity data (logos, colors, tone, assets) and optionally rights clearance for licensable content (talent, music, stock media).
    */
   brand?: {
-    /**
-     * Supports get_brand_identity for retrieving brand identity data
-     */
-    identity?: boolean;
     /**
      * Supports get_rights and acquire_rights for rights discovery and clearance
      */

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -66,7 +66,7 @@ export function unwrapProtocolResponse(
   protocolResponse: any,
   toolName?: string,
   protocol?: 'mcp' | 'a2a',
-  options?: { filterInvalidArrayItems?: boolean }
+  options?: { filterInvalidProducts?: boolean }
 ): AdCPResponse & { _message?: string } {
   if (!protocolResponse) {
     throw new Error('Protocol response is null or undefined');
@@ -105,10 +105,10 @@ export function unwrapProtocolResponse(
       const { _message: _msg, ...dataToValidate } = unwrapped as Record<string, unknown>;
       const result = schema.safeParse(dataToValidate);
       if (!result.success) {
-        // When filterInvalidArrayItems is enabled, try filtering invalid items from
-        // array fields individually rather than rejecting the entire response.
-        if (options?.filterInvalidArrayItems) {
-          const filtered = filterInvalidItems(schema, dataToValidate);
+        // When filterInvalidArrayItems is enabled and this is a get_products response,
+        // try filtering invalid products individually rather than rejecting the entire response.
+        if (options?.filterInvalidProducts && toolName === 'get_products') {
+          const filtered = filterInvalidProducts(schema, dataToValidate);
           if (filtered) {
             const validated = filtered as unknown as AdCPResponse & { _message?: string };
             if (_msg) validated._message = _msg as string;
@@ -144,88 +144,42 @@ export function unwrapProtocolResponse(
 }
 
 /**
- * Attempt to salvage a response that fails whole-response validation by
- * filtering invalid items out of array fields and re-validating.
+ * Filter invalid products from a get_products response.
  *
- * Walks the top-level schema shape, finds required array fields (e.g. `products`),
- * validates each element individually, and keeps only valid ones.
- * Returns the filtered + re-validated response, or null if filtering can't help
- * (e.g. all items invalid, or the failure isn't in an array field).
+ * Validates each product individually against the ProductSchema,
+ * keeps only valid ones, and re-validates the full response.
+ * Returns the filtered response, or null if filtering can't help.
  */
-function filterInvalidItems(schema: z.ZodType, data: Record<string, unknown>): Record<string, unknown> | null {
-  // Extract the object schema — unwrap unions/effects to find the underlying z.object
-  const objectSchema = extractObjectSchema(schema);
-  if (!objectSchema) return null;
+function filterInvalidProducts(schema: z.ZodType, data: Record<string, unknown>): Record<string, unknown> | null {
+  const products = data.products;
+  if (!Array.isArray(products)) return null;
 
-  const shape = objectSchema.shape as Record<string, z.ZodType>;
-  const filtered = { ...data };
-  let didFilter = false;
+  const ProductSchema = (schema as z.ZodObject<any>).shape?.products;
+  if (!(ProductSchema instanceof z.ZodArray)) return null;
 
-  for (const [key, fieldSchema] of Object.entries(shape)) {
-    const arrayValue = data[key];
-    if (!Array.isArray(arrayValue)) continue;
-
-    // Unwrap to find the inner array schema and its element type
-    const elementSchema = extractArrayElementSchema(fieldSchema);
-    if (!elementSchema) continue;
-
-    const validItems: unknown[] = [];
-    for (const item of arrayValue) {
-      if (elementSchema.safeParse(item).success) {
-        validItems.push(item);
-      }
-    }
-
-    if (validItems.length < arrayValue.length) {
-      didFilter = true;
-      filtered[key] = validItems;
+  const elementSchema = (ProductSchema as z.ZodArray<any>).element;
+  const validProducts: unknown[] = [];
+  for (const product of products) {
+    if (elementSchema.safeParse(product).success) {
+      validProducts.push(product);
     }
   }
 
-  if (!didFilter) return null;
+  // Nothing was filtered — all products are individually valid, so the validation
+  // error is at the response level (not caused by invalid products). Fall through
+  // to the normal error path.
+  if (validProducts.length === products.length) return null;
 
-  // Re-validate the filtered response against the full schema
+  const filtered = { ...data, products: validProducts };
   const revalidated = schema.safeParse(filtered);
   if (revalidated.success) {
+    const droppedCount = products.length - validProducts.length;
+    console.warn(
+      `[adcp-client] Filtered ${droppedCount} invalid product(s) from get_products response (${validProducts.length} valid, ${products.length} total)`
+    );
     return revalidated.data as Record<string, unknown>;
   }
 
-  return null;
-}
-
-/**
- * Extract the underlying z.object schema from a potentially wrapped type
- * (union, passthrough, etc.)
- */
-function extractObjectSchema(schema: z.ZodType): z.ZodObject<any> | null {
-  if (schema instanceof z.ZodObject) return schema as z.ZodObject<any>;
-  if (schema instanceof z.ZodUnion) {
-    // Try each union variant — return the first object schema found
-    for (const option of (schema as z.ZodUnion<any>).options) {
-      const obj = extractObjectSchema(option);
-      if (obj) return obj;
-    }
-  }
-  return null;
-}
-
-/**
- * Extract the element schema from a z.array() field, unwrapping
- * optional/nullable/default wrappers.
- */
-function extractArrayElementSchema(fieldSchema: z.ZodType): z.ZodType | null {
-  if (fieldSchema instanceof z.ZodArray) {
-    return (fieldSchema as z.ZodArray<any>).element;
-  }
-  if (fieldSchema instanceof z.ZodOptional) {
-    return extractArrayElementSchema((fieldSchema as z.ZodOptional<any>).unwrap());
-  }
-  if (fieldSchema instanceof z.ZodNullable) {
-    return extractArrayElementSchema((fieldSchema as z.ZodNullable<any>).unwrap());
-  }
-  if (fieldSchema instanceof z.ZodDefault) {
-    return extractArrayElementSchema((fieldSchema as z.ZodDefault<any>)._def.innerType);
-  }
   return null;
 }
 

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -58,13 +58,15 @@ export type AdCPResponse =
  * @param protocolResponse - Raw response from MCP or A2A protocol
  * @param toolName - Optional AdCP tool name for validation
  * @param protocol - Protocol type ('mcp' or 'a2a'), if known. If not provided, will auto-detect.
+ * @param options - Optional validation behavior overrides
  * @returns Raw AdCP response data matching schema exactly
  * @throws {Error} If response doesn't match expected schema for the tool
  */
 export function unwrapProtocolResponse(
   protocolResponse: any,
   toolName?: string,
-  protocol?: 'mcp' | 'a2a'
+  protocol?: 'mcp' | 'a2a',
+  options?: { filterInvalidArrayItems?: boolean }
 ): AdCPResponse & { _message?: string } {
   if (!protocolResponse) {
     throw new Error('Protocol response is null or undefined');
@@ -103,6 +105,17 @@ export function unwrapProtocolResponse(
       const { _message: _msg, ...dataToValidate } = unwrapped as Record<string, unknown>;
       const result = schema.safeParse(dataToValidate);
       if (!result.success) {
+        // When filterInvalidArrayItems is enabled, try filtering invalid items from
+        // array fields individually rather than rejecting the entire response.
+        if (options?.filterInvalidArrayItems) {
+          const filtered = filterInvalidItems(schema, dataToValidate);
+          if (filtered) {
+            const validated = filtered as unknown as AdCPResponse & { _message?: string };
+            if (_msg) validated._message = _msg as string;
+            return validated;
+          }
+        }
+
         // Union schemas produce a generic "Invalid input" at (root).
         // Try each variant to surface the actual missing/invalid fields.
         const firstIssue = result.error.issues[0];
@@ -128,6 +141,92 @@ export function unwrapProtocolResponse(
 
   // Return unwrapped response (no validation)
   return unwrapped as AdCPResponse;
+}
+
+/**
+ * Attempt to salvage a response that fails whole-response validation by
+ * filtering invalid items out of array fields and re-validating.
+ *
+ * Walks the top-level schema shape, finds required array fields (e.g. `products`),
+ * validates each element individually, and keeps only valid ones.
+ * Returns the filtered + re-validated response, or null if filtering can't help
+ * (e.g. all items invalid, or the failure isn't in an array field).
+ */
+function filterInvalidItems(schema: z.ZodType, data: Record<string, unknown>): Record<string, unknown> | null {
+  // Extract the object schema — unwrap unions/effects to find the underlying z.object
+  const objectSchema = extractObjectSchema(schema);
+  if (!objectSchema) return null;
+
+  const shape = objectSchema.shape as Record<string, z.ZodType>;
+  const filtered = { ...data };
+  let didFilter = false;
+
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const arrayValue = data[key];
+    if (!Array.isArray(arrayValue)) continue;
+
+    // Unwrap to find the inner array schema and its element type
+    const elementSchema = extractArrayElementSchema(fieldSchema);
+    if (!elementSchema) continue;
+
+    const validItems: unknown[] = [];
+    for (const item of arrayValue) {
+      if (elementSchema.safeParse(item).success) {
+        validItems.push(item);
+      }
+    }
+
+    if (validItems.length < arrayValue.length) {
+      didFilter = true;
+      filtered[key] = validItems;
+    }
+  }
+
+  if (!didFilter) return null;
+
+  // Re-validate the filtered response against the full schema
+  const revalidated = schema.safeParse(filtered);
+  if (revalidated.success) {
+    return revalidated.data as Record<string, unknown>;
+  }
+
+  return null;
+}
+
+/**
+ * Extract the underlying z.object schema from a potentially wrapped type
+ * (union, passthrough, etc.)
+ */
+function extractObjectSchema(schema: z.ZodType): z.ZodObject<any> | null {
+  if (schema instanceof z.ZodObject) return schema as z.ZodObject<any>;
+  if (schema instanceof z.ZodUnion) {
+    // Try each union variant — return the first object schema found
+    for (const option of (schema as z.ZodUnion<any>).options) {
+      const obj = extractObjectSchema(option);
+      if (obj) return obj;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the element schema from a z.array() field, unwrapping
+ * optional/nullable/default wrappers.
+ */
+function extractArrayElementSchema(fieldSchema: z.ZodType): z.ZodType | null {
+  if (fieldSchema instanceof z.ZodArray) {
+    return (fieldSchema as z.ZodArray<any>).element;
+  }
+  if (fieldSchema instanceof z.ZodOptional) {
+    return extractArrayElementSchema((fieldSchema as z.ZodOptional<any>).unwrap());
+  }
+  if (fieldSchema instanceof z.ZodNullable) {
+    return extractArrayElementSchema((fieldSchema as z.ZodNullable<any>).unwrap());
+  }
+  if (fieldSchema instanceof z.ZodDefault) {
+    return extractArrayElementSchema((fieldSchema as z.ZodDefault<any>)._def.innerType);
+  }
+  return null;
 }
 
 /**

--- a/test/lib/response-schema-validation.test.js
+++ b/test/lib/response-schema-validation.test.js
@@ -22,6 +22,14 @@ const validProduct = {
   format_ids: [{ agent_url: 'https://example.com', id: 'fmt1' }],
   delivery_type: 'guaranteed',
   pricing_options: [{ pricing_option_id: 'po1', pricing_model: 'cpm', rate: 10, currency: 'USD' }],
+  reporting_capabilities: {
+    available_reporting_frequencies: ['daily'],
+    expected_delay_minutes: 60,
+    timezone: 'UTC',
+    supports_webhooks: false,
+    available_metrics: ['impressions'],
+    date_range_support: 'date_range',
+  },
 };
 
 const validCreateMediaBuySuccess = {

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -633,6 +633,62 @@ describe('Response Unwrapper', () => {
         }
       );
     });
+
+    test('should filter invalid products when filterInvalidArrayItems is enabled', () => {
+      const validProduct = createTestProduct({ product_id: 'valid-1' });
+      const invalidProduct = { product_id: 'invalid-1' }; // Missing required fields
+
+      const mcpResponse = {
+        structuredContent: {
+          products: [validProduct, invalidProduct],
+        },
+      };
+
+      // Without filtering, should throw
+      assert.throws(
+        () => unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp'),
+        /validation failed/i
+      );
+
+      // With filtering, should return only the valid product
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
+        filterInvalidArrayItems: true,
+      });
+      assert.strictEqual(result.products.length, 1);
+      assert.strictEqual(result.products[0].product_id, 'valid-1');
+    });
+
+    test('should return empty array when all items are invalid and filtering is enabled', () => {
+      const invalidProduct1 = { product_id: 'bad-1' };
+      const invalidProduct2 = { product_id: 'bad-2' };
+
+      const mcpResponse = {
+        structuredContent: {
+          products: [invalidProduct1, invalidProduct2],
+        },
+      };
+
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
+        filterInvalidArrayItems: true,
+      });
+      assert.strictEqual(result.products.length, 0);
+    });
+
+    test('should pass through fully valid responses unchanged when filtering is enabled', () => {
+      const product1 = createTestProduct({ product_id: 'p1' });
+      const product2 = createTestProduct({ product_id: 'p2' });
+
+      const mcpResponse = {
+        structuredContent: {
+          products: [product1, product2],
+        },
+      };
+
+      const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
+        filterInvalidArrayItems: true,
+      });
+      assert.strictEqual(result.products.length, 2);
+    });
   });
 
   describe('Protocol Auto-Detection Edge Cases', () => {

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -536,20 +536,7 @@ describe('Response Unwrapper', () => {
                 {
                   kind: 'data',
                   data: {
-                    products: [
-                      {
-                        product_id: 'prod-1',
-                        name: 'Test Product',
-                        description: 'A test product',
-                        publisher_properties: [{ publisher_domain: 'example.com', selection_type: 'all' }],
-                        format_ids: [{ agent_url: 'https://agent.example.com', id: 'banner-300x250' }],
-                        delivery_type: 'guaranteed',
-                        pricing_options: [
-                          { pricing_option_id: 'cpm-1', pricing_model: 'cpm', currency: 'USD', fixed_price: 5.0 },
-                        ],
-                        delivery_measurement: { provider: 'Internal' },
-                      },
-                    ],
+                    products: [createTestProduct({ product_id: 'prod-1' })],
                   },
                 },
               ],
@@ -634,7 +621,7 @@ describe('Response Unwrapper', () => {
       );
     });
 
-    test('should filter invalid products when filterInvalidArrayItems is enabled', () => {
+    test('should filter invalid products when filterInvalidProducts is enabled', () => {
       const validProduct = createTestProduct({ product_id: 'valid-1' });
       const invalidProduct = { product_id: 'invalid-1' }; // Missing required fields
 
@@ -645,20 +632,17 @@ describe('Response Unwrapper', () => {
       };
 
       // Without filtering, should throw
-      assert.throws(
-        () => unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp'),
-        /validation failed/i
-      );
+      assert.throws(() => unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp'), /validation failed/i);
 
       // With filtering, should return only the valid product
       const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
-        filterInvalidArrayItems: true,
+        filterInvalidProducts: true,
       });
       assert.strictEqual(result.products.length, 1);
       assert.strictEqual(result.products[0].product_id, 'valid-1');
     });
 
-    test('should return empty array when all items are invalid and filtering is enabled', () => {
+    test('should return empty array when all products are invalid and filtering is enabled', () => {
       const invalidProduct1 = { product_id: 'bad-1' };
       const invalidProduct2 = { product_id: 'bad-2' };
 
@@ -669,7 +653,7 @@ describe('Response Unwrapper', () => {
       };
 
       const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
-        filterInvalidArrayItems: true,
+        filterInvalidProducts: true,
       });
       assert.strictEqual(result.products.length, 0);
     });
@@ -685,9 +669,72 @@ describe('Response Unwrapper', () => {
       };
 
       const result = unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
-        filterInvalidArrayItems: true,
+        filterInvalidProducts: true,
       });
       assert.strictEqual(result.products.length, 2);
+    });
+
+    test('should NOT filter other tools even when filterInvalidProducts is enabled', () => {
+      const mcpResponse = {
+        structuredContent: {
+          media_buy_id: 'mb-1',
+          // Missing required fields like buyer_ref, packages
+        },
+      };
+
+      assert.throws(
+        () =>
+          unwrapProtocolResponse(mcpResponse, 'create_media_buy', 'mcp', {
+            filterInvalidProducts: true,
+          }),
+        /validation failed/i
+      );
+    });
+
+    test('should filter invalid products via A2A protocol path', () => {
+      const validProduct = createTestProduct({ product_id: 'a2a-valid' });
+      const invalidProduct = { product_id: 'a2a-bad' };
+
+      const a2aResponse = {
+        result: {
+          status: { state: 'completed' },
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    products: [validProduct, invalidProduct],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(a2aResponse, 'get_products', 'a2a', {
+        filterInvalidProducts: true,
+      });
+      assert.strictEqual(result.products.length, 1);
+      assert.strictEqual(result.products[0].product_id, 'a2a-valid');
+    });
+
+    test('should return null from filtering when products field is not an array', () => {
+      const mcpResponse = {
+        structuredContent: {
+          products: 'not-an-array',
+        },
+      };
+
+      // Should still throw validation error, filtering can't help
+      assert.throws(
+        () =>
+          unwrapProtocolResponse(mcpResponse, 'get_products', 'mcp', {
+            filterInvalidProducts: true,
+          }),
+        /validation failed/i
+      );
     });
   });
 

--- a/test/lib/response-validator.test.js
+++ b/test/lib/response-validator.test.js
@@ -42,6 +42,14 @@ describe('ResponseValidator Tests', () => {
     delivery_measurement: {
       provider: 'Test Measurement Provider',
     },
+    reporting_capabilities: {
+      available_reporting_frequencies: ['daily'],
+      expected_delay_minutes: 60,
+      timezone: 'UTC',
+      supports_webhooks: false,
+      available_metrics: ['impressions'],
+      date_range_support: 'date_range',
+    },
     ...overrides,
   });
 

--- a/test/lib/test-fixtures.js
+++ b/test/lib/test-fixtures.js
@@ -31,6 +31,14 @@ function createTestProduct(overrides = {}) {
     delivery_measurement: {
       provider: 'test-provider',
     },
+    reporting_capabilities: {
+      available_reporting_frequencies: ['daily'],
+      expected_delay_minutes: 60,
+      timezone: 'UTC',
+      supports_webhooks: false,
+      available_metrics: ['impressions'],
+      date_range_support: 'date_range',
+    },
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Adds `validation.filterInvalidProducts` client config option (default: `false`)
- When enabled, invalid products in `get_products` responses are filtered out individually instead of rejecting the entire response
- Only applies to `get_products` — all other tool responses use standard validation
- Includes 3 new tests covering filtering, empty result, and passthrough scenarios

## How it works
When `get_products` whole-response Zod validation fails and this option is `true`:
1. Validates each product individually against `ProductSchema`
2. Keeps valid products, drops invalid ones
3. Re-validates the filtered response against the full `GetProductsResponseSchema`
4. Returns it if valid — otherwise falls through to the normal error path

## How this differs from `strictSchemaValidation: false`

| | `strictSchemaValidation: false` | `filterInvalidProducts: true` |
|---|---|---|
| Invalid product in array | Returns the **entire raw response** unmodified (all 10 products, including the 9 bad ones) | Returns only the **1 valid product**, drops the 9 bad ones |
| Missing required top-level field | Logs warning, returns response anyway | Still throws — only filters products |
| Type guarantee | **None** — you get unvalidated data | **Validated** — returned data passes the full Zod schema |
| Scope | All tool responses | `get_products` only |

`strictSchemaValidation: false` already lets data through when some products are bad, but passes everything unvalidated. `filterInvalidProducts` gives you Zod-validated output with only the bad products removed — the response you get back is guaranteed to match the schema.

## Usage
```ts
const client = new AdCPClient(agents, {
  validation: {
    filterInvalidProducts: true,
  },
});
```

## Test plan
- [x] Existing 44 response-unwrapper tests pass
- [x] New test: filters invalid products, returns valid ones
- [x] New test: returns empty array when all products invalid
- [x] New test: passes through fully valid responses unchanged
- [x] TypeScript compiles cleanly
- [x] Lint passes (0 errors)