### PR TITLE
fix(validation): accept envelope-level replayed field on all response schemas

### DIFF
--- a/.changeset/relax-response-additional-properties.md
+++ b/.changeset/relax-response-additional-properties.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+Fix: response-schema AJV validators now accept envelope fields (`replayed`, `context`, `ext`, and future envelope additions) at the response root on every tool.
+
+The bundled JSON response schemas for the property-list family (`create_property_list`, `update_property_list`, `delete_property_list`, `get_property_list`, `list_property_lists`, `validate_property_delivery`) ship with `additionalProperties: false` at the root, which rejected `replayed: false` — even though security.mdx specifies `replayed` as a protocol-level envelope field that MAY appear on any response. That left a two-faced contract: the universal-idempotency storyboard requires `replayed: false` on the initial `create_media_buy`, but emitting the same envelope field on property-list tools tripped strict response validation.
+
+`schema-loader` now flips `additionalProperties: false` to `true` at the response root (and at each direct `oneOf` / `anyOf` / `allOf` branch one level deep) when compiling response validators. Nested body objects stay strict so drift inside a `Product`, `Package`, or list body still fails validation. Request schemas remain strict so outgoing drift fails at the edge. Matches the envelope extensibility the Zod generator already expresses via `.passthrough()`. Fixes #774.

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -74,6 +74,42 @@ function loadJson(file: string): LoadedSchema {
 }
 
 /**
+ * Clear `additionalProperties: false` at the response root so envelope
+ * fields (`replayed`, `context`, `ext`, and future envelope additions)
+ * can ride alongside the tool-specific body — per security.mdx the
+ * envelope is always extensible. Upstream bundled schemas pin
+ * `additionalProperties: false` at the root on a handful of mutating
+ * tools (the property-list family), which rejects `replayed: false`.
+ *
+ * Scope is deliberately narrow: only the top-level object, plus each
+ * direct branch of a root-level `oneOf` / `anyOf` / `allOf`. Nested
+ * bodies stay strict so response-side drift detection still catches
+ * typos inside `Product`, `Package`, `MediaBuy` etc. Applied only to
+ * response variants; request schemas stay strict so outgoing drift
+ * fails at the edge.
+ */
+function relaxResponseRoot(schema: LoadedSchema): LoadedSchema {
+  const clone = { ...schema };
+  if (clone.additionalProperties === false) {
+    clone.additionalProperties = true;
+  }
+  for (const key of ['oneOf', 'anyOf', 'allOf'] as const) {
+    const branches = clone[key];
+    if (Array.isArray(branches)) {
+      clone[key] = branches.map(branch => {
+        if (!branch || typeof branch !== 'object') return branch;
+        const branchClone = { ...(branch as Record<string, unknown>) };
+        if (branchClone.additionalProperties === false) {
+          branchClone.additionalProperties = true;
+        }
+        return branchClone;
+      });
+    }
+  }
+  return clone;
+}
+
+/**
  * Build the (toolName, direction) → file path index by scanning the schema
  * tree once. Runs eagerly at first validator lookup.
  */
@@ -177,7 +213,8 @@ export function getValidator(toolName: string, direction: Direction): ValidateFu
     ensureCoreLoaded(s);
   }
 
-  const schema = loadJson(file);
+  const rawSchema = loadJson(file);
+  const schema = direction === 'request' ? rawSchema : relaxResponseRoot(rawSchema);
   const existing = typeof schema.$id === 'string' ? s.ajv.getSchema(schema.$id) : undefined;
   const compiled = existing ?? s.ajv.compile(schema);
   s.validators.set(cacheKey, compiled);

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -89,6 +89,75 @@ describe('schema-driven validation', () => {
       assert.strictEqual(productsIssue.keyword, 'type');
       assert.ok(productsIssue.schemaPath.length > 0);
     });
+
+    test('accepts envelope fields (replayed, unknown vendor keys) at the response root when bundled schema is additionalProperties:false', () => {
+      // create_property_list-response declares additionalProperties:false at root.
+      // Envelope fields like `replayed` (per security.mdx) must ride alongside.
+      // Body fields (`list`, `auth_token`) are intentionally omitted — AJV runs
+      // with allErrors, so required-field issues don't mask the envelope check.
+      const outcome = validateResponse('create_property_list', {
+        replayed: false,
+        unknown_envelope_field: { any: 'value' },
+      });
+      const rootAdditional = outcome.issues.filter(
+        i => i.keyword === 'additionalProperties' && (i.pointer === '' || i.pointer === '/')
+      );
+      assert.deepStrictEqual(
+        rootAdditional,
+        [],
+        `envelope fields should not trigger additionalProperties at the response root: ${JSON.stringify(rootAdditional)}`
+      );
+    });
+
+    test('envelope passthrough applies across the property-list family (not just create)', () => {
+      // delete_property_list and get_property_list ship the same root-level
+      // additionalProperties:false. One tool passing could be schema-specific;
+      // a second tool confirms the loader fix is general.
+      for (const tool of ['delete_property_list', 'get_property_list']) {
+        const outcome = validateResponse(tool, { replayed: false });
+        const rootAdditional = outcome.issues.filter(
+          i => i.keyword === 'additionalProperties' && (i.pointer === '' || i.pointer === '/')
+        );
+        assert.deepStrictEqual(
+          rootAdditional,
+          [],
+          `${tool}: envelope passthrough regressed at root: ${JSON.stringify(rootAdditional)}`
+        );
+      }
+    });
+
+    test('nested-body drift is still caught (relaxation does not recurse)', () => {
+      // get_property_list-response nests `list: { ... }` with its own
+      // additionalProperties:false. Typos inside the body must still fail
+      // — envelope passthrough is a root-level concession only.
+      const outcome = validateResponse('get_property_list', {
+        list: { unknown_nested_field: 'typo' },
+      });
+      const nestedAdditional = outcome.issues.filter(
+        i => i.keyword === 'additionalProperties' && i.pointer.startsWith('/list')
+      );
+      assert.ok(
+        nestedAdditional.length > 0,
+        `expected additionalProperties failure inside /list body, got: ${JSON.stringify(outcome.issues)}`
+      );
+    });
+  });
+
+  describe('validateRequest envelope strictness', () => {
+    test('request schemas stay strict — unknown top-level fields are rejected', () => {
+      // The fix explicitly preserves request strictness so outgoing drift
+      // fails at the edge. Regression guard: if relaxResponseRoot ever leaks
+      // to requests, this test catches it.
+      const outcome = validateRequest('create_property_list', {
+        name: 'Test',
+        unknown_request_field: { should: 'reject' },
+      });
+      const additional = outcome.issues.filter(i => i.keyword === 'additionalProperties');
+      assert.ok(
+        additional.length > 0,
+        `request validation should still reject unknown top-level fields: ${JSON.stringify(outcome.issues)}`
+      );
+    });
   });
 
   describe('formatIssues', () => {


### PR DESCRIPTION
## Summary

- `schema-loader` flips root-level `additionalProperties: false → true` on response variants at AJV compile time so envelope fields (`replayed`, future envelope additions) ride alongside the tool-specific body. Matches the `.passthrough()` the Zod generator already emits for every `*ResponseSchema`.
- Scope is deliberately narrow: only the response root + each direct `oneOf` / `anyOf` / `allOf` branch. Nested bodies stay strict so drift inside `Product` / `Package` / list shapes still fails validation. Request schemas stay strict so outgoing drift fails at the edge.
- Upstream spec bug (the schemas should declare `replayed` at the root rather than relying on client relaxation) tracked at adcontextprotocol/adcp#2839. This PR is the pragmatic SDK-side stopgap — Python and Go SDKs will hit the same wall until the spec fix lands.

Closes #774.

## Why this fix

Per `security.mdx` and the `idempotency-key-required` changeset, mutating response envelopes carry a top-level `replayed` boolean. But 14 bundled response schemas (property-list family, collection-list family, governance) pin `additionalProperties: false` at the root and omit `replayed` from known properties. AJV rejected every response that emitted it, even though the Zod validator in the same SDK accepted it. Sellers had to scope `replayed` to `create_media_buy` only to dodge strict response validation — leaving buyers with `undefined` for dedup decisions on every other mutating tool.

## Reviewed by

Dispatched `code-reviewer`, `security-reviewer`, `ad-tech-protocol-expert`, and `nodejs-testing-expert` subagents before this PR. Feedback addressed in-PR:

- Narrowed recursion to root + `oneOf` branches (code-reviewer, security-reviewer, protocol-expert all flagged recursive relaxation defeated drift detection inside bodies).
- Minimized test payload (`list` object dropped — AJV's `allErrors: true` means `additionalProperties` issues surface independently of required-field issues).
- Added second-tool test (`delete_property_list`, `get_property_list`) proving schema-general not `create_property_list`-specific.
- Added nested-drift-still-caught test.
- Added request-strictness negative test as regression guard against `relaxResponseRoot` leaking to requests.
- Changeset reworded to match narrowed scope.

## Test plan

- [x] `npm run build:lib` clean
- [x] `npm run test:lib` — 4347/4353 pass (6 pre-existing skips)
- [x] `test/lib/schema-validation.test.js` — 25/25 pass including 4 new assertions
- [ ] CI green on all required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)