### PR TITLE
docs(skills): v2 schema refresh — DEFAULT_REPORTING_CAPABILITIES + currency + affected_packages

### DIFF
--- a/.changeset/skill-schema-refresh-v2.md
+++ b/.changeset/skill-schema-refresh-v2.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+Follow-up to the skill schema refresh (PR #716) targeting matrix failures that persisted:
+
+- **`DEFAULT_REPORTING_CAPABILITIES` over hand-rolled literals** — seller, generative-seller, and retail-media skill product examples previously hand-rolled `reporting_capabilities: { ... }` which drifts every time the spec adds a required field (most recently `date_range_support` in AdCP latest). Skills now use the SDK-provided constant and flag the drift tax explicitly.
+- **`create_media_buy` must persist `currency` + `total_budget`** — seller skill's `createMediaBuy` example flattens request `total_budget: { amount, currency }` into top-level `currency` + `total_budget` fields on the persisted buy, so subsequent `get_media_buys` responses pass the new required-field schema check. The old example stored only `packages[].budget` and the required top-level fields weren't reconstructable.
+- **`update_media_buy.affected_packages` must be `Package[]`, not `string[]`** — seller skill's `updateMediaBuy` example now returns package objects (`{ package_id, ... }`) instead of bare IDs. The `update-media-buy-response` oneOf discriminator rejects string arrays with `/affected_packages/0: must be object`.

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -113,18 +113,13 @@ productsResponse({
       fixed_price: 15.00,
       currency: 'USD',
     }],
-    reporting_capabilities: {
-      available_reporting_frequencies: ['daily'],
-      expected_delay_minutes: 240,
-      timezone: 'UTC',
-      supports_webhooks: false,
-      available_metrics: ['impressions', 'spend', 'clicks'],
-      date_range_support: 'date_range',
-    },
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,  // from @adcp/client/server — stays in sync with schema
   }],
   sandbox: true,
 })
 ```
+
+Import: `import { DEFAULT_REPORTING_CAPABILITIES } from '@adcp/client/server';`. Hand-rolling `reporting_capabilities: { ... }` on every product is the biggest source of schema-drift failures — the constant stays in sync with the spec.
 
 **`create_media_buy`** — `CreateMediaBuyRequestSchema.shape`
 

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -89,9 +89,27 @@ taskToolResponse({
 
 **`get_products`** — `GetProductsRequestSchema.shape`
 
+```typescript
+import { DEFAULT_REPORTING_CAPABILITIES } from '@adcp/client/server';
+
+productsResponse({
+  products: [{
+    product_id: 'sponsored-home',
+    name: 'Sponsored Products — Home',
+    description: 'On-site sponsored placements.',
+    publisher_properties: [{ publisher_domain: 'retailer.example', selection_type: 'all' }],
+    format_ids: [{ agent_url: 'https://retailer.example/mcp', id: 'display_300x250' }],
+    delivery_type: 'non_guaranteed',
+    pricing_options: [{ pricing_option_id: 'cpc-std', pricing_model: 'cpc', fixed_price: 0.75, currency: 'USD' }],
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,  // required — never hand-roll
+    supports_catalog: true,
+    supports_conversion_tracking: true,
+  }],
+  sandbox: true,
+})
 ```
-productsResponse({ products: Product[], sandbox: true })
-```
+
+Hand-rolling `reporting_capabilities: { ... }` is the biggest drift tax — the spec adds required fields (most recently `date_range_support`) and literals go stale. Always use `DEFAULT_REPORTING_CAPABILITIES`.
 
 **`create_media_buy`** — `CreateMediaBuyRequestSchema.shape`
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -368,18 +368,13 @@ productsResponse({
       fixed_price: 12.00,
       currency: 'USD',
     }],
-    reporting_capabilities: {
-      available_reporting_frequencies: ['daily'],
-      expected_delay_minutes: 240,
-      timezone: 'UTC',
-      supports_webhooks: false,
-      available_metrics: ['impressions', 'spend', 'clicks'],
-      date_range_support: 'date_range',
-    },
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,  // from @adcp/client/server — stays in sync with schema
   }],
   sandbox: true,        // for mock data
 })
 ```
+
+`DEFAULT_REPORTING_CAPABILITIES` is the SDK-provided default. Hand-rolling this object is an ongoing drift tax — the spec adds required fields (most recently `date_range_support`) and every copy of the literal gets stale. Reach for the constant unless you have a concrete reason to override a field.
 
 **`create_media_buy`** — `CreateMediaBuyRequestSchema.shape`
 
@@ -729,9 +724,17 @@ function createAgent({ taskStore }: ServeContext) {
         // Use randomUUID (not Date.now) so ids are unguessable — a guessable
         // media_buy_id lets another buyer probe or cancel. Same applies to
         // any seller-issued id (package_id, creative_id, etc.).
+        // `currency` + `total_budget` are REQUIRED on get_media_buys response rows.
+        // The request carries them under `total_budget: { amount, currency }` (object).
+        // Flatten to top-level fields at create time — storing only `packages[].budget`
+        // and reconstructing later fails schema validation in get_media_buys/update_media_buy.
+        const currency = params.total_budget?.currency ?? 'USD';
+        const totalBudget = params.total_budget?.amount ?? (params.packages ?? []).reduce((a, p) => a + (p.budget ?? 0), 0);
         const buy = {
           media_buy_id: `mb_${randomUUID()}`,
           status: 'pending_creatives' as const,
+          currency,
+          total_budget: totalBudget,
           packages:
             params.packages?.map(pkg => ({
               package_id: `pkg_${randomUUID()}`,
@@ -760,7 +763,13 @@ function createAgent({ taskStore }: ServeContext) {
         return {
           media_buy_id: params.media_buy_id,
           status: updated.status as 'paused' | 'active',
-          affected_packages: [],
+          // `affected_packages` is `Package[]` (per `/schemas/latest/core/package.json`)
+          // — objects with at minimum `package_id`. Don't return bare strings;
+          // the update-media-buy-response oneOf discriminates against them and
+          // the error looks like `/affected_packages/0: must be object`.
+          affected_packages: (existing.packages ?? []).map((p: { package_id: string }) => ({
+            package_id: p.package_id,
+          })),
         };
       },
       getMediaBuys: async (params, ctx) => {


### PR DESCRIPTION
Follow-up to #716. Matrix v2 still 0/14 because upstream kept adding required fields. Redirects skills toward SDK helpers.

## Fixes

1. DEFAULT_REPORTING_CAPABILITIES over hand-rolled literals (12 pairs) — seller, generative-seller, retail-media.
2. create_media_buy persists currency + total_budget flattened from request (6 pairs).
3. update_media_buy.affected_packages returns Package[] not string[] (6 pairs).

## Still open
- SDK bug: si_get_offering context field collision (request string vs response object). Filing separately.
- Controller adoption (10 pairs still controller_detected: false). Iterating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)