### PR TITLE
feat(auth): adcp diagnose-auth + OAuth introspection utilities

### DIFF
--- a/.changeset/oauth-diagnostic-utilities.md
+++ b/.changeset/oauth-diagnostic-utilities.md
@@ -1,0 +1,24 @@
+---
+'@adcp/client': minor
+---
+
+OAuth DX: `adcp diagnose-auth` + introspection utilities.
+
+Debugging an OAuth misconfiguration against an MCP agent previously took hours of manual wire-level probing. These utilities collapse that into a single command with ranked hypotheses — and expose the underlying primitives so consumers can introspect the handshake themselves.
+
+**New CLI**
+
+- `adcp diagnose-auth <alias|url>` — end-to-end diagnostic that probes RFC 9728 protected-resource metadata, RFC 8414 authorization-server metadata, decodes the saved access token, optionally attempts a refresh with a `resource` indicator (RFC 8707), and calls `tools/list` + a tool on the agent. Emits ranked hypotheses (H1 resource-URL mismatch, H2 refresh grant ignores `resource`, H4 401 without `WWW-Authenticate`, H5 token-audience mismatch, H6 agent accepts token but doesn't validate audience).
+- `--json` for structured output, `--skip-refresh` / `--skip-tool-call` for read-only runs, `--tool NAME` to override the probe tool.
+
+**New library exports (from `@adcp/client` and `@adcp/client/auth`)**
+
+- `runAuthDiagnosis(agent, options)` — programmatic access to the diagnosis runner; returns `AuthDiagnosisReport` with per-step HTTP captures and ranked hypotheses.
+- `parseWWWAuthenticate(header)` — parse an RFC 9110 / RFC 6750 challenge and surface `realm`, `error`, `error_description`, `scope`, and the RFC 9728 `resource_metadata` URL.
+- `decodeAccessTokenClaims(token)` — unsigned JWT claim decoder for diagnostics. Returns `{ header, claims, signature }` or `null` for opaque tokens. Does not verify the signature.
+- `validateTokenAudience(token, expectedResource)` — checks whether the `aud` claim matches an expected resource URL with URL normalization. Returns `{ ok, reason, actualAudience }`.
+- `InvalidTokenError`, `InsufficientScopeError` — re-exported from `@modelcontextprotocol/sdk/server/auth/errors.js` so consumers can discriminate 401 causes with `instanceof` rather than string-matching error messages.
+
+**Bugfix**
+
+- `ssrfSafeFetch` now handles undici's `lookup` callback correctly when it's called with `{ all: true }` (undici's default on Node 22+ for HTTPS targets). The previous scalar-only callback path caused "Invalid IP address: undefined" errors on every external HTTPS probe.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -707,6 +707,7 @@ USAGE:
 COMMANDS:
   storyboard <subcommand>     Test agent flows (run, list, show, step)
   check-network               Validate managed publisher network deployment
+  diagnose-auth <alias|url>   Diagnose OAuth handshake with ranked hypotheses
   comply <agent> [options]    DEPRECATED — use "storyboard run" instead
   test <agent> [scenario]     Run individual test scenarios (legacy)
   registry <command>          Brand/property registry lookups
@@ -1446,6 +1447,220 @@ EXAMPLES:
   }
 }
 
+// ────────────────────────────────────────────────────────────
+// diagnose-auth command
+// ────────────────────────────────────────────────────────────
+
+async function handleDiagnoseAuthCommand(args) {
+  if (args.includes('--help') || args.includes('-h') || args.length === 0) {
+    console.log(`
+Diagnose the OAuth handshake for a saved agent or URL.
+
+Use this when: tools/call returns 401/403; a saved token has stopped working;
+a refresh succeeds but the next call fails; or you're not sure whether the
+agent or your client is at fault.
+
+Probes the RFC 9728 protected-resource metadata, RFC 8414 auth-server metadata,
+decodes the saved access token, optionally attempts a refresh with resource
+indicator (RFC 8707), and calls tools/list + a tool on the agent. Reports
+ranked hypotheses about what's likely wrong.
+
+USAGE:
+  adcp diagnose-auth <alias|url> [options]
+
+OPTIONS:
+  --json              Emit the full structured report as JSON
+  --allow-http        Allow http:// and private-IP targets (dev loops only)
+  --skip-refresh      Do not attempt a token refresh
+  --skip-tool-call    Do not attempt the authenticated tool_call probe
+  --tool NAME         Tool to exercise in the tool_call probe (default: get_products)
+  --include-tokens    Include raw access/refresh tokens in JSON output (default: redacted)
+  --help, -h          Show this help
+
+EXIT CODES:
+  0   No likely failures identified
+  1   At least one hypothesis flagged as 'likely'
+  2   Usage error (missing arg, invalid flag)
+
+EXAMPLES:
+  adcp diagnose-auth myagent
+  adcp diagnose-auth myagent --json > diagnosis.json
+  adcp diagnose-auth https://agent.example.com/mcp --allow-http
+`);
+    return;
+  }
+
+  const jsonOutput = args.includes('--json');
+  const allowPrivateIp = args.includes('--allow-http');
+  const skipRefresh = args.includes('--skip-refresh');
+  const skipToolCall = args.includes('--skip-tool-call');
+  const includeTokens = args.includes('--include-tokens');
+  const toolIndex = args.indexOf('--tool');
+  let probeToolName;
+  if (toolIndex !== -1) {
+    const value = args[toolIndex + 1];
+    if (!value || value.startsWith('--')) {
+      console.error('ERROR: --tool requires a tool name\n');
+      process.exit(2);
+    }
+    probeToolName = value;
+  }
+
+  const positional = args.filter((a, i) => {
+    if (a.startsWith('--')) return false;
+    if (i > 0 && args[i - 1] === '--tool') return false;
+    return true;
+  });
+  const target = positional[0];
+  if (!target) {
+    console.error('ERROR: diagnose-auth requires an alias or URL\n');
+    console.error('Run "adcp diagnose-auth --help" for usage');
+    process.exit(2);
+  }
+
+  // Resolve the agent config (alias, built-in, or bare URL). Protocol is fixed
+  // to MCP because diagnose-auth exercises MCP-specific wire behavior.
+  let agentConfig;
+  if (BUILT_IN_AGENTS[target]) {
+    const builtIn = BUILT_IN_AGENTS[target];
+    agentConfig = {
+      id: target,
+      name: target,
+      agent_uri: builtIn.url,
+      protocol: builtIn.protocol || 'mcp',
+      auth_token: builtIn.auth_token,
+    };
+  } else if (isAlias(target)) {
+    const saved = getAgent(target);
+    agentConfig = {
+      id: target,
+      name: target,
+      agent_uri: saved.url,
+      protocol: saved.protocol || 'mcp',
+      oauth_tokens: saved.oauth_tokens,
+      oauth_client: saved.oauth_client,
+      auth_token: saved.auth_token,
+    };
+  } else if (target.startsWith('http://') || target.startsWith('https://')) {
+    agentConfig = {
+      id: target,
+      name: target,
+      agent_uri: target,
+      protocol: 'mcp',
+    };
+  } else {
+    console.error(`ERROR: '${target}' is not a valid alias or URL\n`);
+    process.exit(2);
+  }
+
+  const { runAuthDiagnosis } = require('../dist/lib/auth/oauth/index.js');
+  const report = await runAuthDiagnosis(agentConfig, {
+    allowPrivateIp,
+    skipRefresh,
+    skipToolCall,
+    probeToolName,
+    includeTokens,
+  });
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(report, null, 2));
+    process.exit(hasLikelyHypothesis(report) ? 1 : 0);
+  }
+
+  renderDiagnosisReport(report);
+  process.exit(hasLikelyHypothesis(report) ? 1 : 0);
+}
+
+function hasLikelyHypothesis(report) {
+  return report.hypotheses.some(h => h.verdict === 'likely');
+}
+
+const STEP_LABELS = {
+  probe_protected_resource_metadata: 'RFC 9728 protected-resource metadata',
+  probe_authorization_server_metadata: 'RFC 8414 authorization-server metadata',
+  decode_current_token: 'Decode current access token',
+  token_refresh_attempt: 'Refresh grant (RFC 8707 `resource`)',
+  decode_refreshed_token: 'Decode refreshed access token',
+  list_tools_probe: 'Unauthenticated tools/list probe',
+  tool_call_probe: 'Authenticated tool_call probe',
+};
+
+function renderDiagnosisReport(report) {
+  console.log(`\n🔍 OAuth Diagnosis — ${report.agentUrl}`);
+  if (report.aliasId && report.aliasId !== report.agentUrl) {
+    console.log(`   Alias: ${report.aliasId}`);
+  }
+  console.log(`   Generated: ${report.generatedAt}\n`);
+
+  console.log(`WIRE STEPS`);
+  for (const step of report.steps) {
+    const label = STEP_LABELS[step.name] || step.name;
+    const prefix = `  • ${label}`;
+    if (step.error) {
+      console.log(`${prefix}  ↳ skipped: ${step.error}`);
+      continue;
+    }
+    if (step.http) {
+      const statusBadge = step.http.status === 0 ? 'ERR' : `HTTP ${step.http.status}`;
+      console.log(`${prefix}  ↳ ${step.http.method} ${step.http.url}  ${statusBadge}`);
+      if (step.http.error) console.log(`      error: ${step.http.error}`);
+      const wwwAuth = step.http.headers['www-authenticate'];
+      if (wwwAuth) console.log(`      WWW-Authenticate: ${wwwAuth}`);
+    } else if (step.decodedToken) {
+      const audClaim = step.decodedToken.claims.aud;
+      const aud = audClaim === undefined ? '(missing)' : JSON.stringify(audClaim);
+      const iss = step.decodedToken.claims.iss ?? '(missing)';
+      const exp = step.decodedToken.claims.exp;
+      const expStr = exp ? new Date(exp * 1000).toISOString() : '(missing)';
+      console.log(`${prefix}  ↳ JWT: iss=${iss}  aud=${aud}  exp=${expStr}`);
+    } else {
+      console.log(`${prefix}  ↳ (no token / opaque token)`);
+    }
+    if (step.notes) {
+      for (const note of step.notes) console.log(`      note: ${note}`);
+    }
+  }
+
+  console.log(`\nHYPOTHESES (ranked)`);
+  for (const h of report.hypotheses) {
+    const badge = formatVerdict(h.verdict);
+    const id = h.id.padEnd(3);
+    console.log(`\n  ${id} ${badge}  ${h.title}`);
+    console.log(`       ${h.summary}`);
+    for (const ev of h.evidence) console.log(`       · ${ev}`);
+  }
+
+  const likely = report.hypotheses.filter(h => h.verdict === 'likely');
+  if (likely.length === 0) {
+    console.log(`\n✅ No likely failures identified.\n`);
+  } else {
+    console.log(`\n⚠️  ${likely.length} likely issue(s) identified.\n`);
+    console.log(`NEXT STEPS`);
+    for (const h of likely) {
+      const fix = h.evidence.find(e => e.startsWith('Fix:'));
+      if (fix) {
+        console.log(`  ${h.id}: ${fix.replace(/^Fix:\s*/, '')}`);
+      } else {
+        console.log(`  ${h.id}: ${h.summary}`);
+      }
+    }
+    console.log();
+  }
+}
+
+function formatVerdict(verdict) {
+  switch (verdict) {
+    case 'likely':
+      return '[likely]   ';
+    case 'possible':
+      return '[possible] ';
+    case 'ruled_out':
+      return '[ruled-out]';
+    default:
+      return '[n/a]      ';
+  }
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -1478,6 +1693,11 @@ async function main() {
   if (args[0] === 'signing') {
     const { handleSigningCommand } = require('./adcp-signing.js');
     await handleSigningCommand(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'diagnose-auth') {
+    await handleDiagnoseAuthCommand(args.slice(1));
     return;
   }
 

--- a/src/lib/auth/oauth/diagnose.ts
+++ b/src/lib/auth/oauth/diagnose.ts
@@ -1,0 +1,787 @@
+/**
+ * `adcp diagnose-auth` — structured OAuth handshake diagnostics.
+ *
+ * Performs an end-to-end trace of the OAuth flow for a single MCP agent and
+ * emits a structured {@link AuthDiagnosisReport} with wire-level HTTP captures,
+ * decoded token claims, and ranked hypotheses about what might be wrong.
+ *
+ * Designed for incident diagnosis, not continuous monitoring — each run does
+ * a full round-trip including (optionally) a token refresh and a `tools/call`
+ * attempt, so don't call this in a tight loop.
+ *
+ * The runner is decoupled from the CLI so library consumers can invoke it
+ * programmatically (e.g. from a monitoring agent or a test-controller fixture)
+ * and render their own output.
+ */
+import { ssrfSafeFetch, decodeBodyAsJsonOrText, SsrfRefusedError } from '../../net';
+import type { AgentConfig } from './types';
+import { decodeAccessTokenClaims, parseWWWAuthenticate, validateTokenAudience } from './diagnostics';
+import type { DecodedAccessToken } from './diagnostics';
+
+/**
+ * Options for {@link runAuthDiagnosis}. Most callers pass an `AgentConfig` and
+ * accept the defaults.
+ */
+export interface DiagnoseOptions {
+  /** Allow http:// and private-IP probe targets. Default false. */
+  allowPrivateIp?: boolean;
+  /** Skip the `tools/call` probe (e.g. if the agent doesn't expose a no-op tool). */
+  skipToolCall?: boolean;
+  /**
+   * Name of the tool to exercise in the `tools/call` probe. Default: `get_products`.
+   * This default is AdCP-specific; for non-AdCP MCP agents, pass a tool name that exists.
+   */
+  probeToolName?: string;
+  /** Arguments to send with the probe tool call. Default: `{ brief: 'diagnose-auth probe' }`. */
+  probeToolArgs?: Record<string, unknown>;
+  /** Skip the token-refresh attempt even when a refresh_token is available. */
+  skipRefresh?: boolean;
+  /** Replace the default timeout for individual HTTP probes (ms). Default inherits from ssrfSafeFetch (10s). */
+  timeoutMs?: number;
+  /**
+   * Include raw access_token / refresh_token / id_token values in the report.
+   * Default false — tokens are replaced with `<redacted length=N>` markers so
+   * that `--json` output is safe to paste into bug reports and log aggregators.
+   */
+  includeTokens?: boolean;
+}
+
+/** Wire-level capture of a single HTTP probe. */
+export interface HttpCapture {
+  url: string;
+  method: string;
+  /** 0 if the request never left the client (DNS failure, SSRF refusal, …). */
+  status: number;
+  /** Response headers with lowercased keys. */
+  headers: Record<string, string>;
+  /** Parsed JSON body if `content-type` is JSON, raw text otherwise, or `null` on error. */
+  body: unknown;
+  /** Client-side error message, if any. */
+  error?: string;
+}
+
+/** One step of the diagnosis, in execution order. */
+export interface DiagnosisStep {
+  name:
+    | 'probe_protected_resource_metadata'
+    | 'probe_authorization_server_metadata'
+    | 'decode_current_token'
+    | 'token_refresh_attempt'
+    | 'decode_refreshed_token'
+    | 'list_tools_probe'
+    | 'tool_call_probe';
+  /** Present for HTTP steps. */
+  http?: HttpCapture;
+  /** Present for decode steps. Claims are unverified. */
+  decodedToken?: DecodedAccessToken | null;
+  /** Free-form notes attached by the step for hypothesis ranking. */
+  notes?: string[];
+  /** Step-level error (distinct from `http.error` — set when the step was skipped or could not run). */
+  error?: string;
+}
+
+/** Rank verdict for a hypothesis. Ordered most-to-least actionable. */
+export type HypothesisVerdict = 'likely' | 'possible' | 'ruled_out' | 'not_observed';
+
+/** One ranked hypothesis about what might be wrong. */
+export interface Hypothesis {
+  /**
+   * Stable ID. Currently `H1`, `H2`, `H4`, `H5`, `H6` — `H3` (session ID handling)
+   * is reserved for a future addition. Downstream consumers should treat this as
+   * an opaque string rather than exhaustively switching on it.
+   */
+  id: string;
+  /** Short human-readable title. */
+  title: string;
+  /** One-line summary, tailored with evidence from this run. */
+  summary: string;
+  verdict: HypothesisVerdict;
+  /** Supporting evidence extracted from the steps above. */
+  evidence: string[];
+}
+
+/**
+ * Report schema version. Bumped when breaking changes to the shape of
+ * {@link AuthDiagnosisReport} land. Dashboards and downstream consumers should
+ * check this before relying on specific fields.
+ */
+export const AUTH_DIAGNOSIS_SCHEMA_VERSION = 1 as const;
+
+/** Full diagnosis report returned by {@link runAuthDiagnosis}. */
+export interface AuthDiagnosisReport {
+  /** See {@link AUTH_DIAGNOSIS_SCHEMA_VERSION}. */
+  schemaVersion: typeof AUTH_DIAGNOSIS_SCHEMA_VERSION;
+  /** Agent URL under test. */
+  agentUrl: string;
+  /** Alias from saved config, if one was provided. */
+  aliasId?: string;
+  /** Per-step wire captures, in execution order. */
+  steps: DiagnosisStep[];
+  /** Ranked hypotheses — `likely` first, then `possible`, then `ruled_out`. */
+  hypotheses: Hypothesis[];
+  /** Report generation timestamp (ISO-8601, UTC). */
+  generatedAt: string;
+}
+
+/**
+ * Run the full diagnosis. Pass an agent config with (optionally) saved
+ * `oauth_tokens` to exercise a realistic handshake. Returns a structured
+ * report — rendering is the caller's job (CLI renders a text summary;
+ * programmatic consumers typically serialize to JSON).
+ */
+export async function runAuthDiagnosis(
+  agent: AgentConfig,
+  options: DiagnoseOptions = {}
+): Promise<AuthDiagnosisReport> {
+  const steps: DiagnosisStep[] = [];
+  const agentUrl = agent.agent_uri;
+  const allowPrivateIp = options.allowPrivateIp ?? false;
+  const includeTokens = options.includeTokens ?? false;
+  // Per-invocation RPC id counter so concurrent `runAuthDiagnosis` calls don't share state.
+  let rpcId = 0;
+  const nextRpcId = () => ++rpcId;
+
+  // Step 1: protected-resource metadata (RFC 9728)
+  const prmCapture = await probeProtectedResourceMetadata(agentUrl, allowPrivateIp, options.timeoutMs);
+  steps.push({ name: 'probe_protected_resource_metadata', http: prmCapture });
+
+  // Step 2: authorization-server metadata (RFC 8414) — derives issuer from PRM
+  const asCapture = await probeAuthorizationServerMetadata(prmCapture, allowPrivateIp, options.timeoutMs);
+  steps.push({ name: 'probe_authorization_server_metadata', http: asCapture });
+
+  // Step 3: decode the current access token (if saved)
+  const currentToken = agent.oauth_tokens?.access_token;
+  const currentDecoded = currentToken ? decodeAccessTokenClaims(currentToken) : null;
+  steps.push({
+    name: 'decode_current_token',
+    decodedToken: currentDecoded,
+    notes: currentToken
+      ? currentDecoded
+        ? [`Decoded JWT with claims: ${Object.keys(currentDecoded.claims).join(', ')}`]
+        : ['Saved access_token is opaque (not a JWT) — `aud` inspection is not possible']
+      : ['No saved access_token'],
+  });
+
+  // Step 4: token refresh (only if we have a refresh_token AND the user didn't skip)
+  let refreshedAccessToken: string | undefined;
+  let refreshedDecoded: DecodedAccessToken | null = null;
+  if (!options.skipRefresh && agent.oauth_tokens?.refresh_token) {
+    const tokenEndpoint = extractTokenEndpoint(asCapture);
+    const clientId = agent.oauth_client?.client_id;
+    // Always request the agent URL as the resource indicator, even if PRM
+    // advertises something different — a well-behaved client sends what it
+    // actually wants to talk to, and using PRM.resource here would cause H2
+    // to fire spuriously when the real problem is H1.
+    const resource = agentUrl;
+    if (!tokenEndpoint) {
+      steps.push({
+        name: 'token_refresh_attempt',
+        error: 'No token_endpoint available from authorization-server metadata — cannot attempt refresh',
+      });
+    } else if (!clientId) {
+      steps.push({
+        name: 'token_refresh_attempt',
+        error: 'No saved oauth_client.client_id — cannot attempt refresh without it',
+      });
+    } else {
+      const refreshCapture = await attemptTokenRefresh({
+        tokenEndpoint,
+        clientId,
+        clientSecret: agent.oauth_client?.client_secret,
+        refreshToken: agent.oauth_tokens.refresh_token,
+        resource,
+        allowPrivateIp,
+        timeoutMs: options.timeoutMs,
+      });
+      // Capture the raw access_token string BEFORE redaction so we can still
+      // decode claims for H2 analysis. The report body itself uses the
+      // redacted capture unless includeTokens is set.
+      if (refreshCapture.status === 200 && refreshCapture.body && typeof refreshCapture.body === 'object') {
+        const body = refreshCapture.body as Record<string, unknown>;
+        if (typeof body.access_token === 'string') {
+          refreshedAccessToken = body.access_token;
+          refreshedDecoded = decodeAccessTokenClaims(refreshedAccessToken);
+        }
+      }
+      steps.push({
+        name: 'token_refresh_attempt',
+        http: includeTokens ? refreshCapture : redactTokenMaterial(refreshCapture),
+      });
+      if (refreshedAccessToken) {
+        steps.push({
+          name: 'decode_refreshed_token',
+          decodedToken: refreshedDecoded,
+          notes: refreshedDecoded
+            ? [`Decoded refreshed JWT with claims: ${Object.keys(refreshedDecoded.claims).join(', ')}`]
+            : ['Refreshed access_token is opaque (not a JWT)'],
+        });
+      }
+    }
+  }
+
+  // Step 5: unauthenticated list_tools to surface 401 + WWW-Authenticate
+  const listToolsCapture = await probeListTools(agentUrl, undefined, allowPrivateIp, options.timeoutMs, nextRpcId);
+  steps.push({ name: 'list_tools_probe', http: listToolsCapture });
+
+  // Step 6: authenticated tool_call (skip if no token or if caller opts out)
+  const tokenForCall = refreshedAccessToken ?? currentToken;
+  if (!options.skipToolCall && tokenForCall) {
+    const toolName = options.probeToolName ?? 'get_products';
+    const args = options.probeToolArgs ?? { brief: 'diagnose-auth probe' };
+    const toolCapture = await probeToolCall(
+      agentUrl,
+      tokenForCall,
+      toolName,
+      args,
+      allowPrivateIp,
+      options.timeoutMs,
+      nextRpcId
+    );
+    steps.push({ name: 'tool_call_probe', http: toolCapture });
+  } else if (!tokenForCall) {
+    steps.push({
+      name: 'tool_call_probe',
+      error: 'No access_token available — skipping authenticated tool call probe',
+    });
+  }
+
+  const hypotheses = rankHypotheses({
+    agentUrl,
+    steps,
+    currentDecoded,
+    refreshedDecoded,
+  });
+
+  return {
+    schemaVersion: AUTH_DIAGNOSIS_SCHEMA_VERSION,
+    agentUrl,
+    aliasId: agent.id,
+    steps,
+    hypotheses,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Probes
+// ---------------------------------------------------------------------------
+
+async function probeProtectedResourceMetadata(
+  agentUrl: string,
+  allowPrivateIp: boolean,
+  timeoutMs?: number
+): Promise<HttpCapture> {
+  const u = new URL(agentUrl);
+  const url = `${u.origin}/.well-known/oauth-protected-resource${u.pathname}`;
+  return httpGet(url, allowPrivateIp, timeoutMs);
+}
+
+async function probeAuthorizationServerMetadata(
+  prm: HttpCapture,
+  allowPrivateIp: boolean,
+  timeoutMs?: number
+): Promise<HttpCapture> {
+  const issuer = extractIssuer(prm);
+  if (!issuer) {
+    return {
+      url: '',
+      method: 'GET',
+      status: 0,
+      headers: {},
+      body: null,
+      error: 'protected-resource metadata did not yield an authorization_servers[0] entry',
+    };
+  }
+  const url = `${issuer.replace(/\/$/, '')}/.well-known/oauth-authorization-server`;
+  return httpGet(url, allowPrivateIp, timeoutMs);
+}
+
+async function probeListTools(
+  agentUrl: string,
+  bearerToken: string | undefined,
+  allowPrivateIp: boolean,
+  timeoutMs: number | undefined,
+  nextRpcId: () => number
+): Promise<HttpCapture> {
+  return httpJsonRpc(agentUrl, { method: 'tools/list' }, bearerToken, allowPrivateIp, timeoutMs, nextRpcId);
+}
+
+async function probeToolCall(
+  agentUrl: string,
+  bearerToken: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  allowPrivateIp: boolean,
+  timeoutMs: number | undefined,
+  nextRpcId: () => number
+): Promise<HttpCapture> {
+  return httpJsonRpc(
+    agentUrl,
+    { method: 'tools/call', params: { name: toolName, arguments: args } },
+    bearerToken,
+    allowPrivateIp,
+    timeoutMs,
+    nextRpcId
+  );
+}
+
+async function attemptTokenRefresh(options: {
+  tokenEndpoint: string;
+  clientId: string;
+  clientSecret?: string;
+  refreshToken: string;
+  resource: string;
+  allowPrivateIp: boolean;
+  timeoutMs?: number;
+}): Promise<HttpCapture> {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: options.refreshToken,
+    client_id: options.clientId,
+    // RFC 8707: explicitly request a token for this resource. If the AS
+    // ignores this (H2), the refreshed token's aud claim will still be wrong.
+    resource: options.resource,
+  });
+  if (options.clientSecret) body.set('client_secret', options.clientSecret);
+
+  return httpFormPost(options.tokenEndpoint, body, options.allowPrivateIp, options.timeoutMs);
+}
+
+async function httpGet(url: string, allowPrivateIp: boolean, timeoutMs?: number): Promise<HttpCapture> {
+  try {
+    const res = await ssrfSafeFetch(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      allowPrivateIp,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+    return {
+      url,
+      method: 'GET',
+      status: res.status,
+      headers: res.headers,
+      body: decodeBodyAsJsonOrText(res.body, res.headers['content-type']),
+    };
+  } catch (err) {
+    return { url, method: 'GET', status: 0, headers: {}, body: null, error: formatError(err) };
+  }
+}
+
+async function httpJsonRpc(
+  url: string,
+  rpc: { method: string; params?: unknown },
+  bearerToken: string | undefined,
+  allowPrivateIp: boolean,
+  timeoutMs: number | undefined,
+  nextRpcId: () => number
+): Promise<HttpCapture> {
+  const body = JSON.stringify({ jsonrpc: '2.0', id: nextRpcId(), ...rpc });
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json',
+  };
+  if (bearerToken) headers.authorization = `Bearer ${bearerToken}`;
+
+  try {
+    const res = await ssrfSafeFetch(url, {
+      method: 'POST',
+      headers,
+      body,
+      allowPrivateIp,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+    return {
+      url,
+      method: 'POST',
+      status: res.status,
+      headers: res.headers,
+      body: decodeBodyAsJsonOrText(res.body, res.headers['content-type']),
+    };
+  } catch (err) {
+    return { url, method: 'POST', status: 0, headers: {}, body: null, error: formatError(err) };
+  }
+}
+
+async function httpFormPost(
+  url: string,
+  body: URLSearchParams,
+  allowPrivateIp: boolean,
+  timeoutMs?: number
+): Promise<HttpCapture> {
+  try {
+    const res = await ssrfSafeFetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        accept: 'application/json',
+      },
+      body: body.toString(),
+      allowPrivateIp,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+    return {
+      url,
+      method: 'POST',
+      status: res.status,
+      headers: res.headers,
+      body: decodeBodyAsJsonOrText(res.body, res.headers['content-type']),
+    };
+  } catch (err) {
+    return { url, method: 'POST', status: 0, headers: {}, body: null, error: formatError(err) };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hypothesis ranking
+// ---------------------------------------------------------------------------
+
+interface RankInput {
+  agentUrl: string;
+  steps: DiagnosisStep[];
+  currentDecoded: DecodedAccessToken | null;
+  refreshedDecoded: DecodedAccessToken | null;
+}
+
+function rankHypotheses(input: RankInput): Hypothesis[] {
+  const out: Hypothesis[] = [];
+  const prmStep = input.steps.find(s => s.name === 'probe_protected_resource_metadata');
+  const asStep = input.steps.find(s => s.name === 'probe_authorization_server_metadata');
+  const listStep = input.steps.find(s => s.name === 'list_tools_probe');
+  const toolStep = input.steps.find(s => s.name === 'tool_call_probe');
+  const refreshStep = input.steps.find(s => s.name === 'token_refresh_attempt');
+
+  // H1: Resource URL mismatch between well-known and agent host
+  out.push(rankH1(input.agentUrl, prmStep));
+
+  // H2: Refresh grant missing `resource` parameter (RFC 8707)
+  out.push(rankH2(input.agentUrl, refreshStep, input.refreshedDecoded));
+
+  // H4: Agent endpoint returns 401 with no WWW-Authenticate (RFC 6750 violation)
+  out.push(rankH4(listStep, toolStep));
+
+  // H5: Token `aud` claim missing or doesn't match agent URL
+  out.push(rankH5(input.agentUrl, input.currentDecoded, prmStep));
+
+  // H6: Agent endpoint doesn't validate audience (accepts token but ignores it)
+  out.push(rankH6(input.agentUrl, input.currentDecoded, toolStep));
+
+  // Order: likely > possible > ruled_out > not_observed
+  const order: Record<HypothesisVerdict, number> = {
+    likely: 0,
+    possible: 1,
+    ruled_out: 2,
+    not_observed: 3,
+  };
+  return out.sort((a, b) => order[a.verdict] - order[b.verdict]);
+}
+
+function rankH1(agentUrl: string, prmStep?: DiagnosisStep): Hypothesis {
+  const base: Hypothesis = {
+    id: 'H1',
+    title: 'Resource URL mismatch between well-known and agent host',
+    summary: '',
+    verdict: 'not_observed',
+    evidence: [],
+  };
+  if (
+    !prmStep?.http ||
+    prmStep.http.status !== 200 ||
+    typeof prmStep.http.body !== 'object' ||
+    prmStep.http.body === null
+  ) {
+    base.verdict = 'not_observed';
+    base.summary = 'No protected-resource metadata was retrieved — cannot compare `resource` to agent URL';
+    return base;
+  }
+  const advertised = (prmStep.http.body as { resource?: unknown }).resource;
+  if (typeof advertised !== 'string') {
+    base.verdict = 'not_observed';
+    base.summary = 'protected-resource metadata has no `resource` field';
+    return base;
+  }
+
+  const normAdvertised = normalizeForCompare(advertised);
+  const normAgent = normalizeForCompare(agentUrl);
+  if (normAdvertised === normAgent) {
+    base.verdict = 'ruled_out';
+    base.summary = `Advertised resource matches agent URL (${advertised})`;
+  } else {
+    base.verdict = 'likely';
+    base.summary = `Advertised resource "${advertised}" does not match agent URL "${agentUrl}"`;
+    base.evidence = [
+      `PRM resource: ${advertised}`,
+      `Agent URL: ${agentUrl}`,
+      'Fix: align the agent server config so `.well-known/oauth-protected-resource` advertises the same origin+path as the agent endpoint itself.',
+    ];
+  }
+  return base;
+}
+
+function rankH2(
+  agentUrl: string,
+  refreshStep: DiagnosisStep | undefined,
+  refreshedDecoded: DecodedAccessToken | null
+): Hypothesis {
+  const base: Hypothesis = {
+    id: 'H2',
+    title: 'Refresh grant missing `resource` parameter (RFC 8707)',
+    summary: '',
+    verdict: 'not_observed',
+    evidence: [],
+  };
+  if (!refreshStep) {
+    base.summary = 'No token refresh was attempted (skipped, missing refresh_token, or missing client registration)';
+    return base;
+  }
+  if (refreshStep.error) {
+    base.summary = `Token refresh could not run: ${refreshStep.error}`;
+    return base;
+  }
+  if (!refreshStep.http || refreshStep.http.status !== 200) {
+    base.summary = `Token refresh returned HTTP ${refreshStep.http?.status ?? 0}; cannot evaluate aud handling`;
+    base.evidence = refreshStep.http ? [`Body: ${safeStringify(refreshStep.http.body)}`] : [];
+    return base;
+  }
+  if (!refreshedDecoded) {
+    base.verdict = 'possible';
+    base.summary = 'Refreshed token is opaque — audience cannot be inspected from the wire';
+    base.evidence = [
+      'If this agent is a public resource server, an opaque token should still carry `aud` when inspected via introspection.',
+    ];
+    return base;
+  }
+  const result = validateTokenAudience(jwtFromDecoded(refreshedDecoded), agentUrl);
+  if (result.ok) {
+    base.verdict = 'ruled_out';
+    base.summary = 'Refreshed token `aud` claim matches the expected resource — AS honors RFC 8707 `resource`';
+    return base;
+  }
+  base.verdict = 'likely';
+  base.summary = 'We asked the AS to refresh with `resource=<agent-url>` but the new token `aud` still does not match';
+  base.evidence = [
+    `Expected aud: ${agentUrl}`,
+    `Actual aud: ${safeStringify(result.actualAudience)}`,
+    'Fix: update the AS to honor RFC 8707 `resource` and emit the corresponding `aud` claim on refresh_token grants.',
+  ];
+  return base;
+}
+
+function rankH4(listStep?: DiagnosisStep, toolStep?: DiagnosisStep): Hypothesis {
+  const base: Hypothesis = {
+    id: 'H4',
+    title: 'Agent endpoint returns 401 with no `WWW-Authenticate` (RFC 6750 violation)',
+    summary: '',
+    verdict: 'not_observed',
+    evidence: [],
+  };
+  const unauthed = listStep?.http;
+  const authed = toolStep?.http;
+  const rfc6750Offender = (cap: HttpCapture | undefined) =>
+    cap && cap.status === 401 && !cap.headers['www-authenticate'];
+
+  if (rfc6750Offender(unauthed) || rfc6750Offender(authed)) {
+    base.verdict = 'likely';
+    base.summary = 'Agent returned 401 without a `WWW-Authenticate` header — breaks RFC 6750 §3 and RFC 9728 discovery';
+    base.evidence = [];
+    if (rfc6750Offender(unauthed))
+      base.evidence.push(`unauthenticated tools/list: ${unauthed!.status} (no WWW-Authenticate)`);
+    if (rfc6750Offender(authed))
+      base.evidence.push(`authenticated tools/call: ${authed!.status} (no WWW-Authenticate)`);
+    base.evidence.push('Fix: emit `WWW-Authenticate: Bearer error="…", resource_metadata="…"` on 401 responses.');
+    return base;
+  }
+
+  if (
+    (unauthed?.status === 401 && unauthed.headers['www-authenticate']) ||
+    (authed?.status === 401 && authed.headers['www-authenticate'])
+  ) {
+    base.verdict = 'ruled_out';
+    base.summary = 'Agent correctly emits a WWW-Authenticate challenge on 401';
+    const challenge = parseWWWAuthenticate(
+      unauthed?.headers['www-authenticate'] ?? authed?.headers['www-authenticate']
+    );
+    if (challenge) {
+      base.evidence = [
+        `Scheme: ${challenge.scheme}`,
+        ...(challenge.error ? [`error: ${challenge.error}`] : []),
+        ...(challenge.resource_metadata ? [`resource_metadata: ${challenge.resource_metadata}`] : []),
+      ];
+    }
+    return base;
+  }
+
+  base.summary = 'No 401 was observed on either probe — cannot evaluate challenge format';
+  return base;
+}
+
+function rankH5(
+  agentUrl: string,
+  currentDecoded: DecodedAccessToken | null,
+  prmStep: DiagnosisStep | undefined
+): Hypothesis {
+  const base: Hypothesis = {
+    id: 'H5',
+    title: 'Token `aud` claim missing or does not match agent URL',
+    summary: '',
+    verdict: 'not_observed',
+    evidence: [],
+  };
+  if (!currentDecoded) {
+    base.summary = 'No saved access token was decodable — cannot inspect `aud`';
+    return base;
+  }
+  // Prefer the advertised resource (PRM) when available, fall back to agent URL.
+  const prmResource =
+    prmStep?.http?.body && typeof (prmStep.http.body as { resource?: unknown }).resource === 'string'
+      ? (prmStep.http.body as { resource: string }).resource
+      : undefined;
+  const expected = prmResource ?? agentUrl;
+  const prmDiffersFromAgent =
+    prmResource !== undefined && normalizeForCompare(prmResource) !== normalizeForCompare(agentUrl);
+  const result = validateTokenAudience(jwtFromDecoded(currentDecoded), expected);
+  if (result.ok) {
+    base.verdict = 'ruled_out';
+    base.summary = `Saved token \`aud\` matches expected resource (${expected})`;
+    if (prmDiffersFromAgent) {
+      base.evidence = [
+        `Compared against advertised PRM resource; agent URL differs (see H1). Token is valid for the resource the AS thinks it's protecting, not for the agent URL you configured.`,
+      ];
+    }
+    return base;
+  }
+  base.verdict = 'likely';
+  base.summary = result.reason ?? 'Saved token audience does not match expected resource';
+  base.evidence = [
+    `Expected: ${expected}${prmDiffersFromAgent ? ' (from PRM; see H1 — agent URL differs)' : ''}`,
+    `Actual aud: ${safeStringify(result.actualAudience ?? '(missing)')}`,
+    'Fix: ensure the AS sets `aud` to the resource URL on token issuance (RFC 9068 §2.2 / RFC 8707).',
+  ];
+  return base;
+}
+
+function rankH6(agentUrl: string, currentDecoded: DecodedAccessToken | null, toolStep?: DiagnosisStep): Hypothesis {
+  const base: Hypothesis = {
+    id: 'H6',
+    title: 'Agent accepts token but does not validate audience',
+    summary: '',
+    verdict: 'not_observed',
+    evidence: [],
+  };
+  if (!toolStep?.http || !currentDecoded) {
+    base.summary = 'Need both a decoded token and a tool_call probe to evaluate';
+    return base;
+  }
+  if (toolStep.http.status !== 200) {
+    base.verdict = 'ruled_out';
+    base.summary = `tool_call returned HTTP ${toolStep.http.status} — agent did not accept the token blindly`;
+    return base;
+  }
+  const audResult = validateTokenAudience(jwtFromDecoded(currentDecoded), agentUrl);
+  if (audResult.ok) {
+    base.verdict = 'ruled_out';
+    base.summary = 'Token `aud` matches agent URL and tool_call succeeded — cannot distinguish from correct behavior';
+    return base;
+  }
+  base.verdict = 'likely';
+  base.summary =
+    'tool_call succeeded with a token whose `aud` does not match the agent URL — agent is not enforcing audience';
+  base.evidence = [
+    `tool_call status: ${toolStep.http.status}`,
+    `Token aud: ${safeStringify(audResult.actualAudience ?? '(missing)')}`,
+    `Agent URL: ${agentUrl}`,
+    'Fix: have the agent reject tokens whose `aud` does not include its own resource URL (RFC 9068).',
+  ];
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractIssuer(prm: HttpCapture): string | undefined {
+  if (prm.status !== 200 || !prm.body || typeof prm.body !== 'object') return undefined;
+  const servers = (prm.body as { authorization_servers?: unknown }).authorization_servers;
+  if (!Array.isArray(servers) || typeof servers[0] !== 'string') return undefined;
+  return servers[0];
+}
+
+function extractTokenEndpoint(as: HttpCapture): string | undefined {
+  if (as.status !== 200 || !as.body || typeof as.body !== 'object') return undefined;
+  const endpoint = (as.body as { token_endpoint?: unknown }).token_endpoint;
+  return typeof endpoint === 'string' ? endpoint : undefined;
+}
+
+function extractResourceUri(prm: HttpCapture): string | undefined {
+  if (prm.status !== 200 || !prm.body || typeof prm.body !== 'object') return undefined;
+  const resource = (prm.body as { resource?: unknown }).resource;
+  return typeof resource === 'string' ? resource : undefined;
+}
+
+/** Fields in an OAuth token-endpoint response that should never leak to disk/logs. */
+const TOKEN_MATERIAL_FIELDS = new Set(['access_token', 'refresh_token', 'id_token']);
+
+/**
+ * Redact token-bearing fields from a token-endpoint capture so that `--json`
+ * output can safely be pasted into bug reports. The redacted form preserves
+ * the original length (useful for "wrong length" diagnostics) without leaking
+ * the secret. Set `includeTokens: true` on {@link DiagnoseOptions} to skip.
+ */
+function redactTokenMaterial(capture: HttpCapture): HttpCapture {
+  if (!capture.body || typeof capture.body !== 'object' || Array.isArray(capture.body)) return capture;
+  const body = capture.body as Record<string, unknown>;
+  const redacted: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) {
+    if (TOKEN_MATERIAL_FIELDS.has(k) && typeof v === 'string') {
+      redacted[k] = `<redacted length=${v.length}>`;
+    } else {
+      redacted[k] = v;
+    }
+  }
+  return { ...capture, body: redacted };
+}
+
+function normalizeForCompare(value: string): string {
+  try {
+    const u = new URL(value);
+    const port = u.port && !isDefaultPort(u.protocol, u.port) ? `:${u.port}` : '';
+    const path = u.pathname.length > 1 && u.pathname.endsWith('/') ? u.pathname.slice(0, -1) : u.pathname;
+    return `${u.protocol.toLowerCase()}//${u.hostname.toLowerCase()}${port}${path}`;
+  } catch {
+    return value;
+  }
+}
+
+function isDefaultPort(scheme: string, port: string): boolean {
+  if (scheme === 'https:' && port === '443') return true;
+  if (scheme === 'http:' && port === '80') return true;
+  return false;
+}
+
+function jwtFromDecoded(_decoded: DecodedAccessToken): string {
+  // validateTokenAudience re-decodes from a JWT string, so we round-trip.
+  // Since we already decoded this, we can't reconstruct the original signature,
+  // but the validator only cares about the claims segment — so we synthesize a
+  // three-segment token with the original claims and dummy header/signature.
+  const h = base64url(JSON.stringify(_decoded.header));
+  const c = base64url(JSON.stringify(_decoded.claims));
+  return `${h}.${c}.${_decoded.signature || 'sig'}`;
+}
+
+function base64url(input: string): string {
+  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof SsrfRefusedError) {
+    return `SSRF guard refused: ${err.code} (${err.message})`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/lib/auth/oauth/diagnose.ts
+++ b/src/lib/auth/oauth/diagnose.ts
@@ -770,7 +770,11 @@ function jwtFromDecoded(_decoded: DecodedAccessToken): string {
 function base64url(input: string): string {
   // `base64` output has at most 2 trailing `=` characters; the bounded form
   // `={0,2}$` avoids the polynomial-regex flag CodeQL raises on `=+$`.
-  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/={0,2}$/, '');
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/={0,2}$/, '');
 }
 
 function formatError(err: unknown): string {

--- a/src/lib/auth/oauth/diagnose.ts
+++ b/src/lib/auth/oauth/diagnose.ts
@@ -768,7 +768,9 @@ function jwtFromDecoded(_decoded: DecodedAccessToken): string {
 }
 
 function base64url(input: string): string {
-  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  // `base64` output has at most 2 trailing `=` characters; the bounded form
+  // `={0,2}$` avoids the polynomial-regex flag CodeQL raises on `=+$`.
+  return Buffer.from(input).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/={0,2}$/, '');
 }
 
 function formatError(err: unknown): string {

--- a/src/lib/auth/oauth/diagnose.ts
+++ b/src/lib/auth/oauth/diagnose.ts
@@ -445,7 +445,6 @@ interface RankInput {
 function rankHypotheses(input: RankInput): Hypothesis[] {
   const out: Hypothesis[] = [];
   const prmStep = input.steps.find(s => s.name === 'probe_protected_resource_metadata');
-  const asStep = input.steps.find(s => s.name === 'probe_authorization_server_metadata');
   const listStep = input.steps.find(s => s.name === 'list_tools_probe');
   const toolStep = input.steps.find(s => s.name === 'tool_call_probe');
   const refreshStep = input.steps.find(s => s.name === 'token_refresh_attempt');
@@ -709,12 +708,6 @@ function extractTokenEndpoint(as: HttpCapture): string | undefined {
   if (as.status !== 200 || !as.body || typeof as.body !== 'object') return undefined;
   const endpoint = (as.body as { token_endpoint?: unknown }).token_endpoint;
   return typeof endpoint === 'string' ? endpoint : undefined;
-}
-
-function extractResourceUri(prm: HttpCapture): string | undefined {
-  if (prm.status !== 200 || !prm.body || typeof prm.body !== 'object') return undefined;
-  const resource = (prm.body as { resource?: unknown }).resource;
-  return typeof resource === 'string' ? resource : undefined;
 }
 
 /** Fields in an OAuth token-endpoint response that should never leak to disk/logs. */

--- a/src/lib/auth/oauth/diagnostics.ts
+++ b/src/lib/auth/oauth/diagnostics.ts
@@ -1,0 +1,271 @@
+/**
+ * OAuth diagnostics utilities.
+ *
+ * Small, pure helpers used by `adcp diagnose-auth` and by consumers who want
+ * to introspect OAuth wire-level state without rolling their own parsers.
+ *
+ * None of these helpers perform cryptographic validation. `decodeAccessTokenClaims`
+ * reads a JWT without checking its signature, and `validateTokenAudience` only
+ * compares the `aud` claim — it does not verify the token is authentic.
+ */
+
+/**
+ * Parsed WWW-Authenticate challenge (RFC 9110 §11.6.1, RFC 6750, RFC 9728).
+ *
+ * Only the fields most relevant to OAuth diagnostics are surfaced; unknown
+ * auth-params are preserved under `params` so callers can inspect them.
+ */
+export interface WWWAuthenticateChallenge {
+  /** Auth-scheme token, e.g. "Bearer" or "DPoP". Always lowercased. */
+  scheme: string;
+  /** `realm` auth-param, if present. */
+  realm?: string;
+  /** `error` auth-param (RFC 6750 §3), e.g. "invalid_token". */
+  error?: string;
+  /** `error_description` auth-param (RFC 6750 §3). */
+  error_description?: string;
+  /** `scope` auth-param (RFC 6750 §3). */
+  scope?: string;
+  /** `resource_metadata` auth-param (RFC 9728 §5.3) — URL of the protected-resource metadata document. */
+  resource_metadata?: string;
+  /** All auth-params (lowercased keys), including unknown ones. */
+  params: Record<string, string>;
+}
+
+/**
+ * Parse a `WWW-Authenticate` header into its auth-scheme and parameters.
+ *
+ * Handles the single-challenge case used by MCP servers in practice: one scheme
+ * (typically `Bearer`) followed by comma-separated `key=value` or `key="value"`
+ * auth-params. Returns `null` for an empty or malformed header.
+ *
+ * Quoted-string values may contain escaped quotes (`\"`) and backslashes (`\\`),
+ * per RFC 9110 §5.6.4; these are unescaped on the way out.
+ *
+ * @example
+ * ```ts
+ * const c = parseWWWAuthenticate(
+ *   'Bearer realm="api", error="invalid_token", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"'
+ * );
+ * // c.scheme === 'bearer'
+ * // c.error === 'invalid_token'
+ * // c.resource_metadata === 'https://api.example.com/.well-known/oauth-protected-resource'
+ * ```
+ */
+export function parseWWWAuthenticate(header: string | null | undefined): WWWAuthenticateChallenge | null {
+  if (!header) return null;
+  const trimmed = header.trim();
+  if (!trimmed) return null;
+
+  // Scheme is the leading token, up to the first whitespace (or end of string for bare schemes).
+  const schemeMatch = /^([!#$%&'*+\-.^_`|~0-9A-Za-z]+)(?:\s+([\s\S]*))?$/.exec(trimmed);
+  if (!schemeMatch) return null;
+
+  const scheme = schemeMatch[1]!.toLowerCase();
+  const rest = schemeMatch[2] ?? '';
+  const params: Record<string, string> = {};
+
+  // Walk the param list, handling quoted values with backslash escapes.
+  let i = 0;
+  while (i < rest.length) {
+    // skip leading whitespace and commas
+    while (i < rest.length && (rest[i] === ' ' || rest[i] === '\t' || rest[i] === ',')) i++;
+    if (i >= rest.length) break;
+
+    // read key
+    const keyStart = i;
+    while (i < rest.length && /[!#$%&'*+\-.^_`|~0-9A-Za-z]/.test(rest[i]!)) i++;
+    const key = rest.slice(keyStart, i).toLowerCase();
+    if (!key) break;
+
+    // expect '='
+    while (i < rest.length && (rest[i] === ' ' || rest[i] === '\t')) i++;
+    if (rest[i] !== '=') {
+      // Not a key=value pair — could be a token68. Ignore and move on.
+      while (i < rest.length && rest[i] !== ',') i++;
+      continue;
+    }
+    i++; // skip '='
+    while (i < rest.length && (rest[i] === ' ' || rest[i] === '\t')) i++;
+
+    // read value: either quoted-string or token
+    let value = '';
+    if (rest[i] === '"') {
+      i++;
+      while (i < rest.length && rest[i] !== '"') {
+        if (rest[i] === '\\' && i + 1 < rest.length) {
+          value += rest[i + 1];
+          i += 2;
+        } else {
+          value += rest[i];
+          i++;
+        }
+      }
+      if (rest[i] === '"') i++;
+    } else {
+      const valStart = i;
+      while (i < rest.length && rest[i] !== ',' && rest[i] !== ' ' && rest[i] !== '\t') i++;
+      value = rest.slice(valStart, i);
+    }
+
+    params[key] = value;
+  }
+
+  return {
+    scheme,
+    realm: params.realm,
+    error: params.error,
+    error_description: params.error_description,
+    scope: params.scope,
+    resource_metadata: params.resource_metadata,
+    params,
+  };
+}
+
+/**
+ * JWT header section (first segment), decoded but unverified.
+ */
+export interface DecodedJWTHeader {
+  alg?: string;
+  typ?: string;
+  kid?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * JWT claims section (second segment), decoded but unverified.
+ *
+ * Standard registered claims (RFC 7519 §4.1) are typed; everything else
+ * flows through as `unknown`.
+ */
+export interface DecodedJWTClaims {
+  iss?: string;
+  sub?: string;
+  /** Audience — string or array of strings per RFC 7519. */
+  aud?: string | string[];
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  jti?: string;
+  scope?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Result of decoding an access token.
+ */
+export interface DecodedAccessToken {
+  header: DecodedJWTHeader;
+  claims: DecodedJWTClaims;
+  /** Raw signature segment (base64url, unverified). */
+  signature: string;
+}
+
+/**
+ * Decode a JWT access token without verifying its signature.
+ *
+ * For diagnostics only — the returned claims MUST NOT be trusted for
+ * authorization decisions. Returns `null` if the token is not a well-formed
+ * three-part JWT, or if the header/claims segments are not valid JSON.
+ *
+ * Opaque (non-JWT) tokens always return `null`, which is the expected outcome
+ * for servers that issue reference tokens rather than JWTs.
+ */
+export function decodeAccessTokenClaims(token: string | null | undefined): DecodedAccessToken | null {
+  if (!token || typeof token !== 'string') return null;
+
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+
+  try {
+    const header = JSON.parse(base64UrlDecode(parts[0]!)) as DecodedJWTHeader;
+    const claims = JSON.parse(base64UrlDecode(parts[1]!)) as DecodedJWTClaims;
+    if (typeof header !== 'object' || header === null) return null;
+    if (typeof claims !== 'object' || claims === null) return null;
+    return { header, claims, signature: parts[2]! };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Result of audience validation.
+ */
+export interface TokenAudienceResult {
+  ok: boolean;
+  /** Human-readable reason when `ok` is false. */
+  reason?: string;
+  /** The `aud` claim value actually found in the token (undefined if missing or token unparseable). */
+  actualAudience?: string | string[];
+}
+
+/**
+ * Check whether an access token's `aud` claim matches an expected resource URL.
+ *
+ * Returns `{ ok: true }` when the `aud` claim is a string equal to
+ * `expectedResource` (after URL normalization), or is an array containing
+ * such a string. Returns `{ ok: false, reason }` otherwise, including when
+ * the token is opaque (not a JWT) or has no `aud` claim.
+ *
+ * URL normalization: lowercased scheme and host, default ports (80 for http,
+ * 443 for https) stripped, trailing slash on the path stripped. Query and
+ * fragment are preserved verbatim. Non-URL audience strings are compared
+ * byte-for-byte.
+ *
+ * Defense-in-depth helper. A server that mis-issues a token with the wrong
+ * `aud` would still be accepted by the resource server; this helper flags
+ * the mismatch on the client side for diagnostics.
+ */
+export function validateTokenAudience(token: string | null | undefined, expectedResource: string): TokenAudienceResult {
+  const decoded = decodeAccessTokenClaims(token ?? undefined);
+  if (!decoded) {
+    return { ok: false, reason: 'Token is opaque or not a valid JWT; audience cannot be inspected' };
+  }
+
+  const aud = decoded.claims.aud;
+  if (aud === undefined) {
+    return { ok: false, reason: 'Token has no `aud` claim (RFC 8707 violation for resource-indicator flows)' };
+  }
+
+  const expected = normalizeResource(expectedResource);
+  const audList = Array.isArray(aud) ? aud : [aud];
+
+  for (const candidate of audList) {
+    if (typeof candidate !== 'string') continue;
+    if (normalizeResource(candidate) === expected) {
+      return { ok: true, actualAudience: aud };
+    }
+  }
+
+  return {
+    ok: false,
+    reason: `Token \`aud\` claim does not match expected resource "${expectedResource}"`,
+    actualAudience: aud,
+  };
+}
+
+function normalizeResource(value: string): string {
+  try {
+    const u = new URL(value);
+    const scheme = u.protocol.toLowerCase();
+    const host = u.hostname.toLowerCase();
+    const port = u.port && !isDefaultPort(scheme, u.port) ? `:${u.port}` : '';
+    const path = u.pathname.length > 1 && u.pathname.endsWith('/') ? u.pathname.slice(0, -1) : u.pathname;
+    return `${scheme}//${host}${port}${path}${u.search}${u.hash}`;
+  } catch {
+    return value;
+  }
+}
+
+function isDefaultPort(scheme: string, port: string): boolean {
+  if (scheme === 'https:' && port === '443') return true;
+  if (scheme === 'http:' && port === '80') return true;
+  return false;
+}
+
+function base64UrlDecode(input: string): string {
+  const padded = input.replace(/-/g, '+').replace(/_/g, '/');
+  const padLen = padded.length % 4;
+  const full = padLen ? padded + '='.repeat(4 - padLen) : padded;
+  return Buffer.from(full, 'base64').toString('utf8');
+}

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -245,3 +245,32 @@ export {
   type OAuthMetadata,
   type DiscoveryOptions,
 } from './discovery';
+
+// Diagnostics utilities — for `adcp diagnose-auth` and consumer introspection
+export {
+  parseWWWAuthenticate,
+  decodeAccessTokenClaims,
+  validateTokenAudience,
+  type WWWAuthenticateChallenge,
+  type DecodedJWTHeader,
+  type DecodedJWTClaims,
+  type DecodedAccessToken,
+  type TokenAudienceResult,
+} from './diagnostics';
+
+// End-to-end OAuth handshake diagnosis (powers `adcp diagnose-auth`)
+export {
+  runAuthDiagnosis,
+  AUTH_DIAGNOSIS_SCHEMA_VERSION,
+  type DiagnoseOptions,
+  type HttpCapture,
+  type DiagnosisStep,
+  type Hypothesis,
+  type HypothesisVerdict,
+  type AuthDiagnosisReport,
+} from './diagnose';
+
+// Re-exported MCP SDK OAuth error types so consumers can discriminate 401 causes
+// without string-matching on error messages. These originate from the MCP server
+// auth module but are the canonical OAuth error classes for client-side handling too.
+export { InvalidTokenError, InsufficientScopeError } from '@modelcontextprotocol/sdk/server/auth/errors.js';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -598,6 +598,32 @@ export * from './types/schemas.generated';
 // Auth utilities for custom integrations
 export { getAuthToken, createAdCPHeaders, createMCPAuthHeaders, createAuthenticatedFetch } from './auth';
 
+// OAuth diagnostics utilities (see src/lib/auth/oauth/diagnostics.ts)
+export {
+  parseWWWAuthenticate,
+  decodeAccessTokenClaims,
+  validateTokenAudience,
+  type WWWAuthenticateChallenge,
+  type DecodedJWTHeader,
+  type DecodedJWTClaims,
+  type DecodedAccessToken,
+  type TokenAudienceResult,
+  InvalidTokenError,
+  InsufficientScopeError,
+} from './auth/oauth';
+
+// End-to-end OAuth handshake diagnosis — powers `adcp diagnose-auth`
+export {
+  runAuthDiagnosis,
+  AUTH_DIAGNOSIS_SCHEMA_VERSION,
+  type DiagnoseOptions,
+  type HttpCapture as DiagnosisHttpCapture,
+  type DiagnosisStep,
+  type Hypothesis as DiagnosisHypothesis,
+  type HypothesisVerdict as DiagnosisHypothesisVerdict,
+  type AuthDiagnosisReport,
+} from './auth/oauth';
+
 // ====== TOOL SCHEMA MAPS ======
 // Zod schemas keyed by tool name — use with server.tool(name, schema.shape, handler)
 export { TOOL_REQUEST_SCHEMAS } from './utils/tool-request-schemas';

--- a/src/lib/net/ssrf-fetch.ts
+++ b/src/lib/net/ssrf-fetch.ts
@@ -30,7 +30,7 @@
  * Returns a fully-buffered result. Callers that need streaming or large bodies
  * should extend this primitive rather than bypass it.
  */
-import { lookup as dnsLookup, type LookupAddress, type LookupOptions } from 'dns';
+import { type LookupAddress, type LookupOptions } from 'dns';
 import { lookup as dnsLookupAsync } from 'dns/promises';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { isAlwaysBlocked, isPrivateIp } from './address-guards';

--- a/src/lib/net/ssrf-fetch.ts
+++ b/src/lib/net/ssrf-fetch.ts
@@ -30,7 +30,8 @@
  * Returns a fully-buffered result. Callers that need streaming or large bodies
  * should extend this primitive rather than bypass it.
  */
-import { lookup as dnsLookup } from 'dns/promises';
+import { lookup as dnsLookup, type LookupAddress, type LookupOptions } from 'dns';
+import { lookup as dnsLookupAsync } from 'dns/promises';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { isAlwaysBlocked, isPrivateIp } from './address-guards';
 
@@ -137,7 +138,7 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
 
   let addresses: { address: string; family: number }[];
   try {
-    addresses = await dnsLookup(hostname, { all: true });
+    addresses = await dnsLookupAsync(hostname, { all: true });
   } catch (err) {
     throw new SsrfRefusedError(
       'dns_lookup_failed',
@@ -183,7 +184,19 @@ export async function ssrfSafeFetch(url: string, options: SsrfFetchOptions = {})
     connect: {
       // All addresses were validated above; pin the connect to the first. The
       // custom lookup also means undici won't re-resolve and pick up a rebind.
-      lookup: (_h, _o, cb) => cb(null, pinned.address, pinned.family),
+      // undici's Agent may call lookup with `{ all: true }` (it does for HTTPS
+      // targets under Node 22+), which expects the array form of the callback.
+      lookup: (
+        _h: string,
+        opts: LookupOptions | undefined,
+        cb: (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void
+      ) => {
+        if (opts?.all) {
+          cb(null, [{ address: pinned.address, family: pinnedFamily }]);
+        } else {
+          cb(null, pinned.address, pinnedFamily);
+        }
+      },
     },
   });
 

--- a/test/lib/oauth-diagnose.test.js
+++ b/test/lib/oauth-diagnose.test.js
@@ -1,0 +1,469 @@
+/**
+ * Tests for the diagnose-auth runner.
+ *
+ * Uses a real in-process HTTP server so we exercise the actual
+ * ssrfSafeFetch path (with --allow-http for loopback). Each scenario
+ * drives a specific hypothesis branch in the ranking logic.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { runAuthDiagnosis } = require('../../dist/lib/auth/oauth');
+
+// ---------------------------------------------------------------------------
+// Test fixture: a single HTTP server that routes agent + AS + PRM paths
+// based on mutable response handlers. Scenarios swap handlers per test.
+// ---------------------------------------------------------------------------
+
+const state = {
+  handlers: {},
+  server: null,
+  port: 0,
+};
+
+function makeJWT(claims) {
+  const b64 = o =>
+    Buffer.from(JSON.stringify(o)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${b64({ alg: 'RS256', typ: 'JWT' })}.${b64(claims)}.signature`;
+}
+
+before(async () => {
+  state.server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const path = url.pathname;
+    const handler = state.handlers[path];
+    if (!handler) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        handler(req, res, body);
+      } catch (err) {
+        res.statusCode = 500;
+        res.end(String(err));
+      }
+    });
+  });
+  await new Promise(r => state.server.listen(0, '127.0.0.1', r));
+  state.port = state.server.address().port;
+});
+
+after(async () => {
+  await new Promise(r => state.server.close(r));
+});
+
+function agentUrl() {
+  return `http://127.0.0.1:${state.port}/mcp`;
+}
+
+function tokenEndpoint() {
+  return `http://127.0.0.1:${state.port}/oauth/token`;
+}
+
+function issuer() {
+  return `http://127.0.0.1:${state.port}`;
+}
+
+function setHandlers(handlers) {
+  state.handlers = handlers;
+}
+
+// JSON helper
+function jsonRes(res, status, body, extraHeaders = {}) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  for (const [k, v] of Object.entries(extraHeaders)) res.setHeader(k, v);
+  res.end(JSON.stringify(body));
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+describe('runAuthDiagnosis: H1 resource URL mismatch', () => {
+  test('flags H1 when PRM advertises a different resource URL', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, {
+          resource: 'https://wrong-host.example.com/mcp',
+          authorization_servers: [issuer()],
+        }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'likely');
+    assert.match(h1.summary, /does not match agent URL/);
+  });
+
+  test('rules out H1 when PRM resource matches agent URL', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'ruled_out');
+  });
+});
+
+describe('runAuthDiagnosis: H4 missing WWW-Authenticate', () => {
+  test('flags H4 when the 401 has no WWW-Authenticate header', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h4 = report.hypotheses.find(h => h.id === 'H4');
+    assert.strictEqual(h4.verdict, 'likely');
+    assert.match(h4.summary, /RFC 6750/);
+  });
+
+  test('rules out H4 when the 401 carries a WWW-Authenticate header', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer realm="api", error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h4 = report.hypotheses.find(h => h.id === 'H4');
+    assert.strictEqual(h4.verdict, 'ruled_out');
+  });
+});
+
+describe('runAuthDiagnosis: H5 token audience mismatch', () => {
+  test('flags H5 when saved token aud does not match expected resource', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const token = makeJWT({ aud: 'https://someone-else.example.com', iss: issuer() });
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: token },
+      },
+      { allowPrivateIp: true, skipRefresh: true, skipToolCall: true }
+    );
+
+    const h5 = report.hypotheses.find(h => h.id === 'H5');
+    assert.strictEqual(h5.verdict, 'likely');
+  });
+
+  test('rules out H5 when saved token aud matches the advertised resource', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const token = makeJWT({ aud: agentUrl(), iss: issuer() });
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: token },
+      },
+      { allowPrivateIp: true, skipRefresh: true, skipToolCall: true }
+    );
+
+    const h5 = report.hypotheses.find(h => h.id === 'H5');
+    assert.strictEqual(h5.verdict, 'ruled_out');
+  });
+});
+
+describe('runAuthDiagnosis: H6 agent ignores audience', () => {
+  test('flags H6 when tool_call succeeds despite aud mismatch', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res, body) => {
+        const parsed = JSON.parse(body);
+        // Return 200 regardless of whether the token aud is right —
+        // this is the permissive-agent bug H6 is designed to catch.
+        jsonRes(res, 200, {
+          jsonrpc: '2.0',
+          id: parsed.id,
+          result: { isError: false, structuredContent: { products: [] } },
+        });
+      },
+    });
+
+    const token = makeJWT({ aud: 'https://wrong.example.com', iss: issuer() });
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: token },
+      },
+      { allowPrivateIp: true, skipRefresh: true }
+    );
+
+    const h6 = report.hypotheses.find(h => h.id === 'H6');
+    assert.strictEqual(h6.verdict, 'likely');
+    assert.match(h6.summary, /not enforcing audience/);
+  });
+});
+
+describe('runAuthDiagnosis: H2 refresh grant ignoring resource', () => {
+  test('flags H2 when a refresh with resource indicator yields a token with wrong aud', async () => {
+    let refreshCallSawResource = false;
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/oauth/token': (req, res, body) => {
+        const params = new URLSearchParams(body);
+        if (params.get('resource')) refreshCallSawResource = true;
+        // AS ignores the `resource` param and emits a token with wrong aud —
+        // this is the H2 signature.
+        jsonRes(res, 200, {
+          access_token: makeJWT({ aud: 'https://wrong.example.com', iss: issuer() }),
+          token_type: 'Bearer',
+          expires_in: 3600,
+        });
+      },
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: makeJWT({ aud: agentUrl() }), refresh_token: 'rt-1' },
+        oauth_client: { client_id: 'test-client', redirect_uris: [] },
+      },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    assert.strictEqual(refreshCallSawResource, true, 'runner should send resource param on refresh');
+    const h2 = report.hypotheses.find(h => h.id === 'H2');
+    assert.strictEqual(h2.verdict, 'likely');
+  });
+});
+
+describe('runAuthDiagnosis: token redaction', () => {
+  test('redacts access_token/refresh_token in the token-refresh capture by default', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/oauth/token': (req, res) =>
+        jsonRes(res, 200, {
+          access_token: makeJWT({ aud: agentUrl() }),
+          refresh_token: 'super-secret-refresh',
+          id_token: 'super-secret-id',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: makeJWT({ aud: agentUrl() }), refresh_token: 'rt-1' },
+        oauth_client: { client_id: 'c', redirect_uris: [] },
+      },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const refreshStep = report.steps.find(s => s.name === 'token_refresh_attempt');
+    const body = refreshStep.http.body;
+    assert.match(body.access_token, /^<redacted length=\d+>$/);
+    assert.match(body.refresh_token, /^<redacted length=\d+>$/);
+    assert.match(body.id_token, /^<redacted length=\d+>$/);
+    // Non-token fields preserved
+    assert.strictEqual(body.token_type, 'Bearer');
+    assert.strictEqual(body.expires_in, 3600);
+  });
+
+  test('includeTokens: true keeps raw token material in the capture', async () => {
+    const realAccessToken = makeJWT({ aud: agentUrl() });
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/oauth/token': (req, res) =>
+        jsonRes(res, 200, {
+          access_token: realAccessToken,
+          refresh_token: 'super-secret-refresh',
+        }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: makeJWT({ aud: agentUrl() }), refresh_token: 'rt-1' },
+        oauth_client: { client_id: 'c', redirect_uris: [] },
+      },
+      { allowPrivateIp: true, skipToolCall: true, includeTokens: true }
+    );
+
+    const refreshStep = report.steps.find(s => s.name === 'token_refresh_attempt');
+    assert.strictEqual(refreshStep.http.body.access_token, realAccessToken);
+    assert.strictEqual(refreshStep.http.body.refresh_token, 'super-secret-refresh');
+  });
+});
+
+describe('runAuthDiagnosis: report shape', () => {
+  test('includes every expected step when all inputs are present', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/oauth/token': (req, res) =>
+        jsonRes(res, 200, {
+          access_token: makeJWT({ aud: agentUrl(), iss: issuer() }),
+          token_type: 'Bearer',
+          expires_in: 3600,
+        }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      {
+        id: 'test-alias',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+        oauth_tokens: { access_token: makeJWT({ aud: agentUrl() }), refresh_token: 'rt-1' },
+        oauth_client: { client_id: 'test-client', redirect_uris: [] },
+      },
+      { allowPrivateIp: true }
+    );
+
+    const stepNames = report.steps.map(s => s.name);
+    assert.deepStrictEqual(stepNames.sort(), [
+      'decode_current_token',
+      'decode_refreshed_token',
+      'list_tools_probe',
+      'probe_authorization_server_metadata',
+      'probe_protected_resource_metadata',
+      'token_refresh_attempt',
+      'tool_call_probe',
+    ]);
+    assert.strictEqual(report.aliasId, 'test-alias');
+    assert.ok(report.generatedAt);
+    assert.strictEqual(report.hypotheses.length, 5);
+  });
+
+  test('orders hypotheses: likely first, then possible, then ruled_out/not_observed', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: 'https://wrong.example.com/mcp' }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const verdicts = report.hypotheses.map(h => h.verdict);
+    const order = { likely: 0, possible: 1, ruled_out: 2, not_observed: 3 };
+    for (let i = 1; i < verdicts.length; i++) {
+      assert.ok(order[verdicts[i - 1]] <= order[verdicts[i]], `verdicts out of order: ${verdicts.join(', ')}`);
+    }
+    // H1 + H4 should both be likely here
+    assert.ok(report.hypotheses.find(h => h.id === 'H1').verdict === 'likely');
+    assert.ok(report.hypotheses.find(h => h.id === 'H4').verdict === 'likely');
+  });
+});

--- a/test/lib/oauth-diagnose.test.js
+++ b/test/lib/oauth-diagnose.test.js
@@ -45,8 +45,12 @@ before(async () => {
       try {
         handler(req, res, body);
       } catch (err) {
+        // Test fixture: swallow error into a generic 500 so CodeQL doesn't
+        // flag exception-text reflection; real failures surface via the
+        // assertion phase of the driving test.
+        console.error('test fixture handler threw:', err);
         res.statusCode = 500;
-        res.end(String(err));
+        res.end('test fixture error');
       }
     });
   });

--- a/test/lib/oauth-diagnostics.test.js
+++ b/test/lib/oauth-diagnostics.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for OAuth diagnostics utilities.
+ *
+ * Covers parseWWWAuthenticate, decodeAccessTokenClaims, validateTokenAudience,
+ * and the MCP SDK error-type re-exports.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  parseWWWAuthenticate,
+  decodeAccessTokenClaims,
+  validateTokenAudience,
+  InvalidTokenError,
+  InsufficientScopeError,
+} = require('../../dist/lib/auth/oauth');
+
+// Minimal unsigned JWT constructor for test fixtures.
+function makeJWT(header, claims, signature = 'sig') {
+  const b64 = obj =>
+    Buffer.from(JSON.stringify(obj)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `${b64(header)}.${b64(claims)}.${signature}`;
+}
+
+describe('parseWWWAuthenticate', () => {
+  test('returns null for missing or empty input', () => {
+    assert.strictEqual(parseWWWAuthenticate(null), null);
+    assert.strictEqual(parseWWWAuthenticate(undefined), null);
+    assert.strictEqual(parseWWWAuthenticate(''), null);
+    assert.strictEqual(parseWWWAuthenticate('   '), null);
+  });
+
+  test('parses a bare scheme', () => {
+    const c = parseWWWAuthenticate('Bearer');
+    assert.strictEqual(c.scheme, 'bearer');
+    assert.deepStrictEqual(c.params, {});
+  });
+
+  test('parses typical MCP Bearer challenge with resource_metadata', () => {
+    const header =
+      'Bearer realm="api", error="invalid_token", error_description="The access token expired", resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"';
+    const c = parseWWWAuthenticate(header);
+    assert.strictEqual(c.scheme, 'bearer');
+    assert.strictEqual(c.realm, 'api');
+    assert.strictEqual(c.error, 'invalid_token');
+    assert.strictEqual(c.error_description, 'The access token expired');
+    assert.strictEqual(c.resource_metadata, 'https://api.example.com/.well-known/oauth-protected-resource');
+  });
+
+  test('lowercases scheme and param keys but preserves value casing', () => {
+    const c = parseWWWAuthenticate('BEARER Realm="Protected Area"');
+    assert.strictEqual(c.scheme, 'bearer');
+    assert.strictEqual(c.realm, 'Protected Area');
+    assert.ok('realm' in c.params);
+  });
+
+  test('parses unquoted token values', () => {
+    const c = parseWWWAuthenticate('Bearer error=invalid_token, scope=read');
+    assert.strictEqual(c.error, 'invalid_token');
+    assert.strictEqual(c.scope, 'read');
+  });
+
+  test('unescapes backslash-escaped quotes in quoted-string values', () => {
+    const c = parseWWWAuthenticate('Bearer error_description="quote: \\"oops\\""');
+    assert.strictEqual(c.error_description, 'quote: "oops"');
+  });
+
+  test('preserves unknown auth-params under params', () => {
+    const c = parseWWWAuthenticate('Bearer nonce="abc", algs="ES256 RS256"');
+    assert.strictEqual(c.params.nonce, 'abc');
+    assert.strictEqual(c.params.algs, 'ES256 RS256');
+  });
+
+  test('handles DPoP scheme', () => {
+    const c = parseWWWAuthenticate('DPoP algs="ES256 RS256", error="invalid_token"');
+    assert.strictEqual(c.scheme, 'dpop');
+    assert.strictEqual(c.error, 'invalid_token');
+  });
+
+  test('tolerates extra whitespace and missing spaces', () => {
+    const c = parseWWWAuthenticate('Bearer realm="api",error="invalid_token"');
+    assert.strictEqual(c.realm, 'api');
+    assert.strictEqual(c.error, 'invalid_token');
+  });
+
+  test('returns null for header that does not start with a valid scheme token', () => {
+    assert.strictEqual(parseWWWAuthenticate('  ,="broken"'), null);
+  });
+});
+
+describe('decodeAccessTokenClaims', () => {
+  test('returns null for missing input', () => {
+    assert.strictEqual(decodeAccessTokenClaims(null), null);
+    assert.strictEqual(decodeAccessTokenClaims(undefined), null);
+    assert.strictEqual(decodeAccessTokenClaims(''), null);
+  });
+
+  test('returns null for opaque (non-JWT) tokens', () => {
+    assert.strictEqual(decodeAccessTokenClaims('not-a-jwt'), null);
+    assert.strictEqual(decodeAccessTokenClaims('only.two'), null);
+    assert.strictEqual(decodeAccessTokenClaims('a.b.c.d'), null);
+  });
+
+  test('returns null when segments are not valid JSON', () => {
+    // Valid base64url but garbage content
+    const bad = 'bm90LWpzb24.bm90LWpzb24.sig';
+    assert.strictEqual(decodeAccessTokenClaims(bad), null);
+  });
+
+  test('decodes header, claims, and signature of a well-formed JWT', () => {
+    const jwt = makeJWT(
+      { alg: 'RS256', typ: 'JWT', kid: 'abc' },
+      { iss: 'https://as.example.com', sub: 'user-1', aud: 'https://api.example.com', exp: 9999999999 }
+    );
+    const decoded = decodeAccessTokenClaims(jwt);
+    assert.ok(decoded);
+    assert.strictEqual(decoded.header.alg, 'RS256');
+    assert.strictEqual(decoded.header.kid, 'abc');
+    assert.strictEqual(decoded.claims.iss, 'https://as.example.com');
+    assert.strictEqual(decoded.claims.sub, 'user-1');
+    assert.strictEqual(decoded.claims.aud, 'https://api.example.com');
+    assert.strictEqual(decoded.claims.exp, 9999999999);
+    assert.strictEqual(decoded.signature, 'sig');
+  });
+
+  test('handles JWT with array aud claim', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { aud: ['a', 'b'] });
+    const decoded = decodeAccessTokenClaims(jwt);
+    assert.deepStrictEqual(decoded.claims.aud, ['a', 'b']);
+  });
+
+  test('does NOT verify signature — even tampered tokens decode successfully', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { sub: 'attacker' }, 'obviously-wrong');
+    const decoded = decodeAccessTokenClaims(jwt);
+    assert.ok(decoded);
+    assert.strictEqual(decoded.claims.sub, 'attacker');
+  });
+});
+
+describe('validateTokenAudience', () => {
+  const expected = 'https://api.example.com/mcp';
+
+  test('returns ok when aud is a string matching expected', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { aud: 'https://api.example.com/mcp' });
+    const res = validateTokenAudience(jwt, expected);
+    assert.strictEqual(res.ok, true);
+    assert.strictEqual(res.actualAudience, 'https://api.example.com/mcp');
+  });
+
+  test('returns ok when aud is an array containing expected', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { aud: ['other', 'https://api.example.com/mcp'] });
+    const res = validateTokenAudience(jwt, expected);
+    assert.strictEqual(res.ok, true);
+  });
+
+  test('normalizes URL differences (default port, trailing slash, host casing)', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { aud: 'https://API.example.com:443/mcp/' });
+    const res = validateTokenAudience(jwt, expected);
+    assert.strictEqual(res.ok, true);
+  });
+
+  test('returns not-ok with reason when aud is missing', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { sub: 'user-1' });
+    const res = validateTokenAudience(jwt, expected);
+    assert.strictEqual(res.ok, false);
+    assert.match(res.reason, /no `aud` claim/);
+  });
+
+  test('returns not-ok with actual audience when mismatched', () => {
+    const jwt = makeJWT({ alg: 'HS256' }, { aud: 'https://other.example.com' });
+    const res = validateTokenAudience(jwt, expected);
+    assert.strictEqual(res.ok, false);
+    assert.strictEqual(res.actualAudience, 'https://other.example.com');
+    assert.match(res.reason, /does not match expected/);
+  });
+
+  test('returns not-ok for opaque tokens (cannot inspect)', () => {
+    const res = validateTokenAudience('opaque-reference-token', expected);
+    assert.strictEqual(res.ok, false);
+    assert.match(res.reason, /opaque|not a valid JWT/);
+  });
+});
+
+describe('MCP SDK error re-exports', () => {
+  test('InvalidTokenError is exported and instantiable', () => {
+    const err = new InvalidTokenError('expired');
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errorCode, 'invalid_token');
+  });
+
+  test('InsufficientScopeError is exported and instantiable', () => {
+    const err = new InsufficientScopeError('need read scope');
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.errorCode, 'insufficient_scope');
+  });
+
+  test('errors are discriminable by instanceof instead of string matching', () => {
+    const err = new InvalidTokenError('expired');
+    assert.ok(err instanceof InvalidTokenError);
+    assert.ok(!(err instanceof InsufficientScopeError));
+  });
+});


### PR DESCRIPTION
Closes #563.

Debugging OAuth handshake failures against an MCP agent previously took hours of manual wire-level probing. This ships a single command that does the probing for you and prints ranked hypotheses, plus the underlying primitives as library exports.

## Summary

- **`adcp diagnose-auth <alias|url>`** — new CLI. Probes RFC 9728 protected-resource metadata, RFC 8414 authorization-server metadata, decodes the saved access token, optionally attempts a refresh with an RFC 8707 `resource` indicator, and calls `tools/list` + a tool on the agent. Emits ranked hypotheses (`likely` / `possible` / `ruled_out` / `not_observed`):
  - **H1** Resource URL mismatch between well-known and agent host
  - **H2** Refresh grant ignores `resource` parameter (RFC 8707)
  - **H4** 401 without `WWW-Authenticate` (RFC 6750 violation)
  - **H5** Token `aud` missing or doesn't match agent URL
  - **H6** Agent accepts token but doesn't validate audience
  - (H3 is reserved for a future session-ID hypothesis.)
- **`runAuthDiagnosis(agent, opts)`** — programmatic entry point returning an `AuthDiagnosisReport` with `schemaVersion: 1` for dashboard consumers.
- **`parseWWWAuthenticate`**, **`decodeAccessTokenClaims`**, **`validateTokenAudience`** — exported utilities so consumers don't have to roll their own parsers.
- **`InvalidTokenError`** + **`InsufficientScopeError`** re-exported from the MCP SDK so consumers can discriminate 401 causes by `instanceof` rather than string-matching error messages.
- **`ssrfSafeFetch` bugfix** — undici's `Agent` calls the custom `lookup` callback with `{ all: true }` on Node 22+, and the previous scalar-only path caused `Invalid IP address: undefined` on every external HTTPS probe. Confirmed to fix 28 pre-existing test failures.

## Security posture

- Token material in the token-endpoint response is **redacted by default** in `HttpCapture.body` (`<redacted length=N>` markers). `--include-tokens` / `includeTokens: true` opts in for full-fidelity captures.
- All outbound probes go through `ssrfSafeFetch` (DNS pinning, private-IP guard, `redirect: 'manual'`). The `Authorization: Bearer` header cannot be re-sent to a 3xx `Location`.
- `--allow-http` gates both http:// and private-IP targets for dev loops; default is https-only.

## Scope vs issue #563

This PR closes items 1–5 from the issue (CLI + utilities + MCP error re-exports). Item 6 (automatic OAuth on `callTool`) is scoped for a follow-up PR — it's a larger design change.

## Test plan

- [x] 37 new tests (25 utility unit tests + 12 runner tests using a real in-process HTTP server)
- [x] `npm run ci:quick` — 3702/3733 pass (the 21 failures are pre-existing governance E2E tests against a remote training agent; baseline on main is 49 failures)
- [x] Typecheck clean, format clean
- [x] E2E: `adcp diagnose-auth test-mcp --skip-tool-call` against the real `test-agent.adcontextprotocol.org` correctly surfaces an H1 resource URL mismatch (PRM advertises `agenticadvertising.org`, agent is at `test-agent.adcontextprotocol.org`)
- [x] Reviewed by code-reviewer, dx-expert, and security-reviewer subagents; Must-Fix and Should-Fix items addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)