### PR TITLE
docs(compliance): operator index + skill § Validate-locally across all 8 skills

### DIFF
--- a/.changeset/compliance-testing-index.md
+++ b/.changeset/compliance-testing-index.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+Adds `docs/guides/VALIDATE-YOUR-AGENT.md` — the operator-facing checklist covering `adcp storyboard run`, `adcp fuzz` (Tier 1/2/3), `adcp grade request-signing`, multi-instance testing, `--webhook-receiver`, schema-driven validation hooks, custom `--invariants`, and `SubstitutionEncoder`/`Observer`. Cross-linked from `BUILD-AN-AGENT.md` and the repo `CLAUDE.md`.
+
+Ships `npm run compliance:skill-matrix` (new `scripts/manual-testing/run-skill-matrix.ts` driver + `skill-matrix.json`) which fans the existing `agent-skill-storyboard.ts` harness across skill × storyboard pairs with `--filter`, `--parallel`, and `--stop-on-first-fail`.
+
+Every `skills/build-*-agent/SKILL.md` replaces its ad-hoc `## Validation` section with a uniform `## Validate Locally` block: canonical storyboard IDs, cross-cutting bundles (`security_baseline,idempotency,schema_validation,error_compliance`), `adcp fuzz` with per-specialism `--tools`, per-specialism failure decoder, and a pointer back to the operator checklist. `build-retail-media-agent/SKILL.md` gains `SubstitutionEncoder.encode_for_url_context` wiring guidance for catalog-driven macro URLs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ your context: `src/lib/types/*.generated.ts`, `src/lib/agents/index.generated.ts
 
 **Building a server-side agent?** Read `docs/guides/BUILD-AN-AGENT.md`. Storyboards live at `https://adcontextprotocol.org/compliance/{version}/` (pulled into `compliance/cache/{version}/` by `npm run sync-schemas`).
 
+**Validating a server-side agent?** Read `docs/guides/VALIDATE-YOUR-AGENT.md` — the five-command checklist plus deep references for `adcp storyboard run`, `adcp fuzz` (T1/T2/T3), `adcp grade request-signing`, multi-instance testing, webhook conformance, schema-driven validation hooks, custom `--invariants`, and the `npm run compliance:skill-matrix` dogfood harness.
+
 **Building a seller agent?** Read and follow `skills/build-seller-agent/SKILL.md` — covers guaranteed vs non-guaranteed, pricing, approval workflows, creative management.
 
 **Building a generative seller / AI ad network?** Read and follow `skills/build-generative-seller-agent/SKILL.md` — covers brief-based creative generation, standard + generative format catalogs, brand resolution.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -396,7 +396,7 @@ npx @adcp/client http://localhost:3001/mcp get_signals '{}' --json
 npx @adcp/client storyboard run http://localhost:3001/mcp
 ```
 
-This runs a standard validation suite against your agent to check AdCP compliance.
+This runs a standard validation suite against your agent to check AdCP compliance. For the full validation picture — storyboard runner, property-based fuzzing (`adcp fuzz`), multi-instance testing, webhook conformance, request-signing, schema-driven validation, and the skill→agent→grader dogfood harness — see [**VALIDATE-YOUR-AGENT.md**](./VALIDATE-YOUR-AGENT.md).
 
 ## Complete Example
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -1,0 +1,276 @@
+# Validate Your Agent
+
+Your checklist to get from "agent boots" to "agent ships." Every tool below is already in `@adcp/client`; this page tells you which one runs when, what it catches, and how to read the output.
+
+## TL;DR — five commands, roughly in order
+
+```bash
+# 1. Does it answer at all? (60s)
+npx @adcp/client http://localhost:3001/mcp get_adcp_capabilities '{}'
+
+# 2. Does it walk the golden path? (2–5 min)
+npx @adcp/client storyboard run http://localhost:3001/mcp --auth $TOKEN
+
+# 3. Does it crash on weird inputs? (1–3 min)
+npx @adcp/client fuzz http://localhost:3001/mcp --auth-token $TOKEN
+
+# 4. Does webhook/async conformance pass? (2–5 min)
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --webhook-receiver --auth $TOKEN
+
+# 5. Does it survive horizontal scaling? (same as 2, two URLs)
+npx @adcp/client storyboard run \
+  --url https://a.agent.example/mcp --url https://b.agent.example/mcp \
+  sales-guaranteed --auth $TOKEN
+```
+
+If all five pass and your skill's specialism-specific checks below pass, you're conformant. The rest of this page explains why each check exists and how to debug failures.
+
+---
+
+## What catches what
+
+| Command | What it catches | Run when |
+|---|---|---|
+| `adcp storyboard run` | Missing tools, broken happy-path flows, state leaks, validation drift, capability-vs-behavior mismatch | Every commit |
+| `adcp fuzz` | Crashes on edge-case inputs, 500s instead of typed errors, schema drift, shape bugs your storyboards don't exercise | Before PR merge |
+| `--webhook-receiver` | Unsigned webhooks, unstable `idempotency_key` across retries, missing HMAC/RFC 9421 headers | When you add webhook emission |
+| `--url --url ...` (multi-instance) | `(brand, account)`-scoped state stored per-process instead of in a shared backing store | Before production deploy |
+| `adcp grade request-signing` | RFC 9421 signature verification bugs if you claim `signed-requests` | If you claim `signed-requests` |
+| `runConformance({ autoSeed: true })` | Tier-3 update-tool bugs with real IDs (not just random-rejection paths) | Against a sandbox tenant |
+| Schema validation hooks | Field-name drift, enum drift, missing required fields — caught at dev time, not runtime | In your dev/test harness |
+
+Each row is a different failure mode. Passing storyboard and failing fuzz is common — storyboards walk happy paths, fuzz walks rejection paths.
+
+---
+
+## Command reference
+
+### `adcp storyboard run` — capability-driven assessment
+
+The main compliance entry point. Runs every storyboard that applies to your agent based on its declared `get_adcp_capabilities` output.
+
+```bash
+# Full capability-driven run — resolves bundles from your capabilities
+npx @adcp/client storyboard run http://localhost:3001/mcp --auth $TOKEN
+
+# Single bundle or storyboard by id
+npx @adcp/client storyboard run http://localhost:3001/mcp sales-guaranteed --auth $TOKEN
+
+# Specific tracks only (faster feedback when iterating)
+npx @adcp/client storyboard run http://localhost:3001/mcp --tracks core,products --auth $TOKEN
+
+# Ad-hoc YAML (new storyboards under development)
+npx @adcp/client storyboard run http://localhost:3001/mcp --file ./my-wip.yaml --auth $TOKEN
+
+# JSON report for CI / tooling
+npx @adcp/client storyboard run http://localhost:3001/mcp --json > report.json
+```
+
+**Flags you'll actually use:**
+
+- `--tracks <a,b,c>` — limit to named tracks (e.g., `core,products,security_baseline`)
+- `--storyboards <id1,id2>` — limit to specific storyboard IDs
+- `--webhook-receiver [loopback|proxy]` — host a webhook sink so async steps grade instead of skip
+- `--webhook-receiver-auto-tunnel` — autodetect `ngrok`/`cloudflared` on `PATH`, spawn and plug into proxy mode
+- `--invariants <mod1,mod2>` — load custom cross-step assertion modules
+- `--multi-instance-strategy round-robin|multi-pass` — when paired with two or more `--url`s
+- `--brief <text>` — custom product-discovery brief (default varies by storyboard)
+- `--auth <token>` — bearer token (also accepts `$ADCP_AUTH_TOKEN`)
+
+**Output:** JSON with `tracks[].status` (`passed`/`failed`/`skipped`), `steps[]` with diagnostics, and validations per step.
+
+### `adcp fuzz` — property-based schema fuzzing
+
+Generates schema-valid requests, calls your agent, checks every response under the two-path oracle (schema-valid success *or* well-formed AdCP error envelope with uppercase reason code). Anything else — 500, stack traces, lowercase error codes, token leaks — fails.
+
+```bash
+# Tier 1 + Tier 2 stateless + referential (safe, no mutation)
+npx @adcp/client fuzz http://localhost:3001/mcp --auth-token $TOKEN
+
+# Reproducible (rerun with same seed to repro a failure)
+npx @adcp/client fuzz http://localhost:3001/mcp --seed 42 --auth-token $TOKEN
+
+# Pre-seeded ID pools for referential tools (Tier 2)
+npx @adcp/client fuzz http://localhost:3001/mcp \
+  --fixture creative_ids=cre_a,cre_b \
+  --fixture media_buy_ids=mb_1
+
+# Auto-seed + Tier 3 update-tool fuzzing (mutates agent state — SANDBOX ONLY)
+npx @adcp/client fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
+
+# Inspect the tool list + tier classification
+npx @adcp/client fuzz --list-tools
+```
+
+See [`docs/guides/CONFORMANCE.md`](./CONFORMANCE.md) for the fixture map, tier-by-tier tool list, and failure interpretation.
+
+### Request signing — `adcp grade request-signing`
+
+If you claim the `signed-requests` specialism, run the RFC 9421 grader. The grader signs its own requests with test keypairs from `compliance/cache/<version>/test-kits/signed-requests-runner.yaml` — no `--auth` flag; your agent's verifier must accept the runner's JWKS ahead of time.
+
+```bash
+# All 38 vectors
+npx @adcp/client grade request-signing https://sandbox.agent.example/mcp
+
+# Skip rate-abuse (vector 020 fires cap+1 requests; skip in dev loops)
+npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --skip-rate-abuse
+
+# MCP transport (wraps vectors in JSON-RPC envelopes)
+npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --transport mcp
+
+# Isolate a single vector
+npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --only 016-replayed-nonce
+```
+
+### Multi-instance testing
+
+Exposes `(brand, account)`-scoped state that lives per-process instead of in a shared store — a class of bug that single-URL runs never catch. See [`docs/guides/MULTI-INSTANCE-TESTING.md`](./MULTI-INSTANCE-TESTING.md).
+
+```bash
+npx @adcp/client storyboard run \
+  --url https://a.agent.example/mcp \
+  --url https://b.agent.example/mcp \
+  sales-guaranteed --auth $TOKEN
+```
+
+---
+
+## Schema-driven validation (catch field drift at dev time)
+
+Wire AJV-based validation into your client or server so payload drift surfaces in tests, not production:
+
+```typescript
+// Client side — strict response validation in dev
+import { SingleAgentClient } from '@adcp/client';
+
+const client = new SingleAgentClient(url, {
+  validation: {
+    requests: 'warn',        // log shape issues before they hit the wire
+    responses: 'strict',     // throw on schema mismatch from the agent
+  },
+});
+
+// Server side — opt-in validation on incoming requests + handler responses
+import { createAdcpServer } from '@adcp/client';
+
+createAdcpServer({
+  validation: {
+    requests: 'strict',      // reject malformed requests with VALIDATION_ERROR
+    responses: 'strict',     // catch handler-returned drift (dev/test canary)
+  },
+  // ... other config
+});
+```
+
+Modes are `'strict'` (throw/reject), `'warn'` (log, continue), or `'off'` (skip, default). One AJV compile per tool on cold start; one validator invocation per call. Cheap in dev, optional in prod hot paths.
+
+Validation issues carry path + expected-vs-actual so the fix location is obvious. Cheap to enable in CI, cheap to disable in prod hot paths.
+
+---
+
+## Cross-step invariants (custom assertions)
+
+Use `--invariants` to load modules that assert properties across storyboard steps. Example invariant: "every mutating call's `idempotency_key` is echoed in the response," "no secret in `$TOKEN` ever appears in any response body," "governance denial MUST block every subsequent mutation in the same session."
+
+```bash
+# Load ./my-invariants.js (relative path) or a bare specifier (npm package)
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --invariants ./assertions/idempotency.js,@my-org/adcp-invariants
+```
+
+The invariant module calls `registerAssertion({ id, onStep, onEnd, ... })`; failures flip `overall_passed` to `false`. Assertion modules ship upstream as part of the AdCP spec; the SDK provides the registry + CLI wire-up.
+
+---
+
+## Substitution verification (catalog-driven sellers)
+
+If you ship catalog-driven products with macro-expandable tracker URLs, wire `SubstitutionEncoder` into your seller-side macro path and `SubstitutionObserver` into your test harness:
+
+```typescript
+import {
+  SubstitutionEncoder,
+  SubstitutionObserver,
+  CATALOG_MACRO_VECTORS,
+} from '@adcp/client';
+
+// Seller side — encode every substituted value:
+const encoder = new SubstitutionEncoder();
+const url = template.replace(macro, encoder.encode_for_url_context(rawValue));
+
+// Runner side — parse preview HTML, match bindings, assert RFC 3986 safety:
+const observer = new SubstitutionObserver();
+const records = observer.parse_html(previewHtml);
+const matches = observer.match_bindings(records, template, bindings);
+for (const m of matches) {
+  const result = observer.assert_rfc3986_safe(m);
+  if (!result.ok) throw new Error(result.error_code); // substitution_encoding_violation, etc.
+}
+```
+
+Unencoded substitution is a common XSS / scheme-injection vector. `CATALOG_MACRO_VECTORS` exports the seven canonical test bindings (`url-scheme-injection-neutralized`, `reserved-character-breakout`, `nested-expansion-preserved-as-literal`, etc.). For preview-URL fetches, `observer.fetch_and_parse(url)` enforces an SSRF policy — DNS revalidation, bare-IP rejection, cloud-metadata deny — before the HTTP connect.
+
+---
+
+## The dogfood test: skill → built agent → compliance
+
+`scripts/manual-testing/agent-skill-storyboard.ts` is the capstone test. It spawns a fresh Claude Code instance, hands it one of the `skills/build-*-agent/SKILL.md` files plus a target storyboard, lets Claude build an agent, then runs the compliance grader against what Claude produced. Catches skill regressions — if the skill drifts from the SDK surface, a freshly-built agent will fail conformance.
+
+```bash
+# Single skill × storyboard pair
+npm run compliance:agent-skill -- \
+  --skill skills/build-seller-agent/SKILL.md \
+  --storyboard idempotency
+
+# Full matrix (every skill × its canonical storyboards)
+npm run compliance:skill-matrix
+```
+
+Use before merging skill changes. ~60s per pair; matrix runs fan out.
+
+---
+
+## When each check fails: debug first-lookups
+
+| Failure | First lookup |
+|---|---|
+| `storyboard run` skips steps with "no webhook_receiver_runner" | Add `--webhook-receiver` |
+| `storyboard run` fails on `security_baseline` | You skipped `authenticate` in `serve()` — see [build-seller-agent/SKILL.md § signed-requests](../../skills/build-seller-agent/SKILL.md) |
+| `fuzz` reports `500` status with stack trace | Validate inputs and return `adcpError('REFERENCE_NOT_FOUND', ...)` instead |
+| `fuzz` reports `response_shape_mismatch` | Response drifted from schema — regen with `npm run sync-schemas` + check your handler |
+| Multi-instance fails with `NOT_FOUND` on read-after-write | State keyed by session ID instead of `(brand, account)` — see multi-instance guide |
+| `grade request-signing` fails every negative vector | Missing `verifyRequestSignature` middleware; see [build-seller-agent/SKILL.md § signed-requests](../../skills/build-seller-agent/SKILL.md) |
+| `--invariants` load errors | Relative path relative to cwd; bare specifier requires installed package |
+
+---
+
+## CI recipes
+
+### Per-PR smoke (fast, blocks merge)
+
+```yaml
+- name: Storyboard (core + products)
+  run: npx @adcp/client storyboard run $AGENT_URL --tracks core,products --auth $TOKEN
+- name: Fuzz (fixed seed)
+  run: npx @adcp/client fuzz $AGENT_URL --seed 42 --auth-token $TOKEN --format json
+```
+
+### Nightly (slow, broader coverage)
+
+```yaml
+- name: Fuzz (random seed, auto-seed)
+  run: npx @adcp/client fuzz $AGENT_URL --auto-seed --auth-token $TOKEN
+- name: Full storyboard assessment
+  run: npx @adcp/client storyboard run $AGENT_URL --auth $TOKEN --json > report.json
+```
+
+Random seed on nightly broadens the surface; fixed seed on per-PR keeps reproducibility.
+
+---
+
+## Deeper dives
+
+- [`CONFORMANCE.md`](./CONFORMANCE.md) — `runConformance` + `adcp fuzz` in depth
+- [`MULTI-INSTANCE-TESTING.md`](./MULTI-INSTANCE-TESTING.md) — horizontal scaling bug hunt
+- [`BUILD-AN-AGENT.md`](./BUILD-AN-AGENT.md) — server-side implementation
+- `skills/build-*-agent/SKILL.md` — per-specialism obligations and storyboard IDs

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -136,6 +136,40 @@ npx @adcp/client storyboard run \
 
 ---
 
+## Deterministic testing (force state transitions the happy path can't reach)
+
+The `deterministic_testing` universal storyboard — plus rejection-branch and delivery-reporting sub-scenarios across several specialisms — requires your agent to expose `comply_test_controller`. Without it, the grader records `controller_detected: false` and skips or fails every step that needs a forced state transition, simulated delivery, or seeded error condition.
+
+**Use `createComplyController`** — adapter-based scaffold that handles dispatch, param validation, typed error envelopes, and re-seed idempotency for you:
+
+```typescript
+import { createComplyController } from '@adcp/client/testing';
+
+const controller = createComplyController({
+  sandboxGate: input => input.auth?.sandbox === true,   // fail closed
+  seed: {
+    product:  (params) => productRepo.upsert(params.product_id, params.fixture),
+    creative: (params) => creativeRepo.upsert(params.creative_id, params.fixture),
+    media_buy: (params) => mediaBuyRepo.upsert(params.media_buy_id, params.fixture),
+  },
+  force: {
+    creative_status:  (params) => creativeRepo.transition(params.creative_id, params.status),
+    media_buy_status: (params) => mediaBuyRepo.transition(params.media_buy_id, params.status),
+  },
+  simulate: {
+    delivery: (params) => deliveryRepo.simulate(params),   // needed for delivery_reporting
+  },
+});
+
+controller.register(server);
+```
+
+Omit adapters you don't support — they auto-return `UNKNOWN_SCENARIO`. Throw `TestControllerError('INVALID_TRANSITION', msg, currentState)` when the state machine disallows a transition; the helper emits the typed envelope. Declare `compliance_testing` in `supported_protocols` when registered.
+
+For lower-level store-based access (shared enforcement with production code, session-keyed stores), use `registerTestController(server, store)` — same primitives, flatter API.
+
+---
+
 ## Schema-driven validation (catch field drift at dev time)
 
 Wire AJV-based validation into your client or server so payload drift surfaces in tests, not production:

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -595,9 +595,6 @@ Flow: `get_adcp_capabilities → sync_plans → check_governance → create_medi
 **Media buy seller agent** — Seller agent that receives briefs, returns products, accepts media buys, and reports delivery.
 Flow: `get_adcp_capabilities → sync_accounts → sync_governance → get_products → list_creative_formats → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → get_media_buy_delivery`
 
-**Creative lifecycle is decoupled from media buy lifecycle** — Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy.
-Flow: `get_products → create_media_buy → sync_creatives → list_creatives → update_media_buy → list_creatives → create_media_buy → sync_creatives`
-
 **Seller creates buy when governance approves** — Verifies that the seller creates a media buy when governance approves the transaction.
 Flow: `sync_plans → sync_accounts → sync_governance → get_products → create_media_buy`
 
@@ -643,7 +640,7 @@ Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → get
 Flow: `get_adcp_capabilities → get_products → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → expect_webhook → get_media_buy_delivery`
 
 **Catalog-driven creative and conversion tracking** — Seller that renders dynamic ads from product catalogs, tracks conversions, and optimizes delivery based on performance feedback.
-Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → sync_catalogs → build_creative → expect_substitution_safe → get_products → create_media_buy → sync_event_sources → log_event → provide_performance_feedback → get_media_buy_delivery`
+Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → sync_catalogs → get_products → create_media_buy → sync_event_sources → log_event → provide_performance_feedback → get_media_buy_delivery`
 
 **Guaranteed media buy with human IO approval** — Seller agent that requires human-in-the-loop IO signing before guaranteed media buys go live.
 Flow: `get_adcp_capabilities → sync_accounts → get_products → create_media_buy → get_media_buys → sync_creatives → get_media_buy_delivery`
@@ -684,7 +681,7 @@ Flow: `get_adcp_capabilities → si_get_offering → si_initiate_session → si_
 Flow: `get_adcp_capabilities → list_accounts → sync_audiences`
 
 **Social platform** — Social media platform that accepts audience segments, native creatives, and conversion events from buyer agents.
-Flow: `get_adcp_capabilities → sync_accounts → list_accounts → sync_audiences → sync_creatives → sync_catalogs → sync_creatives → log_event → get_account_financials`
+Flow: `get_adcp_capabilities → sync_accounts → list_accounts → sync_audiences → sync_creatives → log_event → get_account_financials`
 
 ### Core
 
@@ -722,7 +719,7 @@ Flow: `get_adcp_capabilities → create_property_list → list_property_lists �
 ### 
 
 **Generative creative agent** — Agent that takes a brief and generates finished creatives from scratch — no input assets required.
-Flow: `get_adcp_capabilities → list_creative_formats → build_creative → sync_catalogs → build_creative`
+Flow: `get_adcp_capabilities → list_creative_formats → build_creative`
 
 **Runner output contract** — Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures.
 
@@ -731,7 +728,6 @@ Flow: `get_adcp_capabilities → list_creative_formats → build_creative → sy
 **Programmatic exchange sales** — Programmatic exchange or SSP — auction-based inventory access with real-time bidding semantics and multi-seller inventory pooling.
 
 **Retail media sales** — Retail media network seller — onsite, offsite, and in-store inventory tied to commerce signals and SKU-level reporting.
-Flow: `sync_catalogs`
 
 **Streaming TV sales** — Connected TV and streaming sellers — ad-supported video inventory, audience-based buying, and frequency management across CTV apps.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -595,6 +595,9 @@ Flow: `get_adcp_capabilities → sync_plans → check_governance → create_medi
 **Media buy seller agent** — Seller agent that receives briefs, returns products, accepts media buys, and reports delivery.
 Flow: `get_adcp_capabilities → sync_accounts → sync_governance → get_products → list_creative_formats → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → get_media_buy_delivery`
 
+**Creative lifecycle is decoupled from media buy lifecycle** — Validates that canceling a media buy releases package-creative assignments but leaves the underlying creatives in the library with their review state intact, and that buyers can reuse released creatives on a new buy.
+Flow: `get_products → create_media_buy → sync_creatives → list_creatives → update_media_buy → list_creatives → create_media_buy → sync_creatives`
+
 **Seller creates buy when governance approves** — Verifies that the seller creates a media buy when governance approves the transaction.
 Flow: `sync_plans → sync_accounts → sync_governance → get_products → create_media_buy`
 
@@ -640,7 +643,7 @@ Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → get
 Flow: `get_adcp_capabilities → get_products → create_media_buy → get_media_buys → list_creative_formats → sync_creatives → expect_webhook → get_media_buy_delivery`
 
 **Catalog-driven creative and conversion tracking** — Seller that renders dynamic ads from product catalogs, tracks conversions, and optimizes delivery based on performance feedback.
-Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → sync_catalogs → get_products → create_media_buy → sync_event_sources → log_event → provide_performance_feedback → get_media_buy_delivery`
+Flow: `get_adcp_capabilities → sync_accounts → list_creative_formats → sync_catalogs → build_creative → expect_substitution_safe → get_products → create_media_buy → sync_event_sources → log_event → provide_performance_feedback → get_media_buy_delivery`
 
 **Guaranteed media buy with human IO approval** — Seller agent that requires human-in-the-loop IO signing before guaranteed media buys go live.
 Flow: `get_adcp_capabilities → sync_accounts → get_products → create_media_buy → get_media_buys → sync_creatives → get_media_buy_delivery`
@@ -681,7 +684,7 @@ Flow: `get_adcp_capabilities → si_get_offering → si_initiate_session → si_
 Flow: `get_adcp_capabilities → list_accounts → sync_audiences`
 
 **Social platform** — Social media platform that accepts audience segments, native creatives, and conversion events from buyer agents.
-Flow: `get_adcp_capabilities → sync_accounts → list_accounts → sync_audiences → sync_creatives → log_event → get_account_financials`
+Flow: `get_adcp_capabilities → sync_accounts → list_accounts → sync_audiences → sync_creatives → sync_catalogs → sync_creatives → log_event → get_account_financials`
 
 ### Core
 
@@ -719,7 +722,7 @@ Flow: `get_adcp_capabilities → create_property_list → list_property_lists �
 ### 
 
 **Generative creative agent** — Agent that takes a brief and generates finished creatives from scratch — no input assets required.
-Flow: `get_adcp_capabilities → list_creative_formats → build_creative`
+Flow: `get_adcp_capabilities → list_creative_formats → build_creative → sync_catalogs → build_creative → sync_catalogs → build_creative → expect_substitution_safe`
 
 **Runner output contract** — Required failure-detail shape that AdCP storyboard runners MUST emit so implementors can self-diagnose validation failures.
 
@@ -728,6 +731,7 @@ Flow: `get_adcp_capabilities → list_creative_formats → build_creative`
 **Programmatic exchange sales** — Programmatic exchange or SSP — auction-based inventory access with real-time bidding semantics and multi-seller inventory pooling.
 
 **Retail media sales** — Retail media network seller — onsite, offsite, and in-store inventory tied to commerce signals and SKU-level reporting.
+Flow: `sync_catalogs`
 
 **Streaming TV sales** — Connected TV and streaming sellers — ad-supported video inventory, audience-based buying, and frequency management across CTV apps.
 

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "generate-wellknown-schemas": "tsx scripts/generate-wellknown-schemas.ts",
     "generate-agent-docs": "tsx scripts/generate-agent-docs.ts",
     "compliance:agent-skill": "tsx scripts/manual-testing/agent-skill-storyboard.ts",
+    "compliance:skill-matrix": "tsx scripts/manual-testing/run-skill-matrix.ts",
     "sync-version": "tsx scripts/sync-version.ts",
     "validate-schemas": "tsx scripts/validate-schemas.ts",
     "lint": "eslint 'src/lib/testing/**/*.ts'",

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -30,7 +30,7 @@
  */
 
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { mkdtemp, readFile, writeFile, rm, stat, chmod } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile, rm, stat, chmod, symlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { connect } from 'node:net';
@@ -42,6 +42,11 @@ interface Args {
   workDir?: string;
   timeoutMs: number;
   keep: boolean;
+  /** When set, skip `npm install` and symlink `node_modules` from this path
+   * instead. Matrix driver uses this to amortize the ~15-30s per-workspace
+   * install across many pairs — the template's node_modules is valid for
+   * every harness run since the deps are fixed (@adcp/client + tsx). */
+  sharedNodeModules?: string;
 }
 
 const REPO_ROOT = resolve(__dirname, '..', '..');
@@ -56,6 +61,7 @@ function parseArgs(argv: string[]): Args {
     else if (a === '--work-dir') out.workDir = argv[++i];
     else if (a === '--timeout-ms') out.timeoutMs = Number(argv[++i]);
     else if (a === '--keep') out.keep = true;
+    else if (a === '--shared-node-modules') out.sharedNodeModules = argv[++i];
     else if (a === '--help' || a === '-h') {
       printUsage();
       process.exit(0);
@@ -76,7 +82,8 @@ function printUsage(): void {
   [--port 4200] \\
   [--work-dir <path>] \\
   [--timeout-ms 600000] \\
-  [--keep]`
+  [--keep] \\
+  [--shared-node-modules <path>]`
   );
 }
 
@@ -137,7 +144,7 @@ The harness grader sends \`Authorization: Bearer sk_harness_do_not_use_in_prod\`
 `;
 }
 
-async function bootstrapWorkspace(dir: string, port: number): Promise<void> {
+async function bootstrapWorkspace(dir: string, port: number, sharedNodeModules?: string): Promise<void> {
   const pkgPath = join(dir, 'package.json');
   const pkg = {
     name: 'adcp-agent-skill-harness-workspace',
@@ -159,6 +166,15 @@ async function bootstrapWorkspace(dir: string, port: number): Promise<void> {
     `Port: ${port}\nAgent URL after start.sh: http://127.0.0.1:${port}/mcp\n`,
     'utf8'
   );
+
+  if (sharedNodeModules) {
+    // Matrix mode: symlink to a prepared node_modules so we skip the 15-30s
+    // `npm install` per pair. The shared dir was built from the same
+    // package.json shape above, so resolution is valid.
+    log(`linking node_modules from ${sharedNodeModules}`);
+    await symlink(sharedNodeModules, join(dir, 'node_modules'), 'dir');
+    return;
+  }
 
   log(`bootstrapping deps via npm install (this takes a minute)`);
   const npm = spawnSync('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {
@@ -290,7 +306,7 @@ async function main(): Promise<void> {
 
   let agent: ChildProcess | undefined;
   try {
-    await bootstrapWorkspace(workDir, args.port);
+    await bootstrapWorkspace(workDir, args.port, args.sharedNodeModules);
     await runClaude(buildPrompt(skillContent, args.storyboard, args.port), workDir, args.timeoutMs);
 
     log(`starting agent`);

--- a/scripts/manual-testing/run-skill-matrix.ts
+++ b/scripts/manual-testing/run-skill-matrix.ts
@@ -4,22 +4,33 @@
  * declared in `skill-matrix.json`. Summary table at the end — pass/fail per
  * pair plus wall time. Exits non-zero if any pair fails.
  *
+ * Perf:
+ * - `--parallel N` fans pairs across N workers (each gets a port base).
+ *   Default is min(4, os.cpus/2) — matrix is CPU-bound on Claude spin-up +
+ *   TypeScript build + grader; >4 on a laptop deadlocks easily.
+ * - Shared `node_modules` prepared once in `.cache/harness-template/` and
+ *   symlinked into each scratch workspace, amortizing the 15–30s per-pair
+ *   `npm install` across the whole matrix.
+ * - Fast-fails up front if the `claude` CLI is missing.
+ *
  * Usage:
  *   tsx scripts/manual-testing/run-skill-matrix.ts [options]
  *
  * Options:
  *   --filter <substring>   Run only pairs whose skill path or storyboard id
  *                          matches the substring. Repeatable via comma.
- *   --parallel <N>         Run up to N pairs concurrently. Default 1
- *                          (builds are CPU-bound; >2 on a laptop is unwise).
+ *   --parallel <N>         Worker pool size. Default auto (see above).
  *   --matrix <path>        Override matrix JSON location.
  *   --keep-workspaces      Pass --keep to each harness run for post-mortem.
  *   --timeout-ms <N>       Per-pair timeout. Default 600000 (10 min).
  *   --stop-on-first-fail   Abort the whole matrix on first failure.
+ *   --no-shared-install    Force each pair to run its own `npm install`
+ *                          (useful when debugging cache-related weirdness).
  */
 
-import { spawn } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
+import { spawn, spawnSync } from 'node:child_process';
+import { readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { availableParallelism } from 'node:os';
 import { join, resolve } from 'node:path';
 
 interface Pair {
@@ -38,19 +49,29 @@ interface Args {
   keep: boolean;
   timeoutMs: number;
   stopOnFail: boolean;
+  sharedInstall: boolean;
 }
 
 const REPO_ROOT = resolve(__dirname, '..', '..');
 const HARNESS = join(REPO_ROOT, 'scripts/manual-testing/agent-skill-storyboard.ts');
+const TEMPLATE_DIR = join(REPO_ROOT, '.cache/harness-template');
+const TEMPLATE_NODE_MODULES = join(TEMPLATE_DIR, 'node_modules');
+
+function defaultParallel(): number {
+  // Claude spin-up + tsc/tsx transpile + grader share one CPU each. 4 is a
+  // safe cap on modern laptops; half of cpus handles smaller boxes sanely.
+  return Math.max(1, Math.min(4, Math.floor(availableParallelism() / 2)));
+}
 
 function parseArgs(argv: string[]): Args {
   const out: Args = {
     filter: [],
-    parallel: 1,
+    parallel: defaultParallel(),
     matrix: join(REPO_ROOT, 'scripts/manual-testing/skill-matrix.json'),
     keep: false,
     timeoutMs: 600_000,
     stopOnFail: false,
+    sharedInstall: true,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -60,6 +81,7 @@ function parseArgs(argv: string[]): Args {
     else if (a === '--keep-workspaces') out.keep = true;
     else if (a === '--timeout-ms') out.timeoutMs = Number(argv[++i]);
     else if (a === '--stop-on-first-fail') out.stopOnFail = true;
+    else if (a === '--no-shared-install') out.sharedInstall = false;
     else if (a === '-h' || a === '--help') {
       printUsage();
       process.exit(0);
@@ -70,7 +92,7 @@ function parseArgs(argv: string[]): Args {
 
 function printUsage(): void {
   console.error(
-    `Usage: run-skill-matrix [--filter <substr>] [--parallel <N>] [--matrix <path>] [--keep-workspaces] [--timeout-ms <N>] [--stop-on-first-fail]`
+    `Usage: run-skill-matrix [--filter <substr>] [--parallel <N>] [--matrix <path>] [--keep-workspaces] [--timeout-ms <N>] [--stop-on-first-fail] [--no-shared-install]`
   );
 }
 
@@ -85,6 +107,68 @@ function portFor(workerId: number): number {
   return 4200 + workerId * 100;
 }
 
+/**
+ * Fast-fail if the `claude` CLI isn't available. The harness would fail ~5s
+ * in anyway but by then Claude spawn has blocked the spinner and the error
+ * is less actionable. Doing it up-front saves every pair from hitting the
+ * same wall.
+ */
+function requireClaude(): void {
+  const res = spawnSync('claude', ['--version'], { stdio: 'ignore' });
+  if (res.error || res.status !== 0) {
+    console.error(
+      '[matrix] fatal: `claude` CLI not found on PATH. ' +
+        'Install Claude Code (https://github.com/anthropics/claude-code) and retry.'
+    );
+    process.exit(2);
+  }
+}
+
+/**
+ * Prepare a cached node_modules once per matrix run. Each scratch workspace
+ * symlinks this into place instead of doing its own `npm install`, cutting
+ * per-pair wall time by 15–30s. The template's `package.json` must match
+ * exactly what `agent-skill-storyboard.ts` writes into scratch dirs —
+ * deps are hardcoded there so drift between the two is the only failure
+ * mode. When it does drift, pass `--no-shared-install` as the escape hatch.
+ */
+async function prepareSharedNodeModules(): Promise<string> {
+  // Check if the template is already built. A node_modules directory at the
+  // expected path is sufficient — the `file:<repo>` dep re-resolves against
+  // the current repo every time, so stale builds are cheap to rebuild but
+  // don't produce wrong answers.
+  const existing = await stat(TEMPLATE_NODE_MODULES).catch(() => null);
+  if (existing?.isDirectory()) {
+    console.error(`[matrix] reusing cached node_modules at ${TEMPLATE_NODE_MODULES}`);
+    return TEMPLATE_NODE_MODULES;
+  }
+
+  console.error(`[matrix] preparing shared node_modules (one-time, ~30s)`);
+  await mkdir(TEMPLATE_DIR, { recursive: true });
+  const pkg = {
+    name: 'adcp-agent-skill-harness-template',
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+    dependencies: {
+      '@adcp/client': `file:${REPO_ROOT}`,
+      tsx: '^4.7.0',
+    },
+  };
+  await writeFile(join(TEMPLATE_DIR, 'package.json'), JSON.stringify(pkg, null, 2) + '\n', 'utf8');
+
+  const npm = spawnSync('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {
+    cwd: TEMPLATE_DIR,
+    stdio: 'inherit',
+  });
+  if (npm.status !== 0) {
+    throw new Error(
+      `[matrix] template install failed (exit ${npm.status}). Re-run with --no-shared-install to bypass.`
+    );
+  }
+  return TEMPLATE_NODE_MODULES;
+}
+
 interface RunResult {
   pair: Pair;
   passed: boolean;
@@ -93,7 +177,7 @@ interface RunResult {
   stderr: string;
 }
 
-function runOne(pair: Pair, port: number, args: Args): Promise<RunResult> {
+function runOne(pair: Pair, port: number, args: Args, sharedNodeModules?: string): Promise<RunResult> {
   return new Promise(resolvePromise => {
     const harnessArgs = [
       HARNESS,
@@ -107,6 +191,7 @@ function runOne(pair: Pair, port: number, args: Args): Promise<RunResult> {
       String(args.timeoutMs),
     ];
     if (args.keep) harnessArgs.push('--keep');
+    if (sharedNodeModules) harnessArgs.push('--shared-node-modules', sharedNodeModules);
 
     const started = Date.now();
     const stderrChunks: Buffer[] = [];
@@ -129,6 +214,8 @@ function runOne(pair: Pair, port: number, args: Args): Promise<RunResult> {
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  requireClaude();
+
   const raw = await readFile(args.matrix, 'utf8');
   const matrix = JSON.parse(raw) as Matrix;
   const pairs = selectPairs(matrix.pairs, args.filter);
@@ -138,7 +225,12 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  console.error(`[matrix] ${pairs.length} pair(s) × parallel=${args.parallel} × timeout=${args.timeoutMs}ms`);
+  const sharedNodeModules = args.sharedInstall ? await prepareSharedNodeModules() : undefined;
+
+  const matrixStart = Date.now();
+  console.error(
+    `[matrix] ${pairs.length} pair(s) × parallel=${args.parallel} × timeout=${args.timeoutMs}ms${sharedNodeModules ? ' × shared-nm=on' : ''}`
+  );
 
   const queue = pairs.map((p, i) => ({ pair: p, index: i }));
   const results: RunResult[] = [];
@@ -156,7 +248,7 @@ async function main(): Promise<void> {
       const port = portFor(workerId);
       const label = `[${i + 1}/${queue.length}] ${item.pair.skill.replace(/^skills\//, '').replace(/\/SKILL\.md$/, '')} × ${item.pair.storyboard}`;
       console.error(`\n▶ ${label} (port ${port})`);
-      const result = await runOne(item.pair, port, args);
+      const result = await runOne(item.pair, port, args, sharedNodeModules);
       results.push(result);
       const durSec = (result.durationMs / 1000).toFixed(1);
       if (result.passed) {
@@ -173,6 +265,8 @@ async function main(): Promise<void> {
 
   const passed = results.filter(r => r.passed).length;
   const failed = results.length - passed;
+  const matrixWall = Date.now() - matrixStart;
+  const totalCpu = results.reduce((a, r) => a + r.durationMs, 0);
 
   console.error('\n' + '═'.repeat(72));
   console.error('MATRIX SUMMARY');
@@ -187,7 +281,9 @@ async function main(): Promise<void> {
     console.error(`${sym} ${durSec}s  ${skill} ${r.pair.storyboard}`);
   }
   console.error('─'.repeat(72));
-  console.error(`${passed} passed, ${failed} failed (of ${results.length})`);
+  console.error(
+    `${passed} passed, ${failed} failed (of ${results.length}) — wall ${(matrixWall / 1000).toFixed(1)}s, cpu ${(totalCpu / 1000).toFixed(1)}s (speedup ${(totalCpu / Math.max(1, matrixWall)).toFixed(1)}×)`
+  );
   if (stopped && nextIdx < queue.length) {
     const remaining = queue.length - results.length;
     console.error(`(${remaining} pair(s) skipped due to --stop-on-first-fail)`);

--- a/scripts/manual-testing/run-skill-matrix.ts
+++ b/scripts/manual-testing/run-skill-matrix.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env tsx
+/**
+ * Run agent-skill-storyboard harness across every skill × storyboard pair
+ * declared in `skill-matrix.json`. Summary table at the end — pass/fail per
+ * pair plus wall time. Exits non-zero if any pair fails.
+ *
+ * Usage:
+ *   tsx scripts/manual-testing/run-skill-matrix.ts [options]
+ *
+ * Options:
+ *   --filter <substring>   Run only pairs whose skill path or storyboard id
+ *                          matches the substring. Repeatable via comma.
+ *   --parallel <N>         Run up to N pairs concurrently. Default 1
+ *                          (builds are CPU-bound; >2 on a laptop is unwise).
+ *   --matrix <path>        Override matrix JSON location.
+ *   --keep-workspaces      Pass --keep to each harness run for post-mortem.
+ *   --timeout-ms <N>       Per-pair timeout. Default 600000 (10 min).
+ *   --stop-on-first-fail   Abort the whole matrix on first failure.
+ */
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+interface Pair {
+  skill: string;
+  storyboard: string;
+}
+
+interface Matrix {
+  pairs: Pair[];
+}
+
+interface Args {
+  filter: string[];
+  parallel: number;
+  matrix: string;
+  keep: boolean;
+  timeoutMs: number;
+  stopOnFail: boolean;
+}
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const HARNESS = join(REPO_ROOT, 'scripts/manual-testing/agent-skill-storyboard.ts');
+
+function parseArgs(argv: string[]): Args {
+  const out: Args = {
+    filter: [],
+    parallel: 1,
+    matrix: join(REPO_ROOT, 'scripts/manual-testing/skill-matrix.json'),
+    keep: false,
+    timeoutMs: 600_000,
+    stopOnFail: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--filter') out.filter.push(...argv[++i].split(','));
+    else if (a === '--parallel') out.parallel = Math.max(1, Number(argv[++i]));
+    else if (a === '--matrix') out.matrix = resolve(argv[++i]);
+    else if (a === '--keep-workspaces') out.keep = true;
+    else if (a === '--timeout-ms') out.timeoutMs = Number(argv[++i]);
+    else if (a === '--stop-on-first-fail') out.stopOnFail = true;
+    else if (a === '-h' || a === '--help') {
+      printUsage();
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+function printUsage(): void {
+  console.error(
+    `Usage: run-skill-matrix [--filter <substr>] [--parallel <N>] [--matrix <path>] [--keep-workspaces] [--timeout-ms <N>] [--stop-on-first-fail]`
+  );
+}
+
+function selectPairs(all: Pair[], filters: string[]): Pair[] {
+  if (filters.length === 0) return all;
+  return all.filter(p =>
+    filters.some(f => p.skill.includes(f) || p.storyboard.includes(f))
+  );
+}
+
+// Ports are assigned from a per-worker base to avoid collisions when pairs run
+// in parallel. A fixed offset of 100 per worker slot leaves plenty of headroom.
+function portFor(workerId: number): number {
+  return 4200 + workerId * 100;
+}
+
+interface RunResult {
+  pair: Pair;
+  passed: boolean;
+  durationMs: number;
+  exitCode: number;
+  stderr: string;
+}
+
+function runOne(pair: Pair, port: number, args: Args): Promise<RunResult> {
+  return new Promise(resolvePromise => {
+    const harnessArgs = [
+      HARNESS,
+      '--skill',
+      pair.skill,
+      '--storyboard',
+      pair.storyboard,
+      '--port',
+      String(port),
+      '--timeout-ms',
+      String(args.timeoutMs),
+    ];
+    if (args.keep) harnessArgs.push('--keep');
+
+    const started = Date.now();
+    const stderrChunks: Buffer[] = [];
+    const child = spawn('tsx', harnessArgs, {
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'inherit', 'pipe'],
+    });
+    child.stderr.on('data', chunk => stderrChunks.push(chunk));
+    child.on('exit', code => {
+      resolvePromise({
+        pair,
+        passed: code === 0,
+        durationMs: Date.now() - started,
+        exitCode: code ?? -1,
+        stderr: Buffer.concat(stderrChunks).toString('utf8'),
+      });
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = await readFile(args.matrix, 'utf8');
+  const matrix = JSON.parse(raw) as Matrix;
+  const pairs = selectPairs(matrix.pairs, args.filter);
+
+  if (pairs.length === 0) {
+    console.error('No matrix pairs matched filter.');
+    process.exit(2);
+  }
+
+  console.error(
+    `[matrix] ${pairs.length} pair(s) × parallel=${args.parallel} × timeout=${args.timeoutMs}ms`
+  );
+
+  const queue = pairs.map((p, i) => ({ pair: p, index: i }));
+  const results: RunResult[] = [];
+  let nextIdx = 0;
+  let stopped = false;
+
+  // Simple worker pool. Each worker pulls from the queue, runs one pair at
+  // a time, and terminates when the queue is empty. Port offset per worker
+  // id keeps concurrent pairs from fighting over the same listen port.
+  async function worker(workerId: number): Promise<void> {
+    while (!stopped) {
+      const i = nextIdx++;
+      if (i >= queue.length) return;
+      const item = queue[i];
+      const port = portFor(workerId);
+      const label = `[${i + 1}/${queue.length}] ${item.pair.skill.replace(/^skills\//, '').replace(/\/SKILL\.md$/, '')} × ${item.pair.storyboard}`;
+      console.error(`\n▶ ${label} (port ${port})`);
+      const result = await runOne(item.pair, port, args);
+      results.push(result);
+      const durSec = (result.durationMs / 1000).toFixed(1);
+      if (result.passed) {
+        console.error(`✓ ${label} (${durSec}s)`);
+      } else {
+        console.error(`✗ ${label} (${durSec}s, exit=${result.exitCode})`);
+        if (args.stopOnFail) stopped = true;
+      }
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(args.parallel, pairs.length) }, (_, i) =>
+    worker(i)
+  );
+  await Promise.all(workers);
+
+  const passed = results.filter(r => r.passed).length;
+  const failed = results.length - passed;
+
+  console.error('\n' + '═'.repeat(72));
+  console.error('MATRIX SUMMARY');
+  console.error('═'.repeat(72));
+  for (const r of results) {
+    const sym = r.passed ? '✓' : '✗';
+    const durSec = (r.durationMs / 1000).toFixed(1).padStart(5);
+    const skill = r.pair.skill.replace(/^skills\//, '').replace(/\/SKILL\.md$/, '').padEnd(32);
+    console.error(`${sym} ${durSec}s  ${skill} ${r.pair.storyboard}`);
+  }
+  console.error('─'.repeat(72));
+  console.error(`${passed} passed, ${failed} failed (of ${results.length})`);
+  if (stopped && nextIdx < queue.length) {
+    const remaining = queue.length - results.length;
+    console.error(`(${remaining} pair(s) skipped due to --stop-on-first-fail)`);
+  }
+
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch(err => {
+  console.error('[matrix] fatal:', err);
+  process.exit(2);
+});

--- a/scripts/manual-testing/run-skill-matrix.ts
+++ b/scripts/manual-testing/run-skill-matrix.ts
@@ -76,9 +76,7 @@ function printUsage(): void {
 
 function selectPairs(all: Pair[], filters: string[]): Pair[] {
   if (filters.length === 0) return all;
-  return all.filter(p =>
-    filters.some(f => p.skill.includes(f) || p.storyboard.includes(f))
-  );
+  return all.filter(p => filters.some(f => p.skill.includes(f) || p.storyboard.includes(f)));
 }
 
 // Ports are assigned from a per-worker base to avoid collisions when pairs run
@@ -140,9 +138,7 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  console.error(
-    `[matrix] ${pairs.length} pair(s) × parallel=${args.parallel} × timeout=${args.timeoutMs}ms`
-  );
+  console.error(`[matrix] ${pairs.length} pair(s) × parallel=${args.parallel} × timeout=${args.timeoutMs}ms`);
 
   const queue = pairs.map((p, i) => ({ pair: p, index: i }));
   const results: RunResult[] = [];
@@ -172,9 +168,7 @@ async function main(): Promise<void> {
     }
   }
 
-  const workers = Array.from({ length: Math.min(args.parallel, pairs.length) }, (_, i) =>
-    worker(i)
-  );
+  const workers = Array.from({ length: Math.min(args.parallel, pairs.length) }, (_, i) => worker(i));
   await Promise.all(workers);
 
   const passed = results.filter(r => r.passed).length;
@@ -186,7 +180,10 @@ async function main(): Promise<void> {
   for (const r of results) {
     const sym = r.passed ? '✓' : '✗';
     const durSec = (r.durationMs / 1000).toFixed(1).padStart(5);
-    const skill = r.pair.skill.replace(/^skills\//, '').replace(/\/SKILL\.md$/, '').padEnd(32);
+    const skill = r.pair.skill
+      .replace(/^skills\//, '')
+      .replace(/\/SKILL\.md$/, '')
+      .padEnd(32);
     console.error(`${sym} ${durSec}s  ${skill} ${r.pair.storyboard}`);
   }
   console.error('─'.repeat(72));

--- a/scripts/manual-testing/skill-matrix.json
+++ b/scripts/manual-testing/skill-matrix.json
@@ -1,0 +1,19 @@
+{
+  "description": "Skill × storyboard pairs exercised by `npm run compliance:skill-matrix`. Each entry spawns a fresh Claude instance against the skill, lets it build an agent, then grades against the storyboard. Add or remove pairs as the skill surface evolves.",
+  "pairs": [
+    { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "sales_guaranteed" },
+    { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "idempotency" },
+    { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "webhook_emission" },
+    { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "security_baseline" },
+    { "skill": "skills/build-brand-rights-agent/SKILL.md", "storyboard": "brand_rights" },
+    { "skill": "skills/build-creative-agent/SKILL.md", "storyboard": "creative_ad_server" },
+    { "skill": "skills/build-creative-agent/SKILL.md", "storyboard": "creative_template" },
+    { "skill": "skills/build-generative-seller-agent/SKILL.md", "storyboard": "creative_generative" },
+    { "skill": "skills/build-governance-agent/SKILL.md", "storyboard": "governance_spend_authority" },
+    { "skill": "skills/build-governance-agent/SKILL.md", "storyboard": "property_lists" },
+    { "skill": "skills/build-retail-media-agent/SKILL.md", "storyboard": "sales_catalog_driven" },
+    { "skill": "skills/build-si-agent/SKILL.md", "storyboard": "si_baseline" },
+    { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_marketplace" },
+    { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_owned" }
+  ]
+}

--- a/skills/build-brand-rights-agent/SKILL.md
+++ b/skills/build-brand-rights-agent/SKILL.md
@@ -378,14 +378,35 @@ serve(createAgent, {
 
 For OAuth, `anyOf(verifyApiKey, verifyBearer)` composition, or `publicUrl` + `protectedResource` see [seller skill § Protecting your agent](../build-seller-agent/SKILL.md#protecting-your-agent).
 
-## Validation
+## Validate Locally
+
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Brand-rights-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp brand_rights --json
+
+# Happy path — brand_rights bundle (includes governance_denied sub-scenario)
+npx @adcp/client storyboard run http://localhost:3001/mcp brand_rights --auth $TOKEN
+
+# Cross-cutting obligations
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation --auth $TOKEN
+
+# Revocation webhook conformance (if you emit revocations)
+npx @adcp/client storyboard run http://localhost:3001/mcp webhook_emission \
+  --webhook-receiver --auth $TOKEN
+
+# Rejection-surface fuzz
+npx @adcp/client fuzz http://localhost:3001/mcp --auth-token $TOKEN
 ```
 
-**Keep iterating until all steps pass.**
+Common failure decoder:
+- `exclusivity: 'non_exclusive'` (string) → must be object `{ scope, countries }` — see § Concept model
+- `available_uses` enum mismatch → `right-use.json` enum is the source of truth; includes `ai_generated_image` in AdCP 3.0+
+- `acquire_rights` rejected with `Invalid input` → buyer omitted required `revocation_webhook: { url }`
+
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter brand-rights` runs an isolated end-to-end test.
 
 ## Common Mistakes
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -420,24 +420,36 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
-## Validation
+## Validate Locally
 
-**After writing the agent, validate it. Fix failures. Repeat.**
-
-**Full validation** (if you can bind ports):
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Creative-agent-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_lifecycle --json
+
+# Happy path — the archetype you're claiming
+npx @adcp/client storyboard run http://localhost:3001/mcp creative_ad_server --auth $TOKEN     # stateful
+npx @adcp/client storyboard run http://localhost:3001/mcp creative_template --auth $TOKEN      # stateless
+npx @adcp/client storyboard run http://localhost:3001/mcp creative_generative --auth $TOKEN    # brief-to-creative
+
+# Cross-cutting obligations (all creative agents)
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
+
+# Rejection-surface fuzz — includes preview_creative (referential, fixture-eligible)
+npx @adcp/client fuzz http://localhost:3001/mcp \
+  --tools list_creative_formats,list_creatives,get_creative_features,preview_creative \
+  --fixture creative_ids=cre_a,cre_b \
+  --auth-token $TOKEN
 ```
 
-**Sandbox validation** (if ports are blocked):
+Common failure decoder:
+- `response_schema` on `preview_creative` → the union schema requires manual registration; see § creative-template
+- `mcp_error` on creative lifecycle → confirm `sync_creatives` status enum is `approved`/`rejected`/`pending_approval`, not a custom value
+- `field_present` on build response → `creative_manifest` must be fully populated, not just `id`
 
-```bash
-npx tsc --noEmit agent.ts
-```
-
-**Keep iterating until all steps pass.**
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter creative` runs an isolated end-to-end test.
 
 ## Common Mistakes
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -420,6 +420,35 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
+## Deterministic Testing (for `creative_generative/seller` and `deterministic_testing`)
+
+Creative generative sellers — and any creative agent that wants to pass `deterministic_testing` — must expose `comply_test_controller` so the grader can force creative-status transitions deterministically. `createComplyController` handles the scaffolding:
+
+```ts
+import { createComplyController } from '@adcp/client/testing';
+
+const controller = createComplyController({
+  sandboxGate: input => input.auth?.sandbox === true,
+  seed: {
+    creative: (params) => creativeRepo.upsert(params.creative_id, params.fixture),
+  },
+  force: {
+    creative_status: (params) => creativeRepo.transition(
+      params.creative_id,
+      params.status,
+      params.rejection_reason,
+    ),
+  },
+});
+
+controller.register(server);
+```
+
+Declare `compliance_testing` in `supported_protocols` when registered. Throw `TestControllerError('INVALID_TRANSITION', msg, currentState)` from the adapter when the state machine disallows the transition — the helper emits the typed error envelope. Omitted adapters auto-return `UNKNOWN_SCENARIO`.
+
+Validate with: `adcp storyboard run <agent> deterministic_testing --auth $TOKEN`.
+
+
 ## Validate Locally
 
 **Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Creative-agent-specific commands:

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -451,30 +451,34 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
-## Validation
+## Validate Locally
 
-**After writing the agent, validate it. Fix failures. Repeat.**
-
-**Full validation** (if you can bind ports):
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Generative-seller-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_seller --json
+
+# Happy paths — sells inventory AND generates creatives
+npx @adcp/client storyboard run http://localhost:3001/mcp creative_generative/seller --auth $TOKEN
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --auth $TOKEN
+
+# Cross-cutting obligations
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
+
+# Rejection-surface fuzz
+npx @adcp/client fuzz http://localhost:3001/mcp \
+  --tools get_products,list_creative_formats,get_creative_features,preview_creative \
+  --auth-token $TOKEN
 ```
 
-**Sandbox validation** (if ports are blocked):
-
-```bash
-npx tsc --noEmit agent.ts
-```
-
-When storyboard output shows failures, fix each one:
-
+Common failure decoder:
 - `response_schema` → response doesn't match Zod schema
-- `field_present` → required field missing
-- MCP error → check tool registration (schema, name)
+- `field_present` → required field missing (often `creative_manifest` on generated output)
+- `mcp_error` → check tool registration; generative formats must be in `list_creative_formats`
 
-**Keep iterating until all steps pass.**
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter generative` runs an isolated end-to-end test.
 
 ## Common Mistakes
 

--- a/skills/build-governance-agent/SKILL.md
+++ b/skills/build-governance-agent/SKILL.md
@@ -629,20 +629,37 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
-## Validation
+## Validate Locally
 
-**After writing the agent, validate it. Fix failures. Repeat.**
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Governance-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp campaign_governance_conditions --json
-npx @adcp/client storyboard run http://localhost:3001/mcp campaign_governance_denied --json
-npx @adcp/client storyboard run http://localhost:3001/mcp property_lists --json
-npx @adcp/client storyboard run http://localhost:3001/mcp collection_lists --json
-npx @adcp/client storyboard run http://localhost:3001/mcp content_standards --json
+
+# Happy paths — run the storyboards matching your claimed specialisms
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards governance_spend_authority,governance_spend_authority/denied,governance_delivery_monitor \
+  --auth $TOKEN
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards property_lists,collection_lists,content_standards \
+  --auth $TOKEN
+
+# Cross-cutting obligations
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
+
+# Rejection-surface fuzz — includes update_property_list / update_content_standards (Tier 3)
+npx @adcp/client fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
 ```
 
-**Keep iterating until all steps pass.**
+Common failure decoder:
+- `authority_level` field present → 3.0 GA removed it; use `human_review_required: boolean` instead
+- `status: 'escalated'` on `check_governance` → enum is `approved` / `denied` / `conditions`
+- Missing `check_id` on `check_governance` response → required; generate a unique ID per check
+- `finding.code` / `finding.message` → schema requires `category_id`, `severity`, `explanation`
+
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter governance` runs an isolated end-to-end test.
 
 ## Common Mistakes
 

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -406,16 +406,37 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
-## Validation
+## Validate Locally
 
-**After writing the agent, validate it. Fix failures. Repeat.**
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Retail-media-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_creative --json
+
+# Happy path — catalog-driven creative + conversion tracking
+npx @adcp/client storyboard run http://localhost:3001/mcp sales_catalog_driven --auth $TOKEN
+
+# Cross-cutting obligations
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
+
+# Rejection-surface fuzz — includes the catalog surface
+npx @adcp/client fuzz http://localhost:3001/mcp \
+  --tools get_products,list_creative_formats \
+  --auth-token $TOKEN
 ```
 
-**Keep iterating until all steps pass.**
+**Substitution verification** (required for catalog-driven macro URLs):
+
+Wire `SubstitutionEncoder.encode_for_url_context()` into your tracker-URL macro expansion. The storyboard `sales_catalog_driven` asserts that emitted preview URLs pass `SubstitutionObserver.assert_rfc3986_safe()` — unencoded values (especially those containing `javascript:`, reserved chars, or nested macros) fail with `substitution_encoding_violation`. See [VALIDATE-YOUR-AGENT.md § Substitution](../../docs/guides/VALIDATE-YOUR-AGENT.md#substitution-verification-catalog-driven-sellers) for the API.
+
+Common failure decoder:
+- `substitution_encoding_violation` → switch from `encodeURIComponent` to `SubstitutionEncoder.encode_for_url_context`
+- `substitution_binding_missing` → seller stripped the macro entirely; return the rendered URL with the macro expanded, not deleted
+- `log_event` missing `events_received` / `events_processed` → required counters on the response
+
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter retail-media` runs an isolated end-to-end test.
 
 ## Common Mistakes
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -473,9 +473,53 @@ Do not modify, inspect, or omit the context — treat it as opaque. If the reque
 
 Some schemas also define an `ext` field for vendor-namespaced extensions. If your request schema includes `ext`, accept it without error. Tools with explicit `ext` support: `sync_governance`, `provide_performance_feedback`, `sync_event_sources`.
 
-## Compliance Testing (Optional)
+## Compliance Testing (Required for deterministic_testing storyboard)
 
-Add `registerTestController` so the comply framework can deterministically test your state machines. Without it, compliance testing relies on observational storyboards that can't force state transitions.
+To pass the `deterministic_testing` storyboard — and the rejection-branch steps in most other storyboards (`governance_denied`, `invalid_transitions`, `measurement_terms_rejected`, etc.) — your agent must expose the `comply_test_controller` tool. Without it, the grader can only observe the happy path; forced state transitions, error-condition seeding, and simulation all silently degrade to skips or fail with `controller_detected: false`.
+
+**Preferred: `createComplyController`** (adapter-based, handles dispatch + validation + re-seed idempotency + sandbox gating for you):
+
+```ts
+import { createComplyController } from '@adcp/client/testing';
+
+const controller = createComplyController({
+  sandboxGate: input => input.auth?.sandbox === true,
+  seed: {
+    product:  (params) => productRepo.upsert(params.product_id, params.fixture),
+    creative: (params) => creativeRepo.upsert(params.creative_id, params.fixture),
+    plan:     (params) => planRepo.upsert(params.plan_id, params.fixture),
+    media_buy: (params) => mediaBuyRepo.upsert(params.media_buy_id, params.fixture),
+  },
+  force: {
+    creative_status:  (params) => creativeRepo.transition(params.creative_id, params.status),
+    media_buy_status: (params) => mediaBuyRepo.transition(params.media_buy_id, params.status),
+    account_status:   (params) => accountRepo.setStatus(params.account_id, params.status),
+  },
+  simulate: {
+    delivery:     (params) => deliveryRepo.simulate(params),
+    budget_spend: (params) => budgetRepo.spendPercentage(params),
+  },
+});
+
+controller.register(server);
+```
+
+Omit adapters you don't support — they auto-return `UNKNOWN_SCENARIO` (not schema errors). Throw `TestControllerError('INVALID_TRANSITION', msg, currentState)` from an adapter when the state machine disallows the transition; the helper emits the typed error envelope.
+
+When registered, declare `compliance_testing` in `supported_protocols`:
+
+```ts
+capabilitiesResponse({
+  adcp: { major_versions: [3] },
+  supported_protocols: ['media_buy', 'compliance_testing'],
+});
+```
+
+Validate with: `adcp storyboard run <agent> deterministic_testing --auth $TOKEN`.
+
+### Low-level alternative: `registerTestController`
+
+If you need direct store access — e.g., shared enforcement with production code, or a session-keyed store factory — use the flat `registerTestController(server, store)` API. `createComplyController` calls into the same primitives, so picking one or the other is mostly ergonomic preference.
 
 ```
 import { registerTestController } from '@adcp/client';

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -1006,30 +1006,55 @@ The `security_baseline` storyboard verifies:
 2. At least one of API-key or OAuth discovery must succeed.
 3. If OAuth is advertised, the `resource` field in `/.well-known/oauth-protected-resource` MUST match the URL being called. Set `publicUrl` once — the framework enforces this automatically.
 
-## Validation
+## Validate Locally
 
-**After writing the agent, validate it. Fix failures. Repeat.**
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). The commands below cover what a seller agent specifically needs.
 
-**Full validation** (if you can bind ports):
+**Boot the agent:**
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
-**Sandbox validation** (if ports are blocked):
+**Happy-path conformance (storyboard runner):**
 
 ```bash
-npx tsc --noEmit
+# Full seller lifecycle
+npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --auth $TOKEN
+
+# Your specialism bundle (one of: sales_guaranteed, sales_non_guaranteed,
+# sales_broadcast_tv, sales_streaming_tv, sales_social, sales_proposal_mode)
+npx @adcp/client storyboard run http://localhost:3001/mcp sales_guaranteed --auth $TOKEN
+
+# Cross-cutting obligations — every seller must pass these
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards idempotency,security_baseline,schema_validation,error_compliance --auth $TOKEN
+
+# Webhook conformance (if you claim async task lifecycles)
+npx @adcp/client storyboard run http://localhost:3001/mcp webhook_emission \
+  --webhook-receiver --auth $TOKEN
 ```
 
-When storyboard output shows failures, fix each one:
+**Rejection-surface conformance (property-based fuzzer — catches crashes on edge inputs):**
+
+```bash
+npx @adcp/client fuzz http://localhost:3001/mcp \
+  --tools get_products,get_media_buys,list_creative_formats \
+  --auth-token $TOKEN
+```
+
+**Request signing (if you claim `signed-requests`):** point `adcp grade request-signing` at your sandbox — see [VALIDATE-YOUR-AGENT.md § Request signing](../../docs/guides/VALIDATE-YOUR-AGENT.md#request-signing--adcp-grade-request-signing).
+
+**Multi-instance (before production):** run with two `--url` flags to catch `(brand, account)`-scoped state that lives per-process. See [VALIDATE-YOUR-AGENT.md § Multi-instance](../../docs/guides/VALIDATE-YOUR-AGENT.md#multi-instance-testing).
+
+Common failure decoder:
 
 - `response_schema` → response doesn't match Zod schema
 - `field_present` → required field missing
-- MCP error → check tool registration (schema, name)
+- `mcp_error` → check tool registration (schema, name)
+- `authority_level` / `human_review_required` mismatch → check governance plan shape — schema moved in AdCP 3.0 GA
 
-**Keep iterating until all steps pass.**
+**Keep iterating until all steps pass.** If you can't bind ports locally, skip `tsx agent.ts` and run `npm run compliance:skill-matrix -- --filter seller` — it builds an isolated sandbox and grades end-to-end.
 
 ## Storyboards
 

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -291,14 +291,34 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
-## Validation
+## Validate Locally
+
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). SI-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp si_session --json
+
+# Happy path — session lifecycle
+npx @adcp/client storyboard run http://localhost:3001/mcp si_baseline --auth $TOKEN
+
+# Cross-cutting obligations
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
+
+# Rejection-surface fuzz
+npx @adcp/client fuzz http://localhost:3001/mcp \
+  --tools si_get_offering --auth-token $TOKEN
 ```
 
-**Keep iterating until all steps pass.**
+Common failure decoder:
+- `status` field on session response → rename to `session_status` (the canonical field name)
+- `status: 'terminated'` → use boolean `terminated: true`
+- Missing `session_id` on `si_send_message` response → echo from request — required
+- Missing `available` boolean on `si_get_offering` → required even for mock data
+- Missing `reason` on `si_terminate_session` request → enum: `user_exit` / `session_timeout` / `host_terminated` / `handoff_transaction` / `handoff_complete`
+
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter si` runs an isolated end-to-end test.
 
 ## Common Mistakes
 

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -362,25 +362,36 @@ serve(createAgent, {
 The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
 
 
-## Validation
+## Validate Locally
 
-**After writing the agent, validate it. Fix failures. Repeat.**
-
-**Full validation** (if you can bind ports):
+**Full validation checklist:** [docs/guides/VALIDATE-YOUR-AGENT.md](../../docs/guides/VALIDATE-YOUR-AGENT.md). Signals-specific commands:
 
 ```bash
+# Boot
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_owned --json       # for owned data
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace --json  # for marketplace
+
+# Happy path — the specialism you're claiming
+npx @adcp/client storyboard run http://localhost:3001/mcp signal_owned --auth $TOKEN        # owned data
+npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace --auth $TOKEN  # marketplace
+
+# Marketplace governance sub-scenario (if you claim signal_marketplace)
+npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace/governance_denied --auth $TOKEN
+
+# Cross-cutting obligations
+npx @adcp/client storyboard run http://localhost:3001/mcp \
+  --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
+
+# Rejection-surface fuzz
+npx @adcp/client fuzz http://localhost:3001/mcp --tools get_signals --auth-token $TOKEN
 ```
 
-**Sandbox validation** (if ports are blocked):
+Common failure decoder:
+- `value_type` mismatch → `binary` vs. `continuous` — pick one; continuous signals return `value`, binary signals return membership
+- Missing `deployments` on signal → required even if empty `[]`
+- `activate_signal` returns sync success on a marketplace signal → marketplace activations are async; commit to an `activation_key` up-front and return `submitted`
+- Missing `coverage_percentage` or `pricing_options` → required on every signal
 
-```bash
-npx tsc --noEmit
-```
-
-**Keep iterating until all steps pass.**
+**Keep iterating until all steps pass.** Can't bind ports? `npm run compliance:skill-matrix -- --filter signals` runs an isolated end-to-end test.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary

Closes the compliance-testing discoverability gap: the SDK has a mature surface (`adcp storyboard run`, `adcp fuzz` T1/T2/T3, `adcp grade request-signing`, `--webhook-receiver`, `--invariants`, validation hooks, `SubstitutionEncoder`, multi-instance, dogfood harness) but skills barely referenced it and operators had to read source to find the right command.

### Two commits

**1. `docs(validation): VALIDATE-YOUR-AGENT index + skill-matrix harness`**
- New `docs/guides/VALIDATE-YOUR-AGENT.md` — five-command operator checklist plus deep command reference for storyboard runner, `adcp fuzz` (Tier 1/2/3), request-signing grader, multi-instance, webhook conformance, schema-driven validation, custom `--invariants`, and `SubstitutionEncoder`/`Observer`.
- `BUILD-AN-AGENT.md § Compliance Check` and root `CLAUDE.md` link to the new doc.
- `scripts/manual-testing/skill-matrix.json` — 14 skill × storyboard pairs.
- `scripts/manual-testing/run-skill-matrix.ts` — driver exposed as `npm run compliance:skill-matrix`. Supports `--filter`, `--parallel`, `--stop-on-first-fail`, `--keep-workspaces`.

**2. `docs(skills): unified § Validate Locally section across all 8 build-*-agent`**

All 8 skills (seller, brand-rights, creative, generative-seller, governance, retail-media, si, signals) get a consistent § Validate Locally block pointing at `VALIDATE-YOUR-AGENT.md`, then listing:
- Canonical storyboard IDs for that specialism
- Cross-cutting bundles (`security_baseline,idempotency,schema_validation,error_compliance`)
- `adcp fuzz` with the right `--tools` list
- Per-specialism failure decoder
- `npm run compliance:skill-matrix -- --filter <name>` as the port-less fallback

Skill-specific extras: retail-media gets `SubstitutionEncoder` wiring; seller gets specialism-bundle enumeration + signed-requests + multi-instance pointers; governance gets Tier-3 `--auto-seed` fuzz + 3.0 GA `authority_level → human_review_required` reminder.

## Test plan

- [x] `npm run compliance:skill-matrix -- --help` — works
- [x] `npm run compliance:skill-matrix -- --filter seller` — correctly selects 5 pairs
- [x] `npm run compliance:skill-matrix -- --filter nonexistentfilter` — exits 2 with helpful message
- [x] Every skill file has exactly one `## Validate Locally` heading (no leftover `## Validation`)
- [ ] Run full matrix end-to-end (next PR — that's the dogfood test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)