### PR TITLE
fix(server): tighten handler return types so schema drift fails tsc

### DIFF
--- a/.changeset/tighten-brand-rights-result-types.md
+++ b/.changeset/tighten-brand-rights-result-types.md
@@ -1,0 +1,58 @@
+---
+'@adcp/client': minor
+---
+
+fix(server): tighten handler return types so schema drift fails `tsc`
+
+Two related tightenings close #727 (B).
+
+**1. `AdcpToolMap` brand rights results.** `acquire_rights`,
+`get_rights`, and `get_brand_identity` had `result: Record<string,
+unknown>` — a stale scaffold from before the response types were
+code-generated. Replaced with the proper generated types:
+
+- `acquire_rights` → `AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected`
+- `get_rights` → `GetRightsSuccess`
+- `get_brand_identity` → `GetBrandIdentitySuccess`
+
+**2. `DomainHandler` return type.** The handler return union
+previously included `| Record<string, unknown>` as a general escape
+hatch, so any handler could return any shape. Sparse returns like
+`{ rights_id, status: 'acquired' }` passed `tsc` and only failed at
+wire-level validation. Handler return type is now just
+`AdcpToolMap[K]['result'] | McpToolResponse`, so drift fails at
+compile time. `adcpError(...)` still works — it returns
+`McpToolResponse`.
+
+**Migration.** If a handler returns a plain object literal without
+spelling out the full success shape, `tsc` will now flag the drift
+with an error like:
+
+```
+Type '{ products: [{ product_id: 'p1' }] }' is not assignable to type
+'McpToolResponse | GetProductsResponse'.
+  Property 'reporting_capabilities' is missing in type
+  '{ product_id: 'p1' }' but required in type 'Product'.
+```
+
+Two ways to fix:
+
+- Fill in the missing required fields to match the AdCP schema (what
+  the wire-level validator would have demanded anyway). Use
+  `DEFAULT_REPORTING_CAPABILITIES` for `Product.reporting_capabilities`
+  if you don't have seller-specific reporting policy yet.
+- If you genuinely need a loose return (e.g. a test fixture), wrap
+  with a response builder — `productsResponse({ ... })`,
+  `acquireRightsResponse({ ... })`, etc. The builders accept typed
+  inputs so the drift surfaces there instead of silently passing
+  through.
+
+**Reference agents.** `test-agents/seller-agent.ts` now uses
+`DEFAULT_REPORTING_CAPABILITIES` on each product (the old code had
+a "Use plain objects instead of Product type" comment whose premise
+was wrong — `reporting_capabilities` is required, not optional).
+`test-agents/seller-agent-signed-mcp.ts` had a latent bug:
+`createMediaBuy` was reading `pkg.package_id` from the request, but
+`PackageRequest` has no such field — buyers send `buyer_ref` and
+the seller mints `package_id` per spec. The handler now mints
+`crypto.randomUUID()` like a real seller would.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -142,6 +142,13 @@ import type {
 } from '../types/schemas.generated';
 
 import type {
+  AcquireRightsAcquired,
+  AcquireRightsPendingApproval,
+  AcquireRightsRejected,
+  GetBrandIdentitySuccess,
+  GetRightsSuccess,
+} from '../types/core.generated';
+import type {
   GetProductsResponse,
   CreateMediaBuySuccess,
   UpdateMediaBuySuccess,
@@ -388,11 +395,12 @@ export interface AdcpToolMap {
   si_send_message: { params: z.input<typeof SISendMessageRequestSchema>; result: SISendMessageResponse };
   si_terminate_session: { params: z.input<typeof SITerminateSessionRequestSchema>; result: SITerminateSessionResponse };
 
-  // Brand rights — response types are not yet code-generated. Handlers return
-  // loose records which the framework wraps with `genericResponse`.
-  get_brand_identity: { params: z.input<typeof GetBrandIdentityRequestSchema>; result: Record<string, unknown> };
-  get_rights: { params: z.input<typeof GetRightsRequestSchema>; result: Record<string, unknown> };
-  acquire_rights: { params: z.input<typeof AcquireRightsRequestSchema>; result: Record<string, unknown> };
+  get_brand_identity: { params: z.input<typeof GetBrandIdentityRequestSchema>; result: GetBrandIdentitySuccess };
+  get_rights: { params: z.input<typeof GetRightsRequestSchema>; result: GetRightsSuccess };
+  acquire_rights: {
+    params: z.input<typeof AcquireRightsRequestSchema>;
+    result: AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected;
+  };
 }
 
 export type AdcpServerToolName = keyof AdcpToolMap;
@@ -402,12 +410,12 @@ export type AdcpServerToolName = keyof AdcpToolMap;
 // ---------------------------------------------------------------------------
 
 /** Handler that receives validated params and a resolved context.
- *  Return the exact response type for autocomplete, or a plain object —
- *  the response builder layer handles shaping either way. */
+ *  Return the tool's typed success shape, or an error envelope via
+ *  `adcpError(...)` (typed as `McpToolResponse`). */
 type DomainHandler<K extends AdcpServerToolName, TAccount> = (
   params: AdcpToolMap[K]['params'],
   ctx: HandlerContext<TAccount>
-) => Promise<AdcpToolMap[K]['result'] | McpToolResponse | Record<string, unknown>>;
+) => Promise<AdcpToolMap[K]['result'] | McpToolResponse>;
 
 export interface MediaBuyHandlers<TAccount = unknown> {
   getProducts?: DomainHandler<'get_products', TAccount>;

--- a/test-agents/seller-agent-signed-mcp.ts
+++ b/test-agents/seller-agent-signed-mcp.ts
@@ -127,8 +127,8 @@ function createAgent({ taskStore }: ServeContext) {
         status: 'active' as const,
         confirmed_at: new Date().toISOString(),
         revision: 1,
-        packages: (params.packages ?? []).map(pkg => ({
-          package_id: pkg.package_id,
+        packages: (params.packages ?? []).map(() => ({
+          package_id: crypto.randomUUID(),
           status: 'active' as const,
         })),
         context: params.context,

--- a/test-agents/seller-agent.ts
+++ b/test-agents/seller-agent.ts
@@ -10,6 +10,7 @@ import {
   InMemoryStateStore,
   registerTestController,
   TestControllerError,
+  DEFAULT_REPORTING_CAPABILITIES,
 } from '@adcp/client';
 import type { ServeContext, TestControllerStore } from '@adcp/client';
 
@@ -17,43 +18,44 @@ import type { ServeContext, TestControllerStore } from '@adcp/client';
 // Product catalog
 // ---------------------------------------------------------------------------
 
-// Use plain objects instead of Product type — avoids requiring every optional field
 const PRODUCTS = [
   {
     product_id: 'prod-display-300x250',
     name: 'Display Banner 300x250',
     description: 'Standard IAB display banner across premium news sites',
-    publisher_properties: [{ publisher_domain: 'example-news.com', selection_type: 'all' }],
-    channels: ['display'],
+    publisher_properties: [{ publisher_domain: 'example-news.com', selection_type: 'all' as const }],
+    channels: ['display' as const],
     format_ids: [{ agent_url: 'https://creatives.example.com/mcp', id: 'display-300x250' }],
-    delivery_type: 'non_guaranteed',
+    delivery_type: 'non_guaranteed' as const,
     pricing_options: [
       {
         pricing_option_id: 'cpm-display',
-        pricing_model: 'cpm',
+        pricing_model: 'cpm' as const,
         floor_price: 5.0,
         currency: 'USD',
         min_spend_per_package: 500,
       },
     ],
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,
   },
   {
     product_id: 'prod-video-preroll',
     name: 'Pre-Roll Video 15s',
     description: 'Skippable pre-roll on premium video content',
-    publisher_properties: [{ publisher_domain: 'example-news.com', selection_type: 'all' }],
-    channels: ['olv'],
+    publisher_properties: [{ publisher_domain: 'example-news.com', selection_type: 'all' as const }],
+    channels: ['olv' as const],
     format_ids: [{ agent_url: 'https://creatives.example.com/mcp', id: 'video-preroll' }],
-    delivery_type: 'non_guaranteed',
+    delivery_type: 'non_guaranteed' as const,
     pricing_options: [
       {
         pricing_option_id: 'cpm-video',
-        pricing_model: 'cpm',
+        pricing_model: 'cpm' as const,
         floor_price: 12.0,
         currency: 'USD',
         min_spend_per_package: 1000,
       },
     ],
+    reporting_capabilities: DEFAULT_REPORTING_CAPABILITIES,
   },
 ];
 

--- a/test/handler-return-tightness.test.js
+++ b/test/handler-return-tightness.test.js
@@ -1,0 +1,57 @@
+/**
+ * Handler Return Type Tightness Test
+ *
+ * Guards against regression of issue #727 (B): handler return types in
+ * `create-adcp-server.ts` must be tight enough that `tsc` rejects sparse
+ * returns like `{ rights_id, status: 'acquired' }` against
+ * `AcquireRightsResponse`.
+ *
+ * The runtime suite cannot catch a reintroduced compile-time escape hatch,
+ * so this test guards the two levers that make tightness hold:
+ *
+ *   1. `AdcpToolMap['acquire_rights' | 'get_rights' | 'get_brand_identity']['result']`
+ *      must not be `Record<string, unknown>` — those slots are now typed with
+ *      the generated success types.
+ *   2. `DomainHandler`'s return union must not contain `Record<string, unknown>`.
+ *      The general escape hatch was removed so sparse handler returns fail tsc.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const SERVER_PATH = path.join(__dirname, '../src/lib/server/create-adcp-server.ts');
+
+describe('handler return type tightness (issue #727 B)', () => {
+  test('AdcpToolMap brand-rights slots are not `Record<string, unknown>`', () => {
+    const src = fs.readFileSync(SERVER_PATH, 'utf8');
+    const looseTools = ['acquire_rights', 'get_rights', 'get_brand_identity'].filter(tool => {
+      const pattern = new RegExp(
+        `^\\s*${tool}:\\s*\\{[^}]*result:\\s*Record<string,\\s*unknown>`,
+        'm'
+      );
+      return pattern.test(src);
+    });
+    assert.deepStrictEqual(
+      looseTools,
+      [],
+      `Re-tighten these tools in AdcpToolMap: ${looseTools.join(', ')}. ` +
+        `They should reference generated success types, not Record<string, unknown>.`
+    );
+  });
+
+  test('DomainHandler return union does not include `Record<string, unknown>`', () => {
+    const src = fs.readFileSync(SERVER_PATH, 'utf8');
+    const match = src.match(
+      /type DomainHandler<[^>]+>\s*=\s*\([^)]*\)\s*=>\s*Promise<([^;]+)>;/m
+    );
+    assert.ok(match, 'Could not locate DomainHandler type definition');
+    const returnUnion = match[1];
+    assert.ok(
+      !/Record<string,\s*unknown>/.test(returnUnion),
+      `DomainHandler return union must not include \`Record<string, unknown>\`. ` +
+        `That escape hatch lets sparse returns pass tsc. Found: ${returnUnion.trim()}`
+    );
+  });
+});

--- a/test/handler-return-tightness.test.js
+++ b/test/handler-return-tightness.test.js
@@ -27,10 +27,7 @@ describe('handler return type tightness (issue #727 B)', () => {
   test('AdcpToolMap brand-rights slots are not `Record<string, unknown>`', () => {
     const src = fs.readFileSync(SERVER_PATH, 'utf8');
     const looseTools = ['acquire_rights', 'get_rights', 'get_brand_identity'].filter(tool => {
-      const pattern = new RegExp(
-        `^\\s*${tool}:\\s*\\{[^}]*result:\\s*Record<string,\\s*unknown>`,
-        'm'
-      );
+      const pattern = new RegExp(`^\\s*${tool}:\\s*\\{[^}]*result:\\s*Record<string,\\s*unknown>`, 'm');
       return pattern.test(src);
     });
     assert.deepStrictEqual(
@@ -43,9 +40,7 @@ describe('handler return type tightness (issue #727 B)', () => {
 
   test('DomainHandler return union does not include `Record<string, unknown>`', () => {
     const src = fs.readFileSync(SERVER_PATH, 'utf8');
-    const match = src.match(
-      /type DomainHandler<[^>]+>\s*=\s*\([^)]*\)\s*=>\s*Promise<([^;]+)>;/m
-    );
+    const match = src.match(/type DomainHandler<[^>]+>\s*=\s*\([^)]*\)\s*=>\s*Promise<([^;]+)>;/m);
     assert.ok(match, 'Could not locate DomainHandler type definition');
     const returnUnion = match[1];
     assert.ok(


### PR DESCRIPTION
## Summary

Closes #727 (B). Makes sparse handler returns like `{ rights_id, status: 'acquired' }` fail `tsc` at compile time against `AcquireRightsResponse`, instead of only failing at wire-level validation.

Two hand-written type bindings in `create-adcp-server.ts` were routing around the (already-tight) generated discriminated unions:

- **`AdcpToolMap` brand-rights slots** were typed `result: Record<string, unknown>` — stale scaffold from before the response types were code-generated. Swapped for the generated success types (`AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected`, `GetRightsSuccess`, `GetBrandIdentitySuccess`).
- **`DomainHandler`'s return union** included `| Record<string, unknown>` as a general escape hatch for every tool. Removed. Handler returns are now `AdcpToolMap[K]['result'] | McpToolResponse` — `adcpError(...)` still works unchanged.

No upstream schema or generator changes needed. The looseness was purely in SDK plumbing; the generated types were already correct discriminated unions with proper `required` arrays.

## What this surfaced

Removing the escape hatch caught two real latent bugs in the reference test agents:

- `test-agents/seller-agent.ts`: `PRODUCTS` were missing `reporting_capabilities` (required on `Product`). Strict response validation (default in dev/test per #757) would have caught this at runtime; now it fails at build. Fixed with `DEFAULT_REPORTING_CAPABILITIES`.
- `test-agents/seller-agent-signed-mcp.ts`: `createMediaBuy` was reading `pkg.package_id` from the request, but `PackageRequest` has no such field per spec — buyers send `buyer_ref` and the seller mints `package_id`. Fixed to mint `crypto.randomUUID()`.

## Regression guard

`test/handler-return-tightness.test.js` asserts (a) no brand-rights slot in `AdcpToolMap` is typed `Record<string, unknown>` and (b) `DomainHandler`'s return union does not contain `Record<string, unknown>`. The runtime suite alone can't catch a reintroduced compile-time escape hatch.

## Test plan

- [x] `npm run build:lib` — clean
- [x] `npm run build:test-agents` — clean (was 2 errors before the test-agent fixes)
- [x] `npm run test:lib` — 4391 pass, 0 fail
- [x] Verified with `@ts-expect-error` harness: sparse shapes, empty objects, and `{ anything: 'goes' }` all fail tsc at `BrandRightsHandlers['acquireRights']` return position; valid shapes compile
- [x] code-reviewer + security-reviewer feedback addressed

## Migration

Minor bump. If a handler returns a plain object literal without the full success shape, tsc will now flag it. Either fill in the missing required fields (use `DEFAULT_REPORTING_CAPABILITIES` for `Product.reporting_capabilities`) or wrap with a response builder (`productsResponse({ ... })`, `acquireRightsResponse({ ... })`) — details in the changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)