### PR TITLE
feat(webhooks): receiver-side idempotency_key dedup on AsyncHandler

### DIFF
--- a/.changeset/webhook-receiver-dedup.md
+++ b/.changeset/webhook-receiver-dedup.md
@@ -1,0 +1,50 @@
+---
+'@adcp/client': minor
+---
+
+Webhook receiver-side deduplication via `AsyncHandlerConfig.webhookDedup`.
+
+AdCP webhooks use at-least-once delivery — publishers retry until they see a 2xx, so the same event can arrive more than once. The spec now requires an `idempotency_key` on every MCP, governance, artifact, and revocation webhook payload so receivers have a canonical dedup field. This release plumbs that key through the client pipeline and ships a drop-in dedup layer for the MCP envelope path.
+
+**New**
+
+- `AsyncHandlerConfig.webhookDedup?: { backend: IdempotencyBackend; ttlSeconds?: number }` — drop duplicate deliveries with a single config. Reuses `IdempotencyBackend` from `@adcp/client/server`, so the same `memoryBackend()` or `pgBackend(...)` used for request-side idempotency can back webhook dedup. Defaults to 24h retention.
+- `WebhookMetadata.idempotency_key?: string` — extracted from the MCP envelope and passed to every `onXxxStatusChange` handler so application code can log, trace, or build its own dedup on top.
+- `WebhookMetadata.protocol?: 'mcp' | 'a2a'` — transport that delivered the webhook; useful for handler code that branches on protocol (A2A lacks `idempotency_key`).
+- `Activity` union gains `'webhook_duplicate'` — surfaced via `onActivity` when a repeat key is dropped. The typed handler is NOT called for duplicates.
+- `Activity.idempotency_key?: string` — surfaced on both `webhook_received` and `webhook_duplicate` for correlation.
+
+**Type changes (strict-TS callers may need to update)**
+
+- The `Activity.type` union gains `'webhook_duplicate'`. TypeScript users doing exhaustive `switch (activity.type)` with a `never`-check will see a new missing-case error. Treat `webhook_duplicate` the same as `webhook_received` in `onActivity` logging, or branch on `activity.type` to suppress side effects for duplicates.
+
+**Behavior**
+
+- Scope is per-agent under a reserved prefix (`adcp\u001fwebhook\u001fv1\u001f{agent_id}\u001f{idempotency_key}`) — keys from different senders are independent, and the prefix guarantees no collision with request-side idempotency entries when sharing a backend.
+- `putIfAbsent` closes the concurrent-retry race: when two retries race on the same fresh key, exactly one wins the claim and dispatches; the rest surface as `webhook_duplicate`.
+- MCP payloads missing or violating the `idempotency_key` format (`^[A-Za-z0-9_.:-]{16,255}$`) dispatch without dedup and log a `console.warn` with the spec pattern and a docs pointer. A2A payloads (which do not carry the field) dispatch silently — the absence is expected and unactionable.
+- Handler exceptions inside the dispatched handler are caught and logged as today; the dedup claim is intentionally NOT released on handler error. This preserves at-most-once handler execution: the publisher sees 2xx once (because `handleWebhook` returns normally) and won't retry, so releasing the claim would only matter on a future unrelated retry of the same key, which is never expected.
+
+**Schema sync**
+
+- `MCPWebhookPayload`, `CollectionListChangedWebhook`, `PropertyListChangedWebhook`, `ArtifactWebhookPayload`, and `RevocationNotification` now include `idempotency_key` as a required field (picked up from AdCP `latest`).
+
+**Example**
+
+```typescript
+import { AdCPClient } from '@adcp/client';
+import { memoryBackend } from '@adcp/client/server';
+
+const client = new AdCPClient(agents, {
+  webhookUrlTemplate: 'https://your-app.com/adcp/webhook/{task_type}/{agent_id}/{operation_id}',
+  webhookSecret: process.env.WEBHOOK_SECRET,
+  handlers: {
+    webhookDedup: { backend: memoryBackend() },
+    onCreateMediaBuyStatusChange: async (result, metadata) => {
+      // First delivery runs here; publisher retries are dropped.
+    },
+  },
+});
+```
+
+Governance list-change / artifact / brand-rights revocation webhooks are not yet routed through `AsyncHandler`; dedup for those payload types is a follow-up.

--- a/docs/guides/PUSH-NOTIFICATION-CONFIG.md
+++ b/docs/guides/PUSH-NOTIFICATION-CONFIG.md
@@ -106,3 +106,53 @@ function verifyWebhook(payload: string, signature: string, secret: string): bool
   return expected === signature;
 }
 ```
+
+## Deduplication
+
+AdCP webhooks use at-least-once delivery — publishers retry until they see a 2xx response, so the same event can arrive more than once. Every MCP webhook payload carries a required `idempotency_key` the publisher keeps stable across retries; receivers dedupe by it.
+
+Wire the client's `webhookDedup` on the `AsyncHandler` to get this for free:
+
+```typescript
+import { AdCPClient } from '@adcp/client';
+import { memoryBackend } from '@adcp/client/server';
+
+const client = new AdCPClient(agents, {
+  webhookUrlTemplate: 'https://your-app.com/adcp/webhook/{task_type}/{agent_id}/{operation_id}',
+  webhookSecret: process.env.WEBHOOK_SECRET,
+  handlers: {
+    webhookDedup: { backend: memoryBackend(), ttlSeconds: 86_400 }, // 24h
+    onCreateMediaBuyStatusChange: async (result, metadata) => {
+      // First delivery for this idempotency_key runs here; retries are dropped.
+    },
+  },
+});
+```
+
+Scope is per-agent so keys from different senders never collide. Swap `memoryBackend()` for `pgBackend(...)` when running multiple replicas — the same backend can be shared with the request-side idempotency store, the scoped key is namespaced under a reserved `adcp\u001fwebhook\u001fv1\u001f…` prefix so there is no collision risk.
+
+### Activity stream emits both events
+
+On a duplicate the typed handler (e.g. `onCreateMediaBuyStatusChange`) is NOT called, but the `onActivity` stream DOES fire — once as `webhook_received` for the first delivery and once as `webhook_duplicate` for each retry. If you wire side effects into `onActivity`, branch on `activity.type` so metrics and logs don't double-count:
+
+```typescript
+onActivity: (activity) => {
+  if (activity.type === 'webhook_duplicate') {
+    metrics.increment('webhook.duplicate', { agent: activity.agent_id });
+    return;
+  }
+  if (activity.type === 'webhook_received') {
+    metrics.increment('webhook.received', { agent: activity.agent_id });
+  }
+},
+```
+
+The `webhook_duplicate` event intentionally omits `payload` (the original `webhook_received` already carries it) but includes `idempotency_key` on both events for correlation.
+
+### Migrating from ad-hoc dedup
+
+If you previously tracked processed webhooks by `(task_id, status, timestamp)`, replace that with `webhookDedup`. The tuple is fragile — two status transitions sharing a millisecond collide, and governance/artifact webhooks have no `task_id` to key on. `idempotency_key` is the canonical dedup field per AdCP 3.0. Running both layers in parallel is a silent footgun: the ad-hoc tuple can drop events that the key-based layer would have dispatched correctly.
+
+### A2A and missing keys
+
+A2A webhooks do not carry `idempotency_key` — the field is an MCP envelope addition. With `webhookDedup` configured, A2A deliveries dispatch without dedup and no warning is logged (the absence is expected). MCP senders that omit the field, or emit a value that fails the spec regex `^[A-Za-z0-9_.:-]{16,255}$`, fall back to dispatch-without-dedup and log a `console.warn` so you notice non-conforming publishers.

--- a/src/lib/core/AsyncHandler.ts
+++ b/src/lib/core/AsyncHandler.ts
@@ -3,6 +3,7 @@
  * Provides type-safe callbacks for each AdCP tool completion
  */
 
+import type { IdempotencyBackend } from '../server/idempotency/store';
 import type {
   ListCreativeFormatsResponse,
   ListCreativesResponse,
@@ -81,6 +82,18 @@ export interface WebhookMetadata {
   timestamp: string;
   /** raw HTTP payload */
   rawHTTPPayload?: any;
+  /**
+   * Wire protocol that delivered this webhook. Useful for handler code
+   * that needs to treat MCP and A2A transports differently (e.g.,
+   * `idempotency_key` is only present on MCP payloads).
+   */
+  protocol?: 'mcp' | 'a2a';
+  /**
+   * Sender-generated key stable across retries of the same webhook event
+   * (MCP envelope only — A2A webhooks do not carry this field). Use this
+   * as the canonical dedup key; see `AsyncHandlerConfig.webhookDedup`.
+   */
+  idempotency_key?: string;
 }
 
 /**
@@ -167,6 +180,7 @@ export interface Activity {
     | 'protocol_response'
     | 'status_change'
     | 'webhook_received'
+    | 'webhook_duplicate'
     | 'governance_check'
     | 'governance_outcome';
   operation_id: string;
@@ -175,7 +189,20 @@ export interface Activity {
   task_id?: string;
   task_type: string;
   status?: string;
+  /**
+   * Full AdCP response payload. Populated on `webhook_received` and
+   * protocol/status events. INTENTIONALLY omitted on `webhook_duplicate`
+   * to avoid re-logging potentially-sensitive data on every retry — the
+   * originating `webhook_received` event already carries it. Correlate
+   * the two via `idempotency_key`.
+   */
   payload?: any;
+  /**
+   * Webhook idempotency key when available. Present on `webhook_received`
+   * and `webhook_duplicate` events from MCP envelopes, enabling
+   * correlation between a first delivery and its retry echoes.
+   */
+  idempotency_key?: string;
   timestamp: string;
 }
 
@@ -265,6 +292,31 @@ export interface AsyncHandlerConfig {
   // Activity logging (low-level protocol events)
   onActivity?: (activity: Activity) => void | Promise<void>;
 
+  /**
+   * Receiver-side deduplication of webhook payloads by `idempotency_key`.
+   *
+   * AdCP webhooks use at-least-once delivery — publishers retry until they
+   * see a 2xx, so the same event may arrive more than once. When configured,
+   * the first delivery for a given `(agent_id, idempotency_key)` tuple
+   * dispatches to handlers; subsequent deliveries are dropped and surface
+   * as a `webhook_duplicate` activity.
+   *
+   * Reuses `IdempotencyBackend` from `@adcp/client/server` — you can share
+   * the same backend across request-side and webhook-side dedup, or use a
+   * dedicated one. Scope is per-agent so keys from different senders are
+   * independent, matching the spec's "scoped to authenticated sender
+   * identity" rule.
+   *
+   * If a payload arrives without `idempotency_key` (non-conforming sender,
+   * or A2A transport which does not carry the field), dispatch proceeds
+   * without dedup and a warning is logged.
+   */
+  webhookDedup?: {
+    backend: IdempotencyBackend;
+    /** Retention for dedup keys. Defaults to 86_400 (24h). */
+    ttlSeconds?: number;
+  };
+
   // Notification handlers (agent-initiated, no operation_id)
   onMediaBuyDeliveryNotification?: (
     notification: MediaBuyDeliveryNotification,
@@ -288,9 +340,25 @@ export class AsyncHandler {
     result: AdCPAsyncResponseData | undefined;
     metadata: WebhookMetadata;
   }): Promise<void> {
+    if (await this.isDuplicate(metadata)) {
+      await this.emitActivity({
+        type: 'webhook_duplicate',
+        operation_id: metadata.operation_id,
+        agent_id: metadata.agent_id,
+        context_id: metadata.context_id,
+        task_id: metadata.task_id,
+        task_type: metadata.task_type,
+        status: metadata.status,
+        idempotency_key: metadata.idempotency_key,
+        timestamp: metadata.timestamp,
+      });
+      return;
+    }
+
     // Emit activity
     await this.emitActivity({
       type: 'webhook_received',
+      idempotency_key: metadata.idempotency_key,
       operation_id: metadata.operation_id,
       agent_id: metadata.agent_id,
       context_id: metadata.context_id,
@@ -409,7 +477,59 @@ export class AsyncHandler {
   private async emitActivity(activity: Activity): Promise<void> {
     await this.config.onActivity?.(activity);
   }
+
+  /**
+   * Claim the webhook for processing, returning true if the event has
+   * already been delivered for this `(agent_id, idempotency_key)` tuple.
+   *
+   * Uses `IdempotencyBackend.putIfAbsent` so concurrent retries race on a
+   * single claim: exactly one caller gets `true` and proceeds, the rest
+   * observe the existing entry and return.
+   */
+  private async isDuplicate(metadata: WebhookMetadata): Promise<boolean> {
+    const dedup = this.config.webhookDedup;
+    if (!dedup) return false;
+
+    const key = metadata.idempotency_key;
+    if (!key || !IDEMPOTENCY_KEY_PATTERN.test(key)) {
+      // No valid key. MCP senders MUST emit one per AdCP 3.0; A2A
+      // transport doesn't carry the field at all. Warn MCP (so
+      // integrators notice non-conforming publishers) and stay quiet
+      // for A2A (expected and unactionable).
+      if (metadata.protocol !== 'a2a') {
+        console.warn(
+          `[AdCP] webhookDedup enabled but webhook from agent=${metadata.agent_id} task=${metadata.task_id} has ${
+            key ? 'an invalid' : 'no'
+          } idempotency_key. Expected format: ${IDEMPOTENCY_KEY_PATTERN.source}. ` +
+            'Dispatching without dedup — duplicate deliveries from this sender will re-trigger handlers. ' +
+            'See docs/guides/PUSH-NOTIFICATION-CONFIG.md#deduplication'
+        );
+      }
+      return false;
+    }
+
+    const ttlSeconds = dedup.ttlSeconds ?? 86_400;
+    // Reserved prefix `adcp\u001fwebhook\u001fv1\u001f...` namespaces the
+    // claim so webhook dedup entries can coexist with request-side
+    // idempotency entries in a shared backend — a request-side principal
+    // can never produce a scoped key with this prefix because the
+    // principal regex excludes U+001F.
+    const scopedKey = `adcp\u001fwebhook\u001fv1\u001f${metadata.agent_id}\u001f${key}`;
+    const expiresAt = Math.floor(Date.now() / 1000) + ttlSeconds;
+
+    const claimed = await dedup.backend.putIfAbsent(scopedKey, {
+      payloadHash: '',
+      response: null,
+      expiresAt,
+    });
+    return !claimed;
+  }
 }
+
+// AdCP spec: `^[A-Za-z0-9_.:-]{16,255}$`. Any key not matching this
+// pattern is malformed — treat as missing rather than forming a scoped
+// key from arbitrary sender-supplied bytes.
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9_.:-]{16,255}$/;
 
 /**
  * Factory function to create async handler

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -169,6 +169,8 @@ type NormalizedWebhookPayload = {
   result?: AdCPAsyncResponseData;
   message?: string;
   timestamp?: string;
+  idempotency_key?: string;
+  protocol?: 'mcp' | 'a2a';
 };
 
 /**
@@ -184,7 +186,14 @@ export interface SingleAgentClientConfig extends ConversationConfig {
   headers?: Record<string, string>;
   /** Activity callback for observability (logging, UI updates, etc) */
   onActivity?: (activity: Activity) => void | Promise<void>;
-  /** Task completion handlers - called for both sync responses and webhook completions */
+  /**
+   * Task completion handlers — called for both sync responses and webhook
+   * completions.
+   *
+   * For at-least-once webhook delivery, set `handlers.webhookDedup` to
+   * drop duplicate retries by `idempotency_key`. See
+   * `docs/guides/PUSH-NOTIFICATION-CONFIG.md#deduplication`.
+   */
   handlers?: AsyncHandlerConfig;
   /** Webhook secret for signature verification (recommended for production) */
   webhookSecret?: string;
@@ -702,6 +711,8 @@ export class SingleAgentClient {
       status: normalizedPayload.status,
       message: normalizedPayload.message,
       timestamp: normalizedPayload.timestamp || new Date().toISOString(),
+      idempotency_key: normalizedPayload.idempotency_key,
+      protocol: normalizedPayload.protocol,
     };
 
     // Emit activity
@@ -756,6 +767,8 @@ export class SingleAgentClient {
         result: mcpPayload.result ?? undefined,
         message: mcpPayload.message ?? undefined,
         timestamp: mcpPayload.timestamp,
+        idempotency_key: mcpPayload.idempotency_key,
+        protocol: 'mcp',
       };
     }
 
@@ -817,6 +830,7 @@ export class SingleAgentClient {
         result,
         message: message,
         timestamp: a2aPayload.status?.timestamp || new Date().toISOString(),
+        protocol: 'a2a',
       };
     }
 

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-19T21:08:25.600Z
+// Generated at: 2026-04-19T21:26:32.598Z
 
 // MEDIA-BUY SCHEMA
 /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-19T21:32:38.407Z
+// Generated at: 2026-04-19T23:44:05.221Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)

--- a/src/lib/types/wellknown-schemas.generated.ts
+++ b/src/lib/types/wellknown-schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod schemas for AdCP well-known files (brand.json, adagents.json)
-// Generated at: 2026-04-19T21:32:38.958Z
+// Generated at: 2026-04-19T23:13:14.626Z
 // Source: schemas/cache/latest/*.json → json-schema-to-zod
 //
 // DO NOT EDIT — regenerate with: npm run generate-wellknown-schemas

--- a/test/lib/async-handler-webhook-dedup.test.js
+++ b/test/lib/async-handler-webhook-dedup.test.js
@@ -1,0 +1,305 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { AsyncHandler } = require('../../dist/lib/core/AsyncHandler');
+const { memoryBackend } = require('../../dist/lib/server/idempotency/backends/memory');
+const { AdCPClient } = require('../../dist/lib/index.js');
+
+function baseMetadata(overrides = {}) {
+  return {
+    operation_id: 'op_1',
+    task_id: 'task_1',
+    agent_id: 'agent_1',
+    task_type: 'create_media_buy',
+    status: 'completed',
+    timestamp: new Date().toISOString(),
+    idempotency_key: 'whk_01HW9D3H8FZP2N6R8T0V4X6Z9B',
+    ...overrides,
+  };
+}
+
+test('webhookDedup drops duplicate delivery by idempotency_key', async () => {
+  const calls = [];
+  const activities = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: (_response, metadata) => {
+      calls.push(metadata.idempotency_key);
+    },
+    onActivity: a => activities.push(a.type),
+  });
+
+  const args = { result: { media_buy_id: 'mb_1' }, metadata: baseMetadata() };
+  await handler.handleWebhook(args);
+  await handler.handleWebhook(args);
+  await handler.handleWebhook(args);
+
+  assert.deepStrictEqual(calls, ['whk_01HW9D3H8FZP2N6R8T0V4X6Z9B']);
+  assert.deepStrictEqual(activities, ['webhook_received', 'webhook_duplicate', 'webhook_duplicate']);
+});
+
+test('webhookDedup dispatches distinct idempotency_keys independently', async () => {
+  const calls = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: (_response, metadata) => {
+      calls.push(metadata.idempotency_key);
+    },
+  });
+
+  await handler.handleWebhook({
+    result: { media_buy_id: 'mb_1' },
+    metadata: baseMetadata({ idempotency_key: 'whk_0000000000000001' }),
+  });
+  await handler.handleWebhook({
+    result: { media_buy_id: 'mb_1' },
+    metadata: baseMetadata({ idempotency_key: 'whk_0000000000000002' }),
+  });
+
+  assert.deepStrictEqual(calls, ['whk_0000000000000001', 'whk_0000000000000002']);
+});
+
+test('webhookDedup scopes by agent_id so different senders do not collide', async () => {
+  const calls = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: (_response, metadata) => {
+      calls.push(`${metadata.agent_id}:${metadata.idempotency_key}`);
+    },
+  });
+
+  const sharedKey = 'whk_0000000000000001';
+  await handler.handleWebhook({
+    result: { media_buy_id: 'mb_1' },
+    metadata: baseMetadata({ agent_id: 'agent_a', idempotency_key: sharedKey }),
+  });
+  await handler.handleWebhook({
+    result: { media_buy_id: 'mb_1' },
+    metadata: baseMetadata({ agent_id: 'agent_b', idempotency_key: sharedKey }),
+  });
+
+  assert.deepStrictEqual(calls, [`agent_a:${sharedKey}`, `agent_b:${sharedKey}`]);
+});
+
+test('webhookDedup missing idempotency_key: warns and dispatches', async () => {
+  const calls = [];
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = msg => warnings.push(msg);
+  try {
+    const handler = new AsyncHandler({
+      webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+      onCreateMediaBuyStatusChange: (_response, metadata) => {
+        calls.push(metadata.task_id);
+      },
+    });
+
+    const meta = baseMetadata();
+    delete meta.idempotency_key;
+    await handler.handleWebhook({ result: { media_buy_id: 'mb_1' }, metadata: meta });
+    await handler.handleWebhook({ result: { media_buy_id: 'mb_1' }, metadata: meta });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.strictEqual(calls.length, 2, 'should dispatch both deliveries without dedup');
+  assert.strictEqual(warnings.length, 2);
+  assert.match(warnings[0], /no idempotency_key/);
+});
+
+test('no webhookDedup config: duplicates still dispatch (back-compat)', async () => {
+  const calls = [];
+  const handler = new AsyncHandler({
+    onCreateMediaBuyStatusChange: (_response, metadata) => {
+      calls.push(metadata.idempotency_key);
+    },
+  });
+
+  const args = { result: { media_buy_id: 'mb_1' }, metadata: baseMetadata() };
+  await handler.handleWebhook(args);
+  await handler.handleWebhook(args);
+
+  assert.strictEqual(calls.length, 2);
+});
+
+test('idempotency_key propagates from MCP envelope through SingleAgentClient to handler metadata', async () => {
+  const client = new AdCPClient(
+    [{ id: 'agent_mcp', name: 'MCP', agent_uri: 'https://agent.example', protocol: 'mcp' }],
+    {
+      handlers: {
+        onCreateMediaBuyStatusChange: (_response, metadata) => {
+          seenMetadata = metadata;
+        },
+      },
+    }
+  );
+  let seenMetadata = null;
+
+  const envelope = {
+    idempotency_key: 'whk_01HW9D3H8FZP2N6R8T0V4X6Z9B',
+    operation_id: 'op_1',
+    task_id: 'task_1',
+    task_type: 'create_media_buy',
+    status: 'completed',
+    timestamp: new Date().toISOString(),
+    result: { media_buy_id: 'mb_1' },
+  };
+
+  const handled = await client.agent('agent_mcp').handleWebhook(envelope, 'create_media_buy', 'op_1');
+  assert.strictEqual(handled, true);
+  assert.ok(seenMetadata, 'handler should be called');
+  assert.strictEqual(seenMetadata.idempotency_key, 'whk_01HW9D3H8FZP2N6R8T0V4X6Z9B');
+});
+
+test('webhookDedup re-dispatches after backend eviction (TTL expiry path)', async () => {
+  const backend = memoryBackend({ sweepIntervalMs: 0 });
+  const activities = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend, ttlSeconds: 1 },
+    onActivity: a => activities.push(a.type),
+  });
+
+  const meta = baseMetadata({ idempotency_key: 'whk_expiry_test_0000001' });
+  await handler.handleWebhook({ result: {}, metadata: meta });
+
+  // Simulate TTL expiry by evicting the dedup entry directly. Scoped key
+  // uses the reserved `adcp\u001fwebhook\u001fv1\u001f...` prefix.
+  await backend.delete(`adcp\u001fwebhook\u001fv1\u001fagent_1\u001fwhk_expiry_test_0000001`);
+
+  await handler.handleWebhook({ result: {}, metadata: meta });
+  assert.deepStrictEqual(activities, ['webhook_received', 'webhook_received']);
+});
+
+test('webhookDedup: concurrent retries race on one claim, exactly one handler call', async () => {
+  const calls = [];
+  const activities = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: async (_response, metadata) => {
+      // Simulate a slow handler to widen the race window.
+      await new Promise(r => setTimeout(r, 10));
+      calls.push(metadata.idempotency_key);
+    },
+    onActivity: a => activities.push(a.type),
+  });
+
+  const args = { result: { media_buy_id: 'mb_1' }, metadata: baseMetadata() };
+  await Promise.all([
+    handler.handleWebhook(args),
+    handler.handleWebhook(args),
+    handler.handleWebhook(args),
+    handler.handleWebhook(args),
+    handler.handleWebhook(args),
+  ]);
+
+  assert.strictEqual(calls.length, 1, 'exactly one handler call for five concurrent retries');
+  const received = activities.filter(t => t === 'webhook_received').length;
+  const duplicates = activities.filter(t => t === 'webhook_duplicate').length;
+  assert.strictEqual(received, 1);
+  assert.strictEqual(duplicates, 4);
+});
+
+test('webhookDedup: handler exception does NOT release the claim (at-most-once contract)', async () => {
+  // Current behavior: handler errors are caught and logged; the publisher
+  // sees 2xx. The claim must stay so the publisher's non-retry doesn't
+  // leak into a later unrelated retry re-triggering the broken handler.
+  const calls = [];
+  const originalError = console.error;
+  console.error = () => {}; // swallow expected handler-error log
+  try {
+    const handler = new AsyncHandler({
+      webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+      onCreateMediaBuyStatusChange: (_response, metadata) => {
+        calls.push(metadata.idempotency_key);
+        throw new Error('downstream db write failed');
+      },
+    });
+
+    const args = { result: { media_buy_id: 'mb_1' }, metadata: baseMetadata() };
+    await handler.handleWebhook(args);
+    await handler.handleWebhook(args);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.strictEqual(calls.length, 1, 'handler runs once even though it threw');
+});
+
+test('webhookDedup: invalid idempotency_key (fails spec regex) treated as missing', async () => {
+  const calls = [];
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = msg => warnings.push(msg);
+  try {
+    const handler = new AsyncHandler({
+      webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+      onCreateMediaBuyStatusChange: (_response, metadata) => {
+        calls.push(metadata.task_id);
+      },
+    });
+
+    // Too short (min 16 chars).
+    const tooShort = baseMetadata({ idempotency_key: 'short', protocol: 'mcp' });
+    await handler.handleWebhook({ result: {}, metadata: tooShort });
+    await handler.handleWebhook({ result: {}, metadata: tooShort });
+
+    // Contains separator byte (U+001F).
+    const separator = baseMetadata({
+      idempotency_key: `poisoned\u001fagent_other\u001fkey`,
+      protocol: 'mcp',
+    });
+    await handler.handleWebhook({ result: {}, metadata: separator });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.strictEqual(calls.length, 3, 'all three dispatch (no dedup applied)');
+  assert.strictEqual(warnings.length, 3);
+  assert.ok(
+    warnings.every(w => /invalid idempotency_key/.test(w)),
+    'warning indicates the key is invalid, not missing'
+  );
+});
+
+test('webhookDedup: A2A webhook without idempotency_key does NOT warn', async () => {
+  const warnings = [];
+  const originalWarn = console.warn;
+  console.warn = msg => warnings.push(msg);
+  try {
+    const handler = new AsyncHandler({
+      webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+      onCreateMediaBuyStatusChange: () => {},
+    });
+
+    const meta = baseMetadata({ protocol: 'a2a' });
+    delete meta.idempotency_key;
+    await handler.handleWebhook({ result: {}, metadata: meta });
+    await handler.handleWebhook({ result: {}, metadata: meta });
+  } finally {
+    console.warn = originalWarn;
+  }
+
+  assert.strictEqual(warnings.length, 0, 'A2A should not warn — field is not in the protocol');
+});
+
+test('webhook_duplicate activity omits payload, includes idempotency_key for correlation', async () => {
+  const activities = [];
+  const handler = new AsyncHandler({
+    webhookDedup: { backend: memoryBackend({ sweepIntervalMs: 0 }) },
+    onCreateMediaBuyStatusChange: () => {},
+    onActivity: a => activities.push(a),
+  });
+
+  const result = { media_buy_id: 'mb_1', secret_token: 'SHOULD_NOT_APPEAR_IN_DUP_ACTIVITY' };
+  const meta = baseMetadata();
+  await handler.handleWebhook({ result, metadata: meta });
+  await handler.handleWebhook({ result, metadata: meta });
+
+  const received = activities.find(a => a.type === 'webhook_received');
+  const duplicate = activities.find(a => a.type === 'webhook_duplicate');
+
+  assert.ok(received && duplicate, 'both events present');
+  assert.strictEqual(received.payload.media_buy_id, 'mb_1');
+  assert.strictEqual(received.idempotency_key, meta.idempotency_key);
+  assert.strictEqual(duplicate.payload, undefined, 'duplicate omits payload');
+  assert.strictEqual(duplicate.idempotency_key, meta.idempotency_key, 'duplicate carries key for correlation');
+});


### PR DESCRIPTION
## Summary

Closes the receiver-side half of AdCP [#2417](https://github.com/adcontextprotocol/adcp/pull/2417) in the client library. Every MCP webhook payload now carries a required `idempotency_key`; this PR plumbs it through the pipeline and adds a drop-in dedup layer so at-least-once retries no longer trigger duplicate side effects in handler code.

## What's new

- **`AsyncHandlerConfig.webhookDedup?: { backend, ttlSeconds? }`** — reuses `IdempotencyBackend` from `@adcp/client/server`, so the same `memoryBackend()` / `pgBackend(...)` used for request-side idempotency can back webhook dedup. Defaults to 24h.
- **`WebhookMetadata.idempotency_key?: string`** — extracted from the MCP envelope and passed to every `onXxxStatusChange` handler so application code can log, trace, or layer its own dedup.
- **`Activity` union gains `'webhook_duplicate'`** — emitted via `onActivity` when a repeat key is dropped. Typed handlers are NOT called for duplicates (no side effects).

## Behavior

- Scope is **per-agent** (`webhook\u001f{agent_id}\u001f{idempotency_key}`) — matches the spec's "scoped to authenticated sender identity" rule, keys from different senders never collide.
- `putIfAbsent` closes the concurrent-retry race: when two retries race on the same fresh key, exactly one wins the claim and dispatches; the rest surface as `webhook_duplicate`.
- Payloads without `idempotency_key` (non-conforming senders, or A2A transport which doesn't carry the field) dispatch without dedup and log a `console.warn`. No silent drops, no tuple fallback.

## Schema sync

Pulled from AdCP `latest` — `idempotency_key` now required on:
- `MCPWebhookPayload`
- `CollectionListChangedWebhook`
- `PropertyListChangedWebhook`
- `ArtifactWebhookPayload`
- `RevocationNotification` (brand rights — not previously flagged in #2417)

## Usage

```typescript
import { AdCPClient } from '@adcp/client';
import { memoryBackend } from '@adcp/client/server';

const client = new AdCPClient(agents, {
  webhookUrlTemplate: 'https://your-app.com/adcp/webhook/{task_type}/{agent_id}/{operation_id}',
  webhookSecret: process.env.WEBHOOK_SECRET,
  handlers: {
    webhookDedup: { backend: memoryBackend() },
    onCreateMediaBuyStatusChange: async (result, metadata) => {
      // First delivery runs here; publisher retries are dropped.
    },
  },
});
```

## Out of scope (follow-ups)

- **Governance list-change / artifact / revocation webhooks** — not currently routed through `AsyncHandler`; dedup for those payload types is a follow-up.
- **Sender-side webhook emission helper** — `@adcp/client` doesn't currently emit webhooks for sellers. When added, it will need to generate one `idempotency_key` per event and reuse across retries.
- **RFC 9421 webhook signing** — AdCP [#2423](https://github.com/adcontextprotocol/adcp/pull/2423) landed upstream; client implementation will follow in a separate PR.

## Changeset

`minor` — new optional config + new metadata field + `Activity` union gains a new string literal. See `.changeset/webhook-receiver-dedup.md`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 4067 pass / 0 fail
- [x] 7 new tests in `test/lib/async-handler-webhook-dedup.test.js`:
  - duplicate delivery dropped
  - distinct keys dispatched independently
  - per-agent scoping prevents cross-sender collisions
  - missing key warns + dispatches
  - back-compat when `webhookDedup` unset
  - TTL expiry re-dispatches
  - end-to-end: `idempotency_key` propagates from MCP envelope → `WebhookMetadata` → handler