### PR TITLE
feat(client): typed asset builders for discriminator injection

### DIFF
--- a/.changeset/asset-builder-helpers.md
+++ b/.changeset/asset-builder-helpers.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': minor
+---
+
+Add typed factory helpers for creative asset construction that inject the `asset_type` discriminator: `imageAsset`, `videoAsset`, `audioAsset`, `textAsset`, `urlAsset`, `htmlAsset`, `javascriptAsset`, `cssAsset`, `markdownAsset`, `webhookAsset`, plus a grouped `Asset` namespace (`Asset.image({...})`) over the same functions.
+
+Each helper takes the asset shape without `asset_type` and returns an object tagged with the canonical literal — `imageAsset({ url, width, height })` produces `{ url, width, height, asset_type: 'image' }` — eliminating the boilerplate at every construction site. The discriminator is written last in the returned object so a runtime bypass (cast that slips `asset_type` into the input) cannot overwrite it.
+
+Return type is `Omit<T, 'asset_type'> & { asset_type: '<literal>' }` (intersection) rather than the raw generated interface, so the builders compile regardless of whether the generated TypeScript types currently carry the discriminator — a defensive choice that makes the helpers stable across schema regenerations.

--- a/examples/generative-creative-demo.ts
+++ b/examples/generative-creative-demo.ts
@@ -3,7 +3,7 @@
 // This example shows how to use the new format_id and assets structure for both
 // static and generative creative workflows
 
-import { ADCPMultiAgentClient, type SyncCreativesRequest } from '../src/lib';
+import { ADCPMultiAgentClient, imageAsset, textAsset, urlAsset, type SyncCreativesRequest } from '../src/lib';
 
 async function demonstrateGenerativeCreatives() {
   console.log('🎨 Generative Creative Format Demo');
@@ -36,18 +36,16 @@ async function demonstrateGenerativeCreatives() {
           id: 'display_300x250',
         },
         assets: {
-          image: {
-            asset_type: 'image',
+          image: imageAsset({
             url: 'https://example.com/banner-300x250.jpg',
             width: 300,
             height: 250,
             alt_text: 'Summer sale banner',
-          },
-          click_url: {
-            asset_type: 'url',
+          }),
+          click_url: urlAsset({
             url: 'https://example.com/summer-sale',
             description: 'Landing page for summer sale campaign',
-          },
+          }),
         },
         tags: ['display', 'static', 'summer-sale'],
       },
@@ -71,21 +69,18 @@ async function demonstrateGenerativeCreatives() {
           id: 'display_300x250_generative',
         },
         assets: {
-          brand_context: {
-            asset_type: 'url',
+          brand_context: urlAsset({
             url: 'https://example.com',
             description: 'Brand website for context extraction',
-          },
-          generation_prompt: {
-            asset_type: 'text',
+          }),
+          generation_prompt: textAsset({
             content: 'Create a vibrant summer sale banner highlighting 30% off outdoor furniture',
-          },
-          logo: {
-            asset_type: 'image',
+          }),
+          logo: imageAsset({
             url: 'https://example.com/logo.png',
             width: 100,
             height: 100,
-          },
+          }),
         },
         inputs: [
           {
@@ -125,15 +120,13 @@ async function demonstrateGenerativeCreatives() {
           id: 'display_300x250_generative',
         },
         assets: {
-          brand_context: {
-            asset_type: 'url',
+          brand_context: urlAsset({
             url: 'https://example.com',
             description: 'Brand website for context extraction',
-          },
-          generation_prompt: {
-            asset_type: 'text',
+          }),
+          generation_prompt: textAsset({
             content: 'Create a vibrant summer sale banner highlighting 30% off outdoor furniture',
-          },
+          }),
         },
         approved: true, // Approve the generated preview
       },
@@ -158,16 +151,14 @@ async function demonstrateGenerativeCreatives() {
           id: 'display_300x250_generative',
         },
         assets: {
-          brand_context: {
-            asset_type: 'url',
+          brand_context: urlAsset({
             url: 'https://example.com',
             description: 'Brand website for context extraction',
-          },
-          generation_prompt: {
-            asset_type: 'text',
+          }),
+          generation_prompt: textAsset({
             content:
               'Create a warm, inviting summer sale banner with emphasis on comfort and quality. Show 30% off outdoor furniture with natural colors.',
-          },
+          }),
         },
         approved: false, // Request regeneration with updated prompt
       },

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -760,6 +760,26 @@ export {
   hasAssets,
 } from './utils/format-assets';
 
+// ====== CREATIVE ASSET BUILDERS ======
+// Typed factories that inject the `asset_type` discriminator.
+// `imageAsset({ url, width, height })` returns a valid `ImageAsset`
+// without repeating `asset_type: 'image'` at every call site.
+// Prefer the named exports; use `Asset.image({...})` when constructing
+// several asset types together (assets-by-role manifests).
+export {
+  Asset,
+  imageAsset,
+  videoAsset,
+  audioAsset,
+  textAsset,
+  urlAsset,
+  htmlAsset,
+  javascriptAsset,
+  cssAsset,
+  markdownAsset,
+  webhookAsset,
+} from './utils/asset-builders';
+
 // ====== V3.0 COMPATIBILITY UTILITIES ======
 // Capabilities detection, version negotiation, and v3 enforcement.
 // See also:

--- a/src/lib/utils/asset-builders.ts
+++ b/src/lib/utils/asset-builders.ts
@@ -1,0 +1,100 @@
+// Typed factory helpers for creative asset objects.
+//
+// Every asset interface in the schema carries an `asset_type` literal
+// discriminator (e.g. `asset_type: 'image'`) that's always the canonical
+// tag for its class. Requiring callers to type it by hand is boilerplate
+// that the compiler already knows the answer to. These builders take the
+// rest of the asset shape and inject the discriminator, so
+// `imageAsset({ url, width, height })` produces a valid `ImageAsset`
+// without repeating `asset_type: 'image'` at every call site.
+
+import type {
+  AudioAsset,
+  CSSAsset,
+  HTMLAsset,
+  ImageAsset,
+  JavaScriptAsset,
+  MarkdownAsset,
+  TextAsset,
+  URLAsset,
+  VideoAsset,
+  WebhookAsset,
+} from '../types/tools.generated';
+
+// Intersecting with `{ asset_type: Tag }` instead of relying on the imported
+// type's own discriminator keeps these builders robust across schema
+// regenerations, whether or not the generated interface carries the tag.
+type Tagged<T, Tag extends string> = Omit<T, 'asset_type'> & { asset_type: Tag };
+
+// Spread order matters: the discriminator is written last so a runtime
+// bypass (e.g. an `as unknown` cast that slips `asset_type` into `fields`)
+// can't clobber it.
+
+/** Build an `ImageAsset` with `asset_type: 'image'` injected. */
+export function imageAsset(fields: Omit<ImageAsset, 'asset_type'>): Tagged<ImageAsset, 'image'> {
+  return { ...fields, asset_type: 'image' };
+}
+
+/** Build a `VideoAsset` with `asset_type: 'video'` injected. */
+export function videoAsset(fields: Omit<VideoAsset, 'asset_type'>): Tagged<VideoAsset, 'video'> {
+  return { ...fields, asset_type: 'video' };
+}
+
+/** Build an `AudioAsset` with `asset_type: 'audio'` injected. */
+export function audioAsset(fields: Omit<AudioAsset, 'asset_type'>): Tagged<AudioAsset, 'audio'> {
+  return { ...fields, asset_type: 'audio' };
+}
+
+/** Build a `TextAsset` with `asset_type: 'text'` injected. */
+export function textAsset(fields: Omit<TextAsset, 'asset_type'>): Tagged<TextAsset, 'text'> {
+  return { ...fields, asset_type: 'text' };
+}
+
+/** Build a `URLAsset` with `asset_type: 'url'` injected. */
+export function urlAsset(fields: Omit<URLAsset, 'asset_type'>): Tagged<URLAsset, 'url'> {
+  return { ...fields, asset_type: 'url' };
+}
+
+/** Build an `HTMLAsset` with `asset_type: 'html'` injected. */
+export function htmlAsset(fields: Omit<HTMLAsset, 'asset_type'>): Tagged<HTMLAsset, 'html'> {
+  return { ...fields, asset_type: 'html' };
+}
+
+/** Build a `JavaScriptAsset` with `asset_type: 'javascript'` injected. */
+export function javascriptAsset(fields: Omit<JavaScriptAsset, 'asset_type'>): Tagged<JavaScriptAsset, 'javascript'> {
+  return { ...fields, asset_type: 'javascript' };
+}
+
+/** Build a `CSSAsset` with `asset_type: 'css'` injected. */
+export function cssAsset(fields: Omit<CSSAsset, 'asset_type'>): Tagged<CSSAsset, 'css'> {
+  return { ...fields, asset_type: 'css' };
+}
+
+/** Build a `MarkdownAsset` with `asset_type: 'markdown'` injected. */
+export function markdownAsset(fields: Omit<MarkdownAsset, 'asset_type'>): Tagged<MarkdownAsset, 'markdown'> {
+  return { ...fields, asset_type: 'markdown' };
+}
+
+/** Build a `WebhookAsset` with `asset_type: 'webhook'` injected. */
+export function webhookAsset(fields: Omit<WebhookAsset, 'asset_type'>): Tagged<WebhookAsset, 'webhook'> {
+  return { ...fields, asset_type: 'webhook' };
+}
+
+/**
+ * Grouped accessor for every creative-asset builder. `Asset.image({...})`
+ * reads better in assets-by-role manifests and gives one-dot autocomplete
+ * over the whole family. The individual named exports remain the primary
+ * entry points.
+ */
+export const Asset = {
+  image: imageAsset,
+  video: videoAsset,
+  audio: audioAsset,
+  text: textAsset,
+  url: urlAsset,
+  html: htmlAsset,
+  javascript: javascriptAsset,
+  css: cssAsset,
+  markdown: markdownAsset,
+  webhook: webhookAsset,
+} as const;

--- a/test/lib/asset-builders.test.js
+++ b/test/lib/asset-builders.test.js
@@ -1,0 +1,61 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  Asset,
+  imageAsset,
+  videoAsset,
+  audioAsset,
+  textAsset,
+  urlAsset,
+  htmlAsset,
+  javascriptAsset,
+  cssAsset,
+  markdownAsset,
+  webhookAsset,
+} = require('../../dist/lib/index.js');
+
+test('asset builders', async t => {
+  await t.test('imageAsset injects asset_type and forwards fields', () => {
+    assert.deepStrictEqual(imageAsset({ url: 'https://cdn.example/a.png', width: 300, height: 250, alt_text: 'hi' }), {
+      url: 'https://cdn.example/a.png',
+      width: 300,
+      height: 250,
+      alt_text: 'hi',
+      asset_type: 'image',
+    });
+  });
+
+  await t.test('each builder tags its output with the canonical discriminator', () => {
+    assert.strictEqual(videoAsset({ url: 'x', width: 1920, height: 1080 }).asset_type, 'video');
+    assert.strictEqual(audioAsset({ url: 'x' }).asset_type, 'audio');
+    assert.strictEqual(textAsset({ content: 'x' }).asset_type, 'text');
+    assert.strictEqual(urlAsset({ url: 'x' }).asset_type, 'url');
+    assert.strictEqual(htmlAsset({ content: '<div></div>' }).asset_type, 'html');
+    assert.strictEqual(javascriptAsset({ content: '/* */' }).asset_type, 'javascript');
+    assert.strictEqual(cssAsset({ content: '/* */' }).asset_type, 'css');
+    assert.strictEqual(markdownAsset({ content: '# title' }).asset_type, 'markdown');
+    assert.strictEqual(
+      webhookAsset({
+        url: 'https://hook.example/dco',
+        response_type: 'html',
+        security: { method: 'hmac_sha256', hmac_header: 'X-Signature' },
+      }).asset_type,
+      'webhook'
+    );
+  });
+
+  await t.test('builder overwrites a foreign asset_type that bypasses the types', () => {
+    // The input type `Omit<T, 'asset_type'>` forbids the discriminator at
+    // compile time; spread order guarantees the correct tag still lands at
+    // runtime if a caller casts around the types.
+    const smuggled = { content: 'hello', asset_type: 'image' };
+    assert.strictEqual(textAsset(smuggled).asset_type, 'text');
+  });
+
+  await t.test('Asset namespace exposes every builder and produces matching output', () => {
+    const expected = ['image', 'video', 'audio', 'text', 'url', 'html', 'javascript', 'css', 'markdown', 'webhook'];
+    assert.deepStrictEqual(Object.keys(Asset).sort(), expected.slice().sort());
+    assert.strictEqual(Asset.image, imageAsset);
+    assert.strictEqual(Asset.text({ content: 'hi' }).asset_type, textAsset({ content: 'hi' }).asset_type);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds ten typed factory helpers that inject the `asset_type` literal when constructing creative assets: `imageAsset`, `videoAsset`, `audioAsset`, `textAsset`, `urlAsset`, `htmlAsset`, `javascriptAsset`, `cssAsset`, `markdownAsset`, `webhookAsset`.
- Adds a grouped `Asset.*` namespace over the same functions for assets-by-role manifests. Prefer the named exports; use `Asset.image({...})` when building several types together.
- Return type is `Omit<T, 'asset_type'> & { asset_type: '<literal>' }` so the helpers compile regardless of whether the generated types currently carry the discriminator — stable across schema regenerations.
- Discriminator is spread last in the returned object so a runtime cast cannot overwrite the canonical tag.
- Refactors `examples/generative-creative-demo.ts` to use the helpers — nine call sites, each `{ asset_type: 'image', url, ... }` literal becomes `imageAsset({ url, ... })`.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build:lib` succeeds
- [x] `npm run test:lib` — 4351 passing, 0 failing (5 new sub-tests under `asset builders`)
- [x] Prettier clean on all touched files
- [x] Three independent expert reviews (code-reviewer, dx-expert, javascript-protocol-expert) — all cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)