### PR TITLE
docs: surface response contracts per tool in docs/llms.txt

### DIFF
--- a/.changeset/llms-txt-response-contracts.md
+++ b/.changeset/llms-txt-response-contracts.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+`docs/llms.txt` now includes per-tool response contracts. Each tool section gets a `**Response (success branch):**` block listing the required + optional fields drawn from the bundled JSON schemas — same format the existing request block uses.
+
+Closes the drift path we kept seeing in matrix runs: agents dropped required response fields (missing `format_id` on `creative_manifest`, plural-variant hallucinations like `creative_deliveries` for `creatives`, missing top-level `currency`) because the skill examples documented the intent but the full per-field contract lived in the generated schemas and was never surfaced in the llms.txt index Claude actually reads when building. The contract is now one anchored section away: `docs/llms.txt#build_creative`, `docs/llms.txt#get_creative_delivery`, etc. — same convention as the llms.txt pattern other projects use.
+
+No SDK code change; llms.txt is regenerated via `npm run generate-agent-docs`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -165,7 +165,12 @@ Every tool is an MCP tool called via `agent.<methodName>(params)`. Returns `Task
 
 Request parameters for cross-protocol capability discovery.
 
-Optional: `protocols: string[]`, `context: Context`
+**Request:**
+- Optional: `protocols: string[]`, `context: Context`
+
+**Response (success branch):**
+- Required: `adcp: object`, `supported_protocols: string[]`
+- Optional: `account: object`, `media_buy: object`, `signals: object`, `governance: object`, `sponsored_intelligence: object`, `brand: object`, `creative: object`, `request_signing: object`, +9 more
 
 ### Account Management
 
@@ -173,35 +178,60 @@ Optional: `protocols: string[]`, `context: Context`
 
 Request parameters for listing accounts accessible to the authenticated agent.
 
-Optional: `status: 'active' | 'pending_approval' | 'rejected' | 'payment_required' | 'suspended' | 'closed'`, `pagination: Pagination Request`, `sandbox: boolean`, `context: Context`
+**Request:**
+- Optional: `status: 'active' | 'pending_approval' | 'rejected' | 'payment_required' | 'suspended' | 'closed'`, `pagination: Pagination Request`, `sandbox: boolean`, `context: Context`
+
+**Response (success branch):**
+- Required: `accounts: object[]`
+- Optional: `errors: object[]`, `pagination: Pagination Response`, `context: Context`
 
 #### `sync_accounts`
 
 Request parameters for syncing advertiser accounts with a seller.
 
-Required: `idempotency_key: string`, `accounts: object[]`
-Optional: `delete_missing: boolean`, `dry_run: boolean`, `push_notification_config: Push Notification Config`, `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `accounts: object[]`
+- Optional: `delete_missing: boolean`, `dry_run: boolean`, `push_notification_config: Push Notification Config`, `context: Context`
+
+**Response (success branch):**
+- Required: `accounts: object[]`
+- Optional: `dry_run: boolean`, `context: Context`
 
 #### `sync_governance`
 
 Request parameters for registering governance agent endpoints on accounts.
 
-Required: `idempotency_key: string`, `accounts: object[]`
-Optional: `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `accounts: object[]`
+- Optional: `context: Context`
+
+**Response (success branch):**
+- Required: `accounts: object[]`
+- Optional: `context: Context`
 
 #### `report_usage`
 
 Request parameters for reporting vendor service consumption after delivery.
 
-Required: `idempotency_key: string`, `reporting_period: Datetime Range`, `usage: object[]`
-Optional: `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `reporting_period: Datetime Range`, `usage: object[]`
+- Optional: `context: Context`
+
+**Response (success branch):**
+- Required: `accepted: integer`
+- Optional: `errors: object[]`, `sandbox: boolean`, `context: Context`
 
 #### `get_account_financials`
 
 Request parameters for querying financial status of an operator-billed account.
 
-Required: `account: Account Ref`
-Optional: `period: Date Range`, `context: Context`
+**Request:**
+- Required: `account: Account Ref`
+- Optional: `period: Date Range`, `context: Context`
+
+**Response (success branch):**
+- Required: `account: Account Ref`, `currency: string`, `period: Date Range`, `timezone: string`
+- Optional: `spend: object`, `credit: object`, `balance: object`, `payment_status: 'current' | 'past_due' | 'suspended'`, `payment_terms: 'net_15' | 'net_30' | 'net_45' | 'net_60' | 'net_90' | 'prepay'`, `invoices: object[]`, `context: Context`
 
 **Deep dive:**
 - docs/getting-started.md — authentication and account setup
@@ -212,75 +242,130 @@ Optional: `period: Date Range`, `context: Context`
 
 Request parameters for discovering available advertising products.
 
-Required: `buying_mode: 'brief' | 'wholesale' | 'refine'`
-Optional: `brief: string`, `refine: object[]`, `brand: Brand Ref`, `catalog: Catalog`, `account: Account Ref`, `preferred_delivery_types: object[]`, `filters: Product Filters`, `property_list: Property List Ref`, +5 more
+**Request:**
+- Required: `buying_mode: 'brief' | 'wholesale' | 'refine'`
+- Optional: `brief: string`, `refine: object[]`, `brand: Brand Ref`, `catalog: Catalog`, `account: Account Ref`, `preferred_delivery_types: object[]`, `filters: Product Filters`, `property_list: Property List Ref`, +5 more
+
+**Response (success branch):**
+- Required: `products: object[]`
+- Optional: `proposals: object[]`, `errors: object[]`, `property_list_applied: boolean`, `catalog_applied: boolean`, `refinement_applied: object[]`, `incomplete: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, +1 more
 
 #### `list_creative_formats`
 
 Request parameters for discovering format IDs and creative agents supported by this sales agent.
 
-Optional: `format_ids: object[]`, `asset_types: object[]`, `max_width: integer`, `max_height: integer`, `min_width: integer`, `min_height: integer`, `is_responsive: boolean`, `name_search: string`, +7 more
+**Request:**
+- Optional: `format_ids: object[]`, `asset_types: object[]`, `max_width: integer`, `max_height: integer`, `min_width: integer`, `min_height: integer`, `is_responsive: boolean`, `name_search: string`, +7 more
+
+**Response (success branch):**
+- Required: `formats: object[]`
+- Optional: `creative_agents: object[]`, `errors: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, `context: Context`
 
 #### `create_media_buy`
 
 Request parameters for creating a media buy.
 
-Required: `idempotency_key: string`, `account: Account Ref`, `brand: Brand Ref`, `start_time: Start Timing`, `end_time: string`
-Optional: `plan_id: string`, `proposal_id: string`, `total_budget: object`, `packages: object[]`, `advertiser_industry: Advertiser Industry`, `invoice_recipient: Business Entity`, `io_acceptance: object`, `po_number: string`, +5 more
+**Request:**
+- Required: `idempotency_key: string`, `account: Account Ref`, `brand: Brand Ref`, `start_time: Start Timing`, `end_time: string`
+- Optional: `plan_id: string`, `proposal_id: string`, `total_budget: object`, `packages: object[]`, `advertiser_industry: Advertiser Industry`, `invoice_recipient: Business Entity`, `io_acceptance: object`, `po_number: string`, +5 more
+
+**Response (success branch):**
+- Required: `media_buy_id: string`, `packages: object[]`
+- Optional: `account: Account`, `invoice_recipient: Business Entity`, `status: Media Buy Status`, `confirmed_at: string`, `creative_deadline: string`, `revision: integer`, `valid_actions: string[]`, `planned_delivery: Planned Delivery`, +2 more
 
 #### `update_media_buy`
 
 Request parameters for updating campaign and package settings.
 
-Required: `account: Account Ref`, `media_buy_id: string`, `idempotency_key: string`
-Optional: `revision: integer`, `paused: boolean`, `canceled: 'true'`, `cancellation_reason: string`, `start_time: Start Timing`, `end_time: string`, `packages: object[]`, `invoice_recipient: Business Entity`, +4 more
+**Request:**
+- Required: `account: Account Ref`, `media_buy_id: string`, `idempotency_key: string`
+- Optional: `revision: integer`, `paused: boolean`, `canceled: 'true'`, `cancellation_reason: string`, `start_time: Start Timing`, `end_time: string`, `packages: object[]`, `invoice_recipient: Business Entity`, +4 more
+
+**Response (success branch):**
+- Required: `media_buy_id: string`
+- Optional: `status: Media Buy Status`, `revision: integer`, `implementation_date: string,null`, `invoice_recipient: Business Entity`, `affected_packages: object[]`, `valid_actions: string[]`, `sandbox: boolean`, `context: Context`
 
 #### `get_media_buys`
 
 Request parameters for retrieving media buy status, creative approvals, and delivery snapshots.
 
-Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `include_snapshot: boolean`, `include_history: integer`, `pagination: Pagination Request`, `context: Context`
+**Request:**
+- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `include_snapshot: boolean`, `include_history: integer`, `pagination: Pagination Request`, `context: Context`
+
+**Response (success branch):**
+- Required: `media_buys: object[]`
+- Optional: `errors: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, `context: Context`
 
 #### `get_media_buy_delivery`
 
 Request parameters for retrieving comprehensive delivery metrics.
 
-Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `start_date: string`, `end_date: string`, `include_package_daily_breakdown: boolean`, `attribution_window: object`, `reporting_dimensions: object`, +1 more
+**Request:**
+- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `status_filter: Media Buy Status | object[]`, `start_date: string`, `end_date: string`, `include_package_daily_breakdown: boolean`, `attribution_window: object`, `reporting_dimensions: object`, +1 more
+
+**Response (success branch):**
+- Required: `reporting_period: object`, `currency: string`, `media_buy_deliveries: object[]`
+- Optional: `notification_type: 'scheduled' | 'final' | 'delayed' | 'adjusted' | 'window_update'`, `partial_data: boolean`, `unavailable_count: integer`, `sequence_number: integer`, `next_expected_at: string`, `attribution_window: Attribution Window`, `aggregated_totals: object`, `errors: object[]`, +2 more
 
 #### `provide_performance_feedback`
 
 Request parameters for sharing performance outcomes with publishers.
 
-Required: `media_buy_id: string`, `idempotency_key: string`, `measurement_period: Datetime Range`, `performance_index: number`
-Optional: `package_id: string`, `creative_id: string`, `metric_type: Metric Type`, `feedback_source: Feedback Source`, `context: Context`
+**Request:**
+- Required: `media_buy_id: string`, `idempotency_key: string`, `measurement_period: Datetime Range`, `performance_index: number`
+- Optional: `package_id: string`, `creative_id: string`, `metric_type: Metric Type`, `feedback_source: Feedback Source`, `context: Context`
+
+**Response (success branch):**
+- Required: `success: 'true'`
+- Optional: `sandbox: boolean`, `context: Context`
 
 #### `sync_event_sources`
 
 Request parameters for configuring event sources on an account.
 
-Required: `idempotency_key: string`, `account: Account Ref`
-Optional: `event_sources: object[]`, `delete_missing: boolean`, `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `account: Account Ref`
+- Optional: `event_sources: object[]`, `delete_missing: boolean`, `context: Context`
+
+**Response (success branch):**
+- Required: `event_sources: object[]`
+- Optional: `sandbox: boolean`, `context: Context`
 
 #### `log_event`
 
 Request parameters for logging conversion or marketing events.
 
-Required: `event_source_id: string`, `events: object[]`, `idempotency_key: string`
-Optional: `test_event_code: string`, `context: Context`
+**Request:**
+- Required: `event_source_id: string`, `events: object[]`, `idempotency_key: string`
+- Optional: `test_event_code: string`, `context: Context`
+
+**Response (success branch):**
+- Required: `events_received: integer`, `events_processed: integer`
+- Optional: `partial_failures: object[]`, `warnings: string[]`, `match_quality: number`, `sandbox: boolean`, `context: Context`
 
 #### `sync_audiences`
 
 Request parameters for managing CRM-based audiences on an account.
 
-Required: `idempotency_key: string`, `account: Account Ref`
-Optional: `audiences: object[]`, `delete_missing: boolean`, `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `account: Account Ref`
+- Optional: `audiences: object[]`, `delete_missing: boolean`, `context: Context`
+
+**Response (success branch):**
+- Required: `audiences: object[]`
+- Optional: `sandbox: boolean`, `context: Context`
 
 #### `sync_catalogs`
 
 Request parameters for syncing catalog feeds (products, inventory, stores, promotions, offerings) with approval workflow.
 
-Required: `idempotency_key: string`, `account: Account Ref`
-Optional: `catalogs: object[]`, `catalog_ids: string[]`, `delete_missing: boolean`, `dry_run: boolean`, `validation_mode: Validation Mode`, `push_notification_config: Push Notification Config`, `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `account: Account Ref`
+- Optional: `catalogs: object[]`, `catalog_ids: string[]`, `delete_missing: boolean`, `dry_run: boolean`, `validation_mode: Validation Mode`, `push_notification_config: Push Notification Config`, `context: Context`
+
+**Response (success branch):**
+- Required: `catalogs: object[]`
+- Optional: `dry_run: boolean`, `sandbox: boolean`, `context: Context`
 
 **Deep dive:**
 - docs/getting-started.md — installation, auth, basic usage
@@ -294,40 +379,70 @@ Optional: `catalogs: object[]`, `catalog_ids: string[]`, `delete_missing: boolea
 
 Request parameters for AI-powered creative generation.
 
-Required: `idempotency_key: string`
-Optional: `message: string`, `creative_manifest: Creative Manifest`, `creative_id: string`, `concept_id: string`, `media_buy_id: string`, `package_id: string`, `target_format_id: Format Id`, `target_format_ids: object[]`, +10 more
+**Request:**
+- Required: `idempotency_key: string`
+- Optional: `message: string`, `creative_manifest: Creative Manifest`, `creative_id: string`, `concept_id: string`, `media_buy_id: string`, `package_id: string`, `target_format_id: Format Id`, `target_format_ids: object[]`, +10 more
+
+**Response (success branch):**
+- Required: `creative_manifest: Creative Manifest`
+- Optional: `sandbox: boolean`, `expires_at: string`, `preview: object`, `preview_error: Error`, `pricing_option_id: string`, `vendor_cost: number`, `currency: string`, `consumption: Creative Consumption`, +1 more
 
 #### `preview_creative`
 
 Request parameters for generating creative previews.
 
-Required: `request_type: 'single' | 'batch' | 'variant'`
-Optional: `creative_manifest: Creative Manifest`, `format_id: Format Id`, `inputs: object[]`, `template_id: string`, `quality: Creative Quality`, `output_format: Preview Output Format`, `item_limit: integer`, `requests: object[]`, +3 more
+**Request:**
+- Required: `request_type: 'single' | 'batch' | 'variant'`
+- Optional: `creative_manifest: Creative Manifest`, `format_id: Format Id`, `inputs: object[]`, `template_id: string`, `quality: Creative Quality`, `output_format: Preview Output Format`, `item_limit: integer`, `requests: object[]`, +3 more
+
+**Response (success branch):**
+- Required: `response_type: 'single'`, `previews: object[]`, `expires_at: string`
+- Optional: `interactive_url: string`, `context: Context`
 
 #### `list_creative_formats`
 
 Request parameters for discovering creative formats from this creative agent.
 
-Optional: `format_ids: object[]`, `type: 'audio' | 'video' | 'display' | 'dooh'`, `asset_types: string[]`, `max_width: integer`, `max_height: integer`, `min_width: integer`, `min_height: integer`, `is_responsive: boolean`, +10 more
+**Request:**
+- Optional: `format_ids: object[]`, `type: 'audio' | 'video' | 'display' | 'dooh'`, `asset_types: string[]`, `max_width: integer`, `max_height: integer`, `min_width: integer`, `min_height: integer`, `is_responsive: boolean`, +10 more
+
+**Response (success branch):**
+- Required: `formats: object[]`
+- Optional: `creative_agents: object[]`, `errors: object[]`, `pagination: Pagination Response`, `context: Context`
 
 #### `get_creative_delivery`
 
 Request parameters for retrieving creative delivery data with variant-level breakdowns.
 
-Optional: `account: Account Ref`, `media_buy_ids: string[]`, `creative_ids: string[]`, `start_date: string`, `end_date: string`, `max_variants: integer`, `pagination: Pagination Request`, `context: Context`
+**Request:**
+- Optional: `account: Account Ref`, `media_buy_ids: string[]`, `creative_ids: string[]`, `start_date: string`, `end_date: string`, `max_variants: integer`, `pagination: Pagination Request`, `context: Context`
+
+**Response (success branch):**
+- Required: `currency: string`, `reporting_period: object`, `creatives: object[]`
+- Optional: `account_id: string`, `media_buy_id: string`, `pagination: object`, `errors: object[]`, `context: Context`
 
 #### `list_creatives`
 
 Request parameters for querying creative library with filtering and pagination.
 
-Optional: `filters: Creative Filters`, `sort: object`, `pagination: Pagination Request`, `include_assignments: boolean`, `include_snapshot: boolean`, `include_items: boolean`, `include_variables: boolean`, `include_pricing: boolean`, +3 more
+**Request:**
+- Optional: `filters: Creative Filters`, `sort: object`, `pagination: Pagination Request`, `include_assignments: boolean`, `include_snapshot: boolean`, `include_items: boolean`, `include_variables: boolean`, `include_pricing: boolean`, +3 more
+
+**Response (success branch):**
+- Required: `query_summary: object`, `pagination: Pagination Response`, `creatives: object[]`
+- Optional: `format_summary: object`, `status_summary: object`, `errors: object[]`, `sandbox: boolean`, `context: Context`
 
 #### `sync_creatives`
 
 Request parameters for syncing creative assets with upsert semantics.
 
-Required: `account: Account Ref`, `creatives: object[]`, `idempotency_key: string`
-Optional: `creative_ids: string[]`, `assignments: object[]`, `delete_missing: boolean`, `dry_run: boolean`, `validation_mode: Validation Mode`, `push_notification_config: Push Notification Config`, `context: Context`
+**Request:**
+- Required: `account: Account Ref`, `creatives: object[]`, `idempotency_key: string`
+- Optional: `creative_ids: string[]`, `assignments: object[]`, `delete_missing: boolean`, `dry_run: boolean`, `validation_mode: Validation Mode`, `push_notification_config: Push Notification Config`, `context: Context`
+
+**Response (success branch):**
+- Required: `creatives: object[]`
+- Optional: `dry_run: boolean`, `sandbox: boolean`, `context: Context`
 
 **Deep dive:**
 - docs/guides/BUILD-AN-AGENT.md — building a creative agent (server-side)
@@ -339,14 +454,24 @@ Optional: `creative_ids: string[]`, `assignments: object[]`, `delete_missing: bo
 
 Request parameters for discovering signals based on description.
 
-Optional: `account: Account Ref`, `signal_spec: string`, `signal_ids: object[]`, `destinations: object[]`, `countries: string[]`, `filters: Signal Filters`, `max_results: integer`, `pagination: Pagination Request`, +1 more
+**Request:**
+- Optional: `account: Account Ref`, `signal_spec: string`, `signal_ids: object[]`, `destinations: object[]`, `countries: string[]`, `filters: Signal Filters`, `max_results: integer`, `pagination: Pagination Request`, +1 more
+
+**Response (success branch):**
+- Required: `signals: object[]`
+- Optional: `errors: object[]`, `pagination: Pagination Response`, `sandbox: boolean`, `context: Context`
 
 #### `activate_signal`
 
 Request parameters for activating a signal on a specific platform/account.
 
-Required: `signal_agent_segment_id: string`, `destinations: object[]`, `idempotency_key: string`
-Optional: `action: 'activate' | 'deactivate'`, `pricing_option_id: string`, `account: Account Ref`, `context: Context`
+**Request:**
+- Required: `signal_agent_segment_id: string`, `destinations: object[]`, `idempotency_key: string`
+- Optional: `action: 'activate' | 'deactivate'`, `pricing_option_id: string`, `account: Account Ref`, `context: Context`
+
+**Response (success branch):**
+- Required: `deployments: object[]`
+- Optional: `sandbox: boolean`, `context: Context`
 
 **Deep dive:**
 - docs/guides/BUILD-AN-AGENT.md — signals agent example
@@ -357,151 +482,260 @@ Optional: `action: 'activate' | 'deactivate'`, `pricing_option_id: string`, `acc
 
 Request parameters for creating a new property list.
 
-Required: `name: string`, `idempotency_key: string`
-Optional: `account: Account Ref`, `description: string`, `base_properties: object[]`, `filters: Property List Filters`, `brand: Brand Ref`, `context: Context`
+**Request:**
+- Required: `name: string`, `idempotency_key: string`
+- Optional: `account: Account Ref`, `description: string`, `base_properties: object[]`, `filters: Property List Filters`, `brand: Brand Ref`, `context: Context`
+
+**Response (success branch):**
+- Required: `list: Property List`, `auth_token: string`
+- Optional: `context: Context`
 
 #### `update_property_list`
 
 Request parameters for updating an existing property list.
 
-Required: `list_id: string`, `idempotency_key: string`
-Optional: `account: Account Ref`, `name: string`, `description: string`, `base_properties: object[]`, `filters: Property List Filters`, `brand: Brand Ref`, `webhook_url: string`, `context: Context`
+**Request:**
+- Required: `list_id: string`, `idempotency_key: string`
+- Optional: `account: Account Ref`, `name: string`, `description: string`, `base_properties: object[]`, `filters: Property List Filters`, `brand: Brand Ref`, `webhook_url: string`, `context: Context`
+
+**Response (success branch):**
+- Required: `list: Property List`
+- Optional: `context: Context`
 
 #### `get_property_list`
 
 Request parameters for retrieving a property list with resolved properties.
 
-Required: `list_id: string`
-Optional: `account: Account Ref`, `resolve: boolean`, `pagination: object`, `context: Context`
+**Request:**
+- Required: `list_id: string`
+- Optional: `account: Account Ref`, `resolve: boolean`, `pagination: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `list: Property List`
+- Optional: `identifiers: object[]`, `pagination: Pagination Response`, `resolved_at: string`, `cache_valid_until: string`, `coverage_gaps: object`, `context: Context`
 
 #### `list_property_lists`
 
 Request parameters for listing property lists.
 
-Optional: `account: Account Ref`, `name_contains: string`, `pagination: Pagination Request`, `context: Context`
+**Request:**
+- Optional: `account: Account Ref`, `name_contains: string`, `pagination: Pagination Request`, `context: Context`
+
+**Response (success branch):**
+- Required: `lists: object[]`
+- Optional: `pagination: Pagination Response`, `context: Context`
 
 #### `delete_property_list`
 
 Request parameters for deleting a property list.
 
-Required: `list_id: string`, `idempotency_key: string`
-Optional: `account: Account Ref`, `context: Context`
+**Request:**
+- Required: `list_id: string`, `idempotency_key: string`
+- Optional: `account: Account Ref`, `context: Context`
+
+**Response (success branch):**
+- Required: `deleted: boolean`, `list_id: string`
+- Optional: `context: Context`
 
 #### `create_collection_list`
 
 Request parameters for creating a new collection list.
 
-Required: `name: string`, `idempotency_key: string`
-Optional: `account: Account Ref`, `description: string`, `base_collections: object[]`, `filters: Collection List Filters`, `brand: Brand Ref`, `context: Context`
+**Request:**
+- Required: `name: string`, `idempotency_key: string`
+- Optional: `account: Account Ref`, `description: string`, `base_collections: object[]`, `filters: Collection List Filters`, `brand: Brand Ref`, `context: Context`
+
+**Response (success branch):**
+- Required: `list: Collection List`, `auth_token: string`
+- Optional: `context: Context`
 
 #### `update_collection_list`
 
 Request parameters for updating an existing collection list.
 
-Required: `list_id: string`, `idempotency_key: string`
-Optional: `account: Account Ref`, `name: string`, `description: string`, `base_collections: object[]`, `filters: Collection List Filters`, `brand: Brand Ref`, `webhook_url: string`, `context: Context`
+**Request:**
+- Required: `list_id: string`, `idempotency_key: string`
+- Optional: `account: Account Ref`, `name: string`, `description: string`, `base_collections: object[]`, `filters: Collection List Filters`, `brand: Brand Ref`, `webhook_url: string`, `context: Context`
+
+**Response (success branch):**
+- Required: `list: Collection List`
+- Optional: `context: Context`
 
 #### `get_collection_list`
 
 Request parameters for retrieving a collection list with resolved collections.
 
-Required: `list_id: string`
-Optional: `account: Account Ref`, `resolve: boolean`, `pagination: object`, `context: Context`
+**Request:**
+- Required: `list_id: string`
+- Optional: `account: Account Ref`, `resolve: boolean`, `pagination: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `list: Collection List`
+- Optional: `collections: object[]`, `pagination: Pagination Response`, `resolved_at: string`, `cache_valid_until: string`, `coverage_gaps: object`, `context: Context`
 
 #### `list_collection_lists`
 
 Request parameters for listing collection lists.
 
-Optional: `account: Account Ref`, `name_contains: string`, `pagination: Pagination Request`, `context: Context`
+**Request:**
+- Optional: `account: Account Ref`, `name_contains: string`, `pagination: Pagination Request`, `context: Context`
+
+**Response (success branch):**
+- Required: `lists: object[]`
+- Optional: `pagination: Pagination Response`, `context: Context`
 
 #### `delete_collection_list`
 
 Request parameters for deleting a collection list.
 
-Required: `list_id: string`, `idempotency_key: string`
-Optional: `account: Account Ref`, `context: Context`
+**Request:**
+- Required: `list_id: string`, `idempotency_key: string`
+- Optional: `account: Account Ref`, `context: Context`
+
+**Response (success branch):**
+- Required: `deleted: boolean`, `list_id: string`
+- Optional: `context: Context`
 
 #### `list_content_standards`
 
 Request parameters for listing content standards configurations.
 
-Optional: `channels: object[]`, `languages: string[]`, `countries: string[]`, `pagination: Pagination Request`, `context: Context`
+**Request:**
+- Optional: `channels: object[]`, `languages: string[]`, `countries: string[]`, `pagination: Pagination Request`, `context: Context`
+
+**Response (success branch):**
+- Required: `standards: object[]`
+- Optional: `pagination: Pagination Response`, `context: Context`
 
 #### `get_content_standards`
 
 Request parameters for retrieving a specific standards configuration.
 
-Required: `standards_id: string`
-Optional: `context: Context`
+**Request:**
+- Required: `standards_id: string`
+- Optional: `context: Context`
+
+**Response (success branch):**
+- Optional: `context: Context`
 
 #### `create_content_standards`
 
 Request parameters for creating a new content standards configuration.
 
-Required: `scope: object`, `idempotency_key: string`
-Optional: `registry_policy_ids: string[]`, `policies: object[]`, `calibration_exemplars: object`, `context: Context`
+**Request:**
+- Required: `scope: object`, `idempotency_key: string`
+- Optional: `registry_policy_ids: string[]`, `policies: object[]`, `calibration_exemplars: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `standards_id: string`
+- Optional: `context: Context`
 
 #### `update_content_standards`
 
 Request parameters for updating an existing content standards configuration.
 
-Required: `standards_id: string`, `idempotency_key: string`
-Optional: `scope: object`, `registry_policy_ids: string[]`, `policies: object[]`, `calibration_exemplars: object`, `context: Context`
+**Request:**
+- Required: `standards_id: string`, `idempotency_key: string`
+- Optional: `scope: object`, `registry_policy_ids: string[]`, `policies: object[]`, `calibration_exemplars: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `success: 'true'`, `standards_id: string`
+- Optional: `context: Context`
 
 #### `calibrate_content`
 
 Request parameters for collaborative calibration dialogue.
 
-Required: `standards_id: string`, `artifact: Artifact`, `idempotency_key: string`
-Optional: `context: Context`
+**Request:**
+- Required: `standards_id: string`, `artifact: Artifact`, `idempotency_key: string`
+- Optional: `context: Context`
+
+**Response (success branch):**
+- Required: `verdict: 'pass' | 'fail'`
+- Optional: `confidence: number`, `explanation: string`, `features: object[]`, `context: Context`
 
 #### `validate_content_delivery`
 
 Request parameters for batch validating delivery records.
 
-Required: `standards_id: string`, `records: object[]`
-Optional: `feature_ids: string[]`, `include_passed: boolean`, `context: Context`
+**Request:**
+- Required: `standards_id: string`, `records: object[]`
+- Optional: `feature_ids: string[]`, `include_passed: boolean`, `context: Context`
+
+**Response (success branch):**
+- Required: `summary: object`, `results: object[]`
+- Optional: `context: Context`
 
 #### `get_media_buy_artifacts`
 
 Request parameters for retrieving content artifacts from a media buy.
 
-Required: `media_buy_id: string`
-Optional: `account: Account Ref`, `package_ids: string[]`, `failures_only: boolean`, `time_range: object`, `pagination: object`, `context: Context`
+**Request:**
+- Required: `media_buy_id: string`
+- Optional: `account: Account Ref`, `package_ids: string[]`, `failures_only: boolean`, `time_range: object`, `pagination: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `media_buy_id: string`, `artifacts: object[]`
+- Optional: `collection_info: object`, `pagination: Pagination Response`, `context: Context`
 
 #### `get_creative_features`
 
 Request parameters for evaluating creative features from a governance agent.
 
-Required: `creative_manifest: Creative Manifest`
-Optional: `feature_ids: string[]`, `account: Account Ref`, `context: Context`
+**Request:**
+- Required: `creative_manifest: Creative Manifest`
+- Optional: `feature_ids: string[]`, `account: Account Ref`, `context: Context`
+
+**Response (success branch):**
+- Required: `results: object[]`
+- Optional: `detail_url: string`, `pricing_option_id: string`, `vendor_cost: number`, `currency: string`, `consumption: Creative Consumption`, `context: Context`
 
 #### `sync_plans`
 
 Push campaign plans to the governance agent.
 
-Required: `idempotency_key: string`, `plans: object[]`
-Optional: `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `plans: object[]`
+- Optional: `context: Context`
+
+**Response (success branch):**
+- Required: `plans: object[]`
+- Optional: `context: Context`
 
 #### `report_plan_outcome`
 
 Report the outcome of an action to the governance agent.
 
-Required: `plan_id: string`, `idempotency_key: string`, `outcome: Outcome Type`, `governance_context: string`
-Optional: `check_id: string`, `purchase_type: Purchase Type`, `seller_response: object`, `delivery: object`, `error: object`, `context: Context`
+**Request:**
+- Required: `plan_id: string`, `idempotency_key: string`, `outcome: Outcome Type`, `governance_context: string`
+- Optional: `check_id: string`, `purchase_type: Purchase Type`, `seller_response: object`, `delivery: object`, `error: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `outcome_id: string`, `status: 'accepted' | 'findings'`
+- Optional: `committed_budget: number`, `findings: object[]`, `plan_summary: object`, `context: Context`
 
 #### `get_plan_audit_logs`
 
 Retrieve governance state and audit trail for a plan.
 
-Optional: `plan_ids: string[]`, `portfolio_plan_ids: string[]`, `governance_contexts: string[]`, `purchase_types: object[]`, `include_entries: boolean`, `context: Context`
+**Request:**
+- Optional: `plan_ids: string[]`, `portfolio_plan_ids: string[]`, `governance_contexts: string[]`, `purchase_types: object[]`, `include_entries: boolean`, `context: Context`
+
+**Response (success branch):**
+- Required: `plans: object[]`
+- Optional: `context: Context`
 
 #### `check_governance`
 
 Orchestrator or seller calls the governance agent to validate an action against the campaign plan.
 
-Required: `plan_id: string`, `caller: string`
-Optional: `purchase_type: Purchase Type`, `tool: string`, `payload: object`, `governance_context: string`, `phase: Governance Phase`, `planned_delivery: Planned Delivery`, `delivery_metrics: object`, `modification_summary: string`, +2 more
+**Request:**
+- Required: `plan_id: string`, `caller: string`
+- Optional: `purchase_type: Purchase Type`, `tool: string`, `payload: object`, `governance_context: string`, `phase: Governance Phase`, `planned_delivery: Planned Delivery`, `delivery_metrics: object`, `modification_summary: string`, +2 more
+
+**Response (success branch):**
+- Required: `check_id: string`, `status: 'approved' | 'denied' | 'conditions'`, `plan_id: string`, `explanation: string`
+- Optional: `findings: object[]`, `conditions: object[]`, `expires_at: string`, `next_check: string`, `categories_evaluated: string[]`, `policies_evaluated: string[]`, `governance_context: string`, `context: Context`
 
 **Deep dive:**
 - docs/guides/HANDLER-PATTERNS-GUIDE.md — input handler patterns for governance flows
@@ -512,29 +746,49 @@ Optional: `purchase_type: Purchase Type`, `tool: string`, `payload: object`, `go
 
 Get offering details, availability, and optionally matching products before session handoff.
 
-Required: `offering_id: string`
-Optional: `context: string`, `include_products: boolean`, `product_limit: integer`
+**Request:**
+- Required: `offering_id: string`
+- Optional: `context: string`, `include_products: boolean`, `product_limit: integer`
+
+**Response (success branch):**
+- Required: `available: boolean`
+- Optional: `offering_token: string`, `ttl_seconds: integer`, `checked_at: string`, `offering: object`, `matching_products: object[]`, `total_matching: integer`, `unavailable_reason: string`, `alternative_offering_ids: string[]`, +2 more
 
 #### `si_initiate_session`
 
 Host initiates SI session with brand agent - includes context, identity, and capability negotiation.
 
-Required: `context: string`, `identity: Si Identity`, `idempotency_key: string`
-Optional: `media_buy_id: string`, `placement: string`, `offering_id: string`, `supported_capabilities: Si Capabilities`, `offering_token: string`
+**Request:**
+- Required: `context: string`, `identity: Si Identity`, `idempotency_key: string`
+- Optional: `media_buy_id: string`, `placement: string`, `offering_id: string`, `supported_capabilities: Si Capabilities`, `offering_token: string`
+
+**Response (success branch):**
+- Required: `session_id: string`, `session_status: Si Session Status`
+- Optional: `response: object`, `negotiated_capabilities: Si Capabilities`, `session_ttl_seconds: integer`, `errors: object[]`, `context: Context`
 
 #### `si_send_message`
 
 Send a message within an active SI session.
 
-Required: `idempotency_key: string`, `session_id: string`
-Optional: `message: string`, `action_response: object`, `context: Context`
+**Request:**
+- Required: `idempotency_key: string`, `session_id: string`
+- Optional: `message: string`, `action_response: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `session_id: string`, `session_status: Si Session Status`
+- Optional: `response: object`, `mcp_resource_uri: string`, `handoff: object`, `errors: object[]`, `context: Context`
 
 #### `si_terminate_session`
 
 Terminate an SI session with reason (handoff_transaction, handoff_complete, user_exit, session_timeout, host_terminated).
 
-Required: `session_id: string`, `reason: 'handoff_transaction' | 'handoff_complete' | 'user_exit' | 'session_timeout' | 'host_terminated'`
-Optional: `termination_context: object`, `context: Context`
+**Request:**
+- Required: `session_id: string`, `reason: 'handoff_transaction' | 'handoff_complete' | 'user_exit' | 'session_timeout' | 'host_terminated'`
+- Optional: `termination_context: object`, `context: Context`
+
+**Response (success branch):**
+- Required: `session_id: string`, `terminated: boolean`
+- Optional: `session_status: Si Session Status`, `acp_handoff: object`, `follow_up: object`, `errors: object[]`, `context: Context`
 
 **Deep dive:**
 - docs/guides/ASYNC-DEVELOPER-GUIDE.md — session lifecycle patterns

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -676,18 +676,40 @@ function generateLlmsTxt(
       if (toolDesc) ln(`${toolDesc}.`);
       ln();
 
+      ln(`**Request:**`);
       if (tool.requiredFields.length) {
-        ln(`Required: ${tool.requiredFields.map(f => `\`${f}\``).join(', ')}`);
+        ln(`- Required: ${tool.requiredFields.map(f => `\`${f}\``).join(', ')}`);
       }
       if (tool.optionalFields.length) {
         // Show first 8 optional fields to keep it scannable
         const shown = tool.optionalFields.slice(0, 8);
         const more = tool.optionalFields.length - shown.length;
-        let optLine = `Optional: ${shown.map(f => `\`${f}\``).join(', ')}`;
+        let optLine = `- Optional: ${shown.map(f => `\`${f}\``).join(', ')}`;
         if (more > 0) optLine += `, +${more} more`;
         ln(optLine);
       }
+      if (!tool.requiredFields.length && !tool.optionalFields.length) {
+        ln(`- (no parameters)`);
+      }
       ln();
+
+      // Response contract — most common drift cause is agents dropping a
+      // required response field. Surface the happy-path shape right next to
+      // the request shape so skill authors don't have to leave the file.
+      if (tool.resRequiredFields.length || tool.resOptionalFields.length) {
+        ln(`**Response (success branch):**`);
+        if (tool.resRequiredFields.length) {
+          ln(`- Required: ${tool.resRequiredFields.map(f => `\`${f}\``).join(', ')}`);
+        }
+        if (tool.resOptionalFields.length) {
+          const shown = tool.resOptionalFields.slice(0, 8);
+          const more = tool.resOptionalFields.length - shown.length;
+          let optLine = `- Optional: ${shown.map(f => `\`${f}\``).join(', ')}`;
+          if (more > 0) optLine += `, +${more} more`;
+          ln(optLine);
+        }
+        ln();
+      }
     }
 
     // Deep dive links for this domain


### PR DESCRIPTION
## Summary

Extends the existing \`generate-agent-docs\` generator so each tool section in \`docs/llms.txt\` emits a **Response (success branch)** block with required + optional fields, mirroring the existing request block. Pulled straight from the bundled JSON schemas — no new source of truth.

### Example (build_creative)

Before (request only):

\`\`\`
#### \`build_creative\`

Request parameters for AI-powered creative generation.

Required: \`idempotency_key: string\`
Optional: \`message\`, \`creative_manifest\`, \`creative_id\`, ...
\`\`\`

After (request + response):

\`\`\`
#### \`build_creative\`

Request parameters for AI-powered creative generation.

**Request:**
- Required: \`idempotency_key: string\`
- Optional: \`message\`, \`creative_manifest\`, \`creative_id\`, ...

**Response (success branch):**
- Required: \`creative_manifest: Creative Manifest\`
- Optional: \`sandbox: boolean\`, \`expires_at: string\`, \`preview: object\`, \`context: Context\`
\`\`\`

## Why

Matrix runs kept surfacing the same drift pattern: agents dropped required response fields — missing \`format_id\` on \`creative_manifest\`, plural-variant hallucinations (\`creative_deliveries\` → \`creatives\`), missing top-level \`currency\` — because the skill prose documented the intent but the full per-field contract lived in the generated schemas and was never indexed in the llms.txt file Claude actually reads when building an agent.

With this, the contract is one anchored section away (\`docs/llms.txt#build_creative\`), and skills can lean on pointer references instead of embedding the contract inline.

## Test plan

- [x] \`npm run generate-agent-docs\` runs clean, regens \`docs/llms.txt\` with Response sections
- [x] \`npm run typecheck\` clean
- [x] Spot-checked 5 tools (build_creative, get_creative_delivery, create_property_list, sync_catalogs, check_governance) — response contracts match schema
- [x] Existing CI docs-sync check still passes

## Follow-ups (separate PRs)

- Slim each skill's inline tool contracts down to one-line pointers into \`docs/llms.txt#<tool>\`. Smaller skill files, no duplication.
- Optionally surface \`outputSchema\` on MCP tool definitions so any MCP client can introspect response contracts without reading llms.txt.