### PR TITLE
feat(client): add express-mcp Accept-header middleware

### DIFF
--- a/.changeset/express-mcp-middleware.md
+++ b/.changeset/express-mcp-middleware.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': minor
+---
+
+Add `@adcp/client/express-mcp` middleware that rewrites JSON-only `Accept` headers so they pass the MCP SDK's `StreamableHTTPServerTransport` check when `enableJsonResponse: true`. Local escape hatch pending upstream SDK fix (https://github.com/modelcontextprotocol/typescript-sdk/issues/1944).

--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
       "import": "./dist/lib/substitution/index.js",
       "require": "./dist/lib/substitution/index.js",
       "types": "./dist/lib/substitution/index.d.ts"
+    },
+    "./express-mcp": {
+      "import": "./dist/lib/express-mcp/index.js",
+      "require": "./dist/lib/express-mcp/index.js",
+      "types": "./dist/lib/express-mcp/index.d.ts"
     }
   },
   "typesVersions": {
@@ -109,6 +114,9 @@
       ],
       "substitution": [
         "dist/lib/substitution/index.d.ts"
+      ],
+      "express-mcp": [
+        "dist/lib/express-mcp/index.d.ts"
       ]
     }
   },

--- a/src/lib/express-mcp/index.ts
+++ b/src/lib/express-mcp/index.ts
@@ -35,11 +35,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 type NextFn = (err?: unknown) => void;
 
 /** Minimal Express-compatible handler signature. */
-export type McpAcceptHeaderHandler = (
-  req: IncomingMessage,
-  res: ServerResponse,
-  next: NextFn,
-) => void;
+export type McpAcceptHeaderHandler = (req: IncomingMessage, res: ServerResponse, next: NextFn) => void;
 
 const JSON_TYPE = 'application/json';
 const SSE_TYPE = 'text/event-stream';

--- a/src/lib/express-mcp/index.ts
+++ b/src/lib/express-mcp/index.ts
@@ -1,0 +1,88 @@
+/**
+ * Express middleware that normalizes the `Accept` header so requests reach
+ * `StreamableHTTPServerTransport` without tripping its 406 check.
+ *
+ * The MCP SDK's POST handler requires both `application/json` and
+ * `text/event-stream` in `Accept` even when constructed with
+ * `enableJsonResponse: true` (pure request/response mode — no SSE in play).
+ * Buyer agents and validators that send `Accept: application/json` hit a
+ * 406 Not Acceptable.
+ *
+ * This middleware rewrites `Accept: application/json` (JSON alone) to
+ * `application/json, text/event-stream` on the incoming request, so the
+ * transport's strict check passes. Headers that already advertise both,
+ * or don't advertise JSON, are left alone.
+ *
+ * Mount BEFORE the MCP transport handler:
+ *
+ * ```ts
+ * import express from 'express';
+ * import { mcpAcceptHeaderMiddleware } from '@adcp/client/express-mcp';
+ *
+ * const app = express();
+ * app.use('/mcp', mcpAcceptHeaderMiddleware());
+ * // then mount the MCP transport (StreamableHTTPServerTransport.handleRequest)
+ * ```
+ *
+ * This is a local escape hatch pending upstream SDK fix
+ * (https://github.com/modelcontextprotocol/typescript-sdk/issues/1944).
+ * Remove once the SDK loosens the Accept check for `enableJsonResponse: true`.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http';
+
+/** Minimal next callback shape — avoids a dependency on `@types/express`. */
+type NextFn = (err?: unknown) => void;
+
+/** Minimal Express-compatible handler signature. */
+export type McpAcceptHeaderHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: NextFn,
+) => void;
+
+const JSON_TYPE = 'application/json';
+const SSE_TYPE = 'text/event-stream';
+
+/**
+ * Does the raw `Accept` value advertise `type`? Case-insensitive, tolerant
+ * of parameters (`application/json;q=0.9`) and surrounding whitespace.
+ */
+function acceptsType(accept: string, type: string): boolean {
+  const lower = accept.toLowerCase();
+  const target = type.toLowerCase();
+  for (const raw of lower.split(',')) {
+    const mediaType = raw.split(';')[0]?.trim();
+    if (mediaType === target) return true;
+  }
+  return false;
+}
+
+/**
+ * Create the middleware. No options today; exported as a factory for
+ * symmetry with Express convention and future extensibility.
+ */
+export function mcpAcceptHeaderMiddleware(): McpAcceptHeaderHandler {
+  return function mcpAcceptHeader(req, _res, next) {
+    const accept = req.headers.accept;
+
+    // No Accept header at all — leave it to the SDK to handle however it does.
+    if (typeof accept !== 'string' || accept.length === 0) {
+      next();
+      return;
+    }
+
+    const hasJson = acceptsType(accept, JSON_TYPE);
+    const hasSse = acceptsType(accept, SSE_TYPE);
+
+    // Only rewrite the JSON-only case. If the request already advertises
+    // both, or doesn't advertise JSON at all (e.g. `*/*`, a stray
+    // `text/plain`, or a malformed value), leave the header untouched and
+    // let the transport decide.
+    if (hasJson && !hasSse) {
+      req.headers.accept = `${JSON_TYPE}, ${SSE_TYPE}`;
+    }
+
+    next();
+  };
+}

--- a/test/lib/express-mcp.test.js
+++ b/test/lib/express-mcp.test.js
@@ -18,7 +18,7 @@ function runMiddleware(req) {
   const middleware = mcpAcceptHeaderMiddleware();
   let nextCalled = false;
   let nextErr;
-  middleware(req, /* res */ {}, (err) => {
+  middleware(req, /* res */ {}, err => {
     nextCalled = true;
     nextErr = err;
   });

--- a/test/lib/express-mcp.test.js
+++ b/test/lib/express-mcp.test.js
@@ -1,0 +1,108 @@
+// Unit tests for the @adcp/client/express-mcp Accept-header middleware.
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { mcpAcceptHeaderMiddleware } = require('../../dist/lib/express-mcp/index.js');
+
+/**
+ * Build a minimal IncomingMessage-shaped stub. The middleware only reads
+ * and writes `req.headers.accept`; no actual HTTP machinery is needed.
+ */
+function makeReq(acceptHeader) {
+  const headers = {};
+  if (acceptHeader !== undefined) headers.accept = acceptHeader;
+  return { headers };
+}
+
+function runMiddleware(req) {
+  const middleware = mcpAcceptHeaderMiddleware();
+  let nextCalled = false;
+  let nextErr;
+  middleware(req, /* res */ {}, (err) => {
+    nextCalled = true;
+    nextErr = err;
+  });
+  return { nextCalled, nextErr };
+}
+
+describe('mcpAcceptHeaderMiddleware', () => {
+  test('rewrites Accept: application/json to include text/event-stream', () => {
+    const req = makeReq('application/json');
+    const { nextCalled, nextErr } = runMiddleware(req);
+
+    assert.strictEqual(nextCalled, true);
+    assert.strictEqual(nextErr, undefined);
+    assert.strictEqual(req.headers.accept, 'application/json, text/event-stream');
+  });
+
+  test('rewrites JSON-only Accept with quality params', () => {
+    const req = makeReq('application/json;q=0.9');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, 'application/json, text/event-stream');
+  });
+
+  test('leaves Accept untouched when both types are already present', () => {
+    const req = makeReq('application/json, text/event-stream');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, 'application/json, text/event-stream');
+  });
+
+  test('leaves Accept untouched when both types present in reverse order', () => {
+    const req = makeReq('text/event-stream, application/json');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, 'text/event-stream, application/json');
+  });
+
+  test('leaves Accept untouched when header is absent', () => {
+    const req = makeReq(undefined);
+    const { nextCalled } = runMiddleware(req);
+
+    assert.strictEqual(nextCalled, true);
+    assert.strictEqual(req.headers.accept, undefined);
+  });
+
+  test('leaves Accept untouched when header is empty string', () => {
+    const req = makeReq('');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, '');
+  });
+
+  test('leaves Accept untouched for wildcard (*/*)', () => {
+    const req = makeReq('*/*');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, '*/*');
+  });
+
+  test('leaves Accept untouched for non-MCP media types', () => {
+    const req = makeReq('text/html, application/xhtml+xml');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, 'text/html, application/xhtml+xml');
+  });
+
+  test('leaves Accept untouched for text/event-stream alone', () => {
+    const req = makeReq('text/event-stream');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, 'text/event-stream');
+  });
+
+  test('is case-insensitive on media-type detection', () => {
+    const req = makeReq('Application/JSON');
+    runMiddleware(req);
+    assert.strictEqual(req.headers.accept, 'application/json, text/event-stream');
+  });
+
+  test('always invokes next() without error', () => {
+    for (const header of [
+      'application/json',
+      'application/json, text/event-stream',
+      '*/*',
+      'text/html',
+      '',
+      undefined,
+    ]) {
+      const { nextCalled, nextErr } = runMiddleware(makeReq(header));
+      assert.strictEqual(nextCalled, true, `next should run for header: ${header}`);
+      assert.strictEqual(nextErr, undefined, `next should get no error for header: ${header}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `@adcp/client/express-mcp` — a tiny Express middleware that rewrites JSON-only `Accept` headers to include `text/event-stream`, letting requests pass the MCP SDK's `StreamableHTTPServerTransport` 406 check when the transport is constructed with `enableJsonResponse: true`.

## Why

`StreamableHTTPServerTransport` rejects `Accept: application/json` with `406 Not Acceptable` even in pure JSON-response mode, where `text/event-stream` has no role. Every AdCP MCP seller hits this — buyer agents and validators reasonably default to `Accept: application/json`. Filed upstream: [modelcontextprotocol/typescript-sdk#1944](https://github.com/modelcontextprotocol/typescript-sdk/issues/1944). This PR ships a local escape hatch so sellers don't need to hand-roll the fix; we'll drop it once the SDK is patched.

## Behavior

- `Accept: application/json` (with or without `;q=` params) → rewritten to `application/json, text/event-stream`
- Already has both → untouched
- `*/*`, `text/html`, `text/event-stream` alone, absent header, empty string → untouched

## Usage

```ts
import express from 'express';
import { mcpAcceptHeaderMiddleware } from '@adcp/client/express-mcp';

const app = express();
app.use('/mcp', mcpAcceptHeaderMiddleware());
// then mount StreamableHTTPServerTransport
```

## Test plan

- [x] Unit tests cover rewrite, untouched cases, case-insensitivity, absent/empty headers (`test/lib/express-mcp.test.js`, 11 tests)
- [x] `npm run typecheck` passes
- [x] `npm test` — 5145 pass, 0 fail
- [x] Changeset added (minor bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)