### PR TITLE
fix(testing): sync_catalogs + report_usage builders honor sample_request

### DIFF
--- a/.changeset/fix-sync-catalogs-report-usage-builders.md
+++ b/.changeset/fix-sync-catalogs-report-usage-builders.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': patch
+---
+
+Fix `sync_catalogs` and `report_usage` storyboard request-builders to honor `step.sample_request` when present, and use spec-valid defaults when building a fallback.
+
+**sync_catalogs** — before this fix, the builder ignored the storyboard's `sample_request` entirely and returned a hardcoded catalog with `feed_format: 'json'` (not in the `FeedFormatSchema` union: `google_merchant_center | facebook_catalog | shopify | linkedin_jobs | custom`) and no `type` field (required by `CatalogSchema`). Every conformance agent running the generated Zod schema rejected the request with `-32602` on both paths. The fallback now uses `type: 'product'` + `feed_format: 'custom'`, and the builder reads `sample_request` first.
+
+**report_usage** — same pattern: builder ignored `sample_request` and returned per-entry shape `{ creative_id, impressions, spend: { amount, currency } }` which doesn't match `usage-entry.json` (expects top-level `vendor_cost: number` + `currency: string` + `account` on each entry). Agents rejected with `-32602` listing all three missing fields. Fixed by reading `sample_request` first and aligning the fallback to the spec shape.
+
+Surfaced by the matrix harness — every `sales_catalog_driven` and `creative_ad_server` run showed the same builder-generated -32602 before this patch.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -217,15 +217,24 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Catalogs & Events ─────────────────────────────────
 
-  sync_catalogs(_step, context, options) {
+  sync_catalogs(step, context, options) {
+    // Prefer the fixture's sample_request — it's the authoritative request
+    // shape for the storyboard step. The fallback's hardcoded feed_format
+    // ('json') is NOT in the spec's 5-literal union and its `type` is
+    // missing entirely, so any agent running the generated Zod schema
+    // rejects the fallback with -32602 on both fields.
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
+    }
     return {
       account: context.account ?? resolveAccount(options),
       catalogs: [
         {
           catalog_id: `test-catalog-${Date.now()}`,
           name: 'E2E Test Catalog',
+          type: 'product',
           feed_url: 'https://test-assets.adcontextprotocol.org/feeds/test-catalog.json',
-          feed_format: 'json',
+          feed_format: 'custom',
         },
       ],
     };
@@ -258,7 +267,14 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     };
   },
 
-  report_usage(_step, context, options) {
+  report_usage(step, context, options) {
+    // Prefer the fixture's sample_request — creative-ad-server and other
+    // specialisms carry per-usage-entry fields (vendor_cost, currency,
+    // pricing_option_id) that the hardcoded fallback here omits, causing
+    // agents running the generated Zod schema to reject every step.
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
+    }
     const now = new Date();
     const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
     return {
@@ -269,9 +285,11 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
       },
       usage: [
         {
+          account: context.account ?? resolveAccount(options),
           creative_id: context.creative_id ?? 'test-creative',
           impressions: 10000,
-          spend: { amount: 500, currency: 'USD' },
+          vendor_cost: 500,
+          currency: 'USD',
         },
       ],
     };

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -84,6 +84,31 @@ describe('Request Builder', () => {
       assert.ok(Array.isArray(result.catalogs), 'should have catalogs array');
       assert.ok(result.catalogs[0].catalog_id, 'should have catalog_id');
     });
+
+    test('fallback catalog uses spec-valid type + feed_format', () => {
+      // Regression: the hardcoded fallback used `feed_format: 'json'` which
+      // isn't in the 5-literal union, and omitted `type` entirely. Every
+      // agent running the generated Zod schema rejected with -32602.
+      const result = buildRequest(step('sync_catalogs'), {}, DEFAULT_OPTIONS);
+      const cat = result.catalogs[0];
+      assert.strictEqual(cat.type, 'product', 'type must be in CatalogTypeSchema');
+      assert.ok(
+        ['google_merchant_center', 'facebook_catalog', 'shopify', 'linkedin_jobs', 'custom'].includes(cat.feed_format),
+        `feed_format must be in FeedFormatSchema union, got "${cat.feed_format}"`
+      );
+    });
+
+    test('honors step.sample_request when present', () => {
+      const fixture = {
+        account: { account_id: 'acct_x' },
+        catalogs: [
+          { catalog_id: 'menu_spring_2026', type: 'product', name: 'Spring Menu', items: [{ item_id: 'i1' }] },
+        ],
+      };
+      const result = buildRequest(step('sync_catalogs', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.catalogs[0].catalog_id, 'menu_spring_2026');
+      assert.strictEqual(result.catalogs[0].type, 'product');
+    });
   });
 
   describe('report_usage', () => {
@@ -93,6 +118,27 @@ describe('Request Builder', () => {
       assert.ok(result.reporting_period.start, 'should have start');
       assert.ok(result.reporting_period.end, 'should have end');
       assert.ok(Array.isArray(result.usage), 'should have usage array');
+    });
+
+    test('fallback usage entry has account, vendor_cost, currency', () => {
+      // Regression: per-entry fields required by `usage-entry.json` were
+      // missing from the fallback (used `spend: {amount, currency}` instead
+      // of flat `vendor_cost` + `currency`), causing -32602 on every run.
+      const result = buildRequest(step('report_usage'), {}, DEFAULT_OPTIONS);
+      const entry = result.usage[0];
+      assert.ok(entry.account, 'usage[0].account required');
+      assert.strictEqual(typeof entry.vendor_cost, 'number', 'vendor_cost must be number');
+      assert.strictEqual(typeof entry.currency, 'string', 'currency must be string');
+    });
+
+    test('honors step.sample_request when present', () => {
+      const fixture = {
+        account: { account_id: 'acct_x' },
+        reporting_period: { start: '2026-03-01T00:00:00Z', end: '2026-03-31T23:59:59Z' },
+        usage: [{ account: { account_id: 'acct_x' }, creative_id: 'c1', vendor_cost: 42, currency: 'USD' }],
+      };
+      const result = buildRequest(step('report_usage', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.usage[0].vendor_cost, 42);
     });
   });
 


### PR DESCRIPTION
## Summary

Two storyboard request-builders (\`sync_catalogs\` and \`report_usage\`) had their \`step\` parameter underscored (\`_step\`, meaning ignored). They always returned hardcoded payloads that diverged from the spec schemas, so every conformance agent running generated Zod validation rejected with \`-32602\`:

### sync_catalogs (10 matrix v9 failures)

Old fallback:
- \`feed_format: 'json'\` — not in the 5-literal \`FeedFormatSchema\` union (\`google_merchant_center | facebook_catalog | shopify | linkedin_jobs | custom\`)
- No \`type\` field — required by \`CatalogSchema\`

Error:
\`\`\`
catalogs[0].type — invalid_union
catalogs[0].feed_format — invalid_union
\`\`\`

Fix: read \`step.sample_request\` first (same pattern as \`check_governance\`, \`build_creative\`, \`sync_creatives\`, etc.); fallback now uses \`type: 'product'\` + \`feed_format: 'custom'\`.

### report_usage (5 matrix v9 failures)

Old fallback per-entry shape: \`{ creative_id, impressions, spend: { amount, currency } }\` — doesn't match \`usage-entry.json\` which expects flat \`vendor_cost: number\` + \`currency: string\` + per-entry \`account\`.

Error:
\`\`\`
usage[0].account — expected object, received undefined
usage[0].vendor_cost — expected number, received undefined
usage[0].currency — expected string, received undefined
\`\`\`

Fix: read \`step.sample_request\` first; fallback now includes the three required fields.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] 4 new tests in \`test/lib/request-builder.test.js\`:
  - sync_catalogs fallback has \`type\` + valid \`feed_format\`
  - sync_catalogs honors \`step.sample_request\`
  - report_usage fallback has \`account\` + \`vendor_cost\` + \`currency\`
  - report_usage honors \`step.sample_request\`
- [x] Verified against matrix-kept retail-media workspace: sync_catalogs now passes (was -32602 on every run)
- [ ] Matrix v10 after merge for cumulative delta