### PR TITLE
test(fuzz): A2A integration coverage for uniform-error-response invariant (#738)

### DIFF
--- a/.changeset/uniform-error-invariant-a2a.md
+++ b/.changeset/uniform-error-invariant-a2a.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': patch
+---
+
+Extend the uniform-error-response comparator (adcontextprotocol/adcp-client#738) to walk A2A Task and Message shapes when looking for the AdCP error envelope. `extractEnvelope` now finds `adcp_error` nested in `result.artifacts[].parts[].data` (Task reply) or `result.parts[].data` (Message reply); `peelWrappers` reduces A2A Task/Message bodies to their data-part payloads so per-request `task.id` / `contextId` / `artifactId` / `messageId` don't false-positive structural compares on identical success bodies.
+
+Adds `test/lib/uniform-error-invariant-a2a.test.js` — the A2A-shaped sibling of the existing MCP integration test, running the same five-case matrix (baseline compliant/leak, cross-tenant compliant/leak, baseline fallback) against an in-process A2A seller reached through `@a2a-js/sdk/client`. Closes the gap where only hand-crafted JSON strings exercised the A2A path.

--- a/src/lib/conformance/invariants/uniformErrorComparator.ts
+++ b/src/lib/conformance/invariants/uniformErrorComparator.ts
@@ -207,6 +207,16 @@ function peelWrappers(body: unknown): unknown {
       }
     }
   }
+  // A2A Task / Message — reduce to just the data parts' payloads so
+  // per-request ids (task.id, contextId, artifactId, messageId,
+  // status.timestamp) don't fail structural compare when the domain
+  // data is actually identical.
+  if (obj.kind === 'task' && Array.isArray(obj.artifacts)) {
+    return collectA2ADataParts(obj.artifacts);
+  }
+  if (obj.kind === 'message' && Array.isArray(obj.parts)) {
+    return collectA2ADataParts([obj]);
+  }
   // Strip `_meta` — MCP's per-request metadata channel — before
   // handing the object back for structural comparison.
   if ('_meta' in obj) {
@@ -215,6 +225,20 @@ function peelWrappers(body: unknown): unknown {
     return rest;
   }
   return obj;
+}
+
+function collectA2ADataParts(source: unknown[]): unknown[] {
+  const out: unknown[] = [];
+  for (const entry of source) {
+    const parts = (entry as { parts?: unknown })?.parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      const p = part as { kind?: string; data?: unknown; text?: unknown };
+      if (p?.kind === 'data' && p.data !== undefined) out.push(p.data);
+      else if (p?.kind === 'text' && typeof p.text === 'string') out.push({ text: p.text });
+    }
+  }
+  return out;
 }
 
 function tryParseJson(text: string): unknown {
@@ -348,6 +372,38 @@ function extractEnvelope(body: unknown): ErrorEnvelope | undefined {
           const inner = extractEnvelope(parsed);
           if (inner) return inner;
         }
+      }
+    }
+  }
+
+  // A2A Task: { kind:'task', status, artifacts:[{ parts:[{ kind:'data', data }] }] }.
+  // AdCP sellers over A2A return errors as `adcp_error` nested in an
+  // artifact's data part. Walk every data part — agents may split parts
+  // or use the last-artifact convention from the response unwrapper.
+  if (Array.isArray(obj.artifacts)) {
+    for (const artifact of obj.artifacts) {
+      const parts = (artifact as { parts?: unknown })?.parts;
+      if (Array.isArray(parts)) {
+        for (const part of parts) {
+          const data = (part as { kind?: string; data?: unknown })?.data;
+          if (data && typeof data === 'object') {
+            const inner = extractEnvelope(data);
+            if (inner) return inner;
+          }
+        }
+      }
+    }
+  }
+
+  // A2A Message: { kind:'message', parts:[{ kind:'data', data }] }.
+  // Sellers that skip the Task wrapper and reply with a Message
+  // directly still carry the AdCP payload in a data part.
+  if (obj.kind === 'message' && Array.isArray(obj.parts)) {
+    for (const part of obj.parts) {
+      const data = (part as { kind?: string; data?: unknown })?.data;
+      if (data && typeof data === 'object') {
+        const inner = extractEnvelope(data);
+        if (inner) return inner;
       }
     }
   }

--- a/test/lib/uniform-error-comparator.test.js
+++ b/test/lib/uniform-error-comparator.test.js
@@ -232,6 +232,87 @@ describe('uniformErrorComparator', () => {
     assert.ok(r.differences.some(d => d.includes('A2A task.status.state diverges')));
   });
 
+  // A2A AdCP shape: adcp_error lives inside result.artifacts[0].parts[0].data.
+  // The real @a2a-js/sdk wire response wraps this in a JSON-RPC envelope
+  // with per-request task.id / contextId / artifactId — the comparator must
+  // walk past those to find the envelope without tripping on metadata.
+  const a2aTaskBody = payload =>
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        kind: 'task',
+        id: `task_${Math.random().toString(36).slice(2)}`,
+        contextId: `ctx_${Math.random().toString(36).slice(2)}`,
+        status: { state: 'completed', timestamp: new Date().toISOString() },
+        artifacts: [
+          {
+            artifactId: `art_${Math.random().toString(36).slice(2)}`,
+            parts: [{ kind: 'data', data: payload }],
+          },
+        ],
+      },
+    });
+
+  test('A2A task artifact with identical adcp_error → equivalent (ignores task/contextId/artifactId)', () => {
+    const payload = { adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'not found' } };
+    const r = compareProbes(capture({ body: a2aTaskBody(payload) }), capture({ body: a2aTaskBody(payload) }));
+    assert.equal(r.equivalent, true, `unexpected differences: ${JSON.stringify(r.differences)}`);
+  });
+
+  test('A2A task artifact with divergent adcp_error.code → fail', () => {
+    const r = compareProbes(
+      capture({ body: a2aTaskBody({ adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'not found' } }) }),
+      capture({ body: a2aTaskBody({ adcp_error: { code: 'PERMISSION_DENIED', message: 'not found' } }) })
+    );
+    assert.equal(r.equivalent, false);
+    assert.ok(r.differences.some(d => d.startsWith('error.code diverges')));
+  });
+
+  test('A2A task artifact with divergent adcp_error.details → fail', () => {
+    const r = compareProbes(
+      capture({
+        body: a2aTaskBody({
+          adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'not found', details: { looked_up: 'abc' } },
+        }),
+      }),
+      capture({
+        body: a2aTaskBody({
+          adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'not found', details: { looked_up: 'xyz' } },
+        }),
+      })
+    );
+    assert.equal(r.equivalent, false);
+    assert.ok(r.differences.some(d => d.startsWith('error.details diverges')));
+  });
+
+  test('A2A message reply with identical adcp_error → equivalent (ignores messageId)', () => {
+    // Some sellers skip the Task wrapper and reply with a Message directly.
+    const messageBody = messageId =>
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          kind: 'message',
+          messageId,
+          role: 'agent',
+          parts: [{ kind: 'data', data: { adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'not found' } } }],
+        },
+      });
+    const r = compareProbes(capture({ body: messageBody('msg-a') }), capture({ body: messageBody('msg-b') }));
+    assert.equal(r.equivalent, true, `unexpected differences: ${JSON.stringify(r.differences)}`);
+  });
+
+  test('A2A task success bodies with identical domain payload → equivalent (ignores task/contextId)', () => {
+    // Exercises peelWrappers: two successful Tasks with identical artifact
+    // data but different task.id / contextId / artifactId must compare equal.
+    const r = compareProbes(
+      capture({ body: a2aTaskBody({ list: { list_id: 'L', properties: [] } }) }),
+      capture({ body: a2aTaskBody({ list: { list_id: 'L', properties: [] } }) })
+    );
+    assert.equal(r.equivalent, true, `unexpected differences: ${JSON.stringify(r.differences)}`);
+  });
+
   test('JSON-RPC error shape with tunneled code → envelope-aware diff', () => {
     const body1 = JSON.stringify({
       error: { code: -32001, message: 'domain error', data: { code: 'REFERENCE_NOT_FOUND' } },

--- a/test/lib/uniform-error-invariant-a2a.test.js
+++ b/test/lib/uniform-error-invariant-a2a.test.js
@@ -116,8 +116,12 @@ function handleJsonRpc(req, res, shape) {
 
 function extractBearer(header) {
   if (typeof header !== 'string') return undefined;
-  const match = /^Bearer\s+(.+)$/i.exec(header);
-  return match ? match[1] : undefined;
+  // Case-insensitive "Bearer " prefix + single space, then the token. Avoids
+  // backtracking that CodeQL's js/polynomial-redos flags on /^Bearer\s+(.+)/i.
+  if (header.length < 8) return undefined;
+  if (header.slice(0, 7).toLowerCase() !== 'bearer ') return undefined;
+  const token = header.slice(7);
+  return token.length > 0 ? token : undefined;
 }
 
 function dispatchSkill(rpc, token, shape) {

--- a/test/lib/uniform-error-invariant-a2a.test.js
+++ b/test/lib/uniform-error-invariant-a2a.test.js
@@ -1,0 +1,296 @@
+// Integration: the uniform-error-response invariant wired through the
+// conformance harness, against an in-process A2A-shaped agent served over
+// raw HTTP. Mirrors `uniform-error-invariant.test.js` (MCP) so A2A-shaped
+// sellers get the same five-case coverage that MCP sellers do.
+//
+// The server implements the A2A JSON-RPC wire format directly (agent-card
+// discovery + message/send) rather than wiring `@a2a-js/sdk/server`. The
+// invariant is tested via the official `@a2a-js/sdk/client` (used by the
+// AdcpClient A2A protocol adapter), which is what sellers interoperate
+// with in the wild — that's the code path the capture, runner, and
+// comparator must keep working over. The server is a thin responder that
+// emits the canonical AdCP-over-A2A shape: a completed Task whose
+// artifact carries a DataPart containing either the success payload or an
+// `adcp_error`.
+//
+// Coverage intent:
+//   - extractA2AState end-to-end: the comparator extracts task state from
+//     the real SDK's wire response, not a hand-crafted JSON string.
+//   - capturedProbe POST filter: each fresh-client probe emits a card
+//     GET + a message/send POST; the heuristic must pick the POST.
+//   - A2AClient cache reuse: both probes in a pair share one cached
+//     client under the same token, which means one probe writes captures
+//     for [GET,GET,POST] and the next for [POST]. Both must land a POST
+//     capture.
+
+const { test, describe, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('http');
+const { randomUUID } = require('node:crypto');
+
+const { runConformance } = require('../../dist/lib/conformance/index.js');
+const { closeConnections } = require('../../dist/lib/protocols/index.js');
+
+const TENANT_A_TOKEN = 'tenant_a_key';
+const TENANT_B_TOKEN = 'tenant_b_key';
+const A_LIST_ID = 'list_owned_by_a';
+
+/**
+ * Start an A2A-shaped seller whose `get_property_list` behavior is
+ * controlled by `shape`. Returns `{ server, url }` where `url` is the
+ * base that the conformance harness probes with `protocol: 'a2a'`.
+ *
+ * @param {'compliant' | 'leak_code' | 'echo_id_in_details'} shape
+ */
+async function startA2AAgent(shape) {
+  let actualUrl;
+  const server = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/.well-known/agent-card.json') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          name: 'Uniform Error A2A Test Agent',
+          description: 'Test seller for uniform-error-response invariant over A2A',
+          protocolVersion: '0.3.0',
+          version: '1.0.0',
+          url: `${actualUrl}/a2a`,
+          capabilities: { pushNotifications: false },
+          defaultInputModes: ['application/json'],
+          defaultOutputModes: ['application/json'],
+          skills: [
+            {
+              id: 'get_property_list',
+              name: 'get_property_list',
+              description: 'Fetch a property list by id.',
+              tags: ['test'],
+            },
+          ],
+        })
+      );
+      return;
+    }
+    // The A2A client's first discovery probe tries /.well-known/agent.json
+    // before /.well-known/agent-card.json. 404 that path cleanly so the
+    // client falls through to the card URL.
+    if (req.method === 'GET' && req.url === '/.well-known/agent.json') {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end('{}');
+      return;
+    }
+    if (req.method === 'POST' && req.url === '/a2a') {
+      handleJsonRpc(req, res, shape);
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  actualUrl = `http://127.0.0.1:${server.address().port}`;
+  return { server, url: actualUrl };
+}
+
+function handleJsonRpc(req, res, shape) {
+  let body = '';
+  req.on('data', chunk => (body += chunk));
+  req.on('end', () => {
+    let rpc;
+    try {
+      rpc = JSON.parse(body);
+    } catch {
+      res.writeHead(400, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: null,
+          error: { code: -32700, message: 'parse error' },
+        })
+      );
+      return;
+    }
+    const token = extractBearer(req.headers.authorization);
+    const result = dispatchSkill(rpc, token, shape);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, result }));
+  });
+}
+
+function extractBearer(header) {
+  if (typeof header !== 'string') return undefined;
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  return match ? match[1] : undefined;
+}
+
+function dispatchSkill(rpc, token, shape) {
+  const parts = rpc?.params?.message?.parts;
+  const dataPart = Array.isArray(parts) ? parts.find(p => p?.kind === 'data') : undefined;
+  const skill = dataPart?.data?.skill;
+  const parameters = dataPart?.data?.parameters ?? {};
+
+  let payload;
+  if (skill === 'get_property_list') {
+    payload = getPropertyList(parameters, token, shape);
+  } else {
+    payload = { adcp_error: { code: 'UNKNOWN_TOOL', message: `Unknown skill ${skill}` } };
+  }
+
+  return {
+    kind: 'task',
+    id: `task_${randomUUID()}`,
+    contextId: `ctx_${randomUUID()}`,
+    status: { state: 'completed', timestamp: new Date().toISOString() },
+    artifacts: [
+      {
+        artifactId: `art_${randomUUID()}`,
+        parts: [{ kind: 'data', data: payload }],
+      },
+    ],
+  };
+}
+
+function getPropertyList(parameters, token, shape) {
+  const listId = parameters.list_id;
+  const ownedByA = listId === A_LIST_ID;
+
+  if (shape === 'leak_code') {
+    if (ownedByA && token !== TENANT_A_TOKEN) {
+      return { adcp_error: { code: 'PERMISSION_DENIED', message: 'You cannot access this property list' } };
+    }
+    if (ownedByA && token === TENANT_A_TOKEN) {
+      return { list: minimalPropertyList(A_LIST_ID) };
+    }
+    return { adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'Property list not found' } };
+  }
+
+  if (shape === 'echo_id_in_details') {
+    return {
+      adcp_error: {
+        code: 'REFERENCE_NOT_FOUND',
+        message: 'Property list not found',
+        details: { looked_up: listId },
+      },
+    };
+  }
+
+  if (ownedByA && token === TENANT_A_TOKEN) {
+    return { list: minimalPropertyList(A_LIST_ID) };
+  }
+  return { adcp_error: { code: 'REFERENCE_NOT_FOUND', message: 'Property list not found' } };
+}
+
+function minimalPropertyList(listId) {
+  return {
+    list_id: listId,
+    name: 'Uniform error test list',
+    is_live: true,
+    properties: [],
+  };
+}
+
+describe('conformance: uniform-error-response invariant (A2A)', () => {
+  const servers = [];
+  after(async () => {
+    for (const s of servers) await new Promise(resolve => s.close(resolve));
+    // Cached A2A clients outlive this suite. Drop them so a later suite
+    // on the same port (rare but possible) doesn't reuse a stale entry.
+    closeConnections('a2a');
+  });
+
+  async function start(shape) {
+    const { server, url } = await startA2AAgent(shape);
+    servers.push(server);
+    return url;
+  }
+
+  test('baseline: compliant seller → pass', async () => {
+    const url = await start('compliant');
+    const report = await runConformance(url, {
+      seed: 1,
+      protocol: 'a2a',
+      tools: ['get_property_list'],
+      turnBudget: 1,
+      authToken: TENANT_B_TOKEN,
+    });
+
+    const invariant = report.uniformError.find(r => r.tool === 'get_property_list');
+    assert.ok(invariant, 'invariant entry for get_property_list');
+    assert.equal(invariant.mode, 'baseline');
+    assert.equal(invariant.verdict, 'pass', `unexpected differences: ${JSON.stringify(invariant.differences)}`);
+  });
+
+  test('baseline: seller echoes probe id in error.details → fail', async () => {
+    const url = await start('echo_id_in_details');
+    const report = await runConformance(url, {
+      seed: 2,
+      protocol: 'a2a',
+      tools: ['get_property_list'],
+      turnBudget: 1,
+      authToken: TENANT_B_TOKEN,
+    });
+
+    const invariant = report.uniformError.find(r => r.tool === 'get_property_list');
+    assert.ok(invariant);
+    assert.equal(invariant.mode, 'baseline');
+    assert.equal(invariant.verdict, 'fail');
+    assert.ok(
+      invariant.differences.some(d => d.startsWith('error.details diverges')),
+      `expected error.details divergence, got: ${JSON.stringify(invariant.differences)}`
+    );
+  });
+
+  test('cross-tenant: compliant seller → pass', async () => {
+    const url = await start('compliant');
+    const report = await runConformance(url, {
+      seed: 3,
+      protocol: 'a2a',
+      tools: ['get_property_list'],
+      turnBudget: 1,
+      authToken: TENANT_A_TOKEN,
+      authTokenCrossTenant: TENANT_B_TOKEN,
+      fixtures: { list_ids: [A_LIST_ID] },
+    });
+
+    const invariant = report.uniformError.find(r => r.tool === 'get_property_list');
+    assert.ok(invariant);
+    assert.equal(invariant.mode, 'cross-tenant');
+    assert.equal(invariant.verdict, 'pass', `unexpected differences: ${JSON.stringify(invariant.differences)}`);
+  });
+
+  test('cross-tenant: seller leaks via divergent error.code → fail', async () => {
+    const url = await start('leak_code');
+    const report = await runConformance(url, {
+      seed: 4,
+      protocol: 'a2a',
+      tools: ['get_property_list'],
+      turnBudget: 1,
+      authToken: TENANT_A_TOKEN,
+      authTokenCrossTenant: TENANT_B_TOKEN,
+      fixtures: { list_ids: [A_LIST_ID] },
+    });
+
+    const invariant = report.uniformError.find(r => r.tool === 'get_property_list');
+    assert.ok(invariant);
+    assert.equal(invariant.mode, 'cross-tenant');
+    assert.equal(invariant.verdict, 'fail');
+    assert.ok(
+      invariant.differences.some(d => d.startsWith('error.code diverges')),
+      `expected error.code divergence, got: ${JSON.stringify(invariant.differences)}`
+    );
+  });
+
+  test('baseline fallback: cross-tenant token supplied but no fixture → still runs as baseline', async () => {
+    const url = await start('compliant');
+    const report = await runConformance(url, {
+      seed: 5,
+      protocol: 'a2a',
+      tools: ['get_property_list'],
+      turnBudget: 1,
+      authToken: TENANT_A_TOKEN,
+      authTokenCrossTenant: TENANT_B_TOKEN,
+    });
+
+    const invariant = report.uniformError.find(r => r.tool === 'get_property_list');
+    assert.ok(invariant);
+    assert.equal(invariant.mode, 'baseline');
+    assert.equal(invariant.verdict, 'pass');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `test/lib/uniform-error-invariant-a2a.test.js` — the A2A-shaped sibling of the MCP integration test that landed in #737. Same five-case matrix (baseline compliant/leak, cross-tenant compliant/leak, baseline fallback), reached through `@a2a-js/sdk/client`.
- Extends `uniformErrorComparator` to walk A2A wire shapes: `extractEnvelope` finds `adcp_error` nested in `result.artifacts[].parts[].data` or `result.parts[].data`; `peelWrappers` strips per-request `task.id` / `contextId` / `artifactId` / `messageId` so success bodies with identical domain payloads compare equal.
- Five A2A unit tests in `uniform-error-comparator.test.js` cover both extraction paths and the peel reduction.

Closes #738.

**Housekeeping note:** This was originally #740, which got merged into the wrong base branch (the pre-squash `bokelley/fuzz-uniform-error`) right after #737 squash-merged to main, so the changes never landed. Same diff, new PR targeting main.

## Why this is worth doing

Before this PR, the A2A comparator path was only tested against hand-crafted JSON strings — format drift in `@a2a-js/sdk` output (e.g., status moving from `task.status.state` to `task.state`, or the SDK wrapping the response differently) would silently skip the invariant for every A2A seller. Sellers claiming A2A transport have the same uniform-response MUST as MCP sellers; they should get the same integration-level enforcement.

Scope note vs the original issue: #738 framed this as "test-only" but the existing `extractEnvelope` / `peelWrappers` didn't cover A2A Task/Message shapes — only `extractA2AState` did. Added the minimal comparator support needed to make A2A integration work without per-request-ID false positives.

## Test plan

- [x] `node --test test/lib/uniform-error-invariant-a2a.test.js` — 5/5 pass
- [x] `node --test test/lib/uniform-error-comparator.test.js` — 34/34 pass (29 existing + 5 new A2A)
- [x] `node --test test/lib/uniform-error-invariant.test.js` — 5/5 pass (MCP, unchanged)
- [x] `npm test` — 4276/4282 pass (6 pre-existing skips)
- [x] `npm run typecheck` + `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)