### PR TITLE
feat(storyboard): refs_resolve cross-step validation (#670)

### DIFF
--- a/.changeset/refs-resolve-validation.md
+++ b/.changeset/refs-resolve-validation.md
@@ -1,0 +1,12 @@
+---
+'@adcp/client': minor
+---
+
+Add `refs_resolve` cross-step storyboard validation (adcp#2597, adcp-client#670). A new check that asserts every ref in a source set (e.g., `products[*].format_ids[*]` from a prior `get_products`) resolves to a member of a target set (e.g., `formats[*].format_id` from the current `list_creative_formats`), using configurable `match_keys`. Supports `[*]` wildcard path segments via a new `resolvePathAll` helper, scope filtering by key (with `$agent_url` substitution for the agent under test), and three out-of-scope grading modes (`warn`, `ignore`, `fail`). Failed checks name the exact unresolved ref tuples in `actual.missing` and dedupe on the projected tuple so one bad ref across 50 products shows up once. `runValidations()` now accepts `storyboardContext` on its `ValidationContext` argument so cross-step checks can read prior-step outputs; existing call sites pass it through from the runner.
+
+Hardening for untrusted inputs:
+- `resolvePathAll` caps output at 10,000 terminal values to prevent wildcard fan-out OOM from a malicious agent response shaped for exponential expansion.
+- Path segments `__proto__`, `constructor`, and `prototype` are skipped, and `hasOwnProperty` gates each object lookup so a storyboard path cannot surface prototype-chain state into compliance reports.
+- Path strings over 1 KiB return an empty segment list rather than burning CPU on pathological input.
+- `scope.equals` normalizes trailing slashes on both sides when the scope key ends in `url`, so a storyboard author can pass a literal URL or `$agent_url` interchangeably.
+- `refsMatch` rejects a match when either side is missing a declared `match_key`, preventing two refs that both omit a key from fuzzy-matching on the others.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-20
-> @adcp/client v5.6.0
+> @adcp/client v5.7.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-20
-> Library: @adcp/client v5.6.0
+> Library: @adcp/client v5.7.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.6.0",
+      "version": "5.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "jose": "^6.2.2",

--- a/src/lib/testing/storyboard/path.ts
+++ b/src/lib/testing/storyboard/path.ts
@@ -6,16 +6,67 @@
  */
 
 /**
+ * Wildcard marker produced by `parsePathWithWildcards` for `[*]` segments.
+ * The plain `parsePath` tokenizer does not emit it — callers that need
+ * wildcard semantics (`resolvePathAll`) use the wildcard-aware parser.
+ */
+export const WILDCARD = Symbol('path.wildcard');
+
+/**
+ * Upper bound on the number of terminal values `resolvePathAll` will emit.
+ * Guards the runner against OOM when a wildcard-heavy path (`a[*].b[*].c[*]…`)
+ * is applied to a malicious agent response shaped to maximize fan-out.
+ * The cap is well above any realistic storyboard use (a 1000-product
+ * catalog × 10 formats = 10k terminal values).
+ */
+export const RESOLVE_PATH_ALL_MAX = 10_000;
+
+/**
+ * Upper bound on storyboard path-string length. The parser is linear in
+ * input size, but a hostile storyboard can still spend CPU against a
+ * megabyte-long path with no legitimate use case.
+ */
+const MAX_PATH_LENGTH = 1024;
+
+/**
  * Parse a path string into segments.
  * "accounts[0].account_id" → ["accounts", 0, "account_id"]
+ *
+ * Returns an empty segment list for paths that exceed `MAX_PATH_LENGTH`
+ * so downstream resolvers degrade to "nothing at this path" instead of
+ * burning CPU on a pathological input.
  */
 export function parsePath(path: string): Array<string | number> {
+  if (path.length > MAX_PATH_LENGTH) return [];
   const segments: Array<string | number> = [];
   const re = /([^.\[\]]+)|\[(\d+)\]/g;
   let match: RegExpExecArray | null;
 
   while ((match = re.exec(path)) !== null) {
     if (match[2] !== undefined) {
+      segments.push(parseInt(match[2], 10));
+    } else if (match[1] !== undefined) {
+      segments.push(match[1]);
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Parse a path string into segments, preserving `[*]` wildcards.
+ * "products[*].format_ids[*]" → ["products", WILDCARD, "format_ids", WILDCARD]
+ */
+export function parsePathWithWildcards(path: string): Array<string | number | typeof WILDCARD> {
+  if (path.length > MAX_PATH_LENGTH) return [];
+  const segments: Array<string | number | typeof WILDCARD> = [];
+  const re = /([^.\[\]]+)|\[(\d+)\]|\[(\*)\]/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = re.exec(path)) !== null) {
+    if (match[3] !== undefined) {
+      segments.push(WILDCARD);
+    } else if (match[2] !== undefined) {
       segments.push(parseInt(match[2], 10));
     } else if (match[1] !== undefined) {
       segments.push(match[1]);
@@ -52,6 +103,60 @@ export function resolvePath(obj: unknown, path: string): unknown {
   }
 
   return current;
+}
+
+/**
+ * Resolve a wildcard-aware path and return every terminal value as a flat
+ * array. `[*]` segments fan out over arrays; undefined intermediates
+ * short-circuit the current branch without throwing. `null`, `false`, `0`,
+ * and `""` terminals are preserved — only `undefined` means "no value at
+ * this path." This matches `resolvePath`'s scalar contract.
+ *
+ * Output is capped at `RESOLVE_PATH_ALL_MAX` terminal values. When the cap
+ * is hit the walker stops and returns what it has; callers that need to
+ * know whether truncation happened should compare the length to the cap.
+ *
+ * Examples:
+ *   "products[*].format_ids[*]" on `{products:[{format_ids:[a,b]},{format_ids:[c]}]}` → [a, b, c]
+ *   "formats[*].format_id" on `{formats:[{format_id:x},{format_id:y}]}` → [x, y]
+ *   "status" (no wildcard) → [obj.status] if defined, else []
+ */
+export function resolvePathAll(obj: unknown, path: string): unknown[] {
+  if (obj === undefined) return [];
+  const segments = parsePathWithWildcards(path);
+  const results: unknown[] = [];
+  walk(obj, segments, 0, results);
+  return results;
+}
+
+function walk(current: unknown, segments: Array<string | number | typeof WILDCARD>, i: number, out: unknown[]): void {
+  if (out.length >= RESOLVE_PATH_ALL_MAX) return;
+  if (i === segments.length) {
+    if (current !== undefined) out.push(current);
+    return;
+  }
+  if (current === undefined || current === null) return;
+  const segment = segments[i]!;
+  if (segment === WILDCARD) {
+    if (!Array.isArray(current)) return;
+    for (const item of current) {
+      if (out.length >= RESOLVE_PATH_ALL_MAX) return;
+      walk(item, segments, i + 1, out);
+    }
+    return;
+  }
+  if (typeof segment === 'number') {
+    if (!Array.isArray(current)) return;
+    walk(current[segment], segments, i + 1, out);
+    return;
+  }
+  if (FORBIDDEN_KEYS.has(segment)) return;
+  if (typeof current !== 'object') return;
+  // Gate on own properties so attackers can't surface Object.prototype state
+  // even when a key slips past FORBIDDEN_KEYS (defense-in-depth; FORBIDDEN_KEYS
+  // already catches `__proto__`/`constructor`/`prototype` by name).
+  if (!Object.prototype.hasOwnProperty.call(current, segment)) return;
+  walk((current as Record<string, unknown>)[segment], segments, i + 1, out);
 }
 
 /**

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -949,6 +949,7 @@ async function executeStep(
       ...(effectiveStep.response_schema_ref && { responseSchemaRef: effectiveStep.response_schema_ref }),
       request: requestRecord,
       ...(responseRecord && { response: responseRecord }),
+      storyboardContext: context,
     };
     validations = runValidations(resolvedValidations, vctx);
   }
@@ -1080,6 +1081,7 @@ async function executeProbeStep(
     contributions: runState.contributions,
     request: requestRecord,
     ...(responseRecord && { response: responseRecord }),
+    storyboardContext: context,
   };
   const validations = step.validations?.length ? runValidations(step.validations, vctx) : [];
   const allValidationsPassed = validations.every(v => v.passed);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -218,7 +218,32 @@ export type StoryboardValidationCheck =
   | 'on_401_require_header'
   // Cross-cutting
   | 'resource_equals_agent_url'
-  | 'any_of';
+  | 'any_of'
+  // Cross-step checks
+  | 'refs_resolve';
+
+/**
+ * Set of references for `refs_resolve`. `from` picks the root object —
+ * `current_step` reads the step's task-result `data`; `context` reads the
+ * accumulated `StoryboardContext`. `path` supports `[*]` wildcard segments
+ * that flatten into the aggregated result (so `products[*].format_ids[*]`
+ * walks every product and flattens every `format_ids` array).
+ */
+export interface RefsResolveSet {
+  from: 'current_step' | 'context';
+  path: string;
+}
+
+/**
+ * Scope filter for `refs_resolve`. Only source refs whose `key` equals
+ * (after `$agent_url` substitution + `normalizeAgentUrl` normalization)
+ * are in scope. Out-of-scope refs are graded by `on_out_of_scope`.
+ */
+export interface RefsResolveScope {
+  key: string;
+  /** String to compare against. `$agent_url` expands to the runner target URL. */
+  equals: string;
+}
 
 export interface StoryboardValidation {
   check: StoryboardValidationCheck;
@@ -229,6 +254,22 @@ export interface StoryboardValidation {
   /** Accepted values for list-match checks (passes if actual matches any). */
   allowed_values?: unknown[];
   description: string;
+  // ─── refs_resolve fields ───────────────────────────────────
+  /** Source refs (the refs being checked). */
+  source?: RefsResolveSet;
+  /** Target refs (the set the source refs must resolve into). */
+  target?: RefsResolveSet;
+  /** Keys to compare between each source ref and each target ref. */
+  match_keys?: string[];
+  /** Only enforce integrity for refs matching this scope. */
+  scope?: RefsResolveScope;
+  /**
+   * How to grade source refs that fall outside `scope`.
+   *  - `warn` (default) — attach observations, pass the check
+   *  - `ignore` — silent, pass the check
+   *  - `fail` — treat as missing
+   */
+  on_out_of_scope?: 'warn' | 'ignore' | 'fail';
 }
 
 // ────────────────────────────────────────────────────────────
@@ -627,6 +668,12 @@ export interface ValidationResult {
   response?: RunnerResponseRecord;
   /** Optional remediation hint. */
   remediation?: string;
+  /**
+   * Non-fatal notes emitted by the check — e.g. `refs_resolve` records the
+   * out-of-scope refs it skipped when `on_out_of_scope: warn`. Present only
+   * when the check has something to report; absent otherwise.
+   */
+  observations?: unknown[];
 }
 
 export interface StoryboardStepPreview {

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -873,9 +873,7 @@ function validateRefsResolve(validation: StoryboardValidation, ctx: ValidationCo
       ? dedupRefs(outOfScope, matchKeys).map(ref => ({ kind: 'out_of_scope_ref', ref: projectRef(ref, matchKeys) }))
       : [];
   const observations =
-    warnObservations.length + scalarObservations.length > 0
-      ? [...warnObservations, ...scalarObservations]
-      : undefined;
+    warnObservations.length + scalarObservations.length > 0 ? [...warnObservations, ...scalarObservations] : undefined;
 
   if (allMissing.length === 0) {
     return {

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -16,10 +16,11 @@ import type {
   RunnerRequestRecord,
   RunnerResponseRecord,
   SchemaValidationError,
+  StoryboardContext,
   StoryboardValidation,
   ValidationResult,
 } from './types';
-import { resolvePath, toJsonPointer } from './path';
+import { resolvePath, resolvePathAll, toJsonPointer } from './path';
 import { PROBE_TASK_ALLOWLIST } from './test-kit';
 
 /**
@@ -44,6 +45,12 @@ export interface ValidationContext {
   request?: RunnerRequestRecord;
   /** Exact response observed — echoed on failed validations. */
   response?: RunnerResponseRecord;
+  /**
+   * Accumulated storyboard context from prior steps. Exposed to cross-step
+   * checks (`refs_resolve`) that need to reference values extracted earlier
+   * in the run. Single-step checks ignore it.
+   */
+  storyboardContext?: StoryboardContext;
 }
 
 /**
@@ -91,6 +98,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return requireHttpResult(ctx, validation, hr => validateResourceEqualsAgentUrl(validation, hr, ctx.agentUrl));
     case 'any_of':
       return validateAnyOf(validation, ctx.contributions);
+    case 'refs_resolve':
+      return validateRefsResolve(validation, ctx);
     default:
       return {
         check: validation.check,
@@ -771,6 +780,195 @@ function validateAnyOf(validation: StoryboardValidation, contributions: Set<stri
     expected: flags,
     actual: Array.from(contributions),
   };
+}
+
+// ────────────────────────────────────────────────────────────
+// refs_resolve (cross-step integrity check)
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Assert every ref in a source set resolves to a member of a target set.
+ *
+ * Used by `media_buy_seller` to check that every `format_id` returned on
+ * `get_products` products actually resolves to a format in the subsequent
+ * `list_creative_formats` response — catches invalid references before
+ * `sync_creatives` fails at runtime.
+ *
+ * `scope` lets the check distinguish refs the agent under test owns
+ * (`agent_url` matches) from third-party refs (pointing at a different
+ * creative agent). Third-party refs can't be verified without calling
+ * that agent's `list_creative_formats`, so `on_out_of_scope` controls
+ * whether they pass (`warn` with observations, `ignore` silently) or
+ * fail.
+ */
+function validateRefsResolve(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
+  const source = validation.source;
+  const target = validation.target;
+  const matchKeys = validation.match_keys;
+
+  if (!source || !target || !matchKeys?.length) {
+    return {
+      check: 'refs_resolve',
+      passed: false,
+      description: validation.description,
+      error: '`source`, `target`, and `match_keys` are all required for refs_resolve.',
+      json_pointer: null,
+      expected: '{ source, target, match_keys }',
+      actual: {
+        source: source ?? null,
+        target: target ?? null,
+        match_keys: matchKeys ?? null,
+      },
+    };
+  }
+
+  const sourceRoot = resolveRefsRoot(source.from, ctx);
+  const targetRoot = resolveRefsRoot(target.from, ctx);
+  const sourceRaw = resolvePathAll(sourceRoot, source.path);
+  const targetRaw = resolvePathAll(targetRoot, target.path);
+  const sourceRefs = sourceRaw.filter(isRefObject);
+  const targetRefs = targetRaw.filter(isRefObject);
+
+  const scalarObservations: Array<{ kind: string; side: 'source' | 'target'; count: number }> = [];
+  if (sourceRaw.length > 0 && sourceRefs.length === 0) {
+    scalarObservations.push({ kind: 'non_object_values_filtered', side: 'source', count: sourceRaw.length });
+  }
+  if (targetRaw.length > 0 && targetRefs.length === 0) {
+    scalarObservations.push({ kind: 'non_object_values_filtered', side: 'target', count: targetRaw.length });
+  }
+
+  const scope = validation.scope;
+  const outOfScopeMode = validation.on_out_of_scope ?? 'warn';
+  const scopeEquals = scope ? resolveScopeEquals(scope.equals, scope.key, ctx.agentUrl) : undefined;
+
+  const inScope: Array<Record<string, unknown>> = [];
+  const outOfScope: Array<Record<string, unknown>> = [];
+
+  for (const ref of sourceRefs) {
+    if (!scope) {
+      inScope.push(ref);
+      continue;
+    }
+    const refValue = ref[scope.key];
+    const normalized = normalizeIfUrlKey(refValue, scope.key);
+    if (scopeEquals !== undefined && normalized === scopeEquals) {
+      inScope.push(ref);
+    } else {
+      outOfScope.push(ref);
+    }
+  }
+
+  const missing = dedupRefs(
+    inScope.filter(s => !targetRefs.some(t => refsMatch(s, t, matchKeys))),
+    matchKeys
+  );
+
+  // `fail` mode promotes out-of-scope refs into the missing set so compliance
+  // reports name them the same way they name truly broken refs.
+  const failOutOfScope = outOfScopeMode === 'fail' ? dedupRefs(outOfScope, matchKeys) : [];
+  const allMissing = [...missing, ...failOutOfScope];
+
+  const warnObservations =
+    outOfScopeMode === 'warn' && outOfScope.length > 0
+      ? dedupRefs(outOfScope, matchKeys).map(ref => ({ kind: 'out_of_scope_ref', ref: projectRef(ref, matchKeys) }))
+      : [];
+  const observations =
+    warnObservations.length + scalarObservations.length > 0
+      ? [...warnObservations, ...scalarObservations]
+      : undefined;
+
+  if (allMissing.length === 0) {
+    return {
+      check: 'refs_resolve',
+      passed: true,
+      description: validation.description,
+      ...(observations && { observations }),
+    };
+  }
+
+  const preview = allMissing
+    .slice(0, 3)
+    .map(r => JSON.stringify(projectRef(r, matchKeys)))
+    .join(', ');
+  const errorMsg =
+    allMissing.length > 3
+      ? `${allMissing.length} ref(s) did not resolve; first 3: ${preview}`
+      : `${allMissing.length} ref(s) did not resolve: ${preview}`;
+
+  return {
+    check: 'refs_resolve',
+    passed: false,
+    description: validation.description,
+    path: source.path,
+    error: errorMsg,
+    json_pointer: null,
+    expected: `every source ref resolves to a target ref matched on [${matchKeys.join(', ')}]`,
+    actual: {
+      missing: allMissing.map(r => projectRef(r, matchKeys)),
+      ...(failOutOfScope.length > 0 && {
+        out_of_scope_failed: failOutOfScope.map(r => projectRef(r, matchKeys)),
+      }),
+    },
+    ...(observations && { observations }),
+  };
+}
+
+function resolveRefsRoot(from: 'current_step' | 'context', ctx: ValidationContext): unknown {
+  if (from === 'context') return ctx.storyboardContext ?? {};
+  if (ctx.taskResult) return ctx.taskResult.data;
+  if (ctx.httpResult) return ctx.httpResult.body;
+  return undefined;
+}
+
+function resolveScopeEquals(equals: string, key: string, agentUrl: string): string {
+  const raw = equals === '$agent_url' ? agentUrl : equals;
+  return key.toLowerCase().endsWith('url') ? normalizeAgentUrl(raw) : raw;
+}
+
+function normalizeIfUrlKey(value: unknown, key: string): unknown {
+  return typeof value === 'string' && key.toLowerCase().endsWith('url') ? normalizeAgentUrl(value) : value;
+}
+
+function isRefObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function refsMatch(a: Record<string, unknown>, b: Record<string, unknown>, keys: string[]): boolean {
+  for (const key of keys) {
+    const av = a[key];
+    const bv = b[key];
+    // Missing match-key on either side is NOT a match — agents that omit a
+    // key shouldn't fuzzy-match other agents that also happen to omit it.
+    if (av === undefined || bv === undefined) return false;
+    // URL-ish fields get trailing-slash / case normalization so declared
+    // and probed URLs compare equal even when one side includes a trailing
+    // "/". `format_id` fields are exact-compare.
+    const normA = normalizeIfUrlKey(av, key);
+    const normB = normalizeIfUrlKey(bv, key);
+    if (normA !== normB) return false;
+  }
+  return true;
+}
+
+function projectRef(ref: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (key in ref) out[key] = ref[key];
+  }
+  return out;
+}
+
+/**
+ * Deduplicate refs by their projected match-key tuple so a single broken
+ * reference in a 50-product response doesn't show up 50× in `actual.missing`.
+ */
+function dedupRefs(refs: Array<Record<string, unknown>>, keys: string[]): Array<Record<string, unknown>> {
+  const seen = new Map<string, Record<string, unknown>>();
+  for (const ref of refs) {
+    const k = JSON.stringify(projectRef(ref, keys));
+    if (!seen.has(k)) seen.set(k, ref);
+  }
+  return Array.from(seen.values());
 }
 
 // resolvePath re-exported from ./path for backwards compat

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-20T21:14:57.319Z
+// Generated at: 2026-04-20T23:50:36.784Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -5448,12 +5448,16 @@ export const GetAccountFinancialsErrorSchema = z.object({
 }).passthrough();
 
 export const ComplyTestControllerRequestSchema = z.object({
-    scenario: z.union([z.literal("list_scenarios"), z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend")]),
+    scenario: z.union([z.literal("list_scenarios"), z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy")]),
     params: z.object({
         creative_id: z.string().optional(),
         account_id: z.string().optional(),
         media_buy_id: z.string().optional(),
         session_id: z.string().optional(),
+        product_id: z.string().optional(),
+        pricing_option_id: z.string().optional(),
+        plan_id: z.string().optional(),
+        fixture: z.object({}).passthrough().optional(),
         status: z.string().optional(),
         rejection_reason: z.string().optional(),
         termination_reason: z.string().optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -13892,7 +13892,7 @@ export type ComplyTestControllerRequest = {
   [k: string]: unknown | undefined;
 } & {
   /**
-   * Test scenario to execute. 'list_scenarios' discovers supported scenarios. Others trigger state transitions for the specified domain.
+   * Test scenario to execute. 'list_scenarios' discovers supported scenarios. 'force_*' and 'simulate_*' trigger state transitions. 'seed_*' scenarios pre-populate fixtures (product, pricing option, creative, plan, media buy) so storyboards can reference them by stable ID without the implementer having to guess which IDs the conformance suite expects.
    */
   scenario:
     | 'list_scenarios'
@@ -13901,13 +13901,18 @@ export type ComplyTestControllerRequest = {
     | 'force_media_buy_status'
     | 'force_session_status'
     | 'simulate_delivery'
-    | 'simulate_budget_spend';
+    | 'simulate_budget_spend'
+    | 'seed_product'
+    | 'seed_pricing_option'
+    | 'seed_creative'
+    | 'seed_plan'
+    | 'seed_media_buy';
   /**
    * Scenario-specific parameters. Required for all scenarios except list_scenarios.
    */
   params?: {
     /**
-     * Creative to transition. Used by force_creative_status.
+     * Creative to transition (force_creative_status) or seed (seed_creative).
      */
     creative_id?: string;
     /**
@@ -13915,13 +13920,29 @@ export type ComplyTestControllerRequest = {
      */
     account_id?: string;
     /**
-     * Media buy to transition. Used by force_media_buy_status, simulate_delivery, and simulate_budget_spend.
+     * Media buy to transition (force_media_buy_status, simulate_delivery, simulate_budget_spend) or seed (seed_media_buy).
      */
     media_buy_id?: string;
     /**
      * Session to transition. Used by force_session_status.
      */
     session_id?: string;
+    /**
+     * Product to seed. Used by seed_product and seed_pricing_option.
+     */
+    product_id?: string;
+    /**
+     * Pricing option to seed, scoped to a product. Used by seed_pricing_option.
+     */
+    pricing_option_id?: string;
+    /**
+     * Plan to seed. Used by seed_plan.
+     */
+    plan_id?: string;
+    /**
+     * Arbitrary fixture payload carried by seed_* scenarios. Shape matches the domain object the seed scenario creates (product, creative, plan, media buy, pricing option). Seller MAY reject malformed fixtures with INVALID_PARAMS. Kept permissive so storyboard authors can declare the minimum shape each test needs without the spec locking down every field.
+     */
+    fixture?: {};
     /**
      * Target status for the resource. Type depends on scenario: creative-status for force_creative_status, account-status for force_account_status, media-buy-status for force_media_buy_status. For force_session_status, must be 'complete' or 'terminated'.
      */

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.6.0';
+export const LIBRARY_VERSION = '5.7.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.6.0',
+  library: '5.7.0',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-20T21:33:18.254Z',
+  generatedAt: '2026-04-20T23:27:56.706Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-validations-refs-resolve.test.js
+++ b/test/lib/storyboard-validations-refs-resolve.test.js
@@ -1,0 +1,386 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { runValidations } = require('../../dist/lib/testing/storyboard/validations');
+
+const AGENT_URL = 'https://sales.example.com/mcp';
+const THIRD_PARTY_URL = 'https://creatives.otheragent.com/mcp';
+
+function refsResolveCheck(overrides = {}) {
+  return {
+    check: 'refs_resolve',
+    description: 'Every format_id on products resolves to a format in list_creative_formats',
+    source: { from: 'context', path: 'products[*].format_ids[*]' },
+    target: { from: 'current_step', path: 'formats[*].format_id' },
+    match_keys: ['agent_url', 'id'],
+    ...overrides,
+  };
+}
+
+function runOne(validation, taskResult, storyboardContext) {
+  return runValidations([validation], {
+    taskName: 'list_creative_formats',
+    taskResult,
+    agentUrl: AGENT_URL,
+    contributions: new Set(),
+    storyboardContext,
+  });
+}
+
+describe('validateRefsResolve', () => {
+  it('passes when every source ref matches a target ref', () => {
+    const context = {
+      products: [
+        {
+          product_id: 'p1',
+          format_ids: [
+            { agent_url: AGENT_URL, id: 'display_300x250' },
+            { agent_url: AGENT_URL, id: 'video_pre_roll' },
+          ],
+        },
+        {
+          product_id: 'p2',
+          format_ids: [{ agent_url: AGENT_URL, id: 'display_300x250' }],
+        },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: {
+        formats: [
+          { format_id: { agent_url: AGENT_URL, id: 'display_300x250' }, type: 'display' },
+          { format_id: { agent_url: AGENT_URL, id: 'video_pre_roll' }, type: 'video' },
+          { format_id: { agent_url: AGENT_URL, id: 'native_feed' }, type: 'native' },
+        ],
+      },
+    };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('fails and names each unresolved ref when one is missing from target', () => {
+    const context = {
+      products: [
+        {
+          product_id: 'p1',
+          format_ids: [
+            { agent_url: AGENT_URL, id: 'display_300x250' },
+            { agent_url: AGENT_URL, id: 'stale_format_that_was_removed' },
+          ],
+        },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: {
+        formats: [{ format_id: { agent_url: AGENT_URL, id: 'display_300x250' } }],
+      },
+    };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.actual.missing, [
+      { agent_url: AGENT_URL, id: 'stale_format_that_was_removed' },
+    ]);
+    assert.match(result.error, /stale_format_that_was_removed/);
+  });
+
+  it('scopes on agent_url and emits an observation for third-party refs (warn default)', () => {
+    const context = {
+      products: [
+        {
+          product_id: 'p1',
+          format_ids: [
+            { agent_url: AGENT_URL, id: 'display_300x250' },
+            { agent_url: THIRD_PARTY_URL, id: 'third_party_format' },
+          ],
+        },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: {
+        formats: [{ format_id: { agent_url: AGENT_URL, id: 'display_300x250' } }],
+      },
+    };
+    const [result] = runOne(
+      refsResolveCheck({
+        scope: { key: 'agent_url', equals: '$agent_url' },
+        on_out_of_scope: 'warn',
+      }),
+      taskResult,
+      context
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.ok(Array.isArray(result.observations));
+    assert.strictEqual(result.observations.length, 1);
+    assert.strictEqual(result.observations[0].kind, 'out_of_scope_ref');
+    assert.deepStrictEqual(result.observations[0].ref, {
+      agent_url: THIRD_PARTY_URL,
+      id: 'third_party_format',
+    });
+  });
+
+  it('ignores out-of-scope refs silently when on_out_of_scope is ignore', () => {
+    const context = {
+      products: [
+        { format_ids: [{ agent_url: THIRD_PARTY_URL, id: 'third' }] },
+      ],
+    };
+    const taskResult = { success: true, data: { formats: [] } };
+    const [result] = runOne(
+      refsResolveCheck({
+        scope: { key: 'agent_url', equals: '$agent_url' },
+        on_out_of_scope: 'ignore',
+      }),
+      taskResult,
+      context
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.observations, undefined);
+  });
+
+  it('treats out-of-scope refs as missing when on_out_of_scope is fail', () => {
+    const context = {
+      products: [
+        {
+          format_ids: [
+            { agent_url: AGENT_URL, id: 'display_300x250' },
+            { agent_url: THIRD_PARTY_URL, id: 'third' },
+          ],
+        },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: { formats: [{ format_id: { agent_url: AGENT_URL, id: 'display_300x250' } }] },
+    };
+    const [result] = runOne(
+      refsResolveCheck({
+        scope: { key: 'agent_url', equals: '$agent_url' },
+        on_out_of_scope: 'fail',
+      }),
+      taskResult,
+      context
+    );
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.actual.out_of_scope_failed, [
+      { agent_url: THIRD_PARTY_URL, id: 'third' },
+    ]);
+  });
+
+  it('normalizes trailing slashes when comparing agent_url in scope', () => {
+    const context = {
+      products: [
+        {
+          format_ids: [
+            { agent_url: AGENT_URL + '/', id: 'display_300x250' },
+          ],
+        },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: { formats: [{ format_id: { agent_url: AGENT_URL, id: 'display_300x250' } }] },
+    };
+    const [result] = runOne(
+      refsResolveCheck({
+        scope: { key: 'agent_url', equals: '$agent_url' },
+      }),
+      taskResult,
+      context
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('resolves nested [*] wildcards across multiple products', () => {
+    const context = {
+      products: [
+        { format_ids: [{ agent_url: AGENT_URL, id: 'a' }, { agent_url: AGENT_URL, id: 'b' }] },
+        { format_ids: [{ agent_url: AGENT_URL, id: 'c' }] },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: {
+        formats: [
+          { format_id: { agent_url: AGENT_URL, id: 'a' } },
+          { format_id: { agent_url: AGENT_URL, id: 'b' } },
+          { format_id: { agent_url: AGENT_URL, id: 'c' } },
+        ],
+      },
+    };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('passes when source is empty (no refs to resolve)', () => {
+    const context = { products: [] };
+    const taskResult = { success: true, data: { formats: [] } };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('fails when target is empty and source has in-scope refs', () => {
+    const context = {
+      products: [{ format_ids: [{ agent_url: AGENT_URL, id: 'x' }] }],
+    };
+    const taskResult = { success: true, data: { formats: [] } };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.actual.missing.length, 1);
+  });
+
+  it('returns a config error when source/target/match_keys are missing', () => {
+    const [result] = runOne(
+      { check: 'refs_resolve', description: 'misconfigured' },
+      { success: true, data: {} },
+      {}
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /source.*target.*match_keys/);
+  });
+
+  it('normalizes scope.equals when given a literal URL with trailing slash', () => {
+    const context = {
+      products: [
+        {
+          format_ids: [
+            { agent_url: 'https://creatives.example.com/mcp', id: 'x' },
+            { agent_url: THIRD_PARTY_URL, id: 'third' },
+          ],
+        },
+      ],
+    };
+    const taskResult = {
+      success: true,
+      data: { formats: [{ format_id: { agent_url: 'https://creatives.example.com/mcp', id: 'x' } }] },
+    };
+    const [result] = runOne(
+      refsResolveCheck({
+        target: { from: 'current_step', path: 'formats[*].format_id' },
+        scope: { key: 'agent_url', equals: 'https://creatives.example.com/mcp/' },
+      }),
+      taskResult,
+      context
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('refusal to match when one side is missing a match_key', () => {
+    const context = {
+      products: [{ format_ids: [{ id: 'x' }] }], // no agent_url
+    };
+    const taskResult = {
+      success: true,
+      data: { formats: [{ format_id: { id: 'x' } }] }, // also no agent_url
+    };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.actual.missing.length, 1);
+  });
+
+  it('deduplicates actual.missing on projected match_key tuple', () => {
+    const sameBadRef = { agent_url: AGENT_URL, id: 'stale' };
+    const context = {
+      products: [
+        { format_ids: [sameBadRef] },
+        { format_ids: [sameBadRef] },
+        { format_ids: [sameBadRef] },
+      ],
+    };
+    const taskResult = { success: true, data: { formats: [] } };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, false);
+    assert.deepStrictEqual(result.actual.missing, [sameBadRef]);
+    // error phrasing should reflect the deduped count, not the raw 3
+    assert.match(result.error, /^1 ref\(s\) did not resolve/);
+  });
+
+  it('uses "first 3" phrasing when more than 3 refs are missing', () => {
+    const context = {
+      products: [
+        {
+          format_ids: [
+            { agent_url: AGENT_URL, id: 'a' },
+            { agent_url: AGENT_URL, id: 'b' },
+            { agent_url: AGENT_URL, id: 'c' },
+            { agent_url: AGENT_URL, id: 'd' },
+          ],
+        },
+      ],
+    };
+    const taskResult = { success: true, data: { formats: [] } };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /4 ref\(s\) did not resolve; first 3:/);
+    assert.strictEqual(result.actual.missing.length, 4);
+  });
+
+  it('preserves source.path on the failed result for report attribution', () => {
+    const context = { products: [{ format_ids: [{ agent_url: AGENT_URL, id: 'x' }] }] };
+    const taskResult = { success: true, data: { formats: [] } };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.path, 'products[*].format_ids[*]');
+  });
+
+  it('emits an observation when source values are non-object scalars', () => {
+    const context = {
+      products: [{ format_ids: ['display_300x250', 'video_pre_roll'] }], // legacy v2 string IDs
+    };
+    const taskResult = {
+      success: true,
+      data: { formats: [{ format_id: { agent_url: AGENT_URL, id: 'display_300x250' } }] },
+    };
+    const [result] = runOne(refsResolveCheck(), taskResult, context);
+    assert.strictEqual(result.passed, true, 'empty in-scope source should pass');
+    const scalarObs = (result.observations ?? []).find(o => o.kind === 'non_object_values_filtered');
+    assert.ok(scalarObs, 'expected a non_object_values_filtered observation');
+    assert.strictEqual(scalarObs.side, 'source');
+    assert.strictEqual(scalarObs.count, 2);
+  });
+
+  it('does not surface prototype-chain values like __proto__ or constructor', () => {
+    const context = { products: {} };
+    const taskResult = { success: true, data: { formats: {} } };
+    // A storyboard author (or a bug) asking for __proto__ should get nothing,
+    // not Object.prototype projected through match_keys.
+    const validation = refsResolveCheck({
+      source: { from: 'context', path: 'products.__proto__' },
+      target: { from: 'current_step', path: 'formats.constructor' },
+      match_keys: ['id'],
+    });
+    const [result] = runOne(validation, taskResult, context);
+    // Empty source, so it passes vacuously — but more importantly, no prototype
+    // object ended up in any observation/missing payload.
+    assert.strictEqual(result.passed, true);
+  });
+
+  it('caps wildcard fan-out so a malicious response cannot OOM the runner', () => {
+    // Build a 4-level-deep nested array that would produce >1M values without
+    // a cap. The cap sits at 10_000 so the walker returns early.
+    const build = depth => {
+      if (depth === 0) return [{ agent_url: AGENT_URL, id: 'x' }];
+      const out = [];
+      for (let i = 0; i < 50; i++) out.push({ nested: build(depth - 1) });
+      return out;
+    };
+    const context = { items: build(4) };
+    const taskResult = { success: true, data: { formats: [{ format_id: { agent_url: AGENT_URL, id: 'x' } }] } };
+    const start = Date.now();
+    const [result] = runOne(
+      refsResolveCheck({
+        source: { from: 'context', path: 'items[*].nested[*].nested[*].nested[*]' },
+      }),
+      taskResult,
+      context
+    );
+    const elapsed = Date.now() - start;
+    // The cap is primarily a memory-bound guard; the wall-clock assertion is
+    // a loose ceiling — the real invariant is "the process didn't OOM."
+    assert.ok(elapsed < 5000, `refs_resolve should short-circuit; took ${elapsed}ms`);
+    // A single valid ref in the target means the check passes as long as at
+    // least one capped source ref matches. Don't over-specify pass/fail here —
+    // the point is that the runner survived.
+    assert.strictEqual(typeof result.passed, 'boolean');
+  });
+});

--- a/test/lib/storyboard-validations-refs-resolve.test.js
+++ b/test/lib/storyboard-validations-refs-resolve.test.js
@@ -77,9 +77,7 @@ describe('validateRefsResolve', () => {
     };
     const [result] = runOne(refsResolveCheck(), taskResult, context);
     assert.strictEqual(result.passed, false);
-    assert.deepStrictEqual(result.actual.missing, [
-      { agent_url: AGENT_URL, id: 'stale_format_that_was_removed' },
-    ]);
+    assert.deepStrictEqual(result.actual.missing, [{ agent_url: AGENT_URL, id: 'stale_format_that_was_removed' }]);
     assert.match(result.error, /stale_format_that_was_removed/);
   });
 
@@ -121,9 +119,7 @@ describe('validateRefsResolve', () => {
 
   it('ignores out-of-scope refs silently when on_out_of_scope is ignore', () => {
     const context = {
-      products: [
-        { format_ids: [{ agent_url: THIRD_PARTY_URL, id: 'third' }] },
-      ],
+      products: [{ format_ids: [{ agent_url: THIRD_PARTY_URL, id: 'third' }] }],
     };
     const taskResult = { success: true, data: { formats: [] } };
     const [result] = runOne(
@@ -162,18 +158,14 @@ describe('validateRefsResolve', () => {
       context
     );
     assert.strictEqual(result.passed, false);
-    assert.deepStrictEqual(result.actual.out_of_scope_failed, [
-      { agent_url: THIRD_PARTY_URL, id: 'third' },
-    ]);
+    assert.deepStrictEqual(result.actual.out_of_scope_failed, [{ agent_url: THIRD_PARTY_URL, id: 'third' }]);
   });
 
   it('normalizes trailing slashes when comparing agent_url in scope', () => {
     const context = {
       products: [
         {
-          format_ids: [
-            { agent_url: AGENT_URL + '/', id: 'display_300x250' },
-          ],
+          format_ids: [{ agent_url: AGENT_URL + '/', id: 'display_300x250' }],
         },
       ],
     };
@@ -194,7 +186,12 @@ describe('validateRefsResolve', () => {
   it('resolves nested [*] wildcards across multiple products', () => {
     const context = {
       products: [
-        { format_ids: [{ agent_url: AGENT_URL, id: 'a' }, { agent_url: AGENT_URL, id: 'b' }] },
+        {
+          format_ids: [
+            { agent_url: AGENT_URL, id: 'a' },
+            { agent_url: AGENT_URL, id: 'b' },
+          ],
+        },
         { format_ids: [{ agent_url: AGENT_URL, id: 'c' }] },
       ],
     };
@@ -230,11 +227,7 @@ describe('validateRefsResolve', () => {
   });
 
   it('returns a config error when source/target/match_keys are missing', () => {
-    const [result] = runOne(
-      { check: 'refs_resolve', description: 'misconfigured' },
-      { success: true, data: {} },
-      {}
-    );
+    const [result] = runOne({ check: 'refs_resolve', description: 'misconfigured' }, { success: true, data: {} }, {});
     assert.strictEqual(result.passed, false);
     assert.match(result.error, /source.*target.*match_keys/);
   });
@@ -281,11 +274,7 @@ describe('validateRefsResolve', () => {
   it('deduplicates actual.missing on projected match_key tuple', () => {
     const sameBadRef = { agent_url: AGENT_URL, id: 'stale' };
     const context = {
-      products: [
-        { format_ids: [sameBadRef] },
-        { format_ids: [sameBadRef] },
-        { format_ids: [sameBadRef] },
-      ],
+      products: [{ format_ids: [sameBadRef] }, { format_ids: [sameBadRef] }, { format_ids: [sameBadRef] }],
     };
     const taskResult = { success: true, data: { formats: [] } };
     const [result] = runOne(refsResolveCheck(), taskResult, context);


### PR DESCRIPTION
## Summary

- Adds the `refs_resolve` cross-step storyboard validation described in #670: every `{agent_url, id}` ref in a source set (e.g. `products[*].format_ids[*]` from `get_products`) must resolve to a member of a target set (e.g. `formats[*].format_id` from `list_creative_formats`). Catches broken `format_id` references at grading time instead of when `sync_creatives` fails after the media buy is committed.
- Scope filtering distinguishes refs the agent under test owns (with `$agent_url` substitution + URL normalization on both sides) from third-party refs. Three out-of-scope grading modes: `warn` (default, attaches observations), `ignore` (silent), `fail` (promote to missing).
- Threads `storyboardContext` into `ValidationContext` so cross-step checks can read values extracted by prior steps.
- Hardens `resolvePathAll` against untrusted agent responses: caps wildcard fan-out at 10,000 terminal values, skips `__proto__`/`constructor`/`prototype` path segments, gates lookups on `hasOwnProperty`, and bounds path-string length.

Addresses upstream spec issue adcontextprotocol/adcp#2597.

## Test plan

- [x] 18 new unit cases in `test/lib/storyboard-validations-refs-resolve.test.js` — pass, missing-ref failure, scope warn/ignore/fail, trailing-slash normalization, nested `[*]` wildcards, empty source, empty target, missing-config, URL-literal normalization, missing-match-key, dedup, "first 3" phrasing, source.path attribution, scalar-filtered observation, prototype-key rejection, fan-out cap
- [x] Full test suite: 4,512 pass / 0 fail / 12 skipped (pre-existing)
- [x] Code review: resolved MUST-FIX (scope.equals URL normalization, falsy-terminal preservation) and SHOULD-FIX (dedup, undefined match-key guard, scalar observation)
- [x] Security review: resolved SHOULD-FIX (wildcard fan-out DoS cap, prototype-property guard) + CONSIDER (path length cap). Priority-0 prompt-injection: N/A (no LLM in this path). Deferred to separate PRs: project-wide `redactSecrets` coverage for `actual`/`observations`, context-output allowlisting
- [ ] CI green

## Follow-ups (separate PRs, out of scope here)

- `adcontextprotocol/adcp`: document `refs_resolve` in `static/compliance/source/universal/storyboard-schema.yaml`
- `adcontextprotocol/adcp`: add the check to `media_buy_seller`'s `list_formats` step
- `@adcp/client`: centralize `redactSecrets` over validation `actual`/`observations` payloads; SECRET_KEY_PATTERN filter for `applyContextOutputs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)