### PR TITLE
feat(cli): --brand / --brand-manifest for storyboard run

### DIFF
--- a/.changeset/storyboard-run-brand-flag.md
+++ b/.changeset/storyboard-run-brand-flag.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': minor
+---
+
+Expose `--brand DOMAIN|JSON` and `--brand-manifest JSON|@file.json` on `adcp storyboard run` (single-instance, multi-instance, and full capability-driven assessment). The runner's `applyBrandInvariant` was previously a no-op for CLI-driven runs because `options.brand` was never threaded — any storyboard step that omitted `brand` on its sample_request could slip into the seller's `open:default` session instead of the tenant under test. `--brand` and `--brand-manifest` are mutually exclusive. Also threads `--allow-http` in single-instance storyboard run for parity with multi-instance and full assessment. (adcp-client#639)

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -609,6 +609,34 @@ function parseAgentOptions(args) {
     if (eqArg) file = eqArg.slice('--file='.length);
   }
 
+  // --brand DOMAIN|JSON and --brand-manifest JSON|@file.json — threaded into
+  // TestOptions.brand / .brand_manifest so the runner's applyBrandInvariant
+  // fires for CLI-driven runs (otherwise storyboards that omit brand on a
+  // sub-step land in the seller's `open:default` session instead of the
+  // tenant under test). Mutually exclusive.
+  const brandIndex = args.indexOf('--brand');
+  let brandRawValue = null;
+  if (brandIndex !== -1 && brandIndex + 1 < args.length && !args[brandIndex + 1].startsWith('--')) {
+    brandRawValue = args[brandIndex + 1];
+  }
+  const brand = brandRawValue != null ? parseBrandFlag(brandRawValue) : null;
+
+  const brandManifestIndex = args.indexOf('--brand-manifest');
+  let brandManifestRaw = null;
+  if (
+    brandManifestIndex !== -1 &&
+    brandManifestIndex + 1 < args.length &&
+    !args[brandManifestIndex + 1].startsWith('--')
+  ) {
+    brandManifestRaw = args[brandManifestIndex + 1];
+  }
+  const brandManifest = brandManifestRaw != null ? parseJsonFlag('--brand-manifest', brandManifestRaw) : null;
+
+  if (brand && brandManifest) {
+    console.error('ERROR: --brand and --brand-manifest are mutually exclusive. Use one or the other.');
+    process.exit(2);
+  }
+
   const jsonOutput = args.includes('--json');
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const dryRun = args.includes('--dry-run');
@@ -628,10 +656,42 @@ function parseAgentOptions(args) {
     platformTypeValue,
     timeoutValue,
     fileIndex !== -1 ? file : null,
+    brandRawValue,
+    brandManifestRaw,
   ].filter(Boolean);
   const positionalArgs = args.filter(arg => !arg.startsWith('--') && !flagValues.includes(arg));
 
-  return { authToken, protocolFlag, brief, file, jsonOutput, debug, dryRun, allowHttp, positionalArgs };
+  return {
+    authToken,
+    protocolFlag,
+    brief,
+    file,
+    brand,
+    brandManifest,
+    jsonOutput,
+    debug,
+    dryRun,
+    allowHttp,
+    positionalArgs,
+  };
+}
+
+/**
+ * Parse `--brand` — accepts a bare `domain` (most common) or a JSON object
+ * matching `BrandReference` (`{"domain":"...","brand_id":"..."}`), or
+ * `@file.json` for a JSON file. Returns a `BrandReference` shape.
+ */
+function parseBrandFlag(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('@')) {
+    const parsed = parseJsonFlag('--brand', trimmed);
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.domain !== 'string') {
+      console.error('ERROR: --brand JSON must be a BrandReference object with a string `domain` field.');
+      process.exit(2);
+    }
+    return parsed;
+  }
+  return { domain: trimmed };
 }
 
 /**
@@ -797,6 +857,15 @@ RUN OPTIONS (full assessment):
   --timeout SECONDS   Timeout in seconds (default: 120)
   --brief TEXT        Custom brief for product discovery
 
+BRAND OPTIONS (storyboard run):
+  --brand DOMAIN|JSON      Force every step onto this brand for per-tenant session
+                           isolation (matches sellers that scope state by brand.domain;
+                           same behavior as setting options.brand programmatically).
+                           Accepts a bare domain, a BrandReference JSON object, or
+                           @file.json. Mutually exclusive with --brand-manifest.
+  --brand-manifest JSON    Brand manifest object (or @file.json). Mutually exclusive
+                           with --brand.
+
 OPTIONS:
   --context JSON      Pass context from previous step (step only)
   --request JSON      Override sample_request for the step (step only)
@@ -814,6 +883,7 @@ EXAMPLES:
   adcp storyboard run test-mcp --tracks core,products  # filter report by track
   adcp storyboard run test-mcp sales-guaranteed        # run one specialism bundle
   adcp storyboard run test-mcp --file ./my-wip.yaml    # test a local YAML
+  adcp storyboard run test-mcp sales-guaranteed --brand acme.example   # brand-scoped run
   adcp storyboard list
   adcp storyboard show media_buy_seller
   adcp storyboard step test-mcp media_buy_seller sync_accounts --json
@@ -1085,6 +1155,9 @@ async function handleStoryboardRun(args) {
   const options = {
     protocol,
     ...(resolvedAuth ? { auth: { type: 'bearer', token: resolvedAuth } } : {}),
+    ...(opts.allowHttp && { allow_http: true }),
+    ...(opts.brand && { brand: opts.brand }),
+    ...(opts.brandManifest && { brand_manifest: opts.brandManifest }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -1343,6 +1416,8 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     protocol,
     ...(authToken ? { auth: { type: 'bearer', token: authToken } } : {}),
     ...(opts.allowHttp && { allow_http: true }),
+    ...(opts.brand && { brand: opts.brand }),
+    ...(opts.brandManifest && { brand_manifest: opts.brandManifest }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -1493,6 +1568,8 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     agent_alias: agentArg !== agentUrl ? agentArg : undefined,
     ...(authOption && { auth: authOption }),
     ...(opts.allowHttp && { allow_http: true }),
+    ...(opts.brand && { brand: opts.brand }),
+    ...(opts.brandManifest && { brand_manifest: opts.brandManifest }),
   };
 
   if (!opts.jsonOutput) {
@@ -3107,7 +3184,12 @@ process.on('beforeExit', async () => {
   }
 });
 
-main().catch(error => {
-  console.error('FATAL ERROR:', error.message);
-  process.exit(1);
-});
+// Run as a CLI when invoked directly; expose internals for unit tests when required.
+if (require.main === module) {
+  main().catch(error => {
+    console.error('FATAL ERROR:', error.message);
+    process.exit(1);
+  });
+} else {
+  module.exports = { parseAgentOptions, parseBrandFlag, parseJsonFlag };
+}

--- a/test/lib/cli-storyboard-brand-flag.test.js
+++ b/test/lib/cli-storyboard-brand-flag.test.js
@@ -1,0 +1,112 @@
+/**
+ * CLI: `adcp storyboard run --brand` / `--brand-manifest` passthrough (#639).
+ *
+ * The runner's `applyBrandInvariant` is a no-op unless `options.brand` (or
+ * `options.brand_manifest`) is set. Before this fix the CLI never populated
+ * either, so any CLI-driven storyboard run lost the brand-scoped session
+ * guarantee that PR #586 introduced.
+ *
+ * These tests verify the parse layer directly (fast, hermetic) and a small
+ * end-to-end surface for the mutual-exclusion error.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+const { parseAgentOptions, parseBrandFlag } = require(CLI);
+
+describe('parseBrandFlag', () => {
+  test('treats a bare domain as BrandReference.domain', () => {
+    assert.deepStrictEqual(parseBrandFlag('acmeoutdoor.example'), { domain: 'acmeoutdoor.example' });
+  });
+
+  test('parses inline JSON as a full BrandReference', () => {
+    assert.deepStrictEqual(parseBrandFlag('{"domain":"acme.example","brand_id":"b-1"}'), {
+      domain: 'acme.example',
+      brand_id: 'b-1',
+    });
+  });
+
+  test('trims surrounding whitespace on the domain form', () => {
+    assert.deepStrictEqual(parseBrandFlag('  acme.example  '), { domain: 'acme.example' });
+  });
+});
+
+describe('parseAgentOptions: --brand and --brand-manifest', () => {
+  test('--brand <domain> populates options.brand as a BrandReference', () => {
+    const opts = parseAgentOptions(['agent', 'some-id', '--brand', 'acmeoutdoor.example']);
+    assert.deepStrictEqual(opts.brand, { domain: 'acmeoutdoor.example' });
+    assert.strictEqual(opts.brandManifest, null);
+    assert.deepStrictEqual(opts.positionalArgs, ['agent', 'some-id']);
+  });
+
+  test('--brand JSON populates options.brand with extra fields', () => {
+    const opts = parseAgentOptions(['agent', '--brand', '{"domain":"acme.example","brand_id":"b-1"}']);
+    assert.deepStrictEqual(opts.brand, { domain: 'acme.example', brand_id: 'b-1' });
+  });
+
+  test('--brand-manifest JSON populates options.brandManifest', () => {
+    const opts = parseAgentOptions([
+      'agent',
+      '--brand-manifest',
+      '{"name":"Acme","url":"https://acmeoutdoor.example"}',
+    ]);
+    assert.deepStrictEqual(opts.brandManifest, { name: 'Acme', url: 'https://acmeoutdoor.example' });
+    assert.strictEqual(opts.brand, null);
+  });
+
+  test('strips the --brand value from positional args (does not collide with storyboard ID)', () => {
+    const opts = parseAgentOptions(['agent', 'media_buy_seller', '--brand', 'acmeoutdoor.example']);
+    assert.deepStrictEqual(opts.positionalArgs, ['agent', 'media_buy_seller']);
+  });
+
+  test('--brand before the positional storyboard ID also works', () => {
+    const opts = parseAgentOptions(['agent', '--brand', 'acmeoutdoor.example', 'media_buy_seller']);
+    assert.deepStrictEqual(opts.positionalArgs, ['agent', 'media_buy_seller']);
+  });
+
+  test('returns null brand / null brandManifest when neither flag is passed', () => {
+    const opts = parseAgentOptions(['agent', 'some-id']);
+    assert.strictEqual(opts.brand, null);
+    assert.strictEqual(opts.brandManifest, null);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// CLI surface: mutual-exclusion error path
+// ────────────────────────────────────────────────────────────
+
+describe('adcp storyboard run --brand conflicts', () => {
+  test('rejects --brand combined with --brand-manifest', () => {
+    const result = spawnSync(
+      'node',
+      [
+        CLI,
+        'storyboard',
+        'run',
+        'test-mcp',
+        'media_buy_seller',
+        '--brand',
+        'acme.example',
+        '--brand-manifest',
+        '{"name":"Acme","url":"https://acme.example"}',
+      ],
+      { encoding: 'utf8' }
+    );
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /--brand and --brand-manifest are mutually exclusive/);
+  });
+
+  test('rejects --brand JSON that lacks a string `domain`', () => {
+    const result = spawnSync(
+      'node',
+      [CLI, 'storyboard', 'run', 'test-mcp', 'media_buy_seller', '--brand', '{"brand_id":"x"}'],
+      { encoding: 'utf8' }
+    );
+    assert.strictEqual(result.status, 2);
+    assert.match(result.stderr, /BrandReference object with a string `domain`/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #639 — `applyBrandInvariant` (PR #586) was a no-op for CLI-driven storyboard runs because `options.brand` / `options.brand_manifest` was never threaded. Any step that omitted `brand` on its `sample_request` would fall into the seller's `open:default` session instead of the tenant under test — exactly the cross-session bug adcontextprotocol/adcp#2526 just fixed.
- Accepts `--brand DOMAIN|JSON` (bare domain, inline `BrandReference` JSON, or `@file.json`) and `--brand-manifest JSON|@file.json`. Mutually exclusive.
- Threaded into `TestOptions.brand` / `TestOptions.brand_manifest` on all three paths: single-instance `storyboard run`, multi-instance `storyboard run`, and capability-driven full assessment.
- Also threads `--allow-http` in single-instance storyboard run for parity with the other two paths (closes a gap I noticed while writing the test).

## Implementation notes
- `bin/adcp.js` now exports `parseAgentOptions` / `parseBrandFlag` when `require()`d (guarded by `require.main === module`) so unit tests exercise the parser directly instead of spawning the CLI against a fake MCP server. No new files — same binary.
- Stacked on #640 (`bokelley/issue-637`) because the issue explicitly noted the `--file` parsing bug needs to land alongside the `--brand` work. PR is based on that branch; will retarget to `main` once #640 merges.

## Test plan
- [x] `test/lib/cli-storyboard-brand-flag.test.js` — 11 tests covering `parseBrandFlag` forms, `parseAgentOptions` threading, positional-arg non-collision, mutual-exclusion error path, invalid-JSON rejection.
- [x] `npm test` — full suite passes (4275 pass, 12 skipped, 0 fail).
- [x] Manual: `adcp storyboard run test-mcp --file scenario.yaml --brand acme.example --dry-run` loads YAML and runs; `--brand + --brand-manifest` emits the mutual-exclusion error; `--brand '{"brand_id":"x"}'` rejects JSON missing `domain`.

## Acceptance criteria (from the issue)
- [x] `adcp storyboard run <agent> --brand acmeoutdoor.example <id>` passes the brand through even when sub-step `sample_request.brand` is missing.
- [x] `--brand` / `--brand-manifest` documented in `storyboard run --help`.
- [x] Mutual-exclusion enforcement between the two flags.
- [x] Unit test asserting `options.brand` is populated from the CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)