### PR TITLE
feat(cli): OAuth provider in storyboards + ADCPMultiAgentClient

### DIFF
--- a/.changeset/oauth-provider-in-storyboards.md
+++ b/.changeset/oauth-provider-in-storyboards.md
@@ -1,0 +1,27 @@
+---
+'@adcp/client': minor
+---
+
+Thread OAuth tokens through the storyboard runner + `ADCPMultiAgentClient`.
+
+Storyboards and other `ADCPMultiAgentClient`-based flows were bearer-only — saved OAuth tokens never reached the MCP transport, so OAuth-gated agents always failed with `Authentication required` and couldn't refresh on 401.
+
+**New**
+
+- `NonInteractiveFlowHandler` — an OAuth flow handler that lets the MCP SDK use and refresh saved tokens but refuses to open a browser. Throws an actionable error (`adcp --save-auth <alias> --oauth`) if a full authorization flow is attempted.
+- `createNonInteractiveOAuthProvider(agent, { agentHint? })` — factory that builds an `MCPOAuthProvider` backed by the handler above. Use this in storyboard runs, scheduled jobs, and CI.
+- `TestOptions.auth` gained a third variant: `{ type: 'oauth', tokens, client? }`. Pass saved OAuth tokens here and the test client builds the refresh-capable OAuth provider automatically.
+
+**CLI**
+
+- `adcp storyboard run <alias>` now picks up `oauth_tokens` from saved aliases and routes them through the OAuth provider, so the SDK can refresh on 401 instead of failing immediately.
+- `resolveAgent` returns `oauthTokens` alongside `authToken` for command handlers that want the raw tokens.
+
+**Runtime**
+
+- `ProtocolClient.callTool` detects `agent.oauth_tokens` and routes MCP calls through `callMCPToolWithOAuth` with the non-interactive provider. Plain-bearer agents keep the cached-connection fast path.
+- `SingleAgentClient.getAgentInfo()` — the hand-rolled MCP connection now routes through `connectMCP`, so both bearer and OAuth aliases work.
+
+**Compatibility**
+
+No breaking changes. Agents without `oauth_tokens` keep the existing bearer path. Existing `auth_token` and `auth.type: 'bearer'` call sites are unchanged.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -617,12 +617,12 @@ function parseAgentOptions(args) {
 }
 
 /**
- * Resolve an agent argument (alias or URL) to { agentUrl, protocol, authToken }
+ * Resolve an agent argument (alias or URL) to { agentUrl, protocol, authToken, oauthTokens, oauthClient, aliasId }
  *
  * Auth resolution order:
- *   1. Explicit --auth token from CLI
+ *   1. Explicit --auth token from CLI (bearer)
  *   2. ADCP_AUTH_TOKEN env var
- *   3. Saved OAuth tokens (if alias has them and they're valid)
+ *   3. Saved OAuth tokens (if alias has them — returned as-is so the caller can refresh on 401)
  *   4. Static auth_token from alias or built-in
  *   5. None
  */
@@ -630,6 +630,9 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
   let agentUrl;
   let protocol = protocolFlag;
   let finalAuthToken = authToken;
+  let oauthTokens;
+  let oauthClient;
+  let aliasId;
 
   if (BUILT_IN_AGENTS[agentArg]) {
     const builtIn = BUILT_IN_AGENTS[agentArg];
@@ -640,6 +643,14 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
     const savedAgent = getAgent(agentArg);
     agentUrl = savedAgent.url;
     protocol = protocol || savedAgent.protocol;
+    aliasId = agentArg;
+    // Return saved OAuth tokens even when they look stale — the MCP SDK's
+    // OAuth provider will refresh them on demand. Only fall back to the
+    // static `auth_token` when there's no OAuth material at all.
+    if (savedAgent.oauth_tokens) {
+      oauthTokens = savedAgent.oauth_tokens;
+      oauthClient = savedAgent.oauth_client;
+    }
     finalAuthToken = finalAuthToken || getEffectiveAuthToken(savedAgent);
   } else if (agentArg.startsWith('http://') || agentArg.startsWith('https://')) {
     agentUrl = agentArg;
@@ -662,7 +673,7 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
     }
   }
 
-  return { agentUrl, protocol, authToken: finalAuthToken };
+  return { agentUrl, protocol, authToken: finalAuthToken, oauthTokens, oauthClient, aliasId };
 }
 
 async function handleComplyCommand(args) {
@@ -1088,6 +1099,8 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     agentUrl,
     protocol,
     authToken: finalAuthToken,
+    oauthTokens,
+    oauthClient,
   } = await resolveAgent(agentArg, opts.authToken, opts.protocolFlag, opts.jsonOutput);
 
   // Parse --tracks
@@ -1137,6 +1150,14 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     timeoutMs = seconds * 1000;
   }
 
+  // OAuth tokens take precedence over a bare bearer — the OAuth provider path
+  // auto-refreshes on 401 while a raw bearer can't recover.
+  const authOption = oauthTokens
+    ? { type: 'oauth', tokens: oauthTokens, ...(oauthClient && { client: oauthClient }) }
+    : finalAuthToken
+      ? { type: 'bearer', token: finalAuthToken }
+      : undefined;
+
   const testOptions = {
     protocol,
     brief: opts.brief,
@@ -1144,15 +1165,16 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     storyboards,
     timeout_ms: timeoutMs,
     agent_alias: agentArg !== agentUrl ? agentArg : undefined,
-    ...(finalAuthToken && { auth: { type: 'bearer', token: finalAuthToken } }),
+    ...(authOption && { auth: authOption }),
   };
 
   if (!opts.jsonOutput) {
+    const authLabel = authOption ? (authOption.type === 'oauth' ? 'oauth (auto-refresh)' : 'bearer') : 'none';
     console.log(`\nRunning storyboard assessment against ${agentUrl}`);
     console.log(`   Protocol: ${protocol.toUpperCase()}`);
     if (storyboards) console.log(`   Storyboards: ${storyboards.join(', ')}`);
     console.log(`   Timeout: ${timeoutMs / 1000}s`);
-    console.log(`   Auth: ${finalAuthToken ? 'configured' : 'none'}\n`);
+    console.log(`   Auth: ${authLabel}\n`);
   }
 
   try {

--- a/src/lib/auth/oauth/NonInteractiveFlowHandler.ts
+++ b/src/lib/auth/oauth/NonInteractiveFlowHandler.ts
@@ -1,0 +1,63 @@
+/**
+ * Non-interactive OAuth flow handler for background / headless contexts
+ * (storyboard runs, scheduled compliance jobs, CI).
+ *
+ * Use with {@link MCPOAuthProvider} when you want to **use and refresh**
+ * previously-saved OAuth tokens, but do not want to initiate a new
+ * authorization flow (which would require a browser). Any attempt to
+ * redirect to authorization throws with an actionable error message.
+ *
+ * The MCP SDK will still call this handler's lifecycle — `getRedirectUrl`,
+ * `redirectToAuthorization`, `waitForCallback`, `cleanup` — but only the
+ * first is expected to succeed in practice. The others throw if reached.
+ */
+import type { OAuthFlowHandler } from './types';
+import { OAuthError } from './types';
+
+export interface NonInteractiveFlowHandlerConfig {
+  /**
+   * Redirect URL reported back to the MCP SDK. Should match the
+   * `redirect_uris` of the saved client registration (usually
+   * `http://localhost:8766/callback`). Defaults to that value.
+   */
+  redirectUrl?: string | URL;
+
+  /**
+   * Optional hint shown in the error message when a browser flow is
+   * attempted — e.g., the alias name to pass to `adcp --save-auth`.
+   */
+  agentHint?: string;
+}
+
+export class NonInteractiveFlowHandler implements OAuthFlowHandler {
+  private readonly _redirectUrl: URL;
+  private readonly agentHint?: string;
+
+  constructor(config: NonInteractiveFlowHandlerConfig = {}) {
+    this._redirectUrl = new URL((config.redirectUrl ?? 'http://localhost:8766/callback').toString());
+    this.agentHint = config.agentHint;
+  }
+
+  getRedirectUrl(): URL {
+    return this._redirectUrl;
+  }
+
+  async redirectToAuthorization(): Promise<void> {
+    const target = this.agentHint
+      ? `adcp --save-auth ${this.agentHint} --oauth`
+      : 'adcp --save-auth <alias> <url> --oauth';
+    throw new OAuthError(
+      `OAuth authorization required but this context is non-interactive. ` +
+        `Run \`${target}\` from a terminal with a browser, then retry.`,
+      'interactive_required'
+    );
+  }
+
+  async waitForCallback(): Promise<string> {
+    throw new OAuthError('waitForCallback() is not supported in non-interactive mode.', 'interactive_required');
+  }
+
+  async cleanup(): Promise<void> {
+    // Nothing to clean up — no server was started, no resources allocated.
+  }
+}

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -58,6 +58,7 @@ export {
 
 // Flow handlers
 export { CLIFlowHandler, type CLIFlowHandlerConfig } from './CLIFlowHandler';
+export { NonInteractiveFlowHandler, type NonInteractiveFlowHandlerConfig } from './NonInteractiveFlowHandler';
 
 // Main provider
 export { MCPOAuthProvider } from './MCPOAuthProvider';
@@ -130,6 +131,44 @@ export function createCLIOAuthProvider(
   const flowHandler = new CLIFlowHandler(flowConfig);
 
   // Build complete client metadata
+  const clientMetadata: OAuthClientMetadata = {
+    ...DEFAULT_CLIENT_METADATA,
+    redirect_uris: [flowHandler.getRedirectUrl().toString()],
+    ...options?.clientMetadata,
+  };
+
+  return new MCPOAuthProvider({
+    agent,
+    flowHandler,
+    storage: options?.storage,
+    clientMetadata,
+  });
+}
+
+/**
+ * Create an OAuth provider that uses and auto-refreshes saved tokens but
+ * refuses to start a new interactive browser flow. Use this for storyboard
+ * runs, scheduled jobs, and other non-interactive contexts where you've
+ * already saved tokens via `createCLIOAuthProvider`.
+ *
+ * If refresh fails (e.g., the refresh_token is revoked or expired), the
+ * MCP SDK will throw `UnauthorizedError` at call time — the caller should
+ * treat that as a signal to run `adcp --save-auth <alias> --oauth` and retry.
+ */
+export function createNonInteractiveOAuthProvider(
+  agent: AgentConfig,
+  options?: {
+    /** Hint shown in error messages if an interactive flow is attempted. */
+    agentHint?: string;
+    /** Custom client metadata overrides (inherited from saved registration in practice). */
+    clientMetadata?: Partial<OAuthClientMetadata>;
+    /** Storage for persisting refreshed tokens back to disk. */
+    storage?: OAuthConfigStorage;
+  }
+): MCPOAuthProvider {
+  const { NonInteractiveFlowHandler } = require('./NonInteractiveFlowHandler');
+  const flowHandler = new NonInteractiveFlowHandler({ agentHint: options?.agentHint });
+
   const clientMetadata: OAuthClientMetadata = {
     ...DEFAULT_CLIENT_METADATA,
     redirect_uris: [flowHandler.getRedirectUrl().toString()],

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2328,76 +2328,44 @@ export class SingleAgentClient {
       // Discover endpoint if needed
       const agent = await this.ensureEndpointDiscovered();
 
-      // Use MCP SDK to list tools
-      const { Client: MCPClient } = await import('@modelcontextprotocol/sdk/client/index.js');
-      const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+      // Use the shared connectMCP path so both static bearer AND saved OAuth
+      // tokens work. OAuth takes the refresh-capable authProvider branch.
+      const { connectMCP } = await import('../protocols/mcp');
+      const connectOptions: Parameters<typeof connectMCP>[0] = { agentUrl: agent.agent_uri };
+      if (this.normalizedAgent.oauth_tokens) {
+        const { createNonInteractiveOAuthProvider } = await import('../auth/oauth');
+        connectOptions.authProvider = createNonInteractiveOAuthProvider(this.normalizedAgent, {
+          agentHint: this.normalizedAgent.id,
+        });
+      } else if (this.normalizedAgent.auth_token) {
+        connectOptions.authToken = this.normalizedAgent.auth_token;
+      }
 
-      const mcpClient = new MCPClient({
-        name: 'AdCP-Client',
-        version: '1.0.0',
-      });
+      const { client: mcpClient } = await connectMCP(connectOptions);
+      try {
+        const toolsList = await mcpClient.listTools();
 
-      const authToken = this.normalizedAgent.auth_token;
-      const customFetch = authToken
-        ? async (input: string | URL | Request, init?: RequestInit) => {
-            // IMPORTANT: Must preserve SDK's default headers (especially Accept header)
-            // Convert existing headers to plain object for merging
-            let existingHeaders: Record<string, string> = {};
-            if (init?.headers) {
-              if (init.headers instanceof Headers) {
-                // Headers object - use forEach to extract all headers
-                init.headers.forEach((value: string, key: string) => {
-                  existingHeaders[key] = value;
-                });
-              } else if (Array.isArray(init.headers)) {
-                // Array of [key, value] tuples
-                for (const [key, value] of init.headers) {
-                  existingHeaders[key] = value;
-                }
-              } else {
-                // Plain object - copy all properties
-                for (const key in init.headers) {
-                  if (Object.prototype.hasOwnProperty.call(init.headers, key)) {
-                    existingHeaders[key] = init.headers[key] as string;
-                  }
-                }
-              }
-            }
+        const tools = toolsList.tools.map(tool => ({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          parameters: tool.inputSchema?.properties ? Object.keys(tool.inputSchema.properties) : [],
+        }));
 
-            // Merge auth headers with existing headers
-            // Keep existing headers (including Accept) and only add/override with auth headers
-            const headers = {
-              ...existingHeaders,
-              Authorization: `Bearer ${authToken}`,
-              'x-adcp-auth': authToken,
-            };
-            return fetch(input, { ...init, headers });
-          }
-        : undefined;
-
-      const transport = new StreamableHTTPClientTransport(
-        new URL(agent.agent_uri),
-        customFetch ? { fetch: customFetch } : {}
-      );
-
-      await mcpClient.connect(transport);
-      const toolsList = await mcpClient.listTools();
-      await mcpClient.close();
-
-      const tools = toolsList.tools.map(tool => ({
-        name: tool.name,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-        parameters: tool.inputSchema?.properties ? Object.keys(tool.inputSchema.properties) : [],
-      }));
-
-      return {
-        name: this.normalizedAgent.name,
-        description: undefined,
-        protocol: this.normalizedAgent.protocol,
-        url: agent.agent_uri,
-        tools,
-      };
+        return {
+          name: this.normalizedAgent.name,
+          description: undefined,
+          protocol: this.normalizedAgent.protocol,
+          url: agent.agent_uri,
+          tools,
+        };
+      } finally {
+        try {
+          await mcpClient.close();
+        } catch {
+          /* ignore */
+        }
+      }
     } else if (this.normalizedAgent.protocol === 'a2a') {
       // Use A2A SDK to get agent card
       const clientModule = require('@a2a-js/sdk/client');

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -28,10 +28,12 @@ export {
 } from './mcp-tasks';
 
 import { callMCPToolWithTasks } from './mcp-tasks';
+import { callMCPToolWithOAuth } from './mcp';
 import { callA2ATool } from './a2a';
 import type { AgentConfig, DebugLogEntry } from '../types';
 import type { PushNotificationConfig } from '../types/tools.generated';
 import { getAuthToken } from '../auth';
+import { createNonInteractiveOAuthProvider } from '../auth/oauth';
 import { validateAgentUrl } from '../validation';
 import { withSpan } from '../observability/tracing';
 import { ADCP_MAJOR_VERSION } from '../version';
@@ -100,6 +102,23 @@ export class ProtocolClient {
           const argsWithWebhook = pushNotificationConfig
             ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
             : argsWithVersion;
+
+          // If the agent config carries OAuth tokens, route through the OAuth
+          // provider path so the MCP SDK can refresh on 401 instead of hard-failing.
+          // This path does not cache connections (OAuth token-refresh can't share
+          // a cached transport), so it's slower but correct for OAuth-gated agents.
+          if (agent.oauth_tokens) {
+            const authProvider = createNonInteractiveOAuthProvider(agent, { agentHint: agent.id });
+            return callMCPToolWithOAuth({
+              agentUrl: agent.agent_uri,
+              toolName,
+              args: argsWithWebhook,
+              authProvider,
+              debugLogs,
+              customHeaders: agent.headers,
+            });
+          }
+
           // Use callMCPToolWithTasks which auto-detects server tasks capability
           // and falls back to standard callTool when tasks are not supported
           return callMCPToolWithTasks(agent.agent_uri, toolName, argsWithWebhook, authToken, debugLogs, agent.headers);

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -23,11 +23,19 @@ const DEFAULT_BRAND_REF: BrandReference = { domain: 'test.example' };
 
 /**
  * Extract a principal identifier from TestOptions auth.
- * For bearer auth this is the token; for basic auth this is the username.
+ * For bearer auth this is the token; for basic auth this is the username;
+ * for oauth this is the access_token.
  */
 export function resolveAuthPrincipal(options: TestOptions): string | undefined {
   if (!options.auth) return undefined;
-  return options.auth.type === 'basic' ? options.auth.username : options.auth.token;
+  switch (options.auth.type) {
+    case 'basic':
+      return options.auth.username;
+    case 'oauth':
+      return options.auth.tokens.access_token;
+    case 'bearer':
+      return options.auth.token;
+  }
 }
 
 /**
@@ -97,6 +105,8 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
     agent_uri: string;
     protocol: 'mcp' | 'a2a';
     auth_token?: string;
+    oauth_tokens?: import('../types/adcp').AgentOAuthTokens;
+    oauth_client?: import('../types/adcp').AgentOAuthClient;
     headers?: Record<string, string>;
   } = {
     id: 'test',
@@ -111,6 +121,11 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
       // basic: encode credentials here; library sends the Authorization header as-is
       const encoded = Buffer.from(`${options.auth.username}:${options.auth.password}`).toString('base64');
       agentConfig.headers = { Authorization: `Basic ${encoded}` };
+    } else if (options.auth.type === 'oauth') {
+      // oauth: attach tokens + client registration; ProtocolClient detects
+      // oauth_tokens and routes through the refresh-capable MCP OAuth path.
+      agentConfig.oauth_tokens = options.auth.tokens;
+      if (options.auth.client) agentConfig.oauth_client = options.auth.client;
     } else {
       // bearer: raw token stored; library prepends 'Bearer ' internally via createMCPAuthHeaders
       agentConfig.auth_token = options.auth.token;

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -91,10 +91,21 @@ export interface TestOptions {
   /**
    * Authentication for agents that require it.
    *
-   * For `bearer`, provide the raw token — the library sends it as `Authorization: Bearer <token>`.
-   * For `basic`, provide cleartext `username` and `password` — the library encodes them internally.
+   * - `bearer`: raw token sent as `Authorization: Bearer <token>`.
+   * - `basic`: cleartext `username` and `password`, encoded internally.
+   * - `oauth`: saved OAuth tokens (access_token + refresh_token). MCP only.
+   *   The library auto-refreshes on 401. Obtain tokens interactively via
+   *   `adcp --save-auth <alias> --oauth`, then pass the saved blob here for
+   *   non-interactive reuse.
    */
-  auth?: { type: 'bearer'; token: string } | { type: 'basic'; username: string; password: string };
+  auth?:
+    | { type: 'bearer'; token: string }
+    | { type: 'basic'; username: string; password: string }
+    | {
+        type: 'oauth';
+        tokens: import('../types/adcp').AgentOAuthTokens;
+        client?: import('../types/adcp').AgentOAuthClient;
+      };
   // Brand manifest for creative testing
   brand_manifest?: {
     name: string;

--- a/test/oauth-storyboard-plumbing.test.js
+++ b/test/oauth-storyboard-plumbing.test.js
@@ -1,0 +1,92 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { NonInteractiveFlowHandler, createNonInteractiveOAuthProvider } = require('../dist/lib/auth/oauth/index.js');
+
+describe('NonInteractiveFlowHandler', () => {
+  it('returns the configured redirect URL', () => {
+    const h = new NonInteractiveFlowHandler();
+    assert.strictEqual(h.getRedirectUrl().toString(), 'http://localhost:8766/callback');
+  });
+
+  it('throws with actionable message on redirectToAuthorization', async () => {
+    const h = new NonInteractiveFlowHandler({ agentHint: 'test-agent' });
+    await assert.rejects(
+      () => h.redirectToAuthorization(new URL('https://auth.example/authorize')),
+      err => err.code === 'interactive_required' && /adcp --save-auth test-agent --oauth/.test(err.message)
+    );
+  });
+
+  it('throws on waitForCallback', async () => {
+    const h = new NonInteractiveFlowHandler();
+    await assert.rejects(
+      () => h.waitForCallback(),
+      err => err.code === 'interactive_required'
+    );
+  });
+
+  it('cleanup is a no-op', async () => {
+    const h = new NonInteractiveFlowHandler();
+    await h.cleanup();
+  });
+});
+
+describe('createNonInteractiveOAuthProvider', () => {
+  it('builds a provider that exposes saved tokens and refuses new flow', async () => {
+    const agent = {
+      id: 'test',
+      name: 'Test',
+      agent_uri: 'https://example.com/mcp',
+      protocol: 'mcp',
+      oauth_tokens: {
+        access_token: 'at_123',
+        refresh_token: 'rt_456',
+        token_type: 'Bearer',
+      },
+      oauth_client: { client_id: 'client_abc' },
+    };
+
+    const provider = createNonInteractiveOAuthProvider(agent, { agentHint: 'test' });
+    const tokens = await provider.tokens();
+    assert.strictEqual(tokens?.access_token, 'at_123');
+    assert.strictEqual(tokens?.refresh_token, 'rt_456');
+
+    await assert.rejects(
+      () => provider.redirectToAuthorization(new URL('https://auth.example/authorize')),
+      err => err.code === 'interactive_required'
+    );
+  });
+
+  it('returns undefined tokens when agent has none (forcing fresh flow error on first call)', async () => {
+    const agent = { id: 'test', name: 'T', agent_uri: 'https://ex.com/mcp', protocol: 'mcp' };
+    const provider = createNonInteractiveOAuthProvider(agent);
+    assert.strictEqual(await provider.tokens(), undefined);
+  });
+});
+
+describe('createTestClient auth.type=oauth plumbing', () => {
+  const { createTestClient } = require('../dist/lib/testing/client.js');
+
+  it('accepts oauth auth and does not throw during construction', () => {
+    const client = createTestClient('https://example.com/mcp', 'mcp', {
+      auth: {
+        type: 'oauth',
+        tokens: { access_token: 'at_1', refresh_token: 'rt_1', token_type: 'Bearer' },
+        client: { client_id: 'client_abc' },
+      },
+    });
+    assert.ok(client);
+  });
+});
+
+describe('ProtocolClient routes MCP OAuth calls through the OAuth path', () => {
+  // A thin smoke test: ensure agent with oauth_tokens triggers the OAuth-aware
+  // call site. We don't exercise the network — we just confirm the code path
+  // compiles and imports cleanly together.
+  it('imports the OAuth provider factory alongside ProtocolClient', () => {
+    const { ProtocolClient } = require('../dist/lib/protocols/index.js');
+    const { createNonInteractiveOAuthProvider: f } = require('../dist/lib/auth/oauth/index.js');
+    assert.strictEqual(typeof ProtocolClient.callTool, 'function');
+    assert.strictEqual(typeof f, 'function');
+  });
+});


### PR DESCRIPTION
## Summary

The storyboard runner and `ADCPMultiAgentClient`-based flows were bearer-only. Saved OAuth tokens never reached the MCP transport, so OAuth-gated agents (test-agent.adcontextprotocol.org, scope3-hosted publisher agents, Pinterest, etc.) failed with `Authentication required` on every storyboard run, with no ability to refresh on 401.

This PR plumbs saved `oauth_tokens` all the way through the runner into the MCP SDK's proper OAuth provider path.

## New

- **`NonInteractiveFlowHandler`** — OAuth flow handler that uses and refreshes saved tokens but refuses to open a browser. Throws an actionable error pointing at `adcp --save-auth <alias> --oauth` when a fresh flow is needed.
- **`createNonInteractiveOAuthProvider(agent, opts)`** — `MCPOAuthProvider` factory for headless contexts (storyboards, scheduled jobs, CI). Provider refreshes via `refresh_token` automatically when the access token 401s.
- **`TestOptions.auth`** third variant: `{ type: 'oauth', tokens, client? }`.

## CLI

- `adcp storyboard run <alias>` picks up `oauth_tokens` from saved aliases and routes them through the OAuth provider path. Header now shows `Auth: oauth (auto-refresh)` vs `bearer`.
- `resolveAgent` returns `oauthTokens` / `oauthClient` / `aliasId` alongside `authToken` so other command handlers can opt in.
- `runFullAssessment` prefers OAuth over a raw bearer.

## Runtime

- **`ProtocolClient.callTool`** — detects `agent.oauth_tokens` and routes MCP calls through `callMCPToolWithOAuth` with the non-interactive provider. Plain-bearer agents keep the cached-connection fast path.
- **`SingleAgentClient.getAgentInfo()`** — hand-rolled MCP connection (used during capability discovery) replaced with `connectMCP`, so both bearer and OAuth aliases work. This was the silent block on storyboard discovery for OAuth aliases.

## Compatibility

No breaking changes. Agents without `oauth_tokens` keep the existing bearer path; existing `auth_token` / `auth.type: 'bearer'` call sites are unchanged.

## Test plan

- [x] 8 new tests (`test/oauth-storyboard-plumbing.test.js`) covering the flow handler's actionable errors, `createNonInteractiveOAuthProvider` token exposure, `createTestClient` oauth-variant construction, and `ProtocolClient` + provider-factory import compatibility.
- [x] `npm test` — 3280 / 3282 (2 intentional skips, 0 failures).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier --check` — clean.
- [x] Direct OAuth probe against `test-agent.adcontextprotocol.org`: the SDK now successfully runs `listTools()` OAuth handshake (SDK reports "successful authentication"). The test-agent returns 401 on the follow-up even after the SDK's successful refresh — that's an agent-side issue (token audience / session binding), not our CLI.

## Followup — known-limitation note resolved (2026-04-20)

The original body flagged a "401 after successful authentication" on post-refresh calls against `test-agent.adcontextprotocol.org` as a residual unknown. Subsequent diagnosis traced it fully to the server side — no OAuth validator was wired on the endpoint, and `/.well-known/oauth-protected-resource` was cross-wired to advertise a different `resource` than the agent's canonical URL. The client-side fix in this PR is complete and correct; there is no residual client-side issue. Affected sellers should (a) wire `verifyBearer({ audience: publicUrl })` on their MCP endpoint, (b) set `publicUrl` to the canonical URL buyers actually call, and (c) run `adcp diagnose-auth <alias>` (a.k.a. `adcp diagnose oauth <alias>`) — the ranked-hypothesis report flags `H1: Resource URL mismatch between well-known and agent host` on this exact misconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
