### PR TITLE
fix: stdout discipline for storyboard --json (#588)

### DIFF
--- a/.changeset/storyboard-json-stdout-discipline.md
+++ b/.changeset/storyboard-json-stdout-discipline.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': patch
+---
+
+`adcp storyboard run --json` now guarantees clean JSON on stdout.
+
+The CLI installs a stdout guard around `comply()` / `runStoryboard()` / `runStoryboardStep()` that forwards any stray `console.log` / `console.info` to stderr, and writes the final JSON payload via `process.stdout.write` and waits for drain before exiting. This closes the class of failure reported in adcp-client#588, where a single internal log line turns valid JSON into a parse error for `jq` and `python -c 'json.load(sys.stdin)'`. `--json` stdout is now a single JSON document; everything else goes to stderr.

--- a/bin/adcp-json-stdout.js
+++ b/bin/adcp-json-stdout.js
@@ -1,0 +1,29 @@
+// Stdout discipline for --json CLI commands.
+//
+// The storyboard and comply runners emit their final result as a single JSON
+// blob on stdout; naive consumers (jq, `python -c 'json.load(sys.stdin)'`)
+// then parse that stdout directly. A single stray `console.log` from any
+// library on the path corrupts the JSON. These helpers give the CLI two
+// disciplines: capture stray logs and forward them to stderr, and write the
+// final payload via `process.stdout.write` so nothing else can interleave
+// with it.
+
+function captureStdoutLogs() {
+  const origLog = console.log;
+  const origInfo = console.info;
+  console.log = (...args) => console.error(...args);
+  console.info = (...args) => console.error(...args);
+  return () => {
+    console.log = origLog;
+    console.info = origInfo;
+  };
+}
+
+async function writeJsonOutput(payload) {
+  const str = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+  if (!process.stdout.write(str + '\n')) {
+    await new Promise(resolve => process.stdout.once('drain', resolve));
+  }
+}
+
+module.exports = { captureStdoutLogs, writeJsonOutput };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -27,6 +27,7 @@ const {
   saveAgent,
 } = require('./adcp-config.js');
 const { handleRegistryCommand } = require('./adcp-registry.js');
+const { captureStdoutLogs, writeJsonOutput } = require('./adcp-json-stdout.js');
 const {
   createCLIOAuthProvider,
   hasValidOAuthTokens,
@@ -859,7 +860,7 @@ async function handleStoryboardList(args) {
   }
 
   if (jsonOutput) {
-    console.log(JSON.stringify({ bundles: grouped, storyboards: flat }, null, 2));
+    await writeJsonOutput({ bundles: grouped, storyboards: flat });
     return;
   }
 
@@ -916,7 +917,7 @@ async function handleStoryboardShow(args) {
   }
 
   if (jsonOutput) {
-    console.log(JSON.stringify(storyboard, null, 2));
+    await writeJsonOutput(storyboard);
   } else {
     console.log(`\n${storyboard.title}`);
     console.log(`${'─'.repeat(storyboard.title.length)}`);
@@ -1014,23 +1015,17 @@ async function handleStoryboardRun(args) {
   // --dry-run: preview mode — show the plan without executing
   if (dryRun) {
     if (jsonOutput) {
-      console.log(
-        JSON.stringify(
-          {
-            storyboard_id: storyboard.id,
-            storyboard_title: storyboard.title,
-            agent_url: agentUrl,
-            protocol,
-            preview: true,
-            phases: storyboard.phases.map(p => ({
-              phase: p.title,
-              steps: p.steps.map(s => ({ id: s.id, title: s.title, task: s.task })),
-            })),
-          },
-          null,
-          2
-        )
-      );
+      await writeJsonOutput({
+        storyboard_id: storyboard.id,
+        storyboard_title: storyboard.title,
+        agent_url: agentUrl,
+        protocol,
+        preview: true,
+        phases: storyboard.phases.map(p => ({
+          phase: p.title,
+          steps: p.steps.map(s => ({ id: s.id, title: s.title, task: s.task })),
+        })),
+      });
     } else {
       console.log(`\n${storyboard.title} (${storyboard.id})`);
       console.log('═'.repeat(50));
@@ -1050,10 +1045,16 @@ async function handleStoryboardRun(args) {
     ...(resolvedAuth ? { auth: { type: 'bearer', token: resolvedAuth } } : {}),
   };
 
-  const result = await runStoryboard(agentUrl, storyboard, options);
+  const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
+  let result;
+  try {
+    result = await runStoryboard(agentUrl, storyboard, options);
+  } finally {
+    if (restoreLogs) restoreLogs();
+  }
 
   if (jsonOutput) {
-    console.log(JSON.stringify(result, null, 2));
+    await writeJsonOutput(result);
   } else {
     // Human-readable output
     console.log(`\n${storyboard.title} (${storyboard.id})`);
@@ -1181,6 +1182,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     console.log('');
   }
 
+  const restoreLogs = opts.jsonOutput ? captureStdoutLogs() : null;
   try {
     const { comply, formatComplianceResults, formatComplianceResultsJSON } =
       await import('../dist/lib/testing/compliance/index.js');
@@ -1193,7 +1195,8 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     const result = await comply(agentUrl, testOptions);
 
     if (opts.jsonOutput) {
-      console.log(formatComplianceResultsJSON(result));
+      restoreLogs();
+      await writeJsonOutput(formatComplianceResultsJSON(result));
     } else {
       console.log(formatComplianceResults(result));
     }
@@ -1201,6 +1204,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     const hasFailures = result.summary.tracks_failed > 0;
     process.exit(hasFailures ? 3 : 0);
   } catch (error) {
+    if (restoreLogs) restoreLogs();
     console.error(`\nAssessment failed: ${error.message}`);
     if (opts.debug) console.error(error.stack);
     process.exit(1);
@@ -1251,10 +1255,16 @@ async function handleStoryboardStepCmd(args) {
     ...(resolvedAuth ? { auth: { type: 'bearer', token: resolvedAuth } } : {}),
   };
 
-  const result = await runStoryboardStep(agentUrl, storyboard, stepId, options);
+  const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
+  let result;
+  try {
+    result = await runStoryboardStep(agentUrl, storyboard, stepId, options);
+  } finally {
+    if (restoreLogs) restoreLogs();
+  }
 
   if (jsonOutput) {
-    console.log(JSON.stringify(result, null, 2));
+    await writeJsonOutput(result);
   } else {
     const icon = result.passed ? '✅' : '❌';
     console.log(`\n── Step: ${result.title} ──────────────────────────────`);

--- a/test/lib/cli-json-stdout.test.js
+++ b/test/lib/cli-json-stdout.test.js
@@ -5,7 +5,7 @@ const { captureStdoutLogs, writeJsonOutput } = require('../../bin/adcp-json-stdo
 function withWritePatch(stream, fn) {
   const original = stream.write;
   const captured = [];
-  stream.write = (chunk) => {
+  stream.write = chunk => {
     captured.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
     return true;
   };
@@ -43,18 +43,17 @@ test('captureStdoutLogs restores original console methods', () => {
 });
 
 test('writeJsonOutput writes stringified JSON plus newline to stdout', async () => {
-  const stdoutText = await new Promise((resolve) => {
+  const stdoutText = await new Promise(resolve => {
     const chunks = [];
     const original = process.stdout.write;
-    process.stdout.write = (chunk) => {
+    process.stdout.write = chunk => {
       chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
       return true;
     };
-    writeJsonOutput({ a: 1, b: 'x' })
-      .finally(() => {
-        process.stdout.write = original;
-        resolve(chunks.join(''));
-      });
+    writeJsonOutput({ a: 1, b: 'x' }).finally(() => {
+      process.stdout.write = original;
+      resolve(chunks.join(''));
+    });
   });
   assert.ok(stdoutText.endsWith('\n'), 'output should end with newline');
   const parsed = JSON.parse(stdoutText);
@@ -63,18 +62,17 @@ test('writeJsonOutput writes stringified JSON plus newline to stdout', async () 
 
 test('writeJsonOutput passes strings through unchanged (already formatted)', async () => {
   const preformatted = '{\n  "already": "stringified"\n}';
-  const stdoutText = await new Promise((resolve) => {
+  const stdoutText = await new Promise(resolve => {
     const chunks = [];
     const original = process.stdout.write;
-    process.stdout.write = (chunk) => {
+    process.stdout.write = chunk => {
       chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
       return true;
     };
-    writeJsonOutput(preformatted)
-      .finally(() => {
-        process.stdout.write = original;
-        resolve(chunks.join(''));
-      });
+    writeJsonOutput(preformatted).finally(() => {
+      process.stdout.write = original;
+      resolve(chunks.join(''));
+    });
   });
   assert.strictEqual(stdoutText, preformatted + '\n');
 });

--- a/test/lib/cli-json-stdout.test.js
+++ b/test/lib/cli-json-stdout.test.js
@@ -1,0 +1,112 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { captureStdoutLogs, writeJsonOutput } = require('../../bin/adcp-json-stdout.js');
+
+function withWritePatch(stream, fn) {
+  const original = stream.write;
+  const captured = [];
+  stream.write = (chunk) => {
+    captured.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    return true;
+  };
+  try {
+    fn(captured);
+  } finally {
+    stream.write = original;
+  }
+  return captured.join('');
+}
+
+test('captureStdoutLogs forwards console.log to stderr', () => {
+  const stdoutText = withWritePatch(process.stdout, () => {
+    const stderrText = withWritePatch(process.stderr, () => {
+      const restore = captureStdoutLogs();
+      console.log('hello from log');
+      console.info('hello from info');
+      restore();
+    });
+    assert.ok(stderrText.includes('hello from log'), `stderr should have log message, got: ${stderrText}`);
+    assert.ok(stderrText.includes('hello from info'), `stderr should have info message, got: ${stderrText}`);
+  });
+  assert.strictEqual(stdoutText, '', `stdout should be empty, got: ${JSON.stringify(stdoutText)}`);
+});
+
+test('captureStdoutLogs restores original console methods', () => {
+  const origLog = console.log;
+  const origInfo = console.info;
+  const restore = captureStdoutLogs();
+  assert.notStrictEqual(console.log, origLog);
+  assert.notStrictEqual(console.info, origInfo);
+  restore();
+  assert.strictEqual(console.log, origLog);
+  assert.strictEqual(console.info, origInfo);
+});
+
+test('writeJsonOutput writes stringified JSON plus newline to stdout', async () => {
+  const stdoutText = await new Promise((resolve) => {
+    const chunks = [];
+    const original = process.stdout.write;
+    process.stdout.write = (chunk) => {
+      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      return true;
+    };
+    writeJsonOutput({ a: 1, b: 'x' })
+      .finally(() => {
+        process.stdout.write = original;
+        resolve(chunks.join(''));
+      });
+  });
+  assert.ok(stdoutText.endsWith('\n'), 'output should end with newline');
+  const parsed = JSON.parse(stdoutText);
+  assert.deepStrictEqual(parsed, { a: 1, b: 'x' });
+});
+
+test('writeJsonOutput passes strings through unchanged (already formatted)', async () => {
+  const preformatted = '{\n  "already": "stringified"\n}';
+  const stdoutText = await new Promise((resolve) => {
+    const chunks = [];
+    const original = process.stdout.write;
+    process.stdout.write = (chunk) => {
+      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+      return true;
+    };
+    writeJsonOutput(preformatted)
+      .finally(() => {
+        process.stdout.write = original;
+        resolve(chunks.join(''));
+      });
+  });
+  assert.strictEqual(stdoutText, preformatted + '\n');
+});
+
+test('stdout stays clean when libraries log during a captured region', () => {
+  const stdoutText = withWritePatch(process.stdout, () => {
+    withWritePatch(process.stderr, () => {
+      const restore = captureStdoutLogs();
+      // Simulate a library that logs progress to stdout while the CLI is
+      // about to emit its JSON result — the exact pattern #588 reports.
+      console.log('[lib] progress: step 1 of 10');
+      console.info('some info line');
+      restore();
+    });
+  });
+  assert.strictEqual(stdoutText, '', 'stdout must be empty under capture');
+});
+
+test('callers must restore on throw via try/finally to avoid permanent patch', () => {
+  // The helper itself is intentionally minimal — callers are responsible for
+  // restore. Document that contract: a thrown exception inside the captured
+  // region leaves the patch active until restore() runs, so every call site
+  // must use try/finally.
+  const origLog = console.log;
+  const restore = captureStdoutLogs();
+  try {
+    assert.notStrictEqual(console.log, origLog, 'patch is active inside region');
+    throw new Error('simulated runStoryboard failure');
+  } catch (err) {
+    assert.strictEqual(err.message, 'simulated runStoryboard failure');
+  } finally {
+    restore();
+  }
+  assert.strictEqual(console.log, origLog, 'restore() returns console.log to original after throw');
+});


### PR DESCRIPTION
## Summary

Fixes adcp-client#588 — `adcp storyboard run --json` leaked non-JSON bytes onto stdout during large compliance runs (~65KB), breaking naive parsers (`jq`, `python -c 'json.load(sys.stdin)'`).

- **Defensive stdout discipline** in `--json` mode: `captureStdoutLogs()` forwards stray `console.log` / `console.info` to stderr during the captured region; `writeJsonOutput()` emits the final payload via `process.stdout.write` + drain, so only one JSON document lands on stdout.
- Applied to `storyboard run` (both the compliance path and `--file` path), `storyboard step`, `storyboard list`, `storyboard show`, and the `--dry-run` JSON preview.
- Each captured region is wrapped in `try/finally` so a thrown `comply()` / `runStoryboard()` can't leave the `console` patch active.

Audit did not pinpoint a single deterministic leaker in the current code path — every `console.log` I traced either respected `jsonOutput` or wrote to stderr — so the fix is a defensive contract rather than a targeted patch.

## Test plan

- [x] 6 unit tests in `test/lib/cli-json-stdout.test.js` covering capture → forward, restore, `writeJsonOutput` with object + pre-formatted string, and the throw-then-restore contract.
- [x] End-to-end smoke tests against local signals agent (38KB JSON) and seller agent (417KB JSON) — both parse cleanly with `python json.load` and `jq`.
- [x] `storyboard list --json` (52 storyboards) and `storyboard show signal_marketplace --json` parse cleanly.
- [x] Non-JSON (human) output unchanged.
- [x] `npm run build` clean; existing storyboard/compliance tests (1222 cases) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)