### PR TITLE
feat(client): typed render builders for preview_creative discriminator

### DIFF
--- a/.changeset/render-builder-helpers.md
+++ b/.changeset/render-builder-helpers.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': minor
+---
+
+Add typed factory helpers for `preview_creative` render objects: `urlRender`, `htmlRender`, `bothRender`, plus a grouped `Render` namespace. Each helper takes the render payload without `output_format` and returns an object tagged with the canonical discriminator — `urlRender({ render_id, preview_url, role })` produces a valid url-variant render without repeating `output_format: 'url'` at every call site.
+
+Mirrors the `imageAsset` / `videoAsset` pattern shipped in #771. `PreviewRender` is a oneOf on `output_format` (`url` / `html` / `both`) where the discriminator decides which sibling field becomes required. Matrix runs consistently surfaced renders missing either `output_format` or its required sibling — the helpers make the wrong shape syntactically harder to express because the input type requires the matching `preview_url` / `preview_html` per variant.
+
+Return type uses `Omit<Variant, 'output_format'> & { output_format: <literal> }` so the builders stay robust across schema regenerations. Discriminator is spread last so a runtime cast cannot overwrite the canonical tag.
+
+Skill pitfall callouts in `build-creative-agent` and `build-generative-seller-agent` now recommend the render helpers alongside the asset helpers.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-22
-> @adcp/client v5.9.1
+> @adcp/client v5.10.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-22
-> Library: @adcp/client v5.9.1
+> Library: @adcp/client v5.10.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -93,7 +93,8 @@ What happens when a creative is synced:
 > **Cross-cutting pitfalls matrix runs keep catching:**
 >
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['creative-ad-server']`), NOT `[{id, version}]` objects.
-> - `build_creative` response is `{ creative_manifest: { format_id, assets } }`. Each asset in `creative_manifest.assets` requires an `asset_type` discriminator — `{ serving_tag: { content: '<vast>...' } }` without `asset_type` fails validation.
+> - `build_creative` response is `{ creative_manifest: { format_id, assets } }`. Each asset in `creative_manifest.assets` requires an `asset_type` discriminator — use the typed factories (`imageAsset({...})`, `videoAsset({...})`, `htmlAsset({...})`, `urlAsset({...})`) so the discriminator is injected for you; a plain `{ serving_tag: { content: '<vast>...' } }` fails validation.
+> - `preview_creative` renders have the same pattern — each `renders[]` entry is a oneOf on `output_format`. Use `urlRender({...})`, `htmlRender({...})`, or `bothRender({...})` to inject the discriminator and require the matching `preview_url` / `preview_html` field automatically.
 > - `get_creative_delivery` requires **top-level `currency: string`** (ISO 4217), in addition to any per-row spend fields.
 
 **Handler bindings — read the Contract column entry before writing each return:**

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -84,7 +84,8 @@ Brands should be registered dynamically through `sync_accounts` — when a buyer
 >
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['creative-generative']`), NOT `[{id, version}]` objects.
 > - `build_creative` response is `{ creative_manifest: { format_id, assets } }` — NOT `{ creative_id, status, quality, preview_url }`. Those are `sync_creatives` fields; don't leak them in.
-> - Each asset in `creative_manifest.assets` requires an `asset_type` discriminator (`image`, `video`, `html`, `text`, `url`).
+> - Each asset in `creative_manifest.assets` requires an `asset_type` discriminator — use the typed factories (`imageAsset({...})`, `videoAsset({...})`, `htmlAsset({...})`, `urlAsset({...})`) instead of writing the literal; discriminator is injected for you.
+> - `preview_creative` renders have the same pattern: use `urlRender({...})` / `htmlRender({...})` / `bothRender({...})` — they inject `output_format` and enforce the matching `preview_url` / `preview_html` at the type level.
 > - `get_media_buy_delivery` requires **top-level `currency: string`** (ISO 4217).
 
 Everything from the standard seller skill applies. The delta is in `list_creative_formats` and `sync_creatives`.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -780,6 +780,15 @@ export {
   webhookAsset,
 } from './utils/asset-builders';
 
+// ====== PREVIEW RENDER BUILDERS ======
+// Typed factories that inject the `output_format` discriminator on
+// `PreviewRender` objects. `urlRender({ render_id, preview_url, role })`
+// returns a valid url-variant render without repeating
+// `output_format: 'url'` at every call site. Matrix runs consistently
+// saw this drift: Claude emitted renders that omitted the discriminator
+// or its required sibling field.
+export { Render, urlRender, htmlRender, bothRender } from './utils/render-builders';
+
 // ====== V3.0 COMPATIBILITY UTILITIES ======
 // Capabilities detection, version negotiation, and v3 enforcement.
 // See also:

--- a/src/lib/utils/render-builders.ts
+++ b/src/lib/utils/render-builders.ts
@@ -1,0 +1,57 @@
+// Typed factory helpers for `preview_creative` render objects.
+//
+// `PreviewRender` is a `oneOf` union on `output_format` — three variants:
+//   `url` requires `preview_url`, `html` requires `preview_html`, `both`
+//   requires both. The discriminator decides which field becomes required,
+//   but nothing forces the caller to set it correctly. Matrix runs
+//   repeatedly surfaced renders missing `preview_url` or `output_format`
+//   because an agent wrote the object shape by hand.
+//
+// These builders mirror `imageAsset` / `videoAsset` / etc.: the caller
+// passes the payload fields and the helper injects the discriminator.
+// Spread order places the discriminator last so a runtime cast cannot
+// overwrite the canonical tag.
+
+import type { PreviewRender } from '../types/core.generated';
+
+type UrlRender = Extract<PreviewRender, { output_format: 'url' }>;
+type HtmlRender = Extract<PreviewRender, { output_format: 'html' }>;
+type BothRender = Extract<PreviewRender, { output_format: 'both' }>;
+
+type Tagged<T, Tag extends string> = Omit<T, 'output_format'> & { output_format: Tag };
+
+/**
+ * Build a url-variant `PreviewRender` with `output_format: 'url'` injected.
+ *
+ * Requires `preview_url` — you can't call this without the field the `url`
+ * discriminator makes required, which is the whole point of the helper.
+ */
+export function urlRender(fields: Omit<UrlRender, 'output_format'>): Tagged<UrlRender, 'url'> {
+  return { ...fields, output_format: 'url' };
+}
+
+/**
+ * Build an html-variant `PreviewRender` with `output_format: 'html'` injected.
+ */
+export function htmlRender(fields: Omit<HtmlRender, 'output_format'>): Tagged<HtmlRender, 'html'> {
+  return { ...fields, output_format: 'html' };
+}
+
+/**
+ * Build a both-variant `PreviewRender` with `output_format: 'both'` injected.
+ * Requires both `preview_url` and `preview_html`.
+ */
+export function bothRender(fields: Omit<BothRender, 'output_format'>): Tagged<BothRender, 'both'> {
+  return { ...fields, output_format: 'both' };
+}
+
+/**
+ * Grouped namespace over the same helpers, useful when constructing a
+ * `renders[]` that mixes variants. Prefer the named exports at single
+ * call sites; use `Render.url({...})` when building several types together.
+ */
+export const Render = {
+  url: urlRender,
+  html: htmlRender,
+  both: bothRender,
+} as const;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.9.1';
+export const LIBRARY_VERSION = '5.10.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.9.1',
+  library: '5.10.0',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T02:00:03.447Z',
+  generatedAt: '2026-04-22T05:04:36.214Z',
 } as const;
 
 /**

--- a/test/lib/render-builders.test.js
+++ b/test/lib/render-builders.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { Render, urlRender, htmlRender, bothRender } = require('../../dist/lib/index.js');
+
+test('render builders', async t => {
+  await t.test('urlRender injects output_format and forwards fields', () => {
+    assert.deepStrictEqual(
+      urlRender({
+        render_id: 'r1',
+        preview_url: 'https://preview.example/r1',
+        role: 'primary',
+        dimensions: { width: 300, height: 250 },
+      }),
+      {
+        render_id: 'r1',
+        preview_url: 'https://preview.example/r1',
+        role: 'primary',
+        dimensions: { width: 300, height: 250 },
+        output_format: 'url',
+      }
+    );
+  });
+
+  await t.test('each builder tags its output with the canonical discriminator', () => {
+    assert.strictEqual(urlRender({ render_id: 'r', preview_url: 'https://x', role: 'primary' }).output_format, 'url');
+    assert.strictEqual(
+      htmlRender({ render_id: 'r', preview_html: '<div></div>', role: 'primary' }).output_format,
+      'html'
+    );
+    assert.strictEqual(
+      bothRender({
+        render_id: 'r',
+        preview_url: 'https://x',
+        preview_html: '<div></div>',
+        role: 'primary',
+      }).output_format,
+      'both'
+    );
+  });
+
+  await t.test('builder overwrites a foreign output_format that bypasses the types', () => {
+    // The input type `Omit<T, 'output_format'>` forbids the discriminator at
+    // compile time; spread order guarantees the correct tag still lands at
+    // runtime if a caller casts around the types.
+    const smuggled = { render_id: 'r', preview_html: '<div></div>', role: 'primary', output_format: 'url' };
+    assert.strictEqual(htmlRender(smuggled).output_format, 'html');
+  });
+
+  await t.test('Render namespace exposes every builder and matches the named exports', () => {
+    assert.deepStrictEqual(Object.keys(Render).sort(), ['both', 'html', 'url']);
+    assert.strictEqual(Render.url, urlRender);
+    assert.strictEqual(Render.html, htmlRender);
+    assert.strictEqual(Render.both, bothRender);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `urlRender` / `htmlRender` / `bothRender` factory helpers + a grouped `Render` namespace — directly targets the `preview_creative` drift class matrix v13 surfaced (2 hits on `/previews/0/renders/0/preview_url: must have required property 'preview_url'`).

Mirrors the asset-builder pattern shipped in #771. `PreviewRender` is a oneOf on `output_format` with three variants (`url` / `html` / `both`); the discriminator decides which sibling becomes required. Matrix runs kept catching renders that dropped either the discriminator or the sibling it makes required.

```ts
// Before — easy to forget output_format or preview_url
renders: [{ render_id: 'r1', role: 'primary', preview_url: 'https://preview/r1' }]
// ↑ fails validation: missing `output_format`

// After — helper injects the discriminator; input type requires preview_url
renders: [urlRender({ render_id: 'r1', role: 'primary', preview_url: 'https://preview/r1' })]
```

### Design

- **Three helpers**, one per variant. Can't call `urlRender({...})` without `preview_url` because its input type requires it.
- **Return type** `Omit<Variant, 'output_format'> & { output_format: <literal> }` — regen-stable whether or not the generated interface declares the discriminator in the future.
- **Discriminator spread last** so a runtime cast that slips `output_format: 'wrong'` into the input still produces the correct tag.
- **`Render` namespace** (`Render.url(...)`) as convenience for renders[] arrays that mix variants.

### Skill updates

`build-creative-agent` and `build-generative-seller-agent` cross-cutting pitfall callouts now recommend the render helpers alongside the asset helpers, completing the set:

- `imageAsset` / `videoAsset` / `htmlAsset` / `urlAsset` for each asset
- `urlRender` / `htmlRender` / `bothRender` for each render

Both classes of drift the matrix has been catching now have typed construction paths Claude can lean on.

## Test plan

- [x] `npm run typecheck` clean
- [x] 5 subtests under `render builders` — discriminator injection per variant, field forwarding, spread-order invariant, namespace equivalence
- [x] `npm test` — no regressions
- [ ] Matrix v14 (post-merge) measures whether the preview_creative drift class clears

Minor version bump — new public API, no breaking change.