### PR TITLE
fix(runner): construct account in applyBrandInvariant when missing

### DIFF
--- a/.changeset/brand-invariant-construct-account.md
+++ b/.changeset/brand-invariant-construct-account.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': patch
+---
+
+Fix `applyBrandInvariant` scoping for tools whose schema declares `account` but not top-level `brand` (e.g. `get_media_buys`, `get_media_buy_delivery`, `list_creatives`). The helper was only injecting top-level `brand` and merging into an existing `account`; when the request-builder produced no `account`, `adaptRequestForServerVersion` would strip the unrecognized top-level `brand` and the run-scoped brand was lost on the wire. Now the helper constructs an `account` (via `resolveAccount(options)`) when the request omits one, so session scoping survives for every schema shape. Non-object `account` values (`null`, arrays) are still passed through unchanged. (adcp-client#643)

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -20,7 +20,7 @@ import {
 } from './context';
 import { runValidations, type ValidationContext } from './validations';
 import { buildRequest, hasRequestBuilder } from './request-builder';
-import { resolveBrand } from '../client';
+import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask } from '../../utils/idempotency';
 import {
   PROBE_TASKS,
@@ -1107,15 +1107,24 @@ function evalContributesIf(expr: string | undefined, priorStepResults: Map<strin
  * different brand, it lands in a different session and can't see state
  * created by earlier steps.
  *
- * This helper runs after builder / sample_request resolution and overwrites
- * any conflicting brand on the request with `options.brand`. When the
- * request carries an `account` object, we also set `account.brand` so both
- * addressing forms converge.
+ * This helper runs after builder / sample_request resolution and writes the
+ * run-scoped brand into both addressing forms:
+ *
+ *   - Top-level `brand` — for tools whose schema declares it (e.g.
+ *     `get_products`, `create_media_buy`, signal tools).
+ *   - `account.brand` — for tools whose schema declares `account` but not
+ *     top-level `brand` (e.g. `get_media_buys`, `get_media_buy_delivery`,
+ *     `list_creatives`). When the incoming request has no `account`, we
+ *     construct one from `resolveAccount(options)` so the scoping survives
+ *     `adaptRequestForServerVersion`'s schema-aware field stripping.
+ *
+ * For any given tool, only one of the two addressing forms is declared in
+ * its schema; the other is stripped downstream. Setting both here lets the
+ * helper stay tool-agnostic.
  *
  * `AccountReference` is a union of `{account_id}` or `{brand, operator, sandbox?}`.
  * Injecting `brand` into an `{account_id}`-branch account still passes schema
- * validation (request schemas use `.passthrough()`) but is semantically
- * redundant. No storyboard currently uses the `{account_id}` branch.
+ * validation but is semantically redundant.
  */
 export function applyBrandInvariant(
   request: Record<string, unknown>,
@@ -1127,9 +1136,19 @@ export function applyBrandInvariant(
   if (!options.brand && !options.brand_manifest) return request;
   const brand = resolveBrand(options);
   const result: Record<string, unknown> = { ...request, brand };
-  const existingAccount = request.account;
-  if (existingAccount && typeof existingAccount === 'object' && !Array.isArray(existingAccount)) {
-    result.account = { ...(existingAccount as Record<string, unknown>), brand };
+  if ('account' in request) {
+    // Caller sent an account — merge brand in when it's a plain object.
+    // Leave non-object values (null, array) alone so intentionally malformed
+    // requests aren't silently "corrected."
+    const existingAccount = request.account;
+    if (existingAccount && typeof existingAccount === 'object' && !Array.isArray(existingAccount)) {
+      result.account = { ...(existingAccount as Record<string, unknown>), brand };
+    }
+  } else {
+    // No account on the request — construct one so tools whose schema
+    // declares `account` but not top-level `brand` (e.g. get_media_buys,
+    // list_creatives) still carry the run-scoped brand on the wire.
+    result.account = resolveAccount(options);
   }
   return result;
 }

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -70,9 +70,15 @@ describe('applyBrandInvariant', () => {
     assert.strictEqual(result.account, account);
   });
 
-  test('does not add account when the request has no account', () => {
+  test('constructs account when the request omits it, so tools whose schema declares account but not top-level brand still carry the run-scoped brand on the wire (get_media_buys, list_creatives, etc.)', () => {
     const result = applyBrandInvariant({ list_id: 'pl-1' }, { brand: BRAND });
-    assert.strictEqual(result.account, undefined);
+    assert.deepStrictEqual(result.account, { brand: BRAND, operator: BRAND.domain, sandbox: undefined });
+    assert.deepStrictEqual(result.brand, BRAND);
+  });
+
+  test('passes sandbox through into the constructed account when options.sandbox is set', () => {
+    const result = applyBrandInvariant({ list_id: 'pl-1' }, { brand: BRAND, sandbox: true });
+    assert.deepStrictEqual(result.account, { brand: BRAND, operator: BRAND.domain, sandbox: true });
   });
 
   test('does not mutate the input request', () => {


### PR DESCRIPTION
## Summary
- Closes #643 — with a scope pivot. The original issue proposed removing or reworking `applyBrandInvariant`'s silent-rewrite behavior; investigation during a related monkey-patch surfaced a higher-priority correctness bug in the primitive itself. Fixing that first.
- **Bug**: `applyBrandInvariant` at \`src/lib/testing/storyboard/runner.ts:1120\` injects top-level \`brand\` and merges into any existing \`account\`. For tools whose schema declares \`account\` but not top-level \`brand\` — \`get_media_buys\`, \`get_media_buy_delivery\`, \`list_creatives\`, and several others — the request-builder produces no \`account\`, so the only thing the invariant sets is top-level \`brand\`. \`SingleAgentClient.adaptRequestForServerVersion\` (SingleAgentClient.ts:1129-1177) then strips the unrecognized top-level \`brand\` against the agent's declared tool schema, and the run-scoped brand is lost on the wire. Create→get→update→delete flows on brand-scoped sellers break because the get/update/delete calls land in the seller's \`open:default\` session instead of the tenant the create used.
- **Fix**: when the request omits \`account\`, construct one via \`resolveAccount(options)\` so \`account.brand\` survives schema-aware stripping. Non-object \`account\` values (\`null\`, arrays) still pass through unchanged — the helper only synthesizes when the key is absent.

## Why the existing test suite didn't catch this
The wire-level integration test (\`runStoryboard: brand invariant on the wire\`) uses \`auth: 'none'\` steps, which dispatch through \`rawMcpProbe\` and skip \`adaptRequestForServerVersion\` entirely. So the invariant appeared to work for the test harness but silently dropped brand on the wire in production (typed-client) paths.

## Why the silent-rewrite question in #643 stays open (separately)
The programmatic tenant-routing use case the monkey-patch was serving is legitimate — the lint (adcontextprotocol/adcp#2527) covers storyboard authoring mistakes but not runtime SDK callers passing \`options.brand\`. Removing \`applyBrandInvariant\` would break that use case. The silent-rewrite concern (still real) can be revisited in a follow-up once this correctness fix lands.

## Test plan
- [x] \`test/lib/storyboard-brand-invariant.test.js\` — flipped the assertion that pinned the bug (\"does not add account when the request has no account\" → \"constructs account when the request omits it\"); added \`sandbox\` passthrough coverage.
- [x] \`npm test\` — 4220 pass, 12 skipped, 0 fail.
- [x] Manual trace: confirmed \`GetMediaBuysRequestSchema\` (schemas.generated.ts:2153) declares \`account\` but not top-level \`brand\`, and \`adaptRequestForServerVersion\` strips by \`this.cachedToolSchemas.get(taskType)\` declared fields — so without the fix, top-level brand is silently dropped before the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)