### PR TITLE
feat: finish client-side idempotency gaps from #568

### DIFF
--- a/.changeset/idempotency-client-completeness.md
+++ b/.changeset/idempotency-client-completeness.md
@@ -1,0 +1,57 @@
+---
+'@adcp/client': minor
+---
+
+Complete the remaining client-side idempotency gaps from [#568](https://github.com/adcontextprotocol/adcp-client/issues/568) left open after PR #590.
+
+## What changed
+
+### Typed error instances on `TaskResult` for idempotency failures
+
+`result.errorInstance` is populated with a typed `ADCPError` subclass when the seller's error code has a dedicated class — currently `IdempotencyConflictError` and `IdempotencyExpiredError`. Callers can now write:
+
+```ts
+const result = await client.createMediaBuy({...});
+if (result.errorInstance instanceof IdempotencyConflictError) {
+  // Mint a fresh UUID v4 and retry
+}
+```
+
+The SDK pulls the sent `idempotency_key` from tracked task state when constructing the error — the server intentionally omits the key from error bodies (it's a read-oracle), so the transport-layer caller is the authoritative source. A new `adcpErrorToTypedError(adcpError, key)` helper is exported for callers who already have an `AdcpErrorInfo` in hand and want to type-narrow it themselves.
+
+### `getIdempotencyReplayTtlSeconds()` with fail-closed behaviour
+
+New method on `SingleAgentClient` / `AgentClient` that reads `adcp.idempotency.replay_ttl_seconds` from cached capabilities. Returns `undefined` on v2 sellers (pre-idempotency-envelope), the declared number on compliant v3 sellers, and **throws** when a v3 seller omits the declaration. No silent 24h default — the spec makes the declaration REQUIRED, and silently defaulting would mislead retry-sensitive flows.
+
+`AdcpCapabilities` now carries an `idempotency?: { replayTtlSeconds }` field populated from the v3 capabilities response. `parseCapabilitiesResponse` treats `0`, negative, or non-numeric values as "not declared" rather than coercing them.
+
+### `useIdempotencyKey(key)` BYOK helper
+
+Validates against `IDEMPOTENCY_KEY_PATTERN` (`^[A-Za-z0-9_.:-]{16,255}$`) up front and returns a `{ idempotency_key }` fragment to spread into mutating params. Catches persisted-key drift before the round-trip:
+
+```ts
+const key = await db.getOrCreateIdempotencyKey(campaign.id);
+await client.createMediaBuy({ ...params, ...useIdempotencyKey(key) });
+```
+
+### Key logging hygiene
+
+Idempotency keys are a retry-pattern oracle within their TTL, so the SDK no longer writes full keys to debug logs by default. MCP and A2A debug logs now show the first 8 characters of any `idempotency_key` followed by `…`. Set `ADCP_LOG_IDEMPOTENCY_KEYS=1` to opt into full logging for local debugging. New `redactIdempotencyKey(key)` helper is exported for applications that emit their own logs.
+
+## Public API additions
+
+```ts
+import {
+  adcpErrorToTypedError,
+  useIdempotencyKey,
+  redactIdempotencyKey,
+  type IdempotencyCapabilities,
+} from '@adcp/client';
+
+// On SingleAgentClient / AgentClient:
+const ttl = await client.getIdempotencyReplayTtlSeconds(); // throws on non-compliant v3
+```
+
+## Not a breaking change
+
+`TaskResult.errorInstance` is additive — existing code that switches on `adcpError.code` still works untouched. The new `getIdempotencyReplayTtlSeconds()` method only throws when callers explicitly ask for it against a non-compliant seller.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,50 @@ results.forEach((result, i) => {
 });
 ```
 
+## Idempotency
+
+Every mutating tool call (`createMediaBuy`, `syncCreatives`, `activateSignal`, etc.) auto-generates an `idempotency_key` (UUID v4) when the caller omits one. Internal retries reuse the key so a re-sent request returns the cached response rather than double-booking. See `docs/llms.txt` for the full protocol story.
+
+```typescript
+const result = await client.createMediaBuy({ account, brand, start_time, end_time, packages });
+
+// Key used on the wire (auto-generated or caller-supplied). Log alongside your own IDs.
+result.metadata.idempotency_key;
+
+// true when the response was a cached replay. Side-effecting callers MUST gate
+// notifications, memory writes, downstream calls on this flag.
+result.metadata.replayed;
+```
+
+**Typed errors on replay conflicts** — check `result.errorInstance` with `instanceof` instead of switching on error codes:
+
+```typescript
+import { IdempotencyConflictError, IdempotencyExpiredError } from '@adcp/client';
+
+if (result.errorInstance instanceof IdempotencyConflictError) {
+  // Agent re-planned with a different payload. Mint a fresh key and retry.
+}
+if (result.errorInstance instanceof IdempotencyExpiredError) {
+  // Key past the seller's replay window. Look up by natural key before retrying.
+}
+```
+
+**BYOK** (persist keys across process restarts so crash-recovery can resend the exact key):
+
+```typescript
+import { useIdempotencyKey } from '@adcp/client';
+
+// Validates against the spec pattern `^[A-Za-z0-9_.:-]{16,255}$` before the round-trip.
+const key = await db.getOrCreateIdempotencyKey(campaign.id);
+await client.createMediaBuy({ ...params, ...useIdempotencyKey(key) });
+
+// Check the seller's replay window so you know when to fall back to natural-key lookup.
+// Throws on v3 sellers that omit the declaration — the SDK does NOT default to 24h.
+const ttlSeconds = await client.getIdempotencyReplayTtlSeconds();
+```
+
+Idempotency keys are retry-pattern oracles within their TTL, so the SDK truncates them to the first 8 characters in debug logs by default. Set `ADCP_LOG_IDEMPOTENCY_KEYS=1` to opt into full logging for local debugging.
+
 ## Security
 
 ### Webhook Signature Verification
@@ -381,9 +425,9 @@ app.post(
     jwks: new StaticJwksResolver(publishedBuyerKeys),
     replayStore: new InMemoryReplayStore(),
     revocationStore: new InMemoryRevocationStore(),
-    resolveOperation: (req) => 'create_media_buy',
+    resolveOperation: req => 'create_media_buy',
   }),
-  handler,
+  handler
 );
 // On verify, req.verifiedSigner = { keyid, agent_url?, verified_at }.
 // On reject, the middleware returns 401 with
@@ -757,13 +801,13 @@ npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --jso
 
 Available skills:
 
-| Skill | For | Storyboard |
-|-------|-----|------------|
-| [`skills/build-seller-agent/`](skills/build-seller-agent/SKILL.md) | Publishers, SSPs, retail media | `media_buy_seller` |
-| [`skills/build-generative-seller-agent/`](skills/build-generative-seller-agent/SKILL.md) | AI ad networks, generative DSPs | `media_buy_generative_seller` |
-| [`skills/build-signals-agent/`](skills/build-signals-agent/SKILL.md) | CDPs, data providers | `signal_owned`, `signal_marketplace` |
-| [`skills/build-retail-media-agent/`](skills/build-retail-media-agent/SKILL.md) | Retail media networks | `media_buy_catalog_creative` |
-| [`skills/build-creative-agent/`](skills/build-creative-agent/SKILL.md) | Ad servers, creative platforms | `creative_lifecycle` |
+| Skill                                                                                    | For                             | Storyboard                           |
+| ---------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------ |
+| [`skills/build-seller-agent/`](skills/build-seller-agent/SKILL.md)                       | Publishers, SSPs, retail media  | `media_buy_seller`                   |
+| [`skills/build-generative-seller-agent/`](skills/build-generative-seller-agent/SKILL.md) | AI ad networks, generative DSPs | `media_buy_generative_seller`        |
+| [`skills/build-signals-agent/`](skills/build-signals-agent/SKILL.md)                     | CDPs, data providers            | `signal_owned`, `signal_marketplace` |
+| [`skills/build-retail-media-agent/`](skills/build-retail-media-agent/SKILL.md)           | Retail media networks           | `media_buy_catalog_creative`         |
+| [`skills/build-creative-agent/`](skills/build-creative-agent/SKILL.md)                   | Ad servers, creative platforms  | `creative_lifecycle`                 |
 
 For manual implementation, see the [Build an Agent guide](docs/guides/BUILD-AN-AGENT.md) and [`examples/signals-agent.ts`](examples/signals-agent.ts).
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -101,22 +101,39 @@ if (result.success && !result.metadata.replayed) {
 
 2. **Agent re-plan vs. network retry.** A network retry (same bytes, socket timeout) reuses the same key — the SDK handles this. An agent re-plan (LLM re-ran its planner and produced a different payload) means a NEW intent — mint a fresh key by calling the method again without passing one. Reusing the prior key with a different payload returns `IdempotencyConflictError`.
 
-**Typed errors:**
+**Typed errors:** on failure, `result.errorInstance` carries a typed `ADCPError` subclass for codes with dedicated classes — currently `IdempotencyConflictError` and `IdempotencyExpiredError`. Prefer `instanceof` checks over switching on `adcpError.code` strings.
 
 ```typescript
 import { IdempotencyConflictError, IdempotencyExpiredError } from '@adcp/client';
 
-if (result.adcpError?.code === 'IDEMPOTENCY_CONFLICT') {
+if (result.errorInstance instanceof IdempotencyConflictError) {
   // Agent re-planned with different payload. Retry with a fresh key.
+  // result.errorInstance.idempotencyKey carries the key the server omitted.
 }
-if (result.adcpError?.code === 'IDEMPOTENCY_EXPIRED') {
+if (result.errorInstance instanceof IdempotencyExpiredError) {
   // Key past replay window. If you know the prior call succeeded, look up
   // by natural key (e.g., get_media_buys by context.internal_campaign_id).
   // Otherwise mint a fresh key.
 }
 ```
 
-**BYOK** (persist keys in your DB across process restarts): you own the replay-window boundary. Compare key age against `adcp.idempotency.replay_ttl_seconds` from `get_adcp_capabilities` before reusing. Past the window, fall back to a natural-key lookup rather than minting a new key — otherwise a second resource is created silently.
+**BYOK** (persist keys in your DB across process restarts): you own the replay-window boundary. Ask the client for the seller's declared TTL:
+
+```typescript
+const ttl = await client.getIdempotencyReplayTtlSeconds();
+// Returns the declared number. Throws ConfigurationError if the seller is v3
+// but omits adcp.idempotency.replay_ttl_seconds — the SDK does NOT default to
+// 24h, because a silent default misleads retry-sensitive flows. Returns
+// undefined on v2 sellers (pre-idempotency-envelope).
+```
+
+Pass your persisted key with `useIdempotencyKey(key)` — it validates against the spec pattern (`^[A-Za-z0-9_.:-]{16,255}$`) before the network round-trip:
+
+```typescript
+import { useIdempotencyKey } from '@adcp/client';
+const key = await db.getOrCreateIdempotencyKey(campaign.id);
+await client.createMediaBuy({ ...params, ...useIdempotencyKey(key) });
+```
 
 ## Tools
 

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -561,15 +561,18 @@ function generateLlmsTxt(
     `2. **Agent re-plan vs. network retry.** A network retry (same bytes, socket timeout) reuses the same key — the SDK handles this. An agent re-plan (LLM re-ran its planner and produced a different payload) means a NEW intent — mint a fresh key by calling the method again without passing one. Reusing the prior key with a different payload returns \`IdempotencyConflictError\`.`
   );
   ln();
-  ln(`**Typed errors:**`);
+  ln(
+    `**Typed errors:** on failure, \`result.errorInstance\` carries a typed \`ADCPError\` subclass for codes with dedicated classes — currently \`IdempotencyConflictError\` and \`IdempotencyExpiredError\`. Prefer \`instanceof\` checks over switching on \`adcpError.code\` strings.`
+  );
   ln();
   ln('```typescript');
   ln("import { IdempotencyConflictError, IdempotencyExpiredError } from '@adcp/client';");
   ln();
-  ln("if (result.adcpError?.code === 'IDEMPOTENCY_CONFLICT') {");
+  ln('if (result.errorInstance instanceof IdempotencyConflictError) {');
   ln('  // Agent re-planned with different payload. Retry with a fresh key.');
+  ln('  // result.errorInstance.idempotencyKey carries the key the server omitted.');
   ln('}');
-  ln("if (result.adcpError?.code === 'IDEMPOTENCY_EXPIRED') {");
+  ln('if (result.errorInstance instanceof IdempotencyExpiredError) {');
   ln('  // Key past replay window. If you know the prior call succeeded, look up');
   ln('  // by natural key (e.g., get_media_buys by context.internal_campaign_id).');
   ln('  // Otherwise mint a fresh key.');
@@ -577,8 +580,26 @@ function generateLlmsTxt(
   ln('```');
   ln();
   ln(
-    `**BYOK** (persist keys in your DB across process restarts): you own the replay-window boundary. Compare key age against \`adcp.idempotency.replay_ttl_seconds\` from \`get_adcp_capabilities\` before reusing. Past the window, fall back to a natural-key lookup rather than minting a new key — otherwise a second resource is created silently.`
+    `**BYOK** (persist keys in your DB across process restarts): you own the replay-window boundary. Ask the client for the seller's declared TTL:`
   );
+  ln();
+  ln('```typescript');
+  ln('const ttl = await client.getIdempotencyReplayTtlSeconds();');
+  ln('// Returns the declared number. Throws ConfigurationError if the seller is v3');
+  ln('// but omits adcp.idempotency.replay_ttl_seconds — the SDK does NOT default to');
+  ln('// 24h, because a silent default misleads retry-sensitive flows. Returns');
+  ln('// undefined on v2 sellers (pre-idempotency-envelope).');
+  ln('```');
+  ln();
+  ln(
+    `Pass your persisted key with \`useIdempotencyKey(key)\` — it validates against the spec pattern (\`^[A-Za-z0-9_.:-]{16,255}$\`) before the network round-trip:`
+  );
+  ln();
+  ln('```typescript');
+  ln("import { useIdempotencyKey } from '@adcp/client';");
+  ln('const key = await db.getOrCreateIdempotencyKey(campaign.id);');
+  ln('await client.createMediaBuy({ ...params, ...useIdempotencyKey(key) });');
+  ln('```');
   ln();
 
   // --- Tools by domain ---

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -432,6 +432,16 @@ export class AgentClient {
   }
 
   /**
+   * Return the seller's declared `adcp.idempotency.replay_ttl_seconds`, or
+   * throw when a v3 seller omits the (required) declaration.
+   *
+   * Returns `undefined` for v2 agents — v2 pre-dates the idempotency envelope.
+   */
+  async getIdempotencyReplayTtlSeconds(): Promise<number | undefined> {
+    return this.client.getIdempotencyReplayTtlSeconds();
+  }
+
+  /**
    * Preview a creative
    */
   async previewCreative(

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -301,6 +301,7 @@ export interface TaskResultCompleted<T> extends TaskResultBase {
   data: T;
   error?: undefined;
   adcpError?: undefined;
+  errorInstance?: undefined;
   correlationId?: undefined;
   deferred?: undefined;
   submitted?: undefined;
@@ -313,6 +314,7 @@ export interface TaskResultIntermediate<T> extends TaskResultBase {
   data?: T;
   error?: undefined;
   adcpError?: undefined;
+  errorInstance?: undefined;
   correlationId?: undefined;
   /** Deferred continuation (client needs time for input) */
   deferred?: DeferredContinuation<T>;
@@ -330,6 +332,15 @@ export interface TaskResultFailure<T> extends TaskResultBase {
   error: string;
   /** Structured AdCP error (code, recovery, suggestion, retryAfterMs) */
   adcpError?: AdcpErrorInfo;
+  /**
+   * Typed `ADCPError` subclass instance when the seller's error code has a
+   * dedicated class — currently `IdempotencyConflictError` and
+   * `IdempotencyExpiredError`. Lets callers write
+   * `if (result.errorInstance instanceof IdempotencyConflictError)` instead of
+   * switching on `adcpError.code` strings. Absent for codes without a typed
+   * mapping.
+   */
+  errorInstance?: import('../errors').ADCPError;
   /** Correlation ID from the error response context, for tracing across agents */
   correlationId?: string;
   deferred?: undefined;

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -83,7 +83,13 @@ import type { Task as A2ATask, TaskStatusUpdateEvent } from '@a2a-js/sdk';
 
 import { TaskExecutor, DeferredTaskError } from './TaskExecutor';
 import { createMCPAuthHeaders } from '../auth';
-import { AuthenticationRequiredError, FeatureUnsupportedError, TaskTimeoutError, is401Error } from '../errors';
+import {
+  AuthenticationRequiredError,
+  ConfigurationError,
+  FeatureUnsupportedError,
+  TaskTimeoutError,
+  is401Error,
+} from '../errors';
 import type { InputHandler, TaskOptions, TaskResult, ConversationConfig, TaskInfo } from './ConversationTypes';
 import type { Activity, AsyncHandlerConfig, WebhookMetadata } from './AsyncHandler';
 import { AsyncHandler } from './AsyncHandler';
@@ -2554,6 +2560,30 @@ export class SingleAgentClient {
   async supportsVersion(version: 2 | 3): Promise<boolean> {
     const capabilities = await this.getCapabilities();
     return capabilities.majorVersions.includes(version);
+  }
+
+  /**
+   * Return the seller's declared `adcp.idempotency.replay_ttl_seconds`.
+   *
+   * BYOK callers use this to compare the age of persisted keys against the
+   * seller's replay window — past the window, the safe recovery is a
+   * natural-key lookup rather than reusing the key.
+   *
+   * Fails closed when the seller is v3 but does not declare the field: the
+   * spec makes the declaration REQUIRED, and silently defaulting to 24h
+   * would mislead buyers about retry safety. Callers on v2 servers get
+   * `undefined` instead of a throw — v2 pre-dates the idempotency envelope.
+   */
+  async getIdempotencyReplayTtlSeconds(): Promise<number | undefined> {
+    const capabilities = await this.getCapabilities();
+    if (capabilities.idempotency) return capabilities.idempotency.replayTtlSeconds;
+    if (capabilities.version !== 'v3') return undefined;
+    throw new ConfigurationError(
+      `Agent "${this.agent.id}" is v3 but does not declare adcp.idempotency.replay_ttl_seconds. ` +
+        `The spec requires this for v3 sellers — treating the agent as non-compliant rather than ` +
+        `defaulting to 24h, which would silently mislead retry-sensitive flows.`,
+      'adcp.idempotency.replay_ttl_seconds'
+    );
   }
 
   /**

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -6,7 +6,8 @@ import type { AgentConfig } from '../types';
 import { ProtocolClient } from '../protocols';
 import { getMCPTaskStatus, listMCPTasks } from '../protocols/mcp-tasks';
 import { getAuthToken } from '../auth';
-import { is401Error } from '../errors';
+import { is401Error, adcpErrorToTypedError } from '../errors';
+import type { ADCPError } from '../errors';
 import type { Storage } from '../storage/interfaces';
 import { responseValidator } from './ResponseValidator';
 import { unwrapProtocolResponse, isAdcpError } from '../utils/response-unwrapper';
@@ -194,6 +195,19 @@ export class TaskExecutor {
       if (replayed !== undefined) meta.replayed = replayed;
     }
     return meta;
+  }
+
+  /**
+   * Map a task's structured AdCP error to a typed `ADCPError` subclass when
+   * the code has a dedicated class (e.g., `IDEMPOTENCY_CONFLICT` →
+   * `IdempotencyConflictError`). The idempotency key is pulled from tracked
+   * task state because the server intentionally omits it from error bodies
+   * (it's a read-oracle).
+   */
+  private buildErrorInstance(taskId: string, adcpError: ReturnType<typeof extractAdcpErrorInfo>): ADCPError | undefined {
+    if (!adcpError) return undefined;
+    const key = this.activeTasks.get(taskId)?.idempotencyKey;
+    return adcpErrorToTypedError(adcpError, key);
   }
 
   private generateWebhookUrl(taskName: string, operationId: string): string | undefined {
@@ -500,12 +514,14 @@ export class TaskExecutor {
             debug_logs: debugLogs,
           };
         }
+        const completedAdcpError = extractAdcpErrorInfo(completedData);
         return {
           success: false as const,
           status: 'failed' as const,
           data: completedData,
           error: finalError ?? 'Unknown error',
-          adcpError: extractAdcpErrorInfo(completedData),
+          adcpError: completedAdcpError,
+          errorInstance: this.buildErrorInstance(taskId, completedAdcpError),
           correlationId: extractCorrelationId(completedData),
           metadata: this.buildMetadata({
             taskId,
@@ -568,6 +584,7 @@ export class TaskExecutor {
           data: hasStructuredError ? failedData : undefined,
           error: typeof failedError === 'string' ? failedError : `Task ${status}`,
           adcpError: adcpErrorInfo,
+          errorInstance: this.buildErrorInstance(taskId, adcpErrorInfo),
           correlationId: extractCorrelationId(failedData),
           metadata: this.buildMetadata({
             taskId,
@@ -619,12 +636,14 @@ export class TaskExecutor {
               debug_logs: debugLogs,
             };
           }
+          const defaultAdcpError = extractAdcpErrorInfo(defaultData);
           return {
             success: false as const,
             status: 'failed' as const,
             data: defaultData,
             error: defaultFinalError!,
-            adcpError: extractAdcpErrorInfo(defaultData),
+            adcpError: defaultAdcpError,
+            errorInstance: this.buildErrorInstance(taskId, defaultAdcpError),
             correlationId: extractCorrelationId(defaultData),
             metadata: this.buildMetadata({
               taskId,
@@ -1086,12 +1105,14 @@ export class TaskExecutor {
             }),
           };
         }
+        const asyncResultErr = extractAdcpErrorInfo(status.result);
         return {
           success: false as const,
           status: 'failed' as const,
           data: status.result,
           error: this.extractOperationError(status.result),
-          adcpError: extractAdcpErrorInfo(status.result),
+          adcpError: asyncResultErr,
+          errorInstance: this.buildErrorInstance(taskId, asyncResultErr),
           correlationId: extractCorrelationId(status.result),
           metadata: this.buildMetadata({
             taskId,
@@ -1105,12 +1126,14 @@ export class TaskExecutor {
       }
 
       if (status.status === ADCP_STATUS.FAILED || status.status === ADCP_STATUS.CANCELED) {
+        const asyncFailedErr = extractAdcpErrorInfo(status.result);
         return {
           success: false as const,
           status: 'failed' as const,
           data: status.result,
           error: status.error || `Task ${status.status}`,
-          adcpError: extractAdcpErrorInfo(status.result),
+          adcpError: asyncFailedErr,
+          errorInstance: this.buildErrorInstance(taskId, asyncFailedErr),
           correlationId: extractCorrelationId(status.result),
           metadata: this.buildMetadata({
             taskId,
@@ -1244,6 +1267,7 @@ export class TaskExecutor {
       status: 'failed' as const,
       error: error.message || String(error),
       adcpError: adcpErrorInfo,
+      errorInstance: this.buildErrorInstance(taskId, adcpErrorInfo),
       correlationId,
       metadata: this.buildMetadata({
         taskId,

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -204,7 +204,10 @@ export class TaskExecutor {
    * task state because the server intentionally omits it from error bodies
    * (it's a read-oracle).
    */
-  private buildErrorInstance(taskId: string, adcpError: ReturnType<typeof extractAdcpErrorInfo>): ADCPError | undefined {
+  private buildErrorInstance(
+    taskId: string,
+    adcpError: ReturnType<typeof extractAdcpErrorInfo>
+  ): ADCPError | undefined {
     if (!adcpError) return undefined;
     const key = this.activeTasks.get(taskId)?.idempotencyKey;
     return adcpErrorToTypedError(adcpError, key);

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -12,7 +12,7 @@ import type { Storage } from '../storage/interfaces';
 import { responseValidator } from './ResponseValidator';
 import { unwrapProtocolResponse, isAdcpError } from '../utils/response-unwrapper';
 import { extractAdcpErrorInfo, extractCorrelationId } from '../utils/error-extraction';
-import { generateIdempotencyKey, isMutatingTask } from '../utils/idempotency';
+import { generateIdempotencyKey, isMutatingTask, redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
 import type {
   Message,
@@ -289,7 +289,10 @@ export class TaskExecutor {
     let effectiveParams = params;
 
     try {
-      // Emit protocol_request activity
+      // Emit protocol_request activity. The activity payload is the boundary
+      // callers typically pipe into external observability stacks, so redact
+      // the idempotency key — it's a retry-pattern oracle within the seller's
+      // TTL. Full logging is opt-in via ADCP_LOG_IDEMPOTENCY_KEYS=1.
       await this.config.onActivity?.({
         type: 'protocol_request',
         operation_id: taskId,
@@ -298,7 +301,7 @@ export class TaskExecutor {
         task_id: taskId,
         task_type: taskName,
         status: 'pending',
-        payload: { params },
+        payload: { params: redactIdempotencyKeyInArgs(params) },
         timestamp: new Date().toISOString(),
       });
 

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -361,6 +361,31 @@ export function is401Error(error: unknown, got401Flag = false): boolean {
 }
 
 /**
+ * Map a structured AdCP error (code + message) to a typed ADCPError subclass
+ * when the code has a dedicated class. Returns `undefined` for codes that
+ * don't have a typed mapping — callers should continue to use the untyped
+ * `AdcpErrorInfo` for those.
+ *
+ * Pass the `idempotencyKey` the SDK sent so the constructed error carries it
+ * for the caller's recovery logic. The server intentionally omits the key
+ * from error bodies (it's a read-oracle), so the transport-layer caller is
+ * the authoritative source.
+ */
+export function adcpErrorToTypedError(
+  adcpError: { code: string; message?: string },
+  idempotencyKey?: string
+): ADCPError | undefined {
+  switch (adcpError.code) {
+    case 'IDEMPOTENCY_CONFLICT':
+      return new IdempotencyConflictError(idempotencyKey, adcpError.message);
+    case 'IDEMPOTENCY_EXPIRED':
+      return new IdempotencyExpiredError(idempotencyKey, adcpError.message);
+    default:
+      return undefined;
+  }
+}
+
+/**
  * Type guard to check if an error is an ADCP error
  */
 export function isADCPError(error: unknown): error is ADCPError {

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -266,15 +266,23 @@ export class AuthenticationRequiredError extends ADCPError {
 export class IdempotencyConflictError extends ADCPError {
   readonly code = 'IDEMPOTENCY_CONFLICT';
 
-  constructor(
-    public readonly idempotencyKey: string | undefined,
-    message?: string
-  ) {
+  // Exposed via the getter so `console.log(err)` and JSON.stringify don't
+  // leak the key (it's a retry-pattern oracle within the seller's TTL).
+  // Callers reading `err.idempotencyKey` get it normally.
+  readonly idempotencyKey: string | undefined;
+
+  constructor(idempotencyKey: string | undefined, message?: string) {
     super(
       message ||
         'idempotency_key was used earlier with a different canonical payload. ' +
           'Use a fresh UUID v4 for the new request, or resend the exact original payload to get the cached response.'
     );
+    Object.defineProperty(this, 'idempotencyKey', {
+      value: idempotencyKey,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
   }
 }
 
@@ -294,15 +302,22 @@ export class IdempotencyConflictError extends ADCPError {
 export class IdempotencyExpiredError extends ADCPError {
   readonly code = 'IDEMPOTENCY_EXPIRED';
 
-  constructor(
-    public readonly idempotencyKey: string | undefined,
-    message?: string
-  ) {
+  // Non-enumerable so `console.log(err)` / JSON.stringify don't leak it —
+  // same reasoning as IdempotencyConflictError.idempotencyKey.
+  readonly idempotencyKey: string | undefined;
+
+  constructor(idempotencyKey: string | undefined, message?: string) {
     super(
       message ||
         "idempotency_key is past the seller's replay window. " +
           'If you know the prior call succeeded, look up the resource by natural key before retrying. Otherwise, mint a fresh UUID v4.'
     );
+    Object.defineProperty(this, 'idempotencyKey', {
+      value: idempotencyKey,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
   }
 }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -211,6 +211,7 @@ export {
   FeatureUnsupportedError,
   IdempotencyConflictError,
   IdempotencyExpiredError,
+  adcpErrorToTypedError,
   isADCPError,
   isErrorOfType,
   extractErrorInfo,
@@ -224,9 +225,12 @@ export {
   generateIdempotencyKey,
   isMutatingTask,
   isValidIdempotencyKey,
+  useIdempotencyKey,
+  redactIdempotencyKey,
   IDEMPOTENCY_KEY_PATTERN,
   MUTATING_TASKS,
 } from './utils/idempotency';
+export type { IdempotencyCapabilities } from './utils/capabilities';
 export type { MutatingRequestInput } from './utils/idempotency';
 export { canonicalize, canonicalJsonSha256 } from './utils/jcs';
 

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -11,6 +11,7 @@ import { discoverOAuthMetadata } from '../auth/oauth/discovery';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, type AgentSigningContext } from '../signing/client';
+import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 
 if (!A2AClient) {
   throw new Error('A2A SDK client is required. Please install @a2a-js/sdk');
@@ -276,14 +277,30 @@ async function callA2AToolImpl(
     }
 
     const payloadSize = JSON.stringify(requestPayload).length;
+    const redactedParameters = redactIdempotencyKeyInArgs(parameters);
+    const redactedPayload =
+      redactedParameters === parameters
+        ? requestPayload
+        : {
+            ...requestPayload,
+            message: {
+              ...requestPayload.message,
+              parts: [
+                {
+                  kind: 'data',
+                  data: { skill: toolName, parameters: redactedParameters },
+                },
+              ],
+            },
+          };
     debugLogs.push({
       type: 'info',
       message: `A2A: Calling skill ${toolName} with parameters: ${JSON.stringify(
-        parameters
+        redactedParameters
       )}. Payload size: ${payloadSize} bytes`,
       timestamp: new Date().toISOString(),
       payloadSize,
-      actualPayload: requestPayload,
+      actualPayload: redactedPayload,
     });
 
     debugLogs.push({

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -16,6 +16,7 @@ import { withCachedConnection } from './mcp';
 import { createMCPAuthHeaders } from '../auth';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import type { AgentSigningContext } from '../signing/client';
+import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 
 /** Response shape returned by MCPClient.callTool(). */
 type CallToolResponse = {
@@ -110,13 +111,24 @@ function buildAuthHeaders(authToken?: string, customHeaders?: Record<string, str
 
 /**
  * Redact sensitive fields from tool args before logging.
+ *
+ * Redacts:
+ * - `push_notification_config.authentication` — webhook signing secret
+ * - `idempotency_key` — retry-pattern oracle within the seller's TTL; opt-in
+ *   full logging via `ADCP_LOG_IDEMPOTENCY_KEYS=1`
  */
 function redactArgsForLog(args: Record<string, unknown>): Record<string, unknown> {
-  if (!args.push_notification_config) return args;
-  return {
-    ...args,
-    push_notification_config: { ...(args.push_notification_config as object), authentication: '***' },
-  };
+  let redacted: Record<string, unknown> = args;
+  if (redacted.push_notification_config) {
+    redacted = {
+      ...redacted,
+      push_notification_config: {
+        ...(redacted.push_notification_config as object),
+        authentication: '***',
+      },
+    };
+  }
+  return redactIdempotencyKeyInArgs(redacted);
 }
 
 /**

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -14,6 +14,7 @@ import { is401Error } from '../errors';
 import type { DebugLogEntry } from '../types/adcp';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { buildAgentSigningFetch, type AgentSigningContext } from '../signing/client';
+import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 
 // Re-export for convenience
 export { UnauthorizedError };
@@ -480,7 +481,7 @@ async function callMCPToolImpl(
 
   debugLogs.push({
     type: 'info',
-    message: `MCP: Calling tool ${toolName} with args: ${JSON.stringify(args)}`,
+    message: `MCP: Calling tool ${toolName} with args: ${JSON.stringify(redactIdempotencyKeyInArgs(args))}`,
     timestamp: new Date().toISOString(),
   });
 

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -98,6 +98,23 @@ export interface CreativeCapabilities {
 }
 
 /**
+ * Idempotency capabilities declared by the seller.
+ *
+ * Clients MUST NOT fall back to an assumed TTL when the seller omits this —
+ * `getIdempotencyReplayTtlSeconds()` throws when the declaration is missing
+ * on a v3 server rather than silently defaulting to 24h. A seller without the
+ * declaration is non-compliant and unsafe for retry-sensitive operations.
+ */
+export interface IdempotencyCapabilities {
+  /**
+   * Seconds the seller retains cached `(principal, idempotency_key, payload)`
+   * tuples. BYOK callers compare their persisted key's age against this to
+   * decide whether a fresh key + natural-key lookup is safer than reusing.
+   */
+  replayTtlSeconds: number;
+}
+
+/**
  * Normalized capabilities response that works for both v2 and v3 servers
  */
 export interface AdcpCapabilities {
@@ -118,6 +135,9 @@ export interface AdcpCapabilities {
 
   /** Creative protocol capabilities */
   creative?: CreativeCapabilities;
+
+  /** Idempotency replay capabilities (v3 sellers declaring `adcp.idempotency`) */
+  idempotency?: IdempotencyCapabilities;
 
   /** Supported extension namespaces (e.g., 'scope3', 'garm') */
   extensions: string[];
@@ -355,6 +375,15 @@ export function parseCapabilitiesResponse(response: any): AdcpCapabilities {
     };
   }
 
+  // adcp.idempotency.replay_ttl_seconds is REQUIRED per spec when the seller
+  // supports mutating tools. Absence is surfaced downstream as a fail-closed
+  // error in getIdempotencyReplayTtlSeconds() — we deliberately do NOT default.
+  let idempotency: IdempotencyCapabilities | undefined;
+  const rawTtl = response.adcp?.idempotency?.replay_ttl_seconds;
+  if (typeof rawTtl === 'number' && Number.isFinite(rawTtl) && rawTtl > 0) {
+    idempotency = { replayTtlSeconds: rawTtl };
+  }
+
   return {
     version: highestVersion >= 3 ? 'v3' : 'v2',
     majorVersions,
@@ -362,6 +391,7 @@ export function parseCapabilitiesResponse(response: any): AdcpCapabilities {
     features,
     account,
     creative,
+    idempotency,
     extensions: response.extensions_supported ?? [],
     publisherDomains: response.media_buy?.portfolio?.publisher_domains,
     channels: response.media_buy?.portfolio?.channels,

--- a/src/lib/utils/idempotency.ts
+++ b/src/lib/utils/idempotency.ts
@@ -116,8 +116,11 @@ export type MutatingRequestInput<T extends { idempotency_key: string }> = Omit<T
  */
 export function useIdempotencyKey(key: string): { idempotency_key: string } {
   if (typeof key !== 'string' || !isValidIdempotencyKey(key)) {
+    // Preview only 8 chars so near-valid keys (16+ chars, minor drift) don't
+    // flow verbatim into exception messages and stack traces. Matches the
+    // redactIdempotencyKey() policy for debug logs.
     const preview =
-      typeof key === 'string' ? `${JSON.stringify(key.slice(0, 32))}${key.length > 32 ? '…' : ''}` : typeof key;
+      typeof key === 'string' ? `${JSON.stringify(key.slice(0, 8))}${key.length > 8 ? '…' : ''}` : typeof key;
     throw new Error(`Invalid idempotency_key: must match ${IDEMPOTENCY_KEY_PATTERN}. Received: ${preview}`);
   }
   return { idempotency_key: key };

--- a/src/lib/utils/idempotency.ts
+++ b/src/lib/utils/idempotency.ts
@@ -95,3 +95,65 @@ export function isValidIdempotencyKey(key: string): boolean {
 export type MutatingRequestInput<T extends { idempotency_key: string }> = Omit<T, 'idempotency_key'> & {
   idempotency_key?: string;
 };
+
+/**
+ * Validate a bring-your-own-key `idempotency_key` up front and return a
+ * `{ idempotency_key }` fragment to spread into a mutating request.
+ *
+ * Useful when the caller persists keys across process restarts (e.g., key
+ * stored in a DB alongside a campaign row) and wants to catch drift before
+ * the round-trip — the server would reject a malformed key with
+ * `INVALID_REQUEST`, but failing locally produces a faster, cleaner error.
+ *
+ * Throws when the key doesn't match `IDEMPOTENCY_KEY_PATTERN`
+ * (`^[A-Za-z0-9_.:-]{16,255}$`).
+ *
+ * @example
+ * ```ts
+ * const key = await db.getOrCreateIdempotencyKey(campaign.id);
+ * const result = await client.createMediaBuy({ ...params, ...useIdempotencyKey(key) });
+ * ```
+ */
+export function useIdempotencyKey(key: string): { idempotency_key: string } {
+  if (typeof key !== 'string' || !isValidIdempotencyKey(key)) {
+    const preview =
+      typeof key === 'string' ? `${JSON.stringify(key.slice(0, 32))}${key.length > 32 ? '…' : ''}` : typeof key;
+    throw new Error(`Invalid idempotency_key: must match ${IDEMPOTENCY_KEY_PATTERN}. Received: ${preview}`);
+  }
+  return { idempotency_key: key };
+}
+
+/**
+ * True when the caller has opted into logging full idempotency keys via the
+ * `ADCP_LOG_IDEMPOTENCY_KEYS` environment variable. Keys are a retry-pattern
+ * oracle within their TTL, so the default is to truncate.
+ */
+function fullIdempotencyKeyLoggingEnabled(): boolean {
+  const value = process.env.ADCP_LOG_IDEMPOTENCY_KEYS;
+  if (!value) return false;
+  const v = value.toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+/**
+ * Truncate an idempotency key for logging — first 8 chars followed by `…`.
+ * Callers who need the full key for debugging can opt in via
+ * `ADCP_LOG_IDEMPOTENCY_KEYS=1`.
+ */
+export function redactIdempotencyKey(key: string): string {
+  if (fullIdempotencyKeyLoggingEnabled()) return key;
+  if (typeof key !== 'string' || key.length === 0) return key;
+  return `${key.slice(0, 8)}…`;
+}
+
+/**
+ * Return a shallow copy of `args` with any `idempotency_key` field replaced by
+ * its truncated form for safe debug logging. Leaves non-key fields untouched.
+ * No-op when `ADCP_LOG_IDEMPOTENCY_KEYS` is set.
+ */
+export function redactIdempotencyKeyInArgs<T extends Record<string, unknown>>(args: T): T {
+  if (!args || typeof args !== 'object') return args;
+  if (!('idempotency_key' in args) || typeof args.idempotency_key !== 'string') return args;
+  if (fullIdempotencyKeyLoggingEnabled()) return args;
+  return { ...args, idempotency_key: redactIdempotencyKey(args.idempotency_key) } as T;
+}

--- a/test/lib/idempotency-capabilities.test.js
+++ b/test/lib/idempotency-capabilities.test.js
@@ -1,0 +1,92 @@
+/**
+ * Client-side reading of `adcp.idempotency.replay_ttl_seconds` from
+ * get_adcp_capabilities, and fail-closed behaviour when a v3 seller omits it.
+ *
+ * The fail-closed test covers `SingleAgentClient.getIdempotencyReplayTtlSeconds()`
+ * by constructing a client and stubbing `getCapabilities()` to return
+ * controlled capability shapes.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parseCapabilitiesResponse } = require('../../dist/lib/utils/capabilities.js');
+const { SingleAgentClient } = require('../../dist/lib/core/SingleAgentClient.js');
+
+const stubAgent = {
+  id: 'a1',
+  name: 'stub',
+  protocol: 'mcp',
+  agent_uri: 'https://stub.example/mcp',
+};
+
+describe('parseCapabilitiesResponse reads adcp.idempotency.replay_ttl_seconds', () => {
+  it('surfaces declared TTL from v3 capability response', () => {
+    const caps = parseCapabilitiesResponse({
+      adcp: { major_versions: [3], idempotency: { replay_ttl_seconds: 86400 } },
+      supported_protocols: ['media_buy'],
+    });
+    assert.equal(caps.idempotency?.replayTtlSeconds, 86400);
+    assert.equal(caps.version, 'v3');
+  });
+
+  it('omits the idempotency field when the seller does not declare it', () => {
+    const caps = parseCapabilitiesResponse({
+      adcp: { major_versions: [3] },
+      supported_protocols: ['media_buy'],
+    });
+    assert.equal(caps.idempotency, undefined);
+  });
+
+  it('ignores non-positive or non-numeric values (treat as missing)', () => {
+    const caps = parseCapabilitiesResponse({
+      adcp: { major_versions: [3], idempotency: { replay_ttl_seconds: 0 } },
+    });
+    assert.equal(caps.idempotency, undefined);
+  });
+});
+
+describe('SingleAgentClient.getIdempotencyReplayTtlSeconds()', () => {
+  it('returns the declared TTL on a v3 seller', async () => {
+    const client = new SingleAgentClient(stubAgent);
+    client.cachedCapabilities = {
+      version: 'v3',
+      majorVersions: [3],
+      protocols: ['media_buy'],
+      features: {},
+      idempotency: { replayTtlSeconds: 86400 },
+      extensions: [],
+      _synthetic: false,
+    };
+    assert.equal(await client.getIdempotencyReplayTtlSeconds(), 86400);
+  });
+
+  it('fails closed when a v3 seller omits the declaration', async () => {
+    const client = new SingleAgentClient(stubAgent);
+    client.cachedCapabilities = {
+      version: 'v3',
+      majorVersions: [3],
+      protocols: ['media_buy'],
+      features: {},
+      extensions: [],
+      _synthetic: false,
+    };
+    await assert.rejects(
+      () => client.getIdempotencyReplayTtlSeconds(),
+      /does not declare adcp\.idempotency\.replay_ttl_seconds/
+    );
+  });
+
+  it('returns undefined on v2 sellers (pre-idempotency-envelope)', async () => {
+    const client = new SingleAgentClient(stubAgent);
+    client.cachedCapabilities = {
+      version: 'v2',
+      majorVersions: [2],
+      protocols: ['media_buy'],
+      features: {},
+      extensions: [],
+      _synthetic: true,
+    };
+    assert.equal(await client.getIdempotencyReplayTtlSeconds(), undefined);
+  });
+});

--- a/test/lib/idempotency-client.test.js
+++ b/test/lib/idempotency-client.test.js
@@ -14,6 +14,7 @@ const assert = require('node:assert/strict');
 const { TaskExecutor } = require('../../dist/lib/core/TaskExecutor.js');
 const protocols = require('../../dist/lib/protocols/index.js');
 const { isMutatingTask } = require('../../dist/lib/utils/idempotency.js');
+const { IdempotencyConflictError, IdempotencyExpiredError } = require('../../dist/lib/index.js');
 
 function buildResponse({ replayed } = {}) {
   return {
@@ -117,6 +118,63 @@ describe('TaskExecutor surfaces replayed on result metadata', () => {
       const executor = new TaskExecutor();
       const result = await executor.executeTask(agent, 'create_media_buy', baseParams);
       assert.equal(result.metadata.replayed, undefined);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('TaskExecutor surfaces typed error instances on IDEMPOTENCY_CONFLICT/EXPIRED', () => {
+  function failedResponse(code) {
+    return {
+      structuredContent: {
+        status: 'failed',
+        adcp_error: { code, message: `seller returned ${code}` },
+      },
+      content: [{ type: 'text', text: JSON.stringify({ status: 'failed', adcp_error: { code } }) }],
+    };
+  }
+
+  it('IDEMPOTENCY_CONFLICT response → result.errorInstance is IdempotencyConflictError with the sent key', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({ response: failedResponse('IDEMPOTENCY_CONFLICT'), capture });
+    try {
+      const executor = new TaskExecutor();
+      const myKey = 'my_persisted_key_abcdefghij1234';
+      const result = await executor.executeTask(agent, 'create_media_buy', {
+        ...baseParams,
+        idempotency_key: myKey,
+      });
+      assert.equal(result.success, false);
+      assert.equal(result.adcpError?.code, 'IDEMPOTENCY_CONFLICT');
+      assert.ok(result.errorInstance instanceof IdempotencyConflictError, 'expected typed error instance');
+      assert.equal(result.errorInstance.idempotencyKey, myKey);
+    } finally {
+      restore();
+    }
+  });
+
+  it('IDEMPOTENCY_EXPIRED response → result.errorInstance is IdempotencyExpiredError', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({ response: failedResponse('IDEMPOTENCY_EXPIRED'), capture });
+    try {
+      const executor = new TaskExecutor();
+      const result = await executor.executeTask(agent, 'create_media_buy', baseParams);
+      assert.equal(result.success, false);
+      assert.ok(result.errorInstance instanceof IdempotencyExpiredError);
+    } finally {
+      restore();
+    }
+  });
+
+  it('non-idempotency errors leave errorInstance undefined', async () => {
+    const capture = [];
+    const restore = stubProtocolClient({ response: failedResponse('RATE_LIMITED'), capture });
+    try {
+      const executor = new TaskExecutor();
+      const result = await executor.executeTask(agent, 'create_media_buy', baseParams);
+      assert.equal(result.success, false);
+      assert.equal(result.errorInstance, undefined);
     } finally {
       restore();
     }

--- a/test/lib/idempotency.test.js
+++ b/test/lib/idempotency.test.js
@@ -191,3 +191,54 @@ describe('redactIdempotencyKey', () => {
     }
   });
 });
+
+describe('redactIdempotencyKeyInArgs', () => {
+  const { redactIdempotencyKeyInArgs } = require('../../dist/lib/utils/idempotency.js');
+
+  it('returns the same reference when args has no idempotency_key', () => {
+    const args = { brief: 'hi', account: { account_id: 'a1' } };
+    assert.equal(redactIdempotencyKeyInArgs(args), args, 'no-key path must preserve reference (A2A relies on this)');
+  });
+
+  it('returns a shallow clone with the key redacted when present', () => {
+    delete process.env.ADCP_LOG_IDEMPOTENCY_KEYS;
+    const args = { brief: 'hi', idempotency_key: 'abcdefgh-1234-5678-ij-sensitive' };
+    const out = redactIdempotencyKeyInArgs(args);
+    assert.notEqual(out, args, 'must return a clone, not mutate the original');
+    assert.equal(out.idempotency_key, 'abcdefgh…');
+    assert.equal(args.idempotency_key, 'abcdefgh-1234-5678-ij-sensitive', 'original must not be mutated');
+    assert.equal(out.brief, 'hi');
+  });
+
+  it('returns the same reference when ADCP_LOG_IDEMPOTENCY_KEYS is enabled', () => {
+    process.env.ADCP_LOG_IDEMPOTENCY_KEYS = '1';
+    try {
+      const args = { brief: 'hi', idempotency_key: 'abcdefgh-1234-5678-ij-full' };
+      assert.equal(redactIdempotencyKeyInArgs(args), args, 'opt-in full logging must preserve reference');
+    } finally {
+      delete process.env.ADCP_LOG_IDEMPOTENCY_KEYS;
+    }
+  });
+});
+
+describe('IdempotencyConflictError/ExpiredError do not leak key on serialization', () => {
+  it('idempotencyKey is non-enumerable on IdempotencyConflictError', () => {
+    const err = new IdempotencyConflictError('secret-key-abcdefghij1234');
+    assert.equal(err.idempotencyKey, 'secret-key-abcdefghij1234', 'direct access still works');
+    assert.ok(
+      !Object.keys(err).includes('idempotencyKey'),
+      'key must not appear in Object.keys (blocks JSON.stringify leak)'
+    );
+    assert.ok(
+      !JSON.stringify(err).includes('secret-key'),
+      `JSON.stringify(err) leaked the key: ${JSON.stringify(err)}`
+    );
+  });
+
+  it('idempotencyKey is non-enumerable on IdempotencyExpiredError', () => {
+    const err = new IdempotencyExpiredError('secret-key-abcdefghij1234');
+    assert.equal(err.idempotencyKey, 'secret-key-abcdefghij1234');
+    assert.ok(!Object.keys(err).includes('idempotencyKey'));
+    assert.ok(!JSON.stringify(err).includes('secret-key'));
+  });
+});

--- a/test/lib/idempotency.test.js
+++ b/test/lib/idempotency.test.js
@@ -5,10 +5,13 @@ const {
   generateIdempotencyKey,
   isMutatingTask,
   isValidIdempotencyKey,
+  useIdempotencyKey,
+  redactIdempotencyKey,
   IDEMPOTENCY_KEY_PATTERN,
   MUTATING_TASKS,
   IdempotencyConflictError,
   IdempotencyExpiredError,
+  adcpErrorToTypedError,
   isADCPError,
 } = require('../../dist/lib/index.js');
 
@@ -124,5 +127,67 @@ describe('IdempotencyExpiredError', () => {
   it('default message nudges callers toward natural-key lookup', () => {
     const err = new IdempotencyExpiredError('abc-123');
     assert.match(err.message, /natural key|replay window/i);
+  });
+});
+
+describe('adcpErrorToTypedError', () => {
+  it('maps IDEMPOTENCY_CONFLICT to IdempotencyConflictError with the caller-supplied key', () => {
+    const typed = adcpErrorToTypedError({ code: 'IDEMPOTENCY_CONFLICT', message: 'seller msg' }, 'abc-123');
+    assert.ok(typed instanceof IdempotencyConflictError);
+    assert.equal(typed.idempotencyKey, 'abc-123');
+    assert.equal(typed.message, 'seller msg');
+  });
+
+  it('maps IDEMPOTENCY_EXPIRED to IdempotencyExpiredError', () => {
+    const typed = adcpErrorToTypedError({ code: 'IDEMPOTENCY_EXPIRED' }, 'abc-123');
+    assert.ok(typed instanceof IdempotencyExpiredError);
+  });
+
+  it('returns undefined for codes without a typed mapping', () => {
+    assert.equal(adcpErrorToTypedError({ code: 'RATE_LIMITED' }, 'abc'), undefined);
+    assert.equal(adcpErrorToTypedError({ code: 'INVALID_REQUEST' }), undefined);
+  });
+});
+
+describe('useIdempotencyKey', () => {
+  it('returns a spread-able object for valid keys', () => {
+    const fragment = useIdempotencyKey('abcdefghij1234-abc');
+    assert.deepEqual(fragment, { idempotency_key: 'abcdefghij1234-abc' });
+  });
+
+  it('throws on keys that fail the spec pattern', () => {
+    assert.throws(() => useIdempotencyKey('too-short'), /Invalid idempotency_key/);
+    assert.throws(() => useIdempotencyKey('has space here-1234'), /Invalid idempotency_key/);
+    assert.throws(() => useIdempotencyKey(null), /Invalid idempotency_key/);
+  });
+
+  it('error message does not leak the full key', () => {
+    const longKey = 'a'.repeat(500);
+    try {
+      useIdempotencyKey(longKey);
+      assert.fail('should have thrown');
+    } catch (e) {
+      assert.ok(e.message.length < longKey.length, 'error should truncate the offending key');
+    }
+  });
+});
+
+describe('redactIdempotencyKey', () => {
+  it('truncates to first 8 chars plus ellipsis by default', () => {
+    delete process.env.ADCP_LOG_IDEMPOTENCY_KEYS;
+    const key = 'abcdefgh-1234-5678-ij-this-is-sensitive';
+    const redacted = redactIdempotencyKey(key);
+    assert.equal(redacted, 'abcdefgh…');
+    assert.ok(!redacted.includes('sensitive'));
+  });
+
+  it('returns the full key when ADCP_LOG_IDEMPOTENCY_KEYS is enabled', () => {
+    process.env.ADCP_LOG_IDEMPOTENCY_KEYS = '1';
+    try {
+      const key = 'abcdefgh-1234-5678-ij-full';
+      assert.equal(redactIdempotencyKey(key), key);
+    } finally {
+      delete process.env.ADCP_LOG_IDEMPOTENCY_KEYS;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes the remaining acceptance criteria from [#568](https://github.com/adcontextprotocol/adcp-client/issues/568) that were left open after PR #590. Four concrete additions, all additive / non-breaking.

1. **Typed error instances surface on `TaskResult`.** When the seller returns `IDEMPOTENCY_CONFLICT` / `IDEMPOTENCY_EXPIRED`, the result now carries an `errorInstance` populated with the corresponding `ADCPError` subclass. Callers who want \`if (result.errorInstance instanceof IdempotencyConflictError)\` get it without switching on code strings. The SDK pulls the sent \`idempotency_key\` from tracked task state — the server intentionally omits it from error bodies (read-oracle).
2. **\`getIdempotencyReplayTtlSeconds()\` on \`SingleAgentClient\` / \`AgentClient\`.** Reads \`adcp.idempotency.replay_ttl_seconds\` from cached capabilities. Returns \`undefined\` on v2, the declared number on compliant v3, and **throws** when a v3 seller omits the declaration. No silent 24h default — spec requires it, and defaulting would mislead BYOK callers about their replay window.
3. **\`useIdempotencyKey(key)\` BYOK helper.** Validates against \`IDEMPOTENCY_KEY_PATTERN\` up front and returns \`{ idempotency_key }\` for spreading into params. Catches persisted-key drift before the round-trip.
4. **Key logging hygiene.** MCP and A2A debug logs truncate \`idempotency_key\` values to the first 8 chars + \`…\` by default. Set \`ADCP_LOG_IDEMPOTENCY_KEYS=1\` for full logging. Retry-pattern oracle within TTL — shouldn't land in debug transcripts.

Plus \`adcpErrorToTypedError(adcpError, key)\` exported for callers that already hold an \`AdcpErrorInfo\` and want to type-narrow themselves.

## Public API additions

\`\`\`ts
import {
  adcpErrorToTypedError,
  useIdempotencyKey,
  redactIdempotencyKey,
  type IdempotencyCapabilities,
} from '@adcp/client';

const ttl = await client.getIdempotencyReplayTtlSeconds(); // throws on non-compliant v3
\`\`\`

## Not a breaking change

\`TaskResult.errorInstance\` is additive — existing code switching on \`adcpError.code\` still works. The new method only throws when callers explicitly ask for it against a non-compliant seller.

## Test plan

- [x] \`npm run build:lib\` — clean compile
- [x] New unit tests for \`adcpErrorToTypedError\`, \`useIdempotencyKey\`, \`redactIdempotencyKey\`, \`errorInstance\` wiring through \`TaskExecutor\`, and \`getIdempotencyReplayTtlSeconds\` (fail-closed on v3, undefined on v2, pass-through on declared)
- [x] All 44 tests in \`test/lib/idempotency{,-client,-capabilities}.test.js\` pass
- [x] Full \`npm test\` matches baseline (governance-e2e pre-existing fails; no new regressions)
- [x] \`npx eslint\` clean for the touched files (no new warnings introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)