### PR TITLE
feat(server): presence-gated signature composition (#659)

### DIFF
--- a/.changeset/presence-gated-signature-compose.md
+++ b/.changeset/presence-gated-signature-compose.md
@@ -1,0 +1,58 @@
+---
+'@adcp/client': minor
+---
+
+Add `requireSignatureWhenPresent(signatureAuth, fallbackAuth)` — presence-gated composition for RFC 9421 signatures (#659)
+
+`anyOf(verifyApiKey, verifySignatureAsAuthenticator)` has either-or
+semantics: a request with a valid bearer and a present-but-invalid
+signature is accepted because `anyOf` catches the sig adapter's
+`AuthError` and falls through. That's wrong for the `signed-requests`
+specialism, whose conformance vectors include negatives like
+`request_signature_revoked` and `request_signature_window_invalid`
+that must reject even when a bearer is also supplied.
+
+`requireSignatureWhenPresent` encodes the spec-compliant contract:
+
+| RFC 9421 signature header present? | Outcome                           |
+|------------------------------------|-----------------------------------|
+| yes                                | signature authenticator runs; principal / `AuthError` / `null→AuthError` is final — fallback never runs |
+| no                                 | fallback runs verbatim            |
+
+Presence is detected from either `Signature-Input` OR `Signature` — a
+request with only one of the pair is malformed but still signed intent
+and MUST NOT silently fall through to bearer. The existing
+`verifySignatureAsAuthenticator` adapter now recognizes the same pair
+(previously it required `Signature-Input`; a solo `Signature` header
+incorrectly fell through).
+
+The composed authenticator propagates `AUTH_NEEDS_RAW_BODY` when either
+branch needs it, so `serve()` still buffers `req.rawBody` ahead of
+authentication.
+
+**Composition guard**: the returned authenticator is tagged
+`AUTH_PRESENCE_GATED`; `anyOf` throws at wire-up time when any child
+carries the tag, because wrapping would re-open the bypass the gate
+exists to prevent. Invert the order instead:
+`requireSignatureWhenPresent(sig, anyOf(bearer, apiKey))`.
+
+```ts
+import {
+  serve,
+  anyOf,
+  verifyApiKey,
+  verifyBearer,
+  verifySignatureAsAuthenticator,
+  requireSignatureWhenPresent,
+} from '@adcp/client/server';
+
+serve(createAgent, {
+  authenticate: requireSignatureWhenPresent(
+    verifySignatureAsAuthenticator({ jwks, replayStore, revocationStore, capability, resolveOperation }),
+    anyOf(verifyApiKey({ keys }), verifyBearer({ jwksUri, issuer, audience })),
+  ),
+});
+```
+
+New public exports: `requireSignatureWhenPresent`, `AUTH_PRESENCE_GATED`,
+`tagAuthenticatorPresenceGated`, `isAuthenticatorPresenceGated`.

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -248,10 +248,7 @@ export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthent
  * wire-up time (throws synchronously) — invert the order instead:
  * `requireSignatureWhenPresent(sig, anyOf(bearer, apiKey))`.
  */
-export function requireSignatureWhenPresent(
-  signatureAuth: Authenticator,
-  fallbackAuth: Authenticator
-): Authenticator {
+export function requireSignatureWhenPresent(signatureAuth: Authenticator, fallbackAuth: Authenticator): Authenticator {
   const combined: Authenticator = async req => {
     if (hasSignatureHeader(req)) {
       const result = await signatureAuth(req);

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -45,7 +45,14 @@ import type { ReplayStore } from '../signing/replay';
 import type { RevocationStore } from '../signing/revocation';
 import type { VerifiedSigner, VerifierCapability, VerifyResult } from '../signing/types';
 import { verifyRequestSignature } from '../signing/verifier';
-import { AuthError, type AuthPrincipal, type Authenticator, tagAuthenticatorNeedsRawBody } from './auth';
+import {
+  AuthError,
+  type AuthPrincipal,
+  type Authenticator,
+  authenticatorNeedsRawBody,
+  tagAuthenticatorNeedsRawBody,
+  tagAuthenticatorPresenceGated,
+} from './auth';
 
 export interface VerifySignatureAsAuthenticatorOptions {
   /** Verifier capability block. `required_for` is not enforced here — unsigned
@@ -184,10 +191,99 @@ export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthent
   return tagAuthenticatorNeedsRawBody(authenticator);
 }
 
+/**
+ * Compose a signature authenticator with a fallback under presence-gated
+ * semantics: if the incoming request declares a `Signature-Input` header,
+ * the signature authenticator is the ONLY path — its result (principal,
+ * `null`, or thrown {@link AuthError}) is the final outcome and the fallback
+ * never runs. Without `Signature-Input`, the fallback handles the request.
+ *
+ * This is the correct composition for the `signed-requests` specialism.
+ * {@link anyOf}'s either-or contract incorrectly accepts a bearer-authed
+ * request whose signature is present-but-invalid — fine for "either
+ * credential is sufficient" but wrong for spec conformance, where a
+ * declared-but-invalid signature MUST be rejected even when a valid bearer
+ * accompanies it (revocation, window expiry, malformed covered-components,
+ * etc.).
+ *
+ * ```ts
+ * import {
+ *   serve,
+ *   anyOf,
+ *   verifyApiKey,
+ *   verifySignatureAsAuthenticator,
+ *   requireSignatureWhenPresent,
+ * } from '@adcp/client/server';
+ *
+ * serve(createAgent, {
+ *   authenticate: requireSignatureWhenPresent(
+ *     verifySignatureAsAuthenticator({ jwks, replayStore, revocationStore, capability, resolveOperation }),
+ *     anyOf(verifyApiKey({ keys }), verifyBearer({ jwksUri, issuer, audience })),
+ *   ),
+ * });
+ * ```
+ *
+ * Presence is detected from RFC 9421 signature headers: either
+ * `Signature-Input` or the paired `Signature`. A request carrying only one of
+ * the two is malformed but still treated as "signed intent" — the signature
+ * authenticator runs and throws, which is what AdCP's negative conformance
+ * vectors expect.
+ *
+ * Behavior matrix:
+ *
+ * | RFC 9421 signature header present? | Signature result          | Outcome                      |
+ * |------------------------------------|---------------------------|------------------------------|
+ * | yes                                | verified                  | signature principal          |
+ * | yes                                | throws {@link AuthError}  | 401 (does NOT fall through)  |
+ * | yes                                | returns `null`            | 401 via re-thrown `AuthError` (does NOT fall through) |
+ * | no                                 | —                         | fallback runs verbatim       |
+ *
+ * The returned authenticator is tagged with {@link AUTH_NEEDS_RAW_BODY} when
+ * either branch needs the raw body, so `serve()` buffers `req.rawBody` ahead
+ * of authentication.
+ *
+ * **Do not nest this helper inside {@link anyOf}.** `anyOf` catches thrown
+ * `AuthError`s and tries the next authenticator, which re-introduces the
+ * bypass this helper exists to prevent. `anyOf` refuses such composition at
+ * wire-up time (throws synchronously) — invert the order instead:
+ * `requireSignatureWhenPresent(sig, anyOf(bearer, apiKey))`.
+ */
+export function requireSignatureWhenPresent(
+  signatureAuth: Authenticator,
+  fallbackAuth: Authenticator
+): Authenticator {
+  const combined: Authenticator = async req => {
+    if (hasSignatureHeader(req)) {
+      const result = await signatureAuth(req);
+      if (result === null) {
+        // A signature was declared but the sig authenticator didn't recognize
+        // it. Falling through to the fallback would re-open the bypass the
+        // presence gate exists to prevent — fail closed.
+        throw new AuthError('Signature declared but not recognized.');
+      }
+      return result;
+    }
+    return await fallbackAuth(req);
+  };
+  if (authenticatorNeedsRawBody(signatureAuth) || authenticatorNeedsRawBody(fallbackAuth)) {
+    tagAuthenticatorNeedsRawBody(combined);
+  }
+  tagAuthenticatorPresenceGated(combined);
+  return combined;
+}
+
 const SAFE_KEYID = /^[A-Za-z0-9._-]{1,256}$/;
 
 function hasSignatureHeader(req: IncomingMessage): boolean {
-  const v = req.headers['signature-input'];
+  // RFC 9421 pairs `Signature-Input` with `Signature`. Either is sufficient
+  // "signed intent" — a request carrying only one is malformed, but routing
+  // it to the fallback would mean a half-formed signing attempt (e.g., client
+  // bug that dropped the Signature-Input header) silently auths via bearer.
+  // Fail closed: send it to the signature authenticator, which will throw.
+  return nonEmptyHeader(req.headers['signature-input']) || nonEmptyHeader(req.headers['signature']);
+}
+
+function nonEmptyHeader(v: string | string[] | undefined): boolean {
   if (typeof v === 'string') return v.length > 0;
   if (Array.isArray(v)) return v.length > 0;
   return false;

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -106,8 +106,23 @@ export class AuthError extends Error {
  */
 export const AUTH_NEEDS_RAW_BODY: unique symbol = Symbol.for('@adcp/client.auth.needsRawBody');
 
+/**
+ * Marker tag on an {@link Authenticator} whose contract depends on being the
+ * sole path for some class of requests — wrapping it in {@link anyOf} would
+ * reintroduce an either-or fall-through that the gate was built to prevent.
+ *
+ * Currently carried by the authenticator returned from
+ * `requireSignatureWhenPresent`, which guarantees "if `Signature-Input` is
+ * present, the signature path is the ONLY outcome." Composing it under
+ * `anyOf` would let a valid bearer silently accept an invalid signature —
+ * the exact bug the helper closes. `anyOf` throws at composition time when
+ * any child is tagged.
+ */
+export const AUTH_PRESENCE_GATED: unique symbol = Symbol.for('@adcp/client.auth.presenceGated');
+
 interface AuthenticatorFlags {
   [AUTH_NEEDS_RAW_BODY]?: boolean;
+  [AUTH_PRESENCE_GATED]?: boolean;
 }
 
 /**
@@ -124,6 +139,22 @@ export function tagAuthenticatorNeedsRawBody(auth: Authenticator): Authenticator
  */
 export function authenticatorNeedsRawBody(auth: Authenticator | undefined): boolean {
   return !!auth && (auth as unknown as AuthenticatorFlags)[AUTH_NEEDS_RAW_BODY] === true;
+}
+
+/**
+ * Mark an authenticator as presence-gated. {@link anyOf} refuses to wrap a
+ * tagged authenticator — wrapping would defeat the gate.
+ */
+export function tagAuthenticatorPresenceGated(auth: Authenticator): Authenticator {
+  (auth as unknown as AuthenticatorFlags)[AUTH_PRESENCE_GATED] = true;
+  return auth;
+}
+
+/**
+ * Check whether an authenticator is presence-gated (see {@link AUTH_PRESENCE_GATED}).
+ */
+export function isAuthenticatorPresenceGated(auth: Authenticator | undefined): boolean {
+  return !!auth && (auth as unknown as AuthenticatorFlags)[AUTH_PRESENCE_GATED] === true;
 }
 
 // ---------------------------------------------------------------------------
@@ -318,6 +349,15 @@ function extractScopes(payload: JWTPayload): string[] {
  * which mechanism rejected them.
  */
 export function anyOf(...authenticators: Authenticator[]): Authenticator {
+  for (const auth of authenticators) {
+    if (isAuthenticatorPresenceGated(auth)) {
+      throw new Error(
+        'anyOf: refusing to wrap a presence-gated authenticator. Wrapping would ' +
+          'reintroduce the bearer-bypass bug the gate was built to prevent. ' +
+          'Invert the composition: requireSignatureWhenPresent(sig, anyOf(...others)).'
+      );
+    }
+  }
   const combined: Authenticator = async req => {
     let rejected = false;
     const causes: unknown[] = [];

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -85,6 +85,9 @@ export {
   AUTH_NEEDS_RAW_BODY,
   tagAuthenticatorNeedsRawBody,
   authenticatorNeedsRawBody,
+  AUTH_PRESENCE_GATED,
+  tagAuthenticatorPresenceGated,
+  isAuthenticatorPresenceGated,
   DEFAULT_JWT_ALGORITHMS,
   DEFAULT_JWT_CLOCK_TOLERANCE_SECONDS,
 } from './auth';
@@ -97,7 +100,7 @@ export type {
   RespondUnauthorizedOptions,
 } from './auth';
 
-export { verifySignatureAsAuthenticator } from './auth-signature';
+export { verifySignatureAsAuthenticator, requireSignatureWhenPresent } from './auth-signature';
 export type { VerifySignatureAsAuthenticatorOptions } from './auth-signature';
 
 export {

--- a/test/auth-signature-compose.test.js
+++ b/test/auth-signature-compose.test.js
@@ -6,10 +6,13 @@ const path = require('node:path');
 const {
   AuthError,
   AUTH_NEEDS_RAW_BODY,
+  AUTH_PRESENCE_GATED,
   anyOf,
   authenticatorNeedsRawBody,
+  isAuthenticatorPresenceGated,
   verifyApiKey,
   verifySignatureAsAuthenticator,
+  requireSignatureWhenPresent,
   tagAuthenticatorNeedsRawBody,
 } = require('../dist/lib/server/index.js');
 const {
@@ -451,5 +454,313 @@ describe('anyOf(verifyApiKey, verifySignatureAsAuthenticator)', () => {
       () => composed(req),
       err => err instanceof AuthError
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSignatureWhenPresent — presence-gated composition (unit)
+// ---------------------------------------------------------------------------
+
+describe('requireSignatureWhenPresent(signatureAuth, fallbackAuth)', () => {
+  it('runs the fallback when no Signature-Input header is present', async () => {
+    const now = 1_776_520_800;
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions({ now: () => now })),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const req = makeReq({
+      headers: {
+        host: 'seller.example.com',
+        authorization: 'Bearer sk_test',
+      },
+    });
+    const result = await composed(req);
+    assert.strictEqual(result.principal, 'acct_42');
+  });
+
+  it('returns null from the fallback when no Signature-Input and no fallback credential', async () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const result = await composed(makeReq());
+    assert.strictEqual(result, null);
+  });
+
+  it('runs the signature authenticator and returns its principal when Signature-Input is present', async () => {
+    const now = 1_776_520_800;
+    const body = '{}';
+    const url = 'https://seller.example.com/mcp';
+    const req = signedReq({ now, url, body, nonce: 'require-sig-valid-01' });
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions({ now: () => now })),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const result = await composed(req);
+    assert.strictEqual(result.principal, 'signing:test-ed25519-2026');
+    assert.ok(req.verifiedSigner, 'req.verifiedSigner populated on sig path');
+  });
+
+  it('throws AuthError when signature is present-but-invalid, even if a valid bearer is also supplied', async () => {
+    const now = 1_776_520_800;
+    const body = '{}';
+    const url = 'https://seller.example.com/mcp';
+    const req = signedReq({ now, url, body, nonce: 'require-sig-invalid-01' });
+    req.headers.signature = req.headers.signature.replace(/[A-Za-z0-9+/]/, c => (c === 'A' ? 'B' : 'A'));
+    req.headers.authorization = 'Bearer sk_test';
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions({ now: () => now })),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    await assert.rejects(
+      () => composed(req),
+      err => err instanceof AuthError && /^Signature rejected/.test(err.publicMessage)
+    );
+    assert.strictEqual(req.verifiedSigner, undefined, 'bad sig leaves verifiedSigner unset');
+  });
+
+  it('propagates AUTH_NEEDS_RAW_BODY when the signature authenticator needs it', () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    assert.strictEqual(authenticatorNeedsRawBody(composed), true);
+    assert.strictEqual(composed[AUTH_NEEDS_RAW_BODY], true);
+  });
+
+  it('does NOT propagate AUTH_NEEDS_RAW_BODY when neither branch needs it', () => {
+    const composed = requireSignatureWhenPresent(
+      verifyApiKey({ keys: { sk_sig: { principal: 'sig' } } }),
+      verifyApiKey({ keys: { sk_fb: { principal: 'fb' } } })
+    );
+    assert.strictEqual(authenticatorNeedsRawBody(composed), false);
+  });
+
+  it('propagates a fallback AuthError verbatim (no double-wrapping)', async () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      async () => {
+        throw new AuthError('Insufficient scope.');
+      }
+    );
+    await assert.rejects(
+      () => composed(makeReq()),
+      err => err instanceof AuthError && err.publicMessage === 'Insufficient scope.'
+    );
+  });
+
+  it('throws AuthError when the sig authenticator returns null despite Signature-Input being present', async () => {
+    // A custom sig authenticator that returns null on a signed request would
+    // otherwise silently surface as "no credentials" — the presence gate must
+    // convert that into a hard 401 to preserve the contract.
+    const composed = requireSignatureWhenPresent(
+      async () => null,
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const now = 1_776_520_800;
+    const body = '{}';
+    const url = 'https://seller.example.com/mcp';
+    const req = signedReq({ now, url, body, nonce: 'null-sig-path-01' });
+    req.headers.authorization = 'Bearer sk_test'; // valid bearer MUST NOT rescue
+    await assert.rejects(
+      () => composed(req),
+      err => err instanceof AuthError && /declared but not recognized/.test(err.publicMessage)
+    );
+  });
+
+  it('routes a `Signature`-only request (missing Signature-Input) to the sig authenticator', async () => {
+    // RFC 9421 pairs both headers. A request with only `Signature` is
+    // malformed, but is signed intent — must not fall through to bearer.
+    const now = 1_776_520_800;
+    const body = '{}';
+    const url = 'https://seller.example.com/mcp';
+    const req = signedReq({ now, url, body, nonce: 'sig-only-header-01' });
+    delete req.headers['signature-input'];
+    req.headers.authorization = 'Bearer sk_test'; // valid bearer MUST NOT rescue
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions({ now: () => now })),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    await assert.rejects(
+      () => composed(req),
+      err => err instanceof AuthError
+    );
+  });
+
+  it('is tagged AUTH_PRESENCE_GATED', () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    assert.strictEqual(isAuthenticatorPresenceGated(composed), true);
+    assert.strictEqual(composed[AUTH_PRESENCE_GATED], true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// anyOf + presence-gated composition guard
+// ---------------------------------------------------------------------------
+
+describe('anyOf refuses to wrap a presence-gated authenticator', () => {
+  it('throws synchronously when the first child is presence-gated', () => {
+    const gated = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    assert.throws(
+      () => anyOf(gated, verifyApiKey({ keys: { other: { principal: 'x' } } })),
+      /refusing to wrap a presence-gated authenticator/
+    );
+  });
+
+  it('throws synchronously when a later child is presence-gated', () => {
+    const gated = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    assert.throws(
+      () => anyOf(verifyApiKey({ keys: { other: { principal: 'x' } } }), gated),
+      /refusing to wrap a presence-gated authenticator/
+    );
+  });
+
+  it('permits the recommended inversion: requireSignatureWhenPresent(sig, anyOf(...))', () => {
+    assert.doesNotThrow(() =>
+      requireSignatureWhenPresent(
+        verifySignatureAsAuthenticator(baseOptions()),
+        anyOf(
+          verifyApiKey({ keys: { sk_a: { principal: 'a' } } }),
+          verifyApiKey({ keys: { sk_b: { principal: 'b' } } })
+        )
+      )
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requireSignatureWhenPresent — end-to-end through serve()
+// ---------------------------------------------------------------------------
+
+describe('serve() + requireSignatureWhenPresent', () => {
+  function makeAgent() {
+    return createAdcpServer({
+      name: 'Test Agent',
+      version: '1.0.0',
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+  }
+
+  function startServer(authenticate) {
+    return new Promise(resolve => {
+      const srv = serve(() => makeAgent(), {
+        port: 0,
+        authenticate,
+        onListening: url => resolve({ server: srv, url, port: new URL(url).port }),
+      });
+    });
+  }
+
+  it('accepts a bearer-authed request with no signature', async () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(baseOptions()),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const { server, port } = await startServer(composed);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          Authorization: 'Bearer sk_test',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      });
+      assert.strictEqual(res.status, 200);
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  });
+
+  it('rejects a signed-but-invalid request with 401 even when a valid bearer is supplied', async () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(
+        baseOptions({ getUrl: req => `http://${req.headers.host}${req.url}` })
+      ),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const { server, port } = await startServer(composed);
+    try {
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {},
+      });
+      const now = Math.floor(Date.now() / 1000);
+      const signed = signRequest(
+        {
+          method: 'POST',
+          url: `http://127.0.0.1:${port}/mcp`,
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+          body,
+        },
+        { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: primaryPrivate },
+        { now: () => now, windowSeconds: 300, nonce: 'e2e-require-badsig-01' }
+      );
+      signed.headers.Signature = signed.headers.Signature.replace(
+        /[A-Za-z0-9+/]/,
+        c => (c === 'A' ? 'B' : 'A')
+      );
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          ...signed.headers,
+          Accept: 'application/json, text/event-stream',
+          Authorization: 'Bearer sk_test',
+        },
+        body,
+      });
+      assert.strictEqual(res.status, 401, 'present-but-invalid signature must reject despite valid bearer');
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  });
+
+  it('accepts a signed request with no bearer (body buffered before auth)', async () => {
+    const composed = requireSignatureWhenPresent(
+      verifySignatureAsAuthenticator(
+        baseOptions({ getUrl: req => `http://${req.headers.host}${req.url}` })
+      ),
+      verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
+    );
+    const { server, port } = await startServer(composed);
+    try {
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {},
+      });
+      const now = Math.floor(Date.now() / 1000);
+      const signed = signRequest(
+        {
+          method: 'POST',
+          url: `http://127.0.0.1:${port}/mcp`,
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+          body,
+        },
+        { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: primaryPrivate },
+        { now: () => now, windowSeconds: 300, nonce: 'e2e-require-good-01' }
+      );
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { ...signed.headers, Accept: 'application/json, text/event-stream' },
+        body,
+      });
+      assert.strictEqual(res.status, 200);
+    } finally {
+      await new Promise(r => server.close(r));
+    }
   });
 });

--- a/test/auth-signature-compose.test.js
+++ b/test/auth-signature-compose.test.js
@@ -537,12 +537,9 @@ describe('requireSignatureWhenPresent(signatureAuth, fallbackAuth)', () => {
   });
 
   it('propagates a fallback AuthError verbatim (no double-wrapping)', async () => {
-    const composed = requireSignatureWhenPresent(
-      verifySignatureAsAuthenticator(baseOptions()),
-      async () => {
-        throw new AuthError('Insufficient scope.');
-      }
-    );
+    const composed = requireSignatureWhenPresent(verifySignatureAsAuthenticator(baseOptions()), async () => {
+      throw new AuthError('Insufficient scope.');
+    });
     await assert.rejects(
       () => composed(makeReq()),
       err => err instanceof AuthError && err.publicMessage === 'Insufficient scope.'
@@ -684,9 +681,7 @@ describe('serve() + requireSignatureWhenPresent', () => {
 
   it('rejects a signed-but-invalid request with 401 even when a valid bearer is supplied', async () => {
     const composed = requireSignatureWhenPresent(
-      verifySignatureAsAuthenticator(
-        baseOptions({ getUrl: req => `http://${req.headers.host}${req.url}` })
-      ),
+      verifySignatureAsAuthenticator(baseOptions({ getUrl: req => `http://${req.headers.host}${req.url}` })),
       verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
     );
     const { server, port } = await startServer(composed);
@@ -708,10 +703,7 @@ describe('serve() + requireSignatureWhenPresent', () => {
         { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: primaryPrivate },
         { now: () => now, windowSeconds: 300, nonce: 'e2e-require-badsig-01' }
       );
-      signed.headers.Signature = signed.headers.Signature.replace(
-        /[A-Za-z0-9+/]/,
-        c => (c === 'A' ? 'B' : 'A')
-      );
+      signed.headers.Signature = signed.headers.Signature.replace(/[A-Za-z0-9+/]/, c => (c === 'A' ? 'B' : 'A'));
       const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
         method: 'POST',
         headers: {
@@ -729,9 +721,7 @@ describe('serve() + requireSignatureWhenPresent', () => {
 
   it('accepts a signed request with no bearer (body buffered before auth)', async () => {
     const composed = requireSignatureWhenPresent(
-      verifySignatureAsAuthenticator(
-        baseOptions({ getUrl: req => `http://${req.headers.host}${req.url}` })
-      ),
+      verifySignatureAsAuthenticator(baseOptions({ getUrl: req => `http://${req.headers.host}${req.url}` })),
       verifyApiKey({ keys: { sk_test: { principal: 'acct_42' } } })
     );
     const { server, port } = await startServer(composed);


### PR DESCRIPTION
## Summary

Closes #659 by adding `requireSignatureWhenPresent(signatureAuth, fallbackAuth)` — the presence-gated authenticator composer the issue proposed.

`anyOf(verifyApiKey, verifySignatureAsAuthenticator)` has wrong semantics for the `signed-requests` specialism: when a request carries a valid bearer AND a present-but-invalid signature, `anyOf` catches the sig adapter's `AuthError` and falls through to the bearer authenticator — silently accepting the request. This breaks 25 negative conformance vectors (`request_signature_revoked`, `request_signature_window_invalid`, etc.).

The helper encodes the spec-compliant contract:

| RFC 9421 signature header present? | Outcome                           |
|------------------------------------|-----------------------------------|
| yes                                | signature authenticator runs; principal / `AuthError` / `null→AuthError` is final — fallback never runs |
| no                                 | fallback runs verbatim            |

```ts
import { serve, anyOf, verifyApiKey, verifyBearer, verifySignatureAsAuthenticator, requireSignatureWhenPresent } from '@adcp/client/server';

serve(createAgent, {
  authenticate: requireSignatureWhenPresent(
    verifySignatureAsAuthenticator({ jwks, replayStore, revocationStore, capability, resolveOperation }),
    anyOf(verifyApiKey({ keys }), verifyBearer({ jwksUri, issuer, audience })),
  ),
});
```

## Review response

Addressed all **Should fix** findings from code + security review:

- **`null`-from-sig contract hole** (code-reviewer): converted to `AuthError` so a custom sig authenticator returning `null` on a signed request fails closed instead of surfacing as "no credentials".
- **`hasSignatureHeader` missed `Signature`-only case** (security-reviewer): detection now matches either `Signature-Input` OR `Signature` — a request carrying only one of the pair is malformed but still signed intent and must not fall through to bearer. Tightens the existing `verifySignatureAsAuthenticator` adapter in the same direction.
- **`anyOf(requireSignatureWhenPresent(...), ...)` re-opens the bypass** (security-reviewer, option b): added `AUTH_PRESENCE_GATED` marker symbol; `anyOf` throws synchronously at wire-up when any child carries the tag. Fails at composition time, not under attack.
- **Test gap for null-from-sig** (code-reviewer): added. Plus tests for `Signature`-only routing and the `anyOf`-composition guard (both positions + inverted composition accepted).

## New public exports (`@adcp/client/server`)

- `requireSignatureWhenPresent` — the presence-gated composer
- `AUTH_PRESENCE_GATED`, `tagAuthenticatorPresenceGated`, `isAuthenticatorPresenceGated` — the marker + helpers

## Test plan

- [x] `node --test test/auth-signature-compose.test.js` — 44 tests: unit behavior, raw-body tag propagation, serve() e2e (3 scenarios), null-sig + Signature-only + anyOf-guard.
- [x] `node --test test/server-auth.test.js test/server-auto-signed-requests.test.js test/server-create-adcp-server.test.js` — 162 related tests pass.
- [x] `npm test` — 4320 pass, 12 skipped, 0 fail across the full repo.
- [x] `tsc --noEmit` clean.
- [x] Changeset: minor (new public API, non-breaking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)