### PR TITLE
refactor(signing): thread signingContext via AsyncLocalStorage

### DIFF
--- a/.changeset/signing-context-async-local-storage.md
+++ b/.changeset/signing-context-async-local-storage.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+refactor: thread signing context via AsyncLocalStorage
+
+Flattens the `signingContext` parameter that PR #593 pushed through nine function signatures in the MCP and A2A transports. Top-level entries (`callMCPTool`, `callMCPToolRaw`, `callMCPToolWithTasks`, `callA2ATool`) now push the context onto a new `signingContextStorage` AsyncLocalStorage for the duration of the call, and the internal helpers (`withCachedConnection`, `getOrCreateConnection`, `connectMCPWithFallback`, `getOrCreateA2AClient`, `createA2AClient`, `buildFetchImpl`) read it from storage instead of receiving it as a parameter. The public entry-point signatures are unchanged, so external callers and integration tests continue to pass `signingContext` explicitly.
+
+Adds tests that fire interleaved concurrent `callTool`s with distinct signing identities to verify each sees its own context, and that a signing call followed by a non-signing call in the same async chain does not leak the stale context.

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -10,7 +10,7 @@ import { AuthenticationRequiredError, is401Error } from '../errors';
 import { discoverOAuthMetadata } from '../auth/oauth/discovery';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
-import { buildAgentSigningFetch, type AgentSigningContext } from '../signing/client';
+import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 
 if (!A2AClient) {
@@ -63,9 +63,9 @@ export function closeA2AConnections(): void {
 
 async function getOrCreateA2AClient(
   agentUrl: string,
-  authToken: string | undefined,
-  signingContext: AgentSigningContext | undefined
+  authToken: string | undefined
 ): Promise<InstanceType<typeof A2AClient>> {
+  const signingContext = signingContextStorage.getStore();
   const cacheKey = a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey);
   const cached = a2aClientCache.get(cacheKey);
   if (cached) return cached;
@@ -73,7 +73,7 @@ async function getOrCreateA2AClient(
   const pending = pendingA2AClients.get(cacheKey);
   if (pending) return pending;
 
-  const promise = createA2AClient(agentUrl, authToken, signingContext)
+  const promise = createA2AClient(agentUrl, authToken)
     .then(client => {
       a2aClientCache.set(cacheKey, client);
       return client;
@@ -88,10 +88,9 @@ async function getOrCreateA2AClient(
 
 async function createA2AClient(
   agentUrl: string,
-  authToken: string | undefined,
-  signingContext: AgentSigningContext | undefined
+  authToken: string | undefined
 ): Promise<InstanceType<typeof A2AClient>> {
-  const fetchImpl = buildFetchImpl(authToken, signingContext);
+  const fetchImpl = buildFetchImpl(authToken);
   const cardUrls = buildCardUrls(agentUrl);
 
   const context = callContextStorage.getStore();
@@ -117,7 +116,14 @@ async function createA2AClient(
   return client;
 }
 
-function buildFetchImpl(authToken: string | undefined, signingContext: AgentSigningContext | undefined) {
+function buildFetchImpl(authToken: string | undefined) {
+  // The A2A client is cached per (url, authToken, signingCacheKey). We capture
+  // the signing context at client-creation time so all subsequent calls that
+  // share this cached client use the same signing identity — changing identity
+  // requires a different cache entry, built on a separate call that enters ALS
+  // with a different context.
+  const signingContext = signingContextStorage.getStore();
+
   // Inner fetch handles auth/header injection and 401 detection. If the
   // agent has request-signing configured, we wrap it with the AdCP signing
   // fetch so the signature covers the exact bytes we're about to send (auth
@@ -216,16 +222,9 @@ export async function callA2ATool(
         debugLogs,
         got401Ref: { value: false },
       };
-      return callContextStorage.run(context, () =>
-        callA2AToolImpl(
-          agentUrl,
-          toolName,
-          parameters,
-          authToken,
-          debugLogs,
-          pushNotificationConfig,
-          context,
-          signingContext
+      return signingContextStorage.run(signingContext, () =>
+        callContextStorage.run(context, () =>
+          callA2AToolImpl(agentUrl, toolName, parameters, authToken, debugLogs, pushNotificationConfig, context)
         )
       );
     }
@@ -239,11 +238,10 @@ async function callA2AToolImpl(
   authToken: string | undefined,
   debugLogs: DebugLogEntry[],
   pushNotificationConfig: PushNotificationConfig | undefined,
-  context: A2ACallContext,
-  signingContext: AgentSigningContext | undefined
+  context: A2ACallContext
 ): Promise<unknown> {
   try {
-    const client = await getOrCreateA2AClient(agentUrl, authToken, signingContext);
+    const client = await getOrCreateA2AClient(agentUrl, authToken);
 
     const requestPayload: {
       message: {
@@ -330,6 +328,7 @@ async function callA2AToolImpl(
   } catch (error: unknown) {
     if (is401Error(error, context.got401Ref.value)) {
       // Evict this cache entry — token may have expired or been revoked.
+      const signingContext = signingContextStorage.getStore();
       a2aClientCache.delete(a2aCacheKey(agentUrl, authToken, signingContext?.cacheKey));
 
       debugLogs.push({

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -80,11 +80,15 @@ export class ProtocolClient {
 
         const authToken = getAuthToken(agent);
 
-        // RFC 9421 signing context. Built once per call; the transport
-        // attaches a fetch wrapper that reads the cached capability on every
-        // outbound request. `get_adcp_capabilities` is exempt from signing
-        // (it's the discovery call itself) and also triggers cache priming
-        // for any other op on agents with `request_signing` configured.
+        // RFC 9421 signing context. Built once per call and passed through
+        // to each protocol-layer entry (`callMCPToolWithTasks`, `callA2ATool`,
+        // `callMCPToolWithOAuth`) — those entries seed `signingContextStorage`
+        // (AsyncLocalStorage) so the internal transport helpers read it
+        // without an explicit parameter. Keep the explicit arg here: it's the
+        // ALS seed, not incidental plumbing. `get_adcp_capabilities` is
+        // exempt from signing (it's the discovery call itself) and also
+        // triggers cache priming for any other op on agents with
+        // `request_signing` configured.
         const signingContext = buildAgentSigningContext(agent);
         if (signingContext && toolName !== CAPABILITY_OP) {
           await ensureCapabilityLoaded(agent, signingContext, primeArgs =>

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -15,7 +15,7 @@ import type { TaskInfo } from '../core/ConversationTypes';
 import { withCachedConnection } from './mcp';
 import { createMCPAuthHeaders } from '../auth';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
-import type { AgentSigningContext } from '../signing/client';
+import { signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 
 /** Response shape returned by MCPClient.callTool(). */
@@ -166,41 +166,36 @@ export async function callMCPToolWithTasks(
       'adcp.tool': toolName,
       'http.url': agentUrl,
     },
-    async () => {
-      const authHeaders = buildAuthHeaders(authToken, customHeaders);
-      const workingTimeout = options?.workingTimeout ?? 120_000;
+    async () =>
+      signingContextStorage.run(options?.signingContext, async () => {
+        const authHeaders = buildAuthHeaders(authToken, customHeaders);
+        const workingTimeout = options?.workingTimeout ?? 120_000;
 
-      // Log auth configuration (matching callMCPTool debug format for test compatibility)
-      debugLogs.push({
-        type: 'info',
-        message: `MCP: Auth configuration`,
-        timestamp: new Date().toISOString(),
-        hasAuth: !!authToken,
-        headers: authToken ? { 'x-adcp-auth': '***' } : {},
-        customHeaderKeys: customHeaders ? Object.keys(customHeaders) : [],
-      });
-
-      debugLogs.push({
-        type: 'info',
-        message: `MCP: Calling tool ${toolName} with args: ${JSON.stringify(redactArgsForLog(args))}`,
-        timestamp: new Date().toISOString(),
-      });
-
-      if (authToken) {
+        // Log auth configuration (matching callMCPTool debug format for test compatibility)
         debugLogs.push({
           type: 'info',
-          message: `MCP: Transport configured with x-adcp-auth header for ${toolName}`,
+          message: `MCP: Auth configuration`,
+          timestamp: new Date().toISOString(),
+          hasAuth: !!authToken,
+          headers: authToken ? { 'x-adcp-auth': '***' } : {},
+          customHeaderKeys: customHeaders ? Object.keys(customHeaders) : [],
+        });
+
+        debugLogs.push({
+          type: 'info',
+          message: `MCP: Calling tool ${toolName} with args: ${JSON.stringify(redactArgsForLog(args))}`,
           timestamp: new Date().toISOString(),
         });
-      }
 
-      return withCachedConnection(
-        agentUrl,
-        authToken,
-        authHeaders,
-        debugLogs,
-        toolName,
-        async client => {
+        if (authToken) {
+          debugLogs.push({
+            type: 'info',
+            message: `MCP: Transport configured with x-adcp-auth header for ${toolName}`,
+            timestamp: new Date().toISOString(),
+          });
+        }
+
+        return withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, toolName, async client => {
           // Check if server supports MCP Tasks
           if (!serverSupportsTasks(client)) {
             debugLogs.push({
@@ -347,10 +342,8 @@ export async function callMCPToolWithTasks(
           }
 
           throw new Error(`MCP Tasks: callToolStream for ${toolName} ended without result or task`);
-        },
-        options?.signingContext
-      );
-    }
+        });
+      })
   );
 }
 

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -349,6 +349,14 @@ export async function callMCPToolWithTasks(
 
 /**
  * Get task status via MCP Tasks protocol method (not tool call).
+ *
+ * Task lifecycle methods (`tasks/get`, `tasks/result`, `tasks/list`,
+ * `tasks/cancel`) are MCP protocol methods, not AdCP operations.
+ * `extractAdcpOperation` returns `undefined` for them, so the signing fetch
+ * passes them through unsigned regardless of whether an `AgentSigningContext`
+ * is present in ALS. That matches the RFC 9421 signing profile, which only
+ * covers AdCP tool calls (`tools/call` / `message/send`).
+ *
  * Re-throws auth errors (401) — only catches protocol capability errors.
  */
 export async function getMCPTaskStatus(

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -13,7 +13,7 @@ import { createMCPAuthHeaders } from '../auth';
 import { is401Error } from '../errors';
 import type { DebugLogEntry } from '../types/adcp';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
-import { buildAgentSigningFetch, type AgentSigningContext } from '../signing/client';
+import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 
 // Re-export for convenience
@@ -124,8 +124,7 @@ async function getOrCreateConnection(
   baseUrl: URL,
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[],
-  label: string,
-  signingContext?: AgentSigningContext
+  label: string
 ): Promise<MCPClient> {
   const cached = getCachedConnection(cacheKey);
   if (cached) return cached;
@@ -133,7 +132,7 @@ async function getOrCreateConnection(
   const pending = pendingConnections.get(cacheKey);
   if (pending) return pending;
 
-  const promise = connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label, signingContext)
+  const promise = connectMCPWithFallback(baseUrl, authHeaders, debugLogs, label)
     .then(client => {
       connectionCache.set(cacheKey, client);
       evictLeastRecentlyUsed();
@@ -161,13 +160,13 @@ export async function withCachedConnection<T>(
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[],
   label: string,
-  fn: (client: MCPClient) => Promise<T>,
-  signingContext?: AgentSigningContext
+  fn: (client: MCPClient) => Promise<T>
 ): Promise<T> {
+  const signingContext = signingContextStorage.getStore();
   const cacheKey = connectionCacheKey(agentUrl, authToken, signingContext?.cacheKey);
   const baseUrl = new URL(agentUrl);
 
-  const mcpClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, label, signingContext);
+  const mcpClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, label);
 
   try {
     return await fn(mcpClient);
@@ -204,14 +203,7 @@ export async function withCachedConnection<T>(
       /* ignore */
     }
 
-    const retryClient = await getOrCreateConnection(
-      cacheKey,
-      baseUrl,
-      authHeaders,
-      debugLogs,
-      `${label} (retry)`,
-      signingContext
-    );
+    const retryClient = await getOrCreateConnection(cacheKey, baseUrl, authHeaders, debugLogs, `${label} (retry)`);
 
     try {
       return await fn(retryClient);
@@ -273,8 +265,7 @@ export async function connectMCPWithFallback(
   url: URL,
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[] = [],
-  label = 'connection',
-  signingContext?: AgentSigningContext
+  label = 'connection'
 ): Promise<MCPClient> {
   return withSpan(
     'adcp.mcp.connect',
@@ -283,7 +274,7 @@ export async function connectMCPWithFallback(
       'adcp.connection_label': label,
     },
     async () => {
-      return connectMCPWithFallbackImpl(url, authHeaders, debugLogs, label, signingContext);
+      return connectMCPWithFallbackImpl(url, authHeaders, debugLogs, label);
     }
   );
 }
@@ -292,9 +283,9 @@ async function connectMCPWithFallbackImpl(
   url: URL,
   authHeaders: Record<string, string>,
   debugLogs: DebugLogEntry[] = [],
-  label = 'connection',
-  signingContext?: AgentSigningContext
+  label = 'connection'
 ): Promise<MCPClient> {
+  const signingContext = signingContextStorage.getStore();
   const signingFetch = signingContext
     ? buildAgentSigningFetch({
         upstream: (input, init) => fetch(input as any, init),
@@ -429,7 +420,9 @@ export async function callMCPTool(
       'http.url': agentUrl,
     },
     async () => {
-      return callMCPToolImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext);
+      return signingContextStorage.run(signingContext, () =>
+        callMCPToolImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders)
+      );
     }
   );
 }
@@ -447,7 +440,9 @@ export async function callMCPToolRaw(
   customHeaders?: Record<string, string>,
   signingContext?: AgentSigningContext
 ): Promise<unknown> {
-  return callMCPToolRawImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders, signingContext);
+  return signingContextStorage.run(signingContext, () =>
+    callMCPToolRawImpl(agentUrl, toolName, args, authToken, debugLogs, customHeaders)
+  );
 }
 
 async function callMCPToolImpl(
@@ -456,8 +451,7 @@ async function callMCPToolImpl(
   args: Record<string, unknown>,
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
-  customHeaders?: Record<string, string>,
-  signingContext?: AgentSigningContext
+  customHeaders?: Record<string, string>
 ): Promise<unknown> {
   // Inject trace context headers for distributed tracing
   const traceHeaders = injectTraceHeaders();
@@ -499,8 +493,7 @@ async function callMCPToolImpl(
     authHeaders,
     debugLogs,
     toolName,
-    client => client.callTool({ name: toolName, arguments: args }) as Promise<CallToolResponse>,
-    signingContext
+    client => client.callTool({ name: toolName, arguments: args }) as Promise<CallToolResponse>
   );
 
   debugLogs.push({
@@ -522,8 +515,7 @@ async function callMCPToolRawImpl(
   args: Record<string, unknown>,
   authToken?: string,
   debugLogs: DebugLogEntry[] = [],
-  customHeaders?: Record<string, string>,
-  signingContext?: AgentSigningContext
+  customHeaders?: Record<string, string>
 ): Promise<unknown> {
   const traceHeaders = injectTraceHeaders();
   const authHeaders = {
@@ -532,14 +524,8 @@ async function callMCPToolRawImpl(
     ...(authToken ? createMCPAuthHeaders(authToken) : {}),
   };
 
-  return withCachedConnection(
-    agentUrl,
-    authToken,
-    authHeaders,
-    debugLogs,
-    toolName,
-    client => client.callTool({ name: toolName, arguments: args }),
-    signingContext
+  return withCachedConnection(agentUrl, authToken, authHeaders, debugLogs, toolName, client =>
+    client.callTool({ name: toolName, arguments: args })
   );
 }
 

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -653,6 +653,13 @@ export async function connectMCP(options: {
  * incompatible with connection pooling. This is acceptable because OAuth flows
  * are interactive and infrequent.
  *
+ * Signing: this path consumes `options.signingContext` via the transport —
+ * `connectMCP` attaches a signing-fetch wrapper at transport-creation time —
+ * rather than via `signingContextStorage`. Because each OAuth call creates a
+ * fresh transport that isn't shared across calls, there's no cache-key
+ * disambiguation concern and no need to seed ALS. The non-OAuth fallback
+ * (`callMCPTool`) does enter ALS.
+ *
  * @param options Call options
  * @returns Tool response
  * @throws UnauthorizedError if OAuth is required (with transport attached)

--- a/src/lib/signing/agent-context.ts
+++ b/src/lib/signing/agent-context.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
 import type { AgentConfig, AgentRequestSigningConfig } from '../types/adcp';
 import {
@@ -34,6 +35,20 @@ export interface AgentSigningContext {
    */
   invalidate(): void;
 }
+
+/**
+ * AsyncLocalStorage carrying the signing context across the transport layer.
+ * Top-level protocol entries (`callMCPTool`, `callA2ATool`, etc.) push a
+ * context onto this storage for the duration of the call; internal helpers
+ * (`withCachedConnection`, `connectMCPWithFallback`, `buildFetchImpl`) read
+ * it when building cache keys and signing-fetch wrappers, avoiding the need
+ * to thread `signingContext` through every intermediate signature.
+ *
+ * The top-level entries always call `run()` — including with `undefined` —
+ * so a non-signing call cannot inherit a stale context from an enclosing
+ * scope.
+ */
+export const signingContextStorage = new AsyncLocalStorage<AgentSigningContext | undefined>();
 
 /**
  * Build an `AgentSigningContext` from an `AgentConfig` when signing is

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -44,5 +44,5 @@ export {
   toSignerKey,
   type BuildAgentSigningFetchOptions,
 } from './agent-fetch';
-export { buildAgentSigningContext, type AgentSigningContext } from './agent-context';
+export { buildAgentSigningContext, signingContextStorage, type AgentSigningContext } from './agent-context';
 export { ensureCapabilityLoaded, CAPABILITY_OP } from './capability-priming';

--- a/test/request-signing-agent-integration.test.js
+++ b/test/request-signing-agent-integration.test.js
@@ -23,6 +23,17 @@ const KEYS_PATH = path.join(
 );
 
 const keys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys;
+
+function jwkFor(kid) {
+  const raw = keys.find(k => k.kid === kid);
+  if (!raw) throw new Error(`No key in test vectors for kid=${kid}`);
+  const jwk = { ...raw, d: raw._private_d_for_test_only };
+  delete jwk._private_d_for_test_only;
+  delete jwk.key_ops;
+  delete jwk.use;
+  return jwk;
+}
+
 const ed = keys.find(k => k.kid === 'test-ed25519-2026');
 const privateJwk = { ...ed, d: ed._private_d_for_test_only };
 delete privateJwk._private_d_for_test_only;
@@ -409,6 +420,95 @@ test('ensureCapabilityLoaded: network-level fetch rejection → 60s negative cac
   const window = entry.staleAt - entry.fetchedAt;
   assert.strictEqual(window, 60, 'negative-cache window is 60s (shorter than the 300s positive TTL)');
   assert.ok(entry.fetchedAt >= before && entry.fetchedAt <= after, 'fetchedAt is "now"');
+});
+
+test('ALS: concurrent callTool invocations with distinct signingContexts do not cross-contaminate', async () => {
+  await resetGlobalState();
+  const stub = await startMcpStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: ['create_media_buy'],
+  });
+  try {
+    // Two agents with distinct signing identities. Same seller URL so the
+    // only thing differentiating them is the signingContext — if the ALS
+    // refactor leaks, one agent's Signature-Input would end up labelled with
+    // the other agent's keyid.
+    const agentA = agentFor(stub.url);
+    agentA.id = 'agent-a';
+    agentA.request_signing = {
+      kid: 'test-ed25519-2026',
+      alg: 'ed25519',
+      private_key: privateJwk,
+      agent_url: 'https://buyer-a.example.com',
+    };
+
+    const agentB = agentFor(stub.url);
+    agentB.id = 'agent-b';
+    agentB.request_signing = {
+      kid: 'test-es256-2026',
+      alg: 'ecdsa-p256-sha256',
+      private_key: jwkFor('test-es256-2026'),
+      agent_url: 'https://buyer-b.example.com',
+    };
+
+    await Promise.all([
+      ProtocolClient.callTool(agentA, 'create_media_buy', { plan_id: 'a1' }),
+      ProtocolClient.callTool(agentB, 'create_media_buy', { plan_id: 'b1' }),
+      ProtocolClient.callTool(agentA, 'create_media_buy', { plan_id: 'a2' }),
+      ProtocolClient.callTool(agentB, 'create_media_buy', { plan_id: 'b2' }),
+    ]);
+
+    const cmbCalls = stub.state.toolCallHeaders.filter(r => r.toolName === 'create_media_buy');
+    assert.strictEqual(cmbCalls.length, 4, 'four create_media_buy requests landed on the stub');
+
+    const keyids = cmbCalls.map(c => {
+      const match = /keyid="([^"]+)"/.exec(c.headers['signature-input'] || '');
+      return match ? match[1] : undefined;
+    });
+    const countA = keyids.filter(k => k === 'test-ed25519-2026').length;
+    const countB = keyids.filter(k => k === 'test-es256-2026').length;
+    assert.strictEqual(countA, 2, 'agentA signed exactly 2 requests with its own keyid');
+    assert.strictEqual(countB, 2, 'agentB signed exactly 2 requests with its own keyid');
+  } finally {
+    await cleanup(stub);
+  }
+});
+
+test('ALS: signing call followed by non-signing call in the same async chain does not leak context', async () => {
+  await resetGlobalState();
+  const stub = await startMcpStub({
+    supported: true,
+    covers_content_digest: 'either',
+    required_for: ['create_media_buy'],
+  });
+  try {
+    const signingAgent = agentFor(stub.url);
+    const nonSigningAgent = {
+      id: 'unsigned-agent',
+      name: 'Unsigned Agent',
+      agent_uri: stub.url,
+      protocol: 'mcp',
+      // no request_signing block
+    };
+
+    // Sequential in the same async chain — if the ALS scope leaked past the
+    // first call's resolution, the second call would pick up a stale
+    // signingContext and sign create_media_buy.
+    await ProtocolClient.callTool(signingAgent, 'create_media_buy', { plan_id: 'first' });
+    await ProtocolClient.callTool(nonSigningAgent, 'create_media_buy', { plan_id: 'second' });
+
+    const cmbCalls = stub.state.toolCallHeaders.filter(r => r.toolName === 'create_media_buy');
+    assert.strictEqual(cmbCalls.length, 2);
+    assert.ok(cmbCalls[0].headers['signature-input'], 'first call (signing agent) was signed');
+    assert.strictEqual(
+      cmbCalls[1].headers['signature-input'],
+      undefined,
+      'second call (unsigned agent) did not inherit the signing context from the first'
+    );
+  } finally {
+    await cleanup(stub);
+  }
 });
 
 test('teardown: close pooled MCP connections', async () => {


### PR DESCRIPTION
Closes #597.

## Summary
- Adds `signingContextStorage` (`AsyncLocalStorage<AgentSigningContext | undefined>`) alongside the existing capability cache helpers in `src/lib/signing/agent-context.ts`.
- Top-level protocol entries (`callMCPTool`, `callMCPToolRaw`, `callMCPToolWithTasks`, `callA2ATool`) now wrap their implementations in `signingContextStorage.run(signingContext, ...)` so the internal helpers can read the context from storage instead of receiving it as a parameter.
- Drops the `signingContext` parameter from the internal plumbing — `withCachedConnection`, `getOrCreateConnection`, `connectMCPWithFallback`, `connectMCPWithFallbackImpl`, `callMCPToolImpl`, `callMCPToolRawImpl`, `getOrCreateA2AClient`, `createA2AClient`, `buildFetchImpl`. Each now reads `signingContextStorage.getStore()` at the point it needs the context (cache-key build, fetch-wrapper build).
- Keeps the public entry-point signatures untouched — `ProtocolClient.callTool`, `callMCPToolWithOAuth`, `connectMCP`, and the top-level MCP / A2A helpers still accept an explicit `signingContext`, per the issue's non-goal.
- `buildFetchImpl` captures the context at client-creation time; the A2A client cache is already keyed per signing-fingerprint, so different signing identities get different cached clients and build their own fetch wrappers in separate ALS scopes.
- Always wraps in `ALS.run(context)` — including with `undefined` — so non-signing calls cannot inherit a stale context from an enclosing scope.

## Test plan
- [x] Existing `test/request-signing-agent-integration.test.js` (all 12 prior tests) — passes unmodified.
- [x] New test: four concurrent `ProtocolClient.callTool`s against the same seller URL with two distinct signing identities (Ed25519 + ES256) — each inbound request's `Signature-Input` carries its own `keyid`, proving no cross-contamination.
- [x] New test: signing call followed by non-signing call in the same async chain — the non-signing request lands at the stub without `Signature-Input`, proving the ALS scope is released when the first call resolves.
- [x] Full suite: 3860 pass, 4 pre-existing governance failures that also fail on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)