### PR TITLE
feat: AdCP 3.0 release blockers — adapter, fixtures, schemas, grader, reset

### DIFF
--- a/.changeset/adcp-3-0-release-blockers.md
+++ b/.changeset/adcp-3-0-release-blockers.md
@@ -1,0 +1,21 @@
+---
+'@adcp/client': minor
+---
+
+AdCP 3.0 release blockers — SDK-level wiring for conformance-runner integration.
+
+**New subpath exports**
+
+- `@adcp/client/compliance-fixtures` — canonical `COMPLIANCE_FIXTURES` data for every hardcoded ID storyboards reference (`test-product`, `sports_ctv_q2`, `video_30s`, `native_post`, `native_content`, `campaign_hero_video`, `gov_acme_q2_2027`, `mb_acme_q2_2026_auction`, `cpm_guaranteed`, etc.) plus a `seedComplianceFixtures(server)` helper that writes fixtures into the state store under well-known `compliance:*` collections. Closes [#663](https://github.com/adcontextprotocol/adcp-client/issues/663).
+- `@adcp/client/schemas` — re-exports every generated Zod request schema plus `TOOL_INPUT_SHAPES` (ready-to-register `inputSchema` map covering non-framework tools like `creative_approval` and `update_rights`) and a `customToolFor(name, description, shape, handler)` helper. Closes [#667](https://github.com/adcontextprotocol/adcp-client/issues/667).
+
+**Server (`@adcp/client/server`)**
+
+- `createExpressAdapter({ mountPath, publicUrl, prm, server })` returns the four pieces an Express-mounted agent needs: `rawBodyVerify` (captures raw bytes for RFC 9421), `protectedResourceMiddleware` (RFC 9728 PRM at the origin root), `getUrl` (mount-aware URL reconstruction for the signature verifier), and `resetHook` (delegates to `server.compliance.reset()`). Closes [#664](https://github.com/adcontextprotocol/adcp-client/issues/664).
+- `requireAuthenticatedOrSigned({ signature, fallback, requiredFor, resolveOperation })` bundles presence-gated signature composition with `required_for` enforcement on the no-signature path. `requireSignatureWhenPresent` grew an options parameter that carries the same `requiredFor` + `resolveOperation` semantics. Unsigned requests with no credentials on a `required_for` operation throw `AuthError` whose cause is `RequestSignatureError('request_signature_required')`; valid bearer bypass stays valid. Closes [#665](https://github.com/adcontextprotocol/adcp-client/issues/665).
+- `respondUnauthorized({ signatureError })` emits a `WWW-Authenticate: Signature error="<code>"` challenge when the rejection comes from the RFC 9421 verifier. `serve()` auto-detects this via `signatureErrorCodeFromCause(err)` — the signed_requests negative-vector grader reads the error code off the challenge, so previously callers had to override the 401 response by hand.
+- `AdcpServer.compliance.reset({ force? })` drops session state and the idempotency cache between storyboards. Refuses to run in production-like deployments unless `force: true` is passed. `IdempotencyStore.clearAll` is now an optional method on the store; `memoryBackend` implements it, production backends leave it undefined. Closes [#666](https://github.com/adcontextprotocol/adcp-client/issues/666).
+
+**Testing (`@adcp/client/testing`)**
+
+- Request-signing grader accepts an `agentCapability` option. When present, vectors whose `verifier_capability` can't coexist with the agent's declared profile (`covers_content_digest` disagreement, vector-asserted `required_for` not in agent's list) auto-skip with `skip_reason: 'capability_profile_mismatch'`. `skipVectors` stays available for operator-driven overrides. Closes [#668](https://github.com/adcontextprotocol/adcp-client/issues/668).

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-20
-> @adcp/client v5.5.0
+> @adcp/client v5.6.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-20
-> Library: @adcp/client v5.5.0
+> Library: @adcp/client v5.6.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.5.0",
+      "version": "5.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,16 @@
       "import": "./dist/lib/signing/server.js",
       "require": "./dist/lib/signing/server.js",
       "types": "./dist/lib/signing/server.d.ts"
+    },
+    "./schemas": {
+      "import": "./dist/lib/schemas/index.js",
+      "require": "./dist/lib/schemas/index.js",
+      "types": "./dist/lib/schemas/index.d.ts"
+    },
+    "./compliance-fixtures": {
+      "import": "./dist/lib/compliance-fixtures/index.js",
+      "require": "./dist/lib/compliance-fixtures/index.js",
+      "types": "./dist/lib/compliance-fixtures/index.d.ts"
     }
   },
   "typesVersions": {
@@ -77,6 +87,12 @@
       ],
       "signing/server": [
         "dist/lib/signing/server.d.ts"
+      ],
+      "schemas": [
+        "dist/lib/schemas/index.d.ts"
+      ],
+      "compliance-fixtures": [
+        "dist/lib/compliance-fixtures/index.d.ts"
       ]
     }
   },

--- a/src/lib/compliance-fixtures/index.ts
+++ b/src/lib/compliance-fixtures/index.ts
@@ -51,6 +51,12 @@
 
 import { ADCP_STATE_STORE, type AdcpServer } from '../server/adcp-server';
 import type { AdcpStateStore } from '../server/state-store';
+// Pull canonical unions/shapes from the generated spec types so fixture
+// typings can't drift from the schema. Hand-typing `pricing_model` as
+// `'cpm' | 'cpc' | 'cpv' | 'flat'` is how we shipped `'flat'` (which
+// doesn't exist in the spec) — the generated `PricingModel` has the
+// authoritative union.
+import type { PricingModel } from '../types/tools.generated';
 
 export type ComplianceFixtureCategory =
   | 'products'
@@ -95,9 +101,25 @@ export interface ComplianceFormatFixture {
 
 export interface CompliancePricingOptionFixture {
   pricing_option_id: string;
+  /** ISO 4217 currency code, per the spec's `PricingOption.currency`. */
   currency: string;
-  pricing_model: 'cpm' | 'cpc' | 'cpv' | 'flat';
-  cpm?: number;
+  /**
+   * Pricing model — uses the authoritative generated union. The spec
+   * discriminates `PricingOption` on this field across 9 variants
+   * (`cpm`, `vcpm`, `cpc`, `cpcv`, `cpv`, `cpp`, `cpa`, `flat_rate`,
+   * `time`); mismatches here silently fail schema validation in
+   * seller-side `get_products` responses that merge fixture data in.
+   */
+  pricing_model: PricingModel;
+  /**
+   * Fixed price per unit per the matching `*PricingOption.fixed_price`
+   * field (CPM, CPC, etc.). Present when this is a fixed-price option;
+   * omit for auction-based options that advertise `floor_price` /
+   * `price_guidance` instead.
+   */
+  fixed_price?: number;
+  /** Floor price for auction-based options. */
+  floor_price?: number;
 }
 
 export interface ComplianceCreativeFixture {
@@ -182,19 +204,19 @@ export const COMPLIANCE_FIXTURES: ComplianceFixtureSet = Object.freeze({
       pricing_option_id: 'test-pricing',
       currency: 'USD',
       pricing_model: 'cpm',
-      cpm: 5,
+      fixed_price: 5,
     }),
     default: Object.freeze({
       pricing_option_id: 'default',
       currency: 'USD',
       pricing_model: 'cpm',
-      cpm: 10,
+      fixed_price: 10,
     }),
     cpm_guaranteed: Object.freeze({
       pricing_option_id: 'cpm_guaranteed',
       currency: 'USD',
       pricing_model: 'cpm',
-      cpm: 25,
+      fixed_price: 25,
     }),
   }),
 

--- a/src/lib/compliance-fixtures/index.ts
+++ b/src/lib/compliance-fixtures/index.ts
@@ -51,12 +51,12 @@
 
 import { ADCP_STATE_STORE, type AdcpServer } from '../server/adcp-server';
 import type { AdcpStateStore } from '../server/state-store';
-// Pull canonical unions/shapes from the generated spec types so fixture
-// typings can't drift from the schema. Hand-typing `pricing_model` as
-// `'cpm' | 'cpc' | 'cpv' | 'flat'` is how we shipped `'flat'` (which
-// doesn't exist in the spec) — the generated `PricingModel` has the
-// authoritative union.
-import type { PricingModel } from '../types/tools.generated';
+// Pull canonical shapes from the generated spec types so fixture typings
+// can't drift from the schema. `PricingOption` is the discriminated
+// union (`CPMPricingOption | VCPMPricingOption | ...`) — typing
+// fixture bodies as this union gives consumers full TS narrowing and
+// guarantees the fixture matches at least one spec variant.
+import type { PricingOption } from '../types/tools.generated';
 
 export type ComplianceFixtureCategory =
   | 'products'
@@ -99,28 +99,15 @@ export interface ComplianceFormatFixture {
   duration_ms?: number;
 }
 
-export interface CompliancePricingOptionFixture {
-  pricing_option_id: string;
-  /** ISO 4217 currency code, per the spec's `PricingOption.currency`. */
-  currency: string;
-  /**
-   * Pricing model — uses the authoritative generated union. The spec
-   * discriminates `PricingOption` on this field across 9 variants
-   * (`cpm`, `vcpm`, `cpc`, `cpcv`, `cpv`, `cpp`, `cpa`, `flat_rate`,
-   * `time`); mismatches here silently fail schema validation in
-   * seller-side `get_products` responses that merge fixture data in.
-   */
-  pricing_model: PricingModel;
-  /**
-   * Fixed price per unit per the matching `*PricingOption.fixed_price`
-   * field (CPM, CPC, etc.). Present when this is a fixed-price option;
-   * omit for auction-based options that advertise `floor_price` /
-   * `price_guidance` instead.
-   */
-  fixed_price?: number;
-  /** Floor price for auction-based options. */
-  floor_price?: number;
-}
+/**
+ * Fixture body for a pricing option. Aliases the spec's discriminated
+ * `PricingOption` union so callers that spread a fixture into a
+ * `get_products` response get full TypeScript narrowing on
+ * `pricing_model`. The shipped bodies are all `CPMPricingOption`
+ * (fixed-price CPM); sellers who need other variants should supply
+ * overrides via {@link SeedComplianceFixturesOptions.overrides}.
+ */
+export type CompliancePricingOptionFixture = PricingOption;
 
 export interface ComplianceCreativeFixture {
   creative_id: string;

--- a/src/lib/compliance-fixtures/index.ts
+++ b/src/lib/compliance-fixtures/index.ts
@@ -1,0 +1,321 @@
+/**
+ * Canonical AdCP compliance storyboard fixtures.
+ *
+ * Conformance storyboards reference entities by hardcoded ID —
+ * `test-product`, `test-pricing`, `video_30s`, `native_post`,
+ * `native_content`, `campaign_hero_video`, `sports_ctv_q2`,
+ * `cpm_guaranteed`, `gov_acme_q2_2027`, `mb_acme_q2_2026_auction`,
+ * and a handful of others. None are discoverable from the JSON
+ * Schemas alone; every implementer hits the same wall (failing
+ * storyboards → grep YAML source → hand-seed matching fixtures).
+ *
+ * This module owns the canonical data and offers two integration
+ * paths:
+ *
+ *   - {@link COMPLIANCE_FIXTURES}: a typed object literal with every
+ *     known fixture ID and a minimal-but-storyboard-compatible body.
+ *     Sellers can merge these into whatever handlers answer the
+ *     relevant tools (`get_products`, `list_creative_formats`,
+ *     `list_creatives`, …).
+ *
+ *   - {@link seedComplianceFixtures}: writes the fixtures into the
+ *     server's state store under well-known collection names (see
+ *     {@link COMPLIANCE_COLLECTIONS}). Sellers whose handlers already
+ *     read-through the state store get fixtures populated without
+ *     touching handler code.
+ *
+ * ```ts
+ * import { createAdcpServer } from '@adcp/client/server';
+ * import { seedComplianceFixtures, COMPLIANCE_FIXTURES } from '@adcp/client/compliance-fixtures';
+ *
+ * const server = createAdcpServer({
+ *   mediaBuy: {
+ *     getProducts: async (_params, ctx) => ({
+ *       products: [
+ *         ...(await ctx.store.list('compliance:products')).items.map(r => r.value),
+ *         ...myCatalog,
+ *       ],
+ *     }),
+ *   },
+ *   ...handlers,
+ * });
+ *
+ * await seedComplianceFixtures(server);
+ * ```
+ *
+ * The shipped bodies are minimal on purpose: they contain exactly the
+ * fields storyboards probe. Sellers whose catalog shape differs (richer
+ * pricing, per-brand variants, etc.) SHOULD override via
+ * {@link SeedComplianceFixturesOptions.overrides}.
+ */
+
+import { ADCP_STATE_STORE, type AdcpServer } from '../server/adcp-server';
+import type { AdcpStateStore } from '../server/state-store';
+
+export type ComplianceFixtureCategory =
+  | 'products'
+  | 'formats'
+  | 'creatives'
+  | 'plans'
+  | 'media_buys'
+  | 'pricing_options';
+
+/**
+ * State-store collection names the seeder writes into. Handlers that
+ * read-through the state store should use the same names when
+ * integrating fixture data into their own responses.
+ */
+export const COMPLIANCE_COLLECTIONS: Readonly<Record<ComplianceFixtureCategory, string>> = Object.freeze({
+  products: 'compliance:products',
+  formats: 'compliance:formats',
+  creatives: 'compliance:creatives',
+  plans: 'compliance:plans',
+  media_buys: 'compliance:media_buys',
+  pricing_options: 'compliance:pricing_options',
+});
+
+export interface ComplianceProductFixture {
+  product_id: string;
+  name: string;
+  description: string;
+  delivery_type: 'guaranteed' | 'non_guaranteed';
+  channels: string[];
+  formats: string[];
+  pricing_options: string[];
+}
+
+export interface ComplianceFormatFixture {
+  format_id: string;
+  name: string;
+  type: string;
+  width?: number;
+  height?: number;
+  duration_ms?: number;
+}
+
+export interface CompliancePricingOptionFixture {
+  pricing_option_id: string;
+  currency: string;
+  pricing_model: 'cpm' | 'cpc' | 'cpv' | 'flat';
+  cpm?: number;
+}
+
+export interface ComplianceCreativeFixture {
+  creative_id: string;
+  format_id: string;
+  status: 'approved' | 'pending' | 'rejected';
+  name: string;
+}
+
+export interface CompliancePlanFixture {
+  plan_id: string;
+  brand_domain: string;
+  total_budget: { amount: number; currency: string };
+  status: 'active' | 'paused';
+}
+
+export interface ComplianceMediaBuyFixture {
+  media_buy_id: string;
+  status: 'active' | 'pending_start' | 'completed';
+  total_budget: { amount: number; currency: string };
+}
+
+export interface ComplianceFixtureSet {
+  products: Readonly<Record<string, Readonly<ComplianceProductFixture>>>;
+  formats: Readonly<Record<string, Readonly<ComplianceFormatFixture>>>;
+  pricing_options: Readonly<Record<string, Readonly<CompliancePricingOptionFixture>>>;
+  creatives: Readonly<Record<string, Readonly<ComplianceCreativeFixture>>>;
+  plans: Readonly<Record<string, Readonly<CompliancePlanFixture>>>;
+  media_buys: Readonly<Record<string, Readonly<ComplianceMediaBuyFixture>>>;
+}
+
+/**
+ * Canonical storyboard fixtures. Every ID here appears verbatim in at
+ * least one `compliance/cache/latest/**\/*.yaml` storyboard — CI lints
+ * the tie between source storyboards and this set (not yet; see
+ * {@link https://github.com/adcontextprotocol/adcp-client/issues/663}).
+ */
+export const COMPLIANCE_FIXTURES: ComplianceFixtureSet = Object.freeze({
+  products: Object.freeze({
+    'test-product': Object.freeze({
+      product_id: 'test-product',
+      name: 'Test Product',
+      description:
+        'Generic non-guaranteed inventory used by universal storyboards (error-compliance, idempotency, deterministic-testing, schema-validation).',
+      delivery_type: 'non_guaranteed',
+      channels: ['display', 'video'],
+      formats: ['video_30s', 'native_post', 'native_content'],
+      pricing_options: ['test-pricing', 'default'],
+    }),
+    sports_ctv_q2: Object.freeze({
+      product_id: 'sports_ctv_q2',
+      name: 'Sports CTV — Q2',
+      description: 'CTV variant referenced by governance-spend-authority and governance-delivery-monitor storyboards.',
+      delivery_type: 'guaranteed',
+      channels: ['ctv'],
+      formats: ['video_30s'],
+      pricing_options: ['cpm_guaranteed'],
+    }),
+  }),
+
+  formats: Object.freeze({
+    video_30s: Object.freeze({
+      format_id: 'video_30s',
+      name: '30-second Video',
+      type: 'video',
+      duration_ms: 30_000,
+    }),
+    native_post: Object.freeze({
+      format_id: 'native_post',
+      name: 'Native Post',
+      type: 'native',
+    }),
+    native_content: Object.freeze({
+      format_id: 'native_content',
+      name: 'Native Content',
+      type: 'native',
+    }),
+  }),
+
+  pricing_options: Object.freeze({
+    'test-pricing': Object.freeze({
+      pricing_option_id: 'test-pricing',
+      currency: 'USD',
+      pricing_model: 'cpm',
+      cpm: 5,
+    }),
+    default: Object.freeze({
+      pricing_option_id: 'default',
+      currency: 'USD',
+      pricing_model: 'cpm',
+      cpm: 10,
+    }),
+    cpm_guaranteed: Object.freeze({
+      pricing_option_id: 'cpm_guaranteed',
+      currency: 'USD',
+      pricing_model: 'cpm',
+      cpm: 25,
+    }),
+  }),
+
+  creatives: Object.freeze({
+    campaign_hero_video: Object.freeze({
+      creative_id: 'campaign_hero_video',
+      format_id: 'video_30s',
+      status: 'approved',
+      name: 'Campaign Hero Video',
+    }),
+  }),
+
+  plans: Object.freeze({
+    gov_acme_q2_2027: Object.freeze({
+      plan_id: 'gov_acme_q2_2027',
+      brand_domain: 'acmeoutdoor.example',
+      total_budget: Object.freeze({ amount: 50_000, currency: 'USD' }),
+      status: 'active',
+    }),
+  }),
+
+  media_buys: Object.freeze({
+    mb_acme_q2_2026_auction: Object.freeze({
+      media_buy_id: 'mb_acme_q2_2026_auction',
+      status: 'active',
+      total_budget: Object.freeze({ amount: 25_000, currency: 'USD' }),
+    }),
+  }),
+}) as ComplianceFixtureSet;
+
+export interface SeedComplianceFixturesOptions {
+  /**
+   * Subset of fixture categories to seed. Defaults to all six.
+   */
+  categories?: ComplianceFixtureCategory[];
+  /**
+   * Per-category overrides to merge ON TOP of the canonical fixtures.
+   * Keys are the fixture IDs — replacing an entry with `null` deletes
+   * it from the seed set (for sellers whose catalog shape legitimately
+   * can't satisfy a given storyboard's expectations).
+   */
+  overrides?: {
+    [K in ComplianceFixtureCategory]?: Record<string, ComplianceFixtureSet[K][string] | null>;
+  };
+  /**
+   * Collection-name prefix override. Defaults to the
+   * {@link COMPLIANCE_COLLECTIONS} defaults (`compliance:*`). Use when
+   * your handlers already read from a different collection convention.
+   */
+  collections?: Partial<Record<ComplianceFixtureCategory, string>>;
+}
+
+/**
+ * Write {@link COMPLIANCE_FIXTURES} into the server's state store
+ * under {@link COMPLIANCE_COLLECTIONS}. Handlers that read from the
+ * same collections get compliance fixtures without hand-seeding.
+ *
+ * Idempotent: re-seeding overwrites existing entries with the same ID
+ * (the state store's `put` is the write primitive — no version check).
+ * Between storyboards, call `server.compliance.reset()` to clear state
+ * AND re-seed (reset itself doesn't restore fixtures).
+ *
+ * Throws when the server doesn't expose a state store with the shape
+ * {@link AdcpStateStore}. Custom servers that wrap the MCP SDK directly
+ * should use {@link COMPLIANCE_FIXTURES} as the source of truth and
+ * wire seeding themselves.
+ */
+export async function seedComplianceFixtures(
+  server: AdcpServer,
+  options: SeedComplianceFixturesOptions = {}
+): Promise<void> {
+  const store = resolveStateStore(server);
+  const categories: ComplianceFixtureCategory[] =
+    options.categories ?? (Object.keys(COMPLIANCE_COLLECTIONS) as ComplianceFixtureCategory[]);
+
+  for (const category of categories) {
+    const fixtures = COMPLIANCE_FIXTURES[category] as Record<string, Record<string, unknown>>;
+    const overrides = (options.overrides?.[category] ?? {}) as Record<string, Record<string, unknown> | null>;
+    const collection = options.collections?.[category] ?? COMPLIANCE_COLLECTIONS[category];
+
+    const merged: Record<string, Record<string, unknown>> = { ...fixtures };
+    for (const [id, override] of Object.entries(overrides)) {
+      if (override === null) {
+        delete merged[id];
+      } else {
+        merged[id] = override;
+      }
+    }
+
+    for (const [id, body] of Object.entries(merged)) {
+      await store.put(collection, id, body);
+    }
+  }
+}
+
+/**
+ * Look up a single fixture by category and ID. Convenience for
+ * handlers that don't want to iterate the entire fixture set.
+ */
+export function getComplianceFixture<K extends ComplianceFixtureCategory>(
+  category: K,
+  id: string
+): ComplianceFixtureSet[K][string] | undefined {
+  return (COMPLIANCE_FIXTURES[category] as Record<string, ComplianceFixtureSet[K][string]>)[id];
+}
+
+function resolveStateStore(server: AdcpServer): AdcpStateStore {
+  const candidate = (server as unknown as { [k: symbol]: unknown })[ADCP_STATE_STORE];
+  if (isStateStore(candidate)) return candidate;
+  throw new Error(
+    'seedComplianceFixtures: argument is not an AdcpServer produced by `createAdcpServer()`. ' +
+      'Use `COMPLIANCE_FIXTURES` directly and seed via your own integration path.'
+  );
+}
+
+function isStateStore(value: unknown): value is AdcpStateStore {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    typeof (value as { put?: unknown }).put === 'function' &&
+    typeof (value as { get?: unknown }).get === 'function' &&
+    typeof (value as { list?: unknown }).list === 'function'
+  );
+}

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -1,0 +1,101 @@
+/**
+ * Consolidated schema exports for MCP tool registration.
+ *
+ * The generated Zod schemas in `../types/schemas.generated` cover every
+ * AdCP tool — the framework-registered {@link AdcpToolMap} tools AND
+ * tools like `creative_approval` / `update_rights` that ship as
+ * `customTools` extensions because the spec models them as out-of-band
+ * callbacks rather than MCP-registered surfaces.
+ *
+ * This module re-exports the generated schemas plus two convenience
+ * helpers for the `customTools` registration path:
+ *
+ *   - {@link TOOL_INPUT_SHAPES}: `toolName → inputSchema` map, ready to
+ *     pass as `inputSchema` to MCP SDK's `server.registerTool()`. Uses
+ *     the same tool-name keys as `AdcpServerConfig.customTools`.
+ *   - {@link customToolFor}: sugar for registering a single custom tool
+ *     with type-safe `handler` params derived from the schema's shape.
+ *
+ * ```ts
+ * import { createAdcpServer } from '@adcp/client/server';
+ * import { TOOL_INPUT_SHAPES, customToolFor } from '@adcp/client/schemas';
+ *
+ * createAdcpServer({
+ *   customTools: {
+ *     creative_approval: customToolFor(
+ *       'creative_approval',
+ *       'Accept a buyer creative for approval.',
+ *       TOOL_INPUT_SHAPES.creative_approval,
+ *       async (args, extra) => { ... },
+ *     ),
+ *   },
+ *   ...,
+ * });
+ * ```
+ */
+
+import type { z } from 'zod';
+import * as schemas from '../types/schemas.generated';
+import { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
+
+export * from '../types/schemas.generated';
+export { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
+
+type InputShape = Record<string, z.ZodType>;
+
+function shapeOf(s: unknown): InputShape | undefined {
+  if (!s) return undefined;
+  const candidate = (s as { shape?: InputShape }).shape;
+  return candidate && typeof candidate === 'object' ? candidate : undefined;
+}
+
+/**
+ * Map of every known AdCP tool name to its Zod input shape — i.e., the
+ * `.shape` of its request schema, ready to pass as `inputSchema` to MCP
+ * SDK's `server.registerTool()`.
+ *
+ * Superset of {@link TOOL_REQUEST_SCHEMAS}: also includes tools like
+ * `creative_approval` and `update_rights` that have generated schemas
+ * but aren't framework-registered in `AdcpToolMap` (sellers register
+ * them via `customTools`).
+ */
+export const TOOL_INPUT_SHAPES: Readonly<Record<string, Readonly<InputShape>>> = Object.freeze({
+  ...Object.fromEntries(
+    Object.entries(TOOL_REQUEST_SCHEMAS).flatMap(([k, s]) => {
+      const shape = shapeOf(s);
+      return shape ? [[k, shape] as const] : [];
+    })
+  ),
+  creative_approval: schemas.CreativeApprovalRequestSchema.shape,
+  update_rights: schemas.UpdateRightsRequestSchema.shape,
+});
+
+/**
+ * Register a custom tool with MCP-compatible `inputSchema` + handler
+ * wiring. Returns an object shaped for
+ * `AdcpServerConfig.customTools[name]` — pass it straight through.
+ *
+ * Why it exists: sellers adding tools outside `AdcpToolMap` have to
+ * publish an `inputSchema` via `tools/list` (MCP spec requirement). Doing
+ * that by hand means authoring a Zod shape that matches the generated
+ * AdCP spec schema — easy to drift silently. Using this helper guarantees
+ * the advertised shape is the same shape the SDK validates the request
+ * against.
+ */
+export function customToolFor<TShape extends InputShape>(
+  name: string,
+  description: string,
+  inputSchema: TShape,
+  handler: (args: z.input<z.ZodObject<TShape>>, extra?: unknown) => unknown | Promise<unknown>
+): {
+  description: string;
+  inputSchema: TShape;
+  handler: (args: z.input<z.ZodObject<TShape>>, extra?: unknown) => unknown | Promise<unknown>;
+} {
+  // `name` participates in the return contract's narrowing only indirectly
+  // (via the caller's key when spread into `customTools`). Callers retain
+  // it as a parameter so future stricter registration (logging, metrics,
+  // schema-registry lookups) can be added without an API break.
+  void name;
+  return { description, inputSchema, handler };
+}

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -54,10 +54,18 @@ function shapeOf(s: unknown): InputShape | undefined {
  * `.shape` of its request schema, ready to pass as `inputSchema` to MCP
  * SDK's `server.registerTool()`.
  *
- * Superset of {@link TOOL_REQUEST_SCHEMAS}: also includes tools like
- * `creative_approval` and `update_rights` that have generated schemas
- * but aren't framework-registered in `AdcpToolMap` (sellers register
- * them via `customTools`).
+ * Superset of {@link TOOL_REQUEST_SCHEMAS}: covers every tool already
+ * registered with the framework (get_products, create_media_buy,
+ * sync_catalogs, check_governance, comply_test_controller, all five
+ * *_collection_list tools, validate_property_delivery, acquire_rights,
+ * et al.) PLUS the two tools the spec models as customTool-only
+ * extensions — `creative_approval` and `update_rights` — so sellers
+ * don't have to hand-author shapes for those either.
+ *
+ * If a future AdCP release adds a new tool with a generated request
+ * schema, add its entry here (or to `TOOL_REQUEST_SCHEMAS` if it's
+ * framework-registrable) — CI's `ci:schema-check` catches missing
+ * map entries by diffing against the generated schemas.
  */
 export const TOOL_INPUT_SHAPES: Readonly<Record<string, Readonly<InputShape>>> = Object.freeze({
   ...Object.fromEntries(

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -103,15 +103,21 @@ export interface AdcpServerComplianceApi {
    * `media_buy_seller/governance_denied` would intercept a $50K buy in
    * `sales_guaranteed`.
    *
-   * Refuses to run in production-like deployments: throws when the
-   * state store doesn't expose a `clear` method (anything other than
-   * the in-memory shipped default), or the idempotency store's backend
-   * doesn't expose `clearAll`. Pass `{ force: true }` to bypass the
-   * guard when you've deliberately wired a Postgres backend for a test
-   * DB — the flush is still scoped to the stores configured on this
-   * server, so the guard is belt-and-suspenders, not a safety net.
+   * Refuses to run by default unless BOTH guardrails hold:
+   *   - `NODE_ENV !== 'production'` (opt out with `allowProduction: true`)
+   *   - The configured stores are the in-memory SDK defaults
+   *     (`InMemoryStateStore` + memory idempotency backend). Opt out
+   *     with `force: true` when you've wired a disposable test
+   *     Postgres cluster and know the flush is safe.
+   *
+   * The two flags are independent on purpose: `force` lets you flush
+   * a non-memory store you've verified is a test DB, WITHOUT also
+   * opening the door to running against a production `NODE_ENV`.
+   * Same the other way: `allowProduction` lets you run in a prod-
+   * labeled CI environment against memory stores, without bypassing
+   * the store-shape safety check.
    */
-  reset(options?: { force?: boolean }): Promise<void>;
+  reset(options?: { force?: boolean; allowProduction?: boolean }): Promise<void>;
 }
 
 /**

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -89,6 +89,32 @@ export interface AdcpTestToolsCallRequest {
 export type AdcpTestResponse = unknown;
 
 /**
+ * Test-harness hooks attached to every `AdcpServer`. Namespaced under
+ * `compliance` so production code paths don't accidentally reach for
+ * them — `reset()` drops cached state and is intended for storyboard
+ * runners that exercise many scenarios in one process.
+ */
+export interface AdcpServerComplianceApi {
+  /**
+   * Drop session state and the idempotency cache so subsequent
+   * storyboards don't inherit plans, media buys, or cached replies from
+   * earlier runs. Conformance storyboards share brand domains across
+   * test kits — without this hook, a $10K governance plan seeded by
+   * `media_buy_seller/governance_denied` would intercept a $50K buy in
+   * `sales_guaranteed`.
+   *
+   * Refuses to run in production-like deployments: throws when the
+   * state store doesn't expose a `clear` method (anything other than
+   * the in-memory shipped default), or the idempotency store's backend
+   * doesn't expose `clearAll`. Pass `{ force: true }` to bypass the
+   * guard when you've deliberately wired a Postgres backend for a test
+   * DB — the flush is still scoped to the stores configured on this
+   * server, so the guard is belt-and-suspenders, not a safety net.
+   */
+  reset(options?: { force?: boolean }): Promise<void>;
+}
+
+/**
  * Opaque handle returned by `createAdcpServer()`.
  *
  * Pass to `serve()` to mount on an HTTP transport, or use
@@ -107,6 +133,13 @@ export interface AdcpServer {
 
   /** Close the server and release resources. */
   close(): Promise<void>;
+
+  /**
+   * Test-harness hooks — see {@link AdcpServerComplianceApi}. Not
+   * intended for production call sites; production code paths should
+   * use `close()` to release resources.
+   */
+  readonly compliance: AdcpServerComplianceApi;
 
   /**
    * Invoke a registered handler in-process and return its response.
@@ -147,6 +180,18 @@ export interface AdcpServer {
  * @internal
  */
 export const ADCP_SDK_SERVER: unique symbol = Symbol.for('@adcp/client.sdkServer');
+
+/**
+ * Symbol-keyed accessor for the state store backing an `AdcpServer`.
+ * Test harnesses and helpers like
+ * `@adcp/client/compliance-fixtures`'s `seedComplianceFixtures` need
+ * to reach the store without widening the public `AdcpServer`
+ * interface (handlers already get `ctx.store`; production code paths
+ * don't need a second accessor).
+ *
+ * @internal
+ */
+export const ADCP_STATE_STORE: unique symbol = Symbol.for('@adcp/client.stateStore');
 
 /** @internal */
 export interface AdcpServerInternal extends AdcpServer {
@@ -229,9 +274,20 @@ function getRequestHandler(
  *
  * @internal
  */
-export function wrapMcpServer(inner: McpServer | AdcpServerInternal): AdcpServerInternal {
+export function wrapMcpServer(
+  inner: McpServer | AdcpServerInternal,
+  compliance?: AdcpServerComplianceApi
+): AdcpServerInternal {
   if (isAdcpServer(inner)) return inner;
   const mcp = inner as McpServer;
+  const resolvedCompliance: AdcpServerComplianceApi = compliance ?? {
+    async reset() {
+      throw new Error(
+        'AdcpServer.compliance.reset: no-op handle returned by `wrapMcpServer` without a compliance implementation. ' +
+          'Use `createAdcpServer()` to get a server whose `compliance.reset()` flushes the state and idempotency stores.'
+      );
+    },
+  };
   const dispatch = async (request: AdcpTestRequest): Promise<AdcpTestResponse> => {
     const extra = { signal: new AbortController().signal };
 
@@ -263,6 +319,7 @@ export function wrapMcpServer(inner: McpServer | AdcpServerInternal): AdcpServer
     close() {
       return mcp.close();
     },
+    compliance: resolvedCompliance,
     // Satisfies both overloads (typed tools/call + generic fallback) — the
     // runtime dispatcher is a single function that narrows by method.
     dispatchTestRequest: dispatch as AdcpServerInternal['dispatchTestRequest'],

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -350,7 +350,15 @@ export function requireSignatureWhenPresent(
     }
     return null;
   };
-  if (authenticatorNeedsRawBody(signatureAuth) || authenticatorNeedsRawBody(fallbackAuth)) {
+  const anyChildNeedsRawBody = authenticatorNeedsRawBody(signatureAuth) || authenticatorNeedsRawBody(fallbackAuth);
+  // When `resolveOperation` is wired, it almost always reads
+  // `req.rawBody` to parse the JSON-RPC body — the SDK's documented
+  // pattern. If no child is tagged (test stubs, agents whose signature
+  // path is non-SDK), `serve()` won't buffer the body and
+  // `resolveOperation` silently sees `undefined`, bypassing
+  // `requiredFor`. Tag the combined authenticator whenever a resolver
+  // is present so buffering happens regardless of the child shapes.
+  if (anyChildNeedsRawBody || resolveOperation) {
     tagAuthenticatorNeedsRawBody(combined);
   }
   tagAuthenticatorPresenceGated(combined);

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -345,14 +345,19 @@ export function requireSignatureWhenPresent(
       fallbackThrew = true;
       fallbackError = err;
     }
+    // Valid fallback principal short-circuits everything: this is the
+    // documented "bearer bypass on required_for" semantic (per adcp#2586 —
+    // a valid credential is sufficient even when signing is required for
+    // unauthenticated callers). Return before the pre-check so the
+    // control flow below only runs on `fallbackResult === null`.
+    if (fallbackResult !== null) return fallbackResult;
     // `requiredFor` pre-check: when the op requires a signature AND no
-    // signature was presented, surface `request_signature_required`
-    // REGARDLESS of whether the fallback threw (bad bearer) or returned
-    // null (no creds). Valid bearer is the only escape — if the fallback
-    // returned a principal, we already returned above.
+    // signature was presented AND no valid fallback credential,
+    // surface `request_signature_required` regardless of whether the
+    // fallback threw (bad bearer) or returned null (no creds).
     if (requiredFor.size > 0 && resolveOperation) {
       const operation = resolveOperation(req as IncomingMessage & { rawBody?: string });
-      if (operation && requiredFor.has(operation) && fallbackResult === null) {
+      if (operation && requiredFor.has(operation)) {
         throw new AuthError(`Signature required for ${operation}.`, {
           cause: new RequestSignatureError(
             'request_signature_required',
@@ -366,7 +371,6 @@ export function requireSignatureWhenPresent(
     // original error so the 401 carries the fallback's challenge
     // (Bearer for bad-bearer, invalid_token for no-creds).
     if (fallbackThrew) throw fallbackError;
-    if (fallbackResult !== null) return fallbackResult;
     return null;
   };
   const anyChildNeedsRawBody = authenticatorNeedsRawBody(signatureAuth) || authenticatorNeedsRawBody(fallbackAuth);

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -248,7 +248,75 @@ export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthent
  * wire-up time (throws synchronously) — invert the order instead:
  * `requireSignatureWhenPresent(sig, anyOf(bearer, apiKey))`.
  */
-export function requireSignatureWhenPresent(signatureAuth: Authenticator, fallbackAuth: Authenticator): Authenticator {
+export interface RequireSignatureWhenPresentOptions {
+  /**
+   * Operations that MUST be signed. When the incoming request carries no
+   * RFC 9421 signature header AND the fallback authenticator returns
+   * `null` (no credentials at all), the gate throws an {@link AuthError}
+   * whose `cause` is {@link RequestSignatureError} with
+   * `request_signature_required` — `serve()` maps that into a 401 with
+   * `WWW-Authenticate: Signature error="request_signature_required"`.
+   *
+   * "Fallback bypass" is deliberately allowed: if the caller presents a
+   * valid bearer (or API key) on a `requiredFor` operation, the fallback
+   * succeeds and the request is accepted without a signature. This
+   * matches the consensus on
+   * [adcp#2586](https://github.com/adcontextprotocol/adcp/issues/2586):
+   * `required_for` signals "signatures are the mandatory mechanism for
+   * unauthenticated callers" — not "signatures are mandatory on top of
+   * every other credential."
+   *
+   * When the request IS signed, `required_for` enforcement happens inside
+   * the signature verifier itself (via `capability.required_for`), not
+   * here — this pre-check is only for the no-signature path.
+   */
+  requiredFor?: readonly string[];
+  /**
+   * Extract the AdCP operation name (or any identifier that can be
+   * matched against `requiredFor`) from the incoming request.
+   *
+   * For MCP agents, this usually parses `req.rawBody` as JSON-RPC and
+   * pulls `params.name` when `method === 'tools/call'`:
+   *
+   * ```ts
+   * resolveOperation: (req) => {
+   *   try {
+   *     const body = JSON.parse(req.rawBody ?? '');
+   *     if (body?.method === 'tools/call') return body.params?.name;
+   *   } catch {}
+   *   return undefined;
+   * }
+   * ```
+   *
+   * When `requiredFor` is set but `resolveOperation` is omitted OR
+   * returns `undefined`, the pre-check is skipped — better to let the
+   * downstream handler produce a precise `INVALID_REQUEST` than to
+   * reject every unsigned call as signature-required.
+   */
+  resolveOperation?: (req: IncomingMessage & { rawBody?: string }) => string | undefined;
+}
+
+/**
+ * Compose a signature authenticator with a fallback under presence-gated
+ * semantics: if the incoming request declares a `Signature-Input` header,
+ * the signature authenticator is the ONLY path — its result (principal,
+ * `null`, or thrown {@link AuthError}) is the final outcome and the fallback
+ * never runs. Without `Signature-Input`, the fallback handles the request.
+ *
+ * Pass {@link RequireSignatureWhenPresentOptions.requiredFor} to enforce
+ * `required_for` for the no-signature path: when the fallback produces no
+ * principal on an operation that MUST be signed, the gate throws an
+ * {@link AuthError} whose cause is a {@link RequestSignatureError} with
+ * code `request_signature_required` — `serve()` maps that into a 401
+ * with the RFC 9421 `WWW-Authenticate: Signature` challenge.
+ */
+export function requireSignatureWhenPresent(
+  signatureAuth: Authenticator,
+  fallbackAuth: Authenticator,
+  options: RequireSignatureWhenPresentOptions = {}
+): Authenticator {
+  const requiredFor = new Set(options.requiredFor ?? []);
+  const resolveOperation = options.resolveOperation;
   const combined: Authenticator = async req => {
     if (hasSignatureHeader(req)) {
       const result = await signatureAuth(req);
@@ -260,13 +328,104 @@ export function requireSignatureWhenPresent(signatureAuth: Authenticator, fallba
       }
       return result;
     }
-    return await fallbackAuth(req);
+    const fallbackResult = await fallbackAuth(req);
+    if (fallbackResult !== null) return fallbackResult;
+    // No signature and fallback produced no principal. If the operation is
+    // in `requiredFor`, reject with a signature challenge so the buyer SDK
+    // surfaces `request_signature_required` — the error code the
+    // signed_requests grader's negative vectors expect on the
+    // missing-signature edge. Without `requiredFor`/`resolveOperation`
+    // wired, fall through so `serve()` emits the default bearer challenge.
+    if (requiredFor.size > 0 && resolveOperation) {
+      const operation = resolveOperation(req as IncomingMessage & { rawBody?: string });
+      if (operation && requiredFor.has(operation)) {
+        throw new AuthError(`Signature required for ${operation}.`, {
+          cause: new RequestSignatureError(
+            'request_signature_required',
+            0,
+            `Operation ${operation} requires an RFC 9421 request signature when no other credentials are presented.`
+          ),
+        });
+      }
+    }
+    return null;
   };
   if (authenticatorNeedsRawBody(signatureAuth) || authenticatorNeedsRawBody(fallbackAuth)) {
     tagAuthenticatorNeedsRawBody(combined);
   }
   tagAuthenticatorPresenceGated(combined);
   return combined;
+}
+
+export interface RequireAuthenticatedOrSignedOptions {
+  /** RFC 9421 request-signature authenticator. Usually built with {@link verifySignatureAsAuthenticator}. */
+  signature: Authenticator;
+  /**
+   * Credential authenticator that runs when no signature is present.
+   * Usually {@link anyOf} of `verifyApiKey` / `verifyBearer` — whatever
+   * credential types the agent accepts on unsigned calls.
+   */
+  fallback: Authenticator;
+  /**
+   * Operations that MUST be authenticated with a signature when no other
+   * credential is presented. See
+   * {@link RequireSignatureWhenPresentOptions.requiredFor}.
+   *
+   * Pass `MUTATING_TASKS` (exported from `@adcp/client`) to require
+   * signatures on every mutating AdCP operation — matches the common
+   * declaration in `capabilities.request_signing.required_for`.
+   */
+  requiredFor?: readonly string[];
+  /** See {@link RequireSignatureWhenPresentOptions.resolveOperation}. */
+  resolveOperation?: (req: IncomingMessage & { rawBody?: string }) => string | undefined;
+}
+
+/**
+ * Bundled composition of {@link requireSignatureWhenPresent} with an
+ * operation resolver — one call produces an authenticator that:
+ *
+ *   1. Prefers the RFC 9421 signature path when a `Signature-Input`
+ *      header is present, with no bearer fall-through on invalid
+ *      signatures (matches the `signed-requests` specialism contract).
+ *   2. Accepts bearer / API key when no signature is present, including
+ *      on `requiredFor` operations — valid credentials bypass the
+ *      signature requirement.
+ *   3. Rejects unsigned calls with no credentials on `requiredFor`
+ *      operations with a `WWW-Authenticate: Signature` challenge whose
+ *      error is `request_signature_required`.
+ *
+ * ```ts
+ * import {
+ *   serve,
+ *   verifyApiKey,
+ *   verifyBearer,
+ *   anyOf,
+ *   verifySignatureAsAuthenticator,
+ *   requireAuthenticatedOrSigned,
+ *   MUTATING_TASKS,
+ * } from '@adcp/client/server';
+ *
+ * serve(createAgent, {
+ *   authenticate: requireAuthenticatedOrSigned({
+ *     signature: verifySignatureAsAuthenticator({ jwks, replayStore, revocationStore, capability, resolveOperation }),
+ *     fallback: anyOf(verifyApiKey({ keys }), verifyBearer({ jwksUri, issuer, audience })),
+ *     requiredFor: [...MUTATING_TASKS],
+ *     resolveOperation: req => {
+ *       try {
+ *         const body = JSON.parse(req.rawBody ?? '');
+ *         if (body?.method === 'tools/call') return body.params?.name;
+ *       } catch {}
+ *       return undefined;
+ *     },
+ *   }),
+ * });
+ * ```
+ */
+export function requireAuthenticatedOrSigned(options: RequireAuthenticatedOrSignedOptions): Authenticator {
+  return requireSignatureWhenPresent(options.signature, options.fallback, {
+    requiredFor: options.requiredFor,
+    resolveOperation: options.resolveOperation,
+  });
 }
 
 const SAFE_KEYID = /^[A-Za-z0-9._-]{1,256}$/;

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -48,6 +48,7 @@ import { verifyRequestSignature } from '../signing/verifier';
 import {
   AuthError,
   type AuthPrincipal,
+  type AuthResult,
   type Authenticator,
   authenticatorNeedsRawBody,
   tagAuthenticatorNeedsRawBody,
@@ -328,17 +329,30 @@ export function requireSignatureWhenPresent(
       }
       return result;
     }
-    const fallbackResult = await fallbackAuth(req);
-    if (fallbackResult !== null) return fallbackResult;
-    // No signature and fallback produced no principal. If the operation is
-    // in `requiredFor`, reject with a signature challenge so the buyer SDK
-    // surfaces `request_signature_required` — the error code the
-    // signed_requests grader's negative vectors expect on the
-    // missing-signature edge. Without `requiredFor`/`resolveOperation`
-    // wired, fall through so `serve()` emits the default bearer challenge.
+    // Catch the fallback's throw so the `requiredFor` pre-check can run
+    // regardless of fallback outcome. Without this, a caller presenting
+    // a bad bearer on a required-for op triggers `anyOf` to throw an
+    // `AuthError` with Bearer semantics, propagating past the pre-check
+    // and producing `WWW-Authenticate: Bearer` — the conformance grader
+    // reads the wrong error code on the exact vector this helper
+    // exists to close.
+    let fallbackResult: AuthResult | null = null;
+    let fallbackError: unknown;
+    let fallbackThrew = false;
+    try {
+      fallbackResult = await fallbackAuth(req);
+    } catch (err) {
+      fallbackThrew = true;
+      fallbackError = err;
+    }
+    // `requiredFor` pre-check: when the op requires a signature AND no
+    // signature was presented, surface `request_signature_required`
+    // REGARDLESS of whether the fallback threw (bad bearer) or returned
+    // null (no creds). Valid bearer is the only escape — if the fallback
+    // returned a principal, we already returned above.
     if (requiredFor.size > 0 && resolveOperation) {
       const operation = resolveOperation(req as IncomingMessage & { rawBody?: string });
-      if (operation && requiredFor.has(operation)) {
+      if (operation && requiredFor.has(operation) && fallbackResult === null) {
         throw new AuthError(`Signature required for ${operation}.`, {
           cause: new RequestSignatureError(
             'request_signature_required',
@@ -348,6 +362,11 @@ export function requireSignatureWhenPresent(
         });
       }
     }
+    // Op not in requiredFor (or no resolver): rethrow the fallback's
+    // original error so the 401 carries the fallback's challenge
+    // (Bearer for bad-bearer, invalid_token for no-creds).
+    if (fallbackThrew) throw fallbackError;
+    if (fallbackResult !== null) return fallbackResult;
     return null;
   };
   const anyChildNeedsRawBody = authenticatorNeedsRawBody(signatureAuth) || authenticatorNeedsRawBody(fallbackAuth);

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -28,6 +28,8 @@
  */
 import type { IncomingMessage, ServerResponse } from 'http';
 import { createRemoteJWKSet, jwtVerify, type JWTPayload, type JWTVerifyOptions } from 'jose';
+import type { RequestSignatureErrorCode } from '../signing/errors';
+import { RequestSignatureError } from '../signing/errors';
 
 /**
  * Default JWT algorithm allowlist. Asymmetric only — HS-family is intentionally
@@ -402,12 +404,30 @@ export interface RespondUnauthorizedOptions {
   resourceMetadata?: string;
   /** Set to 403 instead of 401 for valid-but-unauthorized scenarios. */
   status?: 401 | 403;
+  /**
+   * RFC 9421 signature error code. When set, the challenge scheme switches
+   * from `Bearer` to `Signature` and the body's `error` field carries the
+   * signature code verbatim — what the `signed_requests` conformance grader
+   * reads from `WWW-Authenticate` to decide pass/fail on negative vectors.
+   *
+   * Set this whenever the rejection is a signature-layer failure (invalid
+   * signature, missing required signature, revoked key, replayed nonce,
+   * etc.). `serve()` auto-detects this from an {@link AuthError} whose
+   * `cause` is a {@link RequestSignatureError}; callers rarely set it
+   * directly.
+   */
+  signatureError?: RequestSignatureErrorCode;
 }
 
 /**
  * Send an RFC 6750-compliant 401/403 response with the `WWW-Authenticate`
  * header set. Called automatically by {@link serve} when `authenticate`
  * returns `null` or throws.
+ *
+ * When {@link RespondUnauthorizedOptions.signatureError} is set, the
+ * challenge scheme becomes `Signature` (per the `signed-requests`
+ * specialism) and the body's `error` field carries the RFC 9421 error
+ * code — the `signed_requests` grader reads both from the challenge.
  */
 export function respondUnauthorized(
   _req: IncomingMessage,
@@ -416,20 +436,43 @@ export function respondUnauthorized(
 ): void {
   const realm = options.realm ?? 'mcp';
   const parts = [`realm="${escapeQuotes(realm)}"`];
-  if (options.error) parts.push(`error="${options.error}"`);
+  const useSignatureChallenge = options.signatureError !== undefined;
+  if (useSignatureChallenge) {
+    parts.push(`error="${options.signatureError}"`);
+  } else if (options.error) {
+    parts.push(`error="${options.error}"`);
+  }
   if (options.errorDescription) parts.push(`error_description="${escapeQuotes(options.errorDescription)}"`);
   if (options.resourceMetadata) parts.push(`resource_metadata="${escapeQuotes(options.resourceMetadata)}"`);
 
+  const scheme = useSignatureChallenge ? 'Signature' : 'Bearer';
   res.writeHead(options.status ?? 401, {
     'Content-Type': 'application/json',
-    'WWW-Authenticate': `Bearer ${parts.join(', ')}`,
+    'WWW-Authenticate': `${scheme} ${parts.join(', ')}`,
   });
   res.end(
     JSON.stringify({
-      error: options.error ?? 'unauthorized',
+      error: useSignatureChallenge ? options.signatureError : (options.error ?? 'unauthorized'),
       error_description: options.errorDescription ?? 'Authentication required.',
     })
   );
+}
+
+/**
+ * Unwrap the first {@link RequestSignatureError} found walking the
+ * `cause` chain of an {@link AuthError} (or any error), so callers can
+ * switch the `WWW-Authenticate` challenge scheme on signature-layer
+ * failures. Returns `null` for non-signature errors.
+ */
+export function signatureErrorCodeFromCause(err: unknown): RequestSignatureErrorCode | null {
+  let current: unknown = err;
+  // Walk at most 8 links — well above anything legitimate code produces, but
+  // bounded so a self-referential `cause` chain can't spin.
+  for (let i = 0; i < 8 && current != null; i++) {
+    if (current instanceof RequestSignatureError) return current.code;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return null;
 }
 
 function escapeQuotes(s: string): string {

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -437,10 +437,14 @@ export function respondUnauthorized(
   const realm = options.realm ?? 'mcp';
   const parts = [`realm="${escapeQuotes(realm)}"`];
   const useSignatureChallenge = options.signatureError !== undefined;
+  // The `error` codes are typed unions — the type system gives us the
+  // only quote-safe guarantee. Route through `escapeQuotes` so a future
+  // widening to `string` or a code that happens to include `"` doesn't
+  // inject a new parameter into the challenge header.
   if (useSignatureChallenge) {
-    parts.push(`error="${options.signatureError}"`);
+    parts.push(`error="${escapeQuotes(options.signatureError!)}"`);
   } else if (options.error) {
-    parts.push(`error="${options.error}"`);
+    parts.push(`error="${escapeQuotes(options.error)}"`);
   }
   if (options.errorDescription) parts.push(`error_description="${escapeQuotes(options.errorDescription)}"`);
   if (options.resourceMetadata) parts.push(`resource_metadata="${escapeQuotes(options.resourceMetadata)}"`);
@@ -465,12 +469,19 @@ export function respondUnauthorized(
  * failures. Returns `null` for non-signature errors.
  */
 export function signatureErrorCodeFromCause(err: unknown): RequestSignatureErrorCode | null {
+  // Track visited refs to break arbitrary cycles (self-reference, N-cycles,
+  // or a long non-signature chain that would otherwise exhaust the walker).
+  // The visited set is a belt-and-suspenders companion to the hop cap —
+  // either one alone is enough for legitimate chains, but cycle resistance
+  // is the security-relevant property.
+  const visited = new Set<unknown>();
   let current: unknown = err;
-  // Walk at most 8 links — well above anything legitimate code produces, but
-  // bounded so a self-referential `cause` chain can't spin.
-  for (let i = 0; i < 8 && current != null; i++) {
+  let hops = 0;
+  while (current != null && hops < 32 && !visited.has(current)) {
     if (current instanceof RequestSignatureError) return current.code;
+    visited.add(current);
     current = (current as { cause?: unknown }).cause;
+    hops++;
   }
   return null;
 }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -36,7 +36,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ZodRawShapeCompat, AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-import { wrapMcpServer, type AdcpServer, type AdcpServerInternal } from './adcp-server';
+import { ADCP_STATE_STORE, wrapMcpServer, type AdcpServer, type AdcpServerInternal } from './adcp-server';
 import { createTaskCapableServer } from './tasks';
 import type { TaskStore, TaskMessageQueue } from './tasks';
 import { adcpError } from './errors';
@@ -64,6 +64,12 @@ import {
 } from './responses';
 
 import { TOOL_REQUEST_SCHEMAS } from '../utils/tool-request-schemas';
+
+function hasIdempotencyClearAll(store: IdempotencyStore): boolean {
+  // `clearAll` is optional on `IdempotencyStore` — only present when the
+  // configured backend opts in (memory backend does; pg backend does not).
+  return typeof store.clearAll === 'function';
+}
 import { isMutatingTask, IDEMPOTENCY_KEY_PATTERN, MUTATING_TASKS } from '../utils/idempotency';
 import type { IdempotencyStore } from './idempotency';
 import {
@@ -2002,7 +2008,39 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     return capabilitiesResponse(data);
   });
 
-  const wrapped: AdcpServerInternal = wrapMcpServer(server);
+  const compliance = {
+    async reset({ force = false }: { force?: boolean } = {}): Promise<void> {
+      const stateStoreHasClear = typeof (stateStore as unknown as { clear?: unknown }).clear === 'function';
+      const idempotencyBackendHasClearAll = idempotency ? hasIdempotencyClearAll(idempotency) : true;
+      if (!force) {
+        if (!stateStoreHasClear) {
+          throw new Error(
+            'AdcpServer.compliance.reset: configured stateStore does not expose `clear()`. ' +
+              'Use the default `InMemoryStateStore` for test harnesses, or pass `{ force: true }` if you know the store is safe to flush.'
+          );
+        }
+        if (!idempotencyBackendHasClearAll) {
+          throw new Error(
+            'AdcpServer.compliance.reset: configured idempotency backend does not expose `clearAll()`. ' +
+              'Use `memoryBackend()` for test harnesses, or pass `{ force: true }` to skip idempotency flush and clear only state.'
+          );
+        }
+        if (process.env.NODE_ENV === 'production') {
+          throw new Error(
+            'AdcpServer.compliance.reset: refused to run with NODE_ENV=production. ' +
+              'Pass `{ force: true }` to acknowledge the flush, or unset NODE_ENV when running storyboards.'
+          );
+        }
+      }
+      if (stateStoreHasClear) {
+        (stateStore as unknown as { clear: () => void }).clear();
+      }
+      if (idempotency && idempotency.clearAll) {
+        await idempotency.clearAll();
+      }
+    },
+  };
+  const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance);
 
   // Attach the auto-wired preTransport so `serve()` mounts the verifier
   // on the HTTP transport. Stashed under a non-enumerable symbol property
@@ -2026,6 +2064,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   };
   Object.defineProperty(wrapped, ADCP_SIGNED_REQUESTS_STATE, {
     value: signedRequestsState,
+    enumerable: false,
+    configurable: true,
+    writable: false,
+  });
+  Object.defineProperty(wrapped, ADCP_STATE_STORE, {
+    value: stateStore,
     enumerable: false,
     configurable: true,
     writable: false,

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2009,35 +2009,52 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   });
 
   const compliance = {
-    async reset({ force = false }: { force?: boolean } = {}): Promise<void> {
-      const stateStoreHasClear = typeof (stateStore as unknown as { clear?: unknown }).clear === 'function';
-      const idempotencyBackendHasClearAll = idempotency ? hasIdempotencyClearAll(idempotency) : true;
+    async reset({
+      force = false,
+      allowProduction = false,
+    }: { force?: boolean; allowProduction?: boolean } = {}): Promise<void> {
+      // Check NODE_ENV BEFORE store-shape probes: the environment guard
+      // is the strongest signal that "this is not a test harness." An
+      // operator who reached this call in production by mistake hits the
+      // env gate regardless of which backend they wired.
+      if (!allowProduction && process.env.NODE_ENV === 'production') {
+        throw new Error(
+          'AdcpServer.compliance.reset: refused to run with NODE_ENV=production. ' +
+            'Pass `{ allowProduction: true }` if you deliberately set NODE_ENV=production in a test environment, ' +
+            'or unset NODE_ENV before running storyboards.'
+        );
+      }
+      // Positive allowlist for stores, not method-presence. A
+      // PostgresStateStore might expose `.clear()` for its own test
+      // utility needs — we don't want method-existence alone to permit
+      // a flush that would take out a shared test cluster. `force: true`
+      // is the documented opt-in for non-memory backends.
+      const stateStoreIsMemory = stateStore instanceof InMemoryStateStore;
+      const idempotencyIsFlushable = !idempotency || hasIdempotencyClearAll(idempotency);
       if (!force) {
-        if (!stateStoreHasClear) {
+        if (!stateStoreIsMemory) {
           throw new Error(
-            'AdcpServer.compliance.reset: configured stateStore does not expose `clear()`. ' +
-              'Use the default `InMemoryStateStore` for test harnesses, or pass `{ force: true }` if you know the store is safe to flush.'
+            'AdcpServer.compliance.reset: configured stateStore is not InMemoryStateStore. ' +
+              'Pass `{ force: true }` to acknowledge that flushing the configured backend is safe for this environment ' +
+              '(e.g., a disposable test Postgres).'
           );
         }
-        if (!idempotencyBackendHasClearAll) {
+        if (!idempotencyIsFlushable) {
           throw new Error(
             'AdcpServer.compliance.reset: configured idempotency backend does not expose `clearAll()`. ' +
-              'Use `memoryBackend()` for test harnesses, or pass `{ force: true }` to skip idempotency flush and clear only state.'
-          );
-        }
-        if (process.env.NODE_ENV === 'production') {
-          throw new Error(
-            'AdcpServer.compliance.reset: refused to run with NODE_ENV=production. ' +
-              'Pass `{ force: true }` to acknowledge the flush, or unset NODE_ENV when running storyboards.'
+              'Use `memoryBackend()` for test harnesses, or pass `{ force: true }` to skip idempotency flush.'
           );
         }
       }
-      if (stateStoreHasClear) {
-        (stateStore as unknown as { clear: () => void }).clear();
-      }
-      if (idempotency && idempotency.clearAll) {
-        await idempotency.clearAll();
-      }
+      // `force` bypasses the allowlist checks but never the flush
+      // itself — if we reached here, the caller wants the flush to
+      // happen. `clear()` is only called when the store exposes it;
+      // a store without `clear()` reaching here under `force: true`
+      // is a no-op for the state side, which matches the shape the
+      // caller opted into.
+      const storeWithClear = stateStore as unknown as { clear?: () => void };
+      if (typeof storeWithClear.clear === 'function') storeWithClear.clear();
+      if (idempotency && idempotency.clearAll) await idempotency.clearAll();
     },
   };
   const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance);

--- a/src/lib/server/express-adapter.ts
+++ b/src/lib/server/express-adapter.ts
@@ -67,12 +67,30 @@ export interface ExpressAdapterOptions {
   mountPath: string;
   /**
    * Canonical public URL of the MCP endpoint, origin + mount + `/mcp`.
+   *
+   * **Required for any deployment that pipes `getUrl` into an RFC 9421
+   * signature verifier.** Without `publicUrl`, `getUrl` reconstructs
+   * the URL from `x-forwarded-host`/`host` — which an attacker can set
+   * to any value, letting them present a signature signed for a
+   * different audience and have it verify against the wrong origin.
+   * `getUrl` throws when neither `publicUrl` nor the explicit opt-in
+   * `trustForwardedHost` is set, so accidental misconfiguration fails
+   * closed.
+   *
    * When omitted, {@link ExpressAdapter.protectedResourceMiddleware}
-   * reconstructs the resource URL from `x-forwarded-proto` / `host` per
-   * request — convenient for multi-host deployments but subject to
-   * `Host`-header spoofing attacks. Set this explicitly in production.
+   * also refuses to start unless `trustForwardedHost: true` is set —
+   * it can't advertise a stable `resource` URL without one of the two.
    */
   publicUrl?: string;
+  /**
+   * Explicit opt-in for header-derived URL reconstruction in
+   * multi-host deployments where `publicUrl` can't be fixed at adapter
+   * construction. Setting this acknowledges that `x-forwarded-host` /
+   * `host` are trusted inputs (the upstream proxy sanitizes them).
+   * Prefer `publicUrl` when possible — it's the only configuration
+   * that closes the signed-payload audience-confusion attack.
+   */
+  trustForwardedHost?: boolean;
   /**
    * RFC 9728 Protected Resource Metadata body. Required unless you're
    * wiring the PRM response yourself; omitting this disables
@@ -138,6 +156,18 @@ export interface ExpressAdapter {
  */
 export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAdapter {
   const mountPath = normalizeMountPath(options.mountPath);
+  const trustForwardedHost = options.trustForwardedHost === true;
+
+  let fixedOrigin: string | undefined;
+  if (options.publicUrl) {
+    let parsed: URL;
+    try {
+      parsed = new URL(options.publicUrl);
+    } catch {
+      throw new Error(`createExpressAdapter: \`publicUrl\` is not a valid URL: ${options.publicUrl}`);
+    }
+    fixedOrigin = parsed.origin;
+  }
 
   const rawBodyVerify = (req: IncomingMessage, _res: ServerResponse, buf: Buffer): void => {
     // Attach the raw body as a string — that's what
@@ -148,9 +178,17 @@ export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAda
     (req as IncomingMessage & { rawBody?: string }).rawBody = buf.toString('utf8');
   };
 
-  const protectedResourceMiddleware = options.prm
-    ? buildProtectedResourceMiddleware(options.prm, options.publicUrl)
-    : undefined;
+  let protectedResourceMiddleware: ExpressAdapter['protectedResourceMiddleware'];
+  if (options.prm) {
+    if (!fixedOrigin && !trustForwardedHost) {
+      throw new Error(
+        'createExpressAdapter: `prm` requires either `publicUrl` (fixed origin) or `trustForwardedHost: true` ' +
+          '(acknowledging that upstream sanitizes `x-forwarded-host`/`host`). Header-derived origin reconstruction ' +
+          'without one of these lets an attacker pick the advertised OAuth resource URL.'
+      );
+    }
+    protectedResourceMiddleware = buildProtectedResourceMiddleware(options.prm, options.publicUrl, trustForwardedHost);
+  }
 
   const getUrl = (req: IncomingMessage): string => {
     // Express strips the mount prefix from `req.url`, but leaves the
@@ -159,15 +197,27 @@ export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAda
     // mountPath + req.url composition for non-Express frameworks.
     const reqAny = req as IncomingMessage & { originalUrl?: string };
     const path = reqAny.originalUrl ?? joinPath(mountPath, req.url ?? '/');
+    if (fixedOrigin) {
+      // publicUrl wins unconditionally — ignoring `x-forwarded-host` /
+      // `host` is exactly what closes the signed-payload audience-
+      // confusion attack. Attacker-controlled headers can't influence
+      // the origin the verifier sees.
+      return `${fixedOrigin}${path}`;
+    }
+    if (!trustForwardedHost) {
+      throw new Error(
+        'createExpressAdapter.getUrl: neither `publicUrl` nor `trustForwardedHost: true` is set. ' +
+          'Header-derived URL reconstruction lets an attacker pick the origin a signed payload verifies against — ' +
+          'the verifier would recompute the signature base against the spoofed host and accept a signature signed for a different audience. ' +
+          'Set `publicUrl` at adapter construction, or opt into `trustForwardedHost` with an upstream that sanitizes the headers.'
+      );
+    }
     const forwardedProto = firstHeader(req.headers['x-forwarded-proto']);
     const encrypted = (req.socket as { encrypted?: boolean } | undefined)?.encrypted === true;
     const proto = forwardedProto ?? (encrypted ? 'https' : 'http');
     const host = firstHeader(req.headers['x-forwarded-host']) ?? firstHeader(req.headers['host']);
     if (!host) {
-      throw new Error(
-        'createExpressAdapter.getUrl: missing Host header. Set `ExpressAdapterOptions.publicUrl` ' +
-          'or trust a `x-forwarded-host` header upstream.'
-      );
+      throw new Error('createExpressAdapter.getUrl: missing Host header under `trustForwardedHost`.');
     }
     return `${proto}://${host}${path}`;
   };
@@ -190,7 +240,8 @@ export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAda
 
 function buildProtectedResourceMiddleware(
   prm: ProtectedResourceMetadata,
-  publicUrl?: string
+  publicUrl: string | undefined,
+  trustForwardedHost: boolean
 ): (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => void {
   // OAuth graders probe `/.well-known/oauth-protected-resource/<mount>`.
   // The `<mount>` suffix varies by agent, so match the well-known prefix
@@ -205,7 +256,18 @@ function buildProtectedResourceMiddleware(
       next();
       return;
     }
-    const resource = publicUrl ?? reconstructResource(req, pathname.slice(WELL_KNOWN.length));
+    let resource: string;
+    if (publicUrl) {
+      // Fixed origin — same security property as `getUrl`'s
+      // publicUrl path: attacker-controlled headers can't influence
+      // the advertised resource URL.
+      resource = publicUrl;
+    } else {
+      // trustForwardedHost: true was checked at construction — if we
+      // got here without publicUrl, upstream is responsible for
+      // sanitizing the headers we read below.
+      resource = reconstructResource(req, pathname.slice(WELL_KNOWN.length), trustForwardedHost);
+    }
     const body = {
       resource,
       ...prm,
@@ -216,17 +278,28 @@ function buildProtectedResourceMiddleware(
   };
 }
 
-function reconstructResource(req: IncomingMessage, suffix: string): string {
+function reconstructResource(req: IncomingMessage, suffix: string, trustForwardedHost: boolean): string {
   const forwardedProto = firstHeader(req.headers['x-forwarded-proto']);
   const encrypted = (req.socket as { encrypted?: boolean } | undefined)?.encrypted === true;
   const proto = forwardedProto ?? (encrypted ? 'https' : 'http');
   const host = firstHeader(req.headers['x-forwarded-host']) ?? firstHeader(req.headers['host']);
   if (!host) {
-    // Defensive — should never happen on a valid HTTP request, but if
-    // an upstream proxy stripped `Host`, advertise a placeholder that
-    // will fail audience validation rather than silently lying about
-    // the resource URL.
-    return 'about:invalid-prm';
+    // Fail closed rather than advertising a placeholder: a PRM with a
+    // garbage `resource` would silently mint audience-mismatched tokens
+    // across the fleet. Returning 500 surfaces the misconfiguration to
+    // the operator; the OAuth grader's probe fails loud.
+    throw new Error(
+      'createExpressAdapter.protectedResourceMiddleware: upstream did not forward a Host header. ' +
+        'Set `publicUrl` at adapter construction so the advertised OAuth resource URL is stable.'
+    );
+  }
+  if (!trustForwardedHost && req.headers['x-forwarded-host'] !== undefined) {
+    // Defense-in-depth: reaching this path at all means `publicUrl`
+    // wasn't set. If an upstream forwards `x-forwarded-host` without
+    // the caller opting into trust, that's a misconfiguration.
+    throw new Error(
+      'createExpressAdapter.protectedResourceMiddleware: x-forwarded-host present but trustForwardedHost is false.'
+    );
   }
   const normalizedSuffix = suffix && !suffix.startsWith('/') ? `/${suffix}` : suffix || '/';
   return `${proto}://${host}${normalizedSuffix}`;

--- a/src/lib/server/express-adapter.ts
+++ b/src/lib/server/express-adapter.ts
@@ -55,6 +55,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { AdcpServer } from './adcp-server';
 import type { ProtectedResourceMetadata } from './serve';
+import { seedComplianceFixtures, type SeedComplianceFixturesOptions } from '../compliance-fixtures';
 
 export interface ExpressAdapterOptions {
   /**
@@ -110,6 +111,23 @@ export interface ExpressAdapterOptions {
    * environment (a disposable test DB, for example).
    */
   resetForce?: boolean;
+  /**
+   * When truthy, {@link ExpressAdapter.resetHook} re-seeds the AdCP
+   * compliance fixtures (via `seedComplianceFixtures`) after
+   * `compliance.reset()` flushes the state store. Without this, a
+   * runner that resets between storyboards loses fixtures seeded
+   * before storyboard #1, and every subsequent fixture lookup returns
+   * `null` — surfacing as fixture-not-found 404s across the run.
+   *
+   * - `true` seeds the full canonical fixture set with default options.
+   * - An object applies the matching `seedComplianceFixtures`
+   *   configuration (category filter, overrides, collection names).
+   *
+   * Leave undefined when handlers don't read from the compliance
+   * state-store collections, or when you seed through a different
+   * path (e.g., a `comply_test_controller` scenario).
+   */
+  seedFixtures?: boolean | SeedComplianceFixturesOptions;
 }
 
 /** Return shape of {@link createExpressAdapter}. */
@@ -223,10 +241,17 @@ export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAda
   };
 
   const resetHook = async (): Promise<void> => {
-    if (options.server) {
-      await options.server.compliance.reset({
-        ...(options.resetForce ? { force: true } : {}),
-      });
+    if (!options.server) return;
+    await options.server.compliance.reset({
+      ...(options.resetForce ? { force: true } : {}),
+    });
+    // Re-seed AFTER the flush so subsequent storyboards find fixtures
+    // at the same IDs. Without this step the first storyboard consumes
+    // the seed from pre-run setup, then every storyboard after N+1
+    // misses because `reset()` wiped `compliance:*` collections.
+    if (options.seedFixtures) {
+      const seedOptions: SeedComplianceFixturesOptions = options.seedFixtures === true ? {} : options.seedFixtures;
+      await seedComplianceFixtures(options.server, seedOptions);
     }
   };
 

--- a/src/lib/server/express-adapter.ts
+++ b/src/lib/server/express-adapter.ts
@@ -55,7 +55,12 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { AdcpServer } from './adcp-server';
 import type { ProtectedResourceMetadata } from './serve';
-import { seedComplianceFixtures, type SeedComplianceFixturesOptions } from '../compliance-fixtures';
+// `SeedComplianceFixturesOptions` is only a type import — zero runtime
+// cost for sellers who don't use `seedFixtures`. The runtime
+// `seedComplianceFixtures` is loaded lazily inside `resetHook` so
+// the fixture set's JS bytes stay out of the server barrel for
+// production sellers who never seed.
+import type { SeedComplianceFixturesOptions } from '../compliance-fixtures';
 
 export interface ExpressAdapterOptions {
   /**
@@ -249,8 +254,16 @@ export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAda
     // at the same IDs. Without this step the first storyboard consumes
     // the seed from pre-run setup, then every storyboard after N+1
     // misses because `reset()` wiped `compliance:*` collections.
+    //
+    // NOT atomic: if `compliance.reset()` succeeds and
+    // `seedComplianceFixtures` throws mid-loop, the state store is
+    // left with a partial seed. For a conformance-runner use case
+    // that's fine — the next storyboard surfaces the error loudly.
+    // Lazy-loaded so sellers who never set `seedFixtures` don't
+    // carry the fixture set's bytes in their server bundle.
     if (options.seedFixtures) {
       const seedOptions: SeedComplianceFixturesOptions = options.seedFixtures === true ? {} : options.seedFixtures;
+      const { seedComplianceFixtures } = await import('../compliance-fixtures');
       await seedComplianceFixtures(options.server, seedOptions);
     }
   };

--- a/src/lib/server/express-adapter.ts
+++ b/src/lib/server/express-adapter.ts
@@ -1,0 +1,261 @@
+/**
+ * Express / Connect adapter for AdCP MCP agents.
+ *
+ * Mounting an MCP agent inside an existing Express app — rather than using
+ * {@link serve}'s standalone HTTP server — requires five specific pieces
+ * of plumbing, none of which are obvious the first time you wire them:
+ *
+ *   1. `rawBody` capture: `express.json()` consumes the body stream before
+ *      the RFC 9421 signature verifier runs; the verifier needs the exact
+ *      signed bytes. The seller has to pass a custom `verify` callback to
+ *      `express.json` that stashes a copy on `req.rawBody`.
+ *   2. Mount-path URL reconstruction: Express strips the router mount
+ *      prefix from `req.url`, so when the verifier reconstructs the
+ *      canonical URL from `req.url` it sees `/mcp` instead of
+ *      `/api/training-agent/mcp`. The signed base was the second; the
+ *      verifier sees the first; every signature fails.
+ *   3. RFC 9728 protected-resource metadata at the ORIGIN root: the
+ *      OAuth graders probe `${origin}/.well-known/oauth-protected-resource${pathname}`,
+ *      NOT a path inside the router. The well-known route must be mounted
+ *      on `app`, not on the sub-router.
+ *   4. Session reset between storyboards: conformance runners execute
+ *      many storyboards in sequence against one process; cached state
+ *      from storyboard N leaks into N+1.
+ *   5. Presence-gated signature composition (closed by
+ *      {@link requireSignatureWhenPresent} / {@link requireAuthenticatedOrSigned}).
+ *
+ * {@link createExpressAdapter} returns all four of the remaining pieces
+ * so the seller's wiring collapses to:
+ *
+ * ```ts
+ * import express from 'express';
+ * import { createAdcpServer, createExpressAdapter } from '@adcp/client/server';
+ *
+ * const agent = createAdcpServer({ ...handlers });
+ * const adapter = createExpressAdapter({
+ *   server: agent,
+ *   mountPath: '/api/training-agent',
+ *   publicUrl: 'https://agent.example.com/api/training-agent',
+ *   prm: { authorizationServers: ['https://auth.example.com'] },
+ * });
+ *
+ * const app = express();
+ * app.use(express.json({ limit: '5mb', verify: adapter.rawBodyVerify }));
+ * app.use(adapter.protectedResourceMiddleware);
+ * app.use('/api/training-agent', myRouter);
+ *
+ * // In a conformance runner:
+ * for (const storyboard of storyboards) {
+ *   await adapter.resetHook();
+ *   await run(storyboard);
+ * }
+ * ```
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { AdcpServer } from './adcp-server';
+import type { ProtectedResourceMetadata } from './serve';
+
+export interface ExpressAdapterOptions {
+  /**
+   * Mount path the agent router is attached at (must match what you
+   * pass to `app.use(mountPath, router)`). Used by {@link ExpressAdapter.getUrl}
+   * to reconstruct the canonical request URL for signature verification.
+   *
+   * Leading slash required; no trailing slash. Example: `/api/training-agent`.
+   */
+  mountPath: string;
+  /**
+   * Canonical public URL of the MCP endpoint, origin + mount + `/mcp`.
+   * When omitted, {@link ExpressAdapter.protectedResourceMiddleware}
+   * reconstructs the resource URL from `x-forwarded-proto` / `host` per
+   * request — convenient for multi-host deployments but subject to
+   * `Host`-header spoofing attacks. Set this explicitly in production.
+   */
+  publicUrl?: string;
+  /**
+   * RFC 9728 Protected Resource Metadata body. Required unless you're
+   * wiring the PRM response yourself; omitting this disables
+   * {@link ExpressAdapter.protectedResourceMiddleware}.
+   */
+  prm?: ProtectedResourceMetadata;
+  /**
+   * When present, {@link ExpressAdapter.resetHook} dispatches to
+   * `server.compliance.reset()`. Leave undefined if you've wired the
+   * reset yourself (e.g., via a test-controller scenario).
+   */
+  server?: AdcpServer;
+  /**
+   * Pass `{ force: true }` to the underlying `server.compliance.reset()`
+   * call. Use when your deployment wires a state store other than the
+   * in-memory default but you've verified the flush is safe for this
+   * environment (a disposable test DB, for example).
+   */
+  resetForce?: boolean;
+}
+
+/** Return shape of {@link createExpressAdapter}. */
+export interface ExpressAdapter {
+  /**
+   * Pass as `express.json({ verify })` — populates `req.rawBody` with
+   * the exact bytes signed, which is what the RFC 9421 verifier needs
+   * for `Content-Digest` recompute. Safe no-op when the route doesn't
+   * run behind `express.json`.
+   */
+  rawBodyVerify: (req: IncomingMessage, res: ServerResponse, buf: Buffer) => void;
+
+  /**
+   * Mount on the top-level `app` (NOT inside your agent router) with
+   * `app.use(adapter.protectedResourceMiddleware)`. Responds to
+   * `/.well-known/oauth-protected-resource/*` at the origin root —
+   * which is where the OAuth graders probe. Forwards everything else
+   * via `next()`.
+   *
+   * Undefined when {@link ExpressAdapterOptions.prm} is omitted.
+   */
+  protectedResourceMiddleware?: (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => void;
+
+  /**
+   * Reconstruct the full request URL for an incoming request, including
+   * the Express mount prefix that `req.url` strips. Pass this as the
+   * `getUrl` option to {@link verifySignatureAsAuthenticator} so the
+   * recomputed signature base matches what the signer signed.
+   */
+  getUrl: (req: IncomingMessage) => string;
+
+  /**
+   * Drop session state and the idempotency cache between storyboards.
+   * Delegates to `server.compliance.reset()` when a server is
+   * configured; returns a no-op otherwise.
+   */
+  resetHook: () => Promise<void>;
+}
+
+/**
+ * Build all four Express-integration helpers an AdCP agent needs to run
+ * behind a mounted router. See the module docstring for the full wiring
+ * example.
+ */
+export function createExpressAdapter(options: ExpressAdapterOptions): ExpressAdapter {
+  const mountPath = normalizeMountPath(options.mountPath);
+
+  const rawBodyVerify = (req: IncomingMessage, _res: ServerResponse, buf: Buffer): void => {
+    // Attach the raw body as a string — that's what
+    // `verifySignatureAsAuthenticator` expects on `req.rawBody`. The
+    // verifier's Content-Digest recompute runs over these exact bytes
+    // regardless of express.json's subsequent parsing, so the buffer
+    // copy here is the source of truth for signature verification.
+    (req as IncomingMessage & { rawBody?: string }).rawBody = buf.toString('utf8');
+  };
+
+  const protectedResourceMiddleware = options.prm
+    ? buildProtectedResourceMiddleware(options.prm, options.publicUrl)
+    : undefined;
+
+  const getUrl = (req: IncomingMessage): string => {
+    // Express strips the mount prefix from `req.url`, but leaves the
+    // pre-strip value on `req.originalUrl`. Prefer `originalUrl` when
+    // it exists — that's what the signer signed. Fall back to a
+    // mountPath + req.url composition for non-Express frameworks.
+    const reqAny = req as IncomingMessage & { originalUrl?: string };
+    const path = reqAny.originalUrl ?? joinPath(mountPath, req.url ?? '/');
+    const forwardedProto = firstHeader(req.headers['x-forwarded-proto']);
+    const encrypted = (req.socket as { encrypted?: boolean } | undefined)?.encrypted === true;
+    const proto = forwardedProto ?? (encrypted ? 'https' : 'http');
+    const host = firstHeader(req.headers['x-forwarded-host']) ?? firstHeader(req.headers['host']);
+    if (!host) {
+      throw new Error(
+        'createExpressAdapter.getUrl: missing Host header. Set `ExpressAdapterOptions.publicUrl` ' +
+          'or trust a `x-forwarded-host` header upstream.'
+      );
+    }
+    return `${proto}://${host}${path}`;
+  };
+
+  const resetHook = async (): Promise<void> => {
+    if (options.server) {
+      await options.server.compliance.reset({
+        ...(options.resetForce ? { force: true } : {}),
+      });
+    }
+  };
+
+  return {
+    rawBodyVerify,
+    ...(protectedResourceMiddleware ? { protectedResourceMiddleware } : {}),
+    getUrl,
+    resetHook,
+  };
+}
+
+function buildProtectedResourceMiddleware(
+  prm: ProtectedResourceMetadata,
+  publicUrl?: string
+): (req: IncomingMessage, res: ServerResponse, next: (err?: unknown) => void) => void {
+  // OAuth graders probe `/.well-known/oauth-protected-resource/<mount>`.
+  // The `<mount>` suffix varies by agent, so match the well-known prefix
+  // and return PRM for any suffix. Agents that host multiple MCP mounts
+  // behind one origin should override this middleware — the default
+  // advertises the same `resource` for every probed path, which is the
+  // common single-mount case.
+  const WELL_KNOWN = '/.well-known/oauth-protected-resource';
+  return (req, res, next) => {
+    const pathname = parsePathname(req);
+    if (!pathname.startsWith(WELL_KNOWN)) {
+      next();
+      return;
+    }
+    const resource = publicUrl ?? reconstructResource(req, pathname.slice(WELL_KNOWN.length));
+    const body = {
+      resource,
+      ...prm,
+      bearer_methods_supported: prm.bearer_methods_supported ?? ['header'],
+    };
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(body));
+  };
+}
+
+function reconstructResource(req: IncomingMessage, suffix: string): string {
+  const forwardedProto = firstHeader(req.headers['x-forwarded-proto']);
+  const encrypted = (req.socket as { encrypted?: boolean } | undefined)?.encrypted === true;
+  const proto = forwardedProto ?? (encrypted ? 'https' : 'http');
+  const host = firstHeader(req.headers['x-forwarded-host']) ?? firstHeader(req.headers['host']);
+  if (!host) {
+    // Defensive — should never happen on a valid HTTP request, but if
+    // an upstream proxy stripped `Host`, advertise a placeholder that
+    // will fail audience validation rather than silently lying about
+    // the resource URL.
+    return 'about:invalid-prm';
+  }
+  const normalizedSuffix = suffix && !suffix.startsWith('/') ? `/${suffix}` : suffix || '/';
+  return `${proto}://${host}${normalizedSuffix}`;
+}
+
+function parsePathname(req: IncomingMessage): string {
+  try {
+    return new URL(req.url ?? '', 'http://_').pathname;
+  } catch {
+    return req.url ?? '/';
+  }
+}
+
+function normalizeMountPath(mountPath: string): string {
+  if (!mountPath.startsWith('/')) {
+    throw new Error(`createExpressAdapter: mountPath must start with '/'. Got: ${mountPath}`);
+  }
+  let end = mountPath.length;
+  while (end > 1 && mountPath.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return mountPath.slice(0, end);
+}
+
+function joinPath(mount: string, rest: string): string {
+  const r = rest.startsWith('/') ? rest : `/${rest}`;
+  return mount === '/' ? r : `${mount}${r}`;
+}
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value) && value.length > 0) return value[0];
+  return undefined;
+}

--- a/src/lib/server/idempotency/backends/memory.ts
+++ b/src/lib/server/idempotency/backends/memory.ts
@@ -69,6 +69,9 @@ export function memoryBackend(options: MemoryBackendOptions = {}): IdempotencyBa
       if (sweeper) clearInterval(sweeper);
       store.clear();
     },
+    async clearAll(): Promise<void> {
+      store.clear();
+    },
   };
 }
 

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -118,6 +118,18 @@ export interface IdempotencyBackend {
    * (close pools, clear timers). Called by `store.close()`.
    */
   close?(): Promise<void>;
+  /**
+   * Optional test-harness hook that drops every cached entry without
+   * releasing backend resources. Used by `AdcpServer.compliance.reset()`
+   * between storyboards so idempotency cache hits from one storyboard
+   * don't replay into the next (shared brand domain, same key prefix).
+   *
+   * Production backends that can't cheaply flush everything (e.g., a
+   * shared Postgres cluster) should leave this undefined — the reset
+   * hook refuses to run when this method is missing unless the caller
+   * explicitly opts in with `{ force: true }`.
+   */
+  clearAll?(): Promise<void>;
 }
 
 /**
@@ -218,6 +230,16 @@ export interface IdempotencyStore {
   readonly ttlSeconds: number;
   /** Release backend resources (close pools, clear timers). */
   close(): Promise<void>;
+  /**
+   * Drop every cached entry without releasing backend resources.
+   * Present only when the configured backend supports it (e.g.,
+   * `memoryBackend`). Production-leaning backends leave this undefined
+   * so an accidental production call can't flush the cache.
+   *
+   * Only invoked from `AdcpServer.compliance.reset()` — do not call from
+   * production code paths.
+   */
+  clearAll?(): Promise<void>;
 }
 
 const MIN_TTL = 3600; // 1 hour
@@ -315,6 +337,14 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
     async close() {
       if (backend.close) await backend.close();
     },
+
+    ...(backend.clearAll
+      ? {
+          async clearAll() {
+            await backend.clearAll!();
+          },
+        }
+      : {}),
   };
 }
 

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -75,12 +75,16 @@ export type {
 export { serve } from './serve';
 export type { ServeContext, ServeOptions, ProtectedResourceMetadata } from './serve';
 
+export { createExpressAdapter } from './express-adapter';
+export type { ExpressAdapter, ExpressAdapterOptions } from './express-adapter';
+
 export {
   verifyApiKey,
   verifyBearer,
   anyOf,
   extractBearerToken,
   respondUnauthorized,
+  signatureErrorCodeFromCause,
   AuthError,
   AUTH_NEEDS_RAW_BODY,
   tagAuthenticatorNeedsRawBody,
@@ -100,8 +104,16 @@ export type {
   RespondUnauthorizedOptions,
 } from './auth';
 
-export { verifySignatureAsAuthenticator, requireSignatureWhenPresent } from './auth-signature';
-export type { VerifySignatureAsAuthenticatorOptions } from './auth-signature';
+export {
+  verifySignatureAsAuthenticator,
+  requireSignatureWhenPresent,
+  requireAuthenticatedOrSigned,
+} from './auth-signature';
+export type {
+  VerifySignatureAsAuthenticatorOptions,
+  RequireSignatureWhenPresentOptions,
+  RequireAuthenticatedOrSignedOptions,
+} from './auth-signature';
 
 export {
   InMemoryStateStore,
@@ -142,6 +154,7 @@ export {
 } from './create-adcp-server';
 export type {
   AdcpServer,
+  AdcpServerComplianceApi,
   AdcpServerTransport,
   AdcpTestRequest,
   AdcpTestToolsCallRequest,

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -25,7 +25,7 @@ import type { TaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/int
 import { InMemoryTaskStore } from '@modelcontextprotocol/sdk/experimental/tasks/stores/in-memory.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { AuthPrincipal, Authenticator } from './auth';
-import { AuthError, authenticatorNeedsRawBody, respondUnauthorized } from './auth';
+import { AuthError, authenticatorNeedsRawBody, respondUnauthorized, signatureErrorCodeFromCause } from './auth';
 import { ADCP_PRE_TRANSPORT, type AdcpPreTransport } from './create-adcp-server';
 import type { AdcpServer } from './adcp-server';
 
@@ -274,6 +274,21 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
           // Surface only sanitized messages to the client; log internal cause server-side.
           const publicMessage = err instanceof AuthError ? err.publicMessage : 'Credentials rejected.';
           console.error('[adcp/auth] rejected:', err);
+          // Switch challenge scheme to `Signature` when the rejection
+          // originates in the RFC 9421 verifier — the signed_requests
+          // negative-vector grader reads the error code from the
+          // `WWW-Authenticate` header, so collapsing it into the generic
+          // `Bearer error="invalid_token"` challenge would surface the
+          // wrong code and fail every negative vector.
+          const signatureCode = signatureErrorCodeFromCause(err);
+          if (signatureCode) {
+            respondUnauthorized(req, res, {
+              signatureError: signatureCode,
+              errorDescription: publicMessage,
+              resourceMetadata: resourceMetadataUrl,
+            });
+            return;
+          }
           respondUnauthorized(req, res, {
             error: 'invalid_token',
             errorDescription: publicMessage,

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -11,7 +11,7 @@ import {
   verifyRequestSignature,
   type AdcpJsonWebKey,
 } from '../../../signing';
-import type { NegativeVector, PositiveVector } from './types';
+import type { NegativeVector, PositiveVector, VerifierCapabilityFixture } from './types';
 
 export interface GradeOptions extends LoadVectorsOptions {
   /** Allow http:// and private-IP destinations. Off by default (match fetchProbe). */
@@ -26,12 +26,29 @@ export interface GradeOptions extends LoadVectorsOptions {
    */
   rateAbuseCap?: number;
   /**
-   * Vector IDs to skip. Use for capability-profile mismatches — vectors 007
-   * and 018 each assume the verifier advertises a specific
-   * `covers_content_digest` policy (`"required"` and `"forbidden"`
-   * respectively) that a given agent may not match.
+   * Vector IDs to skip for operator-driven reasons (SDK-internal vectors,
+   * environment-specific quirks, etc.). Capability-profile mismatches
+   * don't belong here — pass {@link agentCapability} and the grader auto-
+   * skips vectors whose `verifier_capability` can't match the agent.
    */
   skipVectors?: string[];
+  /**
+   * Agent's declared `request_signing` capability block — exactly the shape
+   * in `get_adcp_capabilities.response.request_signing`. When provided, the
+   * grader pre-flights every vector's `verifier_capability` against this
+   * profile and auto-skips any vector that asserts a policy the agent
+   * didn't advertise (e.g., vector 007 requires `covers_content_digest:
+   * 'required'`; agent declares `'either'` — auto-skipped with
+   * `skip_reason: 'capability_profile_mismatch'`).
+   *
+   * Without this option, every vector runs and cap-profile mismatches
+   * produce failed vectors that the operator has to manually translate
+   * into `skipVectors` entries — fragile and easy to get wrong per
+   * profile. Set `agentCapability` and `skipVectors` collapses to just
+   * the handful of operator-specific overrides (like vector 025, which
+   * exercises the SDK library rather than the agent).
+   */
+  agentCapability?: VerifierCapabilityFixture;
   /**
    * When set, run only the named vector ids (all others auto-skip). Takes
    * precedence over `skipVectors`. Useful for isolated regression tests
@@ -224,6 +241,17 @@ function preflightSkip(
   }
   if (options.skipVectors?.includes(vector.id)) {
     return { ...base, skipped: true, skip_reason: 'operator_skip' };
+  }
+  if (options.agentCapability) {
+    const mismatch = capabilityMismatch(vector.verifier_capability, options.agentCapability);
+    if (mismatch) {
+      return {
+        ...base,
+        skipped: true,
+        skip_reason: 'capability_profile_mismatch',
+        diagnostic: mismatch,
+      };
+    }
   }
   const transportReason = TRANSPORT_UNGRADABLE[vector.id];
   if (transportReason) {
@@ -529,6 +557,61 @@ function buildPositiveRequestFromNegative(
 
 function negativeAcceptedErrorCode(vector: NegativeVector, probe: ProbeResult): boolean {
   return probe.status === 401 && probe.wwwAuthenticateErrorCode === vector.expected_error_code;
+}
+
+/**
+ * Compare a vector's `verifier_capability` fixture against the agent's
+ * declared capability profile. Returns a human-readable diagnostic when
+ * the two can't coexist — the vector asserts a policy the agent didn't
+ * advertise — or `undefined` when the vector is gradable under the
+ * agent's profile.
+ *
+ * Rules (all three must hold for a graded run):
+ *   - `covers_content_digest`: agent's `'either'` is permissive enough
+ *     for any vector value. Otherwise, agent and vector must agree.
+ *   - `required_for`: if the vector asserts a required_for operation,
+ *     the agent's `required_for` must include it. The reverse is fine
+ *     — an agent that requires MORE operations is still conformant
+ *     against a vector that asserts fewer.
+ *   - `supported`: must match. A vector with `supported: true` doesn't
+ *     grade against an agent that declares `supported: false` (the
+ *     conformance storyboard already skips such agents outright, but
+ *     defense-in-depth).
+ */
+function capabilityMismatch(
+  vectorCap: VerifierCapabilityFixture,
+  agentCap: VerifierCapabilityFixture
+): string | undefined {
+  if (vectorCap.supported !== agentCap.supported) {
+    return (
+      `Vector asserts supported=${vectorCap.supported} but agent declares supported=${agentCap.supported}. ` +
+      `Verify the agent's request_signing capability block.`
+    );
+  }
+  if (
+    vectorCap.covers_content_digest !== 'either' &&
+    agentCap.covers_content_digest !== 'either' &&
+    vectorCap.covers_content_digest !== agentCap.covers_content_digest
+  ) {
+    return (
+      `Vector asserts covers_content_digest='${vectorCap.covers_content_digest}' but agent declares '${agentCap.covers_content_digest}'. ` +
+      `The vector can't grade against this profile — its expected verifier behavior doesn't match what the agent implements.`
+    );
+  }
+  // `required_for` on the vector: every op the vector expects to be
+  // required must also be required by the agent. Otherwise a negative
+  // vector (e.g., missing signature on `create_media_buy`) would test a
+  // rejection path the agent didn't opt into.
+  const vectorRequiredFor = vectorCap.required_for ?? [];
+  const agentRequiredForSet = new Set(agentCap.required_for ?? []);
+  const missingRequiredFor = vectorRequiredFor.filter(op => !agentRequiredForSet.has(op));
+  if (missingRequiredFor.length > 0) {
+    return (
+      `Vector asserts required_for includes [${missingRequiredFor.join(', ')}] but agent's required_for does not. ` +
+      `Either add the operation to the agent's request_signing.required_for, or accept the skip.`
+    );
+  }
+  return undefined;
 }
 
 function buildNegativeDiagnostic(vector: NegativeVector, probe: ProbeResult): string | undefined {

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -216,9 +216,11 @@ const TRANSPORT_UNGRADABLE: Record<string, string> = {
 };
 
 /**
- * Centralized skip decisions. Checks (in order): onlyVectors filter, operator
- * skipVectors, MCP-mode URL-edge flattening, rate-abuse opt-out,
- * stateful-contract missing, side-effect gate.
+ * Centralized skip decisions. Checks (in order): onlyVectors filter,
+ * operator skipVectors, agent-capability-profile mismatch
+ * (`agentCapability` wired), transport-ungradable, MCP-mode URL-edge
+ * flattening, rate-abuse opt-out, stateful-contract missing, and the
+ * live-side-effect gate.
  */
 function preflightSkip(
   vector: PositiveVector | NegativeVector,
@@ -245,6 +247,13 @@ function preflightSkip(
   if (options.agentCapability) {
     const mismatch = capabilityMismatch(vector.verifier_capability, options.agentCapability);
     if (mismatch) {
+      // Surface the mismatch in the diagnostic so operators can audit
+      // which vectors were dodged. An agent that under-declares its
+      // capability (claims `required_for: []` while it actually
+      // enforces on multiple ops) would hide negative-vector failures
+      // here — the operator needs to see the skip count to catch that
+      // pattern. The caller inspects `report.skipped_count` plus the
+      // individual `skip_reason`/`diagnostic` pairs.
       return {
         ...base,
         skipped: true,

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -597,9 +597,17 @@ function capabilityMismatch(
       `Verify the agent's request_signing capability block.`
     );
   }
+  // `covers_content_digest` asymmetry: vector-side `'either'` is
+  // permissive (any agent policy can grade the vector), but agent-side
+  // `'either'` is NOT permissive against a strict vector — an agent
+  // that declares `'either'` accepts requests with OR without
+  // Content-Digest, so vector 007's "MUST reject uncovered request"
+  // and vector 018's "MUST reject covered-when-forbidden" are
+  // structurally incompatible with the agent's stance. The check
+  // fires whenever the VECTOR is strict and the agent's declaration
+  // can't pass the vector's assertion.
   if (
     vectorCap.covers_content_digest !== 'either' &&
-    agentCap.covers_content_digest !== 'either' &&
     vectorCap.covers_content_digest !== agentCap.covers_content_digest
   ) {
     return (

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -576,8 +576,12 @@ function negativeAcceptedErrorCode(vector: NegativeVector, probe: ProbeResult): 
  * agent's profile.
  *
  * Rules (all three must hold for a graded run):
- *   - `covers_content_digest`: agent's `'either'` is permissive enough
- *     for any vector value. Otherwise, agent and vector must agree.
+ *   - `covers_content_digest`: asymmetric. Vector-side `'either'` is
+ *     permissive (any agent policy can grade the vector). Agent-side
+ *     `'either'` is NOT permissive against a strict vector — an agent
+ *     that declares `'either'` accepts covered AND uncovered requests,
+ *     so it can't pass vectors 007 (`'required'`) or 018
+ *     (`'forbidden'`). Those auto-skip with `capability_profile_mismatch`.
  *   - `required_for`: if the vector asserts a required_for operation,
  *     the agent's `required_for` must include it. The reverse is fine
  *     — an agent that requires MORE operations is still conformant

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-20T13:22:18.724Z
+// Generated at: 2026-04-20T21:14:57.319Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)

--- a/src/lib/utils/tool-request-schemas.ts
+++ b/src/lib/utils/tool-request-schemas.ts
@@ -70,6 +70,7 @@ export const TOOL_REQUEST_SCHEMAS: Partial<Record<string, z.ZodType>> = {
   update_content_standards: schemas.UpdateContentStandardsRequestSchema,
   calibrate_content: schemas.CalibrateContentRequestSchema,
   validate_content_delivery: schemas.ValidateContentDeliveryRequestSchema,
+  validate_property_delivery: schemas.ValidatePropertyDeliveryRequestSchema,
 
   // Campaign governance
   sync_plans: schemas.SyncPlansRequestSchema,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.5.0';
+export const LIBRARY_VERSION = '5.6.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.5.0',
+  library: '5.6.0',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-20T19:15:43.016Z',
+  generatedAt: '2026-04-20T21:33:18.254Z',
 } as const;
 
 /**

--- a/test/lib/adcp-3-0-blockers.test.js
+++ b/test/lib/adcp-3-0-blockers.test.js
@@ -4,6 +4,7 @@ const assert = require('node:assert');
 const {
   createAdcpServer,
   verifyApiKey,
+  anyOf,
   respondUnauthorized,
   requireSignatureWhenPresent,
   requireAuthenticatedOrSigned,
@@ -112,12 +113,24 @@ describe('#665 requireSignatureWhenPresent + requiredFor', () => {
     );
   });
 
-  it('throws RequestSignatureError cause when fallback throws on required_for op (bad bearer path)', async () => {
-    // Regression: originally the requiredFor pre-check only ran after a
-    // `fallbackResult === null`, so a bad bearer that made `anyOf` throw
-    // skipped the pre-check entirely and surfaced as `Bearer` challenge.
-    // Fix: pre-check runs regardless of fallback throw/return.
-    const gate = requireSignatureWhenPresent(fakeSig, fakeBearer({ sk_live: { principal: 'acct_1' } }), {
+  it('throws RequestSignatureError cause when anyOf fallback rejects a bad bearer on a required_for op', async () => {
+    // Regression — the EXACT downstream-reported failure mode:
+    // fallback is `anyOf(verifyApiKey(...))`. A caller presents
+    // `Authorization: Bearer wrong-token`. `verifyApiKey` finds no
+    // match and returns null (it only throws if it recognized but
+    // rejected a key); `anyOf` with a single non-matching child
+    // returns null too. If we expand the fallback to multiple
+    // authenticators that legitimately throw on a bad credential
+    // (e.g., verifyBearer with a mismatched signature), the PRE
+    // version of this gate surfaced the wrong challenge. The new
+    // gate fires the requiredFor pre-check before rethrowing.
+    const throwingApiKey = () => {
+      // Simulates an authenticator that recognized but rejected the
+      // token (e.g., verifyBearer with an invalid signature).
+      throw new AuthError('Token validation failed.');
+    };
+    const composedFallback = anyOf(throwingApiKey);
+    const gate = requireSignatureWhenPresent(fakeSig, composedFallback, {
       requiredFor: ['create_media_buy'],
       resolveOperation: () => 'create_media_buy',
     });
@@ -136,18 +149,25 @@ describe('#665 requireSignatureWhenPresent + requiredFor', () => {
     );
   });
 
-  it('rethrows fallback error on ops NOT in requiredFor (bearer challenge preserved)', async () => {
-    // When op isn't in requiredFor, we want the fallback's original
-    // challenge (Bearer) — pre-check must not swallow that error.
-    class ThrowyAuth extends Error {}
-    const throwingFallback = async () => {
-      throw new ThrowyAuth('bearer rejected');
+  it('rethrows the anyOf fallback error on ops NOT in requiredFor — preserves challenge scheme', async () => {
+    // When op isn't in requiredFor, the original fallback error must
+    // propagate so `serve()` emits the correct challenge scheme
+    // (Bearer/invalid_token for this scenario) — NOT the signature
+    // challenge.
+    const throwingApiKey = () => {
+      const err = new AuthError('Token validation failed.');
+      err.publicMessage = 'Token validation failed.';
+      throw err;
     };
-    const gate = requireSignatureWhenPresent(fakeSig, throwingFallback, {
+    const composedFallback = anyOf(throwingApiKey);
+    const gate = requireSignatureWhenPresent(fakeSig, composedFallback, {
       requiredFor: ['create_media_buy'],
       resolveOperation: () => 'get_products',
     });
-    await assert.rejects(() => gate(unsignedReqWithBody('{}')), ThrowyAuth);
+    await assert.rejects(
+      () => gate(unsignedReqWithBody('{}')),
+      err => err instanceof AuthError && !(err.cause instanceof RequestSignatureError)
+    );
   });
 });
 

--- a/test/lib/adcp-3-0-blockers.test.js
+++ b/test/lib/adcp-3-0-blockers.test.js
@@ -111,6 +111,44 @@ describe('#665 requireSignatureWhenPresent + requiredFor', () => {
       err => err.cause instanceof RequestSignatureError && err.cause.code === 'request_signature_required'
     );
   });
+
+  it('throws RequestSignatureError cause when fallback throws on required_for op (bad bearer path)', async () => {
+    // Regression: originally the requiredFor pre-check only ran after a
+    // `fallbackResult === null`, so a bad bearer that made `anyOf` throw
+    // skipped the pre-check entirely and surfaced as `Bearer` challenge.
+    // Fix: pre-check runs regardless of fallback throw/return.
+    const gate = requireSignatureWhenPresent(fakeSig, fakeBearer({ sk_live: { principal: 'acct_1' } }), {
+      requiredFor: ['create_media_buy'],
+      resolveOperation: () => 'create_media_buy',
+    });
+    const reqWithBadBearer = {
+      method: 'POST',
+      url: '/mcp',
+      headers: { host: 'x', authorization: 'Bearer wrong-token' },
+      rawBody: '{}',
+    };
+    await assert.rejects(
+      () => gate(reqWithBadBearer),
+      err =>
+        err instanceof AuthError &&
+        err.cause instanceof RequestSignatureError &&
+        err.cause.code === 'request_signature_required'
+    );
+  });
+
+  it('rethrows fallback error on ops NOT in requiredFor (bearer challenge preserved)', async () => {
+    // When op isn't in requiredFor, we want the fallback's original
+    // challenge (Bearer) — pre-check must not swallow that error.
+    class ThrowyAuth extends Error {}
+    const throwingFallback = async () => {
+      throw new ThrowyAuth('bearer rejected');
+    };
+    const gate = requireSignatureWhenPresent(fakeSig, throwingFallback, {
+      requiredFor: ['create_media_buy'],
+      resolveOperation: () => 'get_products',
+    });
+    await assert.rejects(() => gate(unsignedReqWithBody('{}')), ThrowyAuth);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -279,6 +317,22 @@ describe('#666 AdcpServer.compliance.reset()', () => {
 // ---------------------------------------------------------------------------
 
 describe('#663 compliance-fixtures', () => {
+  it('pricing_options use spec-correct pricing_model values (not the hand-typed flat)', () => {
+    // Regression: originally shipped `pricing_model: 'flat'` which doesn't
+    // exist in the spec (the spec's `PricingModel` union uses `'flat_rate'`).
+    // Every pricing option body here must name a member of the spec union.
+    const specValues = ['cpm', 'vcpm', 'cpc', 'cpcv', 'cpv', 'cpp', 'cpa', 'flat_rate', 'time'];
+    for (const opt of Object.values(COMPLIANCE_FIXTURES.pricing_options)) {
+      assert.ok(
+        specValues.includes(opt.pricing_model),
+        `pricing_model "${opt.pricing_model}" not in spec union [${specValues.join(', ')}]`
+      );
+    }
+    // fixed_price (correct field on CPMPricingOption) should be present where applicable
+    assert.strictEqual(COMPLIANCE_FIXTURES.pricing_options['test-pricing'].fixed_price, 5);
+    assert.strictEqual(COMPLIANCE_FIXTURES.pricing_options['cpm_guaranteed'].fixed_price, 25);
+  });
+
   it('exposes canonical fixture IDs required by storyboards', () => {
     assert.ok(COMPLIANCE_FIXTURES.products['test-product']);
     assert.ok(COMPLIANCE_FIXTURES.products['sports_ctv_q2']);
@@ -492,6 +546,42 @@ describe('#664 createExpressAdapter', () => {
     await adapter.resetHook();
     assert.strictEqual(await stateStore.get('c', 'k'), null);
   });
+
+  it('resetHook re-seeds compliance fixtures when seedFixtures is set', async () => {
+    // Regression: without `seedFixtures`, a runner looping storyboards
+    // loses fixtures on the first reset and every subsequent storyboard
+    // fails fixture-lookup. With `seedFixtures: true`, the hook flushes
+    // state AND re-seeds from COMPLIANCE_FIXTURES.
+    const stateStore = new InMemoryStateStore();
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    const adapter = createExpressAdapter({
+      mountPath: '/api/x',
+      publicUrl: 'https://x.example.com/api/x/mcp',
+      server,
+      seedFixtures: true,
+    });
+    // First pass: seed via the hook itself (clean state).
+    await adapter.resetHook();
+    const testProduct = await stateStore.get(COMPLIANCE_COLLECTIONS.products, 'test-product');
+    assert.ok(testProduct, 'fixtures present after first reset');
+
+    // Add a stray key between storyboards (simulate handler state from sb #1).
+    await stateStore.put('campaigns', 'c1', { name: 'leftover' });
+    assert.ok(await stateStore.get('campaigns', 'c1'));
+
+    // Second pass: reset must flush the stray AND restore fixtures.
+    await adapter.resetHook();
+    assert.strictEqual(await stateStore.get('campaigns', 'c1'), null);
+    assert.ok(
+      await stateStore.get(COMPLIANCE_COLLECTIONS.products, 'test-product'),
+      'fixtures survive the second reset cycle'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -560,6 +650,25 @@ describe('#668 grader capability-profile mismatch skip', () => {
     assert.strictEqual(result.skipped, true);
     assert.strictEqual(result.skip_reason, 'capability_profile_mismatch');
     assert.match(result.diagnostic, /covers_content_digest/);
+  });
+
+  it('agent-side `either` + strict vector `required` is a mismatch (asymmetry fix)', async () => {
+    // Regression for downstream nit #1: an agent declaring `either`
+    // accepts Content-Digest either way — it doesn't commit to the
+    // strict `required` or `forbidden` policy vectors 007/018 grade.
+    // Those vectors can never pass against an `either` agent, so
+    // auto-skip them.
+    const { negative } = loadRequestSigningVectors();
+    const v007 = negative.find(v => v.id.includes('007'));
+    const result = await gradeOneVector(v007.id, 'negative', 'http://127.0.0.1:1', {
+      agentCapability: {
+        supported: true,
+        covers_content_digest: 'either',
+        required_for: [...(v007.verifier_capability.required_for ?? [])],
+      },
+    });
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.skip_reason, 'capability_profile_mismatch');
   });
 
   it('runs vectors whose verifier_capability is permissive under the agent profile', async () => {

--- a/test/lib/adcp-3-0-blockers.test.js
+++ b/test/lib/adcp-3-0-blockers.test.js
@@ -1,0 +1,500 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  createAdcpServer,
+  verifyApiKey,
+  anyOf,
+  respondUnauthorized,
+  requireSignatureWhenPresent,
+  requireAuthenticatedOrSigned,
+  signatureErrorCodeFromCause,
+  createExpressAdapter,
+  AuthError,
+  createIdempotencyStore,
+  memoryBackend,
+  InMemoryStateStore,
+} = require('../../dist/lib/server/index.js');
+
+const {
+  COMPLIANCE_FIXTURES,
+  COMPLIANCE_COLLECTIONS,
+  seedComplianceFixtures,
+  getComplianceFixture,
+} = require('../../dist/lib/compliance-fixtures/index.js');
+
+const { TOOL_INPUT_SHAPES, customToolFor } = require('../../dist/lib/schemas/index.js');
+
+const { RequestSignatureError } = require('../../dist/lib/signing/index.js');
+
+// ---------------------------------------------------------------------------
+// #665 — requireSignatureWhenPresent + requiredFor / requireAuthenticatedOrSigned
+// ---------------------------------------------------------------------------
+
+describe('#665 requireSignatureWhenPresent + requiredFor', () => {
+  const fakeSig = () => null;
+  const fakeBearer = keys => verifyApiKey({ keys });
+
+  function unsignedReqWithBody(body) {
+    return {
+      method: 'POST',
+      url: '/mcp',
+      headers: { host: 'seller.example.com', 'content-type': 'application/json' },
+      rawBody: body,
+    };
+  }
+
+  it('throws AuthError with RequestSignatureError cause when op is in requiredFor and no creds present', async () => {
+    const gate = requireSignatureWhenPresent(fakeSig, fakeBearer({}), {
+      requiredFor: ['create_media_buy'],
+      resolveOperation: req => {
+        try {
+          const body = JSON.parse(req.rawBody);
+          if (body.method === 'tools/call') return body.params?.name;
+        } catch {}
+        return undefined;
+      },
+    });
+    const req = unsignedReqWithBody(JSON.stringify({ method: 'tools/call', params: { name: 'create_media_buy' } }));
+    await assert.rejects(
+      () => gate(req),
+      err =>
+        err instanceof AuthError &&
+        err.cause instanceof RequestSignatureError &&
+        err.cause.code === 'request_signature_required'
+    );
+  });
+
+  it('returns fallback principal when op IS in requiredFor but valid bearer is presented', async () => {
+    const gate = requireSignatureWhenPresent(fakeSig, fakeBearer({ sk_live: { principal: 'acct_1' } }), {
+      requiredFor: ['create_media_buy'],
+      resolveOperation: () => 'create_media_buy',
+    });
+    const req = {
+      method: 'POST',
+      url: '/mcp',
+      headers: { host: 'x', authorization: 'Bearer sk_live' },
+      rawBody: '{}',
+    };
+    const result = await gate(req);
+    assert.ok(result);
+    assert.strictEqual(result.principal, 'acct_1');
+  });
+
+  it('returns null when op is NOT in requiredFor and no creds present (default 401 path)', async () => {
+    const gate = requireSignatureWhenPresent(fakeSig, fakeBearer({}), {
+      requiredFor: ['create_media_buy'],
+      resolveOperation: () => 'get_products',
+    });
+    const req = unsignedReqWithBody('{}');
+    const result = await gate(req);
+    assert.strictEqual(result, null);
+  });
+
+  it('skips requiredFor pre-check when resolveOperation returns undefined', async () => {
+    const gate = requireSignatureWhenPresent(fakeSig, fakeBearer({}), {
+      requiredFor: ['create_media_buy'],
+      resolveOperation: () => undefined,
+    });
+    const result = await gate(unsignedReqWithBody('{}'));
+    assert.strictEqual(result, null);
+  });
+
+  it('requireAuthenticatedOrSigned bundles the same semantics', async () => {
+    const gate = requireAuthenticatedOrSigned({
+      signature: fakeSig,
+      fallback: fakeBearer({}),
+      requiredFor: ['create_media_buy'],
+      resolveOperation: () => 'create_media_buy',
+    });
+    await assert.rejects(
+      () => gate(unsignedReqWithBody('{}')),
+      err => err.cause instanceof RequestSignatureError && err.cause.code === 'request_signature_required'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #665 — respondUnauthorized signature challenge + signatureErrorCodeFromCause
+// ---------------------------------------------------------------------------
+
+describe('#665 respondUnauthorized signature challenge', () => {
+  function fakeRes() {
+    const state = { status: 0, headers: {}, body: '' };
+    return {
+      state,
+      writeHead(status, headers) {
+        state.status = status;
+        Object.assign(state.headers, headers);
+      },
+      end(body) {
+        state.body = body;
+      },
+    };
+  }
+
+  it('emits `WWW-Authenticate: Signature ...` when signatureError is set', () => {
+    const res = fakeRes();
+    respondUnauthorized({}, res, {
+      signatureError: 'request_signature_invalid',
+      errorDescription: 'Bad sig.',
+    });
+    assert.strictEqual(res.state.status, 401);
+    const challenge = res.state.headers['WWW-Authenticate'];
+    assert.match(challenge, /^Signature /);
+    assert.match(challenge, /error="request_signature_invalid"/);
+    const body = JSON.parse(res.state.body);
+    assert.strictEqual(body.error, 'request_signature_invalid');
+  });
+
+  it('emits Bearer challenge when no signatureError is set (default path)', () => {
+    const res = fakeRes();
+    respondUnauthorized({}, res, { error: 'invalid_token' });
+    assert.match(res.state.headers['WWW-Authenticate'], /^Bearer /);
+  });
+
+  it('signatureErrorCodeFromCause unwraps AuthError → RequestSignatureError cause chain', () => {
+    const inner = new RequestSignatureError('request_signature_replayed', 13, 'replay');
+    const wrapped = new AuthError('rejected', { cause: inner });
+    assert.strictEqual(signatureErrorCodeFromCause(wrapped), 'request_signature_replayed');
+  });
+
+  it('signatureErrorCodeFromCause returns null for non-signature errors', () => {
+    const e = new Error('x');
+    assert.strictEqual(signatureErrorCodeFromCause(e), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #666 — AdcpServer.compliance.reset()
+// ---------------------------------------------------------------------------
+
+describe('#666 AdcpServer.compliance.reset()', () => {
+  it('clears the state store on reset', async () => {
+    const stateStore = new InMemoryStateStore();
+    await stateStore.put('campaigns', 'c1', { name: 'one' });
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    assert.ok(await stateStore.get('campaigns', 'c1'), 'seeded');
+    await server.compliance.reset();
+    assert.strictEqual(await stateStore.get('campaigns', 'c1'), null);
+  });
+
+  it('clears the idempotency cache on reset', async () => {
+    const stateStore = new InMemoryStateStore();
+    const idempotency = createIdempotencyStore({ backend: memoryBackend(), ttlSeconds: 3600 });
+    await idempotency.save({
+      principal: 'p',
+      key: 'aaaaaaaaaaaaaaaa',
+      payloadHash: 'h',
+      response: { ok: true },
+    });
+    const check1 = await idempotency.check({
+      principal: 'p',
+      key: 'aaaaaaaaaaaaaaaa',
+      payload: {},
+    });
+    assert.notStrictEqual(check1.kind, 'miss', 'pre-reset: cached');
+
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore,
+      idempotency,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    await server.compliance.reset();
+    const check2 = await idempotency.check({
+      principal: 'p',
+      key: 'aaaaaaaaaaaaaaaa',
+      payload: {},
+    });
+    assert.strictEqual(check2.kind, 'miss', 'post-reset: miss');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #663 — compliance-fixtures
+// ---------------------------------------------------------------------------
+
+describe('#663 compliance-fixtures', () => {
+  it('exposes canonical fixture IDs required by storyboards', () => {
+    assert.ok(COMPLIANCE_FIXTURES.products['test-product']);
+    assert.ok(COMPLIANCE_FIXTURES.products['sports_ctv_q2']);
+    assert.ok(COMPLIANCE_FIXTURES.formats['video_30s']);
+    assert.ok(COMPLIANCE_FIXTURES.formats['native_post']);
+    assert.ok(COMPLIANCE_FIXTURES.formats['native_content']);
+    assert.ok(COMPLIANCE_FIXTURES.pricing_options['test-pricing']);
+    assert.ok(COMPLIANCE_FIXTURES.pricing_options['cpm_guaranteed']);
+    assert.ok(COMPLIANCE_FIXTURES.creatives['campaign_hero_video']);
+    assert.strictEqual(COMPLIANCE_FIXTURES.creatives['campaign_hero_video'].status, 'approved');
+    assert.ok(COMPLIANCE_FIXTURES.plans['gov_acme_q2_2027']);
+    assert.ok(COMPLIANCE_FIXTURES.media_buys['mb_acme_q2_2026_auction']);
+  });
+
+  it('seedComplianceFixtures writes all six collections to the state store', async () => {
+    const stateStore = new InMemoryStateStore();
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    await seedComplianceFixtures(server);
+    const testProduct = await stateStore.get(COMPLIANCE_COLLECTIONS.products, 'test-product');
+    assert.ok(testProduct, 'test-product seeded');
+    assert.strictEqual(testProduct.product_id, 'test-product');
+    assert.ok(await stateStore.get(COMPLIANCE_COLLECTIONS.products, 'sports_ctv_q2'));
+
+    const seeded = await stateStore.get(COMPLIANCE_COLLECTIONS.creatives, 'campaign_hero_video');
+    assert.ok(seeded);
+    assert.strictEqual(seeded.status, 'approved');
+    assert.ok(await stateStore.get(COMPLIANCE_COLLECTIONS.plans, 'gov_acme_q2_2027'));
+    assert.ok(await stateStore.get(COMPLIANCE_COLLECTIONS.media_buys, 'mb_acme_q2_2026_auction'));
+  });
+
+  it('seedComplianceFixtures honors category filter and override:null', async () => {
+    const stateStore = new InMemoryStateStore();
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    await seedComplianceFixtures(server, {
+      categories: ['products'],
+      overrides: { products: { sports_ctv_q2: null } },
+    });
+    assert.ok(await stateStore.get(COMPLIANCE_COLLECTIONS.products, 'test-product'));
+    assert.strictEqual(
+      await stateStore.get(COMPLIANCE_COLLECTIONS.products, 'sports_ctv_q2'),
+      null,
+      'override:null deletes'
+    );
+    const formats = await stateStore.list(COMPLIANCE_COLLECTIONS.formats);
+    assert.strictEqual(formats.items.length, 0, 'formats NOT seeded when not in categories');
+  });
+
+  it('getComplianceFixture looks up a fixture by category + id', () => {
+    const fx = getComplianceFixture('products', 'test-product');
+    assert.ok(fx);
+    assert.strictEqual(fx.product_id, 'test-product');
+    assert.strictEqual(getComplianceFixture('products', 'missing'), undefined);
+  });
+
+  it('seedComplianceFixtures rejects non-AdcpServer', async () => {
+    await assert.rejects(() => seedComplianceFixtures({}), /is not an AdcpServer/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #664 — createExpressAdapter
+// ---------------------------------------------------------------------------
+
+describe('#664 createExpressAdapter', () => {
+  it('rawBodyVerify attaches rawBody to the request', () => {
+    const adapter = createExpressAdapter({ mountPath: '/api/x' });
+    const req = {};
+    adapter.rawBodyVerify(req, null, Buffer.from('{"hi":1}', 'utf8'));
+    assert.strictEqual(req.rawBody, '{"hi":1}');
+  });
+
+  it('getUrl reconstructs the full URL including mount prefix via originalUrl', () => {
+    const adapter = createExpressAdapter({ mountPath: '/api/agent' });
+    const url = adapter.getUrl({
+      url: '/mcp',
+      originalUrl: '/api/agent/mcp',
+      headers: { host: 'agent.example.com' },
+      socket: { encrypted: true },
+    });
+    assert.strictEqual(url, 'https://agent.example.com/api/agent/mcp');
+  });
+
+  it('getUrl composes mountPath + req.url when originalUrl is absent', () => {
+    const adapter = createExpressAdapter({ mountPath: '/api/agent' });
+    const url = adapter.getUrl({
+      url: '/mcp',
+      headers: { host: 'agent.example.com' },
+      socket: { encrypted: true },
+    });
+    assert.strictEqual(url, 'https://agent.example.com/api/agent/mcp');
+  });
+
+  it('protectedResourceMiddleware responds for /.well-known/oauth-protected-resource/*', () => {
+    const adapter = createExpressAdapter({
+      mountPath: '/api/agent',
+      publicUrl: 'https://agent.example.com/api/agent/mcp',
+      prm: { authorization_servers: ['https://auth.example.com'] },
+    });
+    const res = {
+      state: { status: 0, body: '' },
+      writeHead(status) {
+        this.state.status = status;
+      },
+      end(body) {
+        this.state.body = body;
+      },
+    };
+    let nextCalled = false;
+    adapter.protectedResourceMiddleware(
+      { url: '/.well-known/oauth-protected-resource/api/agent/mcp', headers: { host: 'agent.example.com' } },
+      res,
+      () => {
+        nextCalled = true;
+      }
+    );
+    assert.strictEqual(res.state.status, 200);
+    assert.strictEqual(nextCalled, false, 'should not call next when handling PRM');
+    const body = JSON.parse(res.state.body);
+    assert.strictEqual(body.resource, 'https://agent.example.com/api/agent/mcp');
+    assert.deepStrictEqual(body.authorization_servers, ['https://auth.example.com']);
+    assert.deepStrictEqual(body.bearer_methods_supported, ['header']);
+  });
+
+  it('protectedResourceMiddleware calls next() for unrelated paths', () => {
+    const adapter = createExpressAdapter({
+      mountPath: '/api/agent',
+      prm: { authorization_servers: ['https://auth.example.com'] },
+    });
+    let nextCalled = false;
+    adapter.protectedResourceMiddleware(
+      { url: '/api/agent/mcp', headers: { host: 'x' } },
+      { writeHead() {}, end() {} },
+      () => {
+        nextCalled = true;
+      }
+    );
+    assert.ok(nextCalled);
+  });
+
+  it('resetHook delegates to server.compliance.reset when server is set', async () => {
+    const stateStore = new InMemoryStateStore();
+    await stateStore.put('c', 'k', { v: 1 });
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    const adapter = createExpressAdapter({ mountPath: '/api/x', server });
+    await adapter.resetHook();
+    assert.strictEqual(await stateStore.get('c', 'k'), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #667 — TOOL_INPUT_SHAPES + customToolFor
+// ---------------------------------------------------------------------------
+
+describe('#667 TOOL_INPUT_SHAPES', () => {
+  it('includes both framework tools and custom-only tools', () => {
+    // Framework tool
+    assert.ok(TOOL_INPUT_SHAPES.get_products);
+    assert.ok(TOOL_INPUT_SHAPES.create_media_buy);
+    // Non-framework custom tools the issue enumerates:
+    assert.ok(TOOL_INPUT_SHAPES.creative_approval);
+    assert.ok(TOOL_INPUT_SHAPES.update_rights);
+    assert.ok(TOOL_INPUT_SHAPES.comply_test_controller);
+    assert.ok(TOOL_INPUT_SHAPES.check_governance);
+    assert.ok(TOOL_INPUT_SHAPES.acquire_rights);
+  });
+
+  it('each entry is a raw shape object (Record<string, ZodType>)', () => {
+    const shape = TOOL_INPUT_SHAPES.creative_approval;
+    assert.strictEqual(typeof shape, 'object');
+    // rights_id is a required string in creative_approval
+    assert.ok(shape.rights_id);
+    // idempotency_key is required on mutating tools
+    assert.ok(shape.idempotency_key);
+  });
+
+  it('customToolFor returns an MCP-compatible registration object', () => {
+    const shape = TOOL_INPUT_SHAPES.creative_approval;
+    const reg = customToolFor('creative_approval', 'Submit creative for approval', shape, async args => ({
+      status: 'approved',
+      rights_id: args.rights_id,
+    }));
+    assert.strictEqual(reg.description, 'Submit creative for approval');
+    assert.strictEqual(reg.inputSchema, shape);
+    assert.strictEqual(typeof reg.handler, 'function');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #668 — grader capability-profile mismatch auto-skip
+// ---------------------------------------------------------------------------
+
+describe('#668 grader capability-profile mismatch skip', () => {
+  const {
+    gradeOneVector,
+    loadRequestSigningVectors,
+  } = require('../../dist/lib/testing/storyboard/request-signing/index.js');
+
+  it('auto-skips vectors whose covers_content_digest demands conflict with agentCapability', async () => {
+    // Vector 007 ships `covers_content_digest: 'required'`; an agent that
+    // declares `'forbidden'` can never grade this vector truthfully.
+    const { negative } = loadRequestSigningVectors();
+    const v007 = negative.find(v => v.id.includes('007'));
+    assert.ok(v007, 'vector 007 should exist');
+    assert.strictEqual(v007.verifier_capability.covers_content_digest, 'required');
+
+    const result = await gradeOneVector(v007.id, 'negative', 'http://127.0.0.1:1', {
+      agentCapability: {
+        supported: true,
+        covers_content_digest: 'forbidden',
+        required_for: [],
+      },
+    });
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.skip_reason, 'capability_profile_mismatch');
+    assert.match(result.diagnostic, /covers_content_digest/);
+  });
+
+  it('runs vectors whose verifier_capability is permissive under the agent profile', async () => {
+    // Vector 001 ships `covers_content_digest: 'either'` — ANY agent
+    // profile should grade against it (no auto-skip).
+    const { positive } = loadRequestSigningVectors();
+    const v001 = positive.find(v => v.id.includes('001'));
+    assert.ok(v001);
+    // We need the probe to short-circuit without hitting a network. Use an
+    // unreachable address — the grader returns a failed result (probe error),
+    // NOT a skipped one. That's what we're asserting here: not skipped.
+    const result = await gradeOneVector(v001.id, 'positive', 'http://127.0.0.1:1', {
+      agentCapability: {
+        supported: true,
+        covers_content_digest: 'either',
+        // Superset of the vector's required_for — agents that require MORE
+        // than the vector asserts are still conformant against that vector.
+        required_for: [...(v001.verifier_capability.required_for ?? []), 'update_media_buy'],
+      },
+      timeoutMs: 500,
+    });
+    assert.notStrictEqual(result.skip_reason, 'capability_profile_mismatch');
+  });
+
+  it('auto-skips when vector asserts required_for includes an op the agent does not require', async () => {
+    // Vectors with `required_for: ['create_media_buy']` in their capability
+    // fixture shouldn't grade against an agent whose required_for is empty.
+    const { negative } = loadRequestSigningVectors();
+    const vecWithRequiredFor = negative.find(v => v.verifier_capability.required_for?.length);
+    if (!vecWithRequiredFor) {
+      // If no shipped vector asserts a non-empty required_for, skip — the
+      // mismatch path still has unit coverage via the capabilityMismatch helper.
+      return;
+    }
+    const result = await gradeOneVector(vecWithRequiredFor.id, 'negative', 'http://127.0.0.1:1', {
+      agentCapability: {
+        supported: true,
+        covers_content_digest: 'either',
+        required_for: [],
+      },
+    });
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.skip_reason, 'capability_profile_mismatch');
+    assert.match(result.diagnostic, /required_for/);
+  });
+});

--- a/test/lib/adcp-3-0-blockers.test.js
+++ b/test/lib/adcp-3-0-blockers.test.js
@@ -163,6 +163,64 @@ describe('#665 respondUnauthorized signature challenge', () => {
     const e = new Error('x');
     assert.strictEqual(signatureErrorCodeFromCause(e), null);
   });
+
+  it('signatureErrorCodeFromCause breaks on self-referential cause cycle', () => {
+    const a = new Error('a');
+    a.cause = a;
+    assert.strictEqual(signatureErrorCodeFromCause(a), null);
+  });
+
+  it('signatureErrorCodeFromCause breaks on 2-cycle cause chains', () => {
+    const a = new Error('a');
+    const b = new Error('b');
+    a.cause = b;
+    b.cause = a;
+    assert.strictEqual(signatureErrorCodeFromCause(a), null);
+  });
+});
+
+describe('#666 compliance.reset() guardrails', () => {
+  it('refuses to run in NODE_ENV=production without allowProduction', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const server = createAdcpServer({
+        name: 'x',
+        version: '0.0.1',
+        stateStore: new InMemoryStateStore(),
+        mediaBuy: { getProducts: async () => ({ products: [] }) },
+      });
+      await assert.rejects(() => server.compliance.reset(), /NODE_ENV=production/);
+      // Opt-out works:
+      await server.compliance.reset({ allowProduction: true });
+    } finally {
+      if (originalEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it('refuses to run when stateStore is not InMemoryStateStore without force', async () => {
+    // Fake a non-InMemoryStateStore — fulfills the AdcpStateStore shape but isn't the sentinel.
+    const fakeStore = {
+      get: async () => null,
+      getWithVersion: async () => null,
+      put: async () => {},
+      putIfMatch: async () => ({ ok: true, version: 1 }),
+      patch: async () => {},
+      delete: async () => true,
+      list: async () => ({ items: [], nextCursor: undefined }),
+      clear: () => {},
+    };
+    const server = createAdcpServer({
+      name: 'x',
+      version: '0.0.1',
+      stateStore: fakeStore,
+      mediaBuy: { getProducts: async () => ({ products: [] }) },
+    });
+    await assert.rejects(() => server.compliance.reset(), /is not InMemoryStateStore/);
+    // Opt-out works:
+    await server.compliance.reset({ force: true });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -303,8 +361,40 @@ describe('#664 createExpressAdapter', () => {
     assert.strictEqual(req.rawBody, '{"hi":1}');
   });
 
-  it('getUrl reconstructs the full URL including mount prefix via originalUrl', () => {
+  it('getUrl uses publicUrl origin and ignores x-forwarded-host (closes audience-confusion)', () => {
+    const adapter = createExpressAdapter({
+      mountPath: '/api/agent',
+      publicUrl: 'https://agent.example.com/api/agent/mcp',
+    });
+    const url = adapter.getUrl({
+      url: '/mcp',
+      originalUrl: '/api/agent/mcp',
+      headers: {
+        host: 'evil.example.com',
+        'x-forwarded-host': 'also-evil.example.com',
+        'x-forwarded-proto': 'http',
+      },
+      socket: { encrypted: false },
+    });
+    assert.strictEqual(url, 'https://agent.example.com/api/agent/mcp');
+  });
+
+  it('getUrl throws when neither publicUrl nor trustForwardedHost is set', () => {
     const adapter = createExpressAdapter({ mountPath: '/api/agent' });
+    assert.throws(
+      () =>
+        adapter.getUrl({
+          url: '/mcp',
+          originalUrl: '/api/agent/mcp',
+          headers: { host: 'agent.example.com' },
+          socket: { encrypted: true },
+        }),
+      /neither `publicUrl` nor `trustForwardedHost/
+    );
+  });
+
+  it('getUrl falls back to header reconstruction under trustForwardedHost opt-in', () => {
+    const adapter = createExpressAdapter({ mountPath: '/api/agent', trustForwardedHost: true });
     const url = adapter.getUrl({
       url: '/mcp',
       originalUrl: '/api/agent/mcp',
@@ -314,8 +404,11 @@ describe('#664 createExpressAdapter', () => {
     assert.strictEqual(url, 'https://agent.example.com/api/agent/mcp');
   });
 
-  it('getUrl composes mountPath + req.url when originalUrl is absent', () => {
-    const adapter = createExpressAdapter({ mountPath: '/api/agent' });
+  it('getUrl composes mountPath + req.url when originalUrl is absent (via publicUrl)', () => {
+    const adapter = createExpressAdapter({
+      mountPath: '/api/agent',
+      publicUrl: 'https://agent.example.com/api/agent/mcp',
+    });
     const url = adapter.getUrl({
       url: '/mcp',
       headers: { host: 'agent.example.com' },
@@ -355,9 +448,21 @@ describe('#664 createExpressAdapter', () => {
     assert.deepStrictEqual(body.bearer_methods_supported, ['header']);
   });
 
+  it('createExpressAdapter refuses prm without publicUrl or trustForwardedHost', () => {
+    assert.throws(
+      () =>
+        createExpressAdapter({
+          mountPath: '/api/agent',
+          prm: { authorization_servers: ['https://auth.example.com'] },
+        }),
+      /`prm` requires either `publicUrl`/
+    );
+  });
+
   it('protectedResourceMiddleware calls next() for unrelated paths', () => {
     const adapter = createExpressAdapter({
       mountPath: '/api/agent',
+      publicUrl: 'https://agent.example.com/api/agent/mcp',
       prm: { authorization_servers: ['https://auth.example.com'] },
     });
     let nextCalled = false;
@@ -380,7 +485,11 @@ describe('#664 createExpressAdapter', () => {
       stateStore,
       mediaBuy: { getProducts: async () => ({ products: [] }) },
     });
-    const adapter = createExpressAdapter({ mountPath: '/api/x', server });
+    const adapter = createExpressAdapter({
+      mountPath: '/api/x',
+      publicUrl: 'https://x.example.com/api/x/mcp',
+      server,
+    });
     await adapter.resetHook();
     assert.strictEqual(await stateStore.get('c', 'k'), null);
   });

--- a/test/lib/adcp-3-0-blockers.test.js
+++ b/test/lib/adcp-3-0-blockers.test.js
@@ -4,7 +4,6 @@ const assert = require('node:assert');
 const {
   createAdcpServer,
   verifyApiKey,
-  anyOf,
   respondUnauthorized,
   requireSignatureWhenPresent,
   requireAuthenticatedOrSigned,


### PR DESCRIPTION
## Summary

Closes six AdCP 3.0 release blockers ([#663](https://github.com/adcontextprotocol/adcp-client/issues/663)–[#668](https://github.com/adcontextprotocol/adcp-client/issues/668)) in one PR. All changes are additive — new subpath exports, a new options parameter on `requireSignatureWhenPresent`, new fields on `RespondUnauthorizedOptions` and `GradeOptions`, and a new `compliance` property on `AdcpServer`. No breaking changes.

**New subpath exports**

- **`@adcp/client/compliance-fixtures`** (#663): canonical `COMPLIANCE_FIXTURES` data for every storyboard-hardcoded ID (`test-product`, `sports_ctv_q2`, `video_30s`, `native_post`, `native_content`, `campaign_hero_video`, `gov_acme_q2_2027`, `mb_acme_q2_2026_auction`, `cpm_guaranteed`, …) plus `seedComplianceFixtures(server)` that writes into the state store under `compliance:*` collections.
- **`@adcp/client/schemas`** (#667): re-exports every generated Zod `*RequestSchema`, plus `TOOL_INPUT_SHAPES` (superset of the framework-registered tools — also covers `creative_approval`, `update_rights`, `comply_test_controller`, `check_governance`, etc.) and a `customToolFor(name, description, shape, handler)` helper for MCP `customTools` registration.

**`@adcp/client/server` additions**

- **`createExpressAdapter({ mountPath, publicUrl, prm, server })`** (#664): returns `rawBodyVerify`, `protectedResourceMiddleware`, `getUrl`, and `resetHook` — the four pieces an Express-mounted agent needs to run behind a router. Removes ~20 lines of hand-wired plumbing.
- **`requireAuthenticatedOrSigned`** / **`requireSignatureWhenPresent({ requiredFor, resolveOperation })`** (#665): presence-gated signature composition now enforces `required_for` on the no-signature path. Unsigned requests with no credentials on a `required_for` operation throw `AuthError` whose cause is `RequestSignatureError('request_signature_required')`. Valid bearer still bypasses (per adcp#2586 consensus).
- **`respondUnauthorized({ signatureError })`** (#665): emits `WWW-Authenticate: Signature error="<code>"`. `serve()` auto-detects via `signatureErrorCodeFromCause(err)` so signature-layer 401s carry the right challenge scheme.
- **`AdcpServer.compliance.reset({ force? })`** (#666): drops session state + idempotency cache between storyboards. `IdempotencyStore.clearAll` is optional on the store — `memoryBackend` implements it, production backends leave it undefined. Refuses to run under `NODE_ENV=production` unless `force: true`.

**Testing (`@adcp/client/testing`)**

- **Grader `agentCapability` option** (#668): vectors whose `verifier_capability.covers_content_digest` or `required_for` doesn't match the agent's declared profile auto-skip with `skip_reason: 'capability_profile_mismatch'`. `skipVectors` stays available for operator overrides.

## Test plan

- [x] 28 new unit tests in `test/lib/adcp-3-0-blockers.test.js` — all 6 features covered, all green
- [x] Full `npm run test:lib` — 3826 tests, 0 failures
- [x] `npm run test` (full suite) — 4449 tests, 0 failures
- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm run format` applied
- [x] Changeset added (`.changeset/adcp-3-0-release-blockers.md`, minor bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)