### PR TITLE
feat(runner): conform storyboard output to adcp runner-output contract (#599)

### DIFF
--- a/.changeset/runner-output-contract.md
+++ b/.changeset/runner-output-contract.md
@@ -1,0 +1,83 @@
+---
+'@adcp/client': minor
+---
+
+Conform the storyboard runner and `comply()` output to the universal
+runner-output contract (adcontextprotocol/adcp PR #2364 / issue #2352).
+Failure results are now actionable: the implementor can self-diagnose
+a validation failure from the runner output alone, without re-running
+the step by hand.
+
+**New on every `ValidationResult`:**
+
+- `json_pointer` — RFC 6901 pointer to the failing field
+- `expected` / `actual` — machine-readable values (schema `$id`,
+  allowed enums, observed value, etc.)
+- `schema_id` / `schema_url` — set on `response_schema` checks so the
+  implementor can re-validate locally against the same artifact
+- `request` / `response` — exact bytes the runner sent and observed,
+  attached on failure (not echoed on passing checks)
+- For `response_schema` failures, `actual` is now an AJV-shaped
+  `{ instance_path, schema_path, keyword, message }[]` instead of a
+  flat message string.
+
+**New on every `StoryboardStepResult`:**
+
+- `extraction: { path: "structured_content" | "text_fallback" | "error" | "none" }`
+  — records which MCP extraction path produced the parsed response so
+  runner extraction bugs are separable from agent bugs.
+- `request` / `response_record` — the full transport-level exchange
+  (omitted for synthetic / skipped steps).
+- `storyboard_id` — each step is self-describing.
+- `skip: { reason, detail }` — structured skip result with
+  human-readable explanation (agent tools, prerequisite step id, etc.).
+
+**Spec-aligned skip reasons.** The narrow
+`"not_testable" | "dependency_failed" | "missing_test_harness" | "missing_tool"`
+enum is replaced by the six contract reasons:
+
+| Reason | When it fires |
+|---|---|
+| `not_applicable` | Agent did not declare the protocol / specialism |
+| `no_phases` | Storyboard is a placeholder with no executable phases |
+| `prerequisite_failed` | Prior step or context variable did not produce a value |
+| `missing_tool` | Agent did not advertise a required tool |
+| `missing_test_controller` | Deterministic-testing phase needs `comply_test_controller` |
+| `unsatisfied_contract` | A test-kit harness contract is out of scope |
+
+**Top-level summary gains:**
+
+- `total_steps`, `steps_passed`, `steps_failed`, `steps_skipped`
+- `schemas_used: Array<{ schema_id, schema_url }>` — deduplicated list
+  of schemas applied across the run so implementors can re-validate
+  locally.
+
+**`ComplianceFailure` carries the first failed validation's
+machine-readable detail** (`json_pointer`, `expected`, `actual`,
+`schema_id`, `schema_url`) under a `validation` field, and the terminal
+formatter now renders `At:` / `Expected:` / `Actual:` / `Schema:` for
+each failure instead of the single generic line
+`"Check agent capabilities"`.
+
+**Security hardening.** Request and response payloads echoed on failed
+validations run through a recursive redactor that replaces values at
+keys matching `/^(authorization|credentials?|token|api[_-]?key|…)$/i`
+with `'[redacted]'`. Response headers are allowlisted — only
+`content-type`, `content-length`, `content-encoding`,
+`www-authenticate`, `location`, `retry-after`, `x-request-id`,
+`x-correlation-id` pass through; `set-cookie`, `authorization`,
+`x-internal-*`, `x-amz-*` etc. are dropped so a hostile agent cannot
+bait the runner into publishing internal state in a shared compliance
+report. Agent-controlled `error` / `validation.actual` strings in the
+terminal formatter output are wrapped in the existing
+`fenceAgentText()` nonce so downstream LLM summarizers can't be
+hijacked by hostile error messages.
+
+**Migration.** The changes are additive on `ValidationResult` /
+`StepResult` / `ComplianceFailure`. The skip-reason enum is a
+breaking rename. Call sites that pattern-match on the old values
+(`"not_testable"`, `"dependency_failed"`, `"missing_test_harness"`)
+need to migrate to the spec-aligned names above. The bundled CLI
+(`bin/adcp.js`) is updated in-tree; the only user-visible surface
+that still needs a migration is third-party automation that reads
+`StoryboardStepResult.skip_reason` from the `--json` output.

--- a/.changeset/runner-output-contract.md
+++ b/.changeset/runner-output-contract.md
@@ -25,7 +25,11 @@ the step by hand.
 
 - `extraction: { path: "structured_content" | "text_fallback" | "error" | "none" }`
   — records which MCP extraction path produced the parsed response so
-  runner extraction bugs are separable from agent bugs.
+  runner extraction bugs are separable from agent bugs. The response
+  unwrapper and raw MCP probe stamp the provenance as a non-enumerable
+  `_extraction_path` tag on the unwrapped `AdCPResponse`; the runner reads
+  it via `readExtractionPath()` and surfaces it here. All four values are
+  emitted in practice (previously `text_fallback` was unreachable).
 - `request` / `response_record` — the full transport-level exchange
   (omitted for synthetic / skipped steps).
 - `storyboard_id` — each step is self-describing.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1088,11 +1088,21 @@ async function handleStoryboardRun(args) {
     console.log('═'.repeat(50));
     for (const phase of result.phases) {
       console.log(`\n── Phase: ${phase.phase_title} ──────────────────────────────`);
-      const SKIP_ICONS = { missing_test_harness: '🔧', not_testable: '⏭️', dependency_failed: '⏭️' };
+      const SKIP_ICONS = {
+        missing_tool: '🔧',
+        missing_test_controller: '🔧',
+        not_applicable: '⏭️',
+        no_phases: '⏭️',
+        prerequisite_failed: '⏭️',
+        unsatisfied_contract: '⏭️',
+      };
       const SKIP_LABELS = {
-        missing_test_harness: ' [needs test harness]',
-        not_testable: ' [not testable]',
-        dependency_failed: ' [dependency failed]',
+        missing_tool: ' [missing tool]',
+        missing_test_controller: ' [needs test controller]',
+        not_applicable: ' [not applicable]',
+        no_phases: ' [no phases]',
+        prerequisite_failed: ' [prerequisite failed]',
+        unsatisfied_contract: ' [contract out of scope]',
       };
       for (const step of phase.steps) {
         const icon = step.skipped ? (SKIP_ICONS[step.skip_reason] ?? '⏭️') : step.passed ? '✅' : '❌';

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -617,6 +617,7 @@ function buildNotApplicableStoryboardResult(agentUrl: string, na: NotApplicableS
         duration_ms: 0,
         steps: [
           {
+            storyboard_id: na.storyboard_id,
             step_id: 'not_applicable',
             phase_id: 'not_applicable',
             // Bake the reason into the title so reports show the specific
@@ -627,9 +628,11 @@ function buildNotApplicableStoryboardResult(agentUrl: string, na: NotApplicableS
             passed: true,
             skipped: true,
             skip_reason: 'not_applicable',
+            skip: { reason: 'not_applicable', detail: na.reason },
             duration_ms: 0,
             validations: [],
             context: {},
+            extraction: { path: 'none' },
           },
         ],
       },
@@ -685,6 +688,20 @@ function extractFailures(
           }
         }
 
+        const firstFailedValidation = step.validations.find(v => !v.passed);
+        const validationSummary = firstFailedValidation
+          ? {
+              check: firstFailedValidation.check,
+              description: firstFailedValidation.description,
+              ...(firstFailedValidation.json_pointer !== undefined && {
+                json_pointer: firstFailedValidation.json_pointer,
+              }),
+              ...(firstFailedValidation.expected !== undefined && { expected: firstFailedValidation.expected }),
+              ...(firstFailedValidation.actual !== undefined && { actual: firstFailedValidation.actual }),
+              ...(firstFailedValidation.schema_id !== undefined && { schema_id: firstFailedValidation.schema_id }),
+              ...(firstFailedValidation.schema_url !== undefined && { schema_url: firstFailedValidation.schema_url }),
+            }
+          : undefined;
         failures.push({
           track,
           storyboard_id: result.storyboard_id,
@@ -694,6 +711,7 @@ function extractFailures(
           error: step.error,
           expected,
           fix_command: `adcp storyboard step ${agentRef} ${result.storyboard_id} ${step.step_id} --json`,
+          ...(validationSummary && { validation: validationSummary }),
         });
       }
     }
@@ -935,7 +953,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       }
     }
 
-    const summary = buildSummary(trackResults);
+    const summary = buildSummary(trackResults, storyboardResults);
     const testedTracks = trackResults.filter(t => t.status === 'pass' || t.status === 'fail' || t.status === 'partial');
     const skippedTracks = trackResults
       .filter(t => t.status === 'skip')
@@ -1095,7 +1113,7 @@ async function runWithDegradedProfile(
     }
   }
 
-  const summary = buildSummary(trackResults);
+  const summary = buildSummary(trackResults, storyboardResults);
   const overallStatus = computeOverallStatus(summary);
   const agentRef = options.agent_alias || agentUrl;
   const failures = extractFailures(storyboardResults, storyboards, agentRef);
@@ -1168,7 +1186,7 @@ export function computeOverallStatus(summary: ComplianceSummary): OverallStatus 
   return 'partial';
 }
 
-function buildSummary(tracks: TrackResult[]): ComplianceSummary {
+function buildSummary(tracks: TrackResult[], storyboardResults: StoryboardResult[] = []): ComplianceSummary {
   const passed = tracks.filter(t => t.status === 'pass').length;
   const failed = tracks.filter(t => t.status === 'fail').length;
   const skipped = tracks.filter(t => t.status === 'skip').length;
@@ -1191,12 +1209,34 @@ function buildSummary(tracks: TrackResult[]): ComplianceSummary {
     headline = parts.join(', ');
   }
 
+  // Per the runner-output contract, the top-level summary exposes step-level
+  // counts and the schemas the runner applied so implementors can re-validate
+  // locally against the same artifacts.
+  const stepsPassed = storyboardResults.reduce((s, r) => s + r.passed_count, 0);
+  const stepsFailed = storyboardResults.reduce((s, r) => s + r.failed_count, 0);
+  const stepsSkipped = storyboardResults.reduce((s, r) => s + r.skipped_count, 0);
+  const totalSteps = stepsPassed + stepsFailed + stepsSkipped;
+  const schemasUsed: Array<{ schema_id: string; schema_url: string }> = [];
+  const seenSchemas = new Set<string>();
+  for (const r of storyboardResults) {
+    for (const s of r.schemas_used ?? []) {
+      if (seenSchemas.has(s.schema_id)) continue;
+      seenSchemas.add(s.schema_id);
+      schemasUsed.push(s);
+    }
+  }
+
   return {
     tracks_passed: passed,
     tracks_failed: failed,
     tracks_skipped: skipped,
     tracks_partial: partial,
     headline,
+    total_steps: totalSteps,
+    steps_passed: stepsPassed,
+    steps_failed: stepsFailed,
+    steps_skipped: stepsSkipped,
+    ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
   };
 }
 
@@ -1264,8 +1304,20 @@ export function formatComplianceResults(result: ComplianceResult): string {
     output += `${'─'.repeat(50)}\n`;
     for (const f of failuresWithExpected.slice(0, 5)) {
       output += `❌ ${f.storyboard_id}/${f.step_id} (${f.task})\n`;
-      if (f.error) output += `   Error: ${f.error}\n`;
-      output += `   Expected: ${f.expected!.split('\n')[0]}\n`;
+      // Agent-controlled strings (step.error, validation.actual) are fenced
+      // so downstream LLM summarizers of this output can't be hijacked by an
+      // error message containing hostile instructions. See `fenceAgentText()`.
+      if (f.error) output += `   Error: ${fenceAgentText(f.error, 400)}\n`;
+      if (f.validation?.json_pointer) output += `   At: ${f.validation.json_pointer}\n`;
+      if (f.validation && 'expected' in f.validation) {
+        output += `   Expected: ${formatMachineValue(f.validation.expected)}\n`;
+      } else {
+        output += `   Expected: ${f.expected!.split('\n')[0]}\n`;
+      }
+      if (f.validation && 'actual' in f.validation) {
+        output += `   Actual:   ${fenceAgentText(formatMachineValue(f.validation.actual), 400)}\n`;
+      }
+      if (f.validation?.schema_url) output += `   Schema: ${f.validation.schema_url}\n`;
       output += `   Debug: ${f.fix_command}\n`;
     }
     if (failuresWithExpected.length > 5) {
@@ -1309,4 +1361,16 @@ export function formatComplianceResults(result: ComplianceResult): string {
  */
 export function formatComplianceResultsJSON(result: ComplianceResult): string {
   return JSON.stringify(result, null, 2);
+}
+
+/**
+ * Single-line renderer for `validation.expected` / `validation.actual`.
+ * JSON-encodes objects so structured values (schema-error arrays, expected
+ * enums) survive into the terminal, but truncates after 120 chars so one
+ * overlong value doesn't push the rest of the failure off-screen.
+ */
+function formatMachineValue(value: unknown): string {
+  if (value === null || value === undefined) return 'null';
+  const str = typeof value === 'string' ? value : JSON.stringify(value);
+  return str.length > 120 ? `${str.slice(0, 120)}…` : str;
 }

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -113,19 +113,26 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
     details: validationDetails || undefined,
     observation_data: stepResult.response as Record<string, unknown> | undefined,
     warnings: stepResult.skipped
-      ? [
-          (
-            {
-              missing_test_harness: 'Not testable: requires comply_test_controller harness',
-              missing_tool: 'Skipped: agent does not implement this tool',
-              not_testable: 'Not testable: agent lacks required tool',
-              dependency_failed: 'Skipped: prior stateful step failed',
-              not_applicable: 'Not applicable: storyboard introduced in a later AdCP version',
-            } as Record<string, string>
-          )[stepResult.skip_reason ?? ''] ?? 'Step skipped',
-        ]
+      ? [stepResult.skip?.detail ?? skipReasonLabel(stepResult.skip_reason) ?? 'Step skipped']
       : undefined,
   };
+}
+
+function skipReasonLabel(reason: string | undefined): string | undefined {
+  if (!reason) return undefined;
+  const labels: Record<string, string> = {
+    // `not_applicable` is the spec reason for both
+    // "agent did not declare this protocol/specialism" AND
+    // "storyboard was introduced in a later AdCP version".
+    not_applicable:
+      'Not applicable: agent did not declare this protocol/specialism, or storyboard was introduced in a later AdCP version',
+    no_phases: 'Skipped: storyboard has no executable phases',
+    prerequisite_failed: 'Skipped: a prerequisite did not pass',
+    missing_tool: 'Skipped: agent did not advertise the required tool',
+    missing_test_controller: 'Not testable: requires comply_test_controller',
+    unsatisfied_contract: 'Skipped: test-kit contract is out of scope',
+  };
+  return labels[reason];
 }
 
 /**

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -60,10 +60,24 @@ export interface ComplianceFailure {
   step_title: string;
   task: string;
   error?: string;
-  /** What a correct response looks like (from storyboard YAML) */
+  /** Human-readable expected behavior (from storyboard YAML). */
   expected?: string;
   /** CLI command to re-run just this step for debugging */
   fix_command: string;
+  /**
+   * Structured failure details from the first failed validation, per the
+   * runner-output contract. `undefined` when the step itself failed before
+   * any validation ran.
+   */
+  validation?: {
+    check: string;
+    description: string;
+    json_pointer?: string | null;
+    expected?: unknown;
+    actual?: unknown;
+    schema_id?: string | null;
+    schema_url?: string | null;
+  };
 }
 
 export interface ComplianceResult {
@@ -100,6 +114,19 @@ export interface ComplianceSummary {
   tracks_partial: number;
   /** One-line status */
   headline: string;
+  /** Total storyboard steps executed (per the runner-output contract). */
+  total_steps?: number;
+  /** Storyboard steps that passed. */
+  steps_passed?: number;
+  /** Storyboard steps that failed. */
+  steps_failed?: number;
+  /** Storyboard steps that were skipped. */
+  steps_skipped?: number;
+  /**
+   * Schemas applied across all storyboards. Implementors can re-validate
+   * locally against the same artifacts the runner used.
+   */
+  schemas_used?: Array<{ schema_id: string; schema_url: string }>;
 }
 
 // ============================================================

--- a/src/lib/testing/storyboard/path.ts
+++ b/src/lib/testing/storyboard/path.ts
@@ -54,6 +54,23 @@ export function resolvePath(obj: unknown, path: string): unknown {
   return current;
 }
 
+/**
+ * Convert a dot/bracket path (`accounts[0].account_id`) into an RFC 6901
+ * JSON Pointer (`/accounts/0/account_id`). Returns `""` for the empty path
+ * (the root per RFC 6901). Per RFC 6901 §3, `~` is escaped as `~0` and `/`
+ * as `~1`.
+ */
+export function toJsonPointer(path: string): string {
+  const segments = parsePath(path);
+  if (segments.length === 0) return '';
+  return (
+    '/' +
+    segments
+      .map(seg => (typeof seg === 'number' ? String(seg) : String(seg).replace(/~/g, '~0').replace(/\//g, '~1')))
+      .join('/')
+  );
+}
+
 const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/src/lib/testing/storyboard/probes.ts
+++ b/src/lib/testing/storyboard/probes.ts
@@ -260,6 +260,7 @@ export async function rawMcpProbe(options: {
           success: false,
           data: undefined,
           error: `Non-JSON response body (content-type: ${httpResult.headers['content-type'] ?? 'unknown'}).`,
+          _extraction_path: 'error',
         },
       };
     }
@@ -274,7 +275,12 @@ export async function rawMcpProbe(options: {
     if (httpResult.status >= 400) {
       return {
         httpResult,
-        taskResult: { success: false, data: undefined, error: rpc.error?.message ?? `HTTP ${httpResult.status}` },
+        taskResult: {
+          success: false,
+          data: undefined,
+          error: rpc.error?.message ?? `HTTP ${httpResult.status}`,
+          _extraction_path: 'error',
+        },
       };
     }
     if (rpc.error) {
@@ -293,11 +299,25 @@ export async function rawMcpProbe(options: {
           error: isSessionInit
             ? `MCP session not initialized (${code}: ${rpc.error.message ?? 'no message'}). rawMcpProbe skips the initialize handshake; strict servers will reject here before auth is evaluated.`
             : (rpc.error.message ?? `JSON-RPC error ${code}`),
+          _extraction_path: 'error',
         },
       };
     }
-    const data = rpc.result?.structuredContent ?? rpc.result?.content;
-    return { httpResult, taskResult: { success: !rpc.result?.isError, data } };
+    // Record which branch produced the data — rawMcpProbe reads the JSON-RPC
+    // envelope directly, so the provenance is knowable here (unlike the SDK
+    // path where we have to plumb it through the unwrapper).
+    const structured = rpc.result?.structuredContent;
+    const hasStructured = structured !== undefined && structured !== null;
+    const data = hasStructured ? structured : rpc.result?.content;
+    const isError = !!rpc.result?.isError;
+    const extractionPath: 'structured_content' | 'text_fallback' | 'error' | 'none' = isError
+      ? 'error'
+      : hasStructured
+        ? 'structured_content'
+        : data !== undefined && data !== null
+          ? 'text_fallback'
+          : 'none';
+    return { httpResult, taskResult: { success: !isError, data, _extraction_path: extractionPath } };
   } catch (err) {
     httpResult.error = err instanceof Error ? err.message : String(err);
     return { httpResult };

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -25,6 +25,10 @@ import {
 import { validateTestKit } from './test-kit';
 import type {
   HttpProbeResult,
+  RunnerExtractionRecord,
+  RunnerRequestRecord,
+  RunnerResponseRecord,
+  RunnerSkipReason,
   StepAuthDirective,
   Storyboard,
   StoryboardStep,
@@ -38,6 +42,93 @@ import type {
   ValidationResult,
 } from './types';
 import type { TaskResult } from '../types';
+
+// ────────────────────────────────────────────────────────────
+// Runner-output contract helpers
+// ────────────────────────────────────────────────────────────
+
+const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
+  not_applicable: 'Not applicable: agent did not declare the protocol or specialism this storyboard targets.',
+  no_phases: 'Storyboard has no executable phases (placeholder).',
+  prerequisite_failed: 'Skipped: a prerequisite step or contract did not pass.',
+  missing_tool: 'Skipped: agent did not advertise the required tool.',
+  missing_test_controller:
+    'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
+  unsatisfied_contract: 'Skipped: test-kit contract is out of scope for this grading run.',
+};
+
+function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
+  return { reason, detail: detail ?? SKIP_DETAILS[reason] };
+}
+
+function extractionFromTaskResult(taskResult: TaskResult | undefined): RunnerExtractionRecord {
+  if (!taskResult) return { path: 'none' };
+  if (!taskResult.success && taskResult.error) return { path: 'error' };
+  return taskResult.data !== undefined && taskResult.data !== null ? { path: 'structured_content' } : { path: 'none' };
+}
+
+/**
+ * Keys whose values must never appear verbatim in a compliance report.
+ * Matching is case-insensitive and structural: any property whose final
+ * path segment matches is replaced with `'[redacted]'` before the payload
+ * is persisted on a step result. The contract spec calls for exactly this:
+ * "Secrets SHOULD be redacted with the literal string '[redacted]'".
+ */
+const SECRET_KEY_PATTERN =
+  /^(authorization|credentials?|token|api[_-]?key|password|secret|client[_-]secret|refresh[_-]token|access[_-]token|bearer|session[_-]token|offering[_-]token|cookie|set[_-]cookie)$/i;
+
+export function __redactSecretsForTest(value: unknown): unknown {
+  return redactSecrets(value);
+}
+
+export function __filterResponseHeadersForTest(
+  headers: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  return filterResponseHeaders(headers);
+}
+
+function redactSecrets(value: unknown, depth = 0): unknown {
+  if (depth > 32) return value; // cheap cycle guard
+  if (Array.isArray(value)) return value.map(v => redactSecrets(v, depth + 1));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] =
+        SECRET_KEY_PATTERN.test(k) && (typeof v === 'string' || typeof v === 'number')
+          ? '[redacted]'
+          : redactSecrets(v, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Response headers to echo on a RunnerResponseRecord. Everything else is
+ * dropped — agents can (and do) include `set-cookie`, echoed `authorization`,
+ * reverse-proxy breadcrumbs (`x-amz-*`, `x-azure-*`, `x-internal-*`) that a
+ * hostile agent could use to bait us into publishing internal state in a
+ * shared compliance report.
+ */
+const RESPONSE_HEADER_ALLOWLIST = new Set([
+  'content-type',
+  'content-length',
+  'content-encoding',
+  'www-authenticate',
+  'location',
+  'retry-after',
+  'x-request-id',
+  'x-correlation-id',
+]);
+
+function filterResponseHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (RESPONSE_HEADER_ALLOWLIST.has(k.toLowerCase())) out[k] = v;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
 
 // ────────────────────────────────────────────────────────────
 // runStoryboard: execute all phases/steps
@@ -103,6 +194,40 @@ export async function runStoryboard(
   const allSteps = flattenSteps(storyboard);
   const dispatch = createDispatcher(agentUrls, clients, options.multi_instance_strategy ?? 'round-robin');
 
+  // Placeholder storyboards with no executable phases get a distinct skip
+  // reason per the runner-output contract. Without this, the overall result
+  // would pass vacuously — `passed_count === 0 && failed_count === 0` — and
+  // an implementor reading the report can't tell "nothing tested" from
+  // "everything passed".
+  const hasExecutableSteps = storyboard.phases.some(p => p.steps.length > 0);
+  if (!hasExecutableSteps) {
+    const detail = `Storyboard "${storyboard.id}" has no executable phases — populate \`phases[].steps\` or remove the storyboard.`;
+    const syntheticStep: StoryboardStepResult = {
+      storyboard_id: storyboard.id,
+      step_id: '__no_phases__',
+      phase_id: '__no_phases__',
+      title: 'Storyboard has no executable phases',
+      task: '',
+      passed: true,
+      skipped: true,
+      skip_reason: 'no_phases',
+      skip: buildSkip('no_phases', detail),
+      duration_ms: 0,
+      validations: [],
+      context,
+      error: detail,
+      extraction: { path: 'none' },
+    };
+    phaseResults.push({
+      phase_id: '__no_phases__',
+      phase_title: 'No phases',
+      passed: false,
+      steps: [syntheticStep],
+      duration_ms: 0,
+    });
+    skippedCount++;
+  }
+
   for (const phase of storyboard.phases) {
     const phaseStart = Date.now();
     const stepResults: StoryboardStepResult[] = [];
@@ -123,18 +248,22 @@ export async function runStoryboard(
     for (const step of phase.steps) {
       // Skip remaining steps if a stateful dependency failed
       if (statefulFailed && step.stateful) {
+        const detail = 'Skipped: prior stateful step failed.';
         stepResults.push({
+          storyboard_id: storyboard.id,
           step_id: step.id,
           phase_id: phase.id,
           title: step.title,
           task: step.task,
           passed: false,
           skipped: true,
-          skip_reason: 'dependency_failed',
+          skip_reason: 'prerequisite_failed',
+          skip: buildSkip('prerequisite_failed', detail),
           duration_ms: 0,
           validations: [],
           context,
-          error: 'Skipped: prior stateful step failed',
+          error: detail,
+          extraction: { path: 'none' },
         });
         skippedCount++;
         phasePassed = false;
@@ -142,12 +271,13 @@ export async function runStoryboard(
       }
 
       const assignment = dispatch.nextFor(step);
-      const result = await executeStep(assignment.client, step, phase.id, context, allSteps, options, {
+      const rawResult = await executeStep(assignment.client, step, phase.id, context, allSteps, options, {
         contributions,
         priorStepResults,
         priorProbes,
         agentUrl: assignment.agentUrl,
       });
+      const result: StoryboardStepResult = { ...rawResult, storyboard_id: storyboard.id };
       if (isMultiInstance) {
         result.agent_url = assignment.agentUrl;
         result.agent_index = assignment.instanceIndex + 1;
@@ -205,6 +335,7 @@ export async function runStoryboard(
     if (!phaseDef || phaseDef.optional || !p.passed) return false;
     return p.steps.some(s => !s.skipped && s.passed);
   });
+  const schemasUsed = collectSchemasUsed(phaseResults);
   const result: StoryboardResult = {
     storyboard_id: storyboard.id,
     storyboard_title: storyboard.title,
@@ -219,6 +350,7 @@ export async function runStoryboard(
     failed_count: failedCount,
     skipped_count: skippedCount,
     tested_at: new Date().toISOString(),
+    ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
   };
 
   // Close protocol connections when the runner created its own client. The
@@ -229,6 +361,27 @@ export async function runStoryboard(
   }
 
   return result;
+}
+
+/**
+ * Collect a deduplicated list of schemas applied during this run. Drawn
+ * from every validation result with a schema_id; dropping empties keeps
+ * the list proportional to what actually ran.
+ */
+function collectSchemasUsed(phases: StoryboardPhaseResult[]): Array<{ schema_id: string; schema_url: string }> {
+  const seen = new Set<string>();
+  const out: Array<{ schema_id: string; schema_url: string }> = [];
+  for (const phase of phases) {
+    for (const step of phase.steps) {
+      for (const v of step.validations) {
+        if (v.schema_id && v.schema_url && !seen.has(v.schema_id)) {
+          seen.add(v.schema_id);
+          out.push({ schema_id: v.schema_id, schema_url: v.schema_url });
+        }
+      }
+    }
+  }
+  return out;
 }
 
 // ────────────────────────────────────────────────────────────
@@ -330,6 +483,7 @@ async function executeStep(
       validations: [],
       context,
       error: `Step task "${step.task}" references a test-kit field that resolved to nothing and no task_default is set.`,
+      extraction: { path: 'none' },
     };
   }
   const effectiveStep: StoryboardStep = resolvedTask === step.task ? step : { ...step, task: resolvedTask };
@@ -337,6 +491,12 @@ async function executeStep(
   // Check requires_tool — skip if agent doesn't have it
   if (step.requires_tool && options.agentTools && !options.agentTools.includes(step.requires_tool)) {
     const next = getNextStepPreview(step.id, allSteps, context);
+    const reason: RunnerSkipReason =
+      step.requires_tool === 'comply_test_controller' ? 'missing_test_controller' : 'missing_tool';
+    const detail =
+      reason === 'missing_test_controller'
+        ? `Deterministic-testing phase requires comply_test_controller; agent tools: [${(options.agentTools ?? []).join(', ')}].`
+        : `Required tool "${step.requires_tool}" not advertised; agent tools: [${(options.agentTools ?? []).join(', ')}].`;
     return {
       step_id: step.id,
       phase_id: phaseId,
@@ -344,17 +504,20 @@ async function executeStep(
       task: step.task,
       passed: true,
       skipped: true,
-      skip_reason: step.requires_tool === 'comply_test_controller' ? 'missing_test_harness' : 'not_testable',
+      skip_reason: reason,
+      skip: buildSkip(reason, detail),
       duration_ms: 0,
       validations: [],
       context,
       next,
+      extraction: { path: 'none' },
     };
   }
 
   // Skip if agent doesn't implement the tool this step calls.
   if (options.agentTools && !options.agentTools.includes(effectiveStep.task)) {
     const next = getNextStepPreview(step.id, allSteps, context);
+    const detail = `Agent did not advertise tool "${effectiveStep.task}"; agent tools: [${(options.agentTools ?? []).join(', ')}].`;
     return {
       step_id: step.id,
       phase_id: phaseId,
@@ -363,10 +526,12 @@ async function executeStep(
       passed: true,
       skipped: true,
       skip_reason: 'missing_tool',
+      skip: buildSkip('missing_tool', detail),
       duration_ms: 0,
       validations: [],
       context,
       next,
+      extraction: { path: 'none' },
     };
   }
 
@@ -427,6 +592,7 @@ async function executeStep(
   const unresolvedVars = findUnresolvedContextVars(request);
   if (unresolvedVars.length > 0 && !step.expect_error) {
     const next = getNextStepPreview(step.id, allSteps, context);
+    const detail = `Skipped: unresolved context variables from prior steps: ${unresolvedVars.join(', ')}.`;
     return {
       step_id: step.id,
       phase_id: phaseId,
@@ -434,12 +600,14 @@ async function executeStep(
       task: step.task,
       passed: false,
       skipped: true,
-      skip_reason: 'dependency_failed',
+      skip_reason: 'prerequisite_failed',
+      skip: buildSkip('prerequisite_failed', detail),
       duration_ms: 0,
       validations: [],
       context,
-      error: `Skipped: unresolved context variables: ${unresolvedVars.join(', ')}`,
+      error: detail,
       next,
+      extraction: { path: 'none' },
     };
   }
 
@@ -462,6 +630,7 @@ async function executeStep(
   let taskResult: TaskResult | undefined;
   let stepResult: { duration_ms: number; error?: string; passed: boolean };
   let httpResult: HttpProbeResult | undefined;
+  let responseRecord: RunnerResponseRecord | undefined;
 
   if (step.auth !== undefined) {
     const started = Date.now();
@@ -476,10 +645,19 @@ async function executeStep(
       });
       httpResult = probe.httpResult;
       taskResult = probe.taskResult;
+      const durationMs = Date.now() - started;
       stepResult = {
-        duration_ms: Date.now() - started,
+        duration_ms: durationMs,
         passed: !httpResult.error,
         error: httpResult.error,
+      };
+      const filteredHeaders = filterResponseHeaders(httpResult.headers);
+      responseRecord = {
+        transport: 'mcp',
+        payload: redactSecrets(httpResult.body),
+        ...(typeof httpResult.status === 'number' ? { status: httpResult.status } : {}),
+        ...(filteredHeaders && { headers: filteredHeaders }),
+        duration_ms: durationMs,
       };
     } catch (err) {
       stepResult = {
@@ -496,13 +674,31 @@ async function executeStep(
     );
     taskResult = run.result;
     stepResult = run.step;
+    if (taskResult) {
+      responseRecord = {
+        transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
+        payload: redactSecrets(taskResult.data ?? taskResult.error ?? null),
+        duration_ms: stepResult.duration_ms,
+      };
+    }
   }
+
+  const requestRecord: RunnerRequestRecord = {
+    transport: step.auth !== undefined ? 'mcp' : options.protocol === 'a2a' ? 'a2a' : 'mcp',
+    operation: effectiveStep.task,
+    payload: redactSecrets(request),
+    ...(runState.agentUrl ? { url: runState.agentUrl } : {}),
+  };
 
   // Feature-unsupported or unknown-tool errors → treat as skip
   const isUnsupported = stepResult.error?.includes('does not support:');
   const isUnknownTool = stepResult.error && /Unknown tool[:\s]/i.test(stepResult.error);
   if (!taskResult && (isUnsupported || isUnknownTool)) {
     const next = getNextStepPreview(step.id, allSteps, context);
+    const reason: RunnerSkipReason = isUnknownTool ? 'missing_tool' : 'not_applicable';
+    const detail = isUnknownTool
+      ? `Agent rejected tool "${effectiveStep.task}" as unknown: ${stepResult.error}`
+      : `Agent reported feature not supported: ${stepResult.error}`;
     return {
       step_id: step.id,
       phase_id: phaseId,
@@ -510,12 +706,14 @@ async function executeStep(
       task: step.task,
       passed: true,
       skipped: true,
-      skip_reason: isUnknownTool ? 'missing_tool' : 'not_testable',
+      skip_reason: reason,
+      skip: buildSkip(reason, detail),
       duration_ms: stepResult.duration_ms,
       validations: [],
       context,
       error: stepResult.error,
       next,
+      extraction: { path: 'none' },
     };
   }
 
@@ -555,6 +753,9 @@ async function executeStep(
       ...(httpResult && { httpResult }),
       agentUrl: runState.agentUrl,
       contributions: runState.contributions,
+      ...(effectiveStep.response_schema_ref && { responseSchemaRef: effectiveStep.response_schema_ref }),
+      request: requestRecord,
+      ...(responseRecord && { response: responseRecord }),
     };
     validations = runValidations(resolvedValidations, vctx);
   }
@@ -596,6 +797,9 @@ async function executeStep(
     context: updatedContext,
     error: step.expect_error ? undefined : truncateError(stepResult.error || taskResult?.error),
     next,
+    request: requestRecord,
+    ...(responseRecord && { response_record: responseRecord }),
+    extraction: extractionFromTaskResult(taskResult),
   };
 }
 
@@ -627,11 +831,31 @@ async function executeProbeStep(
 
   if (httpResult) runState.priorProbes.set(step.task, httpResult);
 
+  const duration = Date.now() - start;
+  const requestRecord: RunnerRequestRecord = {
+    transport: 'http',
+    operation: step.task,
+    payload: null,
+    ...(httpResult?.url ? { url: httpResult.url } : runState.agentUrl ? { url: runState.agentUrl } : {}),
+  };
+  const filteredProbeHeaders = filterResponseHeaders(httpResult?.headers);
+  const responseRecord: RunnerResponseRecord | undefined = httpResult
+    ? {
+        transport: 'http',
+        payload: redactSecrets(httpResult.body),
+        status: httpResult.status,
+        ...(filteredProbeHeaders && { headers: filteredProbeHeaders }),
+        duration_ms: duration,
+      }
+    : undefined;
+
   const vctx: ValidationContext = {
     taskName: step.task,
     httpResult,
     agentUrl: runState.agentUrl,
     contributions: runState.contributions,
+    request: requestRecord,
+    ...(responseRecord && { response: responseRecord }),
   };
   const validations = step.validations?.length ? runValidations(step.validations, vctx) : [];
   const allValidationsPassed = validations.every(v => v.passed);
@@ -642,18 +866,27 @@ async function executeProbeStep(
   const fetchOk = httpResult ? !httpResult.error : true;
   const passed = fetchOk && allValidationsPassed;
 
+  const extraction: RunnerExtractionRecord = httpResult
+    ? httpResult.error
+      ? { path: 'error' }
+      : { path: 'structured_content', note: 'http-probe body parsed as JSON' }
+    : { path: 'none' };
+
   return {
     step_id: step.id,
     phase_id: phaseId,
     title: step.title,
     task: step.task,
     passed,
-    duration_ms: Date.now() - start,
+    duration_ms: duration,
     response: httpResult ?? undefined,
     validations,
     context,
     error: httpResult?.error ?? (passed ? undefined : 'Probe validations failed.'),
     next: getNextStepPreview(step.id, allSteps, context),
+    request: requestRecord,
+    ...(responseRecord && { response_record: responseRecord }),
+    extraction,
   };
 }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -66,6 +66,10 @@ function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerS
 
 function extractionFromTaskResult(taskResult: TaskResult | undefined): RunnerExtractionRecord {
   if (!taskResult) return { path: 'none' };
+  // Prefer the explicit provenance stamped by the response unwrapper / raw
+  // MCP probe. Fall back to inference only when the tag is missing (e.g.,
+  // synthetic TaskResults built by validation harnesses).
+  if (taskResult._extraction_path !== undefined) return { path: taskResult._extraction_path };
   if (!taskResult.success && taskResult.error) return { path: 'error' };
   return taskResult.data !== undefined && taskResult.data !== null ? { path: 'structured_content' } : { path: 'none' };
 }

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -8,6 +8,7 @@
  */
 
 import type { TaskResult } from '../types';
+import { readExtractionPath } from '../../utils/response-unwrapper';
 
 /**
  * Map of AdCP task names to SingleAgentClient method names.
@@ -135,9 +136,11 @@ export async function executeStoryboardTask(
     }
   }
 
+  const extractionPath = readExtractionPath(result.data);
   return {
     success: result.success ?? true,
     data: result.data,
     error: result.error,
+    ...(extractionPath !== undefined && { _extraction_path: extractionPath }),
   };
 }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -309,13 +309,12 @@ export interface RunnerResponseRecord {
 /**
  * Which MCP extraction path produced the parsed response. Recording this
  * lets implementors distinguish runner extraction bugs from agent bugs.
+ * Populated by the response unwrapper (normal SDK path) and by the raw MCP
+ * probe (auth-override path); the runner falls back to inference when the
+ * provenance tag is missing.
  *
- *   - `structured_content` — the MCP SDK returned parsed structured data.
- *   - `text_fallback` — parsed from `result.content[].text` JSON. Reserved;
- *     the current SDK collapses structured vs text into a single
- *     `TaskResult.data` before the runner sees it, so this value is not
- *     yet emitted. Will be populated when extraction provenance is
- *     plumbed through `TaskResult`.
+ *   - `structured_content` — parsed from `result.structuredContent`.
+ *   - `text_fallback` — parsed from `result.content[].text` JSON.
  *   - `error` — `result.isError` or transport-level failure; payload is the error.
  *   - `none` — no MCP response (HTTP-probe step, synthetic step, or skipped).
  */

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -229,6 +229,99 @@ export interface StoryboardRunOptions extends TestOptions {
 }
 
 // ────────────────────────────────────────────────────────────
+// Runner-output contract shapes
+//
+// See `static/compliance/source/universal/runner-output-contract.yaml`
+// (adcontextprotocol/adcp PR #2364). The contract defines the minimum
+// failure-result shape every AdCP compliance runner MUST emit so buyers
+// can self-diagnose agent conformance failures. Optional fields stay
+// `undefined` when they don't apply (e.g., schema_url on a non-schema
+// check).
+// ────────────────────────────────────────────────────────────
+
+export type RunnerTransport = 'mcp' | 'a2a' | 'http';
+
+export interface RunnerRequestRecord {
+  transport: RunnerTransport;
+  /** Task/tool/skill name actually invoked (after test-kit resolution). */
+  operation: string;
+  /** Fully-resolved JSON payload with secrets redacted as "[redacted]". */
+  payload: unknown;
+  /**
+   * Observed request headers. Deliberately NOT populated today — the runner
+   * builds `Authorization: Bearer <token>` headers in-flight and echoing them
+   * into a shared compliance report would be a credential leak. The field is
+   * kept in the type for future auth-override request captures that carry a
+   * redacted form.
+   */
+  headers?: Record<string, string>;
+  /** Full URL for http/a2a; omitted for stdio MCP. */
+  url?: string;
+}
+
+export interface RunnerResponseRecord {
+  transport: RunnerTransport;
+  /** Exact response payload, per transport. */
+  payload: unknown;
+  /** HTTP status where applicable. */
+  status?: number;
+  /** Observed response headers. */
+  headers?: Record<string, string>;
+  /** Wall-clock time for the request. */
+  duration_ms?: number;
+}
+
+/**
+ * Which MCP extraction path produced the parsed response. Recording this
+ * lets implementors distinguish runner extraction bugs from agent bugs.
+ *
+ *   - `structured_content` — the MCP SDK returned parsed structured data.
+ *   - `text_fallback` — parsed from `result.content[].text` JSON. Reserved;
+ *     the current SDK collapses structured vs text into a single
+ *     `TaskResult.data` before the runner sees it, so this value is not
+ *     yet emitted. Will be populated when extraction provenance is
+ *     plumbed through `TaskResult`.
+ *   - `error` — `result.isError` or transport-level failure; payload is the error.
+ *   - `none` — no MCP response (HTTP-probe step, synthetic step, or skipped).
+ */
+export type RunnerExtractionPath = 'structured_content' | 'text_fallback' | 'error' | 'none';
+
+export interface RunnerExtractionRecord {
+  path: RunnerExtractionPath;
+  /** Optional note, e.g. "structuredContent contained only adcp_error". */
+  note?: string;
+}
+
+/**
+ * Spec skip reasons. Runners MUST distinguish these so an implementor knows
+ * whether a skip is informative (agent didn't claim the protocol) or masking
+ * (runner couldn't apply the storyboard even though the agent claimed it).
+ */
+export type RunnerSkipReason =
+  | 'not_applicable'
+  | 'no_phases'
+  | 'prerequisite_failed'
+  | 'missing_tool'
+  | 'missing_test_controller'
+  | 'unsatisfied_contract';
+
+export interface RunnerSkipResult {
+  reason: RunnerSkipReason;
+  detail: string;
+}
+
+/**
+ * Machine-readable Zod/AJV-style validation error. Emitted in
+ * `ValidationResult.actual` for `response_schema` failures.
+ */
+export interface SchemaValidationError {
+  instance_path: string;
+  schema_path: string;
+  keyword: string;
+  message: string;
+}
+
+// ────────────────────────────────────────────────────────────
 // Results
 // ────────────────────────────────────────────────────────────
 
@@ -236,8 +329,26 @@ export interface ValidationResult {
   check: string;
   passed: boolean;
   description: string;
+  /** Dot/bracket JSON path (legacy). See `json_pointer` for the RFC 6901 form. */
   path?: string;
+  /** Human-readable failure detail. */
   error?: string;
+  /** RFC 6901 pointer to the failing field. Null when the failure is transport-level. */
+  json_pointer?: string | null;
+  /** Machine-readable expected value / schema $id / acceptable forms. */
+  expected?: unknown;
+  /** Machine-readable actual value / schema errors / observed non-object. */
+  actual?: unknown;
+  /** Schema $id applied; set only for `response_schema`. */
+  schema_id?: string | null;
+  /** Resolvable schema URL; set only for `response_schema`. */
+  schema_url?: string | null;
+  /** Exact request the runner sent (present on failure when available). */
+  request?: RunnerRequestRecord;
+  /** Exact response observed (present on failure when available). */
+  response?: RunnerResponseRecord;
+  /** Optional remediation hint. */
+  remediation?: string;
 }
 
 export interface StoryboardStepPreview {
@@ -252,6 +363,8 @@ export interface StoryboardStepPreview {
 }
 
 export interface StoryboardStepResult {
+  /** Storyboard that produced this step result. */
+  storyboard_id?: string;
   step_id: string;
   phase_id: string;
   title: string;
@@ -259,17 +372,19 @@ export interface StoryboardStepResult {
   passed: boolean;
   /** True when the step was not executed */
   skipped?: boolean;
-  /** Why the step was skipped */
-  skip_reason?:
-    | 'not_testable'
-    | 'dependency_failed'
-    | 'missing_test_harness'
-    | 'missing_tool'
-    /** Storyboard predates the agent's declared adcp.major_versions. */
-    | 'not_applicable';
+  /**
+   * Spec skip reason (see `RunnerSkipReason`). `not_applicable` covers the
+   * `introduced_in` version-mismatch case that main previously emitted with
+   * its narrower enum — it's the right spec reason for "this storyboard
+   * didn't exist at the version the agent certified against."
+   */
+  skip_reason?: RunnerSkipReason;
+  /** Structured skip result with human-readable detail (spec contract). */
+  skip?: RunnerSkipResult;
   /** True when the step expected an error (inverted pass/fail) */
   expect_error?: boolean;
   duration_ms: number;
+  /** Raw parsed response body (legacy field; new code reads `response_record`). */
   response?: unknown;
   validations: ValidationResult[];
   /** Accumulated context after this step */
@@ -281,6 +396,12 @@ export interface StoryboardStepResult {
   agent_url?: string;
   /** 1-based index of the agent instance (multi-instance mode). Absent in single-URL mode. */
   agent_index?: number;
+  /** Exact request the runner sent (contract-required on failures). */
+  request?: RunnerRequestRecord;
+  /** Exact response observed, including transport, status, headers. */
+  response_record?: RunnerResponseRecord;
+  /** Which extraction path produced the parsed response (required per contract). */
+  extraction: RunnerExtractionRecord;
 }
 
 export interface StoryboardPhaseResult {
@@ -309,4 +430,10 @@ export interface StoryboardResult {
   failed_count: number;
   skipped_count: number;
   tested_at: string;
+  /**
+   * Schemas applied during this run. Per the runner-output contract, runners
+   * MUST surface the exact schema identities so implementors can re-validate
+   * locally against the same artifacts.
+   */
+  schemas_used?: Array<{ schema_id: string; schema_url: string }>;
 }

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -1,17 +1,25 @@
 /**
  * Per-step validation engine for storyboard testing.
  *
- * Supports four validation types defined in storyboard YAML:
- * - response_schema: validate against Zod schemas
- * - field_present: check a JSON path exists and is not null/undefined
- * - field_value: check a JSON path equals an expected value
- * - status_code: check the TaskResult status
+ * Emits validation results conforming to the runner-output contract:
+ * failed validations carry RFC 6901 `json_pointer`, machine-readable
+ * `expected`/`actual`, and for `response_schema` checks the `schema_id`
+ * plus resolvable `schema_url`. See
+ * `static/compliance/source/universal/runner-output-contract.yaml`.
  */
 
 import { TOOL_RESPONSE_SCHEMAS } from '../../utils/response-schemas';
+import { ADCP_VERSION } from '../../version';
 import type { TaskResult } from '../types';
-import type { HttpProbeResult, StoryboardValidation, ValidationResult } from './types';
-import { resolvePath } from './path';
+import type {
+  HttpProbeResult,
+  RunnerRequestRecord,
+  RunnerResponseRecord,
+  SchemaValidationError,
+  StoryboardValidation,
+  ValidationResult,
+} from './types';
+import { resolvePath, toJsonPointer } from './path';
 import { PROBE_TASK_ALLOWLIST } from './test-kit';
 
 /**
@@ -26,19 +34,43 @@ export interface ValidationContext {
   httpResult?: HttpProbeResult;
   agentUrl: string;
   contributions: Set<string>;
+  /**
+   * Storyboard-declared response schema reference, e.g.
+   * `"protocol/get-adcp-capabilities-response.json"`. When present the
+   * runner emits schema_id / schema_url conforming to the contract.
+   */
+  responseSchemaRef?: string;
+  /** Exact request the runner sent — echoed on failed validations. */
+  request?: RunnerRequestRecord;
+  /** Exact response observed — echoed on failed validations. */
+  response?: RunnerResponseRecord;
 }
 
 /**
  * Run all validations for a storyboard step.
  */
 export function runValidations(validations: StoryboardValidation[], context: ValidationContext): ValidationResult[] {
-  return validations.map(v => runValidation(v, context));
+  return validations.map(v => attachOnFailure(runValidation(v, context), context));
+}
+
+/**
+ * Attach request / response records to a failed validation so implementors
+ * see the exact bytes the runner sent and observed. Passed validations stay
+ * minimal — carrying the full payload on every passing check bloats the
+ * JSON surface without diagnostic value.
+ */
+function attachOnFailure(result: ValidationResult, context: ValidationContext): ValidationResult {
+  if (result.passed) return result;
+  const augmented: ValidationResult = { ...result };
+  if (context.request && augmented.request === undefined) augmented.request = context.request;
+  if (context.response && augmented.response === undefined) augmented.response = context.response;
+  return augmented;
 }
 
 function runValidation(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
   switch (validation.check) {
     case 'response_schema':
-      return requireTaskResult(ctx, validation, tr => validateResponseSchema(validation, ctx.taskName, tr));
+      return requireTaskResult(ctx, validation, tr => validateResponseSchema(validation, ctx, tr));
     case 'field_present':
       // field_present runs against either MCP task result data OR an HTTP probe body —
       // the storyboard's probe_protected_resource validates fields in the RFC 9728 JSON.
@@ -65,6 +97,7 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
         passed: false,
         description: validation.description,
         error: `Unknown validation check: ${validation.check}`,
+        json_pointer: null,
       };
   }
 }
@@ -80,6 +113,7 @@ function requireTaskResult(
       passed: false,
       description: validation.description,
       error: `Validation "${validation.check}" requires an MCP task result but this step was an HTTP probe.`,
+      json_pointer: null,
     };
   }
   return fn(ctx.taskResult);
@@ -96,6 +130,7 @@ function requireHttpResult(
       passed: false,
       description: validation.description,
       error: `Validation "${validation.check}" requires an HTTP probe result but this step was an MCP task.`,
+      json_pointer: null,
     };
   }
   return fn(ctx.httpResult);
@@ -114,14 +149,95 @@ function resolveTarget(ctx: ValidationContext): TaskResult {
 }
 
 // ────────────────────────────────────────────────────────────
+// Schema URL resolution
+// ────────────────────────────────────────────────────────────
+
+const SCHEMA_URL_BASE = 'https://adcontextprotocol.org';
+
+/**
+ * Build a `{ schema_id, schema_url }` pair from a storyboard-declared
+ * `response_schema_ref`. The id follows the `/schemas/<version>/<path>.json`
+ * convention used by `$id` in cached JSON schemas; the url dereferences
+ * against the public docs origin so implementors can fetch it.
+ */
+function resolveSchemaIdentity(schemaRef: string | undefined): { schema_id: string | null; schema_url: string | null } {
+  if (!schemaRef) return { schema_id: null, schema_url: null };
+  const trimmed = schemaRef.replace(/^\/+/, '');
+  const schemaId = `/schemas/${ADCP_VERSION}/${trimmed}`;
+  const schemaUrl = `${SCHEMA_URL_BASE}${schemaId}`;
+  return { schema_id: schemaId, schema_url: schemaUrl };
+}
+
+/**
+ * Convert a Zod error into the AJV-shaped `SchemaValidationError[]` the
+ * contract calls for. Each issue names the failing instance path, the
+ * schema keyword that rejected it (best-effort from Zod's `code`), and
+ * the original message.
+ */
+/**
+ * Escape a single Zod path segment as an RFC 6901 reference token: `~` → `~0`
+ * (done first), then `/` → `~1`. Numeric segments pass through as-is.
+ */
+function escapeJsonPointerSegment(seg: PropertyKey): string {
+  return String(seg).replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+function zodIssuePathToJsonPointer(path: ReadonlyArray<PropertyKey>): string {
+  return '/' + path.map(escapeJsonPointerSegment).join('/');
+}
+
+function zodIssuesToSchemaErrors(
+  issues: ReadonlyArray<{ path: ReadonlyArray<PropertyKey>; code: string; message: string }>
+): SchemaValidationError[] {
+  return issues.map(issue => {
+    const keyword = mapZodCodeToSchemaKeyword(issue.code);
+    const instancePointer = issue.path.map(escapeJsonPointerSegment).join('/');
+    return {
+      instance_path: '/' + instancePointer,
+      // Zod does not expose the schema-side pointer. Approximate AJV's
+      // `schema_path` (a JSON pointer into the schema) as
+      // `#/properties/<path>/<keyword>` so implementors can locate the
+      // rejecting keyword inside their schema.
+      schema_path: `#/properties/${instancePointer}/${keyword}`,
+      keyword,
+      message: issue.message,
+    };
+  });
+}
+
+function mapZodCodeToSchemaKeyword(code: string): string {
+  switch (code) {
+    case 'invalid_type':
+      return 'type';
+    case 'invalid_literal':
+    case 'invalid_enum_value':
+      return 'enum';
+    case 'too_small':
+      return 'minimum';
+    case 'too_big':
+      return 'maximum';
+    case 'invalid_string':
+      return 'format';
+    case 'unrecognized_keys':
+      return 'additionalProperties';
+    case 'invalid_union':
+      return 'oneOf';
+    default:
+      return code;
+  }
+}
+
+// ────────────────────────────────────────────────────────────
 // response_schema: validate against Zod
 // ────────────────────────────────────────────────────────────
 
 function validateResponseSchema(
   validation: StoryboardValidation,
-  taskName: string,
+  ctx: ValidationContext,
   taskResult: TaskResult
 ): ValidationResult {
+  const taskName = ctx.taskName;
+  const { schema_id, schema_url } = resolveSchemaIdentity(ctx.responseSchemaRef);
   const schema = TOOL_RESPONSE_SCHEMAS[taskName];
   if (!schema) {
     return {
@@ -129,6 +245,13 @@ function validateResponseSchema(
       passed: false,
       description: validation.description,
       error: `No schema registered for task "${taskName}"`,
+      json_pointer: null,
+      expected: schema_id ?? `response schema for ${taskName}`,
+      // The runner failed before observing the agent — distinguish that from
+      // "agent returned null" so implementors don't chase a phantom agent bug.
+      actual: { reason: 'no_schema_registered', task: taskName },
+      schema_id,
+      schema_url,
     };
   }
 
@@ -141,10 +264,14 @@ function validateResponseSchema(
       check: 'response_schema',
       passed: true,
       description: validation.description,
+      schema_id,
+      schema_url,
     };
   }
 
-  // Format Zod errors
+  const schemaErrors = zodIssuesToSchemaErrors(parseResult.error.issues);
+  const firstIssue = parseResult.error.issues[0];
+  const jsonPointer = firstIssue ? zodIssuePathToJsonPointer(firstIssue.path) : null;
   const issues = parseResult.error.issues
     .slice(0, 5)
     .map(i => `${i.path.join('.')}: ${i.message}`)
@@ -155,6 +282,11 @@ function validateResponseSchema(
     passed: false,
     description: validation.description,
     error: issues,
+    json_pointer: jsonPointer,
+    expected: schema_id ?? `response schema for ${taskName}`,
+    actual: schemaErrors,
+    schema_id,
+    schema_url,
   };
 }
 
@@ -170,18 +302,35 @@ function validateFieldPresent(validation: StoryboardValidation, taskResult: Task
       description: validation.description,
       path: validation.path,
       error: 'No path specified for field_present validation',
+      json_pointer: null,
+      expected: 'path must be set in storyboard validation entry',
+      actual: null,
     };
   }
 
   const value = resolvePath(taskResult.data, validation.path);
   const present = value !== undefined && value !== null;
+  const pointer = toJsonPointer(validation.path);
+
+  if (present) {
+    return {
+      check: 'field_present',
+      passed: true,
+      description: validation.description,
+      path: validation.path,
+      json_pointer: pointer,
+    };
+  }
 
   return {
     check: 'field_present',
-    passed: present,
+    passed: false,
     description: validation.description,
     path: validation.path,
-    error: present ? undefined : `Field not found at path: ${validation.path}`,
+    error: `Field not found at path: ${validation.path}`,
+    json_pointer: pointer,
+    expected: validation.path,
+    actual: value ?? null,
   };
 }
 
@@ -204,34 +353,60 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
       description: validation.description,
       path: validation.path,
       error: 'No path specified for field_value validation',
+      json_pointer: null,
+      expected: 'path must be set in storyboard validation entry',
+      actual: null,
     };
   }
 
   const actual = resolvePath(taskResult.data, validation.path);
+  const pointer = toJsonPointer(validation.path);
 
   // allowed_values: pass if actual matches any value in the list
   if (validation.allowed_values?.length) {
     const passed = validation.allowed_values.some(v => valuesMatch(actual, v));
+    if (passed) {
+      return {
+        check: 'field_value',
+        passed: true,
+        description: validation.description,
+        path: validation.path,
+        json_pointer: pointer,
+      };
+    }
     return {
       check: 'field_value',
-      passed,
+      passed: false,
       description: validation.description,
       path: validation.path,
-      error: passed
-        ? undefined
-        : `Expected one of ${JSON.stringify(validation.allowed_values)}, got ${JSON.stringify(actual)}`,
+      error: `Expected one of ${JSON.stringify(validation.allowed_values)}, got ${JSON.stringify(actual)}`,
+      json_pointer: pointer,
+      expected: validation.allowed_values,
+      actual: actual ?? null,
     };
   }
 
   // Exact match against value
   const passed = valuesMatch(actual, validation.value);
 
+  if (passed) {
+    return {
+      check: 'field_value',
+      passed: true,
+      description: validation.description,
+      path: validation.path,
+      json_pointer: pointer,
+    };
+  }
   return {
     check: 'field_value',
-    passed,
+    passed: false,
     description: validation.description,
     path: validation.path,
-    error: passed ? undefined : `Expected ${JSON.stringify(validation.value)}, got ${JSON.stringify(actual)}`,
+    error: `Expected ${JSON.stringify(validation.value)}, got ${JSON.stringify(actual)}`,
+    json_pointer: pointer,
+    expected: validation.value,
+    actual: actual ?? null,
   };
 }
 
@@ -240,14 +415,23 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
 // ────────────────────────────────────────────────────────────
 
 function validateStatusCode(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
-  // Check success status
   const passed = taskResult.success;
 
+  if (passed) {
+    return {
+      check: 'status_code',
+      passed: true,
+      description: validation.description,
+    };
+  }
   return {
     check: 'status_code',
-    passed,
+    passed: false,
     description: validation.description,
-    error: passed ? undefined : `Task failed: ${taskResult.error || 'unknown error'}`,
+    error: `Task failed: ${taskResult.error || 'unknown error'}`,
+    json_pointer: null,
+    expected: 'success',
+    actual: taskResult.error ?? 'failure',
   };
 }
 
@@ -276,36 +460,55 @@ function validateErrorCode(validation: StoryboardValidation, taskResult: TaskRes
     (data?.error as Record<string, unknown> | undefined)?.code ??
     extractCodeFromErrorString(taskResult.error);
 
+  const pointer =
+    adcpError?.code !== undefined ? '/adcp_error/code' : data?.error_code !== undefined ? '/error_code' : null;
+
   if (validation.allowed_values?.length) {
-    const actual = errorCode !== undefined && errorCode !== null ? String(errorCode) : undefined;
-    const passed = actual !== undefined && validation.allowed_values.some(v => String(v) === actual);
+    const actualCode = errorCode !== undefined && errorCode !== null ? String(errorCode) : undefined;
+    const passed = actualCode !== undefined && validation.allowed_values.some(v => String(v) === actualCode);
+    if (passed) {
+      return { check: 'error_code', passed: true, description: validation.description, json_pointer: pointer };
+    }
     return {
       check: 'error_code',
-      passed,
+      passed: false,
       description: validation.description,
-      error: passed
-        ? undefined
-        : `Expected one of ${JSON.stringify(validation.allowed_values)}, got ${JSON.stringify(errorCode)}`,
+      error: `Expected one of ${JSON.stringify(validation.allowed_values)}, got ${JSON.stringify(errorCode)}`,
+      json_pointer: pointer,
+      expected: validation.allowed_values,
+      actual: errorCode ?? null,
     };
   }
 
   if (!validation.value) {
     // Just check that an error code exists
     const hasCode = errorCode !== undefined && errorCode !== null;
+    if (hasCode) {
+      return { check: 'error_code', passed: true, description: validation.description, json_pointer: pointer };
+    }
     return {
       check: 'error_code',
-      passed: hasCode,
+      passed: false,
       description: validation.description,
-      error: hasCode ? undefined : 'No error code found in response',
+      error: 'No error code found in response',
+      json_pointer: pointer,
+      expected: 'any error code',
+      actual: null,
     };
   }
 
   const passed = String(errorCode) === String(validation.value);
+  if (passed) {
+    return { check: 'error_code', passed: true, description: validation.description, json_pointer: pointer };
+  }
   return {
     check: 'error_code',
-    passed,
+    passed: false,
     description: validation.description,
-    error: passed ? undefined : `Expected error code "${validation.value}", got "${errorCode}"`,
+    error: `Expected error code "${validation.value}", got "${errorCode}"`,
+    json_pointer: pointer,
+    expected: validation.value,
+    actual: errorCode ?? null,
   };
 }
 
@@ -316,11 +519,17 @@ function validateErrorCode(validation: StoryboardValidation, taskResult: TaskRes
 function validateHttpStatus(validation: StoryboardValidation, hr: HttpProbeResult): ValidationResult {
   const expected = validation.value as number | undefined;
   const passed = typeof expected === 'number' && hr.status === expected;
+  if (passed) {
+    return { check: 'http_status', passed: true, description: validation.description };
+  }
   return {
     check: 'http_status',
-    passed,
+    passed: false,
     description: validation.description,
-    error: passed ? undefined : `Expected HTTP ${expected}, got ${hr.status}${hr.error ? ` (${hr.error})` : ''}`,
+    error: `Expected HTTP ${expected}, got ${hr.status}${hr.error ? ` (${hr.error})` : ''}`,
+    json_pointer: null,
+    expected: expected ?? null,
+    actual: hr.status,
   };
 }
 
@@ -351,6 +560,9 @@ function validateHttpStatusIn(validation: StoryboardValidation, hr: HttpProbeRes
         `\`probe_task\` to one of ${PROBE_TASK_ALLOWLIST.join(', ')}); or (2) the agent evaluates ` +
         `schema before auth, which is itself a conformance gap (protected endpoints must return ` +
         `401/403 on invalid credentials regardless of body shape).`,
+      json_pointer: null,
+      expected: allowed,
+      actual: hr.status,
     };
   }
   return {
@@ -358,6 +570,9 @@ function validateHttpStatusIn(validation: StoryboardValidation, hr: HttpProbeRes
     passed: false,
     description: validation.description,
     error: `Expected HTTP status in ${JSON.stringify(allowed)}, got ${hr.status}${hr.error ? ` (${hr.error})` : ''}`,
+    json_pointer: null,
+    expected: allowed,
+    actual: hr.status,
   };
 }
 
@@ -412,6 +627,9 @@ function validateOn401RequireHeader(validation: StoryboardValidation, hr: HttpPr
       passed: false,
       description: validation.description,
       error: '`value` is required (the header name to require on 401 responses).',
+      json_pointer: null,
+      expected: 'header name',
+      actual: null,
     };
   }
   // Silent pass when the response isn't a 401 — the conditional is part of
@@ -421,11 +639,17 @@ function validateOn401RequireHeader(validation: StoryboardValidation, hr: HttpPr
   }
   const value = hr.headers[header];
   const passed = typeof value === 'string' && value.length > 0;
+  if (passed) {
+    return { check: 'on_401_require_header', passed: true, description: validation.description };
+  }
   return {
     check: 'on_401_require_header',
-    passed,
+    passed: false,
     description: validation.description,
-    error: passed ? undefined : `401 response missing required header "${header}".`,
+    error: `401 response missing required header "${header}".`,
+    json_pointer: null,
+    expected: `response header "${header}" present`,
+    actual: value ?? null,
   };
 }
 
@@ -461,15 +685,18 @@ function validateResourceEqualsAgentUrl(
       passed: false,
       description: validation.description,
       error: 'Response body missing string `resource` field.',
+      json_pointer: '/resource',
+      expected: normalizeAgentUrl(agentUrl),
+      actual: null,
     };
   }
   const expected = normalizeAgentUrl(agentUrl);
   const actual = normalizeAgentUrl(resource);
   const passed = actual === expected;
-  // Don't echo the advertised value verbatim — compliance reports may be
-  // shared publicly and the raw diff helps attackers probe victim agents.
-  // Surface just enough for the operator to self-diagnose: their own URL,
-  // which part of the advertised URL differs, and a pointer to the fix.
+  // Don't echo the advertised value verbatim in the human-readable message —
+  // compliance reports may be shared publicly and the raw diff helps attackers
+  // probe victim agents. Machine-readable expected/actual are fine: implementors
+  // consuming the JSON already hold both URLs.
   let redactedError: string | undefined;
   if (!passed) {
     let actualHost = 'unknown';
@@ -487,11 +714,22 @@ function validateResourceEqualsAgentUrl(
         : `Advertised path differs from the agent path. `) +
       `Fix: set \`resource\` equal to the full agent URL in your protected-resource metadata document.`;
   }
+  if (passed) {
+    return {
+      check: 'resource_equals_agent_url',
+      passed: true,
+      description: validation.description,
+      json_pointer: '/resource',
+    };
+  }
   return {
     check: 'resource_equals_agent_url',
-    passed,
+    passed: false,
     description: validation.description,
     error: redactedError,
+    json_pointer: '/resource',
+    expected,
+    actual,
   };
 }
 
@@ -502,11 +740,17 @@ function validateResourceEqualsAgentUrl(
 function validateAnyOf(validation: StoryboardValidation, contributions: Set<string>): ValidationResult {
   const flags = Array.isArray(validation.allowed_values) ? validation.allowed_values.map(String) : [];
   const passed = flags.some(f => contributions.has(f));
+  if (passed) {
+    return { check: 'any_of', passed: true, description: validation.description };
+  }
   return {
     check: 'any_of',
-    passed,
+    passed: false,
     description: validation.description,
-    error: passed ? undefined : `None of the required contributions were recorded: ${JSON.stringify(flags)}`,
+    error: `None of the required contributions were recorded: ${JSON.stringify(flags)}`,
+    json_pointer: null,
+    expected: flags,
+    actual: Array.from(contributions),
   };
 }
 

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -278,6 +278,13 @@ export interface TaskResult {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- response shape varies by tool; typed per-access in scenarios
   data?: any;
   error?: string;
+  /**
+   * Internal: which MCP extraction path produced `data`. Set by the response
+   * unwrapper and the raw MCP probe so the storyboard runner can surface it
+   * in its output contract. Consumers outside the runner should treat this
+   * as implementation detail — it's NOT part of the public `AdCPResponse`.
+   */
+  _extraction_path?: 'structured_content' | 'text_fallback' | 'error' | 'none';
 }
 
 // Logger interface for library use

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -74,26 +74,42 @@ export function unwrapProtocolResponse(
 
   // Extract response from protocol wrapper
   let unwrapped: any;
+  let mcpExtractionPath: McpExtractionPath | undefined;
   if (protocol === 'mcp') {
-    unwrapped = unwrapMCPResponse(protocolResponse);
+    const outcome = unwrapMCPResponse(protocolResponse);
+    unwrapped = outcome.result;
+    mcpExtractionPath = outcome.extractionPath;
   } else if (protocol === 'a2a') {
     unwrapped = unwrapA2AResponse(protocolResponse);
   } else {
     // Auto-detect protocol if not specified
     if (isMCPResponse(protocolResponse)) {
-      unwrapped = unwrapMCPResponse(protocolResponse);
+      const outcome = unwrapMCPResponse(protocolResponse);
+      unwrapped = outcome.result;
+      mcpExtractionPath = outcome.extractionPath;
     } else if (isA2AResponse(protocolResponse)) {
       unwrapped = unwrapA2AResponse(protocolResponse);
     } else {
       throw new Error('Unable to extract AdCP response from protocol wrapper');
     }
   }
+  // Preserve the extraction path across Zod's `safeParse` (which returns a
+  // fresh object). `retag` re-attaches the provenance to whichever object we
+  // return so the tag survives validation, filtering, and _message merging.
+  const retag = <T extends AdCPResponse & { _message?: string }>(value: T): T => {
+    if (mcpExtractionPath !== undefined) tagExtractionPath(value, mcpExtractionPath);
+    return value;
+  };
+
+  if (mcpExtractionPath !== undefined) {
+    tagExtractionPath(unwrapped, mcpExtractionPath);
+  }
 
   // Skip schema validation for error responses — they don't include
   // tool-specific fields like `products`. Handles both AdCP-standard
   // { errors: [...] } and legacy singular { error: "..." } patterns.
   if (isAdcpError(unwrapped) || (unwrapped?.error && typeof unwrapped.error === 'string')) {
-    return unwrapped;
+    return retag(unwrapped);
   }
 
   // Validate success responses against tool schema if tool name provided
@@ -112,7 +128,7 @@ export function unwrapProtocolResponse(
           if (filtered) {
             const validated = filtered as unknown as AdCPResponse & { _message?: string };
             if (_msg) validated._message = _msg as string;
-            return validated;
+            return retag(validated);
           }
         }
 
@@ -135,11 +151,11 @@ export function unwrapProtocolResponse(
       // Re-attach _message after validation so it's available for text summaries
       const validated = result.data as AdCPResponse & { _message?: string };
       if (_msg) validated._message = _msg as string;
-      return validated;
+      return retag(validated);
     }
   }
 
-  // Return unwrapped response (no validation)
+  // Return unwrapped response (no validation) — already tagged above.
   return unwrapped as AdCPResponse;
 }
 
@@ -199,16 +215,35 @@ function isA2AResponse(response: any): boolean {
 }
 
 /**
- * Unwrap MCP response - all MCP logic in one place
+ * MCP response extraction provenance. Set as a non-enumerable `_extraction_path`
+ * property on the unwrapped object so the storyboard runner can surface it in
+ * its runner-output contract without leaking into JSON-serialized or spread
+ * responses. See `src/lib/testing/storyboard/types.ts` → `RunnerExtractionPath`.
  */
-function unwrapMCPResponse(response: any): AdCPResponse {
+export type McpExtractionPath = 'structured_content' | 'text_fallback' | 'error' | 'none';
+
+export const EXTRACTION_PATH_KEY = '_extraction_path' as const;
+
+interface McpUnwrapOutcome {
+  result: AdCPResponse;
+  extractionPath: McpExtractionPath;
+}
+
+/**
+ * Unwrap MCP response - all MCP logic in one place.
+ *
+ * Also records which branch produced the parsed response (structuredContent
+ * vs text content) so downstream tooling can tell a runner extraction bug
+ * apart from an agent bug.
+ */
+function unwrapMCPResponse(response: any): McpUnwrapOutcome {
   // MCP error response — preserve full structured data (context, ext, adcp_error)
   if (response.isError === true) {
     // L3: structuredContent has the full error payload.
     // Trust boundary: this is untrusted agent content passed through as-is.
     // Consumers must sanitize fields like suggestion/details before rendering.
     if (response.structuredContent && typeof response.structuredContent === 'object') {
-      return response.structuredContent as AdCPResponse;
+      return { result: response.structuredContent as AdCPResponse, extractionPath: 'error' };
     }
 
     // L2: JSON in text content
@@ -218,7 +253,7 @@ function unwrapMCPResponse(response: any): AdCPResponse {
           try {
             const parsed = JSON.parse(item.text);
             if (parsed?.adcp_error && typeof parsed.adcp_error.code === 'string') {
-              return parsed as AdCPResponse;
+              return { result: parsed as AdCPResponse, extractionPath: 'error' };
             }
           } catch {
             // not JSON, continue to raw text fallback
@@ -233,12 +268,15 @@ function unwrapMCPResponse(response: any): AdCPResponse {
       : response.content?.text || 'Unknown error';
 
     return {
-      adcp_error: {
-        code: ERROR_CODES.MCP_ERROR,
-        message: errorContent || 'MCP tool call failed',
-        synthetic: true,
-      },
-    } as unknown as AdCPResponse;
+      result: {
+        adcp_error: {
+          code: ERROR_CODES.MCP_ERROR,
+          message: errorContent || 'MCP tool call failed',
+          synthetic: true,
+        },
+      } as unknown as AdCPResponse,
+      extractionPath: 'error',
+    };
   }
 
   // MCP success response with structuredContent
@@ -258,12 +296,15 @@ function unwrapMCPResponse(response: any): AdCPResponse {
     // Include text messages if present (same pattern as A2A)
     if (textMessages.length > 0) {
       return {
-        ...data,
-        _message: textMessages.join('\n'),
+        result: {
+          ...data,
+          _message: textMessages.join('\n'),
+        },
+        extractionPath: 'structured_content',
       };
     }
 
-    return data;
+    return { result: data, extractionPath: 'structured_content' };
   }
 
   // MCP text content fallback (try parsing as JSON)
@@ -271,24 +312,59 @@ function unwrapMCPResponse(response: any): AdCPResponse {
     const textContent = response.content.find((c: any) => c.type === 'text');
     if (textContent?.text) {
       try {
-        return JSON.parse(textContent.text);
+        return { result: JSON.parse(textContent.text), extractionPath: 'text_fallback' };
       } catch {
         // Include snippet of text for debugging (max 100 chars)
         const snippet = textContent.text.length > 100 ? textContent.text.substring(0, 100) + '...' : textContent.text;
 
         return {
-          errors: [
-            {
-              code: ERROR_CODES.INVALID_RESPONSE,
-              message: `Response does not contain structured AdCP data. Text content: "${snippet}"`,
-            },
-          ],
+          result: {
+            errors: [
+              {
+                code: ERROR_CODES.INVALID_RESPONSE,
+                message: `Response does not contain structured AdCP data. Text content: "${snippet}"`,
+              },
+            ],
+          },
+          extractionPath: 'text_fallback',
         };
       }
     }
   }
 
   throw new Error('Invalid MCP response format');
+}
+
+/**
+ * Attach the extraction path to an unwrapped object as a non-enumerable
+ * property. Non-enumerable so `JSON.stringify`, `Object.keys`, and spread
+ * ignore it — the storyboard runner reads it via a direct property access
+ * but the rest of the system sees the unwrapped data unchanged.
+ */
+function tagExtractionPath(result: AdCPResponse, path: McpExtractionPath): AdCPResponse {
+  if (result === null || typeof result !== 'object') return result;
+  try {
+    Object.defineProperty(result, EXTRACTION_PATH_KEY, {
+      value: path,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  } catch {
+    // Frozen / sealed objects reject defineProperty; drop the tag silently —
+    // the runner's fallback inference in extractionFromTaskResult still works.
+  }
+  return result;
+}
+
+/**
+ * Read the extraction path from an unwrapped AdCP response, or `undefined`
+ * if the response did not originate from an MCP unwrap path.
+ */
+export function readExtractionPath(data: unknown): McpExtractionPath | undefined {
+  if (data === null || typeof data !== 'object') return undefined;
+  const path = (data as Record<string, unknown>)[EXTRACTION_PATH_KEY];
+  return typeof path === 'string' ? (path as McpExtractionPath) : undefined;
 }
 
 /**

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -213,6 +213,61 @@ describe('runner-output contract: secret redaction', () => {
   });
 });
 
+describe('runner-output contract: MCP extraction provenance', () => {
+  const { unwrapProtocolResponse, readExtractionPath } = require('../../dist/lib/utils/response-unwrapper');
+
+  test('structuredContent response tags structured_content', () => {
+    const unwrapped = unwrapProtocolResponse(
+      {
+        structuredContent: { tools: [{ name: 'get_products' }], adcp_major_versions: [3] },
+        content: [],
+      },
+      undefined,
+      'mcp'
+    );
+    assert.strictEqual(readExtractionPath(unwrapped), 'structured_content');
+  });
+
+  test('text-only JSON response tags text_fallback', () => {
+    const unwrapped = unwrapProtocolResponse(
+      {
+        content: [{ type: 'text', text: JSON.stringify({ tools: [{ name: 'get_products' }] }) }],
+      },
+      undefined,
+      'mcp'
+    );
+    assert.strictEqual(readExtractionPath(unwrapped), 'text_fallback');
+  });
+
+  test('isError response tags error', () => {
+    const unwrapped = unwrapProtocolResponse(
+      {
+        isError: true,
+        structuredContent: { adcp_error: { code: 'VALIDATION_ERROR', message: 'bad input' } },
+      },
+      undefined,
+      'mcp'
+    );
+    assert.strictEqual(readExtractionPath(unwrapped), 'error');
+  });
+
+  test('extraction tag is non-enumerable (does not pollute JSON output)', () => {
+    const unwrapped = unwrapProtocolResponse(
+      {
+        structuredContent: { tools: [], adcp_major_versions: [3] },
+      },
+      undefined,
+      'mcp'
+    );
+    assert.strictEqual(readExtractionPath(unwrapped), 'structured_content');
+    // JSON.stringify MUST NOT include _extraction_path
+    const serialized = JSON.parse(JSON.stringify(unwrapped));
+    assert.strictEqual(serialized._extraction_path, undefined);
+    // Object.keys MUST NOT include _extraction_path
+    assert.ok(!Object.keys(unwrapped).includes('_extraction_path'));
+  });
+});
+
 describe('runner-output contract: top-level summary', () => {
   const { mapStoryboardResultsToTrackResult } = require('../../dist/lib/testing/compliance/storyboard-tracks.js');
 

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -1,0 +1,274 @@
+/**
+ * Runner-output contract conformance tests.
+ *
+ * Asserts the shape defined in
+ * `static/compliance/source/universal/runner-output-contract.yaml`
+ * (adcontextprotocol/adcp PR #2364). These tests verify validation results
+ * and skip results carry the actionable detail implementors need to
+ * diagnose failures — request/response bytes, RFC 6901 `json_pointer`,
+ * machine-readable `expected`/`actual`, and for `response_schema` checks
+ * the `schema_id` + resolvable `schema_url`.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { runValidations } = require('../../dist/lib/testing/storyboard/validations');
+const { toJsonPointer } = require('../../dist/lib/testing/storyboard/path');
+const {
+  __redactSecretsForTest: redactSecrets,
+  __filterResponseHeadersForTest: filterResponseHeaders,
+} = require('../../dist/lib/testing/storyboard/runner');
+
+function runOne(validation, overrides = {}) {
+  return runValidations([validation], {
+    taskName: overrides.taskName ?? 'get_products',
+    taskResult: overrides.taskResult,
+    httpResult: overrides.httpResult,
+    agentUrl: overrides.agentUrl ?? 'https://example.com/mcp',
+    contributions: overrides.contributions ?? new Set(),
+    responseSchemaRef: overrides.responseSchemaRef,
+    request: overrides.request,
+    response: overrides.response,
+  })[0];
+}
+
+describe('runner-output contract: validation_result', () => {
+  test('field_present failure carries json_pointer, expected, actual', () => {
+    const result = runOne(
+      { check: 'field_present', path: 'accounts[0].account_id', description: 'account_id is present' },
+      { taskResult: { success: true, data: { accounts: [{}] } } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/accounts/0/account_id');
+    assert.strictEqual(result.expected, 'accounts[0].account_id');
+    assert.strictEqual(result.actual, null);
+  });
+
+  test('field_value failure carries json_pointer, structured expected/actual', () => {
+    const result = runOne(
+      { check: 'field_value', path: 'status', value: 'active', description: 'status == active' },
+      { taskResult: { success: true, data: { status: 'paused' } } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/status');
+    assert.strictEqual(result.expected, 'active');
+    assert.strictEqual(result.actual, 'paused');
+  });
+
+  test('field_value allowed_values failure exposes the enumeration as expected', () => {
+    const result = runOne(
+      {
+        check: 'field_value',
+        path: 'status',
+        allowed_values: ['active', 'paused'],
+        description: 'status in active|paused',
+      },
+      { taskResult: { success: true, data: { status: 'canceled' } } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.expected, ['active', 'paused']);
+    assert.strictEqual(result.actual, 'canceled');
+  });
+
+  test('response_schema failure carries schema_id, schema_url, AJV-shaped actual', () => {
+    const result = runOne(
+      { check: 'response_schema', description: 'Response matches get-adcp-capabilities-response.json schema' },
+      {
+        taskName: 'get_adcp_capabilities',
+        responseSchemaRef: 'protocol/get-adcp-capabilities-response.json',
+        taskResult: { success: true, data: { adcp: {} /* missing required fields */ } },
+      }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.schema_id, 'schema_id must be set on response_schema failure');
+    assert.ok(result.schema_id.endsWith('/protocol/get-adcp-capabilities-response.json'));
+    assert.ok(
+      result.schema_url && result.schema_url.startsWith('https://'),
+      'schema_url must be a resolvable https URL'
+    );
+    assert.ok(Array.isArray(result.actual), 'actual must be an array of schema errors');
+    for (const issue of result.actual) {
+      assert.strictEqual(typeof issue.instance_path, 'string');
+      assert.strictEqual(typeof issue.schema_path, 'string');
+      // schema_path is a schema-pointer, not the raw keyword — prefix rules
+      // out the bug where the two fields collapsed to the same value.
+      assert.ok(issue.schema_path.startsWith('#/'), 'schema_path is a JSON pointer into the schema');
+      assert.strictEqual(typeof issue.keyword, 'string');
+      assert.strictEqual(typeof issue.message, 'string');
+    }
+  });
+
+  test('response_schema with no registered schema returns structured actual', () => {
+    const result = runOne(
+      { check: 'response_schema', description: 'Response matches schema' },
+      {
+        taskName: 'totally_unknown_tool_xyz',
+        responseSchemaRef: 'unknown/totally-unknown.json',
+        taskResult: { success: true, data: {} },
+      }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.actual, { reason: 'no_schema_registered', task: 'totally_unknown_tool_xyz' });
+  });
+
+  test('http_status failure carries expected + actual status', () => {
+    const result = runOne(
+      { check: 'http_status', value: 401, description: 'unauth probe returns 401' },
+      { httpResult: { url: 'https://example.com/mcp', status: 200, headers: {}, body: null } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.expected, 401);
+    assert.strictEqual(result.actual, 200);
+  });
+
+  test('failed validation echoes request / response records', () => {
+    const request = {
+      transport: 'mcp',
+      operation: 'get_products',
+      payload: { brief: 'example' },
+      url: 'https://example.com/mcp',
+    };
+    const response = { transport: 'mcp', payload: { accounts: [{}] }, duration_ms: 12 };
+    const result = runOne(
+      { check: 'field_present', path: 'accounts[0].account_id', description: 'id present' },
+      { taskResult: { success: true, data: { accounts: [{}] } }, request, response }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.request, request);
+    assert.deepStrictEqual(result.response, response);
+  });
+
+  test('passed validation does not bloat payload with request/response', () => {
+    const request = { transport: 'mcp', operation: 'get_products', payload: {} };
+    const response = { transport: 'mcp', payload: {} };
+    const result = runOne(
+      { check: 'field_present', path: 'status', description: 'status present' },
+      { taskResult: { success: true, data: { status: 'active' } }, request, response }
+    );
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.request, undefined);
+    assert.strictEqual(result.response, undefined);
+  });
+});
+
+describe('runner-output contract: JSON Pointer conversion', () => {
+  test('toJsonPointer handles dot and bracket notation', () => {
+    assert.strictEqual(toJsonPointer('status'), '/status');
+    assert.strictEqual(toJsonPointer('accounts[0].account_id'), '/accounts/0/account_id');
+    assert.strictEqual(toJsonPointer('formats[2].format_id.id'), '/formats/2/format_id/id');
+  });
+
+  test('toJsonPointer escapes ~ and / per RFC 6901', () => {
+    assert.strictEqual(toJsonPointer('a/b'), '/a~1b');
+    assert.strictEqual(toJsonPointer('a~b'), '/a~0b');
+  });
+
+  test('toJsonPointer returns empty string for the root', () => {
+    assert.strictEqual(toJsonPointer(''), '');
+  });
+});
+
+describe('runner-output contract: secret redaction', () => {
+  test('redactSecrets scrubs bearer tokens, api keys, and credentials by key name', () => {
+    const out = redactSecrets({
+      brand: 'nike',
+      authorization: 'Bearer sk-live-123',
+      api_key: 'apk_abc',
+      nested: {
+        credentials: 'hunter2',
+        push_notification_config: { authentication: { credentials: 'secret-bearer' } },
+      },
+      benign: 'keep me',
+    });
+    assert.strictEqual(out.authorization, '[redacted]');
+    assert.strictEqual(out.api_key, '[redacted]');
+    assert.strictEqual(out.nested.credentials, '[redacted]');
+    assert.strictEqual(out.nested.push_notification_config.authentication.credentials, '[redacted]');
+    assert.strictEqual(out.benign, 'keep me');
+    assert.strictEqual(out.brand, 'nike');
+  });
+
+  test('redactSecrets preserves arrays and non-matching keys', () => {
+    const out = redactSecrets({ tokens: ['a', 'b'], list: [{ name: 'x' }] });
+    // "tokens" matches the secret pattern — plural is allowed.
+    // The value is an array so the whole array is preserved (we only redact
+    // scalar values at matching keys); document that behaviour here.
+    assert.deepStrictEqual(out.list, [{ name: 'x' }]);
+  });
+
+  test('filterResponseHeaders allowlists safe headers and drops the rest', () => {
+    const out = filterResponseHeaders({
+      'content-type': 'application/json',
+      'www-authenticate': 'Bearer realm="agent"',
+      'set-cookie': 'session=abc; HttpOnly',
+      authorization: 'Bearer leaked',
+      'x-amzn-request-id': 'abc',
+      'x-internal-tenant': 'acme',
+    });
+    assert.deepStrictEqual(out, {
+      'content-type': 'application/json',
+      'www-authenticate': 'Bearer realm="agent"',
+    });
+  });
+});
+
+describe('runner-output contract: top-level summary', () => {
+  const { mapStoryboardResultsToTrackResult } = require('../../dist/lib/testing/compliance/storyboard-tracks.js');
+
+  test('skip detail surfaces through warnings regardless of reason', () => {
+    const reasons = [
+      ['not_applicable', 'Not applicable: agent did not declare this protocol'],
+      ['prerequisite_failed', 'Skipped: a prerequisite did not pass'],
+      ['missing_tool', 'Required tool get_signals not advertised.'],
+      ['missing_test_controller', 'Deterministic-testing phase requires comply_test_controller.'],
+      ['unsatisfied_contract', 'Skipped: signed-requests-runner contract is out of scope'],
+    ];
+    for (const [reason, detail] of reasons) {
+      const trackResult = mapStoryboardResultsToTrackResult(
+        'core',
+        [
+          {
+            storyboard_id: 'sb',
+            storyboard_title: 'sb',
+            agent_url: 'https://example.com/mcp',
+            overall_passed: true,
+            phases: [
+              {
+                phase_id: 'phase-1',
+                phase_title: 'phase-1',
+                passed: true,
+                steps: [
+                  {
+                    step_id: 'step-1',
+                    phase_id: 'phase-1',
+                    title: 'step-1',
+                    task: 'get_products',
+                    passed: true,
+                    skipped: true,
+                    skip_reason: reason,
+                    skip: { reason, detail },
+                    duration_ms: 0,
+                    validations: [],
+                    context: {},
+                    extraction: { path: 'none' },
+                  },
+                ],
+                duration_ms: 0,
+              },
+            ],
+            context: {},
+            total_duration_ms: 0,
+            passed_count: 1,
+            failed_count: 0,
+            skipped_count: 1,
+            tested_at: '2026-04-19T00:00:00.000Z',
+          },
+        ],
+        { name: 'Test Agent', tools: [] }
+      );
+      const skipped = trackResult.scenarios[0].steps[0];
+      assert.deepStrictEqual(skipped.warnings, [detail], `warning for ${reason} should echo the detail`);
+    }
+  });
+});

--- a/test/lib/storyboard-skip-counting.test.js
+++ b/test/lib/storyboard-skip-counting.test.js
@@ -124,7 +124,7 @@ describe('storyboard skip counting', () => {
       assert.strictEqual(trackResult.status, 'fail', 'track with all-failed steps should have fail status');
     });
 
-    test('missing_test_harness skip_reason maps to test harness warning', () => {
+    test('missing_test_controller skip_reason surfaces controller detail', () => {
       const result = storyboardResult({
         passed_count: 2,
         failed_count: 0,
@@ -140,7 +140,11 @@ describe('storyboard skip counting', () => {
               stepResult({
                 step_id: 'step-3',
                 skipped: true,
-                skip_reason: 'missing_test_harness',
+                skip_reason: 'missing_test_controller',
+                skip: {
+                  reason: 'missing_test_controller',
+                  detail: 'Deterministic-testing phase requires comply_test_controller; agent tools: [get_products].',
+                },
                 duration_ms: 0,
               }),
             ],


### PR DESCRIPTION
## Summary

Closes #599. Conforms the storyboard runner and `comply()` output to the universal runner-output contract in adcontextprotocol/adcp#2364 / issue #2352.

Today a failed validation reads:
```
FAILED: schema_validation/capability_discovery
  - Check agent capabilities
```
with no actionable detail. After this PR, the same failure carries RFC 6901 `json_pointer`, the exact `schema_id` + fetchable `schema_url`, AJV-shaped error array, and the request/response bytes — so the buyer diagnoses their agent from the report instead of re-running the step by hand.

### What changes

**Per-validation (on every failure):**
- `json_pointer` — RFC 6901 pointer to the failing field
- `expected` / `actual` — machine-readable values
- `schema_id` / `schema_url` — on `response_schema` checks
- `request` / `response` — exact bytes the runner sent + observed
- `response_schema` failures now emit AJV-shaped `{ instance_path, schema_path, keyword, message }[]` instead of a flat message string

**Per-step:**
- `extraction: { path: "structured_content" | "text_fallback" | "error" | "none" }`
- `request` / `response_record`
- `storyboard_id` — each step is self-describing
- `skip: { reason, detail }` — structured skip result

**Spec skip reasons.** The narrow `"not_testable" | "dependency_failed" | "missing_test_harness" | "missing_tool"` enum is replaced by the six contract reasons, each with a human-readable `detail` explaining why (naming the missing tool, the prerequisite step id, the agent's advertised tool list, etc.).

**Top-level summary:** gains `total_steps`, `steps_passed`, `steps_failed`, `steps_skipped`, and `schemas_used: Array<{ schema_id, schema_url }>`.

**Formatter:** terminal output now renders `At:` / `Expected:` / `Actual:` / `Schema:` for each failure. Agent-controlled `error` and `actual` strings run through the existing `fenceAgentText()` nonce.

### Security hardening

- **Redaction.** Request and response payloads are recursively scrubbed; values at keys matching `/^(authorization|credentials?|token|api[_-]?key|password|secret|client[_-]secret|refresh[_-]token|access[_-]token|bearer|session[_-]token|offering[_-]token|cookie|set[_-]cookie)$/i` become `"[redacted]"` before they're persisted. The contract spec calls for exactly this.
- **Header allowlist.** Response headers pass through a short allowlist (`content-type`, `content-length`, `content-encoding`, `www-authenticate`, `location`, `retry-after`, `x-request-id`, `x-correlation-id`); everything else (including `set-cookie`, `authorization`, `x-internal-*`, `x-amz-*`) is dropped. Without this a hostile agent could bait the runner into publishing internal breadcrumbs in a shared report.
- **Request headers are deliberately NOT captured** to avoid echoing `Authorization: Bearer <token>` from auth-override probes.
- **LLM fencing.** Formatter output runs agent-controlled `error` + `actual` through `fenceAgentText()` so downstream summarizers can't be hijacked by hostile error messages.

### Tests

- `test/lib/storyboard-runner-contract.test.js` — 14 new tests covering: `json_pointer` on field_present/field_value, allowed_values expected/actual, schema_id/schema_url on response_schema, AJV shape, no-schema-registered structured `actual`, http_status expected/actual, request/response echo on failure (and omission on pass), JSON Pointer RFC 6901 escaping, redaction, header allowlist, skip-reason warnings.
- `test/lib/storyboard-skip-counting.test.js` — migrated `missing_test_harness` → `missing_test_controller`.

### Breaking change

The `StoryboardStepResult.skip_reason` enum is renamed. Third-party automation reading the `--json` output needs to migrate from `"not_testable"` / `"dependency_failed"` / `"missing_test_harness"` to the six spec-aligned values. The bundled CLI (`bin/adcp.js`) is updated in-tree. Minor bump per the changeset.

### Review

- Reviewed by `code-reviewer` and `security-reviewer` subagents; all Must Fix and load-bearing Should Fix findings addressed in the committed diff (CLI skip-icon migration, AJV `schema_path` correctness, structured actual on no-schema, `no_phases` wired into the runner, response-header allowlist, request/response redaction, LLM fencing).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `node --test test/lib/storyboard-runner-contract.test.js test/lib/storyboard-skip-counting.test.js test/lib/storyboard-validations.test.js test/lib/storyboard-observations.test.js test/lib/compliance.test.js test/lib/storyboard-brand-invariant.test.js` — all green
- [x] `node --test test/lib/storyboard-security.test.js` — all green (one pre-existing network-dependent test times out; identical behavior on `main`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)