### PR TITLE
feat(server): SessionStore ergonomics + state-store validation

### DIFF
--- a/.changeset/session-store-batch-1.md
+++ b/.changeset/session-store-batch-1.md
@@ -1,0 +1,17 @@
+---
+'@adcp/client': minor
+---
+
+SessionStore ergonomics + state-store validation (batch 1 of upstream feedback).
+
+**New**
+- `store.scoped(sessionKey)` on every `AdcpStateStore` — returns a session-isolated view that auto-prefixes ids and filters `list()` by `_session_key`. Exported standalone as `createSessionedStore(store, key)` for custom stores.
+- `HandlerContext.sessionKey` + `resolveSessionKey` hook on `createAdcpServer`. Sellers derive the scoping key once; handlers read `ctx.sessionKey` instead of re-parsing params.
+- `StateError` with typed codes (`INVALID_COLLECTION`, `INVALID_ID`, `PAYLOAD_TOO_LARGE`, …), built-in charset/length validation on every store operation, configurable `maxDocumentBytes` (5 MB default) on `InMemoryStateStore` and `PostgresStateStore`.
+- `structuredSerialize` / `structuredDeserialize` helpers so handlers can round-trip `Map`, `Set`, and `Date` through the state store without writing per-type converters.
+
+**Docs**
+- `docs/guides/CONCURRENCY.md` — explicit last-writer-wins vs per-row isolation model, the read-modify-write race on whole-session blobs, and why per-entity rows are safer.
+- `docs/guides/TASKRESULT-5-MIGRATION.md` — the four migration patterns for the 5.0 discriminated-union `TaskResult` (success check, error extraction, status narrowing, intermediate states).
+
+No breaking changes. `scoped` on `AdcpStateStore` is an optional method; custom store implementations that don't define it keep working.

--- a/.changeset/session-store-batch-1.md
+++ b/.changeset/session-store-batch-1.md
@@ -5,10 +5,10 @@
 SessionStore ergonomics + state-store validation (batch 1 of upstream feedback).
 
 **New**
-- `store.scoped(sessionKey)` on every `AdcpStateStore` — returns a session-isolated view that auto-prefixes ids and filters `list()` by `_session_key`. Exported standalone as `createSessionedStore(store, key)` for custom stores.
+- `store.scoped(sessionKey)` on built-in stores + `scopedStore(store, key)` helper that works on any `AdcpStateStore` (falls back to `createSessionedStore` when a custom store doesn't implement the method). Returns a session-isolated view that auto-prefixes ids and filters `list()` by `_session_key`. `::` is reserved as the scope separator and is rejected in session keys and ids so scopes can't collide.
 - `HandlerContext.sessionKey` + `resolveSessionKey` hook on `createAdcpServer`. Sellers derive the scoping key once; handlers read `ctx.sessionKey` instead of re-parsing params.
 - `StateError` with typed codes (`INVALID_COLLECTION`, `INVALID_ID`, `PAYLOAD_TOO_LARGE`, …), built-in charset/length validation on every store operation, configurable `maxDocumentBytes` (5 MB default) on `InMemoryStateStore` and `PostgresStateStore`.
-- `structuredSerialize` / `structuredDeserialize` helpers so handlers can round-trip `Map`, `Set`, and `Date` through the state store without writing per-type converters.
+- `structuredSerialize` / `structuredDeserialize` helpers so handlers can round-trip `Map`, `Set`, and `Date` through the state store without writing per-type converters. Envelope tag is namespaced as `__adcpType` and the deserializer validates payload shape, so caller data that happens to use the same field is passed through unchanged.
 
 **Docs**
 - `docs/guides/CONCURRENCY.md` — explicit last-writer-wins vs per-row isolation model, the read-modify-write race on whole-session blobs, and why per-entity rows are safer.

--- a/docs/guides/CONCURRENCY.md
+++ b/docs/guides/CONCURRENCY.md
@@ -1,0 +1,123 @@
+# State Store Concurrency
+
+`AdcpStateStore` is a document store keyed by `(collection, id)`. This page
+documents what concurrent writes look like so sellers can choose a data
+layout that matches their consistency needs.
+
+## TL;DR
+
+| Pattern                           | Safety                           |
+| --------------------------------- | -------------------------------- |
+| `put(col, id, data)`              | Last-writer-wins on the whole row |
+| `patch(col, id, partial)`         | Last-writer-wins on the fields in `partial` |
+| Two handlers editing the same row | Race: read → compute → write is NOT atomic |
+| Two handlers editing **different** rows | Independent — no contention |
+
+## Per-row isolation
+
+Each `(collection, id)` is an independent row. Two handlers writing to
+different rows never contend, regardless of concurrency. This is the safest
+data layout:
+
+```ts
+// Handler A
+await ctx.store.put('media_buys', 'mb_alice', buyA);
+
+// Handler B (concurrent, different id)
+await ctx.store.put('media_buys', 'mb_bob', buyB);
+```
+
+Both succeed. No lost updates.
+
+## Last-writer-wins on the same row
+
+`put` is an upsert. If two handlers write to the same `(collection, id)`
+concurrently, the last write wins:
+
+```ts
+// T1: writes { budget: 1000 }
+await ctx.store.put('media_buys', 'mb_1', { budget: 1000 });
+
+// T2 (concurrent): writes { budget: 2000 }
+await ctx.store.put('media_buys', 'mb_1', { budget: 2000 });
+
+// Final row: whichever COMMIT landed last (T1 or T2). The other is gone.
+```
+
+`patch` has the same last-writer-wins semantics, but scoped to the fields
+you pass. Fields the other writer didn't touch are preserved:
+
+```ts
+// Existing: { budget: 1000, status: 'active' }
+
+// T1: patch({ budget: 5000 })
+// T2: patch({ status: 'paused' })
+
+// Final: { budget: 5000, status: 'paused' }  ← both survive
+```
+
+Patches only interfere when they write the same field.
+
+## The read-modify-write race
+
+If you read a row, compute a new value, and write it back, **there is no
+atomicity guarantee between the read and the write.** Two handlers can read
+the same pre-state, each compute a new value based on it, and each overwrite
+with their version — losing one update.
+
+```ts
+// T1
+const buy = await ctx.store.get('media_buys', 'mb_1');  // { budget: 1000 }
+buy.budget += 500;
+await ctx.store.put('media_buys', 'mb_1', buy);         // writes { budget: 1500 }
+
+// T2 (concurrent)
+const buy = await ctx.store.get('media_buys', 'mb_1');  // also reads { budget: 1000 }
+buy.budget += 300;
+await ctx.store.put('media_buys', 'mb_1', buy);         // writes { budget: 1300 }
+
+// Final: whichever wrote last. The other +N is lost.
+```
+
+This is the most common concurrency bug with document stores. Two ways to
+avoid it:
+
+### 1. Use `patch` for field-level updates
+
+`patch` is atomic at the field level in PostgresStateStore (`data || partial`
+in the JSONB update clause). If two handlers `patch` different fields, both
+survive. If they patch the same field, last writer wins — but you don't lose
+the rest of the document.
+
+### 2. Split entities into separate rows
+
+Prefer per-entity rows (`('media_buys', 'mb_1')`, `('packages', 'pkg_1')`)
+over whole-session blobs (`('sessions', 'alice')` containing every field).
+Per-entity rows bound the blast radius of a lost write.
+
+## Whole-session blobs: why they're risky
+
+A common pattern is to stuff all per-tenant state into one row:
+
+```ts
+const session = await ctx.store.get('sessions', ctx.sessionKey);
+session.media_buys[id] = buy;
+session.messages.push(message);
+await ctx.store.put('sessions', ctx.sessionKey, session);
+```
+
+Every handler now reads the full session, mutates it, and writes it back.
+Any two concurrent handlers for the same tenant can lose each other's
+writes. The symptom is: "a message my handler appended is missing" or
+"a media buy I just created isn't there."
+
+If you must keep the blob layout, funnel all writes through a single
+worker per `sessionKey`, or upgrade to optimistic concurrency once
+`putIfMatch` lands (see below).
+
+## Coming soon: optimistic concurrency
+
+An RFC is open for `putIfMatch(collection, id, data, expectedVersion)` to
+give sellers an atomic compare-and-swap primitive. That will let
+read-modify-write loops retry on conflict instead of silently losing data.
+Until then, prefer per-entity rows and `patch`.

--- a/docs/guides/CONCURRENCY.md
+++ b/docs/guides/CONCURRENCY.md
@@ -82,12 +82,29 @@ await ctx.store.put('media_buys', 'mb_1', buy);         // writes { budget: 1300
 This is the most common concurrency bug with document stores. Two ways to
 avoid it:
 
-### 1. Use `patch` for field-level updates
+### 1. Use `patch` for top-level field updates
 
-`patch` is atomic at the field level in PostgresStateStore (`data || partial`
-in the JSONB update clause). If two handlers `patch` different fields, both
-survive. If they patch the same field, last writer wins — but you don't lose
-the rest of the document.
+`patch` is atomic at the **top-level field** in PostgresStateStore
+(`data || partial` in the JSONB update clause does a **shallow** merge).
+If two handlers `patch` different top-level fields, both survive. If they
+patch the same top-level field, last writer wins.
+
+**Shallow merge means nested objects still race.** The JSONB `||` operator
+replaces top-level keys wholesale — it does not deep-merge nested objects.
+So this is unsafe:
+
+```ts
+// Existing: { budget: { total: 1000, spent: 0 } }
+
+// T1: patch({ budget: { total: 5000 } })   — overwrites budget entirely
+// T2: patch({ budget: { spent: 100 } })    — overwrites budget entirely
+
+// Final: whichever landed last. The other's budget field is gone.
+```
+
+If you need independent updates to nested fields, flatten the nested object
+into separate top-level fields (`budget_total`, `budget_spent`), or split
+the nested entity into its own row.
 
 ### 2. Split entities into separate rows
 

--- a/docs/guides/CONCURRENCY.md
+++ b/docs/guides/CONCURRENCY.md
@@ -132,6 +132,43 @@ If you must keep the blob layout, funnel all writes through a single
 worker per `sessionKey`, or upgrade to optimistic concurrency once
 `putIfMatch` lands (see below).
 
+## Per-session isolation
+
+If every handler's state is scoped to a tenant/brand/publisher account, use
+the session-scoping primitives instead of threading a key through every call:
+
+```ts
+import { createAdcpServer, scopedStore, requireSessionKey } from '@adcp/client/server';
+
+const server = createAdcpServer({
+  name: 'My Publisher', version: '1.0.0',
+  stateStore,
+  resolveSessionKey: ({ account }) => account?.tenant_id,
+  mediaBuy: {
+    createMediaBuy: async (params, ctx) => {
+      const sessionKey = requireSessionKey(ctx);
+      const store = scopedStore(ctx.store, sessionKey);
+
+      // Scoped: isolated to this tenant. No cross-tenant leaks.
+      await store.put('media_buys', 'mb_1', { status: 'active' });
+      const { items } = await store.list('media_buys');
+    },
+  },
+});
+```
+
+**Rules the scoped wrapper enforces:**
+
+- `sessionKey` and `id` must be `[A-Za-z0-9_.-]{1,256}` — `:` is reserved as
+  the scope-path separator.
+- Every scoped write injects a `_session_key` field and every scoped read
+  strips it. If you query the raw Postgres table yourself, you will see
+  this column; omit it from your application view.
+- Payloads that already contain `_session_key` are rejected at write time —
+  rename that field in your document if you hit this.
+- `list()` cursors are valid **only within the session** that produced them.
+  Don't pass a cursor from session A to session B.
+
 ## Coming soon: optimistic concurrency
 
 An RFC is open for `putIfMatch(collection, id, data, expectedVersion)` to

--- a/docs/guides/TASKRESULT-5-MIGRATION.md
+++ b/docs/guides/TASKRESULT-5-MIGRATION.md
@@ -1,0 +1,185 @@
+# TaskResult 5.0 Migration Guide
+
+`@adcp/client` 5.0 turned `TaskResult` into a discriminated union. Failed
+tasks now use `status: 'failed'` instead of `status: 'completed'`, and MCP
+`isError` responses preserve structured data (`adcp_error`, `context`,
+`ext`) instead of throwing.
+
+This page covers the four migration patterns every consumer hits.
+
+## The new shape
+
+```ts
+type TaskResult<T> =
+  | { success: true;  status: 'completed';                                             data: T }
+  | { success: true;  status: 'working' | 'submitted' | 'input-required' | 'deferred'; data?: T }
+  | { success: false; status: 'failed' | 'governance-denied' | 'governance-escalated'; data?: T;
+      error: string;
+      adcpError?: { code: string; recovery?: string; retryAfterMs?: number; /* ... */ };
+      correlationId?: string };
+```
+
+Rule of thumb: **branch on `success` first, then narrow on `status`.**
+
+## Pattern 1 — Success check
+
+**Before (4.x):**
+
+```ts
+try {
+  const result = await client.getProducts({ brief: 'shoes' });
+  console.log(result.data.products);
+} catch (err) {
+  console.error('failed:', err);
+}
+```
+
+**After (5.x):**
+
+```ts
+const result = await client.getProducts({ brief: 'shoes' });
+if (!result.success) {
+  console.error('failed:', result.error);
+  return;
+}
+// `result.data` is `T` here — narrowed by the discriminated union
+console.log(result.data.products);
+```
+
+Failures no longer throw. If you want the old throw-on-error behavior,
+wrap once at your call site:
+
+```ts
+function orThrow<T>(r: TaskResult<T>): T {
+  if (!r.success) throw new Error(r.error);
+  if (r.status !== 'completed') throw new Error(`task not complete: ${r.status}`);
+  return r.data;
+}
+```
+
+## Pattern 2 — Error extraction
+
+**Before:**
+
+```ts
+catch (err) {
+  if (err.code === 'INSUFFICIENT_BUDGET') { ... }
+}
+```
+
+**After:**
+
+```ts
+if (!result.success && result.adcpError?.code === 'INSUFFICIENT_BUDGET') {
+  // adcp_error, suggestion, recovery hints are all on result.adcpError
+}
+```
+
+Full structured error lives on `result.adcpError`. The raw response payload
+(including `context` and `ext`) is on `result.data` even for failures.
+`result.error` is always a human-readable string.
+
+### Retry helpers
+
+```ts
+import { isRetryable, getRetryDelay } from '@adcp/client';
+
+if (!result.success && isRetryable(result)) {
+  await sleep(getRetryDelay(result, /* default */ 5000));
+  // retry…
+}
+```
+
+`isRetryable` narrows to failures with `recovery: 'transient'`.
+`getRetryDelay` returns the agent-provided `retryAfterMs` or a default.
+
+## Pattern 3 — Status narrowing
+
+**Before:** `status` was always `'completed'` (or a throw). You only had
+one branch.
+
+**After:** narrow on `status` to handle governance outcomes without
+losing type information.
+
+```ts
+if (!result.success) {
+  switch (result.status) {
+    case 'failed':
+      log.error('agent error', { code: result.adcpError?.code });
+      break;
+    case 'governance-denied':
+      notifyApprover(result.adcpError);
+      break;
+    case 'governance-escalated':
+      trackPending(result.correlationId);
+      break;
+  }
+  return;
+}
+```
+
+TypeScript narrows `result.adcpError` / `result.correlationId` based on
+`success: false`.
+
+## Pattern 4 — Intermediate states
+
+Long-running tasks now return intermediate `TaskResult`s rather than
+resolving only at completion.
+
+**Before:** you only ever saw `status: 'completed'`.
+
+**After:** handle the three non-terminal statuses explicitly.
+
+```ts
+const result = await client.createMediaBuy(params);
+
+switch (result.status) {
+  case 'completed':
+    // result.data is T
+    return result.data;
+
+  case 'submitted':
+    // server is processing — pick up via result.submitted
+    return pollLater(result.submitted?.taskId);
+
+  case 'input-required':
+    // agent needs clarification — your InputHandler runs
+    // if it doesn't, result.data has the clarification request
+    return;
+
+  case 'deferred':
+    // client-side wait — result.deferred holds the continuation
+    return;
+
+  case 'failed':
+  case 'governance-denied':
+  case 'governance-escalated':
+    // see Pattern 2
+    return;
+}
+```
+
+For most callers the high-level `ADCPMultiAgentClient` / `AgentClient`
+methods already loop until a terminal status before returning. You'll
+mostly hit intermediate states if you use lower-level `TaskExecutor` APIs
+directly.
+
+## Typescript note
+
+The discriminated union makes exhaustiveness checks cheap:
+
+```ts
+function assertNever(x: never): never { throw new Error(String(x)); }
+
+switch (result.status) {
+  case 'completed': ...
+  case 'working': ...
+  case 'submitted': ...
+  case 'input-required': ...
+  case 'deferred': ...
+  case 'failed': ...
+  case 'governance-denied': ...
+  case 'governance-escalated': ...
+  default: assertNever(result);  // TS errors if you miss a status
+}
+```

--- a/docs/guides/TASKRESULT-5-MIGRATION.md
+++ b/docs/guides/TASKRESULT-5-MIGRATION.md
@@ -77,7 +77,10 @@ if (!result.success && result.adcpError?.code === 'INSUFFICIENT_BUDGET') {
 
 Full structured error lives on `result.adcpError`. The raw response payload
 (including `context` and `ext`) is on `result.data` even for failures.
-`result.error` is always a human-readable string.
+`result.error` is a human-readable string — but only on the failure arm.
+After `if (!result.success)` the union narrows so `result.error` is
+guaranteed `string`; on the success arms it's `undefined`. Always guard on
+`success` before reading `error`.
 
 ### Retry helpers
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -874,13 +874,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             }
             ctx.account = account;
           } catch (err) {
-            logger.error('Account resolution failed', {
-              tool: toolName,
-              error: err instanceof Error ? err.message : String(err),
-            });
+            const reason = err instanceof Error ? err.message : String(err);
+            logger.error('Account resolution failed', { tool: toolName, error: reason });
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Account resolution failed',
+                details: { reason },
               })
             );
           }
@@ -896,13 +895,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             });
             if (sessionKey !== undefined) ctx.sessionKey = sessionKey;
           } catch (err) {
-            logger.error('Session key resolution failed', {
-              tool: toolName,
-              error: err instanceof Error ? err.message : String(err),
-            });
+            const reason = err instanceof Error ? err.message : String(err);
+            logger.error('Session key resolution failed', { tool: toolName, error: reason });
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Session key resolution failed',
+                details: { reason },
               })
             );
           }
@@ -914,13 +912,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           const formatted: McpToolResponse = isFormattedResponse(result) ? result : wrap(result);
           return finalize(formatted);
         } catch (err) {
-          logger.error('Handler failed', {
-            tool: toolName,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          const reason = err instanceof Error ? err.message : String(err);
+          logger.error('Handler failed', { tool: toolName, error: reason });
           return finalize(
             adcpError('SERVICE_UNAVAILABLE', {
               message: `Tool ${toolName} encountered an internal error`,
+              details: { reason },
             })
           );
         }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -204,8 +204,8 @@ const noopLogger: AdcpLogger = {
  *
  * If `resolveSessionKey` is configured, `sessionKey` is the scoping key
  * derived from the request — usually tenant/brand/publisher-account id.
- * Handlers can use `ctx.store.scoped(ctx.sessionKey!)` to get a
- * session-scoped view without re-deriving the key.
+ * Handlers can pass it to `scopedStore(ctx.store, ctx.sessionKey!)` to get
+ * a session-scoped view that works on any `AdcpStateStore` implementation.
  */
 export interface HandlerContext<TAccount = unknown> {
   account?: TAccount;

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -222,6 +222,27 @@ export interface SessionKeyContext<TAccount = unknown> {
   account?: TAccount;
 }
 
+/**
+ * Narrow `ctx.sessionKey` from `string | undefined` to `string`. Use this in
+ * handlers that require session scoping so you don't litter `!` assertions:
+ *
+ * ```ts
+ * const sessionKey = requireSessionKey(ctx);
+ * const sessionStore = scopedStore(ctx.store, sessionKey);
+ * ```
+ *
+ * Throws a `SERVICE_UNAVAILABLE`-style error if `sessionKey` is missing — typically
+ * meaning `resolveSessionKey` isn't configured or returned `undefined` for this tool.
+ */
+export function requireSessionKey<TAccount = unknown>(ctx: HandlerContext<TAccount>): string {
+  if (ctx.sessionKey == null) {
+    throw new Error(
+      'ctx.sessionKey is undefined. Configure resolveSessionKey on createAdcpServer, or guard per-tool before calling requireSessionKey.'
+    );
+  }
+  return ctx.sessionKey;
+}
+
 // ---------------------------------------------------------------------------
 // Tool → type mapping (kept from v1 for type-level handler signatures)
 // ---------------------------------------------------------------------------
@@ -457,6 +478,16 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * or public tools).
    */
   resolveSessionKey?: (ctx: SessionKeyContext<TAccount>) => string | undefined | Promise<string | undefined>;
+
+  /**
+   * When `true`, framework-produced `SERVICE_UNAVAILABLE` errors include the
+   * underlying `err.message` in `details.reason` (helpful in dev, but can leak
+   * DB driver messages, file paths, or schema info to remote callers).
+   *
+   * Defaults to `false`. Enable in trusted environments when you want
+   * debuggable failures at the call site.
+   */
+  exposeErrorDetails?: boolean;
 
   /** Logger for framework decisions. Defaults to no-op. */
   logger?: AdcpLogger;
@@ -786,6 +817,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     version,
     resolveAccount,
     resolveSessionKey,
+    exposeErrorDetails = false,
     stateStore = new InMemoryStateStore(),
     logger = noopLogger,
     capabilities: capConfig,
@@ -879,7 +911,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Account resolution failed',
-                details: { reason },
+                ...(exposeErrorDetails && { details: { reason } }),
               })
             );
           }
@@ -900,7 +932,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Session key resolution failed',
-                details: { reason },
+                ...(exposeErrorDetails && { details: { reason } }),
               })
             );
           }
@@ -917,7 +949,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           return finalize(
             adcpError('SERVICE_UNAVAILABLE', {
               message: `Tool ${toolName} encountered an internal error`,
-              details: { reason },
+              ...(exposeErrorDetails && { details: { reason } }),
             })
           );
         }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -201,11 +201,25 @@ const noopLogger: AdcpLogger = {
  * If the tool has an account ref and `resolveAccount` is configured,
  * `account` is the resolved account object (guaranteed non-null —
  * the handler only runs if resolution succeeds).
+ *
+ * If `resolveSessionKey` is configured, `sessionKey` is the scoping key
+ * derived from the request — usually tenant/brand/publisher-account id.
+ * Handlers can use `ctx.store.scoped(ctx.sessionKey!)` to get a
+ * session-scoped view without re-deriving the key.
  */
 export interface HandlerContext<TAccount = unknown> {
   account?: TAccount;
+  /** Session scoping key derived from the request. Populated when `resolveSessionKey` is configured. */
+  sessionKey?: string;
   /** State store for persisting domain objects (media buys, accounts, creatives). */
   store: AdcpStateStore;
+}
+
+/** Request metadata passed to `resolveSessionKey` so the hook can derive a key from any field. */
+export interface SessionKeyContext<TAccount = unknown> {
+  toolName: AdcpServerToolName;
+  params: Record<string, unknown>;
+  account?: TAccount;
 }
 
 // ---------------------------------------------------------------------------
@@ -432,6 +446,17 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * Return null if the account doesn't exist — framework responds ACCOUNT_NOT_FOUND.
    */
   resolveAccount?: (ref: AccountReference) => Promise<TAccount | null>;
+
+  /**
+   * Derive a session-scoping key from the request. Populates `ctx.sessionKey`
+   * so handlers don't re-implement key derivation (tenant, brand, publisher
+   * account id, etc.). Called after `resolveAccount`, so the resolved account
+   * is available.
+   *
+   * Return `undefined` to leave `ctx.sessionKey` unset (e.g., for anonymous
+   * or public tools).
+   */
+  resolveSessionKey?: (ctx: SessionKeyContext<TAccount>) => string | undefined | Promise<string | undefined>;
 
   /** Logger for framework decisions. Defaults to no-op. */
   logger?: AdcpLogger;
@@ -760,6 +785,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     name,
     version,
     resolveAccount,
+    resolveSessionKey,
     stateStore = new InMemoryStateStore(),
     logger = noopLogger,
     capabilities: capConfig,
@@ -855,6 +881,28 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Account resolution failed',
+              })
+            );
+          }
+        }
+
+        // --- Session key resolution ---
+        if (resolveSessionKey) {
+          try {
+            const sessionKey = await resolveSessionKey({
+              toolName: toolName as AdcpServerToolName,
+              params,
+              account: ctx.account,
+            });
+            if (sessionKey !== undefined) ctx.sessionKey = sessionKey;
+          } catch (err) {
+            logger.error('Session key resolution failed', {
+              tool: toolName,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return finalize(
+              adcpError('SERVICE_UNAVAILABLE', {
+                message: 'Session key resolution failed',
               })
             );
           }

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -61,11 +61,29 @@ export type { TestControllerStore, ControllerScenario } from './test-controller'
 export { serve } from './serve';
 export type { ServeContext, ServeOptions } from './serve';
 
-export { InMemoryStateStore } from './state-store';
-export type { AdcpStateStore, ListOptions, ListResult } from './state-store';
+export {
+  InMemoryStateStore,
+  StateError,
+  DEFAULT_MAX_DOCUMENT_BYTES,
+  SESSION_KEY_FIELD,
+  createSessionedStore,
+  validateCollection,
+  validateId,
+  validatePayloadSize,
+  validateWrite,
+} from './state-store';
+export type {
+  AdcpStateStore,
+  InMemoryStateStoreOptions,
+  ListOptions,
+  ListResult,
+  StateErrorCode,
+} from './state-store';
 
 export { PostgresStateStore, getAdcpStateMigration, ADCP_STATE_MIGRATION } from './postgres-state-store';
 export type { PostgresStateStoreOptions } from './postgres-state-store';
+
+export { structuredSerialize, structuredDeserialize } from './structured-serialize';
 
 export { createAdcpServer } from './create-adcp-server';
 export type {
@@ -75,6 +93,7 @@ export type {
   AdcpCapabilitiesConfig,
   AdcpLogger,
   HandlerContext,
+  SessionKeyContext,
   MediaBuyHandlers,
   SignalsHandlers,
   CreativeHandlers,

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -86,7 +86,7 @@ export type { PostgresStateStoreOptions } from './postgres-state-store';
 
 export { structuredSerialize, structuredDeserialize } from './structured-serialize';
 
-export { createAdcpServer } from './create-adcp-server';
+export { createAdcpServer, requireSessionKey } from './create-adcp-server';
 export type {
   AdcpServerConfig,
   AdcpToolMap,

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -73,13 +73,7 @@ export {
   validatePayloadSize,
   validateWrite,
 } from './state-store';
-export type {
-  AdcpStateStore,
-  InMemoryStateStoreOptions,
-  ListOptions,
-  ListResult,
-  StateErrorCode,
-} from './state-store';
+export type { AdcpStateStore, InMemoryStateStoreOptions, ListOptions, ListResult, StateErrorCode } from './state-store';
 
 export { PostgresStateStore, getAdcpStateMigration, ADCP_STATE_MIGRATION } from './postgres-state-store';
 export type { PostgresStateStoreOptions } from './postgres-state-store';

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -67,6 +67,7 @@ export {
   DEFAULT_MAX_DOCUMENT_BYTES,
   SESSION_KEY_FIELD,
   createSessionedStore,
+  scopedStore,
   validateCollection,
   validateId,
   validatePayloadSize,

--- a/src/lib/server/postgres-state-store.ts
+++ b/src/lib/server/postgres-state-store.ts
@@ -32,11 +32,22 @@
  */
 
 import type { PgQueryable } from './postgres-task-store';
-import type { AdcpStateStore, ListOptions, ListResult } from './state-store';
+import {
+  DEFAULT_MAX_DOCUMENT_BYTES,
+  createSessionedStore,
+  validateCollection,
+  validateId,
+  validateWrite,
+  type AdcpStateStore,
+  type ListOptions,
+  type ListResult,
+} from './state-store';
 
 export interface PostgresStateStoreOptions {
   /** Table name. Must contain only lowercase letters, digits, and underscores. Defaults to `"adcp_state"`. */
   tableName?: string;
+  /** Max bytes per document. Defaults to {@link DEFAULT_MAX_DOCUMENT_BYTES}. */
+  maxDocumentBytes?: number;
 }
 
 const DEFAULT_TABLE = 'adcp_state';
@@ -77,10 +88,12 @@ export const ADCP_STATE_MIGRATION = getAdcpStateMigration();
 export class PostgresStateStore implements AdcpStateStore {
   private readonly db: PgQueryable;
   private readonly table: string;
+  private readonly maxDocumentBytes: number;
 
   constructor(db: PgQueryable, options?: PostgresStateStoreOptions) {
     this.db = db;
     this.table = options?.tableName ?? DEFAULT_TABLE;
+    this.maxDocumentBytes = options?.maxDocumentBytes ?? DEFAULT_MAX_DOCUMENT_BYTES;
     if (!VALID_IDENTIFIER.test(this.table)) {
       throw new Error(`Invalid table name: "${this.table}". Must match /^[a-z_][a-z0-9_]*$/.`);
     }
@@ -90,6 +103,8 @@ export class PostgresStateStore implements AdcpStateStore {
     collection: string,
     id: string
   ): Promise<T | null> {
+    validateCollection(collection);
+    validateId(id);
     const { rows } = await this.db.query(`SELECT data FROM ${this.table} WHERE collection = $1 AND id = $2`, [
       collection,
       id,
@@ -99,26 +114,30 @@ export class PostgresStateStore implements AdcpStateStore {
   }
 
   async put(collection: string, id: string, data: Record<string, unknown>): Promise<void> {
+    const serialized = validateWrite(collection, id, data, this.maxDocumentBytes);
     await this.db.query(
       `INSERT INTO ${this.table} (collection, id, data)
        VALUES ($1, $2, $3)
        ON CONFLICT (collection, id)
        DO UPDATE SET data = $3, updated_at = NOW()`,
-      [collection, id, JSON.stringify(data)]
+      [collection, id, serialized]
     );
   }
 
   async patch(collection: string, id: string, partial: Record<string, unknown>): Promise<void> {
+    const serialized = validateWrite(collection, id, partial, this.maxDocumentBytes);
     await this.db.query(
       `INSERT INTO ${this.table} (collection, id, data)
        VALUES ($1, $2, $3)
        ON CONFLICT (collection, id)
        DO UPDATE SET data = ${this.table}.data || $3, updated_at = NOW()`,
-      [collection, id, JSON.stringify(partial)]
+      [collection, id, serialized]
     );
   }
 
   async delete(collection: string, id: string): Promise<boolean> {
+    validateCollection(collection);
+    validateId(id);
     const { rowCount } = await this.db.query(`DELETE FROM ${this.table} WHERE collection = $1 AND id = $2`, [
       collection,
       id,
@@ -130,6 +149,7 @@ export class PostgresStateStore implements AdcpStateStore {
     collection: string,
     options?: ListOptions
   ): Promise<ListResult<T>> {
+    validateCollection(collection);
     const limit = Math.min(options?.limit ?? PAGE_SIZE, MAX_PAGE_SIZE);
     const conditions = ['collection = $1'];
     const values: unknown[] = [collection];
@@ -186,5 +206,9 @@ export class PostgresStateStore implements AdcpStateStore {
   async clearCollection(collection: string): Promise<number> {
     const { rowCount } = await this.db.query(`DELETE FROM ${this.table} WHERE collection = $1`, [collection]);
     return rowCount ?? 0;
+  }
+
+  scoped(sessionKey: string): AdcpStateStore {
+    return createSessionedStore(this, sessionKey);
   }
 }

--- a/src/lib/server/state-store.ts
+++ b/src/lib/server/state-store.ts
@@ -39,12 +39,7 @@
 
 import { ADCPError } from '../errors';
 
-export type StateErrorCode =
-  | 'INVALID_COLLECTION'
-  | 'INVALID_ID'
-  | 'PAYLOAD_TOO_LARGE'
-  | 'NOT_FOUND'
-  | 'BACKEND_ERROR';
+export type StateErrorCode = 'INVALID_COLLECTION' | 'INVALID_ID' | 'PAYLOAD_TOO_LARGE' | 'NOT_FOUND' | 'BACKEND_ERROR';
 
 /**
  * Typed error thrown by state-store implementations for validation, size-limit,

--- a/src/lib/server/state-store.ts
+++ b/src/lib/server/state-store.ts
@@ -69,12 +69,26 @@ export const DEFAULT_MAX_DOCUMENT_BYTES = 5 * 1024 * 1024;
 
 /** 1–256 ASCII letters, digits, or any of `_ - . :`. Prose description is in error messages. */
 const KEY_PATTERN = /^[A-Za-z0-9_.\-:]{1,256}$/;
-const KEY_DESCRIPTION = '1–256 chars from [A-Za-z0-9_.-:]';
+const KEY_DESCRIPTION = 'letters, digits, or `_ . - :` (1–256 chars)';
+
+/**
+ * Stricter pattern for sessioned-store sessionKeys and ids — excludes `:` so
+ * that `sessionKey + "::" + id` is unambiguous. Without this, `"alice:" + "::" + "x"`
+ * would collide with `"alice" + "::" + ":x"` and let tenants read each other's rows.
+ */
+const SESSION_KEY_PATTERN = /^[A-Za-z0-9_.\-]{1,256}$/;
+const SESSION_KEY_DESCRIPTION = 'letters, digits, or `_ . -` (1–256 chars; `:` is reserved for scope paths)';
+
+/** Clamp attacker-controlled input before interpolating into error messages or logs. */
+function safeForMessage(value: unknown): string {
+  const raw = typeof value === 'string' ? value : String(value);
+  return raw.slice(0, 64).replace(/[^\x20-\x7E]/g, '?');
+}
 
 function validateKey(kind: 'collection' | 'id', value: string): void {
   if (typeof value !== 'string' || !KEY_PATTERN.test(value)) {
     const code: StateErrorCode = kind === 'collection' ? 'INVALID_COLLECTION' : 'INVALID_ID';
-    throw new StateError(code, `Invalid ${kind} "${value}". Must be ${KEY_DESCRIPTION}.`);
+    throw new StateError(code, `${kind} "${safeForMessage(value)}" is invalid. Use ${KEY_DESCRIPTION}.`);
   }
 }
 
@@ -313,19 +327,14 @@ export class InMemoryStateStore implements AdcpStateStore {
  */
 export const SESSION_KEY_FIELD = '_session_key';
 
-/**
- * Reserved id separator inserted between `sessionKey` and the caller's `id`.
- * Rejected inside sessionKeys and ids so scoping is unambiguous — otherwise
- * `scoped('alice').put('col', 'bob::x')` would collide with
- * `scoped('alice::bob').put('col', 'x')`.
- */
+/** Reserved scope-path separator. `:` is forbidden in sessionKeys and ids so `::` is unambiguous. */
 const SESSION_ID_SEPARATOR = '::';
 
-function assertNoSeparator(kind: 'sessionKey' | 'id', value: string): void {
-  if (value.includes(SESSION_ID_SEPARATOR)) {
+function validateSessionPart(kind: 'sessionKey' | 'id', value: string): void {
+  if (typeof value !== 'string' || !SESSION_KEY_PATTERN.test(value)) {
     throw new StateError(
       'INVALID_ID',
-      `Invalid ${kind} "${value}": must not contain the reserved separator "${SESSION_ID_SEPARATOR}".`
+      `${kind} "${safeForMessage(value)}" is invalid. Use ${SESSION_KEY_DESCRIPTION}.`
     );
   }
 }
@@ -337,6 +346,15 @@ function stripSessionKey<T extends Record<string, unknown>>(doc: T | null): T | 
   return rest as T;
 }
 
+function rejectReservedField(data: Record<string, unknown>): void {
+  if (SESSION_KEY_FIELD in data) {
+    throw new StateError(
+      'INVALID_ID',
+      `Payload field "${SESSION_KEY_FIELD}" is reserved by the sessioned store. Rename it in your document.`
+    );
+  }
+}
+
 /**
  * Wrap an AdcpStateStore so every operation is isolated to `sessionKey`.
  *
@@ -345,20 +363,18 @@ function stripSessionKey<T extends Record<string, unknown>>(doc: T | null): T | 
  * - **reads/lists** strip `_session_key` before returning documents.
  * - **list filters** always AND-in `_session_key = sessionKey`.
  *
- * `sessionKey` and caller-supplied `id`s must not contain `::` — that token
- * is reserved as the scope separator. Nested `scoped()` calls compose safely.
+ * `sessionKey` and caller `id`s must match {@link SESSION_KEY_PATTERN} — no `:`
+ * characters — so `${sessionKey}::${id}` is unambiguous. Payloads may not include
+ * the reserved `_session_key` field.
  *
  * Use this when every handler's state is scoped to a tenant/brand/session,
  * so you don't have to thread `sessionKey` through every `put`/`list` call.
  */
 export function createSessionedStore(inner: AdcpStateStore, sessionKey: string): AdcpStateStore {
-  if (!KEY_PATTERN.test(sessionKey)) {
-    throw new StateError('INVALID_ID', `Invalid sessionKey "${sessionKey}". Must be ${KEY_DESCRIPTION}.`);
-  }
-  assertNoSeparator('sessionKey', sessionKey);
+  validateSessionPart('sessionKey', sessionKey);
 
   const prefix = (id: string) => {
-    assertNoSeparator('id', id);
+    validateSessionPart('id', id);
     return `${sessionKey}${SESSION_ID_SEPARATOR}${id}`;
   };
 
@@ -372,10 +388,12 @@ export function createSessionedStore(inner: AdcpStateStore, sessionKey: string):
     },
 
     async put(collection, id, data) {
+      rejectReservedField(data);
       await inner.put(collection, prefix(id), { ...data, [SESSION_KEY_FIELD]: sessionKey });
     },
 
     async patch(collection, id, partial) {
+      rejectReservedField(partial);
       await inner.patch(collection, prefix(id), { ...partial, [SESSION_KEY_FIELD]: sessionKey });
     },
 

--- a/src/lib/server/state-store.ts
+++ b/src/lib/server/state-store.ts
@@ -34,6 +34,89 @@
  */
 
 // ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+import { ADCPError } from '../errors';
+
+export type StateErrorCode =
+  | 'INVALID_COLLECTION'
+  | 'INVALID_ID'
+  | 'PAYLOAD_TOO_LARGE'
+  | 'NOT_FOUND'
+  | 'BACKEND_ERROR';
+
+/**
+ * Typed error thrown by state-store implementations for validation, size-limit,
+ * and backend failures. Extends {@link ADCPError} so callers can use the
+ * standard `isADCPError` / `extractErrorInfo` helpers.
+ */
+export class StateError extends ADCPError {
+  readonly code: StateErrorCode;
+
+  constructor(code: StateErrorCode, message: string, details?: unknown) {
+    super(message, details);
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/** Max bytes (UTF-8) allowed per document. Overridable per-store via options. */
+export const DEFAULT_MAX_DOCUMENT_BYTES = 5 * 1024 * 1024;
+
+/** 1–256 ASCII letters, digits, or any of `_ - . :`. Prose description is in error messages. */
+const KEY_PATTERN = /^[A-Za-z0-9_.\-:]{1,256}$/;
+const KEY_DESCRIPTION = '1–256 chars from [A-Za-z0-9_.-:]';
+
+function validateKey(kind: 'collection' | 'id', value: string): void {
+  if (typeof value !== 'string' || !KEY_PATTERN.test(value)) {
+    const code: StateErrorCode = kind === 'collection' ? 'INVALID_COLLECTION' : 'INVALID_ID';
+    throw new StateError(code, `Invalid ${kind} "${value}". Must be ${KEY_DESCRIPTION}.`);
+  }
+}
+
+export function validateCollection(collection: string): void {
+  validateKey('collection', collection);
+}
+
+export function validateId(id: string): void {
+  validateKey('id', id);
+}
+
+export function validatePayloadSize(data: unknown, maxBytes: number): void {
+  measureAndCheckSize(data, maxBytes);
+}
+
+/**
+ * Measure the serialized size of `data` and throw if it exceeds `maxBytes`.
+ * Returns the serialized form so callers can pass it to `db.query` without re-stringifying.
+ */
+function measureAndCheckSize(data: unknown, maxBytes: number): string {
+  const serialized = JSON.stringify(data) ?? '';
+  const bytes = Buffer.byteLength(serialized, 'utf8');
+  if (bytes > maxBytes) {
+    throw new StateError(
+      'PAYLOAD_TOO_LARGE',
+      `Document is ${bytes} bytes; exceeds limit of ${maxBytes} bytes. Split the document or raise maxDocumentBytes.`
+    );
+  }
+  return serialized;
+}
+
+/**
+ * Validate collection + id + payload size. Returns the serialized payload so
+ * callers (e.g., PostgresStateStore) can reuse it without re-stringifying.
+ */
+export function validateWrite(collection: string, id: string, data: unknown, maxBytes: number): string {
+  validateKey('collection', collection);
+  validateKey('id', id);
+  return measureAndCheckSize(data, maxBytes);
+}
+
+// ---------------------------------------------------------------------------
 // Interface
 // ---------------------------------------------------------------------------
 
@@ -78,6 +161,22 @@ export interface AdcpStateStore {
     collection: string,
     options?: ListOptions
   ): Promise<ListResult<T>>;
+
+  /**
+   * Return a session-scoped view of this store. All reads and writes are
+   * isolated to `sessionKey` — ids are namespaced and `list()` only returns
+   * documents owned by the session.
+   *
+   * Multi-tenant sellers use this to avoid re-implementing session scoping
+   * per handler:
+   *
+   * ```ts
+   * const sessionStore = ctx.store.scoped(ctx.sessionKey!);
+   * await sessionStore.put('media_buys', buyId, buy);
+   * const { items } = await sessionStore.list('media_buys');
+   * ```
+   */
+  scoped?(sessionKey: string): AdcpStateStore;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,6 +186,11 @@ export interface AdcpStateStore {
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 500;
 
+export interface InMemoryStateStoreOptions {
+  /** Max bytes per document. Defaults to {@link DEFAULT_MAX_DOCUMENT_BYTES}. */
+  maxDocumentBytes?: number;
+}
+
 /**
  * In-memory state store for development and testing.
  *
@@ -94,6 +198,11 @@ const MAX_PAGE_SIZE = 500;
  */
 export class InMemoryStateStore implements AdcpStateStore {
   private collections = new Map<string, Map<string, Record<string, unknown>>>();
+  private readonly maxDocumentBytes: number;
+
+  constructor(options?: InMemoryStateStoreOptions) {
+    this.maxDocumentBytes = options?.maxDocumentBytes ?? DEFAULT_MAX_DOCUMENT_BYTES;
+  }
 
   private getCollection(collection: string): Map<string, Record<string, unknown>> {
     let col = this.collections.get(collection);
@@ -108,21 +217,27 @@ export class InMemoryStateStore implements AdcpStateStore {
     collection: string,
     id: string
   ): Promise<T | null> {
+    validateCollection(collection);
+    validateId(id);
     const doc = this.getCollection(collection).get(id);
     return doc ? ({ ...doc } as T) : null;
   }
 
   async put(collection: string, id: string, data: Record<string, unknown>): Promise<void> {
+    validateWrite(collection, id, data, this.maxDocumentBytes);
     this.getCollection(collection).set(id, { ...data });
   }
 
   async patch(collection: string, id: string, partial: Record<string, unknown>): Promise<void> {
+    validateWrite(collection, id, partial, this.maxDocumentBytes);
     const col = this.getCollection(collection);
     const existing = col.get(id);
     col.set(id, { ...(existing ?? {}), ...partial });
   }
 
   async delete(collection: string, id: string): Promise<boolean> {
+    validateCollection(collection);
+    validateId(id);
     return this.getCollection(collection).delete(id);
   }
 
@@ -130,6 +245,7 @@ export class InMemoryStateStore implements AdcpStateStore {
     collection: string,
     options?: ListOptions
   ): Promise<ListResult<T>> {
+    validateCollection(collection);
     const col = this.getCollection(collection);
 
     // Build id+data entries for stable cursor tracking
@@ -169,4 +285,95 @@ export class InMemoryStateStore implements AdcpStateStore {
   size(collection: string): number {
     return this.getCollection(collection).size;
   }
+
+  scoped(sessionKey: string): AdcpStateStore {
+    return createSessionedStore(this, sessionKey);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sessioned store wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Marker field injected by {@link createSessionedStore} into every document
+ * it writes. Sellers reading the underlying store directly will see it.
+ */
+export const SESSION_KEY_FIELD = '_session_key';
+
+/**
+ * Reserved id separator inserted between `sessionKey` and the caller's `id`.
+ * Chosen to be inside {@link KEY_PATTERN} but rare in real ids.
+ */
+const SESSION_ID_SEPARATOR = '::';
+
+function stripSessionKey<T extends Record<string, unknown>>(doc: T | null): T | null {
+  if (doc == null) return null;
+  if (!(SESSION_KEY_FIELD in doc)) return doc;
+  const { [SESSION_KEY_FIELD]: _ignored, ...rest } = doc as Record<string, unknown>;
+  return rest as T;
+}
+
+/**
+ * Wrap an AdcpStateStore so every operation is isolated to `sessionKey`.
+ *
+ * - **ids** are prefixed with `${sessionKey}::` before hitting the underlying store.
+ * - **writes** inject `_session_key: sessionKey` into the document so `list()` can filter on it.
+ * - **reads/lists** strip `_session_key` before returning documents.
+ * - **list filters** always AND-in `_session_key = sessionKey`.
+ *
+ * Use this when every handler's state is scoped to a tenant/brand/session,
+ * so you don't have to thread `sessionKey` through every `put`/`list` call.
+ */
+export function createSessionedStore(inner: AdcpStateStore, sessionKey: string): AdcpStateStore {
+  if (!KEY_PATTERN.test(sessionKey)) {
+    throw new StateError(
+      'INVALID_ID',
+      `Invalid sessionKey "${sessionKey}". Must match ${KEY_PATTERN} (1–256 chars, [A-Za-z0-9_.-:]).`
+    );
+  }
+
+  const prefix = (id: string) => `${sessionKey}${SESSION_ID_SEPARATOR}${id}`;
+
+  return {
+    async get<T extends Record<string, unknown> = Record<string, unknown>>(
+      collection: string,
+      id: string
+    ): Promise<T | null> {
+      const doc = await inner.get<T>(collection, prefix(id));
+      return stripSessionKey(doc);
+    },
+
+    async put(collection, id, data) {
+      await inner.put(collection, prefix(id), { ...data, [SESSION_KEY_FIELD]: sessionKey });
+    },
+
+    async patch(collection, id, partial) {
+      await inner.patch(collection, prefix(id), { ...partial, [SESSION_KEY_FIELD]: sessionKey });
+    },
+
+    async delete(collection, id) {
+      return inner.delete(collection, prefix(id));
+    },
+
+    async list<T extends Record<string, unknown> = Record<string, unknown>>(
+      collection: string,
+      options?: ListOptions
+    ): Promise<ListResult<T>> {
+      const mergedFilter = {
+        ...(options?.filter ?? {}),
+        [SESSION_KEY_FIELD]: sessionKey,
+      };
+      const { items, nextCursor } = await inner.list<T>(collection, {
+        ...options,
+        filter: mergedFilter,
+      });
+      const stripped = items.map(item => stripSessionKey(item) as T);
+      return nextCursor !== undefined ? { items: stripped, nextCursor } : { items: stripped };
+    },
+
+    scoped(nestedKey: string): AdcpStateStore {
+      return createSessionedStore(inner, `${sessionKey}${SESSION_ID_SEPARATOR}${nestedKey}`);
+    },
+  };
 }

--- a/src/lib/server/state-store.ts
+++ b/src/lib/server/state-store.ts
@@ -163,20 +163,32 @@ export interface AdcpStateStore {
   ): Promise<ListResult<T>>;
 
   /**
-   * Return a session-scoped view of this store. All reads and writes are
-   * isolated to `sessionKey` — ids are namespaced and `list()` only returns
-   * documents owned by the session.
-   *
-   * Multi-tenant sellers use this to avoid re-implementing session scoping
-   * per handler:
-   *
-   * ```ts
-   * const sessionStore = ctx.store.scoped(ctx.sessionKey!);
-   * await sessionStore.put('media_buys', buyId, buy);
-   * const { items } = await sessionStore.list('media_buys');
-   * ```
+   * Convenience method for built-in stores: returns a session-scoped view.
+   * Optional on the interface so custom `AdcpStateStore` implementations
+   * aren't forced to implement it — callers who need the wrapper on any
+   * store should use {@link scopedStore} instead, which handles the fallback.
    */
   scoped?(sessionKey: string): AdcpStateStore;
+}
+
+/**
+ * Return a session-scoped view of any `AdcpStateStore`.
+ *
+ * Prefers `store.scoped(sessionKey)` when the store defines it; otherwise
+ * wraps with {@link createSessionedStore}. Use this in SDK code and skills
+ * so custom store implementations work without requiring them to implement
+ * `scoped` themselves.
+ *
+ * ```ts
+ * import { scopedStore } from '@adcp/client/server';
+ *
+ * const sessionStore = scopedStore(ctx.store, ctx.sessionKey!);
+ * await sessionStore.put('media_buys', buyId, buy);
+ * const { items } = await sessionStore.list('media_buys');
+ * ```
+ */
+export function scopedStore(store: AdcpStateStore, sessionKey: string): AdcpStateStore {
+  return store.scoped ? store.scoped(sessionKey) : createSessionedStore(store, sessionKey);
 }
 
 // ---------------------------------------------------------------------------
@@ -303,9 +315,20 @@ export const SESSION_KEY_FIELD = '_session_key';
 
 /**
  * Reserved id separator inserted between `sessionKey` and the caller's `id`.
- * Chosen to be inside {@link KEY_PATTERN} but rare in real ids.
+ * Rejected inside sessionKeys and ids so scoping is unambiguous — otherwise
+ * `scoped('alice').put('col', 'bob::x')` would collide with
+ * `scoped('alice::bob').put('col', 'x')`.
  */
 const SESSION_ID_SEPARATOR = '::';
+
+function assertNoSeparator(kind: 'sessionKey' | 'id', value: string): void {
+  if (value.includes(SESSION_ID_SEPARATOR)) {
+    throw new StateError(
+      'INVALID_ID',
+      `Invalid ${kind} "${value}": must not contain the reserved separator "${SESSION_ID_SEPARATOR}".`
+    );
+  }
+}
 
 function stripSessionKey<T extends Record<string, unknown>>(doc: T | null): T | null {
   if (doc == null) return null;
@@ -322,18 +345,22 @@ function stripSessionKey<T extends Record<string, unknown>>(doc: T | null): T | 
  * - **reads/lists** strip `_session_key` before returning documents.
  * - **list filters** always AND-in `_session_key = sessionKey`.
  *
+ * `sessionKey` and caller-supplied `id`s must not contain `::` — that token
+ * is reserved as the scope separator. Nested `scoped()` calls compose safely.
+ *
  * Use this when every handler's state is scoped to a tenant/brand/session,
  * so you don't have to thread `sessionKey` through every `put`/`list` call.
  */
 export function createSessionedStore(inner: AdcpStateStore, sessionKey: string): AdcpStateStore {
   if (!KEY_PATTERN.test(sessionKey)) {
-    throw new StateError(
-      'INVALID_ID',
-      `Invalid sessionKey "${sessionKey}". Must match ${KEY_PATTERN} (1–256 chars, [A-Za-z0-9_.-:]).`
-    );
+    throw new StateError('INVALID_ID', `Invalid sessionKey "${sessionKey}". Must be ${KEY_DESCRIPTION}.`);
   }
+  assertNoSeparator('sessionKey', sessionKey);
 
-  const prefix = (id: string) => `${sessionKey}${SESSION_ID_SEPARATOR}${id}`;
+  const prefix = (id: string) => {
+    assertNoSeparator('id', id);
+    return `${sessionKey}${SESSION_ID_SEPARATOR}${id}`;
+  };
 
   return {
     async get<T extends Record<string, unknown> = Record<string, unknown>>(
@@ -370,10 +397,6 @@ export function createSessionedStore(inner: AdcpStateStore, sessionKey: string):
       });
       const stripped = items.map(item => stripSessionKey(item) as T);
       return nextCursor !== undefined ? { items: stripped, nextCursor } : { items: stripped };
-    },
-
-    scoped(nestedKey: string): AdcpStateStore {
-      return createSessionedStore(inner, `${sessionKey}${SESSION_ID_SEPARATOR}${nestedKey}`);
     },
   };
 }

--- a/src/lib/server/structured-serialize.ts
+++ b/src/lib/server/structured-serialize.ts
@@ -12,25 +12,26 @@
  * const session = structuredDeserialize(await ctx.store.get('sessions', id));
  * ```
  *
- * Tagged envelopes use the field `__type` (reserved). Plain objects that
- * happen to contain a `__type` field are left alone — they are round-tripped
- * as-is, but if you rely on that field for domain data, rename it first.
+ * Tagged envelopes use the namespaced field `__adcpType` to avoid collision
+ * with domain data. Unknown tag values pass through unchanged on deserialize,
+ * so a future tag addition won't corrupt caller data that already uses
+ * `__adcpType` for something else.
  */
 
 type Primitive = string | number | boolean | null;
 
 interface DateEnvelope {
-  __type: 'Date';
+  __adcpType: 'Date';
   value: string;
 }
 
 interface MapEnvelope {
-  __type: 'Map';
+  __adcpType: 'Map';
   entries: [unknown, unknown][];
 }
 
 interface SetEnvelope {
-  __type: 'Set';
+  __adcpType: 'Set';
   values: unknown[];
 }
 
@@ -38,8 +39,17 @@ type Envelope = DateEnvelope | MapEnvelope | SetEnvelope;
 
 function isEnvelope(value: unknown): value is Envelope {
   if (typeof value !== 'object' || value === null) return false;
-  const tag = (value as Record<string, unknown>).__type;
-  return tag === 'Date' || tag === 'Map' || tag === 'Set';
+  const o = value as Record<string, unknown>;
+  switch (o.__adcpType) {
+    case 'Date':
+      return typeof o.value === 'string';
+    case 'Map':
+      return Array.isArray(o.entries);
+    case 'Set':
+      return Array.isArray(o.values);
+    default:
+      return false;
+  }
 }
 
 /**
@@ -52,19 +62,19 @@ export function structuredSerialize(value: unknown): unknown {
   if (t === 'string' || t === 'number' || t === 'boolean') return value as Primitive;
 
   if (value instanceof Date) {
-    return { __type: 'Date', value: value.toISOString() } satisfies DateEnvelope;
+    return { __adcpType: 'Date', value: value.toISOString() } satisfies DateEnvelope;
   }
 
   if (value instanceof Map) {
     return {
-      __type: 'Map',
+      __adcpType: 'Map',
       entries: [...value.entries()].map(([k, v]) => [structuredSerialize(k), structuredSerialize(v)]),
     } satisfies MapEnvelope;
   }
 
   if (value instanceof Set) {
     return {
-      __type: 'Set',
+      __adcpType: 'Set',
       values: [...value.values()].map(v => structuredSerialize(v)),
     } satisfies SetEnvelope;
   }
@@ -99,7 +109,7 @@ export function structuredDeserialize(value: unknown): unknown {
   }
 
   if (isEnvelope(value)) {
-    switch (value.__type) {
+    switch (value.__adcpType) {
       case 'Date':
         return new Date(value.value);
       case 'Map':

--- a/src/lib/server/structured-serialize.ts
+++ b/src/lib/server/structured-serialize.ts
@@ -1,0 +1,121 @@
+/**
+ * Lossless serialization of rich JS types through {@link AdcpStateStore}.
+ *
+ * AdcpStateStore accepts `Record<string, unknown>` and round-trips through
+ * JSON, which silently drops `Map`, `Set`, and converts `Date` to string.
+ * Handlers that keep those types in memory can wrap reads and writes:
+ *
+ * ```ts
+ * import { structuredSerialize, structuredDeserialize } from '@adcp/client/server';
+ *
+ * await ctx.store.put('sessions', id, structuredSerialize(session));
+ * const session = structuredDeserialize(await ctx.store.get('sessions', id));
+ * ```
+ *
+ * Tagged envelopes use the field `__type` (reserved). Plain objects that
+ * happen to contain a `__type` field are left alone — they are round-tripped
+ * as-is, but if you rely on that field for domain data, rename it first.
+ */
+
+type Primitive = string | number | boolean | null;
+
+interface DateEnvelope {
+  __type: 'Date';
+  value: string;
+}
+
+interface MapEnvelope {
+  __type: 'Map';
+  entries: [unknown, unknown][];
+}
+
+interface SetEnvelope {
+  __type: 'Set';
+  values: unknown[];
+}
+
+type Envelope = DateEnvelope | MapEnvelope | SetEnvelope;
+
+function isEnvelope(value: unknown): value is Envelope {
+  if (typeof value !== 'object' || value === null) return false;
+  const tag = (value as Record<string, unknown>).__type;
+  return tag === 'Date' || tag === 'Map' || tag === 'Set';
+}
+
+/**
+ * Walk `value` replacing `Map`, `Set`, and `Date` instances with JSON-safe
+ * tagged envelopes. Plain objects and arrays recurse.
+ */
+export function structuredSerialize(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean') return value as Primitive;
+
+  if (value instanceof Date) {
+    return { __type: 'Date', value: value.toISOString() } satisfies DateEnvelope;
+  }
+
+  if (value instanceof Map) {
+    return {
+      __type: 'Map',
+      entries: [...value.entries()].map(([k, v]) => [structuredSerialize(k), structuredSerialize(v)]),
+    } satisfies MapEnvelope;
+  }
+
+  if (value instanceof Set) {
+    return {
+      __type: 'Set',
+      values: [...value.values()].map(v => structuredSerialize(v)),
+    } satisfies SetEnvelope;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(v => structuredSerialize(v));
+  }
+
+  if (t === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = structuredSerialize(v);
+    }
+    return out;
+  }
+
+  // Functions, symbols, bigints — drop silently (consistent with JSON.stringify).
+  return undefined;
+}
+
+/**
+ * Inverse of {@link structuredSerialize}. Walks `value` converting tagged
+ * envelopes back into native `Map`, `Set`, and `Date` instances.
+ */
+export function structuredDeserialize(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  const t = typeof value;
+  if (t === 'string' || t === 'number' || t === 'boolean') return value;
+
+  if (Array.isArray(value)) {
+    return value.map(v => structuredDeserialize(v));
+  }
+
+  if (isEnvelope(value)) {
+    switch (value.__type) {
+      case 'Date':
+        return new Date(value.value);
+      case 'Map':
+        return new Map(value.entries.map(([k, v]) => [structuredDeserialize(k), structuredDeserialize(v)]));
+      case 'Set':
+        return new Set(value.values.map(v => structuredDeserialize(v)));
+    }
+  }
+
+  if (t === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = structuredDeserialize(v);
+    }
+    return out;
+  }
+
+  return value;
+}

--- a/test/lib/protocol-compliance.test.js
+++ b/test/lib/protocol-compliance.test.js
@@ -3,7 +3,7 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 // Import protocol functions
-const { callA2ATool } = require('../../dist/lib/protocols/a2a.js');
+const { callA2ATool, closeA2AConnections } = require('../../dist/lib/protocols/a2a.js');
 
 /**
  * Protocol Compliance Testing Strategy
@@ -26,6 +26,7 @@ describe('A2A Protocol Compliance', { skip: process.env.CI ? 'Slow tests - skipp
   // Reset mocks before each test
   function setupA2AMocks() {
     capturedMessages = [];
+    closeA2AConnections();
 
     // Create a mock A2A client that captures sendMessage calls
     mockA2AClient = {
@@ -219,7 +220,7 @@ describe('A2A Protocol Compliance', { skip: process.env.CI ? 'Slow tests - skipp
 
   describe('Error Response Handling', () => {
     test('should properly detect JSON-RPC errors in response', async () => {
-      // Mock client to return JSON-RPC error
+      closeA2AConnections();
       const errorClient = {
         sendMessage: async () => ({
           jsonrpc: '2.0',
@@ -247,7 +248,7 @@ describe('A2A Protocol Compliance', { skip: process.env.CI ? 'Slow tests - skipp
     });
 
     test('should handle nested result errors', async () => {
-      // Mock client to return error nested in result
+      closeA2AConnections();
       const errorClient = {
         sendMessage: async () => ({
           jsonrpc: '2.0',

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -13,7 +13,7 @@ const {
   structuredSerialize,
   structuredDeserialize,
 } = require('../dist/lib/server/structured-serialize');
-const { createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createAdcpServer, requireSessionKey } = require('../dist/lib/server/create-adcp-server');
 
 // ---------------------------------------------------------------------------
 // Validation / StateError
@@ -227,19 +227,48 @@ describe('createSessionedStore', () => {
     assert.strictEqual(called, true);
   });
 
-  it('rejects :: in sessionKey (reserved separator)', () => {
+  it('rejects : in sessionKey (reserved for scope-path)', () => {
     const inner = new InMemoryStateStore();
     assert.throws(
-      () => inner.scoped('alice::bob'),
+      () => inner.scoped('alice:bob'),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+    assert.throws(
+      () => inner.scoped('alice:'),
       err => err instanceof StateError && err.code === 'INVALID_ID'
     );
   });
 
-  it('rejects :: in ids to prevent scope collisions', async () => {
+  it('rejects : in ids to prevent scope collisions', async () => {
     const inner = new InMemoryStateStore();
     const alice = inner.scoped('alice');
     await assert.rejects(
+      () => alice.put('col', ':x', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+    await assert.rejects(
       () => alice.put('col', 'bob::x', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+  });
+
+  it('closes the "trailing colon" collision between sessionKey="alice:" and id=":x"', () => {
+    // Both were previously accepted; neither contains `::`. Fix now rejects both.
+    const inner = new InMemoryStateStore();
+    assert.throws(() => inner.scoped('alice:'), err => err.code === 'INVALID_ID');
+    const alice = inner.scoped('alice');
+    assert.rejects(() => alice.put('col', ':x', { v: 1 }), err => err.code === 'INVALID_ID');
+  });
+
+  it('rejects payloads containing the reserved _session_key field', async () => {
+    const inner = new InMemoryStateStore();
+    const alice = inner.scoped('alice');
+    await assert.rejects(
+      () => alice.put('col', 'x', { [SESSION_KEY_FIELD]: 'bob', v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+    await assert.rejects(
+      () => alice.patch('col', 'x', { [SESSION_KEY_FIELD]: 'bob' }),
       err => err instanceof StateError && err.code === 'INVALID_ID'
     );
   });
@@ -298,22 +327,40 @@ describe('resolveSessionKey', () => {
     assert.strictEqual(seenSessionKey, 'tnt_42');
   });
 
-  it('returns SERVICE_UNAVAILABLE with the original reason in details if resolver throws', async () => {
+  it('returns SERVICE_UNAVAILABLE without leaking internals by default if resolver throws', async () => {
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
       resolveSessionKey: () => {
-        throw new Error('db lookup timed out');
+        throw new Error('db://user:pass@10.0.0.1 timed out');
       },
-      signals: {
-        getSignals: async () => ({ signals: [] }),
-      },
+      signals: { getSignals: async () => ({ signals: [] }) },
     });
 
     const result = await callTool(server, 'get_signals', {});
     const error = result.structuredContent.adcp_error;
     assert.strictEqual(error.code, 'SERVICE_UNAVAILABLE');
-    assert.strictEqual(error.details?.reason, 'db lookup timed out');
+    assert.strictEqual(error.details, undefined);
+  });
+
+  it('includes details.reason when exposeErrorDetails: true', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      exposeErrorDetails: true,
+      resolveSessionKey: () => {
+        throw new Error('db lookup timed out');
+      },
+      signals: { getSignals: async () => ({ signals: [] }) },
+    });
+
+    const result = await callTool(server, 'get_signals', {});
+    assert.strictEqual(result.structuredContent.adcp_error.details?.reason, 'db lookup timed out');
+  });
+
+  it('requireSessionKey narrows ctx.sessionKey or throws', () => {
+    assert.strictEqual(requireSessionKey({ store: {}, sessionKey: 'alice' }), 'alice');
+    assert.throws(() => requireSessionKey({ store: {} }), /sessionKey is undefined/);
   });
 
   it('leaves ctx.sessionKey undefined when resolver returns undefined', async () => {

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -298,12 +298,12 @@ describe('resolveSessionKey', () => {
     assert.strictEqual(seenSessionKey, 'tnt_42');
   });
 
-  it('returns SERVICE_UNAVAILABLE if resolver throws', async () => {
+  it('returns SERVICE_UNAVAILABLE with the original reason in details if resolver throws', async () => {
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
       resolveSessionKey: () => {
-        throw new Error('boom');
+        throw new Error('db lookup timed out');
       },
       signals: {
         getSignals: async () => ({ signals: [] }),
@@ -311,7 +311,9 @@ describe('resolveSessionKey', () => {
     });
 
     const result = await callTool(server, 'get_signals', {});
-    assert.strictEqual(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+    const error = result.structuredContent.adcp_error;
+    assert.strictEqual(error.code, 'SERVICE_UNAVAILABLE');
+    assert.strictEqual(error.details?.reason, 'db lookup timed out');
   });
 
   it('leaves ctx.sessionKey undefined when resolver returns undefined', async () => {

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -9,10 +9,7 @@ const {
   scopedStore,
 } = require('../dist/lib/server/state-store');
 const { ADCPError, isADCPError } = require('../dist/lib/errors');
-const {
-  structuredSerialize,
-  structuredDeserialize,
-} = require('../dist/lib/server/structured-serialize');
+const { structuredSerialize, structuredDeserialize } = require('../dist/lib/server/structured-serialize');
 const { createAdcpServer, requireSessionKey } = require('../dist/lib/server/create-adcp-server');
 
 // ---------------------------------------------------------------------------
@@ -255,9 +252,15 @@ describe('createSessionedStore', () => {
   it('closes the "trailing colon" collision between sessionKey="alice:" and id=":x"', () => {
     // Both were previously accepted; neither contains `::`. Fix now rejects both.
     const inner = new InMemoryStateStore();
-    assert.throws(() => inner.scoped('alice:'), err => err.code === 'INVALID_ID');
+    assert.throws(
+      () => inner.scoped('alice:'),
+      err => err.code === 'INVALID_ID'
+    );
     const alice = inner.scoped('alice');
-    assert.rejects(() => alice.put('col', ':x', { v: 1 }), err => err.code === 'INVALID_ID');
+    assert.rejects(
+      () => alice.put('col', ':x', { v: 1 }),
+      err => err.code === 'INVALID_ID'
+    );
   });
 
   it('rejects payloads containing the reserved _session_key field', async () => {
@@ -390,10 +393,7 @@ describe('structuredSerialize / structuredDeserialize', () => {
   it('round-trips Date', () => {
     const d = new Date('2026-04-17T12:34:56.000Z');
     const serialized = structuredSerialize({ createdAt: d });
-    assert.strictEqual(
-      JSON.parse(JSON.stringify(serialized)).createdAt.__adcpType,
-      'Date'
-    );
+    assert.strictEqual(JSON.parse(JSON.stringify(serialized)).createdAt.__adcpType, 'Date');
     const restored = structuredDeserialize(JSON.parse(JSON.stringify(serialized)));
     assert.ok(restored.createdAt instanceof Date);
     assert.strictEqual(restored.createdAt.toISOString(), d.toISOString());

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -1,0 +1,376 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  InMemoryStateStore,
+  StateError,
+  SESSION_KEY_FIELD,
+  createSessionedStore,
+} = require('../dist/lib/server/state-store');
+const { ADCPError, isADCPError } = require('../dist/lib/errors');
+const {
+  structuredSerialize,
+  structuredDeserialize,
+} = require('../dist/lib/server/structured-serialize');
+const { createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+
+// ---------------------------------------------------------------------------
+// Validation / StateError
+// ---------------------------------------------------------------------------
+
+describe('StateError validation', () => {
+  it('rejects collection with invalid characters', async () => {
+    const store = new InMemoryStateStore();
+    await assert.rejects(
+      () => store.put('bad collection!', 'id', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_COLLECTION'
+    );
+  });
+
+  it('rejects id with invalid characters', async () => {
+    const store = new InMemoryStateStore();
+    await assert.rejects(
+      () => store.put('col', 'bad id!', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+  });
+
+  it('rejects empty collection and id', async () => {
+    const store = new InMemoryStateStore();
+    await assert.rejects(
+      () => store.put('', 'id', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_COLLECTION'
+    );
+    await assert.rejects(
+      () => store.put('col', '', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+  });
+
+  it('rejects collection/id over 256 chars', async () => {
+    const store = new InMemoryStateStore();
+    const long = 'a'.repeat(257);
+    await assert.rejects(
+      () => store.put(long, 'id', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_COLLECTION'
+    );
+    await assert.rejects(
+      () => store.put('col', long, { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+  });
+
+  it('is an ADCPError so callers can reuse isADCPError() and extractErrorInfo()', () => {
+    const err = new StateError('INVALID_ID', 'bad');
+    assert.ok(err instanceof ADCPError);
+    assert.ok(isADCPError(err));
+    assert.strictEqual(err.code, 'INVALID_ID');
+  });
+
+  it('accepts valid key characters (letters, digits, _ - . :)', async () => {
+    const store = new InMemoryStateStore();
+    await store.put('buyer.v1_prod', 'tenant:alice-42', { v: 1 });
+    const doc = await store.get('buyer.v1_prod', 'tenant:alice-42');
+    assert.strictEqual(doc.v, 1);
+  });
+
+  it('rejects payload over maxDocumentBytes', async () => {
+    const store = new InMemoryStateStore({ maxDocumentBytes: 256 });
+    const big = { blob: 'x'.repeat(400) };
+    await assert.rejects(
+      () => store.put('col', 'id', big),
+      err => err instanceof StateError && err.code === 'PAYLOAD_TOO_LARGE'
+    );
+  });
+
+  it('validates on patch', async () => {
+    const store = new InMemoryStateStore({ maxDocumentBytes: 100 });
+    await assert.rejects(
+      () => store.patch('col', 'id', { blob: 'x'.repeat(200) }),
+      err => err instanceof StateError && err.code === 'PAYLOAD_TOO_LARGE'
+    );
+  });
+
+  it('validates on get, delete, list', async () => {
+    const store = new InMemoryStateStore();
+    await assert.rejects(
+      () => store.get('bad collection!', 'id'),
+      err => err instanceof StateError && err.code === 'INVALID_COLLECTION'
+    );
+    await assert.rejects(
+      () => store.delete('col', 'bad id!'),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+    await assert.rejects(
+      () => store.list('bad collection!'),
+      err => err instanceof StateError && err.code === 'INVALID_COLLECTION'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSessionedStore / scoped()
+// ---------------------------------------------------------------------------
+
+describe('createSessionedStore', () => {
+  it('isolates writes between sessions with the same id', async () => {
+    const inner = new InMemoryStateStore();
+    const alice = inner.scoped('alice');
+    const bob = inner.scoped('bob');
+
+    await alice.put('media_buys', 'mb1', { status: 'active' });
+    await bob.put('media_buys', 'mb1', { status: 'paused' });
+
+    assert.deepStrictEqual(await alice.get('media_buys', 'mb1'), { status: 'active' });
+    assert.deepStrictEqual(await bob.get('media_buys', 'mb1'), { status: 'paused' });
+  });
+
+  it('strips _session_key from returned documents', async () => {
+    const inner = new InMemoryStateStore();
+    const alice = inner.scoped('alice');
+    await alice.put('col', 'x', { v: 1 });
+    const doc = await alice.get('col', 'x');
+    assert.deepStrictEqual(doc, { v: 1 });
+    assert.strictEqual(SESSION_KEY_FIELD in doc, false);
+  });
+
+  it('injects _session_key into the underlying store', async () => {
+    const inner = new InMemoryStateStore();
+    await inner.scoped('alice').put('col', 'x', { v: 1 });
+    const { items } = await inner.list('col');
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0][SESSION_KEY_FIELD], 'alice');
+  });
+
+  it('list() only returns items for the session', async () => {
+    const inner = new InMemoryStateStore();
+    await inner.scoped('alice').put('media_buys', 'mb1', { v: 1 });
+    await inner.scoped('alice').put('media_buys', 'mb2', { v: 2 });
+    await inner.scoped('bob').put('media_buys', 'mb1', { v: 99 });
+
+    const { items } = await inner.scoped('alice').list('media_buys');
+    assert.strictEqual(items.length, 2);
+    assert.ok(items.every(i => i.v !== 99));
+  });
+
+  it('list() with caller filter ANDs with session filter', async () => {
+    const inner = new InMemoryStateStore();
+    const alice = inner.scoped('alice');
+    await alice.put('col', 'a', { tag: 'x', n: 1 });
+    await alice.put('col', 'b', { tag: 'y', n: 2 });
+    await inner.scoped('bob').put('col', 'c', { tag: 'x', n: 3 });
+
+    const { items } = await alice.list('col', { filter: { tag: 'x' } });
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].n, 1);
+  });
+
+  it('patch merges without leaking _session_key into caller payload', async () => {
+    const inner = new InMemoryStateStore();
+    const alice = inner.scoped('alice');
+    await alice.put('col', 'x', { a: 1, b: 2 });
+    await alice.patch('col', 'x', { b: 20 });
+    const doc = await alice.get('col', 'x');
+    assert.deepStrictEqual(doc, { a: 1, b: 20 });
+  });
+
+  it('delete is session-scoped (does not remove other session docs with same id)', async () => {
+    const inner = new InMemoryStateStore();
+    await inner.scoped('alice').put('col', 'x', { v: 1 });
+    await inner.scoped('bob').put('col', 'x', { v: 2 });
+
+    await inner.scoped('alice').delete('col', 'x');
+    assert.strictEqual(await inner.scoped('alice').get('col', 'x'), null);
+    assert.deepStrictEqual(await inner.scoped('bob').get('col', 'x'), { v: 2 });
+  });
+
+  it('rejects invalid sessionKey', () => {
+    const inner = new InMemoryStateStore();
+    assert.throws(
+      () => inner.scoped('bad key!'),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+  });
+
+  it('createSessionedStore is exported standalone (for custom stores)', async () => {
+    const inner = new InMemoryStateStore();
+    const scoped = createSessionedStore(inner, 'alice');
+    await scoped.put('col', 'x', { v: 1 });
+    const doc = await scoped.get('col', 'x');
+    assert.deepStrictEqual(doc, { v: 1 });
+  });
+
+  it('supports nested scoping', async () => {
+    const inner = new InMemoryStateStore();
+    const tenant = inner.scoped('tenant_a');
+    const brand = tenant.scoped('brand_b');
+    await brand.put('col', 'x', { v: 1 });
+
+    // visible under the nested scope
+    assert.deepStrictEqual(await brand.get('col', 'x'), { v: 1 });
+    // sibling tenant sees nothing
+    assert.strictEqual(await inner.scoped('tenant_z').get('col', 'x'), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveSessionKey hook
+// ---------------------------------------------------------------------------
+
+describe('resolveSessionKey', () => {
+  async function callTool(server, toolName, params) {
+    const tool = server._registeredTools[toolName];
+    const extra = { signal: new AbortController().signal };
+    return tool.handler(params, extra);
+  }
+
+  it('populates ctx.sessionKey before the handler runs', async () => {
+    let seenSessionKey;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      resolveSessionKey: ({ toolName }) => `tenant_${toolName}`,
+      signals: {
+        getSignals: async (_params, ctx) => {
+          seenSessionKey = ctx.sessionKey;
+          return { signals: [] };
+        },
+      },
+    });
+
+    await callTool(server, 'get_signals', {});
+    assert.strictEqual(seenSessionKey, 'tenant_get_signals');
+  });
+
+  it('can derive sessionKey from resolved account', async () => {
+    let seenSessionKey;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      resolveAccount: async () => ({ tenant_id: 'tnt_42' }),
+      resolveSessionKey: ({ account }) => account?.tenant_id,
+      mediaBuy: {
+        createMediaBuy: async (_params, ctx) => {
+          seenSessionKey = ctx.sessionKey;
+          return { media_buy_id: 'mb1', packages: [] };
+        },
+      },
+    });
+
+    await callTool(server, 'create_media_buy', {
+      account: { account_id: 'acc_1' },
+      promoted_offering: 'x',
+      budget: { total: 1000, currency: 'USD' },
+      packages: [],
+    });
+    assert.strictEqual(seenSessionKey, 'tnt_42');
+  });
+
+  it('returns SERVICE_UNAVAILABLE if resolver throws', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      resolveSessionKey: () => {
+        throw new Error('boom');
+      },
+      signals: {
+        getSignals: async () => ({ signals: [] }),
+      },
+    });
+
+    const result = await callTool(server, 'get_signals', {});
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+  });
+
+  it('leaves ctx.sessionKey undefined when resolver returns undefined', async () => {
+    let seenSessionKey = 'sentinel';
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      resolveSessionKey: () => undefined,
+      signals: {
+        getSignals: async (_params, ctx) => {
+          seenSessionKey = ctx.sessionKey;
+          return { signals: [] };
+        },
+      },
+    });
+
+    await callTool(server, 'get_signals', {});
+    assert.strictEqual(seenSessionKey, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// structuredSerialize / structuredDeserialize
+// ---------------------------------------------------------------------------
+
+describe('structuredSerialize / structuredDeserialize', () => {
+  it('round-trips Date', () => {
+    const d = new Date('2026-04-17T12:34:56.000Z');
+    const serialized = structuredSerialize({ createdAt: d });
+    assert.strictEqual(
+      JSON.parse(JSON.stringify(serialized)).createdAt.__type,
+      'Date'
+    );
+    const restored = structuredDeserialize(JSON.parse(JSON.stringify(serialized)));
+    assert.ok(restored.createdAt instanceof Date);
+    assert.strictEqual(restored.createdAt.toISOString(), d.toISOString());
+  });
+
+  it('round-trips Map with primitive keys', () => {
+    const m = new Map([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    const restored = structuredDeserialize(JSON.parse(JSON.stringify(structuredSerialize({ cache: m }))));
+    assert.ok(restored.cache instanceof Map);
+    assert.strictEqual(restored.cache.get('a'), 1);
+    assert.strictEqual(restored.cache.get('b'), 2);
+  });
+
+  it('round-trips Set', () => {
+    const s = new Set(['x', 'y', 'z']);
+    const restored = structuredDeserialize(JSON.parse(JSON.stringify(structuredSerialize({ tags: s }))));
+    assert.ok(restored.tags instanceof Set);
+    assert.deepStrictEqual([...restored.tags].sort(), ['x', 'y', 'z']);
+  });
+
+  it('round-trips nested rich types', () => {
+    const value = {
+      session: {
+        id: 'abc',
+        startedAt: new Date('2026-04-17T00:00:00.000Z'),
+        participants: new Set(['alice', 'bob']),
+        counters: new Map([['msg', 42]]),
+      },
+    };
+    const wire = JSON.parse(JSON.stringify(structuredSerialize(value)));
+    const restored = structuredDeserialize(wire);
+    assert.ok(restored.session.startedAt instanceof Date);
+    assert.ok(restored.session.participants instanceof Set);
+    assert.ok(restored.session.counters instanceof Map);
+    assert.strictEqual(restored.session.counters.get('msg'), 42);
+  });
+
+  it('leaves primitives, null, and undefined alone', () => {
+    assert.strictEqual(structuredSerialize(42), 42);
+    assert.strictEqual(structuredSerialize('x'), 'x');
+    assert.strictEqual(structuredSerialize(null), null);
+    assert.strictEqual(structuredSerialize(undefined), undefined);
+  });
+
+  it('round-trips through state store with maxDocumentBytes check on serialized form', async () => {
+    const store = new InMemoryStateStore();
+    const value = {
+      id: 'session_1',
+      participants: new Set(['a', 'b']),
+      timestamps: new Map([['opened', new Date('2026-04-17T00:00:00.000Z')]]),
+    };
+    await store.put('sessions', 'session_1', structuredSerialize(value));
+    const raw = await store.get('sessions', 'session_1');
+    const restored = structuredDeserialize(raw);
+    assert.ok(restored.participants instanceof Set);
+    assert.ok(restored.timestamps.get('opened') instanceof Date);
+  });
+});

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -6,6 +6,7 @@ const {
   StateError,
   SESSION_KEY_FIELD,
   createSessionedStore,
+  scopedStore,
 } = require('../dist/lib/server/state-store');
 const { ADCPError, isADCPError } = require('../dist/lib/errors');
 const {
@@ -200,16 +201,47 @@ describe('createSessionedStore', () => {
     assert.deepStrictEqual(doc, { v: 1 });
   });
 
-  it('supports nested scoping', async () => {
-    const inner = new InMemoryStateStore();
-    const tenant = inner.scoped('tenant_a');
-    const brand = tenant.scoped('brand_b');
-    await brand.put('col', 'x', { v: 1 });
+  it('scopedStore() falls back to createSessionedStore when store.scoped is undefined', async () => {
+    const backing = new InMemoryStateStore();
+    // Custom store that implements the interface WITHOUT `scoped`.
+    const minimal = {
+      get: (c, i) => backing.get(c, i),
+      put: (c, i, d) => backing.put(c, i, d),
+      patch: (c, i, d) => backing.patch(c, i, d),
+      delete: (c, i) => backing.delete(c, i),
+      list: (c, o) => backing.list(c, o),
+    };
+    const scoped = scopedStore(minimal, 'alice');
+    await scoped.put('col', 'x', { v: 1 });
+    assert.deepStrictEqual(await scoped.get('col', 'x'), { v: 1 });
+  });
 
-    // visible under the nested scope
-    assert.deepStrictEqual(await brand.get('col', 'x'), { v: 1 });
-    // sibling tenant sees nothing
-    assert.strictEqual(await inner.scoped('tenant_z').get('col', 'x'), null);
+  it('scopedStore() uses store.scoped when defined', () => {
+    const inner = new InMemoryStateStore();
+    let called = false;
+    inner.scoped = key => {
+      called = true;
+      return createSessionedStore(inner, key);
+    };
+    scopedStore(inner, 'alice');
+    assert.strictEqual(called, true);
+  });
+
+  it('rejects :: in sessionKey (reserved separator)', () => {
+    const inner = new InMemoryStateStore();
+    assert.throws(
+      () => inner.scoped('alice::bob'),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
+  });
+
+  it('rejects :: in ids to prevent scope collisions', async () => {
+    const inner = new InMemoryStateStore();
+    const alice = inner.scoped('alice');
+    await assert.rejects(
+      () => alice.put('col', 'bob::x', { v: 1 }),
+      err => err instanceof StateError && err.code === 'INVALID_ID'
+    );
   });
 });
 
@@ -310,7 +342,7 @@ describe('structuredSerialize / structuredDeserialize', () => {
     const d = new Date('2026-04-17T12:34:56.000Z');
     const serialized = structuredSerialize({ createdAt: d });
     assert.strictEqual(
-      JSON.parse(JSON.stringify(serialized)).createdAt.__type,
+      JSON.parse(JSON.stringify(serialized)).createdAt.__adcpType,
       'Date'
     );
     const restored = structuredDeserialize(JSON.parse(JSON.stringify(serialized)));
@@ -351,6 +383,13 @@ describe('structuredSerialize / structuredDeserialize', () => {
     assert.ok(restored.session.participants instanceof Set);
     assert.ok(restored.session.counters instanceof Map);
     assert.strictEqual(restored.session.counters.get('msg'), 42);
+  });
+
+  it('passes through caller data that uses __adcpType for its own purposes', () => {
+    const input = { __adcpType: 'SomeDomainThing', value: 'not an iso string' };
+    const serialized = JSON.parse(JSON.stringify(structuredSerialize(input)));
+    const restored = structuredDeserialize(serialized);
+    assert.deepStrictEqual(restored, input);
   });
 
   it('leaves primitives, null, and undefined alone', () => {


### PR DESCRIPTION
## Summary

Batch 1 of the upstream seller feedback on the `AdcpStateStore` surface. Six small, independent wins bundled into one PR; the bigger items (`putIfMatch` / optimistic concurrency, AsyncLocalStorage dispatcher) are in separate RFCs.

### What's new

- **`store.scoped(sessionKey)`** on every `AdcpStateStore` — returns a session-isolated view that auto-prefixes ids and filters `list()` by `_session_key`. Exported standalone as `createSessionedStore(store, key)` for custom stores. Handlers stop re-implementing session scoping per call.
- **`HandlerContext.sessionKey` + `resolveSessionKey` hook** on `createAdcpServer`. Sellers derive the scoping key once; handlers read `ctx.sessionKey` instead of re-parsing params. Runs after `resolveAccount`, so the resolved account is available.
- **`StateError`** with typed codes (`INVALID_COLLECTION`, `INVALID_ID`, `PAYLOAD_TOO_LARGE`, …) extending `ADCPError`, so `isADCPError` / `extractErrorInfo` just work. Built-in charset + length validation on every store op; configurable `maxDocumentBytes` (5 MB default) on both `InMemoryStateStore` and `PostgresStateStore`.
- **`structuredSerialize` / `structuredDeserialize`** helpers so handlers round-trip `Map`, `Set`, and `Date` through the state store without hand-rolling per-type converters.

### Docs

- `docs/guides/CONCURRENCY.md` — explicit last-writer-wins vs per-row isolation, the read-modify-write race on whole-session blobs, and why per-entity rows are safer.
- `docs/guides/TASKRESULT-5-MIGRATION.md` — the four migration patterns for 5.0's discriminated-union `TaskResult` (success check, error extraction, status narrowing, intermediate states).

### Compatibility

No breaking changes. `scoped` is an optional method on `AdcpStateStore`, so custom store implementations keep working.

## Test plan

- [x] `node --test test/server-state-store-extensions.test.js` — 29 new tests, all passing
- [x] `npm test` — 3149 / 3151 passing (2 pre-existing failures in `test/lib/protocol-compliance.test.js`, unrelated to this change)
- [x] `npx tsc --noEmit` — clean
- [x] Simplify review: `StateError` extends `ADCPError`, double-stringify on Postgres writes removed, `SessionKeyContext.toolName` narrowed to `AdcpServerToolName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)