### PR TITLE
feat(storyboard): branch_set, contributes shorthand, peer_branch_taken grading (#693)

### DIFF
--- a/.changeset/contributes-shorthand.md
+++ b/.changeset/contributes-shorthand.md
@@ -1,0 +1,52 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard runner now implements first-class branch-set grading, the
+`contributes: true` boolean shorthand, and the implicit-detection fallback
+the AdCP spec requires (adcp-client#693, adcp#2633, adcp#2646).
+
+**Authoring (parser):** phases can declare `branch_set: { id, semantics }`
+and contributing steps can use `contributes: true` as shorthand for
+`contributes_to: <enclosing phase's branch_set.id>`. Enforced at parse time:
+
+- `contributes: true` is only legal inside a phase that declares `branch_set:`.
+- A step MUST NOT set both `contributes` and `contributes_to` (ambiguous).
+- `contributes_to:` inside a branch-set phase MUST equal `branch_set.id`.
+- Phases declaring `branch_set:` MUST set `optional: true`.
+- `branch_set.semantics` must be a supported value (`any_of` today; future
+  `all_of` / `at_least_n` are reserved). Unknown values are rejected at
+  parse rather than silently skipping grading.
+
+**Grading (runner):** after all phases run, branch-set peers are re-graded
+per the schema rule (storyboard-schema.yaml "Per-step grading in any_of
+branch patterns"). Branch-set membership is resolved two ways:
+
+1. Explicit `branch_set: { id, semantics: 'any_of' }` declaration.
+2. Implicit fallback: an optional phase with a step declaring
+   `contributes_to: <flag>` that matches a later `assert_contribution
+   check: any_of` target. Keeps pre-adcp#2633 storyboards working
+   unchanged.
+
+When a peer contributes the flag, non-contributing peers' failing steps are
+re-labeled as `skipped: true` with a new canonical skip reason
+`peer_branch_taken` and the mandated detail format:
+
+```
+<flag> contributed by <peer_phase_id>.<peer_step_id> — <this_phase_id> is moot
+```
+
+Hard failures (non-optional phases and `presenceDetected` PRM 2xx paths,
+adcp-client#677) are exempt from re-grading — the invariants they enforce
+must stand even when a peer branch contributed.
+
+`peer_branch_taken` is distinct from `not_applicable` (coverage gap) and
+raw `failed` — dashboards can tell "agent took the other branch" apart
+from "agent misbehaved." When no peer contributes, failures stay raw and
+`assert_contribution` is the single signal that fails the storyboard.
+
+`comply.ts` observation generators (`check_governance` + slow-response)
+now guard on `!step.warnings?.length` so re-graded moot peers don't emit
+stale observations.
+
+No storyboard migration is required.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -345,7 +345,7 @@ function collectObservations(
     let anyCheckMissingContext = false;
     for (const result of results) {
       for (const step of result.steps ?? []) {
-        if (step.task === 'check_governance' && step.passed && step.observation_data) {
+        if (step.task === 'check_governance' && step.passed && !step.skipped && step.observation_data) {
           if (!step.observation_data.governance_context) {
             anyCheckMissingContext = true;
           }
@@ -367,7 +367,12 @@ function collectObservations(
   // Check for slow responses
   for (const result of results) {
     for (const step of result.steps ?? []) {
-      if (step.passed && step.duration_ms > 10000) {
+      // Skip re-graded peers: a `peer_branch_taken` peer carries `passed:
+      // true` plus the original duration from when the branch ran, which
+      // would produce a spurious slow-response warning for a branch the
+      // agent didn't take. `warnings` alone is not a stable proxy for
+      // skipped — deprecation/governance warnings land there on real steps.
+      if (step.passed && !step.skipped && step.duration_ms > 10000) {
         observations.push({
           category: 'performance',
           severity: 'warning',

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -115,6 +115,8 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
     warnings: stepResult.skipped
       ? [stepResult.skip?.detail ?? skipReasonLabel(stepResult.skip_reason) ?? 'Step skipped']
       : undefined,
+    ...(stepResult.skipped && { skipped: true as const }),
+    ...(stepResult.skip_reason && { skip_reason: stepResult.skip_reason }),
   };
 }
 
@@ -131,6 +133,7 @@ function skipReasonLabel(reason: string | undefined): string | undefined {
     missing_tool: 'Skipped: agent did not advertise the required tool',
     missing_test_controller: 'Not testable: requires comply_test_controller',
     unsatisfied_contract: 'Skipped: test-kit contract is out of scope',
+    peer_branch_taken: 'Skipped: a peer branch in the same any_of branch set already contributed the aggregation flag',
   };
   return labels[reason];
 }

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -10,33 +10,133 @@ import { readFileSync } from 'fs';
 import { parse } from 'yaml';
 import type { Storyboard } from './types';
 
+/**
+ * Supported `branch_set.semantics` values. Extend when AdCP adds `all_of`,
+ * `at_least_n`, etc. Exported so the runner can enforce the same whitelist
+ * on programmatically-constructed storyboards that bypass the YAML parser.
+ */
+export const BRANCH_SET_SEMANTICS = ['any_of'] as const;
+
 /** Parse a YAML string into a Storyboard. Throws if required fields are missing. */
 export function parseStoryboard(yamlContent: string): Storyboard {
   const parsed = parse(yamlContent) as Storyboard;
   if (!parsed?.id || !parsed?.phases) {
     throw new Error('Invalid storyboard YAML: missing required fields (id, phases)');
   }
-  // YAML uses `name:` for context outputs but our runtime expects `key:`.
-  // Specialism YAMLs may declare a phase with no `steps:` — the steps are
-  // synthesized at runtime from fixtures (see request-signing/synthesize.ts).
-  // Treat missing steps as an empty list so the parser stays phase-agnostic.
   for (const phase of parsed.phases) {
+    // Specialism YAMLs may declare a phase with no `steps:` — the steps are
+    // synthesized at runtime from fixtures (see request-signing/synthesize.ts).
+    // Treat missing steps as an empty list so the parser stays phase-agnostic.
     if (!phase.steps) phase.steps = [];
+    // YAML uses `name:` for context outputs but our runtime expects `key:`.
     for (const step of phase.steps) {
-      if (step.context_outputs) {
-        for (const output of step.context_outputs) {
-          const raw = output as unknown as Record<string, unknown>;
-          if (raw.name && !raw.key) {
-            output.key = raw.name as string;
-          }
+      if (!step.context_outputs) continue;
+      for (const output of step.context_outputs) {
+        const raw = output as unknown as Record<string, unknown>;
+        if (raw.name && !raw.key) {
+          output.key = raw.name as string;
         }
       }
     }
   }
+  validateStoryboardShape(parsed);
   return parsed;
 }
 
 /** Load and parse a single storyboard file. Useful for ad-hoc testing of in-development YAMLs. */
 export function loadStoryboardFile(filePath: string): Storyboard {
   return parseStoryboard(readFileSync(filePath, 'utf-8'));
+}
+
+/**
+ * Enforce authoring-time invariants on a Storyboard. Called by
+ * `parseStoryboard`, and should also be called by any runner entry point
+ * that accepts a programmatically-built `Storyboard` object so the same
+ * loud-fail-on-drift guarantee holds regardless of how the storyboard was
+ * constructed. Mutates steps (resolves `contributes: true` to
+ * `contributes_to`) and is idempotent on already-validated inputs.
+ */
+export function validateStoryboardShape(storyboard: Storyboard): void {
+  for (const phase of storyboard.phases) {
+    validateBranchSet(storyboard.id, phase);
+    if (!phase.steps) continue;
+    for (const step of phase.steps) {
+      resolveContributesShorthand(storyboard.id, phase, step);
+    }
+  }
+}
+
+function validateBranchSet(storyboardId: string, phase: Storyboard['phases'][number]): void {
+  if (phase.branch_set === undefined) return;
+  const bs = phase.branch_set as unknown;
+  if (!bs || typeof bs !== 'object') {
+    throw new Error(`[${storyboardId}] phase '${phase.id}': branch_set must be an object with { id, semantics }`);
+  }
+  const { id, semantics } = bs as Record<string, unknown>;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error(`[${storyboardId}] phase '${phase.id}': branch_set.id must be a non-empty string`);
+  }
+  if (typeof semantics !== 'string' || semantics.length === 0) {
+    throw new Error(`[${storyboardId}] phase '${phase.id}': branch_set.semantics must be a non-empty string`);
+  }
+  // Only `any_of` is defined in AdCP today (adcp#2646 lint rule 2 —
+  // `at_least_n` and `all_of` are reserved but not defined). Reject unknown
+  // values at parse rather than silently skipping grading at runtime, so
+  // spec-drift typos fail loud instead of degrading to raw `failed` peers.
+  if (!(BRANCH_SET_SEMANTICS as readonly string[]).includes(semantics)) {
+    throw new Error(
+      `[${storyboardId}] phase '${phase.id}': branch_set.semantics='${semantics}' is not supported (valid: ${BRANCH_SET_SEMANTICS.join(', ')})`
+    );
+  }
+  // Schema constraint: every phase in a branch set MUST be optional. A
+  // non-optional branch-set phase would fail the storyboard on any step
+  // failure regardless of peer contribution, defeating the any_of gate.
+  if (phase.optional !== true) {
+    throw new Error(`[${storyboardId}] phase '${phase.id}': phases declaring branch_set must set 'optional: true'`);
+  }
+}
+
+/**
+ * Resolve the `contributes: true` boolean shorthand introduced alongside the
+ * first-class `branch_set:` phase field (adcp-client#693, adcp#2646).
+ *
+ * Rules:
+ *   - `contributes: true` is legal only inside a phase that declares `branch_set:`.
+ *   - A step MUST NOT set both `contributes` and `contributes_to` (ambiguous).
+ *   - A string `contributes_to` inside a branch_set phase MUST equal `branch_set.id`
+ *     (otherwise the aggregation target drifts — same invariant the spec lint enforces).
+ *
+ * After resolution, `step.contributes_to` carries the flag name and `step.contributes`
+ * is cleared, so the runner reads a single field regardless of authoring form.
+ */
+function resolveContributesShorthand(
+  storyboardId: string,
+  phase: Storyboard['phases'][number],
+  step: Storyboard['phases'][number]['steps'][number]
+): void {
+  const hasBoolean = step.contributes !== undefined;
+  const hasString = step.contributes_to !== undefined;
+
+  if (hasBoolean && hasString) {
+    throw new Error(`[${storyboardId}] step '${step.id}' declares both 'contributes' and 'contributes_to' — pick one`);
+  }
+
+  if (hasBoolean) {
+    if (step.contributes === true) {
+      if (!phase.branch_set) {
+        throw new Error(
+          `[${storyboardId}] step '${step.id}': 'contributes: true' is only legal inside a phase that declares branch_set`
+        );
+      }
+      step.contributes_to = phase.branch_set.id;
+    }
+    delete step.contributes;
+    return;
+  }
+
+  if (hasString && phase.branch_set && step.contributes_to !== phase.branch_set.id) {
+    throw new Error(
+      `[${storyboardId}] step '${step.id}': contributes_to='${step.contributes_to}' must equal enclosing phase's branch_set.id='${phase.branch_set.id}'`
+    );
+  }
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -31,10 +31,12 @@ import {
   generateRandomInvalidJwt,
 } from './probes';
 import { validateTestKit } from './test-kit';
+import { validateStoryboardShape } from './loader';
 import { probeRequestSigningVector } from './request-signing/probe-dispatch';
 import { createWebhookReceiver, type WebhookReceiver } from './webhook-receiver';
 import { WEBHOOK_ASSERTION_TASKS, armWebhookAssertions, executeWebhookAssertionStep } from './webhook-assertions';
 import type {
+  BranchSetSpec,
   HttpProbeResult,
   RunnerDetailedSkipReason,
   RunnerExtractionRecord,
@@ -69,6 +71,7 @@ const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
   missing_test_controller:
     'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
   unsatisfied_contract: 'Skipped: test-kit contract is out of scope for this grading run.',
+  peer_branch_taken: 'Skipped: a peer branch in the same any_of branch set already contributed the aggregation flag.',
 };
 
 const OAUTH_NOT_ADVERTISED_DETAIL =
@@ -85,6 +88,120 @@ const DETAILED_SKIP_DETAILS: Partial<Record<RunnerDetailedSkipReason, string>> =
 
 function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
   return { reason, detail: detail ?? SKIP_DETAILS[reason] };
+}
+
+/**
+ * Resolve each phase's branch-set membership, combining explicit
+ * `branch_set: { id, semantics }` declarations with the implicit detection
+ * fallback the schema + adcp#2646 mandate: an `optional: true` phase with a
+ * step declaring `contributes_to: <flag>` that matches a later
+ * `assert_contribution check: any_of, allowed_values: [<flag>]` target is a
+ * branch-set member even when the author hasn't migrated to the explicit
+ * keyword. Explicit declarations take precedence. Returned map is keyed by
+ * phase id; phases outside any branch set are absent from the map.
+ *
+ * First-match wins: if an optional phase has steps contributing to more
+ * than one any_of flag, the earliest matching step (by storyboard
+ * declaration order) decides the phase's branch-set membership. Authors
+ * wanting a phase in multiple branch sets should declare `branch_set:`
+ * explicitly — the implicit path does not synthesize multi-set membership.
+ */
+function resolveBranchSets(storyboard: Storyboard): Map<string, BranchSetSpec> {
+  const resolved = new Map<string, BranchSetSpec>();
+  for (const phase of storyboard.phases) {
+    if (phase.branch_set) resolved.set(phase.id, phase.branch_set);
+  }
+  const anyOfFlags = new Set<string>();
+  for (const phase of storyboard.phases) {
+    for (const step of phase.steps) {
+      if (step.task !== 'assert_contribution') continue;
+      for (const v of step.validations ?? []) {
+        if (v.check !== 'any_of') continue;
+        for (const flag of v.allowed_values ?? []) {
+          if (typeof flag === 'string') anyOfFlags.add(flag);
+        }
+      }
+    }
+  }
+  for (const phase of storyboard.phases) {
+    if (resolved.has(phase.id)) continue;
+    if (!phase.optional) continue;
+    for (const step of phase.steps) {
+      if (!step.contributes_to) continue;
+      if (!anyOfFlags.has(step.contributes_to)) continue;
+      resolved.set(phase.id, { id: step.contributes_to, semantics: 'any_of' });
+      break;
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Re-grade non-contributing branch-set peers per the `any_of` semantics in
+ * storyboard-schema.yaml ("Per-step grading in any_of branch patterns").
+ *
+ * Runs after the main phase loop because peer contribution status isn't
+ * knowable until all peer phases have executed. For every phase in a
+ * branch set (explicit `branch_set:` declaration or implicit detection via
+ * `resolveBranchSets`) whose flag was contributed by a different phase,
+ * this phase's raw step failures are moot — the agent took the other
+ * branch. Each such failed step is rewritten to a skipped result with
+ * `skip_reason: 'peer_branch_taken'` and the detail string the
+ * runner-output-contract mandates:
+ *
+ *   "<flag> contributed by <peer_phase_id>.<peer_step_id> — <this_phase_id> is moot"
+ *
+ * The `<this_branch_id>` contract placeholder resolves to the non-chosen
+ * peer's phase id — `branch_set.id` is shared across peers and could not
+ * disambiguate. Only `any_of` semantics drives re-grading today; other
+ * (reserved) values are rejected at parse in `validateBranchSet`.
+ *
+ * `countedAsFailed` names step results the main loop added to `failedCount`
+ * as hard failures — either non-optional phases or the `presenceDetected`
+ * PRM 2xx path (adcp-client#677: "an agent that serves PRM MUST serve it
+ * correctly"). These stand: re-grading them would paper over the exact
+ * invariants the hard-failure paths exist to enforce. The post-pass only
+ * relabels swallowed optional-phase failures, which by construction are not
+ * in `countedAsFailed`.
+ */
+function applyBranchSetGrading(
+  phases: StoryboardPhase[],
+  phaseResults: StoryboardPhaseResult[],
+  branchSetByPhaseId: Map<string, BranchSetSpec>,
+  contributions: Set<string>,
+  contributionSources: Map<string, { phaseId: string; stepId: string }>,
+  countedAsFailed: Set<StoryboardStepResult>
+): { skippedDelta: number } {
+  let skippedDelta = 0;
+  for (let i = 0; i < phases.length; i++) {
+    const phaseDef = phases[i];
+    const phaseResult = phaseResults[i];
+    if (!phaseDef || !phaseResult) continue;
+    const branchSet = branchSetByPhaseId.get(phaseDef.id);
+    if (!branchSet) continue;
+    if (branchSet.semantics !== 'any_of') continue;
+    const flag = branchSet.id;
+    if (!contributions.has(flag)) continue;
+    const source = contributionSources.get(flag);
+    if (!source || source.phaseId === phaseDef.id) continue;
+    const detail = `${flag} contributed by ${source.phaseId}.${source.stepId} — ${phaseDef.id} is moot`;
+    let regraded = false;
+    for (const step of phaseResult.steps) {
+      if (step.passed || step.skipped) continue;
+      if (countedAsFailed.has(step)) continue;
+      step.passed = true;
+      step.skipped = true;
+      step.skip_reason = 'peer_branch_taken';
+      step.skip = { reason: 'peer_branch_taken', detail };
+      delete step.error;
+      skippedDelta++;
+      regraded = true;
+    }
+    if (regraded) {
+      phaseResult.passed = phaseResult.steps.every(s => s.passed || s.skipped);
+    }
+  }
+  return { skippedDelta };
 }
 
 function extractionFromTaskResult(taskResult: TaskResult | undefined): RunnerExtractionRecord {
@@ -187,6 +304,13 @@ export async function runStoryboard(
   options: StoryboardRunOptions = {}
 ): Promise<StoryboardResult> {
   validateTestKit(options.test_kit);
+  // Enforce authoring-time branch_set invariants regardless of how the
+  // storyboard reached us. YAML callers already ran these rules in
+  // parseStoryboard; programmatic callers (hand-built Storyboard objects or
+  // alternative YAML loaders) reach this point without the loader having
+  // fired, and the runtime's grading depends on the invariants holding.
+  // `validateStoryboardShape` is idempotent so the double-pass is safe.
+  validateStoryboardShape(storyboard);
   const agentUrls = Array.isArray(agentUrlOrUrls) ? agentUrlOrUrls : [agentUrlOrUrls];
   if (agentUrls.length === 0) {
     throw new Error('runStoryboard: at least one agent URL required');
@@ -254,12 +378,23 @@ async function executeStoryboardPass(
   let context: StoryboardContext = { ...options.context };
   if (options.context) forwardAliasCache(options.context, context);
   const contributions = new Set<string>();
+  // First phase/step that contributed each flag. Branch-set post-pass reads
+  // this to emit the contract-mandated peer_branch_taken detail string
+  // ("<flag> contributed by <peer_phase_id>.<peer_step_id> — …"). Only the
+  // first contributor is recorded — downstream peers observing the same flag
+  // are redundant and the contract calls out a single peer.
+  const contributionSources = new Map<string, { phaseId: string; stepId: string }>();
   const priorStepResults = new Map<string, StoryboardStepResult>();
   const priorProbes = new Map<string, HttpProbeResult>();
   const phaseResults: StoryboardPhaseResult[] = [];
   let passedCount = 0;
   let failedCount = 0;
   let skippedCount = 0;
+  // Step results whose failures the main loop added to failedCount. The
+  // branch-set post-pass decrements only for entries that were actually
+  // counted, so an optional phase that hit `presenceDetected` (a PRM 2xx
+  // inside an otherwise-optional phase) has its leak correctly reversed.
+  const countedAsFailed = new Set<StoryboardStepResult>();
 
   // Start an ephemeral webhook receiver when the run opts in. The base URL
   // is exposed via `{{runner.webhook_base}}` / `{{runner.webhook_url:<id>}}`
@@ -430,7 +565,11 @@ async function executeStoryboardPass(
       // Record contribution on success, honoring optional contributes_if predicate.
       if (!result.skipped && result.passed && step.contributes_to) {
         if (evalContributesIf(step.contributes_if, priorStepResults)) {
-          contributions.add(step.contributes_to);
+          const flag = step.contributes_to;
+          if (!contributions.has(flag)) {
+            contributionSources.set(flag, { phaseId: phase.id, stepId: step.id });
+          }
+          contributions.add(flag);
         }
       }
 
@@ -448,7 +587,10 @@ async function executeStoryboardPass(
         // detected the agent IS advertising OAuth, subsequent validation
         // failures in this phase are hard failures (adcp-client#677). An
         // agent that serves PRM MUST serve it correctly.
-        if (!phase.optional || presenceDetected) failedCount++;
+        if (!phase.optional || presenceDetected) {
+          failedCount++;
+          countedAsFailed.add(result);
+        }
         if (step.stateful) statefulFailed = true;
         // In multi-instance mode, annotate the failure with the cross-instance
         // attribution block so CI readers pattern-match it as a deployment bug.
@@ -466,6 +608,24 @@ async function executeStoryboardPass(
       duration_ms: Date.now() - phaseStart,
     });
   }
+
+  // Branch-set post-pass: phases in a branch set (explicit `branch_set:`
+  // declaration or implicit detection via shared `contributes_to` + a later
+  // any_of `assert_contribution`) whose flag was contributed by a peer have
+  // their failed steps re-graded as skipped with `peer_branch_taken`. See
+  // storyboard-schema.yaml (lines 205-223) and runner-output-contract.yaml
+  // (reasons.peer_branch_taken). Done after all phases run — peer
+  // contribution status isn't knowable inside the per-phase loop.
+  const branchSetsByPhaseId = resolveBranchSets(storyboard);
+  const branchSetDelta = applyBranchSetGrading(
+    storyboard.phases,
+    phaseResults,
+    branchSetsByPhaseId,
+    contributions,
+    contributionSources,
+    countedAsFailed
+  );
+  skippedCount += branchSetDelta.skippedDelta;
 
   // Overall pass requires (a) no required-phase failures AND (b) at least one
   // required phase actually passed with at least one non-skipped step.

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -63,6 +63,27 @@ export interface StoryboardPhase {
    * Other expressions are rejected (unknown → fail closed: phase runs).
    */
   skip_if?: string;
+  /**
+   * First-class branch-set declaration (see adcp#2633 / adcp#2646). When
+   * present, contributing steps inside this phase MAY use the boolean
+   * shorthand `contributes: true` in lieu of repeating `contributes_to: <id>`.
+   * The loader resolves the shorthand to `branch_set.id` at parse time, so
+   * downstream runner code continues to read `step.contributes_to`.
+   */
+  branch_set?: BranchSetSpec;
+}
+
+export interface BranchSetSpec {
+  /** Aggregation flag shared by every contributing step in this phase. */
+  id: string;
+  /**
+   * Grading semantics for the branch set. `any_of` (the only value defined
+   * today) means: at most one peer branch is expected to contribute; failures
+   * in non-contributing peers grade as `peer_branch_taken` rather than
+   * `failed`. Kept as a string so future semantics (`all_of`, `one_of`) do
+   * not require a type change.
+   */
+  semantics: string;
 }
 
 export interface ContextOutput {
@@ -158,6 +179,16 @@ export interface StoryboardStep {
   auth?: StepAuthDirective;
   /** Contribute a flag to the run-level accumulator on success. Used with `any_of` validations downstream. */
   contributes_to?: string;
+  /**
+   * Boolean shorthand for `contributes_to: <enclosing phase's branch_set.id>`.
+   * Only legal inside a phase that declares `branch_set:`. The loader
+   * resolves `contributes: true` to the phase's `branch_set.id` and clears
+   * this field, so runner code reads `contributes_to` exclusively.
+   * `contributes: false` (or absent) marks a non-contributing step.
+   * Declaring both `contributes` and `contributes_to` on the same step is a
+   * parse-time authoring error.
+   */
+  contributes?: boolean;
   /**
    * Conditional contribution expression. Current grammar:
    *   - `"prior_step.<step_id>.passed"` — contribution fires only if the named step passed.
@@ -587,7 +618,15 @@ export type RunnerSkipReason =
   | 'prerequisite_failed'
   | 'missing_tool'
   | 'missing_test_controller'
-  | 'unsatisfied_contract';
+  | 'unsatisfied_contract'
+  /**
+   * A peer optional phase in the same `branch_set` already contributed the
+   * aggregation flag, so this non-chosen branch's failing steps are moot
+   * (see storyboard-schema.yaml > "Per-step grading in any_of branch
+   * patterns" and runner-output-contract.yaml). Kept distinct from
+   * `not_applicable` (coverage gap) and raw `failed` (agent misbehavior).
+   */
+  | 'peer_branch_taken';
 
 /**
  * Grader-specific skip reasons. These are narrower than the six canonical

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -197,6 +197,10 @@ export interface TestStepResult {
   created_id?: string;
   // Deprecation or other warnings
   warnings?: string[];
+  /** True when the step was skipped (including re-graded branch-set peers). */
+  skipped?: boolean;
+  /** Canonical skip reason when `skipped` is true; maps to `RunnerSkipReason`. */
+  skip_reason?: string;
 }
 
 export interface AgentProfile {

--- a/test/lib/storyboard-branch-set-grading.test.js
+++ b/test/lib/storyboard-branch-set-grading.test.js
@@ -121,7 +121,6 @@ describe('branch_set any_of: peer_branch_taken grading', () => {
 
       const acceptStep = result.phases[0].steps[0];
       const rejectStep = result.phases[1].steps[0];
-      const gateStep = result.phases[2].steps[0];
 
       assert.strictEqual(acceptStep.passed, true, 'accept branch contributes');
       assert.notStrictEqual(acceptStep.skipped, true);

--- a/test/lib/storyboard-branch-set-grading.test.js
+++ b/test/lib/storyboard-branch-set-grading.test.js
@@ -1,0 +1,573 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+const { parseStoryboard } = require('../../dist/lib/testing/storyboard/loader');
+
+/**
+ * Build a minimal http stub that answers every request with the given status
+ * and JSON body. Used as the "agent" target so the runner has a deterministic
+ * transport response to assert against.
+ */
+async function startStub(status, body) {
+  const server = http.createServer((_, res) => {
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(JSON.stringify(body));
+  });
+  await new Promise(r => server.listen(0, r));
+  const url = `http://127.0.0.1:${server.address().port}/mcp`;
+  return { server, url };
+}
+
+/**
+ * Build a branch-set storyboard with two optional peer phases and a final
+ * required assert_contribution phase. `acceptExpectedStatus` / `rejectExpectedStatus`
+ * drive which phase's validation will pass against a 500 stub, so the test
+ * can choose which branch contributes.
+ */
+function branchSetStoryboard({ acceptExpectedStatus, rejectExpectedStatus }) {
+  return {
+    id: 'bs_sb',
+    version: '1.0.0',
+    title: 'Branch set grading',
+    category: 'test',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'past_start_accept',
+        title: 'Accept branch',
+        optional: true,
+        branch_set: { id: 'past_start_handled', semantics: 'any_of' },
+        steps: [
+          {
+            id: 'accept_step',
+            title: 'accept',
+            task: 'list_creatives',
+            auth: 'none',
+            expect_error: true,
+            contributes_to: 'past_start_handled',
+            validations: [
+              {
+                check: 'http_status',
+                value: acceptExpectedStatus,
+                description: 'accept branch expects this status',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'past_start_reject',
+        title: 'Reject branch',
+        optional: true,
+        branch_set: { id: 'past_start_handled', semantics: 'any_of' },
+        steps: [
+          {
+            id: 'reject_step',
+            title: 'reject',
+            task: 'list_creatives',
+            auth: 'none',
+            expect_error: true,
+            contributes_to: 'past_start_handled',
+            validations: [
+              {
+                check: 'http_status',
+                value: rejectExpectedStatus,
+                description: 'reject branch expects this status',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'gate',
+        title: 'gate',
+        steps: [
+          {
+            id: 'assert',
+            title: 'assert',
+            task: 'assert_contribution',
+            validations: [{ check: 'any_of', allowed_values: ['past_start_handled'], description: '' }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const runOpts = {
+  protocol: 'mcp',
+  allow_http: true,
+  agentTools: ['list_creatives'],
+  _profile: { name: 'T', tools: ['list_creatives'] },
+  _client: { getAgentInfo: async () => ({ name: 'T', tools: [{ name: 'list_creatives' }] }) },
+};
+
+describe('branch_set any_of: peer_branch_taken grading', () => {
+  it('re-grades non-contributing peer failures as skipped with the schema-mandated detail string', async () => {
+    const { server, url } = await startStub(500, {});
+    try {
+      // Accept branch expects 500 → passes, contributes the flag.
+      // Reject branch expects 200 → fails; should re-grade as peer_branch_taken.
+      const storyboard = branchSetStoryboard({
+        acceptExpectedStatus: 500,
+        rejectExpectedStatus: 200,
+      });
+      const result = await runStoryboard(url, storyboard, runOpts);
+
+      const acceptStep = result.phases[0].steps[0];
+      const rejectStep = result.phases[1].steps[0];
+      const gateStep = result.phases[2].steps[0];
+
+      assert.strictEqual(acceptStep.passed, true, 'accept branch contributes');
+      assert.notStrictEqual(acceptStep.skipped, true);
+
+      assert.strictEqual(rejectStep.skipped, true, 'reject branch re-graded to skipped');
+      assert.strictEqual(rejectStep.skip_reason, 'peer_branch_taken');
+      assert.strictEqual(rejectStep.skip.reason, 'peer_branch_taken');
+      assert.strictEqual(
+        rejectStep.skip.detail,
+        'past_start_handled contributed by past_start_accept.accept_step — past_start_reject is moot',
+        'detail must match the runner-output contract exactly'
+      );
+      assert.strictEqual(rejectStep.error, undefined, 'residual error string cleared on re-grade');
+
+      assert.strictEqual(result.phases[1].passed, true, 'peer phase with all steps skipped grades passed');
+      assert.strictEqual(result.phases[2].passed, true, 'gate passes via accumulated flag');
+      assert.strictEqual(result.overall_passed, true);
+      assert.strictEqual(result.failed_count, 0);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('leaves failures as failed when NO peer contributes (assert_contribution must be the single failure signal)', async () => {
+    const { server, url } = await startStub(500, {});
+    try {
+      // Both branches expect 200 → both fail → nothing contributes → gate fails.
+      const storyboard = branchSetStoryboard({
+        acceptExpectedStatus: 200,
+        rejectExpectedStatus: 200,
+      });
+      const result = await runStoryboard(url, storyboard, runOpts);
+
+      const acceptStep = result.phases[0].steps[0];
+      const rejectStep = result.phases[1].steps[0];
+      const gateStep = result.phases[2].steps[0];
+
+      assert.strictEqual(acceptStep.passed, false, 'accept branch failed');
+      assert.notStrictEqual(acceptStep.skipped, true, 'not re-graded — no peer took the flag');
+      assert.strictEqual(rejectStep.passed, false, 'reject branch failed');
+      assert.notStrictEqual(rejectStep.skipped, true, 'not re-graded — no peer took the flag');
+
+      assert.strictEqual(gateStep.passed, false, 'assert_contribution fails when no branch contributed');
+      assert.strictEqual(result.overall_passed, false);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('wires through the parseStoryboard shorthand — `contributes: true` resolves and grades the same way', async () => {
+    const { server, url } = await startStub(500, {});
+    try {
+      const yaml = `
+id: bs_yaml
+version: "1.0"
+title: Branch set via shorthand
+category: test
+summary: ""
+narrative: ""
+agent:
+  interaction_model: "*"
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: accept
+    title: Accept
+    optional: true
+    branch_set:
+      id: handled
+      semantics: any_of
+    steps:
+      - id: a
+        title: a
+        task: list_creatives
+        auth: none
+        expect_error: true
+        contributes: true
+        validations:
+          - { check: http_status, value: 500, description: "" }
+  - id: reject
+    title: Reject
+    optional: true
+    branch_set:
+      id: handled
+      semantics: any_of
+    steps:
+      - id: r
+        title: r
+        task: list_creatives
+        auth: none
+        expect_error: true
+        contributes: true
+        validations:
+          - { check: http_status, value: 200, description: "" }
+  - id: gate
+    title: gate
+    steps:
+      - id: g
+        title: g
+        task: assert_contribution
+        validations:
+          - { check: any_of, allowed_values: [handled], description: "" }
+`;
+      const storyboard = parseStoryboard(yaml);
+      // Sanity: shorthand was resolved at parse time.
+      assert.strictEqual(storyboard.phases[0].steps[0].contributes_to, 'handled');
+      assert.strictEqual(storyboard.phases[1].steps[0].contributes_to, 'handled');
+
+      const result = await runStoryboard(url, storyboard, runOpts);
+      assert.strictEqual(result.phases[1].steps[0].skip_reason, 'peer_branch_taken');
+      assert.strictEqual(result.phases[1].steps[0].skip.detail, 'handled contributed by accept.a — reject is moot');
+      assert.strictEqual(result.overall_passed, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('implicit detection: storyboard without branch_set declarations still re-grades peers', async () => {
+    // Pre-adcp#2646 shape — no `branch_set:` keyword on the phases; runner
+    // must infer branch-set membership from the shared `contributes_to`
+    // flag + a later any_of assert_contribution. Guarantees existing
+    // storyboards in the compliance cache keep working unchanged.
+    const { server, url } = await startStub(500, {});
+    try {
+      const storyboard = {
+        id: 'implicit_sb',
+        version: '1.0.0',
+        title: 'Implicit branch set',
+        category: 'test',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'impl_accept',
+            title: 'accept',
+            optional: true,
+            steps: [
+              {
+                id: 'acc_step',
+                title: 'acc',
+                task: 'list_creatives',
+                auth: 'none',
+                expect_error: true,
+                contributes_to: 'impl_handled',
+                validations: [{ check: 'http_status', value: 500, description: '' }],
+              },
+            ],
+          },
+          {
+            id: 'impl_reject',
+            title: 'reject',
+            optional: true,
+            steps: [
+              {
+                id: 'rej_step',
+                title: 'rej',
+                task: 'list_creatives',
+                auth: 'none',
+                expect_error: true,
+                contributes_to: 'impl_handled',
+                validations: [{ check: 'http_status', value: 200, description: '' }],
+              },
+            ],
+          },
+          {
+            id: 'gate',
+            title: 'gate',
+            steps: [
+              {
+                id: 'g',
+                title: 'g',
+                task: 'assert_contribution',
+                validations: [{ check: 'any_of', allowed_values: ['impl_handled'], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(url, storyboard, runOpts);
+      const rejectStep = result.phases[1].steps[0];
+      assert.strictEqual(rejectStep.skip_reason, 'peer_branch_taken');
+      assert.strictEqual(
+        rejectStep.skip.detail,
+        'impl_handled contributed by impl_accept.acc_step — impl_reject is moot'
+      );
+      assert.strictEqual(result.overall_passed, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('three-peer branch set: one contributes, two fail — both moot peers cite the same contributor', async () => {
+    const { server, url } = await startStub(500, {});
+    try {
+      const phase = (id, stepId, expectedStatus) => ({
+        id,
+        title: id,
+        optional: true,
+        branch_set: { id: 'tri_flag', semantics: 'any_of' },
+        steps: [
+          {
+            id: stepId,
+            title: stepId,
+            task: 'list_creatives',
+            auth: 'none',
+            expect_error: true,
+            contributes_to: 'tri_flag',
+            validations: [{ check: 'http_status', value: expectedStatus, description: '' }],
+          },
+        ],
+      });
+      const storyboard = {
+        id: 'tri_sb',
+        version: '1.0.0',
+        title: 'three peers',
+        category: 'test',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          phase('winner', 'w', 500),
+          phase('loser_a', 'la', 200),
+          phase('loser_b', 'lb', 201),
+          {
+            id: 'gate',
+            title: 'gate',
+            steps: [
+              {
+                id: 'g',
+                title: 'g',
+                task: 'assert_contribution',
+                validations: [{ check: 'any_of', allowed_values: ['tri_flag'], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(url, storyboard, runOpts);
+      const expectedDetail = 'tri_flag contributed by winner.w — ';
+      assert.strictEqual(result.phases[1].steps[0].skip_reason, 'peer_branch_taken');
+      assert.strictEqual(result.phases[1].steps[0].skip.detail, expectedDetail + 'loser_a is moot');
+      assert.strictEqual(result.phases[2].steps[0].skip_reason, 'peer_branch_taken');
+      assert.strictEqual(result.phases[2].steps[0].skip.detail, expectedDetail + 'loser_b is moot');
+      assert.strictEqual(result.overall_passed, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('multiple branch sets in one storyboard do not bleed flags across each other', async () => {
+    const { server, url } = await startStub(500, {});
+    try {
+      // Branch set A: accept_a passes (contributes flag_a), reject_a fails.
+      // Branch set B: accept_b fails, reject_b passes (contributes flag_b).
+      // Each failing peer must cite ITS OWN branch-set contributor — never
+      // the other set's.
+      const mkPeer = (id, stepId, flag, expectedStatus) => ({
+        id,
+        title: id,
+        optional: true,
+        branch_set: { id: flag, semantics: 'any_of' },
+        steps: [
+          {
+            id: stepId,
+            title: stepId,
+            task: 'list_creatives',
+            auth: 'none',
+            expect_error: true,
+            contributes_to: flag,
+            validations: [{ check: 'http_status', value: expectedStatus, description: '' }],
+          },
+        ],
+      });
+      const storyboard = {
+        id: 'multi_bs_sb',
+        version: '1.0.0',
+        title: 'multi branch sets',
+        category: 'test',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          mkPeer('accept_a', 'a_step', 'flag_a', 500),
+          mkPeer('reject_a', 'ra_step', 'flag_a', 200),
+          mkPeer('accept_b', 'b_step', 'flag_b', 200),
+          mkPeer('reject_b', 'rb_step', 'flag_b', 500),
+          {
+            id: 'gate',
+            title: 'gate',
+            steps: [
+              {
+                id: 'gate_a',
+                title: 'gate_a',
+                task: 'assert_contribution',
+                validations: [{ check: 'any_of', allowed_values: ['flag_a'], description: '' }],
+              },
+              {
+                id: 'gate_b',
+                title: 'gate_b',
+                task: 'assert_contribution',
+                validations: [{ check: 'any_of', allowed_values: ['flag_b'], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(url, storyboard, runOpts);
+      assert.strictEqual(
+        result.phases[1].steps[0].skip.detail,
+        'flag_a contributed by accept_a.a_step — reject_a is moot'
+      );
+      assert.strictEqual(
+        result.phases[2].steps[0].skip.detail,
+        'flag_b contributed by reject_b.rb_step — accept_b is moot'
+      );
+      assert.strictEqual(result.overall_passed, true);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('runStoryboard rejects programmatic storyboards that violate branch_set invariants', async () => {
+    // Security-review concern: a caller bypassing parseStoryboard must not
+    // reach the grading path with spec-drift inputs. The runtime validator
+    // mirrors the loader's rules.
+    const { server, url } = await startStub(500, {});
+    try {
+      const bad = {
+        id: 'bad_sb',
+        version: '1.0.0',
+        title: 'bad',
+        category: 'test',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'p',
+            title: 'P',
+            optional: true,
+            branch_set: { id: 'flag', semantics: 'all_of' }, // unsupported
+            steps: [],
+          },
+        ],
+      };
+      await assert.rejects(() => runStoryboard(url, bad, runOpts), /semantics='all_of' is not supported/);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('contributes_if that evaluates false suppresses contribution and leaves peer failures raw', async () => {
+    // Accept branch's step passes locally but `contributes_if` points at a
+    // prior step that failed → contribution is NOT recorded. Reject branch
+    // fails. Since no peer contributed the flag, the reject failure must
+    // stay raw (not re-graded peer_branch_taken) and the gate must fail —
+    // that's the "no_branch_taken" path implementors need to see.
+    const { server, url } = await startStub(500, {});
+    try {
+      const storyboard = {
+        id: 'cond_sb',
+        version: '1.0.0',
+        title: 'contributes_if false',
+        category: 'test',
+        summary: '',
+        narrative: '',
+        agent: { interaction_model: '*', capabilities: [] },
+        caller: { role: 'buyer_agent' },
+        phases: [
+          {
+            id: 'setup',
+            title: 'setup',
+            optional: true,
+            steps: [
+              {
+                id: 'doomed_precursor',
+                title: 'doomed precursor',
+                task: 'list_creatives',
+                auth: 'none',
+                validations: [{ check: 'http_status', value: 200, description: 'stub is 500' }],
+              },
+            ],
+          },
+          {
+            id: 'accept',
+            title: 'accept',
+            optional: true,
+            branch_set: { id: 'cond_flag', semantics: 'any_of' },
+            steps: [
+              {
+                id: 'acc',
+                title: 'acc',
+                task: 'list_creatives',
+                auth: 'none',
+                expect_error: true,
+                contributes_to: 'cond_flag',
+                contributes_if: 'prior_step.doomed_precursor.passed',
+                validations: [{ check: 'http_status', value: 500, description: '' }],
+              },
+            ],
+          },
+          {
+            id: 'reject',
+            title: 'reject',
+            optional: true,
+            branch_set: { id: 'cond_flag', semantics: 'any_of' },
+            steps: [
+              {
+                id: 'rej',
+                title: 'rej',
+                task: 'list_creatives',
+                auth: 'none',
+                expect_error: true,
+                contributes_to: 'cond_flag',
+                validations: [{ check: 'http_status', value: 200, description: '' }],
+              },
+            ],
+          },
+          {
+            id: 'gate',
+            title: 'gate',
+            steps: [
+              {
+                id: 'g',
+                title: 'g',
+                task: 'assert_contribution',
+                validations: [{ check: 'any_of', allowed_values: ['cond_flag'], description: '' }],
+              },
+            ],
+          },
+        ],
+      };
+      const result = await runStoryboard(url, storyboard, runOpts);
+      const rejectStep = result.phases[2].steps[0];
+      assert.strictEqual(rejectStep.passed, false, 'reject branch stays failed — no peer contributed');
+      assert.notStrictEqual(rejectStep.skipped, true);
+      assert.strictEqual(result.phases[3].steps[0].passed, false, 'gate fails');
+      assert.strictEqual(result.overall_passed, false);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/lib/storyboard-contributes-shorthand.test.js
+++ b/test/lib/storyboard-contributes-shorthand.test.js
@@ -1,0 +1,186 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { parseStoryboard } = require('../../dist/lib/testing/storyboard/loader');
+
+function yaml(strings, ...values) {
+  let out = '';
+  strings.forEach((s, i) => {
+    out += s;
+    if (i < values.length) out += String(values[i]);
+  });
+  return out;
+}
+
+function minimalStoryboard(phases) {
+  return [
+    'id: test_storyboard',
+    'version: "1.0"',
+    'title: Test',
+    'category: test',
+    'summary: s',
+    'narrative: n',
+    'agent:',
+    '  interaction_model: async',
+    '  capabilities: []',
+    'caller:',
+    '  role: buyer',
+    'phases:',
+    phases,
+  ].join('\n');
+}
+
+describe('storyboard loader: branch_set + contributes shorthand', () => {
+  it("resolves `contributes: true` to the enclosing phase's branch_set.id", () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: past_start_reject_path
+    title: Reject path
+    optional: true
+    branch_set:
+      id: past_start_handled
+      semantics: any_of
+    steps:
+      - id: create_buy_past_start_reject
+        title: Reject
+        task: create_media_buy
+        contributes: true`
+    );
+    const parsed = parseStoryboard(yamlContent);
+    const step = parsed.phases[0].steps[0];
+    assert.strictEqual(step.contributes_to, 'past_start_handled');
+    assert.strictEqual(step.contributes, undefined);
+  });
+
+  it('treats `contributes: false` as non-contributing and clears the field', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      id: f
+      semantics: any_of
+    steps:
+      - id: s
+        title: S
+        task: create_media_buy
+        contributes: false`
+    );
+    const parsed = parseStoryboard(yamlContent);
+    const step = parsed.phases[0].steps[0];
+    assert.strictEqual(step.contributes_to, undefined);
+    assert.strictEqual(step.contributes, undefined);
+  });
+
+  it('preserves the string form `contributes_to:` unchanged', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      id: f
+      semantics: any_of
+    steps:
+      - id: s
+        title: S
+        task: create_media_buy
+        contributes_to: f`
+    );
+    const parsed = parseStoryboard(yamlContent);
+    assert.strictEqual(parsed.phases[0].steps[0].contributes_to, 'f');
+  });
+
+  it('rejects a step that declares both `contributes` and `contributes_to`', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      id: f
+      semantics: any_of
+    steps:
+      - id: s
+        title: S
+        task: create_media_buy
+        contributes: true
+        contributes_to: f`
+    );
+    assert.throws(() => parseStoryboard(yamlContent), /both 'contributes' and 'contributes_to'/);
+  });
+
+  it('rejects `contributes: true` outside a branch_set phase', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    steps:
+      - id: s
+        title: S
+        task: create_media_buy
+        contributes: true`
+    );
+    assert.throws(() => parseStoryboard(yamlContent), /only legal inside a phase that declares branch_set/);
+  });
+
+  it('rejects `contributes_to:` inside a branch_set phase that disagrees with branch_set.id', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      id: f
+      semantics: any_of
+    steps:
+      - id: s
+        title: S
+        task: create_media_buy
+        contributes_to: other_flag`
+    );
+    assert.throws(() => parseStoryboard(yamlContent), /must equal enclosing phase's branch_set\.id/);
+  });
+
+  it('rejects a branch_set phase that is not optional', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    branch_set:
+      id: f
+      semantics: any_of
+    steps: []`
+    );
+    assert.throws(() => parseStoryboard(yamlContent), /must set 'optional: true'/);
+  });
+
+  it('rejects unknown branch_set.semantics values (adcp#2646 lint rule 2)', () => {
+    const yamlContent = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      id: f
+      semantics: all_of
+    steps: []`
+    );
+    assert.throws(() => parseStoryboard(yamlContent), /semantics='all_of' is not supported/);
+  });
+
+  it('rejects a branch_set missing id or semantics', () => {
+    const missingId = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      semantics: any_of
+    steps: []`
+    );
+    assert.throws(() => parseStoryboard(missingId), /branch_set\.id/);
+
+    const missingSemantics = minimalStoryboard(
+      yaml`  - id: p
+    title: P
+    optional: true
+    branch_set:
+      id: f
+    steps: []`
+    );
+    assert.throws(() => parseStoryboard(missingSemantics), /branch_set\.semantics/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes [#693](https://github.com/adcontextprotocol/adcp-client/issues/693). Implements adcp#2633 / adcp#2646 in the `@adcp/client` storyboard runner.

- **Parser**: accepts first-class `branch_set: { id, semantics }` on phases and the `contributes: true` boolean shorthand on contributing steps.
- **Runner**: re-grades non-chosen branch peers as `skipped` with a new canonical `peer_branch_taken` skip reason and the contract-mandated detail string `<flag> contributed by <peer_phase_id>.<peer_step_id> — <this_phase_id> is moot`.
- **Implicit-detection fallback**: branch-set membership resolves from explicit `branch_set:` declarations AND from shared `contributes_to` + a later any_of `assert_contribution` target. Pre-adcp#2633 storyboards in `compliance/cache/latest/universal/security.yaml` and `schema-validation.yaml` keep working unchanged.
- **Hard failures are exempt from re-grading** — non-optional phases and `presenceDetected` PRM 2xx paths (adcp-client#677 spoofing-catch) keep their `failed` grade even when a peer contributed.

## Authoring rules (enforced at parse *and* at runtime)

The invariants run from both `parseStoryboard` and `runStoryboard`, so programmatic callers that hand-build a `Storyboard` object can't bypass the checks:

- Branch-set phases MUST set `optional: true` (non-optional would unconditionally fail the storyboard and defeat the any_of gate).
- `branch_set.semantics` MUST be `any_of` (future `all_of` / `at_least_n` reserved — unknown values fail loud rather than silently skipping grading).
- A step MUST NOT declare both `contributes: true` and `contributes_to` (ambiguous).
- `contributes_to:` inside a branch-set phase MUST equal `branch_set.id` (the typo-drift vector adcp#2646 exists to close).
- `contributes: true` is only legal inside a branch-set phase.

## What's new in the runtime output

- New canonical skip reason `peer_branch_taken` on `RunnerSkipReason`; distinct from `not_applicable` (coverage gap) and raw `failed` (agent misbehavior) so dashboards can tell "agent took the other branch" apart.
- `TestStepResult` gains `skipped?: boolean` and `skip_reason?: string`.
- `comply.ts` observation generators (slow-response, `check_governance` completeness) now guard on `!step.skipped` — the previous `!step.warnings?.length` proxy was wrong (three production paths set `warnings` on passing non-skipped steps, so the guard silently dropped legitimate observations).

## Expert review

Ran through `code-reviewer`, `javascript-protocol-expert`, and `nodejs-testing-expert` (twice each for the post-fix pass), plus `security-reviewer`. All Must-Fix / Should-Fix findings addressed in-tree:

1. `comply.ts` warnings-proxy bug → proper `skipped` field + guard.
2. Unknown `branch_set.semantics` silently skipping grading → parse-time rejection with named whitelist.
3. Missing implicit-detection fallback the adcp#2646 PR body mandates → `resolveBranchSets` synthesizes implicit associations.
4. PRM × branch-set `failedCount` leak → `countedAsFailed: Set<StoryboardStepResult>` tracks actual counter contributions; hard failures exempt from re-grading.
5. Programmatic bypass of branch-set validation → `validateStoryboardShape` is exported from `loader.ts` and called by `runStoryboard` too.

## Test plan

- [x] 17 new unit + E2E tests (parser rules, grading across 2/3/multiple branch sets, implicit detection, `contributes_if` × branch-set interaction, programmatic-bypass rejection, detail-string format per runner-output contract).
- [x] Full storyboard suite: 1982/1982 pass, 0 fail (pre-existing 1 timeout + 4 skips unrelated).
- [x] Non-storyboard suite: 100/100 pass.
- [x] `npm run typecheck` clean.
- [x] `npm run format:check` clean.
- [x] Security-baseline PRM spoofing-catch tests (adcp-client#677) still pass — hard-failure exemption preserves the invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)