### PR TITLE
feat(auth): zero-config OAuth discovery on 401 + NeedsAuthorizationError

### DIFF
--- a/.changeset/oauth-auto-discovery-on-401.md
+++ b/.changeset/oauth-auto-discovery-on-401.md
@@ -1,0 +1,24 @@
+---
+'@adcp/client': minor
+---
+
+Zero-config OAuth: auto-discovery on 401 + actionable `NeedsAuthorizationError`.
+
+Closes the remaining item from #563. Calling an OAuth-gated MCP agent without saved credentials used to bubble up a generic 401 or `UnauthorizedError`. Now the library automatically walks RFC 9728 protected-resource metadata + RFC 8414 authorization-server metadata from the server's `WWW-Authenticate` challenge and throws a structured `NeedsAuthorizationError` with everything a caller needs to recover — no re-probing required.
+
+**New exports**
+
+- `NeedsAuthorizationError` — thrown automatically by `ProtocolClient.callTool` / `ADCPMultiAgentClient` when an MCP agent returns a 401 Bearer challenge and no saved tokens can satisfy it. Carries `agentUrl`, `resource`, `resourceMetadataUrl`, `authorizationServer`, `authorizationEndpoint`, `tokenEndpoint`, `registrationEndpoint`, `scopesSupported`, and the parsed challenge.
+- `discoverAuthorizationRequirements(agentUrl, options?)` — programmatic access to the same walk. Returns `null` if the agent responds 200 without auth or 401 without a Bearer challenge.
+- `createFileOAuthStorage({ configPath, agentKey? })` — file-backed `OAuthConfigStorage` against the `adcp` CLI's agents.json format. Atomic writes via write-then-rename; preserves non-OAuth fields on save. `agentKey` override keys all writes under a fixed alias regardless of `agent.id` (CLI pattern).
+- `bindAgentStorage(agent, storage)` / `getAgentStorage(agent)` — per-agent `WeakMap` binding that threads an `OAuthConfigStorage` through `ProtocolClient.callTool` without changing its signature.
+
+**Behavior changes**
+
+- `ProtocolClient.callTool` now catches 401-shaped errors from both the OAuth-token path and the plain-bearer path and, if the agent returns a Bearer challenge, throws `NeedsAuthorizationError` instead of the generic error. Non-401 errors propagate unchanged.
+- When `agent.oauth_tokens` is present and storage has been bound via `bindAgentStorage`, the non-interactive OAuth provider now receives the storage so refreshed tokens persist to disk.
+- `adcp <alias> <tool>` automatically binds file-backed storage for saved OAuth aliases and prints an actionable prompt when authorization is required.
+
+**Not breaking**
+
+Existing callers that construct their own OAuth providers keep working. Existing bearer-only agents keep working. The only visible change on the error path is a more informative error class where `UnauthorizedError` would have propagated before.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -33,6 +33,9 @@ const {
   hasValidOAuthTokens,
   clearOAuthTokens,
   getEffectiveAuthToken,
+  createFileOAuthStorage,
+  bindAgentStorage,
+  NeedsAuthorizationError,
 } = require('../dist/lib/auth/oauth/index.js');
 
 // Test scenarios available
@@ -2126,6 +2129,18 @@ async function main() {
     ...(agentOAuthClient && { oauth_client: agentOAuthClient }),
   };
 
+  // For saved aliases with OAuth, attach a file-backed storage so the MCP
+  // SDK's OAuthProvider can persist refreshed tokens back to the config
+  // file. The storage keys writes under the actual alias regardless of the
+  // synthetic `cli-agent` id we use in memory.
+  if (agentAlias && agentOAuthTokens) {
+    const storage = createFileOAuthStorage({
+      configPath: getConfigPath(),
+      agentKey: agentAlias,
+    });
+    bindAgentStorage(agentConfig, storage);
+  }
+
   try {
     // If no tool name provided, display agent info
     if (!toolName) {
@@ -2544,6 +2559,48 @@ async function main() {
       process.exit(3);
     }
   } catch (error) {
+    // NeedsAuthorizationError carries walked discovery metadata. Route it
+    // through the CLI's existing auto-OAuth flow when conditions are right,
+    // so the user gets a browser prompt instead of a cold error message.
+    if (error instanceof NeedsAuthorizationError) {
+      if (jsonOutput) {
+        console.log(
+          JSON.stringify(
+            {
+              error: {
+                code: error.code,
+                message: error.message,
+                requirements: error.requirements,
+              },
+            },
+            null,
+            2
+          )
+        );
+        process.exit(1);
+      }
+      // Defense-in-depth: the library already strips ASCII control chars from
+      // server-supplied strings before storing them on `requirements`, but
+      // sanitize again at the point of terminal output in case a downstream
+      // field is added that bypasses the library's sanitizer.
+      const safe = s => (typeof s === 'string' ? s.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') : s);
+      console.error('\n🔐 Agent requires OAuth authorization.');
+      console.error(`   Authorization server: ${safe(error.requirements.authorizationServer) ?? '(unknown)'}`);
+      if (error.requirements.registrationEndpoint) {
+        console.error(`   Dynamic client registration: supported`);
+      }
+      if (error.requirements.scopesSupported?.length) {
+        console.error(`   Scopes: ${error.requirements.scopesSupported.map(safe).join(', ')}`);
+      }
+      if (agentAlias) {
+        console.error(`\n   Run: adcp --save-auth ${agentAlias} ${agentUrl} --oauth`);
+      } else {
+        console.error(`\n   Save the agent with OAuth: adcp --save-auth <alias> ${agentUrl} --oauth`);
+      }
+      console.error('');
+      process.exit(1);
+    }
+
     // Check if this is an OAuth-required error for MCP and offer auto-authentication
     const isUnauthorized =
       error.name === 'UnauthorizedError' ||

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2564,11 +2564,15 @@ async function main() {
     // so the user gets a browser prompt instead of a cold error message.
     if (error instanceof NeedsAuthorizationError) {
       if (jsonOutput) {
+        // Emit both `code` (inherited from AuthenticationRequiredError) and
+        // `subCode` (narrow discriminator) so downstream tools see the same
+        // shape the in-process error object exposes. Keying on either works.
         console.log(
           JSON.stringify(
             {
               error: {
-                code: error.subCode,
+                code: error.code,
+                subCode: error.subCode,
                 message: error.message,
                 requirements: error.requirements,
               },

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2559,21 +2559,34 @@ async function main() {
       process.exit(3);
     }
   } catch (error) {
+    // Defense-in-depth: the library already strips ASCII control chars from
+    // server-supplied strings before storing them on `requirements`, but
+    // re-apply at the output call site in case a downstream field is added
+    // that bypasses the library's sanitizer.
+    const safe = s => (typeof s === 'string' ? s.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') : s);
+
     // NeedsAuthorizationError carries walked discovery metadata. Route it
     // through the CLI's existing auto-OAuth flow when conditions are right,
     // so the user gets a browser prompt instead of a cold error message.
     if (error instanceof NeedsAuthorizationError) {
-      // Non-interactive contexts (JSON output, piped stdin, CI) get the
-      // structured actionable error — we never spawn a browser we can't
-      // guarantee a human will see.
-      const interactive = !jsonOutput && !!process.stdout.isTTY && !process.env.CI;
+      // Auto-browser requires:
+      //   - stdout + stdin are TTYs (the OAuth flow blocks on stdin/terminal focus)
+      //   - no explicit opt-out (ADCP_NO_BROWSER) and not in CI
+      //   - a protocol we can drive interactively (MCP only today)
+      //   - no conflicting auth source already provided
+      //   - not asked for JSON (scripts/dashboards must stay deterministic)
+      const canAutoBrowse =
+        !jsonOutput &&
+        !!process.stdout.isTTY &&
+        !!process.stdin.isTTY &&
+        !process.env.CI &&
+        !process.env.ADCP_NO_BROWSER &&
+        process.env.TERM !== 'dumb' &&
+        protocol === 'mcp' &&
+        !useOAuth &&
+        !authToken;
 
-      if (!interactive) {
-        // Defense-in-depth: the library already strips ASCII control chars
-        // from server-supplied strings before storing them on `requirements`,
-        // but sanitize again at the point of terminal output in case a
-        // downstream field is added that bypasses the library's sanitizer.
-        const safe = s => (typeof s === 'string' ? s.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') : s);
+      if (!canAutoBrowse) {
         if (jsonOutput) {
           console.log(
             JSON.stringify(
@@ -2608,15 +2621,15 @@ async function main() {
         process.exit(1);
       }
 
-      // Interactive context: open browser, complete OAuth, retry the task.
-      // The auto-OAuth flow below (originally gated on `isUnauthorized`) does
-      // exactly this; re-run via a synthetic tag so we share the same code path.
-      console.log('\n🔐 Agent requires OAuth authorization.');
+      // Interactive context: print a short header on stderr (so stdout stays
+      // clean for the eventual tool result) then fall through to the
+      // auto-OAuth branch below which opens the browser and retries the call.
+      console.error('\n🔐 Agent requires OAuth authorization.');
       if (error.requirements.authorizationServer) {
-        console.log(`   Authorization server: ${error.requirements.authorizationServer}`);
+        console.error(`   Authorization server: ${safe(error.requirements.authorizationServer)}`);
       }
       if (error.requirements.scopesSupported?.length) {
-        console.log(`   Scopes: ${error.requirements.scopesSupported.join(', ')}`);
+        console.error(`   Scopes: ${error.requirements.scopesSupported.map(safe).join(', ')}`);
       }
       // Let execution fall through to the auto-OAuth path below.
     }

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2563,50 +2563,70 @@ async function main() {
     // through the CLI's existing auto-OAuth flow when conditions are right,
     // so the user gets a browser prompt instead of a cold error message.
     if (error instanceof NeedsAuthorizationError) {
-      if (jsonOutput) {
-        // Emit both `code` (inherited from AuthenticationRequiredError) and
-        // `subCode` (narrow discriminator) so downstream tools see the same
-        // shape the in-process error object exposes. Keying on either works.
-        console.log(
-          JSON.stringify(
-            {
-              error: {
-                code: error.code,
-                subCode: error.subCode,
-                message: error.message,
-                requirements: error.requirements,
+      // Non-interactive contexts (JSON output, piped stdin, CI) get the
+      // structured actionable error — we never spawn a browser we can't
+      // guarantee a human will see.
+      const interactive = !jsonOutput && !!process.stdout.isTTY && !process.env.CI;
+
+      if (!interactive) {
+        // Defense-in-depth: the library already strips ASCII control chars
+        // from server-supplied strings before storing them on `requirements`,
+        // but sanitize again at the point of terminal output in case a
+        // downstream field is added that bypasses the library's sanitizer.
+        const safe = s => (typeof s === 'string' ? s.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') : s);
+        if (jsonOutput) {
+          console.log(
+            JSON.stringify(
+              {
+                error: {
+                  code: error.code,
+                  subCode: error.subCode,
+                  message: error.message,
+                  requirements: error.requirements,
+                },
               },
-            },
-            null,
-            2
-          )
-        );
+              null,
+              2
+            )
+          );
+        } else {
+          console.error('\n🔐 Agent requires OAuth authorization.');
+          console.error(`   Authorization server: ${safe(error.requirements.authorizationServer) ?? '(unknown)'}`);
+          if (error.requirements.registrationEndpoint) {
+            console.error(`   Dynamic client registration: supported`);
+          }
+          if (error.requirements.scopesSupported?.length) {
+            console.error(`   Scopes: ${error.requirements.scopesSupported.map(safe).join(', ')}`);
+          }
+          if (agentAlias) {
+            console.error(`\n   Run: adcp --save-auth ${agentAlias} ${agentUrl} --oauth`);
+          } else {
+            console.error(`\n   Save the agent with OAuth: adcp --save-auth <alias> ${agentUrl} --oauth`);
+          }
+          console.error('');
+        }
         process.exit(1);
       }
-      // Defense-in-depth: the library already strips ASCII control chars from
-      // server-supplied strings before storing them on `requirements`, but
-      // sanitize again at the point of terminal output in case a downstream
-      // field is added that bypasses the library's sanitizer.
-      const safe = s => (typeof s === 'string' ? s.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '') : s);
-      console.error('\n🔐 Agent requires OAuth authorization.');
-      console.error(`   Authorization server: ${safe(error.requirements.authorizationServer) ?? '(unknown)'}`);
-      if (error.requirements.registrationEndpoint) {
-        console.error(`   Dynamic client registration: supported`);
+
+      // Interactive context: open browser, complete OAuth, retry the task.
+      // The auto-OAuth flow below (originally gated on `isUnauthorized`) does
+      // exactly this; re-run via a synthetic tag so we share the same code path.
+      console.log('\n🔐 Agent requires OAuth authorization.');
+      if (error.requirements.authorizationServer) {
+        console.log(`   Authorization server: ${error.requirements.authorizationServer}`);
       }
       if (error.requirements.scopesSupported?.length) {
-        console.error(`   Scopes: ${error.requirements.scopesSupported.map(safe).join(', ')}`);
+        console.log(`   Scopes: ${error.requirements.scopesSupported.join(', ')}`);
       }
-      if (agentAlias) {
-        console.error(`\n   Run: adcp --save-auth ${agentAlias} ${agentUrl} --oauth`);
-      } else {
-        console.error(`\n   Save the agent with OAuth: adcp --save-auth <alias> ${agentUrl} --oauth`);
-      }
-      console.error('');
-      process.exit(1);
+      // Let execution fall through to the auto-OAuth path below.
     }
 
-    // Check if this is an OAuth-required error for MCP and offer auto-authentication
+    // Check if this is an OAuth-required error for MCP and offer auto-authentication.
+    // `NeedsAuthorizationError` is the richer form (already extended from
+    // AuthenticationRequiredError); the string-match branches cover older
+    // error shapes from the MCP SDK and other 401 paths.
     const isUnauthorized =
+      error instanceof NeedsAuthorizationError ||
       error.name === 'UnauthorizedError' ||
       error.message?.toLowerCase().includes('unauthorized') ||
       error.message?.includes('401');

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2568,7 +2568,7 @@ async function main() {
           JSON.stringify(
             {
               error: {
-                code: error.code,
+                code: error.subCode,
                 message: error.message,
                 requirements: error.requirements,
               },

--- a/src/lib/auth/oauth/authorization-required.ts
+++ b/src/lib/auth/oauth/authorization-required.ts
@@ -29,6 +29,13 @@ const MAX_DISPLAY_STRING = 256;
 const MAX_SCOPES = 64;
 
 /**
+ * Maximum number of auth-params we preserve under `challenge.params`. Bounds
+ * memory pressure from hostile servers that pack the `WWW-Authenticate`
+ * header with unknown auth-params.
+ */
+const MAX_CHALLENGE_PARAMS = 32;
+
+/**
  * Strip ASCII control characters (excluding TAB) from a server-supplied
  * string that may be shown to a human. Defeats terminal-hijack tricks like
  * `\x1b]0;pwned\x07` (rewrites terminal title), `\r` (overwrites prompt),
@@ -38,6 +45,33 @@ function sanitizeDisplay(value: string): string {
   const stripped = value.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '');
   if (stripped.length <= MAX_DISPLAY_STRING) return stripped;
   return `${stripped.slice(0, MAX_DISPLAY_STRING - 1)}…`;
+}
+
+/**
+ * Sanitize the parsed `WWW-Authenticate` challenge before embedding it in a
+ * `NeedsAuthorizationError`. Consumers that render `requirements.challenge`
+ * to a terminal should never see control characters. Caps `params` count to
+ * bound hostile servers.
+ *
+ * The `scheme` is already lowercased + token-constrained by the parser.
+ * Param keys are also token-constrained so they're safe; only values need
+ * sanitizing.
+ */
+function sanitizeChallenge(c: WWWAuthenticateChallenge): WWWAuthenticateChallenge {
+  const params: Record<string, string> = {};
+  for (const [k, v] of Object.entries(c.params)) {
+    if (Object.keys(params).length >= MAX_CHALLENGE_PARAMS) break;
+    params[k] = sanitizeDisplay(v);
+  }
+  return {
+    scheme: c.scheme,
+    ...(c.realm !== undefined ? { realm: sanitizeDisplay(c.realm) } : {}),
+    ...(c.error !== undefined ? { error: sanitizeDisplay(c.error) } : {}),
+    ...(c.error_description !== undefined ? { error_description: sanitizeDisplay(c.error_description) } : {}),
+    ...(c.scope !== undefined ? { scope: sanitizeDisplay(c.scope) } : {}),
+    ...(c.resource_metadata !== undefined ? { resource_metadata: sanitizeDisplay(c.resource_metadata) } : {}),
+    params,
+  };
 }
 
 /**
@@ -78,9 +112,20 @@ export interface AuthorizationRequirements {
  * they can downcast with `instanceof NeedsAuthorizationError` when they
  * want walked discovery metadata.
  *
- * Note: the inherited `code` is `'AUTHENTICATION_REQUIRED'` so that code
- * comparisons done by pre-existing callers still match. The specific
- * `'needs_authorization'` discriminator is available as `subCode`.
+ * Note on `code` vs `subCode`:
+ *   The parent class declares `readonly code = 'AUTHENTICATION_REQUIRED'` as
+ *   a class field that re-initializes on every construction, so a child-side
+ *   override attempt is silently overwritten under `useDefineForClassFields`.
+ *   The narrow discriminator is exposed as `subCode` — prefer
+ *   `instanceof NeedsAuthorizationError` for type-narrowing and use `subCode`
+ *   only for structured-log keying.
+ *
+ * Note on `hasOAuth`:
+ *   The inherited getter returns `true` only when both `authorization_endpoint`
+ *   and `token_endpoint` were walked successfully. A partially-walked
+ *   requirements record (PRM reachable but AS metadata missing) still yields
+ *   `hasOAuth === false` even though `requirements.authorizationServer` is set.
+ *   Treat it as "we have enough to start a flow," not "server wants OAuth."
  */
 export class NeedsAuthorizationError extends AuthenticationRequiredError {
   /** Narrow discriminator for consumers that already know about this class. */
@@ -91,6 +136,10 @@ export class NeedsAuthorizationError extends AuthenticationRequiredError {
     super(requirements.agentUrl, synthesizeOAuthMetadata(requirements), message ?? defaultMessage(requirements));
     this.name = 'NeedsAuthorizationError';
     this.requirements = requirements;
+    // Extend the parent's `details` payload so structured-logging consumers
+    // that read `err.details` (via `extractErrorInfo` or equivalent) see the
+    // full walked chain, not just the synthesized one-hop oauthMetadata.
+    this.details = { ...(this.details as object | undefined), requirements };
   }
 }
 
@@ -191,7 +240,7 @@ export async function discoverAuthorizationRequirements(
     agentUrl,
     resourceMetadataUrl: challenge.resource_metadata ? sanitizeDisplay(challenge.resource_metadata) : undefined,
     challengeScope: challenge.scope ? sanitizeDisplay(challenge.scope) : undefined,
-    challenge,
+    challenge: sanitizeChallenge(challenge),
   };
 
   // Walk protected-resource metadata (RFC 9728 §3). Private-IP targets are

--- a/src/lib/auth/oauth/authorization-required.ts
+++ b/src/lib/auth/oauth/authorization-required.ts
@@ -1,0 +1,305 @@
+/**
+ * Zero-config OAuth discovery + actionable authorization errors.
+ *
+ * When a library consumer calls an OAuth-gated MCP agent without saved
+ * credentials, they get a `NeedsAuthorizationError` containing everything
+ * needed to either run an interactive flow or present a clear prompt — no
+ * re-probing required.
+ *
+ * Design note: this module only *discovers* — it never opens a browser or
+ * writes state. Interactive flow handling stays in the caller (CLI or a
+ * bespoke `OAuthFlowHandler`) so library behavior is predictable.
+ */
+import { ssrfSafeFetch, decodeBodyAsJsonOrText } from '../../net';
+import { parseWWWAuthenticate, type WWWAuthenticateChallenge } from './diagnostics';
+
+/**
+ * Maximum length of an individual server-supplied string we copy into the
+ * `AuthorizationRequirements` payload. Anything longer is truncated with a
+ * `…` suffix so hostile agents can't smuggle megabyte error-descriptions
+ * into operator-facing prompts and logs.
+ */
+const MAX_DISPLAY_STRING = 256;
+
+/**
+ * Maximum number of scope strings we copy into `scopesSupported`. RFC 8414
+ * allows an unbounded array; hostile servers have sent thousands.
+ */
+const MAX_SCOPES = 64;
+
+/**
+ * Strip ASCII control characters (excluding TAB) from a server-supplied
+ * string that may be shown to a human. Defeats terminal-hijack tricks like
+ * `\x1b]0;pwned\x07` (rewrites terminal title), `\r` (overwrites prompt),
+ * and `\x1b[2J` (clears screen). Also truncates over-long values.
+ */
+function sanitizeDisplay(value: string): string {
+  const stripped = value.replace(/[\x00-\x08\x0b-\x1f\x7f]/g, '');
+  if (stripped.length <= MAX_DISPLAY_STRING) return stripped;
+  return `${stripped.slice(0, MAX_DISPLAY_STRING - 1)}…`;
+}
+
+/**
+ * Structured description of what an agent's authorization server requires
+ * before it will accept a `tools/call`. Produced by
+ * {@link discoverAuthorizationRequirements}.
+ */
+export interface AuthorizationRequirements {
+  /** The agent URL we probed. */
+  agentUrl: string;
+  /** Resource URL the agent advertises in its `WWW-Authenticate` / PRM (RFC 9728). */
+  resource?: string;
+  /** URL of the protected-resource-metadata document (from `WWW-Authenticate: resource_metadata=…`). */
+  resourceMetadataUrl?: string;
+  /** First `authorization_servers[0]` from the protected-resource metadata. */
+  authorizationServer?: string;
+  /** `authorization_endpoint` from the authorization-server metadata (RFC 8414). */
+  authorizationEndpoint?: string;
+  /** `token_endpoint` from the authorization-server metadata. */
+  tokenEndpoint?: string;
+  /** `registration_endpoint` if the AS supports RFC 7591 dynamic client registration. */
+  registrationEndpoint?: string;
+  /** Scopes advertised by the AS (RFC 8414 `scopes_supported`). */
+  scopesSupported?: string[];
+  /** Scope hinted in the `WWW-Authenticate` challenge's `scope` auth-param. */
+  challengeScope?: string;
+  /** Raw parsed challenge the agent returned on the 401. */
+  challenge: WWWAuthenticateChallenge;
+}
+
+/**
+ * Error raised when an agent returns a 401 and we do not have credentials
+ * to satisfy it. Carries everything needed to run an interactive OAuth flow
+ * or show the operator an actionable prompt.
+ */
+export class NeedsAuthorizationError extends Error {
+  /** Stable error code for `instanceof`-averse consumers. */
+  readonly code = 'needs_authorization' as const;
+  readonly agentUrl: string;
+  readonly requirements: AuthorizationRequirements;
+
+  constructor(requirements: AuthorizationRequirements, message?: string) {
+    super(message ?? defaultMessage(requirements));
+    this.name = 'NeedsAuthorizationError';
+    this.agentUrl = requirements.agentUrl;
+    this.requirements = requirements;
+  }
+}
+
+function defaultMessage(req: AuthorizationRequirements): string {
+  const parts = [`Agent ${sanitizeDisplay(req.agentUrl)} requires OAuth authorization.`];
+  if (req.authorizationServer) {
+    parts.push(`Authorization server: ${req.authorizationServer}.`);
+  }
+  if (req.challenge.error_description) {
+    parts.push(`Server said: ${sanitizeDisplay(req.challenge.error_description)}.`);
+  }
+  parts.push('Provide an OAuthFlowHandler or run an interactive flow to complete authorization.');
+  return parts.join(' ');
+}
+
+/**
+ * Options for {@link discoverAuthorizationRequirements}.
+ */
+export interface DiscoverAuthorizationOptions {
+  /** Allow http:// and private-IP probe targets. Default false. */
+  allowPrivateIp?: boolean;
+  /** Override per-probe HTTP timeout (ms). Default inherits from ssrfSafeFetch (10s). */
+  timeoutMs?: number;
+  /**
+   * If provided, use this `WWW-Authenticate` header verbatim instead of
+   * re-probing the agent. Use this when you already have a 401 response in
+   * hand and want to avoid a second round-trip.
+   */
+  wwwAuthenticate?: string;
+}
+
+/**
+ * Walk the OAuth discovery chain starting from an agent URL. Returns
+ * `AuthorizationRequirements` when the agent demands OAuth, or `null` when a
+ * `tools/list` call succeeds without credentials.
+ *
+ * Strategy:
+ *   1. POST `tools/list` to the agent with no `Authorization` header.
+ *   2. If 401 + `WWW-Authenticate: Bearer`: parse the challenge.
+ *   3. If the challenge carries `resource_metadata=…`: GET it and read
+ *      `resource` + `authorization_servers`.
+ *   4. For the first `authorization_servers[0]`: GET `/.well-known/oauth-authorization-server`
+ *      and read `authorization_endpoint`, `token_endpoint`, `registration_endpoint`,
+ *      `scopes_supported`.
+ *   5. Return a structured record.
+ *
+ * Anything missing from the chain surfaces as `undefined` on the result —
+ * callers can still present a partial picture without re-probing.
+ */
+export async function discoverAuthorizationRequirements(
+  agentUrl: string,
+  options: DiscoverAuthorizationOptions = {}
+): Promise<AuthorizationRequirements | null> {
+  // `allowPrivateIp` authorizes the agent probe. Chain hops (PRM, AS
+  // metadata) inherit that trust ONLY when they share the agent's origin —
+  // a compromised agent that advertises a private-IP authorization server
+  // on a different origin would otherwise pivot a discovery walk into the
+  // host's internal network.
+  const allowPrivateIpOnAgent = options.allowPrivateIp ?? false;
+  const agentOrigin = originOf(agentUrl);
+  const allowPrivateIpForHop = (url: string): boolean =>
+    allowPrivateIpOnAgent && agentOrigin !== undefined && originOf(url) === agentOrigin;
+
+  let challengeHeader = options.wwwAuthenticate;
+  if (!challengeHeader) {
+    const probe = await probeAgent401(agentUrl, allowPrivateIpOnAgent, options.timeoutMs);
+    if (probe.status !== 401) {
+      // 200, 403, 5xx, or network error — not an OAuth 401 we can act on.
+      return null;
+    }
+    challengeHeader = probe.wwwAuthenticate;
+  }
+
+  const challenge = parseWWWAuthenticate(challengeHeader ?? null);
+  if (!challenge || challenge.scheme !== 'bearer') {
+    // A 401 without a Bearer challenge isn't our kind of problem — let it propagate.
+    return null;
+  }
+
+  const requirements: AuthorizationRequirements = {
+    agentUrl,
+    resourceMetadataUrl: challenge.resource_metadata ? sanitizeDisplay(challenge.resource_metadata) : undefined,
+    challengeScope: challenge.scope ? sanitizeDisplay(challenge.scope) : undefined,
+    challenge,
+  };
+
+  // Walk protected-resource metadata (RFC 9728 §3). Private-IP targets are
+  // only allowed when the hop's origin matches the agent's.
+  if (challenge.resource_metadata && isSafeHttpUrl(challenge.resource_metadata)) {
+    const prm = await fetchJson(
+      challenge.resource_metadata,
+      allowPrivateIpForHop(challenge.resource_metadata),
+      options.timeoutMs
+    );
+    if (prm && typeof prm === 'object') {
+      const resource = (prm as { resource?: unknown }).resource;
+      const servers = (prm as { authorization_servers?: unknown }).authorization_servers;
+      if (typeof resource === 'string') requirements.resource = sanitizeDisplay(resource);
+      if (Array.isArray(servers) && typeof servers[0] === 'string' && isSafeHttpUrl(servers[0])) {
+        requirements.authorizationServer = sanitizeDisplay(servers[0]);
+      }
+    }
+  }
+
+  // Walk authorization-server metadata (RFC 8414 §3) using the first issuer.
+  if (requirements.authorizationServer) {
+    const asUrl = buildAuthorizationServerMetadataUrl(requirements.authorizationServer);
+    if (asUrl) {
+      const as = await fetchJson(asUrl, allowPrivateIpForHop(asUrl), options.timeoutMs);
+      if (as && typeof as === 'object') {
+        const md = as as {
+          authorization_endpoint?: unknown;
+          token_endpoint?: unknown;
+          registration_endpoint?: unknown;
+          scopes_supported?: unknown;
+        };
+        if (typeof md.authorization_endpoint === 'string') {
+          requirements.authorizationEndpoint = sanitizeDisplay(md.authorization_endpoint);
+        }
+        if (typeof md.token_endpoint === 'string') {
+          requirements.tokenEndpoint = sanitizeDisplay(md.token_endpoint);
+        }
+        if (typeof md.registration_endpoint === 'string') {
+          requirements.registrationEndpoint = sanitizeDisplay(md.registration_endpoint);
+        }
+        if (Array.isArray(md.scopes_supported)) {
+          const scopes = md.scopes_supported
+            .filter((s: unknown): s is string => typeof s === 'string')
+            .slice(0, MAX_SCOPES)
+            .map(sanitizeDisplay);
+          if (scopes.length > 0) requirements.scopesSupported = scopes;
+        }
+      }
+    }
+  }
+
+  return requirements;
+}
+
+/**
+ * Fire a single unauthenticated `tools/list` at the agent and return the
+ * status + `WWW-Authenticate` header. Used when the caller hasn't provided
+ * a cached 401 response.
+ */
+async function probeAgent401(
+  agentUrl: string,
+  allowPrivateIp: boolean,
+  timeoutMs?: number
+): Promise<{ status: number; wwwAuthenticate?: string }> {
+  const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+  try {
+    const res = await ssrfSafeFetch(agentUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      body,
+      allowPrivateIp,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+    return { status: res.status, wwwAuthenticate: res.headers['www-authenticate'] };
+  } catch {
+    return { status: 0 };
+  }
+}
+
+/**
+ * Check a URL is an absolute `http:`/`https:` URL before we hand it to
+ * `ssrfSafeFetch`. Defeats `javascript:`, `file:`, `data:`, etc. the agent
+ * might echo back in PRM or AS metadata. `ssrfSafeFetch` refuses non-HTTP
+ * schemes too, but failing fast here gives a cleaner discovery flow and
+ * avoids surfacing scheme errors as mysterious discovery misses.
+ */
+function originOf(value: string): string | undefined {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function isSafeHttpUrl(value: string): boolean {
+  try {
+    const u = new URL(value);
+    return u.protocol === 'https:' || u.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Build the authorization-server metadata URL for an issuer per RFC 8414 §3.
+ *
+ * For issuer `https://as.example.com/tenant1`, metadata lives at
+ * `https://as.example.com/.well-known/oauth-authorization-server/tenant1`
+ * (well-known prefix inserted BEFORE the issuer path, not after). This
+ * matches how the MCP SDK and most authorization servers advertise metadata.
+ */
+function buildAuthorizationServerMetadataUrl(issuer: string): string | undefined {
+  if (!isSafeHttpUrl(issuer)) return undefined;
+  const u = new URL(issuer);
+  const pathname = u.pathname.endsWith('/') ? u.pathname.slice(0, -1) : u.pathname;
+  return `${u.origin}/.well-known/oauth-authorization-server${pathname}`;
+}
+
+async function fetchJson(url: string, allowPrivateIp: boolean, timeoutMs?: number): Promise<unknown> {
+  try {
+    const res = await ssrfSafeFetch(url, {
+      method: 'GET',
+      headers: { accept: 'application/json' },
+      allowPrivateIp,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+    });
+    if (res.status !== 200) return undefined;
+    return decodeBodyAsJsonOrText(res.body, res.headers['content-type']);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/lib/auth/oauth/authorization-required.ts
+++ b/src/lib/auth/oauth/authorization-required.ts
@@ -11,6 +11,7 @@
  * bespoke `OAuthFlowHandler`) so library behavior is predictable.
  */
 import { ssrfSafeFetch, decodeBodyAsJsonOrText } from '../../net';
+import { AuthenticationRequiredError, type OAuthMetadataInfo } from '../../errors';
 import { parseWWWAuthenticate, type WWWAuthenticateChallenge } from './diagnostics';
 
 /**
@@ -71,19 +72,43 @@ export interface AuthorizationRequirements {
  * Error raised when an agent returns a 401 and we do not have credentials
  * to satisfy it. Carries everything needed to run an interactive OAuth flow
  * or show the operator an actionable prompt.
+ *
+ * Extends {@link AuthenticationRequiredError} so existing callers that catch
+ * `AuthenticationRequiredError` automatically receive the richer variant —
+ * they can downcast with `instanceof NeedsAuthorizationError` when they
+ * want walked discovery metadata.
+ *
+ * Note: the inherited `code` is `'AUTHENTICATION_REQUIRED'` so that code
+ * comparisons done by pre-existing callers still match. The specific
+ * `'needs_authorization'` discriminator is available as `subCode`.
  */
-export class NeedsAuthorizationError extends Error {
-  /** Stable error code for `instanceof`-averse consumers. */
-  readonly code = 'needs_authorization' as const;
-  readonly agentUrl: string;
+export class NeedsAuthorizationError extends AuthenticationRequiredError {
+  /** Narrow discriminator for consumers that already know about this class. */
+  readonly subCode = 'needs_authorization' as const;
   readonly requirements: AuthorizationRequirements;
 
   constructor(requirements: AuthorizationRequirements, message?: string) {
-    super(message ?? defaultMessage(requirements));
+    super(requirements.agentUrl, synthesizeOAuthMetadata(requirements), message ?? defaultMessage(requirements));
     this.name = 'NeedsAuthorizationError';
-    this.agentUrl = requirements.agentUrl;
     this.requirements = requirements;
   }
+}
+
+/**
+ * Build an {@link OAuthMetadataInfo} for the base-class constructor so that
+ * legacy callers still see a non-empty `oauthMetadata` + working
+ * `hasOAuth`/`authorizationUrl` getters on the error. When discovery didn't
+ * yield enough info, return undefined and let the base class degrade
+ * gracefully.
+ */
+function synthesizeOAuthMetadata(req: AuthorizationRequirements): OAuthMetadataInfo | undefined {
+  if (!req.authorizationEndpoint || !req.tokenEndpoint) return undefined;
+  return {
+    authorization_endpoint: req.authorizationEndpoint,
+    token_endpoint: req.tokenEndpoint,
+    ...(req.registrationEndpoint ? { registration_endpoint: req.registrationEndpoint } : {}),
+    ...(req.authorizationServer ? { issuer: req.authorizationServer } : {}),
+  };
 }
 
 function defaultMessage(req: AuthorizationRequirements): string {

--- a/src/lib/auth/oauth/file-storage.ts
+++ b/src/lib/auth/oauth/file-storage.ts
@@ -1,0 +1,147 @@
+/**
+ * File-backed {@link OAuthConfigStorage} implementation.
+ *
+ * Persists refreshed OAuth tokens back to a JSON file so that subsequent
+ * `callTool` invocations use the latest access + refresh tokens without
+ * triggering a redundant refresh (or worse, a re-login).
+ *
+ * On-disk format is the shape used by the `adcp` CLI's agents.json — agents
+ * keyed by alias, each with `{ url, protocol, auth_token?, oauth_tokens?, oauth_client? }`.
+ * Library consumers who want a different shape can implement
+ * {@link OAuthConfigStorage} directly.
+ */
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomBytes } from 'crypto';
+import type { AgentConfig } from '../../types/adcp';
+import type { OAuthConfigStorage } from './types';
+
+/**
+ * Shape of a single agent record on disk (matches the `adcp` CLI's config format).
+ */
+interface StoredAgent {
+  url: string;
+  protocol?: 'mcp' | 'a2a';
+  auth_token?: string;
+  oauth_tokens?: AgentConfig['oauth_tokens'];
+  oauth_client?: AgentConfig['oauth_client'];
+  oauth_code_verifier?: string;
+}
+
+/**
+ * Shape of the whole config file.
+ */
+interface StoredConfig {
+  agents: Record<string, StoredAgent>;
+  defaults?: Record<string, unknown>;
+}
+
+/**
+ * Options for {@link createFileOAuthStorage}.
+ */
+export interface FileOAuthStorageOptions {
+  /** Absolute path to the config JSON file. Must be a file, not a directory. */
+  configPath: string;
+  /**
+   * Key persistence under a stable alias regardless of `agent.id`. Use this
+   * when the in-memory `AgentConfig` carries an ephemeral identifier (e.g.
+   * a per-request tenant id, or a synthetic `cli-agent`) but on-disk storage
+   * should be organized by a long-lived alias chosen by the operator.
+   */
+  agentKey?: string;
+  /**
+   * Create the parent directory (with mode 0o700) if it doesn't exist.
+   * Default true — CLI users expect first-run to create `~/.adcp/`.
+   */
+  autoCreateDir?: boolean;
+  /** File mode for the config file when we create it. Default 0o600. */
+  fileMode?: number;
+}
+
+/**
+ * Create a file-backed `OAuthConfigStorage`.
+ *
+ * Reads are cheap: a single JSON.parse per call. Writes are atomic via
+ * `write-then-rename` so a crash mid-save cannot produce a half-written file.
+ *
+ * Does NOT touch fields outside the OAuth envelope (`auth_token`, custom
+ * fields) when saving — the MCP provider only mutates `oauth_tokens`,
+ * `oauth_client`, and `oauth_code_verifier`, and we preserve everything else.
+ *
+ * @example
+ * ```ts
+ * const storage = createFileOAuthStorage({ configPath: '/home/user/.adcp/config.json' });
+ * const provider = createNonInteractiveOAuthProvider(agent, { storage });
+ * ```
+ */
+export function createFileOAuthStorage(options: FileOAuthStorageOptions): OAuthConfigStorage {
+  const configPath = options.configPath;
+  const agentKeyOverride = options.agentKey;
+  const autoCreateDir = options.autoCreateDir ?? true;
+  const fileMode = options.fileMode ?? 0o600;
+
+  async function readConfig(): Promise<StoredConfig> {
+    try {
+      const raw = await fs.readFile(configPath, 'utf-8');
+      const parsed = JSON.parse(raw) as StoredConfig;
+      if (!parsed.agents || typeof parsed.agents !== 'object') parsed.agents = {};
+      return parsed;
+    } catch (err) {
+      if (isNotFound(err)) return { agents: {} };
+      throw err;
+    }
+  }
+
+  async function writeConfig(config: StoredConfig): Promise<void> {
+    if (autoCreateDir) {
+      await fs.mkdir(path.dirname(configPath), { recursive: true, mode: 0o700 });
+    }
+    // Atomic write: stage next to the target, then rename. Same filesystem →
+    // rename is atomic on POSIX and on NTFS (MoveFileEx under the hood).
+    // Random suffix guards against two concurrent saves in the same process
+    // racing on the same temp path.
+    const tempPath = `${configPath}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
+    const serialized = JSON.stringify(config, null, 2);
+    await fs.writeFile(tempPath, serialized, { mode: fileMode });
+    await fs.rename(tempPath, configPath);
+  }
+
+  return {
+    async loadAgent(agentId: string): Promise<AgentConfig | undefined> {
+      const key = agentKeyOverride ?? agentId;
+      const config = await readConfig();
+      const stored = config.agents[key];
+      if (!stored) return undefined;
+      return {
+        id: agentId,
+        name: agentId,
+        agent_uri: stored.url,
+        protocol: stored.protocol ?? 'mcp',
+        auth_token: stored.auth_token,
+        oauth_tokens: stored.oauth_tokens,
+        oauth_client: stored.oauth_client,
+        oauth_code_verifier: stored.oauth_code_verifier,
+      };
+    },
+
+    async saveAgent(agent: AgentConfig): Promise<void> {
+      const key = agentKeyOverride ?? agent.id;
+      const config = await readConfig();
+      const existing = config.agents[key] ?? { url: agent.agent_uri };
+      config.agents[key] = {
+        ...existing,
+        url: agent.agent_uri,
+        protocol: agent.protocol,
+        ...(agent.auth_token !== undefined ? { auth_token: agent.auth_token } : {}),
+        ...(agent.oauth_tokens !== undefined ? { oauth_tokens: agent.oauth_tokens } : {}),
+        ...(agent.oauth_client !== undefined ? { oauth_client: agent.oauth_client } : {}),
+        ...(agent.oauth_code_verifier !== undefined ? { oauth_code_verifier: agent.oauth_code_verifier } : {}),
+      };
+      await writeConfig(config);
+    },
+  };
+}
+
+function isNotFound(err: unknown): boolean {
+  return Boolean(err && typeof err === 'object' && (err as { code?: string }).code === 'ENOENT');
+}

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -270,6 +270,23 @@ export {
   type AuthDiagnosisReport,
 } from './diagnose';
 
+// Zero-config authorization discovery + actionable error type.
+// Raised automatically by `ProtocolClient.callTool` when an MCP agent returns
+// a 401 Bearer challenge and the caller has no saved tokens.
+export {
+  NeedsAuthorizationError,
+  discoverAuthorizationRequirements,
+  type AuthorizationRequirements,
+  type DiscoverAuthorizationOptions,
+} from './authorization-required';
+
+// File-backed `OAuthConfigStorage` implementation (agents.json format).
+export { createFileOAuthStorage, type FileOAuthStorageOptions } from './file-storage';
+
+// Per-agent storage binding — the bridge that lets `callTool` pick up the
+// caller's chosen `OAuthConfigStorage` without a signature change.
+export { bindAgentStorage, getAgentStorage, unbindAgentStorage } from './storage-registry';
+
 // Re-exported MCP SDK OAuth error types so consumers can discriminate 401 causes
 // without string-matching on error messages. These originate from the MCP server
 // auth module but are the canonical OAuth error classes for client-side handling too.

--- a/src/lib/auth/oauth/storage-registry.ts
+++ b/src/lib/auth/oauth/storage-registry.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-agent OAuth storage binding.
+ *
+ * `ProtocolClient.callTool` constructs the non-interactive OAuth provider
+ * inline from an `AgentConfig`, and needs to attach an `OAuthConfigStorage`
+ * implementation when one is available — but only when the caller configured
+ * one for that particular agent. Rather than threading storage through every
+ * positional parameter of `callTool`, we attach it to the agent via a
+ * `Symbol`-keyed enumerable property.
+ *
+ * Why a symbol and not a `WeakMap` or a string-keyed field:
+ *
+ * - `{...agent}` spreads copy enumerable string *and* symbol properties, so
+ *   the binding survives the normalization + discovery passes that
+ *   `SingleAgentClient` performs before calling `ProtocolClient.callTool`.
+ * - `JSON.stringify` ignores symbol keys, so the binding never lands on
+ *   disk when an agent is persisted.
+ * - Using `Symbol.for(…)` (the global registry) keeps the binding readable
+ *   across module instances — relevant when the library is loaded from both
+ *   `dist/` and a workspace link during dev-loops.
+ */
+import type { AgentConfig } from '../../types/adcp';
+import type { OAuthConfigStorage } from './types';
+
+const STORAGE_KEY = Symbol.for('@adcp/client:oauth-config-storage');
+
+/**
+ * Attach an `OAuthConfigStorage` to an `AgentConfig` so that downstream
+ * `callTool` invocations pick it up when constructing an OAuth provider.
+ *
+ * Call this once after resolving the agent (typically in the CLI after
+ * loading from `~/.adcp/config.json`, or in a multi-tenant service after
+ * looking up the agent record for a request).
+ */
+export function bindAgentStorage(agent: AgentConfig, storage: OAuthConfigStorage): void {
+  (agent as unknown as Record<symbol, OAuthConfigStorage>)[STORAGE_KEY] = storage;
+}
+
+/**
+ * Read the `OAuthConfigStorage` bound to an `AgentConfig`, or `undefined`
+ * if none was bound. Used by the protocol client when wiring the OAuth
+ * provider at call time.
+ */
+export function getAgentStorage(agent: AgentConfig): OAuthConfigStorage | undefined {
+  return (agent as unknown as Record<symbol, OAuthConfigStorage | undefined>)[STORAGE_KEY];
+}
+
+/**
+ * Remove the binding for an agent. Typically not needed (GC handles it) but
+ * useful in tests that reuse agent objects across scenarios.
+ */
+export function unbindAgentStorage(agent: AgentConfig): void {
+  delete (agent as unknown as Record<symbol, OAuthConfigStorage>)[STORAGE_KEY];
+}

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -91,6 +91,8 @@ import {
   is401Error,
 } from '../errors';
 import { isLikelyPrivateUrl } from '../net';
+import { discoverAuthorizationRequirements, NeedsAuthorizationError } from '../auth/oauth/authorization-required';
+import { discoverOAuthMetadata } from '../auth/oauth/discovery';
 import type { InputHandler, TaskOptions, TaskResult, ConversationConfig, TaskInfo } from './ConversationTypes';
 import type { Activity, AsyncHandlerConfig, WebhookMetadata } from './AsyncHandler';
 import { AsyncHandler } from './AsyncHandler';
@@ -385,7 +387,6 @@ export class SingleAgentClient {
   private async fetchA2ACanonicalUrl(agentUri: string): Promise<string> {
     const clientModule = require('@a2a-js/sdk/client');
     const A2AClient = clientModule.A2AClient;
-    const { discoverOAuthMetadata } = await import('../auth/oauth/discovery');
 
     const authToken = this.normalizedAgent.auth_token;
     let got401 = false;
@@ -440,8 +441,6 @@ export class SingleAgentClient {
       // full discovery walk succeeds; otherwise fall back to the simpler
       // one-hop AuthenticationRequiredError so behavior degrades gracefully.
       if (is401Error(error, got401)) {
-        const { discoverAuthorizationRequirements, NeedsAuthorizationError } =
-          await import('../auth/oauth/authorization-required');
         const requirements = await discoverAuthorizationRequirements(agentUri, {
           allowPrivateIp: isLikelyPrivateUrl(agentUri),
         });
@@ -499,7 +498,6 @@ export class SingleAgentClient {
    */
   private async discoverMCPEndpoint(providedUri: string): Promise<string> {
     const { connectMCPWithFallback } = await import('../protocols/mcp');
-    const { discoverOAuthMetadata } = await import('../auth/oauth/discovery');
 
     const authToken = this.agent.auth_token;
     const agentHeaders = this.agent.headers;
@@ -579,8 +577,6 @@ export class SingleAgentClient {
     // Fall back to the simpler AuthenticationRequiredError with one-hop AS
     // metadata when the walk doesn't yield enough.
     if (got401) {
-      const { discoverAuthorizationRequirements, NeedsAuthorizationError } =
-        await import('../auth/oauth/authorization-required');
       const requirements = await discoverAuthorizationRequirements(providedUri, {
         allowPrivateIp: isLikelyPrivateUrl(providedUri),
       });

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -90,6 +90,7 @@ import {
   TaskTimeoutError,
   is401Error,
 } from '../errors';
+import { isLikelyPrivateUrl } from '../net';
 import type { InputHandler, TaskOptions, TaskResult, ConversationConfig, TaskInfo } from './ConversationTypes';
 import type { Activity, AsyncHandlerConfig, WebhookMetadata } from './AsyncHandler';
 import { AsyncHandler } from './AsyncHandler';
@@ -435,8 +436,18 @@ export class SingleAgentClient {
 
       return this.computeBaseUrl(agentUri);
     } catch (error: unknown) {
-      // If we got a 401, throw AuthenticationRequiredError
+      // If we got a 401, throw the richer NeedsAuthorizationError when the
+      // full discovery walk succeeds; otherwise fall back to the simpler
+      // one-hop AuthenticationRequiredError so behavior degrades gracefully.
       if (is401Error(error, got401)) {
+        const { discoverAuthorizationRequirements, NeedsAuthorizationError } =
+          await import('../auth/oauth/authorization-required');
+        const requirements = await discoverAuthorizationRequirements(agentUri, {
+          allowPrivateIp: isLikelyPrivateUrl(agentUri),
+        });
+        if (requirements) {
+          throw new NeedsAuthorizationError(requirements);
+        }
         const oauthMetadata = await discoverOAuthMetadata(agentUri);
         throw new AuthenticationRequiredError(agentUri, oauthMetadata || undefined);
       }
@@ -562,11 +573,21 @@ export class SingleAgentClient {
       return firstWorkingUrl;
     }
 
-    // If we got 401 from any endpoint, throw AuthenticationRequiredError
+    // If we got 401 from any endpoint, throw an authentication-required error.
+    // Prefer the richer NeedsAuthorizationError when we can walk the full
+    // RFC 9728 chain (PRM → AS metadata → endpoints + scopes + DCR hint).
+    // Fall back to the simpler AuthenticationRequiredError with one-hop AS
+    // metadata when the walk doesn't yield enough.
     if (got401) {
-      // Try to fetch OAuth metadata to provide helpful guidance
+      const { discoverAuthorizationRequirements, NeedsAuthorizationError } =
+        await import('../auth/oauth/authorization-required');
+      const requirements = await discoverAuthorizationRequirements(providedUri, {
+        allowPrivateIp: isLikelyPrivateUrl(providedUri),
+      });
+      if (requirements) {
+        throw new NeedsAuthorizationError(requirements);
+      }
       const oauthMetadata = await discoverOAuthMetadata(providedUri);
-
       throw new AuthenticationRequiredError(providedUri, oauthMetadata || undefined);
     }
 

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -369,10 +369,11 @@ export function is401Error(error: unknown, got401Flag = false): boolean {
     return true;
   }
 
-  // Fall back to string matching in error message
-  // This is fragile but necessary since different SDKs format errors differently
+  // Fall back to string matching in error message. Use word boundaries so
+  // we don't misidentify things like "product prod-401-xyz" as an HTTP 401,
+  // and require "Unauthorized" as a whole word rather than as a substring.
   const message = (errorObj as { message?: string })?.message || '';
-  return message.includes('401') || message.includes('Unauthorized');
+  return /\b401\b/.test(message) || /\bunauthorized\b/i.test(message);
 }
 
 /**

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -650,6 +650,19 @@ export {
   type AuthDiagnosisReport,
 } from './auth/oauth';
 
+// Zero-config OAuth: actionable error + discovery + file storage + per-agent binding
+export {
+  NeedsAuthorizationError,
+  discoverAuthorizationRequirements,
+  createFileOAuthStorage,
+  bindAgentStorage,
+  getAgentStorage,
+  unbindAgentStorage,
+  type AuthorizationRequirements,
+  type DiscoverAuthorizationOptions,
+  type FileOAuthStorageOptions,
+} from './auth/oauth';
+
 // ====== TOOL SCHEMA MAPS ======
 // Zod schemas keyed by tool name — use with server.tool(name, schema.shape, handler)
 export { TOOL_REQUEST_SCHEMAS } from './utils/tool-request-schemas';

--- a/src/lib/net/address-guards.ts
+++ b/src/lib/net/address-guards.ts
@@ -98,3 +98,27 @@ export function isPrivateIp(address: string): boolean {
   if (!n) return false;
   return privateIp.check(n.addr, n.family);
 }
+
+/**
+ * Best-effort check that a URL targets a development/private host, without
+ * doing a DNS lookup. Matches loopback hostnames (`localhost`) and any IP
+ * literal that {@link isPrivateIp} would reject. Public domain names always
+ * return `false`.
+ *
+ * Used by higher layers that need to inherit the operator's "private is OK"
+ * trust from a primary probe and propagate it to same-origin chain hops —
+ * callers that pass this flag into `ssrfSafeFetch` should do so only when
+ * they've already decided the target origin is trusted.
+ *
+ * Returns `false` on unparseable inputs.
+ */
+export function isLikelyPrivateUrl(url: string): boolean {
+  try {
+    const u = new URL(url);
+    const host = u.hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    if (host === 'localhost') return true;
+    return isPrivateIp(host);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/net/index.ts
+++ b/src/lib/net/index.ts
@@ -11,4 +11,4 @@ export {
   type SsrfFetchOptions,
   type SsrfFetchResult,
 } from './ssrf-fetch';
-export { isPrivateIp, isAlwaysBlocked } from './address-guards';
+export { isPrivateIp, isAlwaysBlocked, isLikelyPrivateUrl } from './address-guards';

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -40,6 +40,7 @@ import {
   getAgentStorage,
 } from '../auth/oauth';
 import { is401Error } from '../errors';
+import { isLikelyPrivateUrl } from '../net';
 import { validateAgentUrl } from '../validation';
 import { withSpan } from '../observability/tracing';
 import { ADCP_MAJOR_VERSION } from '../version';
@@ -212,7 +213,7 @@ async function rethrowAsNeedsAuthorization(err: unknown, agentUrl: string): Prom
   // If the caller has already connected to the agent URL, they've implicitly
   // trusted it — inherit that trust for the discovery probe so loopback /
   // private-IP development agents work the same way as public ones.
-  const allowPrivateIp = isLikelyPrivateHost(agentUrl);
+  const allowPrivateIp = isLikelyPrivateUrl(agentUrl);
 
   // discoverAuthorizationRequirements internally catches network failures and
   // returns null rather than throwing — anything that escapes is a genuine
@@ -222,38 +223,6 @@ async function rethrowAsNeedsAuthorization(err: unknown, agentUrl: string): Prom
     throw new NeedsAuthorizationError(requirements);
   }
   // No requirements walked; let the caller re-throw the original error.
-}
-
-function isLikelyPrivateHost(agentUrl: string): boolean {
-  try {
-    const u = new URL(agentUrl);
-    const host = u.hostname.toLowerCase();
-    if (host === 'localhost') return true;
-    // `isIP` guards against matching domain names that happen to start with
-    // a number (e.g. `10.corp.example.com`) — private-IP regex only fires
-    // when the host is an actual IP literal.
-    const { isIP } = require('net') as typeof import('net');
-    if (isIP(host) === 4) {
-      return (
-        /^10\./.test(host) ||
-        /^192\.168\./.test(host) ||
-        /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(host) ||
-        /^127\./.test(host) ||
-        /^169\.254\./.test(host) || // link-local
-        /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./.test(host) // CGNAT 100.64.0.0/10
-      );
-    }
-    if (isIP(host) === 6) {
-      return (
-        host === '::1' ||
-        host.startsWith('fe80:') || // link-local
-        /^f[cd][0-9a-f]{0,2}:/.test(host) // ULA fc00::/7
-      );
-    }
-    return false;
-  } catch {
-    return false;
-  }
 }
 
 /**

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -33,7 +33,13 @@ import { callA2ATool } from './a2a';
 import type { AgentConfig, DebugLogEntry } from '../types';
 import type { PushNotificationConfig } from '../types/tools.generated';
 import { getAuthToken } from '../auth';
-import { createNonInteractiveOAuthProvider } from '../auth/oauth';
+import {
+  createNonInteractiveOAuthProvider,
+  discoverAuthorizationRequirements,
+  NeedsAuthorizationError,
+  getAgentStorage,
+} from '../auth/oauth';
+import { is401Error } from '../errors';
 import { validateAgentUrl } from '../validation';
 import { withSpan } from '../observability/tracing';
 import { ADCP_MAJOR_VERSION } from '../version';
@@ -130,29 +136,46 @@ export class ProtocolClient {
           // This path does not cache connections (OAuth token-refresh can't share
           // a cached transport), so it's slower but correct for OAuth-gated agents.
           if (agent.oauth_tokens) {
-            const authProvider = createNonInteractiveOAuthProvider(agent, { agentHint: agent.id });
-            return callMCPToolWithOAuth({
-              agentUrl: agent.agent_uri,
-              toolName,
-              args: argsWithWebhook,
-              authProvider,
-              debugLogs,
-              customHeaders: agent.headers,
-              signingContext,
+            const storage = getAgentStorage(agent);
+            const authProvider = createNonInteractiveOAuthProvider(agent, {
+              agentHint: agent.id,
+              storage,
             });
+            try {
+              return await callMCPToolWithOAuth({
+                agentUrl: agent.agent_uri,
+                toolName,
+                args: argsWithWebhook,
+                authProvider,
+                debugLogs,
+                customHeaders: agent.headers,
+                signingContext,
+              });
+            } catch (err) {
+              // Refresh failed or server rejected the refreshed token — walk the
+              // discovery chain so the caller can distinguish "re-auth needed"
+              // from other failure modes.
+              await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+              throw err;
+            }
           }
 
           // Use callMCPToolWithTasks which auto-detects server tasks capability
           // and falls back to standard callTool when tasks are not supported
-          return callMCPToolWithTasks(
-            agent.agent_uri,
-            toolName,
-            argsWithWebhook,
-            authToken,
-            debugLogs,
-            agent.headers,
-            signingContext ? { signingContext } : undefined
-          );
+          try {
+            return await callMCPToolWithTasks(
+              agent.agent_uri,
+              toolName,
+              argsWithWebhook,
+              authToken,
+              debugLogs,
+              agent.headers,
+              signingContext ? { signingContext } : undefined
+            );
+          } catch (err) {
+            await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+            throw err;
+          }
         } else if (agent.protocol === 'a2a') {
           // For A2A, pass pushNotificationConfig separately (not in skill parameters)
           return callA2ATool(
@@ -170,6 +193,66 @@ export class ProtocolClient {
         }
       }
     );
+  }
+}
+
+/**
+ * If `err` looks like a 401 from the MCP transport, probe the agent for a
+ * Bearer challenge and throw a {@link NeedsAuthorizationError} carrying
+ * walked discovery metadata. If the error isn't a 401 or we can't build a
+ * requirements record, return silently so the caller re-throws the original.
+ *
+ * Keeping this off the hot path: we only probe on error, and the probe is
+ * a single unauthenticated `tools/list` POST — no retries, no DNS rebind.
+ */
+async function rethrowAsNeedsAuthorization(err: unknown, agentUrl: string): Promise<void> {
+  if (err instanceof NeedsAuthorizationError) throw err;
+  if (!is401Error(err)) return;
+
+  // If the caller has already connected to the agent URL, they've implicitly
+  // trusted it — inherit that trust for the discovery probe so loopback /
+  // private-IP development agents work the same way as public ones.
+  const allowPrivateIp = isLikelyPrivateHost(agentUrl);
+
+  // discoverAuthorizationRequirements internally catches network failures and
+  // returns null rather than throwing — anything that escapes is a genuine
+  // bug we want to surface rather than mask the 401 with.
+  const requirements = await discoverAuthorizationRequirements(agentUrl, { allowPrivateIp });
+  if (requirements) {
+    throw new NeedsAuthorizationError(requirements);
+  }
+  // No requirements walked; let the caller re-throw the original error.
+}
+
+function isLikelyPrivateHost(agentUrl: string): boolean {
+  try {
+    const u = new URL(agentUrl);
+    const host = u.hostname.toLowerCase();
+    if (host === 'localhost') return true;
+    // `isIP` guards against matching domain names that happen to start with
+    // a number (e.g. `10.corp.example.com`) — private-IP regex only fires
+    // when the host is an actual IP literal.
+    const { isIP } = require('net') as typeof import('net');
+    if (isIP(host) === 4) {
+      return (
+        /^10\./.test(host) ||
+        /^192\.168\./.test(host) ||
+        /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(host) ||
+        /^127\./.test(host) ||
+        /^169\.254\./.test(host) || // link-local
+        /^100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\./.test(host) // CGNAT 100.64.0.0/10
+      );
+    }
+    if (isIP(host) === 6) {
+      return (
+        host === '::1' ||
+        host.startsWith('fe80:') || // link-local
+        /^f[cd][0-9a-f]{0,2}:/.test(host) // ULA fc00::/7
+      );
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 

--- a/test/lib/oauth-authorization-required.test.js
+++ b/test/lib/oauth-authorization-required.test.js
@@ -1,0 +1,300 @@
+/**
+ * Tests for NeedsAuthorizationError + discoverAuthorizationRequirements.
+ *
+ * Drives the discovery runner against an in-process HTTP server that
+ * swaps handlers per scenario, covering each branch of the walk
+ * (PRM present/missing, AS metadata present/missing, DCR supported/not).
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { NeedsAuthorizationError, discoverAuthorizationRequirements } = require('../../dist/lib/auth/oauth');
+
+const state = { handlers: {}, server: null, port: 0 };
+
+before(async () => {
+  state.server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const handler = state.handlers[url.pathname];
+    if (!handler) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        handler(req, res, body);
+      } catch (err) {
+        console.error('test fixture handler threw:', err);
+        res.statusCode = 500;
+        res.end('test fixture error');
+      }
+    });
+  });
+  await new Promise(r => state.server.listen(0, '127.0.0.1', r));
+  state.port = state.server.address().port;
+});
+
+after(async () => {
+  await new Promise(r => state.server.close(r));
+});
+
+function agentUrl() {
+  return `http://127.0.0.1:${state.port}/mcp`;
+}
+function issuer() {
+  return `http://127.0.0.1:${state.port}`;
+}
+function jsonRes(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+describe('NeedsAuthorizationError', () => {
+  test('carries walked requirements and renders a helpful default message', () => {
+    const err = new NeedsAuthorizationError({
+      agentUrl: 'https://agent.example.com/mcp',
+      authorizationServer: 'https://as.example.com',
+      challenge: {
+        scheme: 'bearer',
+        error: 'invalid_token',
+        error_description: 'Token expired.',
+        params: { error: 'invalid_token', error_description: 'Token expired.' },
+      },
+    });
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.code, 'needs_authorization');
+    assert.strictEqual(err.agentUrl, 'https://agent.example.com/mcp');
+    assert.match(err.message, /requires OAuth authorization/);
+    assert.match(err.message, /as\.example\.com/);
+    assert.match(err.message, /Token expired/);
+    assert.match(err.message, /OAuthFlowHandler/);
+  });
+
+  test('accepts a caller-supplied message override', () => {
+    const err = new NeedsAuthorizationError(
+      {
+        agentUrl: 'https://x',
+        challenge: { scheme: 'bearer', params: {} },
+      },
+      'custom: bring creds and try again'
+    );
+    assert.strictEqual(err.message, 'custom: bring creds and try again');
+  });
+});
+
+describe('discoverAuthorizationRequirements', () => {
+  test('returns null when the agent responds 200 without auth', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => jsonRes(res, 200, { jsonrpc: '2.0', id: 1, result: { tools: [] } }),
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.strictEqual(result, null);
+  });
+
+  test('returns null on 401 without a Bearer challenge', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Basic realm="api"');
+        res.end();
+      },
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.strictEqual(result, null);
+  });
+
+  test('walks PRM + AS metadata into a full requirements record', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer realm="api", error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp", scope="mcp.read mcp.write"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, {
+          resource: agentUrl(),
+          authorization_servers: [issuer()],
+        }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, {
+          authorization_endpoint: `${issuer()}/oauth/authorize`,
+          token_endpoint: `${issuer()}/oauth/token`,
+          registration_endpoint: `${issuer()}/oauth/register`,
+          scopes_supported: ['mcp.read', 'mcp.write'],
+        }),
+    };
+
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result, 'expected requirements record');
+    assert.strictEqual(result.agentUrl, agentUrl());
+    assert.strictEqual(result.resource, agentUrl());
+    assert.strictEqual(result.authorizationServer, issuer());
+    assert.strictEqual(result.authorizationEndpoint, `${issuer()}/oauth/authorize`);
+    assert.strictEqual(result.tokenEndpoint, `${issuer()}/oauth/token`);
+    assert.strictEqual(result.registrationEndpoint, `${issuer()}/oauth/register`);
+    assert.deepStrictEqual(result.scopesSupported, ['mcp.read', 'mcp.write']);
+    assert.strictEqual(result.challengeScope, 'mcp.read mcp.write');
+    assert.strictEqual(result.challenge.error, 'invalid_token');
+  });
+
+  test('returns partial record when PRM is 404 (still captures challenge)', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer realm="api", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/missing"`
+        );
+        res.end();
+      },
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result);
+    assert.strictEqual(result.authorizationServer, undefined);
+    assert.strictEqual(result.tokenEndpoint, undefined);
+    assert.strictEqual(result.challenge.scheme, 'bearer');
+    assert.strictEqual(result.resourceMetadataUrl, `${issuer()}/.well-known/oauth-protected-resource/missing`);
+  });
+
+  test('strips ASCII control characters from server-supplied strings in AS metadata', async () => {
+    // Node's http server rejects CR/LF in header values, so the actual
+    // WWW-Authenticate vector can't include those bytes on the wire. But
+    // JSON bodies CAN carry escape codes — a hostile AS metadata response
+    // is the realistic attack surface, so test that path end-to-end.
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, {
+          authorization_endpoint: `${issuer()}/oauth/authorize\x1b]0;pwned\x07`,
+          token_endpoint: `${issuer()}/oauth/token`,
+          scopes_supported: ['good.scope', 'evil\x1b[31mred\x1b[0m'],
+        }),
+    };
+
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result);
+    assert.doesNotMatch(
+      result.authorizationEndpoint,
+      /[\x00-\x08\x0b-\x1f\x7f]/,
+      'authorization_endpoint must be sanitized'
+    );
+    assert.doesNotMatch(
+      result.scopesSupported.join(','),
+      /[\x00-\x08\x0b-\x1f\x7f]/,
+      'scopesSupported must be sanitized'
+    );
+    // NeedsAuthorizationError's default message incorporates server-supplied
+    // fields; verify it too comes out clean.
+    const err = new NeedsAuthorizationError(result);
+    assert.doesNotMatch(err.message, /[\x00-\x08\x0b-\x1f\x7f]/, 'error message must be sanitized');
+  });
+
+  test('caps the scopesSupported list to bound hostile metadata', async () => {
+    const many = Array.from({ length: 500 }, (_, i) => `scope-${i}`);
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { scopes_supported: many }),
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result.scopesSupported.length <= 64, `expected <=64 scopes, got ${result.scopesSupported.length}`);
+  });
+
+  test('refuses non-HTTP schemes smuggled into authorization_servers[0]', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, {
+          resource: agentUrl(),
+          authorization_servers: ['javascript:alert(1)'],
+        }),
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result);
+    assert.strictEqual(result.authorizationServer, undefined, 'non-http(s) schemes must be rejected');
+  });
+
+  test('builds RFC 8414 path-aware metadata URL when issuer has a path', async () => {
+    // Issuer has a /tenant1 path — AS metadata must live at
+    // /.well-known/oauth-authorization-server/tenant1, not at /tenant1/.well-known/...
+    const pathAwareCalled = { hit: false };
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, {
+          resource: agentUrl(),
+          authorization_servers: [`${issuer()}/tenant1`],
+        }),
+      '/.well-known/oauth-authorization-server/tenant1': (req, res) => {
+        pathAwareCalled.hit = true;
+        jsonRes(res, 200, { token_endpoint: `${issuer()}/oauth/token` });
+      },
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(pathAwareCalled.hit, 'expected path-aware metadata URL to be probed');
+    assert.strictEqual(result.tokenEndpoint, `${issuer()}/oauth/token`);
+  });
+
+  test('honors a caller-supplied WWW-Authenticate header (no extra probe)', async () => {
+    // Agent handler that would fail the assertion if invoked — we want to
+    // prove the caller's header is used instead of a fresh probe.
+    state.handlers = {
+      '/mcp': () => {
+        throw new Error('agent should not be probed when wwwAuthenticate is supplied');
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, {
+          authorization_endpoint: `${issuer()}/oauth/authorize`,
+          token_endpoint: `${issuer()}/oauth/token`,
+        }),
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), {
+      allowPrivateIp: true,
+      wwwAuthenticate: `Bearer resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`,
+    });
+    assert.ok(result);
+    assert.strictEqual(result.tokenEndpoint, `${issuer()}/oauth/token`);
+  });
+});

--- a/test/lib/oauth-authorization-required.test.js
+++ b/test/lib/oauth-authorization-required.test.js
@@ -210,6 +210,50 @@ describe('discoverAuthorizationRequirements', () => {
     assert.doesNotMatch(err.message, /[\x00-\x08\x0b-\x1f\x7f]/, 'error message must be sanitized');
   });
 
+  test('sanitizes nested challenge params and caps their count', async () => {
+    // Send a challenge with lots of unknown auth-params AND values with ANSI
+    // escape codes via `\t` (the only control char `setHeader` tolerates).
+    const hostileParams = Array.from({ length: 100 }, (_, i) => `custom${i}="evil\tcolor${i}"`).join(', ');
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer realm="api", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp", ${hostileParams}`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+    };
+    const result = await discoverAuthorizationRequirements(agentUrl(), { allowPrivateIp: true });
+    assert.ok(result);
+    for (const v of Object.values(result.challenge.params)) {
+      assert.doesNotMatch(v, /[\x00-\x08\x0b-\x1f\x7f]/);
+    }
+    assert.ok(
+      Object.keys(result.challenge.params).length <= 32,
+      `expected ≤32 params, got ${Object.keys(result.challenge.params).length}`
+    );
+  });
+
+  test('attaches requirements to error.details for structured-logging consumers', () => {
+    const requirements = {
+      agentUrl: 'https://agent.example.com/mcp',
+      authorizationServer: 'https://as.example.com',
+      authorizationEndpoint: 'https://as.example.com/oauth/authorize',
+      tokenEndpoint: 'https://as.example.com/oauth/token',
+      challenge: { scheme: 'bearer', params: {} },
+    };
+    const err = new NeedsAuthorizationError(requirements);
+    assert.ok(err.details, 'expected details to be set');
+    assert.strictEqual(err.details.requirements, requirements);
+    // Parent's detail fields should also still be present so existing log
+    // pipelines keep working.
+    assert.strictEqual(err.details.agentUrl, 'https://agent.example.com/mcp');
+    assert.ok(err.details.oauthMetadata);
+  });
+
   test('caps the scopesSupported list to bound hostile metadata', async () => {
     const many = Array.from({ length: 500 }, (_, i) => `scope-${i}`);
     state.handlers = {

--- a/test/lib/oauth-authorization-required.test.js
+++ b/test/lib/oauth-authorization-required.test.js
@@ -68,7 +68,10 @@ describe('NeedsAuthorizationError', () => {
       },
     });
     assert.ok(err instanceof Error);
-    assert.strictEqual(err.code, 'needs_authorization');
+    // Inherits from AuthenticationRequiredError, so the high-level code is
+    // the legacy constant; the narrow discriminator is `subCode`.
+    assert.strictEqual(err.code, 'AUTHENTICATION_REQUIRED');
+    assert.strictEqual(err.subCode, 'needs_authorization');
     assert.strictEqual(err.agentUrl, 'https://agent.example.com/mcp');
     assert.match(err.message, /requires OAuth authorization/);
     assert.match(err.message, /as\.example\.com/);

--- a/test/lib/oauth-file-storage.test.js
+++ b/test/lib/oauth-file-storage.test.js
@@ -1,0 +1,99 @@
+/**
+ * Tests for the file-backed OAuthConfigStorage.
+ *
+ * Focuses on the round-trip (save → load round-trip preserves OAuth fields,
+ * non-OAuth fields survive overwrites) and the CLI-oriented `agentKey`
+ * override that keys writes by alias rather than by `agent.id`.
+ */
+
+const { test, describe, before, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const os = require('node:os');
+
+const { createFileOAuthStorage } = require('../../dist/lib/auth/oauth');
+
+let tmpDir;
+let configPath;
+
+before(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'adcp-oauth-'));
+});
+
+beforeEach(async () => {
+  configPath = path.join(tmpDir, `config-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+});
+
+describe('createFileOAuthStorage', () => {
+  test('returns undefined when the file does not exist', async () => {
+    const storage = createFileOAuthStorage({ configPath });
+    const loaded = await storage.loadAgent('missing');
+    assert.strictEqual(loaded, undefined);
+  });
+
+  test('saveAgent creates the file and loadAgent round-trips OAuth fields', async () => {
+    const storage = createFileOAuthStorage({ configPath });
+    await storage.saveAgent({
+      id: 'my-agent',
+      name: 'my-agent',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_tokens: { access_token: 'at', refresh_token: 'rt', expires_in: 3600 },
+      oauth_client: { client_id: 'cid', redirect_uris: ['http://localhost/cb'] },
+    });
+    const loaded = await storage.loadAgent('my-agent');
+    assert.ok(loaded);
+    assert.strictEqual(loaded.agent_uri, 'https://agent.example.com/mcp');
+    assert.strictEqual(loaded.oauth_tokens.access_token, 'at');
+    assert.strictEqual(loaded.oauth_client.client_id, 'cid');
+  });
+
+  test('preserves unrelated fields (e.g. auth_token) across saves', async () => {
+    // Pre-seed the file with a saved agent that has a static auth_token.
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          'my-agent': {
+            url: 'https://agent.example.com/mcp',
+            protocol: 'mcp',
+            auth_token: 'static-bearer-should-survive',
+          },
+        },
+      })
+    );
+    const storage = createFileOAuthStorage({ configPath });
+    await storage.saveAgent({
+      id: 'my-agent',
+      name: 'my-agent',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_tokens: { access_token: 'new-at' },
+    });
+    const loaded = await storage.loadAgent('my-agent');
+    assert.strictEqual(loaded.auth_token, 'static-bearer-should-survive');
+    assert.strictEqual(loaded.oauth_tokens.access_token, 'new-at');
+  });
+
+  test('agentKey override keys all writes under the fixed alias', async () => {
+    const storage = createFileOAuthStorage({ configPath, agentKey: 'real-alias' });
+    // The in-memory agent has a synthetic id (CLI pattern: 'cli-agent').
+    await storage.saveAgent({
+      id: 'cli-agent',
+      name: 'CLI Agent',
+      agent_uri: 'https://agent.example.com/mcp',
+      protocol: 'mcp',
+      oauth_tokens: { access_token: 'at' },
+    });
+    // The storage should have written under 'real-alias', not 'cli-agent'.
+    const raw = JSON.parse(await fs.readFile(configPath, 'utf-8'));
+    assert.ok(raw.agents['real-alias']);
+    assert.strictEqual(raw.agents['cli-agent'], undefined);
+    // loadAgent also honors the override.
+    const loaded = await storage.loadAgent('cli-agent');
+    assert.ok(loaded);
+    assert.strictEqual(loaded.oauth_tokens.access_token, 'at');
+  });
+});

--- a/test/lib/protocol-client-needs-auth.test.js
+++ b/test/lib/protocol-client-needs-auth.test.js
@@ -1,0 +1,153 @@
+/**
+ * Integration test: ProtocolClient.callTool → 401 → NeedsAuthorizationError.
+ *
+ * Proves the hot-path wiring: when an MCP agent responds 401 with a Bearer
+ * challenge carrying `resource_metadata=…`, the library automatically walks
+ * discovery and surfaces a structured error the caller can act on —
+ * without the caller doing anything special.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { ProtocolClient } = require('../../dist/lib/protocols');
+const { NeedsAuthorizationError, bindAgentStorage, getAgentStorage } = require('../../dist/lib/auth/oauth');
+
+const state = { handlers: {}, server: null, port: 0 };
+
+before(async () => {
+  state.server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const handler = state.handlers[url.pathname];
+    if (!handler) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        handler(req, res, body);
+      } catch (err) {
+        console.error('test fixture handler threw:', err);
+        res.statusCode = 500;
+        res.end('test fixture error');
+      }
+    });
+  });
+  await new Promise(r => state.server.listen(0, '127.0.0.1', r));
+  state.port = state.server.address().port;
+});
+
+after(async () => {
+  await new Promise(r => state.server.close(r));
+});
+
+function agentUrl() {
+  return `http://127.0.0.1:${state.port}/mcp`;
+}
+function issuer() {
+  return `http://127.0.0.1:${state.port}`;
+}
+function jsonRes(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+describe('ProtocolClient.callTool: auto-auth discovery', () => {
+  test('translates MCP 401 + Bearer challenge into NeedsAuthorizationError with walked metadata', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer realm="api", error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, {
+          authorization_endpoint: `${issuer()}/oauth/authorize`,
+          token_endpoint: `${issuer()}/oauth/token`,
+          registration_endpoint: `${issuer()}/oauth/register`,
+        }),
+    };
+
+    const agent = {
+      id: 'test-agent',
+      name: 'test',
+      agent_uri: agentUrl(),
+      protocol: 'mcp',
+    };
+
+    await assert.rejects(
+      () => ProtocolClient.callTool(agent, 'get_products', { brief: 'test' }),
+      err => {
+        assert.ok(
+          err instanceof NeedsAuthorizationError,
+          `expected NeedsAuthorizationError, got ${err.constructor.name}`
+        );
+        assert.strictEqual(err.requirements.authorizationServer, issuer());
+        assert.strictEqual(err.requirements.registrationEndpoint, `${issuer()}/oauth/register`);
+        assert.strictEqual(err.requirements.challenge.error, 'invalid_token');
+        return true;
+      }
+    );
+  });
+
+  test('bound OAuthConfigStorage survives object spread (symbol property)', async () => {
+    const storage = { loadAgent: async () => undefined, saveAgent: async () => {} };
+    const agent = {
+      id: 'test-agent',
+      name: 'test',
+      agent_uri: agentUrl(),
+      protocol: 'mcp',
+    };
+    bindAgentStorage(agent, storage);
+
+    // Spread the agent multiple times (mirrors SingleAgentClient.normalizeAgentConfig
+    // + discovery rewrites). The binding must survive every copy or the CLI /
+    // library path never picks up the storage, and refreshed tokens never persist.
+    const spread1 = { ...agent };
+    const spread2 = { ...spread1, headers: { foo: 'bar' } };
+    const spread3 = { ...spread2 };
+
+    assert.strictEqual(getAgentStorage(spread1), storage);
+    assert.strictEqual(getAgentStorage(spread2), storage);
+    assert.strictEqual(getAgentStorage(spread3), storage);
+    // And the binding is invisible to JSON.stringify, so the config never lands on disk.
+    assert.strictEqual(JSON.stringify(spread3).includes('oauth-config-storage'), false);
+  });
+
+  test('passes through non-auth errors unchanged', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 500;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'server bug' } }));
+      },
+    };
+    const agent = {
+      id: 'test-agent',
+      name: 'test',
+      agent_uri: agentUrl(),
+      protocol: 'mcp',
+    };
+
+    await assert.rejects(
+      () => ProtocolClient.callTool(agent, 'get_products', {}),
+      err => {
+        assert.ok(
+          !(err instanceof NeedsAuthorizationError),
+          'must not be NeedsAuthorizationError for non-401 failures'
+        );
+        return true;
+      }
+    );
+  });
+});

--- a/test/lib/single-agent-client-needs-auth.test.js
+++ b/test/lib/single-agent-client-needs-auth.test.js
@@ -1,0 +1,141 @@
+/**
+ * Pre-flight integration test: AgentClient → SingleAgentClient → 401 →
+ * NeedsAuthorizationError.
+ *
+ * The inner-path hook in `ProtocolClient.callTool` is covered elsewhere.
+ * This test covers the PRE-flight path in `SingleAgentClient.discoverMCPEndpoint`,
+ * which fires before the inner call — the scenario that revealed the bug
+ * during end-to-end testing against a local OAuth-gated MCP fake.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { AdCPClient } = require('../../dist/lib/index');
+const { NeedsAuthorizationError } = require('../../dist/lib/auth/oauth');
+const { AuthenticationRequiredError } = require('../../dist/lib/errors');
+
+const state = { handlers: {}, server: null, port: 0 };
+
+before(async () => {
+  state.server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const handler = state.handlers[url.pathname];
+    if (!handler) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        handler(req, res, body);
+      } catch (err) {
+        console.error('test fixture handler threw:', err);
+        res.statusCode = 500;
+        res.end('test fixture error');
+      }
+    });
+  });
+  await new Promise(r => state.server.listen(0, '127.0.0.1', r));
+  state.port = state.server.address().port;
+});
+
+after(async () => {
+  await new Promise(r => state.server.close(r));
+});
+
+function agentUrl() {
+  return `http://127.0.0.1:${state.port}/mcp`;
+}
+function issuer() {
+  return `http://127.0.0.1:${state.port}`;
+}
+function jsonRes(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+describe('SingleAgentClient pre-flight discovery: 401 → NeedsAuthorizationError', () => {
+  test('throws NeedsAuthorizationError (IS-A AuthenticationRequiredError) with walked chain', async () => {
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader(
+          'www-authenticate',
+          `Bearer realm="mcp-test", error="invalid_token", resource_metadata="${issuer()}/.well-known/oauth-protected-resource/mcp"`
+        );
+        res.end();
+      },
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) =>
+        jsonRes(res, 200, {
+          authorization_endpoint: `${issuer()}/oauth/authorize`,
+          token_endpoint: `${issuer()}/oauth/token`,
+          registration_endpoint: `${issuer()}/oauth/register`,
+          scopes_supported: ['mcp.read'],
+        }),
+    };
+
+    const client = new AdCPClient([
+      {
+        id: 'test-agent',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+      },
+    ]);
+    const agentClient = client.agent('test-agent');
+
+    await assert.rejects(
+      () => agentClient.executeTask('get_products', { brief: 'test' }),
+      err => {
+        assert.ok(
+          err instanceof NeedsAuthorizationError,
+          `expected NeedsAuthorizationError, got ${err.constructor.name}: ${err.message}`
+        );
+        // Backward compat: the richer class IS-A AuthenticationRequiredError
+        // so existing catch sites continue to match.
+        assert.ok(err instanceof AuthenticationRequiredError, 'must also be an AuthenticationRequiredError');
+        assert.strictEqual(err.requirements.authorizationServer, issuer());
+        assert.strictEqual(err.requirements.registrationEndpoint, `${issuer()}/oauth/register`);
+        assert.strictEqual(err.subCode, 'needs_authorization');
+        return true;
+      }
+    );
+  });
+
+  test('falls back to plain AuthenticationRequiredError when discovery walk yields nothing', async () => {
+    // 401 without a resource_metadata hint and no PRM endpoint → walk returns null.
+    state.handlers = {
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        // No www-authenticate at all — walk returns null, so we fall back.
+        res.end();
+      },
+    };
+
+    const client = new AdCPClient([
+      {
+        id: 'test-agent',
+        name: 'test',
+        agent_uri: agentUrl(),
+        protocol: 'mcp',
+      },
+    ]);
+    const agentClient = client.agent('test-agent');
+
+    await assert.rejects(
+      () => agentClient.executeTask('get_products', { brief: 'test' }),
+      err => {
+        assert.ok(err instanceof AuthenticationRequiredError, `expected AuthenticationRequiredError`);
+        assert.ok(!(err instanceof NeedsAuthorizationError), `must NOT upgrade when walk yielded nothing`);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
Closes #563 (final item — automatic OAuth on `callTool`).

When `ProtocolClient.callTool` hits a 401 the caller can't satisfy, the library now walks the OAuth discovery chain and throws a structured `NeedsAuthorizationError` carrying everything needed to run an interactive flow or show the operator an actionable prompt. Path A from the design discussion — no surprise browser launches, but a richly diagnosable error that the CLI can render and a dashboard can consume.

## Summary

- **`NeedsAuthorizationError`** — thrown automatically by `ProtocolClient.callTool` when an MCP 401 Bearer challenge is encountered and the caller has no saved tokens. Carries `agentUrl`, `resource`, `resourceMetadataUrl`, `authorizationServer`, `authorizationEndpoint`, `tokenEndpoint`, `registrationEndpoint`, `scopesSupported`, and the parsed challenge.
- **`discoverAuthorizationRequirements(agentUrl, options?)`** — programmatic access to the same walk. Returns `null` when the agent responds 200 without auth or 401 without a Bearer challenge.
- **`createFileOAuthStorage({ configPath, agentKey? })`** — file-backed `OAuthConfigStorage` (atomic writes, preserves non-OAuth fields, per-alias keying for multi-tenant / CLI use).
- **`bindAgentStorage` / `getAgentStorage`** — `Symbol.for`-keyed binding that survives `{...agent}` spreads applied by `SingleAgentClient` during normalization.
- **CLI**: saved OAuth aliases get file-backed storage auto-bound so refreshed tokens persist; `NeedsAuthorizationError` is caught and rendered with actionable metadata.

## Scope

Closes #563 entirely. Items 1–5 landed in #605; this PR does item 6.

## Security posture

- Same-origin chain hops inherit `allowPrivateIp`; cross-origin hops always require public endpoints so a compromised agent can't pivot discovery into the host's internal network.
- Server-supplied strings stripped of ASCII control chars + truncated to 256 chars before landing in operator-facing prompts (defeats terminal-hijack tricks via OSC/CSI sequences).
- `scopes_supported` capped at 64 entries.
- Non-HTTP schemes refused before hitting `ssrfSafeFetch`.
- RFC 8414 path-aware metadata URL construction.
- `is401Error` string fallback tightened to `\b401\b` / `\bunauthorized\b` to prevent false-positives on product codes.

## Test plan

- [x] 18 new tests (9 discovery scenarios, 4 file-storage round-trips, 3 ProtocolClient integration + 2 binding-survives-spread)
- [x] `npm run ci:quick` — 3865/3871 (4 pre-existing Governance E2E failures unrelated)
- [x] Typecheck + format clean
- [x] Reviewed by code-reviewer (WeakMap→Symbol fix) and security-reviewer (M2 control-char stripping, L2 same-origin gating). All Must-Fix / Should-Fix addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)