### PR TITLE
feat: context passthrough, format_id reconciliation, and identifier roundtrip testing

### DIFF
--- a/.changeset/context-ext-storyboards.md
+++ b/.changeset/context-ext-storyboards.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": minor
+---
+
+Add context passthrough testing, format_id reconciliation, and identifier roundtrip validations across all storyboards. Client SDK now preserves context and ext through field stripping via ADCP_ENVELOPE_FIELDS. Runner merges context/ext from sample_request into request builder output.

--- a/skills/build-brand-rights-agent/SKILL.md
+++ b/skills/build-brand-rights-agent/SKILL.md
@@ -139,6 +139,23 @@ taskToolResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
 ## SDK Quick Reference
 
 | SDK piece                                               | Usage                                                               |
@@ -205,6 +222,7 @@ npx @adcp/client storyboard run http://localhost:3001/mcp brand_rights --json
 | `update_rights` missing `rights_id` in response  | Same — echo `rights_id` back                                    |
 | `creative_approval` returns `status` not `decision` | Field name is `decision`, values: `approved`, `rejected`, `review` |
 | Using typed schemas for brand rights tools       | No generated schemas — use `{}` for all input schemas            |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Storyboards
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -173,6 +173,25 @@ Asset values use type-specific shapes, not a generic `asset_type` discriminator:
 - HTML: `{ content: string }` (not `{ html: string }`)
 - Text: `{ text: string }`
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
+Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `get_creative_delivery`, `get_creative_features`.
+
 ## SDK Quick Reference
 
 | SDK piece                                               | Usage                                                               |
@@ -270,6 +289,8 @@ npx tsc --noEmit agent.ts
 | `creative_manifest` includes `name` field            | `CreativeManifest` has no `name` — only `format_id` and `assets`                  |
 | HTML asset uses `{ html: '...' }`                    | Use `{ content: '...' }` — the schema field is `content`, not `html`              |
 | No in-memory store for synced creatives              | `list_creatives` and `build_creative` need to find previously synced creatives    |
+| format_ids in list_creative_formats don't match what sellers reference | Sellers include your format_ids in their products — if the buyer can't look them up via list_creative_formats, creative sync breaks |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Storyboards
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -210,6 +210,25 @@ deliveryResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
+Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `sync_governance`, `provide_performance_feedback`.
+
 ## Compliance Testing (Optional)
 
 Add `registerTestController` so the comply framework can deterministically test your state machines. One function call — the SDK handles request parsing, status validation, and response formatting.
@@ -337,9 +356,11 @@ When storyboard output shows failures, fix each one:
 | Only generative formats, no standard IAB      | Programmatic sellers must accept pre-built assets too |
 | Ignore brand domain on brief sync             | Validate brand, reject if unresolvable                |
 | Same handler for brief and standard creatives | Check format_id to decide processing path             |
+| format_ids in products don't match list_creative_formats  | Buyers echo format_ids from products into sync_creatives — if your validation rejects your own format_ids, the buyer can't fulfill creative requirements |
 | Skip `get_adcp_capabilities`                  | Must be the first tool registered                     |
 | Pass `Schema` instead of `Schema.shape`       | MCP SDK needs unwrapped Zod fields                    |
 | `sandbox: false` on mock data                 | Buyers may treat mock data as real                    |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Reference
 

--- a/skills/build-governance-agent/SKILL.md
+++ b/skills/build-governance-agent/SKILL.md
@@ -271,6 +271,25 @@ taskToolResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
+Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `sync_governance`.
+
 ## SDK Quick Reference
 
 | SDK piece                                               | Usage                                                               |
@@ -358,6 +377,7 @@ npx @adcp/client storyboard run http://localhost:3001/mcp content_standards --js
 | `sync_plans` response missing `version`          | Each plan needs `version: 1` (integer) — required field                                  |
 | `delete_property_list` missing `deleted: true`   | Boolean `deleted` field is required in response                                          |
 | `create_property_list` missing `auth_token`      | `auth_token` is required — generate a token string                                       |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Storyboards
 

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -170,6 +170,25 @@ deliveryResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
+Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `sync_event_sources`, `provide_performance_feedback`.
+
 ## Compliance Testing (Optional)
 
 Add `registerTestController` so the comply framework can deterministically test your state machines. One function call — the SDK handles request parsing, status validation, and response formatting.
@@ -275,8 +294,10 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_crea
 | Skip `get_adcp_capabilities`                             | Must be the first tool registered              |
 | Pass `Schema` instead of `Schema.shape`                  | MCP SDK needs unwrapped Zod fields             |
 | sync_catalogs missing `item_count` / `items_approved`    | Optional but recommended for catalog validation results |
+| format_ids in products don't match list_creative_formats  | Buyers echo format_ids from products into sync_creatives — if your validation rejects your own format_ids, the buyer can't fulfill creative requirements |
 | log_event missing `events_received` / `events_processed` | Required counters                              |
 | `sandbox: false` on mock data                            | Buyers may treat mock data as real             |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Reference
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -206,6 +206,25 @@ deliveryResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
+Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `sync_governance`, `provide_performance_feedback`, `sync_event_sources`.
+
 ## Compliance Testing (Optional)
 
 Add `registerTestController` so the comply framework can deterministically test your state machines. Without it, compliance testing relies on observational storyboards that can't force state transitions.
@@ -380,7 +399,9 @@ When storyboard output shows failures, fix each one:
 | `sandbox: false` on mock data                        | Buyers may treat mock data as real                            |
 | Returns raw JSON for validation failures             | Use `adcpError('INVALID_REQUEST', { message })` — storyboards validate the `adcp_error` structure    |
 | Missing `publisher_properties` or `format_ids` on Product | Both are required — see product example in `get_products` section |
+| format_ids in products don't match list_creative_formats  | Buyers echo format_ids from products into sync_creatives — if your validation rejects your own format_ids, the buyer can't fulfill creative requirements |
 | Missing `@types/node` in devDependencies             | `process.env` doesn't resolve without it — see Setup section  |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Reference
 

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -99,6 +99,23 @@ taskToolResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
 ## SDK Quick Reference
 
 | SDK piece                                               | Usage                                                               |
@@ -167,6 +184,7 @@ npx @adcp/client storyboard run http://localhost:3001/mcp si_session --json
 | Missing `session_id` in si_send_message response     | Echo `session_id` back from request — required                         |
 | Missing `available` in si_get_offering               | Boolean `available` is required — even for mock data                   |
 | Missing `reason` in si_terminate_session request     | `reason` is required — one of: `user_exit`, `session_timeout`, `host_terminated`, `handoff_transaction`, `handoff_complete` |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Storyboards
 

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -142,6 +142,25 @@ activateSignalResponse({
 })
 ```
 
+### Context and Ext Passthrough
+
+Every AdCP request includes an optional `context` field. Buyers use it to carry correlation IDs, orchestration metadata, and workflow state across multi-agent calls. Your agent **must** echo the `context` object back unchanged in every response.
+
+```typescript
+// In every tool handler:
+const context = args.context; // may be undefined — that's fine
+
+// In every response:
+return taskToolResponse({
+  // ... your response fields ...
+  context,  // echo it back unchanged
+});
+```
+
+Do not modify, inspect, or omit the context — treat it as opaque. If the request has no context, omit it from the response.
+
+Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `activate_signal`.
+
 ## SDK Quick Reference
 
 | SDK piece                                               | Usage                                                               |
@@ -228,6 +247,7 @@ npx tsc --noEmit agent.ts
 | `is_live: true` in get_signals deployments   | Signals aren't live until `activate_signal` — use empty `deployments: []`                                   |
 | Activation doesn't match destination type    | If request has `type: "platform"`, deployment must be `type: "platform"`                                    |
 | `sandbox: false` on mock data                | Buyers may treat mock data as real                                                                          |
+| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
 
 ## Reference
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod';
 import * as schemas from '../types/schemas.generated';
 import type { AgentConfig } from '../types';
+import { ADCP_ENVELOPE_FIELDS } from '../types/adcp';
 import type {
   GetProductsRequest,
   GetProductsResponse,
@@ -1065,8 +1066,8 @@ export class SingleAgentClient {
 
     // Strip any top-level fields not declared in the agent's tool schema.
     // This handles partial implementations (agents that omit some fields)
-    // and prevents unknown fields like idempotency_key from causing
-    // validation errors on the remote server.
+    // and prevents unknown fields from causing validation errors on the
+    // remote server.
     // Fails open when no schema is cached — better to send unknown fields and
     // let the agent respond than to silently drop data that might be required.
     // MCP-only in practice: A2A agents don't populate cachedToolSchemas.
@@ -1093,7 +1094,7 @@ export class SingleAgentClient {
 
     // Protocol envelope fields are always preserved — they live at the
     // protocol layer, not in individual tool schemas.
-    const envelopeFields = new Set(['governance_context', 'push_notification_config', 'context_id', 'ext']);
+    const envelopeFields = ADCP_ENVELOPE_FIELDS;
     const filtered: Record<string, unknown> = {};
     const stripped: string[] = [];
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -237,6 +237,20 @@ async function executeStep(
     request = injectContext({ ...step.sample_request }, context);
   } else if (hasRequestBuilder(step.task)) {
     request = buildRequest(step, context, options);
+    // Merge pass-through envelope fields from sample_request — builders
+    // don't include these, but storyboards define them for compliance testing.
+    // Only context and ext are merged: they are opaque pass-through fields with
+    // no schema validation. Other envelope fields (push_notification_config,
+    // governance_context, idempotency_key) have structured schemas and are
+    // handled by the request builder when needed.
+    if (step.sample_request) {
+      if (step.sample_request.context !== undefined && request.context === undefined) {
+        request.context = injectContext({ context: step.sample_request.context }, context).context;
+      }
+      if (step.sample_request.ext !== undefined && request.ext === undefined) {
+        request.ext = step.sample_request.ext;
+      }
+    }
   } else if (step.sample_request) {
     request = injectContext({ ...step.sample_request }, context);
   } else {

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -1,6 +1,20 @@
 // AdCP Types - Based on official AdCP specification
 // https://adcontextprotocol.org/docs/reference/data-models
 
+/**
+ * Protocol-level fields that bypass per-tool schema stripping.
+ * These fields live at the AdCP envelope layer, not in individual tool schemas,
+ * and must always be preserved when sending requests to agents.
+ */
+export const ADCP_ENVELOPE_FIELDS = new Set([
+  'context',                   // Opaque pass-through for correlation and workflow state
+  'ext',                       // Vendor-namespaced extensions
+  'governance_context',        // Governance approval token
+  'push_notification_config',  // Webhook configuration for async operations
+  'context_id',                // Legacy context identifier
+  'idempotency_key',           // Prevents duplicate processing on retries
+]);
+
 // Import structured FormatID from generated core types
 import type {
   CreateMediaBuyAsyncInputRequired,

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -7,12 +7,12 @@
  * and must always be preserved when sending requests to agents.
  */
 export const ADCP_ENVELOPE_FIELDS = new Set([
-  'context',                   // Opaque pass-through for correlation and workflow state
-  'ext',                       // Vendor-namespaced extensions
-  'governance_context',        // Governance approval token
-  'push_notification_config',  // Webhook configuration for async operations
-  'context_id',                // Legacy context identifier
-  'idempotency_key',           // Prevents duplicate processing on retries
+  'context', // Opaque pass-through for correlation and workflow state
+  'ext', // Vendor-namespaced extensions
+  'governance_context', // Governance approval token
+  'push_notification_config', // Webhook configuration for async operations
+  'context_id', // Legacy context identifier
+  'idempotency_key', // Prevents duplicate processing on retries
 ]);
 
 // Import structured FormatID from generated core types

--- a/storyboards/audience_sync.yaml
+++ b/storyboards/audience_sync.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "audience_sync--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "audience_sync--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account setup"
     narrative: |
@@ -94,7 +103,9 @@ phases:
           - account_id: platform-assigned identifier
           - status: active (required for audience sync)
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "audience_sync--discover_account"
 
         validations:
           - check: response_schema
@@ -103,6 +114,13 @@ phases:
             path: "accounts[0].account_id"
             description: "At least one account exists with an account_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "audience_sync--discover_account"
+            description: "Context correlation_id returned unchanged"
   - id: audience_sync
     title: "Audience sync"
     narrative: |
@@ -135,10 +153,19 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
 
+          context:
+            correlation_id: "audience_sync--discover_audiences"
         validations:
           - check: response_schema
             description: "Response matches sync-audiences-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "audience_sync--discover_audiences"
+            description: "Context correlation_id returned unchanged"
       - id: create_audience
         title: "Create test audience"
         narrative: |
@@ -172,6 +199,8 @@ phases:
                 - hashed_email: "a000000000000000000000000000000000000000000000000000000000000000"
                 - hashed_phone: "b000000000000000000000000000000000000000000000000000000000000000"
 
+          context:
+            correlation_id: "audience_sync--create_audience"
         validations:
           - check: response_schema
             description: "Response matches sync-audiences-response.json schema"
@@ -182,6 +211,13 @@ phases:
             path: "audiences[0].action"
             description: "Audience has an action (created or updated)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "audience_sync--create_audience"
+            description: "Context correlation_id returned unchanged"
       - id: delete_audience
         title: "Delete test audience"
         narrative: |
@@ -207,9 +243,19 @@ phases:
             - audience_id: "adcp-test-audience-001"
               delete: true
 
+          context:
+            correlation_id: "audience_sync--delete_audience"
         validations:
           - check: response_schema
             description: "Response matches sync-audiences-response.json schema"
           - check: field_present
             path: "audiences[0].action"
             description: "Audience deletion acknowledged with action field"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "audience_sync--delete_audience"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/behavioral_analysis.yaml
+++ b/storyboards/behavioral_analysis.yaml
@@ -71,7 +71,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "behavioral_analysis--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -79,6 +81,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "behavioral_analysis--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: behavior_analysis
     title: "Brief filtering behavior"
     narrative: |
@@ -109,6 +118,8 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "behavioral_analysis--get_products_narrow"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -116,6 +127,22 @@ phases:
             path: "products"
             description: "Response contains a products array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "behavioral_analysis--get_products_narrow"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
       - id: get_products_broad
         title: "Get products with broad brief"
         narrative: |
@@ -138,10 +165,28 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "behavioral_analysis--get_products_broad"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "behavioral_analysis--get_products_broad"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: response_consistency
     title: "Response consistency"
     narrative: |
@@ -170,10 +215,28 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "behavioral_analysis--get_products_first"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "behavioral_analysis--get_products_first"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
       - id: get_products_second
         title: "Second request with identical brief"
         narrative: |
@@ -195,10 +258,28 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "behavioral_analysis--get_products_second"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "behavioral_analysis--get_products_second"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: pricing_edge_cases
     title: "Pricing structure validation"
     narrative: |
@@ -228,6 +309,8 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "behavioral_analysis--get_products_pricing"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -237,3 +320,20 @@ phases:
           - check: field_present
             path: "products[0].pricing_options"
             description: "Products include pricing_options"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "behavioral_analysis--get_products_pricing"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"

--- a/storyboards/brand_rights.yaml
+++ b/storyboards/brand_rights.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring brand in supported_protocols, confirming the agent serves brand identity and rights.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "brand_rights--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: identity_discovery
     title: "Brand identity discovery"
     narrative: |
@@ -102,6 +111,8 @@ phases:
         sample_request:
           brand_id: "acme_outdoor"
 
+          context:
+            correlation_id: "brand_rights--get_brand_identity"
         context_outputs:
           - path: "brand_id"
             key: "brand_id"
@@ -113,6 +124,13 @@ phases:
             path: "brand_id"
             description: "Response includes brand_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--get_brand_identity"
+            description: "Context correlation_id returned unchanged"
   - id: rights_search
     title: "Browse available rights"
     narrative: |
@@ -145,6 +163,8 @@ phases:
             - "ai_generated_image"
           brand_id: "$context.brand_id"
 
+          context:
+            correlation_id: "brand_rights--get_rights"
         context_outputs:
           - path: "rights.0.rights_id"
             key: "rights_id"
@@ -156,6 +176,13 @@ phases:
             path: "rights"
             description: "Response includes rights array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--get_rights"
+            description: "Context correlation_id returned unchanged"
   - id: rights_acquisition
     title: "Acquire a rights license"
     narrative: |
@@ -202,6 +229,8 @@ phases:
                 - "Bearer"
               credentials: "pinnacle-revocation-webhook-secret-token"
 
+          context:
+            correlation_id: "brand_rights--acquire_rights"
         context_outputs:
           - path: "rights_grant_id"
             key: "rights_grant_id"
@@ -213,6 +242,13 @@ phases:
             path: "rights_id"
             description: "Response includes rights_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--acquire_rights"
+            description: "Context correlation_id returned unchanged"
   - id: rights_management
     title: "Manage rights"
     narrative: |
@@ -243,6 +279,8 @@ phases:
             end_date: "2026-09-30"
             impression_cap: 5000000
 
+          context:
+            correlation_id: "brand_rights--update_rights"
         validations:
           - check: response_schema
             description: "Response matches update_rights schema"
@@ -250,6 +288,13 @@ phases:
             path: "rights_id"
             description: "Response includes rights_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--update_rights"
+            description: "Context correlation_id returned unchanged"
   - id: creative_approval
     title: "Creative approval"
     narrative: |
@@ -284,9 +329,19 @@ phases:
               - asset_type: "image"
                 url: "https://cdn.pinnacle-agency.example/gen-trail-pro-300x250.png"
 
+          context:
+            correlation_id: "brand_rights--creative_approval"
         validations:
           - check: response_schema
             description: "Response matches creative_approval schema"
           - check: field_present
             path: "decision"
             description: "Response includes approval decision"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "brand_rights--creative_approval"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/campaign_governance_conditions.yaml
+++ b/storyboards/campaign_governance_conditions.yaml
@@ -59,7 +59,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "campaign_governance_conditions--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -67,6 +69,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_conditions--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: plan_registration
     title: "Register governance plan with policy conditions"
     narrative: |
@@ -104,10 +113,28 @@ phases:
                 - "CTV buys require weekly delivery reporting"
                 - "UGC placements require brand safety review before go-live"
 
+          context:
+            correlation_id: "campaign_governance_conditions--sync_plans"
+        context_outputs:
+          - name: plan_id
+            path: 'plans[0].plan_id'
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_conditions--sync_plans"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "plans[0].plan_id"
+            description: "Governance agent assigns plan_id — must be echoed in check_governance"
+          - check: field_present
+            path: "plans[0].version"
+            description: "Plan includes version for concurrency"
   - id: governance_check_conditions
     title: "Governance check — approved with conditions"
     narrative: |
@@ -137,7 +164,7 @@ phases:
           - findings: may include should-severity findings noting the conditions
 
         sample_request:
-          plan_id: "gov_acme_conditional"
+          plan_id: "$context.plan_id"
           binding:
             type: "media_buy"
             account:
@@ -151,6 +178,8 @@ phases:
               - product_id: "lifestyle_display_q2"
                 budget: 15000
 
+          context:
+            correlation_id: "campaign_governance_conditions--check_governance_conditions"
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -164,6 +193,13 @@ phases:
             path: "governance_context"
             description: "Response includes governance context for the media buy"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_conditions--check_governance_conditions"
+            description: "Context correlation_id returned unchanged"
   - id: create_buy_with_conditions
     title: "Create media buy with governance conditions"
     narrative: |
@@ -209,6 +245,16 @@ phases:
               budget: 15000
               pricing_option_id: "cpm_standard"
 
+          context:
+            correlation_id: "campaign_governance_conditions--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_conditions--create_media_buy"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/campaign_governance_delivery.yaml
+++ b/storyboards/campaign_governance_delivery.yaml
@@ -57,7 +57,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "campaign_governance_delivery--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -65,6 +67,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_delivery--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: plan_registration
     title: "Register governance plan with delivery monitoring"
     narrative: |
@@ -102,10 +111,25 @@ phases:
               conditions:
                 - "Re-evaluate governance if any line item drifts >20% from plan"
 
+          context:
+            correlation_id: "campaign_governance_delivery--sync_plans"
+        context_outputs:
+          - name: plan_id
+            path: 'plans[0].plan_id'
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_delivery--sync_plans"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "plans[0].plan_id"
+            description: "Governance agent assigns plan_id — must be echoed in check_governance"
   - id: initial_approval
     title: "Initial governance check — approved"
     narrative: |
@@ -132,7 +156,7 @@ phases:
           - monitoring: delivery phase governance is active
 
         sample_request:
-          plan_id: "gov_acme_delivery"
+          plan_id: "$context.plan_id"
           binding:
             type: "media_buy"
             account:
@@ -146,6 +170,8 @@ phases:
               - product_id: "outdoor_video_q2"
                 budget: 20000
 
+          context:
+            correlation_id: "campaign_governance_delivery--check_governance_approved"
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -153,6 +179,13 @@ phases:
             path: "status"
             description: "Response contains a governance decision"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_delivery--check_governance_approved"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery metrics show budget drift"
     narrative: |
@@ -187,6 +220,8 @@ phases:
             - "mb_acme_q2_2026"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "campaign_governance_delivery--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
@@ -194,6 +229,13 @@ phases:
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_delivery--get_delivery"
+            description: "Context correlation_id returned unchanged"
   - id: drift_recheck
     title: "Governance re-check — drift detected"
     narrative: |
@@ -226,7 +268,7 @@ phases:
           - conditions: if approved, conditions for rebalancing (e.g., "Reallocate $5K from CTV to video")
 
         sample_request:
-          plan_id: "gov_acme_delivery"
+          plan_id: "$context.plan_id"
           governance_phase: "delivery"
           governance_context: "gov_ctx_acme_delivery_approved"
           binding:
@@ -247,6 +289,8 @@ phases:
                   spend_to_date: 6000
                   flight_progress: 0.50
 
+          context:
+            correlation_id: "campaign_governance_delivery--check_governance_drift"
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -256,3 +300,11 @@ phases:
           - check: field_present
             path: "findings"
             description: "Response contains findings about the drift"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_delivery--check_governance_drift"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/campaign_governance_denied.yaml
+++ b/storyboards/campaign_governance_denied.yaml
@@ -56,7 +56,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "campaign_governance_denied--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -64,6 +66,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_denied--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: plan_registration
     title: "Register governance plan"
     narrative: |
@@ -99,10 +108,25 @@ phases:
               per_transaction_threshold: 10000
               escalation_path: "none"
 
+          context:
+            correlation_id: "campaign_governance_denied--sync_plans"
+        context_outputs:
+          - name: plan_id
+            path: 'plans[0].plan_id'
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_denied--sync_plans"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "plans[0].plan_id"
+            description: "Governance agent assigns plan_id — must be echoed in check_governance"
   - id: governance_check
     title: "Governance check — denied"
     narrative: |
@@ -134,7 +158,7 @@ phases:
           - No escalation instructions (plan has no escalation path)
 
         sample_request:
-          plan_id: "gov_acme_strict"
+          plan_id: "$context.plan_id"
           binding:
             type: "media_buy"
             account:
@@ -148,6 +172,8 @@ phases:
               - product_id: "outdoor_video_q2"
                 budget: 20000
 
+          context:
+            correlation_id: "campaign_governance_denied--check_governance_denied"
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -161,3 +187,11 @@ phases:
           - check: field_present
             path: "findings"
             description: "Response contains findings explaining the denial"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "campaign_governance_denied--check_governance_denied"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/capability_discovery.yaml
+++ b/storyboards/capability_discovery.yaml
@@ -69,7 +69,9 @@ phases:
           - governance: property and creative features the governance agent can evaluate
           - account: auth model, billing support, sandbox mode
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "capability_discovery--get_capabilities"
 
         validations:
           - check: response_schema
@@ -81,6 +83,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares which protocol domains it supports"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "capability_discovery--get_capabilities"
+            description: "Context correlation_id returned unchanged"
       - id: get_capabilities_filtered
         title: "Discover capabilities filtered by protocol"
         narrative: |
@@ -101,6 +110,16 @@ phases:
           protocols:
             - "media_buy"
 
+          context:
+            correlation_id: "capability_discovery--get_capabilities_filtered"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "capability_discovery--get_capabilities_filtered"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/content_standards.yaml
+++ b/storyboards/content_standards.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring governance in supported_protocols, confirming the agent provides governance services.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "content_standards--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: create_standards
     title: "Define content standards"
     narrative: |
@@ -100,10 +109,19 @@ phases:
             description: "Acme Outdoor creative quality standards"
           policy: "No violent or controversial imagery (must). Minimum 72 DPI for display assets (should). Brand colors must match palette within 5% tolerance (must)."
 
+          context:
+            correlation_id: "content_standards--create_content_standards"
         validations:
           - check: response_schema
             description: "Response matches create-content-standards-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--create_content_standards"
+            description: "Context correlation_id returned unchanged"
   - id: list_and_get
     title: "Query content standards"
     narrative: |
@@ -131,10 +149,19 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "content_standards--list_content_standards"
         validations:
           - check: response_schema
             description: "Response matches list-content-standards-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--list_content_standards"
+            description: "Context correlation_id returned unchanged"
       - id: get_content_standards
         title: "Get a specific content standard"
         narrative: |
@@ -154,10 +181,19 @@ phases:
         sample_request:
           standards_id: "$context.content_standards_id"
 
+          context:
+            correlation_id: "content_standards--get_content_standards"
         validations:
           - check: response_schema
             description: "Response matches get-content-standards-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--get_content_standards"
+            description: "Context correlation_id returned unchanged"
   - id: update_standards
     title: "Update content standards"
     narrative: |
@@ -184,10 +220,19 @@ phases:
           standards_id: "$context.content_standards_id"
           policy: "No violent or controversial imagery (must). Minimum 72 DPI (should). Brand colors within 5% tolerance (must). All images must have alt text (should)."
 
+          context:
+            correlation_id: "content_standards--update_content_standards"
         validations:
           - check: response_schema
             description: "Response matches update-content-standards-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--update_content_standards"
+            description: "Context correlation_id returned unchanged"
   - id: calibration
     title: "Calibrate content"
     narrative: |
@@ -225,10 +270,19 @@ phases:
                 width: 300
                 height: 250
 
+          context:
+            correlation_id: "content_standards--calibrate_content"
         validations:
           - check: response_schema
             description: "Response matches calibrate-content-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--calibrate_content"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_validation
     title: "Validate delivered content"
     narrative: |
@@ -276,6 +330,16 @@ phases:
                     url: "https://cdn.pinnacle-agency.example/trail-pro-30s.mp4"
                     duration_ms: 30000
 
+          context:
+            correlation_id: "content_standards--validate_content_delivery"
         validations:
           - check: response_schema
             description: "Response matches validate-content-delivery-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "content_standards--validate_content_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/creative_ad_server.yaml
+++ b/storyboards/creative_ad_server.yaml
@@ -64,7 +64,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring creative in supported_protocols, confirming the agent handles creative operations.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_ad_server--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -72,6 +74,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_ad_server--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: browse_library
     title: "Browse the creative library"
     narrative: |
@@ -115,6 +124,8 @@ phases:
             statuses:
               - "approved"
 
+          context:
+            correlation_id: "creative_ad_server--list_creatives"
         validations:
           - check: response_schema
             description: "Response matches list-creatives-response.json schema"
@@ -125,6 +136,13 @@ phases:
             path: "creatives[0].pricing_options[0].pricing_option_id"
             description: "Pricing option includes pricing_option_id for billing reference"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_ad_server--list_creatives"
+            description: "Context correlation_id returned unchanged"
       - id: list_output_formats
         title: "Check available output formats"
         narrative: |
@@ -193,6 +211,8 @@ phases:
           media_buy_id: "mb_summer_campaign_001"
           package_id: "pkg_ctv_premium"
 
+          context:
+            correlation_id: "creative_ad_server--build_tag"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
@@ -203,6 +223,13 @@ phases:
             path: "pricing_option_id"
             description: "Response includes pricing_option_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_ad_server--build_tag"
+            description: "Context correlation_id returned unchanged"
   - id: track_delivery
     title: "Track creative delivery"
     narrative: |
@@ -233,10 +260,22 @@ phases:
           media_buy_ids:
             - "mb_summer_campaign_001"
 
+          context:
+            correlation_id: "creative_ad_server--get_delivery"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches get-creative-delivery-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_ad_server--get_delivery"
+            description: "Context correlation_id returned unchanged"
   - id: report_billing
     title: "Report usage for billing"
     narrative: |
@@ -281,6 +320,8 @@ phases:
               vendor_cost: 1200.00
               currency: "USD"
 
+          context:
+            correlation_id: "creative_ad_server--report_usage"
         validations:
           - check: response_schema
             description: "Response matches report-usage-response.json schema"
@@ -288,3 +329,11 @@ phases:
             path: "accepted"
             value: 1
             description: "One usage record accepted"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_ad_server--report_usage"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/creative_generative.yaml
+++ b/storyboards/creative_generative.yaml
@@ -60,7 +60,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring creative in supported_protocols, confirming the agent handles creative operations.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_generative--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -68,6 +70,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: format_discovery
     title: "Discover generative formats"
     narrative: |
@@ -98,7 +107,9 @@ phases:
           - Render dimensions for the output
           - Variables for any dynamic fields the buyer can control
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_generative--discover_formats"
 
         validations:
           - check: response_schema
@@ -110,6 +121,13 @@ phases:
             path: "formats[0].format_id.agent_url"
             description: "Each format has a format_id with agent_url"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--discover_formats"
+            description: "Context correlation_id returned unchanged"
   - id: generate_from_brief
     title: "Generate from brief"
     narrative: |
@@ -155,6 +173,8 @@ phases:
           quality: "draft"
           include_preview: true
 
+          context:
+            correlation_id: "creative_generative--build_draft"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
@@ -165,6 +185,13 @@ phases:
             path: "creative_manifest.format_id"
             description: "Output manifest includes format_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--build_draft"
+            description: "Context correlation_id returned unchanged"
   - id: refine
     title: "Refine the creative"
     narrative: |
@@ -213,6 +240,8 @@ phases:
           quality: "draft"
           include_preview: true
 
+          context:
+            correlation_id: "creative_generative--refine_creative"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
@@ -220,6 +249,13 @@ phases:
             path: "creative_manifest.assets"
             description: "Refined manifest includes assets"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--refine_creative"
+            description: "Context correlation_id returned unchanged"
   - id: multi_format
     title: "Multi-format generation"
     narrative: |
@@ -278,6 +314,8 @@ phases:
             domain: "acme-outdoor.example.com"
           quality: "production"
 
+          context:
+            correlation_id: "creative_generative--build_multi_format"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
@@ -285,6 +323,13 @@ phases:
             path: "creative_manifests"
             description: "Response contains creative_manifests array (plural)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--build_multi_format"
+            description: "Context correlation_id returned unchanged"
   - id: production_build
     title: "Production build"
     narrative: |
@@ -335,6 +380,8 @@ phases:
           quality: "production"
           include_preview: true
 
+          context:
+            correlation_id: "creative_generative--build_production"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
@@ -344,3 +391,11 @@ phases:
           - check: field_present
             path: "creative_manifest.format_id"
             description: "Production manifest includes format_id"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_generative--build_production"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/creative_lifecycle.yaml
+++ b/storyboards/creative_lifecycle.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring creative in supported_protocols, confirming the agent handles creative operations.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_lifecycle--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: discover_formats
     title: "Discover accepted formats"
     narrative: |
@@ -96,7 +105,9 @@ phases:
           - Render dimensions
           - At least two formats (e.g., display and video)
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_lifecycle--list_formats"
 
         validations:
           - check: response_schema
@@ -105,6 +116,19 @@ phases:
             path: "formats"
             description: "Response contains formats array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--list_formats"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Format IDs include id — must match those in get_products"
   - id: sync_multiple
     title: "Sync multiple creatives"
     narrative: |
@@ -172,6 +196,8 @@ phases:
                   asset_type: "text"
                   content: "Trail Pro 3000 — Built for the Summit"
 
+          context:
+            correlation_id: "creative_lifecycle--sync_creatives"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -179,6 +205,13 @@ phases:
             path: "creatives"
             description: "Response contains per-creative results"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--sync_creatives"
+            description: "Context correlation_id returned unchanged"
   - id: list_and_filter
     title: "List creatives with filtering"
     narrative: |
@@ -211,6 +244,8 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
 
+          context:
+            correlation_id: "creative_lifecycle--list_all"
         validations:
           - check: response_schema
             description: "Response matches list-creatives-response.json schema"
@@ -218,6 +253,13 @@ phases:
             path: "creatives"
             description: "Response contains creatives array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--list_all"
+            description: "Context correlation_id returned unchanged"
       - id: list_filtered
         title: "List creatives filtered by format"
         narrative: |
@@ -244,6 +286,8 @@ phases:
               - agent_url: "https://your-platform.example.com"
                 id: "display_300x250"
 
+          context:
+            correlation_id: "creative_lifecycle--list_filtered"
         validations:
           - check: response_schema
             description: "Response matches list-creatives-response.json schema"
@@ -251,6 +295,13 @@ phases:
             path: "creatives"
             description: "Response contains filtered creatives"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--list_filtered"
+            description: "Context correlation_id returned unchanged"
   - id: build_and_preview
     title: "Build and preview across formats"
     narrative: |
@@ -279,10 +330,19 @@ phases:
         sample_request:
           creative_id: "display_trail_pro_300x250"
 
+          context:
+            correlation_id: "creative_lifecycle--preview_display"
         validations:
           - check: response_schema
             description: "Response matches preview-creative-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--preview_display"
+            description: "Context correlation_id returned unchanged"
       - id: build_video_tag
         title: "Build a VAST tag for the video creative"
         narrative: |
@@ -306,6 +366,16 @@ phases:
             agent_url: "https://your-platform.example.com"
             id: "vast_30s"
 
+          context:
+            correlation_id: "creative_lifecycle--build_video_tag"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_lifecycle--build_video_tag"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/creative_sales_agent.yaml
+++ b/storyboards/creative_sales_agent.yaml
@@ -58,7 +58,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring creative in supported_protocols, confirming the agent handles creative operations.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_sales_agent--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -66,6 +68,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_sales_agent--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: discover_accepted_formats
     title: "Discover accepted formats"
     narrative: |
@@ -141,6 +150,8 @@ phases:
                   asset_type: "url"
                   url: "https://acme-outdoor.example.com/summer-sale"
 
+          context:
+            correlation_id: "creative_sales_agent--sync_creatives"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -148,6 +159,13 @@ phases:
             path: "creatives[0].action"
             description: "Each creative has an action (created/updated)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_sales_agent--sync_creatives"
+            description: "Context correlation_id returned unchanged"
   - id: preview
     title: "Preview pushed creatives"
     narrative: |
@@ -184,9 +202,19 @@ phases:
           output_format: "url"
           quality: "draft"
 
+          context:
+            correlation_id: "creative_sales_agent--preview_synced"
         validations:
           - check: response_schema
             description: "Response matches preview-creative-response.json schema"
           - check: field_present
             path: "previews[0].renders[0].preview_url"
             description: "Preview includes a renderable URL"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_sales_agent--preview_synced"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/creative_template.yaml
+++ b/storyboards/creative_template.yaml
@@ -59,7 +59,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring creative in supported_protocols, confirming the agent handles creative operations.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_template--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -67,6 +69,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_template--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: format_exposure
     title: "Format discovery"
     narrative: |
@@ -101,7 +110,9 @@ phases:
           - Render dimensions (width/height per render)
           - Variables array if the format supports dynamic fields (text, colors, images)
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "creative_template--discover_formats"
 
         validations:
           - check: response_schema
@@ -119,6 +130,13 @@ phases:
             path: "formats[0].renders"
             description: "Each format defines its render dimensions"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_template--discover_formats"
+            description: "Context correlation_id returned unchanged"
       - id: filter_by_type
         title: "Filter formats by type"
         narrative: |
@@ -140,10 +158,25 @@ phases:
           max_width: 728
           max_height: 90
 
+          context:
+            correlation_id: "creative_template--filter_by_type"
         validations:
           - check: response_schema
             description: "Response matches schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_template--filter_by_type"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Format IDs include id — must match those in get_products"
   - id: preview
     title: "Preview with real assets"
     narrative: |
@@ -202,6 +235,8 @@ phases:
           output_format: "url"
           quality: "draft"
 
+          context:
+            correlation_id: "creative_template--preview_creative"
         validations:
           - check: response_schema
             description: "Response matches preview-creative-response.json schema"
@@ -209,6 +244,13 @@ phases:
             path: "previews[0].renders[0].preview_url"
             description: "Preview includes a renderable URL"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_template--preview_creative"
+            description: "Context correlation_id returned unchanged"
   - id: build
     title: "Full build (transformation)"
     narrative: |
@@ -269,6 +311,8 @@ phases:
           brand:
             domain: "acme-outdoor.example.com"
 
+          context:
+            correlation_id: "creative_template--build_creative"
         validations:
           - check: response_schema
             description: "Response matches build-creative-response.json schema"
@@ -279,6 +323,13 @@ phases:
             path: "creative_manifest.format_id"
             description: "Output manifest includes format_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_template--build_creative"
+            description: "Context correlation_id returned unchanged"
       - id: build_multi_format
         title: "Build for multiple formats"
         narrative: |
@@ -321,6 +372,16 @@ phases:
           brand:
             domain: "acme-outdoor.example.com"
 
+          context:
+            correlation_id: "creative_template--build_multi_format"
         validations:
           - check: response_schema
             description: "Response matches schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "creative_template--build_multi_format"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/deterministic_testing.yaml
+++ b/storyboards/deterministic_testing.yaml
@@ -69,7 +69,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "deterministic_testing--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -77,6 +79,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: controller_validation
     title: 'Controller validation'
     narrative: |
@@ -105,6 +114,8 @@ phases:
         sample_request:
           scenario: 'list_scenarios'
 
+          context:
+            correlation_id: "deterministic_testing--list_scenarios"
         validations:
           - check: field_present
             path: 'scenarios'
@@ -115,6 +126,13 @@ phases:
               - true
             description: 'list_scenarios succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--list_scenarios"
+            description: "Context correlation_id returned unchanged"
       - id: unknown_scenario
         title: 'Unknown scenario returns error'
         requires_tool: comply_test_controller
@@ -134,6 +152,8 @@ phases:
           scenario: 'nonexistent_scenario'
           params: {}
 
+          context:
+            correlation_id: "deterministic_testing--unknown_scenario"
         validations:
           - check: field_value
             path: 'success'
@@ -146,6 +166,13 @@ phases:
               - 'UNKNOWN_SCENARIO'
             description: 'Error code is UNKNOWN_SCENARIO'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--unknown_scenario"
+            description: "Context correlation_id returned unchanged"
       - id: missing_params
         title: 'Missing params returns error'
         requires_tool: comply_test_controller
@@ -165,6 +192,8 @@ phases:
           scenario: 'force_creative_status'
           params: {}
 
+          context:
+            correlation_id: "deterministic_testing--missing_params"
         validations:
           - check: field_value
             path: 'success'
@@ -177,6 +206,13 @@ phases:
               - 'INVALID_PARAMS'
             description: 'Error code is INVALID_PARAMS'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--missing_params"
+            description: "Context correlation_id returned unchanged"
       - id: not_found_entity
         title: 'Nonexistent entity returns NOT_FOUND'
         requires_tool: comply_test_controller
@@ -198,6 +234,8 @@ phases:
             creative_id: 'comply-test-nonexistent-000000000000'
             status: 'approved'
 
+          context:
+            correlation_id: "deterministic_testing--not_found_entity"
         validations:
           - check: field_value
             path: 'success'
@@ -210,6 +248,13 @@ phases:
               - 'NOT_FOUND'
             description: 'Error code is NOT_FOUND'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--not_found_entity"
+            description: "Context correlation_id returned unchanged"
   - id: deterministic_account
     title: 'Deterministic account state machine'
     narrative: |
@@ -234,11 +279,20 @@ phases:
           operator: 'test.example'
           sandbox: true
 
+          context:
+            correlation_id: "deterministic_testing--sync_accounts_for_state"
         validations:
           - check: field_present
             path: 'accounts[0].account_id'
             description: 'Account sync returns account_id'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--sync_accounts_for_state"
+            description: "Context correlation_id returned unchanged"
       - id: list_accounts_for_state
         title: 'Find account for state machine test'
         requires_tool: comply_test_controller
@@ -253,13 +307,22 @@ phases:
         expected: |
           Return at least one account with an account_id.
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "deterministic_testing--list_accounts_for_state"
 
         validations:
           - check: field_present
             path: 'accounts[0].account_id'
             description: 'At least one account exists'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--list_accounts_for_state"
+            description: "Context correlation_id returned unchanged"
       - id: force_account_suspended
         title: 'Force account to suspended'
         requires_tool: comply_test_controller
@@ -281,6 +344,8 @@ phases:
             account_id: '$context.account_id'
             status: 'suspended'
 
+          context:
+            correlation_id: "deterministic_testing--force_account_suspended"
         validations:
           - check: field_value
             path: 'success'
@@ -293,6 +358,13 @@ phases:
               - 'suspended'
             description: 'Account is now suspended'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_account_suspended"
+            description: "Context correlation_id returned unchanged"
       - id: force_account_active
         title: 'Reactivate account'
         requires_tool: comply_test_controller
@@ -314,6 +386,8 @@ phases:
             account_id: '$context.account_id'
             status: 'active'
 
+          context:
+            correlation_id: "deterministic_testing--force_account_active"
         validations:
           - check: field_value
             path: 'success'
@@ -326,6 +400,13 @@ phases:
               - 'active'
             description: 'Account is now active'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_account_active"
+            description: "Context correlation_id returned unchanged"
       - id: force_account_payment_required
         title: 'Force account to payment_required'
         requires_tool: comply_test_controller
@@ -344,6 +425,8 @@ phases:
             account_id: '$context.account_id'
             status: 'payment_required'
 
+          context:
+            correlation_id: "deterministic_testing--force_account_payment_required"
         validations:
           - check: field_value
             path: 'success'
@@ -351,6 +434,13 @@ phases:
               - true
             description: 'Transition to payment_required succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_account_payment_required"
+            description: "Context correlation_id returned unchanged"
       - id: restore_account_active
         title: 'Restore account to active'
         requires_tool: comply_test_controller
@@ -368,6 +458,8 @@ phases:
             account_id: '$context.account_id'
             status: 'active'
 
+          context:
+            correlation_id: "deterministic_testing--restore_account_active"
         validations:
           - check: field_value
             path: 'success'
@@ -375,6 +467,13 @@ phases:
               - true
             description: 'Account restored to active'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--restore_account_active"
+            description: "Context correlation_id returned unchanged"
   - id: deterministic_media_buy
     title: 'Deterministic media buy state machine'
     narrative: |
@@ -415,10 +514,19 @@ phases:
               budget: 5000
               pricing_option_id: 'test-pricing'
 
+          context:
+            correlation_id: "deterministic_testing--create_media_buy"
         validations:
           - check: response_schema
             description: 'Response matches create-media-buy-response.json schema'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--create_media_buy"
+            description: "Context correlation_id returned unchanged"
       - id: force_media_buy_active
         title: 'Force media buy to active'
         requires_tool: comply_test_controller
@@ -436,6 +544,8 @@ phases:
             media_buy_id: '$context.media_buy_id'
             status: 'active'
 
+          context:
+            correlation_id: "deterministic_testing--force_media_buy_active"
         validations:
           - check: field_value
             path: 'success'
@@ -448,6 +558,13 @@ phases:
               - 'active'
             description: 'Media buy is now active'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_media_buy_active"
+            description: "Context correlation_id returned unchanged"
       - id: verify_media_buy_active
         title: 'Verify media buy status via get_media_buys'
         requires_tool: comply_test_controller
@@ -471,6 +588,8 @@ phases:
           media_buy_ids:
             - '$context.media_buy_id'
 
+          context:
+            correlation_id: "deterministic_testing--verify_media_buy_active"
         validations:
           - check: response_schema
             description: 'Response matches get-media-buys-response.json schema'
@@ -478,6 +597,13 @@ phases:
             path: 'media_buys[0].status'
             description: 'Media buy has a status field'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--verify_media_buy_active"
+            description: "Context correlation_id returned unchanged"
       - id: force_media_buy_completed
         title: 'Force media buy to completed (terminal)'
         requires_tool: comply_test_controller
@@ -496,6 +622,8 @@ phases:
             media_buy_id: '$context.media_buy_id'
             status: 'completed'
 
+          context:
+            correlation_id: "deterministic_testing--force_media_buy_completed"
         validations:
           - check: field_value
             path: 'success'
@@ -508,6 +636,13 @@ phases:
               - 'completed'
             description: 'Media buy is now completed'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_media_buy_completed"
+            description: "Context correlation_id returned unchanged"
       - id: invalid_transition_from_terminal
         title: 'Reject transition from terminal state'
         requires_tool: comply_test_controller
@@ -529,6 +664,8 @@ phases:
             media_buy_id: '$context.media_buy_id'
             status: 'active'
 
+          context:
+            correlation_id: "deterministic_testing--invalid_transition_from_terminal"
         validations:
           - check: field_value
             path: 'success'
@@ -541,6 +678,13 @@ phases:
               - 'INVALID_TRANSITION'
             description: 'Error code is INVALID_TRANSITION'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--invalid_transition_from_terminal"
+            description: "Context correlation_id returned unchanged"
   - id: deterministic_creative
     title: 'Deterministic creative state machine'
     narrative: |
@@ -584,10 +728,19 @@ phases:
                   url: 'https://via.placeholder.com/300x250'
                   mime_type: 'image/png'
 
+          context:
+            correlation_id: "deterministic_testing--sync_creative_for_state"
         validations:
           - check: response_schema
             description: 'Response matches sync-creatives-response.json schema'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--sync_creative_for_state"
+            description: "Context correlation_id returned unchanged"
       - id: force_creative_approved
         title: 'Force creative to approved'
         requires_tool: comply_test_controller
@@ -605,6 +758,8 @@ phases:
             creative_id: '$context.creative_id'
             status: 'approved'
 
+          context:
+            correlation_id: "deterministic_testing--force_creative_approved"
         validations:
           - check: field_value
             path: 'success'
@@ -617,6 +772,13 @@ phases:
               - 'approved'
             description: 'Creative is now approved'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_creative_approved"
+            description: "Context correlation_id returned unchanged"
       - id: force_creative_archived
         title: 'Force creative to archived (terminal)'
         requires_tool: comply_test_controller
@@ -634,6 +796,8 @@ phases:
             creative_id: '$context.creative_id'
             status: 'archived'
 
+          context:
+            correlation_id: "deterministic_testing--force_creative_archived"
         validations:
           - check: field_value
             path: 'success'
@@ -641,6 +805,13 @@ phases:
               - true
             description: 'Transition to archived succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_creative_archived"
+            description: "Context correlation_id returned unchanged"
       - id: invalid_creative_transition
         title: 'Reject archived to processing'
         requires_tool: comply_test_controller
@@ -660,6 +831,8 @@ phases:
             creative_id: '$context.creative_id'
             status: 'processing'
 
+          context:
+            correlation_id: "deterministic_testing--invalid_creative_transition"
         validations:
           - check: field_value
             path: 'success'
@@ -672,6 +845,13 @@ phases:
               - 'INVALID_TRANSITION'
             description: 'Error code is INVALID_TRANSITION'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--invalid_creative_transition"
+            description: "Context correlation_id returned unchanged"
       - id: force_creative_rejected
         title: 'Force fresh creative to rejected with reason'
         requires_tool: comply_test_controller
@@ -691,6 +871,8 @@ phases:
             status: 'rejected'
             rejection_reason: 'Brand safety policy violation (comply test)'
 
+          context:
+            correlation_id: "deterministic_testing--force_creative_rejected"
         validations:
           - check: field_value
             path: 'success'
@@ -698,6 +880,13 @@ phases:
               - true
             description: 'Creative rejection succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_creative_rejected"
+            description: "Context correlation_id returned unchanged"
   - id: deterministic_session
     title: 'Deterministic SI session state machine'
     narrative: |
@@ -727,11 +916,20 @@ phases:
             response_formats:
               - 'text'
 
+          context:
+            correlation_id: "deterministic_testing--initiate_session"
         validations:
           - check: field_present
             path: 'session_id'
             description: 'Session has a session_id'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--initiate_session"
+            description: "Context correlation_id returned unchanged"
       - id: force_session_terminated
         title: 'Force session timeout'
         requires_tool: comply_test_controller
@@ -751,6 +949,8 @@ phases:
             status: 'terminated'
             termination_reason: 'session_timeout'
 
+          context:
+            correlation_id: "deterministic_testing--force_session_terminated"
         validations:
           - check: field_value
             path: 'success'
@@ -758,6 +958,13 @@ phases:
               - true
             description: 'Session termination succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--force_session_terminated"
+            description: "Context correlation_id returned unchanged"
       - id: verify_terminated_session
         title: 'Verify messaging fails on terminated session'
         requires_tool: comply_test_controller
@@ -775,6 +982,8 @@ phases:
           session_id: '$context.session_id'
           message: 'comply test — session should be terminated'
 
+          context:
+            correlation_id: "deterministic_testing--verify_terminated_session"
         validations:
           - check: field_value
             path: 'success'
@@ -782,6 +991,13 @@ phases:
               - false
             description: 'Message on terminated session fails'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--verify_terminated_session"
+            description: "Context correlation_id returned unchanged"
   - id: deterministic_delivery
     title: 'Deterministic delivery simulation'
     narrative: |
@@ -820,10 +1036,19 @@ phases:
               budget: 5000
               pricing_option_id: 'test-pricing'
 
+          context:
+            correlation_id: "deterministic_testing--create_media_buy_for_delivery"
         validations:
           - check: response_schema
             description: 'Response matches create-media-buy-response.json schema'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--create_media_buy_for_delivery"
+            description: "Context correlation_id returned unchanged"
       - id: simulate_delivery
         title: 'Simulate delivery data'
         requires_tool: comply_test_controller
@@ -846,6 +1071,8 @@ phases:
               amount: 150.00
               currency: 'USD'
 
+          context:
+            correlation_id: "deterministic_testing--simulate_delivery"
         validations:
           - check: field_value
             path: 'success'
@@ -853,6 +1080,13 @@ phases:
               - true
             description: 'Delivery simulation succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--simulate_delivery"
+            description: "Context correlation_id returned unchanged"
       - id: verify_delivery
         title: 'Verify delivery via get_media_buy_delivery'
         requires_tool: comply_test_controller
@@ -878,6 +1112,8 @@ phases:
           media_buy_ids:
             - '$context.delivery_media_buy_id'
 
+          context:
+            correlation_id: "deterministic_testing--verify_delivery"
         validations:
           - check: response_schema
             description: 'Response matches get-media-buy-delivery-response.json schema'
@@ -885,6 +1121,13 @@ phases:
             path: 'media_buy_deliveries'
             description: 'Response contains delivery data'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--verify_delivery"
+            description: "Context correlation_id returned unchanged"
   - id: deterministic_budget
     title: 'Deterministic budget simulation'
     narrative: |
@@ -923,10 +1166,19 @@ phases:
               budget: 10000
               pricing_option_id: 'test-pricing'
 
+          context:
+            correlation_id: "deterministic_testing--create_media_buy_for_budget"
         validations:
           - check: response_schema
             description: 'Response matches create-media-buy-response.json schema'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--create_media_buy_for_budget"
+            description: "Context correlation_id returned unchanged"
       - id: simulate_budget_95
         title: 'Simulate 95% budget spend'
         requires_tool: comply_test_controller
@@ -945,6 +1197,8 @@ phases:
             media_buy_id: '$context.budget_media_buy_id'
             spend_percentage: 95
 
+          context:
+            correlation_id: "deterministic_testing--simulate_budget_95"
         validations:
           - check: field_value
             path: 'success'
@@ -952,6 +1206,13 @@ phases:
               - true
             description: '95% budget simulation succeeds'
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--simulate_budget_95"
+            description: "Context correlation_id returned unchanged"
       - id: simulate_budget_100
         title: 'Simulate 100% budget depletion'
         requires_tool: comply_test_controller
@@ -970,9 +1231,19 @@ phases:
             media_buy_id: '$context.budget_media_buy_id'
             spend_percentage: 100
 
+          context:
+            correlation_id: "deterministic_testing--simulate_budget_100"
         validations:
           - check: field_value
             path: 'success'
             allowed_values:
               - true
             description: '100% budget depletion simulation succeeds'
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "deterministic_testing--simulate_budget_100"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/error_compliance.yaml
+++ b/storyboards/error_compliance.yaml
@@ -21,6 +21,12 @@ narrative: |
   the correct error code, recovery classification, and transport binding. Agents that use the
   adcpError() helper from @adcp/client get L3 compliance automatically.
 
+  Context echo is required on error responses — the correlation ID is even more important for
+  error diagnosis than for success cases. Every error response must include the caller's context
+  object unchanged. This contract applies to application-level errors (your tool handler returns
+  an error). MCP transport errors (unknown tool, malformed request) are outside the agent's
+  control and do not carry AdCP context.
+
 agent:
   interaction_model: media_buy_seller
   capabilities:
@@ -58,7 +64,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "error_compliance--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -66,6 +74,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: error_responses
     title: "Error responses for invalid input"
     narrative: |
@@ -84,6 +99,7 @@ phases:
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: error_handling
+        expect_error: true
         stateful: false
         expected: |
           Reject the request with an error containing:
@@ -100,17 +116,27 @@ phases:
               budget: -500
               pricing_option_id: "test-pricing"
 
+          context:
+            correlation_id: "error_compliance--negative_budget"
         validations:
           - check: field_present
             path: "errors"
             description: "Response contains an error for negative budget"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--negative_budget"
+            description: "Context correlation_id returned unchanged"
       - id: nonexistent_product
         title: "Reject nonexistent product ID"
         narrative: |
           The buyer references a product ID that does not exist on this platform.
           The agent should return PRODUCT_NOT_FOUND or INVALID_REQUEST.
         task: create_media_buy
+        expect_error: true
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
@@ -130,11 +156,20 @@ phases:
               budget: 10000
               pricing_option_id: "test-pricing"
 
+          context:
+            correlation_id: "error_compliance--nonexistent_product"
         validations:
           - check: field_present
             path: "errors"
             description: "Response contains an error for nonexistent product"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--nonexistent_product"
+            description: "Context correlation_id returned unchanged"
       - id: missing_fields
         title: "Reject empty get_products request"
         narrative: |
@@ -155,16 +190,26 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "error_compliance--missing_fields"
         validations:
           - check: response_schema
             description: "Response is either valid products or a structured error"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--missing_fields"
+            description: "Context correlation_id returned unchanged"
       - id: reversed_dates_error
         title: "Reject reversed dates with error code"
         narrative: |
           Send a create_media_buy with end_time before start_time and verify the error
           response includes the correct code and recovery classification.
         task: create_media_buy
+        expect_error: true
         schema_ref: "media-buy/create-media-buy-request.json"
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
@@ -182,11 +227,20 @@ phases:
               budget: 10000
               pricing_option_id: "test-pricing"
 
+          context:
+            correlation_id: "error_compliance--reversed_dates_error"
         validations:
           - check: field_present
             path: "errors"
             description: "Response contains an error for reversed dates"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--reversed_dates_error"
+            description: "Context correlation_id returned unchanged"
   - id: error_structure
     title: "Error structure compliance"
     narrative: |
@@ -205,6 +259,7 @@ phases:
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: error_codes
+        expect_error: true
         stateful: false
         expected: |
           Error response with:
@@ -220,6 +275,20 @@ phases:
             - product_id: "test-product"
               budget: -1
               pricing_option_id: "test-pricing"
+
+          context:
+            correlation_id: "error_compliance--validate_error_shape"
+        validations:
+          - check: field_present
+            path: "errors"
+            description: "Response contains errors array"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--validate_error_shape"
+            description: "Context correlation_id returned unchanged"
 
   - id: error_transport
     title: "Error transport bindings"
@@ -239,6 +308,7 @@ phases:
         response_schema_ref: "media-buy/create-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/create_media_buy"
         comply_scenario: error_transport
+        expect_error: true
         stateful: false
         expected: |
           MCP response with:
@@ -253,3 +323,17 @@ phases:
             - product_id: "nonexistent"
               budget: -1
               pricing_option_id: "bad-pricing"
+
+          context:
+            correlation_id: "error_compliance--validate_transport_binding"
+        validations:
+          - check: field_present
+            path: "errors"
+            description: "Response contains errors array"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object even on errors"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "error_compliance--validate_transport_binding"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_broadcast_seller.yaml
+++ b/storyboards/media_buy_broadcast_seller.yaml
@@ -70,7 +70,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_broadcast_seller--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -78,6 +80,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: product_discovery
     title: "Product discovery"
     narrative: |
@@ -133,6 +142,8 @@ phases:
               domain: "novamotors.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_broadcast_seller--get_products_brief"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -146,6 +157,22 @@ phases:
             path: "products[0].delivery_type"
             description: "Each product declares guaranteed delivery"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: create_buy
     title: "Create the media buy"
     narrative: |
@@ -227,10 +254,19 @@ phases:
             authentication:
               scheme: "HMAC-SHA256"
 
+          context:
+            correlation_id: "media_buy_broadcast_seller--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--create_media_buy"
+            description: "Context correlation_id returned unchanged"
       - id: check_buy_status
         title: "Check media buy status"
         narrative: |
@@ -262,6 +298,8 @@ phases:
           media_buy_ids:
             - "mb_nova_q4_2026"
 
+          context:
+            correlation_id: "media_buy_broadcast_seller--check_buy_status"
         validations:
           - check: response_schema
             description: "Response matches get-media-buys-response.json schema"
@@ -269,6 +307,13 @@ phases:
             path: "media_buys[0].status"
             description: "Each media buy has a status"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--check_buy_status"
+            description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
     narrative: |
@@ -299,7 +344,9 @@ phases:
           - Duration constraints matching the spot length
           - No VAST, VPAID, or tracker-related asset slots
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_broadcast_seller--list_formats"
 
         validations:
           - check: response_schema
@@ -308,6 +355,19 @@ phases:
             path: "formats"
             description: "Response contains formats array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--list_formats"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Format IDs include id — must match those in get_products"
       - id: sync_creatives
         title: "Push broadcast spot files"
         narrative: |
@@ -372,6 +432,8 @@ phases:
                   container_format: "mp4"
                   video_codec: "h264"
 
+          context:
+            correlation_id: "media_buy_broadcast_seller--sync_creatives"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -379,6 +441,13 @@ phases:
             path: "creatives[0].action"
             description: "Each creative has an action (created/updated)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--sync_creatives"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
     narrative: |
@@ -442,6 +511,8 @@ phases:
             - "mb_nova_q4_2026"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_broadcast_seller--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
@@ -449,6 +520,13 @@ phases:
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--get_delivery"
+            description: "Context correlation_id returned unchanged"
   - id: reconciliation
     title: "Post-flight reconciliation"
     narrative: |
@@ -501,9 +579,19 @@ phases:
             - "mb_nova_q4_2026"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_broadcast_seller--get_final_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains final delivery data"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_broadcast_seller--get_final_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_catalog_creative.yaml
+++ b/storyboards/media_buy_catalog_creative.yaml
@@ -67,7 +67,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_catalog_creative--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -75,6 +77,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account setup"
     narrative: |
@@ -104,6 +113,8 @@ phases:
               billing: "operator"
               sandbox: true
 
+          context:
+            correlation_id: "media_buy_catalog_creative--sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -111,6 +122,13 @@ phases:
             path: "accounts[0].account_id"
             description: "Account has a platform-assigned ID"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--sync_accounts"
+            description: "Context correlation_id returned unchanged"
   - id: catalog_sync
     title: "Product catalog sync"
     narrative: |
@@ -146,6 +164,8 @@ phases:
         sample_request:
           channels: ["display", "native"]
 
+          context:
+            correlation_id: "media_buy_catalog_creative--discover_catalog_formats"
         validations:
           - check: response_schema
             description: "Response matches list-creative-formats-response.json schema"
@@ -153,6 +173,19 @@ phases:
             path: "formats"
             description: "Response contains formats array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--discover_catalog_formats"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Format IDs include id — must match those in get_products"
       - id: sync_catalogs
         title: "Push product catalog"
         narrative: |
@@ -211,6 +244,8 @@ phases:
                     amount: 195.00
                     currency: "USD"
 
+          context:
+            correlation_id: "media_buy_catalog_creative--sync_catalogs"
         validations:
           - check: response_schema
             description: "Response matches sync-catalogs-response.json schema"
@@ -224,6 +259,13 @@ phases:
             path: "catalogs[0].items_approved"
             description: "Catalog reports approved item count"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--sync_catalogs"
+            description: "Context correlation_id returned unchanged"
   - id: create_buy
     title: "Create catalog-driven media buy"
     narrative: |
@@ -261,6 +303,8 @@ phases:
               domain: "amsterdam-steakhouse.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_catalog_creative--get_products"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -268,6 +312,22 @@ phases:
             path: "products"
             description: "Response contains products"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--get_products"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
       - id: create_media_buy
         title: "Create media buy with catalog packages"
         narrative: |
@@ -307,10 +367,19 @@ phases:
                 - catalog_id: "menu_spring_2026"
                   catalog_type: "product"
 
+          context:
+            correlation_id: "media_buy_catalog_creative--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--create_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: event_setup
     title: "Conversion tracking setup"
     narrative: |
@@ -351,6 +420,11 @@ phases:
               event_types: ["purchase", "add_to_cart", "page_view", "lead"]
               allowed_domains: ["amsterdam-steakhouse.com", "book.amsterdam-steakhouse.com"]
 
+          context:
+            correlation_id: "media_buy_catalog_creative--sync_event_sources"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches sync-event-sources-response.json schema"
@@ -358,6 +432,13 @@ phases:
             path: "event_sources[0].setup.snippet"
             description: "Event source includes setup snippet"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--sync_event_sources"
+            description: "Context correlation_id returned unchanged"
   - id: conversion_tracking
     title: "Log conversions"
     narrative: |
@@ -406,6 +487,8 @@ phases:
               timestamp: "2026-04-15T20:45:00Z"
               content_ids: ["seafood_tower"]
 
+          context:
+            correlation_id: "media_buy_catalog_creative--log_events"
         validations:
           - check: response_schema
             description: "Response matches log-event-response.json schema"
@@ -416,6 +499,13 @@ phases:
             path: "match_quality"
             description: "Response includes match quality score"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--log_events"
+            description: "Context correlation_id returned unchanged"
   - id: optimization_loop
     title: "Performance feedback and optimization"
     narrative: |
@@ -450,6 +540,11 @@ phases:
           metric_type: "conversion_rate"
           feedback_source: "buyer_attribution"
 
+          context:
+            correlation_id: "media_buy_catalog_creative--provide_feedback"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches provide-performance-feedback-response.json schema"
@@ -458,6 +553,13 @@ phases:
             value: true
             description: "Feedback accepted"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--provide_feedback"
+            description: "Context correlation_id returned unchanged"
       - id: check_delivery
         title: "Monitor delivery with catalog attribution"
         narrative: |
@@ -482,6 +584,16 @@ phases:
             - "mb_amsterdam_spring_2026"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_catalog_creative--check_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_catalog_creative--check_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_generative_seller.yaml
+++ b/storyboards/media_buy_generative_seller.yaml
@@ -76,7 +76,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_generative_seller--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -84,6 +86,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account setup"
     narrative: |
@@ -120,6 +129,8 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          context:
+            correlation_id: "media_buy_generative_seller--sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -130,6 +141,13 @@ phases:
             path: "accounts[0].status"
             description: "Account has a status (active or pending_approval)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--sync_accounts"
+            description: "Context correlation_id returned unchanged"
   - id: format_discovery
     title: "Format discovery"
     narrative: |
@@ -179,7 +197,9 @@ phases:
           Both types should be present for a programmatic seller. Buyers who already
           have creatives need to be able to upload them directly.
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_generative_seller--list_formats"
 
         validations:
           - check: response_schema
@@ -191,6 +211,13 @@ phases:
             path: "formats[0].format_id.agent_url"
             description: "Each format has a format_id with agent_url"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--list_formats"
+            description: "Context correlation_id returned unchanged"
   - id: product_discovery
     title: "Product discovery"
     narrative: |
@@ -234,6 +261,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_generative_seller--get_products_brief"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -244,6 +273,22 @@ phases:
             path: "products[0].product_id"
             description: "Each product has a product_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: create_buy
     title: "Create the media buy"
     narrative: |
@@ -292,10 +337,19 @@ phases:
             authentication:
               scheme: "HMAC-SHA256"
 
+          context:
+            correlation_id: "media_buy_generative_seller--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--create_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: creative_brief_sync
     title: "Creative brief sync"
     narrative: |
@@ -395,6 +449,8 @@ phases:
             - creative_id: "gen_video_summer_sale"
               package_id: "outdoor_video_q2"
 
+          context:
+            correlation_id: "media_buy_generative_seller--sync_creatives_brief"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -405,6 +461,13 @@ phases:
             path: "creatives[0].action"
             description: "Each creative has a status (pending_review or accepted)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--sync_creatives_brief"
+            description: "Context correlation_id returned unchanged"
       - id: sync_creatives_standard
         title: "Sync standard creatives alongside generative"
         narrative: |
@@ -440,6 +503,8 @@ phases:
                   width: 300
                   height: 250
 
+          context:
+            correlation_id: "media_buy_generative_seller--sync_creatives_standard"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -447,6 +512,13 @@ phases:
             path: "creatives[0].action"
             description: "Standard creative has an action"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--sync_creatives_standard"
+            description: "Context correlation_id returned unchanged"
       - id: sync_creatives_invalid_brand
         title: "Reject brief with invalid brand"
         narrative: |
@@ -485,6 +557,8 @@ phases:
                     headline: "Test"
                     cta: "Click"
 
+          context:
+            correlation_id: "media_buy_generative_seller--sync_creatives_invalid_brand"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -492,6 +566,13 @@ phases:
             path: "creatives[0].action"
             description: "Creative has a status (expected: rejected)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--sync_creatives_invalid_brand"
+            description: "Context correlation_id returned unchanged"
   - id: creative_generation_lifecycle
     title: "Creative generation lifecycle"
     narrative: |
@@ -558,6 +639,8 @@ phases:
                     headline: "Your Next Adventure Starts Here"
                     cta: "Shop the Sale"
 
+          context:
+            correlation_id: "media_buy_generative_seller--check_creative_status"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -565,6 +648,13 @@ phases:
             path: "creatives[0].action"
             description: "Each creative has a current status"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--check_creative_status"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
     narrative: |
@@ -600,9 +690,19 @@ phases:
             - "mb_acme_q2_2026"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_generative_seller--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_generative_seller--get_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_governance_escalation.yaml
+++ b/storyboards/media_buy_governance_escalation.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_governance_escalation--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account and governance setup"
     narrative: |
@@ -101,6 +110,8 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          context:
+            correlation_id: "media_buy_governance_escalation--sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -108,6 +119,13 @@ phases:
             path: "accounts[0].account_id"
             description: "Account has a platform-assigned ID"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--sync_accounts"
+            description: "Context correlation_id returned unchanged"
       - id: sync_governance
         title: "Register governance agent"
         narrative: |
@@ -138,10 +156,22 @@ phases:
                     credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
                   categories: ["budget_authority", "brand_policy"]
 
+          context:
+            correlation_id: "media_buy_governance_escalation--sync_governance"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--sync_governance"
+            description: "Context correlation_id returned unchanged"
   - id: register_plan
     title: "Register governance plan with spending limits"
     narrative: |
@@ -183,10 +213,25 @@ phases:
                 - "Weekly reporting required for buys over $10K"
                 - "No single-seller concentration above 60% of total budget"
 
+          context:
+            correlation_id: "media_buy_governance_escalation--sync_plans"
+        context_outputs:
+          - name: plan_id
+            path: 'plans[0].plan_id'
         validations:
           - check: response_schema
             description: "Response matches sync-plans-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--sync_plans"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "plans[0].plan_id"
+            description: "Governance agent assigns plan_id — must be echoed in check_governance"
   - id: discover_products
     title: "Product discovery"
     narrative: |
@@ -223,6 +268,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_governance_escalation--get_products_brief"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -230,6 +277,22 @@ phases:
             path: "products"
             description: "Response contains a products array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: governance_check_denied
     title: "Governance check — denied"
     narrative: |
@@ -264,7 +327,7 @@ phases:
           - plan_id: the governance plan that triggered the denial
 
         sample_request:
-          plan_id: "gov_acme_q2_2026"
+          plan_id: "$context.plan_id"
           binding:
             type: "media_buy"
             account:
@@ -278,6 +341,8 @@ phases:
               - product_id: "outdoor_video_q2"
                 budget: 20000
 
+          context:
+            correlation_id: "media_buy_governance_escalation--check_governance_denied"
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -288,6 +353,13 @@ phases:
             path: "findings"
             description: "Response contains findings explaining the denial"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--check_governance_denied"
+            description: "Context correlation_id returned unchanged"
   - id: human_escalation
     title: "Human escalation — conditional approval"
     narrative: |
@@ -322,7 +394,7 @@ phases:
           - approved_at: timestamp of approval
 
         sample_request:
-          plan_id: "gov_acme_q2_2026"
+          plan_id: "$context.plan_id"
           governance_context: "gov_ctx_acme_q2_escalated"
           binding:
             type: "media_buy"
@@ -343,6 +415,11 @@ phases:
               - "Weekly delivery reporting required"
               - "Human review required for any budget increase above 10%"
 
+          context:
+            correlation_id: "media_buy_governance_escalation--check_governance_approved"
+        context_outputs:
+          - name: check_id
+            path: 'check_id'
         validations:
           - check: response_schema
             description: "Response matches check-governance-response.json schema"
@@ -353,6 +430,16 @@ phases:
             path: "conditions"
             description: "Approval includes conditions"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--check_governance_approved"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "check_id"
+            description: "Check ID for audit trail — must be echoed in report_plan_outcome"
   - id: create_buy_with_governance
     title: "Create media buy with governance context"
     narrative: |
@@ -405,10 +492,19 @@ phases:
               creative_assignments:
                 - creative_id: "video_15s_trail_pro"
 
+          context:
+            correlation_id: "media_buy_governance_escalation--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--create_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: report_outcome
     title: "Report governance outcome"
     narrative: |
@@ -438,7 +534,7 @@ phases:
           - status: recorded
 
         sample_request:
-          plan_id: "gov_acme_q2_2026"
+          plan_id: "$context.plan_id"
           governance_context: "gov_ctx_acme_q2_approved"
           outcome:
             type: "media_buy_created"
@@ -450,10 +546,19 @@ phases:
               - product_id: "outdoor_video_q2"
                 budget: 20000
 
+          context:
+            correlation_id: "media_buy_governance_escalation--report_plan_outcome"
         validations:
           - check: response_schema
             description: "Response matches report-plan-outcome-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--report_plan_outcome"
+            description: "Context correlation_id returned unchanged"
   - id: audit_trail
     title: "Governance audit trail"
     narrative: |
@@ -488,11 +593,21 @@ phases:
           - Each entry includes: timestamp, event_type, actor, decision, details
 
         sample_request:
-          plan_id: "gov_acme_q2_2026"
+          plan_id: "$context.plan_id"
 
+          context:
+            correlation_id: "media_buy_governance_escalation--get_plan_audit_logs"
         validations:
           - check: response_schema
             description: "Response matches get-plan-audit-logs-response.json schema"
           - check: field_present
             path: "plans"
             description: "Response contains audit log entries"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_governance_escalation--get_plan_audit_logs"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_guaranteed_approval.yaml
+++ b/storyboards/media_buy_guaranteed_approval.yaml
@@ -63,7 +63,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_guaranteed_approval--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -71,6 +73,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account setup"
     narrative: |
@@ -108,6 +117,8 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -118,6 +129,13 @@ phases:
             path: "accounts[0].status"
             description: "Account has a status (active or pending_approval)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--sync_accounts"
+            description: "Context correlation_id returned unchanged"
   - id: product_discovery
     title: "Discover guaranteed products"
     narrative: |
@@ -159,6 +177,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--get_products_brief"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -172,6 +192,22 @@ phases:
             path: "products[0].delivery_type"
             description: "Each product declares delivery_type: guaranteed"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: create_buy_submitted
     title: "Create guaranteed buy (submitted for approval)"
     narrative: |
@@ -231,10 +267,19 @@ phases:
             authentication:
               scheme: "HMAC-SHA256"
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--create_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: poll_approval
     title: "Poll for IO approval"
     narrative: |
@@ -273,6 +318,8 @@ phases:
           media_buy_ids:
             - "mb_acme_q2_2026_guaranteed"
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--get_media_buys_pending"
         validations:
           - check: response_schema
             description: "Response matches get-media-buys-response.json schema"
@@ -283,6 +330,13 @@ phases:
             path: "media_buys[0].valid_actions"
             description: "Pending approval buy includes valid actions"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--get_media_buys_pending"
+            description: "Context correlation_id returned unchanged"
   - id: confirm_active
     title: "Confirm active after IO signing"
     narrative: |
@@ -320,6 +374,8 @@ phases:
           media_buy_ids:
             - "mb_acme_q2_2026_guaranteed"
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--get_media_buys_active"
         validations:
           - check: response_schema
             description: "Response matches get-media-buys-response.json schema"
@@ -330,6 +386,13 @@ phases:
             path: "media_buys[0].confirmed_at"
             description: "Active buy includes a confirmed_at timestamp"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--get_media_buys_active"
+            description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
     narrative: |
@@ -372,6 +435,8 @@ phases:
                   url: "https://cdn.pinnacle-agency.example/trail-pro-30s.mp4"
                   mime_type: "video/mp4"
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--sync_creatives"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -379,6 +444,13 @@ phases:
             path: "creatives[0].action"
             description: "Each creative has an action (created/updated)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--sync_creatives"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_monitoring
     title: "Delivery and reporting"
     narrative: |
@@ -414,9 +486,19 @@ phases:
             - "mb_acme_q2_2026_guaranteed"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_guaranteed_approval--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_guaranteed_approval--get_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_non_guaranteed.yaml
+++ b/storyboards/media_buy_non_guaranteed.yaml
@@ -63,7 +63,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_non_guaranteed--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -71,6 +73,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_non_guaranteed--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: product_discovery
     title: "Discover auction-based products"
     narrative: |
@@ -111,6 +120,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_non_guaranteed--get_products_brief"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -124,6 +135,22 @@ phases:
             path: "products[0].delivery_type"
             description: "Each product declares delivery_type: non_guaranteed"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_non_guaranteed--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: create_buy
     title: "Create non-guaranteed buy"
     narrative: |
@@ -181,10 +208,22 @@ phases:
               creative_assignments:
                 - creative_id: "video_30s_trail_pro"
 
+          context:
+            correlation_id: "media_buy_non_guaranteed--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_non_guaranteed--create_media_buy"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "packages[0].package_id"
+            description: "Seller assigns package_id — must be echoed in update_media_buy"
   - id: monitor_pacing
     title: "Monitor win rates and pacing"
     narrative: |
@@ -220,6 +259,8 @@ phases:
           media_buy_ids:
             - "mb_acme_q2_2026_auction"
 
+          context:
+            correlation_id: "media_buy_non_guaranteed--get_media_buys_pacing"
         validations:
           - check: response_schema
             description: "Response matches get-media-buys-response.json schema"
@@ -227,6 +268,13 @@ phases:
             path: "media_buys[0].status"
             description: "Media buy has a status"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_non_guaranteed--get_media_buys_pacing"
+            description: "Context correlation_id returned unchanged"
   - id: adjust_bids
     title: "Adjust bids and budget"
     narrative: |
@@ -268,10 +316,19 @@ phases:
               bid_price: 20.00
               budget: 13000
 
+          context:
+            correlation_id: "media_buy_non_guaranteed--update_media_buy"
         validations:
           - check: response_schema
             description: "Response matches update-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_non_guaranteed--update_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: delivery
     title: "Delivery and auction metrics"
     narrative: |
@@ -308,9 +365,19 @@ phases:
             - "mb_acme_q2_2026_auction"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_non_guaranteed--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_non_guaranteed--get_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_proposal_mode.yaml
+++ b/storyboards/media_buy_proposal_mode.yaml
@@ -64,7 +64,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_proposal_mode--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -72,6 +74,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account setup"
     narrative: |
@@ -103,6 +112,8 @@ phases:
               billing: "operator"
               payment_terms: "net_30"
 
+          context:
+            correlation_id: "media_buy_proposal_mode--sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -110,6 +121,13 @@ phases:
             path: "accounts[0].account_id"
             description: "Account has a platform-assigned ID"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--sync_accounts"
+            description: "Context correlation_id returned unchanged"
   - id: brief_with_proposals
     title: "Brief with proposals"
     narrative: |
@@ -155,6 +173,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_proposal_mode--get_products_brief"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -168,6 +188,22 @@ phases:
             path: "proposals[0].proposal_id"
             description: "Each proposal has a proposal_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: review_refine
     title: "Refine a proposal"
     narrative: |
@@ -211,6 +247,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_proposal_mode--get_products_refine"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -218,6 +256,22 @@ phases:
             path: "proposals"
             description: "Response contains updated proposals"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--get_products_refine"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
   - id: accept_proposal
     title: "Accept the proposal"
     narrative: |
@@ -264,10 +318,19 @@ phases:
           start_time: "2026-04-01T00:00:00Z"
           end_time: "2026-06-30T23:59:59Z"
 
+          context:
+            correlation_id: "media_buy_proposal_mode--create_media_buy"
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--create_media_buy"
+            description: "Context correlation_id returned unchanged"
   - id: creative_sync
     title: "Creative sync"
     narrative: |
@@ -293,7 +356,9 @@ phases:
           - Asset requirements (dimensions, file sizes, mime types)
           - Render dimensions
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_proposal_mode--list_formats"
 
         validations:
           - check: response_schema
@@ -302,6 +367,19 @@ phases:
             path: "formats"
             description: "Response contains formats array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--list_formats"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Format IDs include id — must match those in get_products"
       - id: sync_creatives
         title: "Push creative assets"
         narrative: |
@@ -347,6 +425,8 @@ phases:
                   url: "https://cdn.pinnacle-agency.example/trail-pro-15s.mp4"
                   mime_type: "video/mp4"
 
+          context:
+            correlation_id: "media_buy_proposal_mode--sync_creatives"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
@@ -354,6 +434,13 @@ phases:
             path: "creatives[0].action"
             description: "Each creative has an action (created/updated)"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--sync_creatives"
+            description: "Context correlation_id returned unchanged"
   - id: delivery
     title: "Delivery and reporting"
     narrative: |
@@ -389,9 +476,19 @@ phases:
             - "mb_acme_q2_2026_proposal"
           include_package_daily_breakdown: true
 
+          context:
+            correlation_id: "media_buy_proposal_mode--get_delivery"
         validations:
           - check: response_schema
             description: "Response matches get-media-buy-delivery-response.json schema"
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_proposal_mode--get_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_seller.yaml
+++ b/storyboards/media_buy_seller.yaml
@@ -65,13 +65,22 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_seller--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
           - check: field_present
             path: "supported_protocols"
             description: "Agent declares supported protocols"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--get_capabilities"
+            description: "Context correlation_id returned unchanged"
 
   - id: account_setup
     title: "Account setup"
@@ -119,6 +128,8 @@ phases:
               operator: "pinnacle-agency.com"
               billing: "operator"
               payment_terms: "net_30"
+          context:
+            correlation_id: "media_buy_seller--sync_accounts"
 
         validations:
           - check: response_schema
@@ -129,6 +140,13 @@ phases:
           - check: field_present
             path: "accounts[0].status"
             description: "Account has a status (active or pending_approval)"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--sync_accounts"
+            description: "Context correlation_id returned unchanged"
 
   - id: governance_setup
     title: "Governance agent registration"
@@ -176,10 +194,22 @@ phases:
                     schemes: ["Bearer"]
                     credentials: "gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
                   categories: ["budget_authority", "brand_policy"]
+          context:
+            correlation_id: "media_buy_seller--sync_governance"
+          ext:
+            test_platform:
+              governance_tier: "standard"
 
         validations:
           - check: response_schema
             description: "Response matches sync-governance-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--sync_governance"
+            description: "Context correlation_id returned unchanged"
 
   - id: product_discovery
     title: "Product discovery"
@@ -234,7 +264,16 @@ phases:
             brand:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
+          context:
+            correlation_id: "media_buy_seller--get_products_brief"
 
+        context_outputs:
+          - name: product_format_id
+            path: 'products[0].format_ids[0]'
+          - name: product_id
+            path: 'products[0].product_id'
+          - name: pricing_option_id
+            path: 'products[0].pricing_options[0].pricing_option_id'
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -247,7 +286,26 @@ phases:
           - check: field_present
             path: "products[0].delivery_type"
             description: "Each product declares guaranteed or non_guaranteed delivery"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--get_products_brief"
+            description: "Context correlation_id returned unchanged"
 
+          - check: field_present
+            path: "products[0].publisher_properties"
+            description: "Products include publisher_properties"
   - id: proposal_refinement
     title: "Proposal refinement"
     narrative: |
@@ -294,6 +352,8 @@ phases:
               domain: "acmeoutdoor.com"
             operator: "pinnacle-agency.com"
 
+          context:
+            correlation_id: "media_buy_seller--get_products_refine"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -301,6 +361,13 @@ phases:
             path: "products"
             description: "Response contains updated products"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--get_products_refine"
+            description: "Context correlation_id returned unchanged"
   - id: create_buy
     title: "Create the media buy"
     narrative: |
@@ -385,10 +452,22 @@ phases:
             url: "https://buyer.example/webhooks/adcp"
             authentication:
               scheme: "HMAC-SHA256"
+          context:
+            correlation_id: "media_buy_seller--create_media_buy"
 
+        context_outputs:
+          - name: media_buy_id
+            path: 'media_buy_id'
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--create_media_buy"
+            description: "Context correlation_id returned unchanged"
 
       - id: check_buy_status
         title: "Check media buy status"
@@ -425,6 +504,8 @@ phases:
             operator: "pinnacle-agency.com"
           media_buy_ids:
             - "mb_acme_q2_2026"
+          context:
+            correlation_id: "media_buy_seller--check_buy_status"
 
         validations:
           - check: response_schema
@@ -432,6 +513,13 @@ phases:
           - check: field_present
             path: "media_buys[0].status"
             description: "Each media buy has a status"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--check_buy_status"
+            description: "Context correlation_id returned unchanged"
 
   - id: creative_sync
     title: "Creative sync"
@@ -439,6 +527,11 @@ phases:
       With the media buy confirmed, the buyer syncs creative assets to your platform.
       Each package in the buy has creative format requirements — the buyer discovered
       these during product discovery and now pushes matching assets.
+
+      The format_ids used in sync_creatives must match those returned by your platform
+      in get_products and list_creative_formats. If your platform returns a format_id
+      in a product but rejects it when the buyer echoes it back in sync_creatives, the
+      buyer cannot fulfill the creative requirements. This is a common compliance failure.
 
       Your platform validates each creative against the format specs and returns
       per-creative status. If assets need review or transcoding, the operation may
@@ -463,7 +556,9 @@ phases:
           - Asset requirements (dimensions, file sizes, mime types)
           - Render dimensions
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_seller--list_formats"
 
         validations:
           - check: response_schema
@@ -471,13 +566,31 @@ phases:
           - check: field_present
             path: "formats"
             description: "Response contains formats array"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Format IDs include id — must match those in get_products"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--list_formats"
+            description: "Context correlation_id returned unchanged"
 
       - id: sync_creatives
-        title: "Push creative assets"
+        title: "Push creative assets (format_id roundtrip)"
         narrative: |
-          The buyer uploads creative assets for the confirmed packages. Your platform
-          validates each creative against the format specs, transcodes if necessary,
-          and returns per-creative status.
+          The buyer uploads creative assets for the confirmed packages. The first
+          creative uses $context.product_format_id — the exact format_id object
+          returned by get_products. This is the roundtrip test: the seller must
+          accept its own format_ids without modification. If the seller's validation
+          rejects a format_id that it returned in products, this step fails.
+
+          Your platform validates each creative against the format specs, transcodes
+          if necessary, and returns per-creative status.
         task: sync_creatives
         schema_ref: "creative/sync-creatives-request.json"
         response_schema_ref: "creative/sync-creatives-response.json"
@@ -491,6 +604,9 @@ phases:
           - Validation errors for rejected creatives
           - Platform-assigned IDs if applicable
 
+          The first creative uses a format_id extracted from get_products.
+          If this is rejected, your format_ids do not roundtrip correctly.
+
         sample_request:
           account:
             brand:
@@ -499,9 +615,7 @@ phases:
           creatives:
             - creative_id: "video_30s_trail_pro"
               name: "Trail Pro 3000 - 30s CTV Spot"
-              format_id:
-                agent_url: "https://your-platform.example.com"
-                id: "ssai_30s"
+              format_id: "$context.product_format_id"
               assets:
                 - asset_id: "video"
                   asset_type: "video"
@@ -517,6 +631,8 @@ phases:
                   asset_type: "image"
                   url: "https://cdn.pinnacle-agency.example/trail-pro-300x250.png"
                   mime_type: "image/png"
+          context:
+            correlation_id: "media_buy_seller--sync_creatives"
 
         validations:
           - check: response_schema
@@ -524,6 +640,13 @@ phases:
           - check: field_present
             path: "creatives[0].action"
             description: "Each creative has an action (created/updated)"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--sync_creatives"
+            description: "Context correlation_id returned unchanged"
 
   - id: delivery_monitoring
     title: "Delivery and reporting"
@@ -566,6 +689,8 @@ phases:
           media_buy_ids:
             - "mb_acme_q2_2026"
           include_package_daily_breakdown: true
+          context:
+            correlation_id: "media_buy_seller--get_delivery"
 
         validations:
           - check: response_schema
@@ -573,3 +698,10 @@ phases:
           - check: field_present
             path: "media_buy_deliveries"
             description: "Response contains media buy delivery data"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_seller--get_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/media_buy_state_machine.yaml
+++ b/storyboards/media_buy_state_machine.yaml
@@ -58,7 +58,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "media_buy_state_machine--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -66,6 +68,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: setup
     title: "Create a media buy"
     narrative: |
@@ -95,6 +104,13 @@ phases:
           brand:
             domain: "acmeoutdoor.com"
 
+          context:
+            correlation_id: "media_buy_state_machine--discover_products"
+        context_outputs:
+          - name: product_id
+            path: 'products[0].product_id'
+          - name: pricing_option_id
+            path: 'products[0].pricing_options[0].pricing_option_id'
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -102,6 +118,22 @@ phases:
             path: "products[0].product_id"
             description: "At least one product with a product_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--discover_products"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids for creative requirements"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url — must match this agent's URL"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id — must be accepted back in sync_creatives"
       - id: create_buy
         title: "Create the test media buy"
         narrative: |
@@ -128,6 +160,13 @@ phases:
               budget: 10000
               pricing_option_id: "test-pricing"
 
+          context:
+            correlation_id: "media_buy_state_machine--create_buy"
+        context_outputs:
+          - name: media_buy_id
+            path: 'media_buy_id'
+          - name: package_id
+            path: 'packages[0].package_id'
         validations:
           - check: response_schema
             description: "Response matches create-media-buy-response.json schema"
@@ -135,6 +174,16 @@ phases:
             path: "media_buy_id"
             description: "Response includes a media_buy_id"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--create_buy"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "packages[0].package_id"
+            description: "Seller assigns package_id — must be echoed in update_media_buy"
   - id: state_transitions
     title: "Valid state transitions"
     narrative: |
@@ -156,14 +205,23 @@ phases:
           Media buy status transitions to paused.
 
         sample_request:
-          media_buy_id: "test-media-buy"
+          media_buy_id: "$context.media_buy_id"
           paused: true
 
+          context:
+            correlation_id: "media_buy_state_machine--pause_buy"
         validations:
           - check: field_present
             path: "status"
             description: "Response includes updated status"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--pause_buy"
+            description: "Context correlation_id returned unchanged"
       - id: resume_buy
         title: "Resume the media buy"
         narrative: |
@@ -178,14 +236,23 @@ phases:
           Media buy status transitions back to active.
 
         sample_request:
-          media_buy_id: "test-media-buy"
+          media_buy_id: "$context.media_buy_id"
           paused: false
 
+          context:
+            correlation_id: "media_buy_state_machine--resume_buy"
         validations:
           - check: field_present
             path: "status"
             description: "Response includes updated status"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--resume_buy"
+            description: "Context correlation_id returned unchanged"
       - id: cancel_buy
         title: "Cancel the media buy"
         narrative: |
@@ -201,14 +268,23 @@ phases:
           Media buy status transitions to canceled. This is terminal.
 
         sample_request:
-          media_buy_id: "test-media-buy"
+          media_buy_id: "$context.media_buy_id"
           canceled: true
 
+          context:
+            correlation_id: "media_buy_state_machine--cancel_buy"
         validations:
           - check: field_present
             path: "status"
             description: "Response includes canceled status"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--cancel_buy"
+            description: "Context correlation_id returned unchanged"
   - id: terminal_enforcement
     title: "Terminal state enforcement"
     narrative: |
@@ -226,19 +302,29 @@ phases:
         response_schema_ref: "media-buy/update-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/update_media_buy"
         comply_scenario: terminal_state_enforcement
+        expect_error: true
         stateful: true
         expected: |
           Reject with INVALID_STATE_TRANSITION — cannot pause a canceled buy.
 
         sample_request:
-          media_buy_id: "test-media-buy"
+          media_buy_id: "$context.media_buy_id"
           paused: true
 
+          context:
+            correlation_id: "media_buy_state_machine--pause_canceled_buy"
         validations:
           - check: field_present
             path: "errors"
             description: "Response contains an error for invalid transition"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--pause_canceled_buy"
+            description: "Context correlation_id returned unchanged"
       - id: resume_canceled_buy
         title: "Reject resume on canceled buy"
         narrative: |
@@ -249,24 +335,36 @@ phases:
         response_schema_ref: "media-buy/update-media-buy-response.json"
         doc_ref: "/media-buy/task-reference/update_media_buy"
         comply_scenario: terminal_state_enforcement
+        expect_error: true
         stateful: true
         expected: |
           Reject with INVALID_STATE_TRANSITION — cannot resume a canceled buy.
 
         sample_request:
-          media_buy_id: "test-media-buy"
+          media_buy_id: "$context.media_buy_id"
           paused: false
 
+          context:
+            correlation_id: "media_buy_state_machine--resume_canceled_buy"
         validations:
           - check: field_present
             path: "errors"
             description: "Response contains an error for invalid transition"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "media_buy_state_machine--resume_canceled_buy"
+            description: "Context correlation_id returned unchanged"
       - id: recancel_buy
         title: "Handle re-cancel of canceled buy"
         narrative: |
           Attempt to cancel an already-canceled media buy. The agent should either
-          return an error or accept it idempotently.
+          return an error or accept it idempotently. Both are valid, so no context
+          echo validation — the error path loses structured data without expect_error,
+          and we cannot set expect_error when success is also valid.
         task: update_media_buy
         schema_ref: "media-buy/update-media-buy-request.json"
         response_schema_ref: "media-buy/update-media-buy-response.json"
@@ -278,5 +376,8 @@ phases:
           Both behaviors are valid.
 
         sample_request:
-          media_buy_id: "test-media-buy"
+          media_buy_id: "$context.media_buy_id"
           canceled: true
+
+          context:
+            correlation_id: "media_buy_state_machine--recancel_buy"

--- a/storyboards/property_governance.yaml
+++ b/storyboards/property_governance.yaml
@@ -61,7 +61,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring governance in supported_protocols, confirming the agent provides governance services.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "property_governance--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -69,6 +71,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: create_list
     title: "Create property lists"
     narrative: |
@@ -108,10 +117,25 @@ phases:
                 - type: "domain"
                   value: "campinggear.example"
 
+          context:
+            correlation_id: "property_governance--create_inclusion_list"
+        context_outputs:
+          - name: list_id
+            path: 'list.list_id'
         validations:
           - check: response_schema
             description: "Response matches create-property-list-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--create_inclusion_list"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "list.list_id"
+            description: "Governance agent assigns list_id — must be echoed in get/update/delete"
   - id: list_and_get
     title: "Query property lists"
     narrative: |
@@ -139,10 +163,19 @@ phases:
           principal: "acmeoutdoor.example"
           name_contains: "Acme Outdoor"
 
+          context:
+            correlation_id: "property_governance--list_property_lists"
         validations:
           - check: response_schema
             description: "Response matches list-property-lists-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--list_property_lists"
+            description: "Context correlation_id returned unchanged"
       - id: get_property_list
         title: "Get a specific property list"
         narrative: |
@@ -160,12 +193,21 @@ phases:
           - All properties in the list with their details
 
         sample_request:
-          list_id: "pl_acme_inclusion_001"
+          list_id: "$context.list_id"
 
+          context:
+            correlation_id: "property_governance--get_property_list"
         validations:
           - check: response_schema
             description: "Response matches get-property-list-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--get_property_list"
+            description: "Context correlation_id returned unchanged"
   - id: update_list
     title: "Update property lists"
     narrative: |
@@ -189,7 +231,7 @@ phases:
           - Confirmation of the replaced base properties
 
         sample_request:
-          list_id: "pl_acme_inclusion_001"
+          list_id: "$context.list_id"
           base_properties:
             - selection_type: "identifiers"
               identifiers:
@@ -200,10 +242,19 @@ phases:
                 - type: "domain"
                   value: "mountaineering.example"
 
+          context:
+            correlation_id: "property_governance--update_property_list"
         validations:
           - check: response_schema
             description: "Response matches update-property-list-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--update_property_list"
+            description: "Context correlation_id returned unchanged"
   - id: delete_list
     title: "Delete a property list"
     narrative: |
@@ -228,12 +279,21 @@ phases:
           - status: deleted
 
         sample_request:
-          list_id: "pl_acme_inclusion_001"
+          list_id: "$context.list_id"
 
+          context:
+            correlation_id: "property_governance--delete_property_list"
         validations:
           - check: response_schema
             description: "Response matches delete-property-list-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--delete_property_list"
+            description: "Context correlation_id returned unchanged"
   - id: delivery_validation
     title: "Validate delivery compliance"
     narrative: |
@@ -263,7 +323,7 @@ phases:
         sample_request:
           brand:
             domain: "acmeoutdoor.example"
-          list_id: "pl_acme_inclusion_001"
+          list_id: "$context.list_id"
           records:
             - record_id: "delivery_outdoor_001"
               property:
@@ -276,6 +336,16 @@ phases:
                 value: "randomsite.example"
               impressions: 200
 
+          context:
+            correlation_id: "property_governance--validate_property_delivery"
         validations:
           - check: response_schema
             description: "Response matches validate-property-delivery-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "property_governance--validate_property_delivery"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/schema_validation.yaml
+++ b/storyboards/schema_validation.yaml
@@ -53,7 +53,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "schema_validation--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -61,6 +63,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: schema_compliance
     title: "Response schema compliance"
     narrative: |
@@ -94,6 +103,8 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "schema_validation--get_products_schema"
         validations:
           - check: response_schema
             description: "Response matches get-products-response.json schema"
@@ -107,6 +118,13 @@ phases:
             path: "products[0].delivery_type"
             description: "Each product declares guaranteed or non_guaranteed delivery"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--get_products_schema"
+            description: "Context correlation_id returned unchanged"
       - id: pricing_options_present
         title: "Validate pricing options structure"
         narrative: |
@@ -130,6 +148,8 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "schema_validation--pricing_options_present"
         validations:
           - check: field_present
             path: "products[0].pricing_options[0].pricing_option_id"
@@ -137,6 +157,131 @@ phases:
           - check: field_present
             path: "products[0].pricing_options[0].pricing_model"
             description: "Pricing options declare a pricing_model"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--pricing_options_present"
+            description: "Context correlation_id returned unchanged"
+  - id: format_id_reconciliation
+    title: "Format ID and pricing option reconciliation"
+    narrative: |
+      Identifiers returned by get_products must be accepted back by the same agent in
+      subsequent calls. Two common reconciliation failures:
+
+      1. Format IDs: the seller returns format_id objects in products that their own
+         validation rejects when the buyer echoes them back in sync_creatives.
+      2. Pricing option IDs: the seller returns pricing_option_id values in products
+         that create_media_buy rejects when the buyer references them.
+
+      These validations confirm structural correctness — that required fields exist and
+      are well-formed. Full roundtrip verification (echoing a product's format_id into
+      sync_creatives and confirming acceptance) requires a stateful multi-step test,
+      which is covered by the media_buy_seller storyboard's creative_sync phase.
+
+    steps:
+      - id: get_products_for_formats
+        title: "Get products and verify identifiers"
+        narrative: |
+          Request products and verify that each product includes format_ids and
+          pricing_options with the required fields. These identifiers will be echoed
+          back in create_media_buy and sync_creatives — if they are malformed or
+          missing, the buyer cannot complete the purchase.
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: schema_compliance
+        stateful: false
+        expected: |
+          Return products with format_ids and pricing_options. Each format_id must have:
+          - agent_url: URI of the agent that defines the format
+          - id: format identifier within that agent's namespace
+          - Optional: width, height, duration_ms for parameterized formats
+
+          Each pricing_option must have:
+          - pricing_option_id: unique identifier echoed in create_media_buy
+          - pricing_model: CPM, CPC, flat_rate, etc.
+
+          These identifiers must be accepted unchanged in subsequent requests.
+
+        sample_request:
+          buying_mode: "brief"
+          brief: "Show all available advertising products with creative format requirements"
+          brand:
+            domain: "acmeoutdoor.example"
+          context:
+            correlation_id: "schema_validation--get_products_for_formats"
+
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products[0].format_ids"
+            description: "Products include format_ids array"
+          - check: field_present
+            path: "products[0].format_ids[0].agent_url"
+            description: "Format IDs include agent_url"
+          - check: field_present
+            path: "products[0].format_ids[0].id"
+            description: "Format IDs include id"
+          - check: field_present
+            path: "products[0].pricing_options[0].pricing_option_id"
+            description: "Pricing options include pricing_option_id — must be accepted in create_media_buy"
+          - check: field_present
+            path: "products[0].pricing_options[0].pricing_model"
+            description: "Pricing options include pricing_model"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--get_products_for_formats"
+            description: "Context correlation_id returned unchanged"
+
+      - id: list_formats_match
+        title: "Verify format catalog includes product formats"
+        narrative: |
+          Call list_creative_formats and verify that the formats returned include
+          the same agent_url as the format_ids on products. The seller's format
+          catalog must cover every format referenced by its products.
+        task: list_creative_formats
+        schema_ref: "creative/list-creative-formats-request.json"
+        response_schema_ref: "creative/list-creative-formats-response.json"
+        doc_ref: "/creative/task-reference/list_creative_formats"
+        comply_scenario: schema_compliance
+        stateful: false
+        expected: |
+          Return formats matching the agent's own product format_ids:
+          - format_id.agent_url must match the agent's own URL
+          - format_id.id values must include those referenced by products
+          - Each format must define asset requirements (types, dimensions, mime types)
+
+          If the agent returns format_ids in products that don't appear in
+          list_creative_formats, buyers cannot construct valid sync_creatives requests.
+
+        sample_request:
+          context:
+            correlation_id: "schema_validation--list_formats_match"
+
+        validations:
+          - check: response_schema
+            description: "Response matches list-creative-formats-response.json schema"
+          - check: field_present
+            path: "formats[0].format_id.agent_url"
+            description: "Formats include format_id with agent_url"
+          - check: field_present
+            path: "formats[0].format_id.id"
+            description: "Formats include format_id with id"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--list_formats_match"
+            description: "Context correlation_id returned unchanged"
 
   - id: temporal_validation
     title: "Temporal constraint enforcement"
@@ -171,11 +316,20 @@ phases:
               budget: 10000
               pricing_option_id: "test-pricing"
 
+          context:
+            correlation_id: "schema_validation--reversed_dates"
         validations:
           - check: field_present
             path: "adcp_error"
             description: "Response contains an error for reversed dates"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--reversed_dates"
+            description: "Context correlation_id returned unchanged"
       - id: past_start_date
         title: "Handle past start date"
         narrative: |
@@ -199,3 +353,14 @@ phases:
             - product_id: "test-product"
               budget: 10000
               pricing_option_id: "test-pricing"
+
+          context:
+            correlation_id: "schema_validation--past_start_date"
+        validations:
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "schema_validation--past_start_date"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/si_session.yaml
+++ b/storyboards/si_session.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring sponsored_intelligence in supported_protocols, confirming the agent supports conversational ad experiences.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "si_session--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "si_session--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: offering_discovery
     title: "Discover SI offerings"
     narrative: |
@@ -97,12 +106,24 @@ phases:
           - Targeting and context options
           - Format specifications for sponsored content
 
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "si_session--si_get_offering"
 
+        context_outputs:
+          - name: offering_id
+            path: 'offering_id'
         validations:
           - check: response_schema
             description: "Response matches si-get-offering-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "si_session--si_get_offering"
+            description: "Context correlation_id returned unchanged"
   - id: session_lifecycle
     title: "Session lifecycle"
     narrative: |
@@ -136,10 +157,25 @@ phases:
             domain: "novamotors.example"
           campaign_context: "Nova EV launch — targeting environmentally conscious drivers interested in electric vehicles"
 
+          context:
+            correlation_id: "si_session--si_initiate_session"
+        context_outputs:
+          - name: session_id
+            path: 'session_id'
         validations:
           - check: response_schema
             description: "Response matches si-initiate-session-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "si_session--si_initiate_session"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "session_id"
+            description: "Platform assigns session_id — must be echoed in si_send_message and si_terminate_session"
       - id: si_send_message
         title: "Exchange messages"
         narrative: |
@@ -159,13 +195,22 @@ phases:
           - Session state (active, waiting, etc.)
 
         sample_request:
-          session_id: "si_nova_ev_001"
+          session_id: "$context.session_id"
           message: "What are the best electric vehicles for long road trips?"
 
+          context:
+            correlation_id: "si_session--si_send_message"
         validations:
           - check: response_schema
             description: "Response matches si-send-message-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "si_session--si_send_message"
+            description: "Context correlation_id returned unchanged"
       - id: si_terminate_session
         title: "End the session"
         narrative: |
@@ -186,8 +231,18 @@ phases:
           - Sponsored content delivery summary
 
         sample_request:
-          session_id: "si_nova_ev_001"
+          session_id: "$context.session_id"
 
+          context:
+            correlation_id: "si_session--si_terminate_session"
         validations:
           - check: response_schema
             description: "Response matches si-terminate-session-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "si_session--si_terminate_session"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/signal_marketplace.yaml
+++ b/storyboards/signal_marketplace.yaml
@@ -65,7 +65,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring signals in supported_protocols, confirming the agent serves audience signals.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "signal_marketplace--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -73,6 +75,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_marketplace--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: discovery
     title: "Signal discovery"
     narrative: |
@@ -109,6 +118,8 @@ phases:
         sample_request:
           signal_spec: "In-market EV buyers with high purchase propensity, near auto dealerships"
 
+          context:
+            correlation_id: "signal_marketplace--search_by_spec"
         validations:
           - check: response_schema
             description: "Response matches get-signals-response.json schema"
@@ -125,6 +136,19 @@ phases:
             path: "signals[0].coverage_percentage"
             description: "Each signal has a coverage estimate"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_marketplace--search_by_spec"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "signals[0].signal_id.source"
+            description: "Signal ID includes source discriminator"
+          - check: field_present
+            path: "signals[0].signal_id.data_provider_domain"
+            description: "Signal ID includes data_provider_domain for provenance"
       - id: search_by_ids
         title: "Look up specific signals by ID"
         narrative: |
@@ -150,6 +174,8 @@ phases:
               data_provider_domain: "meridiangeo.example"
               id: "competitor_visitors"
 
+          context:
+            correlation_id: "signal_marketplace--search_by_ids"
         validations:
           - check: response_schema
             description: "Response matches schema"
@@ -157,6 +183,13 @@ phases:
             path: "signals"
             description: "Response contains a signals array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_marketplace--search_by_ids"
+            description: "Context correlation_id returned unchanged"
   - id: verification
     title: "Catalog verification"
     narrative: |
@@ -197,6 +230,8 @@ phases:
               data_provider_domain: "shopgrid.example"
               id: "new_to_brand"
 
+          context:
+            correlation_id: "signal_marketplace--verify_provenance_metadata"
         validations:
           - check: field_value
             path: "signals[0].signal_id.source"
@@ -206,6 +241,13 @@ phases:
             path: "signals[0].signal_id.data_provider_domain"
             description: "Data provider domain is present for independent verification"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_marketplace--verify_provenance_metadata"
+            description: "Context correlation_id returned unchanged"
   - id: platform_activation
     title: "Activate on a DSP"
     narrative: |
@@ -248,6 +290,11 @@ phases:
               platform: "the-trade-desk"
               account: "agency-123-ttd"
 
+          context:
+            correlation_id: "signal_marketplace--activate_on_platform"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches activate-signal-response.json schema"
@@ -259,6 +306,16 @@ phases:
             value: "platform"
             description: "Deployment type is 'platform'"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_marketplace--activate_on_platform"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "deployments[0].activation_key"
+            description: "Deployment includes activation_key for targeting"
   - id: agent_activation
     title: "Activate on a sales agent"
     narrative: |
@@ -302,6 +359,11 @@ phases:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
 
+          context:
+            correlation_id: "signal_marketplace--activate_on_agent"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches activate-signal-response.json schema"
@@ -312,3 +374,11 @@ phases:
             path: "deployments[0].type"
             value: "agent"
             description: "Deployment type is 'agent'"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_marketplace--activate_on_agent"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/signal_owned.yaml
+++ b/storyboards/signal_owned.yaml
@@ -62,7 +62,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring signals in supported_protocols, confirming the agent serves audience signals.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "signal_owned--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -70,6 +72,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_owned--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: discovery
     title: "Signal discovery"
     narrative: |
@@ -109,6 +118,8 @@ phases:
         sample_request:
           signal_spec: "High-value customers likely to purchase electronics, with loyalty program data"
 
+          context:
+            correlation_id: "signal_owned--search_owned_signals"
         validations:
           - check: response_schema
             description: "Response matches get-signals-response.json schema"
@@ -119,6 +130,16 @@ phases:
             path: "signals[0].pricing_options"
             description: "Each signal has pricing options"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_owned--search_owned_signals"
+            description: "Context correlation_id returned unchanged"
+          - check: field_present
+            path: "signals[0].signal_id.source"
+            description: "Signal ID includes source discriminator"
       - id: filter_by_criteria
         title: "Filter signals by criteria"
         narrative: |
@@ -140,6 +161,8 @@ phases:
           filters:
             max_cpm: 5.00
 
+          context:
+            correlation_id: "signal_owned--filter_by_criteria"
         validations:
           - check: response_schema
             description: "Response matches schema"
@@ -147,6 +170,13 @@ phases:
             path: "signals"
             description: "Response contains a signals array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_owned--filter_by_criteria"
+            description: "Context correlation_id returned unchanged"
   - id: platform_activation
     title: "Activate on a DSP"
     narrative: |
@@ -183,6 +213,11 @@ phases:
               platform: "the-trade-desk"
               account: "agency-123-ttd"
 
+          context:
+            correlation_id: "signal_owned--activate_on_platform"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches activate-signal-response.json schema"
@@ -190,6 +225,13 @@ phases:
             path: "deployments[0].type"
             description: "Deployment includes type"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_owned--activate_on_platform"
+            description: "Context correlation_id returned unchanged"
   - id: agent_activation
     title: "Activate on a sales agent"
     narrative: |
@@ -227,6 +269,11 @@ phases:
             - type: "agent"
               agent_url: "https://wonderstruck.salesagents.example"
 
+          context:
+            correlation_id: "signal_owned--activate_on_agent"
+          ext:
+            test_platform:
+              test_run: true
         validations:
           - check: response_schema
             description: "Response matches activate-signal-response.json schema"
@@ -237,3 +284,11 @@ phases:
             path: "deployments[0].type"
             value: "agent"
             description: "Deployment type is 'agent'"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "signal_owned--activate_on_agent"
+            description: "Context correlation_id returned unchanged"

--- a/storyboards/social_platform.yaml
+++ b/storyboards/social_platform.yaml
@@ -64,7 +64,9 @@ phases:
         stateful: false
         expected: |
           Return capabilities declaring media_buy in supported_protocols, confirming the agent sells media.
-        sample_request: {}
+        sample_request:
+          context:
+            correlation_id: "social_platform--get_capabilities"
         validations:
           - check: response_schema
             description: "Response matches get-adcp-capabilities-response.json schema"
@@ -72,6 +74,13 @@ phases:
             path: "supported_protocols"
             description: "Agent declares supported protocols"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--get_capabilities"
+            description: "Context correlation_id returned unchanged"
   - id: account_setup
     title: "Account setup"
     narrative: |
@@ -103,6 +112,8 @@ phases:
               operator: "pinnacle-agency.example"
               billing: "operator"
 
+          context:
+            correlation_id: "social_platform--sync_accounts"
         validations:
           - check: response_schema
             description: "Response matches sync-accounts-response.json schema"
@@ -110,6 +121,13 @@ phases:
             path: "accounts[0].account_id"
             description: "Account has a platform-assigned ID"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--sync_accounts"
+            description: "Context correlation_id returned unchanged"
       - id: list_accounts
         title: "Verify account status"
         narrative: |
@@ -130,6 +148,8 @@ phases:
           brand:
             domain: "acmeoutdoor.example"
 
+          context:
+            correlation_id: "social_platform--list_accounts"
         validations:
           - check: response_schema
             description: "Response matches list-accounts-response.json schema"
@@ -137,6 +157,13 @@ phases:
             path: "accounts"
             description: "Response contains accounts array"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--list_accounts"
+            description: "Context correlation_id returned unchanged"
   - id: audience_sync
     title: "Audience activation"
     narrative: |
@@ -173,10 +200,19 @@ phases:
               name: "Outdoor enthusiasts 25-54"
               description: "Adults 25-54 interested in hiking, camping, and outdoor gear"
 
+          context:
+            correlation_id: "social_platform--sync_audiences"
         validations:
           - check: response_schema
             description: "Response matches sync-audiences-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--sync_audiences"
+            description: "Context correlation_id returned unchanged"
   - id: creative_push
     title: "Native creative sync"
     narrative: |
@@ -222,10 +258,19 @@ phases:
                   asset_type: "text"
                   content: "Trail Pro 3000 — Built for the Summit"
 
+          context:
+            correlation_id: "social_platform--sync_creatives"
         validations:
           - check: response_schema
             description: "Response matches sync-creatives-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--sync_creatives"
+            description: "Context correlation_id returned unchanged"
   - id: event_logging
     title: "Conversion event tracking"
     narrative: |
@@ -262,10 +307,19 @@ phases:
               value: 149.99
               currency: "USD"
 
+          context:
+            correlation_id: "social_platform--log_event"
         validations:
           - check: response_schema
             description: "Response matches log-event-response.json schema"
 
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--log_event"
+            description: "Context correlation_id returned unchanged"
   - id: financials
     title: "Account financials"
     narrative: |
@@ -296,6 +350,16 @@ phases:
               domain: "acmeoutdoor.example"
             operator: "pinnacle-agency.example"
 
+          context:
+            correlation_id: "social_platform--get_account_financials"
         validations:
           - check: response_schema
             description: "Response matches get-account-financials-response.json schema"
+
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "social_platform--get_account_financials"
+            description: "Context correlation_id returned unchanged"

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -95,6 +95,10 @@ function isPathReachable(schema, segments) {
 // here only if its validations target runtime metadata rather than tool response data.
 const HARNESS_STORYBOARDS = new Set(['deterministic_testing']);
 
+// Protocol envelope fields validated at runtime but not always declared
+// in individual tool response schemas. Skip these in schema drift checks.
+const ENVELOPE_PATHS = new Set(['context', 'context.correlation_id', 'ext']);
+
 function collectFieldValidations(storyboards) {
   const entries = [];
   for (const sb of storyboards) {
@@ -105,6 +109,7 @@ function collectFieldValidations(storyboards) {
         if (step.expect_error) continue; // error steps validate extracted error data, not response schemas
         for (const v of step.validations) {
           if ((v.check === 'field_present' || v.check === 'field_value') && v.path) {
+            if (ENVELOPE_PATHS.has(v.path)) continue; // protocol-level, not per-schema
             entries.push({
               storyboard: sb.id,
               step: step.id,


### PR DESCRIPTION
## Summary

- Every storyboard step (216 total) now sends `context` with a `correlation_id` and validates the agent echoes it back unchanged
- Format_id reconciliation phase in `schema_validation` verifies format_ids and pricing_option_ids roundtrip correctly (the Magnite bug class)
- Cross-step roundtrip testing via `context_outputs` for format_id, media_buy_id, package_id, session_id, plan_id, and list_id
- Client SDK preserves `context` and `ext` through field stripping via `ADCP_ENVELOPE_FIELDS`
- Runner merges `context`/`ext` from sample_request into request builder output
- Error steps marked `expect_error: true` so the runner parses structured error data including context
- All 8 build-* skills updated with context passthrough guidance and format_id reconciliation in Common Mistakes

### Verified against test agent

| Storyboard | Result |
|---|---|
| `capability_discovery` | 2/2 passed |
| `schema_validation` | 7/7 passed |
| `error_compliance` | 7/7 passed |
| `media_buy_seller` | 9/10 passed (1 pre-existing) |

### Related

- adcontextprotocol/adcp#2155 — test agent context echo (shipped)
- #533 — SDK structured error data preservation (deferred)

## Test plan

- [x] All 2914 unit tests pass (0 failures)
- [x] All 32 storyboard YAML files parse correctly
- [x] Storyboard drift test passes (context/ext paths excluded as envelope fields)
- [x] Verified against `test-agent.adcontextprotocol.org`: context echo works on success and error responses
- [x] Format_id structural validations pass against test agent
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)