### PR TITLE
fix(server): defensive build_creative summary + omit replayed:false

### DIFF
--- a/.changeset/defensive-build-creative-summary-and-replayed-omission.md
+++ b/.changeset/defensive-build-creative-summary-and-replayed-omission.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': patch
+---
+
+Two response-layer fixes for agents built from partial skill coverage:
+
+**`buildCreativeResponse` / `buildCreativeMultiResponse` no longer crash on missing fields.** The default summary previously dereferenced `data.creative_manifest.format_id.id` without guards — handlers that drop `format_id` (required by `creative-manifest.json`) crashed the dispatcher with `Cannot read properties of undefined (reading 'id')`, swallowing the real schema violation behind an opaque `SERVICE_UNAVAILABLE`. Now the summary optional-chains through the field chain and falls back to a generic string, so the response reaches wire-level validation and the buyer sees the actual missing-field error.
+
+**`replayed: false` is no longer injected on fresh executions.** `protocol-envelope.json` permits the field to be "omitted when the request was executed fresh"; emitting `false` violates strict task response schemas that declare `additionalProperties: false` (`create-property-list-response`, etc.). Fresh responses now drop any prior `replayed` marker; replays still carry `replayed: true`. The existing `test/lib/idempotency-client.test.js` "replayed omitted is surfaced as undefined" test aligns with this shift.
+
+Surfaced by matrix v10: six `creative_generative` pairs crashed with the dereference, and every `property_lists` pair hit the `additionalProperties` violation.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
-> Generated at: 2026-04-21
-> @adcp/client v5.8.2
+> Generated at: 2026-04-22
+> @adcp/client v5.9.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-04-21
-> Library: @adcp/client v5.8.2
+> Generated at: 2026-04-22
+> Library: @adcp/client v5.9.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -984,15 +984,24 @@ function deepMergePlainObjects(target: unknown, source: unknown): unknown {
 }
 
 /**
- * Set `replayed` on the response envelope (MCP structuredContent).
- * Both fresh executions (`false`) and replays (`true`) carry the field,
- * per spec — a buyer that checks `replayed` to decide whether side
- * effects already fired needs the field present on every mutating
- * response, not just replays.
+ * Set `replayed: true` on the response envelope (MCP structuredContent)
+ * for replays only. `protocol-envelope.json` permits the field to be
+ * **"omitted when the request was executed fresh"** — emitting
+ * `replayed: false` pollutes task payloads and violates strict task
+ * response schemas that declare `additionalProperties: false`
+ * (`create-property-list-response`, etc.). Absence implies fresh exec.
+ *
+ * Callers pass `false` during the fresh-path call so replay bookkeeping
+ * can be reset cleanly; we honor that at the metadata layer by stripping
+ * any prior `replayed` rather than re-stamping it.
  */
 function injectReplayed(response: McpToolResponse, value: boolean): void {
-  if (response.structuredContent && typeof response.structuredContent === 'object') {
-    (response.structuredContent as Record<string, unknown>).replayed = value;
+  if (!response.structuredContent || typeof response.structuredContent !== 'object') return;
+  const sc = response.structuredContent as Record<string, unknown>;
+  if (value) {
+    sc.replayed = true;
+  } else {
+    delete sc.replayed;
   }
 }
 

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -241,8 +241,13 @@ export function performanceFeedbackResponse(
  * Build a successful build_creative response (single format).
  */
 export function buildCreativeResponse(data: BuildCreativeSuccess, summary?: string): McpToolResponse {
+  // Optional-chain the default summary — handler responses that drop
+  // `format_id` still reach the wire-level schema validator (which names
+  // the missing field), instead of crashing the dispatcher here with an
+  // opaque `Cannot read properties of undefined (reading 'id')`.
+  const formatId = data.creative_manifest?.format_id?.id;
   return {
-    content: [{ type: 'text', text: summary ?? `Creative built: ${data.creative_manifest.format_id.id}` }],
+    content: [{ type: 'text', text: summary ?? (formatId ? `Creative built: ${formatId}` : 'Creative built') }],
     structuredContent: toStructuredContent(data),
   };
 }
@@ -251,8 +256,9 @@ export function buildCreativeResponse(data: BuildCreativeSuccess, summary?: stri
  * Build a successful build_creative response (multi-format).
  */
 export function buildCreativeMultiResponse(data: BuildCreativeMultiSuccess, summary?: string): McpToolResponse {
+  const count = data.creative_manifests?.length ?? 0;
   return {
-    content: [{ type: 'text', text: summary ?? `Built ${data.creative_manifests.length} creative formats` }],
+    content: [{ type: 'text', text: summary ?? `Built ${count} creative formats` }],
     structuredContent: toStructuredContent(data),
   };
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.8.2';
+export const LIBRARY_VERSION = '5.9.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.8.2',
+  library: '5.9.0',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-21T19:05:08.212Z',
+  generatedAt: '2026-04-22T01:32:38.134Z',
 } as const;
 
 /**

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -69,11 +69,12 @@ describe('createAdcpServer with idempotency', () => {
     });
     assert.equal(calls.length, 1);
     assert.equal(result.media_buy_id, 'mb_1');
-    assert.equal(
-      result.replayed,
-      false,
-      'fresh execution must set replayed:false so buyers can distinguish retry-vs-first'
-    );
+    // `protocol-envelope.json` permits `replayed` to be "omitted when the
+    // request was executed fresh" (the spec text). Absence signals fresh
+    // exec; presence with `true` signals a cached replay. Emitting
+    // `replayed:false` breaks strict task response schemas that declare
+    // `additionalProperties: false` (create-property-list-response, etc.).
+    assert.ok(!('replayed' in result), 'fresh execution must omit `replayed` so strict task schemas still validate');
   });
 
   it('replay with same key + equivalent payload returns cached response with replayed:true', async () => {

--- a/test/server-responses.test.js
+++ b/test/server-responses.test.js
@@ -252,6 +252,22 @@ describe('buildCreativeResponse', () => {
     });
     assert.strictEqual(result.content[0].text, 'Creative built: banner_300x250');
   });
+
+  it('falls back gracefully when creative_manifest is missing format_id', () => {
+    // Regression: the default summary used to crash with
+    // "Cannot read properties of undefined (reading 'id')" — swallowing
+    // the real schema violation (missing required `format_id` per
+    // `creative-manifest.json`) behind an opaque SERVICE_UNAVAILABLE.
+    const result = buildCreativeResponse({
+      creative_manifest: { renders: [{ role: 'primary', media_type: 'image/png' }] },
+    });
+    assert.strictEqual(result.content[0].text, 'Creative built');
+  });
+
+  it('accepts a fully-missing creative_manifest without crashing', () => {
+    const result = buildCreativeResponse({});
+    assert.strictEqual(result.content[0].text, 'Creative built');
+  });
 });
 
 describe('buildCreativeMultiResponse', () => {
@@ -263,6 +279,11 @@ describe('buildCreativeMultiResponse', () => {
       ],
     });
     assert.strictEqual(result.content[0].text, 'Built 2 creative formats');
+  });
+
+  it('falls back to count=0 when creative_manifests is missing', () => {
+    const result = buildCreativeMultiResponse({});
+    assert.strictEqual(result.content[0].text, 'Built 0 creative formats');
   });
 });
 


### PR DESCRIPTION
## Summary

Two response-layer fixes surfaced by matrix v10 (covers the two dominant post-fixture-lint failure classes):

### 1. buildCreative summary no longer crashes on missing format_id

Matrix v10 had 6 \`creative_generative\` failures with \`SERVICE_UNAVAILABLE: Tool build_creative handler threw: Cannot read properties of undefined (reading 'id')\`. Root cause:

\`\`\`ts
// responses.ts:245 (before)
content: [{ type: 'text', text: summary ?? \`Creative built: \${data.creative_manifest.format_id.id}\` }],
\`\`\`

When the handler returns a \`creative_manifest\` without \`format_id\`, the dispatcher throws instead of reaching wire-level validation. The buyer sees an opaque internal error instead of the actual \`creative-manifest.json\` schema violation (\`format_id\` is required).

Fix: optional-chain + generic fallback. Schema-shape violations now surface as typed validation errors instead of dispatcher crashes.

### 2. replayed:false is no longer injected on fresh executions

Every \`property_lists\` pair hit \`/: must NOT have additional properties\` response schema violations. Root cause: \`injectReplayed(formatted, false)\` stamps \`replayed: false\` on every fresh response. \`protocol-envelope.json\` permits the field to be "omitted when the request was executed fresh" — but \`create-property-list-response.json\` and similar strict task schemas declare \`additionalProperties: false\` and reject any extra field.

Fix: only emit \`replayed: true\` on replays. Fresh responses strip any prior marker. Absence implies fresh exec per spec.

## Behavior change

\`server-idempotency.test.js\` previously asserted \`result.replayed === false\` on fresh execution. Updated to assert \`!('replayed' in result)\`, matching spec's "omitted when fresh" language and the existing client-side test that already expects \`undefined\`.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`test/server-responses.test.js\` gets 2 new tests: (a) missing format_id produces generic summary, (b) fully-missing creative_manifest doesn't crash
- [x] \`test/server-responses.test.js\` gets 1 new test for multi-response missing creative_manifests
- [x] \`test/server-idempotency.test.js\` updated fresh-execution assertion (omit, not false)
- [x] All 89 affected tests pass
- [ ] Matrix v11 after merge to measure cumulative delta