### PR TITLE
feat(server): default exposeErrorDetails to true outside NODE_ENV=production

### DIFF
--- a/.changeset/expose-handler-errors-in-dev.md
+++ b/.changeset/expose-handler-errors-in-dev.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': minor
+---
+
+`createAdcpServer`'s `exposeErrorDetails` now defaults to `true` outside `NODE_ENV=production`. Handler throws emit the underlying cause message and handler name in `adcp_error.details` + the human-readable text, so agent authors see `SERVICE_UNAVAILABLE: Tool acquire_rights handler threw: Cannot find module '@adcp/client/foo'` instead of the opaque `encountered an internal error` we used to ship.
+
+- Production behavior is unchanged (errors stay redacted for live agents).
+- Explicit `exposeErrorDetails: false` still wins — production deployments that want the redaction without relying on `NODE_ENV` should keep setting it.
+- `logger.error('Handler failed', ...)` now includes the full stack (`err.stack`) so server logs point at the exact line that blew up, not just the message.
+
+Matrix-harness debuggability was the driver: every `SERVICE_UNAVAILABLE` in matrix v5–v7 was an opaque black box that required re-running with `--keep-workspaces` and inspecting Claude-generated code to figure out why a handler threw. With this default, the matrix log shows the fault line on the first run.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -747,8 +747,14 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * underlying `err.message` in `details.reason` (helpful in dev, but can leak
    * DB driver messages, file paths, or schema info to remote callers).
    *
-   * Defaults to `false`. Enable in trusted environments when you want
-   * debuggable failures at the call site.
+   * Defaults:
+   *   - `NODE_ENV === 'production'` → `false` (safe default for live agents).
+   *   - Otherwise → `true` (dev/test/CI surface the cause chain so
+   *     `SERVICE_UNAVAILABLE: encountered an internal error` becomes
+   *     `SERVICE_UNAVAILABLE: Cannot find module '@adcp/client/foo'`.
+   *     Matrix runs spent weeks on opaque SU errors before this default flipped).
+   *
+   * Explicit `exposeErrorDetails: true | false` always wins.
    */
   exposeErrorDetails?: boolean;
 
@@ -1504,7 +1510,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     version,
     resolveAccount,
     resolveSessionKey,
-    exposeErrorDetails = false,
+    exposeErrorDetails = process.env.NODE_ENV !== 'production',
     stateStore = new InMemoryStateStore(),
     logger = noopLogger,
     capabilities: capConfig,
@@ -1904,7 +1910,15 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           return finalize(formatted);
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
-          logger.error('Handler failed', { tool: toolName, error: reason });
+          // Log the full stack — `logger.error` with just the message turned
+          // every "Handler failed" into a guessing game for agent authors.
+          // Stack tells you which import/typo/access chain blew up.
+          logger.error('Handler failed', {
+            tool: toolName,
+            handler: handlerKey,
+            error: reason,
+            stack: err instanceof Error ? err.stack : undefined,
+          });
           if (idempotencyCheck && idempotency) {
             try {
               await idempotency.release({
@@ -1922,8 +1936,15 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
           return finalize(
             adcpError('SERVICE_UNAVAILABLE', {
-              message: `Tool ${toolName} encountered an internal error`,
-              ...(exposeErrorDetails && { details: { reason } }),
+              // Include the cause message directly in the response text when
+              // `exposeErrorDetails` is on. The opaque
+              // "Tool X encountered an internal error" string cost us weeks
+              // of diagnostic time on the matrix harness — dev callers want
+              // the real reason at the call site, not hidden in server logs.
+              message: exposeErrorDetails
+                ? `Tool ${toolName} handler threw: ${reason}`
+                : `Tool ${toolName} encountered an internal error`,
+              ...(exposeErrorDetails && { details: { reason, handler: handlerKey } }),
             })
           );
         }

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-21T20:38:55.080Z
+// Generated at: 2026-04-21T21:11:04.729Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -16421,7 +16421,8 @@ export type XEntityTypes =
   | 'governance_check'
   | 'content_standards'
   | 'task'
-  | 'si_session';
+  | 'si_session'
+  | 'offering';
 
 
 // enums/brand-agent-type.json

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-21T20:38:58.904Z
+// Generated at: 2026-04-21T21:11:08.908Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -3585,7 +3585,7 @@ export const VehicleItemSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const XEntityTypesSchema = z.union([z.literal("advertiser_brand"), z.literal("rights_holder_brand"), z.literal("rights_grant"), z.literal("account"), z.literal("operator"), z.literal("media_buy"), z.literal("package"), z.literal("product"), z.literal("product_pricing_option"), z.literal("vendor_pricing_option"), z.literal("creative"), z.literal("creative_format"), z.literal("audience"), z.literal("signal"), z.literal("signal_activation_id"), z.literal("event_source"), z.literal("collection_list"), z.literal("property_list"), z.literal("catalog"), z.literal("property"), z.literal("media_plan"), z.literal("governance_plan"), z.literal("governance_policy"), z.literal("governance_check"), z.literal("content_standards"), z.literal("task"), z.literal("si_session")]);
+export const XEntityTypesSchema = z.union([z.literal("advertiser_brand"), z.literal("rights_holder_brand"), z.literal("rights_grant"), z.literal("account"), z.literal("operator"), z.literal("media_buy"), z.literal("package"), z.literal("product"), z.literal("product_pricing_option"), z.literal("vendor_pricing_option"), z.literal("creative"), z.literal("creative_format"), z.literal("audience"), z.literal("signal"), z.literal("signal_activation_id"), z.literal("event_source"), z.literal("collection_list"), z.literal("property_list"), z.literal("catalog"), z.literal("property"), z.literal("media_plan"), z.literal("governance_plan"), z.literal("governance_policy"), z.literal("governance_check"), z.literal("content_standards"), z.literal("task"), z.literal("si_session"), z.literal("offering")]);
 
 export const BrandAgentTypeSchema = z.union([z.literal("brand"), z.literal("rights"), z.literal("measurement"), z.literal("governance"), z.literal("creative"), z.literal("sales"), z.literal("buying"), z.literal("signals")]);
 

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -331,10 +331,15 @@ describe('resolveSessionKey', () => {
     assert.strictEqual(seenSessionKey, 'tnt_42');
   });
 
-  it('returns SERVICE_UNAVAILABLE without leaking internals by default if resolver throws', async () => {
+  it('returns SERVICE_UNAVAILABLE without leaking internals when exposeErrorDetails: false', async () => {
+    // Explicit opt-out. The default flipped to true outside NODE_ENV=production
+    // so dev-mode matrix runs stop wasting hours on opaque internal errors;
+    // production deployments that want the redaction still get it by default
+    // (NODE_ENV=production) or by setting `exposeErrorDetails: false` explicitly.
     const server = createAdcpServer({
       name: 'Test',
       version: '1.0.0',
+      exposeErrorDetails: false,
       resolveSessionKey: () => {
         throw new Error('db://user:pass@10.0.0.1 timed out');
       },


### PR DESCRIPTION
Handler throws now emit the actual cause + handler name in dev/test/CI, so matrix runs and local dev stop losing hours on opaque 'encountered an internal error'. Production behavior unchanged — set NODE_ENV=production (or pass `exposeErrorDetails: false`) to get the old redacted behavior.

## What changes

`createAdcpServer({ exposeErrorDetails })` default:
- Before: `false` (always redact).
- After: `process.env.NODE_ENV !== 'production'` (redact only in prod).

`logger.error('Handler failed', ...)` now includes `err.stack` and `handler` key.

When `exposeErrorDetails` is on, the `SERVICE_UNAVAILABLE` message text is also upgraded from `Tool X encountered an internal error` to `Tool X handler threw: <cause message>` so the failure is readable at the call site — not just in server logs.

## Why now

Matrix v6/v7 had 20–26 `SERVICE_UNAVAILABLE` rows per run with zero diagnostic. Each one was a handler throw, opaque. Validation default-on (#732) can't help — it only fires when the handler returns successfully. The fix has to be at the catch site.

### Before (v7)
```
SERVICE_UNAVAILABLE: Tool acquire_rights encountered an internal error
```

### After
```
SERVICE_UNAVAILABLE: Tool acquire_rights handler threw: Cannot find module '@adcp/client/foo'
details: { reason: "Cannot find module ...", handler: "acquireRights" }
```

## Test plan

- [x] Existing test `returns SERVICE_UNAVAILABLE without leaking internals` updated to pass `exposeErrorDetails: false` explicitly (documents the production-prod path).
- [x] Full suite: 4968 pass / 0 fail.
- [x] Typecheck clean.
- [ ] Matrix v8 after merge — expect opaque SU lines to gain specific causes, unlocking the next round of skill fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)