### PR TITLE
fix(parser): disambiguate MCP task status from domain status in getStatus (#646)

### DIFF
--- a/src/lib/core/ProtocolResponseParser.ts
+++ b/src/lib/core/ProtocolResponseParser.ts
@@ -87,9 +87,53 @@ export class ProtocolResponseParser {
       return response.status as ADCPStatus;
     }
 
-    // Check MCP structuredContent.status
-    if (response?.structuredContent?.status && Object.values(ADCP_STATUS).includes(response.structuredContent.status)) {
-      return response.structuredContent.status as ADCPStatus;
+    // Check MCP structuredContent.status.
+    //
+    // Several ADCP_STATUS literals (completed, canceled, failed, rejected) also
+    // appear as values in domain status enums (e.g. MediaBuyStatus). When a
+    // seller returns a spec-compliant domain envelope like
+    //   { status: "canceled", media_buy: {...}, adcp_version: "3.0.0" }
+    // we must NOT classify that as an MCP task status, or TaskExecutor's
+    // terminal-state branches short-circuit the response with data:undefined
+    // and skip Zod validation. See issue #646.
+    //
+    // Heuristic: only treat structuredContent.status as an ADCP task status
+    // when the envelope looks like a plain task wrapper — i.e. contains only
+    // task-envelope keys. Any domain payload key present alongside `status`
+    // means this is a domain response; fall through so it's classified as
+    // COMPLETED and validators run on the payload.
+    const sc = response?.structuredContent;
+    if (sc?.status && Object.values(ADCP_STATUS).includes(sc.status)) {
+      const TASK_ENVELOPE_KEYS = new Set([
+        'status',
+        'message',
+        'messages',
+        'errors',
+        'warnings',
+        'adcp_version',
+        'context_id',
+        'task_id',
+        'task_status',
+        'replayed',
+      ]);
+      const hasDomainPayload = Object.keys(sc).some((k) => !TASK_ENVELOPE_KEYS.has(k));
+      if (!hasDomainPayload) {
+        return sc.status as ADCPStatus;
+      }
+      // Exception: preserve the task-lifecycle states that are never domain
+      // enum values, even when a domain payload is attached (e.g. a server
+      // returning partial data while still working).
+      const TASK_ONLY_STATES: string[] = [
+        ADCP_STATUS.SUBMITTED,
+        ADCP_STATUS.WORKING,
+        ADCP_STATUS.INPUT_REQUIRED,
+        ADCP_STATUS.AUTH_REQUIRED,
+      ];
+      if (TASK_ONLY_STATES.includes(sc.status)) {
+        return sc.status as ADCPStatus;
+      }
+      // Shared literal (completed/canceled/failed/rejected) + domain payload
+      // → fall through to the "has structuredContent → COMPLETED" branch.
     }
 
     // Check for MCP error responses

--- a/test/lib/protocol-response-parser-status.test.js
+++ b/test/lib/protocol-response-parser-status.test.js
@@ -1,0 +1,133 @@
+// Regression tests for ProtocolResponseParser.getStatus() — see issue #646.
+//
+// ADCP_STATUS (MCP task lifecycle) shares literals with AdCP v3 domain status
+// enums (e.g. MediaBuyStatus: "completed", "canceled"). The parser must NOT
+// misclassify a domain response whose `status` happens to be a shared literal
+// as an MCP task state, because TaskExecutor's terminal-state branches skip
+// Zod validation and return data:undefined.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { ProtocolResponseParser, ADCP_STATUS } = require('../../dist/lib/core/ProtocolResponseParser.js');
+
+describe('ProtocolResponseParser.getStatus — domain vs task status collision (#646)', () => {
+  const parser = new ProtocolResponseParser();
+
+  test('domain response with status:"canceled" and domain payload → COMPLETED', () => {
+    // Simulates a spec-compliant cancel_media_buy envelope.
+    const response = {
+      structuredContent: {
+        status: 'canceled',
+        media_buy: { media_buy_id: 'mb_abc', status: 'canceled' },
+        adcp_version: '3.0.0',
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+  });
+
+  test('domain response with status:"completed" and domain payload → COMPLETED', () => {
+    const response = {
+      structuredContent: {
+        status: 'completed',
+        media_buy: { media_buy_id: 'mb_abc' },
+        adcp_version: '3.0.0',
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+  });
+
+  test('domain response with status:"rejected" and domain payload → COMPLETED (payload drives validation)', () => {
+    const response = {
+      structuredContent: {
+        status: 'rejected',
+        media_buy: { media_buy_id: 'mb_abc', status: 'rejected' },
+        adcp_version: '3.0.0',
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+  });
+
+  test('bare task envelope with status:"canceled" (no domain payload) → CANCELED', () => {
+    // True MCP task envelope: only envelope-level keys.
+    const response = {
+      structuredContent: {
+        status: 'canceled',
+        message: 'Task canceled by user',
+        adcp_version: '3.0.0',
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.CANCELED);
+  });
+
+  test('bare task envelope with status:"completed" (no domain payload) → COMPLETED', () => {
+    const response = {
+      structuredContent: {
+        status: 'completed',
+        adcp_version: '3.0.0',
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.COMPLETED);
+  });
+
+  test('task-only state "working" with domain payload still classifies as WORKING', () => {
+    // Server returning partial data while still processing.
+    const response = {
+      structuredContent: {
+        status: 'working',
+        media_buy: { media_buy_id: 'mb_abc' },
+        adcp_version: '3.0.0',
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.WORKING);
+  });
+
+  test('task-only state "submitted" with domain payload still classifies as SUBMITTED', () => {
+    const response = {
+      structuredContent: {
+        status: 'submitted',
+        task_id: 'tsk_123',
+        media_buy: { media_buy_id: 'mb_abc' },
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.SUBMITTED);
+  });
+
+  test('input-required with domain payload still classifies as INPUT_REQUIRED', () => {
+    const response = {
+      structuredContent: {
+        status: 'input-required',
+        question: 'Confirm?',
+        media_buy: { media_buy_id: 'mb_abc' },
+      },
+    };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.INPUT_REQUIRED);
+  });
+
+  test('top-level status still honored (A2A / direct responses unchanged)', () => {
+    assert.strictEqual(parser.getStatus({ status: 'canceled' }), ADCP_STATUS.CANCELED);
+    assert.strictEqual(parser.getStatus({ status: 'completed' }), ADCP_STATUS.COMPLETED);
+  });
+
+  test('A2A wrapped status still honored', () => {
+    const response = { result: { status: { state: 'canceled' } } };
+    assert.strictEqual(parser.getStatus(response), ADCP_STATUS.CANCELED);
+  });
+
+  test('isError=true still returns FAILED', () => {
+    assert.strictEqual(parser.getStatus({ isError: true }), ADCP_STATUS.FAILED);
+  });
+
+  test('response with only content (no status) → COMPLETED', () => {
+    assert.strictEqual(
+      parser.getStatus({ content: [{ type: 'text', text: 'ok' }] }),
+      ADCP_STATUS.COMPLETED,
+    );
+  });
+
+  test('null/undefined/empty response → null', () => {
+    assert.strictEqual(parser.getStatus(null), null);
+    assert.strictEqual(parser.getStatus(undefined), null);
+    assert.strictEqual(parser.getStatus({}), null);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #646.

`ProtocolResponseParser.getStatus()` classified any `structuredContent.status` matching an `ADCP_STATUS` literal as an MCP task state. Several of those literals (`completed` / `canceled` / `failed` / `rejected`) also appear as values in AdCP v3 domain status enums (e.g. `MediaBuyStatus`). A spec-compliant domain envelope like `{ status: 'canceled', media_buy: {...} }` was misrouted through `TaskExecutor`'s terminal-state branches, which return `data: undefined` and skip Zod validation.

## Fix

In the `structuredContent.status` branch of `getStatus()`:

- Only treat the value as an ADCP task status when either
  - (a) the envelope contains no domain-payload keys (i.e. only task-envelope keys: `status`, `message`, `messages`, `errors`, `warnings`, `adcp_version`, `context_id`, `task_id`, `task_status`, `replayed`), **or**
  - (b) the value is an unambiguous task-only lifecycle state (`submitted`, `working`, `input-required`, `auth-required`).
- Shared literals (`completed`/`canceled`/`failed`/`rejected`) alongside a domain payload fall through to the existing "has `structuredContent` → `COMPLETED`" branch so Zod validators run on the payload.

This preserves behaviour for bare task envelopes, A2A-wrapped responses, top-level `status`, `isError` errors, and all task-only lifecycle states.

## Test plan

- [x] New test file `test/lib/protocol-response-parser-status.test.js` — 13 cases covering the collision (canceled/completed/rejected with a domain payload → COMPLETED), bare task envelopes (→ CANCELED/COMPLETED), task-only states with a domain payload (working/submitted/input-required preserved), and the A2A-wrapped / top-level / isError / bare-content / null paths.
- [x] Full suite (`CI=1 npm test`): 2251 pass / 27 fail / 19 cancelled before and after the change — identical counts, and the 27 failures are pre-existing environmental issues (missing `compliance/cache/latest/test-vectors/request-signing/keys.json` fixtures not present in the repo). No regressions introduced by this change.

## Impact

Unblocks the `media_buy_state_machine` storyboard (`cancel_buy` and the chain-effect `resume_canceled_buy`) against any AdCP v3 seller that correctly returns `MediaBuyStatus` values in the envelope `status` field.
