### PR TITLE
chore: regenerate schemas and registry from upstream AdCP

### DIFF
--- a/.changeset/schema-regen-2026-04-17.md
+++ b/.changeset/schema-regen-2026-04-17.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': patch
+---
+
+Regenerate AdCP schemas and registry from upstream. Pulls in sponsored-intelligence / sales specialism and related domain enums into the generated type exports. Mechanical regen — no handwritten code changes.

--- a/schemas/registry/registry.yaml
+++ b/schemas/registry/registry.yaml
@@ -668,6 +668,7 @@ components:
                   - measurement
                   - governance
                   - creative
+                  - sales
                   - buying
                   - signals
                   - unknown

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-16T22:22:26.623Z
+// Generated at: 2026-04-17T15:26:27.555Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -3761,7 +3761,7 @@ export type TaskType =
 /**
  * AdCP domain this task belongs to. Helps classify the operation type at a high level.
  */
-export type AdCPDomain = 'media-buy' | 'signals' | 'governance' | 'creative' | 'brand';
+export type AdCPDomain = 'media-buy' | 'signals' | 'governance' | 'creative' | 'brand' | 'sponsored-intelligence';
 /**
  * Current task status. Webhooks are triggered for status changes after initial submission.
  */
@@ -10638,6 +10638,34 @@ export type SortMetric =
   | 'profile_visits'
   | 'engagement_rate'
   | 'cost_per_click';
+
+
+// enums/specialism.json
+/**
+ * Specialized capability claims an agent can make. Each specialism maps to a compliance storyboard bundle published at /compliance/{version}/specialisms/{id}/. An agent asserts specialisms it supports in get_adcp_capabilities; the AAO compliance runner executes the matching storyboards to verify the claim.
+ */
+export type AdCPSpecialism =
+  | 'audience-sync'
+  | 'brand-rights'
+  | 'content-standards'
+  | 'creative-ad-server'
+  | 'creative-generative'
+  | 'creative-template'
+  | 'governance-delivery-monitor'
+  | 'governance-spend-authority'
+  | 'inventory-lists'
+  | 'measurement-verification'
+  | 'sales-broadcast-tv'
+  | 'sales-catalog-driven'
+  | 'sales-exchange'
+  | 'sales-guaranteed'
+  | 'sales-non-guaranteed'
+  | 'sales-proposal-mode'
+  | 'sales-retail-media'
+  | 'sales-social'
+  | 'sales-streaming-tv'
+  | 'signal-marketplace'
+  | 'signal-owned';
 
 
 // enums/validation-mode.json

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-16T22:22:29.220Z
+// Generated at: 2026-04-17T15:26:50.412Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -809,7 +809,7 @@ export const PropertySchema = z.object({
 
 export const TaskTypeSchema = z.union([z.literal("create_media_buy"), z.literal("update_media_buy"), z.literal("sync_creatives"), z.literal("activate_signal"), z.literal("get_signals"), z.literal("create_property_list"), z.literal("update_property_list"), z.literal("get_property_list"), z.literal("list_property_lists"), z.literal("delete_property_list"), z.literal("sync_accounts"), z.literal("get_account_financials"), z.literal("get_creative_delivery"), z.literal("sync_event_sources"), z.literal("sync_audiences"), z.literal("sync_catalogs"), z.literal("log_event"), z.literal("get_brand_identity"), z.literal("get_rights"), z.literal("acquire_rights")]);
 
-export const AdCPDomainSchema = z.union([z.literal("media-buy"), z.literal("signals"), z.literal("governance"), z.literal("creative"), z.literal("brand")]);
+export const AdCPDomainSchema = z.union([z.literal("media-buy"), z.literal("signals"), z.literal("governance"), z.literal("creative"), z.literal("brand"), z.literal("sponsored-intelligence")]);
 
 export const TaskStatusSchema = z.union([z.literal("submitted"), z.literal("working"), z.literal("input-required"), z.literal("completed"), z.literal("canceled"), z.literal("failed"), z.literal("rejected"), z.literal("auth-required"), z.literal("unknown")]);
 
@@ -2585,6 +2585,8 @@ export const SignalSourceSchema = z.union([z.literal("catalog"), z.literal("agen
 export const SortDirectionSchema = z.union([z.literal("asc"), z.literal("desc")]);
 
 export const SortMetricSchema = z.union([z.literal("impressions"), z.literal("spend"), z.literal("clicks"), z.literal("ctr"), z.literal("views"), z.literal("completed_views"), z.literal("completion_rate"), z.literal("conversions"), z.literal("conversion_value"), z.literal("roas"), z.literal("cost_per_acquisition"), z.literal("new_to_brand_rate"), z.literal("leads"), z.literal("grps"), z.literal("reach"), z.literal("frequency"), z.literal("engagements"), z.literal("follows"), z.literal("saves"), z.literal("profile_visits"), z.literal("engagement_rate"), z.literal("cost_per_click")]);
+
+export const AdCPSpecialismSchema = z.union([z.literal("audience-sync"), z.literal("brand-rights"), z.literal("content-standards"), z.literal("creative-ad-server"), z.literal("creative-generative"), z.literal("creative-template"), z.literal("governance-delivery-monitor"), z.literal("governance-spend-authority"), z.literal("inventory-lists"), z.literal("measurement-verification"), z.literal("sales-broadcast-tv"), z.literal("sales-catalog-driven"), z.literal("sales-exchange"), z.literal("sales-guaranteed"), z.literal("sales-non-guaranteed"), z.literal("sales-proposal-mode"), z.literal("sales-retail-media"), z.literal("sales-social"), z.literal("sales-streaming-tv"), z.literal("signal-marketplace"), z.literal("signal-owned")]);
 
 export const ValidationModeSchema = z.union([z.literal("strict"), z.literal("lenient")]);
 
@@ -4872,6 +4874,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
     compliance_testing: z.object({
         scenarios: z.array(z.union([z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend")])).optional()
     }).passthrough().optional(),
+    specialisms: z.array(AdCPSpecialismSchema).optional(),
     extensions_supported: z.array(z.string()).optional(),
     last_updated: z.string().optional(),
     errors: z.array(ErrorSchema).optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -12681,6 +12681,32 @@ export interface GetAdCPCapabilitiesRequest {
  */
 export type TransportMode = 'walking' | 'cycling' | 'driving' | 'public_transport';
 /**
+ * Specialized capability claims an agent can make. Each specialism maps to a compliance storyboard bundle published at /compliance/{version}/specialisms/{id}/. An agent asserts specialisms it supports in get_adcp_capabilities; the AAO compliance runner executes the matching storyboards to verify the claim.
+ */
+export type AdCPSpecialism =
+  | 'audience-sync'
+  | 'brand-rights'
+  | 'content-standards'
+  | 'creative-ad-server'
+  | 'creative-generative'
+  | 'creative-template'
+  | 'governance-delivery-monitor'
+  | 'governance-spend-authority'
+  | 'inventory-lists'
+  | 'measurement-verification'
+  | 'sales-broadcast-tv'
+  | 'sales-catalog-driven'
+  | 'sales-exchange'
+  | 'sales-guaranteed'
+  | 'sales-non-guaranteed'
+  | 'sales-proposal-mode'
+  | 'sales-retail-media'
+  | 'sales-social'
+  | 'sales-streaming-tv'
+  | 'signal-marketplace'
+  | 'signal-owned';
+
+/**
  * Response payload for get_adcp_capabilities task. Protocol-level capability discovery across all AdCP protocols. Each domain protocol has its own capability section.
  */
 export interface GetAdCPCapabilitiesResponse {
@@ -12694,7 +12720,7 @@ export interface GetAdCPCapabilitiesResponse {
     major_versions: number[];
   };
   /**
-   * Which AdCP domain protocols this seller supports
+   * AdCP domain protocols this agent supports. Each value both (a) declares which tools the agent implements and (b) commits the agent to pass the baseline compliance storyboard at /compliance/{version}/domains/{protocol}/ (with snake_case → kebab-case path mapping, e.g. media_buy → /compliance/.../domains/media-buy/). compliance_testing is an RPC surface only and has no compliance baseline.
    */
   supported_protocols: (
     | 'media_buy'
@@ -13198,6 +13224,10 @@ export interface GetAdCPCapabilitiesResponse {
       | 'simulate_budget_spend'
     )[];
   };
+  /**
+   * Optional — specialized compliance claims this agent supports. Omitting the field means the agent declares no specialism claims (it still passes the universal + domain-baseline storyboards implied by supported_protocols). Each specialism maps to a storyboard bundle at /compliance/{version}/specialisms/{id}/ that the AAO compliance runner executes to verify the claim. Each specialism rolls up to one of the protocols in supported_protocols — the runner rejects a specialism claim whose parent protocol is missing. Only list specialisms your agent actually implements — the AAO Verified badge enumerates which specialisms were demonstrably passed.
+   */
+  specialisms?: AdCPSpecialism[];
   /**
    * Extension namespaces this agent supports. Buyers can expect meaningful data in ext.{namespace} fields on responses from this agent. Extension schemas are published in the AdCP extension registry.
    */


### PR DESCRIPTION
## Summary

Mechanical regeneration of AdCP schemas and registry from upstream. No handwritten code — ran `npm run sync-schemas && npm run generate-types && npm run generate-wellknown-schemas` on main.

Pulls in new upstream additions (sponsored-intelligence / sales specialism and related domain enums). Keeping this as its own PR so feature branches don't drag schema drift along and the CI schema-sync check stops flagging unrelated work.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] CI runs the "Validate Schema Synchronization" check — a clean regen means the check will pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)