### PR TITLE
feat(cli): inline --oauth for storyboard run + actionable auth hint

### DIFF
--- a/.changeset/storyboard-oauth-debug.md
+++ b/.changeset/storyboard-oauth-debug.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': minor
+---
+
+Improve OAuth ergonomics for `adcp storyboard run`.
+
+- **Fix classification**: capability-discovery failures whose error message says `"requires OAuth authorization"` (the wording `NeedsAuthorizationError` emits) now classify as `auth_required` with the `Save credentials: adcp --save-auth <alias> <url> --oauth` remediation hint, instead of falling through to `overall_status: 'unreachable'` with no actionable advice. The keyword list in `detectAuthRejection` now matches `"authorization"` and `"oauth"` in addition to `401/unauthorized/authentication/jws/jwt/signature verification`.
+- **Surface the hint earlier**: the OAuth remediation observation now fires whenever the error text looks OAuth-shaped, not only when `discoverOAuthMetadata` successfully walks the well-known chain — an agent that 401s before its OAuth metadata is resolvable still gets a useful hint.
+- **Inline OAuth flow**: `adcp storyboard run <alias> --oauth` now opens the browser to complete PKCE when the saved alias has no valid tokens, then proceeds with the run. Matches the existing `adcp <alias> get_adcp_capabilities --oauth` behavior so the two-step dance (`--save-auth --oauth` then `storyboard run`) is no longer required. Raw URLs still need `--save-auth` first; MCP only.
+
+Docs: `docs/CLI.md` and `docs/guides/VALIDATE-YOUR-AGENT.md` document both flows and add a troubleshooting row for the `Agent requires OAuth` failure.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -699,6 +699,160 @@ function parseAgentOptions(args) {
 }
 
 /**
+ * If `--oauth` appears in `args` and `agentArg` is a saved alias, ensure
+ * the alias has valid OAuth tokens by running the browser flow when
+ * needed. No-op when `--oauth` is absent.
+ *
+ * Mirrors the top-level CLI constraint: `--oauth` requires a saved alias.
+ * Raw URLs get a friendly pointer to `--save-auth` instead of a silent pass.
+ */
+async function maybeRunInlineOAuth(agentArg, args, { jsonOutput } = {}) {
+  if (!args.includes('--oauth')) return;
+  if (!agentArg) return;
+
+  if (isAlias(agentArg)) {
+    const saved = getAgent(agentArg);
+    if (!saved) return;
+    try {
+      await ensureOAuthTokensForAlias(agentArg, saved.url, { quiet: jsonOutput });
+    } catch (err) {
+      const hint = `Run: adcp --save-auth ${agentArg} ${saved.url} --oauth to re-register`;
+      if (jsonOutput) {
+        console.log(
+          JSON.stringify({
+            success: false,
+            error: 'oauth_flow_failed',
+            alias: agentArg,
+            message: err.message,
+            hint,
+          })
+        );
+      } else {
+        console.error(`\n❌ OAuth failed for '${agentArg}': ${err.message}`);
+        console.error(`   ${hint}\n`);
+      }
+      process.exit(1);
+    }
+    if (!jsonOutput) console.log('');
+    return;
+  }
+
+  if (agentArg.startsWith('http://') || agentArg.startsWith('https://')) {
+    // Raw URL + `--oauth` never fires the browser flow (no alias to persist
+    // tokens under). Treat as a hard error under `--json` so CI jobs exit
+    // non-zero instead of silently running and failing N minutes later on
+    // a 401 from the storyboard runner.
+    if (jsonOutput) {
+      console.log(
+        JSON.stringify({
+          success: false,
+          error: 'oauth_requires_alias',
+          message: `--oauth requires a saved alias, not a raw URL. Save first: adcp --save-auth <alias> ${agentArg} --oauth`,
+        })
+      );
+      process.exit(2);
+    }
+    console.error('⚠️  --oauth requires a saved agent alias, not a raw URL.');
+    console.error(`   Save first: adcp --save-auth <alias> ${agentArg} --oauth\n`);
+  }
+}
+
+/**
+ * Run the interactive browser OAuth flow against `url` and persist the
+ * resulting tokens under `alias`. Idempotent — returns early if the alias
+ * already has valid tokens.
+ *
+ * Callers:
+ *   - `adcp --save-auth <alias> <url> --oauth` (first-time setup)
+ *   - `adcp storyboard run <alias> --oauth` (inline auth before a run)
+ *   - any other subcommand that wants the same contract
+ *
+ * Only supports MCP — authorization-code OAuth is an MCP concept in AdCP.
+ * A2A agents use static bearer tokens or client credentials.
+ *
+ * @returns The updated saved agent record (with oauth_tokens and oauth_client).
+ */
+async function ensureOAuthTokensForAlias(alias, url, { quiet = false } = {}) {
+  const existing = getAgent(alias);
+  if (existing && hasValidOAuthTokens(existing)) {
+    if (!quiet) console.log(`Using saved OAuth tokens for '${alias}'.`);
+    return existing;
+  }
+
+  // Spread the in-flight PKCE verifier too: if a prior attempt crashed mid-
+  // flow the verifier lives on the saved record, and without it the MCP SDK
+  // throws "No PKCE code verifier found" when the AS redirects back.
+  const tempAgent = {
+    id: alias,
+    name: alias,
+    agent_uri: url,
+    protocol: 'mcp',
+    ...(existing?.oauth_client && { oauth_client: existing.oauth_client }),
+    ...(existing?.oauth_tokens && { oauth_tokens: existing.oauth_tokens }),
+    ...(existing?.oauth_code_verifier && { oauth_code_verifier: existing.oauth_code_verifier }),
+  };
+
+  const { Client: MCPClient } = require('@modelcontextprotocol/sdk/client/index.js');
+  const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
+  const { UnauthorizedError } = require('@modelcontextprotocol/sdk/client/auth.js');
+
+  const oauthProvider = createCLIOAuthProvider(tempAgent, { quiet });
+  const mcpClient = new MCPClient({ name: 'adcp-cli', version: '1.0.0' });
+  const transport = new StreamableHTTPClientTransport(new URL(url), { authProvider: oauthProvider });
+
+  // Persist back to disk if the MCP SDK silently refreshed tokens during
+  // connect/finishAuth — otherwise the refreshed access_token dies with
+  // tempAgent and the next call burns a second refresh. Saves only when
+  // something changed to avoid a needless write on the happy idempotent path.
+  const persistIfChanged = () => {
+    if (!tempAgent.oauth_tokens) return null;
+    const same =
+      existing?.oauth_tokens?.access_token === tempAgent.oauth_tokens.access_token &&
+      existing?.oauth_tokens?.refresh_token === tempAgent.oauth_tokens.refresh_token;
+    if (same) return existing;
+    const merged = {
+      ...(existing ?? {}),
+      url,
+      protocol: 'mcp',
+      oauth_tokens: tempAgent.oauth_tokens,
+      oauth_client: tempAgent.oauth_client ?? existing?.oauth_client,
+    };
+    saveAgent(alias, merged);
+    return merged;
+  };
+
+  try {
+    if (!quiet) console.log(`Authorizing '${alias}' via browser…`);
+    try {
+      await mcpClient.connect(transport);
+      // Connected without needing OAuth — agent isn't gated. Persist in
+      // case the SDK silently refreshed tokens during connect.
+      const refreshed = persistIfChanged();
+      if (!quiet) {
+        console.log(
+          refreshed && refreshed !== existing
+            ? 'Server accepted refreshed OAuth tokens.'
+            : 'Server did not require OAuth — no tokens saved.'
+        );
+      }
+      return refreshed ?? existing ?? null;
+    } catch (error) {
+      if (!(error instanceof UnauthorizedError) && error.name !== 'UnauthorizedError') {
+        throw error;
+      }
+      const code = await oauthProvider.waitForCallback();
+      await transport.finishAuth(code);
+      const merged = persistIfChanged();
+      if (!quiet) console.log(`OAuth tokens saved to '${alias}'.`);
+      return merged ?? existing ?? null;
+    }
+  } finally {
+    await oauthProvider.cleanup().catch(() => {});
+    await mcpClient.close().catch(() => {});
+  }
+}
+
+/**
  * Build the `auth` option for the testing library from a resolved agent.
  * Single source of truth for CLI → lib auth handoff so every runner
  * (storyboard, step, fuzz, grade) uses the same precedence:
@@ -951,6 +1105,9 @@ OPTIONS:
   --request JSON      Override sample_request for the step (step only)
   --json              JSON output (recommended for LLM consumption)
   --auth TOKEN        Authentication token
+  --oauth             Run the browser OAuth flow inline if the saved alias
+                      has no valid tokens yet. Requires a saved alias
+                      (use --save-auth first for raw URLs). MCP only.
   --protocol PROTO    Force protocol: mcp or a2a
   --dry-run           Preview steps without executing
   --debug             Debug output
@@ -1183,6 +1340,11 @@ async function handleStoryboardRun(args) {
     console.error('ERROR: Cannot combine a storyboard ID with --file. Use one or the other.');
     process.exit(2);
   }
+
+  // Inline OAuth: if --oauth is set and the agent is a saved alias that
+  // doesn't have valid tokens, run the browser flow now so the downstream
+  // runner sees freshly-saved tokens via getAgent().
+  await maybeRunInlineOAuth(agentArg, args, { jsonOutput });
 
   // No storyboard ID and no --file → capability-driven full assessment.
   if (!storyboardId && !filePath) {
@@ -2312,6 +2474,8 @@ async function handleStoryboardStepCmd(args) {
     console.error(`Storyboard not found: ${storyboardId}`);
     process.exit(2);
   }
+
+  await maybeRunInlineOAuth(agentArg, args, { jsonOutput });
 
   const {
     agentUrl,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -279,6 +279,25 @@ Useful flags:
 - `--brief TEXT`: Override the default sample discovery brief
 - `--dry-run`: Preview steps without executing
 - `--json`: Emit machine-readable output for automation
+- `--oauth`: Complete the browser OAuth flow inline when the saved alias has no valid tokens (MCP only — requires a saved alias)
+
+### OAuth-protected agents
+
+Storyboard runs reuse OAuth tokens saved under an alias (see `~/.adcp/agents.json`). Two supported flows:
+
+```bash
+# 1. Save tokens once, then run any number of storyboard assessments
+adcp --save-auth spotify-agent https://agents.scope3.com/spotify --oauth
+adcp storyboard run spotify-agent
+
+# 2. Save the alias without auth, then let the storyboard command drive the flow
+adcp --save-auth spotify-agent https://agents.scope3.com/spotify --no-auth
+adcp storyboard run spotify-agent --oauth
+```
+
+The first time `storyboard run` sees `--oauth` on an alias without valid tokens, it opens a browser, completes the PKCE flow, and persists the tokens to the alias. Subsequent runs reuse the cached tokens (auto-refreshing via the stored `refresh_token`). Static `--auth TOKEN` tokens are unaffected and still work the same way.
+
+**CI / headless environments.** The browser flow requires a local machine. For CI, save tokens once locally (`adcp --save-auth <alias> <url> --oauth`), copy `~/.adcp/agents.json` into the CI runner's home directory (or mount it as a secret), and run `adcp storyboard run <alias>` without `--oauth` — the stored `refresh_token` auto-refreshes on 401. Passing `--oauth` with a raw URL under `--json` exits with `{ "error": "oauth_requires_alias" }` and code 2 so pipelines fail fast instead of hanging on a browser prompt that will never arrive.
 
 ## Environment Variables
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -77,6 +77,23 @@ npx @adcp/client storyboard run http://localhost:3001/mcp --json > report.json
 - `--multi-instance-strategy round-robin|multi-pass` — when paired with two or more `--url`s
 - `--brief <text>` — custom product-discovery brief (default varies by storyboard)
 - `--auth <token>` — bearer token (also accepts `$ADCP_AUTH_TOKEN`)
+- `--oauth` — run the browser OAuth flow inline when the saved alias has no valid tokens (MCP only; equivalent to `adcp --save-auth <alias> <url> --oauth` then re-running)
+
+**OAuth-protected agents.** Storyboard runs reuse tokens saved under an alias. Two supported flows:
+
+```bash
+# (a) pre-save tokens
+npx @adcp/client --save-auth my-agent https://agent.example.com/mcp --oauth
+npx @adcp/client storyboard run my-agent
+
+# (b) inline on first run
+npx @adcp/client --save-auth my-agent https://agent.example.com/mcp --no-auth
+npx @adcp/client storyboard run my-agent --oauth
+```
+
+Either way, subsequent runs reuse the cached tokens (auto-refresh on expiry via the stored `refresh_token`). Raw URLs don't support `--oauth` — save an alias first.
+
+**CI.** `--oauth` needs a browser. In CI, save tokens once locally, ship `~/.adcp/agents.json` to the runner, and drop the `--oauth` flag from the CI command — the stored `refresh_token` auto-renews on 401.
 
 **Output:** JSON with `tracks[].status` (`passed`/`failed`/`skipped`), `steps[]` with diagnostics, and validations per step.
 
@@ -312,6 +329,7 @@ Use before merging skill changes. ~60s per pair; matrix runs fan out.
 |---|---|
 | `storyboard run` skips steps with "no webhook_receiver_runner" | Add `--webhook-receiver` |
 | `storyboard run` fails on `security_baseline` | You skipped `authenticate` in `serve()` — see [build-seller-agent/SKILL.md § signed-requests](../../skills/build-seller-agent/SKILL.md) |
+| `storyboard run` reports `Agent requires OAuth` / exits without running | Save tokens once with `adcp --save-auth <alias> <url> --oauth`, or pass `--oauth` to `storyboard run` to complete auth inline |
 | `fuzz` reports `500` status with stack trace | Validate inputs and return `adcpError('REFERENCE_NOT_FOUND', ...)` instead |
 | `fuzz` reports `response_shape_mismatch` | Response drifted from schema — regen with `npm run sync-schemas` + check your handler |
 | Multi-instance fails with `NOT_FOUND` on read-after-write | State keyed by session ID instead of `(brand, account)` — see multi-instance guide |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.9.0",
+      "version": "5.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/conformance/seeder.ts
+++ b/src/lib/conformance/seeder.ts
@@ -394,15 +394,15 @@ function synthesizeManifestAssets(format: FormatDef): Record<string, unknown> {
 // we can satisfy without format-specific knowledge (dimensions, codecs,
 // etc. use safe defaults).
 const ASSET_PLACEHOLDER = {
-  image: () => ({ url: 'https://conformance.example/placeholder.png', width: 300, height: 250 }),
-  video: () => ({ url: 'https://conformance.example/placeholder.mp4', width: 640, height: 360 }),
-  audio: () => ({ url: 'https://conformance.example/placeholder.mp3' }),
-  text: () => ({ content: 'Conformance seed text' }),
-  url: () => ({ url: 'https://conformance.example/' }),
-  html: () => ({ content: '<div>Conformance seed</div>' }),
-  javascript: () => ({ content: '/* conformance seed */' }),
-  css: () => ({ content: '/* conformance seed */' }),
-  markdown: () => ({ content: 'Conformance seed' }),
+  image: () => ({ asset_type: 'image', url: 'https://conformance.example/placeholder.png', width: 300, height: 250 }),
+  video: () => ({ asset_type: 'video', url: 'https://conformance.example/placeholder.mp4', width: 640, height: 360 }),
+  audio: () => ({ asset_type: 'audio', url: 'https://conformance.example/placeholder.mp3' }),
+  text: () => ({ asset_type: 'text', content: 'Conformance seed text' }),
+  url: () => ({ asset_type: 'url', url: 'https://conformance.example/' }),
+  html: () => ({ asset_type: 'html', content: '<div>Conformance seed</div>' }),
+  javascript: () => ({ asset_type: 'javascript', content: '/* conformance seed */' }),
+  css: () => ({ asset_type: 'css', content: '/* conformance seed */' }),
+  markdown: () => ({ asset_type: 'markdown', content: 'Conformance seed' }),
 } as const;
 
 function extractCreativeIds(data: unknown, fallbackId: string): string[] {

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1023,8 +1023,11 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
  * Detect whether a capability-discovery failure is an auth rejection.
  * Centralized so the "run security.yaml against 401-happy agents" path and
  * the fallback "unreachable result" path share the same truth.
+ *
+ * Exported for direct unit tests of the keyword classifier — callers inside
+ * the library should go through `comply()`, not this helper.
  */
-async function detectAuthRejection(
+export async function detectAuthRejection(
   agentUrl: string,
   errorMsg: string | undefined,
   signal?: AbortSignal
@@ -1034,11 +1037,29 @@ async function detectAuthRejection(
 
   // Check for explicit auth keywords. Case-insensitive so wrapper messages
   // like "Authentication required ..." match alongside raw 401/unauthorized.
+  //
+  // OAuth signals are intentionally narrow — bigrams / fully-qualified names
+  // like "oauth authorization" and "OAuthFlowHandler" rather than the bare
+  // words "authorization" / "oauth". The loose-substring form would false-
+  // match on benign network errors that happen to contain "authorization
+  // header missing from upstream" or "oauth proxy unreachable", which would
+  // then suppress the real "Agent unreachable" classification and tell the
+  // operator to re-authenticate a healthy-but-offline agent.
   const lower = err.toLowerCase();
+  const hasOAuthSignal =
+    lower.includes('oauth authorization') ||
+    lower.includes('requires oauth') ||
+    lower.includes('requires authorization') ||
+    lower.includes('oauth flow') ||
+    lower.includes('oauthflowhandler') ||
+    lower.includes('needsauthorizationerror') ||
+    lower.includes('www-authenticate') ||
+    lower.includes('bearer realm');
   const isExplicitAuthError =
     lower.includes('401') ||
     lower.includes('unauthorized') ||
     lower.includes('authentication') ||
+    hasOAuthSignal ||
     lower.includes('jws') ||
     lower.includes('jwt') ||
     lower.includes('signature verification');
@@ -1066,15 +1087,22 @@ async function detectAuthRejection(
   if (isAuth) {
     const { discoverOAuthMetadata } = await import('../../auth/oauth/discovery');
     const oauthMeta = await discoverOAuthMetadata(agentUrl);
-    if (oauthMeta) {
+    // Classify OAuth vs bearer based on (a) explicit OAuth phrasing in the
+    // error text, or (b) a resolvable OAuth metadata document. Either is
+    // enough; a plain 401 on a static-token endpoint matches neither.
+    const looksOAuth = oauthMeta !== null || hasOAuthSignal;
+    if (looksOAuth) {
       // `oauthMeta.issuer` comes from the agent's well-known document — agent-
       // controlled, same fencing as capabilities_probe_error.
-      const issuer = oauthMeta.issuer ? fenceAgentText(oauthMeta.issuer, 200) : '(unknown)';
+      const issuer = oauthMeta?.issuer ? fenceAgentText(oauthMeta.issuer, 200) : '(unknown)';
       observations.push({
         category: 'auth',
         severity: 'error',
-        message: `Agent requires OAuth. Issuer: ${issuer}. Save credentials: adcp --save-auth <alias> ${agentUrl} --oauth`,
-        evidence: { oauth_issuer: oauthMeta.issuer },
+        message:
+          `Agent requires OAuth (issuer: ${issuer}). ` +
+          `Inline: adcp storyboard run ${agentUrl} --oauth (requires a saved alias). ` +
+          `Save once: adcp --save-auth <alias> ${agentUrl} --oauth.`,
+        ...(oauthMeta?.issuer && { evidence: { oauth_issuer: oauthMeta.issuer } }),
       });
     } else {
       observations.push({

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-22T04:07:15.031Z
+// Generated at: 2026-04-22T03:02:49.814Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -1175,34 +1175,7 @@ export type DisclosurePosition =
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving
  */
-export type VASTAsset = {
-  /**
-   * Discriminator identifying this as a VAST asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'vast';
-  vast_version?: VASTVersion;
-  /**
-   * Whether VPAID (Video Player-Ad Interface Definition) is supported
-   */
-  vpaid_enabled?: boolean;
-  /**
-   * Expected video duration in milliseconds (if known)
-   */
-  duration_ms?: number;
-  /**
-   * Tracking events supported by this VAST tag
-   */
-  tracking_events?: VASTTrackingEvent[];
-  /**
-   * URL to captions file (WebVTT, SRT, etc.)
-   */
-  captions_url?: string;
-  /**
-   * URL to audio description track for visually impaired users
-   */
-  audio_description_url?: string;
-  provenance?: Provenance;
-} & (
+export type VASTAsset =
   | {
       /**
        * Discriminator indicating VAST is delivered via URL endpoint
@@ -1212,6 +1185,28 @@ export type VASTAsset = {
        * URL endpoint that returns VAST XML
        */
       url: string;
+      vast_version?: VASTVersion;
+      /**
+       * Whether VPAID (Video Player-Ad Interface Definition) is supported
+       */
+      vpaid_enabled?: boolean;
+      /**
+       * Expected video duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this VAST tag
+       */
+      tracking_events?: VASTTrackingEvent[];
+      /**
+       * URL to captions file (WebVTT, SRT, etc.)
+       */
+      captions_url?: string;
+      /**
+       * URL to audio description track for visually impaired users
+       */
+      audio_description_url?: string;
+      provenance?: Provenance;
     }
   | {
       /**
@@ -1222,8 +1217,29 @@ export type VASTAsset = {
        * Inline VAST XML content
        */
       content: string;
-    }
-);
+      vast_version?: VASTVersion;
+      /**
+       * Whether VPAID (Video Player-Ad Interface Definition) is supported
+       */
+      vpaid_enabled?: boolean;
+      /**
+       * Expected video duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this VAST tag
+       */
+      tracking_events?: VASTTrackingEvent[];
+      /**
+       * URL to captions file (WebVTT, SRT, etc.)
+       */
+      captions_url?: string;
+      /**
+       * URL to audio description track for visually impaired users
+       */
+      audio_description_url?: string;
+      provenance?: Provenance;
+    };
 /**
  * VAST specification version
  */
@@ -1360,30 +1376,7 @@ export type WebhookSecurityMethod = 'hmac_sha256' | 'api_key' | 'none';
 /**
  * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
  */
-export type DAASTAsset = {
-  /**
-   * Discriminator identifying this as a DAAST asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'daast';
-  daast_version?: DAASTVersion;
-  /**
-   * Expected audio duration in milliseconds (if known)
-   */
-  duration_ms?: number;
-  /**
-   * Tracking events supported by this DAAST tag
-   */
-  tracking_events?: DAASTTrackingEvent[];
-  /**
-   * Whether companion display ads are included
-   */
-  companion_ads?: boolean;
-  /**
-   * URL to text transcript of the audio content
-   */
-  transcript_url?: string;
-  provenance?: Provenance;
-} & (
+export type DAASTAsset =
   | {
       /**
        * Discriminator indicating DAAST is delivered via URL endpoint
@@ -1393,6 +1386,24 @@ export type DAASTAsset = {
        * URL endpoint that returns DAAST XML
        */
       url: string;
+      daast_version?: DAASTVersion;
+      /**
+       * Expected audio duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this DAAST tag
+       */
+      tracking_events?: DAASTTrackingEvent[];
+      /**
+       * Whether companion display ads are included
+       */
+      companion_ads?: boolean;
+      /**
+       * URL to text transcript of the audio content
+       */
+      transcript_url?: string;
+      provenance?: Provenance;
     }
   | {
       /**
@@ -1403,8 +1414,25 @@ export type DAASTAsset = {
        * Inline DAAST XML content
        */
       content: string;
-    }
-);
+      daast_version?: DAASTVersion;
+      /**
+       * Expected audio duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this DAAST tag
+       */
+      tracking_events?: DAASTTrackingEvent[];
+      /**
+       * Whether companion display ads are included
+       */
+      companion_ads?: boolean;
+      /**
+       * URL to text transcript of the audio content
+       */
+      transcript_url?: string;
+      provenance?: Provenance;
+    };
 /**
  * DAAST specification version
  */
@@ -1443,21 +1471,11 @@ export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
  * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export type BriefAsset = CreativeBrief & {
-  /**
-   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'brief';
-};
+export type BriefAsset = CreativeBrief;
 /**
  * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
  */
-export type CatalogAsset = Catalog & {
-  /**
-   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'catalog';
-};
+export type CatalogAsset = Catalog;
 /**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
@@ -1481,7 +1499,7 @@ export interface CreativeAsset {
   name: string;
   format_id: FormatID;
   /**
-   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   * Assets required by the format, keyed by asset_id
    */
   assets: {
     /**
@@ -1546,10 +1564,6 @@ export interface CreativeAsset {
  * Image asset with URL and dimensions
  */
 export interface ImageAsset {
-  /**
-   * Discriminator identifying this as an image asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'image';
   /**
    * URL to the image asset
    */
@@ -1705,10 +1719,6 @@ export interface Provenance {
  */
 export interface VideoAsset {
   /**
-   * Discriminator identifying this as a video asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'video';
-  /**
    * URL to the video asset
    */
   url: string;
@@ -1831,10 +1841,6 @@ export interface VideoAsset {
  */
 export interface AudioAsset {
   /**
-   * Discriminator identifying this as an audio asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'audio';
-  /**
    * URL to the audio asset
    */
   url: string;
@@ -1889,10 +1895,6 @@ export interface AudioAsset {
  */
 export interface TextAsset {
   /**
-   * Discriminator identifying this as a text asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'text';
-  /**
    * Text content
    */
   content: string;
@@ -1906,10 +1908,6 @@ export interface TextAsset {
  * URL reference asset
  */
 export interface URLAsset {
-  /**
-   * Discriminator identifying this as a URL asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'url';
   /**
    * URL reference. May be a plain URI or an RFC 6570 URI template carrying AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`). Buyers MUST NOT pre-encode macro braces at sync time; the ad server URL-encodes substituted values at impression time. See docs/creative/universal-macros.mdx.
    */
@@ -1925,10 +1923,6 @@ export interface URLAsset {
  * HTML content asset
  */
 export interface HTMLAsset {
-  /**
-   * Discriminator identifying this as an HTML asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'html';
   /**
    * HTML content
    */
@@ -1965,10 +1959,6 @@ export interface HTMLAsset {
  */
 export interface JavaScriptAsset {
   /**
-   * Discriminator identifying this as a JavaScript asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'javascript';
-  /**
    * JavaScript content
    */
   content: string;
@@ -2000,10 +1990,6 @@ export interface JavaScriptAsset {
  * Webhook for server-side dynamic content rendering (DCO)
  */
 export interface WebhookAsset {
-  /**
-   * Discriminator identifying this as a webhook asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'webhook';
   /**
    * Webhook URL to call for dynamic content
    */
@@ -2043,10 +2029,6 @@ export interface WebhookAsset {
  */
 export interface CSSAsset {
   /**
-   * Discriminator identifying this as a CSS asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'css';
-  /**
    * CSS content
    */
   content: string;
@@ -2060,10 +2042,6 @@ export interface CSSAsset {
  * Markdown-formatted text content following CommonMark specification
  */
 export interface MarkdownAsset {
-  /**
-   * Discriminator identifying this as a markdown asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'markdown';
   /**
    * Markdown content following CommonMark spec with optional GitHub Flavored Markdown extensions
    */
@@ -4179,60 +4157,26 @@ export interface GetProductsResponse {
    */
   catalog_applied?: boolean;
   /**
-   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'. Each entry MUST echo the request entry's scope and — for product and proposal scopes — the matching id field (product_id or proposal_id), so orchestrators can cross-validate alignment.
+   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'.
    */
-  refinement_applied?: (
-    | {
-        /**
-         * Echoes scope 'request' from the corresponding refine entry.
-         */
-        scope: 'request';
-        /**
-         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-         */
-        status: 'applied' | 'partial' | 'unable';
-        /**
-         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-         */
-        notes?: string;
-      }
-    | {
-        /**
-         * Echoes scope 'product' from the corresponding refine entry.
-         */
-        scope: 'product';
-        /**
-         * Echoes product_id from the corresponding refine entry.
-         */
-        product_id: string;
-        /**
-         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-         */
-        status: 'applied' | 'partial' | 'unable';
-        /**
-         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-         */
-        notes?: string;
-      }
-    | {
-        /**
-         * Echoes scope 'proposal' from the corresponding refine entry.
-         */
-        scope: 'proposal';
-        /**
-         * Echoes proposal_id from the corresponding refine entry.
-         */
-        proposal_id: string;
-        /**
-         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-         */
-        status: 'applied' | 'partial' | 'unable';
-        /**
-         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-         */
-        notes?: string;
-      }
-  )[];
+  refinement_applied?: {
+    /**
+     * Echoes the scope from the corresponding refine entry. Allows orchestrators to cross-validate alignment.
+     */
+    scope?: 'request' | 'product' | 'proposal';
+    /**
+     * Echoes the id from the corresponding refine entry (for product and proposal scopes).
+     */
+    id?: string;
+    /**
+     * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+     */
+    status: 'applied' | 'partial' | 'unable';
+    /**
+     * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+     */
+    notes?: string;
+  }[];
   /**
    * Declares what the seller could not finish within the buyer's time_budget or due to internal limits. Each entry identifies a scope that is missing or partial. Absent when the response is fully complete.
    */
@@ -4870,7 +4814,7 @@ export interface CreativeManifest {
   /**
    * Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.
    *
-   * Each asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   * IMPORTANT: Full validation requires format context. The format defines what type each asset_id should be. Standalone schema validation only checks structural conformance — each asset must match at least one valid asset type schema.
    */
   assets: {
     /**
@@ -8740,7 +8684,7 @@ export interface ListCreativesResponse {
      */
     updated_date: string;
     /**
-     * Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+     * Assets for this creative, keyed by asset_id
      */
     assets?: {
       /**
@@ -9013,62 +8957,6 @@ export type CreativeQuality = 'draft' | 'production';
  * Output format. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML). In batch mode, sets the default for all requests (individual items can override). Default: 'url'.
  */
 export type PreviewOutputFormat = 'url' | 'html';
-/**
- * VAST (Video Ad Serving Template) tag for third-party video ad serving
- */
-export type VASTAsset1 =
-  | {
-      /**
-       * Discriminator indicating VAST is delivered via URL endpoint
-       */
-      delivery_type: 'url';
-      /**
-       * URL endpoint that returns VAST XML
-       */
-      url: string;
-    }
-  | {
-      /**
-       * Discriminator indicating VAST is delivered as inline XML content
-       */
-      delivery_type: 'inline';
-      /**
-       * Inline VAST XML content
-       */
-      content: string;
-    };
-/**
- * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
- */
-export type DAASTAsset1 =
-  | {
-      /**
-       * Discriminator indicating DAAST is delivered via URL endpoint
-       */
-      delivery_type: 'url';
-      /**
-       * URL endpoint that returns DAAST XML
-       */
-      url: string;
-    }
-  | {
-      /**
-       * Discriminator indicating DAAST is delivered as inline XML content
-       */
-      delivery_type: 'inline';
-      /**
-       * Inline DAAST XML content
-       */
-      content: string;
-    };
-/**
- * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
- */
-export type BriefAsset1 = CreativeBrief;
-/**
- * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
- */
-export type CatalogAsset1 = Catalog;
 
 // bundled/creative/preview-creative-response.json
 /**
@@ -10560,11 +10448,11 @@ export interface GetProductsRequest {
         /**
          * Product ID from a previous get_products response.
          */
-        product_id: string;
+        id: string;
         /**
-         * 'include' (default): return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned). Optional — when omitted, the seller treats the entry as action: 'include'.
+         * 'include': return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned).
          */
-        action?: 'include' | 'omit' | 'more_like_this';
+        action: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
          */
@@ -10578,11 +10466,11 @@ export interface GetProductsRequest {
         /**
          * Proposal ID from a previous get_products response.
          */
-        proposal_id: string;
+        id: string;
         /**
-         * 'include' (default): return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result. Optional — when omitted, the seller treats the entry as action: 'include'.
+         * 'include': return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result.
          */
-        action?: 'include' | 'omit' | 'finalize';
+        action: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
          */
@@ -11718,81 +11606,6 @@ export interface PackageUpdate {
   creatives?: CreativeAsset[];
   context?: ContextObject;
   ext?: ExtensionObject;
-}
-/**
- * Creative asset for upload to library - supports static assets, generative formats, and third-party snippets
- */
-export interface CreativeAsset1 {
-  /**
-   * Unique identifier for the creative
-   */
-  creative_id: string;
-  /**
-   * Human-readable creative name
-   */
-  name: string;
-  format_id: FormatID;
-  /**
-   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
-   */
-  assets: {
-    /**
-     * This interface was referenced by `undefined`'s JSON-Schema definition
-     * via the `patternProperty` "^[a-z0-9_]+$".
-     */
-    [k: string]:
-      | ImageAsset
-      | VideoAsset
-      | AudioAsset
-      | VASTAsset1
-      | TextAsset
-      | URLAsset
-      | HTMLAsset
-      | JavaScriptAsset
-      | WebhookAsset
-      | CSSAsset
-      | DAASTAsset1
-      | MarkdownAsset
-      | BriefAsset1
-      | CatalogAsset1;
-  };
-  /**
-   * Preview contexts for generative formats - defines what scenarios to generate previews for
-   */
-  inputs?: {
-    /**
-     * Human-readable name for this preview variant
-     */
-    name: string;
-    /**
-     * Macro values to apply for this preview
-     */
-    macros?: {
-      [k: string]: string | undefined;
-    };
-    /**
-     * Natural language description of the context for AI-generated content
-     */
-    context_description?: string;
-  }[];
-  /**
-   * User-defined tags for organization and searchability
-   */
-  tags?: string[];
-  status?: CreativeStatus;
-  /**
-   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
-   */
-  weight?: number;
-  /**
-   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
-   */
-  placement_ids?: string[];
-  /**
-   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
-   */
-  industry_identifiers?: IndustryIdentifier[];
-  provenance?: Provenance;
 }
 
 // bundled/property/create-property-list-request.json
@@ -14565,7 +14378,7 @@ export interface OfferingAssetGroup {
   asset_group_id: string;
   asset_type: AssetContentType;
   /**
-   * The assets in this group. Each item carries an `asset_type` discriminator that selects the matching asset schema. Note: the group-level `asset_type` declares the expected type; individual items must also self-tag so validators can narrow errors.
+   * The assets in this group. Each item should match the structure for the declared asset_type. Note: JSON Schema validation accepts any valid asset structure here; enforcement that items match asset_type is the responsibility of the consuming agent.
    */
   items: (
     | TextAsset

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-22T03:02:49.814Z
+// Generated at: 2026-04-22T04:07:15.031Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -1175,7 +1175,34 @@ export type DisclosurePosition =
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving
  */
-export type VASTAsset =
+export type VASTAsset = {
+  /**
+   * Discriminator identifying this as a VAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'vast';
+  vast_version?: VASTVersion;
+  /**
+   * Whether VPAID (Video Player-Ad Interface Definition) is supported
+   */
+  vpaid_enabled?: boolean;
+  /**
+   * Expected video duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this VAST tag
+   */
+  tracking_events?: VASTTrackingEvent[];
+  /**
+   * URL to captions file (WebVTT, SRT, etc.)
+   */
+  captions_url?: string;
+  /**
+   * URL to audio description track for visually impaired users
+   */
+  audio_description_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating VAST is delivered via URL endpoint
@@ -1185,28 +1212,6 @@ export type VASTAsset =
        * URL endpoint that returns VAST XML
        */
       url: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -1217,29 +1222,8 @@ export type VASTAsset =
        * Inline VAST XML content
        */
       content: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * VAST specification version
  */
@@ -1376,7 +1360,30 @@ export type WebhookSecurityMethod = 'hmac_sha256' | 'api_key' | 'none';
 /**
  * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
  */
-export type DAASTAsset =
+export type DAASTAsset = {
+  /**
+   * Discriminator identifying this as a DAAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'daast';
+  daast_version?: DAASTVersion;
+  /**
+   * Expected audio duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this DAAST tag
+   */
+  tracking_events?: DAASTTrackingEvent[];
+  /**
+   * Whether companion display ads are included
+   */
+  companion_ads?: boolean;
+  /**
+   * URL to text transcript of the audio content
+   */
+  transcript_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating DAAST is delivered via URL endpoint
@@ -1386,24 +1393,6 @@ export type DAASTAsset =
        * URL endpoint that returns DAAST XML
        */
       url: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -1414,25 +1403,8 @@ export type DAASTAsset =
        * Inline DAAST XML content
        */
       content: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * DAAST specification version
  */
@@ -1471,11 +1443,21 @@ export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
  * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export type BriefAsset = CreativeBrief;
+export type BriefAsset = CreativeBrief & {
+  /**
+   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'brief';
+};
 /**
  * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
  */
-export type CatalogAsset = Catalog;
+export type CatalogAsset = Catalog & {
+  /**
+   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'catalog';
+};
 /**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
@@ -1499,7 +1481,7 @@ export interface CreativeAsset {
   name: string;
   format_id: FormatID;
   /**
-   * Assets required by the format, keyed by asset_id
+   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
    */
   assets: {
     /**
@@ -1564,6 +1546,10 @@ export interface CreativeAsset {
  * Image asset with URL and dimensions
  */
 export interface ImageAsset {
+  /**
+   * Discriminator identifying this as an image asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'image';
   /**
    * URL to the image asset
    */
@@ -1719,6 +1705,10 @@ export interface Provenance {
  */
 export interface VideoAsset {
   /**
+   * Discriminator identifying this as a video asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'video';
+  /**
    * URL to the video asset
    */
   url: string;
@@ -1841,6 +1831,10 @@ export interface VideoAsset {
  */
 export interface AudioAsset {
   /**
+   * Discriminator identifying this as an audio asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'audio';
+  /**
    * URL to the audio asset
    */
   url: string;
@@ -1895,6 +1889,10 @@ export interface AudioAsset {
  */
 export interface TextAsset {
   /**
+   * Discriminator identifying this as a text asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'text';
+  /**
    * Text content
    */
   content: string;
@@ -1908,6 +1906,10 @@ export interface TextAsset {
  * URL reference asset
  */
 export interface URLAsset {
+  /**
+   * Discriminator identifying this as a URL asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'url';
   /**
    * URL reference. May be a plain URI or an RFC 6570 URI template carrying AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`). Buyers MUST NOT pre-encode macro braces at sync time; the ad server URL-encodes substituted values at impression time. See docs/creative/universal-macros.mdx.
    */
@@ -1923,6 +1925,10 @@ export interface URLAsset {
  * HTML content asset
  */
 export interface HTMLAsset {
+  /**
+   * Discriminator identifying this as an HTML asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'html';
   /**
    * HTML content
    */
@@ -1959,6 +1965,10 @@ export interface HTMLAsset {
  */
 export interface JavaScriptAsset {
   /**
+   * Discriminator identifying this as a JavaScript asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'javascript';
+  /**
    * JavaScript content
    */
   content: string;
@@ -1990,6 +2000,10 @@ export interface JavaScriptAsset {
  * Webhook for server-side dynamic content rendering (DCO)
  */
 export interface WebhookAsset {
+  /**
+   * Discriminator identifying this as a webhook asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'webhook';
   /**
    * Webhook URL to call for dynamic content
    */
@@ -2029,6 +2043,10 @@ export interface WebhookAsset {
  */
 export interface CSSAsset {
   /**
+   * Discriminator identifying this as a CSS asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'css';
+  /**
    * CSS content
    */
   content: string;
@@ -2042,6 +2060,10 @@ export interface CSSAsset {
  * Markdown-formatted text content following CommonMark specification
  */
 export interface MarkdownAsset {
+  /**
+   * Discriminator identifying this as a markdown asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'markdown';
   /**
    * Markdown content following CommonMark spec with optional GitHub Flavored Markdown extensions
    */
@@ -4157,26 +4179,60 @@ export interface GetProductsResponse {
    */
   catalog_applied?: boolean;
   /**
-   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'.
+   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'. Each entry MUST echo the request entry's scope and — for product and proposal scopes — the matching id field (product_id or proposal_id), so orchestrators can cross-validate alignment.
    */
-  refinement_applied?: {
-    /**
-     * Echoes the scope from the corresponding refine entry. Allows orchestrators to cross-validate alignment.
-     */
-    scope?: 'request' | 'product' | 'proposal';
-    /**
-     * Echoes the id from the corresponding refine entry (for product and proposal scopes).
-     */
-    id?: string;
-    /**
-     * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-     */
-    status: 'applied' | 'partial' | 'unable';
-    /**
-     * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-     */
-    notes?: string;
-  }[];
+  refinement_applied?: (
+    | {
+        /**
+         * Echoes scope 'request' from the corresponding refine entry.
+         */
+        scope: 'request';
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'product' from the corresponding refine entry.
+         */
+        scope: 'product';
+        /**
+         * Echoes product_id from the corresponding refine entry.
+         */
+        product_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'proposal' from the corresponding refine entry.
+         */
+        scope: 'proposal';
+        /**
+         * Echoes proposal_id from the corresponding refine entry.
+         */
+        proposal_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+  )[];
   /**
    * Declares what the seller could not finish within the buyer's time_budget or due to internal limits. Each entry identifies a scope that is missing or partial. Absent when the response is fully complete.
    */
@@ -4814,7 +4870,7 @@ export interface CreativeManifest {
   /**
    * Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.
    *
-   * IMPORTANT: Full validation requires format context. The format defines what type each asset_id should be. Standalone schema validation only checks structural conformance — each asset must match at least one valid asset type schema.
+   * Each asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
    */
   assets: {
     /**
@@ -8684,7 +8740,7 @@ export interface ListCreativesResponse {
      */
     updated_date: string;
     /**
-     * Assets for this creative, keyed by asset_id
+     * Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
      */
     assets?: {
       /**
@@ -8957,6 +9013,62 @@ export type CreativeQuality = 'draft' | 'production';
  * Output format. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML). In batch mode, sets the default for all requests (individual items can override). Default: 'url'.
  */
 export type PreviewOutputFormat = 'url' | 'html';
+/**
+ * VAST (Video Ad Serving Template) tag for third-party video ad serving
+ */
+export type VASTAsset1 =
+  | {
+      /**
+       * Discriminator indicating VAST is delivered via URL endpoint
+       */
+      delivery_type: 'url';
+      /**
+       * URL endpoint that returns VAST XML
+       */
+      url: string;
+    }
+  | {
+      /**
+       * Discriminator indicating VAST is delivered as inline XML content
+       */
+      delivery_type: 'inline';
+      /**
+       * Inline VAST XML content
+       */
+      content: string;
+    };
+/**
+ * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
+ */
+export type DAASTAsset1 =
+  | {
+      /**
+       * Discriminator indicating DAAST is delivered via URL endpoint
+       */
+      delivery_type: 'url';
+      /**
+       * URL endpoint that returns DAAST XML
+       */
+      url: string;
+    }
+  | {
+      /**
+       * Discriminator indicating DAAST is delivered as inline XML content
+       */
+      delivery_type: 'inline';
+      /**
+       * Inline DAAST XML content
+       */
+      content: string;
+    };
+/**
+ * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
+ */
+export type BriefAsset1 = CreativeBrief;
+/**
+ * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
+ */
+export type CatalogAsset1 = Catalog;
 
 // bundled/creative/preview-creative-response.json
 /**
@@ -10448,11 +10560,11 @@ export interface GetProductsRequest {
         /**
          * Product ID from a previous get_products response.
          */
-        id: string;
+        product_id: string;
         /**
-         * 'include': return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned).
+         * 'include' (default): return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned). Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'more_like_this';
+        action?: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
          */
@@ -10466,11 +10578,11 @@ export interface GetProductsRequest {
         /**
          * Proposal ID from a previous get_products response.
          */
-        id: string;
+        proposal_id: string;
         /**
-         * 'include': return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result.
+         * 'include' (default): return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result. Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'finalize';
+        action?: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
          */
@@ -11606,6 +11718,81 @@ export interface PackageUpdate {
   creatives?: CreativeAsset[];
   context?: ContextObject;
   ext?: ExtensionObject;
+}
+/**
+ * Creative asset for upload to library - supports static assets, generative formats, and third-party snippets
+ */
+export interface CreativeAsset1 {
+  /**
+   * Unique identifier for the creative
+   */
+  creative_id: string;
+  /**
+   * Human-readable creative name
+   */
+  name: string;
+  format_id: FormatID;
+  /**
+   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]:
+      | ImageAsset
+      | VideoAsset
+      | AudioAsset
+      | VASTAsset1
+      | TextAsset
+      | URLAsset
+      | HTMLAsset
+      | JavaScriptAsset
+      | WebhookAsset
+      | CSSAsset
+      | DAASTAsset1
+      | MarkdownAsset
+      | BriefAsset1
+      | CatalogAsset1;
+  };
+  /**
+   * Preview contexts for generative formats - defines what scenarios to generate previews for
+   */
+  inputs?: {
+    /**
+     * Human-readable name for this preview variant
+     */
+    name: string;
+    /**
+     * Macro values to apply for this preview
+     */
+    macros?: {
+      [k: string]: string | undefined;
+    };
+    /**
+     * Natural language description of the context for AI-generated content
+     */
+    context_description?: string;
+  }[];
+  /**
+   * User-defined tags for organization and searchability
+   */
+  tags?: string[];
+  status?: CreativeStatus;
+  /**
+   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   */
+  weight?: number;
+  /**
+   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
+   */
+  placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
 }
 
 // bundled/property/create-property-list-request.json
@@ -14378,7 +14565,7 @@ export interface OfferingAssetGroup {
   asset_group_id: string;
   asset_type: AssetContentType;
   /**
-   * The assets in this group. Each item should match the structure for the declared asset_type. Note: JSON Schema validation accepts any valid asset structure here; enforcement that items match asset_type is the responsibility of the consuming agent.
+   * The assets in this group. Each item carries an `asset_type` discriminator that selects the matching asset schema. Note: the group-level `asset_type` declares the expected type; individual items must also self-tag so validators can narrow errors.
    */
   items: (
     | TextAsset

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-22T02:47:27.524Z
+// Generated at: 2026-04-22T04:07:18.853Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -306,6 +306,7 @@ export const CreativeStatusSchema = z.union([z.literal("processing"), z.literal(
 export const CreativeIdentifierTypeSchema = z.union([z.literal("ad_id"), z.literal("isci"), z.literal("clearcast_clock")]);
 
 export const ImageAssetSchema = z.object({
+    asset_type: z.literal("image"),
     url: z.string(),
     width: z.number(),
     height: z.number(),
@@ -315,6 +316,7 @@ export const ImageAssetSchema = z.object({
 }).passthrough();
 
 export const VideoAssetSchema = z.object({
+    asset_type: z.literal("video"),
     url: z.string(),
     width: z.number(),
     height: z.number(),
@@ -348,6 +350,7 @@ export const VideoAssetSchema = z.object({
 }).passthrough();
 
 export const AudioAssetSchema = z.object({
+    asset_type: z.literal("audio"),
     url: z.string(),
     duration_ms: z.number().optional(),
     file_size_bytes: z.number().optional(),
@@ -363,35 +366,32 @@ export const AudioAssetSchema = z.object({
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const VASTAssetSchema = z.union([z.object({
+export const VASTAssetSchema = z.object({
+    asset_type: z.literal("vast"),
+    vast_version: VASTVersionSchema.optional(),
+    vpaid_enabled: z.boolean().optional(),
+    duration_ms: z.number().optional(),
+    tracking_events: z.array(VASTTrackingEventSchema).optional(),
+    captions_url: z.string().optional(),
+    audio_description_url: z.string().optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([z.object({
         delivery_type: z.literal("url"),
-        url: z.string(),
-        vast_version: VASTVersionSchema.optional(),
-        vpaid_enabled: z.boolean().optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(VASTTrackingEventSchema).optional(),
-        captions_url: z.string().optional(),
-        audio_description_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
+        url: z.string()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
-        content: z.string(),
-        vast_version: VASTVersionSchema.optional(),
-        vpaid_enabled: z.boolean().optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(VASTTrackingEventSchema).optional(),
-        captions_url: z.string().optional(),
-        audio_description_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
-    }).passthrough()]);
+        content: z.string()
+    }).passthrough()]));
 
 export const TextAssetSchema = z.object({
+    asset_type: z.literal("text"),
     content: z.string(),
     language: z.string().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const URLAssetSchema = z.object({
+    asset_type: z.literal("url"),
     url: z.string(),
     url_type: URLAssetTypeSchema.optional(),
     description: z.string().optional(),
@@ -399,6 +399,7 @@ export const URLAssetSchema = z.object({
 }).passthrough();
 
 export const HTMLAssetSchema = z.object({
+    asset_type: z.literal("html"),
     content: z.string(),
     version: z.string().optional(),
     accessibility: z.object({
@@ -411,6 +412,7 @@ export const HTMLAssetSchema = z.object({
 }).passthrough();
 
 export const JavaScriptAssetSchema = z.object({
+    asset_type: z.literal("javascript"),
     content: z.string(),
     module_type: JavaScriptModuleTypeSchema.optional(),
     accessibility: z.object({
@@ -423,6 +425,7 @@ export const JavaScriptAssetSchema = z.object({
 }).passthrough();
 
 export const WebhookAssetSchema = z.object({
+    asset_type: z.literal("webhook"),
     url: z.string(),
     method: HTTPMethodSchema.optional(),
     timeout_ms: z.number().optional(),
@@ -438,39 +441,39 @@ export const WebhookAssetSchema = z.object({
 }).passthrough();
 
 export const CSSAssetSchema = z.object({
+    asset_type: z.literal("css"),
     content: z.string(),
     media: z.string().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const DAASTAssetSchema = z.union([z.object({
+export const DAASTAssetSchema = z.object({
+    asset_type: z.literal("daast"),
+    daast_version: DAASTVersionSchema.optional(),
+    duration_ms: z.number().optional(),
+    tracking_events: z.array(DAASTTrackingEventSchema).optional(),
+    companion_ads: z.boolean().optional(),
+    transcript_url: z.string().optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([z.object({
         delivery_type: z.literal("url"),
-        url: z.string(),
-        daast_version: DAASTVersionSchema.optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(DAASTTrackingEventSchema).optional(),
-        companion_ads: z.boolean().optional(),
-        transcript_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
+        url: z.string()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
-        content: z.string(),
-        daast_version: DAASTVersionSchema.optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(DAASTTrackingEventSchema).optional(),
-        companion_ads: z.boolean().optional(),
-        transcript_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
-    }).passthrough()]);
+        content: z.string()
+    }).passthrough()]));
 
 export const MarkdownAssetSchema = z.object({
+    asset_type: z.literal("markdown"),
     content: z.string(),
     language: z.string().optional(),
     markdown_flavor: MarkdownFlavorSchema.optional(),
     allow_raw_html: z.boolean().optional()
 }).passthrough();
 
-export const CatalogAssetSchema = CatalogSchema;
+export const CatalogAssetSchema = CatalogSchema.and(z.object({
+    asset_type: z.literal("catalog")
+}).passthrough());
 
 export const IndustryIdentifierSchema = z.object({
     type: CreativeIdentifierTypeSchema,
@@ -2143,6 +2146,51 @@ export const CreativeQualitySchema = z.union([z.literal("draft"), z.literal("pro
 
 export const PreviewOutputFormatSchema = z.union([z.literal("url"), z.literal("html")]);
 
+export const VASTAsset1Schema = z.union([z.object({
+        delivery_type: z.literal("url"),
+        url: z.string()
+    }).passthrough(), z.object({
+        delivery_type: z.literal("inline"),
+        content: z.string()
+    }).passthrough()]);
+
+export const DAASTAsset1Schema = z.union([z.object({
+        delivery_type: z.literal("url"),
+        url: z.string()
+    }).passthrough(), z.object({
+        delivery_type: z.literal("inline"),
+        content: z.string()
+    }).passthrough()]);
+
+export const CreativeBriefSchema = z.object({
+    name: z.string(),
+    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
+    tone: z.string().optional(),
+    audience: z.string().optional(),
+    territory: z.string().optional(),
+    messaging: z.object({
+        headline: z.string().optional(),
+        tagline: z.string().optional(),
+        cta: z.string().optional(),
+        key_messages: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    reference_assets: z.array(ReferenceAssetSchema).optional(),
+    compliance: z.object({
+        required_disclosures: z.array(z.object({
+            text: z.string(),
+            position: DisclosurePositionSchema.optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            regulation: z.string().optional(),
+            min_duration_ms: z.number().optional(),
+            language: z.string().optional(),
+            persistence: DisclosurePersistenceSchema.optional()
+        }).passthrough()).optional(),
+        prohibited_claims: z.array(z.string()).optional()
+    }).passthrough().optional()
+}).passthrough();
+
+export const CatalogAsset1Schema = CatalogSchema;
+
 export const PreviewCreativeSingleResponseSchema = z.object({
     response_type: z.literal("single"),
     previews: z.array(z.object({
@@ -2583,6 +2631,8 @@ export const EventSourceHealthSchema = z.object({
 }).passthrough();
 
 export const AgeVerificationMethod1Schema = z.union([z.literal("facial_age_estimation"), z.literal("id_document"), z.literal("digital_id"), z.literal("credit_card"), z.literal("world_id")]);
+
+export const BriefAsset1Schema = CreativeBriefSchema;
 
 export const PublisherTagsSourceSchema = z.object({
     selection_type: z.literal("publisher_tags"),
@@ -3918,34 +3968,27 @@ export const BaseIndividualAssetSchema = z.object({
     overlays: z.array(OverlaySchema).optional()
 }).passthrough();
 
-export const CreativeBriefSchema = z.object({
-    name: z.string(),
-    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
-    tone: z.string().optional(),
-    audience: z.string().optional(),
-    territory: z.string().optional(),
-    messaging: z.object({
-        headline: z.string().optional(),
-        tagline: z.string().optional(),
-        cta: z.string().optional(),
-        key_messages: z.array(z.string()).optional()
-    }).passthrough().optional(),
-    reference_assets: z.array(ReferenceAssetSchema).optional(),
-    compliance: z.object({
-        required_disclosures: z.array(z.object({
-            text: z.string(),
-            position: DisclosurePositionSchema.optional(),
-            jurisdictions: z.array(z.string()).optional(),
-            regulation: z.string().optional(),
-            min_duration_ms: z.number().optional(),
-            language: z.string().optional(),
-            persistence: DisclosurePersistenceSchema.optional()
-        }).passthrough()).optional(),
-        prohibited_claims: z.array(z.string()).optional()
-    }).passthrough().optional()
-}).passthrough();
+export const BriefAssetSchema = CreativeBriefSchema.and(z.object({
+    asset_type: z.literal("brief")
+}).passthrough());
 
-export const BriefAssetSchema = CreativeBriefSchema;
+export const CreativeAssetSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatIDSchema,
+    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough();
 
 export const PackageSchema = z.object({
     package_id: z.string(),
@@ -3997,22 +4040,65 @@ export const PlannedDeliverySchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreativeAssetSchema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatIDSchema,
-    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
+export const PackageUpdateSchema = z.object({
+    package_id: z.string(),
+    budget: z.number().optional(),
+    pacing: PacingSchema.optional(),
+    bid_price: z.number().optional(),
+    impressions: z.number().optional(),
+    start_time: z.string().optional(),
+    end_time: z.string().optional(),
+    paused: z.boolean().optional(),
+    canceled: z.literal(true).optional(),
+    cancellation_reason: z.string().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    keyword_targets_add: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]),
+        bid_price: z.number().optional()
     }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
+    keyword_targets_remove: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    negative_keywords_add: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    negative_keywords_remove: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PackageRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    product_id: z.string(),
+    format_ids: z.array(FormatIDSchema).optional(),
+    budget: z.number(),
+    pacing: PacingSchema.optional(),
+    pricing_option_id: z.string(),
+    bid_price: z.number().optional(),
+    impressions: z.number().optional(),
+    start_time: z.string().optional(),
+    end_time: z.string().optional(),
+    paused: z.boolean().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    measurement_terms: MeasurementTermsSchema.optional(),
+    performance_standards: z.array(PerformanceStandardSchema).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    agency_estimate_number: z.string().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const UpdateMediaBuySuccessSchema = z.object({
@@ -5807,26 +5893,43 @@ export const BuildCreativeRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PackageRequestSchema = z.object({
+export const CreateMediaBuyRequestSchema = z.object({
     adcp_major_version: z.number().optional(),
-    product_id: z.string(),
-    format_ids: z.array(FormatIDSchema).optional(),
-    budget: z.number(),
-    pacing: PacingSchema.optional(),
-    pricing_option_id: z.string(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
-    paused: z.boolean().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    measurement_terms: MeasurementTermsSchema.optional(),
-    performance_standards: z.array(PerformanceStandardSchema).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    idempotency_key: z.string(),
+    plan_id: z.string().optional(),
+    account: AccountReferenceSchema,
+    proposal_id: z.string().optional(),
+    total_budget: z.object({
+        amount: z.number(),
+        currency: z.string()
+    }).passthrough().optional(),
+    packages: z.array(PackageRequestSchema).optional(),
+    brand: BrandReferenceSchema,
+    advertiser_industry: AdvertiserIndustrySchema.optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    io_acceptance: z.object({
+        io_id: z.string(),
+        accepted_at: z.string(),
+        signatory: z.string(),
+        signature_id: z.string().optional()
+    }).passthrough().optional(),
+    po_number: z.string().optional(),
     agency_estimate_number: z.string().optional(),
+    start_time: StartTimingSchema,
+    end_time: z.string(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    artifact_webhook: z.object({
+        url: z.string(),
+        token: z.string().optional(),
+        authentication: z.object({
+            schemes: z.array(AuthenticationSchemeSchema),
+            credentials: z.string()
+        }).passthrough(),
+        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
+        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
+        sampling_rate: z.number().optional()
+    }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -5840,13 +5943,13 @@ export const GetProductsRequestSchema = z.object({
             ask: z.string()
         }).passthrough(), z.object({
             scope: z.literal("product"),
-            id: z.string(),
-            action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]),
+            product_id: z.string(),
+            action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]).optional(),
             ask: z.string().optional()
         }).passthrough(), z.object({
             scope: z.literal("proposal"),
-            id: z.string(),
-            action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]),
+            proposal_id: z.string(),
+            action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]).optional(),
             ask: z.string().optional()
         }).passthrough()])).optional(),
     brand: BrandReferenceSchema.optional(),
@@ -5875,41 +5978,42 @@ export const LogEventRequestSchema = z.object({
 
 export const SyncEventSourcesResponseSchema = z.union([SyncEventSourcesSuccessSchema, SyncEventSourcesErrorSchema]);
 
-export const PackageUpdateSchema = z.object({
-    package_id: z.string(),
-    budget: z.number().optional(),
-    pacing: PacingSchema.optional(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+export const UpdateMediaBuyRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    account: AccountReferenceSchema,
+    media_buy_id: z.string(),
+    revision: z.number().optional(),
     paused: z.boolean().optional(),
     canceled: z.literal(true).optional(),
     cancellation_reason: z.string().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    keyword_targets_add: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]),
-        bid_price: z.number().optional()
-    }).passthrough()).optional(),
-    keyword_targets_remove: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    negative_keywords_add: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    negative_keywords_remove: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    start_time: StartTimingSchema.optional(),
+    end_time: z.string().optional(),
+    packages: z.array(PackageUpdateSchema).optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    new_packages: z.array(PackageRequestSchema).optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    idempotency_key: z.string(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const CreativeAsset1Schema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatIDSchema,
+    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset1Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset1Schema, MarkdownAssetSchema, BriefAsset1Schema, CatalogAsset1Schema])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const CreatePropertyListResponseSchema = z.object({
@@ -6093,12 +6197,21 @@ export const GetProductsResponseSchema = z.object({
     errors: z.array(ErrorSchema).optional(),
     property_list_applied: z.boolean().optional(),
     catalog_applied: z.boolean().optional(),
-    refinement_applied: z.array(z.object({
-        scope: z.union([z.literal("request"), z.literal("product"), z.literal("proposal")]).optional(),
-        id: z.string().optional(),
-        status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
-        notes: z.string().optional()
-    }).passthrough()).optional(),
+    refinement_applied: z.array(z.union([z.object({
+            scope: z.literal("request"),
+            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+            notes: z.string().optional()
+        }).passthrough(), z.object({
+            scope: z.literal("product"),
+            product_id: z.string(),
+            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+            notes: z.string().optional()
+        }).passthrough(), z.object({
+            scope: z.literal("proposal"),
+            proposal_id: z.string(),
+            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+            notes: z.string().optional()
+        }).passthrough()])).optional(),
     incomplete: z.array(z.object({
         scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals")]),
         description: z.string(),
@@ -6124,68 +6237,7 @@ export const ListCreativeFormatsResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
-    plan_id: z.string().optional(),
-    account: AccountReferenceSchema,
-    proposal_id: z.string().optional(),
-    total_budget: z.object({
-        amount: z.number(),
-        currency: z.string()
-    }).passthrough().optional(),
-    packages: z.array(PackageRequestSchema).optional(),
-    brand: BrandReferenceSchema,
-    advertiser_industry: AdvertiserIndustrySchema.optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    io_acceptance: z.object({
-        io_id: z.string(),
-        accepted_at: z.string(),
-        signatory: z.string(),
-        signature_id: z.string().optional()
-    }).passthrough().optional(),
-    po_number: z.string().optional(),
-    agency_estimate_number: z.string().optional(),
-    start_time: StartTimingSchema,
-    end_time: z.string(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    artifact_webhook: z.object({
-        url: z.string(),
-        token: z.string().optional(),
-        authentication: z.object({
-            schemes: z.array(AuthenticationSchemeSchema),
-            credentials: z.string()
-        }).passthrough(),
-        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
-        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
-        sampling_rate: z.number().optional()
-    }).passthrough().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const CreateMediaBuyResponseSchema = z.union([CreateMediaBuySuccessSchema, CreateMediaBuyErrorSchema, CreateMediaBuySubmittedSchema]);
-
-export const UpdateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    account: AccountReferenceSchema,
-    media_buy_id: z.string(),
-    revision: z.number().optional(),
-    paused: z.boolean().optional(),
-    canceled: z.literal(true).optional(),
-    cancellation_reason: z.string().optional(),
-    start_time: StartTimingSchema.optional(),
-    end_time: z.string().optional(),
-    packages: z.array(PackageUpdateSchema).optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    new_packages: z.array(PackageRequestSchema).optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
 
 export const CreateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-22T04:07:18.853Z
+// Generated at: 2026-04-22T02:47:27.524Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -306,7 +306,6 @@ export const CreativeStatusSchema = z.union([z.literal("processing"), z.literal(
 export const CreativeIdentifierTypeSchema = z.union([z.literal("ad_id"), z.literal("isci"), z.literal("clearcast_clock")]);
 
 export const ImageAssetSchema = z.object({
-    asset_type: z.literal("image"),
     url: z.string(),
     width: z.number(),
     height: z.number(),
@@ -316,7 +315,6 @@ export const ImageAssetSchema = z.object({
 }).passthrough();
 
 export const VideoAssetSchema = z.object({
-    asset_type: z.literal("video"),
     url: z.string(),
     width: z.number(),
     height: z.number(),
@@ -350,7 +348,6 @@ export const VideoAssetSchema = z.object({
 }).passthrough();
 
 export const AudioAssetSchema = z.object({
-    asset_type: z.literal("audio"),
     url: z.string(),
     duration_ms: z.number().optional(),
     file_size_bytes: z.number().optional(),
@@ -366,32 +363,35 @@ export const AudioAssetSchema = z.object({
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const VASTAssetSchema = z.object({
-    asset_type: z.literal("vast"),
-    vast_version: VASTVersionSchema.optional(),
-    vpaid_enabled: z.boolean().optional(),
-    duration_ms: z.number().optional(),
-    tracking_events: z.array(VASTTrackingEventSchema).optional(),
-    captions_url: z.string().optional(),
-    audio_description_url: z.string().optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough().and(z.union([z.object({
+export const VASTAssetSchema = z.union([z.object({
         delivery_type: z.literal("url"),
-        url: z.string()
+        url: z.string(),
+        vast_version: VASTVersionSchema.optional(),
+        vpaid_enabled: z.boolean().optional(),
+        duration_ms: z.number().optional(),
+        tracking_events: z.array(VASTTrackingEventSchema).optional(),
+        captions_url: z.string().optional(),
+        audio_description_url: z.string().optional(),
+        provenance: ProvenanceSchema.optional()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
-        content: z.string()
-    }).passthrough()]));
+        content: z.string(),
+        vast_version: VASTVersionSchema.optional(),
+        vpaid_enabled: z.boolean().optional(),
+        duration_ms: z.number().optional(),
+        tracking_events: z.array(VASTTrackingEventSchema).optional(),
+        captions_url: z.string().optional(),
+        audio_description_url: z.string().optional(),
+        provenance: ProvenanceSchema.optional()
+    }).passthrough()]);
 
 export const TextAssetSchema = z.object({
-    asset_type: z.literal("text"),
     content: z.string(),
     language: z.string().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const URLAssetSchema = z.object({
-    asset_type: z.literal("url"),
     url: z.string(),
     url_type: URLAssetTypeSchema.optional(),
     description: z.string().optional(),
@@ -399,7 +399,6 @@ export const URLAssetSchema = z.object({
 }).passthrough();
 
 export const HTMLAssetSchema = z.object({
-    asset_type: z.literal("html"),
     content: z.string(),
     version: z.string().optional(),
     accessibility: z.object({
@@ -412,7 +411,6 @@ export const HTMLAssetSchema = z.object({
 }).passthrough();
 
 export const JavaScriptAssetSchema = z.object({
-    asset_type: z.literal("javascript"),
     content: z.string(),
     module_type: JavaScriptModuleTypeSchema.optional(),
     accessibility: z.object({
@@ -425,7 +423,6 @@ export const JavaScriptAssetSchema = z.object({
 }).passthrough();
 
 export const WebhookAssetSchema = z.object({
-    asset_type: z.literal("webhook"),
     url: z.string(),
     method: HTTPMethodSchema.optional(),
     timeout_ms: z.number().optional(),
@@ -441,39 +438,39 @@ export const WebhookAssetSchema = z.object({
 }).passthrough();
 
 export const CSSAssetSchema = z.object({
-    asset_type: z.literal("css"),
     content: z.string(),
     media: z.string().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const DAASTAssetSchema = z.object({
-    asset_type: z.literal("daast"),
-    daast_version: DAASTVersionSchema.optional(),
-    duration_ms: z.number().optional(),
-    tracking_events: z.array(DAASTTrackingEventSchema).optional(),
-    companion_ads: z.boolean().optional(),
-    transcript_url: z.string().optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough().and(z.union([z.object({
+export const DAASTAssetSchema = z.union([z.object({
         delivery_type: z.literal("url"),
-        url: z.string()
+        url: z.string(),
+        daast_version: DAASTVersionSchema.optional(),
+        duration_ms: z.number().optional(),
+        tracking_events: z.array(DAASTTrackingEventSchema).optional(),
+        companion_ads: z.boolean().optional(),
+        transcript_url: z.string().optional(),
+        provenance: ProvenanceSchema.optional()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
-        content: z.string()
-    }).passthrough()]));
+        content: z.string(),
+        daast_version: DAASTVersionSchema.optional(),
+        duration_ms: z.number().optional(),
+        tracking_events: z.array(DAASTTrackingEventSchema).optional(),
+        companion_ads: z.boolean().optional(),
+        transcript_url: z.string().optional(),
+        provenance: ProvenanceSchema.optional()
+    }).passthrough()]);
 
 export const MarkdownAssetSchema = z.object({
-    asset_type: z.literal("markdown"),
     content: z.string(),
     language: z.string().optional(),
     markdown_flavor: MarkdownFlavorSchema.optional(),
     allow_raw_html: z.boolean().optional()
 }).passthrough();
 
-export const CatalogAssetSchema = CatalogSchema.and(z.object({
-    asset_type: z.literal("catalog")
-}).passthrough());
+export const CatalogAssetSchema = CatalogSchema;
 
 export const IndustryIdentifierSchema = z.object({
     type: CreativeIdentifierTypeSchema,
@@ -2146,51 +2143,6 @@ export const CreativeQualitySchema = z.union([z.literal("draft"), z.literal("pro
 
 export const PreviewOutputFormatSchema = z.union([z.literal("url"), z.literal("html")]);
 
-export const VASTAsset1Schema = z.union([z.object({
-        delivery_type: z.literal("url"),
-        url: z.string()
-    }).passthrough(), z.object({
-        delivery_type: z.literal("inline"),
-        content: z.string()
-    }).passthrough()]);
-
-export const DAASTAsset1Schema = z.union([z.object({
-        delivery_type: z.literal("url"),
-        url: z.string()
-    }).passthrough(), z.object({
-        delivery_type: z.literal("inline"),
-        content: z.string()
-    }).passthrough()]);
-
-export const CreativeBriefSchema = z.object({
-    name: z.string(),
-    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
-    tone: z.string().optional(),
-    audience: z.string().optional(),
-    territory: z.string().optional(),
-    messaging: z.object({
-        headline: z.string().optional(),
-        tagline: z.string().optional(),
-        cta: z.string().optional(),
-        key_messages: z.array(z.string()).optional()
-    }).passthrough().optional(),
-    reference_assets: z.array(ReferenceAssetSchema).optional(),
-    compliance: z.object({
-        required_disclosures: z.array(z.object({
-            text: z.string(),
-            position: DisclosurePositionSchema.optional(),
-            jurisdictions: z.array(z.string()).optional(),
-            regulation: z.string().optional(),
-            min_duration_ms: z.number().optional(),
-            language: z.string().optional(),
-            persistence: DisclosurePersistenceSchema.optional()
-        }).passthrough()).optional(),
-        prohibited_claims: z.array(z.string()).optional()
-    }).passthrough().optional()
-}).passthrough();
-
-export const CatalogAsset1Schema = CatalogSchema;
-
 export const PreviewCreativeSingleResponseSchema = z.object({
     response_type: z.literal("single"),
     previews: z.array(z.object({
@@ -2631,8 +2583,6 @@ export const EventSourceHealthSchema = z.object({
 }).passthrough();
 
 export const AgeVerificationMethod1Schema = z.union([z.literal("facial_age_estimation"), z.literal("id_document"), z.literal("digital_id"), z.literal("credit_card"), z.literal("world_id")]);
-
-export const BriefAsset1Schema = CreativeBriefSchema;
 
 export const PublisherTagsSourceSchema = z.object({
     selection_type: z.literal("publisher_tags"),
@@ -3968,27 +3918,34 @@ export const BaseIndividualAssetSchema = z.object({
     overlays: z.array(OverlaySchema).optional()
 }).passthrough();
 
-export const BriefAssetSchema = CreativeBriefSchema.and(z.object({
-    asset_type: z.literal("brief")
-}).passthrough());
-
-export const CreativeAssetSchema = z.object({
-    creative_id: z.string(),
+export const CreativeBriefSchema = z.object({
     name: z.string(),
-    format_id: FormatIDSchema,
-    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
+    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
+    tone: z.string().optional(),
+    audience: z.string().optional(),
+    territory: z.string().optional(),
+    messaging: z.object({
+        headline: z.string().optional(),
+        tagline: z.string().optional(),
+        cta: z.string().optional(),
+        key_messages: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    reference_assets: z.array(ReferenceAssetSchema).optional(),
+    compliance: z.object({
+        required_disclosures: z.array(z.object({
+            text: z.string(),
+            position: DisclosurePositionSchema.optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            regulation: z.string().optional(),
+            min_duration_ms: z.number().optional(),
+            language: z.string().optional(),
+            persistence: DisclosurePersistenceSchema.optional()
+        }).passthrough()).optional(),
+        prohibited_claims: z.array(z.string()).optional()
+    }).passthrough().optional()
 }).passthrough();
+
+export const BriefAssetSchema = CreativeBriefSchema;
 
 export const PackageSchema = z.object({
     package_id: z.string(),
@@ -4040,65 +3997,22 @@ export const PlannedDeliverySchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PackageUpdateSchema = z.object({
-    package_id: z.string(),
-    budget: z.number().optional(),
-    pacing: PacingSchema.optional(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
-    paused: z.boolean().optional(),
-    canceled: z.literal(true).optional(),
-    cancellation_reason: z.string().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    keyword_targets_add: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]),
-        bid_price: z.number().optional()
+export const CreativeAssetSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatIDSchema,
+    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
     }).passthrough()).optional(),
-    keyword_targets_remove: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    negative_keywords_add: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    negative_keywords_remove: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const PackageRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    product_id: z.string(),
-    format_ids: z.array(FormatIDSchema).optional(),
-    budget: z.number(),
-    pacing: PacingSchema.optional(),
-    pricing_option_id: z.string(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
-    paused: z.boolean().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    measurement_terms: MeasurementTermsSchema.optional(),
-    performance_standards: z.array(PerformanceStandardSchema).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
-    agency_estimate_number: z.string().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const UpdateMediaBuySuccessSchema = z.object({
@@ -5893,43 +5807,26 @@ export const BuildCreativeRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreateMediaBuyRequestSchema = z.object({
+export const PackageRequestSchema = z.object({
     adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
-    plan_id: z.string().optional(),
-    account: AccountReferenceSchema,
-    proposal_id: z.string().optional(),
-    total_budget: z.object({
-        amount: z.number(),
-        currency: z.string()
-    }).passthrough().optional(),
-    packages: z.array(PackageRequestSchema).optional(),
-    brand: BrandReferenceSchema,
-    advertiser_industry: AdvertiserIndustrySchema.optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    io_acceptance: z.object({
-        io_id: z.string(),
-        accepted_at: z.string(),
-        signatory: z.string(),
-        signature_id: z.string().optional()
-    }).passthrough().optional(),
-    po_number: z.string().optional(),
+    product_id: z.string(),
+    format_ids: z.array(FormatIDSchema).optional(),
+    budget: z.number(),
+    pacing: PacingSchema.optional(),
+    pricing_option_id: z.string(),
+    bid_price: z.number().optional(),
+    impressions: z.number().optional(),
+    start_time: z.string().optional(),
+    end_time: z.string().optional(),
+    paused: z.boolean().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    measurement_terms: MeasurementTermsSchema.optional(),
+    performance_standards: z.array(PerformanceStandardSchema).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
     agency_estimate_number: z.string().optional(),
-    start_time: StartTimingSchema,
-    end_time: z.string(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    artifact_webhook: z.object({
-        url: z.string(),
-        token: z.string().optional(),
-        authentication: z.object({
-            schemes: z.array(AuthenticationSchemeSchema),
-            credentials: z.string()
-        }).passthrough(),
-        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
-        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
-        sampling_rate: z.number().optional()
-    }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -5943,13 +5840,13 @@ export const GetProductsRequestSchema = z.object({
             ask: z.string()
         }).passthrough(), z.object({
             scope: z.literal("product"),
-            product_id: z.string(),
-            action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]).optional(),
+            id: z.string(),
+            action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]),
             ask: z.string().optional()
         }).passthrough(), z.object({
             scope: z.literal("proposal"),
-            proposal_id: z.string(),
-            action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]).optional(),
+            id: z.string(),
+            action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]),
             ask: z.string().optional()
         }).passthrough()])).optional(),
     brand: BrandReferenceSchema.optional(),
@@ -5978,42 +5875,41 @@ export const LogEventRequestSchema = z.object({
 
 export const SyncEventSourcesResponseSchema = z.union([SyncEventSourcesSuccessSchema, SyncEventSourcesErrorSchema]);
 
-export const UpdateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    account: AccountReferenceSchema,
-    media_buy_id: z.string(),
-    revision: z.number().optional(),
+export const PackageUpdateSchema = z.object({
+    package_id: z.string(),
+    budget: z.number().optional(),
+    pacing: PacingSchema.optional(),
+    bid_price: z.number().optional(),
+    impressions: z.number().optional(),
+    start_time: z.string().optional(),
+    end_time: z.string().optional(),
     paused: z.boolean().optional(),
     canceled: z.literal(true).optional(),
     cancellation_reason: z.string().optional(),
-    start_time: StartTimingSchema.optional(),
-    end_time: z.string().optional(),
-    packages: z.array(PackageUpdateSchema).optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    new_packages: z.array(PackageRequestSchema).optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    keyword_targets_add: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]),
+        bid_price: z.number().optional()
+    }).passthrough()).optional(),
+    keyword_targets_remove: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    negative_keywords_add: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    negative_keywords_remove: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const CreativeAsset1Schema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatIDSchema,
-    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset1Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset1Schema, MarkdownAssetSchema, BriefAsset1Schema, CatalogAsset1Schema])),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const CreatePropertyListResponseSchema = z.object({
@@ -6197,21 +6093,12 @@ export const GetProductsResponseSchema = z.object({
     errors: z.array(ErrorSchema).optional(),
     property_list_applied: z.boolean().optional(),
     catalog_applied: z.boolean().optional(),
-    refinement_applied: z.array(z.union([z.object({
-            scope: z.literal("request"),
-            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
-            notes: z.string().optional()
-        }).passthrough(), z.object({
-            scope: z.literal("product"),
-            product_id: z.string(),
-            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
-            notes: z.string().optional()
-        }).passthrough(), z.object({
-            scope: z.literal("proposal"),
-            proposal_id: z.string(),
-            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
-            notes: z.string().optional()
-        }).passthrough()])).optional(),
+    refinement_applied: z.array(z.object({
+        scope: z.union([z.literal("request"), z.literal("product"), z.literal("proposal")]).optional(),
+        id: z.string().optional(),
+        status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+        notes: z.string().optional()
+    }).passthrough()).optional(),
     incomplete: z.array(z.object({
         scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals")]),
         description: z.string(),
@@ -6237,7 +6124,68 @@ export const ListCreativeFormatsResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const CreateMediaBuyRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    idempotency_key: z.string(),
+    plan_id: z.string().optional(),
+    account: AccountReferenceSchema,
+    proposal_id: z.string().optional(),
+    total_budget: z.object({
+        amount: z.number(),
+        currency: z.string()
+    }).passthrough().optional(),
+    packages: z.array(PackageRequestSchema).optional(),
+    brand: BrandReferenceSchema,
+    advertiser_industry: AdvertiserIndustrySchema.optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    io_acceptance: z.object({
+        io_id: z.string(),
+        accepted_at: z.string(),
+        signatory: z.string(),
+        signature_id: z.string().optional()
+    }).passthrough().optional(),
+    po_number: z.string().optional(),
+    agency_estimate_number: z.string().optional(),
+    start_time: StartTimingSchema,
+    end_time: z.string(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    artifact_webhook: z.object({
+        url: z.string(),
+        token: z.string().optional(),
+        authentication: z.object({
+            schemes: z.array(AuthenticationSchemeSchema),
+            credentials: z.string()
+        }).passthrough(),
+        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
+        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
+        sampling_rate: z.number().optional()
+    }).passthrough().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
 export const CreateMediaBuyResponseSchema = z.union([CreateMediaBuySuccessSchema, CreateMediaBuyErrorSchema, CreateMediaBuySubmittedSchema]);
+
+export const UpdateMediaBuyRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    account: AccountReferenceSchema,
+    media_buy_id: z.string(),
+    revision: z.number().optional(),
+    paused: z.boolean().optional(),
+    canceled: z.literal(true).optional(),
+    cancellation_reason: z.string().optional(),
+    start_time: StartTimingSchema.optional(),
+    end_time: z.string().optional(),
+    packages: z.array(PackageUpdateSchema).optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    new_packages: z.array(PackageRequestSchema).optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    idempotency_key: z.string(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
 
 export const CreateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -279,11 +279,11 @@ export interface GetProductsRequest {
         /**
          * Product ID from a previous get_products response.
          */
-        product_id: string;
+        id: string;
         /**
-         * 'include' (default): return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned). Optional — when omitted, the seller treats the entry as action: 'include'.
+         * 'include': return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned).
          */
-        action?: 'include' | 'omit' | 'more_like_this';
+        action: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
          */
@@ -297,11 +297,11 @@ export interface GetProductsRequest {
         /**
          * Proposal ID from a previous get_products response.
          */
-        proposal_id: string;
+        id: string;
         /**
-         * 'include' (default): return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result. Optional — when omitted, the seller treats the entry as action: 'include'.
+         * 'include': return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result.
          */
-        action?: 'include' | 'omit' | 'finalize';
+        action: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
          */
@@ -1041,60 +1041,26 @@ export interface GetProductsResponse {
    */
   catalog_applied?: boolean;
   /**
-   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'. Each entry MUST echo the request entry's scope and — for product and proposal scopes — the matching id field (product_id or proposal_id), so orchestrators can cross-validate alignment.
+   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'.
    */
-  refinement_applied?: (
-    | {
-        /**
-         * Echoes scope 'request' from the corresponding refine entry.
-         */
-        scope: 'request';
-        /**
-         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-         */
-        status: 'applied' | 'partial' | 'unable';
-        /**
-         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-         */
-        notes?: string;
-      }
-    | {
-        /**
-         * Echoes scope 'product' from the corresponding refine entry.
-         */
-        scope: 'product';
-        /**
-         * Echoes product_id from the corresponding refine entry.
-         */
-        product_id: string;
-        /**
-         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-         */
-        status: 'applied' | 'partial' | 'unable';
-        /**
-         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-         */
-        notes?: string;
-      }
-    | {
-        /**
-         * Echoes scope 'proposal' from the corresponding refine entry.
-         */
-        scope: 'proposal';
-        /**
-         * Echoes proposal_id from the corresponding refine entry.
-         */
-        proposal_id: string;
-        /**
-         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-         */
-        status: 'applied' | 'partial' | 'unable';
-        /**
-         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-         */
-        notes?: string;
-      }
-  )[];
+  refinement_applied?: {
+    /**
+     * Echoes the scope from the corresponding refine entry. Allows orchestrators to cross-validate alignment.
+     */
+    scope?: 'request' | 'product' | 'proposal';
+    /**
+     * Echoes the id from the corresponding refine entry (for product and proposal scopes).
+     */
+    id?: string;
+    /**
+     * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+     */
+    status: 'applied' | 'partial' | 'unable';
+    /**
+     * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+     */
+    notes?: string;
+  }[];
   /**
    * Declares what the seller could not finish within the buyer's time_budget or due to internal limits. Each entry identifies a scope that is missing or partial. Absent when the response is fully complete.
    */
@@ -3332,34 +3298,7 @@ export type DigitalSourceType =
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving
  */
-export type VASTAsset = {
-  /**
-   * Discriminator identifying this as a VAST asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'vast';
-  vast_version?: VASTVersion;
-  /**
-   * Whether VPAID (Video Player-Ad Interface Definition) is supported
-   */
-  vpaid_enabled?: boolean;
-  /**
-   * Expected video duration in milliseconds (if known)
-   */
-  duration_ms?: number;
-  /**
-   * Tracking events supported by this VAST tag
-   */
-  tracking_events?: VASTTrackingEvent[];
-  /**
-   * URL to captions file (WebVTT, SRT, etc.)
-   */
-  captions_url?: string;
-  /**
-   * URL to audio description track for visually impaired users
-   */
-  audio_description_url?: string;
-  provenance?: Provenance;
-} & (
+export type VASTAsset =
   | {
       /**
        * Discriminator indicating VAST is delivered via URL endpoint
@@ -3369,6 +3308,28 @@ export type VASTAsset = {
        * URL endpoint that returns VAST XML
        */
       url: string;
+      vast_version?: VASTVersion;
+      /**
+       * Whether VPAID (Video Player-Ad Interface Definition) is supported
+       */
+      vpaid_enabled?: boolean;
+      /**
+       * Expected video duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this VAST tag
+       */
+      tracking_events?: VASTTrackingEvent[];
+      /**
+       * URL to captions file (WebVTT, SRT, etc.)
+       */
+      captions_url?: string;
+      /**
+       * URL to audio description track for visually impaired users
+       */
+      audio_description_url?: string;
+      provenance?: Provenance;
     }
   | {
       /**
@@ -3379,8 +3340,29 @@ export type VASTAsset = {
        * Inline VAST XML content
        */
       content: string;
-    }
-);
+      vast_version?: VASTVersion;
+      /**
+       * Whether VPAID (Video Player-Ad Interface Definition) is supported
+       */
+      vpaid_enabled?: boolean;
+      /**
+       * Expected video duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this VAST tag
+       */
+      tracking_events?: VASTTrackingEvent[];
+      /**
+       * URL to captions file (WebVTT, SRT, etc.)
+       */
+      captions_url?: string;
+      /**
+       * URL to audio description track for visually impaired users
+       */
+      audio_description_url?: string;
+      provenance?: Provenance;
+    };
 /**
  * VAST specification version
  */
@@ -3444,30 +3426,7 @@ export type WebhookSecurityMethod = 'hmac_sha256' | 'api_key' | 'none';
 /**
  * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
  */
-export type DAASTAsset = {
-  /**
-   * Discriminator identifying this as a DAAST asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'daast';
-  daast_version?: DAASTVersion;
-  /**
-   * Expected audio duration in milliseconds (if known)
-   */
-  duration_ms?: number;
-  /**
-   * Tracking events supported by this DAAST tag
-   */
-  tracking_events?: DAASTTrackingEvent[];
-  /**
-   * Whether companion display ads are included
-   */
-  companion_ads?: boolean;
-  /**
-   * URL to text transcript of the audio content
-   */
-  transcript_url?: string;
-  provenance?: Provenance;
-} & (
+export type DAASTAsset =
   | {
       /**
        * Discriminator indicating DAAST is delivered via URL endpoint
@@ -3477,6 +3436,24 @@ export type DAASTAsset = {
        * URL endpoint that returns DAAST XML
        */
       url: string;
+      daast_version?: DAASTVersion;
+      /**
+       * Expected audio duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this DAAST tag
+       */
+      tracking_events?: DAASTTrackingEvent[];
+      /**
+       * Whether companion display ads are included
+       */
+      companion_ads?: boolean;
+      /**
+       * URL to text transcript of the audio content
+       */
+      transcript_url?: string;
+      provenance?: Provenance;
     }
   | {
       /**
@@ -3487,8 +3464,25 @@ export type DAASTAsset = {
        * Inline DAAST XML content
        */
       content: string;
-    }
-);
+      daast_version?: DAASTVersion;
+      /**
+       * Expected audio duration in milliseconds (if known)
+       */
+      duration_ms?: number;
+      /**
+       * Tracking events supported by this DAAST tag
+       */
+      tracking_events?: DAASTTrackingEvent[];
+      /**
+       * Whether companion display ads are included
+       */
+      companion_ads?: boolean;
+      /**
+       * URL to text transcript of the audio content
+       */
+      transcript_url?: string;
+      provenance?: Provenance;
+    };
 /**
  * DAAST specification version
  */
@@ -3527,21 +3521,11 @@ export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
  * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export type BriefAsset = CreativeBrief & {
-  /**
-   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'brief';
-};
+export type BriefAsset = CreativeBrief;
 /**
  * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
  */
-export type CatalogAsset = Catalog & {
-  /**
-   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'catalog';
-};
+export type CatalogAsset = Catalog;
 /**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
@@ -4056,7 +4040,7 @@ export interface CreativeAsset {
   name: string;
   format_id: FormatID;
   /**
-   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   * Assets required by the format, keyed by asset_id
    */
   assets: {
     /**
@@ -4121,10 +4105,6 @@ export interface CreativeAsset {
  * Image asset with URL and dimensions
  */
 export interface ImageAsset {
-  /**
-   * Discriminator identifying this as an image asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'image';
   /**
    * URL to the image asset
    */
@@ -4280,10 +4260,6 @@ export interface Provenance {
  */
 export interface VideoAsset {
   /**
-   * Discriminator identifying this as a video asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'video';
-  /**
    * URL to the video asset
    */
   url: string;
@@ -4406,10 +4382,6 @@ export interface VideoAsset {
  */
 export interface AudioAsset {
   /**
-   * Discriminator identifying this as an audio asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'audio';
-  /**
    * URL to the audio asset
    */
   url: string;
@@ -4464,10 +4436,6 @@ export interface AudioAsset {
  */
 export interface TextAsset {
   /**
-   * Discriminator identifying this as a text asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'text';
-  /**
    * Text content
    */
   content: string;
@@ -4481,10 +4449,6 @@ export interface TextAsset {
  * URL reference asset
  */
 export interface URLAsset {
-  /**
-   * Discriminator identifying this as a URL asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'url';
   /**
    * URL reference. May be a plain URI or an RFC 6570 URI template carrying AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`). Buyers MUST NOT pre-encode macro braces at sync time; the ad server URL-encodes substituted values at impression time. See docs/creative/universal-macros.mdx.
    */
@@ -4500,10 +4464,6 @@ export interface URLAsset {
  * HTML content asset
  */
 export interface HTMLAsset {
-  /**
-   * Discriminator identifying this as an HTML asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'html';
   /**
    * HTML content
    */
@@ -4540,10 +4500,6 @@ export interface HTMLAsset {
  */
 export interface JavaScriptAsset {
   /**
-   * Discriminator identifying this as a JavaScript asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'javascript';
-  /**
    * JavaScript content
    */
   content: string;
@@ -4575,10 +4531,6 @@ export interface JavaScriptAsset {
  * Webhook for server-side dynamic content rendering (DCO)
  */
 export interface WebhookAsset {
-  /**
-   * Discriminator identifying this as a webhook asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'webhook';
   /**
    * Webhook URL to call for dynamic content
    */
@@ -4618,10 +4570,6 @@ export interface WebhookAsset {
  */
 export interface CSSAsset {
   /**
-   * Discriminator identifying this as a CSS asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'css';
-  /**
    * CSS content
    */
   content: string;
@@ -4635,10 +4583,6 @@ export interface CSSAsset {
  * Markdown-formatted text content following CommonMark specification
  */
 export interface MarkdownAsset {
-  /**
-   * Discriminator identifying this as a markdown asset. See /schemas/creative/asset-types for the registry.
-   */
-  asset_type: 'markdown';
   /**
    * Markdown content following CommonMark spec with optional GitHub Flavored Markdown extensions
    */
@@ -7542,7 +7486,7 @@ export interface CreativeManifest {
   /**
    * Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.
    *
-   * Each asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
+   * IMPORTANT: Full validation requires format context. The format defines what type each asset_id should be. Standalone schema validation only checks structural conformance — each asset must match at least one valid asset type schema.
    */
   assets: {
     /**
@@ -8617,7 +8561,7 @@ export interface ListCreativesResponse {
      */
     updated_date: string;
     /**
-     * Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+     * Assets for this creative, keyed by asset_id
      */
     assets?: {
       /**
@@ -11316,7 +11260,7 @@ export interface ReportPlanOutcomeRequest {
    */
   adcp_major_version?: number;
   /**
-   * The plan this outcome is for. The plan uniquely scopes the account and operator; do not include a separate `account` field — the governance agent resolves account from the plan. Including `account` is rejected by `additionalProperties: false`.
+   * The plan this outcome is for.
    */
   plan_id: string;
   /**
@@ -11475,7 +11419,7 @@ export type GetPlanAuditLogsRequest = {
    */
   adcp_major_version?: number;
   /**
-   * Plan IDs to retrieve. For a single plan, pass a one-element array. Plans uniquely scope account and operator; do not include a separate `account` field — the governance agent resolves account from each plan. Including `account` is rejected by `additionalProperties: false`.
+   * Plan IDs to retrieve. For a single plan, pass a one-element array.
    */
   plan_ids?: string[];
   /**
@@ -11775,7 +11719,7 @@ export interface CheckGovernanceRequest {
    */
   adcp_major_version?: number;
   /**
-   * Campaign governance plan identifier. The plan uniquely scopes the account and operator; do not include a separate `account` field — the governance agent resolves account from the plan. Including `account` is rejected by `additionalProperties: false`.
+   * Campaign governance plan identifier.
    */
   plan_id: string;
   /**

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -279,11 +279,11 @@ export interface GetProductsRequest {
         /**
          * Product ID from a previous get_products response.
          */
-        id: string;
+        product_id: string;
         /**
-         * 'include': return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned).
+         * 'include' (default): return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned). Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'more_like_this';
+        action?: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
          */
@@ -297,11 +297,11 @@ export interface GetProductsRequest {
         /**
          * Proposal ID from a previous get_products response.
          */
-        id: string;
+        proposal_id: string;
         /**
-         * 'include': return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result.
+         * 'include' (default): return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result. Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'finalize';
+        action?: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
          */
@@ -1041,26 +1041,60 @@ export interface GetProductsResponse {
    */
   catalog_applied?: boolean;
   /**
-   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'.
+   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'. Each entry MUST echo the request entry's scope and — for product and proposal scopes — the matching id field (product_id or proposal_id), so orchestrators can cross-validate alignment.
    */
-  refinement_applied?: {
-    /**
-     * Echoes the scope from the corresponding refine entry. Allows orchestrators to cross-validate alignment.
-     */
-    scope?: 'request' | 'product' | 'proposal';
-    /**
-     * Echoes the id from the corresponding refine entry (for product and proposal scopes).
-     */
-    id?: string;
-    /**
-     * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-     */
-    status: 'applied' | 'partial' | 'unable';
-    /**
-     * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-     */
-    notes?: string;
-  }[];
+  refinement_applied?: (
+    | {
+        /**
+         * Echoes scope 'request' from the corresponding refine entry.
+         */
+        scope: 'request';
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'product' from the corresponding refine entry.
+         */
+        scope: 'product';
+        /**
+         * Echoes product_id from the corresponding refine entry.
+         */
+        product_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'proposal' from the corresponding refine entry.
+         */
+        scope: 'proposal';
+        /**
+         * Echoes proposal_id from the corresponding refine entry.
+         */
+        proposal_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+  )[];
   /**
    * Declares what the seller could not finish within the buyer's time_budget or due to internal limits. Each entry identifies a scope that is missing or partial. Absent when the response is fully complete.
    */
@@ -3298,7 +3332,34 @@ export type DigitalSourceType =
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving
  */
-export type VASTAsset =
+export type VASTAsset = {
+  /**
+   * Discriminator identifying this as a VAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'vast';
+  vast_version?: VASTVersion;
+  /**
+   * Whether VPAID (Video Player-Ad Interface Definition) is supported
+   */
+  vpaid_enabled?: boolean;
+  /**
+   * Expected video duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this VAST tag
+   */
+  tracking_events?: VASTTrackingEvent[];
+  /**
+   * URL to captions file (WebVTT, SRT, etc.)
+   */
+  captions_url?: string;
+  /**
+   * URL to audio description track for visually impaired users
+   */
+  audio_description_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating VAST is delivered via URL endpoint
@@ -3308,28 +3369,6 @@ export type VASTAsset =
        * URL endpoint that returns VAST XML
        */
       url: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -3340,29 +3379,8 @@ export type VASTAsset =
        * Inline VAST XML content
        */
       content: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * VAST specification version
  */
@@ -3426,7 +3444,30 @@ export type WebhookSecurityMethod = 'hmac_sha256' | 'api_key' | 'none';
 /**
  * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
  */
-export type DAASTAsset =
+export type DAASTAsset = {
+  /**
+   * Discriminator identifying this as a DAAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'daast';
+  daast_version?: DAASTVersion;
+  /**
+   * Expected audio duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this DAAST tag
+   */
+  tracking_events?: DAASTTrackingEvent[];
+  /**
+   * Whether companion display ads are included
+   */
+  companion_ads?: boolean;
+  /**
+   * URL to text transcript of the audio content
+   */
+  transcript_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating DAAST is delivered via URL endpoint
@@ -3436,24 +3477,6 @@ export type DAASTAsset =
        * URL endpoint that returns DAAST XML
        */
       url: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -3464,25 +3487,8 @@ export type DAASTAsset =
        * Inline DAAST XML content
        */
       content: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * DAAST specification version
  */
@@ -3521,11 +3527,21 @@ export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
  * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export type BriefAsset = CreativeBrief;
+export type BriefAsset = CreativeBrief & {
+  /**
+   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'brief';
+};
 /**
  * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
  */
-export type CatalogAsset = Catalog;
+export type CatalogAsset = Catalog & {
+  /**
+   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'catalog';
+};
 /**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
@@ -4040,7 +4056,7 @@ export interface CreativeAsset {
   name: string;
   format_id: FormatID;
   /**
-   * Assets required by the format, keyed by asset_id
+   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
    */
   assets: {
     /**
@@ -4105,6 +4121,10 @@ export interface CreativeAsset {
  * Image asset with URL and dimensions
  */
 export interface ImageAsset {
+  /**
+   * Discriminator identifying this as an image asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'image';
   /**
    * URL to the image asset
    */
@@ -4260,6 +4280,10 @@ export interface Provenance {
  */
 export interface VideoAsset {
   /**
+   * Discriminator identifying this as a video asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'video';
+  /**
    * URL to the video asset
    */
   url: string;
@@ -4382,6 +4406,10 @@ export interface VideoAsset {
  */
 export interface AudioAsset {
   /**
+   * Discriminator identifying this as an audio asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'audio';
+  /**
    * URL to the audio asset
    */
   url: string;
@@ -4436,6 +4464,10 @@ export interface AudioAsset {
  */
 export interface TextAsset {
   /**
+   * Discriminator identifying this as a text asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'text';
+  /**
    * Text content
    */
   content: string;
@@ -4449,6 +4481,10 @@ export interface TextAsset {
  * URL reference asset
  */
 export interface URLAsset {
+  /**
+   * Discriminator identifying this as a URL asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'url';
   /**
    * URL reference. May be a plain URI or an RFC 6570 URI template carrying AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`). Buyers MUST NOT pre-encode macro braces at sync time; the ad server URL-encodes substituted values at impression time. See docs/creative/universal-macros.mdx.
    */
@@ -4464,6 +4500,10 @@ export interface URLAsset {
  * HTML content asset
  */
 export interface HTMLAsset {
+  /**
+   * Discriminator identifying this as an HTML asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'html';
   /**
    * HTML content
    */
@@ -4500,6 +4540,10 @@ export interface HTMLAsset {
  */
 export interface JavaScriptAsset {
   /**
+   * Discriminator identifying this as a JavaScript asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'javascript';
+  /**
    * JavaScript content
    */
   content: string;
@@ -4531,6 +4575,10 @@ export interface JavaScriptAsset {
  * Webhook for server-side dynamic content rendering (DCO)
  */
 export interface WebhookAsset {
+  /**
+   * Discriminator identifying this as a webhook asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'webhook';
   /**
    * Webhook URL to call for dynamic content
    */
@@ -4570,6 +4618,10 @@ export interface WebhookAsset {
  */
 export interface CSSAsset {
   /**
+   * Discriminator identifying this as a CSS asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'css';
+  /**
    * CSS content
    */
   content: string;
@@ -4583,6 +4635,10 @@ export interface CSSAsset {
  * Markdown-formatted text content following CommonMark specification
  */
 export interface MarkdownAsset {
+  /**
+   * Discriminator identifying this as a markdown asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'markdown';
   /**
    * Markdown content following CommonMark spec with optional GitHub Flavored Markdown extensions
    */
@@ -7486,7 +7542,7 @@ export interface CreativeManifest {
   /**
    * Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.
    *
-   * IMPORTANT: Full validation requires format context. The format defines what type each asset_id should be. Standalone schema validation only checks structural conformance — each asset must match at least one valid asset type schema.
+   * Each asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
    */
   assets: {
     /**
@@ -8561,7 +8617,7 @@ export interface ListCreativesResponse {
      */
     updated_date: string;
     /**
-     * Assets for this creative, keyed by asset_id
+     * Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
      */
     assets?: {
       /**
@@ -11260,7 +11316,7 @@ export interface ReportPlanOutcomeRequest {
    */
   adcp_major_version?: number;
   /**
-   * The plan this outcome is for.
+   * The plan this outcome is for. The plan uniquely scopes the account and operator; do not include a separate `account` field — the governance agent resolves account from the plan. Including `account` is rejected by `additionalProperties: false`.
    */
   plan_id: string;
   /**
@@ -11419,7 +11475,7 @@ export type GetPlanAuditLogsRequest = {
    */
   adcp_major_version?: number;
   /**
-   * Plan IDs to retrieve. For a single plan, pass a one-element array.
+   * Plan IDs to retrieve. For a single plan, pass a one-element array. Plans uniquely scope account and operator; do not include a separate `account` field — the governance agent resolves account from each plan. Including `account` is rejected by `additionalProperties: false`.
    */
   plan_ids?: string[];
   /**
@@ -11719,7 +11775,7 @@ export interface CheckGovernanceRequest {
    */
   adcp_major_version?: number;
   /**
-   * Campaign governance plan identifier.
+   * Campaign governance plan identifier. The plan uniquely scopes the account and operator; do not include a separate `account` field — the governance agent resolves account from the plan. Including `account` is rejected by `additionalProperties: false`.
    */
   plan_id: string;
   /**

--- a/test/lib/cli-oauth-flag.test.js
+++ b/test/lib/cli-oauth-flag.test.js
@@ -1,0 +1,46 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+
+function runCli(args) {
+  return spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
+}
+
+test('storyboard run --oauth with a raw URL prints a save-first warning and proceeds (human mode)', () => {
+  const result = runCli([
+    'storyboard',
+    'run',
+    'https://example.test/mcp',
+    '--oauth',
+    '--dry-run',
+    '--storyboards',
+    'security_baseline',
+  ]);
+  assert.match(result.stderr, /--oauth requires a saved agent alias/, `stderr: ${result.stderr}`);
+  assert.match(result.stderr, /Save first: adcp --save-auth <alias> https:\/\/example\.test\/mcp --oauth/);
+});
+
+test('storyboard run --oauth --json with a raw URL emits structured error and exits 2', () => {
+  const result = runCli(['storyboard', 'run', 'https://example.test/mcp', '--oauth', '--json', '--dry-run']);
+  assert.strictEqual(result.status, 2, `expected exit 2, got ${result.status}. stderr: ${result.stderr}`);
+  const lines = result.stdout.trim().split('\n');
+  // The structured error is on stdout; the last parsable JSON line is what
+  // CI jobs look at. Find it rather than asserting it's the first line, so
+  // unrelated stdout noise (sync-version banner etc.) doesn't brittle-fail.
+  const payload = lines
+    .reverse()
+    .map(l => {
+      try {
+        return JSON.parse(l);
+      } catch {
+        return null;
+      }
+    })
+    .find(p => p && p.error === 'oauth_requires_alias');
+  assert.ok(payload, `expected oauth_requires_alias payload, got stdout=\n${result.stdout}`);
+  assert.strictEqual(payload.success, false);
+  assert.match(payload.message, /Save first:/);
+});

--- a/test/lib/conformance-seeder.test.js
+++ b/test/lib/conformance-seeder.test.js
@@ -152,7 +152,7 @@ describe('conformance: seedFixtures', () => {
 
     assert.deepEqual(result.fixtures.creative_ids, ['cre_seeded_abc']);
     assert.equal(observed.formatIds[0], 'text_line');
-    assert.deepEqual(observed.assets[0], { headline: { content: 'Conformance seed text' } });
+    assert.deepEqual(observed.assets[0], { headline: { asset_type: 'text', content: 'Conformance seed text' } });
     assert.deepEqual(result.warnings, []);
   });
 

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -66,6 +66,7 @@ describe('SingleAgentClient Request Validation', () => {
                 format_id: { agent_url: 'https://test.example', id: 'format1' },
                 assets: {
                   video: {
+                    asset_type: 'video',
                     url: 'https://example.com/video.mp4',
                     width: 1920,
                     height: 1080,
@@ -608,6 +609,7 @@ describe('SingleAgentClient Request Validation', () => {
                 format_id: { agent_url: 'https://test.example', id: 'format1' },
                 assets: {
                   video: {
+                    asset_type: 'video',
                     url: 'https://example.com/video.mp4',
                     width: 1920,
                     height: 1080,

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -14,7 +14,7 @@ const {
 } = require('../../dist/lib/testing/storyboard/probes');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
 const { loadStoryboardFile } = require('../../dist/lib/testing/storyboard/loader');
-const { comply } = require('../../dist/lib/testing/compliance/comply');
+const { comply, detectAuthRejection } = require('../../dist/lib/testing/compliance/comply');
 const {
   validateTestKit,
   TestKitValidationError,
@@ -948,6 +948,72 @@ describe('comply() degraded-profile path (security_baseline against 401-on-disco
     } finally {
       server.close();
     }
+  });
+
+  it('detectAuthRejection classifies NeedsAuthorizationError-style messages as auth', async () => {
+    // Regression: `NeedsAuthorizationError.defaultMessage()` phrases the
+    // error as "Agent <url> requires OAuth authorization. ... Provide an
+    // OAuthFlowHandler or run an interactive flow to complete authorization."
+    // Those words never appear in the original keyword list
+    // (401/unauthorized/authentication/jws/jwt), and if the probe can't
+    // reach the agent (e.g., offline host), isAuth stays false and the
+    // operator sees "Agent unreachable" instead of the --save-auth hint.
+    //
+    // Point the agent URL at a closed port so the probe fallback fails
+    // cleanly (network-level error → catch block silently returns). With
+    // that guardrail, the keyword match is the only path to isAuth=true.
+    const errMsg =
+      'Agent https://example.test/mcp requires OAuth authorization. ' +
+      'Authorization server: https://example.test/mcp. ' +
+      'Provide an OAuthFlowHandler or run an interactive flow to complete authorization.';
+    const result = await detectAuthRejection('https://127.0.0.1:1/mcp', errMsg);
+    assert.strictEqual(result.isAuth, true, 'keyword match on "authorization"/"oauth" should classify as auth');
+    const hint = result.observations.find(o => o.category === 'auth' && /--save-auth/.test(o.message));
+    assert.ok(hint, `expected a --save-auth remediation hint, got ${JSON.stringify(result.observations)}`);
+    assert.match(hint.message, /--oauth/);
+  });
+
+  it('detectAuthRejection emits the OAuth hint even when OAuth metadata is not discoverable', async () => {
+    // Regression for the "hint only fires when discoverOAuthMetadata returns
+    // non-null" branch. An agent that 401s before its /.well-known/* chain
+    // resolves should still get an actionable hint — the wording in the
+    // error is sufficient signal that it's an OAuth agent.
+    const errMsg = 'Unauthorized — MCP server requires OAuth2 authorization';
+    const result = await detectAuthRejection('https://127.0.0.1:1/mcp', errMsg);
+    assert.strictEqual(result.isAuth, true);
+    const hint = result.observations.find(o => o.category === 'auth' && /--save-auth/.test(o.message));
+    assert.ok(hint, 'hint must fire on OAuth wording even without discovery');
+    assert.match(hint.message, /issuer: \(unknown\)/i);
+  });
+
+  it('detectAuthRejection does not mis-classify benign "authorization header" upstream errors as OAuth', async () => {
+    // Regression: an earlier draft matched the bare substring "authorization"
+    // which false-matched upstream proxy errors like this. With the keyword
+    // list restricted to OAuth-specific bigrams, this stays in the "not
+    // classified as auth" path and the operator sees the real network error.
+    const result = await detectAuthRejection(
+      'https://127.0.0.1:1/mcp',
+      'Failed to connect to oauth proxy upstream (authorization header missing)'
+    );
+    // Network-level failure with no 401/OAuth signal → not auth.
+    assert.strictEqual(
+      result.isAuth,
+      false,
+      'keyword tightening must not classify bare "authorization" / "oauth" substrings as auth'
+    );
+    assert.deepStrictEqual(result.observations, []);
+  });
+
+  it('detectAuthRejection does not mis-classify plain-bearer 401 as OAuth', async () => {
+    // Negative: a 401 with no OAuth signal in the error text and no
+    // discoverable OAuth metadata should stay on the "check your --auth
+    // token" path, not the OAuth remediation path.
+    const result = await detectAuthRejection('https://127.0.0.1:1/mcp', 'HTTP 401 Unauthorized: invalid token');
+    assert.strictEqual(result.isAuth, true);
+    const obs = result.observations.find(o => o.category === 'auth');
+    assert.ok(obs);
+    assert.doesNotMatch(obs.message, /--save-auth/, 'plain bearer 401 should not get the OAuth --save-auth hint');
+    assert.match(obs.message, /--auth token/);
   });
 
   it('falls back to auth_required when selected storyboards all require discovered tools', async () => {

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -454,7 +454,7 @@ describe('Zod Schema Validation', () => {
     const result = schemas.GetCreativeFeaturesRequestSchema.safeParse({
       creative_manifest: {
         format_id: { agent_url: 'https://creative.example.com', id: 'display_300x250' },
-        assets: { banner: { url: 'https://example.com/banner.jpg' } },
+        assets: { banner: { asset_type: 'image', url: 'https://example.com/banner.jpg', width: 300, height: 250 } },
       },
       feature_ids: ['viewability', 'brand_safety'],
     });


### PR DESCRIPTION
## Summary

- **Root cause**: `storyboard run` against an OAuth-protected agent reported `Agent unreachable — requires OAuth authorization` with no actionable hint. `detectAuthRejection`'s keyword list missed `NeedsAuthorizationError`'s "requires OAuth authorization" phrasing, so the classification fell through to the generic unreachable path and the `--save-auth --oauth` remediation observation never fired.
- **Fix classification**: keyword list now matches OAuth-specific bigrams (`oauth authorization`, `requires oauth`, `oauthflowhandler`, `www-authenticate`, `bearer realm`, etc.) instead of the bare substring "authorization" — that was also a security/DX false-match on benign errors like `"authorization header missing from upstream"` or `"failed to connect to oauth proxy"`. The remediation observation now fires whenever OAuth phrasing is present OR metadata is discoverable.
- **Inline `--oauth` on `storyboard run` and `storyboard step`**: opens the browser PKCE flow when the saved alias lacks valid tokens, persists them back, then continues the run. Matches the existing top-level `--oauth` contract. Raw URL + `--oauth` stays a warning in human mode and becomes a structured `oauth_requires_alias` error (exit 2) under `--json` so CI pipelines fail fast.
- **Shared helper hardening**: `ensureOAuthTokensForAlias` wraps cleanup in `try/finally`, persists silently-refreshed tokens on the happy path, and carries `oauth_code_verifier` so a crashed mid-flight PKCE attempt survives.
- **Docs**: `docs/CLI.md` and `docs/guides/VALIDATE-YOUR-AGENT.md` document both flows (pre-save + inline) and the CI path (save tokens once locally, ship `~/.adcp/agents.json` to the runner, drop `--oauth`).

## Test plan

- [x] Unit: `detectAuthRejection` classifies `NeedsAuthorizationError`-style messages as auth, emits the remediation hint even when OAuth metadata isn't discoverable, doesn't mis-classify plain bearer 401s, and — regression guard — doesn't mis-classify benign `"authorization header"` upstream errors.
- [x] CLI: `storyboard run --oauth` with a raw URL prints the save-first warning in human mode and emits the structured `oauth_requires_alias` JSON error + exit 2 under `--json`.
- [x] E2E: cleared stale tokens on the `test-agent` alias → ran `adcp storyboard run test-agent --oauth --storyboards security_baseline` → browser opened → completed auth at `agenticadvertising.org` → tokens persisted → storyboard ran with `Auth: oauth (auto-refresh)`. The new remediation wording renders with fenced issuer.
- [x] Full suite green: 2321/2325 pass across compliance + storyboard + oauth + cli test files (4 skipped, 0 fail).
- [x] Prettier clean; no new lint errors; pre-push typecheck passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)