### PR TITLE
ci(codeql): ignore demo and test paths

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,6 @@
+name: "AdCP Client CodeQL Config"
+
+paths-ignore:
+  - examples/**
+  - scripts/manual-testing/**
+  - test/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,6 +71,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        config-file: ./.github/codeql/codeql-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
## Summary
- Adds `.github/codeql/codeql-config.yml` with `paths-ignore` for `examples/`, `scripts/manual-testing/`, and `test/`.
- Wires the config into the existing `codeql.yml` workflow via `config-file:`.

These three directories produced every historical dismissed alert (OAuth metadata logging in demos, incomplete-URL-substring patterns in tests). They aren't shipped as library surface, so scanning them only created triage churn.

Library source (`src/**`), `bin/**`, and workflows stay under full CodeQL coverage.

## Test plan
- [ ] CodeQL Advanced workflow runs on this PR and succeeds
- [ ] No new alerts are raised for src/ library code
- [ ] Confirm via the Security tab that demo/test paths are no longer scanned