### PR TITLE
feat: RFC 9421 request-signing conformance grader (#585)

### DIFF
--- a/.changeset/request-signing-grader-review-fixes.md
+++ b/.changeset/request-signing-grader-review-fixes.md
@@ -1,0 +1,88 @@
+---
+'@adcp/client': minor
+---
+
+Request-signing conformance grader — review fixes.
+
+Addresses findings from the six-agent expert review of PR #600. Behavioral
+changes:
+
+**Correctness**
+
+- Skipped vectors now report as `skipped: true` through the storyboard
+  runner instead of being scored as failures (previously `probe-dispatch.ts`
+  set `HttpProbeResult.error` on skip, which the runner's `fetchOk` check
+  treated as failed). Requires a new `HttpProbeResult.skipped` flag and
+  `executeProbeStep` branch that bypasses validations for skipped probes.
+- Synthesis failure now surfaces as a failing `synthesis_error` phase in
+  the storyboard rather than a silent empty-phase fallback — CI pipelines
+  would have seen green for an infrastructural bug.
+- Vector 010 (`content-digest-mismatch`) now tests the intended invariant:
+  the signer commits a wrong `Content-Digest` value (zero-byte digest) in
+  the signature base, and the verifier's step-11 recompute fails. Previous
+  mutation (append space to body post-sign) exercised a different bug
+  class (body-tampered-in-transit) and would mask lying-signer detection
+  in verifiers that recompute digest from the received body.
+- Vector 009 (`key-purpose-invalid`) now honors the vector's pinned
+  `jwks_ref` (`test-gov-2026`) directly instead of inferring a non-request-
+  signing key from the keyset.
+
+**Safety (live side effects)**
+
+- Vectors 016 (`replay_window`) and 020 (`rate_abuse`) now auto-skip
+  against non-sandbox endpoints unless the operator passes
+  `allowLiveSideEffects: true`. The contract YAML's `endpoint_scope:
+  sandbox` declaration satisfies the gate when present. Prevents
+  accidental live `create_media_buy` creation or replay-cache flooding
+  against production agents.
+- `GradeReport.endpoint_scope_warning` → renamed to `live_endpoint_warning`
+  and inverted to be `true` when the endpoint is NOT declared sandbox
+  (the dangerous case). Prior semantics were misleading: the field read
+  as "sandbox is bad."
+
+**WWW-Authenticate parser hardening**
+
+- `extractSignatureErrorCode` now constrains returned codes to the
+  `[a-z0-9_]+` alphabet, rejecting malformed / adversarial values from
+  untrusted agent headers. Downstream diagnostic strings and LLM-consumption
+  paths are safe from smuggled content.
+- `splitChallenges` now tracks quote state so adversarial `error="foo,
+  Bar baz"` doesn't spuriously split mid-value.
+
+**DX / ergonomics**
+
+- New CLI: `adcp grade request-signing <agent-url>` with
+  `--skip-rate-abuse`, `--rate-abuse-cap`, `--only`, `--skip`,
+  `--allow-live-side-effects`, `--allow-http`, `--json`. Human-readable
+  table output by default; exit code 0 on pass, 1 on fail, 2 on
+  configuration error.
+- `GradeReport` now carries `passed_count` / `failed_count` /
+  `skipped_count` at the top level — no more client-side `reduce()` to
+  enumerate.
+- `GradeOptions.onlyVectors: string[]` filters to a subset of vector IDs
+  (all others auto-skip) — simplifies isolated regression tests and
+  replaces the three hand-maintained 19-entry skip arrays in the test
+  suite.
+- Barrel (`index.ts`) is now grouped as "Public API" / "Storyboard-runner
+  hooks" / "Advanced harness building blocks" with a top-level module
+  JSDoc and usage snippet.
+- `BuildOptions.baseUrl` now prefixes the agent's mount path to the
+  vector path, so agents served at `/v1/adcp/*` (not `/adcp/*`) receive
+  requests at the right path.
+
+**Hygiene**
+
+- `ContractId` (`replay_window | revocation | rate_abuse`) is now a single
+  source of truth in `types.ts` (was duplicated across three files).
+- `AdcpJsonWebKey.d` is now an explicit optional field with JSDoc
+  explaining its role instead of flowing through the index signature.
+- `loadRequestSigningVectors` memoizes per-cacheDir. Previously every
+  `gradeOneVector` call re-parsed 28 JSON fixtures + keys.json + YAML
+  test-kit (compliance cache is immutable during a process lifetime).
+- New test util `test/utils/reference-verifier.js` extracts the
+  `startReferenceVerifier` + `makeExpressShim` pattern that previously
+  appeared verbatim in three test files.
+- Dispatch wire-up test: `runStoryboardStep` with a synthesized
+  `request_signing_probe` step now has a dedicated test so someone
+  removing the task from `PROBE_TASKS` or flipping the dispatch condition
+  in `runner.ts` gets caught by CI.

--- a/.changeset/request-signing-grader-slice-1.md
+++ b/.changeset/request-signing-grader-slice-1.md
@@ -1,0 +1,25 @@
+---
+'@adcp/client': minor
+---
+
+Request-signing conformance grader — Slice 1: vector loader + adversarial builder.
+
+Internal module at `src/lib/testing/storyboard/request-signing/` that consumes the
+RFC 9421 conformance vectors and test keypairs shipped in
+`compliance/cache/{version}/test-vectors/request-signing/`. Walks the positive/
+and negative/ directories, parses each fixture into typed `PositiveVector` /
+`NegativeVector` values (including the `requires_contract` field for stateful
+vectors 016/017/020 once upstream adcp#2353 lands in `latest.tgz`), and loads
+`keys.json` with the private scalars needed for dynamic re-signing.
+
+Adversarial builder registers one mutation per negative vector (20 total). Each
+mutation starts from a freshly-signed baseline via `src/lib/signing/signer.ts`
+and applies the single documented mutation — wrong tag, expired window,
+missing covered component, content-digest mismatch, malformed Signature-Input,
+etc. — so the grader can send real requests to a live verifier rather than
+replaying stale `reference_now` signatures. Stateful vectors (016 replay, 017
+revoked, 020 rate-abuse) produce a single well-formed request; the storyboard
+runner will orchestrate repeat/flood/revoked-keyid behavior around them per
+the signed-requests-runner test-kit contract (coming in Slice 2).
+
+Not yet public API — consumed by the in-progress storyboard runner phase.

--- a/.changeset/request-signing-grader-slice-2.md
+++ b/.changeset/request-signing-grader-slice-2.md
@@ -1,0 +1,45 @@
+---
+'@adcp/client': minor
+---
+
+Request-signing conformance grader — Slice 2: standalone grader orchestrator
+and end-to-end smoke test against the reference verifier.
+
+New module surface under `src/lib/testing/storyboard/request-signing/`:
+
+- **Test-kit loader** (`test-kit.ts`): parses the signed-requests-runner harness
+  contract YAML shipped by adcp#2353. Typed access to the runner's signing
+  keyids, replay-window contract, revocation contract, and rate-abuse contract
+  (with production-cap vs grading-cap fields kept separate per the spec).
+- **HTTP probe** (`probe.ts`): sends a `SignedHttpRequest` to the agent and
+  captures status + `WWW-Authenticate` error code. Reuses the SSRF guards
+  from `storyboard/probes.ts` (DNS pin, private-IP block, IMDS always-block,
+  64 KiB body cap, 10 s timeout, `redirect: 'manual'`).
+- **Grader orchestrator** (`grader.ts`): `gradeRequestSigning(agentUrl, options)`
+  runs all 28 conformance vectors in black-box mode. Handles the stateful
+  contracts natively — vector 016 uses the replay-window repeat-request
+  behavior, 017 uses the pre-revoked keyid, 020 fills the per-keyid cap then
+  probes cap+1 — and emits per-vector diagnostics keyed to the spec error
+  codes. `skipRateAbuse`, `rateAbuseCap`, and `skipVectors` options let
+  operators tune to their agent's configuration.
+- **Base-URL retargeting** in the builder: the vectors target
+  `seller.example.com`, but real agents live elsewhere. `BuildOptions.baseUrl`
+  swaps the origin into the agent's URL before signing so signatures match
+  the URL the grader actually POSTs to.
+
+Integration test at `test/request-signing-grader-e2e.test.js` stands up a
+reference verifier (the #587 Express middleware) on localhost and grades
+against it. Covers the capability-either profile on 17 non-stateful negatives
++ replay/revocation + 8 positives, plus dedicated tests for the
+content-digest `required`/`forbidden` capability profiles and the rate-abuse
+contract with matched caps. Verifies the full loader → builder → probe →
+grader pipeline catches the step-ordering guarantees of the checklist (9/9a
+before 10, 12 before 13) and the WWW-Authenticate byte-for-byte match.
+
+Storyboard-runner integration (synthesizing per-vector steps into the YAML
+runner's phase structure) is deferred to Slice 3 so it can land as a
+focused change touching `runner.ts` / `probes.ts` / `compliance.ts`.
+
+Not yet a CLI entry point — consume via `loadRequestSigningVectors` /
+`gradeRequestSigning` from
+`@adcp/client/testing/storyboard/request-signing` (internal module path).

--- a/.changeset/request-signing-grader-slice-3.md
+++ b/.changeset/request-signing-grader-slice-3.md
@@ -1,0 +1,46 @@
+---
+'@adcp/client': minor
+---
+
+Request-signing conformance grader — Slice 3: storyboard-runner integration.
+
+The signed-requests specialism YAML declares `positive_vectors` and
+`negative_vectors` phases whose steps are synthesized at runtime from the
+test-vector fixtures (the spec deliberately avoids duplicating fixture data
+in YAML). This change wires those synthesized steps into the storyboard
+runner so `get_adcp_capabilities` → run-storyboard pipelines grade an agent's
+RFC 9421 verifier as part of a normal compliance run.
+
+Changes:
+
+- **Synthesizer** (`storyboard/request-signing/synthesize.ts`): expands
+  `positive_vectors` / `negative_vectors` phases with one
+  `request_signing_probe` step per vector on disk. Step IDs follow a
+  `positive-<vector>` / `negative-<vector>` convention that the dispatch
+  helper decodes. `skipVectors` option filters at synthesis time.
+- **Compliance loader** hooks synthesis into `loadBundleStoryboards` so
+  callers (runner, CLI tools, reporting) see a fully populated storyboard.
+  Falls back to the unsynthesized form with a warning if the compliance
+  cache is missing vectors.
+- **Loader** (`storyboard/loader.ts`) now tolerates phases with no `steps:`
+  key — the signed-requests YAML is the first specialism to ship such
+  phases.
+- **Probe dispatch** (`storyboard/request-signing/probe-dispatch.ts`): new
+  `request_signing_probe` entry in `PROBE_TASKS`. The dispatcher decodes
+  the step ID, runs the grader's per-vector logic
+  (`gradeOneVector`), and maps the `VectorGradeResult` to an
+  `HttpProbeResult`-shaped return so the existing validation pipeline
+  (`http_status`, `http_status_in`) works unchanged.
+- **StoryboardRunOptions** gains a `request_signing?` block —
+  `skipRateAbuse`, `rateAbuseCap`, `skipVectors` — so operators can tune
+  the grader without forking the runner.
+
+Integration tests at `test/request-signing-runner-integration.test.js`:
+verify synthesis produces the right step count/IDs, exercise the probe
+dispatch against a reference verifier (positive accept, negative reject
+with matching WWW-Authenticate, skip-rate-abuse, skip-vectors, unknown
+step ID, capability-profile mismatch surfaces as a probe error).
+
+With this slice, `compliance/specialisms/signed-requests/index.yaml` runs
+end-to-end through the existing storyboard runner — no specialism-specific
+entry point required.

--- a/.changeset/request-signing-grader-slice-4.md
+++ b/.changeset/request-signing-grader-slice-4.md
@@ -1,0 +1,65 @@
+---
+'@adcp/client': minor
+---
+
+Request-signing grader — Slice 4: signed test agent + framework wiring for
+`request_signing` / `specialisms` capability advertisement.
+
+**Framework — `AdcpCapabilitiesConfig`**
+
+`createAdcpServer({ capabilities: { … } })` now accepts two fields previously
+unreachable from the framework:
+
+- `request_signing` — the RFC 9421 verifier capability block
+  (`supported`, `covers_content_digest`, `required_for`, `warn_for`,
+  `supported_for`). Emitted verbatim in `get_adcp_capabilities.request_signing`.
+- `specialisms` — specialism claim list (e.g. `['signed-requests']`).
+  Each entry maps to a compliance bundle under
+  `/compliance/{version}/specialisms/{id}/`; the AAO runner resolves and
+  executes the matching storyboards.
+
+Without these, agents wanting to declare signed-requests support had to
+fork the capability-assembly path. Now it's one-liner capability config.
+
+**Framework — `serve.preTransport` hook**
+
+`serve(createAgent, { preTransport })` accepts a pre-MCP-transport middleware
+that runs after path-matching and before the MCP transport is connected. The
+request body is buffered into `req.rawBody` before the hook fires so
+signature verifiers can hash it. The transport receives the parsed JSON body
+via `transport.handleRequest(req, res, parsedBody)` so the already-consumed
+stream doesn't race.
+
+Intended for transport-layer concerns — RFC 9421 signature verification
+being the primary use case. Returning `true` signals the middleware handled
+the response (e.g. a 401 with `WWW-Authenticate`); returning `false`
+continues into MCP dispatch.
+
+**Test agent — `test-agents/seller-agent-signed.ts`**
+
+Minimal HTTP server pre-configured per the `signed-requests-runner`
+test-kit contract:
+
+- JWKS contains `test-ed25519-2026`, `test-es256-2026`, `test-gov-2026`,
+  `test-revoked-2026` (from `compliance/cache/latest/test-vectors/
+  request-signing/keys.json`).
+- Revocation list pre-includes `test-revoked-2026`.
+- Per-keyid replay cap = 100 (matches contract's
+  `grading_target_per_keyid_cap_requests`).
+- `required_for: ['create_media_buy']` — vector 001 surfaces
+  `request_signature_required`.
+
+Exposes `/get_adcp_capabilities` (unsigned, declares `supported: true` +
+`specialisms: ['signed-requests']`) and accepts signed requests on any
+other path, routing the operation name from the last path segment.
+
+Run `PORT=3100 node test-agents/dist/seller-agent-signed.js` and grade it
+with `node bin/adcp.js grade request-signing http://127.0.0.1:3100
+--allow-http --skip-rate-abuse`. Current results against this agent:
+**25/25 graded vectors pass, 3 skipped** (capability-profile + rate-abuse
+opt-out). Validates the full grader → signer → verifier path end-to-end.
+
+Note: the test agent is not an MCP agent — vectors target raw-HTTP AdCP
+paths, and the RFC 9421 verifier is a transport-layer concern. An
+MCP-aware grader (JSON-RPC envelope wrapping + single-endpoint routing)
+is a separate scope; follow-up ticket to be filed.

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -76,10 +76,18 @@ async function handleGradeCommand(argv) {
         }
         break;
       case '--skip':
-        options.skipVectors = args[++i]?.split(',').map(s => s.trim()).filter(Boolean) ?? [];
+        options.skipVectors =
+          args[++i]
+            ?.split(',')
+            .map(s => s.trim())
+            .filter(Boolean) ?? [];
         break;
       case '--only':
-        options.onlyVectors = args[++i]?.split(',').map(s => s.trim()).filter(Boolean) ?? [];
+        options.onlyVectors =
+          args[++i]
+            ?.split(',')
+            .map(s => s.trim())
+            .filter(Boolean) ?? [];
         break;
       case '--allow-live-side-effects':
         options.allowLiveSideEffects = true;
@@ -131,13 +139,9 @@ function printHumanReport(report) {
 
   console.log();
   console.log(`Agent: ${report.agent_url}`);
-  console.log(
-    `Harness: ${report.harness_mode}${report.contract_loaded ? ' (contract loaded)' : ' (no contract)'}`
-  );
+  console.log(`Harness: ${report.harness_mode}${report.contract_loaded ? ' (contract loaded)' : ' (no contract)'}`);
   if (report.live_endpoint_warning) {
-    console.log(
-      `⚠  Contract does not declare endpoint_scope: sandbox. Vectors 016/020 produce live side effects.`
-    );
+    console.log(`⚠  Contract does not declare endpoint_scope: sandbox. Vectors 016/020 produce live side effects.`);
   }
   console.log();
   console.log(`${'vector'.padEnd(idWidth)}  ${'status'.padEnd(statusWidth)}  detail`);
@@ -162,8 +166,8 @@ function formatRow(r) {
   const detail = r.skipped
     ? (r.skip_reason ?? '')
     : r.passed
-    ? `${r.http_status}${r.actual_error_code ? ` ${r.actual_error_code}` : ''}`
-    : r.diagnostic ?? 'see report';
+      ? `${r.http_status}${r.actual_error_code ? ` ${r.actual_error_code}` : ''}`
+      : (r.diagnostic ?? 'see report');
   return { id, status, detail };
 }
 

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+
+const { gradeRequestSigning } = require('../dist/lib/testing/storyboard/request-signing/index.js');
+
+const USAGE = `Usage: adcp grade request-signing <agent-url> [options]
+
+Runs the RFC 9421 conformance grader against an agent's request-signing
+verifier. Returns a PASS/FAIL report with per-vector diagnostics.
+
+Preconditions (owned by the operator):
+  • Agent advertises \`request_signing.supported: true\` in get_adcp_capabilities.
+  • Agent has pre-configured its verifier per
+    compliance/cache/<version>/test-kits/signed-requests-runner.yaml:
+      - accepts runner signing keyids (test-ed25519-2026, test-es256-2026)
+      - has test-revoked-2026 in its revocation list
+      - per-keyid replay cap ≥ --rate-abuse-cap (or matches contract default)
+  • <agent-url> points at a SANDBOX endpoint — vector 016 fires a live
+    create_media_buy-shaped request the agent will accept, and vector 020
+    floods the replay cache with cap+1 signatures.
+
+Options:
+  --skip-rate-abuse          Skip vector 020 (fastest grading run)
+  --rate-abuse-cap <N>       Override per-keyid cap the grader targets
+  --skip <id[,id...]>        Skip specific vector ids (e.g. 007-…,018-…)
+  --only <id[,id...]>        Run only the named vector ids
+  --allow-live-side-effects  Opt in to vectors 016/020 against non-sandbox
+                             endpoints (USE WITH CARE — creates real orders)
+  --allow-http               Allow http:// URLs + private-IP targets (dev loops)
+  --timeout <ms>             Per-probe timeout (default 10000)
+  --json                     Emit the full GradeReport as JSON
+  -h, --help                 Show this help
+
+Exit code:
+  0   all graded vectors passed (skipped vectors don't count as failures)
+  1   at least one vector failed
+  2   argument / configuration error
+
+Examples:
+  adcp grade request-signing https://agent.example.com/adcp
+  adcp grade request-signing http://127.0.0.1:3000 --allow-http --skip-rate-abuse
+  adcp grade request-signing https://sandbox.seller.com/adcp --json | jq
+`;
+
+async function handleGradeCommand(argv) {
+  if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
+    process.stdout.write(USAGE);
+    return;
+  }
+  if (argv[0] !== 'request-signing') {
+    console.error(`Unknown grade subject: ${argv[0]}\n`);
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+  const args = argv.slice(1);
+  if (args.length === 0 || args[0].startsWith('-')) {
+    console.error('ERROR: agent URL is required\n');
+    process.stderr.write(USAGE);
+    process.exit(2);
+  }
+
+  const agentUrl = args[0];
+  const options = {};
+  let emitJson = false;
+
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    switch (a) {
+      case '--skip-rate-abuse':
+        options.skipRateAbuse = true;
+        break;
+      case '--rate-abuse-cap':
+        options.rateAbuseCap = Number.parseInt(args[++i], 10);
+        if (!Number.isFinite(options.rateAbuseCap) || options.rateAbuseCap < 1) {
+          console.error(`ERROR: --rate-abuse-cap requires a positive integer\n`);
+          process.exit(2);
+        }
+        break;
+      case '--skip':
+        options.skipVectors = args[++i]?.split(',').map(s => s.trim()).filter(Boolean) ?? [];
+        break;
+      case '--only':
+        options.onlyVectors = args[++i]?.split(',').map(s => s.trim()).filter(Boolean) ?? [];
+        break;
+      case '--allow-live-side-effects':
+        options.allowLiveSideEffects = true;
+        break;
+      case '--allow-http':
+        options.allowPrivateIp = true;
+        break;
+      case '--timeout':
+        options.timeoutMs = Number.parseInt(args[++i], 10);
+        if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1) {
+          console.error(`ERROR: --timeout requires a positive integer (ms)\n`);
+          process.exit(2);
+        }
+        break;
+      case '--json':
+        emitJson = true;
+        break;
+      case '-h':
+      case '--help':
+        process.stdout.write(USAGE);
+        return;
+      default:
+        console.error(`Unknown flag: ${a}\n`);
+        process.stderr.write(USAGE);
+        process.exit(2);
+    }
+  }
+
+  try {
+    const report = await gradeRequestSigning(agentUrl, options);
+    if (emitJson) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    } else {
+      printHumanReport(report);
+    }
+    process.exit(report.passed ? 0 : 1);
+  } catch (err) {
+    console.error(`grade-request-signing failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+}
+
+function printHumanReport(report) {
+  const { positive, negative } = report;
+  const all = [...positive, ...negative];
+  const rows = all.map(formatRow);
+  const idWidth = Math.max(...rows.map(r => r.id.length), 10);
+  const statusWidth = 8;
+
+  console.log();
+  console.log(`Agent: ${report.agent_url}`);
+  console.log(
+    `Harness: ${report.harness_mode}${report.contract_loaded ? ' (contract loaded)' : ' (no contract)'}`
+  );
+  if (report.live_endpoint_warning) {
+    console.log(
+      `⚠  Contract does not declare endpoint_scope: sandbox. Vectors 016/020 produce live side effects.`
+    );
+  }
+  console.log();
+  console.log(`${'vector'.padEnd(idWidth)}  ${'status'.padEnd(statusWidth)}  detail`);
+  console.log('─'.repeat(idWidth + statusWidth + 20));
+  for (const row of rows) {
+    console.log(`${row.id.padEnd(idWidth)}  ${row.status.padEnd(statusWidth)}  ${row.detail}`);
+  }
+  console.log();
+  console.log(
+    `${report.passed_count} passed, ${report.failed_count} failed, ${report.skipped_count} skipped — total ${report.total_duration_ms}ms`
+  );
+  console.log(`Overall: ${report.passed ? 'PASS' : 'FAIL'}`);
+  console.log();
+}
+
+function formatRow(r) {
+  const id = `${r.kind === 'positive' ? 'pos' : 'neg'}/${r.vector_id}`;
+  let status;
+  if (r.skipped) status = 'SKIP';
+  else if (r.passed) status = 'PASS';
+  else status = 'FAIL';
+  const detail = r.skipped
+    ? (r.skip_reason ?? '')
+    : r.passed
+    ? `${r.http_status}${r.actual_error_code ? ` ${r.actual_error_code}` : ''}`
+    : r.diagnostic ?? 'see report';
+  return { id, status, detail };
+}
+
+module.exports = { handleGradeCommand };
+
+if (require.main === module) {
+  handleGradeCommand(process.argv.slice(2)).catch(err => {
+    console.error(err);
+    process.exit(2);
+  });
+}

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -76,18 +76,10 @@ async function handleGradeCommand(argv) {
         }
         break;
       case '--skip':
-        options.skipVectors =
-          args[++i]
-            ?.split(',')
-            .map(s => s.trim())
-            .filter(Boolean) ?? [];
+        options.skipVectors = parseVectorList(args[++i], '--skip');
         break;
       case '--only':
-        options.onlyVectors =
-          args[++i]
-            ?.split(',')
-            .map(s => s.trim())
-            .filter(Boolean) ?? [];
+        options.onlyVectors = parseVectorList(args[++i], '--only');
         break;
       case '--allow-live-side-effects':
         options.allowLiveSideEffects = true;
@@ -128,6 +120,22 @@ async function handleGradeCommand(argv) {
     console.error(`grade-request-signing failed: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(2);
   }
+}
+
+function parseVectorList(raw, flagName) {
+  if (!raw) {
+    console.error(`ERROR: ${flagName} requires a comma-separated vector-id list\n`);
+    process.exit(2);
+  }
+  const list = raw
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  if (list.length === 0) {
+    console.error(`ERROR: ${flagName} list is empty\n`);
+    process.exit(2);
+  }
+  return list;
 }
 
 function printHumanReport(report) {

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -706,6 +706,8 @@ USAGE:
 
 COMMANDS:
   storyboard <subcommand>     Test agent flows (run, list, show, step)
+  grade <subject> <url>       Conformance graders (e.g. request-signing)
+  signing <subcommand>        RFC 9421 signing key tools (generate, verify)
   check-network               Validate managed publisher network deployment
   comply <agent> [options]    DEPRECATED — use "storyboard run" instead
   test <agent> [scenario]     Run individual test scenarios (legacy)
@@ -1478,6 +1480,12 @@ async function main() {
   if (args[0] === 'signing') {
     const { handleSigningCommand } = require('./adcp-signing.js');
     await handleSigningCommand(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'grade') {
+    const { handleGradeCommand } = require('./adcp-grade.js');
+    await handleGradeCommand(args.slice(1));
     return;
   }
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -447,6 +447,22 @@ export interface AdcpCapabilitiesConfig {
   creative?: Partial<CreativeCapabilities>;
   extensions_supported?: string[];
   /**
+   * RFC 9421 request-signing verifier capability. See
+   * docs/building/implementation/security.mdx#signed-requests-transport-layer.
+   * Emitted verbatim in `get_adcp_capabilities.request_signing`. Omit unless
+   * the agent actually verifies incoming signatures — a `supported: true`
+   * claim without a working verifier is graded as FAIL by the conformance
+   * runner (see `@adcp/client/testing/storyboard/request-signing`).
+   */
+  request_signing?: NonNullable<GetAdCPCapabilitiesResponse['request_signing']>;
+  /**
+   * Specialism claims the agent supports. Each entry maps to a storyboard
+   * bundle under `/compliance/{version}/specialisms/{id}/`; the AAO
+   * compliance runner executes the matching storyboards to verify. Only
+   * list specialisms the agent actually implements.
+   */
+  specialisms?: NonNullable<GetAdCPCapabilitiesResponse['specialisms']>;
+  /**
    * Seller-declared idempotency replay window, required on `get_adcp_capabilities`
    * responses per AdCP spec. Defaults to 86400 (24h). Spec bounds are 3600
    * (1h) to 604800 (7d); `clampReplayTtl` enforces the range on output.
@@ -1351,6 +1367,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
   if (capConfig?.extensions_supported?.length) {
     capabilitiesData.extensions_supported = capConfig.extensions_supported;
+  }
+
+  if (capConfig?.request_signing) {
+    capabilitiesData.request_signing = capConfig.request_signing;
+  }
+
+  if (capConfig?.specialisms?.length) {
+    capabilitiesData.specialisms = capConfig.specialisms;
   }
 
   const capSchema = TOOL_REQUEST_SCHEMAS['get_adcp_capabilities'] as { shape: Record<string, unknown> } | undefined;

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -54,6 +54,23 @@ export interface ServeOptions {
    * provide a store with automatic eviction to prevent unbounded memory growth.
    */
   taskStore?: TaskStore;
+  /**
+   * Pre-MCP middleware — runs after path-matching but before MCP transport
+   * is connected. Intended for transport-layer concerns like RFC 9421
+   * request-signature verification: the agent's body is already buffered
+   * into `(req as any).rawBody` before the middleware fires so signature
+   * verifiers can hash it without racing the transport's own body read.
+   *
+   * Return `true` to signal the middleware handled the response (e.g. a
+   * 401 with `WWW-Authenticate`); the transport is skipped. Return `false`
+   * to continue into MCP dispatch.
+   *
+   * Throwing from the middleware produces a 500 with a generic body.
+   */
+  preTransport?: (
+    req: import('http').IncomingMessage & { rawBody?: string },
+    res: import('http').ServerResponse
+  ) => Promise<boolean>;
 }
 
 /**
@@ -88,13 +105,47 @@ export function serve(createAgent: (ctx: ServeContext) => McpServer, options?: S
   const httpServer = createServer(async (req, res) => {
     const { pathname } = new URL(req.url || '', 'http://localhost');
     if (pathname === mountPath || pathname === `${mountPath}/`) {
+      // Buffer the request body once when preTransport middleware is wired —
+      // RFC 9421 verifiers need the raw bytes for Content-Digest recompute,
+      // and the MCP transport's own body read would race the verifier otherwise.
+      let parsedBody: unknown;
+      if (options?.preTransport) {
+        try {
+          const raw = await bufferBody(req);
+          (req as { rawBody?: string }).rawBody = raw;
+          if (raw.length > 0) {
+            try {
+              parsedBody = JSON.parse(raw);
+            } catch {
+              // Non-JSON body — let transport reject as malformed JSON-RPC.
+            }
+          }
+          const handled = await options.preTransport(req as import('http').IncomingMessage & { rawBody?: string }, res);
+          if (handled) return;
+        } catch (err) {
+          console.error('preTransport middleware error:', err);
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Internal server error' }));
+          }
+          return;
+        }
+      }
       const agentServer = createAgent(ctx);
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: undefined,
       });
       try {
         await agentServer.connect(transport);
-        await transport.handleRequest(req, res);
+        // When preTransport already consumed the request stream, pass the
+        // parsed body through so the transport doesn't re-read (stream is
+        // drained). MCP SDK's `handleRequest(req, res, parsedBody)` accepts
+        // this shape.
+        if (parsedBody !== undefined) {
+          await transport.handleRequest(req, res, parsedBody);
+        } else {
+          await transport.handleRequest(req, res);
+        }
       } catch (err) {
         console.error('Server error:', err);
         if (!res.headersSent) {
@@ -122,4 +173,23 @@ export function serve(createAgent: (ctx: ServeContext) => McpServer, options?: S
   });
 
   return httpServer;
+}
+
+function bufferBody(req: import('http').IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    const MAX = 2 * 1024 * 1024; // 2 MiB — generous for MCP JSON-RPC payloads
+    req.on('data', chunk => {
+      size += chunk.length;
+      if (size > MAX) {
+        reject(new Error(`Request body exceeded ${MAX} bytes`));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk as Buffer);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
 }

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -23,8 +23,17 @@ export interface AdcpJsonWebKey {
   use?: string;
   key_ops?: string[];
   adcp_use?: string;
+  /** Public-key X coordinate (Ed25519) or x-coordinate (EC P-256). */
   x?: string;
+  /** Public-key Y coordinate (EC P-256 only). */
   y?: string;
+  /**
+   * Private scalar (RFC 7518 §6.2.2.1 / §6.1.2). Present only when the JWK
+   * represents a private key — never published at `jwks_uri`. Test vectors
+   * ship this under `_private_d_for_test_only` in their `keys.json`; runtime
+   * signers load it into `d`.
+   */
+  d?: string;
   [extra: string]: unknown;
 }
 

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -203,10 +203,7 @@ function loadStoryboardsFromDir(dir: string): Storyboard[] {
 
 /** Load storyboards for a single bundle (universal YAML file, domain dir, or specialism dir). */
 export function loadBundleStoryboards(ref: BundleRef): Storyboard[] {
-  const raw =
-    ref.kind === 'universal'
-      ? safeLoadUniversal(ref.path)
-      : loadStoryboardsFromDir(ref.path);
+  const raw = ref.kind === 'universal' ? safeLoadUniversal(ref.path) : loadStoryboardsFromDir(ref.path);
   return raw.map(postProcessStoryboard);
 }
 

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -12,6 +12,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { join, resolve } from 'path';
 import { loadStoryboardFile } from './loader';
 import { ADCP_VERSION } from '../../version';
+import { synthesizeRequestSigningSteps } from './request-signing/synthesize';
 import type { Storyboard } from './types';
 
 /**
@@ -202,15 +203,42 @@ function loadStoryboardsFromDir(dir: string): Storyboard[] {
 
 /** Load storyboards for a single bundle (universal YAML file, domain dir, or specialism dir). */
 export function loadBundleStoryboards(ref: BundleRef): Storyboard[] {
-  if (ref.kind === 'universal') {
-    // Universal bundles are individual YAML files.
+  const raw =
+    ref.kind === 'universal'
+      ? safeLoadUniversal(ref.path)
+      : loadStoryboardsFromDir(ref.path);
+  return raw.map(postProcessStoryboard);
+}
+
+function safeLoadUniversal(path: string): Storyboard[] {
+  try {
+    return [loadStoryboardFile(path)];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Post-process storyboards loaded from the cache. The signed-requests
+ * specialism ships phases whose steps are generated at runtime from the
+ * request-signing test vectors; synthesize them here so downstream callers
+ * (the runner, CLI tooling, reporting) see a fully-populated storyboard.
+ */
+function postProcessStoryboard(storyboard: Storyboard): Storyboard {
+  if (storyboard.id === 'signed_requests') {
     try {
-      return [loadStoryboardFile(ref.path)];
-    } catch {
-      return [];
+      return synthesizeRequestSigningSteps(storyboard);
+    } catch (err) {
+      // Synthesis failure (e.g., compliance cache missing vectors) leaves the
+      // storyboard with empty phases — the runner will report empty steps
+      // rather than crash. Surface the cause so operators can run sync-schemas.
+      console.warn(
+        `[compliance] Failed to synthesize request-signing steps: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return storyboard;
     }
   }
-  return loadStoryboardsFromDir(ref.path);
+  return storyboard;
 }
 
 /** Enumerate every bundle present in the cache (universal + protocols + specialisms). */

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -229,16 +229,37 @@ function postProcessStoryboard(storyboard: Storyboard): Storyboard {
     try {
       return synthesizeRequestSigningSteps(storyboard);
     } catch (err) {
-      // Synthesis failure (e.g., compliance cache missing vectors) leaves the
-      // storyboard with empty phases — the runner will report empty steps
-      // rather than crash. Surface the cause so operators can run sync-schemas.
-      console.warn(
-        `[compliance] Failed to synthesize request-signing steps: ${err instanceof Error ? err.message : String(err)}`
-      );
-      return storyboard;
+      // Synthesis failure = infrastructural problem (cache missing vectors,
+      // schema drift, etc.). Emit a synthetic failing phase so the runner's
+      // existing reporting surfaces the cause — silent empty-phase fallback
+      // would render as a green pass with 0 steps, which is the worst
+      // possible outcome for CI pipelines.
+      return withSynthesisErrorPhase(storyboard, err);
     }
   }
   return storyboard;
+}
+
+function withSynthesisErrorPhase(storyboard: Storyboard, err: unknown): Storyboard {
+  const message = err instanceof Error ? err.message : String(err);
+  const errorPhase = {
+    id: 'synthesis_error',
+    title: 'Request-signing vector synthesis failed',
+    narrative:
+      'The signed-requests specialism requires its phases to be synthesized at load time ' +
+      'from the compliance cache. Synthesis failed — the runner cannot grade against the ' +
+      'conformance vectors. Run `npm run sync-schemas` to refresh the cache.',
+    steps: [
+      {
+        id: 'synthesis_error',
+        title: 'Synthesize vector phases',
+        task: 'synthesis_error',
+        narrative: message,
+        expect_error: false,
+      },
+    ],
+  };
+  return { ...storyboard, phases: [errorPhase, ...storyboard.phases] };
 }
 
 /** Enumerate every bundle present in the cache (universal + protocols + specialisms). */

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -17,7 +17,11 @@ export function parseStoryboard(yamlContent: string): Storyboard {
     throw new Error('Invalid storyboard YAML: missing required fields (id, phases)');
   }
   // YAML uses `name:` for context outputs but our runtime expects `key:`.
+  // Specialism YAMLs may declare a phase with no `steps:` — the steps are
+  // synthesized at runtime from fixtures (see request-signing/synthesize.ts).
+  // Treat missing steps as an empty list so the parser stays phase-agnostic.
   for (const phase of parsed.phases) {
+    if (!phase.steps) phase.steps = [];
     for (const step of phase.steps) {
       if (step.context_outputs) {
         for (const output of step.context_outputs) {

--- a/src/lib/testing/storyboard/probes.ts
+++ b/src/lib/testing/storyboard/probes.ts
@@ -31,6 +31,7 @@ export const PROBE_TASKS = new Set([
   'protected_resource_metadata',
   'oauth_auth_server_metadata',
   'assert_contribution',
+  'request_signing_probe',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -1,0 +1,415 @@
+import { createPrivateKey, randomBytes, sign as nodeSign, type JsonWebKey } from 'crypto';
+import {
+  buildSignatureBase,
+  formatSignatureParams,
+  signRequest,
+  REQUEST_SIGNING_TAG,
+  type AdcpJsonWebKey,
+  type RequestLike,
+  type SignatureParams,
+  type SignerKey,
+} from '../../../signing';
+import { findKey } from './vector-loader';
+import type { NegativeVector, PositiveVector, TestKeyset, TestKeypair, VectorRequest } from './types';
+
+export interface BuildOptions {
+  /** Override the signer clock (unix seconds). Defaults to `Date.now()/1000`. */
+  now?: number;
+  /** Override the nonce. Defaults to freshly-generated. */
+  nonce?: string;
+  /** Override the `expires - created` window (seconds). Defaults to 300. */
+  windowSeconds?: number;
+}
+
+export interface SignedHttpRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export function buildPositiveRequest(
+  vector: PositiveVector,
+  keys: TestKeyset,
+  options: BuildOptions = {}
+): SignedHttpRequest {
+  const key = signerKeyFor(vector, keys);
+  return sign(key, vector, {
+    coverContentDigest: vector.verifier_capability.covers_content_digest === 'required',
+    ...options,
+  });
+}
+
+/**
+ * Apply the adversarial mutation documented for a negative vector.
+ *
+ * Black-box grader: the positive/001 signature bytes sitting in most negative
+ * fixtures are placeholders; we re-sign dynamically, then mutate. Covers all
+ * 20 current negative vectors. Stateful contract vectors (016 replay, 017
+ * revoked, 020 rate abuse) produce a single well-formed request; the
+ * storyboard runner orchestrates the repeat/flood/revoked-keyid behavior
+ * around that request per the signed-requests-runner test-kit.
+ */
+export function buildNegativeRequest(
+  vector: NegativeVector,
+  keys: TestKeyset,
+  options: BuildOptions = {}
+): SignedHttpRequest {
+  const mutation = MUTATIONS[vector.id];
+  if (!mutation) {
+    throw new Error(`No adversarial builder registered for negative vector "${vector.id}"`);
+  }
+  return mutation(vector, keys, options);
+}
+
+export function listSupportedNegativeVectors(): string[] {
+  return Object.keys(MUTATIONS);
+}
+
+type Mutator = (vector: NegativeVector, keys: TestKeyset, options: BuildOptions) => SignedHttpRequest;
+
+const MUTATIONS: Record<string, Mutator> = {
+  '001-no-signature-header': (vector) => ({
+    method: vector.request.method,
+    url: vector.request.url,
+    headers: stripSignatureHeaders(vector.request.headers),
+    body: vector.request.body,
+  }),
+
+  '002-wrong-tag': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, { tag: 'example-org/signing/v1' });
+  },
+
+  '003-expired-signature': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    const now = nowSeconds(options);
+    return sign(key, vector, { ...options, now: now - 600, windowSeconds: 300 });
+  },
+
+  '004-window-too-long': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, {
+      expiresDelta: 301,
+    });
+  },
+
+  '005-alg-not-allowed': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, { alg: 'rsa-pss-sha512' });
+  },
+
+  '006-missing-covered-component': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithComponents(key, vector, options, ['@method', '@target-uri', 'content-type']);
+  },
+
+  '007-missing-content-digest': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return sign(key, vector, { ...options, coverContentDigest: false });
+  },
+
+  '008-unknown-keyid': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, { keyid: 'unknown-key-9999' });
+  },
+
+  '009-key-ops-missing-verify': (vector, keys, options) => {
+    // Sign with test-gov-2026 (adcp_use: governance-signing, not request-signing).
+    const kid = pickKeyidForPurposeMismatch(vector, keys);
+    const key = keyFor(keys, kid);
+    return sign(key, vector, options);
+  },
+
+  '010-content-digest-mismatch': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    const signed = sign(key, vector, { ...options, coverContentDigest: true });
+    // Mutate body after signing so the Content-Digest header no longer matches.
+    return { ...signed, body: (signed.body ?? '') + ' ' };
+  },
+
+  '011-malformed-header': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    const signed = sign(key, vector, options);
+    return {
+      ...signed,
+      headers: {
+        ...signed.headers,
+        'Signature-Input': 'sig1=not a valid structured-field value!!!',
+      },
+    };
+  },
+
+  '012-missing-expires-param': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, { omitExpires: true });
+  },
+
+  '013-expires-le-created': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, { expiresDelta: 0 });
+  },
+
+  '014-missing-nonce-param': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return signWithParamOverride(key, vector, options, { omitNonce: true });
+  },
+
+  '015-signature-invalid': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    const signed = sign(key, vector, options);
+    const zeroSig = Buffer.alloc(64).toString('base64url');
+    return {
+      ...signed,
+      headers: {
+        ...signed.headers,
+        Signature: `sig1=:${zeroSig}:`,
+      },
+    };
+  },
+
+  '016-replayed-nonce': (vector, keys, options) => {
+    // Black-box runner sends the request twice; first accepted, second rejected.
+    // Builder produces the single well-formed request used for both submissions.
+    const key = signerKeyFor(vector, keys);
+    return sign(key, vector, options);
+  },
+
+  '017-key-revoked': (vector, keys, options) => {
+    // Use the dedicated revoked key (`test-revoked-2026`) declared by the
+    // signed-requests-runner test-kit. For current pre-#2353 caches, vector 017
+    // still references test-ed25519-2026; fall back to whatever the vector says.
+    const kid = vector.jwks_ref[0];
+    if (!kid) throw new Error(`${vector.id}: jwks_ref missing`);
+    const key = keyFor(keys, kid);
+    return sign(key, vector, options);
+  },
+
+  '018-digest-covered-when-forbidden': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    return sign(key, vector, { ...options, coverContentDigest: true });
+  },
+
+  '019-signature-without-signature-input': (vector, keys, options) => {
+    const key = signerKeyFor(vector, keys);
+    const signed = sign(key, vector, options);
+    const { 'Signature-Input': _drop, ...rest } = signed.headers;
+    return { ...signed, headers: rest };
+  },
+
+  '020-rate-abuse': (vector, keys, options) => {
+    // Runner floods the agent with distinct-nonce requests from the same keyid.
+    // Builder produces a single well-formed request; the runner generates N
+    // distinct nonces by calling this builder repeatedly with `options.nonce`.
+    const key = signerKeyFor(vector, keys);
+    return sign(key, vector, options);
+  },
+};
+
+// ── Primitives ────────────────────────────────────────────────
+
+interface SignArgs extends BuildOptions {
+  coverContentDigest?: boolean;
+}
+
+function sign(key: SignerKey, vector: PositiveVector | NegativeVector, args: SignArgs): SignedHttpRequest {
+  const request = toRequestLike(vector.request);
+  const signed = signRequest(request, key, {
+    coverContentDigest: args.coverContentDigest === true,
+    now: args.now !== undefined ? () => args.now! : undefined,
+    nonce: args.nonce,
+    windowSeconds: args.windowSeconds,
+  });
+  return {
+    method: vector.request.method,
+    url: vector.request.url,
+    headers: mergeHeaders(vector.request.headers, signed.headers),
+    body: vector.request.body,
+  };
+}
+
+interface ParamOverride {
+  tag?: string;
+  alg?: string;
+  keyid?: string;
+  expiresDelta?: number;
+  omitExpires?: boolean;
+  omitNonce?: boolean;
+}
+
+/**
+ * Build a signature base with overridden params, sign it directly, and emit
+ * the headers. Needed when the mutation lives in `@signature-params` itself
+ * (tag, alg, keyid, expires, nonce) — signRequest won't emit those exact
+ * malformations.
+ */
+function signWithParamOverride(
+  key: SignerKey,
+  vector: PositiveVector | NegativeVector,
+  options: BuildOptions,
+  override: ParamOverride
+): SignedHttpRequest {
+  const request = toRequestLike(vector.request);
+  const hasBody = (request.body ?? '').length > 0;
+  const components = hasBody
+    ? ['@method', '@target-uri', '@authority', 'content-type']
+    : ['@method', '@target-uri', '@authority'];
+
+  const now = nowSeconds(options);
+  const windowSeconds = options.windowSeconds ?? 300;
+  const params: SignatureParams = {
+    created: now,
+    expires: now + (override.expiresDelta ?? windowSeconds),
+    nonce: options.nonce ?? randomNonce(),
+    keyid: override.keyid ?? key.keyid,
+    alg: override.alg ?? key.alg,
+    tag: override.tag ?? REQUEST_SIGNING_TAG,
+  };
+
+  const paramsString = formatParamsWithOmissions(components, params, override);
+  const base = buildSignatureBase(components, request, params, paramsString);
+  const signature = produceSignature(key, Buffer.from(base, 'utf8'));
+
+  return {
+    method: vector.request.method,
+    url: vector.request.url,
+    headers: {
+      ...vector.request.headers,
+      'Signature-Input': `sig1=${paramsString}`,
+      Signature: `sig1=:${Buffer.from(signature).toString('base64url')}:`,
+    },
+    body: vector.request.body,
+  };
+}
+
+function signWithComponents(
+  key: SignerKey,
+  vector: PositiveVector | NegativeVector,
+  options: BuildOptions,
+  components: string[]
+): SignedHttpRequest {
+  const request = toRequestLike(vector.request);
+  const now = nowSeconds(options);
+  const windowSeconds = options.windowSeconds ?? 300;
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce: options.nonce ?? randomNonce(),
+    keyid: key.keyid,
+    alg: key.alg,
+    tag: REQUEST_SIGNING_TAG,
+  };
+  const paramsString = formatSignatureParams(components, params);
+  const base = buildSignatureBase(components, request, params, paramsString);
+  const signature = produceSignature(key, Buffer.from(base, 'utf8'));
+  return {
+    method: vector.request.method,
+    url: vector.request.url,
+    headers: {
+      ...vector.request.headers,
+      'Signature-Input': `sig1=${paramsString}`,
+      Signature: `sig1=:${Buffer.from(signature).toString('base64url')}:`,
+    },
+    body: vector.request.body,
+  };
+}
+
+function formatParamsWithOmissions(
+  components: ReadonlyArray<string>,
+  params: SignatureParams,
+  override: ParamOverride
+): string {
+  const componentList = components.map(c => `"${c}"`).join(' ');
+  const pairs: string[] = [];
+  pairs.push(`created=${params.created}`);
+  if (!override.omitExpires) pairs.push(`expires=${params.expires}`);
+  if (!override.omitNonce) pairs.push(`nonce="${params.nonce}"`);
+  pairs.push(`keyid="${params.keyid}"`);
+  pairs.push(`alg="${params.alg}"`);
+  pairs.push(`tag="${params.tag}"`);
+  return `(${componentList});${pairs.join(';')}`;
+}
+
+function produceSignature(key: SignerKey, data: Buffer): Uint8Array {
+  const privateKey = createPrivateKey({ key: key.privateKey as JsonWebKey, format: 'jwk' });
+  if (key.alg === 'ed25519') {
+    return new Uint8Array(nodeSign(null, data, privateKey));
+  }
+  return new Uint8Array(nodeSign('sha256', data, { key: privateKey, dsaEncoding: 'ieee-p1363' }));
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function signerKeyFor(vector: PositiveVector | NegativeVector, keys: TestKeyset): SignerKey {
+  const kid = vector.jwks_ref[0];
+  if (!kid) throw new Error(`${vector.id}: jwks_ref is empty`);
+  return keyFor(keys, kid);
+}
+
+function keyFor(keys: TestKeyset, kid: string): SignerKey {
+  const keypair = findKey(keys, kid);
+  return toSignerKey(keypair);
+}
+
+function toSignerKey(keypair: TestKeypair): SignerKey {
+  const alg: SignerKey['alg'] = keypair.crv === 'Ed25519' ? 'ed25519' : 'ecdsa-p256-sha256';
+  const privateKey: AdcpJsonWebKey = {
+    kid: keypair.kid,
+    kty: keypair.kty,
+    crv: keypair.crv,
+    alg: keypair.alg,
+    use: keypair.use,
+    key_ops: ['sign'],
+    adcp_use: keypair.adcp_use,
+    x: keypair.x,
+    y: keypair.y,
+    d: keypair.private_d,
+  };
+  return { keyid: keypair.kid, alg, privateKey };
+}
+
+function pickKeyidForPurposeMismatch(vector: NegativeVector, keys: TestKeyset): string {
+  // Vector 009 uses a key whose adcp_use is not request-signing. Prefer the
+  // first such key in the keyset; fall back to the vector's jwks_ref.
+  const nonRequestSigning = keys.keys.find(k => k.adcp_use && k.adcp_use !== 'request-signing');
+  if (nonRequestSigning) return nonRequestSigning.kid;
+  const fallback = vector.jwks_ref[0];
+  if (!fallback) throw new Error(`${vector.id}: jwks_ref empty and no purpose-mismatch key in keyset`);
+  return fallback;
+}
+
+function stripSignatureHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    const lower = k.toLowerCase();
+    if (lower === 'signature' || lower === 'signature-input' || lower === 'content-digest') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+function mergeHeaders(
+  from: Record<string, string>,
+  signed: Record<string, string>
+): Record<string, string> {
+  // Drop original Signature/Signature-Input/Content-Digest before overlaying fresh ones.
+  const base = stripSignatureHeaders(from);
+  return { ...base, ...signed };
+}
+
+function toRequestLike(request: VectorRequest): RequestLike {
+  return {
+    method: request.method,
+    url: request.url,
+    headers: request.headers,
+    body: request.body,
+  };
+}
+
+function nowSeconds(options: BuildOptions): number {
+  return options.now ?? Math.floor(Date.now() / 1000);
+}
+
+function randomNonce(): string {
+  return randomBytes(16).toString('base64url');
+}

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -10,7 +10,7 @@ import {
   type SignerKey,
 } from '../../../signing';
 import { findKey } from './vector-loader';
-import type { NegativeVector, PositiveVector, TestKeyset, TestKeypair, VectorRequest } from './types';
+import type { NegativeVector, PositiveVector, TestKeyset, TestKeypair } from './types';
 
 export interface BuildOptions {
   /** Override the signer clock (unix seconds). Defaults to `Date.now()/1000`. */
@@ -19,6 +19,19 @@ export interface BuildOptions {
   nonce?: string;
   /** Override the `expires - created` window (seconds). Defaults to 300. */
   windowSeconds?: number;
+  /**
+   * Agent base URL. When set, the vector's request URL has its origin replaced
+   * with this base before signing — the vectors point at `seller.example.com`
+   * but real agents live elsewhere. The path and query are preserved so the
+   * operation intent (e.g., `/adcp/create_media_buy`) is unchanged.
+   *
+   * Canonicalization-edge vectors (005 default-port, 006 dot-segment path,
+   * 007 query preservation, 008 percent-encoded path) bake their edge case
+   * into the vector URL; replacing the origin keeps that edge intact in the
+   * path/query, but vectors sensitive to the port or scheme will no longer
+   * exercise the edge against a mismatched agent base.
+   */
+  baseUrl?: string;
 }
 
 export interface SignedHttpRequest {
@@ -69,9 +82,9 @@ export function listSupportedNegativeVectors(): string[] {
 type Mutator = (vector: NegativeVector, keys: TestKeyset, options: BuildOptions) => SignedHttpRequest;
 
 const MUTATIONS: Record<string, Mutator> = {
-  '001-no-signature-header': (vector) => ({
+  '001-no-signature-header': (vector, _keys, options) => ({
     method: vector.request.method,
-    url: vector.request.url,
+    url: retargetUrl(vector.request.url, options.baseUrl),
     headers: stripSignatureHeaders(vector.request.headers),
     body: vector.request.body,
   }),
@@ -213,7 +226,13 @@ interface SignArgs extends BuildOptions {
 }
 
 function sign(key: SignerKey, vector: PositiveVector | NegativeVector, args: SignArgs): SignedHttpRequest {
-  const request = toRequestLike(vector.request);
+  const url = retargetUrl(vector.request.url, args.baseUrl);
+  const request: RequestLike = {
+    method: vector.request.method,
+    url,
+    headers: vector.request.headers,
+    body: vector.request.body,
+  };
   const signed = signRequest(request, key, {
     coverContentDigest: args.coverContentDigest === true,
     now: args.now !== undefined ? () => args.now! : undefined,
@@ -222,10 +241,19 @@ function sign(key: SignerKey, vector: PositiveVector | NegativeVector, args: Sig
   });
   return {
     method: vector.request.method,
-    url: vector.request.url,
+    url,
     headers: mergeHeaders(vector.request.headers, signed.headers),
     body: vector.request.body,
   };
+}
+
+function retargetUrl(vectorUrl: string, baseUrl: string | undefined): string {
+  if (!baseUrl) return vectorUrl;
+  const v = new URL(vectorUrl);
+  const b = new URL(baseUrl);
+  v.protocol = b.protocol;
+  v.host = b.host;
+  return v.toString();
 }
 
 interface ParamOverride {
@@ -249,7 +277,13 @@ function signWithParamOverride(
   options: BuildOptions,
   override: ParamOverride
 ): SignedHttpRequest {
-  const request = toRequestLike(vector.request);
+  const url = retargetUrl(vector.request.url, options.baseUrl);
+  const request: RequestLike = {
+    method: vector.request.method,
+    url,
+    headers: vector.request.headers,
+    body: vector.request.body,
+  };
   const hasBody = (request.body ?? '').length > 0;
   const components = hasBody
     ? ['@method', '@target-uri', '@authority', 'content-type']
@@ -272,7 +306,7 @@ function signWithParamOverride(
 
   return {
     method: vector.request.method,
-    url: vector.request.url,
+    url,
     headers: {
       ...vector.request.headers,
       'Signature-Input': `sig1=${paramsString}`,
@@ -288,7 +322,13 @@ function signWithComponents(
   options: BuildOptions,
   components: string[]
 ): SignedHttpRequest {
-  const request = toRequestLike(vector.request);
+  const url = retargetUrl(vector.request.url, options.baseUrl);
+  const request: RequestLike = {
+    method: vector.request.method,
+    url,
+    headers: vector.request.headers,
+    body: vector.request.body,
+  };
   const now = nowSeconds(options);
   const windowSeconds = options.windowSeconds ?? 300;
   const params: SignatureParams = {
@@ -304,7 +344,7 @@ function signWithComponents(
   const signature = produceSignature(key, Buffer.from(base, 'utf8'));
   return {
     method: vector.request.method,
-    url: vector.request.url,
+    url,
     headers: {
       ...vector.request.headers,
       'Signature-Input': `sig1=${paramsString}`,
@@ -395,15 +435,6 @@ function mergeHeaders(
   // Drop original Signature/Signature-Input/Content-Digest before overlaying fresh ones.
   const base = stripSignatureHeaders(from);
   return { ...base, ...signed };
-}
-
-function toRequestLike(request: VectorRequest): RequestLike {
-  return {
-    method: request.method,
-    url: request.url,
-    headers: request.headers,
-    body: request.body,
-  };
 }
 
 function nowSeconds(options: BuildOptions): number {

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -154,12 +154,13 @@ const MUTATIONS: Record<string, Mutator> = {
     };
     // Sign the request WITH content-digest in covered components, without
     // letting `signRequest` recompute the digest over the real body.
-    return signWithComponents(
-      key,
-      vectorWithBadDigest,
-      options,
-      ['@method', '@target-uri', '@authority', 'content-type', 'content-digest']
-    );
+    return signWithComponents(key, vectorWithBadDigest, options, [
+      '@method',
+      '@target-uri',
+      '@authority',
+      'content-type',
+      'content-digest',
+    ]);
   },
 
   '011-malformed-header': (vector, keys, options) => {
@@ -450,10 +451,7 @@ function stripSignatureHeaders(headers: Record<string, string>): Record<string, 
   return out;
 }
 
-function mergeHeaders(
-  from: Record<string, string>,
-  signed: Record<string, string>
-): Record<string, string> {
+function mergeHeaders(from: Record<string, string>, signed: Record<string, string>): Record<string, string> {
   // Drop original Signature/Signature-Input/Content-Digest before overlaying fresh ones.
   const base = stripSignatureHeaders(from);
   return { ...base, ...signed };

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -128,17 +128,38 @@ const MUTATIONS: Record<string, Mutator> = {
   },
 
   '009-key-ops-missing-verify': (vector, keys, options) => {
-    // Sign with test-gov-2026 (adcp_use: governance-signing, not request-signing).
-    const kid = pickKeyidForPurposeMismatch(vector, keys);
-    const key = keyFor(keys, kid);
+    // Vector 009 pins `jwks_ref: ["test-gov-2026"]` (adcp_use:
+    // governance-signing, not request-signing) — use it directly instead of
+    // inferring. Honors the vector's intent if future keysets add a second
+    // non-request-signing keypair.
+    const key = signerKeyFor(vector, keys);
     return sign(key, vector, options);
   },
 
   '010-content-digest-mismatch': (vector, keys, options) => {
+    // Vector 010 tests "signer committed a wrong Content-Digest value" — the
+    // signature IS valid over the base that includes that wrong value, so the
+    // verifier passes the signature check (step 10) and then fails the
+    // digest-vs-body recompute (step 11). Do NOT mutate the body post-sign —
+    // that tests a different bug (body-tampered-in-transit) and a verifier
+    // that recomputes digest from sent body would not catch the "lying
+    // signer" path this vector exercises.
     const key = signerKeyFor(vector, keys);
-    const signed = sign(key, vector, { ...options, coverContentDigest: true });
-    // Mutate body after signing so the Content-Digest header no longer matches.
-    return { ...signed, body: (signed.body ?? '') + ' ' };
+    // Zero-byte digest: guaranteed not to match the actual body.
+    const zeroDigest = 'sha-256=:' + Buffer.alloc(32).toString('base64') + ':';
+    const headersWithBadDigest = { ...vector.request.headers, 'Content-Digest': zeroDigest };
+    const vectorWithBadDigest = {
+      ...vector,
+      request: { ...vector.request, headers: headersWithBadDigest },
+    };
+    // Sign the request WITH content-digest in covered components, without
+    // letting `signRequest` recompute the digest over the real body.
+    return signWithComponents(
+      key,
+      vectorWithBadDigest,
+      options,
+      ['@method', '@target-uri', '@authority', 'content-type', 'content-digest']
+    );
   },
 
   '011-malformed-header': (vector, keys, options) => {
@@ -253,6 +274,17 @@ function retargetUrl(vectorUrl: string, baseUrl: string | undefined): string {
   const b = new URL(baseUrl);
   v.protocol = b.protocol;
   v.host = b.host;
+  // Prefix the agent's mount path (from baseUrl) ahead of the vector's path
+  // so agents mounted at e.g. `/v1/adcp/*` receive requests at
+  // `/v1/adcp/create_media_buy` rather than the bare `/adcp/create_media_buy`
+  // the vector carries. When baseUrl has no path (or just `/`), this is a
+  // no-op. Canonicalization-edge vectors (005–008) bake their edge into the
+  // vector's path/query; we preserve those bytes by joining, not replacing.
+  if (b.pathname && b.pathname !== '/') {
+    const mount = b.pathname.replace(/\/+$/, '');
+    const vectorPath = v.pathname.startsWith('/') ? v.pathname : `/${v.pathname}`;
+    v.pathname = `${mount}${vectorPath}`;
+  }
   return v.toString();
 }
 
@@ -406,16 +438,6 @@ function toSignerKey(keypair: TestKeypair): SignerKey {
     d: keypair.private_d,
   };
   return { keyid: keypair.kid, alg, privateKey };
-}
-
-function pickKeyidForPurposeMismatch(vector: NegativeVector, keys: TestKeyset): string {
-  // Vector 009 uses a key whose adcp_use is not request-signing. Prefer the
-  // first such key in the keyset; fall back to the vector's jwks_ref.
-  const nonRequestSigning = keys.keys.find(k => k.adcp_use && k.adcp_use !== 'request-signing');
-  if (nonRequestSigning) return nonRequestSigning.kid;
-  const fallback = vector.jwks_ref[0];
-  if (!fallback) throw new Error(`${vector.id}: jwks_ref empty and no purpose-mismatch key in keyset`);
-  return fallback;
 }
 
 function stripSignatureHeaders(headers: Record<string, string>): Record<string, string> {

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -175,6 +175,37 @@ export async function gradeRequestSigning(
   };
 }
 
+/**
+ * Grade a single vector. Loads the vectors+keys+contract on every call; for
+ * the storyboard-runner dispatch path where the caller runs many vectors in
+ * sequence, prefer `gradeRequestSigning` which loads once.
+ */
+export async function gradeOneVector(
+  vectorId: string,
+  kind: 'positive' | 'negative',
+  agentUrl: string,
+  options: GradeOptions = {}
+): Promise<VectorGradeResult> {
+  const loaded = loadRequestSigningVectors(options);
+  const contract = loadSignedRequestsRunnerContract(options);
+  const probeOpts = {
+    allowPrivateIp: options.allowPrivateIp === true,
+    timeoutMs: options.timeoutMs,
+  };
+  const buildOpts = { baseUrl: agentUrl };
+
+  if (kind === 'positive') {
+    const vector = loaded.positive.find(v => v.id === vectorId);
+    if (!vector) throw new Error(`Unknown positive vector "${vectorId}"`);
+    const signed = buildPositiveRequest(vector, loaded.keys, buildOpts);
+    const probe = await probeSignedRequest(signed, probeOpts);
+    return gradePositive(vector, probe);
+  }
+  const vector = loaded.negative.find(v => v.id === vectorId);
+  if (!vector) throw new Error(`Unknown negative vector "${vectorId}"`);
+  return gradeNegative(vector, loaded, contract, probeOpts, buildOpts, options);
+}
+
 // ── Phase helpers ─────────────────────────────────────────────
 
 function gradePositive(vector: PositiveVector, probe: ProbeResult): VectorGradeResult {

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -142,7 +142,10 @@ export async function gradeRequestSigning(agentUrl: string, options: GradeOption
   return {
     agent_url: agentUrl,
     harness_mode: 'black_box',
-    live_endpoint_warning: Boolean(contract) && contract!.endpoint_scope !== 'sandbox',
+    // Default to TRUE when no contract is loaded — we can't prove the endpoint
+    // is sandbox, so warn the operator that 016/020 could produce live side
+    // effects. Only FALSE when a contract is loaded AND declares sandbox.
+    live_endpoint_warning: !contract || contract.endpoint_scope !== 'sandbox',
     contract_loaded: Boolean(contract),
     positive,
     negative,

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -2,10 +2,7 @@ import { randomBytes } from 'crypto';
 import { buildNegativeRequest, buildPositiveRequest, type SignedHttpRequest } from './builder';
 import { probeSignedRequest, type ProbeResult } from './probe';
 import { loadRequestSigningVectors, type LoadVectorsOptions } from './vector-loader';
-import {
-  loadSignedRequestsRunnerContract,
-  type SignedRequestsRunnerContract,
-} from './test-kit';
+import { loadSignedRequestsRunnerContract, type SignedRequestsRunnerContract } from './test-kit';
 import type { NegativeVector, PositiveVector } from './types';
 
 export interface GradeOptions extends LoadVectorsOptions {
@@ -102,10 +99,7 @@ export interface GradeReport {
  *     a live valid request that will be accepted before the second (rejected)
  *     copy fires.
  */
-export async function gradeRequestSigning(
-  agentUrl: string,
-  options: GradeOptions = {}
-): Promise<GradeReport> {
+export async function gradeRequestSigning(agentUrl: string, options: GradeOptions = {}): Promise<GradeReport> {
   const start = Date.now();
   const loaded = loadRequestSigningVectors(options);
   const contract = loadSignedRequestsRunnerContract(options);
@@ -242,9 +236,7 @@ export async function gradeOneVector(
   const buildOpts = { baseUrl: agentUrl };
 
   const vector =
-    kind === 'positive'
-      ? loaded.positive.find(v => v.id === vectorId)
-      : loaded.negative.find(v => v.id === vectorId);
+    kind === 'positive' ? loaded.positive.find(v => v.id === vectorId) : loaded.negative.find(v => v.id === vectorId);
   if (!vector) throw new Error(`Unknown ${kind} vector "${vectorId}"`);
 
   const skip = preflightSkip(vector, kind, contract, options);
@@ -267,9 +259,7 @@ function gradePositive(vector: PositiveVector, probe: ProbeResult): VectorGradeR
     kind: 'positive',
     passed: accepted && !probe.error,
     http_status: probe.status,
-    diagnostic: accepted
-      ? undefined
-      : buildPositiveDiagnostic(vector, probe),
+    diagnostic: accepted ? undefined : buildPositiveDiagnostic(vector, probe),
     probe_duration_ms: probe.duration_ms,
   };
 }
@@ -430,4 +420,3 @@ function buildNegativeDiagnostic(vector: NegativeVector, probe: ProbeResult): st
   }
   return `expected error="${vector.expected_error_code}", got error="${actual}". Check verifier step ordering — several vectors (015/017/020) depend on revocation/cap checks firing BEFORE crypto verify.`;
 }
-

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -28,6 +28,22 @@ export interface GradeOptions extends LoadVectorsOptions {
    */
   skipVectors?: string[];
   /**
+   * When set, run only the named vector ids (all others auto-skip). Takes
+   * precedence over `skipVectors`. Useful for isolated regression tests
+   * against a single vector without hand-maintaining an inverted skip list.
+   */
+  onlyVectors?: string[];
+  /**
+   * Opt in to running vectors that produce live agent-side effects — vector
+   * 016 (replay_window) sends a valid `create_media_buy`-shaped request the
+   * agent will accept, and vector 020 (rate_abuse) floods cap+1 requests.
+   * Required unless the test-kit contract declares `endpoint_scope: sandbox`
+   * (in which case the agent asserts the operation is side-effect-free).
+   * Default: false — side-effectful vectors auto-skip against non-sandbox
+   * endpoints.
+   */
+  allowLiveSideEffects?: boolean;
+  /**
    * Override the agent's base URL used for the grader's HTTP targets. When set,
    * each vector's `request.url` is rewritten by swapping origin+path under this
    * base — useful when the vectors point at `seller.example.com` but the agent
@@ -56,11 +72,20 @@ export interface VectorGradeResult {
 export interface GradeReport {
   agent_url: string;
   harness_mode: 'black_box';
-  endpoint_scope_warning: boolean;
+  /**
+   * `true` when the test-kit contract declares an endpoint_scope other than
+   * `sandbox` — vectors 016 and 020 produce live side effects (a real
+   * `create_media_buy` for 016, cap+1 flooding for 020). Treat as a warning
+   * to the operator.
+   */
+  live_endpoint_warning: boolean;
   contract_loaded: boolean;
   positive: VectorGradeResult[];
   negative: VectorGradeResult[];
   passed: boolean;
+  passed_count: number;
+  failed_count: number;
+  skipped_count: number;
   total_duration_ms: number;
 }
 
@@ -91,20 +116,12 @@ export async function gradeRequestSigning(
   };
 
   const buildOpts = { baseUrl: agentUrl };
-  const skipSet = new Set(options.skipVectors ?? []);
 
   const positive: VectorGradeResult[] = [];
   for (const vector of loaded.positive) {
-    if (skipSet.has(vector.id)) {
-      positive.push({
-        vector_id: vector.id,
-        kind: 'positive',
-        passed: false,
-        skipped: true,
-        skip_reason: 'operator_skip',
-        http_status: 0,
-        probe_duration_ms: 0,
-      });
+    const skip = preflightSkip(vector, 'positive', contract, options);
+    if (skip) {
+      positive.push(skip);
       continue;
     }
     const signed = buildPositiveRequest(vector, loaded.keys, buildOpts);
@@ -114,65 +131,95 @@ export async function gradeRequestSigning(
 
   const negative: VectorGradeResult[] = [];
   for (const vector of loaded.negative) {
-    if (skipSet.has(vector.id)) {
-      negative.push({
-        vector_id: vector.id,
-        kind: 'negative',
-        passed: false,
-        skipped: true,
-        skip_reason: 'operator_skip',
-        expected_error_code: vector.expected_error_code,
-        http_status: 0,
-        probe_duration_ms: 0,
-      });
+    const skip = preflightSkip(vector, 'negative', contract, options);
+    if (skip) {
+      negative.push(skip);
       continue;
     }
-    if (vector.requires_contract === 'rate_abuse' && options.skipRateAbuse) {
-      negative.push({
-        vector_id: vector.id,
-        kind: 'negative',
-        passed: false,
-        skipped: true,
-        skip_reason: 'rate_abuse_opt_out',
-        expected_error_code: vector.expected_error_code,
-        http_status: 0,
-        probe_duration_ms: 0,
-      });
-      continue;
-    }
-    if (vector.requires_contract && !contract) {
-      negative.push({
-        vector_id: vector.id,
-        kind: 'negative',
-        passed: false,
-        skipped: true,
-        skip_reason: 'missing_test_kit_contract',
-        expected_error_code: vector.expected_error_code,
-        diagnostic:
-          'Stateful vector requires `test-kits/signed-requests-runner.yaml` in the compliance cache. Run `npm run sync-schemas`.',
-        http_status: 0,
-        probe_duration_ms: 0,
-      });
-      continue;
-    }
-
-    const result = await gradeNegative(vector, loaded, contract, probeOpts, buildOpts, options);
-    negative.push(result);
+    negative.push(await gradeNegative(vector, loaded, contract, probeOpts, buildOpts, options));
   }
 
-  const passed =
-    positive.every(p => p.passed) && negative.every(n => n.passed || n.skipped);
+  const all = [...positive, ...negative];
+  const passed_count = all.filter(r => r.passed && !r.skipped).length;
+  const skipped_count = all.filter(r => r.skipped).length;
+  const failed_count = all.filter(r => !r.passed && !r.skipped).length;
+  const passed = failed_count === 0;
 
   return {
     agent_url: agentUrl,
     harness_mode: 'black_box',
-    endpoint_scope_warning: contract?.endpoint_scope === 'sandbox',
+    live_endpoint_warning: Boolean(contract) && contract!.endpoint_scope !== 'sandbox',
     contract_loaded: Boolean(contract),
     positive,
     negative,
     passed,
+    passed_count,
+    failed_count,
+    skipped_count,
     total_duration_ms: Date.now() - start,
   };
+}
+
+/**
+ * Centralized skip decisions. Checks (in order): onlyVectors filter, operator
+ * skipVectors, rate-abuse opt-out, stateful-contract missing, side-effect gate.
+ */
+function preflightSkip(
+  vector: PositiveVector | NegativeVector,
+  kind: 'positive' | 'negative',
+  contract: SignedRequestsRunnerContract | undefined,
+  options: GradeOptions
+): VectorGradeResult | undefined {
+  const expected_error_code = kind === 'negative' ? (vector as NegativeVector).expected_error_code : undefined;
+  const base = {
+    vector_id: vector.id,
+    kind,
+    passed: true, // skipped ≠ failed; overall pass/fail excludes skipped
+    http_status: 0,
+    probe_duration_ms: 0,
+    ...(expected_error_code ? { expected_error_code } : {}),
+  } as const;
+
+  if (options.onlyVectors && !options.onlyVectors.includes(vector.id)) {
+    return { ...base, skipped: true, skip_reason: 'not_in_only_vectors' };
+  }
+  if (options.skipVectors?.includes(vector.id)) {
+    return { ...base, skipped: true, skip_reason: 'operator_skip' };
+  }
+  if (kind === 'negative') {
+    const neg = vector as NegativeVector;
+    if (neg.requires_contract === 'rate_abuse' && options.skipRateAbuse) {
+      return { ...base, skipped: true, skip_reason: 'rate_abuse_opt_out' };
+    }
+    if (neg.requires_contract && !contract) {
+      return {
+        ...base,
+        skipped: true,
+        skip_reason: 'missing_test_kit_contract',
+        diagnostic:
+          'Stateful vector requires `test-kits/signed-requests-runner.yaml` in the compliance cache. Run `npm run sync-schemas`.',
+      };
+    }
+    // Sandbox opt-in: vectors 016 (replay_window) and 020 (rate_abuse) produce
+    // live side effects on the agent. Refuse to run unless the contract says
+    // sandbox OR the operator explicitly accepts the side effects.
+    if (
+      (neg.requires_contract === 'replay_window' || neg.requires_contract === 'rate_abuse') &&
+      !options.allowLiveSideEffects &&
+      contract?.endpoint_scope !== 'sandbox'
+    ) {
+      return {
+        ...base,
+        skipped: true,
+        skip_reason: 'live_side_effect_opt_in_required',
+        diagnostic:
+          `Vector ${vector.id} produces live agent-side effects. Pass allowLiveSideEffects: true ` +
+          `(or point the grader at an endpoint whose signed-requests-runner contract declares ` +
+          `endpoint_scope: sandbox) to run it.`,
+      };
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -194,16 +241,21 @@ export async function gradeOneVector(
   };
   const buildOpts = { baseUrl: agentUrl };
 
+  const vector =
+    kind === 'positive'
+      ? loaded.positive.find(v => v.id === vectorId)
+      : loaded.negative.find(v => v.id === vectorId);
+  if (!vector) throw new Error(`Unknown ${kind} vector "${vectorId}"`);
+
+  const skip = preflightSkip(vector, kind, contract, options);
+  if (skip) return skip;
+
   if (kind === 'positive') {
-    const vector = loaded.positive.find(v => v.id === vectorId);
-    if (!vector) throw new Error(`Unknown positive vector "${vectorId}"`);
-    const signed = buildPositiveRequest(vector, loaded.keys, buildOpts);
+    const signed = buildPositiveRequest(vector as PositiveVector, loaded.keys, buildOpts);
     const probe = await probeSignedRequest(signed, probeOpts);
-    return gradePositive(vector, probe);
+    return gradePositive(vector as PositiveVector, probe);
   }
-  const vector = loaded.negative.find(v => v.id === vectorId);
-  if (!vector) throw new Error(`Unknown negative vector "${vectorId}"`);
-  return gradeNegative(vector, loaded, contract, probeOpts, buildOpts, options);
+  return gradeNegative(vector as NegativeVector, loaded, contract, probeOpts, buildOpts, options);
 }
 
 // ── Phase helpers ─────────────────────────────────────────────

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -1,0 +1,350 @@
+import { randomBytes } from 'crypto';
+import { buildNegativeRequest, buildPositiveRequest, type SignedHttpRequest } from './builder';
+import { probeSignedRequest, type ProbeResult } from './probe';
+import { loadRequestSigningVectors, type LoadVectorsOptions } from './vector-loader';
+import {
+  loadSignedRequestsRunnerContract,
+  type SignedRequestsRunnerContract,
+} from './test-kit';
+import type { NegativeVector, PositiveVector } from './types';
+
+export interface GradeOptions extends LoadVectorsOptions {
+  /** Allow http:// and private-IP destinations. Off by default (match fetchProbe). */
+  allowPrivateIp?: boolean;
+  /** Skip the rate-abuse vector (it sends 100+ requests; slow). Defaults to false. */
+  skipRateAbuse?: boolean;
+  /**
+   * Override the rate-abuse cap the grader targets. Defaults to the contract's
+   * `grading_target_per_keyid_cap_requests`. Agents that advertise a smaller
+   * per-keyid cap for the test counterparty MAY lower this so grading finishes
+   * in a reasonable time — see test-kits/signed-requests-runner.yaml.
+   */
+  rateAbuseCap?: number;
+  /**
+   * Vector IDs to skip. Use for capability-profile mismatches — vectors 007
+   * and 018 each assume the verifier advertises a specific
+   * `covers_content_digest` policy (`"required"` and `"forbidden"`
+   * respectively) that a given agent may not match.
+   */
+  skipVectors?: string[];
+  /**
+   * Override the agent's base URL used for the grader's HTTP targets. When set,
+   * each vector's `request.url` is rewritten by swapping origin+path under this
+   * base — useful when the vectors point at `seller.example.com` but the agent
+   * is reachable at a sandbox URL.
+   */
+  agentUrl?: string;
+  /** Per-probe timeout. Default 10s. */
+  timeoutMs?: number;
+}
+
+export interface VectorGradeResult {
+  vector_id: string;
+  kind: 'positive' | 'negative';
+  passed: boolean;
+  skipped?: boolean;
+  skip_reason?: string;
+  /** For negatives: the error code the agent returned (from WWW-Authenticate). */
+  actual_error_code?: string;
+  /** For negatives: the error code the spec says we should see. */
+  expected_error_code?: string;
+  http_status: number;
+  diagnostic?: string;
+  probe_duration_ms: number;
+}
+
+export interface GradeReport {
+  agent_url: string;
+  harness_mode: 'black_box';
+  endpoint_scope_warning: boolean;
+  contract_loaded: boolean;
+  positive: VectorGradeResult[];
+  negative: VectorGradeResult[];
+  passed: boolean;
+  total_duration_ms: number;
+}
+
+/**
+ * Grade an agent's RFC 9421 verifier against the 28 conformance vectors.
+ *
+ * Preconditions the caller owns:
+ *   - Agent advertises `request_signing.supported: true` in `get_adcp_capabilities`.
+ *   - Agent has pre-configured its verifier per `test-kits/signed-requests-runner.yaml`:
+ *     - Runner's signing keyids (`test-ed25519-2026`, `test-es256-2026`) accepted.
+ *     - `test-revoked-2026` pre-revoked.
+ *     - Per-keyid rate cap within grading_target_per_keyid_cap_requests.
+ *   - `agentUrl` targets a sandbox endpoint — the replay-window contract sends
+ *     a live valid request that will be accepted before the second (rejected)
+ *     copy fires.
+ */
+export async function gradeRequestSigning(
+  agentUrl: string,
+  options: GradeOptions = {}
+): Promise<GradeReport> {
+  const start = Date.now();
+  const loaded = loadRequestSigningVectors(options);
+  const contract = loadSignedRequestsRunnerContract(options);
+
+  const probeOpts = {
+    allowPrivateIp: options.allowPrivateIp === true,
+    timeoutMs: options.timeoutMs,
+  };
+
+  const buildOpts = { baseUrl: agentUrl };
+  const skipSet = new Set(options.skipVectors ?? []);
+
+  const positive: VectorGradeResult[] = [];
+  for (const vector of loaded.positive) {
+    if (skipSet.has(vector.id)) {
+      positive.push({
+        vector_id: vector.id,
+        kind: 'positive',
+        passed: false,
+        skipped: true,
+        skip_reason: 'operator_skip',
+        http_status: 0,
+        probe_duration_ms: 0,
+      });
+      continue;
+    }
+    const signed = buildPositiveRequest(vector, loaded.keys, buildOpts);
+    const probed = await probeSignedRequest(signed, probeOpts);
+    positive.push(gradePositive(vector, probed));
+  }
+
+  const negative: VectorGradeResult[] = [];
+  for (const vector of loaded.negative) {
+    if (skipSet.has(vector.id)) {
+      negative.push({
+        vector_id: vector.id,
+        kind: 'negative',
+        passed: false,
+        skipped: true,
+        skip_reason: 'operator_skip',
+        expected_error_code: vector.expected_error_code,
+        http_status: 0,
+        probe_duration_ms: 0,
+      });
+      continue;
+    }
+    if (vector.requires_contract === 'rate_abuse' && options.skipRateAbuse) {
+      negative.push({
+        vector_id: vector.id,
+        kind: 'negative',
+        passed: false,
+        skipped: true,
+        skip_reason: 'rate_abuse_opt_out',
+        expected_error_code: vector.expected_error_code,
+        http_status: 0,
+        probe_duration_ms: 0,
+      });
+      continue;
+    }
+    if (vector.requires_contract && !contract) {
+      negative.push({
+        vector_id: vector.id,
+        kind: 'negative',
+        passed: false,
+        skipped: true,
+        skip_reason: 'missing_test_kit_contract',
+        expected_error_code: vector.expected_error_code,
+        diagnostic:
+          'Stateful vector requires `test-kits/signed-requests-runner.yaml` in the compliance cache. Run `npm run sync-schemas`.',
+        http_status: 0,
+        probe_duration_ms: 0,
+      });
+      continue;
+    }
+
+    const result = await gradeNegative(vector, loaded, contract, probeOpts, buildOpts, options);
+    negative.push(result);
+  }
+
+  const passed =
+    positive.every(p => p.passed) && negative.every(n => n.passed || n.skipped);
+
+  return {
+    agent_url: agentUrl,
+    harness_mode: 'black_box',
+    endpoint_scope_warning: contract?.endpoint_scope === 'sandbox',
+    contract_loaded: Boolean(contract),
+    positive,
+    negative,
+    passed,
+    total_duration_ms: Date.now() - start,
+  };
+}
+
+// ── Phase helpers ─────────────────────────────────────────────
+
+function gradePositive(vector: PositiveVector, probe: ProbeResult): VectorGradeResult {
+  const accepted = probe.status >= 200 && probe.status < 300;
+  return {
+    vector_id: vector.id,
+    kind: 'positive',
+    passed: accepted && !probe.error,
+    http_status: probe.status,
+    diagnostic: accepted
+      ? undefined
+      : buildPositiveDiagnostic(vector, probe),
+    probe_duration_ms: probe.duration_ms,
+  };
+}
+
+function buildPositiveDiagnostic(vector: PositiveVector, probe: ProbeResult): string {
+  if (probe.error) return `probe error: ${probe.error}`;
+  const expected = 'a 2xx status';
+  const sigError = probe.wwwAuthenticateErrorCode;
+  if (sigError) {
+    return `expected ${expected}, got ${probe.status} with WWW-Authenticate error="${sigError}" — signer or agent-side JWKS likely mismatched. Vector: ${vector.name}`;
+  }
+  return `expected ${expected}, got ${probe.status}. Vector: ${vector.name}`;
+}
+
+async function gradeNegative(
+  vector: NegativeVector,
+  loaded: ReturnType<typeof loadRequestSigningVectors>,
+  contract: SignedRequestsRunnerContract | undefined,
+  probeOpts: { allowPrivateIp: boolean; timeoutMs?: number },
+  buildOpts: { baseUrl: string },
+  options: GradeOptions
+): Promise<VectorGradeResult> {
+  switch (vector.requires_contract) {
+    case 'replay_window':
+      return gradeReplayWindow(vector, loaded, probeOpts, buildOpts);
+    case 'rate_abuse':
+      return gradeRateAbuse(vector, loaded, contract!, probeOpts, buildOpts, options);
+    case 'revocation':
+    default:
+      return gradeStaticNegative(vector, loaded, probeOpts, buildOpts);
+  }
+}
+
+function gradeStaticNegative(
+  vector: NegativeVector,
+  loaded: ReturnType<typeof loadRequestSigningVectors>,
+  probeOpts: { allowPrivateIp: boolean; timeoutMs?: number },
+  buildOpts: { baseUrl: string }
+): Promise<VectorGradeResult> {
+  const signed = buildNegativeRequest(vector, loaded.keys, buildOpts);
+  return probeSignedRequest(signed, probeOpts).then(probe => ({
+    vector_id: vector.id,
+    kind: 'negative',
+    passed: negativeAcceptedErrorCode(vector, probe),
+    http_status: probe.status,
+    expected_error_code: vector.expected_error_code,
+    actual_error_code: probe.wwwAuthenticateErrorCode,
+    diagnostic: buildNegativeDiagnostic(vector, probe),
+    probe_duration_ms: probe.duration_ms,
+  }));
+}
+
+async function gradeReplayWindow(
+  vector: NegativeVector,
+  loaded: ReturnType<typeof loadRequestSigningVectors>,
+  probeOpts: { allowPrivateIp: boolean; timeoutMs?: number },
+  buildOpts: { baseUrl: string }
+): Promise<VectorGradeResult> {
+  // Build one valid signed request with a fixed nonce, then send it twice.
+  const fixedNonce = randomBytes(16).toString('base64url');
+  const signed = buildPositiveRequestFromNegative(vector, loaded, { nonce: fixedNonce, baseUrl: buildOpts.baseUrl });
+
+  const first = await probeSignedRequest(signed, probeOpts);
+  if (first.status < 200 || first.status >= 300) {
+    return {
+      vector_id: vector.id,
+      kind: 'negative',
+      passed: false,
+      http_status: first.status,
+      expected_error_code: vector.expected_error_code,
+      actual_error_code: first.wwwAuthenticateErrorCode,
+      diagnostic:
+        `replay_window contract: first submission MUST be accepted but agent returned ${first.status}` +
+        (first.wwwAuthenticateErrorCode ? ` (error="${first.wwwAuthenticateErrorCode}")` : '') +
+        '. Check runner JWKS registration with the agent.',
+      probe_duration_ms: first.duration_ms,
+    };
+  }
+
+  const second = await probeSignedRequest(signed, probeOpts);
+  return {
+    vector_id: vector.id,
+    kind: 'negative',
+    passed: negativeAcceptedErrorCode(vector, second),
+    http_status: second.status,
+    expected_error_code: vector.expected_error_code,
+    actual_error_code: second.wwwAuthenticateErrorCode,
+    diagnostic: buildNegativeDiagnostic(vector, second),
+    probe_duration_ms: first.duration_ms + second.duration_ms,
+  };
+}
+
+async function gradeRateAbuse(
+  vector: NegativeVector,
+  loaded: ReturnType<typeof loadRequestSigningVectors>,
+  contract: SignedRequestsRunnerContract,
+  probeOpts: { allowPrivateIp: boolean; timeoutMs?: number },
+  buildOpts: { baseUrl: string },
+  options: GradeOptions
+): Promise<VectorGradeResult> {
+  const cap =
+    options.rateAbuseCap ?? contract.stateful_vector_contract.rate_abuse.grading_target_per_keyid_cap_requests;
+  // Fill the cap with cap distinct-nonce requests, then probe one more — that
+  // (cap+1)th request is what the vector expects to be rejected.
+  let durationMs = 0;
+  for (let i = 0; i < cap; i++) {
+    const nonce = randomBytes(16).toString('base64url');
+    const signed = buildNegativeRequest(vector, loaded.keys, { nonce, ...buildOpts });
+    const probe = await probeSignedRequest(signed, probeOpts);
+    durationMs += probe.duration_ms;
+  }
+  const finalNonce = randomBytes(16).toString('base64url');
+  const capPlusOne = buildNegativeRequest(vector, loaded.keys, { nonce: finalNonce, ...buildOpts });
+  const probe = await probeSignedRequest(capPlusOne, probeOpts);
+  durationMs += probe.duration_ms;
+  return {
+    vector_id: vector.id,
+    kind: 'negative',
+    passed: negativeAcceptedErrorCode(vector, probe),
+    http_status: probe.status,
+    expected_error_code: vector.expected_error_code,
+    actual_error_code: probe.wwwAuthenticateErrorCode,
+    diagnostic: buildNegativeDiagnostic(vector, probe),
+    probe_duration_ms: durationMs,
+  };
+}
+
+function buildPositiveRequestFromNegative(
+  vector: NegativeVector,
+  loaded: ReturnType<typeof loadRequestSigningVectors>,
+  options: { nonce: string; baseUrl: string }
+): SignedHttpRequest {
+  // Vector 016 is structurally identical to positive/001 — sign it as a positive.
+  const pseudoPositive: PositiveVector = {
+    kind: 'positive',
+    id: vector.id,
+    name: vector.name,
+    reference_now: vector.reference_now,
+    request: vector.request,
+    verifier_capability: vector.verifier_capability,
+    jwks_ref: vector.jwks_ref,
+  };
+  return buildPositiveRequest(pseudoPositive, loaded.keys, options);
+}
+
+function negativeAcceptedErrorCode(vector: NegativeVector, probe: ProbeResult): boolean {
+  return probe.status === 401 && probe.wwwAuthenticateErrorCode === vector.expected_error_code;
+}
+
+function buildNegativeDiagnostic(vector: NegativeVector, probe: ProbeResult): string | undefined {
+  if (probe.error) return `probe error: ${probe.error}`;
+  if (probe.status === 401 && probe.wwwAuthenticateErrorCode === vector.expected_error_code) {
+    return undefined;
+  }
+  const actual = probe.wwwAuthenticateErrorCode ?? '(none)';
+  if (probe.status !== 401) {
+    return `expected 401 with error="${vector.expected_error_code}", got ${probe.status} (error="${actual}"). Vector: ${vector.name}`;
+  }
+  return `expected error="${vector.expected_error_code}", got error="${actual}". Check verifier step ordering — several vectors (015/017/020) depend on revocation/cap checks firing BEFORE crypto verify.`;
+}
+

--- a/src/lib/testing/storyboard/request-signing/index.ts
+++ b/src/lib/testing/storyboard/request-signing/index.ts
@@ -22,3 +22,27 @@ export {
   type BuildOptions,
   type SignedHttpRequest,
 } from './builder';
+
+export {
+  loadSignedRequestsRunnerContract,
+  type LoadTestKitOptions,
+  type RateAbuseContract,
+  type ReplayWindowContract,
+  type RevocationContract,
+  type RunnerSigningKey,
+  type SignedRequestsRunnerContract,
+} from './test-kit';
+
+export {
+  probeSignedRequest,
+  extractSignatureErrorCode,
+  type ProbeOptions,
+  type ProbeResult,
+} from './probe';
+
+export {
+  gradeRequestSigning,
+  type GradeOptions,
+  type GradeReport,
+  type VectorGradeResult,
+} from './grader';

--- a/src/lib/testing/storyboard/request-signing/index.ts
+++ b/src/lib/testing/storyboard/request-signing/index.ts
@@ -70,12 +70,7 @@ export type {
 
 export { CONTRACT_IDS } from './types';
 
-export {
-  loadRequestSigningVectors,
-  findKey,
-  type LoadVectorsOptions,
-  type LoadedVectors,
-} from './vector-loader';
+export { loadRequestSigningVectors, findKey, type LoadVectorsOptions, type LoadedVectors } from './vector-loader';
 
 export {
   buildPositiveRequest,
@@ -95,9 +90,4 @@ export {
   type SignedRequestsRunnerContract,
 } from './test-kit';
 
-export {
-  probeSignedRequest,
-  extractSignatureErrorCode,
-  type ProbeOptions,
-  type ProbeResult,
-} from './probe';
+export { probeSignedRequest, extractSignatureErrorCode, type ProbeOptions, type ProbeResult } from './probe';

--- a/src/lib/testing/storyboard/request-signing/index.ts
+++ b/src/lib/testing/storyboard/request-signing/index.ts
@@ -1,0 +1,24 @@
+export type {
+  NegativeVector,
+  PositiveVector,
+  TestKeypair,
+  TestKeyset,
+  VectorRequest,
+  VerifierCapabilityFixture,
+  Vector,
+} from './types';
+
+export {
+  loadRequestSigningVectors,
+  findKey,
+  type LoadVectorsOptions,
+  type LoadedVectors,
+} from './vector-loader';
+
+export {
+  buildPositiveRequest,
+  buildNegativeRequest,
+  listSupportedNegativeVectors,
+  type BuildOptions,
+  type SignedHttpRequest,
+} from './builder';

--- a/src/lib/testing/storyboard/request-signing/index.ts
+++ b/src/lib/testing/storyboard/request-signing/index.ts
@@ -1,3 +1,62 @@
+/**
+ * RFC 9421 request-signing conformance grader.
+ *
+ * Tests any agent advertising `request_signing.supported: true` against the
+ * 28 conformance vectors shipped under
+ * `compliance/cache/{version}/test-vectors/request-signing/`. Grading is
+ * black-box and observable-behavior only — we construct signed HTTP requests
+ * (dynamically, using the test keypairs in keys.json) and compare the
+ * agent's responses to each vector's `expected_outcome`.
+ *
+ * @example
+ * ```ts
+ * import { gradeRequestSigning } from '@adcp/client/testing/storyboard/request-signing';
+ *
+ * const report = await gradeRequestSigning('https://sandbox.seller.com/adcp', {
+ *   skipRateAbuse: true, // skip the 101-request flood in routine runs
+ * });
+ * if (!report.passed) {
+ *   for (const r of [...report.positive, ...report.negative]) {
+ *     if (!r.passed && !r.skipped) console.log(`${r.vector_id}: ${r.diagnostic}`);
+ *   }
+ * }
+ * ```
+ *
+ * For storyboard-runner integration (synthesized per-vector steps dispatched
+ * through `runStoryboard` / `runStoryboardStep`), see
+ * `StoryboardRunOptions.request_signing` on the runner options.
+ */
+
+// ── Public API ────────────────────────────────────────────────────
+// These are what 95% of consumers need. Start here.
+
+export {
+  gradeRequestSigning,
+  gradeOneVector,
+  type GradeOptions,
+  type GradeReport,
+  type VectorGradeResult,
+} from './grader';
+
+// ── Storyboard-runner hooks ───────────────────────────────────────
+// Surfaces used internally by the runner; exported so external runners and
+// custom harnesses can wire them the same way.
+
+export {
+  synthesizeRequestSigningSteps,
+  parseRequestSigningStepId,
+  REQUEST_SIGNING_PROBE_TASK,
+  POSITIVE_STEP_PREFIX,
+  NEGATIVE_STEP_PREFIX,
+  type SynthesizeOptions,
+} from './synthesize';
+
+export { probeRequestSigningVector } from './probe-dispatch';
+
+// ── Advanced: custom harness building blocks ──────────────────────
+// Escape hatches for constructing custom graders (alternate probe transports,
+// pre-flight staging, etc.). Most consumers should not need these.
+
 export type {
   NegativeVector,
   PositiveVector,
@@ -6,7 +65,10 @@ export type {
   VectorRequest,
   VerifierCapabilityFixture,
   Vector,
+  ContractId,
 } from './types';
+
+export { CONTRACT_IDS } from './types';
 
 export {
   loadRequestSigningVectors,
@@ -39,22 +101,3 @@ export {
   type ProbeOptions,
   type ProbeResult,
 } from './probe';
-
-export {
-  gradeRequestSigning,
-  gradeOneVector,
-  type GradeOptions,
-  type GradeReport,
-  type VectorGradeResult,
-} from './grader';
-
-export {
-  synthesizeRequestSigningSteps,
-  parseRequestSigningStepId,
-  REQUEST_SIGNING_PROBE_TASK,
-  POSITIVE_STEP_PREFIX,
-  NEGATIVE_STEP_PREFIX,
-  type SynthesizeOptions,
-} from './synthesize';
-
-export { probeRequestSigningVector } from './probe-dispatch';

--- a/src/lib/testing/storyboard/request-signing/index.ts
+++ b/src/lib/testing/storyboard/request-signing/index.ts
@@ -42,7 +42,19 @@ export {
 
 export {
   gradeRequestSigning,
+  gradeOneVector,
   type GradeOptions,
   type GradeReport,
   type VectorGradeResult,
 } from './grader';
+
+export {
+  synthesizeRequestSigningSteps,
+  parseRequestSigningStepId,
+  REQUEST_SIGNING_PROBE_TASK,
+  POSITIVE_STEP_PREFIX,
+  NEGATIVE_STEP_PREFIX,
+  type SynthesizeOptions,
+} from './synthesize';
+
+export { probeRequestSigningVector } from './probe-dispatch';

--- a/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
+++ b/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
@@ -1,0 +1,57 @@
+import type { HttpProbeResult, StoryboardRunOptions } from '../types';
+import { gradeOneVector } from './grader';
+import { parseRequestSigningStepId } from './synthesize';
+
+/**
+ * Dispatch a synthesized request-signing step. The step ID encodes the vector
+ * (`positive-<id>` / `negative-<id>`); this helper decodes it, runs the
+ * grader's per-vector logic, and maps the `VectorGradeResult` to an
+ * `HttpProbeResult`-shaped return so the existing validation pipeline
+ * (`http_status`, `http_status_in`) works unchanged.
+ */
+export async function probeRequestSigningVector(
+  stepId: string,
+  agentUrl: string,
+  options: StoryboardRunOptions
+): Promise<HttpProbeResult> {
+  const parsed = parseRequestSigningStepId(stepId);
+  if (!parsed) {
+    return skipResult(agentUrl, `request_signing_probe: step id "${stepId}" does not match positive-/negative- prefix`);
+  }
+  const rsOpts = options.request_signing ?? {};
+  if (parsed.kind === 'negative' && parsed.vector_id === '020-rate-abuse' && rsOpts.skipRateAbuse) {
+    return skipResult(agentUrl, `request_signing_probe: ${parsed.vector_id} skipped via request_signing.skipRateAbuse`);
+  }
+  if (rsOpts.skipVectors?.includes(parsed.vector_id)) {
+    return skipResult(agentUrl, `request_signing_probe: ${parsed.vector_id} skipped via request_signing.skipVectors`);
+  }
+  try {
+    const result = await gradeOneVector(parsed.vector_id, parsed.kind, agentUrl, {
+      allowPrivateIp: options.allow_http === true,
+      rateAbuseCap: rsOpts.rateAbuseCap,
+    });
+    const headers: Record<string, string> = {};
+    if (result.actual_error_code) {
+      headers['www-authenticate'] = `Signature error="${result.actual_error_code}"`;
+    }
+    return {
+      url: agentUrl,
+      status: result.http_status,
+      headers,
+      body: result.diagnostic ?? null,
+      error: result.passed || result.skipped ? undefined : (result.diagnostic ?? 'vector grade failed'),
+    };
+  } catch (err) {
+    return {
+      url: agentUrl,
+      status: 0,
+      headers: {},
+      body: null,
+      error: `request_signing_probe threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function skipResult(url: string, message: string): HttpProbeResult {
+  return { url, status: 0, headers: {}, body: null, error: message };
+}

--- a/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
+++ b/src/lib/testing/storyboard/request-signing/probe-dispatch.ts
@@ -1,6 +1,7 @@
 import type { HttpProbeResult, StoryboardRunOptions } from '../types';
 import { gradeOneVector } from './grader';
 import { parseRequestSigningStepId } from './synthesize';
+import { loadRequestSigningVectors } from './vector-loader';
 
 /**
  * Dispatch a synthesized request-signing step. The step ID encodes the vector
@@ -16,20 +17,43 @@ export async function probeRequestSigningVector(
 ): Promise<HttpProbeResult> {
   const parsed = parseRequestSigningStepId(stepId);
   if (!parsed) {
-    return skipResult(agentUrl, `request_signing_probe: step id "${stepId}" does not match positive-/negative- prefix`);
+    return {
+      url: agentUrl,
+      status: 0,
+      headers: {},
+      body: null,
+      error: `request_signing_probe: step id "${stepId}" does not match positive-/negative- prefix`,
+    };
   }
   const rsOpts = options.request_signing ?? {};
-  if (parsed.kind === 'negative' && parsed.vector_id === '020-rate-abuse' && rsOpts.skipRateAbuse) {
-    return skipResult(agentUrl, `request_signing_probe: ${parsed.vector_id} skipped via request_signing.skipRateAbuse`);
+  // Vector-id lookup so we skip by the vector's `requires_contract`, not by
+  // hardcoded vector id. Keeps the dispatch resilient to upstream renames.
+  if (parsed.kind === 'negative' && rsOpts.skipRateAbuse) {
+    try {
+      const loaded = loadRequestSigningVectors();
+      const vector = loaded.negative.find(v => v.id === parsed.vector_id);
+      if (vector?.requires_contract === 'rate_abuse') {
+        return skipProbe(agentUrl, `${parsed.vector_id} skipped via request_signing.skipRateAbuse`);
+      }
+    } catch {
+      // fall through — surfaces as a grader error below
+    }
   }
   if (rsOpts.skipVectors?.includes(parsed.vector_id)) {
-    return skipResult(agentUrl, `request_signing_probe: ${parsed.vector_id} skipped via request_signing.skipVectors`);
+    return skipProbe(agentUrl, `${parsed.vector_id} skipped via request_signing.skipVectors`);
   }
   try {
     const result = await gradeOneVector(parsed.vector_id, parsed.kind, agentUrl, {
       allowPrivateIp: options.allow_http === true,
       rateAbuseCap: rsOpts.rateAbuseCap,
+      allowLiveSideEffects: rsOpts.allowLiveSideEffects,
+      onlyVectors: rsOpts.onlyVectors,
+      skipVectors: rsOpts.skipVectors,
+      skipRateAbuse: rsOpts.skipRateAbuse,
     });
+    if (result.skipped) {
+      return skipProbe(agentUrl, result.skip_reason ?? 'grader_skipped');
+    }
     const headers: Record<string, string> = {};
     if (result.actual_error_code) {
       headers['www-authenticate'] = `Signature error="${result.actual_error_code}"`;
@@ -39,7 +63,7 @@ export async function probeRequestSigningVector(
       status: result.http_status,
       headers,
       body: result.diagnostic ?? null,
-      error: result.passed || result.skipped ? undefined : (result.diagnostic ?? 'vector grade failed'),
+      error: result.passed ? undefined : (result.diagnostic ?? 'vector grade failed'),
     };
   } catch (err) {
     return {
@@ -52,6 +76,6 @@ export async function probeRequestSigningVector(
   }
 }
 
-function skipResult(url: string, message: string): HttpProbeResult {
-  return { url, status: 0, headers: {}, body: null, error: message };
+function skipProbe(url: string, reason: string): HttpProbeResult {
+  return { url, status: 0, headers: {}, body: null, skipped: true, skip_reason: reason };
 }

--- a/src/lib/testing/storyboard/request-signing/probe.ts
+++ b/src/lib/testing/storyboard/request-signing/probe.ts
@@ -1,0 +1,193 @@
+import { lookup as dnsLookup } from 'dns/promises';
+import { Agent, fetch as undiciFetch } from 'undici';
+import { isAlwaysBlocked, isPrivateIp } from '../probes';
+import type { SignedHttpRequest } from './builder';
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_BODY_BYTES = 64 * 1024;
+
+export interface ProbeOptions {
+  /** Allow http:// and private-IP destinations. Default false. */
+  allowPrivateIp?: boolean;
+  /** Per-call timeout override (ms). */
+  timeoutMs?: number;
+}
+
+export interface ProbeResult {
+  url: string;
+  status: number;
+  headers: Record<string, string>;
+  /** Error code extracted from `WWW-Authenticate: Signature error="<code>"`. */
+  wwwAuthenticateErrorCode?: string;
+  /** Truncated response body (first 64 KiB, JSON-parsed if applicable). */
+  body: unknown;
+  /** Network-level error; non-undefined means the request didn't complete. */
+  error?: string;
+  duration_ms: number;
+}
+
+/**
+ * Send a signed HTTP request to an AdCP agent and capture the response fields
+ * needed for conformance grading (status, WWW-Authenticate error code, body).
+ *
+ * Reuses the SSRF guards established by `fetchProbe` — same classifier, same
+ * IP pin against DNS rebinding. Bodies are capped at 64 KiB and parsed as JSON
+ * when content-type matches; otherwise returned as text. `redirect: 'manual'`
+ * is enforced so an agent that 301s can't smuggle the grader elsewhere.
+ */
+export async function probeSignedRequest(
+  signed: SignedHttpRequest,
+  options: ProbeOptions = {}
+): Promise<ProbeResult> {
+  const start = Date.now();
+  const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const result: ProbeResult = { url: signed.url, status: 0, headers: {}, body: null, duration_ms: 0 };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(signed.url);
+  } catch {
+    result.error = `Invalid URL: ${signed.url}`;
+    result.duration_ms = Date.now() - start;
+    return result;
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    result.error = `Refusing to probe URL with unsupported scheme: ${parsed.protocol}`;
+    result.duration_ms = Date.now() - start;
+    return result;
+  }
+  if (parsed.protocol !== 'https:' && !options.allowPrivateIp) {
+    result.error = `Refusing to probe non-HTTPS URL: ${signed.url}`;
+    result.duration_ms = Date.now() - start;
+    return result;
+  }
+
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await dnsLookup(parsed.hostname, { all: true });
+  } catch (err) {
+    result.error = `DNS lookup failed for ${parsed.hostname}: ${err instanceof Error ? err.message : String(err)}`;
+    result.duration_ms = Date.now() - start;
+    return result;
+  }
+  if (addresses.length === 0) {
+    result.error = `DNS returned no addresses for ${parsed.hostname}`;
+    result.duration_ms = Date.now() - start;
+    return result;
+  }
+  for (const a of addresses) {
+    if (isAlwaysBlocked(a.address)) {
+      result.error = `Refusing to probe always-blocked address ${a.address} for ${parsed.hostname}`;
+      result.duration_ms = Date.now() - start;
+      return result;
+    }
+  }
+  if (!options.allowPrivateIp) {
+    for (const a of addresses) {
+      if (isPrivateIp(a.address)) {
+        result.error = `Refusing to probe private/loopback address ${a.address} for ${parsed.hostname}`;
+        result.duration_ms = Date.now() - start;
+        return result;
+      }
+    }
+  }
+  const pinned = addresses[0]!;
+  const dispatcher = new Agent({
+    connect: { lookup: (_h, _o, cb) => cb(null, pinned.address, pinned.family) },
+  });
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeout);
+  try {
+    const res = await undiciFetch(signed.url, {
+      method: signed.method,
+      redirect: 'manual',
+      signal: ac.signal,
+      headers: signed.headers,
+      body: signed.body,
+      dispatcher,
+    });
+    result.status = res.status;
+    const headers: Record<string, string> = {};
+    res.headers.forEach((v, k) => {
+      headers[k.toLowerCase()] = v;
+    });
+    result.headers = headers;
+
+    const wwwAuth = headers['www-authenticate'];
+    if (wwwAuth) {
+      result.wwwAuthenticateErrorCode = extractSignatureErrorCode(wwwAuth);
+    }
+
+    const reader = res.body?.getReader();
+    if (reader) {
+      const chunks: Uint8Array[] = [];
+      let bytes = 0;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        bytes += value.byteLength;
+        if (bytes > MAX_BODY_BYTES) {
+          await reader.cancel();
+          result.error = `Response body exceeded ${MAX_BODY_BYTES} bytes`;
+          return result;
+        }
+        chunks.push(value);
+      }
+      const buf = Buffer.concat(chunks.map(c => Buffer.from(c.buffer, c.byteOffset, c.byteLength)));
+      const contentType = headers['content-type'] ?? '';
+      if (contentType.includes('application/json')) {
+        try {
+          result.body = JSON.parse(buf.toString('utf8'));
+        } catch {
+          result.body = buf.toString('utf8');
+        }
+      } else {
+        result.body = buf.toString('utf8');
+      }
+    }
+    return result;
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err);
+    return result;
+  } finally {
+    clearTimeout(timer);
+    result.duration_ms = Date.now() - start;
+    await dispatcher.close().catch(() => {});
+  }
+}
+
+/**
+ * Extract `error="<code>"` from a `WWW-Authenticate: Signature ...` header.
+ * Returns undefined when the header isn't a Signature challenge or the param
+ * is absent — grading treats that as a mismatch (agent returned 401 but
+ * didn't advertise a stable error code).
+ */
+export function extractSignatureErrorCode(headerValue: string): string | undefined {
+  // `WWW-Authenticate` may carry multiple challenges concatenated with commas.
+  // We only grade Signature challenges; ignore Basic/Bearer/etc.
+  const challenges = splitChallenges(headerValue);
+  for (const challenge of challenges) {
+    if (!/^Signature\b/i.test(challenge)) continue;
+    const m = /\berror\s*=\s*"([^"]*)"/.exec(challenge);
+    if (m) return m[1];
+  }
+  return undefined;
+}
+
+function splitChallenges(headerValue: string): string[] {
+  // Split on commas, but only when the preceding token looks like a scheme name
+  // followed by whitespace. Challenge params are `k="v"` which may contain
+  // commas — split on the scheme boundary only.
+  const parts: string[] = [];
+  let start = 0;
+  const re = /,\s*([A-Za-z][A-Za-z0-9-]*\s+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(headerValue)) !== null) {
+    parts.push(headerValue.slice(start, m.index).trim());
+    start = m.index + m[0].length - m[1]!.length;
+  }
+  parts.push(headerValue.slice(start).trim());
+  return parts.filter(p => p.length > 0);
+}

--- a/src/lib/testing/storyboard/request-signing/probe.ts
+++ b/src/lib/testing/storyboard/request-signing/probe.ts
@@ -160,9 +160,11 @@ export async function probeSignedRequest(
 
 /**
  * Extract `error="<code>"` from a `WWW-Authenticate: Signature ...` header.
- * Returns undefined when the header isn't a Signature challenge or the param
- * is absent — grading treats that as a mismatch (agent returned 401 but
- * didn't advertise a stable error code).
+ * Returns undefined when the header isn't a Signature challenge, the param
+ * is absent, or the extracted value isn't a well-formed spec error code
+ * (a token in `[a-z0-9_]+`). Sanitizing at source keeps downstream
+ * diagnostics / LLM-consumption paths safe from smuggled content in
+ * attacker-controlled header values.
  */
 export function extractSignatureErrorCode(headerValue: string): string | undefined {
   // `WWW-Authenticate` may carry multiple challenges concatenated with commas.
@@ -171,23 +173,51 @@ export function extractSignatureErrorCode(headerValue: string): string | undefin
   for (const challenge of challenges) {
     if (!/^Signature\b/i.test(challenge)) continue;
     const m = /\berror\s*=\s*"([^"]*)"/.exec(challenge);
-    if (m) return m[1];
+    if (!m) continue;
+    const value = m[1];
+    // Spec error codes are `request_signature_*` — all lowercase-alnum +
+    // underscore. Reject anything else so quotes/newlines/HTML/LLM-poisoning
+    // content can't flow into diagnostic strings or rendered reports.
+    if (value && /^[a-z0-9_]+$/.test(value)) return value;
+    return undefined;
   }
   return undefined;
 }
 
+/**
+ * Split a `WWW-Authenticate` header into per-challenge chunks. RFC 7235 §4.1
+ * lets multiple challenges coexist separated by commas, and challenge params
+ * are `k="v"` where `v` can contain commas. Track quote state so an
+ * adversarial `error="foo, Bar baz"` doesn't spuriously split mid-value.
+ */
 function splitChallenges(headerValue: string): string[] {
-  // Split on commas, but only when the preceding token looks like a scheme name
-  // followed by whitespace. Challenge params are `k="v"` which may contain
-  // commas — split on the scheme boundary only.
   const parts: string[] = [];
-  let start = 0;
-  const re = /,\s*([A-Za-z][A-Za-z0-9-]*\s+)/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(headerValue)) !== null) {
-    parts.push(headerValue.slice(start, m.index).trim());
-    start = m.index + m[0].length - m[1]!.length;
+  let current = '';
+  let inQuotes = false;
+  let lastTokenWasScheme = false;
+  for (let i = 0; i < headerValue.length; i++) {
+    const ch = headerValue[i]!;
+    if (ch === '"' && headerValue[i - 1] !== '\\') {
+      inQuotes = !inQuotes;
+      current += ch;
+      continue;
+    }
+    if (!inQuotes && ch === ',') {
+      // Look ahead for a scheme-like token (`<name><whitespace>`) — only
+      // then treat this comma as a challenge boundary; otherwise it's a
+      // param-list separator inside the current challenge.
+      const rest = headerValue.slice(i + 1);
+      if (/^\s*[A-Za-z][A-Za-z0-9-]*\s+/.test(rest)) {
+        parts.push(current.trim());
+        current = '';
+        lastTokenWasScheme = false;
+        continue;
+      }
+    }
+    current += ch;
+    if (!inQuotes && /\s/.test(ch)) lastTokenWasScheme = true;
   }
-  parts.push(headerValue.slice(start).trim());
+  if (current.trim().length > 0) parts.push(current.trim());
+  void lastTokenWasScheme; // reserved for stricter validation if needed later
   return parts.filter(p => p.length > 0);
 }

--- a/src/lib/testing/storyboard/request-signing/probe.ts
+++ b/src/lib/testing/storyboard/request-signing/probe.ts
@@ -35,10 +35,7 @@ export interface ProbeResult {
  * when content-type matches; otherwise returned as text. `redirect: 'manual'`
  * is enforced so an agent that 301s can't smuggle the grader elsewhere.
  */
-export async function probeSignedRequest(
-  signed: SignedHttpRequest,
-  options: ProbeOptions = {}
-): Promise<ProbeResult> {
+export async function probeSignedRequest(signed: SignedHttpRequest, options: ProbeOptions = {}): Promise<ProbeResult> {
   const start = Date.now();
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const result: ProbeResult = { url: signed.url, status: 0, headers: {}, body: null, duration_ms: 0 };

--- a/src/lib/testing/storyboard/request-signing/probe.ts
+++ b/src/lib/testing/storyboard/request-signing/probe.ts
@@ -191,7 +191,6 @@ function splitChallenges(headerValue: string): string[] {
   const parts: string[] = [];
   let current = '';
   let inQuotes = false;
-  let lastTokenWasScheme = false;
   for (let i = 0; i < headerValue.length; i++) {
     const ch = headerValue[i]!;
     if (ch === '"' && headerValue[i - 1] !== '\\') {
@@ -207,14 +206,11 @@ function splitChallenges(headerValue: string): string[] {
       if (/^\s*[A-Za-z][A-Za-z0-9-]*\s+/.test(rest)) {
         parts.push(current.trim());
         current = '';
-        lastTokenWasScheme = false;
         continue;
       }
     }
     current += ch;
-    if (!inQuotes && /\s/.test(ch)) lastTokenWasScheme = true;
   }
   if (current.trim().length > 0) parts.push(current.trim());
-  void lastTokenWasScheme; // reserved for stricter validation if needed later
   return parts.filter(p => p.length > 0);
 }

--- a/src/lib/testing/storyboard/request-signing/synthesize.ts
+++ b/src/lib/testing/storyboard/request-signing/synthesize.ts
@@ -20,10 +20,7 @@ export interface SynthesizeOptions extends LoadVectorsOptions {
  *
  * Returns the input storyboard unchanged if it isn't signed-requests.
  */
-export function synthesizeRequestSigningSteps(
-  storyboard: Storyboard,
-  options: SynthesizeOptions = {}
-): Storyboard {
+export function synthesizeRequestSigningSteps(storyboard: Storyboard, options: SynthesizeOptions = {}): Storyboard {
   if (storyboard.id !== 'signed_requests') return storyboard;
 
   const loaded = loadRequestSigningVectors(options);

--- a/src/lib/testing/storyboard/request-signing/synthesize.ts
+++ b/src/lib/testing/storyboard/request-signing/synthesize.ts
@@ -1,0 +1,93 @@
+import type { Storyboard, StoryboardStep } from '../types';
+import { loadRequestSigningVectors, type LoadVectorsOptions } from './vector-loader';
+import type { NegativeVector, PositiveVector } from './types';
+
+export const REQUEST_SIGNING_PROBE_TASK = 'request_signing_probe';
+export const POSITIVE_STEP_PREFIX = 'positive-';
+export const NEGATIVE_STEP_PREFIX = 'negative-';
+
+export interface SynthesizeOptions extends LoadVectorsOptions {
+  /** Vector IDs to omit (e.g., capability-profile mismatches). */
+  skipVectors?: string[];
+}
+
+/**
+ * Expand the `positive_vectors` and `negative_vectors` phases of the
+ * signed-requests specialism with one synthesized step per fixture. The YAML
+ * deliberately ships these phases with empty step lists — steps are generated
+ * from the cached test-vector fixtures so a runner can grade any advertising
+ * agent without duplicating fixture data in the spec.
+ *
+ * Returns the input storyboard unchanged if it isn't signed-requests.
+ */
+export function synthesizeRequestSigningSteps(
+  storyboard: Storyboard,
+  options: SynthesizeOptions = {}
+): Storyboard {
+  if (storyboard.id !== 'signed_requests') return storyboard;
+
+  const loaded = loadRequestSigningVectors(options);
+  const skip = new Set(options.skipVectors ?? []);
+
+  const phases = storyboard.phases.map(phase => {
+    if (phase.id === 'positive_vectors') {
+      return { ...phase, steps: loaded.positive.filter(v => !skip.has(v.id)).map(synthesizePositiveStep) };
+    }
+    if (phase.id === 'negative_vectors') {
+      return { ...phase, steps: loaded.negative.filter(v => !skip.has(v.id)).map(synthesizeNegativeStep) };
+    }
+    return phase;
+  });
+
+  return { ...storyboard, phases };
+}
+
+function synthesizePositiveStep(vector: PositiveVector): StoryboardStep {
+  return {
+    id: `${POSITIVE_STEP_PREFIX}${vector.id}`,
+    title: `Positive: ${vector.name}`,
+    task: REQUEST_SIGNING_PROBE_TASK,
+    narrative: `Sign vector ${vector.id} per its component list and send to the agent; accept on 2xx.`,
+    validations: [
+      {
+        check: 'http_status_in',
+        allowed_values: [200, 201, 202, 203, 204],
+        description: `Agent accepts positive vector ${vector.id}`,
+      },
+    ],
+  };
+}
+
+function synthesizeNegativeStep(vector: NegativeVector): StoryboardStep {
+  return {
+    id: `${NEGATIVE_STEP_PREFIX}${vector.id}`,
+    title: `Negative: ${vector.name}`,
+    task: REQUEST_SIGNING_PROBE_TASK,
+    narrative:
+      `Build vector ${vector.id} with its documented mutation and send to the agent; ` +
+      `expect 401 with WWW-Authenticate: Signature error="${vector.expected_error_code}".`,
+    validations: [
+      {
+        check: 'http_status',
+        value: 401,
+        description: `Rejection status for ${vector.id}`,
+      },
+    ],
+  };
+}
+
+/**
+ * Parse the synthesized step ID back into the vector id + kind so the probe
+ * dispatch can look up the fixture.
+ */
+export function parseRequestSigningStepId(
+  stepId: string
+): { kind: 'positive' | 'negative'; vector_id: string } | undefined {
+  if (stepId.startsWith(POSITIVE_STEP_PREFIX)) {
+    return { kind: 'positive', vector_id: stepId.slice(POSITIVE_STEP_PREFIX.length) };
+  }
+  if (stepId.startsWith(NEGATIVE_STEP_PREFIX)) {
+    return { kind: 'negative', vector_id: stepId.slice(NEGATIVE_STEP_PREFIX.length) };
+  }
+  return undefined;
+}

--- a/src/lib/testing/storyboard/request-signing/test-kit.ts
+++ b/src/lib/testing/storyboard/request-signing/test-kit.ts
@@ -2,7 +2,6 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { parse } from 'yaml';
 import { getComplianceCacheDir } from '../compliance';
-import type { ContractId } from './types';
 
 export interface RunnerSigningKey {
   keyid: string;
@@ -33,7 +32,7 @@ export interface SignedRequestsRunnerContract {
   endpoint_scope: 'sandbox' | string;
   harness_mode: 'black_box' | 'white_box';
   runner_signing_keys: RunnerSigningKey[];
-  stateful_vector_contract: Record<ContractId, ReplayWindowContract | RevocationContract | RateAbuseContract> & {
+  stateful_vector_contract: {
     replay_window: ReplayWindowContract;
     revocation: RevocationContract;
     rate_abuse: RateAbuseContract;

--- a/src/lib/testing/storyboard/request-signing/test-kit.ts
+++ b/src/lib/testing/storyboard/request-signing/test-kit.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { parse } from 'yaml';
 import { getComplianceCacheDir } from '../compliance';
+import type { ContractId } from './types';
 
 export interface RunnerSigningKey {
   keyid: string;
@@ -32,7 +33,7 @@ export interface SignedRequestsRunnerContract {
   endpoint_scope: 'sandbox' | string;
   harness_mode: 'black_box' | 'white_box';
   runner_signing_keys: RunnerSigningKey[];
-  stateful_vector_contract: {
+  stateful_vector_contract: Record<ContractId, ReplayWindowContract | RevocationContract | RateAbuseContract> & {
     replay_window: ReplayWindowContract;
     revocation: RevocationContract;
     rate_abuse: RateAbuseContract;

--- a/src/lib/testing/storyboard/request-signing/test-kit.ts
+++ b/src/lib/testing/storyboard/request-signing/test-kit.ts
@@ -86,9 +86,7 @@ function parseSigningKeys(raw: unknown): RunnerSigningKey[] {
   });
 }
 
-function parseStatefulContracts(
-  raw: unknown
-): SignedRequestsRunnerContract['stateful_vector_contract'] {
+function parseStatefulContracts(raw: unknown): SignedRequestsRunnerContract['stateful_vector_contract'] {
   if (!raw || typeof raw !== 'object') {
     throw new Error('stateful_vector_contract block missing');
   }

--- a/src/lib/testing/storyboard/request-signing/test-kit.ts
+++ b/src/lib/testing/storyboard/request-signing/test-kit.ts
@@ -1,0 +1,153 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { parse } from 'yaml';
+import { getComplianceCacheDir } from '../compliance';
+
+export interface RunnerSigningKey {
+  keyid: string;
+  alg: 'ed25519' | 'ecdsa-p256-sha256';
+}
+
+export interface ReplayWindowContract {
+  vector_id: string;
+  black_box_behavior: 'repeat_request';
+  max_interval_seconds: number;
+  min_replay_ttl_seconds: number;
+}
+
+export interface RevocationContract {
+  vector_id: string;
+  pre_revoked_keyid: string;
+}
+
+export interface RateAbuseContract {
+  vector_id: string;
+  grading_target_per_keyid_cap_requests: number;
+  production_min_per_keyid_cap_requests: number;
+  window_seconds: number;
+}
+
+export interface SignedRequestsRunnerContract {
+  id: string;
+  endpoint_scope: 'sandbox' | string;
+  harness_mode: 'black_box' | 'white_box';
+  runner_signing_keys: RunnerSigningKey[];
+  stateful_vector_contract: {
+    replay_window: ReplayWindowContract;
+    revocation: RevocationContract;
+    rate_abuse: RateAbuseContract;
+  };
+}
+
+export interface LoadTestKitOptions {
+  complianceDir?: string;
+  version?: string;
+}
+
+/**
+ * Load and parse `test-kits/signed-requests-runner.yaml` from the compliance
+ * cache. Returns undefined when the file is absent (upstream pre-adcp#2353
+ * caches, or a sync in progress) — callers must decide how to degrade.
+ */
+export function loadSignedRequestsRunnerContract(
+  options: LoadTestKitOptions = {}
+): SignedRequestsRunnerContract | undefined {
+  const cacheDir = getComplianceCacheDir(options);
+  const path = join(cacheDir, 'test-kits', 'signed-requests-runner.yaml');
+  if (!existsSync(path)) return undefined;
+  const raw = parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+  return {
+    id: assertString(raw.id, 'id'),
+    endpoint_scope: assertString(raw.endpoint_scope, 'endpoint_scope'),
+    harness_mode: parseHarnessMode(raw.harness_mode),
+    runner_signing_keys: parseSigningKeys(raw.runner_signing_keys),
+    stateful_vector_contract: parseStatefulContracts(raw.stateful_vector_contract),
+  };
+}
+
+function parseHarnessMode(raw: unknown): 'black_box' | 'white_box' {
+  const s = assertString(raw, 'harness_mode');
+  if (s !== 'black_box' && s !== 'white_box') {
+    throw new Error(`test-kit harness_mode must be "black_box" or "white_box", got "${s}"`);
+  }
+  return s;
+}
+
+function parseSigningKeys(raw: unknown): RunnerSigningKey[] {
+  if (!Array.isArray(raw)) throw new Error('runner_signing_keys must be an array');
+  return raw.map((entry, i) => {
+    const r = entry as Record<string, unknown>;
+    const alg = assertString(r.alg, `runner_signing_keys[${i}].alg`);
+    if (alg !== 'ed25519' && alg !== 'ecdsa-p256-sha256') {
+      throw new Error(`runner_signing_keys[${i}].alg: unsupported "${alg}"`);
+    }
+    return { keyid: assertString(r.keyid, `runner_signing_keys[${i}].keyid`), alg };
+  });
+}
+
+function parseStatefulContracts(
+  raw: unknown
+): SignedRequestsRunnerContract['stateful_vector_contract'] {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('stateful_vector_contract block missing');
+  }
+  const r = raw as Record<string, unknown>;
+  return {
+    replay_window: parseReplay(r.replay_window),
+    revocation: parseRevocation(r.revocation),
+    rate_abuse: parseRateAbuse(r.rate_abuse),
+  };
+}
+
+function parseReplay(raw: unknown): ReplayWindowContract {
+  const r = asObject(raw, 'stateful_vector_contract.replay_window');
+  const behavior = assertString(r.black_box_behavior, 'replay_window.black_box_behavior');
+  if (behavior !== 'repeat_request') {
+    throw new Error(`replay_window.black_box_behavior must be "repeat_request", got "${behavior}"`);
+  }
+  return {
+    vector_id: assertString(r.vector_id, 'replay_window.vector_id'),
+    black_box_behavior: 'repeat_request',
+    max_interval_seconds: assertNumber(r.max_interval_seconds, 'replay_window.max_interval_seconds'),
+    min_replay_ttl_seconds: assertNumber(r.min_replay_ttl_seconds, 'replay_window.min_replay_ttl_seconds'),
+  };
+}
+
+function parseRevocation(raw: unknown): RevocationContract {
+  const r = asObject(raw, 'stateful_vector_contract.revocation');
+  return {
+    vector_id: assertString(r.vector_id, 'revocation.vector_id'),
+    pre_revoked_keyid: assertString(r.pre_revoked_keyid, 'revocation.pre_revoked_keyid'),
+  };
+}
+
+function parseRateAbuse(raw: unknown): RateAbuseContract {
+  const r = asObject(raw, 'stateful_vector_contract.rate_abuse');
+  return {
+    vector_id: assertString(r.vector_id, 'rate_abuse.vector_id'),
+    grading_target_per_keyid_cap_requests: assertNumber(
+      r.grading_target_per_keyid_cap_requests,
+      'rate_abuse.grading_target_per_keyid_cap_requests'
+    ),
+    production_min_per_keyid_cap_requests: assertNumber(
+      r.production_min_per_keyid_cap_requests,
+      'rate_abuse.production_min_per_keyid_cap_requests'
+    ),
+    window_seconds: assertNumber(r.window_seconds, 'rate_abuse.window_seconds'),
+  };
+}
+
+function asObject(raw: unknown, where: string): Record<string, unknown> {
+  if (!raw || typeof raw !== 'object') throw new Error(`${where} missing or not an object`);
+  return raw as Record<string, unknown>;
+}
+
+function assertString(v: unknown, where: string): string {
+  if (typeof v !== 'string') throw new Error(`${where} must be string`);
+  return v;
+}
+
+function assertNumber(v: unknown, where: string): number {
+  if (typeof v !== 'number') throw new Error(`${where} must be number`);
+  return v;
+}

--- a/src/lib/testing/storyboard/request-signing/types.ts
+++ b/src/lib/testing/storyboard/request-signing/types.ts
@@ -1,6 +1,10 @@
 import type { RequestLike } from '../../../signing';
 import type { RequestSignatureErrorCode } from '../../../signing';
 
+/** Stateful-vector contracts declared in `test-kits/signed-requests-runner.yaml`. */
+export const CONTRACT_IDS = ['replay_window', 'revocation', 'rate_abuse'] as const;
+export type ContractId = (typeof CONTRACT_IDS)[number];
+
 export interface VectorRequest extends RequestLike {
   method: string;
   url: string;
@@ -37,7 +41,7 @@ export interface NegativeVector {
   jwks_ref: string[];
   expected_error_code: RequestSignatureErrorCode;
   expected_failed_step: number | string;
-  requires_contract?: 'replay_window' | 'revocation' | 'rate_abuse';
+  requires_contract?: ContractId;
   spec_reference?: string;
 }
 

--- a/src/lib/testing/storyboard/request-signing/types.ts
+++ b/src/lib/testing/storyboard/request-signing/types.ts
@@ -1,0 +1,62 @@
+import type { RequestLike } from '../../../signing';
+import type { RequestSignatureErrorCode } from '../../../signing';
+
+export interface VectorRequest extends RequestLike {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+export interface VerifierCapabilityFixture {
+  supported: boolean;
+  covers_content_digest: 'required' | 'forbidden' | 'either';
+  required_for: string[];
+  supported_for?: string[];
+}
+
+export interface PositiveVector {
+  kind: 'positive';
+  id: string;
+  name: string;
+  reference_now: number;
+  request: VectorRequest;
+  verifier_capability: VerifierCapabilityFixture;
+  jwks_ref: string[];
+  expected_signature_base?: string;
+  spec_reference?: string;
+}
+
+export interface NegativeVector {
+  kind: 'negative';
+  id: string;
+  name: string;
+  reference_now: number;
+  request: VectorRequest;
+  verifier_capability: VerifierCapabilityFixture;
+  jwks_ref: string[];
+  expected_error_code: RequestSignatureErrorCode;
+  expected_failed_step: number | string;
+  requires_contract?: 'replay_window' | 'revocation' | 'rate_abuse';
+  spec_reference?: string;
+}
+
+export type Vector = PositiveVector | NegativeVector;
+
+export interface TestKeypair {
+  kid: string;
+  kty: string;
+  crv?: string;
+  alg?: string;
+  use?: string;
+  key_ops?: string[];
+  adcp_use?: string;
+  x?: string;
+  y?: string;
+  /** base64url-encoded private scalar, published only in test-vector keys.json. */
+  private_d: string;
+}
+
+export interface TestKeyset {
+  keys: TestKeypair[];
+}

--- a/src/lib/testing/storyboard/request-signing/vector-loader.ts
+++ b/src/lib/testing/storyboard/request-signing/vector-loader.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { basename, join } from 'path';
 import { getComplianceCacheDir } from '../compliance';
 import type { RequestSignatureErrorCode } from '../../../signing';
+import { CONTRACT_IDS } from './types';
 import type {
+  ContractId,
   NegativeVector,
   PositiveVector,
   TestKeypair,
@@ -40,23 +42,41 @@ const ERROR_CODES: ReadonlySet<string> = new Set([
   'request_signature_rate_abuse',
 ]);
 
-const CONTRACT_IDS: ReadonlySet<string> = new Set(['replay_window', 'revocation', 'rate_abuse']);
+const CONTRACT_ID_SET: ReadonlySet<string> = new Set(CONTRACT_IDS);
+
+// Memoized per sourceDir — loading 28 JSON fixtures + keys.json on every
+// per-vector call in the runner path added up (~28 disk reads × 2-3 storyboard
+// resolve calls per CLI run). Invariant: the compliance cache is immutable
+// during a process lifetime — `npm run sync-schemas` runs before the process,
+// never concurrently. Cache key is the absolute cacheDir so env-var overrides
+// don't poison the entry.
+const VECTOR_CACHE = new Map<string, LoadedVectors>();
 
 export function loadRequestSigningVectors(options: LoadVectorsOptions = {}): LoadedVectors {
   const cacheDir = getComplianceCacheDir(options);
   const sourceDir = join(cacheDir, 'test-vectors', 'request-signing');
+  const cached = VECTOR_CACHE.get(sourceDir);
+  if (cached) return cached;
+
   if (!existsSync(sourceDir)) {
     throw new Error(
       `Request-signing vectors not found at ${sourceDir}. Run \`npm run sync-schemas\` or check your ADCP_COMPLIANCE_DIR.`
     );
   }
 
-  return {
+  const loaded: LoadedVectors = {
     positive: loadDir(join(sourceDir, 'positive'), parsePositive),
     negative: loadDir(join(sourceDir, 'negative'), parseNegative),
     keys: loadKeys(join(sourceDir, 'keys.json')),
     sourceDir,
   };
+  VECTOR_CACHE.set(sourceDir, loaded);
+  return loaded;
+}
+
+/** Test-only: clear the memoization cache so a fresh cache path is reread. */
+export function __resetVectorCache(): void {
+  VECTOR_CACHE.clear();
 }
 
 function loadDir<T extends Vector>(dir: string, parse: (id: string, raw: unknown) => T): T[] {
@@ -105,13 +125,13 @@ function parseNegative(id: string, raw: unknown): NegativeVector {
   if (typeof failedStep !== 'number' && typeof failedStep !== 'string') {
     throw new Error(`${id}: expected_outcome.failed_step must be number or string`);
   }
-  let contract: NegativeVector['requires_contract'];
+  let contract: ContractId | undefined;
   if (r.requires_contract !== undefined) {
     const c = str(r.requires_contract, `${id}.requires_contract`);
-    if (!CONTRACT_IDS.has(c)) {
+    if (!CONTRACT_ID_SET.has(c)) {
       throw new Error(`${id}: unknown requires_contract "${c}" (spec drift?)`);
     }
-    contract = c as NegativeVector['requires_contract'];
+    contract = c as ContractId;
   }
   return {
     kind: 'negative',

--- a/src/lib/testing/storyboard/request-signing/vector-loader.ts
+++ b/src/lib/testing/storyboard/request-signing/vector-loader.ts
@@ -3,14 +3,7 @@ import { basename, join } from 'path';
 import { getComplianceCacheDir } from '../compliance';
 import type { RequestSignatureErrorCode } from '../../../signing';
 import { CONTRACT_IDS } from './types';
-import type {
-  ContractId,
-  NegativeVector,
-  PositiveVector,
-  TestKeypair,
-  TestKeyset,
-  Vector,
-} from './types';
+import type { ContractId, NegativeVector, PositiveVector, TestKeypair, TestKeyset, Vector } from './types';
 
 export interface LoadVectorsOptions {
   complianceDir?: string;
@@ -107,8 +100,7 @@ function parsePositive(id: string, raw: unknown): PositiveVector {
     request: parseRequest(id, r.request),
     verifier_capability: parseCapability(id, r.verifier_capability),
     jwks_ref: strArray(r.jwks_ref, `${id}.jwks_ref`),
-    expected_signature_base:
-      typeof r.expected_signature_base === 'string' ? r.expected_signature_base : undefined,
+    expected_signature_base: typeof r.expected_signature_base === 'string' ? r.expected_signature_base : undefined,
     spec_reference: typeof r.spec_reference === 'string' ? r.spec_reference : undefined,
   };
 }

--- a/src/lib/testing/storyboard/request-signing/vector-loader.ts
+++ b/src/lib/testing/storyboard/request-signing/vector-loader.ts
@@ -1,0 +1,230 @@
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+import { getComplianceCacheDir } from '../compliance';
+import type { RequestSignatureErrorCode } from '../../../signing';
+import type {
+  NegativeVector,
+  PositiveVector,
+  TestKeypair,
+  TestKeyset,
+  Vector,
+} from './types';
+
+export interface LoadVectorsOptions {
+  complianceDir?: string;
+  version?: string;
+}
+
+export interface LoadedVectors {
+  positive: PositiveVector[];
+  negative: NegativeVector[];
+  keys: TestKeyset;
+  sourceDir: string;
+}
+
+const ERROR_CODES: ReadonlySet<string> = new Set([
+  'request_signature_required',
+  'request_signature_header_malformed',
+  'request_signature_params_incomplete',
+  'request_signature_tag_invalid',
+  'request_signature_alg_not_allowed',
+  'request_signature_window_invalid',
+  'request_signature_components_incomplete',
+  'request_signature_components_unexpected',
+  'request_signature_key_unknown',
+  'request_signature_key_purpose_invalid',
+  'request_signature_key_revoked',
+  'request_signature_invalid',
+  'request_signature_digest_mismatch',
+  'request_signature_replayed',
+  'request_signature_rate_abuse',
+]);
+
+const CONTRACT_IDS: ReadonlySet<string> = new Set(['replay_window', 'revocation', 'rate_abuse']);
+
+export function loadRequestSigningVectors(options: LoadVectorsOptions = {}): LoadedVectors {
+  const cacheDir = getComplianceCacheDir(options);
+  const sourceDir = join(cacheDir, 'test-vectors', 'request-signing');
+  if (!existsSync(sourceDir)) {
+    throw new Error(
+      `Request-signing vectors not found at ${sourceDir}. Run \`npm run sync-schemas\` or check your ADCP_COMPLIANCE_DIR.`
+    );
+  }
+
+  return {
+    positive: loadDir(join(sourceDir, 'positive'), parsePositive),
+    negative: loadDir(join(sourceDir, 'negative'), parseNegative),
+    keys: loadKeys(join(sourceDir, 'keys.json')),
+    sourceDir,
+  };
+}
+
+function loadDir<T extends Vector>(dir: string, parse: (id: string, raw: unknown) => T): T[] {
+  if (!existsSync(dir)) {
+    throw new Error(`Vector directory missing: ${dir}`);
+  }
+  const files = readdirSync(dir)
+    .filter(f => f.endsWith('.json'))
+    .sort();
+  return files.map(f => {
+    const raw = JSON.parse(readFileSync(join(dir, f), 'utf-8'));
+    return parse(vectorIdFromFilename(f), raw);
+  });
+}
+
+function vectorIdFromFilename(file: string): string {
+  return basename(file, '.json');
+}
+
+function parsePositive(id: string, raw: unknown): PositiveVector {
+  const r = raw as Record<string, unknown>;
+  assertSuccess(id, r, true);
+  return {
+    kind: 'positive',
+    id,
+    name: str(r.name, `${id}.name`),
+    reference_now: num(r.reference_now, `${id}.reference_now`),
+    request: parseRequest(id, r.request),
+    verifier_capability: parseCapability(id, r.verifier_capability),
+    jwks_ref: strArray(r.jwks_ref, `${id}.jwks_ref`),
+    expected_signature_base:
+      typeof r.expected_signature_base === 'string' ? r.expected_signature_base : undefined,
+    spec_reference: typeof r.spec_reference === 'string' ? r.spec_reference : undefined,
+  };
+}
+
+function parseNegative(id: string, raw: unknown): NegativeVector {
+  const r = raw as Record<string, unknown>;
+  assertSuccess(id, r, false);
+  const outcome = r.expected_outcome as Record<string, unknown>;
+  const errorCode = str(outcome.error_code, `${id}.expected_outcome.error_code`);
+  if (!ERROR_CODES.has(errorCode)) {
+    throw new Error(`${id}: unknown expected_outcome.error_code "${errorCode}" (spec drift?)`);
+  }
+  const failedStep = outcome.failed_step;
+  if (typeof failedStep !== 'number' && typeof failedStep !== 'string') {
+    throw new Error(`${id}: expected_outcome.failed_step must be number or string`);
+  }
+  let contract: NegativeVector['requires_contract'];
+  if (r.requires_contract !== undefined) {
+    const c = str(r.requires_contract, `${id}.requires_contract`);
+    if (!CONTRACT_IDS.has(c)) {
+      throw new Error(`${id}: unknown requires_contract "${c}" (spec drift?)`);
+    }
+    contract = c as NegativeVector['requires_contract'];
+  }
+  return {
+    kind: 'negative',
+    id,
+    name: str(r.name, `${id}.name`),
+    reference_now: num(r.reference_now, `${id}.reference_now`),
+    request: parseRequest(id, r.request),
+    verifier_capability: parseCapability(id, r.verifier_capability),
+    jwks_ref: strArray(r.jwks_ref, `${id}.jwks_ref`),
+    expected_error_code: errorCode as RequestSignatureErrorCode,
+    expected_failed_step: failedStep,
+    requires_contract: contract,
+    spec_reference: typeof r.spec_reference === 'string' ? r.spec_reference : undefined,
+  };
+}
+
+function assertSuccess(id: string, vector: Record<string, unknown>, expected: boolean): void {
+  const outcome = vector.expected_outcome as Record<string, unknown> | undefined;
+  if (!outcome || outcome.success !== expected) {
+    throw new Error(
+      `${id}: expected_outcome.success must be ${expected} for ${expected ? 'positive' : 'negative'} vector`
+    );
+  }
+}
+
+function parseRequest(id: string, raw: unknown): PositiveVector['request'] {
+  const r = raw as Record<string, unknown> | undefined;
+  if (!r) throw new Error(`${id}.request missing`);
+  const headers = r.headers as Record<string, string> | undefined;
+  if (!headers) throw new Error(`${id}.request.headers missing`);
+  return {
+    method: str(r.method, `${id}.request.method`),
+    url: str(r.url, `${id}.request.url`),
+    headers: { ...headers },
+    body: typeof r.body === 'string' ? r.body : undefined,
+  };
+}
+
+function parseCapability(id: string, raw: unknown): PositiveVector['verifier_capability'] {
+  const r = raw as Record<string, unknown> | undefined;
+  if (!r) throw new Error(`${id}.verifier_capability missing`);
+  const digest = str(r.covers_content_digest, `${id}.verifier_capability.covers_content_digest`);
+  if (digest !== 'required' && digest !== 'forbidden' && digest !== 'either') {
+    throw new Error(`${id}: invalid covers_content_digest "${digest}"`);
+  }
+  return {
+    supported: bool(r.supported, `${id}.verifier_capability.supported`),
+    covers_content_digest: digest,
+    required_for: strArray(r.required_for, `${id}.verifier_capability.required_for`),
+    supported_for: Array.isArray(r.supported_for) ? (r.supported_for as string[]) : undefined,
+  };
+}
+
+function loadKeys(keysPath: string): TestKeyset {
+  if (!existsSync(keysPath)) {
+    throw new Error(`keys.json missing at ${keysPath}`);
+  }
+  const raw = JSON.parse(readFileSync(keysPath, 'utf-8')) as { keys?: unknown };
+  if (!Array.isArray(raw.keys)) {
+    throw new Error(`keys.json must contain a "keys" array`);
+  }
+  return { keys: raw.keys.map((k, i) => parseKey(i, k)) };
+}
+
+function parseKey(index: number, raw: unknown): TestKeypair {
+  const r = raw as Record<string, unknown>;
+  const where = `keys.json[${index}]`;
+  const privateD = r._private_d_for_test_only;
+  if (typeof privateD !== 'string' || privateD.length === 0) {
+    throw new Error(`${where}._private_d_for_test_only missing (required for dynamic signing)`);
+  }
+  return {
+    kid: str(r.kid, `${where}.kid`),
+    kty: str(r.kty, `${where}.kty`),
+    crv: typeof r.crv === 'string' ? r.crv : undefined,
+    alg: typeof r.alg === 'string' ? r.alg : undefined,
+    use: typeof r.use === 'string' ? r.use : undefined,
+    key_ops: Array.isArray(r.key_ops) ? (r.key_ops as string[]) : undefined,
+    adcp_use: typeof r.adcp_use === 'string' ? r.adcp_use : undefined,
+    x: typeof r.x === 'string' ? r.x : undefined,
+    y: typeof r.y === 'string' ? r.y : undefined,
+    private_d: privateD,
+  };
+}
+
+export function findKey(keyset: TestKeyset, kid: string): TestKeypair {
+  const match = keyset.keys.find(k => k.kid === kid);
+  if (!match) {
+    throw new Error(
+      `No test keypair with kid="${kid}" in keys.json (available: ${keyset.keys.map(k => k.kid).join(', ')})`
+    );
+  }
+  return match;
+}
+
+function str(v: unknown, where: string): string {
+  if (typeof v !== 'string') throw new Error(`${where} must be string`);
+  return v;
+}
+
+function num(v: unknown, where: string): number {
+  if (typeof v !== 'number') throw new Error(`${where} must be number`);
+  return v;
+}
+
+function bool(v: unknown, where: string): boolean {
+  if (typeof v !== 'boolean') throw new Error(`${where} must be boolean`);
+  return v;
+}
+
+function strArray(v: unknown, where: string): string[] {
+  if (!Array.isArray(v) || v.some(item => typeof item !== 'string')) {
+    throw new Error(`${where} must be string[]`);
+  }
+  return v as string[];
+}

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -226,7 +226,12 @@ export async function runStoryboardStep(
     );
   }
 
-  const result = await executeStep(client, found.step, found.phaseId, context, allSteps, options);
+  const result = await executeStep(client, found.step, found.phaseId, context, allSteps, options, {
+    contributions: new Set(),
+    priorStepResults: new Map(),
+    priorProbes: new Map(),
+    agentUrl,
+  });
 
   if (!options._client) {
     await closeConnections(options.protocol);
@@ -544,6 +549,26 @@ async function executeProbeStep(
   }
 
   if (httpResult) runState.priorProbes.set(step.task, httpResult);
+
+  // Probe may self-skip (request_signing_probe uses this for operator opt-outs
+  // and capability-profile mismatches). Surface as a skipped step without
+  // running validations — skip ≠ fail.
+  if (httpResult?.skipped) {
+    return {
+      step_id: step.id,
+      phase_id: phaseId,
+      title: step.title,
+      task: step.task,
+      passed: true,
+      skipped: true,
+      skip_reason: (httpResult.skip_reason ?? 'probe_skipped') as StoryboardStepResult['skip_reason'],
+      duration_ms: Date.now() - start,
+      response: httpResult,
+      validations: [],
+      context,
+      next: getNextStepPreview(step.id, allSteps, context),
+    };
+  }
 
   const vctx: ValidationContext = {
     taskName: step.task,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -22,6 +22,7 @@ import {
   generateRandomInvalidJwt,
 } from './probes';
 import { validateTestKit } from './test-kit';
+import { probeRequestSigningVector } from './request-signing/probe-dispatch';
 import type {
   HttpProbeResult,
   StepAuthDirective,
@@ -538,6 +539,8 @@ async function executeProbeStep(
   } else if (step.task === 'assert_contribution') {
     // Synthetic: evaluate only through validations (any_of). No network call.
     httpResult = undefined;
+  } else if (step.task === 'request_signing_probe') {
+    httpResult = await probeRequestSigningVector(step.id, runState.agentUrl, options);
   }
 
   if (httpResult) runState.priorProbes.set(step.task, httpResult);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -220,6 +220,22 @@ export interface StoryboardRunOptions extends TestOptions {
    * in the report when used.
    */
   allow_http?: boolean;
+  /**
+   * Request-signing grader knobs (applied when the runner encounters
+   * synthesized `request_signing_probe` steps from the signed-requests
+   * specialism).
+   */
+  request_signing?: {
+    /** Skip the rate-abuse vector — it sends cap+1 requests and is slow. */
+    skipRateAbuse?: boolean;
+    /** Override the per-keyid cap the grader targets. */
+    rateAbuseCap?: number;
+    /**
+     * Vector IDs to skip (e.g., capability-profile mismatches for vectors
+     * 007/018 when the agent's `covers_content_digest` policy differs).
+     */
+    skipVectors?: string[];
+  };
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -194,6 +194,14 @@ export interface HttpProbeResult {
   body: unknown;
   /** Optional error — set when the fetch failed (network, SSRF guard, etc.). */
   error?: string;
+  /**
+   * Probe was intentionally skipped (e.g. operator opted out of a vector,
+   * capability profile mismatch, or test-kit contract not in scope). When
+   * set, the runner marks the step `skipped: true` and does NOT run
+   * validations — skipped probes neither pass nor fail.
+   */
+  skipped?: boolean;
+  skip_reason?: string;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -235,6 +243,17 @@ export interface StoryboardRunOptions extends TestOptions {
      * 007/018 when the agent's `covers_content_digest` policy differs).
      */
     skipVectors?: string[];
+    /**
+     * Run only the named vector ids — all others auto-skip. Takes precedence
+     * over `skipVectors`.
+     */
+    onlyVectors?: string[];
+    /**
+     * Opt in to running vectors that produce live agent-side effects
+     * (016 replay, 020 rate-abuse). Required unless the test-kit declares
+     * `endpoint_scope: sandbox`.
+     */
+    allowLiveSideEffects?: boolean;
   };
 }
 
@@ -275,8 +294,16 @@ export interface StoryboardStepResult {
     | 'dependency_failed'
     | 'missing_test_harness'
     | 'missing_tool'
-    /** Storyboard predates the agent's declared adcp.major_versions. */
-    | 'not_applicable';
+    /** Storyboard predates the agent's declared adcp.major_versions (#606). */
+    | 'not_applicable'
+    /** Request-signing grader skip paths (#585). */
+    | 'probe_skipped'
+    | 'rate_abuse_opt_out'
+    | 'missing_test_kit_contract'
+    | 'live_side_effect_opt_in_required'
+    | 'operator_skip'
+    | 'not_in_only_vectors'
+    | 'grader_skipped';
   /** True when the step expected an error (inverted pass/fail) */
   expect_error?: boolean;
   duration_ms: number;

--- a/test-agents/seller-agent-signed.ts
+++ b/test-agents/seller-agent-signed.ts
@@ -1,0 +1,225 @@
+/**
+ * Signed-requests test agent — minimal HTTP server that exposes an
+ * `createExpressVerifier` middleware pre-configured per the
+ * `signed-requests-runner` test-kit contract. Intended for end-to-end
+ * smoke-testing the conformance grader shipped in
+ * adcontextprotocol/adcp-client#585.
+ *
+ * This is NOT an MCP agent — the conformance vectors target raw-HTTP AdCP
+ * endpoints (e.g., `/adcp/create_media_buy`), and the RFC 9421 verifier is
+ * a transport-layer concern independent of the MCP/A2A wrapping. A future
+ * MCP-aware grader (issue TBD) will layer JSON-RPC envelope handling on
+ * top; this agent validates the signing-layer contract standalone.
+ *
+ * Run locally:
+ *   npm run build:test-agents
+ *   PORT=3100 node test-agents/dist/seller-agent-signed.js
+ *
+ * Grade from another shell:
+ *   node bin/adcp.js grade request-signing http://127.0.0.1:3100 --allow-http --skip-rate-abuse
+ *
+ * Verifier is pre-configured per `test-kits/signed-requests-runner.yaml`:
+ *   - JWKS includes test-ed25519-2026, test-es256-2026, test-gov-2026,
+ *     test-revoked-2026.
+ *   - test-revoked-2026 pre-revoked.
+ *   - Per-keyid replay cap = 100 (matches the contract's grading target).
+ *
+ * Do NOT deploy to production — the test keypairs are publicly published
+ * in the AdCP spec repository.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  createExpressVerifier,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  StaticJwksResolver,
+  type AdcpJsonWebKey,
+} from '@adcp/client/signing';
+
+const COMPLIANCE_CACHE = process.env.ADCP_COMPLIANCE_DIR ?? resolveComplianceCache();
+
+function resolveComplianceCache(): string {
+  for (const candidate of [
+    join(__dirname, '..', 'compliance', 'cache', 'latest'),
+    join(__dirname, '..', '..', 'compliance', 'cache', 'latest'),
+  ]) {
+    try {
+      readFileSync(join(candidate, 'test-vectors', 'request-signing', 'keys.json'));
+      return candidate;
+    } catch {
+      // try next
+    }
+  }
+  throw new Error(`Cannot locate compliance/cache/latest/ relative to ${__dirname}. Set ADCP_COMPLIANCE_DIR.`);
+}
+
+const KEYS_PATH = join(COMPLIANCE_CACHE, 'test-vectors', 'request-signing', 'keys.json');
+
+const publicKeys: AdcpJsonWebKey[] = (JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys as AdcpJsonWebKey[]).map(k => {
+  const pub: AdcpJsonWebKey = { ...k };
+  delete (pub as { _private_d_for_test_only?: string })._private_d_for_test_only;
+  delete (pub as { d?: string }).d;
+  return pub;
+});
+
+const jwks = new StaticJwksResolver(publicKeys);
+// 100 matches `grading_target_per_keyid_cap_requests` in the test-kit YAML.
+const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 100 });
+const revocationStore = new InMemoryRevocationStore({
+  issuer: 'http://seller.example.com',
+  updated: new Date().toISOString(),
+  next_update: new Date(Date.now() + 3600_000).toISOString(),
+  revoked_kids: ['test-revoked-2026'],
+  revoked_jtis: [],
+});
+
+const verifier = createExpressVerifier({
+  capability: {
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: ['create_media_buy'],
+  },
+  jwks,
+  replayStore,
+  revocationStore,
+  // Operation = last path segment — matches the vectors' `/adcp/<operation>`
+  // shape. Returns undefined for the capability endpoint.
+  resolveOperation: req => {
+    const pathname = new URL(`http://x${req.originalUrl ?? '/'}`).pathname;
+    if (pathname === '/get_adcp_capabilities' || pathname === '/.well-known/adcp-capabilities') return undefined;
+    return pathname.split('/').filter(Boolean).pop();
+  },
+});
+
+function readRawBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', chunk => chunks.push(chunk as Buffer));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+interface ExpressReqShim {
+  method: string;
+  url: string;
+  originalUrl: string;
+  headers: IncomingMessage['headers'];
+  rawBody: string;
+  protocol: string;
+  get(name: string): string | undefined;
+  verifiedSigner?: unknown;
+  [extra: string]: unknown;
+}
+
+function makeExpressShim(req: IncomingMessage, res: ServerResponse) {
+  const reqShim: ExpressReqShim = {
+    method: req.method ?? 'POST',
+    url: req.url ?? '/',
+    originalUrl: req.url ?? '/',
+    headers: req.headers,
+    rawBody: '',
+    protocol: 'http',
+    get(name) {
+      const v = req.headers[name.toLowerCase()];
+      return Array.isArray(v) ? v.join(', ') : v;
+    },
+  };
+  const resShim = {
+    status(code: number) {
+      res.statusCode = code;
+      return {
+        set(k: string, v: string) {
+          res.setHeader(k, v);
+          return {
+            json(body: unknown) {
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify(body));
+            },
+          };
+        },
+      };
+    },
+  };
+  return { reqShim, resShim };
+}
+
+// Capability shape returned from GET /get_adcp_capabilities. Kept inline —
+// this test agent doesn't need the full createAdcpServer surface, just enough
+// to satisfy the grader's capability-discovery precondition.
+const CAPABILITIES_RESPONSE = {
+  adcp: { major_versions: [3], idempotency: { replay_ttl_seconds: 86400 } },
+  supported_protocols: ['media_buy'],
+  media_buy: {
+    features: {
+      inline_creative_management: false,
+      property_list_filtering: false,
+      content_standards: false,
+    },
+  },
+  request_signing: {
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: ['create_media_buy'],
+  },
+  specialisms: ['signed-requests'],
+};
+
+const PORT = Number.parseInt(process.env.PORT ?? '3100', 10);
+
+const server = createServer(async (req, res) => {
+  try {
+    const rawBody = await readRawBody(req);
+    const { reqShim, resShim } = makeExpressShim(req, res);
+    reqShim.rawBody = rawBody;
+
+    // Capability discovery is intentionally unsigned — the grader calls this
+    // BEFORE it starts signing requests, to confirm the agent opts into the
+    // specialism. `resolveOperation` returns undefined here, which the
+    // verifier reads as "not in required_for" → skip the signature pipeline.
+    if (req.url === '/get_adcp_capabilities' || req.url === '/.well-known/adcp-capabilities') {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify(CAPABILITIES_RESPONSE));
+      return;
+    }
+
+    await new Promise<void>(resolve =>
+      verifier(reqShim, resShim, err => {
+        if (err) {
+          if (!res.writableEnded) {
+            res.statusCode = 500;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: 'verifier_error', message: String(err) }));
+          }
+        } else if (!res.writableEnded) {
+          // Verifier accepted (or skipped when operation wasn't in
+          // required_for). Return a 200 stub — the grader doesn't inspect
+          // the response body for positive vectors, only the status.
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ ok: true, verified: reqShim.verifiedSigner ?? null }));
+        }
+        resolve();
+      })
+    );
+  } catch (err) {
+    if (!res.writableEnded) {
+      res.statusCode = 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'internal_error', message: String(err) }));
+    }
+  }
+});
+
+server.listen(PORT, () => {
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr ? addr.port : PORT;
+  console.log(`Signed-requests test agent listening at http://127.0.0.1:${port}`);
+  console.log(
+    `Grade with: node bin/adcp.js grade request-signing http://127.0.0.1:${port} --allow-http --skip-rate-abuse`
+  );
+});

--- a/test/lib/storyboard-completeness.test.js
+++ b/test/lib/storyboard-completeness.test.js
@@ -31,6 +31,9 @@ const HARNESS_TASKS = new Set([
   'protected_resource_metadata',
   'oauth_auth_server_metadata',
   'assert_contribution',
+  // Synthesized request-signing steps — the runner builds each request from
+  // a test-vector fixture; no `sample_request` shape applies.
+  'request_signing_probe',
 ]);
 
 // Tasks that reference test-kit data (e.g. "$test_kit.auth.probe_task"). The

--- a/test/request-signing-grader-e2e.test.js
+++ b/test/request-signing-grader-e2e.test.js
@@ -175,33 +175,11 @@ describe('request-signing grader — end-to-end vs. reference verifier', () => {
     try {
       const report = await gradeRequestSigning(fresh.url, {
         allowPrivateIp: true,
-        skipRateAbuse: true,
-        // Only exercise 007 against this profile; other vectors assume either.
-        skipVectors: [
-          '001-no-signature-header',
-          '002-wrong-tag',
-          '003-expired-signature',
-          '004-window-too-long',
-          '005-alg-not-allowed',
-          '006-missing-covered-component',
-          '008-unknown-keyid',
-          '009-key-ops-missing-verify',
-          '010-content-digest-mismatch',
-          '011-malformed-header',
-          '012-missing-expires-param',
-          '013-expires-le-created',
-          '014-missing-nonce-param',
-          '015-signature-invalid',
-          '016-replayed-nonce',
-          '017-key-revoked',
-          '018-digest-covered-when-forbidden',
-          '019-signature-without-signature-input',
-          '020-rate-abuse',
-        ],
+        onlyVectors: ['007-missing-content-digest'],
       });
       const v007 = report.negative.find(v => v.vector_id === '007-missing-content-digest');
       assert.ok(v007, '007 present');
-      assert.ok(v007.passed, `007 should pass under required profile: ${v007.diagnostic}`);
+      assert.ok(v007.passed && !v007.skipped, `007 should pass under required profile: ${v007.diagnostic}`);
     } finally {
       fresh.server.close();
     }
@@ -212,79 +190,33 @@ describe('request-signing grader — end-to-end vs. reference verifier', () => {
     try {
       const report = await gradeRequestSigning(fresh.url, {
         allowPrivateIp: true,
-        skipRateAbuse: true,
-        skipVectors: [
-          '001-no-signature-header',
-          '002-wrong-tag',
-          '003-expired-signature',
-          '004-window-too-long',
-          '005-alg-not-allowed',
-          '006-missing-covered-component',
-          '007-missing-content-digest',
-          '008-unknown-keyid',
-          '009-key-ops-missing-verify',
-          '010-content-digest-mismatch',
-          '011-malformed-header',
-          '012-missing-expires-param',
-          '013-expires-le-created',
-          '014-missing-nonce-param',
-          '015-signature-invalid',
-          '016-replayed-nonce',
-          '017-key-revoked',
-          '019-signature-without-signature-input',
-          '020-rate-abuse',
-        ],
+        onlyVectors: ['018-digest-covered-when-forbidden'],
       });
       const v018 = report.negative.find(v => v.vector_id === '018-digest-covered-when-forbidden');
       assert.ok(v018, '018 present');
-      assert.ok(v018.passed, `018 should pass under forbidden profile: ${v018.diagnostic}`);
+      assert.ok(v018.passed && !v018.skipped, `018 should pass under forbidden profile: ${v018.diagnostic}`);
     } finally {
       fresh.server.close();
     }
   });
 
   test('rate-abuse vector: cap+1th request rejected with request_signature_rate_abuse', async () => {
-    // Dedicated fresh server with a tight cap matched to the grader so the
-    // (cap+1)th request trips the rejection. Isolating 020 on its own server
-    // means prior vectors' signatures don't consume replay-cache entries from
-    // this test's quota.
+    // Dedicated server with a tight cap matched to the grader so the
+    // (cap+1)th request trips the rejection. `onlyVectors` isolates 020 on
+    // a fresh replay cache so prior vectors don't consume the quota.
     const fresh = await startGraderServer({ replayCap: 10 });
     try {
-      const all = [...Array(20)].map((_, i) => String(i + 1).padStart(3, '0'));
-      const skip = all
-        .filter(n => n !== '020')
-        .map(n => {
-          const files = {
-            '001': '001-no-signature-header',
-            '002': '002-wrong-tag',
-            '003': '003-expired-signature',
-            '004': '004-window-too-long',
-            '005': '005-alg-not-allowed',
-            '006': '006-missing-covered-component',
-            '007': '007-missing-content-digest',
-            '008': '008-unknown-keyid',
-            '009': '009-key-ops-missing-verify',
-            '010': '010-content-digest-mismatch',
-            '011': '011-malformed-header',
-            '012': '012-missing-expires-param',
-            '013': '013-expires-le-created',
-            '014': '014-missing-nonce-param',
-            '015': '015-signature-invalid',
-            '016': '016-replayed-nonce',
-            '017': '017-key-revoked',
-            '018': '018-digest-covered-when-forbidden',
-            '019': '019-signature-without-signature-input',
-          };
-          return files[n];
-        });
       const report = await gradeRequestSigning(fresh.url, {
         allowPrivateIp: true,
         rateAbuseCap: 10,
-        skipVectors: skip,
+        onlyVectors: ['020-rate-abuse'],
+        // 020 produces live side effects (fills the cap); test-kit contract
+        // says sandbox but the localhost verifier doesn't advertise that.
+        allowLiveSideEffects: true,
       });
       const v020 = report.negative.find(v => v.vector_id === '020-rate-abuse');
       assert.ok(v020, '020 present');
-      assert.ok(v020.passed, `020 should pass with matched cap: ${v020.diagnostic}`);
+      assert.ok(v020.passed && !v020.skipped, `020 should pass with matched cap: ${v020.diagnostic}`);
       assert.strictEqual(v020.actual_error_code, 'request_signature_rate_abuse');
     } finally {
       fresh.server.close();

--- a/test/request-signing-grader-e2e.test.js
+++ b/test/request-signing-grader-e2e.test.js
@@ -1,0 +1,327 @@
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  createExpressVerifier,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  StaticJwksResolver,
+} = require('../dist/lib/signing/index.js');
+
+const { gradeRequestSigning } = require('../dist/lib/testing/storyboard/request-signing/index.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function makeExpressShim(req, res) {
+  const reqShim = {
+    method: req.method,
+    url: req.url,
+    originalUrl: req.url,
+    headers: req.headers,
+    protocol: 'http',
+    get(name) {
+      const v = req.headers[name.toLowerCase()];
+      return Array.isArray(v) ? v.join(', ') : v;
+    },
+  };
+  const resShim = {
+    status(code) {
+      res.statusCode = code;
+      return {
+        set(k, v) {
+          res.setHeader(k, v);
+          return {
+            json(body) {
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify(body));
+            },
+          };
+        },
+      };
+    },
+  };
+  return { reqShim, resShim };
+}
+
+/**
+ * Stand up a reference verifier per the signed-requests-runner test-kit:
+ *   - JWKS contains runner's signing keys (test-ed25519-2026, test-es256-2026)
+ *     plus test-gov-2026 (for vector 009 key-purpose check) and
+ *     test-revoked-2026 (pre-revoked for vector 017).
+ *   - Revocation list pre-contains test-revoked-2026.
+ *   - Replay cap tunable so vector 020 finishes in under a second.
+ */
+function startGraderServer({ replayCap, coversContentDigest = 'either' }) {
+  const publicKeys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys.map(k => {
+    const pub = { ...k };
+    delete pub._private_d_for_test_only;
+    return pub;
+  });
+  const jwks = new StaticJwksResolver(publicKeys);
+  const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: replayCap });
+  const revocationStore = new InMemoryRevocationStore({
+    issuer: 'http://127.0.0.1',
+    updated: new Date().toISOString(),
+    next_update: new Date(Date.now() + 3600_000).toISOString(),
+    revoked_kids: ['test-revoked-2026'],
+    revoked_jtis: [],
+  });
+
+  const middleware = createExpressVerifier({
+    capability: {
+      supported: true,
+      covers_content_digest: coversContentDigest,
+      required_for: ['create_media_buy'],
+    },
+    jwks,
+    replayStore,
+    revocationStore,
+    resolveOperation: req => new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
+  });
+
+  const server = http.createServer(async (req, res) => {
+    const body = await readRawBody(req);
+    const { reqShim, resShim } = makeExpressShim(req, res);
+    reqShim.rawBody = body;
+    await new Promise(resolve =>
+      middleware(reqShim, resShim, err => {
+        if (err) {
+          console.error('grader-shim middleware error:', err);
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: 'internal_server_error' }));
+          resolve();
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ ok: true }));
+        resolve();
+      })
+    );
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve({ server, url: `http://127.0.0.1:${addr.port}`, replayStore, revocationStore });
+    });
+  });
+}
+
+// Vectors 007 and 018 depend on the verifier advertising a specific
+// `covers_content_digest` policy. The main-test server advertises `either`;
+// 007 expects `required` and 018 expects `forbidden`. Each has its own test
+// that stands up a matching server.
+const CAPABILITY_PROFILE_VECTORS = ['007-missing-content-digest', '018-digest-covered-when-forbidden'];
+
+describe('request-signing grader — end-to-end vs. reference verifier', () => {
+  let instance;
+
+  before(async () => {
+    instance = await startGraderServer({ replayCap: 1000, coversContentDigest: 'either' });
+  });
+
+  after(() => {
+    instance.server.close();
+  });
+
+  test('grades the 17 non-stateful + 2 non-rate vectors on a covers_content_digest=either verifier', async () => {
+    const report = await gradeRequestSigning(instance.url, {
+      allowPrivateIp: true,
+      skipRateAbuse: true, // 020 has its own test below with matched caps.
+      skipVectors: CAPABILITY_PROFILE_VECTORS,
+    });
+
+    assert.ok(report.contract_loaded, 'test-kit contract loaded');
+    assert.strictEqual(report.harness_mode, 'black_box');
+
+    const failures = [];
+    for (const v of [...report.positive, ...report.negative]) {
+      if (!v.passed && !v.skipped) {
+        failures.push(
+          `${v.kind}/${v.vector_id}: ${v.diagnostic ?? 'no diagnostic'} (status=${v.http_status}, actual=${v.actual_error_code ?? 'none'})`
+        );
+      }
+    }
+    assert.deepStrictEqual(failures, [], 'every non-capability-profile vector grades as expected');
+
+    assert.strictEqual(report.positive.length, 8);
+    assert.strictEqual(report.negative.length, 20);
+  });
+
+  test('capability profile "required": vector 007 grades correctly', async () => {
+    const fresh = await startGraderServer({ replayCap: 1000, coversContentDigest: 'required' });
+    try {
+      const report = await gradeRequestSigning(fresh.url, {
+        allowPrivateIp: true,
+        skipRateAbuse: true,
+        // Only exercise 007 against this profile; other vectors assume either.
+        skipVectors: [
+          '001-no-signature-header',
+          '002-wrong-tag',
+          '003-expired-signature',
+          '004-window-too-long',
+          '005-alg-not-allowed',
+          '006-missing-covered-component',
+          '008-unknown-keyid',
+          '009-key-ops-missing-verify',
+          '010-content-digest-mismatch',
+          '011-malformed-header',
+          '012-missing-expires-param',
+          '013-expires-le-created',
+          '014-missing-nonce-param',
+          '015-signature-invalid',
+          '016-replayed-nonce',
+          '017-key-revoked',
+          '018-digest-covered-when-forbidden',
+          '019-signature-without-signature-input',
+          '020-rate-abuse',
+        ],
+      });
+      const v007 = report.negative.find(v => v.vector_id === '007-missing-content-digest');
+      assert.ok(v007, '007 present');
+      assert.ok(v007.passed, `007 should pass under required profile: ${v007.diagnostic}`);
+    } finally {
+      fresh.server.close();
+    }
+  });
+
+  test('capability profile "forbidden": vector 018 grades correctly', async () => {
+    const fresh = await startGraderServer({ replayCap: 1000, coversContentDigest: 'forbidden' });
+    try {
+      const report = await gradeRequestSigning(fresh.url, {
+        allowPrivateIp: true,
+        skipRateAbuse: true,
+        skipVectors: [
+          '001-no-signature-header',
+          '002-wrong-tag',
+          '003-expired-signature',
+          '004-window-too-long',
+          '005-alg-not-allowed',
+          '006-missing-covered-component',
+          '007-missing-content-digest',
+          '008-unknown-keyid',
+          '009-key-ops-missing-verify',
+          '010-content-digest-mismatch',
+          '011-malformed-header',
+          '012-missing-expires-param',
+          '013-expires-le-created',
+          '014-missing-nonce-param',
+          '015-signature-invalid',
+          '016-replayed-nonce',
+          '017-key-revoked',
+          '019-signature-without-signature-input',
+          '020-rate-abuse',
+        ],
+      });
+      const v018 = report.negative.find(v => v.vector_id === '018-digest-covered-when-forbidden');
+      assert.ok(v018, '018 present');
+      assert.ok(v018.passed, `018 should pass under forbidden profile: ${v018.diagnostic}`);
+    } finally {
+      fresh.server.close();
+    }
+  });
+
+  test('rate-abuse vector: cap+1th request rejected with request_signature_rate_abuse', async () => {
+    // Dedicated fresh server with a tight cap matched to the grader so the
+    // (cap+1)th request trips the rejection. Isolating 020 on its own server
+    // means prior vectors' signatures don't consume replay-cache entries from
+    // this test's quota.
+    const fresh = await startGraderServer({ replayCap: 10 });
+    try {
+      const all = [...Array(20)].map((_, i) => String(i + 1).padStart(3, '0'));
+      const skip = all
+        .filter(n => n !== '020')
+        .map(n => {
+          const files = {
+            '001': '001-no-signature-header',
+            '002': '002-wrong-tag',
+            '003': '003-expired-signature',
+            '004': '004-window-too-long',
+            '005': '005-alg-not-allowed',
+            '006': '006-missing-covered-component',
+            '007': '007-missing-content-digest',
+            '008': '008-unknown-keyid',
+            '009': '009-key-ops-missing-verify',
+            '010': '010-content-digest-mismatch',
+            '011': '011-malformed-header',
+            '012': '012-missing-expires-param',
+            '013': '013-expires-le-created',
+            '014': '014-missing-nonce-param',
+            '015': '015-signature-invalid',
+            '016': '016-replayed-nonce',
+            '017': '017-key-revoked',
+            '018': '018-digest-covered-when-forbidden',
+            '019': '019-signature-without-signature-input',
+          };
+          return files[n];
+        });
+      const report = await gradeRequestSigning(fresh.url, {
+        allowPrivateIp: true,
+        rateAbuseCap: 10,
+        skipVectors: skip,
+      });
+      const v020 = report.negative.find(v => v.vector_id === '020-rate-abuse');
+      assert.ok(v020, '020 present');
+      assert.ok(v020.passed, `020 should pass with matched cap: ${v020.diagnostic}`);
+      assert.strictEqual(v020.actual_error_code, 'request_signature_rate_abuse');
+    } finally {
+      fresh.server.close();
+    }
+  });
+
+  test('skipRateAbuse marks the rate-abuse vector skipped, not failed', async () => {
+    const fresh = await startGraderServer({ replayCap: 1000 });
+    try {
+      const report = await gradeRequestSigning(fresh.url, {
+        allowPrivateIp: true,
+        skipRateAbuse: true,
+        skipVectors: CAPABILITY_PROFILE_VECTORS,
+      });
+      const rateAbuse = report.negative.find(v => v.vector_id === '020-rate-abuse');
+      assert.ok(rateAbuse, '020-rate-abuse present');
+      assert.strictEqual(rateAbuse.skipped, true);
+      assert.strictEqual(rateAbuse.skip_reason, 'rate_abuse_opt_out');
+    } finally {
+      fresh.server.close();
+    }
+  });
+
+  test('positive vectors all accepted with 2xx', async () => {
+    const fresh = await startGraderServer({ replayCap: 1000 });
+    try {
+      const report = await gradeRequestSigning(fresh.url, {
+        allowPrivateIp: true,
+        skipRateAbuse: true,
+        skipVectors: CAPABILITY_PROFILE_VECTORS,
+      });
+      for (const p of report.positive) {
+        assert.ok(p.passed, `positive/${p.vector_id} should pass: ${p.diagnostic}`);
+        assert.ok(p.http_status >= 200 && p.http_status < 300, `${p.vector_id}: status ${p.http_status}`);
+      }
+    } finally {
+      fresh.server.close();
+    }
+  });
+});

--- a/test/request-signing-grader-vectors.test.js
+++ b/test/request-signing-grader-vectors.test.js
@@ -178,7 +178,10 @@ describe('negative builder — one mutation per vector', () => {
     '015-signature-invalid': signed => {
       const match = /sig1=:([^:]+):/.exec(signed.headers['Signature']);
       const decoded = Buffer.from(match[1], 'base64url');
-      assert.ok(decoded.every(b => b === 0), 'all-zero signature bytes');
+      assert.ok(
+        decoded.every(b => b === 0),
+        'all-zero signature bytes'
+      );
     },
     '019-signature-without-signature-input': signed => {
       assert.ok(signed.headers['Signature'], 'Signature present');

--- a/test/request-signing-grader-vectors.test.js
+++ b/test/request-signing-grader-vectors.test.js
@@ -6,6 +6,7 @@ const {
   buildPositiveRequest,
   buildNegativeRequest,
   listSupportedNegativeVectors,
+  gradeOneVector,
 } = require('../dist/lib/testing/storyboard/request-signing/index.js');
 
 const {
@@ -197,4 +198,32 @@ describe('negative builder — one mutation per vector', () => {
       if (assertion) assertion(signed);
     });
   }
+});
+
+describe('preflightSkip — operator-facing skip paths', () => {
+  const FAKE_URL = 'https://agent.example.invalid';
+
+  test('onlyVectors filter skips every vector not in the list', async () => {
+    const result = await gradeOneVector('016-replayed-nonce', 'negative', FAKE_URL, {
+      onlyVectors: ['020-rate-abuse'],
+    });
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.skip_reason, 'not_in_only_vectors');
+  });
+
+  test('skipVectors list skips by vector id', async () => {
+    const result = await gradeOneVector('002-wrong-tag', 'negative', FAKE_URL, {
+      skipVectors: ['002-wrong-tag'],
+    });
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.skip_reason, 'operator_skip');
+  });
+
+  test('skipRateAbuse skips 020 with the rate_abuse_opt_out reason', async () => {
+    const result = await gradeOneVector('020-rate-abuse', 'negative', FAKE_URL, {
+      skipRateAbuse: true,
+    });
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.skip_reason, 'rate_abuse_opt_out');
+  });
 });

--- a/test/request-signing-grader-vectors.test.js
+++ b/test/request-signing-grader-vectors.test.js
@@ -1,0 +1,197 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  loadRequestSigningVectors,
+  buildPositiveRequest,
+  buildNegativeRequest,
+  listSupportedNegativeVectors,
+} = require('../dist/lib/testing/storyboard/request-signing/index.js');
+
+const {
+  parseSignature,
+  parseSignatureInput,
+  verifySignature,
+  jwkToPublicKey,
+  buildSignatureBase,
+  REQUEST_SIGNING_TAG,
+} = require('../dist/lib/signing/index.js');
+
+const loaded = loadRequestSigningVectors();
+
+describe('request-signing vector loader', () => {
+  test('loads 8 positive and 20 negative vectors from the compliance cache', () => {
+    assert.strictEqual(loaded.positive.length, 8, 'positive count');
+    assert.strictEqual(loaded.negative.length, 20, 'negative count');
+  });
+
+  test('every vector carries request, verifier_capability, and jwks_ref', () => {
+    for (const v of [...loaded.positive, ...loaded.negative]) {
+      assert.ok(v.id, `${v.id || '?'}: missing id`);
+      assert.ok(v.request?.method, `${v.id}: missing request.method`);
+      assert.ok(v.request?.url, `${v.id}: missing request.url`);
+      assert.ok(v.verifier_capability, `${v.id}: missing verifier_capability`);
+      assert.ok(Array.isArray(v.jwks_ref) && v.jwks_ref.length > 0, `${v.id}: empty jwks_ref`);
+    }
+  });
+
+  test('keys.json ships private scalars for every test keypair', () => {
+    assert.ok(loaded.keys.keys.length >= 3, 'at least 3 keypairs');
+    for (const k of loaded.keys.keys) {
+      assert.ok(k.private_d, `${k.kid}: _private_d_for_test_only must be present`);
+      assert.ok(k.kid, 'kid');
+      assert.ok(k.kty, 'kty');
+    }
+  });
+
+  test('error codes on negatives belong to the stable enum', () => {
+    const known = new Set([
+      'request_signature_required',
+      'request_signature_header_malformed',
+      'request_signature_params_incomplete',
+      'request_signature_tag_invalid',
+      'request_signature_alg_not_allowed',
+      'request_signature_window_invalid',
+      'request_signature_components_incomplete',
+      'request_signature_components_unexpected',
+      'request_signature_key_unknown',
+      'request_signature_key_purpose_invalid',
+      'request_signature_key_revoked',
+      'request_signature_invalid',
+      'request_signature_digest_mismatch',
+      'request_signature_replayed',
+      'request_signature_rate_abuse',
+    ]);
+    for (const v of loaded.negative) {
+      assert.ok(known.has(v.expected_error_code), `${v.id}: unknown code ${v.expected_error_code}`);
+    }
+  });
+});
+
+describe('positive builder — byte-level correctness against test keys', () => {
+  test('every positive vector produces a request whose fresh signature verifies', () => {
+    for (const vector of loaded.positive) {
+      const signed = buildPositiveRequest(vector, loaded.keys);
+      assert.ok(signed.headers['Signature-Input'], `${vector.id}: no Signature-Input`);
+      assert.ok(signed.headers['Signature'], `${vector.id}: no Signature`);
+
+      const parsedInput = parseSignatureInput(signed.headers['Signature-Input']);
+      const { label, components, params, signatureParamsValue } = parsedInput;
+      const parsedSig = parseSignature(signed.headers['Signature'], label);
+
+      assert.strictEqual(params.tag, REQUEST_SIGNING_TAG, `${vector.id}: tag drift`);
+      assert.ok(params.created, `${vector.id}: missing created`);
+      assert.ok(params.expires > params.created, `${vector.id}: expires must exceed created`);
+      assert.ok(params.nonce && params.nonce.length >= 22, `${vector.id}: weak nonce`);
+
+      const base = buildSignatureBase(
+        components,
+        {
+          method: signed.method,
+          url: signed.url,
+          headers: signed.headers,
+          body: signed.body,
+        },
+        params,
+        signatureParamsValue
+      );
+      const kid = params.keyid;
+      const keypair = loaded.keys.keys.find(k => k.kid === kid);
+      assert.ok(keypair, `${vector.id}: no keypair for ${kid}`);
+      const publicJwk = { ...keypair };
+      delete publicJwk.private_d;
+      const publicKey = jwkToPublicKey(publicJwk);
+      const ok = verifySignature(params.alg, publicKey, Buffer.from(base, 'utf8'), parsedSig.bytes);
+      assert.strictEqual(ok, true, `${vector.id}: signature does not verify`);
+    }
+  });
+
+  test('content-digest coverage follows verifier_capability policy', () => {
+    for (const vector of loaded.positive) {
+      const signed = buildPositiveRequest(vector, loaded.keys);
+      const covers = signed.headers['Signature-Input'].includes('"content-digest"');
+      if (vector.verifier_capability.covers_content_digest === 'required') {
+        assert.ok(covers, `${vector.id}: must cover content-digest`);
+        assert.ok(signed.headers['Content-Digest'], `${vector.id}: must emit Content-Digest`);
+      }
+    }
+  });
+});
+
+describe('negative builder — one mutation per vector', () => {
+  test('registered mutations cover every negative vector on disk', () => {
+    const supported = new Set(listSupportedNegativeVectors());
+    for (const v of loaded.negative) {
+      assert.ok(supported.has(v.id), `no mutation registered for ${v.id}`);
+    }
+  });
+
+  const structuralAssertions = {
+    '001-no-signature-header': signed => {
+      assert.ok(!signed.headers['Signature'], 'Signature must be absent');
+      assert.ok(!signed.headers['Signature-Input'], 'Signature-Input must be absent');
+    },
+    '002-wrong-tag': signed => {
+      assert.match(signed.headers['Signature-Input'], /tag="example-org\/signing\/v1"/);
+    },
+    '003-expired-signature': signed => {
+      const input = signed.headers['Signature-Input'];
+      const match = /created=(\d+);expires=(\d+)/.exec(input);
+      assert.ok(match, 'created/expires params present');
+      const expires = Number(match[2]);
+      assert.ok(expires < Math.floor(Date.now() / 1000), 'expires in the past');
+    },
+    '004-window-too-long': signed => {
+      const match = /created=(\d+);expires=(\d+)/.exec(signed.headers['Signature-Input']);
+      assert.ok(Number(match[2]) - Number(match[1]) > 300, 'window exceeds 300s');
+    },
+    '005-alg-not-allowed': signed => {
+      assert.match(signed.headers['Signature-Input'], /alg="rsa-pss-sha512"/);
+    },
+    '006-missing-covered-component': signed => {
+      assert.ok(!signed.headers['Signature-Input'].includes('"@authority"'), '@authority must be absent');
+    },
+    '007-missing-content-digest': signed => {
+      assert.ok(!signed.headers['Content-Digest'], 'Content-Digest must be absent');
+      assert.ok(!signed.headers['Signature-Input'].includes('"content-digest"'));
+    },
+    '008-unknown-keyid': signed => {
+      assert.match(signed.headers['Signature-Input'], /keyid="unknown-key-9999"/);
+    },
+    '010-content-digest-mismatch': signed => {
+      // Body was mutated post-sign; the Content-Digest no longer matches the payload.
+      assert.ok(signed.headers['Content-Digest'], 'digest header present');
+    },
+    '011-malformed-header': signed => {
+      assert.ok(!/^sig1=\(/.test(signed.headers['Signature-Input']), 'malformed structured-field');
+    },
+    '012-missing-expires-param': signed => {
+      assert.ok(!/\bexpires=/.test(signed.headers['Signature-Input']));
+    },
+    '013-expires-le-created': signed => {
+      const match = /created=(\d+);expires=(\d+)/.exec(signed.headers['Signature-Input']);
+      assert.strictEqual(match[1], match[2], 'expires === created');
+    },
+    '014-missing-nonce-param': signed => {
+      assert.ok(!/\bnonce=/.test(signed.headers['Signature-Input']));
+    },
+    '015-signature-invalid': signed => {
+      const match = /sig1=:([^:]+):/.exec(signed.headers['Signature']);
+      const decoded = Buffer.from(match[1], 'base64url');
+      assert.ok(decoded.every(b => b === 0), 'all-zero signature bytes');
+    },
+    '019-signature-without-signature-input': signed => {
+      assert.ok(signed.headers['Signature'], 'Signature present');
+      assert.ok(!signed.headers['Signature-Input'], 'Signature-Input absent');
+    },
+  };
+
+  for (const vector of loaded.negative) {
+    test(`${vector.id}: mutation is structurally correct`, () => {
+      const signed = buildNegativeRequest(vector, loaded.keys);
+      assert.ok(signed.method && signed.url, 'method + url preserved');
+      const assertion = structuralAssertions[vector.id];
+      if (assertion) assertion(signed);
+    });
+  }
+});

--- a/test/request-signing-runner-integration.test.js
+++ b/test/request-signing-runner-integration.test.js
@@ -230,7 +230,9 @@ describe('request-signing: runner dispatch against reference verifier', () => {
       allow_http: true,
       request_signing: { skipRateAbuse: true },
     });
-    assert.ok(/skipped/.test(result.error ?? ''), `skip reason surfaced: ${result.error}`);
+    assert.strictEqual(result.skipped, true, `expected skipped, got: ${JSON.stringify(result)}`);
+    assert.match(result.skip_reason ?? '', /rate_abuse_opt_out|skipRateAbuse/);
+    assert.strictEqual(result.error, undefined, 'skipped probe should not set error');
   });
 
   test('probe dispatch honors request_signing.skipVectors', async () => {
@@ -238,12 +240,95 @@ describe('request-signing: runner dispatch against reference verifier', () => {
       allow_http: true,
       request_signing: { skipVectors: ['003-expired-signature'] },
     });
-    assert.ok(/skipped/.test(result.error ?? ''), `skip reason: ${result.error}`);
+    assert.strictEqual(result.skipped, true, `expected skipped, got: ${JSON.stringify(result)}`);
+    assert.match(result.skip_reason ?? '', /operator_skip|skipVectors/);
   });
 
   test('probe dispatch rejects unknown step id', async () => {
     const result = await probeRequestSigningVector('random-step', 'http://127.0.0.1:1', {});
     assert.match(result.error ?? '', /does not match positive-\/negative-/);
+  });
+
+  test('runStoryboardStep routes request_signing_probe through the dispatch', async () => {
+    // Guarantees the wire-up in runner.ts (executeProbeStep's dispatch on
+    // step.task === 'request_signing_probe') stays live. If someone
+    // removes the task from PROBE_TASKS or the dispatch condition, this
+    // test catches it — callers to probeRequestSigningVector directly
+    // would not.
+    const fresh = await startReferenceVerifier({ replayCap: 1000 });
+    try {
+      const { runStoryboardStep } = require('../dist/lib/testing/storyboard/runner.js');
+      const storyboard = {
+        id: 'test-wire-up',
+        version: '1.0.0',
+        title: 'Dispatch wire-up smoke',
+        phases: [
+          {
+            id: 'wire_up',
+            title: 'wire_up',
+            steps: [
+              {
+                id: 'positive-001-basic-post',
+                title: 'Positive: wire-up',
+                task: 'request_signing_probe',
+                validations: [
+                  {
+                    check: 'http_status_in',
+                    allowed_values: [200, 201, 202, 203, 204],
+                    description: 'ok',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboardStep(fresh.url, storyboard, 'positive-001-basic-post', {
+        allow_http: true,
+        _client: {}, // bypass MCP profile discovery — probe tasks don't touch the client
+      });
+      assert.strictEqual(result.passed, true, `step should pass: ${result.error}`);
+      assert.strictEqual(result.response.status, 200);
+    } finally {
+      fresh.server.close();
+    }
+  });
+
+  test('runStoryboardStep propagates skipped status to the step result', async () => {
+    const fresh = await startReferenceVerifier({ replayCap: 1000 });
+    try {
+      const { runStoryboardStep } = require('../dist/lib/testing/storyboard/runner.js');
+      const storyboard = {
+        id: 'test-skip-propagation',
+        version: '1.0.0',
+        title: 'Skip propagation',
+        phases: [
+          {
+            id: 'skip_check',
+            title: 'skip_check',
+            steps: [
+              {
+                id: 'negative-020-rate-abuse',
+                title: 'Rate-abuse',
+                task: 'request_signing_probe',
+                validations: [{ check: 'http_status', value: 401, description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboardStep(fresh.url, storyboard, 'negative-020-rate-abuse', {
+        allow_http: true,
+        _client: {},
+        request_signing: { skipRateAbuse: true },
+      });
+      // Skipped ≠ failed — this is the bug the review caught.
+      assert.strictEqual(result.skipped, true, 'step marked skipped');
+      assert.strictEqual(result.passed, true, 'skipped steps do not count as failures');
+      assert.match(result.skip_reason ?? '', /rate_abuse_opt_out|skipRateAbuse/);
+    } finally {
+      fresh.server.close();
+    }
   });
 
   test('probe dispatch propagates grader error on verifier mismatch', async () => {

--- a/test/request-signing-runner-integration.test.js
+++ b/test/request-signing-runner-integration.test.js
@@ -1,0 +1,265 @@
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  createExpressVerifier,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  StaticJwksResolver,
+} = require('../dist/lib/signing/index.js');
+
+const {
+  loadComplianceIndex,
+  loadBundleStoryboards,
+} = require('../dist/lib/testing/storyboard/compliance.js');
+
+const {
+  synthesizeRequestSigningSteps,
+  parseRequestSigningStepId,
+} = require('../dist/lib/testing/storyboard/request-signing/index.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function makeExpressShim(req, res) {
+  const reqShim = {
+    method: req.method,
+    url: req.url,
+    originalUrl: req.url,
+    headers: req.headers,
+    protocol: 'http',
+    get(name) {
+      const v = req.headers[name.toLowerCase()];
+      return Array.isArray(v) ? v.join(', ') : v;
+    },
+  };
+  const resShim = {
+    status(code) {
+      res.statusCode = code;
+      return {
+        set(k, v) {
+          res.setHeader(k, v);
+          return {
+            json(body) {
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify(body));
+            },
+          };
+        },
+      };
+    },
+  };
+  return { reqShim, resShim };
+}
+
+function startReferenceVerifier({ replayCap = 1000 } = {}) {
+  const publicKeys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys.map(k => {
+    const pub = { ...k };
+    delete pub._private_d_for_test_only;
+    return pub;
+  });
+  const jwks = new StaticJwksResolver(publicKeys);
+  const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: replayCap });
+  const revocationStore = new InMemoryRevocationStore({
+    issuer: 'http://127.0.0.1',
+    updated: new Date().toISOString(),
+    next_update: new Date(Date.now() + 3600_000).toISOString(),
+    revoked_kids: ['test-revoked-2026'],
+    revoked_jtis: [],
+  });
+  const middleware = createExpressVerifier({
+    capability: {
+      supported: true,
+      covers_content_digest: 'either',
+      required_for: ['create_media_buy'],
+    },
+    jwks,
+    replayStore,
+    revocationStore,
+    resolveOperation: req =>
+      new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
+  });
+  const server = http.createServer(async (req, res) => {
+    const body = await readRawBody(req);
+    const { reqShim, resShim } = makeExpressShim(req, res);
+    reqShim.rawBody = body;
+    await new Promise(resolve =>
+      middleware(reqShim, resShim, err => {
+        if (err) {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: 'internal_server_error' }));
+          resolve();
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ ok: true }));
+        resolve();
+      })
+    );
+  });
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve({ server, url: `http://127.0.0.1:${addr.port}` });
+    });
+  });
+}
+
+describe('request-signing: synthesize step expansion', () => {
+  test('compliance loader synthesizes per-vector steps for the signed-requests specialism', () => {
+    const index = loadComplianceIndex();
+    const specialism = index.specialisms.find(s => s.id === 'signed-requests');
+    assert.ok(specialism, 'signed-requests specialism is indexed');
+
+    const storyboards = loadBundleStoryboards({
+      kind: 'specialism',
+      id: 'signed-requests',
+      path: path.join('compliance', 'cache', 'latest', 'specialisms', 'signed-requests'),
+    });
+    const sb = storyboards.find(s => s.id === 'signed_requests');
+    assert.ok(sb, 'signed_requests storyboard loaded');
+
+    const positivePhase = sb.phases.find(p => p.id === 'positive_vectors');
+    const negativePhase = sb.phases.find(p => p.id === 'negative_vectors');
+    assert.ok(positivePhase && negativePhase, 'vector phases present');
+    assert.strictEqual(positivePhase.steps.length, 8, 'all 8 positive steps synthesized');
+    assert.strictEqual(negativePhase.steps.length, 20, 'all 20 negative steps synthesized');
+
+    for (const step of positivePhase.steps) {
+      assert.ok(step.id.startsWith('positive-'), `positive step id: ${step.id}`);
+      assert.strictEqual(step.task, 'request_signing_probe');
+    }
+    for (const step of negativePhase.steps) {
+      assert.ok(step.id.startsWith('negative-'), `negative step id: ${step.id}`);
+      assert.strictEqual(step.task, 'request_signing_probe');
+    }
+
+    const roundtrip = parseRequestSigningStepId(positivePhase.steps[0].id);
+    assert.strictEqual(roundtrip.kind, 'positive');
+    assert.strictEqual(roundtrip.vector_id, '001-basic-post');
+  });
+
+  test('synthesizeRequestSigningSteps respects skipVectors', () => {
+    const bare = loadBundleStoryboards({
+      kind: 'specialism',
+      id: 'signed-requests',
+      path: path.join('compliance', 'cache', 'latest', 'specialisms', 'signed-requests'),
+    })[0];
+    // Already synthesized by the loader, so re-synthesize with skipVectors on
+    // a clone with empty phases to check the skip path.
+    const skipped = synthesizeRequestSigningSteps(
+      {
+        ...bare,
+        phases: bare.phases.map(p =>
+          p.id === 'positive_vectors' || p.id === 'negative_vectors' ? { ...p, steps: [] } : p
+        ),
+      },
+      { skipVectors: ['001-basic-post', '015-signature-invalid'] }
+    );
+    const posIds = skipped.phases.find(p => p.id === 'positive_vectors').steps.map(s => s.id);
+    const negIds = skipped.phases.find(p => p.id === 'negative_vectors').steps.map(s => s.id);
+    assert.ok(!posIds.includes('positive-001-basic-post'), 'positive 001 skipped');
+    assert.ok(!negIds.includes('negative-015-signature-invalid'), 'negative 015 skipped');
+    assert.strictEqual(posIds.length, 7, 'remaining positives = 7');
+    assert.strictEqual(negIds.length, 19, 'remaining negatives = 19');
+  });
+});
+
+const { probeRequestSigningVector } = require('../dist/lib/testing/storyboard/request-signing/index.js');
+
+describe('request-signing: runner dispatch against reference verifier', () => {
+  let instance;
+
+  before(async () => {
+    instance = await startReferenceVerifier({ replayCap: 1000 });
+  });
+
+  after(() => {
+    instance.server.close();
+  });
+
+  test('probe dispatch grades a positive vector with 2xx + empty WWW-Authenticate', async () => {
+    const result = await probeRequestSigningVector('positive-001-basic-post', instance.url, {
+      allow_http: true,
+    });
+    assert.ok(!result.error, `probe error: ${result.error}`);
+    assert.ok(result.status >= 200 && result.status < 300, `status ${result.status}`);
+    assert.strictEqual(result.headers['www-authenticate'], undefined);
+  });
+
+  test('probe dispatch grades a negative vector with 401 + matching WWW-Authenticate', async () => {
+    const fresh = await startReferenceVerifier({ replayCap: 1000 });
+    try {
+      const result = await probeRequestSigningVector('negative-002-wrong-tag', fresh.url, {
+        allow_http: true,
+      });
+      assert.ok(!result.error, `probe error: ${result.error}`);
+      assert.strictEqual(result.status, 401);
+      assert.ok(
+        result.headers['www-authenticate']?.includes('request_signature_tag_invalid'),
+        `WWW-Authenticate: ${result.headers['www-authenticate']}`
+      );
+    } finally {
+      fresh.server.close();
+    }
+  });
+
+  test('probe dispatch honors request_signing.skipRateAbuse', async () => {
+    const result = await probeRequestSigningVector('negative-020-rate-abuse', instance.url, {
+      allow_http: true,
+      request_signing: { skipRateAbuse: true },
+    });
+    assert.ok(/skipped/.test(result.error ?? ''), `skip reason surfaced: ${result.error}`);
+  });
+
+  test('probe dispatch honors request_signing.skipVectors', async () => {
+    const result = await probeRequestSigningVector('negative-003-expired-signature', instance.url, {
+      allow_http: true,
+      request_signing: { skipVectors: ['003-expired-signature'] },
+    });
+    assert.ok(/skipped/.test(result.error ?? ''), `skip reason: ${result.error}`);
+  });
+
+  test('probe dispatch rejects unknown step id', async () => {
+    const result = await probeRequestSigningVector('random-step', 'http://127.0.0.1:1', {});
+    assert.match(result.error ?? '', /does not match positive-\/negative-/);
+  });
+
+  test('probe dispatch propagates grader error on verifier mismatch', async () => {
+    // Vector 007 expects request_signature_components_incomplete under the
+    // 'required' covers_content_digest profile. Our default server is
+    // 'either', so the request is accepted (200). The grader surfaces this
+    // as a failure with a diagnostic.
+    const fresh = await startReferenceVerifier({ replayCap: 1000 });
+    try {
+      const result = await probeRequestSigningVector('negative-007-missing-content-digest', fresh.url, {
+        allow_http: true,
+      });
+      assert.ok(result.error, 'grader mismatch surfaces as probe error');
+      assert.ok(/expected 401/.test(result.error), `diagnostic: ${result.error}`);
+    } finally {
+      fresh.server.close();
+    }
+  });
+});

--- a/test/request-signing-runner-integration.test.js
+++ b/test/request-signing-runner-integration.test.js
@@ -11,10 +11,7 @@ const {
   StaticJwksResolver,
 } = require('../dist/lib/signing/index.js');
 
-const {
-  loadComplianceIndex,
-  loadBundleStoryboards,
-} = require('../dist/lib/testing/storyboard/compliance.js');
+const { loadComplianceIndex, loadBundleStoryboards } = require('../dist/lib/testing/storyboard/compliance.js');
 
 const {
   synthesizeRequestSigningSteps,
@@ -96,8 +93,7 @@ function startReferenceVerifier({ replayCap = 1000 } = {}) {
     jwks,
     replayStore,
     revocationStore,
-    resolveOperation: req =>
-      new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
+    resolveOperation: req => new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
   });
   const server = http.createServer(async (req, res) => {
     const body = await readRawBody(req);

--- a/test/utils/reference-verifier.js
+++ b/test/utils/reference-verifier.js
@@ -1,0 +1,159 @@
+/**
+ * Reference verifier test helper — stands up the #587 Express middleware on a
+ * random localhost port, configured per the signed-requests-runner test-kit
+ * contract. Used by request-signing grader tests.
+ */
+
+const http = require('node:http');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const {
+  createExpressVerifier,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  StaticJwksResolver,
+} = require('../../dist/lib/signing/index.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+
+function readRawBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Minimal Express-shaped adapter so createExpressVerifier works atop the
+ * stdlib node:http server. Extracted so tests can share it; the pattern
+ * previously appeared verbatim in three test files.
+ */
+function makeExpressShim(req, res) {
+  const reqShim = {
+    method: req.method,
+    url: req.url,
+    originalUrl: req.url,
+    headers: req.headers,
+    protocol: 'http',
+    get(name) {
+      const v = req.headers[name.toLowerCase()];
+      return Array.isArray(v) ? v.join(', ') : v;
+    },
+  };
+  const resShim = {
+    status(code) {
+      res.statusCode = code;
+      return {
+        set(k, v) {
+          res.setHeader(k, v);
+          return {
+            json(body) {
+              res.setHeader('Content-Type', 'application/json');
+              res.end(JSON.stringify(body));
+            },
+          };
+        },
+      };
+    },
+  };
+  return { reqShim, resShim };
+}
+
+/**
+ * Stand up a reference request-signing verifier on a random localhost port.
+ *
+ * `purpose` encodes the caps the caller needs — the replay-window +
+ * rate-abuse contracts demand specific `maxEntriesPerKeyid` that conflict
+ * with each other on a shared server, so tests spin up purpose-specific
+ * instances.
+ */
+async function startReferenceVerifier({
+  purpose = 'omnibus',
+  replayCap,
+  coversContentDigest = 'either',
+  requiredFor = ['create_media_buy'],
+} = {}) {
+  // Omnibus tests sign every vector with the same keyid; replay cap must be
+  // large enough that we don't trip rate_abuse on an unrelated vector.
+  // Rate-abuse tests want a tight cap matched to the grader's target.
+  const cap = replayCap ?? (purpose === 'rate_abuse' ? 10 : 1000);
+
+  const publicKeys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys.map(k => {
+    const pub = { ...k };
+    delete pub._private_d_for_test_only;
+    return pub;
+  });
+  const jwks = new StaticJwksResolver(publicKeys);
+  const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: cap });
+  const revocationStore = new InMemoryRevocationStore({
+    issuer: 'http://127.0.0.1',
+    updated: new Date().toISOString(),
+    next_update: new Date(Date.now() + 3600_000).toISOString(),
+    revoked_kids: ['test-revoked-2026'],
+    revoked_jtis: [],
+  });
+  const middleware = createExpressVerifier({
+    capability: {
+      supported: true,
+      covers_content_digest: coversContentDigest,
+      required_for: requiredFor,
+    },
+    jwks,
+    replayStore,
+    revocationStore,
+    resolveOperation: req =>
+      new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
+  });
+
+  const server = http.createServer(async (req, res) => {
+    const body = await readRawBody(req);
+    const { reqShim, resShim } = makeExpressShim(req, res);
+    reqShim.rawBody = body;
+    await new Promise(resolve =>
+      middleware(reqShim, resShim, err => {
+        if (err) {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: 'internal_server_error' }));
+          resolve();
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ ok: true }));
+        resolve();
+      })
+    );
+  });
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      resolve({
+        server,
+        url: `http://127.0.0.1:${addr.port}`,
+        replayStore,
+        revocationStore,
+        replayCap: cap,
+      });
+    });
+  });
+}
+
+module.exports = {
+  makeExpressShim,
+  startReferenceVerifier,
+  readRawBody,
+};

--- a/test/utils/reference-verifier.js
+++ b/test/utils/reference-verifier.js
@@ -114,8 +114,7 @@ async function startReferenceVerifier({
     jwks,
     replayStore,
     revocationStore,
-    resolveOperation: req =>
-      new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
+    resolveOperation: req => new URL('http://x' + req.originalUrl).pathname.split('/').filter(Boolean).pop(),
   });
 
   const server = http.createServer(async (req, res) => {


### PR DESCRIPTION
## Summary

Closes #585. Implements the AdCP Verified storyboard grader for the
`signed-requests` specialism — a black-box conformance runner that grades any
agent advertising `request_signing.supported: true` against the 28 RFC 9421
vectors shipped at
`/compliance/{version}/test-vectors/request-signing/`. Ships in three slices,
each independently tested and reviewable:

- **Slice 1** (`a4bbb7d5`) — vector loader + adversarial builder. One mutation
  per negative vector, each starting from a freshly-signed baseline via
  `signRequest()` from #587. 27 unit tests.
- **Slice 2** (`57bdeb7b`) — test-kit YAML loader (adcp#2353 harness
  contract), SSRF-guarded HTTP probe, and standalone grader orchestrator
  (`gradeRequestSigning(agentUrl, options)`). Native handling for the three
  stateful vectors — 016 repeat-send, 017 pre-revoked keyid, 020 cap+1 —
  per the signed-requests-runner test-kit. 6 end-to-end tests against a
  localhost reference verifier.
- **Slice 3** (`22988abe`) — storyboard-runner integration. Synthesizer
  expands `positive_vectors` / `negative_vectors` phases with one step per
  vector; new `request_signing_probe` task dispatches via `PROBE_TASKS` in
  the runner. Operators tune via `StoryboardRunOptions.request_signing`
  (`skipRateAbuse`, `rateAbuseCap`, `skipVectors`). 8 integration tests.

Upstream spec dependency adcp#2353 (harness contract for stateful vectors
016/017/020) landed during this work — synthesizer reads `requires_contract`
and `test-revoked-2026`, grader enforces the contract at runtime.

## Scope

- **In**: grading any agent advertising `request_signing.supported: true`,
  regardless of SDK. Black-box mode only (white-box harnesses can still use
  the vectors' `test_harness_state` directly).
- **Out**: signer-side grading — easier problem, separate storyboard.
- **Out**: CLI entry point — consume programmatically via
  `@adcp/client/testing/storyboard/request-signing` for now.

## Test plan

- [x] `npm run build:lib` clean.
- [x] `npm test` — 3623/3625 pass (2 skipped are pre-existing). 20
      governance-e2e failures are pre-existing and gated on a training
      agent at localhost:4100; verified they fail identically on a
      pristine main checkout.
- [x] Grader-specific tests (41/41 pass):
  - `test/request-signing-grader-vectors.test.js` — loader + builder
    (27 tests).
  - `test/request-signing-grader-e2e.test.js` — standalone grader vs.
    reference verifier, capability-profile subtests for 007/018, tight-cap
    test for 020 (6 tests).
  - `test/request-signing-runner-integration.test.js` — synthesis + probe
    dispatch, skip options, unknown-step handling, mismatch diagnostic
    (8 tests).

## Related

- Upstream spec: adcp#2323 (profile), adcp#2331 (specialism), adcp#2353
  (harness contract).
- SDK verifier side: #587 (merged).
- Follow-ups already landed on main: #593 (auto-wire #578),
  #596 (structured-headers parser + bucketed replay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)