### PR TITLE
chore(types): regenerate for governance-aware-seller specialism

### DIFF
--- a/.changeset/regen-gov-aware-seller.md
+++ b/.changeset/regen-gov-aware-seller.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': patch
+---
+
+Regenerate TypeScript types for the new `governance-aware-seller` specialism in `AdCPSpecialism`. Pure regeneration from upstream schemas — no code changes.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -614,8 +614,10 @@ Flow: `get_adcp_capabilities → get_products → create_media_buy → update_me
 **Generative seller agent** — Seller agent that generates creatives from briefs at buy time — no pre-built assets required.
 Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → get_products → create_media_buy → sync_creatives → get_media_buy_delivery`
 
+**Governance-aware seller** — Seller agent that composes with a campaign-governance agent on the buyer side — accepts sync_governance, calls check_governance before confirming spend, and propagates governance approvals, conditions, and denials unchanged. Optional claim; pure sellers without governance composition do not claim this specialism and skip the governance scenarios as not_applicable.
+
 **Broadcast linear TV seller agent** — Seller agent for broadcast linear TV inventory — primetime and fringe spots with measurement windows, agency estimate numbers, Ad-ID-based creative sync, and delayed delivery reporting.
-Flow: `get_adcp_capabilities → get_products → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → get_media_buy_delivery`
+Flow: `get_adcp_capabilities → get_products → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → expect_webhook → get_media_buy_delivery`
 
 **Catalog-driven creative and conversion tracking** — Seller that renders dynamic ads from product catalogs, tracks conversions, and optimizes delivery based on performance feedback.
 Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → sync_catalogs → get_products → create_media_buy → sync_event_sources → log_event → provide_performance_feedback → get_media_buy_delivery`

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-20T05:54:06.278Z
+// Generated at: 2026-04-20T12:09:23.511Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -11580,6 +11580,7 @@ export type AdCPSpecialism =
   | 'creative-ad-server'
   | 'creative-generative'
   | 'creative-template'
+  | 'governance-aware-seller'
   | 'governance-delivery-monitor'
   | 'governance-spend-authority'
   | 'measurement-verification'

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-20T05:54:10.361Z
+// Generated at: 2026-04-20T12:09:27.401Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2554,7 +2554,7 @@ export const GetAdCPCapabilitiesRequestSchema = z.object({
 
 export const TransportModeSchema = z.union([z.literal("walking"), z.literal("cycling"), z.literal("driving"), z.literal("public_transport")]);
 
-export const AdCPSpecialismSchema = z.union([z.literal("audience-sync"), z.literal("brand-rights"), z.literal("collection-lists"), z.literal("content-standards"), z.literal("creative-ad-server"), z.literal("creative-generative"), z.literal("creative-template"), z.literal("governance-delivery-monitor"), z.literal("governance-spend-authority"), z.literal("measurement-verification"), z.literal("property-lists"), z.literal("sales-broadcast-tv"), z.literal("sales-catalog-driven"), z.literal("sales-exchange"), z.literal("sales-guaranteed"), z.literal("sales-non-guaranteed"), z.literal("sales-proposal-mode"), z.literal("sales-retail-media"), z.literal("sales-social"), z.literal("sales-streaming-tv"), z.literal("signal-marketplace"), z.literal("signal-owned"), z.literal("signed-requests")]);
+export const AdCPSpecialismSchema = z.union([z.literal("audience-sync"), z.literal("brand-rights"), z.literal("collection-lists"), z.literal("content-standards"), z.literal("creative-ad-server"), z.literal("creative-generative"), z.literal("creative-template"), z.literal("governance-aware-seller"), z.literal("governance-delivery-monitor"), z.literal("governance-spend-authority"), z.literal("measurement-verification"), z.literal("property-lists"), z.literal("sales-broadcast-tv"), z.literal("sales-catalog-driven"), z.literal("sales-exchange"), z.literal("sales-guaranteed"), z.literal("sales-non-guaranteed"), z.literal("sales-proposal-mode"), z.literal("sales-retail-media"), z.literal("sales-social"), z.literal("sales-streaming-tv"), z.literal("signal-marketplace"), z.literal("signal-owned"), z.literal("signed-requests")]);
 
 export const IdempotencySupportedSchema = z.object({
     supported: z.literal(true),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -12679,6 +12679,7 @@ export type AdCPSpecialism =
   | 'creative-ad-server'
   | 'creative-generative'
   | 'creative-template'
+  | 'governance-aware-seller'
   | 'governance-delivery-monitor'
   | 'governance-spend-authority'
   | 'measurement-verification'


### PR DESCRIPTION
## Summary
Pure regeneration of generated files after the upstream `AdCPSpecialism` enum gained `governance-aware-seller`. CI's sync-check has been blocking every open PR (#640, #642-adjacent, #644) with:

> ❌ Generated TypeScript files are out of sync with AdCP schemas!
> ⚠️  Agent docs are out of sync. Run: npm run generate-agent-docs

## What ran
```
npm run sync-schemas
npm run generate-types
npm run generate-wellknown-schemas
npm run generate-agent-docs
```

## Diff
- `core.generated.ts`: timestamp + one literal in `AdCPSpecialism` union
- `schemas.generated.ts`: matching literal in `AdCPSpecialismSchema` z.union
- `tools.generated.ts`: matching literal in `AdCPSpecialism` union
- `docs/llms.txt`: governance-aware-seller description + regenerated broadcast linear TV flow (now includes `expect_webhook`, reflecting the current storyboard)

## Test plan
- [x] `npm run build:lib` — clean
- [x] `npm test` — 4211 pass, 10 skipped, 0 fail
- [x] No source code changes

Unblocks #640 and #644 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)