### PR TITLE
fix(storyboard): raw-probe dispatch for omit_idempotency_key (#678)

### DIFF
--- a/.changeset/raw-probe-missing-idempotency-key.md
+++ b/.changeset/raw-probe-missing-idempotency-key.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+Route storyboard steps with `omit_idempotency_key: true` on mutating tasks through the raw-HTTP MCP probe so no SDK-layer normalization can inject a key onto the wire (adcp-client#678, adcp#2607). The `skipIdempotencyAutoInject` plumbing in `normalizeRequestParams`, `SingleAgentClient.executeAndHandle`, and `TaskExecutor.executeTask` already honors the flag, but a single regression in any of those sites would silently make every SDK-speaking agent pass the missing-key conformance vector vacuously. Dispatching via `rawMcpProbe` (the same path already used for `step.auth` overrides and `probeSignedRequest`) removes the escape hatch entirely.
+
+Scope: applies when `options.protocol` is `'mcp'` and `options.auth` is absent, `'bearer'`, or `'basic'`. OAuth and A2A stay on the SDK path — their dispatch requires refresh-capable tokens / a different envelope that the raw probe can't replicate — and continue to rely on the existing `skipIdempotencyAutoInject` plumbing. No YAML surface change: the existing `omit_idempotency_key: true` field on a mutating step is the trigger, matching how the runner already gates the runner-level `applyIdempotencyInvariant` skip.
+
+Hardening for outbound headers: bearer tokens and basic credentials are validated for CR/LF/non-printable ASCII before being placed in headers (errors name the offending field without echoing the value), empty bearer tokens fail loudly instead of silent SDK fallback, and basic-auth usernames containing `:` are rejected per RFC 7617. `X-Test-Session-ID` is added to `SECRET_KEY_PATTERN` so any future code path that persists outbound headers into compliance reports redacts it automatically.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -93,7 +93,7 @@ function extractionFromTaskResult(taskResult: TaskResult | undefined): RunnerExt
  * "Secrets SHOULD be redacted with the literal string '[redacted]'".
  */
 const SECRET_KEY_PATTERN =
-  /^(authorization|credentials?|token|api[_-]?key|password|secret|client[_-]secret|refresh[_-]token|access[_-]token|bearer|session[_-]token|offering[_-]token|cookie|set[_-]cookie)$/i;
+  /^(authorization|credentials?|token|api[_-]?key|password|secret|client[_-]secret|refresh[_-]token|access[_-]token|bearer|session[_-]token|session[_-]id|offering[_-]token|cookie|set[_-]cookie)$/i;
 
 export function __redactSecretsForTest(value: unknown): unknown {
   return redactSecrets(value);
@@ -103,6 +103,12 @@ export function __filterResponseHeadersForTest(
   headers: Record<string, string> | undefined
 ): Record<string, string> | undefined {
   return filterResponseHeaders(headers);
+}
+
+export function __defaultAuthHeadersForRawProbeForTest(
+  options: StoryboardRunOptions
+): Record<string, string> | undefined {
+  return defaultAuthHeadersForRawProbe(options);
 }
 
 function redactSecrets(value: unknown, depth = 0): unknown {
@@ -818,20 +824,34 @@ async function executeStep(
   // layers agree; see `applyIdempotencyInvariant` for the runner-level skip.
   const testsMissingIdempotencyKey = step.omit_idempotency_key === true && isMutatingTask(effectiveStep.task);
 
+  // Defense-in-depth for the missing-key vector: when a mutating step sets
+  // `omit_idempotency_key: true` and `step.auth` is unset, route via
+  // `rawMcpProbe` anyway so no SDK-layer normalization can slip a key onto the
+  // wire. The SDK's `skipIdempotencyAutoInject` plumbing already honors this
+  // flag, but the raw-HTTP path removes the escape hatch entirely. A2A and
+  // oauth stay on the SDK path — their dispatch can't be replicated here
+  // (A2A uses a different envelope; oauth needs refresh semantics).
+  const rawProbeHeaders: Record<string, string> | undefined =
+    step.auth !== undefined
+      ? authHeadersForStep(step.auth, options)
+      : testsMissingIdempotencyKey && options.protocol !== 'a2a'
+        ? defaultAuthHeadersForRawProbe(options)
+        : undefined;
+  const useRawProbe = rawProbeHeaders !== undefined;
+
   let taskResult: TaskResult | undefined;
   let stepResult: { duration_ms: number; error?: string; passed: boolean };
   let httpResult: HttpProbeResult | undefined;
   let responseRecord: RunnerResponseRecord | undefined;
 
-  if (step.auth !== undefined) {
+  if (useRawProbe) {
     const started = Date.now();
     try {
-      const headers = authHeadersForStep(step.auth, options);
       const probe = await rawMcpProbe({
         agentUrl: runState.agentUrl,
         toolName: effectiveStep.task,
         args: request,
-        headers,
+        headers: rawProbeHeaders,
         allowPrivateIp: options.allow_http === true,
       });
       httpResult = probe.httpResult;
@@ -875,7 +895,7 @@ async function executeStep(
   }
 
   const requestRecord: RunnerRequestRecord = {
-    transport: step.auth !== undefined ? 'mcp' : options.protocol === 'a2a' ? 'a2a' : 'mcp',
+    transport: useRawProbe ? 'mcp' : options.protocol === 'a2a' ? 'a2a' : 'mcp',
     operation: effectiveStep.task,
     payload: redactSecrets(request),
     ...(runState.agentUrl ? { url: runState.agentUrl } : {}),
@@ -1172,6 +1192,58 @@ function resolveTaskName(step: StoryboardStep, options: StoryboardRunOptions): s
   }
   if (typeof value === 'string' && value.length > 0) return value;
   return step.task_default;
+}
+
+/**
+ * Build headers for the raw MCP probe when a step needs raw dispatch without
+ * an explicit `auth` override (defense-in-depth for `omit_idempotency_key`).
+ * Returns `undefined` for `oauth` so the caller falls back to the SDK path —
+ * refreshable-token semantics can't be replicated here and the SDK honors
+ * `skipIdempotencyAutoInject` on that path anyway.
+ */
+function defaultAuthHeadersForRawProbe(options: StoryboardRunOptions): Record<string, string> | undefined {
+  // Reject control chars and non-printable ASCII. Without this, undici's header
+  // validator throws a message that includes the offending value — landing
+  // secrets in logs. Validate raw inputs before encoding so the field name in
+  // the error identifies which input to fix without echoing the value.
+  const assertSafe = (value: string, field: string) => {
+    if (/[\r\n]|[^\x20-\x7E]/.test(value)) {
+      throw new Error(`${field} contains invalid characters (control chars or non-printable ASCII)`);
+    }
+  };
+
+  const headers: Record<string, string> = {};
+  if (options.auth) {
+    if (options.auth.type === 'bearer') {
+      if (!options.auth.token) throw new Error('options.auth.token is required for bearer auth');
+      assertSafe(options.auth.token, 'options.auth.token');
+      headers.authorization = `Bearer ${options.auth.token}`;
+    } else if (options.auth.type === 'basic') {
+      // RFC 7617 bans `:` in the userid — a colon would decode ambiguously on
+      // the server. Fail loudly rather than silently producing a mangled header.
+      if (options.auth.username.includes(':')) {
+        throw new Error('options.auth.username must not contain colon (RFC 7617)');
+      }
+      assertSafe(options.auth.username, 'options.auth.username');
+      assertSafe(options.auth.password, 'options.auth.password');
+      const encoded = Buffer.from(`${options.auth.username}:${options.auth.password}`).toString('base64');
+      headers.authorization = `Basic ${encoded}`;
+    } else {
+      return undefined;
+    }
+  }
+  // Match SDK header casing so a raw-probe request is byte-indistinguishable
+  // from an SDK-shaped one at the transport boundary. HTTP is case-insensitive;
+  // this is purely for parity with capture/diff tooling.
+  if (options.test_session_id) {
+    assertSafe(options.test_session_id, 'options.test_session_id');
+    headers['X-Test-Session-ID'] = options.test_session_id;
+  }
+  if (options.userAgent) {
+    assertSafe(options.userAgent, 'options.userAgent');
+    headers['User-Agent'] = options.userAgent;
+  }
+  return headers;
 }
 
 /**

--- a/test/lib/storyboard-idempotency-invariant.test.js
+++ b/test/lib/storyboard-idempotency-invariant.test.js
@@ -14,7 +14,11 @@ const { describe, test, it } = require('node:test');
 const assert = require('node:assert');
 const http = require('http');
 
-const { applyIdempotencyInvariant, runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
+const {
+  applyIdempotencyInvariant,
+  runStoryboard,
+  __defaultAuthHeadersForRawProbeForTest: defaultAuthHeadersForRawProbe,
+} = require('../../dist/lib/testing/storyboard/runner.js');
 
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -304,6 +308,258 @@ describe('runStoryboard: idempotency_key invariant on the wire', () => {
         seen[0].args.idempotency_key,
         undefined,
         'omit_idempotency_key step must not receive auto-injected idempotency_key'
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  // Defense-in-depth (issue #678): an agent that authenticates with a bearer
+  // token (no per-step auth override) MUST still see a missing-key request
+  // when the storyboard declares omit_idempotency_key: true. Before this fix,
+  // the SDK's request normalizer/adapter had three injection sites — any one
+  // failing to honor skipIdempotencyAutoInject would silently populate a key
+  // and the compliance vector would pass vacuously. The runner now routes
+  // the call via the raw MCP probe so no SDK layer can touch the body.
+  it('bypasses the SDK via raw probe when omit_idempotency_key=true on a bearer-authenticated mutating step (defense-in-depth for SDK injection)', async () => {
+    const seen = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      seen.push({
+        name: rpc.params.name,
+        args: rpc.params.arguments,
+        authorization: req.headers['authorization'],
+        sessionId: req.headers['x-test-session-id'],
+      });
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          error: { code: -32000, message: 'INVALID_REQUEST: idempotency_key is required' },
+        })
+      );
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/mcp`;
+    try {
+      const storyboard = {
+        id: 'missing_key_bearer_sb',
+        version: '1.0.0',
+        title: 'Missing key (bearer auth, no step auth override)',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'error',
+            steps: [
+              {
+                id: 's1_bearer_missing_key',
+                title: 'bearer-authenticated missing-key vector must reach the server without a key',
+                task: 'create_property_list',
+                expect_error: true,
+                omit_idempotency_key: true,
+                sample_request: { name: 'pl-bearer', entries: [] },
+                validations: [],
+              },
+            ],
+          },
+        ],
+      };
+      await runStoryboard(agentUrl, storyboard, {
+        protocol: 'mcp',
+        allow_http: true,
+        auth: { type: 'bearer', token: 'tok-678' },
+        test_session_id: 'sess-678',
+        agentTools: ['create_property_list'],
+        _profile: { name: 'Test', tools: ['create_property_list'] },
+        _client: {
+          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_property_list' }] }),
+        },
+      });
+
+      assert.strictEqual(seen.length, 1, `expected 1 tool call, got ${seen.length}`);
+      assert.strictEqual(
+        seen[0].args.idempotency_key,
+        undefined,
+        'SDK-layer normalization must not inject idempotency_key when omit_idempotency_key=true'
+      );
+      assert.strictEqual(
+        seen[0].authorization,
+        'Bearer tok-678',
+        'raw probe must forward the bearer token so the agent can still authenticate'
+      );
+      assert.strictEqual(seen[0].sessionId, 'sess-678', 'raw probe must forward X-Test-Session-ID for test isolation');
+    } finally {
+      server.close();
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Unit: defaultAuthHeadersForRawProbe
+// ────────────────────────────────────────────────────────────
+
+/**
+ * The helper the dispatcher consults to decide whether the defense-in-depth
+ * raw-probe path is available (non-undefined return) and what headers to send
+ * when it is. Direct unit coverage keeps the gates explicit without requiring
+ * a full MCP handshake to run through the SDK.
+ */
+describe('defaultAuthHeadersForRawProbe', () => {
+  test('no auth → empty headers (public agent; raw dispatch still valid)', () => {
+    const h = defaultAuthHeadersForRawProbe({});
+    assert.deepStrictEqual(h, {});
+  });
+
+  test('bearer → authorization header with SDK casing for session + user-agent', () => {
+    const h = defaultAuthHeadersForRawProbe({
+      auth: { type: 'bearer', token: 'abc' },
+      test_session_id: 'sess-1',
+      userAgent: 'compliance-harness/1.0',
+    });
+    assert.deepStrictEqual(h, {
+      authorization: 'Bearer abc',
+      'X-Test-Session-ID': 'sess-1',
+      'User-Agent': 'compliance-harness/1.0',
+    });
+  });
+
+  test('basic → base64(user:pass)', () => {
+    const u = 'test-user';
+    const p = 'test-fixture-not-a-real-secret';
+    const h = defaultAuthHeadersForRawProbe({ auth: { type: 'basic', username: u, password: p } });
+    assert.deepStrictEqual(h, { authorization: 'Basic ' + Buffer.from(`${u}:${p}`).toString('base64') });
+  });
+
+  test('oauth → undefined (SDK fallback; refresh semantics unreplicable)', () => {
+    const h = defaultAuthHeadersForRawProbe({
+      auth: { type: 'oauth', tokens: { access_token: 'x', refresh_token: 'y', token_type: 'Bearer' } },
+    });
+    assert.strictEqual(h, undefined);
+  });
+
+  test('bearer with empty token throws (fail loud, not silent SDK fallback)', () => {
+    assert.throws(
+      () => defaultAuthHeadersForRawProbe({ auth: { type: 'bearer', token: '' } }),
+      /options\.auth\.token is required/
+    );
+  });
+
+  test('basic with colon in username throws (RFC 7617)', () => {
+    assert.throws(
+      () =>
+        defaultAuthHeadersForRawProbe({
+          auth: { type: 'basic', username: 'has:colon', password: 'test-fixture' },
+        }),
+      /must not contain colon/
+    );
+  });
+
+  test('header values with CR/LF throw and name the offending field without echoing the value', () => {
+    let captured;
+    assert.throws(
+      () => defaultAuthHeadersForRawProbe({ auth: { type: 'bearer', token: 'abc\r\nx-injected: yes' } }),
+      err => {
+        captured = err;
+        return /options\.auth\.token contains invalid characters/.test(err.message);
+      }
+    );
+    assert.ok(captured, 'expected an error to be thrown');
+    assert.ok(!/x-injected/.test(captured.message), 'error must not echo the offending value');
+  });
+
+  test('non-printable ASCII in session id throws with field name', () => {
+    assert.throws(
+      () => defaultAuthHeadersForRawProbe({ test_session_id: 'sess\x01' }),
+      /options\.test_session_id contains invalid characters/
+    );
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Dispatch gate: a2a stays on SDK path
+// ────────────────────────────────────────────────────────────
+
+/**
+ * A2A agents use a different envelope than MCP JSON-RPC, so the raw MCP
+ * probe can't substitute. Confirm the dispatcher doesn't route A2A steps
+ * through it even when `omit_idempotency_key: true` would otherwise trigger.
+ * A fetch against the toy server reaching *any* endpoint other than the A2A
+ * URL would indicate leakage; we assert by observing the SDK's failure shape
+ * (no raw probe body ever lands).
+ */
+describe('runStoryboard dispatch: A2A + omit_idempotency_key stays on SDK path', () => {
+  it('does not invoke the raw MCP probe for A2A steps', async () => {
+    const mcpJsonRpcCallsSeen = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const text = Buffer.concat(chunks).toString('utf8');
+      // The raw MCP probe sends exactly a JSON-RPC tools/call body. Anything
+      // matching that shape on an A2A-configured run would be the bug.
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed?.method === 'tools/call') mcpJsonRpcCallsSeen.push(parsed);
+      } catch {
+        // Non-JSON — definitely not the raw MCP probe.
+      }
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+    await new Promise(r => server.listen(0, r));
+    const agentUrl = `http://127.0.0.1:${server.address().port}/`;
+    try {
+      const storyboard = {
+        id: 'a2a_dispatch_sb',
+        version: '1.0.0',
+        title: 'A2A dispatch gate',
+        category: 'compliance',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'a2a',
+            steps: [
+              {
+                id: 's1_a2a_missing_key',
+                title: 'a2a + omit_idempotency_key must not hit the raw MCP probe',
+                task: 'create_property_list',
+                expect_error: true,
+                omit_idempotency_key: true,
+                sample_request: { name: 'pl-a2a', entries: [] },
+                validations: [],
+              },
+            ],
+          },
+        ],
+      };
+      // Feed a pre-discovered A2A profile + a fake client so the runner
+      // proceeds to dispatch without discovery.
+      await runStoryboard(agentUrl, storyboard, {
+        protocol: 'a2a',
+        allow_http: true,
+        auth: { type: 'bearer', token: 'tok-a2a' },
+        agentTools: ['create_property_list'],
+        _profile: { name: 'Test', tools: ['create_property_list'] },
+        _client: {
+          getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'create_property_list' }] }),
+        },
+      });
+
+      assert.strictEqual(
+        mcpJsonRpcCallsSeen.length,
+        0,
+        `A2A run must not emit MCP JSON-RPC tools/call; saw ${mcpJsonRpcCallsSeen.length}`
       );
     } finally {
       server.close();


### PR DESCRIPTION
## Summary

- Closes #678. When a storyboard step sets `omit_idempotency_key: true` on a mutating task, dispatch via the existing `rawMcpProbe` instead of the SDK so no SDK-layer normalization can inject a key onto the wire.
- The SDK's `skipIdempotencyAutoInject` plumbing (in `normalizeRequestParams`, `SingleAgentClient.executeAndHandle`, and `TaskExecutor.executeTask`) already honors the flag, but a regression in any single site would silently make every SDK-speaking agent pass the missing-key conformance vector vacuously. Defense-in-depth.
- Scope: MCP protocol with no-auth / bearer / basic. OAuth and A2A stay on the SDK path (refresh semantics / different envelope can't be replicated).
- Header hardening: validate CR/LF / non-printable ASCII on each outbound header value before it hits undici (errors name the offending field without echoing the value), fail loudly on empty bearer tokens, reject basic-auth usernames containing `:` per RFC 7617. `X-Test-Session-ID` added to `SECRET_KEY_PATTERN` so any future code path that persists outbound headers redacts it automatically.

Paired with upstream adcp YAML change (adcp#2607) that adds `omit_idempotency_key: true` to the `create_media_buy_missing_key` storyboard step.

## Test plan

- [x] Added unit tests for `defaultAuthHeadersForRawProbe` covering: no auth, bearer, basic (with header casing), oauth returns `undefined`, empty bearer throws, basic-auth colon-in-username throws, CR/LF throws without echoing value, non-printable ASCII in session id throws with field name.
- [x] Added integration test: bearer-auth mutating step with `omit_idempotency_key: true` reaches server with no `idempotency_key` and correct `Authorization` + `X-Test-Session-ID` headers.
- [x] Added integration test: A2A + `omit_idempotency_key` does NOT emit an MCP JSON-RPC `tools/call` (stays on SDK path).
- [x] Existing `omit_idempotency_key` integration test (with `auth: 'none'` step override) still passes.
- [x] Build, lint, typecheck, prettier all green.
- [x] 53 tests pass across `storyboard-idempotency-invariant`, `storyboard-runner-contract`, `storyboard-brand-invariant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)