### PR TITLE
fix(validations): resolve error code from spec-canonical errors[0].code

### DIFF
--- a/.changeset/error-code-resolver-errors-array.md
+++ b/.changeset/error-code-resolver-errors-array.md
@@ -1,0 +1,4 @@
+---
+'@adcp/client': patch
+---
+Storyboard `error_code` validation now reads the spec-canonical `data.errors[0].code` envelope (per `core/error.json`), falling back to legacy locations (`adcp_error.code`, `error_code`, `code`, `error.code`) and the regex on `taskResult.error`. Previously, spec-conformant agents returning `{ errors: [...], context }` had their code extracted via regex instead of typed field access.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -452,9 +452,18 @@ function validateErrorCode(validation: StoryboardValidation, taskResult: TaskRes
   // Prefer the spec-canonical `errors[0].code` envelope (core/error.json), then
   // fall back to legacy/structured locations so we get a bare code instead of
   // the "CODE: message" string materialized on taskResult.error.
+  //
+  // Guarded by `success === false` because AdCP async envelopes (`submitted`,
+  // `input-required`) explicitly permit an advisory `errors[]` on non-failed
+  // tasks for non-blocking warnings — reading it unconditionally would
+  // false-positive `error_code` validations on successful responses.
   const data = taskResult.data as Record<string, unknown> | undefined;
-  const errorsArray = Array.isArray(data?.errors) ? (data!.errors as Array<Record<string, unknown>>) : undefined;
-  const firstErrorCode = errorsArray?.[0]?.code;
+  const errors = data?.errors;
+  const firstError = !taskResult.success && Array.isArray(errors) ? errors[0] : undefined;
+  const firstErrorCode =
+    firstError && typeof firstError === 'object' && typeof (firstError as Record<string, unknown>).code === 'string'
+      ? ((firstError as Record<string, unknown>).code as string)
+      : undefined;
   const adcpError = data?.adcp_error as Record<string, unknown> | undefined;
   const errorCode =
     firstErrorCode ??

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -449,11 +449,15 @@ function extractCodeFromErrorString(raw: string | undefined): string | undefined
 
 function validateErrorCode(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
   // Extract error code from various locations agents might put it.
-  // Prefer the L3 structured path (data.adcp_error.code) so we get a bare code
-  // instead of the "CODE: message" string materialized on taskResult.error.
+  // Prefer the spec-canonical `errors[0].code` envelope (core/error.json), then
+  // fall back to legacy/structured locations so we get a bare code instead of
+  // the "CODE: message" string materialized on taskResult.error.
   const data = taskResult.data as Record<string, unknown> | undefined;
+  const errorsArray = Array.isArray(data?.errors) ? (data!.errors as Array<Record<string, unknown>>) : undefined;
+  const firstErrorCode = errorsArray?.[0]?.code;
   const adcpError = data?.adcp_error as Record<string, unknown> | undefined;
   const errorCode =
+    firstErrorCode ??
     adcpError?.code ??
     data?.error_code ??
     data?.code ??
@@ -461,7 +465,13 @@ function validateErrorCode(validation: StoryboardValidation, taskResult: TaskRes
     extractCodeFromErrorString(taskResult.error);
 
   const pointer =
-    adcpError?.code !== undefined ? '/adcp_error/code' : data?.error_code !== undefined ? '/error_code' : null;
+    firstErrorCode !== undefined
+      ? '/errors/0/code'
+      : adcpError?.code !== undefined
+        ? '/adcp_error/code'
+        : data?.error_code !== undefined
+          ? '/error_code'
+          : null;
 
   if (validation.allowed_values?.length) {
     const actualCode = errorCode !== undefined && errorCode !== null ? String(errorCode) : undefined;

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -44,6 +44,42 @@ describe('validateErrorCode', () => {
     assert.strictEqual(result.json_pointer, '/errors/0/code');
   });
 
+  it('ignores advisory errors[0].code on a successful task (submitted/input-required envelopes)', () => {
+    // AdCP permits an advisory `errors` array on non-failed async envelopes
+    // (e.g., `create_media_buy` submitted with non-blocking warnings). A
+    // `error_code` validation should not false-positive on these.
+    const taskResult = {
+      success: true,
+      data: {
+        media_buy_id: 'mb_123',
+        status: 'submitted',
+        errors: [{ code: 'WARN_RATE_LIMITED', message: 'slow response' }],
+      },
+      error: undefined,
+    };
+    const [result] = runOne([errorCodeValidation('WARN_RATE_LIMITED')], 'create_media_buy', taskResult);
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, null);
+  });
+
+  it('handles empty errors[] and non-object entries without throwing', () => {
+    const taskResult = {
+      success: false,
+      data: { errors: [] },
+      error: 'VALIDATION_ERROR: bad request',
+    };
+    const [result] = runOne([errorCodeValidation('VALIDATION_ERROR')], 'create_media_buy', taskResult);
+    assert.strictEqual(result.passed, true, result.error);
+
+    const stringEntry = {
+      success: false,
+      data: { errors: ['not an object'] },
+      error: 'VALIDATION_ERROR: bad',
+    };
+    const [r2] = runOne([errorCodeValidation('VALIDATION_ERROR')], 'create_media_buy', stringEntry);
+    assert.strictEqual(r2.passed, true, r2.error);
+  });
+
   it('reads L3 structured code from data.adcp_error.code', () => {
     const taskResult = {
       success: false,

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -16,6 +16,34 @@ function runOne(validations, taskName, taskResult) {
 }
 
 describe('validateErrorCode', () => {
+  it('reads spec-canonical code from data.errors[0].code', () => {
+    const taskResult = {
+      success: false,
+      data: {
+        errors: [{ code: 'BUDGET_TOO_LOW', message: 'Minimum spend is $100' }],
+        context: { request_id: 'abc' },
+      },
+      error: 'BUDGET_TOO_LOW: Minimum spend is $100',
+    };
+    const [result] = runOne([errorCodeValidation('BUDGET_TOO_LOW')], 'create_media_buy', taskResult);
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.json_pointer, '/errors/0/code');
+  });
+
+  it('prefers data.errors[0].code over legacy adcp_error.code', () => {
+    const taskResult = {
+      success: false,
+      data: {
+        errors: [{ code: 'INVALID_REQUEST', message: 'bad input' }],
+        adcp_error: { code: 'LEGACY_CODE' },
+      },
+      error: 'INVALID_REQUEST: bad input',
+    };
+    const [result] = runOne([errorCodeValidation('INVALID_REQUEST')], 'create_media_buy', taskResult);
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.json_pointer, '/errors/0/code');
+  });
+
   it('reads L3 structured code from data.adcp_error.code', () => {
     const taskResult = {
       success: false,


### PR DESCRIPTION
## Summary

- Adds `data.errors[0].code` (the AdCP spec-canonical error envelope per `core/error.json`) as the highest-priority lookup in the storyboard `error_code` validator's resolution chain.
- Preserves legacy paths (`adcp_error.code`, `error_code`, `code`, `error.code`) and the regex fallback on `taskResult.error` for back-compat.
- Emits `/errors/0/code` as the `json_pointer` when the code comes from the canonical envelope.

## Why

Per adcontextprotocol/adcp#2535, sellers returning a spec-conformant `{ errors: [{ code, message }], context }` envelope had their codes extracted via regex on the `"CODE: message"` string instead of typed field access. This made spec-conformant responses look worse than legacy `adcp_error.code` responses in compliance reports.

## Test plan

- [x] New unit test: reads `data.errors[0].code` and emits `/errors/0/code` pointer
- [x] New unit test: `errors[0].code` wins over legacy `adcp_error.code` when both are present
- [x] Existing `validateErrorCode` tests still pass (legacy paths, prefix stripping, allowed_values)
- [x] `npm test` (full 4,284-test suite)

Fixes adcontextprotocol/adcp#2535

🤖 Generated with [Claude Code](https://claude.com/claude-code)