### PR TITLE
chore(types): regen against latest upstream AdCP schemas

### DIFF
--- a/.changeset/regen-types-upstream-latest.md
+++ b/.changeset/regen-types-upstream-latest.md
@@ -1,0 +1,15 @@
+---
+'@adcp/client': patch
+---
+
+Regenerate TypeScript types against latest upstream AdCP schemas.
+
+Purely additive — surfaces new optional capability fields already present in the `adcontextprotocol/adcp` protocol bundle but not yet reflected in the generated types:
+
+- `GetAdCPCapabilitiesResponse.webhook_signing` — RFC 9421 outbound-webhook signing profile (`supported`, `profile`, `algorithms`, `legacy_hmac_fallback`).
+- `GetAdCPCapabilitiesResponse.identity` — operator identity posture (`per_principal_key_isolation`, `key_origins`, `compromise_notification`).
+- `IdempotencySupported.account_id_is_opaque` — seller-side HKDF-blinded `account_id` flag.
+- `governance` capability `aggregation_window_days` — fragmentation-defense aggregation window declaration.
+- Misc downstream `targeting_overlay` and related field additions.
+
+No library behavior changes. Unblocks CI on `main` (generated-files sync check was failing against the newer upstream bundle).

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-20T04:34:16.675Z
+// Generated at: 2026-04-20T05:58:30.432Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -9563,6 +9563,7 @@ export interface PackageStatus {
    * Goal impression count for impression-based packages
    */
   impressions?: number;
+  targeting_overlay?: TargetingOverlay;
   /**
    * ISO 8601 flight start time for this package. Use to determine whether the package is within its scheduled flight before interpreting delivery status.
    */
@@ -11940,6 +11941,10 @@ export interface GetAdCPCapabilitiesResponse {
    */
   governance?: {
     /**
+     * Trailing window (in days) over which this governance agent aggregates committed spend when evaluating dollar-valued thresholds (reallocation_threshold, human_review triggers, registry-policy floors). Required for fragmentation defense: without aggregation, a buyer can split a single large spend into many sub-threshold commits across plans / task surfaces / time and bypass every dollar-gated escalation. Aggregation is keyed on (buyer_agent, seller_agent, account_id) and spans all spend-commit task types. Upper bound 365 represents a one-year trailing window (fiscal-year alignment with grace); governance agents needing longer scopes negotiate via operator sign-off, not this capability. No schema default: absence of this field indicates the governance agent has not committed to any aggregation window and buyers MUST assume per-commit evaluation only (the fragmentation attack surface is open). A declared value of 30 is a common starting point but is not implied by omission. Buyers depending on a specific window for compliance MUST check this capability before relying on aggregation semantics — an agent declaring 7 days does not defend against fragmentation spread across a 30-day quarter-end push.
+     */
+    aggregation_window_days?: number;
+    /**
      * Property features this governance agent can evaluate. Each feature describes a score, rating, or certification the agent can provide for properties.
      */
     property_features?: {
@@ -12120,6 +12125,70 @@ export interface GetAdCPCapabilitiesResponse {
     supported_for?: string[];
   };
   /**
+   * RFC 9421 webhook-signature support for outbound webhook callbacks (top-level peer of request_signing). Declares which AdCP webhook-signing profile version and algorithms this agent produces on delivery, and whether it supports the legacy HMAC-SHA256 fallback for receivers that have not yet adopted RFC 9421. See docs/building/implementation/webhooks.mdx.
+   */
+  webhook_signing?: {
+    /**
+     * Whether this agent signs outbound webhooks with the AdCP RFC 9421 webhook profile. When false or absent, webhooks are delivered with legacy Bearer or HMAC-SHA256 auth only and receivers MUST NOT expect a Signature header.
+     */
+    supported: boolean;
+    /**
+     * Identifier of the webhook-signing profile version the agent emits. Value MUST match the `tag=` parameter emitted in the RFC 9421 `Signature-Input` header (see docs/building/implementation/webhooks.mdx) so receivers can statically validate the declared profile against the on-wire tag. Closed enum; future profile revisions will extend this enum in a follow-up schema bump.
+     */
+    profile?: 'adcp/webhook-signing/v1';
+    /**
+     * Signature algorithms this agent uses on outbound webhooks. 3.0 profile permits 'ed25519' and 'ecdsa-p256-sha256' only; other values are reserved for future profile versions and MUST NOT be emitted under adcp/webhook-signing/v1.
+     */
+    algorithms?: ('ed25519' | 'ecdsa-p256-sha256')[];
+    /**
+     * Whether this agent will fall back to HMAC-SHA256 on the legacy push_notification_config.authentication path for receivers that have not adopted RFC 9421. Deprecated; removed in AdCP 4.0.
+     */
+    legacy_hmac_fallback?: boolean;
+  };
+  /**
+   * Operator identity posture — key-scoping and compromise-response controls the agent operates. Fields are independent, all advisory in 3.x; receivers use them to reason about blast radius and revocation latency at onboarding rather than discovering the posture after an incident. Semantics of an empty object: `identity: {}` means "posture block present but no posture claimed" — schema-valid but advisory-neutral; receivers MUST treat it as equivalent to omitting the block (no capability claim inferred). Operators SHOULD populate at least one field to make a declaration meaningful.
+   */
+  identity?: {
+    /**
+     * When true, this multi-principal operator scopes signing keys per-principal so a single principal's key compromise does not silently re-scope across principals served by the same operator. `kid` values remain opaque to verifiers per RFC 7517; any operator-side naming convention (e.g., `{operator}:{principal}:{key_version}`) is internal bookkeeping and MUST NOT be parsed by verifiers. See docs/building/understanding/security-model.mdx.
+     */
+    per_principal_key_isolation?: boolean;
+    /**
+     * Map of signing-key purpose → publishing origin, so counterparties can verify origin separation (e.g., governance keys served from a separate origin than transport/webhook keys) at onboarding. Absent means the operator has not declared a separation scheme; receivers SHOULD assume shared-origin. See docs/building/implementation/security.mdx §Origin separation.
+     */
+    key_origins?: {
+      /**
+       * Origin (scheme + host) serving the governance-signing JWKS.
+       */
+      governance_signing?: string;
+      /**
+       * Origin (scheme + host) serving the request-signing JWKS.
+       */
+      request_signing?: string;
+      /**
+       * Origin (scheme + host) serving the webhook-signing JWKS.
+       */
+      webhook_signing?: string;
+      /**
+       * Origin (scheme + host) serving the TMP-signing JWKS, when this operator participates in TMP.
+       */
+      tmp_signing?: string;
+    };
+    /**
+     * Whether this agent emits the `identity.compromise_notification` webhook event on key revocation due to known or suspected compromise (as opposed to scheduled rotation). Subscribers use this to bound the window between compromise detected and verifiers converging on revocation. See docs/building/implementation/webhooks.mdx §identity.compromise_notification.
+     */
+    compromise_notification?: {
+      /**
+       * Whether this agent emits `identity.compromise_notification` events.
+       */
+      emits?: boolean;
+      /**
+       * Whether this agent subscribes to `identity.compromise_notification` events from counterparties it verifies signatures from.
+       */
+      accepts?: boolean;
+    };
+  };
+  /**
    * Compliance testing capabilities. The presence of this block declares that the agent supports deterministic testing via comply_test_controller for lifecycle state machine validation. Omit the block entirely if the agent does not support compliance testing.
    */
   compliance_testing?: {
@@ -12170,6 +12239,10 @@ export interface IdempotencySupported {
    * How long the seller retains a canonical response for an idempotency_key. Within this window, a replay with the same key + equivalent canonical payload returns the cached response; a replay with a different canonical payload returns IDEMPOTENCY_CONFLICT; a replay past the window returns IDEMPOTENCY_EXPIRED when the seller can still distinguish 'seen and evicted' from 'never seen'. Minimum 3600 (1h); recommended 86400 (24h). Maximum 604800 (7 days) — longer windows force buyers to retain secret keys at rest for extended periods and grow the seller's cache table without bounded benefit.
    */
   replay_ttl_seconds: number;
+  /**
+   * When true, the seller derives `account_id` via an HKDF-based one-way transform of the buyer's natural account key rather than echoing the natural key on the wire. Buyers MUST NOT attempt to invert the opaque id and MUST treat it as a blind handle scoped to this seller. Absent or false, callers should assume `account_id` is the natural key (or a server-assigned but non-opaque id). This flag does not change the wire shape, but it DOES change buyer behavior — buyers MUST NOT cache, log, or treat `account_id` as a natural-key analog when this flag is true. Migration note for sellers already returning an opaque id without this flag: set it to true at the next capabilities refresh so buyers stop inferring natural-key semantics; until set, new-buyer replay/retry logic will misclassify these ids as natural keys.
+   */
+  account_id_is_opaque?: boolean;
 }
 /**
  * Seller does NOT honor idempotency_key replay protection — sending a key is a no-op, the seller will NOT return IDEMPOTENCY_CONFLICT or IDEMPOTENCY_EXPIRED, and a naive retry WILL double-process. Buyers MUST use natural-key checks (e.g., get_media_buys by buyer_ref) before retrying spend-committing operations against this seller. replay_ttl_seconds MUST be absent — it has no meaning without replay support.
@@ -16068,7 +16141,10 @@ export type ErrorCode =
   | 'IO_REQUIRED'
   | 'TERMS_REJECTED'
   | 'REQUOTE_REQUIRED'
-  | 'VERSION_UNSUPPORTED';
+  | 'VERSION_UNSUPPORTED'
+  | 'CAMPAIGN_SUSPENDED'
+  | 'GOVERNANCE_UNAVAILABLE'
+  | 'PERMISSION_DENIED';
 
 
 // enums/escalation-severity.json

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-20T05:08:17.213Z
+// Generated at: 2026-04-20T05:58:35.730Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2171,6 +2171,7 @@ export const PackageStatusSchema = z.object({
     currency: z.string().optional(),
     bid_price: z.number().optional(),
     impressions: z.number().optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
     start_time: z.string().optional(),
     end_time: z.string().optional(),
     paused: z.boolean().optional(),
@@ -2557,7 +2558,8 @@ export const AdCPSpecialismSchema = z.union([z.literal("audience-sync"), z.liter
 
 export const IdempotencySupportedSchema = z.object({
     supported: z.literal(true),
-    replay_ttl_seconds: z.number()
+    replay_ttl_seconds: z.number(),
+    account_id_is_opaque: z.boolean().optional()
 }).passthrough();
 
 export const IdempotencyUnsupportedSchema = z.object({
@@ -3511,7 +3513,7 @@ export const CreativeAgentCapabilitySchema = z.union([z.literal("validation"), z
 
 export const DelegationAuthoritySchema = z.union([z.literal("full"), z.literal("execute_only"), z.literal("propose_only")]);
 
-export const ErrorCodeSchema = z.union([z.literal("INVALID_REQUEST"), z.literal("AUTH_REQUIRED"), z.literal("RATE_LIMITED"), z.literal("SERVICE_UNAVAILABLE"), z.literal("POLICY_VIOLATION"), z.literal("PRODUCT_NOT_FOUND"), z.literal("PRODUCT_UNAVAILABLE"), z.literal("PROPOSAL_EXPIRED"), z.literal("BUDGET_TOO_LOW"), z.literal("CREATIVE_REJECTED"), z.literal("UNSUPPORTED_FEATURE"), z.literal("AUDIENCE_TOO_SMALL"), z.literal("ACCOUNT_NOT_FOUND"), z.literal("ACCOUNT_SETUP_REQUIRED"), z.literal("ACCOUNT_AMBIGUOUS"), z.literal("ACCOUNT_PAYMENT_REQUIRED"), z.literal("ACCOUNT_SUSPENDED"), z.literal("COMPLIANCE_UNSATISFIED"), z.literal("GOVERNANCE_DENIED"), z.literal("BUDGET_EXHAUSTED"), z.literal("BUDGET_EXCEEDED"), z.literal("CONFLICT"), z.literal("IDEMPOTENCY_CONFLICT"), z.literal("IDEMPOTENCY_EXPIRED"), z.literal("CREATIVE_DEADLINE_EXCEEDED"), z.literal("INVALID_STATE"), z.literal("MEDIA_BUY_NOT_FOUND"), z.literal("NOT_CANCELLABLE"), z.literal("PACKAGE_NOT_FOUND"), z.literal("CREATIVE_NOT_FOUND"), z.literal("SIGNAL_NOT_FOUND"), z.literal("SESSION_NOT_FOUND"), z.literal("SESSION_TERMINATED"), z.literal("VALIDATION_ERROR"), z.literal("PRODUCT_EXPIRED"), z.literal("PROPOSAL_NOT_COMMITTED"), z.literal("IO_REQUIRED"), z.literal("TERMS_REJECTED"), z.literal("REQUOTE_REQUIRED"), z.literal("VERSION_UNSUPPORTED")]);
+export const ErrorCodeSchema = z.union([z.literal("INVALID_REQUEST"), z.literal("AUTH_REQUIRED"), z.literal("RATE_LIMITED"), z.literal("SERVICE_UNAVAILABLE"), z.literal("POLICY_VIOLATION"), z.literal("PRODUCT_NOT_FOUND"), z.literal("PRODUCT_UNAVAILABLE"), z.literal("PROPOSAL_EXPIRED"), z.literal("BUDGET_TOO_LOW"), z.literal("CREATIVE_REJECTED"), z.literal("UNSUPPORTED_FEATURE"), z.literal("AUDIENCE_TOO_SMALL"), z.literal("ACCOUNT_NOT_FOUND"), z.literal("ACCOUNT_SETUP_REQUIRED"), z.literal("ACCOUNT_AMBIGUOUS"), z.literal("ACCOUNT_PAYMENT_REQUIRED"), z.literal("ACCOUNT_SUSPENDED"), z.literal("COMPLIANCE_UNSATISFIED"), z.literal("GOVERNANCE_DENIED"), z.literal("BUDGET_EXHAUSTED"), z.literal("BUDGET_EXCEEDED"), z.literal("CONFLICT"), z.literal("IDEMPOTENCY_CONFLICT"), z.literal("IDEMPOTENCY_EXPIRED"), z.literal("CREATIVE_DEADLINE_EXCEEDED"), z.literal("INVALID_STATE"), z.literal("MEDIA_BUY_NOT_FOUND"), z.literal("NOT_CANCELLABLE"), z.literal("PACKAGE_NOT_FOUND"), z.literal("CREATIVE_NOT_FOUND"), z.literal("SIGNAL_NOT_FOUND"), z.literal("SESSION_NOT_FOUND"), z.literal("SESSION_TERMINATED"), z.literal("VALIDATION_ERROR"), z.literal("PRODUCT_EXPIRED"), z.literal("PROPOSAL_NOT_COMMITTED"), z.literal("IO_REQUIRED"), z.literal("TERMS_REJECTED"), z.literal("REQUOTE_REQUIRED"), z.literal("VERSION_UNSUPPORTED"), z.literal("CAMPAIGN_SUSPENDED"), z.literal("GOVERNANCE_UNAVAILABLE"), z.literal("PERMISSION_DENIED")]);
 
 export const EscalationSeveritySchema = z.union([z.literal("info"), z.literal("warning"), z.literal("critical")]);
 
@@ -5169,6 +5171,7 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
         }).passthrough()).optional()
     }).passthrough().optional(),
     governance: z.object({
+        aggregation_window_days: z.number().optional(),
         property_features: z.array(z.object({
             feature_id: z.string(),
             type: z.union([z.literal("binary"), z.literal("quantitative"), z.literal("categorical")]),
@@ -5222,6 +5225,25 @@ export const GetAdCPCapabilitiesResponseSchema = z.object({
         required_for: z.array(z.string()).optional(),
         warn_for: z.array(z.string()).optional(),
         supported_for: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    webhook_signing: z.object({
+        supported: z.boolean(),
+        profile: z.literal("adcp/webhook-signing/v1").optional(),
+        algorithms: z.array(z.union([z.literal("ed25519"), z.literal("ecdsa-p256-sha256")])).optional(),
+        legacy_hmac_fallback: z.boolean().optional()
+    }).passthrough().optional(),
+    identity: z.object({
+        per_principal_key_isolation: z.boolean().optional(),
+        key_origins: z.object({
+            governance_signing: z.string().optional(),
+            request_signing: z.string().optional(),
+            webhook_signing: z.string().optional(),
+            tmp_signing: z.string().optional()
+        }).passthrough().optional(),
+        compromise_notification: z.object({
+            emits: z.boolean().optional(),
+            accepts: z.boolean().optional()
+        }).passthrough().optional()
     }).passthrough().optional(),
     compliance_testing: z.object({
         scenarios: z.array(z.union([z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend")]))

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -5724,6 +5724,7 @@ export interface PackageStatus {
    * Goal impression count for impression-based packages
    */
   impressions?: number;
+  targeting_overlay?: TargetingOverlay;
   /**
    * ISO 8601 flight start time for this package. Use to determine whether the package is within its scheduled flight before interpreting delivery status.
    */
@@ -13039,6 +13040,10 @@ export interface GetAdCPCapabilitiesResponse {
    */
   governance?: {
     /**
+     * Trailing window (in days) over which this governance agent aggregates committed spend when evaluating dollar-valued thresholds (reallocation_threshold, human_review triggers, registry-policy floors). Required for fragmentation defense: without aggregation, a buyer can split a single large spend into many sub-threshold commits across plans / task surfaces / time and bypass every dollar-gated escalation. Aggregation is keyed on (buyer_agent, seller_agent, account_id) and spans all spend-commit task types. Upper bound 365 represents a one-year trailing window (fiscal-year alignment with grace); governance agents needing longer scopes negotiate via operator sign-off, not this capability. No schema default: absence of this field indicates the governance agent has not committed to any aggregation window and buyers MUST assume per-commit evaluation only (the fragmentation attack surface is open). A declared value of 30 is a common starting point but is not implied by omission. Buyers depending on a specific window for compliance MUST check this capability before relying on aggregation semantics — an agent declaring 7 days does not defend against fragmentation spread across a 30-day quarter-end push.
+     */
+    aggregation_window_days?: number;
+    /**
      * Property features this governance agent can evaluate. Each feature describes a score, rating, or certification the agent can provide for properties.
      */
     property_features?: {
@@ -13219,6 +13224,70 @@ export interface GetAdCPCapabilitiesResponse {
     supported_for?: string[];
   };
   /**
+   * RFC 9421 webhook-signature support for outbound webhook callbacks (top-level peer of request_signing). Declares which AdCP webhook-signing profile version and algorithms this agent produces on delivery, and whether it supports the legacy HMAC-SHA256 fallback for receivers that have not yet adopted RFC 9421. See docs/building/implementation/webhooks.mdx.
+   */
+  webhook_signing?: {
+    /**
+     * Whether this agent signs outbound webhooks with the AdCP RFC 9421 webhook profile. When false or absent, webhooks are delivered with legacy Bearer or HMAC-SHA256 auth only and receivers MUST NOT expect a Signature header.
+     */
+    supported: boolean;
+    /**
+     * Identifier of the webhook-signing profile version the agent emits. Value MUST match the `tag=` parameter emitted in the RFC 9421 `Signature-Input` header (see docs/building/implementation/webhooks.mdx) so receivers can statically validate the declared profile against the on-wire tag. Closed enum; future profile revisions will extend this enum in a follow-up schema bump.
+     */
+    profile?: 'adcp/webhook-signing/v1';
+    /**
+     * Signature algorithms this agent uses on outbound webhooks. 3.0 profile permits 'ed25519' and 'ecdsa-p256-sha256' only; other values are reserved for future profile versions and MUST NOT be emitted under adcp/webhook-signing/v1.
+     */
+    algorithms?: ('ed25519' | 'ecdsa-p256-sha256')[];
+    /**
+     * Whether this agent will fall back to HMAC-SHA256 on the legacy push_notification_config.authentication path for receivers that have not adopted RFC 9421. Deprecated; removed in AdCP 4.0.
+     */
+    legacy_hmac_fallback?: boolean;
+  };
+  /**
+   * Operator identity posture — key-scoping and compromise-response controls the agent operates. Fields are independent, all advisory in 3.x; receivers use them to reason about blast radius and revocation latency at onboarding rather than discovering the posture after an incident. Semantics of an empty object: `identity: {}` means "posture block present but no posture claimed" — schema-valid but advisory-neutral; receivers MUST treat it as equivalent to omitting the block (no capability claim inferred). Operators SHOULD populate at least one field to make a declaration meaningful.
+   */
+  identity?: {
+    /**
+     * When true, this multi-principal operator scopes signing keys per-principal so a single principal's key compromise does not silently re-scope across principals served by the same operator. `kid` values remain opaque to verifiers per RFC 7517; any operator-side naming convention (e.g., `{operator}:{principal}:{key_version}`) is internal bookkeeping and MUST NOT be parsed by verifiers. See docs/building/understanding/security-model.mdx.
+     */
+    per_principal_key_isolation?: boolean;
+    /**
+     * Map of signing-key purpose → publishing origin, so counterparties can verify origin separation (e.g., governance keys served from a separate origin than transport/webhook keys) at onboarding. Absent means the operator has not declared a separation scheme; receivers SHOULD assume shared-origin. See docs/building/implementation/security.mdx §Origin separation.
+     */
+    key_origins?: {
+      /**
+       * Origin (scheme + host) serving the governance-signing JWKS.
+       */
+      governance_signing?: string;
+      /**
+       * Origin (scheme + host) serving the request-signing JWKS.
+       */
+      request_signing?: string;
+      /**
+       * Origin (scheme + host) serving the webhook-signing JWKS.
+       */
+      webhook_signing?: string;
+      /**
+       * Origin (scheme + host) serving the TMP-signing JWKS, when this operator participates in TMP.
+       */
+      tmp_signing?: string;
+    };
+    /**
+     * Whether this agent emits the `identity.compromise_notification` webhook event on key revocation due to known or suspected compromise (as opposed to scheduled rotation). Subscribers use this to bound the window between compromise detected and verifiers converging on revocation. See docs/building/implementation/webhooks.mdx §identity.compromise_notification.
+     */
+    compromise_notification?: {
+      /**
+       * Whether this agent emits `identity.compromise_notification` events.
+       */
+      emits?: boolean;
+      /**
+       * Whether this agent subscribes to `identity.compromise_notification` events from counterparties it verifies signatures from.
+       */
+      accepts?: boolean;
+    };
+  };
+  /**
    * Compliance testing capabilities. The presence of this block declares that the agent supports deterministic testing via comply_test_controller for lifecycle state machine validation. Omit the block entirely if the agent does not support compliance testing.
    */
   compliance_testing?: {
@@ -13269,6 +13338,10 @@ export interface IdempotencySupported {
    * How long the seller retains a canonical response for an idempotency_key. Within this window, a replay with the same key + equivalent canonical payload returns the cached response; a replay with a different canonical payload returns IDEMPOTENCY_CONFLICT; a replay past the window returns IDEMPOTENCY_EXPIRED when the seller can still distinguish 'seen and evicted' from 'never seen'. Minimum 3600 (1h); recommended 86400 (24h). Maximum 604800 (7 days) — longer windows force buyers to retain secret keys at rest for extended periods and grow the seller's cache table without bounded benefit.
    */
   replay_ttl_seconds: number;
+  /**
+   * When true, the seller derives `account_id` via an HKDF-based one-way transform of the buyer's natural account key rather than echoing the natural key on the wire. Buyers MUST NOT attempt to invert the opaque id and MUST treat it as a blind handle scoped to this seller. Absent or false, callers should assume `account_id` is the natural key (or a server-assigned but non-opaque id). This flag does not change the wire shape, but it DOES change buyer behavior — buyers MUST NOT cache, log, or treat `account_id` as a natural-key analog when this flag is true. Migration note for sellers already returning an opaque id without this flag: set it to true at the next capabilities refresh so buyers stop inferring natural-key semantics; until set, new-buyer replay/retry logic will misclassify these ids as natural keys.
+   */
+  account_id_is_opaque?: boolean;
 }
 /**
  * Seller does NOT honor idempotency_key replay protection — sending a key is a no-op, the seller will NOT return IDEMPOTENCY_CONFLICT or IDEMPOTENCY_EXPIRED, and a naive retry WILL double-process. Buyers MUST use natural-key checks (e.g., get_media_buys by buyer_ref) before retrying spend-committing operations against this seller. replay_ttl_seconds MUST be absent — it has no meaning without replay support.


### PR DESCRIPTION
## Summary

- Regenerates `src/lib/types/{core,tools,schemas}.generated.ts` against the latest upstream AdCP protocol bundle.
- Purely additive — new optional capability fields (`webhook_signing`, `identity`, `account_id_is_opaque`, `aggregation_window_days`, `targeting_overlay`) are already present in the upstream bundle but weren't reflected in the committed generated types.
- Unblocks CI on `main` — the "Validate generated files are in sync" step has been failing since the upstream bundle advanced (e.g., run 24650174615 on #633's merge commit). All open PRs are inheriting that failure.
- Includes a patch changeset. No library behavior change.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [ ] Full CI (`Test & Build`, `Code Quality`, `Security Audit`, `commitlint`, changeset check) — will run on this PR
- [ ] Verify the "Validate generated files are in sync" step now passes

## Follow-up

- Once this merges, rebase #502 (the build-seller-agent Common Mistakes docs PR) to pick up the regen and clear its CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)