### PR TITLE
feat(testing): bundle governance.denial_blocks_mutation + auto-register defaults

### DIFF
--- a/.changeset/bundled-governance-denial-blocks-mutation.md
+++ b/.changeset/bundled-governance-denial-blocks-mutation.md
@@ -1,0 +1,15 @@
+---
+'@adcp/client': minor
+---
+
+Bundle the `governance.denial_blocks_mutation` default assertion and auto-register the existing defaults on any `@adcp/client/testing` import (adcontextprotocol/adcp#2639, #2665 closed as superseded).
+
+**New default assertion** (`default-invariants.ts`):
+
+`governance.denial_blocks_mutation` — once a plan receives a denial signal (`GOVERNANCE_DENIED`, `CAMPAIGN_SUSPENDED`, `PERMISSION_DENIED`, `POLICY_VIOLATION`, `TERMS_REJECTED`, `COMPLIANCE_UNSATISFIED`, or `check_governance` returning `status: "denied"`), no subsequent step in the run may acquire a resource for that plan. Plan-scoped via `plan_id` (pulled from response body or the runner's recorded request payload — never stale step context). Sticky within a run: a later successful `check_governance` does not clear the denial. Write-task allowlist excludes `sync_*` batch shapes for now. Silent pass when no denial signal appears.
+
+**Auto-registration wiring**:
+
+`storyboard/index.ts` now side-imports `default-invariants` so any consumer of `@adcp/client/testing` picks up all three built-ins (`idempotency.conflict_no_payload_leak`, `context.no_secret_echo`, `governance.denial_blocks_mutation`). Previously only `comply()` triggered registration; direct `runStoryboard` callers against storyboards declaring `invariants: [...]` would throw `unregistered assertion` on resolve. Consumers who want to replace the defaults can `clearAssertionRegistry()` and re-register.
+
+**Supersedes** #2665 (the sibling `@adcp/compliance-assertions` package proposal): shipping these in-band is the lower-ceremony path and makes storyboards that reference the ids work out of the box against a fresh `@adcp/client` install.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -16,6 +16,12 @@
  *   - `context.no_secret_echo` — the echoed `context` object on any step
  *     must not contain any bearer token, API key, or auth header value
  *     supplied in the options. Scan recursively.
+ *   - `governance.denial_blocks_mutation` — once a plan is denied by a
+ *     governance signal (GOVERNANCE_DENIED, CAMPAIGN_SUSPENDED, etc., or
+ *     `check_governance` returning `status: "denied"`), no subsequent step
+ *     in the run may acquire a resource for that plan. Catches sellers that
+ *     surface the denial but mutate anyway. Plan-scoped via `plan_id`; runs
+ *     without a denial signal are a silent pass.
  */
 
 import { registerAssertion } from './assertions';
@@ -96,6 +102,171 @@ registerOnce('context.no_secret_echo', {
     return [{ passed: true, description, step_id: stepResult.step_id }];
   },
 });
+
+// ────────────────────────────────────────────────────────────
+// governance.denial_blocks_mutation
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Error codes that signal a seller-side refusal with plan scope. Grounded
+ * in `ErrorCodeSchema` in `src/lib/types/schemas.generated.ts`. Excludes
+ * transient (`GOVERNANCE_UNAVAILABLE` — no decision rendered) and
+ * account-state (`ACCOUNT_SUSPENDED`) codes — those aren't plan denials.
+ */
+const GOVERNANCE_DENIAL_CODES = new Set([
+  'GOVERNANCE_DENIED',
+  'CAMPAIGN_SUSPENDED',
+  'PERMISSION_DENIED',
+  'POLICY_VIOLATION',
+  'TERMS_REJECTED',
+  'COMPLIANCE_UNSATISFIED',
+]);
+
+/**
+ * Write-class tasks whose successful response carries a server-minted
+ * resource id at the top level. Read tasks (`get_*`, `list_*`,
+ * `check_governance`) can echo ids without having created anything; they
+ * are excluded so the assertion doesn't false-positive on lookups after
+ * a denial. Sync-batch tasks (`sync_*`) are excluded until per-item
+ * acquisition detection lands — see follow-up in the spec repo.
+ */
+const GOVERNANCE_WRITE_TASKS = new Set([
+  'create_media_buy',
+  'update_media_buy',
+  'activate_signal',
+  'create_property_list',
+  'update_property_list',
+  'delete_property_list',
+  'create_collection_list',
+  'update_collection_list',
+  'delete_collection_list',
+  'acquire_rights',
+]);
+
+const GOVERNANCE_ACQUIRED_STATUSES = new Set(['pending_creatives', 'pending_start', 'active', 'paused', 'completed']);
+
+const GOVERNANCE_RESOURCE_ID_FIELDS = [
+  'media_buy_id',
+  'plan_id',
+  'creative_id',
+  'audience_id',
+  'catalog_id',
+  'activation_id',
+  'property_list_id',
+  'collection_list_id',
+  'acquisition_id',
+  'operation_id',
+];
+
+interface GovernanceDenialAnchor {
+  stepId: string;
+  signal: string;
+}
+
+registerOnce('governance.denial_blocks_mutation', {
+  id: 'governance.denial_blocks_mutation',
+  description:
+    'Once a governance signal denies a plan, no subsequent step in the run may acquire a resource for that plan.',
+  onStart: ctx => {
+    ctx.state.deniedPlans = new Map<string, GovernanceDenialAnchor>();
+    ctx.state.runDenial = undefined;
+  },
+  onStep: (ctx, stepResult) => {
+    const state = ctx.state as {
+      deniedPlans: Map<string, GovernanceDenialAnchor>;
+      runDenial?: GovernanceDenialAnchor;
+    };
+    const planId = extractGovernancePlanId(stepResult);
+
+    // Denial observation is never itself a failure — record and return.
+    const denial = detectGovernanceDenial(stepResult);
+    if (denial) {
+      const anchor: GovernanceDenialAnchor = { stepId: stepResult.step_id, signal: denial };
+      if (planId) {
+        if (!state.deniedPlans.has(planId)) state.deniedPlans.set(planId, anchor);
+      } else if (!state.runDenial) {
+        state.runDenial = anchor;
+      }
+      return [];
+    }
+
+    const acquired = detectGovernanceAcquisition(stepResult);
+    if (!acquired) return [];
+
+    const anchor = (planId && state.deniedPlans.get(planId)) ?? state.runDenial;
+    if (!anchor) return [];
+
+    return [
+      {
+        passed: false,
+        description: 'Mutation acquired a resource after a governance denial',
+        step_id: stepResult.step_id,
+        error:
+          `step "${anchor.stepId}" returned ${anchor.signal}` +
+          (planId ? ` for plan_id=${planId}` : ' (run-wide)') +
+          `; subsequent step "${stepResult.step_id}" (task=${stepResult.task}) ` +
+          `acquired ${acquired.field}=${acquired.id}` +
+          (planId ? ' for the same plan' : ''),
+      },
+    ];
+  },
+});
+
+function detectGovernanceDenial(step: import('./types').StoryboardStepResult): string | undefined {
+  const err = extractAdcpError(step);
+  if (err && GOVERNANCE_DENIAL_CODES.has(err.code)) return err.code;
+  // `check_governance` decides-no via a 200 response with `status: "denied"`
+  // (see static/schemas/source/governance/check-governance-response.json in
+  // the spec repo). The body isn't wrapped in `adcp_error`.
+  if (step.task === 'check_governance') {
+    const body = (step as unknown as { response?: unknown }).response;
+    if (body && typeof body === 'object') {
+      const status = (body as Record<string, unknown>).status;
+      if (status === 'denied') return 'CHECK_GOVERNANCE_DENIED';
+    }
+  }
+  return undefined;
+}
+
+function extractGovernancePlanId(step: import('./types').StoryboardStepResult): string | undefined {
+  const body = (step as unknown as { response?: unknown }).response;
+  if (body && typeof body === 'object') {
+    const rec = body as Record<string, unknown>;
+    if (typeof rec.plan_id === 'string' && rec.plan_id) return rec.plan_id;
+  }
+  // The runner records the outgoing payload on `stepResult.request` — read
+  // from there rather than accumulated step context to avoid stale plan_id
+  // bleed from earlier unrelated steps.
+  const req = (step as unknown as { request?: { payload?: unknown } }).request;
+  if (req && typeof req.payload === 'object' && req.payload !== null) {
+    const payload = req.payload as Record<string, unknown>;
+    if (typeof payload.plan_id === 'string' && payload.plan_id) return payload.plan_id;
+  }
+  return undefined;
+}
+
+function detectGovernanceAcquisition(
+  step: import('./types').StoryboardStepResult
+): { field: string; id: string } | undefined {
+  if (step.expect_error) return undefined;
+  if (!step.passed) return undefined;
+  if (!GOVERNANCE_WRITE_TASKS.has(step.task)) return undefined;
+
+  const body = (step as unknown as { response?: unknown }).response;
+  if (!body || typeof body !== 'object') return undefined;
+  const record = body as Record<string, unknown>;
+
+  if (step.task === 'create_media_buy' || step.task === 'update_media_buy') {
+    const status = record.status;
+    if (typeof status === 'string' && !GOVERNANCE_ACQUIRED_STATUSES.has(status)) return undefined;
+  }
+
+  for (const field of GOVERNANCE_RESOURCE_ID_FIELDS) {
+    const val = record[field];
+    if (typeof val === 'string' && val.length > 0) return { field, id: val };
+  }
+  return undefined;
+}
 
 // ────────────────────────────────────────────────────────────
 // Helpers

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -7,6 +7,14 @@
  * and is pulled into `compliance/cache/{version}/` via `npm run sync-schemas`.
  */
 
+// Side-effect import: registers the default cross-step assertions that
+// upstream storyboards reference by id (idempotency.conflict_no_payload_leak,
+// context.no_secret_echo, governance.denial_blocks_mutation). Without this
+// import here, any `runStoryboard` call against a storyboard declaring
+// `invariants: [...]` would throw at start on unresolved ids. Consumers who
+// want to replace the defaults can `clearAssertionRegistry()` first.
+import './default-invariants';
+
 // Types
 export type {
   Storyboard,

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -1,0 +1,275 @@
+/**
+ * Default assertion registrations (`default-invariants.ts`).
+ *
+ * Verifies that importing `@adcp/client/testing` auto-registers the three
+ * built-in assertion ids that upstream storyboards reference — fresh
+ * installs of the SDK should just work against storyboards declaring
+ * `invariants: [context.no_secret_echo, idempotency.conflict_no_payload_leak,
+ * governance.denial_blocks_mutation]`.
+ *
+ * Also pins the governance assertion's step-level semantics (plan-scoped,
+ * sticky denial, write-task allowlist) with unit coverage since the
+ * idempotency / context assertions already have indirect coverage via the
+ * compliance flow.
+ */
+
+const { describe, test, it } = require('node:test');
+const assert = require('node:assert');
+
+const { getAssertion, resolveAssertions } = require('../../dist/lib/testing/storyboard/assertions.js');
+// Side-effect import that should register all three built-ins.
+require('../../dist/lib/testing/storyboard/default-invariants.js');
+
+describe('default-invariants: auto-registration', () => {
+  it('registers the three upstream assertion ids', () => {
+    for (const id of [
+      'idempotency.conflict_no_payload_leak',
+      'context.no_secret_echo',
+      'governance.denial_blocks_mutation',
+    ]) {
+      assert.ok(getAssertion(id), `assertion "${id}" must be registered at import time`);
+    }
+  });
+
+  it('resolveAssertions() on a storyboard referencing all three does not throw', () => {
+    assert.doesNotThrow(() =>
+      resolveAssertions([
+        'idempotency.conflict_no_payload_leak',
+        'context.no_secret_echo',
+        'governance.denial_blocks_mutation',
+      ])
+    );
+  });
+});
+
+describe('default-invariants: governance.denial_blocks_mutation', () => {
+  const spec = getAssertion('governance.denial_blocks_mutation');
+
+  function makeCtx() {
+    return {
+      storyboard: {},
+      agentUrl: 'http://agent.example/mcp',
+      options: {},
+      state: {},
+    };
+  }
+
+  function makeStep(overrides = {}) {
+    return {
+      step_id: 's1',
+      phase_id: 'p',
+      title: 't',
+      task: 'create_media_buy',
+      passed: true,
+      duration_ms: 0,
+      validations: [],
+      context: {},
+      extraction: { path: 'none' },
+      ...overrides,
+    };
+  }
+
+  function denialStep(planId, code = 'GOVERNANCE_DENIED') {
+    return makeStep({
+      step_id: 'deny',
+      task: 'check_governance',
+      expect_error: true,
+      response: { plan_id: planId, adcp_error: { code, message: 'denied' } },
+    });
+  }
+
+  function mutateStep({ planId, requestPlanId, task = 'create_media_buy', response } = {}) {
+    const body = response ?? { media_buy_id: 'mb-1', status: 'active' };
+    if (planId) body.plan_id = planId;
+    const step = makeStep({ step_id: 'mutate', task, passed: true, response: body });
+    if (requestPlanId) {
+      step.request = { transport: 'mcp', operation: task, payload: { plan_id: requestPlanId } };
+    }
+    return step;
+  }
+
+  function run(steps) {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    return steps.map(s => ({ step: s.step_id, output: spec.onStep(ctx, s) }));
+  }
+
+  test('silent when there is no denial', () => {
+    const out = run([mutateStep({ planId: 'plan-a' })]);
+    assert.deepStrictEqual(out[0].output, []);
+  });
+
+  test('fires when a mutation follows a plan-scoped denial', () => {
+    const out = run([denialStep('plan-a'), mutateStep({ planId: 'plan-a' })]);
+    const v = out[1].output[0];
+    assert.strictEqual(v.passed, false);
+    assert.match(v.error, /GOVERNANCE_DENIED/);
+    assert.match(v.error, /plan_id=plan-a/);
+    assert.match(v.error, /media_buy_id=mb-1/);
+  });
+
+  test('is plan-scoped — denial on plan A does not block mutation on plan B', () => {
+    const out = run([
+      denialStep('plan-a'),
+      mutateStep({ planId: 'plan-b', response: { media_buy_id: 'mb-b', status: 'active' } }),
+    ]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('reads plan_id from the runner-recorded request payload when the response omits it', () => {
+    const out = run([
+      denialStep('plan-a'),
+      mutateStep({ requestPlanId: 'plan-a', response: { media_buy_id: 'mb-new', status: 'active' } }),
+    ]);
+    assert.strictEqual(out[1].output[0].passed, false);
+    assert.match(out[1].output[0].error, /plan_id=plan-a/);
+  });
+
+  test('does not bind plan_id from accumulated step context (false-positive guard)', () => {
+    // Unlinked mutation: plan-a denial, but the mutation has no plan linkage
+    // on either response or recorded request. Context fallback would wrongly
+    // bind this to plan-a; the assertion must stay silent.
+    const step = mutateStep({ response: { media_buy_id: 'mb-new', status: 'active' } });
+    step.context = { plan_id: 'plan-a' };
+    const out = run([denialStep('plan-a'), step]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('fires on check_governance 200 with status: denied', () => {
+    const step = makeStep({
+      step_id: 'check_denied',
+      task: 'check_governance',
+      expect_error: false,
+      response: { status: 'denied', plan_id: 'plan-b', explanation: 'over threshold' },
+    });
+    const out = run([step, mutateStep({ planId: 'plan-b' })]);
+    assert.match(out[1].output[0].error, /CHECK_GOVERNANCE_DENIED/);
+  });
+
+  test('treats rejected media_buy status as NOT acquired', () => {
+    const out = run([
+      denialStep('plan-a'),
+      makeStep({
+        step_id: 'rejected_mb',
+        task: 'create_media_buy',
+        response: { media_buy_id: 'mb-rej', status: 'rejected', plan_id: 'plan-a' },
+      }),
+    ]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('ignores read tasks even if they echo resource ids', () => {
+    const out = run([
+      denialStep('plan-a'),
+      makeStep({
+        step_id: 'lookup',
+        task: 'get_media_buys',
+        response: { media_buys: [{ media_buy_id: 'mb-x', plan_id: 'plan-a' }] },
+      }),
+    ]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('denial state is sticky — later passing check_governance does not clear it', () => {
+    const out = run([
+      denialStep('plan-a'),
+      makeStep({
+        step_id: 'recheck',
+        task: 'check_governance',
+        response: { status: 'approved', plan_id: 'plan-a' },
+      }),
+      mutateStep({ planId: 'plan-a' }),
+    ]);
+    assert.strictEqual(out[2].output[0].passed, false);
+    assert.match(out[2].output[0].error, /GOVERNANCE_DENIED/);
+  });
+
+  test('records only the first anchor on a plan', () => {
+    const out = run([
+      denialStep('plan-a', 'GOVERNANCE_DENIED'),
+      denialStep('plan-a', 'CAMPAIGN_SUSPENDED'),
+      mutateStep({ planId: 'plan-a' }),
+    ]);
+    const err = out[2].output[0].error;
+    assert.match(err, /GOVERNANCE_DENIED/);
+    assert.doesNotMatch(err, /CAMPAIGN_SUSPENDED/);
+  });
+
+  test('ignores transient signals like GOVERNANCE_UNAVAILABLE', () => {
+    const step = makeStep({
+      step_id: 'transient',
+      task: 'check_governance',
+      expect_error: true,
+      response: { plan_id: 'plan-a', adcp_error: { code: 'GOVERNANCE_UNAVAILABLE', message: 'timeout' } },
+    });
+    const out = run([step, mutateStep({ planId: 'plan-a' })]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('falls back to run-scoped for denial signals without plan linkage', () => {
+    const step = makeStep({
+      step_id: 'deny_no_plan',
+      task: 'get_products',
+      expect_error: true,
+      response: { adcp_error: { code: 'POLICY_VIOLATION', message: 'refused' } },
+    });
+    const out = run([step, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } })]);
+    assert.strictEqual(out[1].output[0].passed, false);
+    assert.match(out[1].output[0].error, /run-wide/);
+  });
+
+  for (const code of [
+    'GOVERNANCE_DENIED',
+    'CAMPAIGN_SUSPENDED',
+    'PERMISSION_DENIED',
+    'POLICY_VIOLATION',
+    'TERMS_REJECTED',
+    'COMPLIANCE_UNSATISFIED',
+  ]) {
+    test(`triggers on error code ${code}`, () => {
+      const out = run([denialStep('plan-a', code), mutateStep({ planId: 'plan-a' })]);
+      assert.strictEqual(out[1].output[0].passed, false);
+      assert.match(out[1].output[0].error, new RegExp(code));
+    });
+  }
+
+  test('accepts failed writes as non-mutations', () => {
+    const failed = makeStep({
+      step_id: 'failed_mutate',
+      task: 'create_media_buy',
+      passed: false,
+      response: { plan_id: 'plan-a', adcp_error: { code: 'VALIDATION_ERROR', message: 'bad input' } },
+    });
+    const out = run([denialStep('plan-a'), failed]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('counts acquire_rights and activate_signal as mutations', () => {
+    const acq = run([
+      denialStep('plan-a'),
+      makeStep({
+        step_id: 'acq',
+        task: 'acquire_rights',
+        response: { plan_id: 'plan-a', acquisition_id: 'acq-1' },
+      }),
+    ]);
+    assert.strictEqual(acq[1].output[0].passed, false);
+    const act = run([
+      denialStep('plan-a'),
+      makeStep({
+        step_id: 'act',
+        task: 'activate_signal',
+        response: { plan_id: 'plan-a', activation_id: 'act-1' },
+      }),
+    ]);
+    assert.strictEqual(act[1].output[0].passed, false);
+  });
+
+  test('onStart resets runDenial so stale state does not bleed across runs', () => {
+    const ctx = makeCtx();
+    ctx.state.runDenial = { stepId: 'stale', signal: 'STALE' };
+    spec.onStart(ctx);
+    const out = spec.onStep(ctx, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } }));
+    assert.strictEqual(out.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last gap in the cross-step assertion framework (adcontextprotocol/adcp#2639). Adds the third upstream default assertion (`governance.denial_blocks_mutation`) to `default-invariants.ts` and wires side-effect registration into the storyboard index so **any** consumer of `@adcp/client/testing` picks up all three built-ins — not just `comply()` callers.

Before this PR:

- `idempotency.conflict_no_payload_leak` and `context.no_secret_echo` were in `default-invariants.ts` but only registered via `compliance/comply.ts`.
- A direct `runStoryboard(agent, storyboard)` call against a storyboard declaring `invariants: [context.no_secret_echo, …]` (e.g. `universal/idempotency.yaml` after adcontextprotocol/adcp#2663) would throw `unregistered assertion "context.no_secret_echo"` at resolve time.
- The CLI `--invariants` flag (#697) was the only escape hatch.

After:

- `storyboard/index.ts` side-imports `default-invariants`, so `import { runStoryboard } from '@adcp/client/testing'` auto-registers all three built-ins.
- Consumers who want to replace the defaults can `clearAssertionRegistry()` and re-register — the module uses `registerOnce` internally so duplicate imports are a no-op.
- Supersedes adcontextprotocol/adcp#2665 (the sibling `@adcp/compliance-assertions` package proposal). Shipping in-band is the lower-ceremony path.

## `governance.denial_blocks_mutation` semantics

Matches the expert-reviewed design in adcontextprotocol/adcp#2663.

**Denial signals** (any one enters denial state for the step's `plan_id`):
- Error-envelope codes: `GOVERNANCE_DENIED`, `CAMPAIGN_SUSPENDED`, `PERMISSION_DENIED`, `POLICY_VIOLATION`, `TERMS_REJECTED`, `COMPLIANCE_UNSATISFIED`.
- `check_governance` 200 response with `status: "denied"` (schema at `static/schemas/source/governance/check-governance-response.json`).
- Explicitly NOT denials: `GOVERNANCE_UNAVAILABLE` (transient), `ACCOUNT_SUSPENDED` (account state), `CONFLICT` / `IDEMPOTENCY_CONFLICT` (retry semantics).

**Plan-scoped** via `plan_id`:
- Response body first (denials carry it per schema), then `stepResult.request.payload.plan_id` (the runner's recorded outgoing request).
- Never falls back to accumulated `step.context` — stale `plan_id` values from much-earlier steps would bind denials to the wrong plan.
- Signals without any `plan_id` linkage fall back to run-wide blocking for that signal only.

**Acquisition detection** (what counts as a post-denial mutation):
- Write-task allowlist: `create_media_buy`, `update_media_buy`, `activate_signal`, `acquire_rights`, `create_property_list` / `update` / `delete`, `create_collection_list` / `update` / `delete`.
- `sync_*` batch tasks excluded for now — batch shapes carry resource ids per-item inside `creatives: [{ creative_id, action: "created" }, …]`, and detecting per-item acquisitions needs schema-specific traversal. Tracked as a follow-up.
- Success response (`passed`, not `expect_error`) with a minted id in `RESOURCE_ID_FIELDS`.
- Media-buy responses additionally gate on status: `rejected`/`canceled` don't count as "acquired".

**Sticky state**: a later passing `check_governance` on the same plan does NOT clear the denial. The correct recovery is a fresh `governance_context` token; within-run monotonicity is the spec-aligned behavior.

**Silent pass**: runs without any denial signal (the common case) produce no assertion output.

## Test coverage

23 new tests in `test/lib/storyboard-default-invariants.test.js`:

- Auto-registration: all three ids resolvable via `getAssertion` after a bare `require('./default-invariants')`; `resolveAssertions()` on a list including all three does not throw.
- Table-driven over all 6 denial error codes (`GOVERNANCE_DENIED`, `CAMPAIGN_SUSPENDED`, `PERMISSION_DENIED`, `POLICY_VIOLATION`, `TERMS_REJECTED`, `COMPLIANCE_UNSATISFIED`) — each fires the assertion.
- Excluded-codes guard: `GOVERNANCE_UNAVAILABLE` stays silent.
- `check_governance` 200 + `status: denied` fires with signal `CHECK_GOVERNANCE_DENIED`.
- Plan-scoped correctness: denial on plan A does not block mutation on plan B.
- Request-payload fallback for `plan_id` when response omits it.
- Context-fallback false-positive guard: accumulated `step.context.plan_id` from prior steps does NOT bind the denial.
- Rejected media-buy status does NOT count as acquired.
- Read tasks (`get_media_buys`) ignored even when echoing resource ids.
- Sticky: later passing `check_governance` on same plan does not clear.
- First-anchor precedence: second denial on same plan doesn't overwrite the first signal in diagnostics.
- `acquire_rights` / `activate_signal` both count as acquisitions.
- Failed writes as non-mutations.
- `onStart` resets `runDenial` so stale state doesn't bleed across runs.
- Run-scoped fallback when denial signal has no plan linkage.

Neighbor storyboard test suite: 293/309 pass — same 16 pre-existing failures as main baseline, no new regressions.

## Related

- adcontextprotocol/adcp#2639 — assertion framework origin
- adcontextprotocol/adcp#2663 — first in-spec wiring (`universal/idempotency.yaml` + `governance-*` specialisms)
- adcontextprotocol/adcp#2665 — closed as superseded (sibling-package extraction is premature; this in-band approach is simpler)
- adcontextprotocol/adcp-client#692 — registry + hooks
- adcontextprotocol/adcp-client#713 — re-export from `@adcp/client/testing`
- adcontextprotocol/adcp-client#697 — CLI `--invariants` flag (still relevant for consumer-authored assertions; built-ins no longer require it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)