### PR TITLE
docs(skills): document mutate-last idempotency contract (#744)

### DIFF
--- a/.changeset/idempotency-mutate-last-guidance.md
+++ b/.changeset/idempotency-mutate-last-guidance.md
@@ -1,0 +1,16 @@
+---
+'@adcp/client': patch
+---
+
+Clarify idempotency-on-error semantics in the seller and creative skill docs, driven by the audit in [#744](https://github.com/adcontextprotocol/adcp-client/issues/744).
+
+**What the audit found.** The dispatcher releases the idempotency claim on every error path — envelope returns, envelope throws, and uncaught exceptions. That's already documented for the "transient failures don't lock into the cache" case, but the handler-author implication wasn't spelled out: a handler that mutates state before erroring will double-write on retry. The surface for this bug widened with [#743](https://github.com/adcontextprotocol/adcp-client/pull/743) (auto-unwrap of thrown envelopes), which blesses `throw adcpError(...)` as a supported path.
+
+**Why not cache terminals instead.** The AdCP `recovery: terminal` catalog is mostly state-dependent (`ACCOUNT_SUSPENDED`, `BUDGET_EXHAUSTED`, `ACCOUNT_PAYMENT_REQUIRED`, `ACCOUNT_SETUP_REQUIRED` all flip after out-of-band remediation). Caching them would lock buyers into stale errors for the full replay TTL. Only `UNSUPPORTED_FEATURE` and `ACCOUNT_NOT_FOUND` are truly immutable, and re-executing them is cheap.
+
+**Changes.**
+
+- `skills/build-seller-agent/SKILL.md` idempotency section now documents the mutate-last contract, with a worked `budgetApproved` example showing the broken-vs-correct ordering and a note on making partial-write paths converge via natural-key upsert.
+- `skills/build-creative-agent/SKILL.md` swaps the now-stale "throw surfaces as `SERVICE_UNAVAILABLE`" rationale (invalidated by #743) for the still-true claim-release rationale.
+
+No runtime behavior changes; docs only. No changes to `compliance/cache/` — storyboards there are machine-synced from the upstream spec repo, so a conformance assertion that locks in error-claim-release semantics is a follow-up for `adcontextprotocol/adcp`.

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -364,8 +364,12 @@ serve(() => {
           : params.creative_id
             ? await ctx.store.get('creatives', params.creative_id)
             : null;
-        // Return structured errors — don't throw. `throw adcpError(...)` bypasses
-        // the adcp_error envelope and the dispatcher surfaces SERVICE_UNAVAILABLE.
+        // Return structured errors — don't throw. The dispatcher now unwraps
+        // thrown envelopes, but throwing still releases the idempotency claim
+        // before the throw is caught. If your handler mutated state before
+        // throwing, a retry with the same key re-executes the write. Returning
+        // an error envelope has the same claim-release semantics, so the rule
+        // holds for both paths: mutate last, or don't mutate at all on error.
         if (!match) return adcpError('CREATIVE_NOT_FOUND', { message: 'No matching creative' });
         return {
           creative_manifest: { format_id: match.format_id, assets: match.assets ?? {} },

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -982,8 +982,23 @@ AdCP v3 requires an `idempotency_key` on every mutating request. For sellers, th
 - Hashes the request payload with RFC 8785 JCS. The emitted error codes and their semantics are in the table at [§ Composing OAuth, signing, and idempotency](#composing-oauth-signing-and-idempotency).
 - Injects `replayed: true` on `result.structuredContent.replayed` when returning a cached response; fresh executions omit the field.
 - Auto-declares `adcp.idempotency.replay_ttl_seconds` on `get_adcp_capabilities`.
-- Only caches successful responses — errors re-execute on retry so transient failures don't lock into the cache.
+- Only caches successful responses — errors re-execute on retry so transient failures don't lock into the cache. This applies to every `recovery` class including `terminal`: the AdCP terminal catalog (`ACCOUNT_SUSPENDED`, `BUDGET_EXHAUSTED`, `ACCOUNT_PAYMENT_REQUIRED`, `ACCOUNT_SETUP_REQUIRED`) is mostly state-dependent, and caching would return stale errors after the buyer remediates. Only `UNSUPPORTED_FEATURE` and `ACCOUNT_NOT_FOUND` are truly immutable, and re-executing them is cheap.
 - Atomic claim on `check()` so concurrent retries with a fresh key don't all race to execute side effects.
+
+**Handler contract: mutate last.** The framework releases the idempotency claim on ANY error path — `return adcpError(...)`, `throw adcpError(...)` (auto-unwrapped by the dispatcher), and uncaught exceptions all release. A handler that writes state then errors will double-write on retry:
+
+```typescript
+// BROKEN: write happens, error releases claim, retry re-writes
+await db.insert(mediaBuy);
+if (!budgetApproved) return adcpError('BUDGET_EXHAUSTED', { ... });  // claim released, insert already persisted
+
+// CORRECT: validate first, write last
+if (!budgetApproved) return adcpError('BUDGET_EXHAUSTED', { ... });  // no write yet, safe to release
+await db.insert(mediaBuy);
+return mediaBuyResponse({ ... });
+```
+
+If the validation can only run after a partial write (rare), make the write itself idempotent — natural-key upsert or the `ctx.store.get` → merge pattern — so re-execution converges on the same state.
 
 **Scoping**: the principal comes from `resolveSessionKey` (or override with `resolveIdempotencyPrincipal(ctx, params, toolName)` for per-tool custom scopes). Two callers with the same principal share a cache namespace; different principals are isolated.
 


### PR DESCRIPTION
## Summary

Audit from #744 (should `recovery: terminal` errors cache instead of release the idempotency claim?) — conclusion: **keep release-all-errors**, document the handler-author contract that #743 widened the surface for.

## Audit reasoning

- Current dispatcher (`create-adcp-server.ts:1865-1936`): success → `idempotency.save`; any error (`isError: true` envelope OR throw) → `idempotency.release`.
- The AdCP `recovery: terminal` catalog is **mostly state-dependent** — `ACCOUNT_SUSPENDED`, `BUDGET_EXHAUSTED`, `ACCOUNT_PAYMENT_REQUIRED`, `ACCOUNT_SETUP_REQUIRED` all flip after out-of-band remediation. Caching them would return stale errors for the full replay TTL — worse UX than re-executing.
- Only `UNSUPPORTED_FEATURE` and `ACCOUNT_NOT_FOUND` are truly immutable, and re-executing them is cheap (capability check, lookup).
- The double-side-effect risk (`await db.insert(...); throw adcpError(...)`) is a handler-correctness issue, not a dispatcher issue. #743 blesses `throw adcpError(...)` as a supported path, which widens that surface — so the mutate-last contract needs to be explicit in the skill corpus.

## Changes

- **`skills/build-seller-agent/SKILL.md`** idempotency section — extends the existing "only caches successful responses" bullet with the terminal-catalog rationale, then adds a new "Handler contract: mutate last" paragraph with a worked `budgetApproved` broken-vs-correct example and guidance for rare partial-write paths (natural-key upsert, `ctx.store.get` → merge).
- **`skills/build-creative-agent/SKILL.md:367`** — swaps the now-stale "`throw adcpError(...)` bypasses the envelope and surfaces SERVICE_UNAVAILABLE" comment (invalidated by #743's auto-unwrap) for the still-true claim-release rationale.
- Changeset: patch-level (`@adcp/client`), docs-only.

## What's NOT in this PR

- No edits to `compliance/cache/latest/universal/idempotency.yaml`. That file is machine-synced from `adcontextprotocol/adcp` via `npm run sync-schemas` — any local edit is clobbered on the next sync. Locking error-claim-release semantics in as a spec-level conformance invariant belongs upstream. **Filed as [adcontextprotocol/adcp#2760](https://github.com/adcontextprotocol/adcp/issues/2760)** — proposes either a new `error_claim_release` phase (using `comply_test_controller` to force a terminal error, then retrying with the same key + different payload, asserting the second request executes) or a narrative-bullet + reviewer-checklist variant if the controller hook is too invasive.

## Test plan

- [x] `npm run typecheck` clean (pre-push hook)
- [x] `npm run build:lib` clean (pre-push hook)
- [x] Docs-only — no behavior changes, so no test additions
- [ ] Skill matrix run after merge to confirm the mutate-last guidance lands in fresh-Claude builds

## Related

- #744 (the audit)
- #743 (auto-unwrap thrown envelopes — lands the behavior this doc stabilizes)
- adcontextprotocol/adcp#2760 (upstream conformance follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)