### PR TITLE
feat: RFC 9421 request-signing profile (AdCP 3.0 optional)

### DIFF
--- a/.changeset/request-signing-rfc-9421.md
+++ b/.changeset/request-signing-rfc-9421.md
@@ -1,0 +1,18 @@
+---
+'@adcp/client': minor
+---
+
+RFC 9421 request-signing profile (AdCP 3.0 optional). Adds `@adcp/client/signing`
+with signer, verifier, Express-shaped middleware, pluggable JWKS/replay/revocation
+stores, and typed error taxonomy (`RequestSignatureError`). Passes all 28 spec
+conformance vectors shipped in `compliance/cache/latest/test-vectors/request-signing/`
+(one positive vector currently skipped pending upstream adcp#2335 tarball
+republish — test auto-unskips when `npm run sync-schemas` pulls the fixed
+vector). Verifier uses the received `Signature-Input` substring verbatim when
+rebuilding the signature base, so peers emitting params in any legal RFC 8941
+order remain byte-identical. Replay TTL floored at one max-window + skew so
+short-validity signers can't escape the replay horizon. Content-Digest parses
+as an RFC 9530 dictionary (accepts `sha-256` alongside other algorithms).
+JWKS-returns-wrong-kid and Content-Length-without-rawBody both reject as typed
+errors. New CLI: `adcp signing generate-key` (suppresses private JWK from
+stdout when `--private-out` is set) and `adcp signing verify-vector`.

--- a/README.md
+++ b/README.md
@@ -324,6 +324,80 @@ const client = new ADCPMultiAgentClient(agents, {
 // Returns 401 if signature invalid
 ```
 
+### Request Signing (RFC 9421, AdCP 3.0 optional)
+
+`@adcp/client/signing` implements the [AdCP request-signing transport profile](https://adcontextprotocol.org/docs/building/implementation/security#signed-requests-transport-layer)
+— HTTP Message Signatures (RFC 9421) with Ed25519 (default) or ES256, a `adcp/request-signing/v1` tag,
+and content-digest support. Conformance is verified against all 28 vectors shipped in the spec repo
+(see `compliance/cache/latest/test-vectors/request-signing/`).
+
+**Generate a signing key + JWKS for publication:**
+
+```bash
+adcp signing generate-key --alg ed25519 --kid my-buyer-2026 \
+  --private-out ./buyer.pem --public-out ./buyer-jwks.json
+# Publish buyer-jwks.json at the jwks_uri of your brand.json agents[] entry.
+```
+
+**Signer (client-side) — wraps `fetch` to sign outbound requests:**
+
+```typescript
+import { createSigningFetch } from '@adcp/client/signing';
+
+const signingFetch = createSigningFetch(fetch, {
+  keyid: 'my-buyer-2026',
+  alg: 'ed25519',
+  privateKey: buyerPrivateJwk, // JWK with `d` field
+});
+
+await signingFetch('https://seller.example.com/adcp/create_media_buy', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ plan_id: 'plan_001' }),
+});
+// Signature, Signature-Input, and (optionally) Content-Digest headers
+// are attached per RFC 9421 before the upstream fetch is called.
+```
+
+**Verifier (server-side) — middleware runs the 12-step checklist:**
+
+```typescript
+import {
+  createExpressVerifier,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  StaticJwksResolver,
+} from '@adcp/client/signing';
+
+app.post(
+  '/adcp/create_media_buy',
+  rawBodyMiddleware(), // req.rawBody must hold the byte-exact body
+  createExpressVerifier({
+    capability: {
+      supported: true,
+      covers_content_digest: 'required', // 'required' | 'forbidden' | 'either'
+      required_for: ['create_media_buy'],
+    },
+    jwks: new StaticJwksResolver(publishedBuyerKeys),
+    replayStore: new InMemoryReplayStore(),
+    revocationStore: new InMemoryRevocationStore(),
+    resolveOperation: (req) => 'create_media_buy',
+  }),
+  handler,
+);
+// On verify, req.verifiedSigner = { keyid, agent_url?, verified_at }.
+// On reject, the middleware returns 401 with
+//   WWW-Authenticate: Signature error="<code>"
+// and JSON { error, message, failed_step }.
+```
+
+**Running a single vector for debugging:**
+
+```bash
+adcp signing verify-vector \
+  --vector compliance/cache/latest/test-vectors/request-signing/positive/001-basic-post.json
+```
+
 ### Authentication
 
 ```typescript

--- a/bin/adcp-signing.js
+++ b/bin/adcp-signing.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+const { generateKeyPairSync } = require('node:crypto');
+const { readFileSync, writeFileSync, existsSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  RequestSignatureError,
+  StaticJwksResolver,
+  verifyRequestSignature,
+} = require('../dist/lib/signing/index.js');
+
+function generateKey(argv) {
+  let alg = 'ed25519';
+  let kid;
+  let outPrivate;
+  let outPublic;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--alg') alg = argv[++i];
+    else if (a === '--kid') kid = argv[++i];
+    else if (a === '--out' || a === '--private-out') outPrivate = argv[++i];
+    else if (a === '--public-out' || a === '--jwk-out') outPublic = argv[++i];
+    else if (a === '--help' || a === '-h') {
+      printGenerateHelp();
+      process.exit(0);
+    } else {
+      console.error(`Unknown flag: ${a}`);
+      printGenerateHelp();
+      process.exit(2);
+    }
+  }
+  if (alg !== 'ed25519' && alg !== 'es256') {
+    console.error(`--alg must be ed25519 or es256 (got ${alg})`);
+    process.exit(2);
+  }
+  if (!kid) {
+    const year = new Date().getUTCFullYear();
+    kid = `adcp-${alg}-${year}`;
+  }
+
+  const { publicKey, privateKey } =
+    alg === 'ed25519' ? generateKeyPairSync('ed25519') : generateKeyPairSync('ec', { namedCurve: 'P-256' });
+
+  const jwkAlg = alg === 'ed25519' ? 'EdDSA' : 'ES256';
+  const privateJwk = privateKey.export({ format: 'jwk' });
+  const publicJwk = publicKey.export({ format: 'jwk' });
+  publicJwk.kid = kid;
+  publicJwk.alg = jwkAlg;
+  publicJwk.use = 'sig';
+  publicJwk.key_ops = ['verify'];
+  publicJwk.adcp_use = 'request-signing';
+
+  const privatePem = privateKey.export({ type: 'pkcs8', format: 'pem' });
+
+  if (outPrivate) {
+    writeFileSync(outPrivate, privatePem, { mode: 0o600 });
+    console.log(`✔ Private key written: ${outPrivate}`);
+  } else {
+    process.stdout.write(privatePem);
+  }
+
+  const publicJson = JSON.stringify({ keys: [publicJwk] }, null, 2);
+  if (outPublic) {
+    writeFileSync(outPublic, publicJson);
+    console.log(`✔ JWKS written: ${outPublic}`);
+  } else {
+    console.log('\n// Publish this JWKS at the jwks_uri of your agents[] entry:');
+    console.log(publicJson);
+  }
+  // Print the private JWK to stdout ONLY when the user explicitly wants it
+  // rendered (no --private-out). Otherwise the private key has already been
+  // written to a 0600 file and we must not leak it into terminal/shell history.
+  if (!outPrivate) {
+    privateJwk.kid = kid;
+    privateJwk.alg = jwkAlg;
+    privateJwk.use = 'sig';
+    privateJwk.key_ops = ['sign'];
+    privateJwk.adcp_use = 'request-signing';
+    console.log(
+      `\n// Private JWK (keep secret — load via { signing_key, keyid: "${kid}", alg: "${alg === 'ed25519' ? 'ed25519' : 'ecdsa-p256-sha256'}" }):`
+    );
+    console.log(JSON.stringify(privateJwk, null, 2));
+  }
+}
+
+async function verifyVector(argv) {
+  let vectorPath;
+  let keysPath;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--vector') vectorPath = argv[++i];
+    else if (a === '--keys') keysPath = argv[++i];
+    else if (a === '--help' || a === '-h') {
+      printVerifyHelp();
+      process.exit(0);
+    } else if (!vectorPath) vectorPath = a;
+    else {
+      console.error(`Unknown argument: ${a}`);
+      printVerifyHelp();
+      process.exit(2);
+    }
+  }
+  if (!vectorPath) {
+    printVerifyHelp();
+    process.exit(2);
+  }
+  if (!existsSync(vectorPath)) {
+    console.error(`Vector file not found: ${vectorPath}`);
+    process.exit(2);
+  }
+  const defaultKeys = path.join(
+    __dirname,
+    '..',
+    'compliance',
+    'cache',
+    'latest',
+    'test-vectors',
+    'request-signing',
+    'keys.json'
+  );
+  const keysJsonPath = keysPath ?? (existsSync(defaultKeys) ? defaultKeys : null);
+  if (!keysJsonPath) {
+    console.error(
+      'No --keys file provided and no default spec keys.json found. Run `npm run sync-schemas` first, or pass --keys <path>.'
+    );
+    process.exit(2);
+  }
+  const keys = JSON.parse(readFileSync(keysJsonPath, 'utf8')).keys;
+  const keysByKid = new Map(keys.map(k => [k.kid, k]));
+  const vector = JSON.parse(readFileSync(vectorPath, 'utf8'));
+  const now = vector.reference_now ?? Math.floor(Date.now() / 1000);
+
+  const replayStore = new InMemoryReplayStore();
+  const revocationStore = new InMemoryRevocationStore();
+  const state = vector.test_harness_state ?? {};
+  if (state.replay_cache_entries) {
+    for (const entry of state.replay_cache_entries) {
+      replayStore.preload(entry.keyid, entry.nonce, entry.ttl_seconds, now);
+    }
+  }
+  if (state.revocation_list) revocationStore.load(state.revocation_list);
+  if (state.replay_cache_per_keyid_cap_hit) {
+    replayStore.setCapHitForTesting(state.replay_cache_per_keyid_cap_hit.keyid);
+  }
+
+  const jwksEntries = vector.jwks_override
+    ? vector.jwks_override.keys
+    : (vector.jwks_ref ?? []).map(kid => keysByKid.get(kid)).filter(Boolean);
+  const jwks = new StaticJwksResolver(jwksEntries);
+  const operation = new URL(vector.request.url).pathname.split('/').filter(Boolean).pop();
+
+  try {
+    const verified = await verifyRequestSignature(vector.request, {
+      capability: vector.verifier_capability,
+      jwks,
+      replayStore,
+      revocationStore,
+      now: () => now,
+      operation,
+    });
+    console.log(JSON.stringify({ outcome: 'accepted', verified_signer: verified, operation }, null, 2));
+    return { accepted: true };
+  } catch (err) {
+    if (err instanceof RequestSignatureError) {
+      const payload = {
+        outcome: 'rejected',
+        error_code: err.code,
+        failed_step: err.failedStep,
+        message: err.message,
+      };
+      console.log(JSON.stringify(payload, null, 2));
+      return { accepted: false, code: err.code };
+    }
+    throw err;
+  }
+}
+
+function printGenerateHelp() {
+  console.log(`Usage: adcp signing generate-key [options]
+
+Generate an Ed25519 (default) or P-256 keypair for AdCP request signing.
+Writes or prints a PEM-encoded PKCS#8 private key + a one-key JWKS you can
+publish at your agent's jwks_uri.
+
+Options:
+  --alg <ed25519|es256>   Signature algorithm (default: ed25519).
+  --kid <value>           JWK kid. Default: adcp-<alg>-<year>.
+  --private-out <path>    Write private PEM to a file (mode 0600) instead of stdout.
+  --public-out <path>     Write JWKS JSON to a file instead of stdout.
+  -h, --help              Show this help.
+`);
+}
+
+function printVerifyHelp() {
+  console.log(`Usage: adcp signing verify-vector --vector <path> [--keys <keys.json>]
+
+Run a single RFC 9421 test vector through the AdCP verifier. Useful for
+debugging conformance failures against the spec's positive/negative vectors
+at compliance/cache/latest/test-vectors/request-signing/.
+
+If --keys is omitted, defaults to the bundled spec keys.json.
+`);
+}
+
+function printSigningHelp() {
+  console.log(`Usage: adcp signing <subcommand>
+
+Subcommands:
+  generate-key       Generate an Ed25519/P-256 keypair + JWKS for publication.
+  verify-vector      Run one RFC 9421 test vector through the verifier.
+`);
+}
+
+async function handleSigningCommand(argv) {
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    printSigningHelp();
+    process.exit(0);
+  }
+  const [sub, ...rest] = argv;
+  if (sub === 'generate-key') return generateKey(rest);
+  if (sub === 'verify-vector') {
+    const result = await verifyVector(rest);
+    process.exit(result.accepted ? 0 : 1);
+  }
+  console.error(`Unknown signing subcommand: ${sub}`);
+  printSigningHelp();
+  process.exit(2);
+}
+
+module.exports = { handleSigningCommand };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1465,6 +1465,12 @@ async function main() {
     return;
   }
 
+  if (args[0] === 'signing') {
+    const { handleSigningCommand } = require('./adcp-signing.js');
+    await handleSigningCommand(args.slice(1));
+    return;
+  }
+
   // Handle help
   if (args.includes('--help') || args.includes('-h') || args.length === 0) {
     printUsage();

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
       "import": "./dist/lib/server/index.js",
       "require": "./dist/lib/server/index.js",
       "types": "./dist/lib/server/index.d.ts"
+    },
+    "./signing": {
+      "import": "./dist/lib/signing/index.js",
+      "require": "./dist/lib/signing/index.js",
+      "types": "./dist/lib/signing/index.d.ts"
     }
   },
   "typesVersions": {
@@ -53,6 +58,9 @@
       ],
       "server": [
         "dist/lib/server/index.d.ts"
+      ],
+      "signing": [
+        "dist/lib/signing/index.d.ts"
       ]
     }
   },

--- a/src/lib/signing/canonicalize.ts
+++ b/src/lib/signing/canonicalize.ts
@@ -1,0 +1,137 @@
+import { RequestSignatureError } from './errors';
+
+export interface RequestLike {
+  method: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  body?: string;
+}
+
+export interface SignatureParams {
+  created: number;
+  expires: number;
+  nonce: string;
+  keyid: string;
+  alg: string;
+  tag: string;
+}
+
+const DEFAULT_PARAM_ORDER: ReadonlyArray<keyof SignatureParams> = [
+  'created',
+  'expires',
+  'nonce',
+  'keyid',
+  'alg',
+  'tag',
+];
+
+const STRING_PARAMS = new Set<keyof SignatureParams>(['nonce', 'keyid', 'alg', 'tag']);
+
+const SUPPORTED_DERIVED = new Set(['@method', '@target-uri', '@authority']);
+
+export function canonicalTargetUri(rawUrl: string): string {
+  const u = new URL(rawUrl);
+  if (u.username || u.password) {
+    throw new RequestSignatureError(
+      'request_signature_header_malformed',
+      1,
+      '@target-uri must not include userinfo; strip credentials before signing'
+    );
+  }
+  const assembled = `${u.protocol}//${u.host}${u.pathname}${u.search}`;
+  return uppercasePercentEncoding(assembled);
+}
+
+export function canonicalAuthority(rawUrl: string): string {
+  const u = new URL(rawUrl);
+  return u.host.toLowerCase();
+}
+
+export function canonicalMethod(method: string): string {
+  return method.toUpperCase();
+}
+
+export function getHeaderValue(
+  headers: Record<string, string | string[] | undefined>,
+  name: string
+): string | undefined {
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === lower) {
+      if (v === undefined) return undefined;
+      if (Array.isArray(v)) {
+        return v.map(entry => entry.trim()).join(', ');
+      }
+      return v.trim();
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Build the RFC 9421 §2.5 signature base.
+ *
+ * When `signatureParamsValue` is supplied (verifier path), the function emits
+ * it verbatim as the value of the `@signature-params` line — this preserves
+ * byte-identity with the `Signature-Input` header a peer actually sent, even
+ * if their param order differs from ours. When omitted (signer path), the
+ * function formats from `params` using a fixed canonical order.
+ */
+export function buildSignatureBase(
+  components: ReadonlyArray<string>,
+  request: RequestLike,
+  params: SignatureParams,
+  signatureParamsValue?: string
+): string {
+  const lines: string[] = [];
+  for (const component of components) {
+    const value = resolveComponentValue(component, request);
+    if (value === undefined) {
+      throw new RequestSignatureError(
+        'request_signature_components_incomplete',
+        6,
+        `Covered component "${component}" not present in request`
+      );
+    }
+    lines.push(`"${component}": ${value}`);
+  }
+  const paramsString = signatureParamsValue ?? formatSignatureParams(components, params);
+  lines.push(`"@signature-params": ${paramsString}`);
+  return lines.join('\n');
+}
+
+export function formatSignatureParams(components: ReadonlyArray<string>, params: SignatureParams): string {
+  const componentList = components.map(c => `"${c}"`).join(' ');
+  const paramPairs: string[] = [];
+  for (const key of DEFAULT_PARAM_ORDER) {
+    const raw = params[key];
+    if (raw === undefined) continue;
+    paramPairs.push(STRING_PARAMS.has(key) ? `${key}="${raw}"` : `${key}=${raw}`);
+  }
+  return `(${componentList});${paramPairs.join(';')}`;
+}
+
+function resolveComponentValue(component: string, request: RequestLike): string | undefined {
+  if (component.startsWith('@')) {
+    if (!SUPPORTED_DERIVED.has(component)) {
+      throw new RequestSignatureError(
+        'request_signature_components_unexpected',
+        6,
+        `Derived component "${component}" is not supported by the AdCP request-signing profile`
+      );
+    }
+    switch (component) {
+      case '@method':
+        return canonicalMethod(request.method);
+      case '@target-uri':
+        return canonicalTargetUri(request.url);
+      case '@authority':
+        return canonicalAuthority(request.url);
+    }
+  }
+  return getHeaderValue(request.headers, component);
+}
+
+function uppercasePercentEncoding(input: string): string {
+  return input.replace(/%([0-9a-fA-F]{2})/g, (_m, hex: string) => `%${hex.toUpperCase()}`);
+}

--- a/src/lib/signing/content-digest.ts
+++ b/src/lib/signing/content-digest.ts
@@ -1,0 +1,35 @@
+import { createHash, timingSafeEqual } from 'crypto';
+
+const SHA256_MEMBER_RE = /(^|[,\s])sha-256=:([A-Za-z0-9+/_-]+={0,2}):/;
+
+export function computeContentDigest(body: string | Uint8Array): string {
+  const buf = toBuffer(body);
+  const hash = createHash('sha256').update(buf).digest('base64');
+  return `sha-256=:${hash}:`;
+}
+
+/**
+ * Extract the `sha-256` member from an RFC 9530 Content-Digest header. The
+ * header is an RFC 8941 Dictionary and MAY list multiple algorithms
+ * (e.g. `sha-256=:...:, sha-512=:...:`); we look up the `sha-256` member
+ * without requiring any particular position.
+ */
+export function parseContentDigest(header: string): Buffer | null {
+  const m = header.trim().match(SHA256_MEMBER_RE);
+  if (!m || !m[2]) return null;
+  return Buffer.from(m[2], 'base64');
+}
+
+export function contentDigestMatches(header: string, body: string | Uint8Array): boolean {
+  const expected = parseContentDigest(header);
+  if (!expected) return false;
+  const buf = toBuffer(body);
+  const actual = createHash('sha256').update(buf).digest();
+  if (expected.length !== actual.length) return false;
+  return timingSafeEqual(expected, actual);
+}
+
+function toBuffer(body: string | Uint8Array): Buffer {
+  if (typeof body === 'string') return Buffer.from(body, 'utf8');
+  return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+}

--- a/src/lib/signing/crypto.ts
+++ b/src/lib/signing/crypto.ts
@@ -1,0 +1,36 @@
+import { createPublicKey, verify as nodeVerify, type JsonWebKey, type KeyObject } from 'crypto';
+import { RequestSignatureError } from './errors';
+import type { AdcpJsonWebKey } from './types';
+
+export function jwkToPublicKey(jwk: AdcpJsonWebKey): KeyObject {
+  const publicJwk: Record<string, unknown> = { ...jwk };
+  delete publicJwk._private_d_for_test_only;
+  delete publicJwk.d;
+  try {
+    return createPublicKey({ key: publicJwk as JsonWebKey, format: 'jwk' });
+  } catch (err) {
+    throw new RequestSignatureError(
+      'request_signature_key_unknown',
+      7,
+      `JWK for keyid "${(jwk.kid as string) ?? '<unknown>'}" is malformed`,
+      err
+    );
+  }
+}
+
+export function verifySignature(alg: string, publicKey: KeyObject, data: Uint8Array, signature: Uint8Array): boolean {
+  try {
+    if (alg === 'ed25519') {
+      return nodeVerify(null, data, publicKey, signature);
+    }
+    if (alg === 'ecdsa-p256-sha256') {
+      return nodeVerify('sha256', data, { key: publicKey, dsaEncoding: 'ieee-p1363' }, signature);
+    }
+    return false;
+  } catch {
+    // Malformed signature bytes, mismatched key/alg, etc. — map to a caller-
+    // observable verify failure rather than letting an opaque crypto Error
+    // escape the 12-step pipeline.
+    return false;
+  }
+}

--- a/src/lib/signing/errors.ts
+++ b/src/lib/signing/errors.ts
@@ -1,0 +1,29 @@
+import { ADCPError } from '../errors';
+
+export type RequestSignatureErrorCode =
+  | 'request_signature_required'
+  | 'request_signature_header_malformed'
+  | 'request_signature_params_incomplete'
+  | 'request_signature_tag_invalid'
+  | 'request_signature_alg_not_allowed'
+  | 'request_signature_window_invalid'
+  | 'request_signature_components_incomplete'
+  | 'request_signature_components_unexpected'
+  | 'request_signature_key_unknown'
+  | 'request_signature_key_purpose_invalid'
+  | 'request_signature_key_revoked'
+  | 'request_signature_invalid'
+  | 'request_signature_digest_mismatch'
+  | 'request_signature_replayed'
+  | 'request_signature_rate_abuse';
+
+export class RequestSignatureError extends ADCPError {
+  readonly code: RequestSignatureErrorCode;
+  readonly failedStep: number;
+
+  constructor(code: RequestSignatureErrorCode, failedStep: number, message: string, details?: unknown) {
+    super(message, details);
+    this.code = code;
+    this.failedStep = failedStep;
+  }
+}

--- a/src/lib/signing/fetch.ts
+++ b/src/lib/signing/fetch.ts
@@ -1,0 +1,60 @@
+import { signRequest, type SignerKey, type SignRequestOptions } from './signer';
+
+export interface SigningFetchOptions extends SignRequestOptions {
+  shouldSign?: (url: string, init: RequestInit | undefined) => boolean;
+}
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export function createSigningFetch(upstream: FetchLike, key: SignerKey, options: SigningFetchOptions = {}): FetchLike {
+  return async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+    const shouldSign = options.shouldSign ?? (() => method !== 'GET');
+    if (!shouldSign(url, init)) return upstream(input, init);
+
+    if (input instanceof Request) {
+      throw new TypeError(
+        'createSigningFetch does not accept Request objects (the body would be consumed out from under the signer). Pass a URL string and a separate init.'
+      );
+    }
+
+    const headers = headersToRecord(init?.headers);
+    const hasContentType = Object.keys(headers).some(k => k.toLowerCase() === 'content-type');
+    if (!hasContentType && (init?.body !== undefined || method !== 'GET')) {
+      headers['content-type'] = 'application/json';
+    }
+    const body = bodyToString(init?.body);
+
+    const signed = signRequest({ method, url, headers, body }, key, options);
+
+    const mergedInit: RequestInit = { ...init, method, headers: signed.headers };
+    if (body !== undefined && mergedInit.body === undefined) mergedInit.body = body;
+    return upstream(url, mergedInit);
+  };
+}
+
+function headersToRecord(headers: HeadersInit | Headers | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      out[k] = v;
+    });
+    return out;
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return { ...(headers as Record<string, string>) };
+}
+
+function bodyToString(body: RequestInit['body']): string | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf8');
+  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('utf8');
+  throw new TypeError(
+    'createSigningFetch requires a string, Uint8Array, or ArrayBuffer body. FormData / Blob / ReadableStream are not supported because the signature must cover the exact wire bytes.'
+  );
+}

--- a/src/lib/signing/index.ts
+++ b/src/lib/signing/index.ts
@@ -1,0 +1,38 @@
+export {
+  buildSignatureBase,
+  canonicalAuthority,
+  canonicalMethod,
+  canonicalTargetUri,
+  formatSignatureParams,
+  getHeaderValue,
+  type RequestLike,
+  type SignatureParams,
+} from './canonicalize';
+export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
+export { jwkToPublicKey, verifySignature } from './crypto';
+export { RequestSignatureError, type RequestSignatureErrorCode } from './errors';
+export { StaticJwksResolver, type JwksResolver } from './jwks';
+export { parseSignature, parseSignatureInput, type ParsedSignature, type ParsedSignatureInput } from './parser';
+export {
+  InMemoryReplayStore,
+  type InMemoryReplayStoreOptions,
+  type ReplayInsertResult,
+  type ReplayStore,
+} from './replay';
+export { InMemoryRevocationStore, type RevocationStore } from './revocation';
+export {
+  ALLOWED_ALGS,
+  CLOCK_SKEW_TOLERANCE_SECONDS,
+  MANDATORY_COMPONENTS,
+  MAX_SIGNATURE_WINDOW_SECONDS,
+  REQUEST_SIGNING_TAG,
+  type AdcpJsonWebKey,
+  type ContentDigestPolicy,
+  type RevocationSnapshot,
+  type VerifiedSigner,
+  type VerifierCapability,
+} from './types';
+export { verifyRequestSignature, type VerifyRequestOptions } from './verifier';
+export { signRequest, type SignedRequest, type SignerKey, type SignRequestOptions } from './signer';
+export { createSigningFetch, type SigningFetchOptions } from './fetch';
+export { createExpressVerifier, type ExpressLike, type ExpressMiddlewareOptions } from './middleware';

--- a/src/lib/signing/jwks.ts
+++ b/src/lib/signing/jwks.ts
@@ -1,0 +1,17 @@
+import type { AdcpJsonWebKey } from './types';
+
+export interface JwksResolver {
+  resolve(keyid: string): Promise<AdcpJsonWebKey | null>;
+}
+
+export class StaticJwksResolver implements JwksResolver {
+  private readonly byKid = new Map<string, AdcpJsonWebKey>();
+
+  constructor(keys: AdcpJsonWebKey[]) {
+    for (const k of keys) this.byKid.set(k.kid, k);
+  }
+
+  async resolve(keyid: string): Promise<AdcpJsonWebKey | null> {
+    return this.byKid.get(keyid) ?? null;
+  }
+}

--- a/src/lib/signing/middleware.ts
+++ b/src/lib/signing/middleware.ts
@@ -1,0 +1,99 @@
+import type { RequestLike } from './canonicalize';
+import { getHeaderValue } from './canonicalize';
+import { RequestSignatureError } from './errors';
+import { verifyRequestSignature, type VerifyRequestOptions } from './verifier';
+import type { VerifiedSigner } from './types';
+
+declare module 'http' {
+  interface IncomingMessage {
+    verifiedSigner?: VerifiedSigner;
+    rawBody?: string;
+  }
+}
+
+export interface ExpressLike {
+  method: string;
+  originalUrl?: string;
+  url: string;
+  headers: Record<string, string | string[] | undefined>;
+  rawBody?: string;
+  body?: unknown;
+  protocol?: string;
+  get?(header: string): string | undefined;
+  [key: string]: unknown;
+}
+
+export interface ExpressMiddlewareOptions extends Omit<VerifyRequestOptions, 'operation'> {
+  resolveOperation: (req: ExpressLike) => string;
+  /**
+   * Override how the request's full URL is reconstructed. Use when the server
+   * sits behind a TLS-terminating or path-rewriting load balancer, since
+   * `req.protocol`/`req.get('host')` may not reflect what the signer signed.
+   * Must return the exact URL the signer used (scheme + authority + path + query).
+   */
+  getUrl?: (req: ExpressLike) => string;
+}
+
+type NextFn = (err?: unknown) => void;
+
+export function createExpressVerifier(options: ExpressMiddlewareOptions) {
+  return async function requestSignatureMiddleware(
+    req: ExpressLike,
+    res: { status: (code: number) => { set: (k: string, v: string) => { json: (body: unknown) => void } } },
+    next: NextFn
+  ): Promise<void> {
+    try {
+      const url = options.getUrl ? options.getUrl(req) : defaultUrl(req);
+      const body = resolveRawBody(req);
+      const requestLike: RequestLike = {
+        method: req.method,
+        url,
+        headers: req.headers,
+        body,
+      };
+      const verified = await verifyRequestSignature(requestLike, {
+        ...options,
+        operation: options.resolveOperation(req),
+      });
+      req.verifiedSigner = verified;
+      next();
+    } catch (err) {
+      if (err instanceof RequestSignatureError) {
+        // `failed_step` is informational per spec; keep it in server-side logs
+        // rather than the 401 body so anonymous callers can't enumerate the
+        // verifier pipeline.
+        res.status(401).set('WWW-Authenticate', `Signature error="${err.code}"`).json({
+          error: err.code,
+          message: err.message,
+        });
+        return;
+      }
+      next(err);
+    }
+  };
+}
+
+function resolveRawBody(req: ExpressLike): string {
+  if (typeof req.rawBody === 'string') return req.rawBody;
+  const contentLengthHeader = getHeaderValue(req.headers, 'content-length');
+  const contentLength = contentLengthHeader ? Number(contentLengthHeader) : 0;
+  if (Number.isFinite(contentLength) && contentLength > 0) {
+    throw new RequestSignatureError(
+      'request_signature_header_malformed',
+      1,
+      'req.rawBody is required for signed requests with a body; install a raw-body capture middleware ahead of createExpressVerifier'
+    );
+  }
+  return '';
+}
+
+function defaultUrl(req: ExpressLike): string {
+  const proto = req.protocol ?? (typeof req.get === 'function' ? req.get('x-forwarded-proto') : undefined) ?? 'https';
+  const host = typeof req.get === 'function' ? req.get('host') : undefined;
+  if (!host) {
+    throw new Error(
+      'Unable to derive request URL: missing Host header. Pass `getUrl` on createExpressVerifier to supply the canonical URL explicitly.'
+    );
+  }
+  return `${proto}://${host}${req.originalUrl ?? req.url}`;
+}

--- a/src/lib/signing/parser.ts
+++ b/src/lib/signing/parser.ts
@@ -1,0 +1,235 @@
+import { RequestSignatureError } from './errors';
+
+export interface ParsedSignatureInput {
+  label: string;
+  components: string[];
+  /**
+   * The `Signature-Input` value verbatim, minus the `<label>=` prefix. Used to
+   * reconstruct the `@signature-params` line in the signature base so verifier
+   * and signer stay byte-identical regardless of the sender's param ordering.
+   */
+  signatureParamsValue: string;
+  params: {
+    created: number;
+    expires: number;
+    nonce: string;
+    keyid: string;
+    alg: string;
+    tag: string;
+    [extra: string]: string | number | undefined;
+  };
+}
+
+export interface ParsedSignature {
+  label: string;
+  bytes: Uint8Array;
+}
+
+const LABEL_RE = /^([A-Za-z][A-Za-z0-9_-]*)=/;
+const INTEGER_RE = /^-?\d+$/;
+const NUMERIC_PARAMS = new Set(['created', 'expires']);
+const STRING_PARAMS = new Set(['nonce', 'keyid', 'alg', 'tag']);
+
+export function parseSignatureInput(headerValue: string): ParsedSignatureInput {
+  const inputs = splitTopLevelLabels(headerValue, 'Signature-Input');
+  let selected: string | undefined;
+  for (const entry of inputs) {
+    const labelMatch = entry.match(LABEL_RE);
+    if (labelMatch && labelMatch[1] === 'sig1') {
+      selected = entry;
+      break;
+    }
+  }
+  if (!selected) selected = inputs[0];
+  if (!selected) {
+    throw new RequestSignatureError('request_signature_header_malformed', 1, 'Signature-Input header is empty');
+  }
+  const labelMatch = selected.match(LABEL_RE);
+  if (!labelMatch || !labelMatch[1]) {
+    throw new RequestSignatureError(
+      'request_signature_header_malformed',
+      1,
+      'Signature-Input header missing label prefix'
+    );
+  }
+  const label = labelMatch[1];
+  const remainder = selected.slice(labelMatch[0].length);
+  const openParen = remainder.indexOf('(');
+  const closeParen = remainder.indexOf(')');
+  if (openParen !== 0 || closeParen < 0) {
+    throw new RequestSignatureError(
+      'request_signature_header_malformed',
+      1,
+      'Signature-Input value must begin with a parenthesized component list'
+    );
+  }
+  const componentsRaw = remainder.slice(1, closeParen);
+  const components: string[] = [];
+  const compRe = /"([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = compRe.exec(componentsRaw)) !== null) {
+    if (m[1]) components.push(m[1]);
+  }
+  const paramsRaw = remainder.slice(closeParen + 1);
+  const params = parseParams(paramsRaw);
+  return { label, components, signatureParamsValue: remainder, params };
+}
+
+export function parseSignature(headerValue: string, expectedLabel: string): ParsedSignature {
+  const entries = splitTopLevelLabels(headerValue, 'Signature');
+  for (const raw of entries) {
+    const labelMatch = raw.match(LABEL_RE);
+    if (!labelMatch) continue;
+    const label = labelMatch[1];
+    if (label !== expectedLabel) continue;
+    const rest = raw.slice(labelMatch[0].length).trim();
+    // sf-binary values are ":<base64>:", optionally followed by `;param=value` pairs.
+    if (!rest.startsWith(':')) {
+      throw new RequestSignatureError(
+        'request_signature_header_malformed',
+        1,
+        'Signature value must begin with a : byte-sequence delimiter'
+      );
+    }
+    const closeIdx = rest.indexOf(':', 1);
+    if (closeIdx < 0) {
+      throw new RequestSignatureError(
+        'request_signature_header_malformed',
+        1,
+        'Signature value is missing the closing : byte-sequence delimiter'
+      );
+    }
+    const b64 = rest.slice(1, closeIdx);
+    if (!isValidBase64(b64)) {
+      throw new RequestSignatureError(
+        'request_signature_header_malformed',
+        1,
+        'Signature value contains non-base64 characters'
+      );
+    }
+    const bytes = Buffer.from(b64, 'base64');
+    return { label: label as string, bytes: new Uint8Array(bytes) };
+  }
+  throw new RequestSignatureError(
+    'request_signature_header_malformed',
+    1,
+    `Signature header does not contain label "${expectedLabel}"`
+  );
+}
+
+function splitTopLevelLabels(headerValue: string, headerName: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inString = false;
+  let buf = '';
+  for (let i = 0; i < headerValue.length; i++) {
+    const ch = headerValue[i];
+    if (inString) {
+      // RFC 8941 §3.3.3: inside a string, `\` introduces a literal-escape
+      // that consumes the following byte (either `\` or `"`). Track the pair
+      // explicitly so `\\"` doesn't prematurely close the string.
+      if (ch === '\\') {
+        const next = headerValue[i + 1];
+        if (next === undefined) {
+          throw new RequestSignatureError(
+            'request_signature_header_malformed',
+            1,
+            `${headerName} header ends mid-escape`
+          );
+        }
+        buf += ch + next;
+        i += 1;
+        continue;
+      }
+      buf += ch;
+      if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      buf += ch;
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    if (ch === ',' && depth === 0) {
+      parts.push(buf.trim());
+      buf = '';
+      continue;
+    }
+    buf += ch;
+  }
+  if (inString) {
+    throw new RequestSignatureError(
+      'request_signature_header_malformed',
+      1,
+      `${headerName} header has an unterminated quoted string`
+    );
+  }
+  if (buf.trim().length) parts.push(buf.trim());
+  if (parts.length === 0) {
+    throw new RequestSignatureError('request_signature_header_malformed', 1, `${headerName} header is empty`);
+  }
+  return parts;
+}
+
+function parseParams(raw: string): ParsedSignatureInput['params'] {
+  const params: Record<string, string | number> = {};
+  for (const pair of raw.split(';')) {
+    if (!pair) continue;
+    const eq = pair.indexOf('=');
+    if (eq < 0) {
+      throw new RequestSignatureError(
+        'request_signature_header_malformed',
+        1,
+        `Malformed signature parameter (no '=') in "${pair}"`
+      );
+    }
+    const key = pair.slice(0, eq).trim();
+    const value = pair.slice(eq + 1).trim();
+    if (value === '') {
+      throw new RequestSignatureError(
+        'request_signature_header_malformed',
+        1,
+        `Signature parameter "${key}" has an empty value`
+      );
+    }
+    if (STRING_PARAMS.has(key)) {
+      if (!value.startsWith('"') || !value.endsWith('"') || value.length < 2) {
+        throw new RequestSignatureError(
+          'request_signature_header_malformed',
+          1,
+          `Signature parameter "${key}" must be a quoted string`
+        );
+      }
+      params[key] = value.slice(1, -1);
+    } else if (NUMERIC_PARAMS.has(key)) {
+      if (!INTEGER_RE.test(value)) {
+        throw new RequestSignatureError(
+          'request_signature_header_malformed',
+          1,
+          `Signature parameter "${key}" must be an integer`
+        );
+      }
+      params[key] = Number(value);
+    } else if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+      params[key] = value.slice(1, -1);
+    } else if (INTEGER_RE.test(value)) {
+      params[key] = Number(value);
+    } else {
+      throw new RequestSignatureError(
+        'request_signature_header_malformed',
+        1,
+        `Signature parameter "${key}" is neither a quoted string nor an integer`
+      );
+    }
+  }
+  return params as ParsedSignatureInput['params'];
+}
+
+function isValidBase64(input: string): boolean {
+  // Accept standard base64 + base64url, with or without padding; reject any
+  // other characters (incl. whitespace) so truncated signatures don't silently
+  // decode to a short-but-"valid" byte buffer.
+  return /^[A-Za-z0-9+/_-]*={0,2}$/.test(input);
+}

--- a/src/lib/signing/replay.ts
+++ b/src/lib/signing/replay.ts
@@ -1,0 +1,70 @@
+export type ReplayInsertResult = 'ok' | 'replayed' | 'rate_abuse';
+
+export interface ReplayStore {
+  has(keyid: string, nonce: string, now: number): Promise<boolean>;
+  isCapHit(keyid: string, now: number): Promise<boolean>;
+  insert(keyid: string, nonce: string, ttlSeconds: number, now: number): Promise<ReplayInsertResult>;
+}
+
+interface Entry {
+  nonce: string;
+  expiresAt: number;
+}
+
+export interface InMemoryReplayStoreOptions {
+  maxEntriesPerKeyid?: number;
+}
+
+export class InMemoryReplayStore implements ReplayStore {
+  private readonly entries = new Map<string, Entry[]>();
+  private readonly capPerKeyid: number;
+  private readonly forcedCapHit = new Set<string>();
+
+  constructor(options: InMemoryReplayStoreOptions = {}) {
+    this.capPerKeyid = options.maxEntriesPerKeyid ?? 1_000_000;
+  }
+
+  setCapHitForTesting(keyid: string): void {
+    this.forcedCapHit.add(keyid);
+  }
+
+  async has(keyid: string, nonce: string, now: number): Promise<boolean> {
+    this.prune(keyid, now);
+    const list = this.entries.get(keyid);
+    if (!list) return false;
+    return list.some(e => e.nonce === nonce);
+  }
+
+  async isCapHit(keyid: string, now: number): Promise<boolean> {
+    if (this.forcedCapHit.has(keyid)) return true;
+    this.prune(keyid, now);
+    const list = this.entries.get(keyid);
+    return (list?.length ?? 0) >= this.capPerKeyid;
+  }
+
+  async insert(keyid: string, nonce: string, ttlSeconds: number, now: number): Promise<ReplayInsertResult> {
+    this.prune(keyid, now);
+    const list = this.entries.get(keyid) ?? [];
+    if (list.some(e => e.nonce === nonce)) return 'replayed';
+    if (this.forcedCapHit.has(keyid) || list.length >= this.capPerKeyid) {
+      return 'rate_abuse';
+    }
+    list.push({ nonce, expiresAt: now + ttlSeconds });
+    this.entries.set(keyid, list);
+    return 'ok';
+  }
+
+  preload(keyid: string, nonce: string, ttlSeconds: number, now: number): void {
+    const list = this.entries.get(keyid) ?? [];
+    list.push({ nonce, expiresAt: now + ttlSeconds });
+    this.entries.set(keyid, list);
+  }
+
+  private prune(keyid: string, now: number): void {
+    const list = this.entries.get(keyid);
+    if (!list) return;
+    const alive = list.filter(e => e.expiresAt > now);
+    if (alive.length === 0) this.entries.delete(keyid);
+    else this.entries.set(keyid, alive);
+  }
+}

--- a/src/lib/signing/revocation.ts
+++ b/src/lib/signing/revocation.ts
@@ -1,0 +1,21 @@
+import type { RevocationSnapshot } from './types';
+
+export interface RevocationStore {
+  isRevoked(keyid: string): Promise<boolean>;
+}
+
+export class InMemoryRevocationStore implements RevocationStore {
+  private revokedKids = new Set<string>();
+
+  constructor(snapshot?: RevocationSnapshot) {
+    if (snapshot) this.load(snapshot);
+  }
+
+  load(snapshot: RevocationSnapshot): void {
+    this.revokedKids = new Set(snapshot.revoked_kids);
+  }
+
+  async isRevoked(keyid: string): Promise<boolean> {
+    return this.revokedKids.has(keyid);
+  }
+}

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -1,0 +1,92 @@
+import { createPrivateKey, randomBytes, sign as nodeSign, type JsonWebKey } from 'crypto';
+import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
+import { computeContentDigest } from './content-digest';
+import { MANDATORY_COMPONENTS, MAX_SIGNATURE_WINDOW_SECONDS, REQUEST_SIGNING_TAG, type AdcpJsonWebKey } from './types';
+
+export interface SignerKey {
+  keyid: string;
+  alg: 'ed25519' | 'ecdsa-p256-sha256';
+  privateKey: AdcpJsonWebKey;
+}
+
+export interface SignRequestOptions {
+  coverContentDigest?: boolean;
+  label?: string;
+  windowSeconds?: number;
+  now?: () => number;
+  nonce?: string;
+}
+
+export interface SignedRequest {
+  headers: Record<string, string>;
+  signatureBase: string;
+  params: SignatureParams;
+}
+
+export function signRequest(request: RequestLike, key: SignerKey, options: SignRequestOptions = {}): SignedRequest {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+  const hasBody = (request.body ?? '').length > 0;
+
+  const coverDigest = options.coverContentDigest === true && hasBody;
+  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
+  if (coverDigest) {
+    headers['Content-Digest'] = computeContentDigest(request.body ?? '');
+  }
+
+  const components = [...MANDATORY_COMPONENTS];
+  if (hasBody) components.push('content-type');
+  if (coverDigest) components.push('content-digest');
+
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: key.keyid,
+    alg: key.alg,
+    tag: REQUEST_SIGNING_TAG,
+  };
+
+  const normalizedRequest: RequestLike = { ...request, headers };
+  const base = buildSignatureBase(components, normalizedRequest, params);
+
+  const signature = produceSignature(key, Buffer.from(base, 'utf8'));
+  // Emit base64url without padding to match the AdCP conformance-vector
+  // format (and deterministic Ed25519 sigs are then byte-identical across
+  // SDKs). Verifiers accept either variant since Node's base64 decoder
+  // treats `+`/`-` and `/`/`_` interchangeably.
+  const sigB64 = Buffer.from(signature).toString('base64url');
+
+  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
+  headers['Signature'] = `${label}=:${sigB64}:`;
+
+  return { headers, signatureBase: base, params };
+}
+
+function produceSignature(key: SignerKey, data: Buffer): Uint8Array {
+  const privateKey = createPrivateKey({
+    key: key.privateKey as JsonWebKey,
+    format: 'jwk',
+  });
+  if (key.alg === 'ed25519') {
+    return new Uint8Array(nodeSign(null, data, privateKey));
+  }
+  return new Uint8Array(nodeSign('sha256', data, { key: privateKey, dsaEncoding: 'ieee-p1363' }));
+}
+
+function flattenHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v === undefined) continue;
+    // Trim each entry and use ", " as the joiner so the signer and verifier
+    // produce the same canonical value when a header was originally multi-line.
+    out[k] = Array.isArray(v) ? v.map(entry => entry.trim()).join(', ') : v.trim();
+  }
+  return out;
+}
+
+function base64UrlRandom(byteLength: number): string {
+  return randomBytes(byteLength).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -1,0 +1,41 @@
+export type ContentDigestPolicy = 'required' | 'forbidden' | 'either';
+
+export interface VerifierCapability {
+  supported: boolean;
+  covers_content_digest: ContentDigestPolicy;
+  required_for: string[];
+  supported_for?: string[];
+}
+
+export interface AdcpJsonWebKey {
+  kid: string;
+  kty: string;
+  crv?: string;
+  alg?: string;
+  use?: string;
+  key_ops?: string[];
+  adcp_use?: string;
+  x?: string;
+  y?: string;
+  [extra: string]: unknown;
+}
+
+export interface RevocationSnapshot {
+  issuer: string;
+  updated: string;
+  next_update: string;
+  revoked_kids: string[];
+  revoked_jtis: string[];
+}
+
+export interface VerifiedSigner {
+  keyid: string;
+  agent_url?: string;
+  verified_at: number;
+}
+
+export const REQUEST_SIGNING_TAG = 'adcp/request-signing/v1';
+export const ALLOWED_ALGS = new Set(['ed25519', 'ecdsa-p256-sha256']);
+export const MAX_SIGNATURE_WINDOW_SECONDS = 300;
+export const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
+export const MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@method', '@target-uri', '@authority'];

--- a/src/lib/signing/verifier.ts
+++ b/src/lib/signing/verifier.ts
@@ -1,0 +1,265 @@
+import { buildSignatureBase, getHeaderValue, type RequestLike } from './canonicalize';
+import { contentDigestMatches } from './content-digest';
+import { RequestSignatureError } from './errors';
+import { parseSignature, parseSignatureInput, type ParsedSignatureInput } from './parser';
+import { jwkToPublicKey, verifySignature } from './crypto';
+import type { JwksResolver } from './jwks';
+import type { ReplayStore } from './replay';
+import type { RevocationStore } from './revocation';
+import {
+  ALLOWED_ALGS,
+  CLOCK_SKEW_TOLERANCE_SECONDS,
+  MANDATORY_COMPONENTS,
+  MAX_SIGNATURE_WINDOW_SECONDS,
+  REQUEST_SIGNING_TAG,
+  type VerifiedSigner,
+  type VerifierCapability,
+} from './types';
+
+export interface VerifyRequestOptions {
+  capability: VerifierCapability;
+  jwks: JwksResolver;
+  replayStore: ReplayStore;
+  revocationStore: RevocationStore;
+  now?: () => number;
+  operation: string;
+  agentUrlForKeyid?: (keyid: string) => string | undefined;
+}
+
+export async function verifyRequestSignature(
+  request: RequestLike,
+  options: VerifyRequestOptions
+): Promise<VerifiedSigner> {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const sigInputHeader = getHeaderValue(request.headers, 'Signature-Input');
+  const sigHeader = getHeaderValue(request.headers, 'Signature');
+
+  // Pre-check: both headers present or both absent.
+  if (!sigInputHeader && !sigHeader) {
+    if (options.capability.required_for.includes(options.operation)) {
+      throw new RequestSignatureError(
+        'request_signature_required',
+        0,
+        `Operation "${options.operation}" requires a signed request`
+      );
+    }
+    return { keyid: '', verified_at: now };
+  }
+  if (!sigInputHeader || !sigHeader) {
+    throw new RequestSignatureError(
+      'request_signature_header_malformed',
+      1,
+      'Signature and Signature-Input headers must be present as a pair'
+    );
+  }
+
+  // Step 1: parse.
+  const parsedInput = parseSignatureInput(sigInputHeader);
+  const parsedSig = parseSignature(sigHeader, parsedInput.label);
+
+  // Step 2: required params present.
+  requireParams(parsedInput);
+
+  // Step 3: tag match.
+  if (parsedInput.params.tag !== REQUEST_SIGNING_TAG) {
+    throw new RequestSignatureError(
+      'request_signature_tag_invalid',
+      3,
+      `Signature tag must be "${REQUEST_SIGNING_TAG}"; got "${parsedInput.params.tag}"`
+    );
+  }
+
+  // Step 4: alg allowlist.
+  if (!ALLOWED_ALGS.has(parsedInput.params.alg)) {
+    throw new RequestSignatureError(
+      'request_signature_alg_not_allowed',
+      4,
+      `Signature alg "${parsedInput.params.alg}" is not in the AdCP allowlist`
+    );
+  }
+
+  // Step 5: window valid.
+  validateWindow(parsedInput.params.created, parsedInput.params.expires, now);
+
+  // Step 6: covered components.
+  validateCoveredComponents(parsedInput.components, options.capability, request);
+
+  // Step 7: resolve keyid.
+  const jwk = await options.jwks.resolve(parsedInput.params.keyid);
+  if (!jwk) {
+    throw new RequestSignatureError(
+      'request_signature_key_unknown',
+      7,
+      `No JWK found for keyid "${parsedInput.params.keyid}"`
+    );
+  }
+  if (jwk.kid !== parsedInput.params.keyid) {
+    throw new RequestSignatureError(
+      'request_signature_key_unknown',
+      7,
+      `JWKS resolver returned a JWK whose kid "${jwk.kid}" does not match requested keyid "${parsedInput.params.keyid}"`
+    );
+  }
+
+  // Step 8: key purpose.
+  if (jwk.adcp_use !== 'request-signing' || !jwk.key_ops?.includes('verify')) {
+    throw new RequestSignatureError(
+      'request_signature_key_purpose_invalid',
+      8,
+      `JWK "${jwk.kid}" is not scoped for request-signing verification`
+    );
+  }
+
+  // Step 9: revocation (runs BEFORE crypto to prevent amplification attacks).
+  if (await options.revocationStore.isRevoked(jwk.kid)) {
+    throw new RequestSignatureError('request_signature_key_revoked', 9, `JWK "${jwk.kid}" is revoked`);
+  }
+
+  // Step 12 pre-checks (rate-abuse cap + replay hit) run before crypto so a
+  // compromised-key cache cap or a replayed nonce short-circuits an expensive
+  // Ed25519/ECDSA verify. The committing insert happens after step 11.
+  if (await options.replayStore.isCapHit(jwk.kid, now)) {
+    throw new RequestSignatureError(
+      'request_signature_rate_abuse',
+      12,
+      `Per-keyid replay cache cap exceeded for keyid=${jwk.kid}`
+    );
+  }
+  if (await options.replayStore.has(jwk.kid, parsedInput.params.nonce, now)) {
+    throw new RequestSignatureError(
+      'request_signature_replayed',
+      12,
+      `Replay of (keyid=${jwk.kid}, nonce=${parsedInput.params.nonce}) within signature window`
+    );
+  }
+
+  // Step 10: cryptographic verify. Use the received Signature-Input value
+  // verbatim as the @signature-params line so a peer emitting params in a
+  // different legal order still produces a byte-identical base.
+  const base = buildSignatureBase(
+    parsedInput.components,
+    request,
+    parsedInput.params,
+    parsedInput.signatureParamsValue
+  );
+  const publicKey = jwkToPublicKey(jwk);
+  const valid = verifySignature(parsedInput.params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
+  if (!valid) {
+    throw new RequestSignatureError(
+      'request_signature_invalid',
+      10,
+      'Cryptographic verification of signature base failed'
+    );
+  }
+
+  // Step 11: content-digest match (only if covered).
+  if (parsedInput.components.includes('content-digest')) {
+    const digestHeader = getHeaderValue(request.headers, 'Content-Digest');
+    if (!digestHeader || !contentDigestMatches(digestHeader, request.body ?? '')) {
+      throw new RequestSignatureError(
+        'request_signature_digest_mismatch',
+        11,
+        'Content-Digest header does not match recomputed body hash'
+      );
+    }
+  }
+
+  // Step 12: commit the (keyid, nonce) into the replay cache now that all
+  // prior checks have passed. Floor the TTL at one max-window + skew so a
+  // signer minting tiny validity windows can't replay outside the configured
+  // replay horizon, and so cross-replica eventual consistency has headroom.
+  const remaining = parsedInput.params.expires - now + CLOCK_SKEW_TOLERANCE_SECONDS;
+  const ttl = Math.max(remaining, MAX_SIGNATURE_WINDOW_SECONDS + CLOCK_SKEW_TOLERANCE_SECONDS);
+  const insertResult = await options.replayStore.insert(jwk.kid, parsedInput.params.nonce, ttl, now);
+  if (insertResult === 'replayed') {
+    throw new RequestSignatureError(
+      'request_signature_replayed',
+      12,
+      `Replay of (keyid=${jwk.kid}, nonce=${parsedInput.params.nonce}) within signature window`
+    );
+  }
+  if (insertResult === 'rate_abuse') {
+    throw new RequestSignatureError(
+      'request_signature_rate_abuse',
+      12,
+      `Per-keyid replay cache cap exceeded for keyid=${jwk.kid}`
+    );
+  }
+
+  const agent_url = options.agentUrlForKeyid?.(jwk.kid);
+  return { keyid: jwk.kid, agent_url, verified_at: now };
+}
+
+function requireParams(parsed: ParsedSignatureInput): void {
+  const required: Array<keyof ParsedSignatureInput['params']> = ['created', 'expires', 'nonce', 'keyid', 'alg', 'tag'];
+  const missing = required.filter(k => parsed.params[k] === undefined);
+  if (missing.length) {
+    throw new RequestSignatureError(
+      'request_signature_params_incomplete',
+      2,
+      `Signature-Input missing required parameter(s): ${missing.join(', ')}`
+    );
+  }
+}
+
+function validateWindow(created: number, expires: number, now: number): void {
+  if (expires <= created) {
+    throw new RequestSignatureError(
+      'request_signature_window_invalid',
+      5,
+      'Signature expires must be strictly greater than created'
+    );
+  }
+  if (expires - created > MAX_SIGNATURE_WINDOW_SECONDS) {
+    throw new RequestSignatureError(
+      'request_signature_window_invalid',
+      5,
+      `Signature window exceeds ${MAX_SIGNATURE_WINDOW_SECONDS}s maximum`
+    );
+  }
+  if (now > expires + CLOCK_SKEW_TOLERANCE_SECONDS) {
+    throw new RequestSignatureError('request_signature_window_invalid', 5, 'Signature is expired');
+  }
+  if (now < created - CLOCK_SKEW_TOLERANCE_SECONDS) {
+    throw new RequestSignatureError(
+      'request_signature_window_invalid',
+      5,
+      'Signature created is in the future beyond skew tolerance'
+    );
+  }
+}
+
+function validateCoveredComponents(components: string[], capability: VerifierCapability, request: RequestLike): void {
+  for (const mandatory of MANDATORY_COMPONENTS) {
+    if (!components.includes(mandatory)) {
+      throw new RequestSignatureError(
+        'request_signature_components_incomplete',
+        6,
+        `Covered components must include "${mandatory}"`
+      );
+    }
+  }
+  const hasBody = (request.body ?? '').length > 0;
+  if (hasBody && !components.includes('content-type')) {
+    throw new RequestSignatureError(
+      'request_signature_components_incomplete',
+      6,
+      'Covered components must include "content-type" when a request body is present'
+    );
+  }
+  const includesDigest = components.includes('content-digest');
+  if (capability.covers_content_digest === 'required' && !includesDigest) {
+    throw new RequestSignatureError(
+      'request_signature_components_incomplete',
+      6,
+      'Verifier requires content-digest coverage'
+    );
+  }
+  if (capability.covers_content_digest === 'forbidden' && includesDigest) {
+    throw new RequestSignatureError(
+      'request_signature_components_unexpected',
+      6,
+      'Verifier forbids content-digest coverage'
+    );
+  }
+}

--- a/test/request-signing-e2e.test.js
+++ b/test/request-signing-e2e.test.js
@@ -95,8 +95,11 @@ function startServer(capability) {
     await new Promise(resolve =>
       middleware(reqShim, resShim, err => {
         if (err) {
+          // Log the cause server-side for debugging; return a generic 500 so
+          // test responses don't echo stack traces or internal state.
+          console.error('test-shim middleware error:', err);
           res.statusCode = 500;
-          res.end(JSON.stringify({ error: String(err) }));
+          res.end(JSON.stringify({ error: 'internal_server_error' }));
           resolve();
           return;
         }

--- a/test/request-signing-e2e.test.js
+++ b/test/request-signing-e2e.test.js
@@ -1,0 +1,244 @@
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { createPublicKey } = require('node:crypto');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  createExpressVerifier,
+  createSigningFetch,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  signRequest,
+  StaticJwksResolver,
+} = require('../dist/lib/signing/index.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+
+const keys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys;
+const ed = keys.find(k => k.kid === 'test-ed25519-2026');
+const privateJwk = { ...ed, d: ed._private_d_for_test_only };
+delete privateJwk._private_d_for_test_only;
+delete privateJwk.key_ops;
+delete privateJwk.use;
+
+const publicJwk = { ...ed };
+delete publicJwk._private_d_for_test_only;
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+// Minimal "express-shaped" adapter so createExpressVerifier works with Node http.
+function makeExpressShim(req, res) {
+  const reqShim = {
+    method: req.method,
+    url: req.url,
+    originalUrl: req.url,
+    headers: req.headers,
+    protocol: 'http',
+    get(name) {
+      const v = req.headers[name.toLowerCase()];
+      return Array.isArray(v) ? v.join(', ') : v;
+    },
+  };
+  const resShim = {
+    status(code) {
+      res.statusCode = code;
+      return {
+        set(k, v) {
+          res.setHeader(k, v);
+          return {
+            json(body) {
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify(body));
+            },
+          };
+        },
+      };
+    },
+  };
+  return { reqShim, resShim };
+}
+
+function startServer(capability) {
+  const jwks = new StaticJwksResolver([publicJwk]);
+  const replayStore = new InMemoryReplayStore();
+  const revocationStore = new InMemoryRevocationStore();
+  const middleware = createExpressVerifier({
+    capability,
+    jwks,
+    replayStore,
+    revocationStore,
+    resolveOperation: req => new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
+  });
+
+  const server = http.createServer(async (req, res) => {
+    const body = await readRawBody(req);
+    const { reqShim, resShim } = makeExpressShim(req, res);
+    reqShim.rawBody = body;
+    await new Promise(resolve =>
+      middleware(reqShim, resShim, err => {
+        if (err) {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: String(err) }));
+          resolve();
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            ok: true,
+            verified_signer: reqShim.verifiedSigner,
+          })
+        );
+        resolve();
+      })
+    );
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve({ server, port: addr.port, replayStore, revocationStore });
+    });
+  });
+}
+
+describe('RFC 9421 e2e: signing-fetch → http server → createExpressVerifier', () => {
+  let instance;
+
+  before(async () => {
+    instance = await startServer({
+      supported: true,
+      covers_content_digest: 'either',
+      required_for: ['create_media_buy'],
+    });
+  });
+
+  after(() => {
+    instance.server.close();
+  });
+
+  test('signed POST is accepted with verified_signer populated', async () => {
+    const signingFetch = createSigningFetch((url, init) => fetch(url, init), {
+      keyid: 'test-ed25519-2026',
+      alg: 'ed25519',
+      privateKey: privateJwk,
+    });
+    const url = `http://127.0.0.1:${instance.port}/adcp/create_media_buy`;
+    const body = JSON.stringify({ plan_id: 'plan_001' });
+    const res = await signingFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    });
+    assert.strictEqual(res.status, 200);
+    const json = await res.json();
+    assert.strictEqual(json.ok, true);
+    assert.strictEqual(json.verified_signer.keyid, 'test-ed25519-2026');
+  });
+
+  test('unsigned POST to required_for op rejects with request_signature_required', async () => {
+    const url = `http://127.0.0.1:${instance.port}/adcp/create_media_buy`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    assert.strictEqual(res.status, 401);
+    const json = await res.json();
+    assert.strictEqual(json.error, 'request_signature_required');
+    assert.strictEqual(res.headers.get('www-authenticate'), 'Signature error="request_signature_required"');
+  });
+
+  test('tampered body fails cryptographic verification', async () => {
+    const url = `http://127.0.0.1:${instance.port}/adcp/create_media_buy`;
+    const body = '{"plan_id":"plan_001"}';
+    const signed = signRequest(
+      { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body },
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk }
+    );
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: signed.headers,
+      body: '{"plan_id":"plan_tampered"}',
+    });
+    // Body isn't covered by the signature (no content-digest), so crypto verify
+    // still succeeds — tamper detection requires content-digest coverage.
+    assert.strictEqual(res.status, 200);
+  });
+
+  test('tampered body with content-digest coverage is rejected at step 11', async () => {
+    const capability = {
+      supported: true,
+      covers_content_digest: 'required',
+      required_for: ['create_media_buy'],
+    };
+    const digestInstance = await startServer(capability);
+    try {
+      const url = `http://127.0.0.1:${digestInstance.port}/adcp/create_media_buy`;
+      const body = '{"plan_id":"plan_001"}';
+      const signed = signRequest(
+        { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body },
+        { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk },
+        { coverContentDigest: true }
+      );
+      const tamperedRes = await fetch(url, {
+        method: 'POST',
+        headers: signed.headers,
+        body: '{"plan_id":"plan_tampered"}',
+      });
+      assert.strictEqual(tamperedRes.status, 401);
+      const json = await tamperedRes.json();
+      assert.strictEqual(json.error, 'request_signature_digest_mismatch');
+    } finally {
+      digestInstance.server.close();
+    }
+  });
+
+  test('replay of accepted signature is rejected', async () => {
+    const replayInstance = await startServer({
+      supported: true,
+      covers_content_digest: 'either',
+      required_for: ['create_media_buy'],
+    });
+    try {
+      const url = `http://127.0.0.1:${replayInstance.port}/adcp/create_media_buy`;
+      const body = '{"plan_id":"plan_001"}';
+      const signed = signRequest(
+        { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body },
+        { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk }
+      );
+      const first = await fetch(url, { method: 'POST', headers: signed.headers, body });
+      assert.strictEqual(first.status, 200);
+      const second = await fetch(url, { method: 'POST', headers: signed.headers, body });
+      assert.strictEqual(second.status, 401);
+      const json = await second.json();
+      assert.strictEqual(json.error, 'request_signature_replayed');
+    } finally {
+      replayInstance.server.close();
+    }
+  });
+
+  test('publicJwk loads as Node KeyObject (sanity check)', () => {
+    const pub = createPublicKey({ key: publicJwk, format: 'jwk' });
+    assert.strictEqual(pub.asymmetricKeyType, 'ed25519');
+  });
+});

--- a/test/request-signing-review-fixes.test.js
+++ b/test/request-signing-review-fixes.test.js
@@ -1,6 +1,5 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
-const http = require('node:http');
 const { spawnSync } = require('node:child_process');
 const { readFileSync, existsSync, unlinkSync, mkdtempSync } = require('node:fs');
 const os = require('node:os');
@@ -11,7 +10,6 @@ const {
   computeContentDigest,
   contentDigestMatches,
   createExpressVerifier,
-  createSigningFetch,
   InMemoryReplayStore,
   InMemoryRevocationStore,
   parseContentDigest,

--- a/test/request-signing-review-fixes.test.js
+++ b/test/request-signing-review-fixes.test.js
@@ -1,0 +1,288 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { spawnSync } = require('node:child_process');
+const { readFileSync, existsSync, unlinkSync, mkdtempSync } = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  buildSignatureBase,
+  computeContentDigest,
+  contentDigestMatches,
+  createExpressVerifier,
+  createSigningFetch,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  parseContentDigest,
+  parseSignatureInput,
+  RequestSignatureError,
+  signRequest,
+  StaticJwksResolver,
+  verifyRequestSignature,
+} = require('../dist/lib/signing/index.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys;
+const ed = keys.find(k => k.kid === 'test-ed25519-2026');
+const privateJwk = { ...ed, d: ed._private_d_for_test_only };
+delete privateJwk._private_d_for_test_only;
+delete privateJwk.key_ops;
+delete privateJwk.use;
+const publicJwk = { ...ed };
+delete publicJwk._private_d_for_test_only;
+
+describe('parser hardening (security/code-review findings)', () => {
+  test('empty-value numeric param is rejected (not silently coerced to 0)', () => {
+    assert.throws(
+      () =>
+        parseSignatureInput(
+          'sig1=("@method" "@target-uri" "@authority");created=;expires=1776521100;nonce="x";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
+        ),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_header_malformed' &&
+        /empty value|empty/i.test(err.message)
+    );
+  });
+
+  test('unquoted string-typed param (tag) is rejected', () => {
+    assert.throws(
+      () =>
+        parseSignatureInput(
+          'sig1=("@method" "@target-uri" "@authority");created=1;expires=2;nonce="x";keyid="k";alg="ed25519";tag=bare'
+        ),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_header_malformed' &&
+        /quoted string/i.test(err.message)
+    );
+  });
+
+  test('non-integer numeric param (1e5) is rejected', () => {
+    assert.throws(
+      () =>
+        parseSignatureInput(
+          'sig1=("@method" "@target-uri" "@authority");created=1e5;expires=2;nonce="x";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
+        ),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_header_malformed' &&
+        /integer/i.test(err.message)
+    );
+  });
+
+  test('escaped quote inside a quoted param does not terminate the string', () => {
+    const parsed = parseSignatureInput(
+      'sig1=("@method" "@target-uri" "@authority");created=1;expires=2;nonce="a\\"b";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
+    );
+    assert.strictEqual(parsed.params.nonce, 'a\\"b');
+  });
+
+  test('Signature-Input with params in non-canonical order still produces byte-identical base', () => {
+    // Our internal DEFAULT_PARAM_ORDER is created;expires;nonce;keyid;alg;tag.
+    // A spec-legal sender could emit keyid first. The verifier path must re-
+    // emit the raw substring, not reformat.
+    const reordered =
+      'sig1=("@method" "@target-uri" "@authority" "content-type");keyid="test-ed25519-2026";created=1776520800;expires=1776521100;nonce="KXYnfEfJ0PBRZXQyVXfVQA";alg="ed25519";tag="adcp/request-signing/v1"';
+    const parsed = parseSignatureInput(reordered);
+    const request = {
+      method: 'POST',
+      url: 'https://seller.example.com/adcp/create_media_buy',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    };
+    const base = buildSignatureBase(parsed.components, request, parsed.params, parsed.signatureParamsValue);
+    // Last line's params MUST match the received substring byte-for-byte.
+    const lastLine = base.split('\n').at(-1);
+    assert.strictEqual(
+      lastLine,
+      '"@signature-params": ("@method" "@target-uri" "@authority" "content-type");keyid="test-ed25519-2026";created=1776520800;expires=1776521100;nonce="KXYnfEfJ0PBRZXQyVXfVQA";alg="ed25519";tag="adcp/request-signing/v1"'
+    );
+  });
+
+  test('Signature-Input with multiple labels selects sig1 even when not first', () => {
+    const header =
+      'proxy=("@method");created=1;expires=2;nonce="x";keyid="k";alg="ed25519";tag="adcp/request-signing/v1", sig1=("@method" "@target-uri" "@authority");created=10;expires=20;nonce="y";keyid="kk";alg="ed25519";tag="adcp/request-signing/v1"';
+    const parsed = parseSignatureInput(header);
+    assert.strictEqual(parsed.label, 'sig1');
+    assert.strictEqual(parsed.params.keyid, 'kk');
+  });
+
+  test('signature value with trailing sf-dictionary parameters is accepted', () => {
+    // RFC 8941 sf-binary values can carry member-level parameters. Our parser
+    // must not reject these — it should decode just the inner :base64: payload.
+    const { parseSignature } = require('../dist/lib/signing/index.js');
+    const parsed = parseSignature('sig1=:dGVzdA==:;created=1776520800', 'sig1');
+    assert.deepStrictEqual(Buffer.from(parsed.bytes).toString('utf8'), 'test');
+  });
+
+  test('signature value with invalid base64 characters is rejected', () => {
+    const { parseSignature } = require('../dist/lib/signing/index.js');
+    assert.throws(
+      () => parseSignature('sig1=:not$base64!:', 'sig1'),
+      err =>
+        err instanceof RequestSignatureError &&
+        err.code === 'request_signature_header_malformed' &&
+        /non-base64/i.test(err.message)
+    );
+  });
+});
+
+describe('content-digest SF dictionary support (protocol finding)', () => {
+  test('parseContentDigest extracts sha-256 member when sha-512 is listed first', () => {
+    const header =
+      'sha-512=:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==:, sha-256=:SNIVma8dgUBx/U1CBaYFQnsJep9S0/tXaNXlQQOdoxQ=:';
+    const buf = parseContentDigest(header);
+    assert.ok(buf);
+    assert.strictEqual(buf.length, 32);
+  });
+
+  test('contentDigestMatches works on multi-member Content-Digest', () => {
+    const body = '{"plan_id":"plan_001"}';
+    const sha256 = computeContentDigest(body).match(/:(.+):/)[1];
+    const header = `sha-512=:AAAA==:, sha-256=:${sha256}:`;
+    assert.strictEqual(contentDigestMatches(header, body), true);
+  });
+});
+
+describe('verifier: kid consistency + replay TTL floor (protocol/security findings)', () => {
+  const buildReq = ({ keyid, now = 1776520800 }) => {
+    const url = 'https://seller.example.com/adcp/create_media_buy';
+    const body = '{"plan_id":"plan_001"}';
+    const signed = signRequest(
+      { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body },
+      { keyid, alg: 'ed25519', privateKey: privateJwk },
+      { now: () => now, windowSeconds: 300, nonce: 'test-nonce-aaaaaaaaaaaa' }
+    );
+    return { method: 'POST', url, headers: signed.headers, body };
+  };
+
+  test('JWKS returning a JWK with mismatched kid is rejected as key_unknown', async () => {
+    const mismatched = { ...publicJwk, kid: 'different-kid' };
+    const jwks = {
+      async resolve() {
+        return mismatched;
+      },
+    };
+    const req = buildReq({ keyid: 'test-ed25519-2026' });
+    await assert.rejects(
+      async () =>
+        await verifyRequestSignature(req, {
+          capability: { supported: true, covers_content_digest: 'either', required_for: ['create_media_buy'] },
+          jwks,
+          replayStore: new InMemoryReplayStore(),
+          revocationStore: new InMemoryRevocationStore(),
+          now: () => 1776520800,
+          operation: 'create_media_buy',
+        }),
+      err =>
+        err instanceof RequestSignatureError && err.code === 'request_signature_key_unknown' && /kid/i.test(err.message)
+    );
+  });
+
+  test('replay TTL is floored at max-window + skew so short-validity signatures cannot escape the replay horizon', async () => {
+    const replayStore = new InMemoryReplayStore();
+    const jwks = new StaticJwksResolver([publicJwk]);
+    const now = 1776520800;
+    // Sign with a 10-second validity window (well below the replay horizon).
+    const url = 'https://seller.example.com/adcp/create_media_buy';
+    const body = '{"plan_id":"plan_001"}';
+    const signed = signRequest(
+      { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body },
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk },
+      { now: () => now, windowSeconds: 10, nonce: 'short-window-nonce-xxxx' }
+    );
+    await verifyRequestSignature(
+      { method: 'POST', url, headers: signed.headers, body },
+      {
+        capability: { supported: true, covers_content_digest: 'either', required_for: [] },
+        jwks,
+        replayStore,
+        revocationStore: new InMemoryRevocationStore(),
+        now: () => now,
+        operation: 'create_media_buy',
+      }
+    );
+    // 61s later (past the 10s validity + 60s skew) — the entry must still be
+    // in the cache so a replay is still caught, not silently forgotten.
+    const stillPresent = await replayStore.has('test-ed25519-2026', 'short-window-nonce-xxxx', now + 75);
+    assert.strictEqual(stillPresent, true);
+    const stillPresentMuchLater = await replayStore.has('test-ed25519-2026', 'short-window-nonce-xxxx', now + 350);
+    assert.strictEqual(stillPresentMuchLater, true);
+  });
+});
+
+describe('middleware: rawBody + failed_step hardening (security findings)', () => {
+  test('request with Content-Length > 0 but no rawBody is rejected as malformed', async () => {
+    const middleware = createExpressVerifier({
+      capability: { supported: true, covers_content_digest: 'either', required_for: ['create_media_buy'] },
+      jwks: new StaticJwksResolver([publicJwk]),
+      replayStore: new InMemoryReplayStore(),
+      revocationStore: new InMemoryRevocationStore(),
+      resolveOperation: () => 'create_media_buy',
+    });
+    const req = {
+      method: 'POST',
+      url: '/adcp/create_media_buy',
+      originalUrl: '/adcp/create_media_buy',
+      headers: { host: 'seller.example.com', 'content-length': '100', 'content-type': 'application/json' },
+      protocol: 'https',
+      get(name) {
+        return this.headers[name.toLowerCase()];
+      },
+    };
+    let captured;
+    const res = {
+      status(code) {
+        captured = { code };
+        return {
+          set(k, v) {
+            captured.wwwAuth = v;
+            return {
+              json(body) {
+                captured.body = body;
+              },
+            };
+          },
+        };
+      },
+    };
+    await middleware(req, res, () => {});
+    assert.strictEqual(captured.code, 401);
+    assert.strictEqual(captured.body.error, 'request_signature_header_malformed');
+    assert.ok(captured.body.failed_step === undefined, 'failed_step must not be exposed in 401 body');
+  });
+});
+
+describe('CLI: private key stdout suppression when --private-out is set (security finding)', () => {
+  const cli = path.join(__dirname, '..', 'bin', 'adcp.js');
+  test('generate-key with --private-out omits private JWK from stdout', () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), 'adcp-signing-test-'));
+    const privateOut = path.join(tmp, 'priv.pem');
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [cli, 'signing', 'generate-key', '--alg', 'ed25519', '--private-out', privateOut],
+        {
+          encoding: 'utf8',
+        }
+      );
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(existsSync(privateOut), 'private key file was written');
+      assert.ok(!/Private JWK/.test(result.stdout), 'private JWK must not appear on stdout when --private-out is set');
+      assert.ok(!/"d":/.test(result.stdout), 'private scalar "d" must not appear on stdout when --private-out is set');
+    } finally {
+      if (existsSync(privateOut)) unlinkSync(privateOut);
+    }
+  });
+});

--- a/test/request-signing-vectors.test.js
+++ b/test/request-signing-vectors.test.js
@@ -1,0 +1,162 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync, readdirSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  RequestSignatureError,
+  StaticJwksResolver,
+  verifyRequestSignature,
+  signRequest,
+  buildSignatureBase,
+} = require('../dist/lib/signing/index.js');
+
+const ROOT = path.join(__dirname, '..', 'compliance', 'cache', 'latest', 'test-vectors', 'request-signing');
+
+const keysData = JSON.parse(readFileSync(path.join(ROOT, 'keys.json'), 'utf8'));
+const keysByKid = new Map(keysData.keys.map(k => [k.kid, k]));
+
+// adcp#2335 fixed the stale Content-Digest in positive/002 at spec head. The
+// fixed vector ships once latest.tgz is rebuilt — until then, `npm run sync-schemas`
+// still pulls the pre-fix digest and this test auto-skips. Remove the skip once
+// the synced vector reports the correct `SNIVma8d...` digest.
+const awaitingUpstreamTarball = (() => {
+  const p = path.join(ROOT, 'positive', '002-post-with-content-digest.json');
+  const vector = JSON.parse(readFileSync(p, 'utf8'));
+  return vector.request.headers['Content-Digest'].includes('X48E9qOokqqr');
+})();
+const KNOWN_UPSTREAM_BUG = awaitingUpstreamTarball ? new Set(['002-post-with-content-digest.json']) : new Set();
+
+function parseSigInput(headerValue) {
+  const m = headerValue.match(/^sig1=\((.*?)\)((?:;[^,]+)*)(?:,|$)/);
+  if (!m) throw new Error('cannot parse Signature-Input: ' + headerValue);
+  const components = [...m[1].matchAll(/"([^"]+)"/g)].map(x => x[1]);
+  const params = {};
+  for (const pair of m[2].split(';').filter(Boolean)) {
+    const eq = pair.indexOf('=');
+    const k = pair.slice(0, eq);
+    let v = pair.slice(eq + 1);
+    if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
+    else v = Number(v);
+    params[k] = v;
+  }
+  return { components, params };
+}
+
+function buildJwksForVector(vector) {
+  if (vector.jwks_override) return new StaticJwksResolver(vector.jwks_override.keys);
+  const entries = (vector.jwks_ref ?? []).map(kid => keysByKid.get(kid)).filter(k => k !== undefined);
+  return new StaticJwksResolver(entries);
+}
+
+function operationFromUrl(url) {
+  const p = new URL(url).pathname;
+  return p.split('/').filter(Boolean).pop();
+}
+
+async function runVector(vector) {
+  const now = vector.reference_now;
+  const replayStore = new InMemoryReplayStore();
+  const revocationStore = new InMemoryRevocationStore();
+  const state = vector.test_harness_state ?? {};
+  if (state.replay_cache_entries) {
+    for (const entry of state.replay_cache_entries) {
+      replayStore.preload(entry.keyid, entry.nonce, entry.ttl_seconds, now);
+    }
+  }
+  if (state.revocation_list) revocationStore.load(state.revocation_list);
+  if (state.replay_cache_per_keyid_cap_hit) {
+    replayStore.setCapHitForTesting(state.replay_cache_per_keyid_cap_hit.keyid);
+  }
+  try {
+    await verifyRequestSignature(vector.request, {
+      capability: vector.verifier_capability,
+      jwks: buildJwksForVector(vector),
+      replayStore,
+      revocationStore,
+      now: () => now,
+      operation: operationFromUrl(vector.request.url),
+    });
+    return { success: true };
+  } catch (err) {
+    if (err instanceof RequestSignatureError) {
+      return { success: false, error_code: err.code, failed_step: err.failedStep };
+    }
+    throw err;
+  }
+}
+
+describe('RFC 9421 canonicalization: positive expected_signature_base (adcp#2323)', () => {
+  const dir = path.join(ROOT, 'positive');
+  for (const file of readdirSync(dir).sort()) {
+    const vector = JSON.parse(readFileSync(path.join(dir, file), 'utf8'));
+    if (!vector.expected_signature_base) continue;
+    test(`${file}: signature base matches spec byte-for-byte`, () => {
+      const { components, params } = parseSigInput(vector.request.headers['Signature-Input']);
+      const base = buildSignatureBase(components, vector.request, params);
+      assert.strictEqual(base, vector.expected_signature_base);
+    });
+  }
+});
+
+describe('RFC 9421 verifier: positive conformance vectors (adcp#2323)', () => {
+  const dir = path.join(ROOT, 'positive');
+  for (const file of readdirSync(dir).sort()) {
+    const vector = JSON.parse(readFileSync(path.join(dir, file), 'utf8'));
+    const isKnownBug = KNOWN_UPSTREAM_BUG.has(file);
+    test(`${file}${isKnownBug ? ' [skipped: upstream adcp#2335]' : ''}`, { skip: isKnownBug }, async () => {
+      const actual = await runVector(vector);
+      assert.strictEqual(actual.success, true, JSON.stringify(actual));
+    });
+  }
+});
+
+describe('RFC 9421 verifier: negative conformance vectors (adcp#2323)', () => {
+  const dir = path.join(ROOT, 'negative');
+  for (const file of readdirSync(dir).sort()) {
+    const vector = JSON.parse(readFileSync(path.join(dir, file), 'utf8'));
+    test(`${file} → ${vector.expected_outcome.error_code}`, async () => {
+      const actual = await runVector(vector);
+      assert.strictEqual(actual.success, false);
+      assert.strictEqual(actual.error_code, vector.expected_outcome.error_code);
+    });
+  }
+});
+
+describe('RFC 9421 signer: reference signature reproduction (adcp#2323)', () => {
+  test('positive/001 reproduces spec Ed25519 signature byte-for-byte', () => {
+    const vectorPath = path.join(ROOT, 'positive', '001-basic-post.json');
+    const vector = JSON.parse(readFileSync(vectorPath, 'utf8'));
+    const sigInput = vector.request.headers['Signature-Input'];
+    const created = Number(sigInput.match(/created=(\d+)/)[1]);
+    const expires = Number(sigInput.match(/expires=(\d+)/)[1]);
+    const nonce = sigInput.match(/nonce="([^"]+)"/)[1];
+
+    const jwk = { ...keysByKid.get('test-ed25519-2026') };
+    jwk.d = jwk._private_d_for_test_only;
+    delete jwk._private_d_for_test_only;
+    delete jwk.key_ops;
+    delete jwk.use;
+
+    const signed = signRequest(
+      {
+        method: vector.request.method,
+        url: vector.request.url,
+        headers: { 'Content-Type': vector.request.headers['Content-Type'] },
+        body: vector.request.body,
+      },
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: jwk },
+      {
+        now: () => created,
+        windowSeconds: expires - created,
+        nonce,
+      }
+    );
+
+    const mySig = signed.headers.Signature.match(/sig1=:([^:]+):/)[1];
+    const expectedSig = vector.request.headers.Signature.match(/sig1=:([^:]+):/)[1];
+    assert.strictEqual(mySig, expectedSig);
+  });
+});

--- a/test/request-signing-vectors.test.js
+++ b/test/request-signing-vectors.test.js
@@ -11,6 +11,7 @@ const {
   verifyRequestSignature,
   signRequest,
   buildSignatureBase,
+  parseSignatureInput,
 } = require('../dist/lib/signing/index.js');
 
 const ROOT = path.join(__dirname, '..', 'compliance', 'cache', 'latest', 'test-vectors', 'request-signing');
@@ -30,19 +31,8 @@ const awaitingUpstreamTarball = (() => {
 const KNOWN_UPSTREAM_BUG = awaitingUpstreamTarball ? new Set(['002-post-with-content-digest.json']) : new Set();
 
 function parseSigInput(headerValue) {
-  const m = headerValue.match(/^sig1=\((.*?)\)((?:;[^,]+)*)(?:,|$)/);
-  if (!m) throw new Error('cannot parse Signature-Input: ' + headerValue);
-  const components = [...m[1].matchAll(/"([^"]+)"/g)].map(x => x[1]);
-  const params = {};
-  for (const pair of m[2].split(';').filter(Boolean)) {
-    const eq = pair.indexOf('=');
-    const k = pair.slice(0, eq);
-    let v = pair.slice(eq + 1);
-    if (v.startsWith('"') && v.endsWith('"')) v = v.slice(1, -1);
-    else v = Number(v);
-    params[k] = v;
-  }
-  return { components, params };
+  const parsed = parseSignatureInput(headerValue);
+  return { components: parsed.components, params: parsed.params };
 }
 
 function buildJwksForVector(vector) {


### PR DESCRIPTION
Closes #575. Paired SDK work for [adcp#2323](https://github.com/adcontextprotocol/adcp/pull/2323) (RFC 9421 request signing, optional in 3.0, required for spend-committing ops in 4.0).

## Summary
- `@adcp/client/signing` ships a signer, 12-step verifier pipeline, Express-shaped middleware, pluggable JWKS / replay / revocation stores, typed `RequestSignatureError` taxonomy, and a CLI (`adcp signing generate-key` / `verify-vector`).
- Conformance against all 28 spec vectors (`compliance/cache/latest/test-vectors/request-signing/`). 27 green today; one positive vector auto-skips pending the `latest.tgz` republish of [adcp#2335](https://github.com/adcontextprotocol/adcp/issues/2335) (already fixed at spec HEAD — skip clears itself on next `npm run sync-schemas`).
- Signer reproduces the spec's Ed25519 reference signatures byte-for-byte (base64url, no padding) from the committed `expected_signature_base` in positive/001.

## What's in the box
- **Canonicalization** — `canonicalize.ts` builds the RFC 9421 §2.5 signature base. URL canonicalization handles default-port stripping, dot-segment collapse, query byte-preservation, and uppercase-hex percent-encoding per RFC 3986 §6.2.
- **Verifier** — `verifier.ts` runs the 12-step checklist with the full 15-code error taxonomy (`request_signature_required` through `_rate_abuse`). Revocation runs before crypto; replay-cap and replay-has run before crypto; replay-insert runs after. Uses the received `Signature-Input` substring verbatim when rebuilding the base, so peers emitting params in any legal RFC 8941 order stay byte-identical.
- **Signer** — `signer.ts` emits sig-params in canonical order with base64url-no-padding signatures to match shipped vectors.
- **Middleware** — `createExpressVerifier` with a `getUrl` override for reverse-proxy deployments; 401 body carries `error` + `message` only (no pipeline enumeration via `failed_step`); rejects missing `rawBody` on Content-Length > 0 as malformed.
- **Stores** — `InMemoryReplayStore` (per-keyid cap with forced-cap test hook) and `InMemoryRevocationStore` (snapshot load). Interfaces are async so Redis / DynamoDB impls slot in cleanly.
- **CLI** — `adcp signing generate-key [--alg ed25519|es256]` writes a 0600 PEM + one-key JWKS for publication (and suppresses the private JWK from stdout when `--private-out` is set). `adcp signing verify-vector --vector <path>` runs a single spec vector through the verifier for debugging.

## Hardened per three parallel review passes
Code review, security review, and ad-tech protocol review all ran concurrently before merge; their intersection was fixed in-PR:

| Finding | Fix |
|---|---|
| Signature base rebuilt from re-formatted params → byte-identity breaks on non-canonical param order | `ParsedSignatureInput.signatureParamsValue` carries the received substring verbatim; verifier passes it through |
| `Number('')` silently coerces empty-value params to `0` | Parser requires explicit integer regex for numeric params, rejects empty values |
| Structured-field escape (`\\"`, `\\\\`) mishandled | State machine consumes the escape pair explicitly |
| Replay TTL = `expires - now + 60s` lets short-validity sigs escape the replay window at edge | TTL floored at `MAX_SIGNATURE_WINDOW_SECONDS + CLOCK_SKEW_TOLERANCE_SECONDS` |
| JWKS resolver returning a mismatched kid not detected | Typed `request_signature_key_unknown` when `jwk.kid !== params.keyid` |
| Missing `req.rawBody` silently substitutes `''` | Middleware throws typed error when Content-Length > 0 |
| Multi-label `Signature-Input` picks `inputs[0]` | Explicitly searches for label `sig1` |
| `nodeVerify` throws leak as generic `Error` | Wrapped; returns `false` → typed `request_signature_invalid` |
| 401 body exposes `failed_step` | Removed from response; kept in server-side logs |
| Multi-algorithm `Content-Digest` header rejected | Parsed as RFC 9530 Dictionary — `sha-256` member resolves regardless of position |
| Unknown derived component throws unclassified `Error` | Typed `request_signature_components_unexpected` |
| CLI prints private JWK to stdout even when `--private-out` is set | Suppresses stdout leak when writing to file |
| Signer emits standard base64 (`+/=`), vectors use base64url | Signer now emits base64url-no-padding; byte-identical to shipped vectors |
| Userinfo in signed URL not rejected | `canonicalTargetUri` throws typed error on credentialed URLs |

## Scope deferred to follow-ups (filed, not silent)
- [adcp-client#578](https://github.com/adcontextprotocol/adcp-client/issues/578) — auto-wire signing into `ADCPMultiAgentClient` MCP + A2A transports (needs seller capability cache + operation-name extraction from JSON-RPC body)
- [adcp-client#581](https://github.com/adcontextprotocol/adcp-client/issues/581) — swap hand-rolled SF parser for `structured-headers` library
- [adcp-client#582](https://github.com/adcontextprotocol/adcp-client/issues/582) — time-bucketed replay store (avoid O(N) prune DoS on hot keyids)
- [adcp-client#583](https://github.com/adcontextprotocol/adcp-client/issues/583) — API ergonomics for 6.0 (optional `operation`, discriminated-union `VerifiedSigner`, sub-barrels)
- [adcp-client#584](https://github.com/adcontextprotocol/adcp-client/issues/584) — JWKS auto-refresh + revocation polling with SSRF-validated fetch
- [adcp#2341](https://github.com/adcontextprotocol/adcp/issues/2341) — upstream: clarify sf-binary base64url vs RFC 8941 standard base64
- [adcp#2343](https://github.com/adcontextprotocol/adcp/issues/2343) — upstream: add URL canonicalization conformance vectors for ~10 RFC 3986 edge cases

## Test plan
- [x] `npm test` green (3439 pass / 3 skip / 0 fail)
- [x] `npm run typecheck` clean
- [x] Full 28 spec vector conformance (`test/request-signing-vectors.test.js`) — 27 pass + 1 auto-skip
- [x] 14 review-hardening regression tests (`test/request-signing-review-fixes.test.js`)
- [x] 6 e2e tests through real HTTP + signing-fetch + middleware (`test/request-signing-e2e.test.js`)
- [x] Signer reproduces spec Ed25519 signature byte-for-byte
- [x] CLI smoke: `generate-key` + `verify-vector` against a live vector
- [ ] CI green
- [ ] Changeset Check passes (minor bump, changeset in `.changeset/request-signing-rfc-9421.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)