### PR TITLE
feat(storyboard): cross-step assertion registry + runner hooks (adcp#2639)

### DIFF
--- a/.changeset/storyboard-assertion-registry.md
+++ b/.changeset/storyboard-assertion-registry.md
@@ -1,0 +1,27 @@
+---
+'@adcp/client': minor
+---
+
+Add a cross-step assertion registry to the storyboard runner
+(adcontextprotocol/adcp#2639). Storyboards now accept a top-level
+`invariants: [id, ...]` array that references assertions registered via
+`registerAssertion(spec)` from `@adcp/client/testing`. The runner resolves
+the ids at start (fails fast on unknowns), fires `onStart` → `onStep`
+(per step) → `onEnd` (once at the end), routes step-scoped failures into
+the step's `validations[]` as `check: "assertion"`, and records every
+result on a new `StoryboardResult.assertions[]` field. A failed assertion
+flips `overall_passed` — assertions are gating conformance signal, not
+advisory output.
+
+New public exports from `@adcp/client/testing`: `registerAssertion`,
+`getAssertion`, `listAssertions`, `clearAssertionRegistry`,
+`resolveAssertions`, and types `AssertionSpec`, `AssertionContext`,
+`AssertionResult`.
+
+Assertions encode cross-step properties that per-step checks can't
+express cleanly: governance denial never mutates, idempotency dedup
+across replays, context never echoes secrets on error, status
+transitions monotonic, and so on. The registry ships the framework;
+concrete assertion modules live alongside the specialisms that own them.
+
+No behavior change for storyboards that don't set `invariants`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -595,6 +595,9 @@ Flow: `get_adcp_capabilities → sync_plans → check_governance → create_medi
 **Media buy seller agent** — Seller agent that receives briefs, returns products, accepts media buys, and reports delivery.
 Flow: `get_adcp_capabilities → sync_accounts → sync_governance → get_products → list_creative_formats → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → get_media_buy_delivery`
 
+**Creative lifecycle is decoupled from media buy lifecycle** — Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy.
+Flow: `get_products → create_media_buy → sync_creatives → list_creatives → update_media_buy → list_creatives → create_media_buy → sync_creatives`
+
 **Seller creates buy when governance approves** — Verifies that the seller creates a media buy when governance approves the transaction.
 Flow: `sync_plans → sync_accounts → sync_governance → get_products → create_media_buy`
 

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -21,12 +21,7 @@
  * See adcontextprotocol/adcp#2639 for the originating design.
  */
 
-import type {
-  AssertionResult,
-  Storyboard,
-  StoryboardRunOptions,
-  StoryboardStepResult,
-} from './types';
+import type { AssertionResult, Storyboard, StoryboardRunOptions, StoryboardStepResult } from './types';
 
 // ────────────────────────────────────────────────────────────
 // Public types

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -1,0 +1,139 @@
+/**
+ * Storyboard cross-step assertion registry.
+ *
+ * Storyboards express per-step checks inline (response_schema, field_value,
+ * http_status, etc.). Assertions encode properties that must hold *across*
+ * a whole run: idempotency dedup, governance denial never mutates, status
+ * monotonic, context never echoes secrets on error. They're specialism- or
+ * protocol-wide, so encoding them per-step duplicates path setup and
+ * catches timing-dependent violations only by accident.
+ *
+ * Assertions are programmatic (TS), not declarative — the paths they walk,
+ * the state they carry across steps, and the outcomes they report are too
+ * varied for a uniform YAML schema. Storyboards reference them by id on
+ * the top-level `invariants: [...]` array; the runner resolves the ids at
+ * start and fails fast on unknowns.
+ *
+ * Registration is explicit: modules that define assertions call
+ * `registerAssertion(...)` at import time, and the code driving `runStoryboard`
+ * imports those modules before invoking the runner. No auto-discovery.
+ *
+ * See adcontextprotocol/adcp#2639 for the originating design.
+ */
+
+import type {
+  AssertionResult,
+  Storyboard,
+  StoryboardRunOptions,
+  StoryboardStepResult,
+} from './types';
+
+// ────────────────────────────────────────────────────────────
+// Public types
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Context passed to every assertion callback. `state` is the assertion's
+ * private scratch space for the current run — the runner constructs one
+ * per-assertion, per-run, so separate assertions and separate runs never
+ * see each other's state.
+ */
+export interface AssertionContext {
+  storyboard: Storyboard;
+  agentUrl: string;
+  options: StoryboardRunOptions;
+  state: Record<string, unknown>;
+}
+
+/**
+ * An assertion definition. All three hooks are optional — most assertions
+ * only need one (e.g. idempotency dedup observes `onStep`; governance
+ * denial mutation-block may do an `onEnd` scan over prior step results).
+ *
+ * Hook semantics:
+ *   - `onStart`: fires once after runner init, before the first step.
+ *   - `onStep`: fires after each step completes (including skips). Return
+ *     step-scoped `AssertionResult[]`; the runner appends each result's
+ *     pass/fail into the step's `validations[]` under `check: "assertion"`
+ *     AND into `StoryboardResult.assertions[]` with `scope: "step"`.
+ *   - `onEnd`: fires once after the last phase, before `overall_passed` is
+ *     computed. Return storyboard-scoped `AssertionResult[]`; they land in
+ *     `StoryboardResult.assertions[]` with `scope: "storyboard"`.
+ *
+ * The runner flips `overall_passed` to false when any assertion fails —
+ * that's what makes them gating conformance signal, not advisory output.
+ */
+export interface AssertionSpec {
+  id: string;
+  description: string;
+  onStart?(ctx: AssertionContext): void | Promise<void>;
+  onStep?(
+    ctx: AssertionContext,
+    stepResult: StoryboardStepResult
+  ): Omit<AssertionResult, 'assertion_id' | 'scope'>[] | Promise<Omit<AssertionResult, 'assertion_id' | 'scope'>[]>;
+  onEnd?(
+    ctx: AssertionContext
+  ): Omit<AssertionResult, 'assertion_id' | 'scope'>[] | Promise<Omit<AssertionResult, 'assertion_id' | 'scope'>[]>;
+}
+
+// ────────────────────────────────────────────────────────────
+// Registry
+// ────────────────────────────────────────────────────────────
+
+const registry = new Map<string, AssertionSpec>();
+
+/**
+ * Register an assertion. Throws on duplicate id — re-registration is almost
+ * always a sign of two modules fighting over the same id, not an intent to
+ * override. Tests that want to replace a registration should call
+ * `clearAssertionRegistry()` first.
+ */
+export function registerAssertion(spec: AssertionSpec): void {
+  if (!spec.id) throw new Error('registerAssertion: spec.id is required');
+  if (registry.has(spec.id)) {
+    throw new Error(`registerAssertion: "${spec.id}" is already registered`);
+  }
+  registry.set(spec.id, spec);
+}
+
+/** Look up a registered assertion. Returns undefined if the id is unknown. */
+export function getAssertion(id: string): AssertionSpec | undefined {
+  return registry.get(id);
+}
+
+/** List every registered assertion id. Useful for diagnostics / tooling. */
+export function listAssertions(): string[] {
+  return [...registry.keys()];
+}
+
+/**
+ * Remove all registrations. Scoped for tests — production runs rely on
+ * module-init registration, and clearing the registry mid-run would break
+ * any in-flight storyboard.
+ */
+export function clearAssertionRegistry(): void {
+  registry.clear();
+}
+
+/**
+ * Resolve a list of ids to their registered specs. Throws with a single
+ * aggregated error naming every unknown id — fails fast at runner start
+ * rather than silently dropping ids.
+ */
+export function resolveAssertions(ids: string[] | undefined): AssertionSpec[] {
+  if (!ids || ids.length === 0) return [];
+  const resolved: AssertionSpec[] = [];
+  const missing: string[] = [];
+  for (const id of ids) {
+    const spec = registry.get(id);
+    if (spec) resolved.push(spec);
+    else missing.push(id);
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Storyboard references unregistered assertion${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}. ` +
+        `Import the module that calls registerAssertion(...) for each id before running the storyboard.`
+    );
+  }
+  return resolved;
+}

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -26,8 +26,19 @@ export type {
   StoryboardStepResult,
   StoryboardPhaseResult,
   StoryboardResult,
+  AssertionResult,
 } from './types';
 export { WEBHOOK_IDEMPOTENCY_KEY_PATTERN } from './types';
+
+// Cross-step assertion registry (adcontextprotocol/adcp#2639)
+export {
+  registerAssertion,
+  getAssertion,
+  listAssertions,
+  clearAssertionRegistry,
+  resolveAssertions,
+} from './assertions';
+export type { AssertionSpec, AssertionContext } from './assertions';
 
 // Webhook receiver (outbound-webhook conformance testing per adcontextprotocol/adcp#2431)
 export { createWebhookReceiver } from './webhook-receiver';

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -35,6 +35,7 @@ import { probeRequestSigningVector } from './request-signing/probe-dispatch';
 import { createWebhookReceiver, type WebhookReceiver } from './webhook-receiver';
 import { WEBHOOK_ASSERTION_TASKS, armWebhookAssertions, executeWebhookAssertionStep } from './webhook-assertions';
 import type {
+  AssertionResult,
   HttpProbeResult,
   RunnerDetailedSkipReason,
   RunnerExtractionRecord,
@@ -56,6 +57,7 @@ import type {
 } from './types';
 import { DETAILED_SKIP_TO_CANONICAL } from './types';
 import type { TaskResult } from '../types';
+import { type AssertionContext, type AssertionSpec, resolveAssertions } from './assertions';
 
 // ────────────────────────────────────────────────────────────
 // Runner-output contract helpers
@@ -289,6 +291,25 @@ async function executeStoryboardPass(
   // strategy parameter narrow.
   const dispatch = createDispatcher(agentUrls, clients, 'round-robin', dispatchOffset);
 
+  // Resolve cross-step assertions declared on `storyboard.invariants`.
+  // `resolveAssertions` throws on unknown ids — fail fast here rather than
+  // silently skip, since a missing assertion means unknown conformance gaps.
+  const assertions = resolveAssertions(storyboard.invariants);
+  const assertionContexts = new Map<string, AssertionContext>();
+  for (const spec of assertions) {
+    assertionContexts.set(spec.id, {
+      storyboard,
+      agentUrl: agentUrls[0]!,
+      options,
+      state: {},
+    });
+  }
+  const assertionResults: AssertionResult[] = [];
+  let assertionsFailed = false;
+  for (const spec of assertions) {
+    if (spec.onStart) await spec.onStart(assertionContexts.get(spec.id)!);
+  }
+
   // Placeholder storyboards with no executable phases get a distinct skip
   // reason per the runner-output contract. Without this, the overall result
   // would pass vacuously — `passed_count === 0 && failed_count === 0` — and
@@ -414,6 +435,31 @@ async function executeStoryboardPass(
       stepResults.push(result);
       priorStepResults.set(step.id, result);
 
+      // Fire per-step assertions. Each result is appended to the step's
+      // `validations[]` under `check: "assertion"` so existing UI renders
+      // them alongside inline checks, and mirrored into `assertionResults`
+      // for the storyboard-level `assertions[]` surface. Any failure flips
+      // `result.passed` so the counting below treats it like a validation
+      // failure — that's what makes assertions gating, not advisory.
+      for (const spec of assertions) {
+        if (!spec.onStep) continue;
+        const raw = await spec.onStep(assertionContexts.get(spec.id)!, result);
+        for (const r of raw) {
+          const full: AssertionResult = { ...r, assertion_id: spec.id, scope: 'step', step_id: step.id };
+          assertionResults.push(full);
+          result.validations.push({
+            check: 'assertion',
+            passed: r.passed,
+            description: `${spec.id}: ${r.description}`,
+            ...(r.error !== undefined && { error: r.error }),
+          });
+          if (!r.passed) {
+            result.passed = false;
+            assertionsFailed = true;
+          }
+        }
+      }
+
       // PRM presence accounting — must happen after the step result lands so
       // both the skipped-404 and 2xx paths are visible.
       if (step.task === 'protected_resource_metadata') {
@@ -467,12 +513,26 @@ async function executeStoryboardPass(
     });
   }
 
+  // Fire storyboard-scoped assertions. These observe the full run and can
+  // emit `scope: "storyboard"` findings that flip `overall_passed` without
+  // being attributable to a single step (e.g. "saw >1 acquire for the same
+  // replayed idempotency_key across the run").
+  for (const spec of assertions) {
+    if (!spec.onEnd) continue;
+    const raw = await spec.onEnd(assertionContexts.get(spec.id)!);
+    for (const r of raw) {
+      assertionResults.push({ ...r, assertion_id: spec.id, scope: 'storyboard' });
+      if (!r.passed) assertionsFailed = true;
+    }
+  }
+
   // Overall pass requires (a) no required-phase failures AND (b) at least one
-  // required phase actually passed with at least one non-skipped step.
-  // Without the second clause, a storyboard where every phase is marked
-  // optional, every required phase's steps are skipped (e.g. required_tools
-  // filtered out everything), would pass vacuously. The storyboard's own gate
-  // (assert_contribution in security_baseline) must live in a required phase.
+  // required phase actually passed with at least one non-skipped step AND
+  // (c) no assertion failures. Without (b) a storyboard where every phase is
+  // marked optional and every required phase's steps are skipped (e.g.
+  // required_tools filtered out everything) would pass vacuously. (c) makes
+  // assertions gating — a run with all validations green but a cross-step
+  // invariant broken is not conformant.
   const requiredPhasesPassed = phaseResults.some((p, idx) => {
     const phaseDef = storyboard.phases[idx];
     if (!phaseDef || phaseDef.optional || !p.passed) return false;
@@ -488,7 +548,7 @@ async function executeStoryboardPass(
     // individually); the aggregating wrapper relabels the top-level result
     // `multi-pass`.
     ...(isMultiInstance && { multi_instance_strategy: 'round-robin' as const }),
-    overall_passed: failedCount === 0 && requiredPhasesPassed,
+    overall_passed: failedCount === 0 && requiredPhasesPassed && !assertionsFailed,
     phases: phaseResults,
     context,
     total_duration_ms: Date.now() - start,
@@ -497,6 +557,7 @@ async function executeStoryboardPass(
     skipped_count: skippedCount,
     tested_at: new Date().toISOString(),
     ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
+    ...(assertionResults.length > 0 ? { assertions: assertionResults } : {}),
   };
 
   // Close protocol connections when the runner created its own client. The
@@ -564,6 +625,11 @@ async function runMultiPass(
   const skipped = passes.reduce((sum, p) => sum + p.skipped_count, 0);
   const schemasUsed = passResults.flatMap(r => r.schemas_used ?? []);
   const schemasDedup = [...new Map(schemasUsed.map(s => [s.schema_id, s])).values()];
+  // Assertions are scoped per-pass — each pass's runner resolved them
+  // independently and reported `assertion_id` identically. Concatenate so
+  // readers see a per-pass timeline; de-duplicating would hide a real
+  // "passed on pass 1, failed on pass 2" divergence.
+  const assertionsAgg = passResults.flatMap(r => r.assertions ?? []);
 
   return {
     storyboard_id: storyboard.id,
@@ -581,6 +647,7 @@ async function runMultiPass(
     skipped_count: skipped,
     tested_at: new Date().toISOString(),
     ...(schemasDedup.length > 0 ? { schemas_used: schemasDedup } : {}),
+    ...(assertionsAgg.length > 0 ? { assertions: assertionsAgg } : {}),
   };
 }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -47,6 +47,16 @@ export interface Storyboard {
     test_kit?: string;
   };
   phases: StoryboardPhase[];
+  /**
+   * Cross-step assertion ids that apply to this storyboard. Each entry names
+   * an assertion registered via `registerAssertion(...)`; the runner resolves
+   * them at start and fails fast on unknown ids. Per-step checks live inline
+   * on steps — assertions encode specialism- or protocol-wide properties
+   * that must hold across the full run (governance denial never mutates,
+   * idempotency dedup, status monotonicity, context never echoes secrets on
+   * error). See `./assertions.ts` for the registry API.
+   */
+  invariants?: string[];
 }
 
 export interface StoryboardPhase {
@@ -778,6 +788,34 @@ export interface StoryboardResult {
    * locally against the same artifacts.
    */
   schemas_used?: Array<{ schema_id: string; schema_url: string }>;
+  /**
+   * Results from cross-step assertions declared on the storyboard's
+   * `invariants` field. Step-scoped failures also surface inside the owning
+   * step's `validations[]` with `check: "assertion"`; storyboard-scoped
+   * failures live only here. `overall_passed` is false when any assertion
+   * failed.
+   */
+  assertions?: AssertionResult[];
+}
+
+/**
+ * Single assertion outcome recorded by the runner. Mirrors the shape of
+ * `ValidationResult` so existing consumers can render assertions with the
+ * same code path, while adding scope + source fields that identify where
+ * the failure originated.
+ */
+export interface AssertionResult {
+  /** Id of the registered assertion that produced this result. */
+  assertion_id: string;
+  passed: boolean;
+  /** Human-readable description of the property being asserted. */
+  description: string;
+  /** Whether this result was raised at a specific step or storyboard-wide. */
+  scope: 'step' | 'storyboard';
+  /** Step that produced the observation, when `scope === "step"`. */
+  step_id?: string;
+  /** Failure detail. Absent on pass. */
+  error?: string;
 }
 
 /**

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -1,0 +1,314 @@
+/**
+ * Storyboard cross-step assertion registry + runner hooks.
+ *
+ * Covers the registry (register/get/duplicate/unknown-id) and the three
+ * runner lifecycle hooks (onStart/onStep/onEnd) end-to-end against a
+ * minimal HTTP agent. See adcontextprotocol/adcp#2639.
+ */
+
+const { describe, test, it, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+const {
+  registerAssertion,
+  getAssertion,
+  listAssertions,
+  clearAssertionRegistry,
+  resolveAssertions,
+} = require('../../dist/lib/testing/storyboard/assertions.js');
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
+
+describe('assertion registry', () => {
+  beforeEach(() => clearAssertionRegistry());
+
+  test('register + get returns the registered spec', () => {
+    const spec = { id: 'a.one', description: 'one' };
+    registerAssertion(spec);
+    assert.strictEqual(getAssertion('a.one'), spec);
+  });
+
+  test('listAssertions reflects current registrations', () => {
+    registerAssertion({ id: 'a.one', description: 'one' });
+    registerAssertion({ id: 'a.two', description: 'two' });
+    assert.deepStrictEqual(listAssertions().sort(), ['a.one', 'a.two']);
+  });
+
+  test('register throws on duplicate id', () => {
+    registerAssertion({ id: 'dup', description: 'first' });
+    assert.throws(
+      () => registerAssertion({ id: 'dup', description: 'second' }),
+      /already registered/
+    );
+  });
+
+  test('register throws on missing id', () => {
+    assert.throws(() => registerAssertion({ description: 'no id' }), /spec\.id is required/);
+  });
+
+  test('clearAssertionRegistry removes all registrations', () => {
+    registerAssertion({ id: 'a.one', description: 'one' });
+    clearAssertionRegistry();
+    assert.strictEqual(getAssertion('a.one'), undefined);
+    assert.deepStrictEqual(listAssertions(), []);
+  });
+
+  test('resolveAssertions returns specs in order, throws on unknown ids listing all missing', () => {
+    registerAssertion({ id: 'known.one', description: 'one' });
+    registerAssertion({ id: 'known.two', description: 'two' });
+    const resolved = resolveAssertions(['known.one', 'known.two']);
+    assert.deepStrictEqual(resolved.map(s => s.id), ['known.one', 'known.two']);
+    assert.throws(
+      () => resolveAssertions(['known.one', 'missing.a', 'missing.b']),
+      /missing\.a, missing\.b/
+    );
+  });
+
+  test('resolveAssertions returns [] on undefined or empty', () => {
+    assert.deepStrictEqual(resolveAssertions(undefined), []);
+    assert.deepStrictEqual(resolveAssertions([]), []);
+  });
+});
+
+/**
+ * Minimal MCP stub: responds 200 to every tool call with a canned structured
+ * response. Lets us drive runStoryboard end-to-end without spinning a real
+ * agent — the point here is the runner's assertion plumbing, not the handler.
+ */
+function startStubAgent() {
+  const server = http.createServer(async (req, res) => {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    const rpcId = rpc.id ?? 1;
+    const body = {
+      jsonrpc: '2.0',
+      id: rpcId,
+      result: {
+        structuredContent: { ok: true, tool: rpc.params?.name },
+        content: [{ type: 'text', text: '{}' }],
+      },
+    };
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+  return new Promise(resolve => {
+    server.listen(0, () => resolve({ server, url: `http://127.0.0.1:${server.address().port}/mcp` }));
+  });
+}
+
+function buildStoryboard({ invariants } = {}) {
+  const sb = {
+    id: 'assertion_sb',
+    version: '1.0.0',
+    title: 'Assertion runner hooks',
+    category: 'compliance',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'p',
+        title: 'steps',
+        steps: [
+          { id: 's1', title: 'first', task: 'list_creatives', sample_request: { list_id: 'pl-1' } },
+          { id: 's2', title: 'second', task: 'list_creatives', sample_request: { list_id: 'pl-2' } },
+        ],
+      },
+    ],
+  };
+  if (invariants) sb.invariants = invariants;
+  return sb;
+}
+
+const runnerOptions = {
+  protocol: 'mcp',
+  allow_http: true,
+  agentTools: ['list_creatives'],
+  _profile: { name: 'Test', tools: ['list_creatives'] },
+  _client: { getAgentInfo: async () => ({ name: 'Test', tools: [{ name: 'list_creatives' }] }) },
+};
+
+describe('runStoryboard: assertion hooks', () => {
+  beforeEach(() => clearAssertionRegistry());
+
+  it('calls onStart once with a fresh state object per assertion', async () => {
+    const startCalls = [];
+    registerAssertion({
+      id: 'obs.start',
+      description: 'observes start',
+      onStart(ctx) {
+        startCalls.push({ id: 'obs.start', state: ctx.state, agentUrl: ctx.agentUrl });
+        ctx.state.initialized = true;
+      },
+    });
+    registerAssertion({
+      id: 'obs.start2',
+      description: 'second',
+      onStart(ctx) {
+        startCalls.push({ id: 'obs.start2', state: ctx.state });
+      },
+    });
+    const { server, url } = await startStubAgent();
+    try {
+      await runStoryboard(url, buildStoryboard({ invariants: ['obs.start', 'obs.start2'] }), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.strictEqual(startCalls.length, 2);
+    assert.strictEqual(startCalls[0].id, 'obs.start');
+    assert.strictEqual(startCalls[0].agentUrl, url);
+    assert.notStrictEqual(startCalls[0].state, startCalls[1].state, 'each assertion must get its own state object');
+  });
+
+  it('calls onStep after every step (including for a 2-step storyboard, twice)', async () => {
+    const stepIds = [];
+    registerAssertion({
+      id: 'obs.step',
+      description: 'observes steps',
+      onStep(ctx, stepResult) {
+        stepIds.push(stepResult.step_id);
+        return [];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    try {
+      await runStoryboard(url, buildStoryboard({ invariants: ['obs.step'] }), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.deepStrictEqual(stepIds, ['s1', 's2']);
+  });
+
+  it('onStep failures flip overall_passed and surface under result.assertions + step.validations', async () => {
+    registerAssertion({
+      id: 'fail.on.second',
+      description: 'fails on the second step',
+      onStep(_ctx, stepResult) {
+        if (stepResult.step_id === 's2') {
+          return [{ passed: false, description: 'step 2 broke the rule', error: 'demo' }];
+        }
+        return [];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    let result;
+    try {
+      result = await runStoryboard(url, buildStoryboard({ invariants: ['fail.on.second'] }), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.strictEqual(result.overall_passed, false, 'a failed assertion must flip overall_passed');
+    assert.ok(Array.isArray(result.assertions), 'assertions[] must be present on the result');
+    const stepFailures = result.assertions.filter(a => !a.passed && a.scope === 'step');
+    assert.strictEqual(stepFailures.length, 1);
+    assert.strictEqual(stepFailures[0].step_id, 's2');
+    assert.strictEqual(stepFailures[0].assertion_id, 'fail.on.second');
+
+    const s2 = result.phases[0].steps.find(s => s.step_id === 's2');
+    const asValidation = s2.validations.find(v => v.check === 'assertion');
+    assert.ok(asValidation, 'step.validations must carry an assertion-check entry');
+    assert.strictEqual(asValidation.passed, false);
+    assert.match(asValidation.description, /fail\.on\.second: step 2 broke the rule/);
+  });
+
+  it('onEnd failures surface storyboard-scoped and flip overall_passed even with all validations green', async () => {
+    registerAssertion({
+      id: 'end.only',
+      description: 'only runs at end',
+      onEnd(_ctx) {
+        return [{ passed: false, description: 'global property broke', error: 'seen-twice' }];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    let result;
+    try {
+      result = await runStoryboard(url, buildStoryboard({ invariants: ['end.only'] }), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.strictEqual(result.overall_passed, false);
+    const globals = result.assertions.filter(a => a.scope === 'storyboard');
+    assert.strictEqual(globals.length, 1);
+    assert.strictEqual(globals[0].step_id, undefined);
+    assert.strictEqual(globals[0].assertion_id, 'end.only');
+  });
+
+  it('state carries across onStart → onStep → onEnd on the same assertion', async () => {
+    let observedEnd = null;
+    registerAssertion({
+      id: 'state.carrier',
+      description: 'tracks state across hooks',
+      onStart(ctx) {
+        ctx.state.seen = [];
+      },
+      onStep(ctx, stepResult) {
+        ctx.state.seen.push(stepResult.step_id);
+        return [];
+      },
+      onEnd(ctx) {
+        observedEnd = ctx.state.seen;
+        return [];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    try {
+      await runStoryboard(url, buildStoryboard({ invariants: ['state.carrier'] }), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.deepStrictEqual(observedEnd, ['s1', 's2']);
+  });
+
+  it('storyboards without `invariants` run unaffected — no assertions on result', async () => {
+    registerAssertion({
+      id: 'never.fires',
+      description: 'should not be invoked',
+      onStep() {
+        throw new Error('onStep was invoked for a storyboard that did not opt in');
+      },
+    });
+    const { server, url } = await startStubAgent();
+    let result;
+    try {
+      result = await runStoryboard(url, buildStoryboard(), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.strictEqual(result.assertions, undefined);
+  });
+
+  it('unknown assertion id in storyboard.invariants throws at run start', async () => {
+    const { server, url } = await startStubAgent();
+    try {
+      await assert.rejects(
+        () => runStoryboard(url, buildStoryboard({ invariants: ['nope.missing'] }), runnerOptions),
+        /unregistered assertion.*nope\.missing/
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it('onStep passing results surface but do not change overall_passed vs baseline', async () => {
+    registerAssertion({
+      id: 'always.passes',
+      description: 'always emits a passing assertion',
+      onStep(_ctx, stepResult) {
+        return [{ passed: true, description: `${stepResult.step_id} ok` }];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    let baseline, withAssertion;
+    try {
+      baseline = await runStoryboard(url, buildStoryboard(), runnerOptions);
+      withAssertion = await runStoryboard(url, buildStoryboard({ invariants: ['always.passes'] }), runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.strictEqual(withAssertion.overall_passed, baseline.overall_passed, 'passing assertions must not change overall_passed');
+    assert.strictEqual(withAssertion.assertions.length, 2);
+    assert.ok(withAssertion.assertions.every(a => a.passed));
+  });
+});

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -36,10 +36,7 @@ describe('assertion registry', () => {
 
   test('register throws on duplicate id', () => {
     registerAssertion({ id: 'dup', description: 'first' });
-    assert.throws(
-      () => registerAssertion({ id: 'dup', description: 'second' }),
-      /already registered/
-    );
+    assert.throws(() => registerAssertion({ id: 'dup', description: 'second' }), /already registered/);
   });
 
   test('register throws on missing id', () => {
@@ -57,11 +54,11 @@ describe('assertion registry', () => {
     registerAssertion({ id: 'known.one', description: 'one' });
     registerAssertion({ id: 'known.two', description: 'two' });
     const resolved = resolveAssertions(['known.one', 'known.two']);
-    assert.deepStrictEqual(resolved.map(s => s.id), ['known.one', 'known.two']);
-    assert.throws(
-      () => resolveAssertions(['known.one', 'missing.a', 'missing.b']),
-      /missing\.a, missing\.b/
+    assert.deepStrictEqual(
+      resolved.map(s => s.id),
+      ['known.one', 'known.two']
     );
+    assert.throws(() => resolveAssertions(['known.one', 'missing.a', 'missing.b']), /missing\.a, missing\.b/);
   });
 
   test('resolveAssertions returns [] on undefined or empty', () => {
@@ -307,7 +304,11 @@ describe('runStoryboard: assertion hooks', () => {
     } finally {
       server.close();
     }
-    assert.strictEqual(withAssertion.overall_passed, baseline.overall_passed, 'passing assertions must not change overall_passed');
+    assert.strictEqual(
+      withAssertion.overall_passed,
+      baseline.overall_passed,
+      'passing assertions must not change overall_passed'
+    );
     assert.strictEqual(withAssertion.assertions.length, 2);
     assert.ok(withAssertion.assertions.every(a => a.passed));
   });


### PR DESCRIPTION
## Summary

Adds a cross-step **assertion registry** and `onStart` / `onStep` / `onEnd` lifecycle hooks to `runStoryboard`. Storyboards express per-step checks inline already (`response_schema`, `field_value`, `http_status`, …); this PR adds the missing layer for properties that must hold *across* a whole run — governance denial never mutates, idempotency dedup across replays, status transitions monotonic, context never echoes secrets on error.

Framework only. Concrete assertion modules (idempotency dedup, governance mutation-block, status monotonicity, secret redaction) live in adcontextprotocol/adcp alongside the specialisms that own them; they'll register via the new API and be declared on their specialism's `invariants: [...]` list.

## What changed

- `src/lib/testing/storyboard/assertions.ts` — new module. `registerAssertion(spec)`, `getAssertion(id)`, `listAssertions()`, `clearAssertionRegistry()`, `resolveAssertions(ids)`. Throws on duplicate ids at registration and on unknown ids at resolve.
- `src/lib/testing/storyboard/types.ts` — `Storyboard` gains optional `invariants?: string[]`. `StoryboardResult` gains optional `assertions?: AssertionResult[]`. New `AssertionResult` type (`scope: "step" | "storyboard"`, optional `step_id`).
- `src/lib/testing/storyboard/runner.ts` — three insertions in `executeStoryboardPass`:
  1. **Start**: resolve `storyboard.invariants` → specs (fails fast on unknown id); init per-assertion state; await `onStart(ctx)` on each.
  2. **Per-step**: after each step completes, await `onStep(ctx, stepResult)`; append each returned result into `step.validations[]` under `check: "assertion"` AND into the storyboard-level `assertions[]` with `scope: "step"`; flip `result.passed = false` on any failure so the existing count/stateful-cascade logic treats it as a validation failure.
  3. **End**: await `onEnd(ctx)`; record results with `scope: "storyboard"`; factor `assertionsFailed` into `overall_passed`.
- Multi-pass aggregator concatenates per-pass `assertions[]` (no dedup — a divergence across passes should surface).
- Public exports from `@adcp/client/testing` for the registry + types.

## Shape

```ts
registerAssertion({
  id: 'governance.denial_blocks_mutation',
  description: 'GOVERNANCE_DENIED responses must not acquire any resources',
  onStart(ctx) { ctx.state.acquired = []; },
  onStep(ctx, stepResult) {
    if (stepResult.response?.media_buy_id) ctx.state.acquired.push(stepResult.step_id);
    return [];
  },
  onEnd(ctx) {
    const denied = /* ...detect DENIED step in context... */;
    if (denied && ctx.state.acquired.length) {
      return [{ passed: false, description: 'resource acquired after denial', error: `steps: ${ctx.state.acquired.join(', ')}` }];
    }
    return [{ passed: true, description: 'no post-denial mutation' }];
  },
});
```

Storyboard wiring:

```yaml
id: governance_spend_authority_sb
# ...
invariants:
  - governance.denial_blocks_mutation
  - idempotency.dedup
phases: [...]
```

## Why gate `overall_passed`?

Assertions encode conformance properties — a run where every validation is green but `plan_hash` churned across re-renders, or a denied plan still acquired a buy, is not a conformant run. Treating assertions as advisory would recreate the problem storyboards already have (authors memorize scripts and ignore broader guarantees).

## Test plan

- [x] Unit: registry register/get/list/clear/resolve + duplicate and unknown-id errors.
- [x] Integration: stub MCP agent + minimal storyboard; verify
  - `onStart` called once with fresh per-assertion `state`
  - `onStep` called for every step in order
  - Step-scoped failure surfaces in both `step.validations[]` and `result.assertions[]` and flips `overall_passed`
  - `onEnd` failure surfaces as `scope: "storyboard"` and flips `overall_passed` even when all steps pass
  - `state` carries across `onStart` → `onStep` → `onEnd` on the same assertion
  - Storyboards without `invariants` are unaffected (no `assertions` key on result; no hooks fire)
  - Unknown id in `invariants` throws at run start
  - Passing assertions don't regress `overall_passed` vs baseline
- [x] Neighbor tests (`storyboard-brand-invariant`, `storyboard-idempotency-invariant`, `storyboard-runner-contract`) still green.
- [x] Full suite: 39 pre-existing failures on this branch = 40 on unmodified main (delta is unrelated flake); no regressions attributable to this PR.

## Non-goals

- No assertion implementations here — they ship from adcontextprotocol/adcp against specialism modules that can register at import time.
- No YAML-declarative assertion DSL. Programmatic TS registration is the contract; YAML just references ids.

## Related

- adcontextprotocol/adcp#2639 — origin issue (cross-step invariants on storyboards)
- adcontextprotocol/adcp#2630 — LLM red-team runner will reuse this registry as its oracle (same invariants, different path generator)
- Supersedes adcontextprotocol/adcp#2624 (the fixed SDK smoke-test framing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)