### PR TITLE
chore(testing): re-export assertion registry from @adcp/client/testing

### DIFF
--- a/.changeset/re-export-assertion-registry.md
+++ b/.changeset/re-export-assertion-registry.md
@@ -1,0 +1,12 @@
+---
+'@adcp/client': patch
+---
+
+Re-export the storyboard assertion registry (`registerAssertion`,
+`getAssertion`, `listAssertions`, `clearAssertionRegistry`,
+`resolveAssertions`, and types `AssertionSpec`, `AssertionContext`,
+`AssertionResult`) from `@adcp/client/testing` so authors of invariant
+modules can import them from the documented package entry point. The
+underlying module (`./storyboard/assertions`) already exported these;
+only the parent `./testing` index was missing the re-exports. Closes
+the gap introduced by #692.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -188,6 +188,17 @@ export {
   getSandboxBrand,
   isSandboxDomain,
   clearSandboxCache,
+  // Assertion registry (adcontextprotocol/adcp#2639) — authors of invariant
+  // modules import these from `@adcp/client/testing` to register cross-step
+  // checks the runner will resolve from `storyboard.invariants: [...]`.
+  registerAssertion,
+  getAssertion,
+  listAssertions,
+  clearAssertionRegistry,
+  resolveAssertions,
+  type AssertionSpec,
+  type AssertionContext,
+  type AssertionResult,
   // Types
   type Storyboard,
   type StoryboardPhase,


### PR DESCRIPTION
## Summary

Small follow-up to #692. The storyboard assertion registry (`registerAssertion`, `getAssertion`, `listAssertions`, `clearAssertionRegistry`, `resolveAssertions`) is exported from `./storyboard/assertions` and re-exported from `./storyboard/index.ts`, but I missed the re-export from the parent `./testing/index.ts`.

The CLI `--invariants` help text (PR #697) and the SDK guide (\`docs/guides/VALIDATE-YOUR-AGENT.md\`) both point users at `@adcp/client/testing` for these imports — today they'd get a runtime \`registerAssertion is not a function\`. This PR closes the gap.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Consumers can \`import { registerAssertion } from '@adcp/client/testing'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)