### PR TITLE
fix: align storyboard params with schemas

### DIFF
--- a/.changeset/fix-storyboard-params.md
+++ b/.changeset/fix-storyboard-params.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix storyboard sample_requests and request-builder fallbacks to match AdCP schemas for brand_rights and property_governance

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -543,7 +543,13 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     return {
       brand: resolveBrand(options),
       list_id: context.property_list_id ?? 'unknown',
-      delivery: [{ property: 'test.example', impressions: 1000 }],
+      records: [
+        {
+          record_id: 'delivery_001',
+          property: { type: 'domain', value: 'test.example' },
+          impressions: 1000,
+        },
+      ],
     };
   },
 
@@ -553,7 +559,19 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     }
     return {
       rights_id: context.rights_id ?? 'unknown',
+      pricing_option_id: 'standard',
       buyer: { domain: resolveBrand(options).domain },
+      campaign: {
+        description: 'E2E storyboard test campaign',
+        uses: ['commercial'],
+      },
+      revocation_webhook: {
+        url: 'https://test.example/webhooks/revocation',
+        authentication: {
+          schemes: ['Bearer'],
+          credentials: 'test-revocation-webhook-secret-token',
+        },
+      },
     };
   },
 

--- a/storyboards/brand_rights.yaml
+++ b/storyboards/brand_rights.yaml
@@ -189,9 +189,18 @@ phases:
           buyer:
             domain: "pinnacle-agency.example"
           campaign:
-            name: "Acme Outdoor Summer 2026"
+            description: "AI-generated display ads for Acme Outdoor summer trail gear campaign"
+            uses:
+              - "likeness"
+              - "commercial"
             start_date: "2026-04-01"
             end_date: "2026-06-30"
+          revocation_webhook:
+            url: "https://pinnacle-agency.example/webhooks/revocation"
+            authentication:
+              schemes:
+                - "Bearer"
+              credentials: "pinnacle-revocation-webhook-secret-token"
 
         context_outputs:
           - path: "rights_grant_id"

--- a/storyboards/property_governance.yaml
+++ b/storyboards/property_governance.yaml
@@ -97,12 +97,16 @@ phases:
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
-          list_type: "inclusion"
           name: "Acme Outdoor approved properties"
-          properties:
-            - domain: "outdoormagazine.example"
-            - domain: "hikingtrails.example"
-            - domain: "campinggear.example"
+          base_properties:
+            - selection_type: "identifiers"
+              identifiers:
+                - type: "domain"
+                  value: "outdoormagazine.example"
+                - type: "domain"
+                  value: "hikingtrails.example"
+                - type: "domain"
+                  value: "campinggear.example"
 
         validations:
           - check: response_schema
@@ -132,8 +136,8 @@ phases:
           - Includes both inclusion and exclusion lists
 
         sample_request:
-          brand:
-            domain: "acmeoutdoor.example"
+          principal: "acmeoutdoor.example"
+          name_contains: "Acme Outdoor"
 
         validations:
           - check: response_schema
@@ -165,14 +169,14 @@ phases:
   - id: update_list
     title: "Update property lists"
     narrative: |
-      The buyer modifies an existing property list — adding or removing properties
+      The buyer modifies an existing property list — replacing the base properties
       as brand safety requirements evolve.
 
     steps:
       - id: update_property_list
         title: "Update a property list"
         narrative: |
-          The buyer adds new properties to or removes properties from an existing list.
+          The buyer replaces the base properties on an existing list with a new set.
         task: update_property_list
         schema_ref: "property/update-property-list-request.json"
         response_schema_ref: "property/update-property-list-response.json"
@@ -182,14 +186,19 @@ phases:
         expected: |
           Return the updated property list:
           - Updated property count
-          - Confirmation of additions and removals
+          - Confirmation of the replaced base properties
 
         sample_request:
           list_id: "pl_acme_inclusion_001"
-          add:
-            - domain: "mountaineering.example"
-          remove:
-            - domain: "campinggear.example"
+          base_properties:
+            - selection_type: "identifiers"
+              identifiers:
+                - type: "domain"
+                  value: "outdoormagazine.example"
+                - type: "domain"
+                  value: "hikingtrails.example"
+                - type: "domain"
+                  value: "mountaineering.example"
 
         validations:
           - check: response_schema
@@ -255,10 +264,16 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
           list_id: "pl_acme_inclusion_001"
-          delivery:
-            - property: "outdoormagazine.example"
+          records:
+            - record_id: "delivery_outdoor_001"
+              property:
+                type: "domain"
+                value: "outdoormagazine.example"
               impressions: 50000
-            - property: "randomsite.example"
+            - record_id: "delivery_random_001"
+              property:
+                type: "domain"
+                value: "randomsite.example"
               impressions: 200
 
         validations:


### PR DESCRIPTION
## Summary

- **brand_rights → acquire_rights**: add required `campaign.description`, `campaign.uses`, `revocation_webhook`; remove non-schema `campaign.name`
- **property_governance → create_property_list**: `properties` → `base_properties` (identifiers discriminated union); drop non-schema `list_type`
- **property_governance → list_property_lists**: `brand` → `principal` + `name_contains`
- **property_governance → update_property_list**: `add`/`remove` → `base_properties` (full replacement per schema)
- **property_governance → validate_property_delivery**: `delivery` → `records` with `record_id` and structured property identifiers
- **request-builder.ts fallbacks**: matching fixes for `validate_property_delivery` and `acquire_rights`

All changes verified against JSON schemas in `schemas/cache/latest/`. Storyboard drift tests (239/239) and request-builder tests (28/28) pass.

Ran storyboards against public test agent — `create_property_list` and `list_property_lists` now pass where they previously sent non-schema fields. Remaining failures are test agent gaps tracked in #530.

## Test plan

- [x] `node test/lib/storyboard-drift.test.js` — 239 pass, 0 fail
- [x] `node test/lib/request-builder.test.js` — 28 pass, 0 fail
- [x] `adcp storyboard run test-mcp property_governance` — create/list steps now pass
- [x] `adcp storyboard run test-mcp brand_rights` — capability + rights discovery pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)