### PR TITLE
fix(cli): parse --file for storyboard run

### DIFF
--- a/.changeset/storyboard-run-file-flag.md
+++ b/.changeset/storyboard-run-file-flag.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': patch
+---
+
+Fix `adcp storyboard run <agent> --file <path.yaml>` erroring out with "Cannot combine a storyboard ID with --file". The CLI parser was not stripping `--file` and its value from the positional-argument list, so the file path collided with the storyboard-ID slot (adcp-client#637). `--file=<path>` (equals form) is now parsed too.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -995,7 +995,7 @@ async function handleStoryboardShow(args) {
 
 async function handleStoryboardRun(args) {
   const opts = parseAgentOptions(args);
-  const { authToken, protocolFlag, jsonOutput, debug, dryRun, positionalArgs, file: filePath } = opts;
+  const { authToken, protocolFlag, jsonOutput, dryRun, positionalArgs, file: filePath } = opts;
 
   // Multi-instance mode: repeated --url flags round-robin steps across N
   // seller URLs. Must share a backing store to pass — catches horizontal

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -599,12 +599,24 @@ function parseAgentOptions(args) {
     timeoutValue = args[timeoutIndex + 1];
   }
 
+  // --file PATH | --file=PATH: ad-hoc storyboard YAML (spec evolution workflow)
+  const fileIndex = args.indexOf('--file');
+  let file = null;
+  if (fileIndex !== -1 && fileIndex + 1 < args.length && !args[fileIndex + 1].startsWith('--')) {
+    file = args[fileIndex + 1];
+  } else {
+    const eqArg = args.find(a => a.startsWith('--file='));
+    if (eqArg) file = eqArg.slice('--file='.length);
+  }
+
   const jsonOutput = args.includes('--json');
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const dryRun = args.includes('--dry-run');
   const allowHttp = args.includes('--allow-http');
 
-  // Filter out flags and their values to find positional args
+  // Filter out flags and their values to find positional args. The `--file=PATH`
+  // form is already removed by the `startsWith('--')` check; only the
+  // space-separated value needs explicit exclusion.
   const flagValues = [
     authToken,
     protocolFlag,
@@ -615,10 +627,11 @@ function parseAgentOptions(args) {
     storyboardsValue,
     platformTypeValue,
     timeoutValue,
+    fileIndex !== -1 ? file : null,
   ].filter(Boolean);
   const positionalArgs = args.filter(arg => !arg.startsWith('--') && !flagValues.includes(arg));
 
-  return { authToken, protocolFlag, brief, jsonOutput, debug, dryRun, allowHttp, positionalArgs };
+  return { authToken, protocolFlag, brief, file, jsonOutput, debug, dryRun, allowHttp, positionalArgs };
 }
 
 /**
@@ -982,7 +995,7 @@ async function handleStoryboardShow(args) {
 
 async function handleStoryboardRun(args) {
   const opts = parseAgentOptions(args);
-  const { authToken, protocolFlag, jsonOutput, debug, dryRun, positionalArgs } = opts;
+  const { authToken, protocolFlag, jsonOutput, debug, dryRun, positionalArgs, file: filePath } = opts;
 
   // Multi-instance mode: repeated --url flags round-robin steps across N
   // seller URLs. Must share a backing store to pass — catches horizontal
@@ -994,10 +1007,6 @@ async function handleStoryboardRun(args) {
 
   const agentArg = positionalArgs[0];
   const storyboardId = positionalArgs[1];
-
-  // --file <path>: ad-hoc storyboard load from a local YAML (spec evolution workflow)
-  const fileIndex = args.indexOf('--file');
-  const filePath = fileIndex !== -1 ? args[fileIndex + 1] : null;
 
   if (!agentArg) {
     console.error('Usage: adcp storyboard run <agent> [storyboard_id|--file path] [options]');
@@ -1193,7 +1202,7 @@ function extractRepeatedUrlFlags(args) {
  * dispatch. Use a specific storyboard or bundle ID.
  */
 async function handleMultiInstanceStoryboardRun(args, opts, urls) {
-  const { authToken, protocolFlag, jsonOutput, dryRun, positionalArgs } = opts;
+  const { authToken, protocolFlag, jsonOutput, dryRun, positionalArgs, file: filePath } = opts;
 
   if (urls.length < 2) {
     console.error('ERROR: Multi-instance mode requires 2+ --url flags. Drop --url for single-instance.');
@@ -1212,8 +1221,6 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     process.exit(2);
   }
 
-  const fileIndex = args.indexOf('--file');
-  const filePath = fileIndex !== -1 ? args[fileIndex + 1] : null;
   const storyboardId = firstPositional;
 
   if (filePath && storyboardId) {

--- a/test/lib/cli-storyboard-file-flag.test.js
+++ b/test/lib/cli-storyboard-file-flag.test.js
@@ -1,0 +1,70 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { writeFileSync, unlinkSync, mkdtempSync } = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+
+let tmpDir;
+let scenarioPath;
+
+before(() => {
+  tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-'));
+  scenarioPath = path.join(tmpDir, 'scenario.yaml');
+  writeFileSync(
+    scenarioPath,
+    [
+      'id: cli-file-flag-test',
+      'title: CLI file-flag test',
+      'protocol: media-buy',
+      'phases:',
+      '  - id: phase-1',
+      '    title: Ping',
+      '    steps:',
+      '      - id: step-1',
+      '        title: Ping',
+      '        task: get_adcp_capabilities',
+      '        request: {}',
+      '',
+    ].join('\n')
+  );
+});
+
+after(() => {
+  try {
+    unlinkSync(scenarioPath);
+  } catch {
+    /* ignore */
+  }
+});
+
+function runCli(args) {
+  return spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
+}
+
+test('--file <path> (space form) loads the YAML', () => {
+  const result = runCli(['storyboard', 'run', 'test-mcp', '--file', scenarioPath, '--dry-run']);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.match(result.stderr, /Running storyboard: CLI file-flag test/);
+  assert.doesNotMatch(result.stderr, /Cannot combine a storyboard ID with --file/);
+});
+
+test('--file=<path> (equals form) loads the YAML', () => {
+  const result = runCli(['storyboard', 'run', 'test-mcp', `--file=${scenarioPath}`, '--dry-run']);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.match(result.stderr, /Running storyboard: CLI file-flag test/);
+});
+
+test('--file before positional agent loads the YAML', () => {
+  const result = runCli(['storyboard', 'run', '--file', scenarioPath, 'test-mcp', '--dry-run']);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.match(result.stderr, /Running storyboard: CLI file-flag test/);
+});
+
+test('--file combined with a storyboard ID is rejected', () => {
+  const result = runCli(['storyboard', 'run', 'test-mcp', 'some-id', '--file', scenarioPath, '--dry-run']);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /Cannot combine a storyboard ID with --file/);
+});


### PR DESCRIPTION
## Summary
- Fixes #637 — `adcp storyboard run <agent> --file <path.yaml>` was erroring with "Cannot combine a storyboard ID with --file" because the parser didn't strip `--file` and its value from the positional-argument list.
- Extraction now lives in `parseAgentOptions` alongside the other flag blocks; the value is added to `flagValues` so it no longer slots into `positionalArgs[1]`.
- Both `--file PATH` and `--file=PATH` forms are accepted; the equals form previously fell through to capability-driven assessment silently.

## Test plan
- [x] `test/lib/cli-storyboard-file-flag.test.js` — spawns the CLI with all four cases (space form, equals form, flag-before-positional, storyboard-ID+--file conflict) and runs with `--dry-run`.
- [x] `npm test` — full suite passes (4264 pass, 12 skipped, 0 fail).
- [x] Manual: `node bin/adcp.js storyboard run test-mcp --file ./scenario.yaml --dry-run` loads the YAML and prints the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)