### PR TITLE
docs(skills): cycle-c — seller response-row billing-quintet pitfalls

### DIFF
--- a/.changeset/cycle-c-seller-response-pitfalls.md
+++ b/.changeset/cycle-c-seller-response-pitfalls.md
@@ -1,0 +1,10 @@
+---
+'@adcp/client': patch
+---
+
+Skill pitfalls for Cycle C — seller-side response-row drift surfaced by matrix v14:
+
+- `get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]` rows require the billing quintet: `package_id`, `spend`, `pricing_model`, `rate`, `currency`. Matrix v14 caught 4 failures on mock handlers that returned `{package_id, impressions, clicks}` without the billing fields. Added to seller + retail-media + generative-seller pitfall callouts.
+- `get_media_buys /media_buys[i]` rows require `media_buy_id`, `status`, `currency`, `total_budget`, `packages`. Matrix v14 caught 2 failures on persist/reconstruct paths. Pitfall callouts now explicitly say: persist `currency` + `total_budget` at `create_media_buy` time, echo verbatim.
+
+No SDK code change. This closes the last two non-specialism-specific drift classes; residual failures after matrix v15 will be storyboard-specific step expectations (generative quality, governance denial shape).

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -86,7 +86,8 @@ Brands should be registered dynamically through `sync_accounts` — when a buyer
 > - `build_creative` response is `{ creative_manifest: { format_id, assets } }` — NOT `{ creative_id, status, quality, preview_url }`. Those are `sync_creatives` fields; don't leak them in.
 > - Each asset in `creative_manifest.assets` requires an `asset_type` discriminator — use the typed factories (`imageAsset({...})`, `videoAsset({...})`, `htmlAsset({...})`, `urlAsset({...})`) instead of writing the literal; discriminator is injected for you.
 > - `preview_creative` renders have the same pattern: use `urlRender({...})` / `htmlRender({...})` / `bothRender({...})` — they inject `output_format` and enforce the matching `preview_url` / `preview_html` at the type level.
-> - `get_media_buy_delivery` requires **top-level `currency: string`** (ISO 4217).
+> - `get_media_buy_delivery` requires **top-level `currency: string`** (ISO 4217), and each `media_buy_deliveries[i]/by_package[j]` row requires `package_id`, `spend`, `pricing_model`, `rate`, `currency` (billing quintet).
+> - `get_media_buys /media_buys[i]` rows require `media_buy_id`, `status`, `currency`, `total_budget`, `packages`. Persist `currency` + `total_budget` from the `create_media_buy` request so they can be echoed back verbatim.
 
 Everything from the standard seller skill applies. The delta is in `list_creative_formats` and `sync_creatives`.
 

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -75,6 +75,8 @@ Does the buyer send performance metrics back for optimization?
 >
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['sales-catalog-driven', 'conversion_tracking']`), NOT `[{id, version}]` objects.
 > - `get_media_buy_delivery` response requires **top-level `currency: string`** (ISO 4217).
+> - `get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]` rows require `package_id`, `spend`, `pricing_model`, `rate`, `currency`. Mock handlers that return `{package_id, impressions, clicks}` fail validation — include the billing quintet on every package row.
+> - `get_media_buys /media_buys[i]` rows require `media_buy_id`, `status`, `currency`, `total_budget`, `packages`. Persist `currency` + `total_budget` from `create_media_buy` so they can be echoed back verbatim.
 
 All standard seller tools apply (see `skills/build-seller-agent/SKILL.md`). The additional tools:
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -356,6 +356,8 @@ Non-guaranteed buys are always instant confirmation.
 >
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['sales-guaranteed']`), NOT `[{id, version}]` objects.
 > - `get_media_buy_delivery` response requires **top-level `currency: string`** (ISO 4217) — per-row `spend.currency` is NOT enough.
+> - `get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]` rows are strict: each requires `package_id`, `spend` (number), `pricing_model`, `rate` (number), and `currency`. A mock that returns `{package_id, impressions, clicks}` fails validation — include the billing quintet on every package row.
+> - `get_media_buys /media_buys[i]` rows require **`media_buy_id`, `status`, `currency`, `total_budget`, `packages`**. When you persist a buy in `create_media_buy`, save `currency` and `total_budget` so the `get_media_buys` response can echo them verbatim — reconstructing later drops one of the required fields in ~every Claude build we've tested.
 
 **`get_adcp_capabilities`** — register first, empty `{}` schema
 


### PR DESCRIPTION
## Summary

Matrix v14 surfaced 2 new drift classes now that v13's creative/preview classes cleared:

1. **`get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]`** rows require the billing quintet: `package_id`, `spend`, `pricing_model`, `rate`, `currency`. Mock handlers returned `{package_id, impressions, clicks}` — 4 v14 failures.
2. **`get_media_buys /media_buys[i]`** rows require `media_buy_id`, `status`, `currency`, `total_budget`, `packages`. Persist/reconstruct paths drop `currency` or `total_budget` — 2 v14 failures.

Both are seller-side non-discriminator shape drift. Added targeted pitfall bullets to:

- `build-seller-agent` (sales_guaranteed storyboard pair)
- `build-retail-media-agent` (sales_catalog_driven pair)
- `build-generative-seller-agent` (creative_generative pair)

## Why skill pitfalls, not a typed factory

Unlike assets/renders where the discriminator enforces the correct sibling field, these rows don't have a discriminator — just a handful of required top-level fields. TypeScript types already enforce this at compile time; the gap is `tsx` bypassing typecheck at agent build time.

A durable fix would be running `tsc --noEmit` in the matrix harness before booting the agent — that would catch every required-field drift at build time. Worth a follow-up PR. For now, the pitfall callouts close the class via skill guidance.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Matrix v15 (post-merge) measures whether these classes clear

## Trajectory

| | v10 | v11 | v12 | v13 | v14 |
|---|---|---|---|---|---|
| Handler throws | 14 | 6 | 0 | 0 | 0 |
| -32602 | 10 | 5 | 0 | 0 | 0 |
| Grader schema fails | — | 11 | 11 | 0 | 0 |
| VALIDATION_ERROR classes | — | — | 6 | 3 | 2 |

After #774, expect v15 to drop to the last mile: storyboard-specific step expectations (generative quality grading, governance denial shape) that are inherently specialism-specific.