### PR TITLE
feat(server): default request validation to 'warn' in dev/test

### DIFF
--- a/.changeset/request-validation-warn-default.md
+++ b/.changeset/request-validation-warn-default.md
@@ -1,0 +1,34 @@
+---
+'@adcp/client': minor
+---
+
+feat(server): request validation defaults to `'warn'` outside production
+
+`createAdcpServer({ validation: { requests } })` previously defaulted to
+`'off'` everywhere. It now defaults to `'warn'` when
+`NODE_ENV !== 'production'`, mirroring the asymmetric default already in
+place for `responses` (`'strict'` in dev/test, `'off'` in production).
+
+Production behaviour is unchanged: the default stays `'off'` when
+`NODE_ENV === 'production'`, so prod request paths pay no AJV cost.
+
+What operators will see: in dev/test/CI, each incoming request that
+doesn't match the bundled AdCP request schema logs a single
+`Schema validation warning (request)` line through the configured
+logger, with the tool name and the field pointer. Nothing is rejected —
+the request still flows to the handler exactly as before. Node's test
+runner does not set `NODE_ENV`, so suites running under `node --test`
+fall into the dev/test bucket and will start emitting these warnings.
+
+How to opt out: pass `validation: { requests: 'off' }` on the server
+config, or set `NODE_ENV=production` for the process.
+
+Why: keeps request and response defaults symmetric, and prepares seller
+operators for upstream AdCP schema tightenings (e.g. adcp#2795, which
+introduces a required `asset_type` discriminator — buyer agents still
+on RC3 fixtures will lack it). Surfacing those drifts as warnings
+during development beats discovering them in a downstream consumer's
+`VALIDATION_ERROR` after deploy.
+
+Related: #694 (original intent for `requests: 'warn'`) and #727 A
+(response-side default precedent).

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -859,13 +859,16 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * Defaults:
    *   - When `NODE_ENV === 'production'` → both sides `'off'` (zero overhead
    *     in prod; trust the handler after its test suite has exercised it).
-   *   - Otherwise (dev, test, CI) → `responses: 'strict'`, `requests: 'off'`.
-   *     The strict default on responses turns handler-returned drift into a
+   *   - Otherwise (dev, test, CI) → `responses: 'strict'`, `requests: 'warn'`.
+   *     Strict on responses turns handler-returned drift into a
    *     `VALIDATION_ERROR` with the offending field path — surfaces the
    *     "handler returned a sparse object that fails the wire schema" class
    *     of bug at development time instead of letting it ship and surface
    *     downstream as a cryptic `SERVICE_UNAVAILABLE` or `oneOf`
-   *     discriminator failure.
+   *     discriminator failure. Warn on requests logs incoming payloads that
+   *     don't match the bundled AdCP schema but still dispatches, so
+   *     upstream schema tightenings show up as diagnostics without breaking
+   *     clients that haven't caught up.
    *
    * Pass an explicit `validation: { requests: 'off', responses: 'off' }` to
    * override the dev-mode default. Set `responses: 'warn'` to keep the
@@ -1560,15 +1563,21 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     validation: validationConfig,
   } = config;
 
-  // Dev/test/CI default: strict response validation — drift fails with
-  // VALIDATION_ERROR and the offending field path. Production default: off
-  // (zero overhead; trust the handler after its test suite has exercised
-  // it). Explicit `validation: { requests, responses }` on the config
-  // always wins. Using `process.env.NODE_ENV` matches the convention every
-  // other SDK consumer already tunes (Express, React, etc.); containers/CI
-  // that want prod-like behavior set NODE_ENV=production before start.
+  // Asymmetric defaults, gated on `process.env.NODE_ENV`:
+  //   - Production → both sides `'off'` (zero AJV overhead; trust the
+  //     handler after its test suite has exercised it).
+  //   - Dev/test/CI → `requests: 'warn'` (log incoming payloads that don't
+  //     match the bundled AdCP schema but still dispatch, so upstream
+  //     schema tightenings surface as diagnostics rather than hard
+  //     breakage); `responses: 'strict'` (handler drift fails with
+  //     VALIDATION_ERROR and the offending field path — catches
+  //     sparse-response bugs at development time).
+  // Explicit `validation: { requests, responses }` on the config always
+  // wins. `process.env.NODE_ENV` matches the convention every other SDK
+  // consumer already tunes (Express, React, etc.); containers/CI that
+  // want prod-like behavior set NODE_ENV=production before start.
   const isProduction = process.env.NODE_ENV === 'production';
-  const requestValidationMode = validationConfig?.requests ?? 'off';
+  const requestValidationMode = validationConfig?.requests ?? (isProduction ? 'off' : 'warn');
   const responseValidationMode = validationConfig?.responses ?? (isProduction ? 'off' : 'strict');
 
   // Enforce lock-step between the `signed-requests` specialism claim and the

--- a/test/lib/schema-validation-server.test.js
+++ b/test/lib/schema-validation-server.test.js
@@ -93,13 +93,14 @@ describe('createAdcpServer validation middleware', () => {
     });
   });
 
-  describe('requests: "off" (default)', () => {
-    test('does not validate when no validation config provided', async () => {
+  describe('requests: "off"', () => {
+    test('does not validate when explicitly disabled', async () => {
       let handlerCalled = false;
       const server = createAdcpServer({
         name: 'test',
         version: '0.0.1',
         stateStore: new InMemoryStateStore(),
+        validation: { requests: 'off' },
         mediaBuy: {
           getProducts: async () => {
             handlerCalled = true;


### PR DESCRIPTION
## Summary

- Flip `createAdcpServer`'s request validation default from `'off'` to `'warn'` when `NODE_ENV !== 'production'`. Production default stays `'off'` (zero AJV overhead).
- Mirrors the asymmetric response-side default shipped in #727 A (strict/off). Warn mode logs a single `Schema validation warning (request)` line per mismatched payload via the configured logger and still dispatches — nothing is rejected.
- Completes the original intent of #694 (which called for `requests: 'warn'` everywhere in its body but shipped `'off'` as code/docs drift).

## Why

Symmetric defaults with responses, and prepares seller operators for upstream schema tightenings — notably adcp#2795, which introduces a required `asset_type` discriminator on creative assets. Buyer agents still on RC3 fixtures will lack it; surfacing that as a warning during handler development beats discovering it in a downstream `VALIDATION_ERROR` after deploy.

## Opt-out

- Per-server: `validation: { requests: 'off' }` on the `createAdcpServer` config.
- Global: set `NODE_ENV=production` for the process.

## Test plan

- [x] `npm run build:lib` passes
- [x] `npm run test:lib` passes (4391 tests, 0 failures, 6 skipped)
- [x] `schema-validation-server.test.js` — the renamed `requests: "off"` test now asserts explicit opt-out instead of relying on it being the default
- [x] `prettier --check` clean on modified files
- [ ] Manual verification: construct a server without `validation:` under `NODE_ENV=test`, send a request that fails the schema, confirm a `Schema validation warning (request)` line appears in the logger and the handler still runs
- [ ] Manual verification: set `validation: { requests: 'off' }` and confirm no warning fires
- [ ] CI green

Refs: #694 (original intent), #727 A (response-side precedent), adcp#2795 (upstream `asset_type` discriminator this prepares for).