### PR TITLE
chore: regenerate types from latest AdCP schema tarball

### DIFF
--- a/.changeset/regen-schema-tarball.md
+++ b/.changeset/regen-schema-tarball.md
@@ -1,0 +1,23 @@
+---
+'@adcp/client': patch
+---
+
+chore: regenerate types from latest AdCP schema tarball
+
+Routine type regen after upstream schema sync. Unblocks matrix v12 — CI's
+"Validate generated files" fails on any branch with stale generated types,
+so landing this before the matrix keeps the failing-pair baseline clean.
+
+Notable wire-level changes picked up from upstream:
+
+- `si_initiate_session` renames `context: string` → `intent: string` and
+  introduces `context?: ContextObject` as a separate structured field.
+- `sync_creatives` response items now require `action` (lifecycle
+  discriminator: `created` / `updated` / `failed` / `deleted`).
+- Creative assets adopt an `asset_type` discriminator on every value under
+  `creative_manifest.assets` (`image`, `video`, `audio`, `text`, `url`,
+  `html`, `javascript`, `css`, `markdown`, etc.).
+
+Conformance seeder placeholders (`src/lib/conformance/seeder.ts`) are
+updated to emit the required `asset_type` discriminator so seeded creatives
+pass the new strict-response validation surface introduced in #757.

--- a/src/lib/conformance/seeder.ts
+++ b/src/lib/conformance/seeder.ts
@@ -394,15 +394,25 @@ function synthesizeManifestAssets(format: FormatDef): Record<string, unknown> {
 // we can satisfy without format-specific knowledge (dimensions, codecs,
 // etc. use safe defaults).
 const ASSET_PLACEHOLDER = {
-  image: () => ({ url: 'https://conformance.example/placeholder.png', width: 300, height: 250 }),
-  video: () => ({ url: 'https://conformance.example/placeholder.mp4', width: 640, height: 360 }),
-  audio: () => ({ url: 'https://conformance.example/placeholder.mp3' }),
-  text: () => ({ content: 'Conformance seed text' }),
-  url: () => ({ url: 'https://conformance.example/' }),
-  html: () => ({ content: '<div>Conformance seed</div>' }),
-  javascript: () => ({ content: '/* conformance seed */' }),
-  css: () => ({ content: '/* conformance seed */' }),
-  markdown: () => ({ content: 'Conformance seed' }),
+  image: () => ({
+    asset_type: 'image',
+    url: 'https://conformance.example/placeholder.png',
+    width: 300,
+    height: 250,
+  }),
+  video: () => ({
+    asset_type: 'video',
+    url: 'https://conformance.example/placeholder.mp4',
+    width: 640,
+    height: 360,
+  }),
+  audio: () => ({ asset_type: 'audio', url: 'https://conformance.example/placeholder.mp3' }),
+  text: () => ({ asset_type: 'text', content: 'Conformance seed text' }),
+  url: () => ({ asset_type: 'url', url: 'https://conformance.example/' }),
+  html: () => ({ asset_type: 'html', content: '<div>Conformance seed</div>' }),
+  javascript: () => ({ asset_type: 'javascript', content: '/* conformance seed */' }),
+  css: () => ({ asset_type: 'css', content: '/* conformance seed */' }),
+  markdown: () => ({ asset_type: 'markdown', content: 'Conformance seed' }),
 } as const;
 
 function extractCreativeIds(data: unknown, fallbackId: string): string[] {

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-22T03:02:49.814Z
+// Generated at: 2026-04-22T04:07:08.356Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -1175,7 +1175,34 @@ export type DisclosurePosition =
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving
  */
-export type VASTAsset =
+export type VASTAsset = {
+  /**
+   * Discriminator identifying this as a VAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'vast';
+  vast_version?: VASTVersion;
+  /**
+   * Whether VPAID (Video Player-Ad Interface Definition) is supported
+   */
+  vpaid_enabled?: boolean;
+  /**
+   * Expected video duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this VAST tag
+   */
+  tracking_events?: VASTTrackingEvent[];
+  /**
+   * URL to captions file (WebVTT, SRT, etc.)
+   */
+  captions_url?: string;
+  /**
+   * URL to audio description track for visually impaired users
+   */
+  audio_description_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating VAST is delivered via URL endpoint
@@ -1185,28 +1212,6 @@ export type VASTAsset =
        * URL endpoint that returns VAST XML
        */
       url: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -1217,29 +1222,8 @@ export type VASTAsset =
        * Inline VAST XML content
        */
       content: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * VAST specification version
  */
@@ -1376,7 +1360,30 @@ export type WebhookSecurityMethod = 'hmac_sha256' | 'api_key' | 'none';
 /**
  * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
  */
-export type DAASTAsset =
+export type DAASTAsset = {
+  /**
+   * Discriminator identifying this as a DAAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'daast';
+  daast_version?: DAASTVersion;
+  /**
+   * Expected audio duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this DAAST tag
+   */
+  tracking_events?: DAASTTrackingEvent[];
+  /**
+   * Whether companion display ads are included
+   */
+  companion_ads?: boolean;
+  /**
+   * URL to text transcript of the audio content
+   */
+  transcript_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating DAAST is delivered via URL endpoint
@@ -1386,24 +1393,6 @@ export type DAASTAsset =
        * URL endpoint that returns DAAST XML
        */
       url: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -1414,25 +1403,8 @@ export type DAASTAsset =
        * Inline DAAST XML content
        */
       content: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * DAAST specification version
  */
@@ -1471,11 +1443,21 @@ export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
  * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export type BriefAsset = CreativeBrief;
+export type BriefAsset = CreativeBrief & {
+  /**
+   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'brief';
+};
 /**
  * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
  */
-export type CatalogAsset = Catalog;
+export type CatalogAsset = Catalog & {
+  /**
+   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'catalog';
+};
 /**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
@@ -1499,7 +1481,7 @@ export interface CreativeAsset {
   name: string;
   format_id: FormatID;
   /**
-   * Assets required by the format, keyed by asset_id
+   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
    */
   assets: {
     /**
@@ -1564,6 +1546,10 @@ export interface CreativeAsset {
  * Image asset with URL and dimensions
  */
 export interface ImageAsset {
+  /**
+   * Discriminator identifying this as an image asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'image';
   /**
    * URL to the image asset
    */
@@ -1719,6 +1705,10 @@ export interface Provenance {
  */
 export interface VideoAsset {
   /**
+   * Discriminator identifying this as a video asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'video';
+  /**
    * URL to the video asset
    */
   url: string;
@@ -1841,6 +1831,10 @@ export interface VideoAsset {
  */
 export interface AudioAsset {
   /**
+   * Discriminator identifying this as an audio asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'audio';
+  /**
    * URL to the audio asset
    */
   url: string;
@@ -1895,6 +1889,10 @@ export interface AudioAsset {
  */
 export interface TextAsset {
   /**
+   * Discriminator identifying this as a text asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'text';
+  /**
    * Text content
    */
   content: string;
@@ -1908,6 +1906,10 @@ export interface TextAsset {
  * URL reference asset
  */
 export interface URLAsset {
+  /**
+   * Discriminator identifying this as a URL asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'url';
   /**
    * URL reference. May be a plain URI or an RFC 6570 URI template carrying AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`). Buyers MUST NOT pre-encode macro braces at sync time; the ad server URL-encodes substituted values at impression time. See docs/creative/universal-macros.mdx.
    */
@@ -1923,6 +1925,10 @@ export interface URLAsset {
  * HTML content asset
  */
 export interface HTMLAsset {
+  /**
+   * Discriminator identifying this as an HTML asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'html';
   /**
    * HTML content
    */
@@ -1959,6 +1965,10 @@ export interface HTMLAsset {
  */
 export interface JavaScriptAsset {
   /**
+   * Discriminator identifying this as a JavaScript asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'javascript';
+  /**
    * JavaScript content
    */
   content: string;
@@ -1990,6 +2000,10 @@ export interface JavaScriptAsset {
  * Webhook for server-side dynamic content rendering (DCO)
  */
 export interface WebhookAsset {
+  /**
+   * Discriminator identifying this as a webhook asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'webhook';
   /**
    * Webhook URL to call for dynamic content
    */
@@ -2029,6 +2043,10 @@ export interface WebhookAsset {
  */
 export interface CSSAsset {
   /**
+   * Discriminator identifying this as a CSS asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'css';
+  /**
    * CSS content
    */
   content: string;
@@ -2042,6 +2060,10 @@ export interface CSSAsset {
  * Markdown-formatted text content following CommonMark specification
  */
 export interface MarkdownAsset {
+  /**
+   * Discriminator identifying this as a markdown asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'markdown';
   /**
    * Markdown content following CommonMark spec with optional GitHub Flavored Markdown extensions
    */
@@ -4157,26 +4179,60 @@ export interface GetProductsResponse {
    */
   catalog_applied?: boolean;
   /**
-   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'.
+   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'. Each entry MUST echo the request entry's scope and — for product and proposal scopes — the matching id field (product_id or proposal_id), so orchestrators can cross-validate alignment.
    */
-  refinement_applied?: {
-    /**
-     * Echoes the scope from the corresponding refine entry. Allows orchestrators to cross-validate alignment.
-     */
-    scope?: 'request' | 'product' | 'proposal';
-    /**
-     * Echoes the id from the corresponding refine entry (for product and proposal scopes).
-     */
-    id?: string;
-    /**
-     * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-     */
-    status: 'applied' | 'partial' | 'unable';
-    /**
-     * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-     */
-    notes?: string;
-  }[];
+  refinement_applied?: (
+    | {
+        /**
+         * Echoes scope 'request' from the corresponding refine entry.
+         */
+        scope: 'request';
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'product' from the corresponding refine entry.
+         */
+        scope: 'product';
+        /**
+         * Echoes product_id from the corresponding refine entry.
+         */
+        product_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'proposal' from the corresponding refine entry.
+         */
+        scope: 'proposal';
+        /**
+         * Echoes proposal_id from the corresponding refine entry.
+         */
+        proposal_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+  )[];
   /**
    * Declares what the seller could not finish within the buyer's time_budget or due to internal limits. Each entry identifies a scope that is missing or partial. Absent when the response is fully complete.
    */
@@ -4814,7 +4870,7 @@ export interface CreativeManifest {
   /**
    * Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.
    *
-   * IMPORTANT: Full validation requires format context. The format defines what type each asset_id should be. Standalone schema validation only checks structural conformance — each asset must match at least one valid asset type schema.
+   * Each asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
    */
   assets: {
     /**
@@ -8684,7 +8740,7 @@ export interface ListCreativesResponse {
      */
     updated_date: string;
     /**
-     * Assets for this creative, keyed by asset_id
+     * Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
      */
     assets?: {
       /**
@@ -8957,6 +9013,62 @@ export type CreativeQuality = 'draft' | 'production';
  * Output format. 'url' returns preview_url (iframe-embeddable URL), 'html' returns preview_html (raw HTML). In batch mode, sets the default for all requests (individual items can override). Default: 'url'.
  */
 export type PreviewOutputFormat = 'url' | 'html';
+/**
+ * VAST (Video Ad Serving Template) tag for third-party video ad serving
+ */
+export type VASTAsset1 =
+  | {
+      /**
+       * Discriminator indicating VAST is delivered via URL endpoint
+       */
+      delivery_type: 'url';
+      /**
+       * URL endpoint that returns VAST XML
+       */
+      url: string;
+    }
+  | {
+      /**
+       * Discriminator indicating VAST is delivered as inline XML content
+       */
+      delivery_type: 'inline';
+      /**
+       * Inline VAST XML content
+       */
+      content: string;
+    };
+/**
+ * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
+ */
+export type DAASTAsset1 =
+  | {
+      /**
+       * Discriminator indicating DAAST is delivered via URL endpoint
+       */
+      delivery_type: 'url';
+      /**
+       * URL endpoint that returns DAAST XML
+       */
+      url: string;
+    }
+  | {
+      /**
+       * Discriminator indicating DAAST is delivered as inline XML content
+       */
+      delivery_type: 'inline';
+      /**
+       * Inline DAAST XML content
+       */
+      content: string;
+    };
+/**
+ * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
+ */
+export type BriefAsset1 = CreativeBrief;
+/**
+ * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
+ */
+export type CatalogAsset1 = Catalog;
 
 // bundled/creative/preview-creative-response.json
 /**
@@ -10448,11 +10560,11 @@ export interface GetProductsRequest {
         /**
          * Product ID from a previous get_products response.
          */
-        id: string;
+        product_id: string;
         /**
-         * 'include': return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned).
+         * 'include' (default): return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned). Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'more_like_this';
+        action?: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
          */
@@ -10466,11 +10578,11 @@ export interface GetProductsRequest {
         /**
          * Proposal ID from a previous get_products response.
          */
-        id: string;
+        proposal_id: string;
         /**
-         * 'include': return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result.
+         * 'include' (default): return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result. Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'finalize';
+        action?: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
          */
@@ -11606,6 +11718,81 @@ export interface PackageUpdate {
   creatives?: CreativeAsset[];
   context?: ContextObject;
   ext?: ExtensionObject;
+}
+/**
+ * Creative asset for upload to library - supports static assets, generative formats, and third-party snippets
+ */
+export interface CreativeAsset1 {
+  /**
+   * Unique identifier for the creative
+   */
+  creative_id: string;
+  /**
+   * Human-readable creative name
+   */
+  name: string;
+  format_id: FormatID;
+  /**
+   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
+   */
+  assets: {
+    /**
+     * This interface was referenced by `undefined`'s JSON-Schema definition
+     * via the `patternProperty` "^[a-z0-9_]+$".
+     */
+    [k: string]:
+      | ImageAsset
+      | VideoAsset
+      | AudioAsset
+      | VASTAsset1
+      | TextAsset
+      | URLAsset
+      | HTMLAsset
+      | JavaScriptAsset
+      | WebhookAsset
+      | CSSAsset
+      | DAASTAsset1
+      | MarkdownAsset
+      | BriefAsset1
+      | CatalogAsset1;
+  };
+  /**
+   * Preview contexts for generative formats - defines what scenarios to generate previews for
+   */
+  inputs?: {
+    /**
+     * Human-readable name for this preview variant
+     */
+    name: string;
+    /**
+     * Macro values to apply for this preview
+     */
+    macros?: {
+      [k: string]: string | undefined;
+    };
+    /**
+     * Natural language description of the context for AI-generated content
+     */
+    context_description?: string;
+  }[];
+  /**
+   * User-defined tags for organization and searchability
+   */
+  tags?: string[];
+  status?: CreativeStatus;
+  /**
+   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
+   */
+  weight?: number;
+  /**
+   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
+   */
+  placement_ids?: string[];
+  /**
+   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
+   */
+  industry_identifiers?: IndustryIdentifier[];
+  provenance?: Provenance;
 }
 
 // bundled/property/create-property-list-request.json
@@ -14378,7 +14565,7 @@ export interface OfferingAssetGroup {
   asset_group_id: string;
   asset_type: AssetContentType;
   /**
-   * The assets in this group. Each item should match the structure for the declared asset_type. Note: JSON Schema validation accepts any valid asset structure here; enforcement that items match asset_type is the responsibility of the consuming agent.
+   * The assets in this group. Each item carries an `asset_type` discriminator that selects the matching asset schema. Note: the group-level `asset_type` declares the expected type; individual items must also self-tag so validators can narrow errors.
    */
   items: (
     | TextAsset

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-22T02:47:27.524Z
+// Generated at: 2026-04-22T04:07:13.095Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -306,6 +306,7 @@ export const CreativeStatusSchema = z.union([z.literal("processing"), z.literal(
 export const CreativeIdentifierTypeSchema = z.union([z.literal("ad_id"), z.literal("isci"), z.literal("clearcast_clock")]);
 
 export const ImageAssetSchema = z.object({
+    asset_type: z.literal("image"),
     url: z.string(),
     width: z.number(),
     height: z.number(),
@@ -315,6 +316,7 @@ export const ImageAssetSchema = z.object({
 }).passthrough();
 
 export const VideoAssetSchema = z.object({
+    asset_type: z.literal("video"),
     url: z.string(),
     width: z.number(),
     height: z.number(),
@@ -348,6 +350,7 @@ export const VideoAssetSchema = z.object({
 }).passthrough();
 
 export const AudioAssetSchema = z.object({
+    asset_type: z.literal("audio"),
     url: z.string(),
     duration_ms: z.number().optional(),
     file_size_bytes: z.number().optional(),
@@ -363,35 +366,32 @@ export const AudioAssetSchema = z.object({
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const VASTAssetSchema = z.union([z.object({
+export const VASTAssetSchema = z.object({
+    asset_type: z.literal("vast"),
+    vast_version: VASTVersionSchema.optional(),
+    vpaid_enabled: z.boolean().optional(),
+    duration_ms: z.number().optional(),
+    tracking_events: z.array(VASTTrackingEventSchema).optional(),
+    captions_url: z.string().optional(),
+    audio_description_url: z.string().optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([z.object({
         delivery_type: z.literal("url"),
-        url: z.string(),
-        vast_version: VASTVersionSchema.optional(),
-        vpaid_enabled: z.boolean().optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(VASTTrackingEventSchema).optional(),
-        captions_url: z.string().optional(),
-        audio_description_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
+        url: z.string()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
-        content: z.string(),
-        vast_version: VASTVersionSchema.optional(),
-        vpaid_enabled: z.boolean().optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(VASTTrackingEventSchema).optional(),
-        captions_url: z.string().optional(),
-        audio_description_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
-    }).passthrough()]);
+        content: z.string()
+    }).passthrough()]));
 
 export const TextAssetSchema = z.object({
+    asset_type: z.literal("text"),
     content: z.string(),
     language: z.string().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const URLAssetSchema = z.object({
+    asset_type: z.literal("url"),
     url: z.string(),
     url_type: URLAssetTypeSchema.optional(),
     description: z.string().optional(),
@@ -399,6 +399,7 @@ export const URLAssetSchema = z.object({
 }).passthrough();
 
 export const HTMLAssetSchema = z.object({
+    asset_type: z.literal("html"),
     content: z.string(),
     version: z.string().optional(),
     accessibility: z.object({
@@ -411,6 +412,7 @@ export const HTMLAssetSchema = z.object({
 }).passthrough();
 
 export const JavaScriptAssetSchema = z.object({
+    asset_type: z.literal("javascript"),
     content: z.string(),
     module_type: JavaScriptModuleTypeSchema.optional(),
     accessibility: z.object({
@@ -423,6 +425,7 @@ export const JavaScriptAssetSchema = z.object({
 }).passthrough();
 
 export const WebhookAssetSchema = z.object({
+    asset_type: z.literal("webhook"),
     url: z.string(),
     method: HTTPMethodSchema.optional(),
     timeout_ms: z.number().optional(),
@@ -438,39 +441,39 @@ export const WebhookAssetSchema = z.object({
 }).passthrough();
 
 export const CSSAssetSchema = z.object({
+    asset_type: z.literal("css"),
     content: z.string(),
     media: z.string().optional(),
     provenance: ProvenanceSchema.optional()
 }).passthrough();
 
-export const DAASTAssetSchema = z.union([z.object({
+export const DAASTAssetSchema = z.object({
+    asset_type: z.literal("daast"),
+    daast_version: DAASTVersionSchema.optional(),
+    duration_ms: z.number().optional(),
+    tracking_events: z.array(DAASTTrackingEventSchema).optional(),
+    companion_ads: z.boolean().optional(),
+    transcript_url: z.string().optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([z.object({
         delivery_type: z.literal("url"),
-        url: z.string(),
-        daast_version: DAASTVersionSchema.optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(DAASTTrackingEventSchema).optional(),
-        companion_ads: z.boolean().optional(),
-        transcript_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
+        url: z.string()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
-        content: z.string(),
-        daast_version: DAASTVersionSchema.optional(),
-        duration_ms: z.number().optional(),
-        tracking_events: z.array(DAASTTrackingEventSchema).optional(),
-        companion_ads: z.boolean().optional(),
-        transcript_url: z.string().optional(),
-        provenance: ProvenanceSchema.optional()
-    }).passthrough()]);
+        content: z.string()
+    }).passthrough()]));
 
 export const MarkdownAssetSchema = z.object({
+    asset_type: z.literal("markdown"),
     content: z.string(),
     language: z.string().optional(),
     markdown_flavor: MarkdownFlavorSchema.optional(),
     allow_raw_html: z.boolean().optional()
 }).passthrough();
 
-export const CatalogAssetSchema = CatalogSchema;
+export const CatalogAssetSchema = CatalogSchema.and(z.object({
+    asset_type: z.literal("catalog")
+}).passthrough());
 
 export const IndustryIdentifierSchema = z.object({
     type: CreativeIdentifierTypeSchema,
@@ -2143,6 +2146,51 @@ export const CreativeQualitySchema = z.union([z.literal("draft"), z.literal("pro
 
 export const PreviewOutputFormatSchema = z.union([z.literal("url"), z.literal("html")]);
 
+export const VASTAsset1Schema = z.union([z.object({
+        delivery_type: z.literal("url"),
+        url: z.string()
+    }).passthrough(), z.object({
+        delivery_type: z.literal("inline"),
+        content: z.string()
+    }).passthrough()]);
+
+export const DAASTAsset1Schema = z.union([z.object({
+        delivery_type: z.literal("url"),
+        url: z.string()
+    }).passthrough(), z.object({
+        delivery_type: z.literal("inline"),
+        content: z.string()
+    }).passthrough()]);
+
+export const CreativeBriefSchema = z.object({
+    name: z.string(),
+    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
+    tone: z.string().optional(),
+    audience: z.string().optional(),
+    territory: z.string().optional(),
+    messaging: z.object({
+        headline: z.string().optional(),
+        tagline: z.string().optional(),
+        cta: z.string().optional(),
+        key_messages: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    reference_assets: z.array(ReferenceAssetSchema).optional(),
+    compliance: z.object({
+        required_disclosures: z.array(z.object({
+            text: z.string(),
+            position: DisclosurePositionSchema.optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            regulation: z.string().optional(),
+            min_duration_ms: z.number().optional(),
+            language: z.string().optional(),
+            persistence: DisclosurePersistenceSchema.optional()
+        }).passthrough()).optional(),
+        prohibited_claims: z.array(z.string()).optional()
+    }).passthrough().optional()
+}).passthrough();
+
+export const CatalogAsset1Schema = CatalogSchema;
+
 export const PreviewCreativeSingleResponseSchema = z.object({
     response_type: z.literal("single"),
     previews: z.array(z.object({
@@ -2583,6 +2631,8 @@ export const EventSourceHealthSchema = z.object({
 }).passthrough();
 
 export const AgeVerificationMethod1Schema = z.union([z.literal("facial_age_estimation"), z.literal("id_document"), z.literal("digital_id"), z.literal("credit_card"), z.literal("world_id")]);
+
+export const BriefAsset1Schema = CreativeBriefSchema;
 
 export const PublisherTagsSourceSchema = z.object({
     selection_type: z.literal("publisher_tags"),
@@ -3918,34 +3968,27 @@ export const BaseIndividualAssetSchema = z.object({
     overlays: z.array(OverlaySchema).optional()
 }).passthrough();
 
-export const CreativeBriefSchema = z.object({
-    name: z.string(),
-    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
-    tone: z.string().optional(),
-    audience: z.string().optional(),
-    territory: z.string().optional(),
-    messaging: z.object({
-        headline: z.string().optional(),
-        tagline: z.string().optional(),
-        cta: z.string().optional(),
-        key_messages: z.array(z.string()).optional()
-    }).passthrough().optional(),
-    reference_assets: z.array(ReferenceAssetSchema).optional(),
-    compliance: z.object({
-        required_disclosures: z.array(z.object({
-            text: z.string(),
-            position: DisclosurePositionSchema.optional(),
-            jurisdictions: z.array(z.string()).optional(),
-            regulation: z.string().optional(),
-            min_duration_ms: z.number().optional(),
-            language: z.string().optional(),
-            persistence: DisclosurePersistenceSchema.optional()
-        }).passthrough()).optional(),
-        prohibited_claims: z.array(z.string()).optional()
-    }).passthrough().optional()
-}).passthrough();
+export const BriefAssetSchema = CreativeBriefSchema.and(z.object({
+    asset_type: z.literal("brief")
+}).passthrough());
 
-export const BriefAssetSchema = CreativeBriefSchema;
+export const CreativeAssetSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatIDSchema,
+    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough();
 
 export const PackageSchema = z.object({
     package_id: z.string(),
@@ -3997,22 +4040,65 @@ export const PlannedDeliverySchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreativeAssetSchema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatIDSchema,
-    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema])),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
+export const PackageUpdateSchema = z.object({
+    package_id: z.string(),
+    budget: z.number().optional(),
+    pacing: PacingSchema.optional(),
+    bid_price: z.number().optional(),
+    impressions: z.number().optional(),
+    start_time: z.string().optional(),
+    end_time: z.string().optional(),
+    paused: z.boolean().optional(),
+    canceled: z.literal(true).optional(),
+    cancellation_reason: z.string().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    keyword_targets_add: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]),
+        bid_price: z.number().optional()
     }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
+    keyword_targets_remove: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    negative_keywords_add: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    negative_keywords_remove: z.array(z.object({
+        keyword: z.string(),
+        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
+    }).passthrough()).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PackageRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    product_id: z.string(),
+    format_ids: z.array(FormatIDSchema).optional(),
+    budget: z.number(),
+    pacing: PacingSchema.optional(),
+    pricing_option_id: z.string(),
+    bid_price: z.number().optional(),
+    impressions: z.number().optional(),
+    start_time: z.string().optional(),
+    end_time: z.string().optional(),
+    paused: z.boolean().optional(),
+    catalogs: z.array(CatalogSchema).optional(),
+    optimization_goals: z.array(OptimizationGoalSchema).optional(),
+    targeting_overlay: TargetingOverlaySchema.optional(),
+    measurement_terms: MeasurementTermsSchema.optional(),
+    performance_standards: z.array(PerformanceStandardSchema).optional(),
+    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).optional(),
+    agency_estimate_number: z.string().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
 export const UpdateMediaBuySuccessSchema = z.object({
@@ -5807,26 +5893,43 @@ export const BuildCreativeRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const PackageRequestSchema = z.object({
+export const CreateMediaBuyRequestSchema = z.object({
     adcp_major_version: z.number().optional(),
-    product_id: z.string(),
-    format_ids: z.array(FormatIDSchema).optional(),
-    budget: z.number(),
-    pacing: PacingSchema.optional(),
-    pricing_option_id: z.string(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
-    paused: z.boolean().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    measurement_terms: MeasurementTermsSchema.optional(),
-    performance_standards: z.array(PerformanceStandardSchema).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    idempotency_key: z.string(),
+    plan_id: z.string().optional(),
+    account: AccountReferenceSchema,
+    proposal_id: z.string().optional(),
+    total_budget: z.object({
+        amount: z.number(),
+        currency: z.string()
+    }).passthrough().optional(),
+    packages: z.array(PackageRequestSchema).optional(),
+    brand: BrandReferenceSchema,
+    advertiser_industry: AdvertiserIndustrySchema.optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    io_acceptance: z.object({
+        io_id: z.string(),
+        accepted_at: z.string(),
+        signatory: z.string(),
+        signature_id: z.string().optional()
+    }).passthrough().optional(),
+    po_number: z.string().optional(),
     agency_estimate_number: z.string().optional(),
+    start_time: StartTimingSchema,
+    end_time: z.string(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    artifact_webhook: z.object({
+        url: z.string(),
+        token: z.string().optional(),
+        authentication: z.object({
+            schemes: z.array(AuthenticationSchemeSchema),
+            credentials: z.string()
+        }).passthrough(),
+        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
+        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
+        sampling_rate: z.number().optional()
+    }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -5840,13 +5943,13 @@ export const GetProductsRequestSchema = z.object({
             ask: z.string()
         }).passthrough(), z.object({
             scope: z.literal("product"),
-            id: z.string(),
-            action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]),
+            product_id: z.string(),
+            action: z.union([z.literal("include"), z.literal("omit"), z.literal("more_like_this")]).optional(),
             ask: z.string().optional()
         }).passthrough(), z.object({
             scope: z.literal("proposal"),
-            id: z.string(),
-            action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]),
+            proposal_id: z.string(),
+            action: z.union([z.literal("include"), z.literal("omit"), z.literal("finalize")]).optional(),
             ask: z.string().optional()
         }).passthrough()])).optional(),
     brand: BrandReferenceSchema.optional(),
@@ -5875,41 +5978,42 @@ export const LogEventRequestSchema = z.object({
 
 export const SyncEventSourcesResponseSchema = z.union([SyncEventSourcesSuccessSchema, SyncEventSourcesErrorSchema]);
 
-export const PackageUpdateSchema = z.object({
-    package_id: z.string(),
-    budget: z.number().optional(),
-    pacing: PacingSchema.optional(),
-    bid_price: z.number().optional(),
-    impressions: z.number().optional(),
-    start_time: z.string().optional(),
-    end_time: z.string().optional(),
+export const UpdateMediaBuyRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    account: AccountReferenceSchema,
+    media_buy_id: z.string(),
+    revision: z.number().optional(),
     paused: z.boolean().optional(),
     canceled: z.literal(true).optional(),
     cancellation_reason: z.string().optional(),
-    catalogs: z.array(CatalogSchema).optional(),
-    optimization_goals: z.array(OptimizationGoalSchema).optional(),
-    targeting_overlay: TargetingOverlaySchema.optional(),
-    keyword_targets_add: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")]),
-        bid_price: z.number().optional()
-    }).passthrough()).optional(),
-    keyword_targets_remove: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    negative_keywords_add: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    negative_keywords_remove: z.array(z.object({
-        keyword: z.string(),
-        match_type: z.union([z.literal("broad"), z.literal("phrase"), z.literal("exact")])
-    }).passthrough()).optional(),
-    creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    start_time: StartTimingSchema.optional(),
+    end_time: z.string().optional(),
+    packages: z.array(PackageUpdateSchema).optional(),
+    invoice_recipient: BusinessEntitySchema.optional(),
+    new_packages: z.array(PackageRequestSchema).optional(),
+    reporting_webhook: ReportingWebhookSchema.optional(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    idempotency_key: z.string(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const CreativeAsset1Schema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatIDSchema,
+    assets: z.record(z.string(), z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset1Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset1Schema, MarkdownAssetSchema, BriefAsset1Schema, CatalogAsset1Schema])),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const CreatePropertyListResponseSchema = z.object({
@@ -6093,12 +6197,21 @@ export const GetProductsResponseSchema = z.object({
     errors: z.array(ErrorSchema).optional(),
     property_list_applied: z.boolean().optional(),
     catalog_applied: z.boolean().optional(),
-    refinement_applied: z.array(z.object({
-        scope: z.union([z.literal("request"), z.literal("product"), z.literal("proposal")]).optional(),
-        id: z.string().optional(),
-        status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
-        notes: z.string().optional()
-    }).passthrough()).optional(),
+    refinement_applied: z.array(z.union([z.object({
+            scope: z.literal("request"),
+            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+            notes: z.string().optional()
+        }).passthrough(), z.object({
+            scope: z.literal("product"),
+            product_id: z.string(),
+            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+            notes: z.string().optional()
+        }).passthrough(), z.object({
+            scope: z.literal("proposal"),
+            proposal_id: z.string(),
+            status: z.union([z.literal("applied"), z.literal("partial"), z.literal("unable")]),
+            notes: z.string().optional()
+        }).passthrough()])).optional(),
     incomplete: z.array(z.object({
         scope: z.union([z.literal("products"), z.literal("pricing"), z.literal("forecast"), z.literal("proposals")]),
         description: z.string(),
@@ -6124,68 +6237,7 @@ export const ListCreativeFormatsResponseSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const CreateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    idempotency_key: z.string(),
-    plan_id: z.string().optional(),
-    account: AccountReferenceSchema,
-    proposal_id: z.string().optional(),
-    total_budget: z.object({
-        amount: z.number(),
-        currency: z.string()
-    }).passthrough().optional(),
-    packages: z.array(PackageRequestSchema).optional(),
-    brand: BrandReferenceSchema,
-    advertiser_industry: AdvertiserIndustrySchema.optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    io_acceptance: z.object({
-        io_id: z.string(),
-        accepted_at: z.string(),
-        signatory: z.string(),
-        signature_id: z.string().optional()
-    }).passthrough().optional(),
-    po_number: z.string().optional(),
-    agency_estimate_number: z.string().optional(),
-    start_time: StartTimingSchema,
-    end_time: z.string(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    artifact_webhook: z.object({
-        url: z.string(),
-        token: z.string().optional(),
-        authentication: z.object({
-            schemes: z.array(AuthenticationSchemeSchema),
-            credentials: z.string()
-        }).passthrough(),
-        delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),
-        batch_frequency: z.union([z.literal("hourly"), z.literal("daily")]).optional(),
-        sampling_rate: z.number().optional()
-    }).passthrough().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const CreateMediaBuyResponseSchema = z.union([CreateMediaBuySuccessSchema, CreateMediaBuyErrorSchema, CreateMediaBuySubmittedSchema]);
-
-export const UpdateMediaBuyRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    account: AccountReferenceSchema,
-    media_buy_id: z.string(),
-    revision: z.number().optional(),
-    paused: z.boolean().optional(),
-    canceled: z.literal(true).optional(),
-    cancellation_reason: z.string().optional(),
-    start_time: StartTimingSchema.optional(),
-    end_time: z.string().optional(),
-    packages: z.array(PackageUpdateSchema).optional(),
-    invoice_recipient: BusinessEntitySchema.optional(),
-    new_packages: z.array(PackageRequestSchema).optional(),
-    reporting_webhook: ReportingWebhookSchema.optional(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
-    idempotency_key: z.string(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
 
 export const CreateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -279,11 +279,11 @@ export interface GetProductsRequest {
         /**
          * Product ID from a previous get_products response.
          */
-        id: string;
+        product_id: string;
         /**
-         * 'include': return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned).
+         * 'include' (default): return this product with updated pricing and data. 'omit': exclude this product from the response. 'more_like_this': find additional products similar to this one (the original is also returned). Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'more_like_this';
+        action?: 'include' | 'omit' | 'more_like_this';
         /**
          * What the buyer is asking for on this product. For 'include': specific changes to request (e.g., 'add 16:9 format'). For 'more_like_this': what 'similar' means (e.g., 'same audience but video format'). Ignored when action is 'omit'.
          */
@@ -297,11 +297,11 @@ export interface GetProductsRequest {
         /**
          * Proposal ID from a previous get_products response.
          */
-        id: string;
+        proposal_id: string;
         /**
-         * 'include': return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result.
+         * 'include' (default): return this proposal with updated allocations and pricing. 'omit': exclude this proposal from the response. 'finalize': request firm pricing and inventory hold — transitions a draft proposal to committed with an expires_at hold window. May trigger seller-side approval (HITL). The buyer should not set a time_budget for finalize requests — they represent a commitment to wait for the result. Optional — when omitted, the seller treats the entry as action: 'include'.
          */
-        action: 'include' | 'omit' | 'finalize';
+        action?: 'include' | 'omit' | 'finalize';
         /**
          * What the buyer is asking for on this proposal (e.g., 'shift more budget toward video', 'reduce total by 10%'). Ignored when action is 'omit'.
          */
@@ -1041,26 +1041,60 @@ export interface GetProductsResponse {
    */
   catalog_applied?: boolean;
   /**
-   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'.
+   * Seller's response to each change request in the refine array, matched by position. Each entry acknowledges whether the corresponding ask was applied, partially applied, or unable to be fulfilled. MUST contain the same number of entries in the same order as the request's refine array. Only present when the request used buying_mode: 'refine'. Each entry MUST echo the request entry's scope and — for product and proposal scopes — the matching id field (product_id or proposal_id), so orchestrators can cross-validate alignment.
    */
-  refinement_applied?: {
-    /**
-     * Echoes the scope from the corresponding refine entry. Allows orchestrators to cross-validate alignment.
-     */
-    scope?: 'request' | 'product' | 'proposal';
-    /**
-     * Echoes the id from the corresponding refine entry (for product and proposal scopes).
-     */
-    id?: string;
-    /**
-     * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
-     */
-    status: 'applied' | 'partial' | 'unable';
-    /**
-     * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
-     */
-    notes?: string;
-  }[];
+  refinement_applied?: (
+    | {
+        /**
+         * Echoes scope 'request' from the corresponding refine entry.
+         */
+        scope: 'request';
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'product' from the corresponding refine entry.
+         */
+        scope: 'product';
+        /**
+         * Echoes product_id from the corresponding refine entry.
+         */
+        product_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+    | {
+        /**
+         * Echoes scope 'proposal' from the corresponding refine entry.
+         */
+        scope: 'proposal';
+        /**
+         * Echoes proposal_id from the corresponding refine entry.
+         */
+        proposal_id: string;
+        /**
+         * 'applied': the ask was fulfilled. 'partial': the ask was partially fulfilled — see notes for details. 'unable': the seller could not fulfill the ask — see notes for why.
+         */
+        status: 'applied' | 'partial' | 'unable';
+        /**
+         * Seller explanation of what was done, what couldn't be done, or why. Recommended when status is 'partial' or 'unable'.
+         */
+        notes?: string;
+      }
+  )[];
   /**
    * Declares what the seller could not finish within the buyer's time_budget or due to internal limits. Each entry identifies a scope that is missing or partial. Absent when the response is fully complete.
    */
@@ -3298,7 +3332,34 @@ export type DigitalSourceType =
 /**
  * VAST (Video Ad Serving Template) tag for third-party video ad serving
  */
-export type VASTAsset =
+export type VASTAsset = {
+  /**
+   * Discriminator identifying this as a VAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'vast';
+  vast_version?: VASTVersion;
+  /**
+   * Whether VPAID (Video Player-Ad Interface Definition) is supported
+   */
+  vpaid_enabled?: boolean;
+  /**
+   * Expected video duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this VAST tag
+   */
+  tracking_events?: VASTTrackingEvent[];
+  /**
+   * URL to captions file (WebVTT, SRT, etc.)
+   */
+  captions_url?: string;
+  /**
+   * URL to audio description track for visually impaired users
+   */
+  audio_description_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating VAST is delivered via URL endpoint
@@ -3308,28 +3369,6 @@ export type VASTAsset =
        * URL endpoint that returns VAST XML
        */
       url: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -3340,29 +3379,8 @@ export type VASTAsset =
        * Inline VAST XML content
        */
       content: string;
-      vast_version?: VASTVersion;
-      /**
-       * Whether VPAID (Video Player-Ad Interface Definition) is supported
-       */
-      vpaid_enabled?: boolean;
-      /**
-       * Expected video duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this VAST tag
-       */
-      tracking_events?: VASTTrackingEvent[];
-      /**
-       * URL to captions file (WebVTT, SRT, etc.)
-       */
-      captions_url?: string;
-      /**
-       * URL to audio description track for visually impaired users
-       */
-      audio_description_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * VAST specification version
  */
@@ -3426,7 +3444,30 @@ export type WebhookSecurityMethod = 'hmac_sha256' | 'api_key' | 'none';
 /**
  * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
  */
-export type DAASTAsset =
+export type DAASTAsset = {
+  /**
+   * Discriminator identifying this as a DAAST asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'daast';
+  daast_version?: DAASTVersion;
+  /**
+   * Expected audio duration in milliseconds (if known)
+   */
+  duration_ms?: number;
+  /**
+   * Tracking events supported by this DAAST tag
+   */
+  tracking_events?: DAASTTrackingEvent[];
+  /**
+   * Whether companion display ads are included
+   */
+  companion_ads?: boolean;
+  /**
+   * URL to text transcript of the audio content
+   */
+  transcript_url?: string;
+  provenance?: Provenance;
+} & (
   | {
       /**
        * Discriminator indicating DAAST is delivered via URL endpoint
@@ -3436,24 +3477,6 @@ export type DAASTAsset =
        * URL endpoint that returns DAAST XML
        */
       url: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
     }
   | {
       /**
@@ -3464,25 +3487,8 @@ export type DAASTAsset =
        * Inline DAAST XML content
        */
       content: string;
-      daast_version?: DAASTVersion;
-      /**
-       * Expected audio duration in milliseconds (if known)
-       */
-      duration_ms?: number;
-      /**
-       * Tracking events supported by this DAAST tag
-       */
-      tracking_events?: DAASTTrackingEvent[];
-      /**
-       * Whether companion display ads are included
-       */
-      companion_ads?: boolean;
-      /**
-       * URL to text transcript of the audio content
-       */
-      transcript_url?: string;
-      provenance?: Provenance;
-    };
+    }
+);
 /**
  * DAAST specification version
  */
@@ -3521,11 +3527,21 @@ export type MarkdownFlavor = 'commonmark' | 'gfm';
 /**
  * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
  */
-export type BriefAsset = CreativeBrief;
+export type BriefAsset = CreativeBrief & {
+  /**
+   * Discriminator identifying this as a brief asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'brief';
+};
 /**
  * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
  */
-export type CatalogAsset = Catalog;
+export type CatalogAsset = Catalog & {
+  /**
+   * Discriminator identifying this as a catalog asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'catalog';
+};
 /**
  * For generative creatives: set to 'approved' to finalize, 'rejected' to request regeneration with updated assets/message. Omit for non-generative creatives (system will set based on processing state).
  */
@@ -4040,7 +4056,7 @@ export interface CreativeAsset {
   name: string;
   format_id: FormatID;
   /**
-   * Assets required by the format, keyed by asset_id
+   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
    */
   assets: {
     /**
@@ -4105,6 +4121,10 @@ export interface CreativeAsset {
  * Image asset with URL and dimensions
  */
 export interface ImageAsset {
+  /**
+   * Discriminator identifying this as an image asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'image';
   /**
    * URL to the image asset
    */
@@ -4260,6 +4280,10 @@ export interface Provenance {
  */
 export interface VideoAsset {
   /**
+   * Discriminator identifying this as a video asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'video';
+  /**
    * URL to the video asset
    */
   url: string;
@@ -4382,6 +4406,10 @@ export interface VideoAsset {
  */
 export interface AudioAsset {
   /**
+   * Discriminator identifying this as an audio asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'audio';
+  /**
    * URL to the audio asset
    */
   url: string;
@@ -4436,6 +4464,10 @@ export interface AudioAsset {
  */
 export interface TextAsset {
   /**
+   * Discriminator identifying this as a text asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'text';
+  /**
    * Text content
    */
   content: string;
@@ -4449,6 +4481,10 @@ export interface TextAsset {
  * URL reference asset
  */
 export interface URLAsset {
+  /**
+   * Discriminator identifying this as a URL asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'url';
   /**
    * URL reference. May be a plain URI or an RFC 6570 URI template carrying AdCP universal macros (e.g., `{SKU}`, `{MEDIA_BUY_ID}`). Buyers MUST NOT pre-encode macro braces at sync time; the ad server URL-encodes substituted values at impression time. See docs/creative/universal-macros.mdx.
    */
@@ -4464,6 +4500,10 @@ export interface URLAsset {
  * HTML content asset
  */
 export interface HTMLAsset {
+  /**
+   * Discriminator identifying this as an HTML asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'html';
   /**
    * HTML content
    */
@@ -4500,6 +4540,10 @@ export interface HTMLAsset {
  */
 export interface JavaScriptAsset {
   /**
+   * Discriminator identifying this as a JavaScript asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'javascript';
+  /**
    * JavaScript content
    */
   content: string;
@@ -4531,6 +4575,10 @@ export interface JavaScriptAsset {
  * Webhook for server-side dynamic content rendering (DCO)
  */
 export interface WebhookAsset {
+  /**
+   * Discriminator identifying this as a webhook asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'webhook';
   /**
    * Webhook URL to call for dynamic content
    */
@@ -4570,6 +4618,10 @@ export interface WebhookAsset {
  */
 export interface CSSAsset {
   /**
+   * Discriminator identifying this as a CSS asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'css';
+  /**
    * CSS content
    */
   content: string;
@@ -4583,6 +4635,10 @@ export interface CSSAsset {
  * Markdown-formatted text content following CommonMark specification
  */
 export interface MarkdownAsset {
+  /**
+   * Discriminator identifying this as a markdown asset. See /schemas/creative/asset-types for the registry.
+   */
+  asset_type: 'markdown';
   /**
    * Markdown content following CommonMark spec with optional GitHub Flavored Markdown extensions
    */
@@ -7486,7 +7542,7 @@ export interface CreativeManifest {
   /**
    * Map of asset IDs to actual asset content. Each key MUST match an asset_id from the format's assets array (e.g., 'banner_image', 'clickthrough_url', 'video_file', 'vast_tag'). The asset_id is the technical identifier used to match assets to format requirements.
    *
-   * IMPORTANT: Full validation requires format context. The format defines what type each asset_id should be. Standalone schema validation only checks structural conformance — each asset must match at least one valid asset type schema.
+   * Each asset value carries an `asset_type` discriminator (image, video, audio, vast, daast, text, markdown, url, html, css, webhook, javascript, brief, catalog) that selects the matching asset schema. Validators with OpenAPI-style discriminator support use `asset_type` to report errors against only the selected branch instead of all branches.
    */
   assets: {
     /**
@@ -8561,7 +8617,7 @@ export interface ListCreativesResponse {
      */
     updated_date: string;
     /**
-     * Assets for this creative, keyed by asset_id
+     * Assets for this creative, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
      */
     assets?: {
       /**
@@ -11260,7 +11316,7 @@ export interface ReportPlanOutcomeRequest {
    */
   adcp_major_version?: number;
   /**
-   * The plan this outcome is for.
+   * The plan this outcome is for. The plan uniquely scopes the account and operator; do not include a separate `account` field — the governance agent resolves account from the plan. Including `account` is rejected by `additionalProperties: false`.
    */
   plan_id: string;
   /**
@@ -11419,7 +11475,7 @@ export type GetPlanAuditLogsRequest = {
    */
   adcp_major_version?: number;
   /**
-   * Plan IDs to retrieve. For a single plan, pass a one-element array.
+   * Plan IDs to retrieve. For a single plan, pass a one-element array. Plans uniquely scope account and operator; do not include a separate `account` field — the governance agent resolves account from each plan. Including `account` is rejected by `additionalProperties: false`.
    */
   plan_ids?: string[];
   /**
@@ -11719,7 +11775,7 @@ export interface CheckGovernanceRequest {
    */
   adcp_major_version?: number;
   /**
-   * Campaign governance plan identifier.
+   * Campaign governance plan identifier. The plan uniquely scopes the account and operator; do not include a separate `account` field — the governance agent resolves account from the plan. Including `account` is rejected by `additionalProperties: false`.
    */
   plan_id: string;
   /**

--- a/test/lib/conformance-seeder.test.js
+++ b/test/lib/conformance-seeder.test.js
@@ -138,7 +138,7 @@ describe('conformance: seedFixtures', () => {
           observed.formatIds.push(params.creatives[0].format_id.id);
           observed.assets.push(params.creatives[0].assets);
           return {
-            creatives: [{ creative_id: 'cre_seeded_abc', buyer_ref: params.creatives[0].creative_id }],
+            creatives: [{ creative_id: 'cre_seeded_abc', action: 'created' }],
           };
         },
       },
@@ -152,7 +152,9 @@ describe('conformance: seedFixtures', () => {
 
     assert.deepEqual(result.fixtures.creative_ids, ['cre_seeded_abc']);
     assert.equal(observed.formatIds[0], 'text_line');
-    assert.deepEqual(observed.assets[0], { headline: { content: 'Conformance seed text' } });
+    assert.deepEqual(observed.assets[0], {
+      headline: { asset_type: 'text', content: 'Conformance seed text' },
+    });
     assert.deepEqual(result.warnings, []);
   });
 

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -66,6 +66,7 @@ describe('SingleAgentClient Request Validation', () => {
                 format_id: { agent_url: 'https://test.example', id: 'format1' },
                 assets: {
                   video: {
+                    asset_type: 'video',
                     url: 'https://example.com/video.mp4',
                     width: 1920,
                     height: 1080,
@@ -608,6 +609,7 @@ describe('SingleAgentClient Request Validation', () => {
                 format_id: { agent_url: 'https://test.example', id: 'format1' },
                 assets: {
                   video: {
+                    asset_type: 'video',
                     url: 'https://example.com/video.mp4',
                     width: 1920,
                     height: 1080,

--- a/test/lib/zod-schemas.test.js
+++ b/test/lib/zod-schemas.test.js
@@ -454,7 +454,14 @@ describe('Zod Schema Validation', () => {
     const result = schemas.GetCreativeFeaturesRequestSchema.safeParse({
       creative_manifest: {
         format_id: { agent_url: 'https://creative.example.com', id: 'display_300x250' },
-        assets: { banner: { url: 'https://example.com/banner.jpg' } },
+        assets: {
+          banner: {
+            asset_type: 'image',
+            url: 'https://example.com/banner.jpg',
+            width: 300,
+            height: 250,
+          },
+        },
       },
       feature_ids: ['viewability', 'brand_safety'],
     });


### PR DESCRIPTION
Routine type regen after upstream schema sync. `npm run typecheck` clean; `npm test` expected clean (runs in CI).

Unblocks matrix v12 — CI's "Validate generated files" fails on any branch with stale generated types, so landing this before the matrix keeps the failing-pair baseline clean.