### PR TITLE
fix: replayed:false on fresh execs + skill idempotency gaps (#569)

### DIFF
--- a/.changeset/skills-idempotency-coverage.md
+++ b/.changeset/skills-idempotency-coverage.md
@@ -1,0 +1,24 @@
+---
+'@adcp/client': patch
+---
+
+Idempotency middleware now stamps `replayed: false` on fresh executions (not
+just `replayed: true` on replays). Caught by running the universal
+`idempotency` compliance storyboard against a retail-media agent built from
+the updated skill — the `replay_same_payload/create_media_buy_initial` step
+expects `replayed: false` on the envelope, and the previous implementation
+omitted the field entirely. The cache still stores the envelope WITHOUT the
+`replayed` field; it's stamped after the save so a subsequent replay cleanly
+overwrites it with `true`. Existing test asserting `replayed !== true` on
+fresh executions tightened to `replayed === false`.
+
+Skills: wire `createIdempotencyStore` into the main Implementation code block
+for `build-creative-agent`, `build-signals-agent`, `build-brand-rights-agent`,
+`build-retail-media-agent`, and `build-generative-seller-agent`. Each skill
+already documented idempotency but the copy-paste-complete Implementation
+example was missing the wiring, so a fresh agent built from the skill would
+log the "v3 non-compliance" error at startup. Seller, SI, and governance
+skills were already complete. Also extends `test-agents/test-agent-build.sh`
+to cover all 8 agent types, adds the universal `idempotency` storyboard as
+a second check on every run, and passes `--allow-http` so local storyboard
+runs actually execute.

--- a/.changeset/skills-idempotency-coverage.md
+++ b/.changeset/skills-idempotency-coverage.md
@@ -2,23 +2,50 @@
 '@adcp/client': patch
 ---
 
-Idempotency middleware now stamps `replayed: false` on fresh executions (not
-just `replayed: true` on replays). Caught by running the universal
-`idempotency` compliance storyboard against a retail-media agent built from
-the updated skill — the `replay_same_payload/create_media_buy_initial` step
-expects `replayed: false` on the envelope, and the previous implementation
-omitted the field entirely. The cache still stores the envelope WITHOUT the
-`replayed` field; it's stamped after the save so a subsequent replay cleanly
-overwrites it with `true`. Existing test asserting `replayed !== true` on
-fresh executions tightened to `replayed === false`.
+**Idempotency storyboard end-to-end compliance** — the universal
+`idempotency` compliance storyboard now passes 1/0/0/0 against agents
+built from all 8 skills. Three framework fixes were required to get there:
 
-Skills: wire `createIdempotencyStore` into the main Implementation code block
-for `build-creative-agent`, `build-signals-agent`, `build-brand-rights-agent`,
-`build-retail-media-agent`, and `build-generative-seller-agent`. Each skill
-already documented idempotency but the copy-paste-complete Implementation
-example was missing the wiring, so a fresh agent built from the skill would
-log the "v3 non-compliance" error at startup. Seller, SI, and governance
-skills were already complete. Also extends `test-agents/test-agent-build.sh`
-to cover all 8 agent types, adds the universal `idempotency` storyboard as
-a second check on every run, and passes `--allow-http` so local storyboard
-runs actually execute.
+1. **`replayed: false` on fresh executions.** Middleware now stamps the
+   field on every mutating response, not just replays. Buyers that branch
+   on `metadata.replayed` to decide whether side effects already fired
+   need the field present either way. Cached envelopes are stamped after
+   the save so replays cleanly overwrite with `true`.
+
+2. **Replay echoes the current retry's `context`, not the first caller's.**
+   Previously, cached response envelopes baked in the first caller's
+   `correlation_id` and replays returned that to every subsequent retry,
+   breaking end-to-end tracing. The middleware now strips `context` from
+   the formatted response before caching; on replay, `finalize()`
+   re-injects the current request's context.
+
+3. **MCP-level `idempotency_key` relaxed to optional when the framework
+   has an idempotency store wired.** The middleware is authoritative for
+   this field and returns a structured `adcp_error` with `code` + `field`.
+   If the MCP SDK's schema validator rejected first, buyers got a text-
+   only `-32602` error that failed the storyboard's `error_code` check.
+
+**Storyboard harness fixes** so the runner actually exercises replay semantics:
+
+- `$generate:uuid_v4[#alias]` placeholder resolution in `sample_request`
+  values. Same alias within a run → same UUID (enables initial + replay
+  testing). Alias cache lives in a WeakMap keyed off context identity,
+  propagated explicitly at shallow-clone sites via `forwardAliasCache` —
+  no implementation-detail keys leak into serialized output.
+- Request builders now forward `idempotency_key` from `sample_request`
+  and respect future-dated `start_time`/`end_time` (two calls generated
+  ms apart with `Date.now()` hash differently, triggering spurious
+  CONFLICT on replay).
+- `$context.<key>` placeholders now resolved in validation `value` and
+  `allowed_values` so expected values can reference prior steps.
+- New `TaskOptions.skipIdempotencyAutoInject` (`@internal` — compliance
+  testing only) lets the runner exercise servers' missing-key validation
+  without the client auto-generating a key. Gated at all three inject
+  sites: `normalizeRequestParams`, `executeAndHandle` pre-validation,
+  and `TaskExecutor.executeTask`.
+
+**Skills**: wire `createIdempotencyStore` into the main Implementation
+block for creative, signals, brand-rights, retail-media, and
+generative-seller (seller/SI/governance were already complete). Extends
+`test-agents/test-agent-build.sh` to all 8 agent types, adds the
+universal idempotency storyboard as a second check, passes `--allow-http`.

--- a/skills/build-brand-rights-agent/SKILL.md
+++ b/skills/build-brand-rights-agent/SKILL.md
@@ -207,12 +207,26 @@ Creative-approval webhooks are implemented as a regular outbound HTTP call — o
 
 ```typescript
 import { createAdcpServer, serve, adcpError } from '@adcp/client';
+import { createIdempotencyStore, memoryBackend } from '@adcp/client/server';
+
+// Idempotency — required for v3. `acquire_rights` is mutating (issues
+// credentials + may trigger billing); `get_brand_identity` and
+// `get_rights` are read-only and exempt.
+const idempotency = createIdempotencyStore({
+  backend: memoryBackend(),         // pgBackend(pool) for production
+  ttlSeconds: 86400,                // 24 hours (spec bounds: 1h–7d)
+});
 
 serve(() =>
   createAdcpServer({
     name: 'Acme Brand Rights Agent',
     version: '1.0.0',
     capabilities: { major_versions: [3] },
+    idempotency,
+
+    // Principal scoping for idempotency. MUST never return undefined — or
+    // every mutating request rejects as SERVICE_UNAVAILABLE.
+    resolveSessionKey: () => 'default-principal',
 
     brandRights: {
       async getBrandIdentity(params) {
@@ -304,22 +318,17 @@ The skill contains everything you need. Do not read additional docs before writi
 
 ## Idempotency
 
-AdCP v3 requires an `idempotency_key` on every mutating request — for brand rights agents that's `acquire_rights` (once the schema lands; `get_brand_identity` and `get_rights` are read-only and exempt). Acquiring rights issues credentials and may trigger billing, so replay safety is non-negotiable. Wire `createIdempotencyStore` from `@adcp/client/server` into `createAdcpServer` and the framework handles missing-key rejection (`INVALID_REQUEST`), JCS-canonicalized payload hashing, `IDEMPOTENCY_CONFLICT` on same-key-different-payload (no payload leaked in the error), `IDEMPOTENCY_EXPIRED` past the TTL, `replayed: true` envelope injection on cache hits, and automatic declaration of `adcp.idempotency.replay_ttl_seconds` on `get_adcp_capabilities`. Only successful responses cache — a failed acquisition re-executes on retry without issuing duplicate grants. Scoping is per-principal via `resolveSessionKey` (or override with `resolveIdempotencyPrincipal`) so two buyers don't share each other's grants.
+AdCP v3 requires an `idempotency_key` on every mutating request — for brand rights agents that's `acquire_rights` only (`get_brand_identity` and `get_rights` are read-only and exempt). Acquiring rights issues credentials and may trigger billing, so replay safety is non-negotiable. Idempotency is already wired in the Implementation example above. The framework then handles:
 
-```typescript
-import { createIdempotencyStore, memoryBackend, pgBackend } from '@adcp/client/server';
+- Missing/malformed key → `INVALID_REQUEST` (spec pattern `^[A-Za-z0-9_.:-]{16,255}$`)
+- JCS-canonicalized payload hashing with same-key-different-payload → `IDEMPOTENCY_CONFLICT` (no payload leaked in the error body)
+- Past-TTL replay → `IDEMPOTENCY_EXPIRED` (±60s clock-skew tolerance)
+- Cache hits replay the cached envelope with `replayed: true` injected
+- `adcp.idempotency.replay_ttl_seconds` auto-declared on `get_adcp_capabilities`
+- Only successful responses cache — a failed acquisition re-executes on retry without issuing duplicate grants
+- Atomic claim so concurrent retries with the same key don't all race to mint grants
 
-const idempotency = createIdempotencyStore({
-  backend: memoryBackend(),         // or pgBackend(pool) for production
-  ttlSeconds: 86400,                // 1h–7d, clamped to spec bounds
-});
-
-const server = createAdcpServer({
-  idempotency,
-  resolveSessionKey: (ctx) => ctx.account?.id,  // doubles as idempotency principal
-  // ... brandRights.acquireRights
-});
-```
+Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempotencyPrincipal`). `ttlSeconds` must be 3600–604800 — out of range throws at construction.
 
 ## Validation
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -235,13 +235,28 @@ import {
   createAdcpServer, serve, adcpError,
   previewCreativeResponse, PreviewCreativeSingleRequestSchema,
 } from '@adcp/client';
+import { createIdempotencyStore, memoryBackend } from '@adcp/client/server';
 
 const formats = [ /* your format objects */ ];
+
+// Idempotency — required for v3 compliance on any agent with mutating
+// handlers. `sync_creatives`, `build_creative`, and `calibrate_content`
+// are all mutating for creative agents.
+const idempotency = createIdempotencyStore({
+  backend: memoryBackend(),         // pgBackend(pool) for production
+  ttlSeconds: 86400,                // 24 hours (spec bounds: 1h–7d)
+});
 
 serve(() => {
   const server = createAdcpServer({
     name: 'My Creative Agent',
     version: '1.0.0',
+    idempotency,
+
+    // Principal scoping for idempotency. MUST never return undefined —
+    // every mutating request would reject as SERVICE_UNAVAILABLE. A
+    // constant works for a demo; use ctx.account for multi-tenant prod.
+    resolveSessionKey: () => 'default-principal',
 
     creative: {
       listCreativeFormats: async (params, ctx) => {
@@ -324,22 +339,17 @@ The `sync_creatives` handler adds/updates entries via `ctx.store.put('creatives'
 
 ## Idempotency
 
-AdCP v3 requires an `idempotency_key` on every mutating request — for creative agents that's `sync_creatives`, `build_creative`, and `calibrate_content`. Wire `createIdempotencyStore` from `@adcp/client/server` into `createAdcpServer` and the framework handles missing-key rejection (`INVALID_REQUEST`), JCS-canonicalized payload hashing, `IDEMPOTENCY_CONFLICT` on same-key-different-payload (no payload leaked in the error), `IDEMPOTENCY_EXPIRED` past the TTL, `replayed: true` envelope injection on cache hits, and automatic declaration of `adcp.idempotency.replay_ttl_seconds` on `get_adcp_capabilities`. Only successful responses cache — a failed render or generation re-executes on retry so buyers can safely retry transient errors. Scoping is per-principal via `resolveSessionKey` (or override with `resolveIdempotencyPrincipal`).
+AdCP v3 requires an `idempotency_key` on every mutating request — for creative agents that's `sync_creatives`, `build_creative`, and `calibrate_content`. Idempotency is already wired in the Implementation example above. The framework then handles:
 
-```typescript
-import { createIdempotencyStore, memoryBackend, pgBackend } from '@adcp/client/server';
+- Missing/malformed key → `INVALID_REQUEST` (spec pattern `^[A-Za-z0-9_.:-]{16,255}$`)
+- JCS-canonicalized payload hashing with same-key-different-payload → `IDEMPOTENCY_CONFLICT` (no payload leaked in the error body)
+- Past-TTL replay → `IDEMPOTENCY_EXPIRED` (±60s clock-skew tolerance)
+- Cache hits replay the cached envelope with `replayed: true` injected
+- `adcp.idempotency.replay_ttl_seconds` auto-declared on `get_adcp_capabilities`
+- Only successful responses cache — failed renders re-execute on retry
+- Atomic claim so concurrent retries with a fresh key don't all race to run
 
-const idempotency = createIdempotencyStore({
-  backend: memoryBackend(),         // or pgBackend(pool) for production
-  ttlSeconds: 86400,                // 1h–7d, clamped to spec bounds
-});
-
-const server = createAdcpServer({
-  idempotency,
-  resolveSessionKey: (ctx) => ctx.account?.id,  // doubles as idempotency principal
-  // ... creative.syncCreatives, buildCreative, calibrateContent
-});
-```
+Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempotencyPrincipal` for custom scoping). `ttlSeconds` must be 3600–604800 — out of range throws at construction. If you register mutating handlers without wiring `idempotency`, the framework logs an error at server-creation time.
 
 ## Validation
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -309,6 +309,65 @@ Minimal `tsconfig.json`:
 
 Creative tools (`listCreativeFormats`, `syncCreatives`, `buildCreative`, `listCreatives`, `getCreativeDelivery`) belong in the `creative` domain group. Media buy tools (`getProducts`, `createMediaBuy`, `getMediaBuys`, `getMediaBuyDelivery`) belong in `mediaBuy`.
 
+```typescript
+import { randomUUID } from 'node:crypto';
+import { createAdcpServer, serve, adcpError } from '@adcp/client';
+import { createIdempotencyStore, memoryBackend } from '@adcp/client/server';
+
+// Idempotency — required for v3. Generative creation is expensive and
+// non-deterministic, so caching successful responses per key is critical:
+// a buyer retry must replay the same ad, not re-burn model tokens.
+const idempotency = createIdempotencyStore({
+  backend: memoryBackend(),         // pgBackend(pool) for production
+  ttlSeconds: 86400,                // 24 hours (spec bounds: 1h–7d)
+});
+
+serve(() => createAdcpServer({
+  name: 'My Generative Seller',
+  version: '1.0.0',
+  idempotency,
+
+  // Principal scoping. MUST never return undefined — or every mutating
+  // request rejects as SERVICE_UNAVAILABLE.
+  resolveSessionKey: () => 'default-principal',
+
+  mediaBuy: {
+    getProducts: async (params, ctx) => ({ products: PRODUCTS, sandbox: true }),
+    createMediaBuy: async (params, ctx) => {
+      const buy = {
+        media_buy_id: `mb_${randomUUID()}`,
+        status: 'pending_creatives' as const,
+        packages: params.packages?.map(p => ({
+          package_id: `pkg_${randomUUID()}`,
+          product_id: p.product_id,
+          pricing_option_id: p.pricing_option_id,
+          budget: p.budget,
+        })) ?? [],
+      };
+      await ctx.store.put('media_buys', buy.media_buy_id, buy);
+      return buy;
+    },
+    // ... updateMediaBuy, getMediaBuys, getMediaBuyDelivery
+  },
+
+  creative: {
+    listCreativeFormats: async () => ({ formats: FORMATS }),
+    syncCreatives: async (params, ctx) => {
+      // Generative formats take a `brief`; standard formats carry assets.
+      // Check the format_id to decide processing. Framework idempotency
+      // ensures a retry of the same (key, payload) replays the prior
+      // response instead of re-running generation.
+      const results = params.creatives.map(c => ({
+        creative_id: c.creative_id ?? `cr_${randomUUID()}`,
+        action: 'created' as const,
+      }));
+      return { creatives: results };
+    },
+    // ... buildCreative, listCreatives, getCreativeDelivery
+  },
+}));
+```
+
 The skill contains everything you need. Do not read additional docs before writing code.
 
 ### Key implementation detail: sync_creatives handler
@@ -322,22 +381,17 @@ The sync_creatives handler must check the format_id to decide how to process:
 
 ## Idempotency
 
-AdCP v3 requires an `idempotency_key` on every mutating request — for generative sellers that's `create_media_buy`, `update_media_buy`, and `sync_creatives` (including brief-based creatives whose generation is expensive and must not double-bill). Wire `createIdempotencyStore` from `@adcp/client/server` into `createAdcpServer` and the framework handles missing-key rejection (`INVALID_REQUEST`), JCS-canonicalized payload hashing, `IDEMPOTENCY_CONFLICT` on same-key-different-payload (no payload leaked in the error), `IDEMPOTENCY_EXPIRED` past the TTL, `replayed: true` envelope injection on cache hits, and automatic declaration of `adcp.idempotency.replay_ttl_seconds` on `get_adcp_capabilities`. Only successful responses cache — errors re-execute on retry, so a failed generation can be retried without burning the key. Scoping is per-principal via `resolveSessionKey` (or override with `resolveIdempotencyPrincipal`).
+AdCP v3 requires an `idempotency_key` on every mutating request — for generative sellers that's `create_media_buy`, `update_media_buy`, and `sync_creatives` (including brief-based creatives whose generation is expensive and must not double-bill). Idempotency is already wired in the Implementation example above. The framework then handles:
 
-```typescript
-import { createIdempotencyStore, memoryBackend, pgBackend } from '@adcp/client/server';
+- Missing/malformed key → `INVALID_REQUEST` (spec pattern `^[A-Za-z0-9_.:-]{16,255}$`)
+- JCS-canonicalized payload hashing with same-key-different-payload → `IDEMPOTENCY_CONFLICT` (no payload leaked in the error body)
+- Past-TTL replay → `IDEMPOTENCY_EXPIRED` (±60s clock-skew tolerance)
+- Cache hits replay the cached envelope with `replayed: true` injected
+- `adcp.idempotency.replay_ttl_seconds` auto-declared on `get_adcp_capabilities`
+- Only successful responses cache — a failed generation re-executes on retry without locking the key
+- Atomic claim so concurrent retries with the same key don't all race to generate
 
-const idempotency = createIdempotencyStore({
-  backend: memoryBackend(),         // or pgBackend(pool) for production
-  ttlSeconds: 86400,                // 1h–7d, clamped to spec bounds
-});
-
-const server = createAdcpServer({
-  idempotency,
-  resolveSessionKey: (ctx) => ctx.account?.id,  // doubles as idempotency principal
-  // ... your domain handlers (mediaBuy.createMediaBuy, updateMediaBuy, creative.syncCreatives)
-});
-```
+Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempotencyPrincipal`). `ttlSeconds` must be 3600–604800 — out of range throws at construction.
 
 ## Validation
 

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -261,26 +261,91 @@ Minimal `tsconfig.json`:
 
 Event tracking tools (`syncEventSources`, `logEvent`, `syncCatalogs`, `syncAudiences`) belong in the `eventTracking` domain group, not `mediaBuy`.
 
+```typescript
+import { randomUUID } from 'node:crypto';
+import { createAdcpServer, serve, adcpError } from '@adcp/client';
+import { createIdempotencyStore, memoryBackend } from '@adcp/client/server';
+
+// Idempotency — required for v3. Retail media has many mutating tools:
+// create/update_media_buy, sync_creatives, sync_catalogs, sync_event_sources,
+// sync_audiences, log_event. Without this, the framework logs a non-
+// compliance error at startup.
+const idempotency = createIdempotencyStore({
+  backend: memoryBackend(),         // pgBackend(pool) for production
+  ttlSeconds: 86400,                // 24 hours (spec bounds: 1h–7d)
+});
+
+serve(() => createAdcpServer({
+  name: 'My Retail Media Agent',
+  version: '1.0.0',
+  idempotency,
+
+  // Principal scoping. MUST never return undefined — or every mutating
+  // request rejects as SERVICE_UNAVAILABLE. Multi-tenant prod uses
+  // ctx.account.
+  resolveSessionKey: () => 'default-principal',
+
+  mediaBuy: {
+    getProducts: async (params, ctx) => ({ products: PRODUCTS, sandbox: true }),
+    createMediaBuy: async (params, ctx) => {
+      const buy = {
+        media_buy_id: `mb_${randomUUID()}`,
+        status: 'pending_creatives' as const,
+        packages: params.packages?.map(p => ({
+          package_id: `pkg_${randomUUID()}`,
+          product_id: p.product_id,
+          pricing_option_id: p.pricing_option_id,
+          budget: p.budget,
+        })) ?? [],
+      };
+      await ctx.store.put('media_buys', buy.media_buy_id, buy);
+      return buy;
+    },
+    // ... updateMediaBuy, getMediaBuyDelivery, syncCreatives, listCreativeFormats
+  },
+
+  eventTracking: {
+    syncCatalogs: async (params, ctx) => ({
+      catalogs: params.catalogs.map(c => ({
+        catalog_id: c.catalog_id,
+        action: 'created' as const,
+        item_count: c.items?.length ?? 0,
+        items_approved: c.items?.length ?? 0,
+      })),
+      sandbox: true,
+    }),
+    syncEventSources: async (params, ctx) => ({
+      event_sources: params.event_sources.map(s => ({
+        event_source_id: s.event_source_id,
+        action: 'created' as const,
+      })),
+      sandbox: true,
+    }),
+    logEvent: async (params, ctx) => ({
+      events_received: params.events?.length ?? 0,
+      events_processed: params.events?.length ?? 0,
+      sandbox: true,
+    }),
+    // ... syncAudiences
+  },
+}));
+```
+
 The skill contains everything you need. Do not read additional docs before writing code.
 
 ## Idempotency
 
-AdCP v3 requires an `idempotency_key` on every mutating request — for retail media networks that means `create_media_buy`, `update_media_buy`, and `sync_creatives`, plus the mutating event-tracking tools (`sync_event_sources`, `sync_catalogs`, `sync_audiences`, `log_event`) where retail-specific replay matters for catalog uploads and conversion ingestion. Wire `createIdempotencyStore` from `@adcp/client/server` into `createAdcpServer` and the framework handles missing-key rejection (`INVALID_REQUEST`), JCS-canonicalized payload hashing, `IDEMPOTENCY_CONFLICT` on same-key-different-payload (no payload leaked in the error), `IDEMPOTENCY_EXPIRED` past the TTL, `replayed: true` envelope injection on cache hits, and automatic declaration of `adcp.idempotency.replay_ttl_seconds` on `get_adcp_capabilities`. Only successful responses cache — errors re-execute on retry. Scoping is per-principal via `resolveSessionKey` (or override with `resolveIdempotencyPrincipal`).
+AdCP v3 requires an `idempotency_key` on every mutating request — for retail media that's `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_event_sources`, `sync_catalogs`, `sync_audiences`, and `log_event`. Idempotency is already wired in the Implementation example above. The framework then handles:
 
-```typescript
-import { createIdempotencyStore, memoryBackend, pgBackend } from '@adcp/client/server';
+- Missing/malformed key → `INVALID_REQUEST` (spec pattern `^[A-Za-z0-9_.:-]{16,255}$`)
+- JCS-canonicalized payload hashing with same-key-different-payload → `IDEMPOTENCY_CONFLICT` (no payload leaked in the error body)
+- Past-TTL replay → `IDEMPOTENCY_EXPIRED` (±60s clock-skew tolerance)
+- Cache hits replay the cached envelope with `replayed: true` injected
+- `adcp.idempotency.replay_ttl_seconds` auto-declared on `get_adcp_capabilities`
+- Only successful responses cache — failed catalog syncs or event ingests re-execute on retry
+- Atomic claim so concurrent retries with the same key don't all race
 
-const idempotency = createIdempotencyStore({
-  backend: memoryBackend(),         // or pgBackend(pool) for production
-  ttlSeconds: 86400,                // 1h–7d, clamped to spec bounds
-});
-
-const server = createAdcpServer({
-  idempotency,
-  resolveSessionKey: (ctx) => ctx.account?.id,  // doubles as idempotency principal
-  // ... mediaBuy + eventTracking handlers
-});
-```
+Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempotencyPrincipal`). `ttlSeconds` must be 3600–604800 — out of range throws at construction.
 
 ## Validation
 

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -194,12 +194,26 @@ Minimal `tsconfig.json`:
 
 ```typescript
 import { createAdcpServer, serve, adcpError } from '@adcp/client';
+import { createIdempotencyStore, memoryBackend } from '@adcp/client/server';
 
 const signals = [ /* your signal objects */ ];
+
+// Idempotency — required for v3 compliance. `activate_signal` is mutating;
+// `get_signals` is read-only and exempt from key validation.
+const idempotency = createIdempotencyStore({
+  backend: memoryBackend(),         // pgBackend(pool) for production
+  ttlSeconds: 86400,                // 24 hours (spec bounds: 1h–7d)
+});
 
 serve(() => createAdcpServer({
   name: 'My Signals Agent',
   version: '1.0.0',
+  idempotency,
+
+  // Principal scoping for idempotency. MUST never return undefined — or
+  // every mutating request rejects as SERVICE_UNAVAILABLE. A constant
+  // works for a demo; for multi-tenant use ctx.account.
+  resolveSessionKey: () => 'default-principal',
 
   signals: {
     getSignals: async (params, ctx) => {
@@ -277,26 +291,17 @@ serve(() => createAdcpServer({
 
 ## Idempotency
 
-AdCP v3 requires an `idempotency_key` on every mutating request — for signals agents that's `activate_signal` (`get_signals` is read-only and exempt). Wire `createIdempotencyStore` from `@adcp/client/server` into `createAdcpServer` and the framework handles missing-key rejection (`INVALID_REQUEST`), JCS-canonicalized payload hashing, `IDEMPOTENCY_CONFLICT` on same-key-different-payload (no payload leaked in the error), `IDEMPOTENCY_EXPIRED` past the TTL, `replayed: true` envelope injection on cache hits, and automatic declaration of `adcp.idempotency.replay_ttl_seconds` on `get_adcp_capabilities`. Only successful responses cache — a failed activation re-executes on retry so buyers can safely retry transient errors. Scoping is per-principal via `resolveSessionKey` (or override with `resolveIdempotencyPrincipal`) so two buyers requesting the same destinations won't collide.
+AdCP v3 requires an `idempotency_key` on every mutating request — for signals agents that's `activate_signal` only (`get_signals` is read-only and exempt). Idempotency is already wired in the Implementation example above. The framework then handles:
 
-```typescript
-import { createIdempotencyStore, memoryBackend } from '@adcp/client/server';
+- Missing/malformed key → `INVALID_REQUEST` (spec pattern `^[A-Za-z0-9_.:-]{16,255}$`)
+- JCS-canonicalized payload hashing with same-key-different-payload → `IDEMPOTENCY_CONFLICT` (no payload leaked in the error body)
+- Past-TTL replay → `IDEMPOTENCY_EXPIRED` (±60s clock-skew tolerance)
+- Cache hits replay the cached envelope with `replayed: true` injected
+- `adcp.idempotency.replay_ttl_seconds` auto-declared on `get_adcp_capabilities`
+- Only successful responses cache — a failed activation re-executes on retry
+- Atomic claim so concurrent retries with a fresh key don't all race to activate
 
-const idempotency = createIdempotencyStore({
-  backend: memoryBackend(),         // or pgBackend(pool) for production
-  ttlSeconds: 86400,                // 3600–604800 per spec; throws if out of range
-});
-
-const server = createAdcpServer({
-  idempotency,
-  // MUST never return undefined — or every mutating request rejects as
-  // SERVICE_UNAVAILABLE. A constant works for a demo; for multi-tenant
-  // production, type the account via `createAdcpServer<MyAccount>({...})`
-  // and use `(ctx) => ctx.account?.id`.
-  resolveSessionKey: () => 'default-principal',
-  // ... your signals.activateSignal handler
-});
-```
+Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempotencyPrincipal` for custom scoping). `ttlSeconds` must be 3600–604800 — out of range throws at construction. If you register mutating handlers without wiring `idempotency`, the framework logs an error at server-creation time.
 
 ## Validation
 

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -131,6 +131,18 @@ export interface TaskOptions {
   debug?: boolean;
   /** Additional metadata to include */
   metadata?: Record<string, any>;
+  /**
+   * INTERNAL — compliance-test-only escape hatch.
+   *
+   * Suppresses the client's automatic `idempotency_key` generation on
+   * mutating requests. The sole caller is the storyboard runner, which
+   * needs to exercise servers' missing-key validation. Auto-injection
+   * is the retry-safety contract for every real buyer — bypassing it
+   * in production breaks at-most-once semantics on network retries.
+   *
+   * @internal Do not set in production buyer code.
+   */
+  skipIdempotencyAutoInject?: boolean;
 }
 
 /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -984,13 +984,18 @@ export class SingleAgentClient {
     options?: TaskOptions
   ): Promise<TaskResult<T>> {
     // Normalize params for backwards compatibility before validation
-    let normalizedParams = normalizeRequestParams(taskType, params);
+    let normalizedParams = normalizeRequestParams(taskType, params, {
+      skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
+    });
 
     // Inject an idempotency_key for mutating tools before schema validation
     // so callers don't have to supply one. TaskExecutor also guards against
     // missing keys, but validation happens here first — do the injection up
     // front so the request passes the spec's required-field check.
+    // `options.skipIdempotencyAutoInject` disables this for compliance
+    // testing that needs to exercise server-side missing-key behavior.
     if (
+      !options?.skipIdempotencyAutoInject &&
       isMutatingTask(taskType) &&
       normalizedParams &&
       typeof normalizedParams === 'object' &&
@@ -999,8 +1004,13 @@ export class SingleAgentClient {
       normalizedParams = { ...normalizedParams, idempotency_key: generateIdempotencyKey() };
     }
 
-    // Validate request params against schema
-    this.validateRequest(taskType, normalizedParams);
+    // Validate request params against schema. When compliance testing has
+    // asked us to suppress idempotency auto-injection, also skip the
+    // client-side required-field check — the whole point of the test is to
+    // send a missing-key request through and observe the server's response.
+    if (!options?.skipIdempotencyAutoInject) {
+      this.validateRequest(taskType, normalizedParams);
+    }
 
     // Validate required features before sending request
     await this.validateTaskFeatures(taskType);

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1964,7 +1964,9 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: TaskOptions
   ): Promise<TaskResult<T>> {
-    const normalizedParams = normalizeRequestParams(taskName, params);
+    const normalizedParams = normalizeRequestParams(taskName, params, {
+      skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
+    });
     await this.validateTaskFeatures(taskName);
     const agent = await this.ensureEndpointDiscovered();
 

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -244,7 +244,9 @@ export class TaskExecutor {
     // Auto-generate idempotency_key for mutating tasks when the caller didn't
     // supply one. The key lives on TaskState so internal retries reuse it —
     // re-generating on retry defeats the whole point of the envelope.
-    const idempotencyKey = resolveIdempotencyKey(taskName, params);
+    // `options.skipIdempotencyAutoInject` disables this for compliance testing
+    // that needs to exercise server-side missing-key behavior.
+    const idempotencyKey = options.skipIdempotencyAutoInject ? undefined : resolveIdempotencyKey(taskName, params);
     if (idempotencyKey && params && typeof params === 'object' && !params.idempotency_key) {
       params = { ...params, idempotency_key: idempotencyKey };
     }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -590,13 +590,15 @@ function clampReplayTtl(seconds: number): number {
 }
 
 /**
- * Set `replayed: true` on the response envelope (MCP structuredContent).
- * Fresh executions omit the field; seller injects it at response time
- * on replay.
+ * Set `replayed` on the response envelope (MCP structuredContent).
+ * Both fresh executions (`false`) and replays (`true`) carry the field,
+ * per spec — a buyer that checks `replayed` to decide whether side
+ * effects already fired needs the field present on every mutating
+ * response, not just replays.
  */
-function injectReplayed(response: McpToolResponse): void {
+function injectReplayed(response: McpToolResponse, value: boolean): void {
   if (response.structuredContent && typeof response.structuredContent === 'object') {
-    (response.structuredContent as Record<string, unknown>).replayed = true;
+    (response.structuredContent as Record<string, unknown>).replayed = value;
   }
 }
 
@@ -1118,7 +1120,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // read, but belt-and-suspenders: handler-returned objects
               // can alias pieces of the formatted envelope.
               const cachedFormatted = cloneFormattedResponse(checkResult.response as McpToolResponse);
-              injectReplayed(cachedFormatted);
+              injectReplayed(cachedFormatted, true);
               return finalize(cachedFormatted);
             }
             if (checkResult.kind === 'conflict') {
@@ -1196,6 +1198,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                   error: reason,
                 });
               }
+              // Stamp replayed:false AFTER caching so the cached copy has
+              // no pre-baked value. On replay we inject replayed:true
+              // from the replay path, overwriting anything.
+              injectReplayed(formatted, false);
             } else {
               try {
                 await idempotency.release({

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -603,6 +603,38 @@ function injectReplayed(response: McpToolResponse, value: boolean): void {
 }
 
 /**
+ * Remove per-request echo fields (`context`) from a formatted MCP response
+ * before caching. The buyer's `correlation_id` is scoped to the individual
+ * retry attempt and must not be baked into the cached envelope — replays
+ * need to echo back the CURRENT retry's context, not the first caller's.
+ * Other fields (media_buy_id, status, timestamps) are part of the pinned
+ * response and stay put.
+ */
+function stripEnvelopeEcho(response: McpToolResponse): McpToolResponse {
+  const cloned = cloneFormattedResponse(response);
+  if (cloned.structuredContent && typeof cloned.structuredContent === 'object') {
+    const sc = cloned.structuredContent as Record<string, unknown>;
+    delete sc.context;
+  }
+  if (Array.isArray(cloned.content)) {
+    for (const item of cloned.content) {
+      if (item && item.type === 'text' && typeof item.text === 'string') {
+        try {
+          const parsed = JSON.parse(item.text);
+          if (parsed && typeof parsed === 'object') {
+            delete parsed.context;
+            item.text = JSON.stringify(parsed);
+          }
+        } catch {
+          // Text isn't JSON — leave it alone
+        }
+      }
+    }
+  }
+  return cloned;
+}
+
+/**
  * Shallow-clone a formatted MCP response so callers can mutate envelope
  * fields (`replayed`, echo-back `context`) without stomping on the cache
  * entry. The backend returns a fresh object (memory clones, pg
@@ -1184,11 +1216,18 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           if (idempotencyCheck && idempotency) {
             if (!isErrorResponse(formatted)) {
               try {
+                // Strip `context` before caching — it's a per-request echo
+                // field (buyer's correlation_id), not part of the cached
+                // payload. If we cached it, replays would return the
+                // FIRST caller's correlation_id to every subsequent
+                // retry, breaking end-to-end request tracing. On replay,
+                // `finalize()` re-injects the current request's context.
+                const cacheable = stripEnvelopeEcho(formatted);
                 await idempotency.save({
                   principal: idempotencyCheck.principal,
                   key: idempotencyCheck.key,
                   payloadHash: idempotencyCheck.payloadHash,
-                  response: formatted,
+                  response: cacheable,
                   extraScope: idempotencyCheck.extraScope,
                 });
               } catch (err) {
@@ -1248,7 +1287,21 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         }
       };
 
-      server.tool(toolName, schema.shape as any, toolHandler);
+      // When idempotency is wired and the tool is mutating, relax
+      // `idempotency_key` to optional in the MCP-level input schema. The
+      // middleware is authoritative for this field and returns a properly-
+      // shaped `adcp_error` (with `code`, `field`, `recovery`) on missing
+      // or malformed keys. If we let the MCP SDK's schema validator
+      // reject the request first, buyers get a text-only `-32602` error
+      // instead of the structured compliance error — breaking the
+      // idempotency storyboard's `error_code` validation.
+      const registersAsMutating = isMutatingTask(toolName);
+      const idempKeyField = (schema.shape as any).idempotency_key;
+      const toolShape =
+        idempotency && registersAsMutating && typeof idempKeyField?.optional === 'function'
+          ? { ...(schema.shape as any), idempotency_key: idempKeyField.optional() }
+          : schema.shape;
+      server.tool(toolName, toolShape as any, toolHandler);
       if (meta?.annotations) {
         const registered = (server as any)._registeredTools[toolName];
         if (registered?.update) {

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -10,6 +10,7 @@
  * (context_outputs/context_inputs) while still enabling stateful flows.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { StoryboardContext, ContextOutput, ContextInput } from './types';
 import { resolvePath, setPath } from './path';
 
@@ -276,8 +277,51 @@ export function extractContext(taskName: string, data: unknown): Record<string, 
 // ────────────────────────────────────────────────────────────
 
 /**
- * Deep-walk an object and replace "$context.<key>" string values
- * with the corresponding value from context.
+ * Per-context alias cache for `$generate:uuid_v4#<alias>` placeholders.
+ *
+ * A WeakMap keyed off the StoryboardContext identity avoids landing
+ * implementation-detail keys on the serialized context object and avoids
+ * fragility when context is shallow-cloned between steps — the cache
+ * follows the context reference rather than riding as an owned key.
+ *
+ * Propagation across steps is handled by `forwardAliasCache` (called by
+ * the runner when it rolls context forward to the next step), keeping
+ * this a deliberate design choice rather than an invisible by-reference
+ * leak through `{ ...context }`.
+ */
+const aliasCaches = new WeakMap<StoryboardContext, Record<string, string>>();
+
+/**
+ * Ensure an alias cache exists for the given context and return it.
+ */
+function getAliasCache(context: StoryboardContext): Record<string, string> {
+  let cache = aliasCaches.get(context);
+  if (!cache) {
+    cache = {};
+    aliasCaches.set(context, cache);
+  }
+  return cache;
+}
+
+/**
+ * Propagate the alias cache from one context to another — call after
+ * shallow-cloning context between storyboard steps so replay tests
+ * (initial + replay sharing `$generate:uuid_v4#<alias>`) resolve to the
+ * same UUID. No-op when `from` has no cache.
+ */
+export function forwardAliasCache(from: StoryboardContext, to: StoryboardContext): void {
+  const cache = aliasCaches.get(from);
+  if (cache) aliasCaches.set(to, cache);
+}
+
+/**
+ * Deep-walk an object and replace recognized placeholder strings:
+ *
+ * - `$context.<key>` → value from `context[key]`
+ * - `$generate:uuid_v4` → fresh UUID v4 per occurrence
+ * - `$generate:uuid_v4#<alias>` → fresh UUID v4 on first occurrence,
+ *   then the same UUID for every subsequent occurrence of the same
+ *   alias within this storyboard run (enables initial + replay testing)
  *
  * Returns a new object (does not mutate the input).
  */
@@ -287,10 +331,20 @@ export function injectContext(obj: Record<string, unknown>, context: StoryboardC
 
 function deepReplace(value: unknown, context: StoryboardContext): unknown {
   if (typeof value === 'string') {
-    const match = value.match(/^\$context\.(\w+)$/);
-    if (match?.[1]) {
-      const key = match[1];
+    const ctxMatch = value.match(/^\$context\.(\w+)$/);
+    if (ctxMatch?.[1]) {
+      const key = ctxMatch[1];
       return key in context ? context[key] : value;
+    }
+    const genMatch = value.match(/^\$generate:uuid_v4(?:#([A-Za-z0-9_.-]+))?$/);
+    if (genMatch) {
+      const alias = genMatch[1];
+      if (alias) {
+        const cache = getAliasCache(context);
+        if (!(alias in cache)) cache[alias] = randomUUID();
+        return cache[alias];
+      }
+      return randomUUID();
     }
     return value;
   }

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -125,7 +125,8 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // generated 5ms apart with `Date.now()` would hash differently,
     // triggering IDEMPOTENCY_CONFLICT on replay. Stale sample dates
     // (authored before the run date) fall back to the dynamic default.
-    const sampleStart = typeof step.sample_request?.start_time === 'string' ? step.sample_request.start_time : undefined;
+    const sampleStart =
+      typeof step.sample_request?.start_time === 'string' ? step.sample_request.start_time : undefined;
     const sampleEnd = typeof step.sample_request?.end_time === 'string' ? step.sample_request.end_time : undefined;
     const startTime = sampleStart && Date.parse(sampleStart) >= now ? sampleStart : defaultStart;
     const endTime = sampleEnd && Date.parse(sampleEnd) >= now ? sampleEnd : defaultEnd;

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -116,8 +116,19 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     const pricingOption = selectPricingOption(product);
 
     const now = Date.now();
-    const startTime = new Date(now + 24 * 60 * 60 * 1000).toISOString();
-    const endTime = new Date(now + 8 * 24 * 60 * 60 * 1000).toISOString();
+    const defaultStart = new Date(now + 24 * 60 * 60 * 1000).toISOString();
+    const defaultEnd = new Date(now + 8 * 24 * 60 * 60 * 1000).toISOString();
+
+    // Respect sample_request dates when they're future-dated — needed for
+    // storyboards that test replay semantics where initial + replay must
+    // produce byte-for-byte identical canonical payloads. Two calls
+    // generated 5ms apart with `Date.now()` would hash differently,
+    // triggering IDEMPOTENCY_CONFLICT on replay. Stale sample dates
+    // (authored before the run date) fall back to the dynamic default.
+    const sampleStart = typeof step.sample_request?.start_time === 'string' ? step.sample_request.start_time : undefined;
+    const sampleEnd = typeof step.sample_request?.end_time === 'string' ? step.sample_request.end_time : undefined;
+    const startTime = sampleStart && Date.parse(sampleStart) >= now ? sampleStart : defaultStart;
+    const endTime = sampleEnd && Date.parse(sampleEnd) >= now ? sampleEnd : defaultEnd;
 
     // Merge any hand-authored package fields from sample_request (targeting_overlay,
     // measurement_terms, creative_assignments, performance_standards, etc.) so

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -9,10 +9,11 @@
 import { getOrCreateClient, getOrDiscoverProfile, runStep } from '../client';
 import { closeConnections } from '../../protocols';
 import { executeStoryboardTask } from './task-map';
-import { extractContext, injectContext, applyContextOutputs, applyContextInputs } from './context';
+import { extractContext, injectContext, applyContextOutputs, applyContextInputs, forwardAliasCache } from './context';
 import { runValidations, type ValidationContext } from './validations';
 import { buildRequest, hasRequestBuilder } from './request-builder';
 import { resolveBrand } from '../client';
+import { isMutatingTask } from '../../utils/idempotency';
 import {
   PROBE_TASKS,
   probeProtectedResourceMetadata,
@@ -64,6 +65,7 @@ export async function runStoryboard(
   }
 
   let context: StoryboardContext = { ...options.context };
+  if (options.context) forwardAliasCache(options.context, context);
   const contributions = new Set<string>();
   const priorStepResults = new Map<string, StoryboardStepResult>();
   const priorProbes = new Map<string, HttpProbeResult>();
@@ -214,6 +216,7 @@ export async function runStoryboardStep(
   }
 
   const context: StoryboardContext = { ...options.context };
+  if (options.context) forwardAliasCache(options.context, context);
 
   // Find the step
   const allSteps = flattenSteps(storyboard);
@@ -225,7 +228,12 @@ export async function runStoryboardStep(
     );
   }
 
-  const result = await executeStep(client, found.step, found.phaseId, context, allSteps, options);
+  const result = await executeStep(client, found.step, found.phaseId, context, allSteps, options, {
+    contributions: new Set(),
+    priorStepResults: new Map(),
+    priorProbes: new Map(),
+    agentUrl,
+  });
 
   if (!options._client) {
     await closeConnections(options.protocol);
@@ -335,17 +343,25 @@ async function executeStep(
   } else if (hasRequestBuilder(effectiveStep.task)) {
     request = buildRequest(effectiveStep, context, options);
     // Merge pass-through envelope fields from sample_request — builders
-    // don't include these, but storyboards define them for compliance testing.
-    // Only context and ext are merged: they are opaque pass-through fields with
-    // no schema validation. Other envelope fields (push_notification_config,
-    // governance_context, idempotency_key) have structured schemas and are
-    // handled by the request builder when needed.
+    // don't include these, but storyboards define them for compliance
+    // testing. `context` and `ext` are opaque pass-through. `idempotency_key`
+    // must be forwarded so compliance storyboards can test replay semantics:
+    // the same `$generate:uuid_v4#<alias>` across two steps resolves to the
+    // same UUID, and the server sees both calls with that UUID (no auto-
+    // generated UUID overriding it at the client layer).
     if (step.sample_request) {
       if (step.sample_request.context !== undefined && request.context === undefined) {
         request.context = injectContext({ context: step.sample_request.context }, context).context;
       }
       if (step.sample_request.ext !== undefined && request.ext === undefined) {
         request.ext = step.sample_request.ext;
+      }
+      if (step.sample_request.idempotency_key !== undefined && request.idempotency_key === undefined) {
+        const resolved = injectContext(
+          { idempotency_key: step.sample_request.idempotency_key },
+          context
+        ).idempotency_key;
+        if (typeof resolved === 'string') request.idempotency_key = resolved;
       }
     }
   } else if (step.sample_request) {
@@ -391,6 +407,18 @@ async function executeStep(
   // probe so we can (a) strip credentials or send arbitrary Bearer values
   // (which the SDK transport doesn't expose), and (b) capture the HTTP status
   // + `WWW-Authenticate` header for http_* validations.
+  //
+  // Tests for envelope validation on mutating tasks (e.g., "missing
+  // idempotency_key returns INVALID_REQUEST") need to suppress the AdCP
+  // client's auto-inject — otherwise the client helpfully generates a
+  // UUID and the server never sees a missing-key request. Narrow trigger:
+  // the step expects an error, the task is mutating, and the request
+  // doesn't provide idempotency_key.
+  const testsMissingIdempotencyKey =
+    step.expect_error === true &&
+    isMutatingTask(effectiveStep.task) &&
+    (request as Record<string, unknown>).idempotency_key === undefined;
+
   let taskResult: TaskResult | undefined;
   let stepResult: { duration_ms: number; error?: string; passed: boolean };
   let httpResult: HttpProbeResult | undefined;
@@ -422,7 +450,9 @@ async function executeStep(
     }
   } else {
     const run = await runStep(step.title, effectiveStep.task, () =>
-      executeStoryboardTask(client, effectiveStep.task, request)
+      executeStoryboardTask(client, effectiveStep.task, request, {
+        skipIdempotencyAutoInject: testsMissingIdempotencyKey,
+      })
     );
     taskResult = run.result;
     stepResult = run.step;
@@ -464,9 +494,23 @@ async function executeStep(
     passed = stepResult.passed && (taskResult?.success ?? false);
   }
 
-  // Run validations
+  // Run validations. Resolve `$context.<key>` placeholders in `value` and
+  // `allowed_values` fields so expected values can reference prior steps
+  // (e.g., replay tests assert `media_buy_id === $context.initial_media_buy_id`).
   let validations: ValidationResult[] = [];
   if (step.validations?.length && (taskResult || httpResult)) {
+    const resolvedValidations = step.validations.map(v => {
+      const resolved = { ...v };
+      if (resolved.value !== undefined) {
+        resolved.value = injectContext({ __v: resolved.value }, context).__v;
+      }
+      if (Array.isArray(resolved.allowed_values)) {
+        resolved.allowed_values = resolved.allowed_values.map(
+          av => injectContext({ __v: av }, context).__v
+        );
+      }
+      return resolved;
+    });
     const vctx: ValidationContext = {
       taskName: effectiveStep.task,
       ...(taskResult && { taskResult }),
@@ -474,13 +518,16 @@ async function executeStep(
       agentUrl: runState.agentUrl,
       contributions: runState.contributions,
     };
-    validations = runValidations(step.validations, vctx);
+    validations = runValidations(resolvedValidations, vctx);
   }
 
   const allValidationsPassed = validations.every(v => v.passed);
 
-  // Extract context from responses
+  // Extract context from responses. Forward the alias cache so
+  // `$generate:uuid_v4#<alias>` placeholders in subsequent steps resolve
+  // to the same UUID as prior steps with the same alias.
   const updatedContext = { ...context };
+  forwardAliasCache(context, updatedContext);
   const hasData = taskResult?.data !== undefined && taskResult?.data !== null;
 
   // Convention-based extraction (for non-error steps, or when expect_error succeeded)

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -505,9 +505,7 @@ async function executeStep(
         resolved.value = injectContext({ __v: resolved.value }, context).__v;
       }
       if (Array.isArray(resolved.allowed_values)) {
-        resolved.allowed_values = resolved.allowed_values.map(
-          av => injectContext({ __v: av }, context).__v
-        );
+        resolved.allowed_values = resolved.allowed_values.map(av => injectContext({ __v: av }, context).__v);
       }
       return resolved;
     });

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -79,16 +79,23 @@ export async function executeStoryboardTask(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic dispatch requires any
   client: any,
   taskName: string,
-  params: Record<string, unknown>
+  params: Record<string, unknown>,
+  opts: { skipIdempotencyAutoInject?: boolean } = {}
 ): Promise<TaskResult> {
   const methodName = Object.hasOwn(TASK_TO_METHOD, taskName) ? TASK_TO_METHOD[taskName] : undefined;
+
+  // Only pass TaskOptions when a flag is actually set — avoids changing
+  // behavior for the common path that relies on method defaults.
+  const taskOptions = opts.skipIdempotencyAutoInject ? { skipIdempotencyAutoInject: true } : undefined;
 
   let result;
   const invoke = async () => {
     if (methodName && typeof client[methodName] === 'function') {
-      return client[methodName](params);
+      // Typed methods take (params, inputHandler?, options?). Pass options
+      // only when set, otherwise they take their defaults.
+      return taskOptions ? client[methodName](params, undefined, taskOptions) : client[methodName](params);
     }
-    return client.executeTask(taskName, params);
+    return client.executeTask(taskName, params, undefined, taskOptions);
   };
 
   // Retry with exponential backoff on rate limit errors

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -82,7 +82,11 @@ export function normalizePackageParams(pkg: any): any {
  * Infers missing fields that can be derived from deprecated params so callers
  * written against older schema versions keep working.
  */
-export function normalizeRequestParams(taskType: string, params: any, opts: { skipIdempotencyAutoInject?: boolean } = {}): any {
+export function normalizeRequestParams(
+  taskType: string,
+  params: any,
+  opts: { skipIdempotencyAutoInject?: boolean } = {}
+): any {
   if (!params) {
     return params;
   }

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -82,7 +82,7 @@ export function normalizePackageParams(pkg: any): any {
  * Infers missing fields that can be derived from deprecated params so callers
  * written against older schema versions keep working.
  */
-export function normalizeRequestParams(taskType: string, params: any): any {
+export function normalizeRequestParams(taskType: string, params: any, opts: { skipIdempotencyAutoInject?: boolean } = {}): any {
   if (!params) {
     return params;
   }
@@ -94,7 +94,9 @@ export function normalizeRequestParams(taskType: string, params: any): any {
   // AdCP spec. When the caller omits it, mint a fresh UUID v4. Most buyer
   // code never needs to track keys of its own — retries via a kept-around
   // key are the less-common path, and those callers supply their own.
+  // `opts.skipIdempotencyAutoInject` disables this for compliance testing.
   if (
+    !opts.skipIdempotencyAutoInject &&
     TASKS_REQUIRING_IDEMPOTENCY_KEY.has(taskType) &&
     (typeof normalized.idempotency_key !== 'string' || normalized.idempotency_key.length === 0)
   ) {

--- a/test-agents/test-agent-build.sh
+++ b/test-agents/test-agent-build.sh
@@ -9,6 +9,7 @@ AGENT_TYPE="${2:-signals}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR=$(mktemp -d)
 SKILL_FILE="$REPO_ROOT/skills/build-${AGENT_TYPE}-agent/SKILL.md"
+AGENT_PORT="${PORT:-3001}"
 
 echo "=== Agent Build Test ==="
 echo "Tool: $TOOL"
@@ -46,6 +47,10 @@ For a signals agent: build a marketplace agent with 4 audience segments, CPM pri
 For a seller agent: build an SSP with non-guaranteed display + video, auction pricing.
 For a si agent: build a toy sponsored-intelligence agent with keyword-based recommendations.
 For a governance agent: build a campaign governance agent that approves plans under a budget threshold and maintains a property list.
+For a creative agent: build a creative management agent with 2 display formats, sync/build/preview/list creatives.
+For a brand-rights agent: build a brand rights agent with one brand (acme_outdoor) offering one rights package; implement get_brand_identity, get_rights, acquire_rights.
+For a retail-media agent: build a retail media network with 2 on-site placements, sync_catalogs for product feeds, log_event for conversions.
+For a generative-seller agent: build an AI ad network with one standard display format and one generative format; sync_creatives handles both.
 
 Implement ALL tools listed in the skill. Use createAdcpServer as instructed. Use ctx.store for state.
 
@@ -102,8 +107,8 @@ if [ -f agent.ts ]; then
 
     # Try running storyboard
     echo ""
-    echo "Starting agent for storyboard test..."
-    npx tsx agent.ts &
+    echo "Starting agent for storyboard test (PORT=$AGENT_PORT)..."
+    PORT=$AGENT_PORT npx tsx agent.ts &
     AGENT_PID=$!
     sleep 4
 
@@ -112,19 +117,21 @@ if [ -f agent.ts ]; then
       signals) STORYBOARD="signal_marketplace" ;;
       si) STORYBOARD="si_baseline" ;;
       governance) STORYBOARD="governance_spend_authority" ;;
-      *) STORYBOARD="signal_marketplace" ;;
+      creative) STORYBOARD="creative_lifecycle" ;;
+      brand-rights) STORYBOARD="brand_rights" ;;
+      retail-media) STORYBOARD="sales_catalog_driven" ;;
+      generative-seller) STORYBOARD="creative_generative/seller" ;;
+      *) STORYBOARD="idempotency" ;;
     esac
 
-    echo "Running storyboard: $STORYBOARD"
     STORYBOARD_BIN="$REPO_ROOT/bin/adcp.js"
-    node "$STORYBOARD_BIN" storyboard run http://localhost:3001/mcp "$STORYBOARD" --json 2>/dev/null | grep -v '^\[AdCP\]' | python3 -c "
+    run_storyboard() {
+      local sb="$1"
+      echo ""
+      echo "Running storyboard: $sb"
+      node "$STORYBOARD_BIN" storyboard run http://localhost:${AGENT_PORT}/mcp "$sb" --json --allow-http 2>/dev/null | grep -v '^\[AdCP\]' | python3 -c "
 import json, sys
 try:
-    # strict=False tolerates raw control characters (newlines, tabs) in
-    # JSON string values — agent responses sometimes carry multi-line
-    # text fields whose control chars didn't get escaped upstream. The
-    # real fix is upstream serialization, but lenient parsing gives us
-    # usable storyboard output until then.
     data = json.loads(sys.stdin.read(), strict=False)
     s = data.get('summary') or {}
     passed = s.get('tracks_passed', 0)
@@ -143,6 +150,14 @@ try:
 except Exception as e:
     print(f'Could not parse storyboard output: {e}')
 " 2>&1 || echo "Storyboard failed to run"
+    }
+
+    run_storyboard "$STORYBOARD"
+    # Universal idempotency storyboard — validates the v3 contract that
+    # all mutating tools enforce idempotency_key, JCS replay, and
+    # IDEMPOTENCY_CONFLICT. Runs on every agent type since it's required
+    # for v3 compliance regardless of domain.
+    run_storyboard "idempotency"
 
     kill $AGENT_PID 2>/dev/null
     wait $AGENT_PID 2>/dev/null

--- a/test/lib/storyboard-context-generate.test.js
+++ b/test/lib/storyboard-context-generate.test.js
@@ -1,0 +1,81 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { injectContext, forwardAliasCache } = require('../../dist/lib/testing/storyboard/context');
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('$generate:uuid_v4 placeholder resolution', () => {
+  it('aliased placeholders resolve to the SAME UUID within a context', () => {
+    const context = {};
+    const a = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, context);
+    const b = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, context);
+
+    assert.match(a.idempotency_key, UUID);
+    assert.strictEqual(a.idempotency_key, b.idempotency_key);
+  });
+
+  it('different aliases resolve to DIFFERENT UUIDs', () => {
+    const context = {};
+    const a = injectContext({ idempotency_key: '$generate:uuid_v4#key_a' }, context);
+    const b = injectContext({ idempotency_key: '$generate:uuid_v4#key_b' }, context);
+
+    assert.match(a.idempotency_key, UUID);
+    assert.match(b.idempotency_key, UUID);
+    assert.notStrictEqual(a.idempotency_key, b.idempotency_key);
+  });
+
+  it('bare (no-alias) placeholders each resolve to a FRESH UUID', () => {
+    const context = {};
+    const a = injectContext({ idempotency_key: '$generate:uuid_v4' }, context);
+    const b = injectContext({ idempotency_key: '$generate:uuid_v4' }, context);
+
+    assert.match(a.idempotency_key, UUID);
+    assert.match(b.idempotency_key, UUID);
+    assert.notStrictEqual(a.idempotency_key, b.idempotency_key);
+  });
+
+  it('placeholder does not leak implementation keys onto the context object', () => {
+    // The alias cache lives in a WeakMap keyed off the context, not as a
+    // property on the context itself. Serialized StoryboardResult output
+    // must not carry implementation-detail keys.
+    const context = {};
+    injectContext({ idempotency_key: '$generate:uuid_v4#alias' }, context);
+
+    assert.deepStrictEqual(Object.keys(context), []);
+    assert.strictEqual(JSON.stringify(context), '{}');
+  });
+
+  it('unrecognized strings pass through unchanged', () => {
+    const context = {};
+    const out = injectContext({ field: 'not a placeholder' }, context);
+    assert.strictEqual(out.field, 'not a placeholder');
+  });
+
+  it('forwardAliasCache propagates aliases across a shallow-cloned context', () => {
+    // Simulates the runner's `updatedContext = { ...context }` step roll.
+    // Without forwardAliasCache, replay tests where step 1 and step 2 share
+    // an alias would silently resolve to different UUIDs.
+    const ctx1 = {};
+    const a = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, ctx1);
+
+    const ctx2 = { ...ctx1 };
+    forwardAliasCache(ctx1, ctx2);
+    const b = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, ctx2);
+
+    assert.strictEqual(a.idempotency_key, b.idempotency_key);
+  });
+
+  it('shallow-cloned context WITHOUT forwardAliasCache gets a fresh cache', () => {
+    // Documents the design: context-following is opt-in. Storyboard runner
+    // must call forwardAliasCache at every clone site. Silent drift here
+    // would make replay tests fall back to fresh UUIDs without erroring.
+    const ctx1 = {};
+    const a = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, ctx1);
+
+    const ctx2 = { ...ctx1 };
+    // No forwardAliasCache — ctx2 gets its own cache.
+    const b = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, ctx2);
+
+    assert.notStrictEqual(a.idempotency_key, b.idempotency_key);
+  });
+});

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -85,6 +85,22 @@ describe('createAdcpServer with idempotency', () => {
     assert.equal(second.replayed, true, 'replay must set replayed:true');
   });
 
+  it('replay echoes the CURRENT retry context, not the first caller\'s', async () => {
+    // Each buyer retry carries its own correlation_id; the envelope must
+    // reflect the current retry, not a cached echo from the first caller.
+    // Otherwise end-to-end tracing breaks — the replayed response would
+    // surface a correlation_id the current caller never sent.
+    const { server } = makeServer();
+    const key = 'replay_key_abcdefghij';
+    const req = { ...basePayload, idempotency_key: key };
+
+    await callTool(server, 'create_media_buy', { ...req, context: { correlation_id: 'first-attempt' } });
+    const replay = await callTool(server, 'create_media_buy', { ...req, context: { correlation_id: 'retry-attempt' } });
+
+    assert.equal(replay.context?.correlation_id, 'retry-attempt');
+    assert.equal(replay.replayed, true);
+  });
+
   it('key-reordering in payload is treated as equivalent', async () => {
     const { server, calls } = makeServer();
     const key = 'replay_key_abcdefghij';

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -69,7 +69,11 @@ describe('createAdcpServer with idempotency', () => {
     });
     assert.equal(calls.length, 1);
     assert.equal(result.media_buy_id, 'mb_1');
-    assert.equal(result.replayed, false, 'fresh execution must set replayed:false so buyers can distinguish retry-vs-first');
+    assert.equal(
+      result.replayed,
+      false,
+      'fresh execution must set replayed:false so buyers can distinguish retry-vs-first'
+    );
   });
 
   it('replay with same key + equivalent payload returns cached response with replayed:true', async () => {
@@ -85,7 +89,7 @@ describe('createAdcpServer with idempotency', () => {
     assert.equal(second.replayed, true, 'replay must set replayed:true');
   });
 
-  it('replay echoes the CURRENT retry context, not the first caller\'s', async () => {
+  it("replay echoes the CURRENT retry context, not the first caller's", async () => {
     // Each buyer retry carries its own correlation_id; the envelope must
     // reflect the current retry, not a cached echo from the first caller.
     // Otherwise end-to-end tracing breaks — the replayed response would

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -69,7 +69,7 @@ describe('createAdcpServer with idempotency', () => {
     });
     assert.equal(calls.length, 1);
     assert.equal(result.media_buy_id, 'mb_1');
-    assert.notEqual(result.replayed, true, 'fresh execution should not set replayed:true');
+    assert.equal(result.replayed, false, 'fresh execution must set replayed:false so buyers can distinguish retry-vs-first');
   });
 
   it('replay with same key + equivalent payload returns cached response with replayed:true', async () => {


### PR DESCRIPTION
Closes #569.

## What this fixes

### Framework: `replayed: false` on fresh executions

The server-side idempotency middleware was stamping `replayed: true` on replays but omitting the field on fresh executions. The spec (and the universal idempotency compliance storyboard) expects `replayed: false` on every fresh mutating response — a buyer that checks `metadata.replayed` to decide whether side effects already fired needs the field present either way.

Caught by running `storyboard run ... idempotency` against a fresh retail-media build: `replay_same_payload/create_media_buy_initial` failed because `replayed` was absent. After the fix it passes cleanly.

The cache still stores the envelope WITHOUT the `replayed` field; the middleware stamps it after the save so a subsequent replay cleanly overwrites with `true`.

Existing test tightened from `assert.notEqual(result.replayed, true)` to `assert.equal(result.replayed, false)` so future regressions fail loud.

### Skills: 5 SKILL.md files had the wiring gap

Each skill documented idempotency in a dedicated section but the main copy-paste-complete Implementation code block didn't wire `createIdempotencyStore` into `createAdcpServer`. Fresh agents built from those skills logged the v3 non-compliance error at startup.

Fixed in: `build-creative-agent`, `build-signals-agent`, `build-brand-rights-agent`, `build-retail-media-agent`, `build-generative-seller-agent`.

Seller/SI/governance skills were already complete — no changes.

### Test harness: full coverage + `--allow-http`

`test-agents/test-agent-build.sh`:
- Extended from 4 agent types (seller, signals, si, governance) to all 8 (+ creative, brand-rights, retail-media, generative-seller)
- Added the universal `idempotency` storyboard as a second check on every run — catches regressions in any domain
- Passes `--allow-http` so local storyboard runs actually execute (the CLI refuses non-HTTPS URLs by default)

## Validation

Ran `test-agent-build.sh claude <type>` in parallel for all 5 updated skills. All 5 produce idempotency-compliant agents on first try. Build times: 29s–229s.

Built-agent storyboards (with the fix):
- signals × signal_marketplace: ✅ passing
- signals × idempotency: ✅ passing (create_media_buy not implemented, tests skipped)
- creative × idempotency: ✅ passing
- brand-rights × idempotency: ✅ passing
- retail-media × idempotency: 1 pass / 1 partial. `create_media_buy_initial` now ✅; `create_media_buy_replay` still fails because the CLIENT (from PR #590) auto-injects a fresh idempotency_key per request, defeating the replay test. Harness-level issue.
- generative-seller × idempotency: same partial as retail-media (same root cause)

`node --test test/server-idempotency.test.js test/lib/idempotency*.test.js test/lib/jcs.test.js test/skill-examples-compile.test.js` — 89/89 pass.

## Follow-up issues worth filing

1. **Client auto-inject defeats storyboard missing_key test.** The client's TaskExecutor auto-injects idempotency_key on mutating requests. The storyboard's `missing_key` test can't actually send a missing key through the client. Either the harness needs an opt-out or the test needs a flag.
2. **Alias placeholder resolution inconsistent across scenarios.** The storyboard's `$generate:uuid_v4#replay_key` placeholder sometimes resolves to a fresh UUID per step (defeating replay) and sometimes passes through as a literal `$generate:...` string (tripping server pattern validation).

Neither is in scope for #569; both are compliance-harness/client issues filed separately once I've repro'd them in isolation.

## Test plan

- [x] `npm run build:lib` — clean compile
- [x] `node --test test/server-idempotency.test.js` — 19/19 pass
- [x] `node --test test/lib/idempotency*.test.js test/lib/jcs.test.js` — all pass
- [x] `node --test test/skill-examples-compile.test.js` — 19/19 skill TS blocks compile
- [x] `test-agent-build.sh claude <type>` for all 5 updated skills — compile clean, wire idempotency correctly
- [x] Retail-media `create_media_buy_initial` passes idempotency storyboard (was failing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)