### PR TITLE
feat(conformance): Stage 4 — creative seeding + oracle depth

### DIFF
--- a/.changeset/conformance-stage-4.md
+++ b/.changeset/conformance-stage-4.md
@@ -1,0 +1,37 @@
+---
+'@adcp/client': minor
+---
+
+Conformance fuzzer Stage 4 — creative seeding, configurable brand,
+broader stack-trace detection, additionalProperties probing, and stricter
+context-echo enforcement.
+
+**Coverage (A)**
+
+- **`sync_creatives` auto-seeder**: preflights `list_creative_formats`,
+  picks the first format whose required assets are all of a simple type
+  (image, video, audio, text, url, html, javascript, css, markdown),
+  synthesizes placeholder values, and captures `creative_id`s from the
+  response. Now runs as part of `seedFixtures` / `autoSeed`.
+- **`seedBrand` option** + **`--seed-brand <domain>`** CLI flag: overrides
+  the mutating-seeder brand reference. Defaults to
+  `{ domain: 'conformance.example' }`, which sellers with brand
+  allowlists reject. Configurable per run.
+
+**Oracle (D)**
+
+- **JVM + .NET stack-trace signatures**: `at com.foo.Bar.method(Bar.java:42)`
+  and `at Foo.Bar() in X.cs:line 42` shapes detected alongside the
+  existing V8/Python/Go/PHP patterns.
+- **additionalProperties injection**: when a schema permits extra keys
+  (`additionalProperties: true`), the generator sometimes injects one
+  (~15% frequency, single extra key from a fixed vocabulary). Exercises
+  the unknown-field tolerance surface — a common crash source where
+  agents deserialize into strict structs and reject unexpected keys.
+- **Stricter context-echo**: when a response schema declares a
+  top-level `context` property, dropping it entirely is now an invariant
+  violation. Silent tolerance preserved for tools whose response schema
+  omits the field.
+
+New public exports: extended `SeederName` with `'sync_creatives'`,
+`SeedOptions.brand`, `RunConformanceOptions.seedBrand`.

--- a/bin/adcp-fuzz.js
+++ b/bin/adcp-fuzz.js
@@ -28,10 +28,14 @@ Options:
                               IDs with commas are not expressible on the CLI —
                               drop to the runConformance() API if you need them.
   --auto-seed                 Before fuzzing, create a property list, a
-                              content-standards config, and a media buy on
-                              the agent; feed the returned IDs into fuzzing
-                              so Tier-3 update_* tools exercise real state.
+                              content-standards config, a media buy, and a
+                              creative on the agent; feed the returned IDs
+                              into fuzzing so Tier-3 update_* tools and
+                              creative-library tools exercise real state.
                               MUTATES the agent — point at a sandbox tenant.
+  --seed-brand <domain>       Brand domain used by mutating seeders.
+                              Defaults to conformance.example; override when
+                              the agent enforces a brand allowlist.
   --max-failures <int>        Cap failures collected (default: 20)
   --max-payload-bytes <int>   Cap serialized failure input/response size (default: 8192)
   --format <human|json>       Output format (default: human)
@@ -158,6 +162,15 @@ async function handleFuzzCommand(argv) {
       case '--auto-seed':
         options.autoSeed = true;
         break;
+      case '--seed-brand': {
+        const domain = requireValue(i, '--seed-brand');
+        if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/.test(domain)) {
+          argError(`--seed-brand must be a valid domain (got ${JSON.stringify(domain)})`);
+        }
+        options.seedBrand = { domain };
+        i++;
+        break;
+      }
       case '--max-failures': {
         const raw = requireValue(i, '--max-failures');
         const v = Number.parseInt(raw, 10);

--- a/docs/guides/CONFORMANCE.md
+++ b/docs/guides/CONFORMANCE.md
@@ -17,8 +17,10 @@ classifies every response under a two-path oracle:
 - **Rejected** — agent returned a well-formed AdCP error envelope with a
   spec-enum reason code. *This is a pass, not a failure* — unknown IDs
   *should* return `REFERENCE_NOT_FOUND`, not 500.
-- **Invalid** — schema mismatch, stack trace in body, credential leak,
-  missing reason code, lowercase reason code, context not echoed.
+- **Invalid** — schema mismatch, stack trace in body (V8 / Node,
+  Python, Go, JVM, PHP, .NET), credential leak, missing reason code,
+  lowercase reason code, context not echoed when the response schema
+  declares a `context` property.
 
 ## Quickstart
 
@@ -60,13 +62,34 @@ Passing `autoSeed: true` (or `--auto-seed` on the CLI) tells
 await runConformance(url, { autoSeed: true, ... });
 ```
 
-The seeder calls `create_property_list`, `create_content_standards`, and
-(via a `get_products` preflight) `create_media_buy` against the agent,
+The seeder calls `create_property_list`, `create_content_standards`,
+(via a `get_products` preflight) `create_media_buy`, and (via a
+`list_creative_formats` preflight) `sync_creatives` against the agent,
 captures the returned IDs, and merges them into `options.fixtures`
 before the fuzz loop starts. Tier-3 update tools (`update_media_buy`,
 `update_property_list`, `update_content_standards`) are added to the
 default tool list automatically — they're no-ops against random IDs, so
 they only run when real IDs are available.
+
+For the creative seeder, the helper picks the first format whose
+required assets are all of a "simple" type (image, video, audio, text,
+url, html, javascript, css, markdown) and synthesizes placeholder
+values. Formats requiring VAST/DAAST/custom assets are skipped with a
+warning; supply `--fixture creative_ids=...` explicitly if you need
+creative coverage on an exotic-format-only agent.
+
+### Brand allowlists
+
+Mutating seeders (`create_media_buy`, `sync_creatives`) need a brand
+reference. Default is `{ domain: 'conformance.example' }`. Sellers that
+enforce brand allowlists will reject this and the pipeline falls through
+to a warning. Override with:
+
+```ts
+runConformance(url, { autoSeed: true, seedBrand: { domain: 'my-sandbox.example' } });
+```
+
+Or on the CLI: `--seed-brand my-sandbox.example`.
 
 The seeder is best-effort: a rejection from any seeder becomes a
 `report.seedWarnings` entry and the pool stays empty for that key. The
@@ -86,12 +109,11 @@ because the pool changed), the report prints a `pin: --fixture ...`
 line with the IDs captured at failure time so you can replay against
 the exact pool.
 
-**Brand-allowlist gotcha**: the `create_media_buy` seeder uses
+**Brand-allowlist gotcha**: mutating seeders use
 `brand.domain: 'conformance.example'` as a placeholder. Sellers that
 enforce brand allowlists will reject this; the pipeline degrades to a
-warning and `media_buy_ids` stays empty. Supply your own media-buy IDs
-via `--fixture media_buy_ids=...` if you need Tier-3 coverage on such
-an agent.
+warning and the affected pool stays empty. Override with `--seed-brand`
+or supply your own IDs via `--fixture media_buy_ids=...` etc.
 
 ## What's fuzzed
 

--- a/src/lib/conformance/oracle.ts
+++ b/src/lib/conformance/oracle.ts
@@ -39,10 +39,12 @@ const STACK_TRACE_REGEXES: readonly RegExp[] = [
   /\.go:\d+ \+0x[0-9a-f]+/,
   // PHP: `#7 /var/www/foo.php(42): Bar->baz()` — numbered frame with file:line
   /#\d+ [^\s]+\.php\(\d+\):/,
-  // JVM: `at com.foo.Bar.method(Bar.java:42)` — fully-qualified method with
-  // source:line. Package names can include nested dots and $ for inner
-  // classes; file is usually .java/.kt/.scala.
-  /at [\w$.]+\.[\w$]+\([\w$]+\.(?:java|kt|kts|scala|groovy):\d+\)/,
+  // JVM: `\n\tat com.foo.Bar.method(Bar.java:42)` — fully-qualified
+  // method with source:line. Anchored to whitespace/newline so an
+  // echoed Javadoc reference in prose (`"at com.foo.Bar(Bar.java:42)"`)
+  // doesn't trigger the detector — real stack frames sit on their own
+  // indented line.
+  /(?:\\n\s*|^\s+|\n\s+)at [\w$.]+\.[\w$]+\([\w$]+\.(?:java|kt|kts|scala|groovy):\d+\)/,
   // .NET: `at Foo.Bar.Baz() in /path/to/X.cs:line 42` — method invocation
   // followed by ` in ` and a file:line marker. The method-name charset
   // includes parens/brackets for generic and overloaded signatures.

--- a/src/lib/conformance/oracle.ts
+++ b/src/lib/conformance/oracle.ts
@@ -39,6 +39,14 @@ const STACK_TRACE_REGEXES: readonly RegExp[] = [
   /\.go:\d+ \+0x[0-9a-f]+/,
   // PHP: `#7 /var/www/foo.php(42): Bar->baz()` — numbered frame with file:line
   /#\d+ [^\s]+\.php\(\d+\):/,
+  // JVM: `at com.foo.Bar.method(Bar.java:42)` — fully-qualified method with
+  // source:line. Package names can include nested dots and $ for inner
+  // classes; file is usually .java/.kt/.scala.
+  /at [\w$.]+\.[\w$]+\([\w$]+\.(?:java|kt|kts|scala|groovy):\d+\)/,
+  // .NET: `at Foo.Bar.Baz() in /path/to/X.cs:line 42` — method invocation
+  // followed by ` in ` and a file:line marker. The method-name charset
+  // includes parens/brackets for generic and overloaded signatures.
+  /at [\w.<>`,()[\]]+ in [^:\s]+\.(?:cs|vb|fs):line \d+/,
 ];
 
 const FS_PATH_SIGNATURES = [/\/Users\/[^ "']+/, /\/home\/[^ "']+/, /[A-Z]:\\\\Users\\\\/];
@@ -60,6 +68,27 @@ function responseValidator(tool: ConformanceToolName): ReturnType<Ajv['compile']
   const validator = getAjv().compile(schema);
   compiledValidators.set(tool, validator);
   return validator;
+}
+
+/**
+ * Does the response schema declare a top-level `context` property —
+ * either directly or on one of its `oneOf` branches? When it does, a
+ * request-context that's not echoed is an invariant violation; when it
+ * doesn't, a missing context field is silent tolerance.
+ */
+const responseSchemaHasContext = new Map<ConformanceToolName, boolean>();
+function responseEchoesContext(tool: ConformanceToolName): boolean {
+  const cached = responseSchemaHasContext.get(tool);
+  if (cached !== undefined) return cached;
+  const schema = loadResponseSchema(tool) as {
+    properties?: Record<string, unknown>;
+    oneOf?: Array<{ properties?: Record<string, unknown> }>;
+  };
+  const direct = !!schema.properties && 'context' in schema.properties;
+  const branched = Array.isArray(schema.oneOf) && schema.oneOf.some(b => !!b.properties && 'context' in b.properties);
+  const answer = direct || branched;
+  responseSchemaHasContext.set(tool, answer);
+  return answer;
 }
 
 /**
@@ -92,7 +121,7 @@ export function evaluate(input: OracleInput): OracleOutput {
   checkNoAuthLeak(result, authToken, invariantFailures);
   checkNoStackLeak(result, invariantFailures);
   checkNoFilesystemLeak(result, invariantFailures);
-  checkContextEchoed(request, result, invariantFailures);
+  checkContextEchoed(tool, request, result, invariantFailures);
 
   if (result.success === false) {
     checkErrorEnvelope(result, invariantFailures);
@@ -173,13 +202,23 @@ function checkNoFilesystemLeak(result: TaskResult<unknown>, failures: string[]):
   }
 }
 
-function checkContextEchoed(request: unknown, result: TaskResult<unknown>, failures: string[]): void {
+function checkContextEchoed(
+  tool: ConformanceToolName,
+  request: unknown,
+  result: TaskResult<unknown>,
+  failures: string[]
+): void {
   const reqContext = (request as { context?: unknown } | undefined)?.context;
   if (reqContext === undefined) return;
   const respContext = (result.data as { context?: unknown } | undefined)?.context;
   if (respContext === undefined) {
-    // Spec says context is echoed unchanged; absent on response is a soft
-    // failure because some tools omit the field from the response schema.
+    // When the response schema declares a `context` property, a missing
+    // echo IS a violation — the spec requires unchanged pass-through.
+    // When the schema omits `context` (some discovery-only responses do),
+    // silent tolerance stands.
+    if (responseEchoesContext(tool)) {
+      failures.push('request.context not echoed on response (schema declares context but response omitted it)');
+    }
     return;
   }
   if (!deepEqual(reqContext, respContext)) {

--- a/src/lib/conformance/runConformance.ts
+++ b/src/lib/conformance/runConformance.ts
@@ -53,6 +53,7 @@ export async function runConformance(
       protocol: options.protocol,
       authToken: options.authToken,
       agentConfig: options.agentConfig,
+      brand: options.seedBrand,
     });
     seededFixtures = seedResult.fixtures;
     seedWarnings = seedResult.warnings;

--- a/src/lib/conformance/schemaArbitrary.ts
+++ b/src/lib/conformance/schemaArbitrary.ts
@@ -160,9 +160,51 @@ function objectArb(schema: JsonSchema, opts: ArbitraryOptions): fc.Arbitrary<Rec
           return fc.record(propertySpec, { requiredKeys });
         });
 
-  if (dependencies.length === 0) return base;
-  return base.map(value => enforceDependencies(value, dependencies));
+  let withDeps = base;
+  if (dependencies.length > 0) withDeps = base.map(value => enforceDependencies(value, dependencies));
+
+  // Unknown-property probe: when the schema allows additional properties,
+  // sometimes inject one. Exercises the "unknown-field tolerance"
+  // surface — a common crash source where agents deserialize into a
+  // strict struct and reject keys they weren't expecting. Kept at ~15%
+  // frequency and capped at one extra key so overall sample validity
+  // stays high; the oracle's two-path design absorbs the rest.
+  if (shape.additionalProperties !== true) return withDeps;
+  return withDeps.chain(value => injectExtraProperty(value, declared));
 }
+
+/**
+ * Probabilistically adds a single unknown key to `value`. The key name
+ * is drawn from a fixed vocabulary that deliberately avoids collisions
+ * with well-known AdCP property names, and the value is a minimal
+ * primitive. Most samples pass through unchanged.
+ */
+function injectExtraProperty(
+  value: Record<string, unknown>,
+  declared: Set<string>
+): fc.Arbitrary<Record<string, unknown>> {
+  const candidates = EXTRA_PROPERTY_NAMES.filter(k => !(k in value) && !declared.has(k));
+  if (candidates.length === 0) return fc.constant(value);
+  // 85% pass-through, 15% injection. `fc.nat({max: 19})` gives a 0-19
+  // roll; values 0-2 (~15%) trigger injection.
+  return fc.nat({ max: 19 }).chain(roll => {
+    if (roll > 2) return fc.constant(value);
+    return fc.tuple(fc.constantFrom(...candidates), EXTRA_VALUE_ARB).map(([key, v]) => ({ ...value, [key]: v }));
+  });
+}
+
+const EXTRA_PROPERTY_NAMES: readonly string[] = [
+  'x_conformance_probe',
+  '_debug_trace',
+  'probe_key',
+  'unknown_field',
+  'test_vendor_ext',
+];
+const EXTRA_VALUE_ARB: fc.Arbitrary<unknown> = fc.oneof(
+  fc.string({ minLength: 1, maxLength: 16 }),
+  fc.integer({ min: 0, max: 999 }),
+  fc.boolean()
+);
 
 function readDependencies(schema: JsonSchema, declared: Set<string>): Array<[string, string[]]> {
   const raw = schema.dependencies;

--- a/src/lib/conformance/seeder.ts
+++ b/src/lib/conformance/seeder.ts
@@ -369,6 +369,10 @@ function pickSimpleFormat(formats: FormatDef[]): FormatDef | null {
   for (const f of formats) {
     if (!f?.format_id?.agent_url || !f.format_id.id) continue;
     const required = (f.assets ?? []).filter(a => a?.required === true && a.item_type === 'individual');
+    // Skip formats with zero required assets — sellers typically reject a
+    // creative with an empty assets dict, so picking one would just
+    // trade "no format available" for "creative rejected" downstream.
+    if (required.length === 0) continue;
     if (required.every(a => ASSET_PLACEHOLDER[a.asset_type as keyof typeof ASSET_PLACEHOLDER])) return f;
   }
   return null;

--- a/src/lib/conformance/seeder.ts
+++ b/src/lib/conformance/seeder.ts
@@ -13,12 +13,20 @@ export interface SeedOptions {
   /**
    * Subset of seeders to run. Default: all.
    * `'create_media_buy'` implicitly runs `get_products` first to discover
-   * a real product_id.
+   * a real product_id. `'sync_creatives'` implicitly runs
+   * `list_creative_formats` first to pick a usable format.
    */
   seeders?: readonly SeederName[];
+  /**
+   * Brand reference for mutating seeders that require one. Default
+   * `{ domain: 'conformance.example' }`. Sellers that enforce brand
+   * allowlists should override this with a domain they're configured to
+   * accept — otherwise `create_media_buy` seeding warns and falls through.
+   */
+  brand?: { domain: string; brand_id?: string };
 }
 
-export type SeederName = 'create_property_list' | 'create_content_standards' | 'create_media_buy';
+export type SeederName = 'create_property_list' | 'create_content_standards' | 'create_media_buy' | 'sync_creatives';
 
 export interface SeedResult {
   fixtures: ConformanceFixtures;
@@ -52,7 +60,13 @@ const UNIQUE_TAG = (): string => 'cf_seed_' + Math.random().toString(36).slice(2
 export async function seedFixtures(agentUrl: string, options: SeedOptions = {}): Promise<SeedResult> {
   const agent = buildAgent(agentUrl, options);
   const seeders =
-    options.seeders ?? (['create_property_list', 'create_content_standards', 'create_media_buy'] as const);
+    options.seeders ??
+    (['create_property_list', 'create_content_standards', 'create_media_buy', 'sync_creatives'] as const);
+
+  const ctx: SeederContext = {
+    agent,
+    brand: options.brand ?? { domain: 'conformance.example' },
+  };
 
   const fixtures: ConformanceFixtures = {};
   const warnings: SeedWarning[] = [];
@@ -64,7 +78,7 @@ export async function seedFixtures(agentUrl: string, options: SeedOptions = {}):
         warnings.push({ seeder: name, reason: `no seeder registered for ${name}` });
         continue;
       }
-      const out = await runner(agent);
+      const out = await runner(ctx);
       mergePool(fixtures, out.ids);
       warnings.push(...out.warnings);
     } catch (err) {
@@ -73,6 +87,11 @@ export async function seedFixtures(agentUrl: string, options: SeedOptions = {}):
   }
 
   return { fixtures, warnings };
+}
+
+interface SeederContext {
+  agent: AgentClient;
+  brand: { domain: string; brand_id?: string };
 }
 
 function buildAgent(agentUrl: string, options: SeedOptions): AgentClient {
@@ -112,15 +131,16 @@ interface SeederOutput {
   ids: Partial<Record<keyof ConformanceFixtures, string[]>>;
   warnings: SeedWarning[];
 }
-type Seeder = (agent: AgentClient) => Promise<SeederOutput>;
+type Seeder = (ctx: SeederContext) => Promise<SeederOutput>;
 
 const SEEDERS: Record<SeederName, Seeder> = {
   create_property_list: seedPropertyList,
   create_content_standards: seedContentStandards,
   create_media_buy: seedMediaBuy,
+  sync_creatives: seedSyncCreatives,
 };
 
-async function seedPropertyList(agent: AgentClient): Promise<SeederOutput> {
+async function seedPropertyList({ agent }: SeederContext): Promise<SeederOutput> {
   const result = await agent.executeTask('create_property_list', {
     idempotency_key: generateIdempotencyKey(),
     name: `Conformance Seeder List ${UNIQUE_TAG()}`,
@@ -141,7 +161,7 @@ async function seedPropertyList(agent: AgentClient): Promise<SeederOutput> {
   return { ids: { list_ids: [listId] }, warnings: [] };
 }
 
-async function seedContentStandards(agent: AgentClient): Promise<SeederOutput> {
+async function seedContentStandards({ agent }: SeederContext): Promise<SeederOutput> {
   // Minimal payload that still satisfies the "at least one of policy,
   // policies, or registry_policy_ids is required" invariant some sellers
   // enforce beyond the raw schema. A single inline policy is the most
@@ -179,7 +199,7 @@ async function seedContentStandards(agent: AgentClient): Promise<SeederOutput> {
  * then calling `create_media_buy` against that product. Captures the
  * returned `media_buy_id` and any `package_id`s from the response.
  */
-async function seedMediaBuy(agent: AgentClient): Promise<SeederOutput> {
+async function seedMediaBuy({ agent, brand }: SeederContext): Promise<SeederOutput> {
   const warnings: SeedWarning[] = [];
   const products = await agent.executeTask('get_products', {
     brief: 'Conformance fuzzer seed — any product acceptable',
@@ -213,10 +233,12 @@ async function seedMediaBuy(agent: AgentClient): Promise<SeederOutput> {
   const start = new Date(now.getTime() + 24 * 60 * 60 * 1000); // +1 day
   const end = new Date(now.getTime() + 8 * 24 * 60 * 60 * 1000); // +8 days
 
+  const brandRef: Record<string, string> = { domain: brand.domain };
+  if (brand.brand_id) brandRef.brand_id = brand.brand_id;
   const result = await agent.executeTask('create_media_buy', {
     idempotency_key: generateIdempotencyKey(),
-    account: { brand: { domain: 'conformance.example' }, operator: 'conformance.example' },
-    brand: { domain: 'conformance.example' },
+    account: { brand: brandRef, operator: brand.domain },
+    brand: brandRef,
     start_time: start.toISOString(),
     end_time: end.toISOString(),
     total_budget: { amount: 100, currency: 'USD' },
@@ -266,4 +288,130 @@ function summarizeResult(result: {
     return `agent rejected with ${code}${result.error ?? 'unknown error'}`;
   }
   return `unexpected status ${result.status ?? 'unknown'}`;
+}
+
+/**
+ * Creates a single creative by first discovering formats via
+ * `list_creative_formats`, picking the first format whose required
+ * assets are all covered by our placeholder synthesis, then calling
+ * `sync_creatives` with a minimal manifest. Captures returned
+ * `creative_id`s into the pool.
+ */
+async function seedSyncCreatives({ agent, brand }: SeederContext): Promise<SeederOutput> {
+  const warnings: SeedWarning[] = [];
+  const formatsResult = await agent.executeTask('list_creative_formats', {});
+  if (!formatsResult.success || formatsResult.status !== 'completed' || !formatsResult.data) {
+    return {
+      ids: {},
+      warnings: [
+        { seeder: 'sync_creatives', reason: 'list_creative_formats preflight: ' + summarizeResult(formatsResult) },
+      ],
+    };
+  }
+  const formats = (formatsResult.data as { formats?: unknown }).formats;
+  if (!Array.isArray(formats) || formats.length === 0) {
+    return { ids: {}, warnings: [{ seeder: 'sync_creatives', reason: 'list_creative_formats returned no formats' }] };
+  }
+
+  const picked = pickSimpleFormat(formats as FormatDef[]);
+  if (!picked) {
+    return {
+      ids: {},
+      warnings: [{ seeder: 'sync_creatives', reason: 'no format with a synthesizable required-asset set' }],
+    };
+  }
+
+  const manifest = synthesizeManifestAssets(picked);
+  const creativeId = `cf_creative_${UNIQUE_TAG()}`;
+  const tag = UNIQUE_TAG();
+
+  const result = await agent.executeTask('sync_creatives', {
+    idempotency_key: generateIdempotencyKey(),
+    account: {
+      brand: { domain: brand.domain, ...(brand.brand_id ? { brand_id: brand.brand_id } : {}) },
+      operator: brand.domain,
+    },
+    creatives: [
+      {
+        creative_id: creativeId,
+        name: `Conformance Seeder Creative ${tag}`,
+        format_id: { agent_url: picked.format_id.agent_url, id: picked.format_id.id },
+        assets: manifest,
+      },
+    ],
+  });
+
+  if (!result.success || result.status !== 'completed' || !result.data) {
+    return { ids: {}, warnings: [...warnings, { seeder: 'sync_creatives', reason: summarizeResult(result) }] };
+  }
+
+  const capturedIds = extractCreativeIds(result.data, creativeId);
+  if (capturedIds.length === 0) {
+    warnings.push({
+      seeder: 'sync_creatives',
+      reason: 'response did not surface a creative_id (may be pending review)',
+    });
+    return { ids: {}, warnings };
+  }
+  return { ids: { creative_ids: capturedIds }, warnings };
+}
+
+/**
+ * Pick the first format whose required assets are all in the set of
+ * types we know how to synthesize placeholder values for. Sorted by the
+ * format's declared order — no clever heuristics.
+ */
+interface FormatDef {
+  format_id: { agent_url: string; id: string };
+  assets?: Array<{ asset_id: string; asset_type?: string; required?: boolean; item_type?: string }>;
+}
+function pickSimpleFormat(formats: FormatDef[]): FormatDef | null {
+  for (const f of formats) {
+    if (!f?.format_id?.agent_url || !f.format_id.id) continue;
+    const required = (f.assets ?? []).filter(a => a?.required === true && a.item_type === 'individual');
+    if (required.every(a => ASSET_PLACEHOLDER[a.asset_type as keyof typeof ASSET_PLACEHOLDER])) return f;
+  }
+  return null;
+}
+
+function synthesizeManifestAssets(format: FormatDef): Record<string, unknown> {
+  const manifest: Record<string, unknown> = {};
+  for (const asset of format.assets ?? []) {
+    if (asset?.required !== true || asset.item_type !== 'individual') continue;
+    const placeholder = ASSET_PLACEHOLDER[asset.asset_type as keyof typeof ASSET_PLACEHOLDER];
+    if (placeholder) manifest[asset.asset_id] = placeholder();
+  }
+  return manifest;
+}
+
+// Placeholder value per asset type. Kept intentionally small: the
+// seeder's job is to produce a creative the agent will accept, not to
+// fuzz the asset surface. We only cover types whose `required` fields
+// we can satisfy without format-specific knowledge (dimensions, codecs,
+// etc. use safe defaults).
+const ASSET_PLACEHOLDER = {
+  image: () => ({ url: 'https://conformance.example/placeholder.png', width: 300, height: 250 }),
+  video: () => ({ url: 'https://conformance.example/placeholder.mp4', width: 640, height: 360 }),
+  audio: () => ({ url: 'https://conformance.example/placeholder.mp3' }),
+  text: () => ({ content: 'Conformance seed text' }),
+  url: () => ({ url: 'https://conformance.example/' }),
+  html: () => ({ content: '<div>Conformance seed</div>' }),
+  javascript: () => ({ content: '/* conformance seed */' }),
+  css: () => ({ content: '/* conformance seed */' }),
+  markdown: () => ({ content: 'Conformance seed' }),
+} as const;
+
+function extractCreativeIds(data: unknown, fallbackId: string): string[] {
+  const d = data as { creatives?: unknown; synced_creatives?: unknown };
+  const items: unknown[] = [];
+  if (Array.isArray(d.creatives)) items.push(...d.creatives);
+  if (Array.isArray(d.synced_creatives)) items.push(...d.synced_creatives);
+  const ids: string[] = [];
+  for (const it of items) {
+    const id = (it as { creative_id?: unknown })?.creative_id;
+    if (typeof id === 'string' && id.length > 0) ids.push(id);
+  }
+  // Fall back to the id we supplied — spec allows sellers to echo back
+  // buyer-supplied creative_ids on success.
+  return ids.length > 0 ? ids : [fallbackId];
 }

--- a/src/lib/conformance/types.ts
+++ b/src/lib/conformance/types.ts
@@ -139,6 +139,14 @@ export interface RunConformanceOptions {
    * @default false
    */
   autoSeed?: boolean;
+  /**
+   * Brand reference used by mutating seeders (currently `create_media_buy`
+   * and `sync_creatives`). Sellers that enforce brand allowlists should
+   * set this to a domain they're configured to accept. When omitted,
+   * seeders fall back to `{ domain: 'conformance.example' }`, which will
+   * warn-and-skip on allowlist-enforcing sellers.
+   */
+  seedBrand?: { domain: string; brand_id?: string };
 }
 
 /**

--- a/test/lib/conformance-arbitrary.test.js
+++ b/test/lib/conformance-arbitrary.test.js
@@ -39,14 +39,18 @@ describe('conformance: schemaToArbitrary', () => {
 
   for (const tool of STATELESS_TIER_TOOLS) {
     if (!RELIABLE.has(tool)) continue;
-    test(`${tool}: ≥90% of generated samples are schema-valid`, () => {
+    // Threshold was 0.9 pre-Stage-4. The additionalProperties injector
+    // trades ~10-15pp validity for unknown-field-tolerance coverage on
+    // tools whose schemas allow extras — a deliberate shift. 0.80 is
+    // still a meaningful regression floor.
+    test(`${tool}: ≥80% of generated samples are schema-valid`, () => {
       const schema = loadRequestSchema(tool);
       const validate = makeAjv().compile(schema);
       const arb = schemaToArbitrary(schema);
       const samples = fc.sample(arb, { numRuns: 100, seed: 42 });
       const invalid = samples.filter(s => !validate(s));
       const validity = (samples.length - invalid.length) / samples.length;
-      assert.ok(validity >= 0.9, `${tool}: validity ${validity.toFixed(2)} below 0.9`);
+      assert.ok(validity >= 0.8, `${tool}: validity ${validity.toFixed(2)} below 0.8`);
     });
   }
 
@@ -188,6 +192,46 @@ describe('conformance: schemaToArbitrary', () => {
     );
     for (const v of fc.sample(arb, { numRuns: 30, seed: 13 })) {
       assert.ok(v.task_id.length >= 5 && v.task_id.length <= 10, `${v.task_id} violates length constraint`);
+    }
+  });
+
+  test('additionalProperties: true → occasionally injects unknown key', () => {
+    // 15% injection rate over 200 runs should produce enough extra
+    // properties to detect reliably. The key name space is small and
+    // known.
+    const schema = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+      additionalProperties: true,
+    };
+    const samples = fc.sample(schemaToArbitrary(schema), { numRuns: 200, seed: 42 });
+    const hasExtras = samples.filter(v => Object.keys(v).some(k => k !== 'a'));
+    assert.ok(hasExtras.length > 0, 'expected at least one sample with an extra key');
+    // All extra keys come from the fixed vocabulary.
+    const extraKeys = new Set();
+    for (const v of hasExtras) {
+      for (const k of Object.keys(v)) if (k !== 'a') extraKeys.add(k);
+    }
+    for (const k of extraKeys) {
+      assert.match(
+        k,
+        /^(x_conformance_probe|_debug_trace|probe_key|unknown_field|test_vendor_ext)$/,
+        `unexpected extra key: ${k}`
+      );
+    }
+  });
+
+  test('additionalProperties: false → never injects unknown key', () => {
+    const schema = {
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      required: ['a'],
+      additionalProperties: false,
+    };
+    const samples = fc.sample(schemaToArbitrary(schema), { numRuns: 100, seed: 42 });
+    for (const v of samples) {
+      assert.deepEqual(Object.keys(v), ['a'], `leaked extra key in strict schema: ${JSON.stringify(v)}`);
     }
   });
 

--- a/test/lib/conformance-arbitrary.test.js
+++ b/test/lib/conformance-arbitrary.test.js
@@ -37,20 +37,25 @@ describe('conformance: schemaToArbitrary', () => {
     'get_creative_features',
   ]);
 
+  // Threshold splits by whether the tool's request schema permits extras.
+  // Tools with `additionalProperties: true` at the root are subject to the
+  // ~15% unknown-field injector; a 0.9 floor is too tight. Tools with
+  // `additionalProperties: false` don't get injected and keep the 0.9
+  // floor — a regression in those would surface without the permissive
+  // tools masking it.
+  const STRICT_SCHEMA = new Set(['list_property_lists']);
+
   for (const tool of STATELESS_TIER_TOOLS) {
     if (!RELIABLE.has(tool)) continue;
-    // Threshold was 0.9 pre-Stage-4. The additionalProperties injector
-    // trades ~10-15pp validity for unknown-field-tolerance coverage on
-    // tools whose schemas allow extras — a deliberate shift. 0.80 is
-    // still a meaningful regression floor.
-    test(`${tool}: ≥80% of generated samples are schema-valid`, () => {
+    const floor = STRICT_SCHEMA.has(tool) ? 0.9 : 0.8;
+    test(`${tool}: ≥${(floor * 100).toFixed(0)}% of generated samples are schema-valid`, () => {
       const schema = loadRequestSchema(tool);
       const validate = makeAjv().compile(schema);
       const arb = schemaToArbitrary(schema);
       const samples = fc.sample(arb, { numRuns: 100, seed: 42 });
       const invalid = samples.filter(s => !validate(s));
       const validity = (samples.length - invalid.length) / samples.length;
-      assert.ok(validity >= 0.8, `${tool}: validity ${validity.toFixed(2)} below 0.8`);
+      assert.ok(validity >= floor, `${tool}: validity ${validity.toFixed(2)} below ${floor}`);
     });
   }
 

--- a/test/lib/conformance-cli.test.js
+++ b/test/lib/conformance-cli.test.js
@@ -216,6 +216,12 @@ describe('adcp fuzz CLI', () => {
     assert.ok(parsed.seedWarnings.length >= 1);
   });
 
+  test('--seed-brand rejects invalid domain', async () => {
+    const { code, stderr } = await runCli([`http://localhost:${port}/mcp`, '--seed-brand', 'NOT A DOMAIN']);
+    assert.equal(code, 2);
+    assert.match(stderr, /--seed-brand must be a valid domain/);
+  });
+
   test('JSON report includes reproducibility metadata', async () => {
     const { stdout } = await runCli([
       `http://localhost:${port}/mcp`,

--- a/test/lib/conformance-oracle.test.js
+++ b/test/lib/conformance-oracle.test.js
@@ -73,6 +73,36 @@ describe('conformance: oracle', () => {
     assert.ok(out.invariantFailures.some(f => f.includes('stack trace leak')));
   });
 
+  test('JVM stack trace in response body → invariant failure', () => {
+    const out = accepted('get_signals', {
+      signals: [],
+      errors: [
+        {
+          code: 'INTERNAL',
+          message:
+            'java.lang.NullPointerException\n\tat com.example.Handler.process(Handler.java:42)\n\tat com.example.App.main(App.java:10)',
+        },
+      ],
+    });
+    assert.equal(out.verdict, 'invalid');
+    assert.ok(out.invariantFailures.some(f => f.includes('stack trace leak')));
+  });
+
+  test('.NET stack trace in response body → invariant failure', () => {
+    const out = accepted('get_signals', {
+      signals: [],
+      errors: [
+        {
+          code: 'INTERNAL',
+          message:
+            'System.NullReferenceException: Object reference not set\n   at Foo.Bar.Baz() in /app/src/Foo.cs:line 42\n   at Foo.Main() in /app/Program.cs:line 10',
+        },
+      ],
+    });
+    assert.equal(out.verdict, 'invalid');
+    assert.ok(out.invariantFailures.some(f => f.includes('stack trace leak')));
+  });
+
   test('PHP stack trace in response body → invariant failure', () => {
     const out = accepted('get_signals', {
       signals: [],
@@ -160,6 +190,19 @@ describe('conformance: oracle', () => {
       result: { success: true, status: 'completed', data: { signals: [], context: ctx } },
     });
     assert.equal(out.verdict, 'accepted');
+  });
+
+  test('context missing from response → invariant failure when schema declares context', () => {
+    // get_signals response schema declares a `context` property, so
+    // dropping it entirely is a violation per spec. Earlier versions of
+    // the oracle silent-tolerated this case.
+    const out = evaluate({
+      tool: 'get_signals',
+      request: { signal_spec: 'x', context: { trace_id: 'abc' } },
+      result: { success: true, status: 'completed', data: { signals: [] } },
+    });
+    assert.equal(out.verdict, 'invalid');
+    assert.ok(out.invariantFailures.some(f => f.includes('context') && f.includes('omitted')));
   });
 
   test('context mutated on response → invariant failure', () => {

--- a/test/lib/conformance-seeder.test.js
+++ b/test/lib/conformance-seeder.test.js
@@ -63,7 +63,12 @@ describe('conformance: seedFixtures', () => {
     });
     agents.push({ server });
 
-    const result = await seedFixtures(`http://localhost:${port}/mcp`, { protocol: 'mcp' });
+    // Restrict to the three seeders this stub implements so the test
+    // isn't sensitive to future additions to the default seed set.
+    const result = await seedFixtures(`http://localhost:${port}/mcp`, {
+      protocol: 'mcp',
+      seeders: ['create_property_list', 'create_content_standards', 'create_media_buy'],
+    });
 
     assert.ok(Array.isArray(result.fixtures.list_ids) && result.fixtures.list_ids.length === 1, 'list_id captured');
     assert.ok(result.fixtures.list_ids[0].startsWith('pl_'));
@@ -100,6 +105,102 @@ describe('conformance: seedFixtures', () => {
     assert.equal(result.warnings.length, 1);
     assert.equal(result.warnings[0].seeder, 'create_property_list');
     assert.match(result.warnings[0].reason, /INVALID_REQUEST/);
+  });
+
+  test('sync_creatives seeds creative_ids via list_creative_formats preflight', async () => {
+    // Minimal format: one required text asset. Seeder should pick it up,
+    // synthesize { content: 'Conformance seed text' }, and capture the
+    // creative_id from sync_creatives's response.
+    const observed = { formatIds: [], assets: [] };
+    const { server, port } = await startAgent({
+      creative: {
+        listCreativeFormats: async () => ({
+          formats: [
+            {
+              format_id: { id: 'text_line', agent_url: 'https://test/' },
+              name: 'Text Line',
+              description: 'single text asset',
+              assets: [{ asset_id: 'headline', asset_type: 'text', required: true, item_type: 'individual' }],
+            },
+          ],
+        }),
+        syncCreatives: async params => {
+          observed.formatIds.push(params.creatives[0].format_id.id);
+          observed.assets.push(params.creatives[0].assets);
+          return {
+            creatives: [{ creative_id: 'cre_seeded_abc', buyer_ref: params.creatives[0].creative_id }],
+          };
+        },
+      },
+    });
+    agents.push({ server });
+
+    const result = await seedFixtures(`http://localhost:${port}/mcp`, {
+      protocol: 'mcp',
+      seeders: ['sync_creatives'],
+    });
+
+    assert.deepEqual(result.fixtures.creative_ids, ['cre_seeded_abc']);
+    assert.equal(observed.formatIds[0], 'text_line');
+    assert.deepEqual(observed.assets[0], { headline: { content: 'Conformance seed text' } });
+    assert.deepEqual(result.warnings, []);
+  });
+
+  test('sync_creatives warns when no format has a synthesizable required-asset set', async () => {
+    const { server, port } = await startAgent({
+      creative: {
+        listCreativeFormats: async () => ({
+          formats: [
+            {
+              format_id: { id: 'exotic', agent_url: 'https://test/' },
+              name: 'Exotic',
+              description: 'requires something unknown',
+              assets: [{ asset_id: 'mystery', asset_type: 'vast', required: true, item_type: 'individual' }],
+            },
+          ],
+        }),
+      },
+    });
+    agents.push({ server });
+
+    const result = await seedFixtures(`http://localhost:${port}/mcp`, {
+      protocol: 'mcp',
+      seeders: ['sync_creatives'],
+    });
+    assert.equal(result.fixtures.creative_ids, undefined);
+    assert.ok(result.warnings[0].reason.includes('synthesizable'));
+  });
+
+  test('brand option is threaded through create_media_buy seeder', async () => {
+    let receivedBrand;
+    const { server, port } = await startAgent({
+      mediaBuy: {
+        getProducts: async () => ({
+          products: [
+            {
+              product_id: 'prod1',
+              name: 'p',
+              description: 'x',
+              format_ids: [{ id: 'f', agent_url: 'https://t/' }],
+              pricing_options: [{ pricing_option_id: 'po', model: 'cpm', cpm: 1, currency: 'USD' }],
+              delivery_type: 'non_guaranteed',
+            },
+          ],
+        }),
+        createMediaBuy: async params => {
+          receivedBrand = params.brand;
+          return { media_buy_id: 'mb_1', packages: [{ package_id: 'pkg_1' }] };
+        },
+      },
+    });
+    agents.push({ server });
+
+    await seedFixtures(`http://localhost:${port}/mcp`, {
+      protocol: 'mcp',
+      seeders: ['create_media_buy'],
+      brand: { domain: 'custom-brand.example', brand_id: 'custom' },
+    });
+    assert.deepEqual(receivedBrand, { domain: 'custom-brand.example', brand_id: 'custom' });
   });
 
   test('create_media_buy warns when get_products returns no products', async () => {


### PR DESCRIPTION
Stage 4 of the conformance fuzzer. Follows Stage 3 (#704).

## Coverage (Option A)

- **`sync_creatives` auto-seeder**. Preflights `list_creative_formats`, picks the first format whose required assets are all of a simple type (image, video, audio, text, url, html, javascript, css, markdown), synthesizes placeholders, calls `sync_creatives`, and captures the returned `creative_id` into the pool. Formats needing VAST/DAAST/custom assets are skipped cleanly with a warning.
- **Configurable seed brand** via `SeedOptions.brand` / `RunConformanceOptions.seedBrand` / `adcp fuzz --seed-brand <domain>`. Default `conformance.example` is rejected by sellers with brand allowlists; override per run.

## Oracle (Option D)

- **JVM and .NET stack signatures** added. Coverage now V8/Node, Python, Go, PHP, JVM, .NET.
- **`additionalProperties: true` injection**. ~15% of generated objects get one unknown key from a fixed vocabulary. Exercises unknown-field tolerance — a common crash source on agents that deserialize into strict structs.
- **Stricter context-echo**. When the response schema declares a top-level `context` property, a missing echo is a violation. Silent tolerance preserved only for schemas that omit the field.

## Live-agent run

```
adcp fuzz https://test-agent.adcontextprotocol.org/mcp/ --seed 42 --turn-budget 30 --auto-seed
```

- **`list_ids=1, creative_ids=1`** auto-seeded — creative seeding is new
- Known seed warnings for `create_content_standards` (needs richer policy payload) and `create_media_buy` (test agent requires bid_price for auction pricing)
- **Same 2 failures as Stage 3** — #700's lowercase `not_found` on `get_property_list` AND `update_property_list`, still caught, pin hint shows both seeded IDs

## Test plan

- [x] 18 arbitrary tests (2 new: additionalProperties injection on/off)
- [x] 16 oracle tests (3 new: JVM stack, .NET stack, context-missing-when-schema-declares)
- [x] 10 seeder tests (3 new: sync_creatives success, sync_creatives unsynthesizable, brand threading)
- [x] 16 CLI tests (1 new: --seed-brand validation)
- [x] 72/72 conformance tests pass locally
- [x] Full suite: 4704 pass / 0 fail (6 skipped pre-existing)
- [x] Format clean, typecheck clean, schema-check clean
- [x] Live run against public test agent

## Docs

- `docs/guides/CONFORMANCE.md` — brand allowlists, creative-seeding section, updated stack-trace coverage list, strict context-echo semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)