### PR TITLE
chore: grader MCP follow-ups — op allowlist + rate-abuse subtest

### DIFF
--- a/.changeset/grader-followups.md
+++ b/.changeset/grader-followups.md
@@ -1,0 +1,23 @@
+---
+'@adcp/client': patch
+---
+
+Request-signing grader — two follow-ups from the #617 review thread.
+
+**Operation-name allowlist** in `extractOperationFromVectorUrl`. Previously
+the extractor returned whatever URL-decoded bytes sat in the vector URL's
+last path segment and inlined that into `params.name`. AdCP operations are
+spec-defined identifiers (lowercase snake_case matching
+`static/schemas/source/enums/operation.json`); constrain the extractor
+output to `/^[a-z][a-z0-9_]*$/` so a corrupted compliance cache can't
+smuggle arbitrary bytes into the JSON-RPC envelope. No exploit today —
+fixtures are spec-published, not attacker-supplied — but defense in depth.
+
+**MCP rate-abuse subtest** in `test/request-signing-grader-mcp.test.js`.
+Spins up a dedicated MCP agent with `ADCP_REPLAY_CAP=10` + grades with
+`onlyVectors: ['020-rate-abuse']`, `rateAbuseCap: 10`,
+`allowLiveSideEffects: true`. Exercises the end-to-end rate-abuse flow
+under MCP transport (previously only covered against the raw-HTTP
+reference verifier). Adds `ADCP_REPLAY_CAP` env override to
+`test-agents/seller-agent-signed-mcp.ts` so tests can tune the cap
+without forking the agent.

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -357,11 +357,24 @@ function applyTransport(vector: PositiveVector | NegativeVector, options: BuildO
   };
 }
 
+// AdCP operation names are spec-defined identifiers (lowercase alnum +
+// underscore — `create_media_buy`, `sync_accounts`, etc). Constrain the
+// extractor output to that shape so a compromised compliance cache can't
+// smuggle arbitrary bytes into `params.name` via a weird vector URL.
+// Matches the spec enum `static/schemas/source/enums/operation.json`.
+const OPERATION_NAME_SAFE = /^[a-z][a-z0-9_]*$/;
+
 function extractOperationFromVectorUrl(vectorUrl: string): string {
   const parsed = new URL(vectorUrl);
   const segments = parsed.pathname.split('/').filter(Boolean);
   const last = segments[segments.length - 1];
   if (!last) throw new Error(`Cannot extract operation from vector URL: ${vectorUrl}`);
+  if (!OPERATION_NAME_SAFE.test(last)) {
+    throw new Error(
+      `Operation name "${last}" extracted from ${vectorUrl} fails identifier check. ` +
+        `AdCP operations are lowercase_snake_case; this is likely a corrupted compliance cache.`
+    );
+  }
   return last;
 }
 

--- a/src/lib/testing/storyboard/request-signing/builder.ts
+++ b/src/lib/testing/storyboard/request-signing/builder.ts
@@ -358,10 +358,11 @@ function applyTransport(vector: PositiveVector | NegativeVector, options: BuildO
 }
 
 // AdCP operation names are spec-defined identifiers (lowercase alnum +
-// underscore — `create_media_buy`, `sync_accounts`, etc). Constrain the
-// extractor output to that shape so a compromised compliance cache can't
-// smuggle arbitrary bytes into `params.name` via a weird vector URL.
-// Matches the spec enum `static/schemas/source/enums/operation.json`.
+// underscore — `create_media_buy`, `sync_creatives`, `si_send_message`,
+// etc.; verified against every `task:` value shipped in
+// `compliance/cache/{version}/protocols/**/*.yaml`). Constrain the extractor
+// output to that shape so a compromised compliance cache can't smuggle
+// arbitrary bytes into `params.name` via a weird vector URL.
 const OPERATION_NAME_SAFE = /^[a-z][a-z0-9_]*$/;
 
 function extractOperationFromVectorUrl(vectorUrl: string): string {

--- a/test-agents/seller-agent-signed-mcp.ts
+++ b/test-agents/seller-agent-signed-mcp.ts
@@ -61,7 +61,11 @@ const publicKeys: AdcpJsonWebKey[] = (JSON.parse(readFileSync(KEYS_PATH, 'utf8')
 });
 
 const jwks = new StaticJwksResolver(publicKeys);
-const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 100 });
+// Per-keyid replay cap defaults to 100 (matches the test-kit's
+// grading_target_per_keyid_cap_requests). Override via ADCP_REPLAY_CAP for
+// the MCP rate-abuse test, which needs a tight cap it can fill quickly.
+const REPLAY_CAP = Number.parseInt(process.env.ADCP_REPLAY_CAP ?? '100', 10);
+const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: REPLAY_CAP });
 const revocationStore = new InMemoryRevocationStore({
   issuer: 'http://seller.example.com',
   updated: new Date().toISOString(),

--- a/test-agents/seller-agent-signed-mcp.ts
+++ b/test-agents/seller-agent-signed-mcp.ts
@@ -64,7 +64,11 @@ const jwks = new StaticJwksResolver(publicKeys);
 // Per-keyid replay cap defaults to 100 (matches the test-kit's
 // grading_target_per_keyid_cap_requests). Override via ADCP_REPLAY_CAP for
 // the MCP rate-abuse test, which needs a tight cap it can fill quickly.
-const REPLAY_CAP = Number.parseInt(process.env.ADCP_REPLAY_CAP ?? '100', 10);
+// Validate: Number.parseInt on garbage returns NaN, and InMemoryReplayStore's
+// size >= NaN comparison is always false — a typo would silently disable
+// the rate-abuse guard. Fall back to the default on any non-positive int.
+const REPLAY_CAP_RAW = Number.parseInt(process.env.ADCP_REPLAY_CAP ?? '100', 10);
+const REPLAY_CAP = Number.isFinite(REPLAY_CAP_RAW) && REPLAY_CAP_RAW > 0 ? REPLAY_CAP_RAW : 100;
 const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: REPLAY_CAP });
 const revocationStore = new InMemoryRevocationStore({
   issuer: 'http://seller.example.com',

--- a/test/request-signing-grader-mcp.test.js
+++ b/test/request-signing-grader-mcp.test.js
@@ -36,9 +36,12 @@ function ensureMcpAgentBuilt() {
 }
 
 function startMcpAgent(port, overrides = {}) {
+  // Spread overrides first so `PORT` always wins — callers shouldn't be able
+  // to clobber the explicit `port` argument through the overrides bag.
+  const env = { ...process.env, ...overrides, PORT: String(port) };
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [MCP_AGENT_SCRIPT], {
-      env: { ...process.env, PORT: String(port), ...overrides },
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let settled = false;
@@ -122,6 +125,9 @@ const CAPABILITY_PROFILE_VECTORS = ['007-missing-content-digest', '018-digest-co
 
 describe('request-signing grader — MCP transport vs. reference MCP agent', () => {
   // Dynamic port so the test is safe to run in parallel; fallback to 3111.
+  // The rate-abuse subtest spins up a second agent on PORT+1, so parallel
+  // runs of this file MUST set ADCP_MCP_TEST_PORT values that differ by at
+  // least 2 (e.g. 3111 and 3113) to avoid the +1 sibling colliding.
   const PORT = Number.parseInt(process.env.ADCP_MCP_TEST_PORT ?? '3111', 10);
   const AGENT_URL = `http://127.0.0.1:${PORT}/mcp`;
   let agent;

--- a/test/request-signing-grader-mcp.test.js
+++ b/test/request-signing-grader-mcp.test.js
@@ -35,10 +35,10 @@ function ensureMcpAgentBuilt() {
   }
 }
 
-function startMcpAgent(port) {
+function startMcpAgent(port, overrides = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [MCP_AGENT_SCRIPT], {
-      env: { ...process.env, PORT: String(port) },
+      env: { ...process.env, PORT: String(port), ...overrides },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let settled = false;
@@ -191,6 +191,32 @@ describe('request-signing grader — MCP transport vs. reference MCP agent', () 
       () => buildPositiveRequest(vector, loaded.keys, { transport: 'mcp' }),
       /transport: 'mcp' requires a baseUrl/
     );
+  });
+
+  test('rate-abuse vector: (cap+1)th request rejected with request_signature_rate_abuse under MCP', async () => {
+    // Dedicated MCP agent instance with a tight cap matched to the grader's
+    // rateAbuseCap so the flood trips the rejection in ~11 requests rather
+    // than 101. Needs `allowLiveSideEffects: true` because the reference
+    // agent doesn't advertise `endpoint_scope: sandbox` — preflightSkip
+    // otherwise refuses to run 020.
+    const rateAbusePort = PORT + 1;
+    const fresh = await startMcpAgent(rateAbusePort, { ADCP_REPLAY_CAP: '10' });
+    try {
+      const report = await gradeRequestSigning(`http://127.0.0.1:${rateAbusePort}/mcp`, {
+        allowPrivateIp: true,
+        transport: 'mcp',
+        onlyVectors: ['020-rate-abuse'],
+        rateAbuseCap: 10,
+        allowLiveSideEffects: true,
+      });
+      const v020 = report.negative.find(v => v.vector_id === '020-rate-abuse');
+      assert.ok(v020, '020-rate-abuse present in report');
+      assert.ok(v020.passed && !v020.skipped, `020 should pass under MCP: ${v020.diagnostic}`);
+      assert.strictEqual(v020.actual_error_code, 'request_signature_rate_abuse');
+      assert.strictEqual(v020.http_status, 401);
+    } finally {
+      await stopMcpAgent(fresh);
+    }
   });
 
   test('every negative mutation produces an MCP-shaped request under transport: mcp', () => {


### PR DESCRIPTION
## Summary

Closes the two deferred items from the #617 review thread (https://github.com/adcontextprotocol/adcp-client/pull/617#issuecomment-4275845501).

- **Operation-name allowlist** on `extractOperationFromVectorUrl`. Constrains the extracted operation to `/^[a-z][a-z0-9_]*$/` (AdCP operation identifier shape per `static/schemas/source/enums/operation.json`). Throws with a clear diagnostic if a vector URL's last path segment doesn't match — defense in depth against a corrupted compliance cache. No exploit today; fixtures are spec-published.

- **MCP rate-abuse subtest**. Spins up a dedicated MCP agent with `ADCP_REPLAY_CAP=10` + grades with `onlyVectors: ['020-rate-abuse']` / `rateAbuseCap: 10` / `allowLiveSideEffects: true` / `transport: 'mcp'`. Validates the 11-request flood trips `request_signature_rate_abuse` under MCP transport. Previously the rate-abuse flow was only tested against the raw-HTTP reference verifier.

- Adds `ADCP_REPLAY_CAP` env override to `test-agents/seller-agent-signed-mcp.ts` so tests can tune the cap without forking the agent.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build:lib` clean  
- [x] `npm run format:check` clean
- [x] `npm test` — 3947/3949 pass, 0 fail, 2 skipped (pre-existing)
- [x] MCP tests: 5/5 pass (up from 4; added rate-abuse subtest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)