### PR TITLE
feat(server): strict response validation default in dev/test (#727)

### DIFF
--- a/.changeset/strict-response-validation-default.md
+++ b/.changeset/strict-response-validation-default.md
@@ -1,0 +1,32 @@
+---
+'@adcp/client': minor
+---
+
+feat(server): response validation defaults to `'strict'` outside production
+
+`createAdcpServer({ validation: { responses } })` previously defaulted to
+`'warn'` when `NODE_ENV !== 'production'`. It now defaults to `'strict'`
+in dev/test/CI so handler-returned schema drift fails with
+`VALIDATION_ERROR` (with the offending field path in `details.issues`)
+instead of logging a warning the caller can silently ignore.
+
+Production behaviour is unchanged: the default stays `'off'` when
+`NODE_ENV === 'production'`, so prod request paths pay no validation
+cost. Pass `validation: { responses: 'warn' }` to restore the previous
+dev-mode behaviour; `validation: { responses: 'off' }` opts out
+entirely.
+
+Why: the `compliance:skill-matrix` harness has repeatedly surfaced
+`SERVICE_UNAVAILABLE` from agents whose responses fail the wire schema.
+The dispatcher's response validator catches this drift with a clear
+field pointer, one layer that every tool inherits automatically. Making
+that the default catches it during handler development rather than in a
+downstream consumer.
+
+Migration: handler tests that use sparse fixtures (e.g.
+`{ products: [{ product_id: 'p1' }] }`) will start returning
+`VALIDATION_ERROR`. Either fill in the missing required fields to match
+the AdCP schema, or set `validation: { responses: 'off' }` on the test
+server to keep the fixture intentionally minimal.
+
+Closes #727 (A).

--- a/.changeset/strict-response-validation-default.md
+++ b/.changeset/strict-response-validation-default.md
@@ -27,6 +27,17 @@ Migration: handler tests that use sparse fixtures (e.g.
 `{ products: [{ product_id: 'p1' }] }`) will start returning
 `VALIDATION_ERROR`. Either fill in the missing required fields to match
 the AdCP schema, or set `validation: { responses: 'off' }` on the test
-server to keep the fixture intentionally minimal.
+server to keep the fixture intentionally minimal. Note that Node's
+test runner does **not** set `NODE_ENV`, so test suites running under
+`node --test` (with `NODE_ENV=undefined`) fall into the dev/test
+bucket and will start validating responses — this is intentional.
+
+Also: the `VALIDATION_ERROR` envelope's `details.issues[].schemaPath`
+is now gated behind `exposeErrorDetails` (same policy as the existing
+`SERVICE_UNAVAILABLE.details.reason` field). Production responses no
+longer leak `#/oneOf/<n>/properties/...` paths that fingerprint the
+handler's internal `oneOf` branch selection — buyers still get
+`pointer`, `message`, and `keyword`, which is sufficient to fix a
+drifted payload.
 
 Closes #727 (A).

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-22
-> @adcp/client v5.9.0
+> @adcp/client v5.9.1
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-22
-> Library: @adcp/client v5.9.0
+> Library: @adcp/client v5.9.1
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -868,9 +868,12 @@ export interface AdcpServerConfig<TAccount = unknown> {
    *     discriminator failure.
    *
    * Pass an explicit `validation: { requests: 'off', responses: 'off' }` to
-   * override the dev-mode default. Set `responses: 'warn'` to downgrade
-   * drift to a logger warning (useful while migrating a handler set from
-   * sparse fixtures to spec-compliant responses).
+   * override the dev-mode default. Set `responses: 'warn'` to keep the
+   * logger diagnostic without failing the request — useful while
+   * migrating a handler set from sparse fixtures to spec-compliant
+   * responses. (The logger warning fires in both `'warn'` and `'strict'`
+   * modes; `'strict'` additionally promotes the failure to a
+   * `VALIDATION_ERROR` envelope.)
    *
    * Per-side modes:
    *   - `requests: 'strict'` — reject malformed requests with VALIDATION_ERROR.
@@ -1868,7 +1871,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 variant: outcome.variant,
               });
               if (responseValidationMode === 'strict') {
-                const errPayload = buildAdcpValidationErrorPayload(toolName, 'response', outcome.issues);
+                const errPayload = buildAdcpValidationErrorPayload(
+                  toolName,
+                  'response',
+                  outcome.issues,
+                  { exposeSchemaPath: exposeErrorDetails }
+                );
                 if (idempotencyCheck && idempotency) {
                   try {
                     await idempotency.release({
@@ -1876,8 +1884,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                       key: idempotencyCheck.key,
                       extraScope: idempotencyCheck.extraScope,
                     });
-                  } catch {
-                    // Best-effort release; claim TTL evicts.
+                  } catch (err) {
+                    const reason = err instanceof Error ? err.message : String(err);
+                    logger.warn('Idempotency release failed — in-flight claim will expire on TTL', {
+                      tool: toolName,
+                      error: reason,
+                    });
                   }
                 }
                 return finalize(adcpError('VALIDATION_ERROR', errPayload));

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1871,12 +1871,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 variant: outcome.variant,
               });
               if (responseValidationMode === 'strict') {
-                const errPayload = buildAdcpValidationErrorPayload(
-                  toolName,
-                  'response',
-                  outcome.issues,
-                  { exposeSchemaPath: exposeErrorDetails }
-                );
+                const errPayload = buildAdcpValidationErrorPayload(toolName, 'response', outcome.issues, {
+                  exposeSchemaPath: exposeErrorDetails,
+                });
                 if (idempotencyCheck && idempotency) {
                   try {
                     await idempotency.release({

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -859,15 +859,18 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * Defaults:
    *   - When `NODE_ENV === 'production'` → both sides `'off'` (zero overhead
    *     in prod; trust the handler after its test suite has exercised it).
-   *   - Otherwise (dev, test, CI) → `responses: 'warn'`, `requests: 'off'`.
-   *     The default warn on responses catches the "handler returned a sparse
-   *     object that fails the wire schema" class of bug at development time
-   *     with a clear field path, instead of letting it surface downstream as
-   *     a cryptic `SERVICE_UNAVAILABLE` or `oneOf` discriminator failure.
+   *   - Otherwise (dev, test, CI) → `responses: 'strict'`, `requests: 'off'`.
+   *     The strict default on responses turns handler-returned drift into a
+   *     `VALIDATION_ERROR` with the offending field path — surfaces the
+   *     "handler returned a sparse object that fails the wire schema" class
+   *     of bug at development time instead of letting it ship and surface
+   *     downstream as a cryptic `SERVICE_UNAVAILABLE` or `oneOf`
+   *     discriminator failure.
    *
    * Pass an explicit `validation: { requests: 'off', responses: 'off' }` to
-   * override the dev-mode default. Set `responses: 'strict'` in CI if you
-   * want drift to fail loudly rather than warn.
+   * override the dev-mode default. Set `responses: 'warn'` to downgrade
+   * drift to a logger warning (useful while migrating a handler set from
+   * sparse fixtures to spec-compliant responses).
    *
    * Per-side modes:
    *   - `requests: 'strict'` — reject malformed requests with VALIDATION_ERROR.
@@ -1554,14 +1557,16 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     validation: validationConfig,
   } = config;
 
-  // Dev/test/CI default: warn on response drift. Production default: off.
-  // Explicit `validation: { requests, responses }` on the config always wins.
-  // Using `process.env.NODE_ENV` matches the convention every other SDK
-  // consumer already tunes (Express, React, etc.); containers/CI that want
-  // prod-like behavior set NODE_ENV=production before start.
+  // Dev/test/CI default: strict response validation — drift fails with
+  // VALIDATION_ERROR and the offending field path. Production default: off
+  // (zero overhead; trust the handler after its test suite has exercised
+  // it). Explicit `validation: { requests, responses }` on the config
+  // always wins. Using `process.env.NODE_ENV` matches the convention every
+  // other SDK consumer already tunes (Express, React, etc.); containers/CI
+  // that want prod-like behavior set NODE_ENV=production before start.
   const isProduction = process.env.NODE_ENV === 'production';
   const requestValidationMode = validationConfig?.requests ?? 'off';
-  const responseValidationMode = validationConfig?.responses ?? (isProduction ? 'off' : 'warn');
+  const responseValidationMode = validationConfig?.responses ?? (isProduction ? 'off' : 'strict');
 
   // Enforce lock-step between the `signed-requests` specialism claim and the
   // verifier config for the auto-wiring path. When `signedRequests` is set

--- a/src/lib/validation/schema-errors.ts
+++ b/src/lib/validation/schema-errors.ts
@@ -69,9 +69,7 @@ export function buildAdcpValidationErrorPayload(
     first != null
       ? `${tool} ${side} failed schema validation at ${first.pointer}: ${first.message}`
       : `${tool} ${side} failed schema validation`;
-  const emittedIssues = options.exposeSchemaPath
-    ? issues
-    : issues.map(({ schemaPath: _schemaPath, ...rest }) => rest);
+  const emittedIssues = options.exposeSchemaPath ? issues : issues.map(({ schemaPath: _schemaPath, ...rest }) => rest);
   const payload: { message: string; field?: string; details: Record<string, unknown> } = {
     message,
     details: { tool, side, issues: emittedIssues } satisfies AdcpValidationErrorDetails as unknown as Record<

--- a/src/lib/validation/schema-errors.ts
+++ b/src/lib/validation/schema-errors.ts
@@ -37,28 +37,47 @@ export function buildValidationError(
 /**
  * Shape of `adcp_error.details` inside a server-side `VALIDATION_ERROR`
  * envelope. Shipped so buyers can index every pointer programmatically
- * instead of parsing the free-text message.
+ * instead of parsing the free-text message. `schemaPath` is optional
+ * per-issue — the builder drops it by default in production so
+ * `oneOf` branch selection doesn't leak to buyers.
  */
 export interface AdcpValidationErrorDetails {
   tool: string;
   side: 'request' | 'response';
-  issues: ValidationIssue[];
+  issues: Array<Omit<ValidationIssue, 'schemaPath'> & { schemaPath?: string }>;
 }
 
-/** Serialize issues for the server-side `adcpError('VALIDATION_ERROR', ...)` call. */
+/**
+ * Serialize issues for the server-side `adcpError('VALIDATION_ERROR', ...)` call.
+ *
+ * `exposeSchemaPath` controls whether each issue's AJV `schemaPath`
+ * (e.g. `#/oneOf/2/properties/status/enum`) crosses the wire. When
+ * false, schemaPath is stripped from the emitted details.issues[] —
+ * buyers still get `pointer`, `message`, and `keyword`, which is
+ * enough to fix their payload, but the internal branch shape of the
+ * seller's handler isn't leaked. Defaults to the same policy as
+ * `exposeErrorDetails`: on in dev/test, off in production.
+ */
 export function buildAdcpValidationErrorPayload(
   tool: string,
   side: 'request' | 'response',
-  issues: ValidationIssue[]
+  issues: ValidationIssue[],
+  options: { exposeSchemaPath?: boolean } = {}
 ): { message: string; field?: string; details: Record<string, unknown> } {
   const first = issues[0];
   const message =
     first != null
       ? `${tool} ${side} failed schema validation at ${first.pointer}: ${first.message}`
       : `${tool} ${side} failed schema validation`;
+  const emittedIssues = options.exposeSchemaPath
+    ? issues
+    : issues.map(({ schemaPath: _schemaPath, ...rest }) => rest);
   const payload: { message: string; field?: string; details: Record<string, unknown> } = {
     message,
-    details: { tool, side, issues } satisfies AdcpValidationErrorDetails as unknown as Record<string, unknown>,
+    details: { tool, side, issues: emittedIssues } satisfies AdcpValidationErrorDetails as unknown as Record<
+      string,
+      unknown
+    >,
   };
   if (first?.pointer) payload.field = first.pointer;
   return payload;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.9.0';
+export const LIBRARY_VERSION = '5.9.1';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.9.0',
+  library: '5.9.1',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T01:32:38.134Z',
+  generatedAt: '2026-04-22T02:00:03.447Z',
 } as const;
 
 /**

--- a/test/lib/conformance-seeder.test.js
+++ b/test/lib/conformance-seeder.test.js
@@ -17,10 +17,16 @@ function waitForListening(server) {
 function startAgent(config) {
   // Seeder tests use deliberately sparse handler fixtures. Opt out of the
   // strict response-validation default so VALIDATION_ERROR envelopes don't
-  // short-circuit the seeder under test.
+  // short-circuit the seeder under test. Shallow-merge so a caller that
+  // explicitly sets one side doesn't accidentally clear the other.
   const s = serve(
     () =>
-      createAdcpServer({ name: 'Seed Test Agent', version: '1.0.0', validation: { responses: 'off' }, ...config }),
+      createAdcpServer({
+        name: 'Seed Test Agent',
+        version: '1.0.0',
+        ...config,
+        validation: { responses: 'off', ...(config?.validation ?? {}) },
+      }),
     { port: 0, onListening: () => {} }
   );
   return waitForListening(s).then(() => ({ server: s, port: s.address().port }));

--- a/test/lib/conformance-seeder.test.js
+++ b/test/lib/conformance-seeder.test.js
@@ -15,10 +15,14 @@ function waitForListening(server) {
 }
 
 function startAgent(config) {
-  const s = serve(() => createAdcpServer({ name: 'Seed Test Agent', version: '1.0.0', ...config }), {
-    port: 0,
-    onListening: () => {},
-  });
+  // Seeder tests use deliberately sparse handler fixtures. Opt out of the
+  // strict response-validation default so VALIDATION_ERROR envelopes don't
+  // short-circuit the seeder under test.
+  const s = serve(
+    () =>
+      createAdcpServer({ name: 'Seed Test Agent', version: '1.0.0', validation: { responses: 'off' }, ...config }),
+    { port: 0, onListening: () => {} }
+  );
   return waitForListening(s).then(() => ({ server: s, port: s.address().port }));
 }
 

--- a/test/lib/schema-validation-server.test.js
+++ b/test/lib/schema-validation-server.test.js
@@ -173,4 +173,96 @@ describe('createAdcpServer validation middleware', () => {
       assert.notStrictEqual(res.isError, true);
     });
   });
+
+  // Default selector: no `validation` config at all — the dispatcher
+  // reads `process.env.NODE_ENV` once at server construction and picks
+  // 'strict' in dev/test, 'off' in prod. Tests here capture the current
+  // env, mutate it around each construction, and restore after. Without
+  // this canary a future refactor that inlines the wrong default (e.g.
+  // 'warn' everywhere) has nothing to trip it.
+  describe('responses: unset (default selector on NODE_ENV)', () => {
+    const originalEnv = process.env.NODE_ENV;
+
+    test('dev default (NODE_ENV unset) fails drifted responses with VALIDATION_ERROR', async () => {
+      delete process.env.NODE_ENV;
+      try {
+        const server = createAdcpServer({
+          name: 'test',
+          version: '0.0.1',
+          stateStore: new InMemoryStateStore(),
+          mediaBuy: { getProducts: async () => ({ products: 'oops' }) },
+        });
+        const res = await callTool(server, 'get_products', VALID_GET_PRODUCTS);
+        assert.strictEqual(res.isError, true);
+        assert.strictEqual(res.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+        assert.strictEqual(res.structuredContent.adcp_error.details.side, 'response');
+      } finally {
+        if (originalEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalEnv;
+      }
+    });
+
+    test('production default (NODE_ENV=production) lets drifted responses through', async () => {
+      process.env.NODE_ENV = 'production';
+      try {
+        const server = createAdcpServer({
+          name: 'test',
+          version: '0.0.1',
+          stateStore: new InMemoryStateStore(),
+          mediaBuy: { getProducts: async () => ({ products: 'oops' }) },
+        });
+        const res = await callTool(server, 'get_products', VALID_GET_PRODUCTS);
+        assert.notStrictEqual(res.isError, true, 'prod default must not validate responses');
+        assert.strictEqual(res.structuredContent.products, 'oops');
+      } finally {
+        if (originalEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalEnv;
+      }
+    });
+
+    test('schemaPath is gated behind exposeErrorDetails', async () => {
+      process.env.NODE_ENV = 'production';
+      try {
+        const server = createAdcpServer({
+          name: 'test',
+          version: '0.0.1',
+          stateStore: new InMemoryStateStore(),
+          validation: { responses: 'strict' },
+          // exposeErrorDetails defaults to false when NODE_ENV=production
+          mediaBuy: { getProducts: async () => ({ products: 'oops' }) },
+        });
+        const res = await callTool(server, 'get_products', VALID_GET_PRODUCTS);
+        assert.strictEqual(res.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
+        const issues = res.structuredContent.adcp_error.details.issues;
+        assert.ok(Array.isArray(issues) && issues.length > 0);
+        for (const issue of issues) {
+          assert.strictEqual(issue.schemaPath, undefined, 'schemaPath must not leak when exposeErrorDetails is off');
+          assert.ok(issue.pointer, 'pointer still present');
+          assert.ok(issue.keyword, 'keyword still present');
+        }
+      } finally {
+        if (originalEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalEnv;
+      }
+    });
+
+    test('schemaPath is present when exposeErrorDetails is on', async () => {
+      delete process.env.NODE_ENV;
+      try {
+        const server = createAdcpServer({
+          name: 'test',
+          version: '0.0.1',
+          stateStore: new InMemoryStateStore(),
+          validation: { responses: 'strict' },
+          mediaBuy: { getProducts: async () => ({ products: 'oops' }) },
+        });
+        const res = await callTool(server, 'get_products', VALID_GET_PRODUCTS);
+        const issues = res.structuredContent.adcp_error.details.issues;
+        assert.ok(issues.some(i => typeof i.schemaPath === 'string' && i.schemaPath.length > 0));
+      } finally {
+        if (originalEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalEnv;
+      }
+    });
+  });
 });

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -1,9 +1,19 @@
 const { describe, it, mock } = require('node:test');
 const assert = require('node:assert');
-const { createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
 const { getSdkServer } = require('../dist/lib/server/adcp-server');
 const { InMemoryStateStore } = require('../dist/lib/server/state-store');
 const { adcpError } = require('../dist/lib/server/errors');
+
+// These tests exercise envelope wrapping, state-store propagation, and
+// idempotency middleware using deliberately sparse handler fixtures
+// (e.g. `{ products: [{ product_id: 'p1' }] }`). The strict response-
+// validation default turns that drift into VALIDATION_ERROR at the
+// dispatcher. Opt out so this file keeps testing middleware behavior;
+// `test/lib/schema-validation-server.test.js` covers the validator itself.
+function createAdcpServer(config) {
+  return _createAdcpServer({ validation: { responses: 'off' }, ...config });
+}
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -11,8 +11,15 @@ const { adcpError } = require('../dist/lib/server/errors');
 // validation default turns that drift into VALIDATION_ERROR at the
 // dispatcher. Opt out so this file keeps testing middleware behavior;
 // `test/lib/schema-validation-server.test.js` covers the validator itself.
+//
+// Shallow-merge `validation` so a per-test `validation: { requests: 'strict' }`
+// doesn't silently re-enable response validation; only keys the test
+// explicitly sets win over the file-level opt-out.
 function createAdcpServer(config) {
-  return _createAdcpServer({ validation: { responses: 'off' }, ...config });
+  return _createAdcpServer({
+    ...config,
+    validation: { responses: 'off', ...(config?.validation ?? {}) },
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -1,8 +1,14 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
 const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/idempotency');
+
+// Idempotency tests use sparse handler fixtures; opt out of the strict
+// response-validation default so we stay focused on replay/claim behavior.
+function createAdcpServer(config) {
+  return _createAdcpServer({ validation: { responses: 'off' }, ...config });
+}
 
 async function callTool(server, toolName, params) {
   const raw = await server.dispatchTestRequest({

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -6,8 +6,13 @@ const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/id
 
 // Idempotency tests use sparse handler fixtures; opt out of the strict
 // response-validation default so we stay focused on replay/claim behavior.
+// Shallow-merge `validation` so a per-test override on one key doesn't
+// silently re-enable the other side.
 function createAdcpServer(config) {
-  return _createAdcpServer({ validation: { responses: 'off' }, ...config });
+  return _createAdcpServer({
+    ...config,
+    validation: { responses: 'off', ...(config?.validation ?? {}) },
+  });
 }
 
 async function callTool(server, toolName, params) {


### PR DESCRIPTION
## Summary

- `createAdcpServer({ validation: { responses } })` now defaults to `'strict'` when `NODE_ENV !== 'production'` (was `'warn'`). Handler drift fails with `VALIDATION_ERROR` carrying the field pointer instead of silently logging a warning.
- Production default is unchanged: `'off'`. Explicit per-call config still wins.
- Three internal test files opt out (`validation: { responses: 'off' }`) because they use deliberately sparse fixtures to exercise envelope/state-store/idempotency middleware — schema conformance isn't their unit under test. `test/lib/schema-validation-server.test.js` continues to cover the validator itself.

## Why

The `compliance:skill-matrix` harness keeps surfacing `SERVICE_UNAVAILABLE` from agents that returned spec-incomplete responses (see the test-agent-team review on #725). The dispatcher's response validator is the right layer — it catches drift once for every tool with a clear field pointer. Making it strict by default in dev/test catches drift while the handler is being written instead of in a downstream consumer.

Closes #727(A). Part (B) (tightening generated discriminated unions in the types generator) remains open.

## Test plan

- [x] `npm test` — 5135 pass / 0 fail (baseline before flip: same count)
- [x] `test/lib/schema-validation-server.test.js` still asserts the three modes (`strict` / `warn` / `off`) behave as documented
- [ ] Post-merge: rerun `npm run compliance:skill-matrix` and confirm any residual drift surfaces as a single validator error per tool (the measurement the issue called for)

🤖 Generated with [Claude Code](https://claude.com/claude-code)