### PR TITLE
fix(signing): structured-headers parser + bucketed replay store (#581, #582)

### DIFF
--- a/.changeset/signing-parser-structured-headers.md
+++ b/.changeset/signing-parser-structured-headers.md
@@ -1,0 +1,14 @@
+---
+'@adcp/client': patch
+---
+
+Signing: swap hand-rolled `Signature-Input` / `Signature` / `Content-Digest`
+parsers for the maintained `structured-headers` library (RFC 8941 / RFC 9651).
+Cuts ~90 lines of bespoke state-machine code and inherits the library's
+coverage of the dictionary/inner-list/token/escape corners we weren't
+exercising. AdCP-profile checks (required params, tag match, alg allowlist,
+quoted-string typing for `nonce`/`keyid`/`alg`/`tag`, integer typing for
+`created`/`expires`) stay in this package as thin typed wrappers. Signature
+byte-sequence values remain base64url-tolerant, and `Content-Digest` keeps
+its regex fallback so a malformed filler member (e.g. truncated `sha-512`)
+does not mask the `sha-256` entry we verify against. Closes #581.

--- a/.changeset/signing-replay-time-buckets.md
+++ b/.changeset/signing-replay-time-buckets.md
@@ -1,0 +1,13 @@
+---
+'@adcp/client': patch
+---
+
+Signing: time-bucket the in-memory replay store so `has()` / `insert()` /
+`isCapHit()` stay O(1) amortized on a hot keyid pinned near the per-keyid
+cap. Entries are grouped by `floor(expiresAt / bucketSizeSeconds)` (default
+60s); whole buckets are evicted in one step when their latest expiry has
+passed, eliminating the per-call O(N) filter sweep that turned a near-cap
+keyid into a quadratic DoS target. Default `maxEntriesPerKeyid` drops from
+1,000,000 → 100,000 (still ample for typical traffic; can be raised via
+`new InMemoryReplayStore({ maxEntriesPerKeyid })` for large deployments).
+The `ReplayStore` interface is unchanged. Closes #582.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "structured-headers": "^2.0.2",
         "undici": "^6.25.0",
         "yaml": "^2.7.1"
       },
@@ -6096,6 +6097,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/structured-headers": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-2.0.2.tgz",
+      "integrity": "sha512-IUul56vVHuMg2UxWhwDj9zVJE6ztYEQQkynr1FQ/NydPhivtk5+Qb2N1RS36owEFk2fNUriTguJ2R7htRObcdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18",
+        "npm": ">=6"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "email": "bugs@adcontextprotocol.org"
   },
   "dependencies": {
+    "structured-headers": "^2.0.2",
     "undici": "^6.25.0",
     "yaml": "^2.7.1"
   },

--- a/src/lib/signing/content-digest.ts
+++ b/src/lib/signing/content-digest.ts
@@ -1,6 +1,7 @@
 import { createHash, timingSafeEqual } from 'crypto';
+import { parseDictionary } from 'structured-headers';
 
-const SHA256_MEMBER_RE = /(^|[,\s])sha-256=:([A-Za-z0-9+/_-]+={0,2}):/;
+const SHA256_MEMBER_RE = /(?:^|[,\s])sha-256=:([A-Za-z0-9+/_-]+={0,2}):/;
 
 export function computeContentDigest(body: string | Uint8Array): string {
   const buf = toBuffer(body);
@@ -10,14 +11,20 @@ export function computeContentDigest(body: string | Uint8Array): string {
 
 /**
  * Extract the `sha-256` member from an RFC 9530 Content-Digest header. The
- * header is an RFC 8941 Dictionary and MAY list multiple algorithms
- * (e.g. `sha-256=:...:, sha-512=:...:`); we look up the `sha-256` member
- * without requiring any particular position.
+ * header is an RFC 8941 Dictionary and MAY list multiple algorithms; we look
+ * up the `sha-256` member without requiring any particular position.
  */
 export function parseContentDigest(header: string): Buffer | null {
-  const m = header.trim().match(SHA256_MEMBER_RE);
-  if (!m || !m[2]) return null;
-  return Buffer.from(m[2], 'base64');
+  try {
+    const dict = parseDictionary(header);
+    const entry = dict.get('sha-256');
+    if (entry && entry[0] instanceof ArrayBuffer) return Buffer.from(entry[0]);
+  } catch {
+    // Fall through: a malformed filler member (e.g. truncated sha-512) should
+    // not mask the sha-256 entry we actually verify against.
+  }
+  const m = header.match(SHA256_MEMBER_RE);
+  return m && m[1] ? Buffer.from(m[1], 'base64') : null;
 }
 
 export function contentDigestMatches(header: string, body: string | Uint8Array): boolean {

--- a/src/lib/signing/parser.ts
+++ b/src/lib/signing/parser.ts
@@ -1,12 +1,14 @@
+import { ParseError, parseDictionary, serializeInnerList, type InnerList } from 'structured-headers';
 import { RequestSignatureError } from './errors';
 
 export interface ParsedSignatureInput {
   label: string;
   components: string[];
   /**
-   * The `Signature-Input` value verbatim, minus the `<label>=` prefix. Used to
-   * reconstruct the `@signature-params` line in the signature base so verifier
-   * and signer stay byte-identical regardless of the sender's param ordering.
+   * The `Signature-Input` value verbatim for the selected label (minus the
+   * `<label>=` prefix). Re-emitted as the `@signature-params` line in the
+   * signature base so verifier and signer stay byte-identical regardless of
+   * the sender's param ordering.
    */
   signatureParamsValue: string;
   params: {
@@ -25,211 +27,111 @@ export interface ParsedSignature {
   bytes: Uint8Array;
 }
 
-const LABEL_RE = /^([A-Za-z][A-Za-z0-9_-]*)=/;
-const INTEGER_RE = /^-?\d+$/;
-const NUMERIC_PARAMS = new Set(['created', 'expires']);
 const STRING_PARAMS = new Set(['nonce', 'keyid', 'alg', 'tag']);
+const INTEGER_PARAMS = new Set(['created', 'expires']);
+
+function malformed(message: string): never {
+  throw new RequestSignatureError('request_signature_header_malformed', 1, message);
+}
 
 export function parseSignatureInput(headerValue: string): ParsedSignatureInput {
-  const inputs = splitTopLevelLabels(headerValue, 'Signature-Input');
-  let selected: string | undefined;
-  for (const entry of inputs) {
-    const labelMatch = entry.match(LABEL_RE);
-    if (labelMatch && labelMatch[1] === 'sig1') {
-      selected = entry;
-      break;
+  let dict;
+  try {
+    dict = parseDictionary(headerValue);
+  } catch (e: unknown) {
+    if (e instanceof ParseError) malformed(`Signature-Input header is malformed: ${e.message}`);
+    throw e;
+  }
+  if (dict.size === 0) malformed('Signature-Input header is empty');
+  const label = dict.has('sig1') ? 'sig1' : (dict.keys().next().value as string);
+  const entry = dict.get(label)!;
+  if (!isInnerList(entry)) {
+    malformed('Signature-Input value must be a parenthesized component list');
+  }
+  const components: string[] = [];
+  for (const [bare] of entry[0]) {
+    if (typeof bare !== 'string') malformed('Signature-Input components must all be strings');
+    components.push(bare);
+  }
+  const params: Record<string, string | number> = {};
+  for (const [key, value] of entry[1]) {
+    if (STRING_PARAMS.has(key)) {
+      if (typeof value !== 'string') {
+        malformed(`Signature parameter "${key}" must be a quoted string`);
+      }
+      params[key] = value;
+    } else if (INTEGER_PARAMS.has(key)) {
+      if (typeof value !== 'number' || !Number.isInteger(value)) {
+        malformed(`Signature parameter "${key}" must be an integer`);
+      }
+      params[key] = value;
+    } else if (typeof value === 'string' || typeof value === 'number') {
+      params[key] = value;
     }
   }
-  if (!selected) selected = inputs[0];
-  if (!selected) {
-    throw new RequestSignatureError('request_signature_header_malformed', 1, 'Signature-Input header is empty');
-  }
-  const labelMatch = selected.match(LABEL_RE);
-  if (!labelMatch || !labelMatch[1]) {
-    throw new RequestSignatureError(
-      'request_signature_header_malformed',
-      1,
-      'Signature-Input header missing label prefix'
-    );
-  }
-  const label = labelMatch[1];
-  const remainder = selected.slice(labelMatch[0].length);
-  const openParen = remainder.indexOf('(');
-  const closeParen = remainder.indexOf(')');
-  if (openParen !== 0 || closeParen < 0) {
-    throw new RequestSignatureError(
-      'request_signature_header_malformed',
-      1,
-      'Signature-Input value must begin with a parenthesized component list'
-    );
-  }
-  const componentsRaw = remainder.slice(1, closeParen);
-  const components: string[] = [];
-  const compRe = /"([^"]+)"/g;
-  let m: RegExpExecArray | null;
-  while ((m = compRe.exec(componentsRaw)) !== null) {
-    if (m[1]) components.push(m[1]);
-  }
-  const paramsRaw = remainder.slice(closeParen + 1);
-  const params = parseParams(paramsRaw);
-  return { label, components, signatureParamsValue: remainder, params };
+  return {
+    label,
+    components,
+    signatureParamsValue: serializeInnerList(entry),
+    params: params as ParsedSignatureInput['params'],
+  };
 }
 
 export function parseSignature(headerValue: string, expectedLabel: string): ParsedSignature {
-  const entries = splitTopLevelLabels(headerValue, 'Signature');
-  for (const raw of entries) {
-    const labelMatch = raw.match(LABEL_RE);
-    if (!labelMatch) continue;
-    const label = labelMatch[1];
-    if (label !== expectedLabel) continue;
-    const rest = raw.slice(labelMatch[0].length).trim();
-    // sf-binary values are ":<base64>:", optionally followed by `;param=value` pairs.
-    if (!rest.startsWith(':')) {
-      throw new RequestSignatureError(
-        'request_signature_header_malformed',
-        1,
-        'Signature value must begin with a : byte-sequence delimiter'
-      );
+  let dict;
+  try {
+    // RFC 9421 signatures commonly use base64url (`-`/`_`); RFC 8941 byte
+    // sequences only permit standard base64. Translate the characters inside
+    // byte-sequence delimiters before handing to the strict parser.
+    dict = parseDictionary(normalizeByteSequenceBase64(headerValue));
+  } catch (e: unknown) {
+    if (e instanceof ParseError) {
+      if (/base64/i.test(e.message)) malformed('Signature value contains non-base64 characters');
+      malformed(`Signature header is malformed: ${e.message}`);
     }
-    const closeIdx = rest.indexOf(':', 1);
-    if (closeIdx < 0) {
-      throw new RequestSignatureError(
-        'request_signature_header_malformed',
-        1,
-        'Signature value is missing the closing : byte-sequence delimiter'
-      );
-    }
-    const b64 = rest.slice(1, closeIdx);
-    if (!isValidBase64(b64)) {
-      throw new RequestSignatureError(
-        'request_signature_header_malformed',
-        1,
-        'Signature value contains non-base64 characters'
-      );
-    }
-    const bytes = Buffer.from(b64, 'base64');
-    return { label: label as string, bytes: new Uint8Array(bytes) };
+    throw e;
   }
-  throw new RequestSignatureError(
-    'request_signature_header_malformed',
-    1,
-    `Signature header does not contain label "${expectedLabel}"`
-  );
+  const entry = dict.get(expectedLabel);
+  if (!entry) {
+    malformed(`Signature header does not contain label "${expectedLabel}"`);
+  }
+  if (!(entry[0] instanceof ArrayBuffer)) {
+    malformed(`Signature value for "${expectedLabel}" must be a byte sequence`);
+  }
+  return { label: expectedLabel, bytes: new Uint8Array(entry[0].slice(0)) };
 }
 
-function splitTopLevelLabels(headerValue: string, headerName: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
+function isInnerList(entry: unknown): entry is InnerList {
+  return Array.isArray(entry) && Array.isArray((entry as unknown[])[0]);
+}
+
+function normalizeByteSequenceBase64(input: string): string {
+  let out = '';
   let inString = false;
-  let buf = '';
-  for (let i = 0; i < headerValue.length; i++) {
-    const ch = headerValue[i];
+  let inBytes = false;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]!;
     if (inString) {
-      // RFC 8941 §3.3.3: inside a string, `\` introduces a literal-escape
-      // that consumes the following byte (either `\` or `"`). Track the pair
-      // explicitly so `\\"` doesn't prematurely close the string.
-      if (ch === '\\') {
-        const next = headerValue[i + 1];
-        if (next === undefined) {
-          throw new RequestSignatureError(
-            'request_signature_header_malformed',
-            1,
-            `${headerName} header ends mid-escape`
-          );
-        }
-        buf += ch + next;
-        i += 1;
+      out += ch;
+      if (ch === '\\' && i + 1 < input.length) {
+        out += input[++i]!;
         continue;
       }
-      buf += ch;
       if (ch === '"') inString = false;
       continue;
     }
-    if (ch === '"') {
-      inString = true;
-      buf += ch;
+    if (inBytes) {
+      if (ch === ':') {
+        inBytes = false;
+        out += ch;
+      } else if (ch === '-') out += '+';
+      else if (ch === '_') out += '/';
+      else out += ch;
       continue;
     }
-    if (ch === '(') depth++;
-    else if (ch === ')') depth--;
-    if (ch === ',' && depth === 0) {
-      parts.push(buf.trim());
-      buf = '';
-      continue;
-    }
-    buf += ch;
+    if (ch === '"') inString = true;
+    else if (ch === ':') inBytes = true;
+    out += ch;
   }
-  if (inString) {
-    throw new RequestSignatureError(
-      'request_signature_header_malformed',
-      1,
-      `${headerName} header has an unterminated quoted string`
-    );
-  }
-  if (buf.trim().length) parts.push(buf.trim());
-  if (parts.length === 0) {
-    throw new RequestSignatureError('request_signature_header_malformed', 1, `${headerName} header is empty`);
-  }
-  return parts;
-}
-
-function parseParams(raw: string): ParsedSignatureInput['params'] {
-  const params: Record<string, string | number> = {};
-  for (const pair of raw.split(';')) {
-    if (!pair) continue;
-    const eq = pair.indexOf('=');
-    if (eq < 0) {
-      throw new RequestSignatureError(
-        'request_signature_header_malformed',
-        1,
-        `Malformed signature parameter (no '=') in "${pair}"`
-      );
-    }
-    const key = pair.slice(0, eq).trim();
-    const value = pair.slice(eq + 1).trim();
-    if (value === '') {
-      throw new RequestSignatureError(
-        'request_signature_header_malformed',
-        1,
-        `Signature parameter "${key}" has an empty value`
-      );
-    }
-    if (STRING_PARAMS.has(key)) {
-      if (!value.startsWith('"') || !value.endsWith('"') || value.length < 2) {
-        throw new RequestSignatureError(
-          'request_signature_header_malformed',
-          1,
-          `Signature parameter "${key}" must be a quoted string`
-        );
-      }
-      params[key] = value.slice(1, -1);
-    } else if (NUMERIC_PARAMS.has(key)) {
-      if (!INTEGER_RE.test(value)) {
-        throw new RequestSignatureError(
-          'request_signature_header_malformed',
-          1,
-          `Signature parameter "${key}" must be an integer`
-        );
-      }
-      params[key] = Number(value);
-    } else if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
-      params[key] = value.slice(1, -1);
-    } else if (INTEGER_RE.test(value)) {
-      params[key] = Number(value);
-    } else {
-      throw new RequestSignatureError(
-        'request_signature_header_malformed',
-        1,
-        `Signature parameter "${key}" is neither a quoted string nor an integer`
-      );
-    }
-  }
-  return params as ParsedSignatureInput['params'];
-}
-
-function isValidBase64(input: string): boolean {
-  // Accept standard base64 + base64url, with or without padding; reject any
-  // other characters (incl. whitespace) so truncated signatures don't silently
-  // decode to a short-but-"valid" byte buffer.
-  return /^[A-Za-z0-9+/_-]*={0,2}$/.test(input);
+  return out;
 }

--- a/src/lib/signing/replay.ts
+++ b/src/lib/signing/replay.ts
@@ -6,22 +6,43 @@ export interface ReplayStore {
   insert(keyid: string, nonce: string, ttlSeconds: number, now: number): Promise<ReplayInsertResult>;
 }
 
-interface Entry {
-  nonce: string;
-  expiresAt: number;
+export interface InMemoryReplayStoreOptions {
+  /**
+   * Maximum retained (unexpired) nonces per keyid before `insert` returns
+   * `rate_abuse`. Defaults to 100,000 — enough headroom for real traffic
+   * without turning the verifier into a DoS amplifier when a hot keyid sits
+   * near the cap. See issue #582.
+   */
+  maxEntriesPerKeyid?: number;
+  /**
+   * Prune granularity in seconds. Entries are grouped by
+   * `floor(expiresAt / bucketSizeSeconds)`; whole buckets are evicted in one
+   * step when their latest expiry has passed. Keeps amortized has/insert/
+   * isCapHit at O(1) per keyid regardless of entries-per-keyid.
+   */
+  bucketSizeSeconds?: number;
 }
 
-export interface InMemoryReplayStoreOptions {
-  maxEntriesPerKeyid?: number;
+interface Bucket {
+  nonces: Set<string>;
+  latestExpiry: number;
+}
+
+interface KeyState {
+  nonces: Set<string>;
+  buckets: Map<number, Bucket>;
+  lastPrunedBucket: number;
 }
 
 export class InMemoryReplayStore implements ReplayStore {
-  private readonly entries = new Map<string, Entry[]>();
+  private readonly state = new Map<string, KeyState>();
   private readonly capPerKeyid: number;
+  private readonly bucketSize: number;
   private readonly forcedCapHit = new Set<string>();
 
   constructor(options: InMemoryReplayStoreOptions = {}) {
-    this.capPerKeyid = options.maxEntriesPerKeyid ?? 1_000_000;
+    this.capPerKeyid = options.maxEntriesPerKeyid ?? 100_000;
+    this.bucketSize = options.bucketSizeSeconds ?? 60;
   }
 
   setCapHitForTesting(keyid: string): void {
@@ -29,42 +50,67 @@ export class InMemoryReplayStore implements ReplayStore {
   }
 
   async has(keyid: string, nonce: string, now: number): Promise<boolean> {
-    this.prune(keyid, now);
-    const list = this.entries.get(keyid);
-    if (!list) return false;
-    return list.some(e => e.nonce === nonce);
+    const state = this.state.get(keyid);
+    if (!state) return false;
+    this.prune(state, now);
+    return state.nonces.has(nonce);
   }
 
   async isCapHit(keyid: string, now: number): Promise<boolean> {
     if (this.forcedCapHit.has(keyid)) return true;
-    this.prune(keyid, now);
-    const list = this.entries.get(keyid);
-    return (list?.length ?? 0) >= this.capPerKeyid;
+    const state = this.state.get(keyid);
+    if (!state) return false;
+    this.prune(state, now);
+    return state.nonces.size >= this.capPerKeyid;
   }
 
   async insert(keyid: string, nonce: string, ttlSeconds: number, now: number): Promise<ReplayInsertResult> {
-    this.prune(keyid, now);
-    const list = this.entries.get(keyid) ?? [];
-    if (list.some(e => e.nonce === nonce)) return 'replayed';
-    if (this.forcedCapHit.has(keyid) || list.length >= this.capPerKeyid) {
-      return 'rate_abuse';
-    }
-    list.push({ nonce, expiresAt: now + ttlSeconds });
-    this.entries.set(keyid, list);
+    const state = this.getOrCreate(keyid);
+    this.prune(state, now);
+    if (state.nonces.has(nonce)) return 'replayed';
+    if (this.forcedCapHit.has(keyid) || state.nonces.size >= this.capPerKeyid) return 'rate_abuse';
+    this.insertEntry(state, nonce, now + ttlSeconds);
     return 'ok';
   }
 
   preload(keyid: string, nonce: string, ttlSeconds: number, now: number): void {
-    const list = this.entries.get(keyid) ?? [];
-    list.push({ nonce, expiresAt: now + ttlSeconds });
-    this.entries.set(keyid, list);
+    this.insertEntry(this.getOrCreate(keyid), nonce, now + ttlSeconds);
   }
 
-  private prune(keyid: string, now: number): void {
-    const list = this.entries.get(keyid);
-    if (!list) return;
-    const alive = list.filter(e => e.expiresAt > now);
-    if (alive.length === 0) this.entries.delete(keyid);
-    else this.entries.set(keyid, alive);
+  private getOrCreate(keyid: string): KeyState {
+    let state = this.state.get(keyid);
+    if (!state) {
+      state = { nonces: new Set(), buckets: new Map(), lastPrunedBucket: Number.NEGATIVE_INFINITY };
+      this.state.set(keyid, state);
+    }
+    return state;
+  }
+
+  private insertEntry(state: KeyState, nonce: string, expiresAt: number): void {
+    const bk = Math.floor(expiresAt / this.bucketSize);
+    let bucket = state.buckets.get(bk);
+    if (!bucket) {
+      bucket = { nonces: new Set(), latestExpiry: expiresAt };
+      state.buckets.set(bk, bucket);
+    } else if (expiresAt > bucket.latestExpiry) {
+      bucket.latestExpiry = expiresAt;
+    }
+    bucket.nonces.add(nonce);
+    state.nonces.add(nonce);
+  }
+
+  private prune(state: KeyState, now: number): void {
+    // Amortize: run at most once per bucket tick per keyid. Whole buckets are
+    // evicted — never iterate per-entry — so pruning cost is O(#expired
+    // buckets), independent of entries-per-keyid.
+    const currentBucket = Math.floor(now / this.bucketSize);
+    if (currentBucket === state.lastPrunedBucket) return;
+    state.lastPrunedBucket = currentBucket;
+    for (const [bk, bucket] of state.buckets) {
+      if (bucket.latestExpiry <= now) {
+        for (const nonce of bucket.nonces) state.nonces.delete(nonce);
+        state.buckets.delete(bk);
+      }
+    }
   }
 }

--- a/test/request-signing-replay-perf.test.js
+++ b/test/request-signing-replay-perf.test.js
@@ -1,0 +1,84 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { InMemoryReplayStore } = require('../dist/lib/signing/index.js');
+
+// Issue #582: steady-state has()/insert() latency must NOT grow linearly with
+// the entries-per-keyid count. The previous naive filter-on-every-call pruner
+// was O(N), turning a hot keyid pinned near the cap into a quadratic DoS
+// target. The time-bucketed store evicts whole buckets at a time, so
+// amortized cost is O(1) per op.
+//
+// Timing on CI runners is noisy; we cap the growth ratio generously (<4x) and
+// take the median of multiple measurement windows.
+
+function timeBatch(fn, iterations) {
+  const samples = [];
+  for (let run = 0; run < 5; run++) {
+    const start = process.hrtime.bigint();
+    for (let i = 0; i < iterations; i++) fn(i);
+    const elapsed = Number(process.hrtime.bigint() - start);
+    samples.push(elapsed / iterations);
+  }
+  samples.sort((a, b) => a - b);
+  return samples[Math.floor(samples.length / 2)];
+}
+
+test('InMemoryReplayStore: has() stays sub-linear as entries-per-keyid grows', () => {
+  const now = 1_000_000;
+  const keyid = 'hotkey';
+  const ttl = 300;
+
+  const smallStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 1_000_000 });
+  for (let i = 0; i < 1_000; i++) smallStore.preload(keyid, `nonce-s-${i}`, ttl, now);
+
+  const bigStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 1_000_000 });
+  for (let i = 0; i < 50_000; i++) bigStore.preload(keyid, `nonce-b-${i}`, ttl, now);
+
+  // has() at now+10 — well within the window, so no bucket eviction runs.
+  const smallNs = timeBatch(i => smallStore.has(keyid, `nonce-s-${i % 1_000}`, now + 10), 10_000);
+  const bigNs = timeBatch(i => bigStore.has(keyid, `nonce-b-${i % 50_000}`, now + 10), 10_000);
+
+  // 50x more entries → at most 4x per-op latency. Linear behaviour would be
+  // ~50x. The fudge factor absorbs GC + measurement jitter on CI.
+  const ratio = bigNs / smallNs;
+  assert.ok(
+    ratio < 4,
+    `has() latency should stay sub-linear as entries grow 50x; measured ratio=${ratio.toFixed(2)} (small=${smallNs.toFixed(0)}ns, big=${bigNs.toFixed(0)}ns)`
+  );
+});
+
+test('InMemoryReplayStore: insert() stays sub-linear as entries-per-keyid grows', () => {
+  const now = 1_000_000;
+  const ttl = 300;
+
+  const smallStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 10_000_000 });
+  for (let i = 0; i < 1_000; i++) smallStore.preload('k1', `seed-s-${i}`, ttl, now);
+
+  const bigStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 10_000_000 });
+  for (let i = 0; i < 50_000; i++) bigStore.preload('k1', `seed-b-${i}`, ttl, now);
+
+  let sCounter = 0;
+  const smallNs = timeBatch(() => smallStore.insert('k1', `fresh-s-${sCounter++}`, ttl, now + 10), 2_000);
+  let bCounter = 0;
+  const bigNs = timeBatch(() => bigStore.insert('k1', `fresh-b-${bCounter++}`, ttl, now + 10), 2_000);
+
+  const ratio = bigNs / smallNs;
+  assert.ok(
+    ratio < 4,
+    `insert() latency should stay sub-linear as entries grow 50x; measured ratio=${ratio.toFixed(2)} (small=${smallNs.toFixed(0)}ns, big=${bigNs.toFixed(0)}ns)`
+  );
+});
+
+test('InMemoryReplayStore: bucket eviction releases memory when entries expire', async () => {
+  const store = new InMemoryReplayStore({ maxEntriesPerKeyid: 1_000_000, bucketSizeSeconds: 60 });
+  const keyid = 'k1';
+
+  // Insert 10k entries that all expire at now+60 (single bucket).
+  for (let i = 0; i < 10_000; i++) store.preload(keyid, `old-${i}`, 60, 1_000_000);
+  assert.strictEqual(await store.isCapHit(keyid, 1_000_000), false);
+  assert.strictEqual(await store.has(keyid, 'old-0', 1_000_059), true);
+
+  // Advance past the bucket's latest expiry. The next call prunes the whole
+  // bucket; old-0 must be gone.
+  assert.strictEqual(await store.has(keyid, 'old-0', 1_000_121), false);
+});

--- a/test/request-signing-review-fixes.test.js
+++ b/test/request-signing-review-fixes.test.js
@@ -46,10 +46,7 @@ describe('parser hardening (security/code-review findings)', () => {
         parseSignatureInput(
           'sig1=("@method" "@target-uri" "@authority");created=;expires=1776521100;nonce="x";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
         ),
-      err =>
-        err instanceof RequestSignatureError &&
-        err.code === 'request_signature_header_malformed' &&
-        /empty value|empty/i.test(err.message)
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_header_malformed'
     );
   });
 
@@ -72,6 +69,16 @@ describe('parser hardening (security/code-review findings)', () => {
         parseSignatureInput(
           'sig1=("@method" "@target-uri" "@authority");created=1e5;expires=2;nonce="x";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
         ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_header_malformed'
+    );
+  });
+
+  test('decimal numeric param (1.5) is rejected — created/expires must be integers', () => {
+    assert.throws(
+      () =>
+        parseSignatureInput(
+          'sig1=("@method" "@target-uri" "@authority");created=1.5;expires=2;nonce="x";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
+        ),
       err =>
         err instanceof RequestSignatureError &&
         err.code === 'request_signature_header_malformed' &&
@@ -80,10 +87,12 @@ describe('parser hardening (security/code-review findings)', () => {
   });
 
   test('escaped quote inside a quoted param does not terminate the string', () => {
+    // RFC 8941 §3.3.3: backslash-escapes decode, so the literal `nonce="a\"b"`
+    // on the wire surfaces as the logical value `a"b` after parsing.
     const parsed = parseSignatureInput(
       'sig1=("@method" "@target-uri" "@authority");created=1;expires=2;nonce="a\\"b";keyid="k";alg="ed25519";tag="adcp/request-signing/v1"'
     );
-    assert.strictEqual(parsed.params.nonce, 'a\\"b');
+    assert.strictEqual(parsed.params.nonce, 'a"b');
   });
 
   test('Signature-Input with params in non-canonical order still produces byte-identical base', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,9 @@
     "declarationMap": true,
     "sourceMap": true,
     "moduleResolution": "node",
+    "paths": {
+      "structured-headers": ["./node_modules/structured-headers/cjs/index.d.cts"]
+    },
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true


### PR DESCRIPTION
Closes #581 (parser swap). Closes #582 (replay store).

## #581 — swap to `structured-headers`

Hand-rolled `Signature-Input` / `Signature` / `Content-Digest` parsers replaced with the maintained `structured-headers` library (RFC 8941 / RFC 9651).

- ~90 lines of bespoke state-machine code removed (`src/lib/signing/parser.ts` + `content-digest.ts`).
- AdCP-profile checks kept as thin typed wrappers: required-param presence, `tag` match, `alg` allowlist, quoted-string typing for `nonce`/`keyid`/`alg`/`tag`, integer typing for `created`/`expires`.
- Signature byte-sequence values stay base64url-tolerant — we normalise `-`/`_` → `+`/`/` only inside `:…:` delimiters before handing to the strict SF parser.
- `Content-Digest` keeps a regex fallback so a malformed filler member (e.g. truncated `sha-512`) does not mask the `sha-256` entry we actually verify against.
- `signatureParamsValue` is now `serializeInnerList(entry)` instead of raw substring splicing — verified byte-identical on the reordered-params review-hardening vector.
- Escape decoding now follows RFC 8941 §3.3.3 (the old parser stored the literal `\"` escape sequence, the library decodes to `"`). The one escape-handling test assertion updated to match correct behaviour.

## #582 — time-bucketed replay store

`InMemoryReplayStore` now groups entries by `floor(expiresAt / bucketSizeSeconds)` (default 60s). Whole buckets evict in one step when their latest expiry has passed, eliminating the per-call O(N) filter sweep that turned a near-cap keyid into a quadratic DoS target.

- `has()` / `insert()` / `isCapHit()` are O(1) amortized per keyid regardless of entries-per-keyid.
- Prune runs at most once per bucket tick per keyid.
- Default `maxEntriesPerKeyid`: 1,000,000 → **100,000** (still ample; `new InMemoryReplayStore({ maxEntriesPerKeyid })` overrides).
- `ReplayStore` interface unchanged.

## Test plan
- [x] All 28 RFC 9421 conformance vectors pass
- [x] `test/request-signing-review-fixes.test.js` passes (with 2 assertion tweaks for the correct RFC 8941 escape-decoding + library-surfaced parse-error messages; intent preserved, + a new `created=1.5` integer-rejection assertion)
- [x] `test/request-signing-e2e.test.js` passes
- [x] New `test/request-signing-replay-perf.test.js` asserts sub-linear (< 4×) growth of `has()` / `insert()` latency when entries-per-keyid grows 50×, plus a bucket-eviction correctness check
- [x] Full `npm test` green (3601 passing)
- [x] Changesets added (two `patch` entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)