### PR TITLE
feat(server): auto-unwrap thrown adcpError envelopes in dispatcher

### DIFF
--- a/.changeset/auto-unwrap-thrown-adcp-error.md
+++ b/.changeset/auto-unwrap-thrown-adcp-error.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': minor
+---
+
+`createAdcpServer`'s dispatcher now auto-unwraps `throw adcpError(...)` into the normal response path. Handlers that `throw` an envelope (instead of `return`-ing it) used to surface as `SERVICE_UNAVAILABLE: Tool X handler threw: [object Object]` — the thrown value is a plain object, not an `Error`, so `err.message` is undefined and `String(err)` yields the `[object Object]` literal. The dispatcher now detects the envelope shape (`{ isError: true, content: [...], structuredContent: { adcp_error: { code } } }`) and returns it directly, preserving the typed code / field / suggestion exactly as if the handler had written `return`.
+
+Driver: matrix v8 showed this pattern persisting across fresh-Claude builds even when the skill examples use `return`. Fixing it at the dispatcher closes the class of bugs once, instead of hoping every skill-corpus update lands. A `logger.warn` still fires on unwrap so agent authors see they should switch to `return`, but buyers stop paying for the mistake.
+
+Idempotency claims are released on unwrap (same as any other thrown path) so retries proceed normally. Non-envelope throws (`TypeError`, custom errors, strings, objects without the full envelope shape) still surface as `SERVICE_UNAVAILABLE` with the underlying cause in `details.reason` — the existing handler-throw disclosure from PR #735 is unchanged.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1066,6 +1066,25 @@ function isErrorResponse(response: McpToolResponse): boolean {
 }
 
 /**
+ * Detect a thrown `adcpError(...)` envelope. Handlers that `throw` an
+ * envelope (instead of `return`-ing it) would otherwise surface as
+ * `[object Object]` inside a SERVICE_UNAVAILABLE wrapper — the dispatcher
+ * unwraps and returns the envelope directly when the shape matches.
+ */
+function isThrownAdcpError(value: unknown): value is McpToolResponse {
+  if (!value || typeof value !== 'object') return false;
+  const sc = (value as { structuredContent?: unknown }).structuredContent;
+  if (!sc || typeof sc !== 'object') return false;
+  const env = (sc as { adcp_error?: unknown }).adcp_error;
+  if (!env || typeof env !== 'object') return false;
+  if (typeof (env as { code?: unknown }).code !== 'string') return false;
+  // `adcpError()` emits all three transport layers; require them to avoid
+  // accidentally unwrapping non-envelope throws that happen to carry a
+  // `structuredContent.adcp_error.code` field.
+  return Array.isArray((value as { content?: unknown }).content) && (value as { isError?: unknown }).isError === true;
+}
+
+/**
  * Resolve the extra scope segment for tools with per-session semantics.
  *
  * For `si_send_message`, the request `session_id` enters the scope so
@@ -1909,16 +1928,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
           return finalize(formatted);
         } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          // Log the full stack — `logger.error` with just the message turned
-          // every "Handler failed" into a guessing game for agent authors.
-          // Stack tells you which import/typo/access chain blew up.
-          logger.error('Handler failed', {
-            tool: toolName,
-            handler: handlerKey,
-            error: reason,
-            stack: err instanceof Error ? err.stack : undefined,
-          });
+          // Release the idempotency claim on any thrown path — whether
+          // we unwrap a typed envelope or fall through to SERVICE_UNAVAILABLE,
+          // the handler did not produce a cached response and the next retry
+          // should proceed normally.
           if (idempotencyCheck && idempotency) {
             try {
               await idempotency.release({
@@ -1934,6 +1947,32 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               });
             }
           }
+          // Auto-unwrap `throw adcpError(...)`. Handlers that throw an
+          // envelope (instead of returning it) should behave identically —
+          // otherwise the envelope surfaces as `[object Object]` inside
+          // SERVICE_UNAVAILABLE and the buyer loses the typed domain code.
+          // Matrix harnesses and fresh-built agents consistently get this
+          // wrong; unwrapping at the dispatcher closes the class of bugs
+          // instead of relying on every skill to show `return` over `throw`.
+          if (isThrownAdcpError(err)) {
+            const code = (err.structuredContent as { adcp_error: { code: string } }).adcp_error.code;
+            logger.warn('Handler threw an adcpError envelope — prefer `return` over `throw` for typed errors', {
+              tool: toolName,
+              handler: handlerKey,
+              code,
+            });
+            return finalize(err);
+          }
+          const reason = err instanceof Error ? err.message : String(err);
+          // Log the full stack — `logger.error` with just the message turned
+          // every "Handler failed" into a guessing game for agent authors.
+          // Stack tells you which import/typo/access chain blew up.
+          logger.error('Handler failed', {
+            tool: toolName,
+            handler: handlerKey,
+            error: reason,
+            stack: err instanceof Error ? err.stack : undefined,
+          });
           return finalize(
             adcpError('SERVICE_UNAVAILABLE', {
               // Include the cause message directly in the response text when

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1077,10 +1077,12 @@ function isThrownAdcpError(value: unknown): value is McpToolResponse {
   if (!sc || typeof sc !== 'object') return false;
   const env = (sc as { adcp_error?: unknown }).adcp_error;
   if (!env || typeof env !== 'object') return false;
+  // `adcpError()` guarantees both `code` and `message` as strings — assert
+  // both so a malformed envelope throw doesn't produce a half-formed
+  // response. Also rules out MCP SDK `McpError` (numeric `code`) and any
+  // other thrown object with a coincidentally-shaped sub-tree.
   if (typeof (env as { code?: unknown }).code !== 'string') return false;
-  // `adcpError()` emits all three transport layers; require them to avoid
-  // accidentally unwrapping non-envelope throws that happen to carry a
-  // `structuredContent.adcp_error.code` field.
+  if (typeof (env as { message?: unknown }).message !== 'string') return false;
   return Array.isArray((value as { content?: unknown }).content) && (value as { isError?: unknown }).isError === true;
 }
 
@@ -1955,11 +1957,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           // wrong; unwrapping at the dispatcher closes the class of bugs
           // instead of relying on every skill to show `return` over `throw`.
           if (isThrownAdcpError(err)) {
-            const code = (err.structuredContent as { adcp_error: { code: string } }).adcp_error.code;
+            const env = (err.structuredContent as { adcp_error: { code: string; message: string } }).adcp_error;
+            // Log message + stack so forensic review sees what was thrown
+            // (not just the code). The thrown envelope is a plain object so
+            // `.stack` is typically absent, but authors sometimes subclass
+            // `Error` and attach envelope fields; capture it defensively.
             logger.warn('Handler threw an adcpError envelope — prefer `return` over `throw` for typed errors', {
               tool: toolName,
               handler: handlerKey,
-              code,
+              code: env.code,
+              message: env.message,
+              stack: err instanceof Error ? err.stack : undefined,
             });
             return finalize(err);
           }

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -11,6 +11,7 @@ const {
 const { ADCPError, isADCPError } = require('../dist/lib/errors');
 const { structuredSerialize, structuredDeserialize } = require('../dist/lib/server/structured-serialize');
 const { createAdcpServer, requireSessionKey } = require('../dist/lib/server/create-adcp-server');
+const { adcpError } = require('../dist/lib/server/errors');
 
 // ---------------------------------------------------------------------------
 // Validation / StateError
@@ -365,6 +366,53 @@ describe('resolveSessionKey', () => {
 
     const result = await callTool(server, 'get_signals', {});
     assert.strictEqual(result.structuredContent.adcp_error.details?.reason, 'db lookup timed out');
+  });
+
+  it('unwraps a thrown adcpError envelope as the response (no SERVICE_UNAVAILABLE wrap)', async () => {
+    // Agent authors regularly write `throw adcpError(...)` instead of
+    // `return adcpError(...)`. The dispatcher auto-unwraps the envelope so
+    // buyers see the typed code (CREATIVE_NOT_FOUND) rather than the
+    // opaque SERVICE_UNAVAILABLE: [object Object] that thrown objects
+    // otherwise produce.
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      exposeErrorDetails: false,
+      signals: {
+        getSignals: async () => {
+          throw adcpError('SIGNAL_NOT_FOUND', {
+            message: 'no signal matched the query',
+            field: 'signal_spec',
+          });
+        },
+      },
+    });
+
+    const result = await callTool(server, 'get_signals', {});
+    const error = result.structuredContent.adcp_error;
+    assert.strictEqual(error.code, 'SIGNAL_NOT_FOUND');
+    assert.strictEqual(error.message, 'no signal matched the query');
+    assert.strictEqual(error.field, 'signal_spec');
+  });
+
+  it('falls back to SERVICE_UNAVAILABLE for thrown non-envelope errors', async () => {
+    // Guard: the unwrap path must only fire for actual `adcpError(...)`
+    // envelopes. A TypeError or a bare object that happens to carry a
+    // `structuredContent` field should still surface as SERVICE_UNAVAILABLE.
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      exposeErrorDetails: true,
+      signals: {
+        getSignals: async () => {
+          throw new TypeError('items.map is not a function');
+        },
+      },
+    });
+
+    const result = await callTool(server, 'get_signals', {});
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+    assert.strictEqual(result.structuredContent.adcp_error.details?.reason, 'items.map is not a function');
   });
 
   it('requireSessionKey narrows ctx.sessionKey or throws', () => {


### PR DESCRIPTION
## Summary

Handlers that write \`throw adcpError(...)\` instead of \`return adcpError(...)\` used to surface as:

> \`SERVICE_UNAVAILABLE: Tool X handler threw: [object Object]\`

because the thrown value is a plain object, not an \`Error\` — so \`err.message\` is undefined and \`String(err)\` yields the \`[object Object]\` literal.

The dispatcher now detects the envelope shape (\`isError: true\` + \`content: [...]\` + \`structuredContent.adcp_error.code\`) and returns it directly, preserving the typed code / field / suggestion as if the handler had written \`return\`. A \`logger.warn\` still fires so agent authors see they should switch to \`return\`, but buyers stop paying for the mistake.

**Why this lives in the SDK, not the skill corpus**: matrix v8 showed this pattern persisting across fresh-Claude builds even when every skill example uses \`return\`. Closing the class of bugs at the dispatcher is a one-time fix vs. an N-skill ongoing drift tax.

## Behavior

- Idempotency claims are released on unwrap (same as any thrown path) so retries proceed normally.
- Non-envelope throws (\`TypeError\`, strings, custom errors) still surface as \`SERVICE_UNAVAILABLE\` with the underlying cause in \`details.reason\` — the handler-throw disclosure from PR #735 is unchanged.
- The shape check requires the full three-layer envelope (\`isError\`, \`content\`, \`structuredContent.adcp_error.code\`) to avoid accidentally unwrapping non-envelope throws that happen to carry a \`structuredContent\` field.

## Test plan

- [x] Two new tests in \`test/server-state-store-extensions.test.js\`:
  - Unwraps a thrown \`adcpError\` envelope and preserves \`code\` / \`message\` / \`field\`
  - Falls back to \`SERVICE_UNAVAILABLE\` for thrown \`TypeError\` (guard for non-envelope throws)
- [x] \`npm run typecheck\` clean
- [x] All 39 tests in the file pass
- [ ] Matrix v9 after merge — expected to drop the \`[object Object]\` cause-3 hits to 0