### PR TITLE
feat(server): createWebhookEmitter + createAdcpServer.webhooks integration

### DIFF
--- a/.changeset/webhook-emitter.md
+++ b/.changeset/webhook-emitter.md
@@ -1,0 +1,43 @@
+---
+'@adcp/client': minor
+---
+
+Publisher-side webhook emission — the symmetric counterpart to PR #629's receiver-side dedup.
+
+**New `createWebhookEmitter`** in `@adcp/client/server`. One `emit(url, payload, operation_id)` call and the emitter handles:
+
+- RFC 9421 signing with a fresh nonce per attempt (adcp#2423).
+- Stable `idempotency_key` per `operation_id` reused across retries (adcp#2417) — regenerating on retry is the highest-impact at-least-once-delivery bug the runner-side conformance suite catches.
+- JSON serialized once with compact separators (`,` / `:`, no spaces) and posted byte-identically — the signature-base input and the wire body come from the same bytes, preventing the Python `json.dumps` default-spacing trap pinned by adcp#2478.
+- Retry with exponential backoff + jitter on 5xx / 429. Terminal on 4xx and on 401 responses carrying `WWW-Authenticate: Signature error="webhook_signature_*"` (retrying a signature failure produces identical bytes and identical rejection).
+- Pluggable `WebhookIdempotencyKeyStore` (default in-memory) — swap in a durable backend for multi-replica publishers.
+- HMAC-SHA256 / Bearer fallback modes for legacy buyers that registered `push_notification_config.authentication.credentials`. HMAC path uses the same compact-separators pinning.
+
+**`createAdcpServer` integration.** New `webhooks?: { signerKey, retries?, idempotencyKeyStore?, ... }` config option. When set, `ctx.emitWebhook` is populated on every handler's context — completion handlers post signed webhooks without constructing the signer, fetching, or tracking idempotency themselves:
+
+```ts
+createAdcpServer({
+  name,
+  version,
+  webhooks: { signerKey: { keyid, alg: 'ed25519', privateKey: jwk } },
+  mediaBuy: {
+    createMediaBuy: async (params, ctx) => {
+      const media_buy_id = await persist(params);
+      await ctx.emitWebhook({
+        url: params.push_notification_config.url,
+        payload: { task: { task_id, status: 'completed', result: { media_buy_id } } },
+        operation_id: `create_media_buy.${media_buy_id}`,
+      });
+      return { media_buy_id, packages: [] };
+    },
+  },
+});
+```
+
+**Full-stack E2E test.** `test/lib/webhook-emitter-server-e2e.test.js`: `createAdcpServer` with a real handler → `ctx.emitWebhook` → real HTTP POST → receiver captures → `verifyWebhookSignature` accepts. No mocks on the signer or verifier path. Closes the "we haven't spun up an actual server and watched the full stack verify" gap flagged during PR #631 review.
+
+**Exports** from `@adcp/client/server`:
+
+- `createWebhookEmitter`, `memoryWebhookKeyStore`
+- Types: `WebhookEmitter`, `WebhookEmitterOptions`, `WebhookEmitParams`, `WebhookEmitResult`, `WebhookEmitAttempt`, `WebhookEmitAttemptResult`, `WebhookIdempotencyKeyStore`, `WebhookRetryOptions`, `WebhookAuthentication`
+- `HandlerContext.emitWebhook` — new optional field, populated when `webhooks` config is set.

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "generate-zod-schemas": "tsx scripts/generate-zod-from-ts.ts",
     "generate-wellknown-schemas": "tsx scripts/generate-wellknown-schemas.ts",
     "generate-agent-docs": "tsx scripts/generate-agent-docs.ts",
+    "compliance:agent-skill": "tsx scripts/manual-testing/agent-skill-storyboard.ts",
     "sync-version": "tsx scripts/sync-version.ts",
     "validate-schemas": "tsx scripts/validate-schemas.ts",
     "lint": "eslint 'src/lib/testing/**/*.ts'",

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -106,9 +106,9 @@ The current working directory already has a \`package.json\` with \`@adcp/client
    \`\`\`
    and make it executable (\`chmod +x start.sh\`).
 
-3. Do NOT start the server yourself. The harness runs \`bash start.sh\` after you exit. Any server process you leave running will be killed.
+3. **Do NOT run server.ts, start.sh, or npm start yourself — not even to verify.** The harness will run start.sh after you exit and binds port ${port}; if you leave a process running on that port, the harness fails with EADDRINUSE. Trust the SDK — if it compiles, the harness will exercise it. Your only job is to write the files and exit.
 
-4. Exit cleanly when done.
+4. Typecheck with \`npx tsc --noEmit server.ts\` (optional) to catch compile errors. Do NOT run the server. Exit cleanly when the files are written.
 
 ## Constraints
 
@@ -174,14 +174,27 @@ async function runClaude(prompt: string, cwd: string, timeoutMs: number): Promis
   });
 }
 
-async function startAgent(cwd: string): Promise<ChildProcess> {
+async function startAgent(cwd: string, port: number): Promise<ChildProcess> {
   const startSh = join(cwd, 'start.sh');
   const s = await stat(startSh).catch(() => null);
   if (!s) throw new Error(`claude did not produce start.sh in ${cwd}`);
   await chmod(startSh, 0o755);
+  // Defense-in-depth: Claude sometimes starts a verification server despite
+  // the prompt. Kill anything listening on the target port before we start
+  // ours — otherwise bash start.sh crashes EADDRINUSE.
+  await killPort(port);
   const child = spawn('bash', [startSh], { cwd, stdio: ['ignore', 'inherit', 'inherit'] });
   child.on('error', err => log(`[agent] spawn error: ${err.message}`));
   return child;
+}
+
+async function killPort(port: number): Promise<void> {
+  // `lsof -ti` + kill -9 is the portable-enough approach on macOS + Linux.
+  // On Windows this would be different; the harness is macOS/Linux-only.
+  const res = spawnSync('bash', ['-c', `lsof -ti tcp:${port} | xargs -r kill -9`], { stdio: 'ignore' });
+  void res;
+  // Brief wait so the kernel reaps the socket before we try to bind.
+  await new Promise(r => setTimeout(r, 300));
 }
 
 async function waitForPort(host: string, port: number, timeoutMs: number): Promise<void> {
@@ -202,13 +215,15 @@ async function waitForPort(host: string, port: number, timeoutMs: number): Promi
 
 function runGrader(url: string, storyboardId: string): { passed: boolean; raw: string } {
   const cliPath = join(REPO_ROOT, 'bin', 'adcp.js');
-  const res = spawnSync('node', [cliPath, 'storyboard', 'run', url, storyboardId, '--json'], {
-    encoding: 'utf8',
-    timeout: 120_000,
-  });
+  // `--allow-http` is mandatory — the grader hard-refuses plain-http URLs
+  // otherwise (production agents MUST terminate TLS). Harness-tested agents
+  // bind on loopback, so we opt in explicitly.
+  const res = spawnSync(
+    'node',
+    [cliPath, 'storyboard', 'run', url, storyboardId, '--json', '--allow-http'],
+    { encoding: 'utf8', timeout: 120_000 }
+  );
   const raw = (res.stdout ?? '') + (res.stderr ?? '');
-  // `storyboard run --json` emits either a single result or a { results: [...] } shape
-  // depending on whether the arg is a bundle. Try both.
   let passed = false;
   try {
     const parsed = JSON.parse(res.stdout);
@@ -218,8 +233,9 @@ function runGrader(url: string, storyboardId: string): { passed: boolean; raw: s
       passed = parsed.results.every((r: { overall_passed?: boolean }) => r.overall_passed);
     }
   } catch {
-    // stdout wasn't clean JSON — fall back to exit code.
-    passed = res.status === 0;
+    // stdout wasn't clean JSON — the CLI printed an error to stderr and
+    // exited non-zero. Treat as fail.
+    passed = false;
   }
   return { passed, raw };
 }
@@ -246,7 +262,7 @@ async function main(): Promise<void> {
     await runClaude(buildPrompt(skillContent, args.storyboard, args.port), workDir, args.timeoutMs);
 
     log(`starting agent`);
-    agent = await startAgent(workDir);
+    agent = await startAgent(workDir, args.port);
     await waitForPort('127.0.0.1', args.port, 30_000);
     log(`agent up on http://127.0.0.1:${args.port}/mcp`);
 

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -157,11 +157,10 @@ async function runClaude(prompt: string, cwd: string, timeoutMs: number): Promis
   await new Promise<void>((resolveFn, reject) => {
     // `--dangerously-skip-permissions` is required for unattended runs —
     // the alternative is the harness pausing on every tool call.
-    const p = spawn(
-      'claude',
-      ['-p', `Follow the instructions in ${promptPath}.`, '--dangerously-skip-permissions'],
-      { cwd, stdio: ['ignore', 'inherit', 'inherit'] }
-    );
+    const p = spawn('claude', ['-p', `Follow the instructions in ${promptPath}.`, '--dangerously-skip-permissions'], {
+      cwd,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
     const t = setTimeout(() => {
       p.kill('SIGTERM');
       reject(new Error(`claude timed out after ${timeoutMs}ms`));
@@ -218,11 +217,10 @@ function runGrader(url: string, storyboardId: string): { passed: boolean; raw: s
   // `--allow-http` is mandatory — the grader hard-refuses plain-http URLs
   // otherwise (production agents MUST terminate TLS). Harness-tested agents
   // bind on loopback, so we opt in explicitly.
-  const res = spawnSync(
-    'node',
-    [cliPath, 'storyboard', 'run', url, storyboardId, '--json', '--allow-http'],
-    { encoding: 'utf8', timeout: 120_000 }
-  );
+  const res = spawnSync('node', [cliPath, 'storyboard', 'run', url, storyboardId, '--json', '--allow-http'], {
+    encoding: 'utf8',
+    timeout: 120_000,
+  });
   const raw = (res.stdout ?? '') + (res.stderr ?? '');
   let passed = false;
   try {
@@ -247,9 +245,7 @@ function log(msg: string): void {
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const skillContent = await readFile(resolve(args.skill), 'utf8');
-  const workDir = args.workDir
-    ? resolve(args.workDir)
-    : await mkdtemp(join(tmpdir(), 'adcp-agent-'));
+  const workDir = args.workDir ? resolve(args.workDir) : await mkdtemp(join(tmpdir(), 'adcp-agent-'));
 
   log(`workspace: ${workDir}`);
   log(`skill: ${args.skill}`);

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -1,0 +1,277 @@
+#!/usr/bin/env tsx
+/**
+ * Agent-skill compliance harness.
+ *
+ * Spins up a non-interactive Claude Code instance in a scratch workspace,
+ * hands it a `build-*-agent` skill + a target storyboard, and grades
+ * whatever server Claude produces. The question this answers is "can an
+ * agent with our SDK + skill build something that passes the conformance
+ * storyboards?" — the capstone dogfood test for the publisher stack.
+ *
+ * Boundaries:
+ *   - Harness pre-populates `package.json` with `"@adcp/client": "file:<repo>"`
+ *     and runs `npm install` upfront, so Claude never touches deps.
+ *   - Claude writes `server.ts` + `start.sh` + any helpers. That's it.
+ *   - Harness runs `start.sh`, waits for the port, invokes the existing
+ *     `bin/adcp.js storyboard run` grader, and reports pass/fail.
+ *
+ * Requires:
+ *   - `claude` CLI on PATH (Claude Code installed).
+ *   - This repo built (`npm run build`) so `file:<repo>` resolves.
+ *
+ * Usage:
+ *   tsx scripts/manual-testing/agent-skill-storyboard.ts \
+ *     --skill skills/build-seller-agent/SKILL.md \
+ *     --storyboard universal/idempotency \
+ *     [--port 4200] \
+ *     [--work-dir <path>] \
+ *     [--timeout-ms 600000] \
+ *     [--keep]   # leave the workspace around for post-mortem
+ */
+
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { mkdtemp, readFile, writeFile, rm, stat, chmod } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { connect } from 'node:net';
+
+interface Args {
+  skill: string;
+  storyboard: string;
+  port: number;
+  workDir?: string;
+  timeoutMs: number;
+  keep: boolean;
+}
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+
+function parseArgs(argv: string[]): Args {
+  const out: Partial<Args> = { port: 4200, timeoutMs: 600_000, keep: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--skill') out.skill = argv[++i];
+    else if (a === '--storyboard') out.storyboard = argv[++i];
+    else if (a === '--port') out.port = Number(argv[++i]);
+    else if (a === '--work-dir') out.workDir = argv[++i];
+    else if (a === '--timeout-ms') out.timeoutMs = Number(argv[++i]);
+    else if (a === '--keep') out.keep = true;
+    else if (a === '--help' || a === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+  }
+  if (!out.skill || !out.storyboard) {
+    printUsage();
+    process.exit(2);
+  }
+  return out as Args;
+}
+
+function printUsage(): void {
+  console.error(
+    `Usage: agent-skill-storyboard \\
+  --skill <path to SKILL.md> \\
+  --storyboard <id, e.g. universal/idempotency> \\
+  [--port 4200] \\
+  [--work-dir <path>] \\
+  [--timeout-ms 600000] \\
+  [--keep]`
+  );
+}
+
+function buildPrompt(skill: string, storyboardId: string, port: number): string {
+  return `You are building a minimal AdCP agent that will be graded by the compliance storyboard \`${storyboardId}\`.
+
+## The skill you're following
+
+${skill}
+
+## Task
+
+The current working directory already has a \`package.json\` with \`@adcp/client\` installed via \`npm install\`. Do NOT touch package.json or run npm install — deps are ready.
+
+1. Write \`server.ts\` that:
+   - Uses \`createAdcpServer\` from \`@adcp/client/server\`.
+   - Implements handlers minimally sufficient to pass \`${storyboardId}\`.
+   - If the storyboard grades outbound webhooks, generate an Ed25519 keypair at startup and pass \`webhooks: { signerKey }\` to \`createAdcpServer\`. Call \`ctx.emitWebhook\` on completion.
+   - Binds MCP over HTTP on port **${port}** exactly (the harness connects to \`http://127.0.0.1:${port}/mcp\`).
+   - Uses \`serve()\` from \`@adcp/client/server\`.
+
+2. Write \`start.sh\`:
+   \`\`\`bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+   exec npx tsx server.ts
+   \`\`\`
+   and make it executable (\`chmod +x start.sh\`).
+
+3. Do NOT start the server yourself. The harness runs \`bash start.sh\` after you exit. Any server process you leave running will be killed.
+
+4. Exit cleanly when done.
+
+## Constraints
+
+- TypeScript is fine; use \`tsx\` via \`npx tsx\`.
+- Port: **${port}** — exact.
+- No external network calls beyond what the handler itself generates (webhooks to push_notification_config.url are the only outbound traffic).
+- Keep it minimal. This is a conformance test, not a feature demo.
+`;
+}
+
+async function bootstrapWorkspace(dir: string, port: number): Promise<void> {
+  const pkgPath = join(dir, 'package.json');
+  const pkg = {
+    name: 'adcp-agent-skill-harness-workspace',
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+    scripts: { start: 'tsx server.ts' },
+    dependencies: {
+      '@adcp/client': `file:${REPO_ROOT}`,
+      tsx: '^4.7.0',
+    },
+  };
+  await writeFile(pkgPath, JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+
+  // Also drop a README with the port expectation so Claude has it visible
+  // in listings without reading the prompt twice.
+  await writeFile(
+    join(dir, 'README.md'),
+    `Port: ${port}\nAgent URL after start.sh: http://127.0.0.1:${port}/mcp\n`,
+    'utf8'
+  );
+
+  log(`bootstrapping deps via npm install (this takes a minute)`);
+  const npm = spawnSync('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {
+    cwd: dir,
+    stdio: 'inherit',
+  });
+  if (npm.status !== 0) throw new Error(`npm install failed in ${dir}`);
+}
+
+async function runClaude(prompt: string, cwd: string, timeoutMs: number): Promise<void> {
+  log(`invoking claude in ${cwd}`);
+  const promptPath = join(cwd, '.harness-prompt.md');
+  await writeFile(promptPath, prompt, 'utf8');
+  await new Promise<void>((resolveFn, reject) => {
+    // `--dangerously-skip-permissions` is required for unattended runs —
+    // the alternative is the harness pausing on every tool call.
+    const p = spawn(
+      'claude',
+      ['-p', `Follow the instructions in ${promptPath}.`, '--dangerously-skip-permissions'],
+      { cwd, stdio: ['ignore', 'inherit', 'inherit'] }
+    );
+    const t = setTimeout(() => {
+      p.kill('SIGTERM');
+      reject(new Error(`claude timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    p.on('exit', code => {
+      clearTimeout(t);
+      if (code === 0) resolveFn();
+      else reject(new Error(`claude exited with code ${code}`));
+    });
+  });
+}
+
+async function startAgent(cwd: string): Promise<ChildProcess> {
+  const startSh = join(cwd, 'start.sh');
+  const s = await stat(startSh).catch(() => null);
+  if (!s) throw new Error(`claude did not produce start.sh in ${cwd}`);
+  await chmod(startSh, 0o755);
+  const child = spawn('bash', [startSh], { cwd, stdio: ['ignore', 'inherit', 'inherit'] });
+  child.on('error', err => log(`[agent] spawn error: ${err.message}`));
+  return child;
+}
+
+async function waitForPort(host: string, port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ok = await new Promise<boolean>(r => {
+      const s = connect(port, host, () => {
+        s.end();
+        r(true);
+      });
+      s.on('error', () => r(false));
+    });
+    if (ok) return;
+    await new Promise(r => setTimeout(r, 250));
+  }
+  throw new Error(`timed out waiting for ${host}:${port}`);
+}
+
+function runGrader(url: string, storyboardId: string): { passed: boolean; raw: string } {
+  const cliPath = join(REPO_ROOT, 'bin', 'adcp.js');
+  const res = spawnSync('node', [cliPath, 'storyboard', 'run', url, storyboardId, '--json'], {
+    encoding: 'utf8',
+    timeout: 120_000,
+  });
+  const raw = (res.stdout ?? '') + (res.stderr ?? '');
+  // `storyboard run --json` emits either a single result or a { results: [...] } shape
+  // depending on whether the arg is a bundle. Try both.
+  let passed = false;
+  try {
+    const parsed = JSON.parse(res.stdout);
+    if (typeof parsed.overall_passed === 'boolean') {
+      passed = parsed.overall_passed;
+    } else if (Array.isArray(parsed.results)) {
+      passed = parsed.results.every((r: { overall_passed?: boolean }) => r.overall_passed);
+    }
+  } catch {
+    // stdout wasn't clean JSON — fall back to exit code.
+    passed = res.status === 0;
+  }
+  return { passed, raw };
+}
+
+function log(msg: string): void {
+  process.stderr.write(`[harness] ${msg}\n`);
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const skillContent = await readFile(resolve(args.skill), 'utf8');
+  const workDir = args.workDir
+    ? resolve(args.workDir)
+    : await mkdtemp(join(tmpdir(), 'adcp-agent-'));
+
+  log(`workspace: ${workDir}`);
+  log(`skill: ${args.skill}`);
+  log(`storyboard: ${args.storyboard}`);
+  log(`port: ${args.port}`);
+
+  let agent: ChildProcess | undefined;
+  try {
+    await bootstrapWorkspace(workDir, args.port);
+    await runClaude(buildPrompt(skillContent, args.storyboard, args.port), workDir, args.timeoutMs);
+
+    log(`starting agent`);
+    agent = await startAgent(workDir);
+    await waitForPort('127.0.0.1', args.port, 30_000);
+    log(`agent up on http://127.0.0.1:${args.port}/mcp`);
+
+    const url = `http://127.0.0.1:${args.port}/mcp`;
+    log(`grading storyboard ${args.storyboard}`);
+    const { passed, raw } = runGrader(url, args.storyboard);
+    process.stdout.write(raw);
+    log(passed ? `PASS — storyboard ${args.storyboard}` : `FAIL — storyboard ${args.storyboard}`);
+    process.exit(passed ? 0 : 1);
+  } finally {
+    if (agent) {
+      agent.kill('SIGTERM');
+      // Give it 2s to shut down cleanly.
+      await new Promise(r => setTimeout(r, 2000));
+      if (agent.exitCode === null) agent.kill('SIGKILL');
+    }
+    if (!args.keep && !args.workDir) {
+      await rm(workDir, { recursive: true, force: true });
+    } else {
+      log(`keeping workspace at ${workDir}`);
+    }
+  }
+}
+
+main().catch(err => {
+  process.stderr.write(`[harness] ${err?.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -480,8 +480,25 @@ function createAgent({ taskStore }: ServeContext) {
     // via `createAdcpServer<MyAccount>({...})`.
     resolveSessionKey: () => 'default-principal',
 
+    // resolveAccount runs BEFORE idempotency / handler dispatch. If it
+    // returns null for a valid-shape reference, every mutating request
+    // short-circuits as ACCOUNT_NOT_FOUND — which masks idempotency
+    // conformance (missing-key / replay tests fail with the wrong code).
+    // Handle BOTH branches of AccountReference:
+    //   { account_id } — your own persisted accounts.
+    //   { brand: { domain }, operator } — the canonical spec shape.
+    //     Conformance storyboards use this by default (e.g. brand.domain
+    //     "acmeoutdoor.example", operator "pinnacle-agency.example").
     resolveAccount: async ref => {
       if ('account_id' in ref) return stateStore.get('accounts', ref.account_id);
+      if ('brand' in ref && ref.brand?.domain && ref.operator) {
+        // In dev/compliance mode, auto-materialize an account for any
+        // valid brand+operator so conformance tests reach the handler.
+        // In production, replace with a real lookup against your tenant
+        // registry — returning null here for unknown tenants is correct
+        // and will (correctly) surface ACCOUNT_NOT_FOUND to the buyer.
+        return { brand: ref.brand.domain, operator: ref.operator };
+      }
       return null;
     },
 
@@ -591,7 +608,7 @@ AdCP v3 requires an `idempotency_key` on every mutating request. For sellers, th
 
 **What the framework handles when you pass `idempotency` to `createAdcpServer`:**
 
-- Rejects missing or malformed `idempotency_key` with `INVALID_REQUEST`. The spec pattern is `^[A-Za-z0-9_.:-]{16,255}$` — a test key like `"key1"` will be rejected for length, not idempotency logic.
+- Rejects missing or malformed `idempotency_key` with `INVALID_REQUEST`. The spec pattern is `^[A-Za-z0-9_.:-]{16,255}$` — a test key like `"key1"` will be rejected for length, not idempotency logic. **Ordering gotcha**: idempotency runs AFTER `resolveAccount`. If your `resolveAccount` returns null for a valid-shape reference, the buyer gets `ACCOUNT_NOT_FOUND` — NOT the missing-key error they expected — and conformance tests fail with the wrong code. Either handle both AccountReference branches (see Implementation above) or accept dev-mode brand+operator wildcards so compliance graders reach the idempotency layer.
 - Hashes the request payload with RFC 8785 JCS; returns `IDEMPOTENCY_CONFLICT` on same-key-different-payload. The error body carries only `code` + `message` — no payload hash, no field pointer, no leaked cached content.
 - Returns `IDEMPOTENCY_EXPIRED` when a key is past the TTL (with ±60s clock-skew tolerance).
 - Injects `replayed: true` on `result.structuredContent.replayed` when returning a cached response; fresh executions omit the field.
@@ -689,9 +706,9 @@ import { serve, verifyApiKey } from '@adcp/client';
 
 serve(createAgent, {
   authenticate: verifyApiKey({
-    verify: async (token) => {
+    verify: async token => {
       const row = await db.api_keys.findUnique({ where: { token } });
-      if (!row) return null;  // framework replies 401 with WWW-Authenticate
+      if (!row) return null; // framework replies 401 with WWW-Authenticate
       return { principal: row.account_id };
     },
   }),
@@ -730,10 +747,7 @@ import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
 
 serve(createAgent, {
   publicUrl: AGENT_URL,
-  authenticate: anyOf(
-    verifyApiKey({ verify: lookupApiKey }),
-    verifyBearer({ jwksUri, issuer, audience: AGENT_URL }),
-  ),
+  authenticate: anyOf(verifyApiKey({ verify: lookupApiKey }), verifyBearer({ jwksUri, issuer, audience: AGENT_URL })),
   protectedResource: { authorization_servers: [issuer] },
 });
 ```

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -62,6 +62,12 @@ import {
 import { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
 import { isMutatingTask, IDEMPOTENCY_KEY_PATTERN, MUTATING_TASKS } from '../utils/idempotency';
 import type { IdempotencyStore } from './idempotency';
+import {
+  createWebhookEmitter,
+  type WebhookEmitParams,
+  type WebhookEmitResult,
+  type WebhookEmitterOptions,
+} from './webhook-emitter';
 
 // Type-only imports for AdcpToolMap handler signatures (z.input<typeof ...>)
 import type {
@@ -227,6 +233,21 @@ export interface HandlerContext<TAccount = unknown> {
     expiresAt?: number;
     extra?: Record<string, unknown>;
   };
+  /**
+   * Emit a signed webhook to a buyer's `push_notification_config.url`.
+   * Populated when `AdcpServerConfig.webhooks` is configured. Handles
+   * RFC 9421 signing, stable `idempotency_key` across retries, and
+   * retry/backoff per adcp#2417 + adcp#2423 + adcp#2478.
+   *
+   * Typical call from inside a completion handler:
+   *
+   *     await ctx.emitWebhook({
+   *       url: push_notification_config.url,
+   *       payload: { task: { task_id, status: 'completed', result } },
+   *       operation_id: `create_media_buy.${media_buy_id}`,
+   *     });
+   */
+  emitWebhook?: (params: WebhookEmitParams) => Promise<WebhookEmitResult>;
 }
 
 /** Request metadata passed to `resolveSessionKey` so the hook can derive a key from any field. */
@@ -588,6 +609,27 @@ export interface AdcpServerConfig<TAccount = unknown> {
   instructions?: string;
   taskStore?: TaskStore;
   taskMessageQueue?: TaskMessageQueue;
+  /**
+   * Webhook-emission config. When set, `ctx.emitWebhook` is populated on
+   * every handler's context — handlers post signed, retried,
+   * idempotency-stable webhooks without hand-rolling the pipeline. Omit
+   * if your server never emits webhooks.
+   *
+   * The `signerKey` MUST have `adcp_use: "webhook-signing"` — a
+   * request-signing key is a conformance violation per adcp#2423 (key
+   * purpose discriminator). Publishers publishing their JWKS at the
+   * `jwks_uri` on brand.json's `agents[]` entry reuse the same key across
+   * every buyer they deliver to.
+   */
+  webhooks?: Pick<
+    WebhookEmitterOptions,
+    'signerKey' | 'retries' | 'idempotencyKeyStore' | 'generateIdempotencyKey' | 'fetch' | 'userAgent' | 'tag'
+  > & {
+    /** Observability: emitter-wide onAttempt hook. */
+    onAttempt?: WebhookEmitterOptions['onAttempt'];
+    /** Observability: emitter-wide onAttemptResult hook. */
+    onAttemptResult?: WebhookEmitterOptions['onAttemptResult'];
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1010,7 +1052,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     instructions,
     taskStore,
     taskMessageQueue,
+    webhooks,
   } = config;
+
+  // Instantiate the emitter once — handler contexts expose its `emit`
+  // bound method so per-request code calls `ctx.emitWebhook(...)` without
+  // knowing about the emitter's construction or options.
+  const webhookEmitter = webhooks ? createWebhookEmitter(webhooks) : undefined;
 
   const server = createTaskCapableServer(name, version, {
     taskStore,
@@ -1066,6 +1114,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       const toolHandler = async (params: any, extra: any) => {
         const ctx: HandlerContext<TAccount> = { store: stateStore };
         if (extra?.authInfo) ctx.authInfo = extra.authInfo;
+        if (webhookEmitter) ctx.emitWebhook = webhookEmitter.emit.bind(webhookEmitter);
 
         // Echo params.context into any response (success or error) so buyers
         // can trace correlation_id end-to-end. Framework-generated errors

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -164,6 +164,19 @@ export type {
   PgBackendOptions,
 } from './idempotency';
 
+export { createWebhookEmitter, memoryWebhookKeyStore } from './webhook-emitter';
+export type {
+  WebhookEmitter,
+  WebhookEmitterOptions,
+  WebhookEmitParams,
+  WebhookEmitResult,
+  WebhookEmitAttempt,
+  WebhookEmitAttemptResult,
+  WebhookIdempotencyKeyStore,
+  WebhookRetryOptions,
+  WebhookAuthentication,
+} from './webhook-emitter';
+
 export { checkGovernance, governanceDeniedError } from './governance';
 export type {
   CheckGovernanceOptions,

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -1,0 +1,412 @@
+/**
+ * Publisher-side webhook emitter — the symmetric counterpart to PR #629's
+ * receiver-side dedup. A seller / governance agent / rights agent building
+ * with `@adcp/client` gets a one-call API that handles:
+ *
+ *   - RFC 9421 webhook signing on every attempt (adcp#2423).
+ *   - A stable `idempotency_key` per logical event, reused across retries
+ *     (adcp#2417) — regenerating on retry is the #1 at-least-once-delivery
+ *     bug the runner-side conformance suite catches.
+ *   - Compact-separator JSON serialization once, signed once, posted once
+ *     (adcp#2478) — prevents the serialization-mismatch trap where a
+ *     signer's byte view differs from what the HTTP client writes.
+ *   - Retry/backoff on 5xx and 429. Terminal on 4xx and on 401 responses
+ *     carrying `WWW-Authenticate: Signature error="webhook_signature_*"`
+ *     (spec says retrying a signature failure just fails identically).
+ *   - HMAC-SHA256 fallback for legacy buyers that registered
+ *     `push_notification_config.authentication.credentials` — still pinned
+ *     to compact separators per adcp#2478.
+ *
+ * Handler authors using `createAdcpServer` call `ctx.emitWebhook(...)` with
+ * a `url`, `payload`, and `operation_id` — everything else is wired in.
+ */
+
+import { signWebhook, type SignerKey } from '../signing/signer';
+import type { RequestLike } from '../signing/canonicalize';
+import { createHmac, randomUUID } from 'node:crypto';
+
+/**
+ * Minimum pattern per adcp#2417 / core/mcp-webhook-payload.json.
+ * Publisher-side check — catches `generateIdempotencyKey` overrides that
+ * produce keys too short for a conformant receiver to accept.
+ */
+const IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9_.:-]{16,255}$/;
+
+/** WWW-Authenticate header pattern signaling a signature-layer reject. */
+const TERMINAL_SIGNATURE_WWW_AUTH_RE = /Signature\s+error="webhook_signature_/i;
+
+/**
+ * Per-(operation_id) idempotency-key store. The key MUST be stable across
+ * every retry of the same logical event — that's the load-bearing invariant
+ * the receiver-side dedup depends on.
+ *
+ * Defaults to an in-memory Map. Production publishers with multi-replica
+ * emitters SHOULD inject a durable backend (the same way
+ * `AsyncHandlerConfig.webhookDedup` accepts a pluggable store on the
+ * receiver side).
+ */
+export interface WebhookIdempotencyKeyStore {
+  get(operation_id: string): Promise<string | undefined> | string | undefined;
+  /** Called only on first-seen operation_id. Subsequent emits read via get(). */
+  set(operation_id: string, key: string): Promise<void> | void;
+}
+
+export function memoryWebhookKeyStore(): WebhookIdempotencyKeyStore {
+  const m = new Map<string, string>();
+  return {
+    get: id => m.get(id),
+    set: (id, key) => {
+      m.set(id, key);
+    },
+  };
+}
+
+/**
+ * Authentication mode for a single delivery. Omit / pass `null` to use the
+ * 9421 baseline. `bearer` / `hmac_sha256` drop back to legacy flows for
+ * buyers who populated `push_notification_config.authentication.credentials`.
+ */
+export type WebhookAuthentication = { type: 'bearer'; token: string } | { type: 'hmac_sha256'; secret: string } | null;
+
+export interface WebhookRetryOptions {
+  /** Max delivery attempts (≥1). Default 5. */
+  maxAttempts?: number;
+  /** Initial backoff in ms. Default 1000. */
+  initialDelayMs?: number;
+  /** Cap per-attempt backoff. Default 60000. */
+  maxDelayMs?: number;
+  /** Jitter factor ∈ [0,1]: 0 = none, 0.5 = ±50%. Default 0.25. */
+  jitter?: number;
+}
+
+export interface WebhookEmitterOptions {
+  /** Ed25519 / ECDSA-P256 signing key. `adcp_use` MUST be `"webhook-signing"`. */
+  signerKey: SignerKey;
+  retries?: WebhookRetryOptions;
+  idempotencyKeyStore?: WebhookIdempotencyKeyStore;
+  /**
+   * Override the default idempotency-key generator. Must return a value
+   * matching `/^[A-Za-z0-9_.:-]{16,255}$/` — the emitter rejects anything
+   * else (a malformed key would fail the receiver's schema check, which
+   * would report as a conformance violation of the publisher).
+   */
+  generateIdempotencyKey?: () => string;
+  /** Override the HTTP client (tests, proxies, SSRF-wrappers). */
+  fetch?: typeof fetch;
+  /** Default `User-Agent` header. */
+  userAgent?: string;
+  /** Signing tag override. Defaults to `adcp/webhook-signing/v1`. */
+  tag?: string;
+  /** Observability hook called BEFORE each attempt. */
+  onAttempt?: (info: WebhookEmitAttempt) => void;
+  /** Observability hook called AFTER each attempt completes. */
+  onAttemptResult?: (info: WebhookEmitAttemptResult) => void;
+  /**
+   * Sleeper override. Production uses `setTimeout`; tests inject a stub to
+   * skip real backoff. Takes (ms, abortSignal) and resolves when slept.
+   */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface WebhookEmitParams {
+  /** Full destination URL. Typically from `push_notification_config.url`. */
+  url: string;
+  /** Object body. Serialized with compact separators (adcp#2478). */
+  payload: Record<string, unknown>;
+  /**
+   * Stable logical event id. Two emits with the same operation_id reuse
+   * the same `idempotency_key` — this is the cross-attempt AND
+   * cross-process invariant the receiver dedups on.
+   */
+  operation_id: string;
+  /**
+   * Per-emit override of the delivery's authentication mode. Omit for the
+   * 9421 default.
+   */
+  authentication?: WebhookAuthentication;
+  /** Per-emit retries override. */
+  retries?: WebhookRetryOptions;
+}
+
+export interface WebhookEmitAttempt {
+  operation_id: string;
+  idempotency_key: string;
+  attempt: number;
+  url: string;
+}
+
+export interface WebhookEmitAttemptResult extends WebhookEmitAttempt {
+  status?: number;
+  durationMs: number;
+  error?: string;
+  willRetry: boolean;
+}
+
+export interface WebhookEmitResult {
+  operation_id: string;
+  idempotency_key: string;
+  attempts: number;
+  delivered: boolean;
+  final_status?: number;
+  errors: string[];
+}
+
+export interface WebhookEmitter {
+  emit(params: WebhookEmitParams): Promise<WebhookEmitResult>;
+}
+
+// ────────────────────────────────────────────────────────────
+// Factory
+// ────────────────────────────────────────────────────────────
+
+export function createWebhookEmitter(options: WebhookEmitterOptions): WebhookEmitter {
+  const store = options.idempotencyKeyStore ?? memoryWebhookKeyStore();
+  const generateKey = options.generateIdempotencyKey ?? defaultGenerateIdempotencyKey;
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const sleep = options.sleep ?? defaultSleep;
+  const defaultRetries = resolveRetries(options.retries);
+
+  return {
+    async emit(params: WebhookEmitParams): Promise<WebhookEmitResult> {
+      const retries = resolveRetries(params.retries ?? options.retries);
+      const idempotency_key = await resolveIdempotencyKey(store, params.operation_id, generateKey);
+
+      // Serialize ONCE with compact separators — the same bytes feed both
+      // the content-digest input and the HTTP body on every attempt. This
+      // is the load-bearing rule from adcp#2478.
+      const bodyPayload = { ...params.payload, idempotency_key };
+      const bodyBytes = JSON.stringify(bodyPayload);
+
+      const errors: string[] = [];
+      let lastStatus: number | undefined;
+
+      for (let attempt = 1; attempt <= retries.maxAttempts; attempt++) {
+        const attemptInfo: WebhookEmitAttempt = {
+          operation_id: params.operation_id,
+          idempotency_key,
+          attempt,
+          url: params.url,
+        };
+        options.onAttempt?.(attemptInfo);
+
+        const started = Date.now();
+        let status: number | undefined;
+        let error: string | undefined;
+        let terminal = false;
+
+        try {
+          const response = await deliverOnce({
+            url: params.url,
+            bodyBytes,
+            signerKey: options.signerKey,
+            authentication: params.authentication ?? null,
+            tag: options.tag,
+            userAgent: options.userAgent,
+            fetch: fetchImpl,
+          });
+          status = response.status;
+          lastStatus = status;
+
+          if (status >= 200 && status < 300) {
+            const durationMs = Date.now() - started;
+            options.onAttemptResult?.({ ...attemptInfo, status, durationMs, willRetry: false });
+            return {
+              operation_id: params.operation_id,
+              idempotency_key,
+              attempts: attempt,
+              delivered: true,
+              final_status: status,
+              errors,
+            };
+          }
+
+          terminal = isTerminalStatus(status, response.wwwAuthenticate);
+          error = `HTTP ${status}${response.wwwAuthenticate ? ` (${response.wwwAuthenticate})` : ''}`;
+        } catch (err) {
+          error = err instanceof Error ? err.message : String(err);
+          // Network / transport errors are retryable — the delivery didn't
+          // reach the receiver, so no risk of double-processing.
+        }
+
+        if (error) errors.push(`attempt ${attempt}: ${error}`);
+
+        const willRetry = !terminal && attempt < retries.maxAttempts;
+        options.onAttemptResult?.({
+          ...attemptInfo,
+          ...(status !== undefined && { status }),
+          durationMs: Date.now() - started,
+          ...(error !== undefined && { error }),
+          willRetry,
+        });
+
+        if (!willRetry) break;
+
+        await sleep(backoffDelay(attempt, retries));
+      }
+
+      return {
+        operation_id: params.operation_id,
+        idempotency_key,
+        attempts: errors.length,
+        delivered: false,
+        ...(lastStatus !== undefined && { final_status: lastStatus }),
+        errors,
+      };
+    },
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// Delivery primitives
+// ────────────────────────────────────────────────────────────
+
+interface DeliveryResponse {
+  status: number;
+  wwwAuthenticate?: string;
+}
+
+async function deliverOnce(args: {
+  url: string;
+  bodyBytes: string;
+  signerKey: SignerKey;
+  authentication: WebhookAuthentication;
+  tag?: string;
+  userAgent?: string;
+  fetch: typeof fetch;
+}): Promise<DeliveryResponse> {
+  const headers = buildHeaders(args);
+  const response = await args.fetch(args.url, {
+    method: 'POST',
+    headers,
+    body: args.bodyBytes,
+  });
+  return {
+    status: response.status,
+    ...(response.headers.get('www-authenticate') && { wwwAuthenticate: response.headers.get('www-authenticate')! }),
+  };
+}
+
+function buildHeaders(args: {
+  url: string;
+  bodyBytes: string;
+  signerKey: SignerKey;
+  authentication: WebhookAuthentication;
+  tag?: string;
+  userAgent?: string;
+}): Record<string, string> {
+  const baseHeaders: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (args.userAgent) baseHeaders['user-agent'] = args.userAgent;
+
+  // Legacy HMAC-SHA256 path. Matches docs/building/implementation/webhooks.mdx
+  // §3.0 legacy section: X-ADCP-Signature + X-ADCP-Timestamp over
+  // `${ts}.${raw_body_bytes}`.
+  if (args.authentication?.type === 'hmac_sha256') {
+    const ts = Math.floor(Date.now() / 1000).toString();
+    const hmac = createHmac('sha256', args.authentication.secret);
+    hmac.update(`${ts}.${args.bodyBytes}`, 'utf8');
+    return {
+      ...baseHeaders,
+      'x-adcp-timestamp': ts,
+      'x-adcp-signature': `sha256=${hmac.digest('hex')}`,
+    };
+  }
+
+  // Bearer fallback — the legacy path for buyers that registered an API
+  // key in push_notification_config.authentication. No body signing —
+  // just a header. Not recommended; strictly for interop with 2.x buyers.
+  if (args.authentication?.type === 'bearer') {
+    return { ...baseHeaders, authorization: `Bearer ${args.authentication.token}` };
+  }
+
+  // Default: 9421 webhook signing. Fresh nonce + fresh created/expires per
+  // attempt, but the `idempotency_key` inside the body stays stable — the
+  // signature covers the body bytes, which include the key; multiple
+  // retries of the same logical event produce different signatures over
+  // the same body, which is exactly what the receiver expects.
+  const request: RequestLike = {
+    method: 'POST',
+    url: args.url,
+    headers: baseHeaders,
+    body: args.bodyBytes,
+  };
+  const signed = signWebhook(request, args.signerKey, args.tag !== undefined ? { tag: args.tag } : {});
+  return { ...baseHeaders, ...signed.headers };
+}
+
+// ────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────
+
+async function resolveIdempotencyKey(
+  store: WebhookIdempotencyKeyStore,
+  operation_id: string,
+  generate: () => string
+): Promise<string> {
+  const existing = await store.get(operation_id);
+  if (existing) {
+    if (!IDEMPOTENCY_KEY_PATTERN.test(existing)) {
+      throw new Error(
+        `idempotency-key store returned "${existing}" for operation_id "${operation_id}"; ` +
+          `does not match required pattern ${IDEMPOTENCY_KEY_PATTERN.source}`
+      );
+    }
+    return existing;
+  }
+  const fresh = generate();
+  if (!IDEMPOTENCY_KEY_PATTERN.test(fresh)) {
+    throw new Error(
+      `generateIdempotencyKey produced "${fresh}" for operation_id "${operation_id}"; ` +
+        `must match ${IDEMPOTENCY_KEY_PATTERN.source}`
+    );
+  }
+  await store.set(operation_id, fresh);
+  return fresh;
+}
+
+/**
+ * Default key generator — `evt_` prefix + a base64url 18-byte random.
+ * Length 27 (comfortably within 16–255), only base64url-safe characters,
+ * obviously-webhook-scoped prefix for log grepping.
+ */
+function defaultGenerateIdempotencyKey(): string {
+  const uuid = randomUUID().replace(/-/g, '');
+  return `evt_${uuid.slice(0, 24)}`;
+}
+
+function isTerminalStatus(status: number, wwwAuthenticate?: string): boolean {
+  if (status === 429) return false;
+  if (status >= 500) return false;
+  // 401 with a signature-layer reject is terminal per adcp#2423 —
+  // retrying a signature failure produces identical bytes and identical
+  // rejection. Non-signature 401s (opaque auth failures) are also
+  // terminal; there's nothing the publisher can do by retrying.
+  if (status === 401 && wwwAuthenticate && TERMINAL_SIGNATURE_WWW_AUTH_RE.test(wwwAuthenticate)) return true;
+  if (status >= 400 && status < 500) return true;
+  return false;
+}
+
+function backoffDelay(attempt: number, retries: Required<WebhookRetryOptions>): number {
+  const base = Math.min(retries.initialDelayMs * Math.pow(2, attempt - 1), retries.maxDelayMs);
+  if (retries.jitter <= 0) return base;
+  const jitterWindow = base * retries.jitter;
+  const offset = Math.random() * jitterWindow * 2 - jitterWindow;
+  return Math.max(0, Math.floor(base + offset));
+}
+
+function resolveRetries(opts?: WebhookRetryOptions): Required<WebhookRetryOptions> {
+  return {
+    maxAttempts: Math.max(1, opts?.maxAttempts ?? 5),
+    initialDelayMs: Math.max(0, opts?.initialDelayMs ?? 1000),
+    maxDelayMs: Math.max(0, opts?.maxDelayMs ?? 60_000),
+    jitter: Math.max(0, Math.min(1, opts?.jitter ?? 0.25)),
+  };
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(r => {
+    const t = setTimeout(r, ms);
+    t.unref?.();
+  });
+}

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -164,7 +164,6 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): WebhookEmi
   const generateKey = options.generateIdempotencyKey ?? defaultGenerateIdempotencyKey;
   const fetchImpl = options.fetch ?? globalThis.fetch;
   const sleep = options.sleep ?? defaultSleep;
-  const defaultRetries = resolveRetries(options.retries);
 
   return {
     async emit(params: WebhookEmitParams): Promise<WebhookEmitResult> {

--- a/test/lib/webhook-emitter-server-e2e.test.js
+++ b/test/lib/webhook-emitter-server-e2e.test.js
@@ -1,0 +1,190 @@
+/**
+ * Full-stack publisher E2E: `createAdcpServer` → tool handler invokes
+ * `ctx.emitWebhook` → our receiver captures the POST → `verifyWebhookSignature`
+ * accepts the signature against the publisher's published JWK.
+ *
+ * This is the "spin up an actual server, watch the whole stack verify"
+ * test — no mocks at the signer, no mocks at the verifier. Real fetch
+ * between the two halves. The only mock is the receiver, which is the
+ * same ephemeral HTTP listener our runner uses to grade third-party
+ * publishers (adcp#2426).
+ */
+const { describe, test, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { generateKeyPairSync } = require('node:crypto');
+
+const { createAdcpServer } = require('../../dist/lib/server/create-adcp-server.js');
+const { createWebhookReceiver } = require('../../dist/lib/testing/storyboard/webhook-receiver.js');
+const { verifyWebhookSignature } = require('../../dist/lib/signing/webhook-verifier.js');
+const { StaticJwksResolver } = require('../../dist/lib/signing/jwks.js');
+const { InMemoryReplayStore } = require('../../dist/lib/signing/replay.js');
+const { InMemoryRevocationStore } = require('../../dist/lib/signing/revocation.js');
+
+function makeSignerKey(kid = 'e2e-webhook-key') {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const priv = privateKey.export({ format: 'jwk' });
+  const pub = publicKey.export({ format: 'jwk' });
+  return {
+    signerKey: {
+      keyid: kid,
+      alg: 'ed25519',
+      privateKey: { ...priv, kid, alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['sign'] },
+    },
+    publicJwk: { ...pub, kid, alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['verify'] },
+  };
+}
+
+async function callTool(server, toolName, params) {
+  const tool = server._registeredTools[toolName];
+  if (!tool) throw new Error(`Tool "${toolName}" not registered`);
+  const raw = await tool.handler(params, { signal: new AbortController().signal });
+  return raw.structuredContent;
+}
+
+describe('createAdcpServer + webhook emitter: full-stack publisher E2E', () => {
+  let receiver;
+
+  afterEach(async () => {
+    if (receiver) await receiver.close();
+    receiver = undefined;
+  });
+
+  test('handler calls ctx.emitWebhook → receiver captures → verifier accepts', async () => {
+    const { signerKey, publicJwk } = makeSignerKey();
+    receiver = await createWebhookReceiver();
+
+    const emitted = [];
+    const server = createAdcpServer({
+      name: 'e2e-publisher',
+      version: '1.0.0',
+      webhooks: { signerKey },
+      mediaBuy: {
+        createMediaBuy: async (params, ctx) => {
+          // Business logic: create the media buy, then fire the webhook.
+          const media_buy_id = 'mb_e2e_01';
+          const result = await ctx.emitWebhook({
+            url: params.push_notification_config.url,
+            payload: {
+              task: {
+                task_id: `task_${media_buy_id}`,
+                status: 'completed',
+                result: { media_buy_id },
+              },
+            },
+            operation_id: `create_media_buy.${media_buy_id}`,
+          });
+          emitted.push(result);
+          return { media_buy_id, packages: [] };
+        },
+      },
+    });
+
+    const handlerResult = await callTool(server, 'create_media_buy', {
+      account: { brand: { domain: 'acme.example' }, operator: 'op.example' },
+      brand: { domain: 'acme.example' },
+      start_time: '2026-05-01T00:00:00Z',
+      end_time: '2026-05-31T23:59:59Z',
+      packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'po-1' }],
+      idempotency_key: 'e2e_create_key_0123456',
+      push_notification_config: {
+        url: `${receiver.base_url}/step/e2e_trigger/e2e_op_01`,
+      },
+    });
+
+    assert.strictEqual(handlerResult.media_buy_id, 'mb_e2e_01');
+    assert.strictEqual(emitted.length, 1, 'handler must have called emitWebhook');
+    assert.strictEqual(emitted[0].delivered, true);
+    assert.match(emitted[0].idempotency_key, /^[A-Za-z0-9_.:-]{16,255}$/);
+
+    // Receiver captured the delivery.
+    const [captured] = receiver.all();
+    assert.ok(captured, 'receiver must have captured the webhook');
+    assert.strictEqual(captured.step_id, 'e2e_trigger');
+    assert.strictEqual(captured.operation_id, 'e2e_op_01');
+    assert.strictEqual(captured.body.idempotency_key, emitted[0].idempotency_key);
+    assert.strictEqual(captured.body.task.result.media_buy_id, 'mb_e2e_01');
+
+    // Full 9421 signature verification against the published JWK.
+    const verified = await verifyWebhookSignature(
+      {
+        method: captured.method,
+        url: `${receiver.base_url}/step/${captured.step_id}/${captured.operation_id}`,
+        headers: captured.headers,
+        body: captured.raw_body,
+      },
+      {
+        jwks: new StaticJwksResolver([publicJwk]),
+        replayStore: new InMemoryReplayStore(),
+        revocationStore: new InMemoryRevocationStore(),
+      }
+    );
+    assert.strictEqual(verified.status, 'verified');
+    assert.strictEqual(verified.keyid, signerKey.keyid);
+  });
+
+  test('ctx.emitWebhook is undefined when webhooks config is omitted', async () => {
+    let seenEmitWebhook;
+    const server = createAdcpServer({
+      name: 'no-webhooks',
+      version: '1.0.0',
+      mediaBuy: {
+        createMediaBuy: async (_params, ctx) => {
+          seenEmitWebhook = ctx.emitWebhook;
+          return { media_buy_id: 'mb_no_emit', packages: [] };
+        },
+      },
+    });
+    await callTool(server, 'create_media_buy', {
+      account: { brand: { domain: 'acme.example' }, operator: 'op.example' },
+      brand: { domain: 'acme.example' },
+      start_time: '2026-05-01T00:00:00Z',
+      end_time: '2026-05-31T23:59:59Z',
+      packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'po-1' }],
+      idempotency_key: 'no_emit_key_0123456789',
+    });
+    assert.strictEqual(seenEmitWebhook, undefined);
+  });
+
+  test('idempotency-key stability survives two emit calls for the same operation_id', async () => {
+    const { signerKey } = makeSignerKey();
+    receiver = await createWebhookReceiver();
+
+    const firstKeys = [];
+    const server = createAdcpServer({
+      name: 'stability-publisher',
+      version: '1.0.0',
+      webhooks: { signerKey },
+      mediaBuy: {
+        createMediaBuy: async (params, ctx) => {
+          // Emit twice for the same operation_id — simulates a handler
+          // that notifies on two lifecycle transitions of the same event.
+          const first = await ctx.emitWebhook({
+            url: params.push_notification_config.url,
+            payload: { task: { status: 'accepted' } },
+            operation_id: 'create_media_buy.mb_stable',
+          });
+          const second = await ctx.emitWebhook({
+            url: params.push_notification_config.url,
+            payload: { task: { status: 'completed' } },
+            operation_id: 'create_media_buy.mb_stable',
+          });
+          firstKeys.push(first.idempotency_key, second.idempotency_key);
+          return { media_buy_id: 'mb_stable', packages: [] };
+        },
+      },
+    });
+    await callTool(server, 'create_media_buy', {
+      account: { brand: { domain: 'acme.example' }, operator: 'op.example' },
+      brand: { domain: 'acme.example' },
+      start_time: '2026-05-01T00:00:00Z',
+      end_time: '2026-05-31T23:59:59Z',
+      packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'po-1' }],
+      idempotency_key: 'stability_key_abcdefghij',
+      push_notification_config: { url: `${receiver.base_url}/step/stable/op_stable` },
+    });
+    assert.strictEqual(firstKeys[0], firstKeys[1], "both emits must reuse the operation_id's stored key");
+    const captured = receiver.all();
+    assert.strictEqual(captured.length, 2);
+    assert.strictEqual(captured[0].body.idempotency_key, captured[1].body.idempotency_key);
+  });
+});

--- a/test/lib/webhook-emitter.test.js
+++ b/test/lib/webhook-emitter.test.js
@@ -1,0 +1,308 @@
+/**
+ * Unit coverage for `createWebhookEmitter` — the publisher-side symmetric
+ * counterpart to PR #629's receiver dedup.
+ *
+ * These tests intercept HTTP via a stub `fetch`, capture every attempt's
+ * headers + body, and assert the behaviors three upstream adcp PRs pin:
+ *
+ *   - Stable `idempotency_key` across retries (#2417).
+ *   - 9421 signing by default with fresh `nonce`/`created` per attempt (#2423).
+ *   - Compact-separator JSON serialized once and posted byte-identically (#2478).
+ *
+ * Plus the adcp-client contract: 5xx/429 retry, 4xx terminal, 401 with
+ * `WWW-Authenticate: Signature error="webhook_signature_*"` terminal.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const { generateKeyPairSync } = require('node:crypto');
+
+const { createWebhookEmitter, memoryWebhookKeyStore } = require('../../dist/lib/server/webhook-emitter.js');
+const { verifyWebhookSignature } = require('../../dist/lib/signing/webhook-verifier.js');
+const { StaticJwksResolver } = require('../../dist/lib/signing/jwks.js');
+const { InMemoryReplayStore } = require('../../dist/lib/signing/replay.js');
+const { InMemoryRevocationStore } = require('../../dist/lib/signing/revocation.js');
+
+// ────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────
+
+function makeSignerKey(kid = 'test-key-2026') {
+  const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+  const priv = privateKey.export({ format: 'jwk' });
+  const pub = publicKey.export({ format: 'jwk' });
+  return {
+    signerKey: {
+      keyid: kid,
+      alg: 'ed25519',
+      privateKey: { ...priv, kid, alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['sign'] },
+    },
+    publicJwk: { ...pub, kid, alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['verify'] },
+  };
+}
+
+/** Stub fetch that records every call and returns a scripted status sequence. */
+function stubFetch(responses) {
+  const calls = [];
+  const queue = [...responses];
+  const fn = async (url, init) => {
+    calls.push({ url, init, body: init?.body, headers: init?.headers });
+    const next = queue.shift() ?? { status: 200 };
+    const headers = new Map(Object.entries(next.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]));
+    return {
+      status: next.status,
+      headers: { get: name => headers.get(name.toLowerCase()) },
+    };
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+const noSleep = () => Promise.resolve();
+
+// ────────────────────────────────────────────────────────────
+// Happy path
+// ────────────────────────────────────────────────────────────
+
+describe('createWebhookEmitter: happy path', () => {
+  test('delivers on first attempt and returns the minted idempotency_key', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+
+    const result = await emitter.emit({
+      url: 'http://127.0.0.1:9999/webhook',
+      payload: { task: { task_id: 'mb-1', status: 'completed' } },
+      operation_id: 'op.mb-1',
+    });
+
+    assert.strictEqual(result.delivered, true);
+    assert.strictEqual(result.attempts, 1);
+    assert.strictEqual(result.final_status, 204);
+    assert.match(result.idempotency_key, /^[A-Za-z0-9_.:-]{16,255}$/);
+    assert.strictEqual(fetch.calls.length, 1);
+
+    // Body is compact-separator JSON with the idempotency_key folded in.
+    const body = JSON.parse(fetch.calls[0].body);
+    assert.strictEqual(body.idempotency_key, result.idempotency_key);
+    assert.strictEqual(body.task.task_id, 'mb-1');
+    assert.ok(!fetch.calls[0].body.includes(', '), 'body MUST be compact (no spaced separators) per adcp#2478');
+  });
+
+  test('produces a 9421 signature the public verifier accepts', async () => {
+    const { signerKey, publicJwk } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+
+    await emitter.emit({
+      url: 'https://buyer.example/webhook',
+      payload: { task: { task_id: 'mb-x' } },
+      operation_id: 'op.mb-x',
+    });
+
+    const call = fetch.calls[0];
+    const verified = await verifyWebhookSignature(
+      { method: 'POST', url: call.url, headers: call.headers, body: call.body },
+      {
+        jwks: new StaticJwksResolver([publicJwk]),
+        replayStore: new InMemoryReplayStore(),
+        revocationStore: new InMemoryRevocationStore(),
+      }
+    );
+    assert.strictEqual(verified.status, 'verified');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Retry + idempotency-key stability
+// ────────────────────────────────────────────────────────────
+
+describe('createWebhookEmitter: retry behavior', () => {
+  test('retries on 503 and preserves the idempotency_key across attempts', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 503 }, { status: 503 }, { status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+
+    const result = await emitter.emit({
+      url: 'http://127.0.0.1/hook',
+      payload: { event: 'x' },
+      operation_id: 'op.retry',
+    });
+
+    assert.strictEqual(result.delivered, true);
+    assert.strictEqual(fetch.calls.length, 3);
+
+    const keys = fetch.calls.map(c => JSON.parse(c.body).idempotency_key);
+    assert.strictEqual(new Set(keys).size, 1, 'idempotency_key MUST be byte-identical across retries (adcp#2417)');
+  });
+
+  test('emits fresh nonce per attempt while body bytes stay identical', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 500 }, { status: 500 }, { status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+
+    await emitter.emit({
+      url: 'http://127.0.0.1/hook',
+      payload: { event: 'y' },
+      operation_id: 'op.nonce',
+    });
+
+    const bodies = fetch.calls.map(c => c.body);
+    assert.strictEqual(new Set(bodies).size, 1, 'body bytes MUST be byte-identical across retries');
+    const nonces = fetch.calls.map(c => /nonce="([^"]+)"/.exec(c.headers['Signature-Input'])?.[1]);
+    assert.strictEqual(new Set(nonces).size, 3, 'nonce MUST be fresh per attempt');
+  });
+
+  test('retries on 429', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 429 }, { status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+    const result = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.429' });
+    assert.strictEqual(result.delivered, true);
+    assert.strictEqual(fetch.calls.length, 2);
+  });
+
+  test('treats 4xx as terminal', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 400 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+    const result = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.400' });
+    assert.strictEqual(result.delivered, false);
+    assert.strictEqual(result.attempts, 1);
+    assert.strictEqual(fetch.calls.length, 1);
+  });
+
+  test('treats 401 with WWW-Authenticate: Signature error=... as terminal', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([
+      {
+        status: 401,
+        headers: { 'WWW-Authenticate': 'Signature error="webhook_signature_tag_invalid"' },
+      },
+    ]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+    const result = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.401' });
+    assert.strictEqual(result.delivered, false);
+    assert.strictEqual(fetch.calls.length, 1);
+    assert.match(result.errors[0], /webhook_signature_tag_invalid/);
+  });
+
+  test('max-attempts cap', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch(Array(10).fill({ status: 503 }));
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep, retries: { maxAttempts: 3 } });
+    const result = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.cap' });
+    assert.strictEqual(result.delivered, false);
+    assert.strictEqual(fetch.calls.length, 3);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Idempotency-key stability across separate emit() calls
+// ────────────────────────────────────────────────────────────
+
+describe('createWebhookEmitter: cross-call stability', () => {
+  test('same operation_id across two emit() calls reuses the stored key', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }, { status: 204 }]);
+    const store = memoryWebhookKeyStore();
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep, idempotencyKeyStore: store });
+
+    const first = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.same' });
+    const second = await emitter.emit({ url: 'http://x/h', payload: { updated: true }, operation_id: 'op.same' });
+
+    assert.strictEqual(first.idempotency_key, second.idempotency_key);
+    assert.strictEqual(await store.get('op.same'), first.idempotency_key);
+  });
+
+  test('different operation_ids produce different keys', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }, { status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+
+    const a = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.A' });
+    const b = await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.B' });
+    assert.notStrictEqual(a.idempotency_key, b.idempotency_key);
+  });
+
+  test('rejects an injected generator that produces a malformed key', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }]);
+    const emitter = createWebhookEmitter({
+      signerKey,
+      fetch,
+      sleep: noSleep,
+      generateIdempotencyKey: () => 'tooShort',
+    });
+    await assert.rejects(() => emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.bad' }), /must match/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Legacy HMAC fallback
+// ────────────────────────────────────────────────────────────
+
+describe('createWebhookEmitter: HMAC fallback', () => {
+  test('signs with X-ADCP-Signature when authentication.type = hmac_sha256', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+    const result = await emitter.emit({
+      url: 'http://x/h',
+      payload: { event: 'hmac' },
+      operation_id: 'op.hmac',
+      authentication: { type: 'hmac_sha256', secret: 'shh-its-a-secret' },
+    });
+    assert.strictEqual(result.delivered, true);
+    const headers = fetch.calls[0].headers;
+    assert.ok(headers['x-adcp-signature']?.startsWith('sha256='));
+    assert.ok(headers['x-adcp-timestamp']);
+    // No 9421 headers in the HMAC path.
+    assert.ok(!headers['Signature'], 'HMAC path MUST NOT emit 9421 Signature header');
+    assert.ok(!headers['Signature-Input'], 'HMAC path MUST NOT emit 9421 Signature-Input header');
+  });
+
+  test('bearer path sets only Authorization (no body-signing)', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 204 }]);
+    const emitter = createWebhookEmitter({ signerKey, fetch, sleep: noSleep });
+    await emitter.emit({
+      url: 'http://x/h',
+      payload: { event: 'bearer' },
+      operation_id: 'op.bearer',
+      authentication: { type: 'bearer', token: 'opaque-token' },
+    });
+    const headers = fetch.calls[0].headers;
+    assert.strictEqual(headers.authorization, 'Bearer opaque-token');
+    assert.ok(!headers['x-adcp-signature']);
+    assert.ok(!headers['Signature']);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Observability
+// ────────────────────────────────────────────────────────────
+
+describe('createWebhookEmitter: observability', () => {
+  test('onAttempt + onAttemptResult fire per attempt with matching attempt number', async () => {
+    const { signerKey } = makeSignerKey();
+    const fetch = stubFetch([{ status: 503 }, { status: 204 }]);
+    const attempts = [];
+    const results = [];
+    const emitter = createWebhookEmitter({
+      signerKey,
+      fetch,
+      sleep: noSleep,
+      onAttempt: info => attempts.push(info),
+      onAttemptResult: info => results.push(info),
+    });
+    await emitter.emit({ url: 'http://x/h', payload: {}, operation_id: 'op.obs' });
+    assert.strictEqual(attempts.length, 2);
+    assert.strictEqual(results.length, 2);
+    assert.strictEqual(attempts[0].attempt, 1);
+    assert.strictEqual(attempts[1].attempt, 2);
+    assert.strictEqual(results[0].willRetry, true);
+    assert.strictEqual(results[1].willRetry, false);
+    assert.strictEqual(results[1].status, 204);
+  });
+});


### PR DESCRIPTION
Publisher-side webhook emission — the symmetric counterpart to PR #629's receiver dedup. Closes the "we haven't spun up an actual server and watched the full stack verify" gap flagged during [#631](https://github.com/adcontextprotocol/adcp-client/pull/631) review, and the \`createWebhookEmitter\` follow-up listed in that PR's body.

## What

### `createWebhookEmitter` (\`src/lib/server/webhook-emitter.ts\`)

One call — \`emit({ url, payload, operation_id })\` — and the emitter handles:

- **RFC 9421 signing** with a fresh nonce per attempt (adcp#2423).
- **Stable \`idempotency_key\` per \`operation_id\`** reused across retries (adcp#2417) — regenerating on retry is the #1 at-least-once-delivery bug the runner-side conformance suite catches.
- **Serialize once, sign once, post once.** JSON with compact separators (\`,\` / \`:\`, no spaces), byte-identical bytes feed both the \`content-digest\` input and the HTTP body. Closes the Python \`json.dumps\` default-spacing trap pinned by adcp#2478.
- **Retry with exponential backoff + jitter** on 5xx / 429. Terminal on 4xx and on 401 responses carrying \`WWW-Authenticate: Signature error="webhook_signature_*"\` — retrying a signature failure produces identical bytes and identical rejection.
- **Pluggable \`WebhookIdempotencyKeyStore\`** (default in-memory). Production publishers with multi-replica emitters swap in a durable backend the same way \`AsyncHandlerConfig.webhookDedup\` accepts one on the receiver side.
- **HMAC-SHA256 / Bearer fallback** for legacy buyers that registered \`push_notification_config.authentication.credentials\`. HMAC path uses the same compact-separators pinning.

### \`createAdcpServer\` integration

New \`webhooks?: { signerKey, retries?, idempotencyKeyStore?, … }\` config option. When set, \`ctx.emitWebhook\` is populated on every handler's context:

\`\`\`ts
createAdcpServer({
  name, version,
  webhooks: { signerKey: { keyid, alg: 'ed25519', privateKey: jwk } },
  mediaBuy: {
    createMediaBuy: async (params, ctx) => {
      const media_buy_id = await persist(params);
      await ctx.emitWebhook({
        url: params.push_notification_config.url,
        payload: { task: { task_id, status: 'completed', result: { media_buy_id } } },
        operation_id: \`create_media_buy.\${media_buy_id}\`,
      });
      return { media_buy_id, packages: [] };
    },
  },
});
\`\`\`

When \`webhooks\` is omitted \`ctx.emitWebhook\` is \`undefined\`, so handlers that don't emit don't need the option.

## Tests

- **14 unit tests** (\`test/lib/webhook-emitter.test.js\`): happy path + 9421 round-trip through our own verifier; retry on 503/429 with stable key + fresh nonce; terminal 4xx; terminal 401 with \`WWW-Authenticate: Signature\`; max-attempts cap; cross-call stability (same operation_id → same key); malformed-generator rejection; HMAC + Bearer fallback headers; observability hooks fire with correct attempt numbers.
- **3 full-stack E2E tests** (\`test/lib/webhook-emitter-server-e2e.test.js\`): \`createAdcpServer\` with a real handler → \`ctx.emitWebhook\` → real HTTP POST → receiver captures → \`verifyWebhookSignature\` accepts. No mocks on the signer or verifier path. Also covers the \`ctx.emitWebhook = undefined\` omission case and cross-emit idempotency-key stability within a single handler invocation.

All 4194 tests pass / 0 fail / 7 annotated skips.

## Exports

From \`@adcp/client/server\`:

- \`createWebhookEmitter\`, \`memoryWebhookKeyStore\`
- Types: \`WebhookEmitter\`, \`WebhookEmitterOptions\`, \`WebhookEmitParams\`, \`WebhookEmitResult\`, \`WebhookEmitAttempt\`, \`WebhookEmitAttemptResult\`, \`WebhookIdempotencyKeyStore\`, \`WebhookRetryOptions\`, \`WebhookAuthentication\`
- \`HandlerContext.emitWebhook\` — new optional field, populated when \`webhooks\` config is set.

## Follow-ups

- **Brand.json → JWKS auto-resolver.** Receiver-side helper so \`webhook_signing: { brand: 'acme.example' }\` works without callers hand-building a \`JwksResolver\`. Separate PR; the current \`StaticJwksResolver\` / \`HttpsJwksResolver\` already cover the direct-URL case.
- **Observability helpers** — today \`onAttempt\` / \`onAttemptResult\` give raw data; a thin metric emitter (retry-count, terminal-errors, latency histograms) could be a small follow-up.

## Changeset

\`.changeset/webhook-emitter.md\` — \`minor\`. Pure additive: new export surface, new optional \`HandlerContext\` field, new optional config option. Nothing breaks.