### PR TITLE
fix(server): skip context echo when request.context is not a protocol echo object

### DIFF
--- a/.changeset/fix-si-context-echo.md
+++ b/.changeset/fix-si-context-echo.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/client": patch
+'@adcp/client': patch
 ---
 
 Fix `createAdcpServer` context echo for Sponsored Intelligence tools. `si_get_offering` and `si_initiate_session` define `context` as a domain-specific string on the request but require the protocol echo object on the response. The response auto-echo now only copies `request.context` when it is a plain object, so SI responses no longer fail with `/context: must be object`.

--- a/.changeset/fix-si-context-echo.md
+++ b/.changeset/fix-si-context-echo.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix `createAdcpServer` context echo for Sponsored Intelligence tools. `si_get_offering` and `si_initiate_session` define `context` as a domain-specific string on the request but require the protocol echo object on the response. The response auto-echo now only copies `request.context` when it is a plain object, so SI responses no longer fail with `/context: must be object`.

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -107,11 +107,11 @@ taskToolResponse({
 
 ### Context and Ext Passthrough
 
-`createAdcpServer` auto-echoes the request's `context` into every response — **do not set `context` yourself in your handler return values.** The framework injects it post-handler when the field isn't already present.
+`createAdcpServer` auto-echoes the request's `context` into every response — **do not set `context` yourself** on responses for tools whose request-side `context` is the protocol echo object (`core/context.json`).
 
-**Crucial:** `context` is schema-typed as an object. If your handler hand-sets a string ("E2E test session", a narrative description, the SI-specific `campaign_context`, etc.), validation fails with `/context: must be object` and the framework does not overwrite. Leave the field out; let the framework echo the request's context object unchanged.
+**SI override.** `si_get_offering` and `si_initiate_session` override `context` on the request as a domain-specific **string** (natural-language intent hint, per spec: *'mens size 14 near Cincinnati'*). The response schema still keeps `context` as the protocol echo object. The framework detects this mismatch and skips the auto-echo for non-object values — your response simply won't carry a `context` field unless you populate it. If you want correlation tracking for SI responses, construct the context object in your handler (e.g., from a buyer-supplied `ext.correlation_id` or your own generator) and return it on the response.
 
-Some requests also carry domain-specific fields that look like context (e.g., `campaign_context: string` on `si_initiate_session`). Those are tool params, **not** the protocol echo field — keep them in your domain logic and never assign them to `context`.
+`si_send_message` and `si_terminate_session` use the standard protocol echo object on both sides — leave `context` out of the handler return and the framework will echo it.
 
 ## SDK Quick Reference
 
@@ -323,7 +323,7 @@ Common failure decoder:
 | Missing `session_id` in si_send_message response     | Echo `session_id` back from request — required                         |
 | Missing `available` in si_get_offering               | Boolean `available` is required — even for mock data                   |
 | Missing `reason` in si_terminate_session request     | `reason` is required — one of: `user_exit`, `session_timeout`, `host_terminated`, `handoff_transaction`, `handoff_complete` |
-| Dropping `context` from responses              | Echo `args.context` back unchanged in every response — buyers use it for correlation |
+| Dropping `context` from responses              | Let the framework echo — except for `si_get_offering` / `si_initiate_session`, whose request `context` is a string. For those, build your own response context object if correlation tracking matters. |
 
 ## Storyboards
 

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -23,9 +23,9 @@ A sponsored intelligence (SI) agent serves conversational sponsored content with
 
 ## Specialisms This Skill Covers
 
-| Specialism | Status | Delta |
-|---|---|---|
-| _(none yet)_ | — | SI has no specialisms in AdCP 3.0 — pass the `sponsored-intelligence` protocol baseline. Specialism storyboards for conversational-ad-specific patterns are pending future AdCP releases. |
+| Specialism   | Status | Delta                                                                                                                                                                                     |
+| ------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _(none yet)_ | —      | SI has no specialisms in AdCP 3.0 — pass the `sponsored-intelligence` protocol baseline. Specialism storyboards for conversational-ad-specific patterns are pending future AdCP releases. |
 
 ## Before Writing Code
 
@@ -109,18 +109,18 @@ taskToolResponse({
 
 `createAdcpServer` auto-echoes the request's `context` into every response — **do not set `context` yourself** on responses for tools whose request-side `context` is the protocol echo object (`core/context.json`).
 
-**SI override.** `si_get_offering` and `si_initiate_session` override `context` on the request as a domain-specific **string** (natural-language intent hint, per spec: *'mens size 14 near Cincinnati'*). The response schema still keeps `context` as the protocol echo object. The framework detects this mismatch and skips the auto-echo for non-object values — your response simply won't carry a `context` field unless you populate it. If you want correlation tracking for SI responses, construct the context object in your handler (e.g., from a buyer-supplied `ext.correlation_id` or your own generator) and return it on the response.
+**SI override.** `si_get_offering` and `si_initiate_session` override `context` on the request as a domain-specific **string** (natural-language intent hint, per spec: _'mens size 14 near Cincinnati'_). The response schema still keeps `context` as the protocol echo object. The framework detects this mismatch and skips the auto-echo for non-object values — your response simply won't carry a `context` field unless you populate it. If you want correlation tracking for SI responses, construct the context object in your handler (e.g., from a buyer-supplied `ext.correlation_id` or your own generator) and return it on the response.
 
 `si_send_message` and `si_terminate_session` use the standard protocol echo object on both sides — leave `context` out of the handler return and the framework will echo it.
 
 ## SDK Quick Reference
 
-| SDK piece                                               | Usage                                                               |
-| ------------------------------------------------------- | ------------------------------------------------------------------- |
-| `createAdcpServer({ name, sponsoredIntelligence })`   | Create server with domain-grouped handlers and auto-generated capabilities |
-| `serve(() => createAdcpServer(...))`                    | Start HTTP server on `:3001/mcp`                                    |
-| `ctx.store`                                             | State persistence — `get/put/patch/delete/list` domain objects      |
-| `adcpError(code, { message })`                          | Structured error                                                    |
+| SDK piece                                           | Usage                                                                      |
+| --------------------------------------------------- | -------------------------------------------------------------------------- |
+| `createAdcpServer({ name, sponsoredIntelligence })` | Create server with domain-grouped handlers and auto-generated capabilities |
+| `serve(() => createAdcpServer(...))`                | Start HTTP server on `:3001/mcp`                                           |
+| `ctx.store`                                         | State persistence — `get/put/patch/delete/list` domain objects             |
+| `adcpError(code, { message })`                      | Structured error                                                           |
 
 Handlers return raw data objects. The framework auto-wraps responses and auto-generates `get_adcp_capabilities` from registered handlers.
 
@@ -169,60 +169,62 @@ const idempotency = createIdempotencyStore({
   ttlSeconds: 86400,
 });
 
-serve(() => createAdcpServer({
-  name: 'SI Agent',
-  version: '1.0.0',
-  idempotency,
-  // Principal scope for idempotency. MUST never return undefined. A
-  // constant is fine for a demo; for multi-tenant production, type the
-  // account via `createAdcpServer<MyAccount>({...})` and use
-  // `(ctx) => ctx.account?.id`. The framework additionally auto-scopes
-  // `si_send_message` by `session_id`, so the same key under two
-  // sessions doesn't cross-replay.
-  resolveSessionKey: () => 'default-principal',
+serve(() =>
+  createAdcpServer({
+    name: 'SI Agent',
+    version: '1.0.0',
+    idempotency,
+    // Principal scope for idempotency. MUST never return undefined. A
+    // constant is fine for a demo; for multi-tenant production, type the
+    // account via `createAdcpServer<MyAccount>({...})` and use
+    // `(ctx) => ctx.account?.id`. The framework additionally auto-scopes
+    // `si_send_message` by `session_id`, so the same key under two
+    // sessions doesn't cross-replay.
+    resolveSessionKey: () => 'default-principal',
 
-  sponsoredIntelligence: {
-    getOffering: async (params, ctx) => ({
-      available: true,
-      offering_token: `tok_${randomUUID()}`,
-      ttl_seconds: 300,
-    }),
-    initiateSession: async (params, ctx) => {
-      // session_id MUST be high-entropy (≥122 bits) per spec — it's the
-      // scope key for conversational isolation. Never use Date.now() or
-      // predictable counters; a guessable session_id lets one buyer
-      // impersonate another's session.
-      const sessionId = `sess_${randomUUID()}`;
-      await ctx.store.put('session', sessionId, { status: 'active' });
-      return {
-        session_id: sessionId,
-        session_status: 'active',
-      };
+    sponsoredIntelligence: {
+      getOffering: async (params, ctx) => ({
+        available: true,
+        offering_token: `tok_${randomUUID()}`,
+        ttl_seconds: 300,
+      }),
+      initiateSession: async (params, ctx) => {
+        // session_id MUST be high-entropy (≥122 bits) per spec — it's the
+        // scope key for conversational isolation. Never use Date.now() or
+        // predictable counters; a guessable session_id lets one buyer
+        // impersonate another's session.
+        const sessionId = `sess_${randomUUID()}`;
+        await ctx.store.put('session', sessionId, { status: 'active' });
+        return {
+          session_id: sessionId,
+          session_status: 'active',
+        };
+      },
+      sendMessage: async (params, ctx) => {
+        const session = await ctx.store.get('session', params.session_id);
+        // Return the error — the framework echoes returned adcpError
+        // responses verbatim. Thrown errors are caught and converted to
+        // SERVICE_UNAVAILABLE, which hides your custom code from the buyer.
+        if (!session) return adcpError('RESOURCE_NOT_FOUND', { message: 'Session not found' });
+        return {
+          session_id: params.session_id,
+          session_status: 'active' as const,
+          response: {
+            content: 'Sponsored content response',
+            content_type: 'text',
+          },
+        };
+      },
+      terminateSession: async (params, ctx) => {
+        await ctx.store.delete('session', params.session_id);
+        return {
+          session_id: params.session_id,
+          terminated: true,
+        };
+      },
     },
-    sendMessage: async (params, ctx) => {
-      const session = await ctx.store.get('session', params.session_id);
-      // Return the error — the framework echoes returned adcpError
-      // responses verbatim. Thrown errors are caught and converted to
-      // SERVICE_UNAVAILABLE, which hides your custom code from the buyer.
-      if (!session) return adcpError('RESOURCE_NOT_FOUND', { message: 'Session not found' });
-      return {
-        session_id: params.session_id,
-        session_status: 'active' as const,
-        response: {
-          content: 'Sponsored content response',
-          content_type: 'text',
-        },
-      };
-    },
-    terminateSession: async (params, ctx) => {
-      await ctx.store.delete('session', params.session_id);
-      return {
-        session_id: params.session_id,
-        terminated: true,
-      };
-    },
-  },
-}));
+  })
+);
 ```
 
 ## Idempotency
@@ -241,7 +243,6 @@ Idempotency is wired in the example above. What the framework handles for you:
 
 `ttlSeconds` must be in `[3600, 604800]` — out of range throws at `createIdempotencyStore` construction. Don't pass minutes thinking they're seconds.
 
-
 ## Protecting your agent
 
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
@@ -252,7 +253,7 @@ import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
 // API key — simplest, good for B2B integrations
 serve(createAgent, {
   authenticate: verifyApiKey({
-    verify: async (token) => {
+    verify: async token => {
       const row = await db.api_keys.findUnique({ where: { token } });
       return row ? { principal: row.account_id } : null;
     },
@@ -279,8 +280,7 @@ serve(createAgent, {
 });
 ```
 
-The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS*/EdDSA) to prevent algorithm-confusion attacks.
-
+The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on failure, and serves `/.well-known/oauth-protected-resource<mountPath>` with `publicUrl` as the `resource` field so buyers get tokens bound to the right audience. The default JWT allowlist is asymmetric-only (RS*/ES*/PS\*/EdDSA) to prevent algorithm-confusion attacks.
 
 ## Validate Locally
 
@@ -303,6 +303,7 @@ npx @adcp/client fuzz http://localhost:3001/mcp \
 ```
 
 Common failure decoder:
+
 - `status` field on session response → rename to `session_status` (the canonical field name)
 - `status: 'terminated'` → use boolean `terminated: true`
 - Missing `session_id` on `si_send_message` response → echo from request — required
@@ -313,23 +314,23 @@ Common failure decoder:
 
 ## Common Mistakes
 
-| Mistake                                              | Fix                                                                    |
-| ---------------------------------------------------- | ---------------------------------------------------------------------- |
-| Manually registering `get_adcp_capabilities`         | Framework auto-generates it from registered handlers — do not register it yourself |
-| Using `server.tool()` instead of domain groups       | Use `sponsoredIntelligence: { getOffering, initiateSession, ... }` — framework wires schemas and response builders |
-| Using in-memory Maps for session state               | Use `ctx.store.put/get/delete` — built-in state persistence            |
-| Returns `status` instead of `session_status`         | Field name is `session_status` — `status` will fail schema validation  |
-| Returns `status: 'terminated'` instead of `terminated: true` | Termination response uses boolean `terminated` field          |
-| Missing `session_id` in si_send_message response     | Echo `session_id` back from request — required                         |
-| Missing `available` in si_get_offering               | Boolean `available` is required — even for mock data                   |
-| Missing `reason` in si_terminate_session request     | `reason` is required — one of: `user_exit`, `session_timeout`, `host_terminated`, `handoff_transaction`, `handoff_complete` |
-| Dropping `context` from responses              | Let the framework echo — except for `si_get_offering` / `si_initiate_session`, whose request `context` is a string. For those, build your own response context object if correlation tracking matters. |
+| Mistake                                                      | Fix                                                                                                                                                                                                    |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Manually registering `get_adcp_capabilities`                 | Framework auto-generates it from registered handlers — do not register it yourself                                                                                                                     |
+| Using `server.tool()` instead of domain groups               | Use `sponsoredIntelligence: { getOffering, initiateSession, ... }` — framework wires schemas and response builders                                                                                     |
+| Using in-memory Maps for session state                       | Use `ctx.store.put/get/delete` — built-in state persistence                                                                                                                                            |
+| Returns `status` instead of `session_status`                 | Field name is `session_status` — `status` will fail schema validation                                                                                                                                  |
+| Returns `status: 'terminated'` instead of `terminated: true` | Termination response uses boolean `terminated` field                                                                                                                                                   |
+| Missing `session_id` in si_send_message response             | Echo `session_id` back from request — required                                                                                                                                                         |
+| Missing `available` in si_get_offering                       | Boolean `available` is required — even for mock data                                                                                                                                                   |
+| Missing `reason` in si_terminate_session request             | `reason` is required — one of: `user_exit`, `session_timeout`, `host_terminated`, `handoff_transaction`, `handoff_complete`                                                                            |
+| Dropping `context` from responses                            | Let the framework echo — except for `si_get_offering` / `si_initiate_session`, whose request `context` is a string. For those, build your own response context object if correlation tracking matters. |
 
 ## Storyboards
 
-| Storyboard    | Tests                                                            |
-| ------------- | ---------------------------------------------------------------- |
-| `si_session`  | Full session lifecycle: offering → initiate → message → terminate |
+| Storyboard   | Tests                                                             |
+| ------------ | ----------------------------------------------------------------- |
+| `si_session` | Full session lifecycle: offering → initiate → message → terminate |
 
 ## Reference
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1299,8 +1299,13 @@ function isFormattedResponse(value: unknown): value is McpToolResponse {
 }
 
 // Echo the request context into a formatted MCP tool response so buyers can
-// trace correlation_id across both success and error responses.
+// trace correlation_id across both success and error responses. Only plain
+// objects are echoed: `si_get_offering` and `si_initiate_session` override
+// the request schema's `context` to a domain-specific string, while the
+// response schema still requires the protocol echo object — copying a
+// string there would fail response validation.
 function injectContextIntoResponse(response: McpToolResponse, context: unknown): void {
+  if (context === null || typeof context !== 'object' || Array.isArray(context)) return;
   const sc = response.structuredContent as Record<string, unknown> | undefined;
   if (sc && typeof sc === 'object' && !('context' in sc)) {
     sc.context = context;
@@ -1606,10 +1611,11 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // Echo params.context into any response (success or error) so buyers
         // can trace correlation_id end-to-end. Framework-generated errors
         // (ACCOUNT_NOT_FOUND, SERVICE_UNAVAILABLE) go through this too.
+        // `injectContextIntoResponse` skips non-object values so SI tools
+        // that override `context` as a string on the request don't leak the
+        // string into the response envelope.
         const finalize = (response: McpToolResponse): McpToolResponse => {
-          if (params.context !== undefined && params.context !== null) {
-            injectContextIntoResponse(response, params.context);
-          }
+          injectContextIntoResponse(response, params.context);
           return response;
         };
 
@@ -2079,8 +2085,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   const capSchema = TOOL_REQUEST_SCHEMAS['get_adcp_capabilities'] as { shape: Record<string, unknown> } | undefined;
   server.tool('get_adcp_capabilities', capSchema?.shape ?? {}, async (params: any) => {
     const data = { ...capabilitiesData };
-    if (params?.context != null) {
-      (data as any).context = params.context;
+    const ctx = params?.context;
+    if (ctx !== null && typeof ctx === 'object' && !Array.isArray(ctx)) {
+      (data as any).context = ctx;
     }
     return capabilitiesResponse(data);
   });

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -701,6 +701,32 @@ describe('createAdcpServer', () => {
       assert.deepStrictEqual(result.structuredContent.context, { correlation_id: 'trace-acct-err' });
     });
 
+    it('does not echo a string request.context into the response (si_get_offering)', async () => {
+      // si_get_offering's request schema overrides `context` as a string
+      // (natural-language intent hint). The response schema still expects a
+      // core/context.json object, so the framework must not copy the string.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        sponsoredIntelligence: {
+          getOffering: async () => ({
+            available: true,
+            offering_token: 'tok_123',
+            ttl_seconds: 300,
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'si_get_offering', {
+        offering_id: 'off_1',
+        context: 'mens size 14 near Cincinnati',
+      });
+      assert.strictEqual(result.isError, undefined);
+      assert.ok(
+        !('context' in result.structuredContent),
+        'string request.context must not leak into response.context'
+      );
+    });
+
     it('echoes context on framework SERVICE_UNAVAILABLE when handler throws', async () => {
       const server = createAdcpServer({
         name: 'Test',

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -721,10 +721,7 @@ describe('createAdcpServer', () => {
         context: 'mens size 14 near Cincinnati',
       });
       assert.strictEqual(result.isError, undefined);
-      assert.ok(
-        !('context' in result.structuredContent),
-        'string request.context must not leak into response.context'
-      );
+      assert.ok(!('context' in result.structuredContent), 'string request.context must not leak into response.context');
     });
 
     it('echoes context on framework SERVICE_UNAVAILABLE when handler throws', async () => {

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -451,4 +451,62 @@ describe('createAdcpServer config warnings', () => {
     });
     assert.equal(messages.length, 0);
   });
+
+  it('si_initiate_session: string request.context does not leak through replay', async () => {
+    // si_initiate_session overrides `context` as a required string on the
+    // request (natural-language handoff) while the response schema keeps the
+    // core/context.json object. On replay, `finalize` must not copy the
+    // string into the replayed envelope; and the string must stay in the
+    // payload hash so a different handoff is flagged as IDEMPOTENCY_CONFLICT.
+    const idempotency = createIdempotencyStore({
+      backend: memoryBackend({ sweepIntervalMs: 0 }),
+      ttlSeconds: 86400,
+    });
+    let calls = 0;
+    const server = createAdcpServer({
+      name: 'T',
+      version: '1.0.0',
+      idempotency,
+      resolveSessionKey: () => 'tenant_si',
+      sponsoredIntelligence: {
+        initiateSession: async () => {
+          calls++;
+          return {
+            session_id: `sess_${calls}`,
+            session_status: 'active',
+            session_ttl_seconds: 300,
+          };
+        },
+      },
+    });
+
+    const identity = { consent_granted: true };
+    const key = 'si_replay_abcdefghij12';
+    const handoff = 'mens size 14 near Cincinnati';
+
+    const first = await callTool(server, 'si_initiate_session', {
+      idempotency_key: key,
+      context: handoff,
+      identity,
+    });
+    assert.equal(first.session_id, 'sess_1');
+    assert.ok(!('context' in first), 'fresh response must not echo the string context');
+
+    const replay = await callTool(server, 'si_initiate_session', {
+      idempotency_key: key,
+      context: handoff,
+      identity,
+    });
+    assert.equal(calls, 1, 'handler must not re-execute on replay');
+    assert.equal(replay.replayed, true);
+    assert.ok(!('context' in replay), 'replay must not echo the string context');
+
+    const conflict = await callTool(server, 'si_initiate_session', {
+      idempotency_key: key,
+      context: 'different intent',
+      identity,
+    });
+    assert.equal(calls, 1);
+    assert.equal(conflict.adcp_error?.code, 'IDEMPOTENCY_CONFLICT');
+  });
 });


### PR DESCRIPTION
## Summary

- `createAdcpServer`'s response auto-echo copied `request.context` into `response.context` unconditionally. For Sponsored Intelligence (`si_get_offering`, `si_initiate_session`), the request schema overrides `context` as a domain-specific string (natural-language intent hint, e.g. *'mens size 14 near Cincinnati'*), while the response schema keeps the protocol echo object. The auto-echo put the string into a slot the response schema requires to be an object — every downstream validator failed with `/context: must be object`.
- `injectContextIntoResponse` now short-circuits on non-object values, so SI responses no longer leak the request string into the envelope. Applied the same guard at the `get_adcp_capabilities` echo site for defense in depth.
- Updated `skills/build-si-agent/SKILL.md` — builders who want correlation tracking on `si_get_offering` / `si_initiate_session` responses must now populate the response context object themselves (it can't be echoed from the request).

Closes #721.

## Test plan

- [x] `npm test` — 4965 pass, 0 fail (added two regression tests: direct string-context skip on `si_get_offering`, and replay-path for `si_initiate_session` covering fresh / replay / `IDEMPOTENCY_CONFLICT` on a different intent string).
- [x] `npm run compliance:skill-matrix -- --filter si_baseline` — the response-schema validation failure reported in #721 (`/context: must be object`) no longer occurs. The storyboard retains separate `field_present /context` assertions that were written assuming echo; those are an upstream storyboard-yaml concern (the SI request has no `correlation_id` to echo back) and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)