### PR TITLE
docs(skills): cycle-d — date-time format + video asset width pitfalls

### DIFF
--- a/.changeset/cycle-d-datetime-video-width.md
+++ b/.changeset/cycle-d-datetime-video-width.md
@@ -1,0 +1,10 @@
+---
+'@adcp/client': patch
+---
+
+Skill pitfalls for Cycle D — two narrow drift classes matrix v15 surfaced after the 3.0 GA schema sync (#773):
+
+- `get_media_buy_delivery /reporting_period/start` and `/end` are ISO 8601 **date-time** strings (`new Date().toISOString()` produces the canonical shape), not date-only. GA added strict `format: "date-time"` validation; `'2026-04-21'` now fails. Added to seller, retail-media, generative-seller, and creative-agent skill pitfall callouts.
+- `videoAsset({...})` now requires `width` and `height` per GA (previously optional on `VideoAsset`). Mocks that passed `{url}` alone fail validation at `/creative_manifest/assets/<name>/width`. Added to creative-agent and generative-seller pitfalls with a concrete pixel-values example.
+
+No SDK code change. Closes v15's two residual schema-drift classes. Residual failures after this land are storyboard-specific step expectations (generative quality grading, governance denial shape specifics) — the tight-loop per-pair phase.

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -95,7 +95,8 @@ What happens when a creative is synced:
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['creative-ad-server']`), NOT `[{id, version}]` objects.
 > - `build_creative` response is `{ creative_manifest: { format_id, assets } }`. Each asset in `creative_manifest.assets` requires an `asset_type` discriminator — use the typed factories (`imageAsset({...})`, `videoAsset({...})`, `htmlAsset({...})`, `urlAsset({...})`) so the discriminator is injected for you; a plain `{ serving_tag: { content: '<vast>...' } }` fails validation.
 > - `preview_creative` renders have the same pattern — each `renders[]` entry is a oneOf on `output_format`. Use `urlRender({...})`, `htmlRender({...})`, or `bothRender({...})` to inject the discriminator and require the matching `preview_url` / `preview_html` field automatically.
-> - `get_creative_delivery` requires **top-level `currency: string`** (ISO 4217), in addition to any per-row spend fields.
+> - `get_creative_delivery` requires **top-level `currency: string`** (ISO 4217), in addition to any per-row spend fields. `reporting_period/start` and `/end` are ISO 8601 **date-time** strings (`new Date().toISOString()`), not date-only.
+> - `videoAsset({...})` requires `width` + `height` per GA (previously optional). Set realistic pixel values — `{ url, width: 1920, height: 1080 }`.
 
 **Handler bindings — read the Contract column entry before writing each return:**
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -87,6 +87,8 @@ Brands should be registered dynamically through `sync_accounts` — when a buyer
 > - Each asset in `creative_manifest.assets` requires an `asset_type` discriminator — use the typed factories (`imageAsset({...})`, `videoAsset({...})`, `htmlAsset({...})`, `urlAsset({...})`) instead of writing the literal; discriminator is injected for you.
 > - `preview_creative` renders have the same pattern: use `urlRender({...})` / `htmlRender({...})` / `bothRender({...})` — they inject `output_format` and enforce the matching `preview_url` / `preview_html` at the type level.
 > - `get_media_buy_delivery` requires **top-level `currency: string`** (ISO 4217), and each `media_buy_deliveries[i]/by_package[j]` row requires `package_id`, `spend`, `pricing_model`, `rate`, `currency` (billing quintet).
+> - `reporting_period/start` and `/end` are ISO 8601 **date-time** strings (`new Date().toISOString()`), not date-only — `'2026-04-21'` fails GA validation.
+> - `videoAsset({...})` requires `width` + `height` in GA (previously optional). Omitting them fails validation at `/creative_manifest/assets/<name>/width` when the asset is constructed from video content.
 > - `get_media_buys /media_buys[i]` rows require `media_buy_id`, `status`, `currency`, `total_budget`, `packages`. Persist `currency` + `total_budget` from the `create_media_buy` request so they can be echoed back verbatim.
 
 Everything from the standard seller skill applies. The delta is in `list_creative_formats` and `sync_creatives`.

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -76,6 +76,7 @@ Does the buyer send performance metrics back for optimization?
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['sales-catalog-driven', 'conversion_tracking']`), NOT `[{id, version}]` objects.
 > - `get_media_buy_delivery` response requires **top-level `currency: string`** (ISO 4217).
 > - `get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]` rows require `package_id`, `spend`, `pricing_model`, `rate`, `currency`. Mock handlers that return `{package_id, impressions, clicks}` fail validation — include the billing quintet on every package row.
+> - `get_media_buy_delivery /reporting_period/start` and `/end` are ISO 8601 **date-time** strings (`new Date().toISOString()`), not date-only. `'2026-04-21'` fails the GA format check.
 > - `get_media_buys /media_buys[i]` rows require `media_buy_id`, `status`, `currency`, `total_budget`, `packages`. Persist `currency` + `total_budget` from `create_media_buy` so they can be echoed back verbatim.
 
 All standard seller tools apply (see `skills/build-seller-agent/SKILL.md`). The additional tools:

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -357,6 +357,7 @@ Non-guaranteed buys are always instant confirmation.
 > - `capabilities.specialisms` is `string[]` of enum ids (e.g. `['sales-guaranteed']`), NOT `[{id, version}]` objects.
 > - `get_media_buy_delivery` response requires **top-level `currency: string`** (ISO 4217) — per-row `spend.currency` is NOT enough.
 > - `get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]` rows are strict: each requires `package_id`, `spend` (number), `pricing_model`, `rate` (number), and `currency`. A mock that returns `{package_id, impressions, clicks}` fails validation — include the billing quintet on every package row.
+> - `get_media_buy_delivery /reporting_period/start` and `/end` are ISO 8601 **date-time** strings (`YYYY-MM-DDTHH:MM:SS.sssZ` via `new Date().toISOString()`), not date-only. A mock that returns `'2026-04-21'` fails the format check in GA.
 > - `get_media_buys /media_buys[i]` rows require **`media_buy_id`, `status`, `currency`, `total_budget`, `packages`**. When you persist a buy in `create_media_buy`, save `currency` and `total_budget` so the `get_media_buys` response can echo them verbatim — reconstructing later drops one of the required fields in ~every Claude build we've tested.
 
 **`get_adcp_capabilities`** — register first, empty `{}` schema

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-22T04:09:05.446Z
+// Generated at: 2026-04-22T06:08:27.815Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -11231,6 +11231,10 @@ export interface SyncAudiencesRequest {
  */
 export type SyncAudiencesResponse = SyncAudiencesSuccess | SyncAudiencesError;
 /**
+ * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed.
+ */
+export type AudienceStatus = 'processing' | 'ready' | 'too_small';
+/**
  * Identifier type. Combines hashed PII types (hashed_email, hashed_phone) with universal ID types (rampid, uid2, maid, etc.).
  */
 export type MatchIDType =
@@ -11268,10 +11272,7 @@ export interface SyncAudiencesSuccess {
      * Action taken for this audience. 'status' is present when action is created, updated, or unchanged. 'status' is absent when action is deleted or failed.
      */
     action: 'created' | 'updated' | 'unchanged' | 'deleted' | 'failed';
-    /**
-     * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed. 'processing': platform is still matching members against its user base. 'ready': audience is available for targeting, matched_count is populated. 'too_small': matched audience is below the platform's minimum size — add more members and re-sync.
-     */
-    status?: 'processing' | 'ready' | 'too_small';
+    status?: AudienceStatus;
     /**
      * Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.
      */

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-22T04:09:10.844Z
+// Generated at: 2026-04-22T06:09:16.717Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2553,6 +2553,8 @@ export const SyncAudiencesErrorSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const AudienceStatusSchema = z.union([z.literal("processing"), z.literal("ready"), z.literal("too_small")]);
+
 export const MatchIDTypeSchema = z.union([z.literal("hashed_email"), z.literal("hashed_phone"), z.literal("rampid"), z.literal("id5"), z.literal("uid2"), z.literal("euid"), z.literal("pairid"), z.literal("maid"), z.literal("other")]);
 
 export const SyncAudiencesSuccessSchema = z.object({
@@ -2561,7 +2563,7 @@ export const SyncAudiencesSuccessSchema = z.object({
         name: z.string().optional(),
         seller_id: z.string().optional(),
         action: z.union([z.literal("created"), z.literal("updated"), z.literal("unchanged"), z.literal("deleted"), z.literal("failed")]),
-        status: z.union([z.literal("processing"), z.literal("ready"), z.literal("too_small")]).optional(),
+        status: AudienceStatusSchema.optional(),
         uploaded_count: z.number().optional(),
         total_uploaded_count: z.number().optional(),
         matched_count: z.number().optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -7238,6 +7238,10 @@ export interface SyncAudiencesRequest {
  */
 export type SyncAudiencesResponse = SyncAudiencesSuccess | SyncAudiencesError;
 /**
+ * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed.
+ */
+export type AudienceStatus = 'processing' | 'ready' | 'too_small';
+/**
  * Identifier type. Combines hashed PII types (hashed_email, hashed_phone) with universal ID types (rampid, uid2, maid, etc.).
  */
 export type MatchIDType =
@@ -7275,10 +7279,7 @@ export interface SyncAudiencesSuccess {
      * Action taken for this audience. 'status' is present when action is created, updated, or unchanged. 'status' is absent when action is deleted or failed.
      */
     action: 'created' | 'updated' | 'unchanged' | 'deleted' | 'failed';
-    /**
-     * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed. 'processing': platform is still matching members against its user base. 'ready': audience is available for targeting, matched_count is populated. 'too_small': matched audience is below the platform's minimum size — add more members and re-sync.
-     */
-    status?: 'processing' | 'ready' | 'too_small';
+    status?: AudienceStatus;
     /**
      * Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.
      */


### PR DESCRIPTION
## Summary

Matrix v15 surfaced 2 narrow drift classes after the 3.0 GA schema sync (#773) added stricter validation:

1. **`reporting_period.start/end` are ISO 8601 date-time strings** per GA — date-only (`'2026-04-21'`) now fails format validation. Mocks should use `new Date().toISOString()`. 4 hits on `get_media_buy_delivery`. Added to seller, retail-media, generative-seller, and creative-agent pitfalls.
2. **`videoAsset` requires `width` + `height`** per GA (previously optional on `VideoAsset`). Mocks returning `{url}` alone fail at `/creative_manifest/assets/<name>/width`. 2 hits. Added to creative-agent + generative-seller pitfalls with concrete pixel-values example.

Both are GA-tightening classes. No SDK code change.

## Trajectory (same filter, same 8 pairs)

| | v10 | v11 | v12 | v13 | v14 | v15 |
|---|---|---|---|---|---|---|
| Handler throws | 14 | 6 | 0 | 0 | 0 | 0 |
| -32602 | 10 | 5 | 0 | 0 | 0 | 0 |
| Grader schema fails | — | 11 | 11 | 0 | 0 | 0 |
| VALIDATION_ERROR classes | — | — | 6 | 3 | 2 | 2 |

Expected v16 after merge: VALIDATION_ERROR classes → 0 on the schema axis. Residual failures will be storyboard-specific step expectations (generative quality grading, governance denial shape specifics) — the tight-loop per-pair phase I flagged at the start of Cycle A.

## Test plan

- [x] `npm run typecheck` clean
- [ ] Matrix v16 post-merge for verification