### PR TITLE
chore: regen types from latest AdCP schemas (idempotency_key)

### DIFF
--- a/.changeset/sync-idempotency-key.md
+++ b/.changeset/sync-idempotency-key.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': minor
+---
+
+Regenerated types from latest AdCP schemas. Adds `idempotency_key` (required, string) to webhook payloads — `MCPWebhookPayload`, `ArtifactWebhookPayload`, `CollectionListChangedWebhook`, `PropertyListChangedWebhook` — and renames `RevocationNotification.notification_id` → `idempotency_key`.
+
+Upstream migrated these surfaces to a single canonical dedup field. Receivers must dedupe by `idempotency_key` scoped to the authenticated sender identity. Publishers populating `RevocationNotification.notification_id` must rename the field.

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-19T15:45:37.826Z
+// Generated at: 2026-04-19T20:03:45.392Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -4115,6 +4115,10 @@ export type CatalogItemStatus = 'approved' | 'pending' | 'rejected' | 'warning';
  */
 export interface MCPWebhookPayload {
   /**
+   * Sender-generated key stable across retries of the same webhook event. Publishers MUST generate a cryptographically random value (UUID v4 recommended) per distinct event and reuse the same key on every retry of that event. Receivers MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different publishers are independent. This is the canonical dedup field — the (task_id, status, timestamp) tuple is insufficient when a single transition is retried with unchanged timestamp or when two transitions share a timestamp.
+   */
+  idempotency_key: string;
+  /**
    * Client-generated identifier that was embedded in the webhook URL by the buyer. Publishers echo this back in webhook payloads so clients can correlate notifications without parsing URL paths. Typically generated as a unique ID per task invocation.
    */
   operation_id?: string;
@@ -6405,9 +6409,9 @@ export interface GetRightsError {
  */
 export interface RevocationNotification {
   /**
-   * Unique identifier for this notification. Buyers use this for deduplication — the same revocation may be delivered multiple times.
+   * Sender-generated key stable across retries of the same revocation notification. Rights holders MUST generate a cryptographically random value (UUID v4 recommended) per distinct revocation event and reuse the same key when retrying delivery. Buyers MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential); keys from different senders are independent.
    */
-  notification_id: string;
+  idempotency_key: string;
   /**
    * The revoked rights grant identifier
    */
@@ -13165,6 +13169,10 @@ export interface PublisherGenresSource {
  */
 export interface CollectionListChangedWebhook {
   /**
+   * Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct list-change event and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different governance agents are independent.
+   */
+  idempotency_key: string;
+  /**
    * The event type
    */
   event: 'collection_list_changed';
@@ -13331,6 +13339,10 @@ export type AssetAccess =
  * Payload sent by sales agents to orchestrators when pushing content artifacts for governance validation. Complements get_media_buy_artifacts for push-based artifact delivery.
  */
 export interface ArtifactWebhookPayload {
+  /**
+   * Sender-generated key stable across retries of the same webhook event. Sales agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct emission of a batch and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different sales agents are independent. Distinct from `batch_id`, which identifies the logical batch: `idempotency_key` identifies this specific emission event, so a re-emission of the same `batch_id` (e.g., after a correction) is a different event and MUST carry a fresh `idempotency_key`.
+   */
+  idempotency_key: string;
   /**
    * Media buy identifier these artifacts belong to
    */
@@ -16615,6 +16627,10 @@ export interface PropertyFeature {
  * Webhook notification sent when a property list's resolved properties change. Contains a summary only - recipients must call get_property_list to retrieve the updated properties. This keeps payloads small and avoids redundant data transfer.
  */
 export interface PropertyListChangedWebhook {
+  /**
+   * Sender-generated key stable across retries of the same webhook event. Governance agents MUST generate a cryptographically random value (UUID v4 recommended) per distinct list-change event and reuse the same key on every retry. Recipients MUST dedupe by this key, scoped to the authenticated sender identity (HMAC secret or Bearer credential) — keys from different governance agents are independent.
+   */
+  idempotency_key: string;
   /**
    * The event type
    */

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-19T18:48:13.148Z
+// Generated at: 2026-04-19T20:03:51.626Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -1532,7 +1532,7 @@ export const RightsPricingOptionSchema = z.object({
 }).passthrough();
 
 export const RevocationNotificationSchema = z.object({
-    notification_id: z.string(),
+    idempotency_key: z.string(),
     rights_id: z.string(),
     brand_id: z.string(),
     reason: z.string(),
@@ -2827,6 +2827,7 @@ export const PublisherGenresSourceSchema = z.object({
 }).passthrough();
 
 export const CollectionListChangedWebhookSchema = z.object({
+    idempotency_key: z.string(),
     event: z.literal("collection_list_changed"),
     list_id: z.string(),
     list_name: z.string().optional(),
@@ -3654,6 +3655,7 @@ export const PropertyFeatureSchema = z.object({
 }).passthrough();
 
 export const PropertyListChangedWebhookSchema = z.object({
+    idempotency_key: z.string(),
     event: z.literal("property_list_changed"),
     list_id: z.string(),
     list_name: z.string().optional(),
@@ -5878,6 +5880,7 @@ export const ValidationResultSchema = z.object({
 export const ActivateSignalResponseSchema = z.union([ActivateSignalSuccessSchema, ActivateSignalErrorSchema]);
 
 export const ArtifactWebhookPayloadSchema = z.object({
+    idempotency_key: z.string(),
     media_buy_id: z.string(),
     batch_id: z.string(),
     timestamp: z.string(),
@@ -6165,6 +6168,7 @@ export const ComplyTestControllerResponseSchema = z.union([ListScenariosSuccessS
 export const AdCPAsyncResponseDataSchema: z.ZodType = z.union([GetProductsResponseSchema, GetProductsAsyncWorkingSchema, GetProductsAsyncInputRequiredSchema, GetProductsAsyncSubmittedSchema, CreateMediaBuyResponseSchema, CreateMediaBuyAsyncWorkingSchema, CreateMediaBuyAsyncInputRequiredSchema, CreateMediaBuyAsyncSubmittedSchema, UpdateMediaBuyResponseSchema, UpdateMediaBuyAsyncWorkingSchema, UpdateMediaBuyAsyncInputRequiredSchema, UpdateMediaBuyAsyncSubmittedSchema, BuildCreativeResponseSchema, BuildCreativeAsyncWorkingSchema, BuildCreativeAsyncInputRequiredSchema, BuildCreativeAsyncSubmittedSchema, SyncCreativesResponseSchema, SyncCreativesAsyncWorkingSchema, SyncCreativesAsyncInputRequiredSchema, SyncCreativesAsyncSubmittedSchema, SyncCatalogsResponseSchema, SyncCatalogsAsyncWorkingSchema, SyncCatalogsAsyncInputRequiredSchema, SyncCatalogsAsyncSubmittedSchema]);
 
 export const MCPWebhookPayloadSchema: z.ZodType = z.object({
+    idempotency_key: z.string(),
     operation_id: z.string().optional(),
     task_id: z.string(),
     task_type: TaskTypeSchema,


### PR DESCRIPTION
## Summary

Every PR has been failing the `Validate generated files are in sync` check because upstream AdCP schemas drifted. This PR regenerates `core.generated.ts` and `schemas.generated.ts` against the current upstream bundle.

## Upstream changes picked up

- `RevocationNotification.notification_id` → `idempotency_key`
- `MCPWebhookPayload` — adds required `idempotency_key`
- `ArtifactWebhookPayload` — adds required `idempotency_key`
- `CollectionListChangedWebhook` — adds required `idempotency_key`
- `PropertyListChangedWebhook` — adds required `idempotency_key`

Upstream consolidated webhook dedup onto a single canonical key scoped to the authenticated sender identity.

## Blast radius

- Published type signatures change — consumers populating or reading `RevocationNotification.notification_id` must rename to `idempotency_key`.
- No runtime code changes; no uses of the renamed field exist in `src/`.
- Unblocks #626 and every other PR (the sync check runs on all of them).

Changeset: minor (published types changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)