### PR TITLE
feat(testing): default TestControllerStore factory wires every scenario

### DIFF
--- a/.changeset/default-test-controller-store.md
+++ b/.changeset/default-test-controller-store.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': minor
+---
+
+Add `createDefaultTestControllerStore` to `@adcp/client/testing` — a default factory that wires every `force_*`, `simulate_*`, `seed_*` scenario against a generic `DefaultSessionShape`. Sellers provide `loadSession` / `saveSession` and get a conformance-ready `TestControllerStore` without hand-rolling 300+ lines of boilerplate. Supports partial overrides for sellers who need to customize specific handlers.

--- a/src/lib/testing/default-controller-store.ts
+++ b/src/lib/testing/default-controller-store.ts
@@ -1,0 +1,541 @@
+/**
+ * Default factory for `comply_test_controller` stores.
+ *
+ * Most sellers implementing conformance wire ~300 lines of boilerplate against
+ * their own session state: a Map per status kind, a Map per seed kind, matching
+ * force/simulate/seed handlers, cap enforcement, and idempotent save calls.
+ * {@link createDefaultTestControllerStore} collapses that to ten lines by
+ * wiring every scenario against a generic {@link DefaultSessionShape} — the
+ * seller brings `loadSession` / `saveSession`, the factory hands back a
+ * conformance-ready {@link TestControllerStore}.
+ *
+ * @example Postgres-backed seller
+ * ```ts
+ * import { createAdcpServer, serve } from '@adcp/client/server';
+ * import {
+ *   createDefaultTestControllerStore,
+ *   createDefaultSession,
+ *   registerTestController,
+ * } from '@adcp/client/testing';
+ *
+ * const controller = createDefaultTestControllerStore({
+ *   async loadSession({ context }) {
+ *     const sessionId = (context as { session_id?: string })?.session_id ?? 'anon';
+ *     const row = await db.query('select state from comply_sessions where id=$1', [sessionId]);
+ *     return row ? deserializeSession(row.state) : createDefaultSession();
+ *   },
+ *   async saveSession(session) {
+ *     await db.query(
+ *       'insert into comply_sessions(id,state) values($1,$2) on conflict (id) do update set state=$2',
+ *       [session.sessionId, serializeSession(session)]
+ *     );
+ *   },
+ * });
+ *
+ * const server = createAdcpServer({ name: 'my-seller', version: '1.0.0' });
+ * registerTestController(server, controller);
+ * serve(server, { port: 3000 });
+ * ```
+ *
+ * @example Partial overrides
+ *
+ * Sellers who want most defaults but need custom behavior for one scenario
+ * pass `overrides`. The override wins for that scenario; every other scenario
+ * still uses the default handler.
+ *
+ * ```ts
+ * const controller = createDefaultTestControllerStore({
+ *   loadSession,
+ *   saveSession,
+ *   overrides: {
+ *     async forceMediaBuyStatus(mediaBuyId, status, rejectionReason) {
+ *       // Seller's production state machine — controller routes through it.
+ *       return await mediaBuys.transition(mediaBuyId, status, rejectionReason);
+ *     },
+ *   },
+ * });
+ * ```
+ */
+
+import type {
+  TestControllerStore,
+  TestControllerStoreFactory,
+  ControllerScenario,
+} from '../server/test-controller';
+import {
+  CONTROLLER_SCENARIOS,
+  SESSION_ENTRY_CAP,
+  TestControllerError,
+  enforceMapCap,
+} from '../server/test-controller';
+import type { AccountStatus, CreativeStatus, MediaBuyStatus } from '../types/core.generated';
+import type { SimulationSuccess, StateTransitionSuccess } from '../types/tools.generated';
+
+// ────────────────────────────────────────────────────────────
+// Session shape
+// ────────────────────────────────────────────────────────────
+
+/** Session-scoped state for a force_session_status entity. */
+export type SessionTerminalStatus = 'complete' | 'terminated';
+
+/** Stored payload for `simulate_delivery`. The latest call wins; cumulative
+ * totals are computed from the history below. */
+export interface DeliverySimulationRecord {
+  impressions?: number;
+  clicks?: number;
+  conversions?: number;
+  reported_spend?: { amount: number; currency: string };
+}
+
+/** Stored payload for `simulate_budget_spend`. One record per
+ * account_id / media_buy_id (whichever key was supplied). */
+export interface BudgetSpendRecord {
+  account_id?: string;
+  media_buy_id?: string;
+  spend_percentage: number;
+}
+
+/** Seed payloads are stored verbatim so downstream handlers (get_products,
+ * sync_creatives, etc.) can read them. Wiring the seeded payload into those
+ * production tools is the seller's responsibility — see the per-Map comments
+ * below for how to reach each payload. */
+export type SeedFixture = Record<string, unknown>;
+
+/**
+ * The default session shape. Every scenario's default handler reads/writes one
+ * of these Maps. Sellers bringing their own session type should structurally
+ * match this interface — additional fields are allowed and ignored by the
+ * default factory.
+ */
+export interface DefaultSessionShape {
+  /** Current status per account_id. Missing keys are treated as `'active'`
+   * on first force — accounts have no seed_* scenario, so upsert is the only
+   * sensible default. */
+  accountStatuses: Map<string, AccountStatus>;
+
+  /** Current status per creative_id. A force_creative_status call on a key
+   * not present here AND not present in {@link seededCreatives} raises
+   * NOT_FOUND — seed first, then force. */
+  creativeStatuses: Map<string, CreativeStatus>;
+
+  /** Optional rejection_reason paired with creativeStatuses. Only set when
+   * the last transition was to `'rejected'`. */
+  creativeRejectionReasons: Map<string, string>;
+
+  /** Current status per media_buy_id. A force_media_buy_status call on a key
+   * not present here AND not present in {@link seededMediaBuys} raises
+   * NOT_FOUND — seed first, then force. */
+  mediaBuyStatuses: Map<string, MediaBuyStatus>;
+
+  /** Optional rejection_reason paired with mediaBuyStatuses. */
+  mediaBuyRejectionReasons: Map<string, string>;
+
+  /** Terminal session state per session_id. Missing keys are treated as
+   * `'active'` on first force — sessions have no seed_* scenario. */
+  sessionStatuses: Map<string, SessionTerminalStatus>;
+
+  /** Optional termination_reason paired with sessionStatuses. */
+  sessionTerminationReasons: Map<string, string>;
+
+  /** Latest simulate_delivery payload per media_buy_id. */
+  simulatedDeliveries: Map<string, DeliverySimulationRecord>;
+
+  /** Cumulative simulate_delivery totals per media_buy_id. Updated on every
+   * simulate_delivery call by summing the delta from the latest record. */
+  cumulativeDeliveries: Map<string, DeliverySimulationRecord>;
+
+  /** Latest simulate_budget_spend payload per entity. Key is
+   * `account_id` or `media_buy_id` prefixed with `account:` / `media_buy:`
+   * to avoid collisions when both spaces share an id. */
+  simulatedBudgetSpends: Map<string, BudgetSpendRecord>;
+
+  /** Seeded product fixtures, keyed by product_id. Consume via
+   * `session.seededProducts.get(id)` from your `get_products` handler. */
+  seededProducts: Map<string, SeedFixture>;
+
+  /** Seeded pricing-option fixtures, keyed by `${product_id}:${pricing_option_id}`. */
+  seededPricingOptions: Map<string, SeedFixture>;
+
+  /** Seeded creative fixtures, keyed by creative_id. Consume via
+   * `session.seededCreatives.get(id)` from your `sync_creatives` or
+   * `list_creatives` handler. */
+  seededCreatives: Map<string, SeedFixture>;
+
+  /** Seeded plan fixtures, keyed by plan_id. Consume via
+   * `session.seededPlans.get(id)` from your `get_plan` handler. */
+  seededPlans: Map<string, SeedFixture>;
+
+  /** Seeded media-buy fixtures, keyed by media_buy_id. Consume via
+   * `session.seededMediaBuys.get(id)` from your `get_media_buy` handler. */
+  seededMediaBuys: Map<string, SeedFixture>;
+}
+
+/** Build a fresh {@link DefaultSessionShape} with empty Maps for every field.
+ * Convenient for sellers starting from nothing or for test fixtures. */
+export function createDefaultSession(): DefaultSessionShape {
+  return {
+    accountStatuses: new Map(),
+    creativeStatuses: new Map(),
+    creativeRejectionReasons: new Map(),
+    mediaBuyStatuses: new Map(),
+    mediaBuyRejectionReasons: new Map(),
+    sessionStatuses: new Map(),
+    sessionTerminationReasons: new Map(),
+    simulatedDeliveries: new Map(),
+    cumulativeDeliveries: new Map(),
+    simulatedBudgetSpends: new Map(),
+    seededProducts: new Map(),
+    seededPricingOptions: new Map(),
+    seededCreatives: new Map(),
+    seededPlans: new Map(),
+    seededMediaBuys: new Map(),
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// Factory options
+// ────────────────────────────────────────────────────────────
+
+/** Input passed to {@link CreateDefaultTestControllerStoreOptions.loadSession}. */
+export interface DefaultLoadSessionInput {
+  /** The raw AdCP `context` object from the `comply_test_controller` request.
+   * Typically used to extract `session_id` for tenant-scoped persistence. */
+  context: unknown;
+}
+
+export interface CreateDefaultTestControllerStoreOptions<S extends DefaultSessionShape> {
+  /** Called per request to load session state. Return a fresh session for
+   * first-seen keys (see {@link createDefaultSession}); otherwise rehydrate
+   * from your persistence layer. */
+  loadSession: (input: DefaultLoadSessionInput) => Promise<S>;
+
+  /** Called after each mutation to persist. Omit for in-memory scenarios
+   * where `loadSession` returns a reference to a long-lived object that the
+   * handler mutates in place. */
+  saveSession?: (session: S) => Promise<void>;
+
+  /** Per-Map cap. Any `.set()` that would push a Map above this cap raises
+   * `INVALID_STATE` via {@link enforceMapCap}. Defaults to
+   * {@link SESSION_ENTRY_CAP} (1000). */
+  mapCap?: number;
+
+  /** Override any default handler. An override REPLACES the default for that
+   * scenario — partial overrides are supported and the remaining scenarios
+   * keep the factory's defaults. */
+  overrides?: Partial<TestControllerStore>;
+}
+
+// ────────────────────────────────────────────────────────────
+// Default handler helpers
+// ────────────────────────────────────────────────────────────
+
+const ACCOUNT_STATUS_DEFAULT: AccountStatus = 'active';
+const CREATIVE_STATUS_DEFAULT: CreativeStatus = 'processing';
+const MEDIA_BUY_STATUS_DEFAULT: MediaBuyStatus = 'pending_creatives';
+const SESSION_STATUS_DEFAULT = 'active' as const;
+
+function budgetSpendKey(record: BudgetSpendRecord): string {
+  if (record.media_buy_id) return `media_buy:${record.media_buy_id}`;
+  if (record.account_id) return `account:${record.account_id}`;
+  // Dispatcher already rejects requests that supply neither, so this branch
+  // is unreachable from the wire. Fail loudly if a seller calls the handler
+  // directly without either id — silent bucketing would corrupt cumulative
+  // totals.
+  throw new TestControllerError(
+    'INVALID_PARAMS',
+    'simulate_budget_spend requires params.account_id or params.media_buy_id'
+  );
+}
+
+function addDelivery(
+  running: DeliverySimulationRecord | undefined,
+  delta: DeliverySimulationRecord
+): DeliverySimulationRecord {
+  const base = running ?? {};
+  const merged: DeliverySimulationRecord = {};
+  if (base.impressions !== undefined || delta.impressions !== undefined) {
+    merged.impressions = (base.impressions ?? 0) + (delta.impressions ?? 0);
+  }
+  if (base.clicks !== undefined || delta.clicks !== undefined) {
+    merged.clicks = (base.clicks ?? 0) + (delta.clicks ?? 0);
+  }
+  if (base.conversions !== undefined || delta.conversions !== undefined) {
+    merged.conversions = (base.conversions ?? 0) + (delta.conversions ?? 0);
+  }
+  // reported_spend: sum amounts when currencies match. Differing currencies is
+  // a seller-side modeling error; keep the latest and let the caller notice.
+  if (delta.reported_spend) {
+    if (base.reported_spend && base.reported_spend.currency === delta.reported_spend.currency) {
+      merged.reported_spend = {
+        amount: base.reported_spend.amount + delta.reported_spend.amount,
+        currency: delta.reported_spend.currency,
+      };
+    } else {
+      merged.reported_spend = { ...delta.reported_spend };
+    }
+  } else if (base.reported_spend) {
+    merged.reported_spend = { ...base.reported_spend };
+  }
+  return merged;
+}
+
+// ────────────────────────────────────────────────────────────
+// Factory
+// ────────────────────────────────────────────────────────────
+
+/** Factory return type — the shape `registerTestController` expects when the
+ * seller wants list_scenarios answered without invoking the loader. */
+export interface DefaultTestControllerStoreResult extends TestControllerStoreFactory {
+  /** Advertised scenarios — the six force_* / simulate_* entries. Seeds are
+   * not advertised per spec, but the store still handles them. */
+  readonly scenarios: readonly ControllerScenario[];
+
+  /** Build a store bound to the current request. Invoked by the dispatcher
+   * for every non-`list_scenarios` request. */
+  createStore(input: Record<string, unknown>): Promise<TestControllerStore>;
+}
+
+/** All advertised scenarios — every entry in {@link CONTROLLER_SCENARIOS}.
+ * The default factory implements all of them; seeds are handled too but not
+ * listed here (they aren't advertised via list_scenarios per spec). */
+const ALL_ADVERTISED_SCENARIOS: readonly ControllerScenario[] = Object.freeze([
+  CONTROLLER_SCENARIOS.FORCE_CREATIVE_STATUS,
+  CONTROLLER_SCENARIOS.FORCE_ACCOUNT_STATUS,
+  CONTROLLER_SCENARIOS.FORCE_MEDIA_BUY_STATUS,
+  CONTROLLER_SCENARIOS.FORCE_SESSION_STATUS,
+  CONTROLLER_SCENARIOS.SIMULATE_DELIVERY,
+  CONTROLLER_SCENARIOS.SIMULATE_BUDGET_SPEND,
+]);
+
+/**
+ * Build a factory-shaped {@link TestControllerStoreFactory} with default
+ * handlers for every `force_*`, `simulate_*`, and `seed_*` scenario, each
+ * operating on a {@link DefaultSessionShape}.
+ *
+ * Pass the result straight to `registerTestController(server, result)`.
+ */
+export function createDefaultTestControllerStore<S extends DefaultSessionShape>(
+  opts: CreateDefaultTestControllerStoreOptions<S>
+): DefaultTestControllerStoreResult {
+  const cap = opts.mapCap ?? SESSION_ENTRY_CAP;
+  const { loadSession, saveSession, overrides } = opts;
+
+  async function persist(session: S): Promise<void> {
+    if (saveSession) await saveSession(session);
+  }
+
+  async function buildStore(input: Record<string, unknown>): Promise<TestControllerStore> {
+    const context = (input.context as unknown) ?? undefined;
+    const session = await loadSession({ context });
+
+    const defaults: TestControllerStore = {
+      // ── force_creative_status ─────────────────────────────
+      async forceCreativeStatus(
+        creativeId,
+        status,
+        rejectionReason
+      ): Promise<StateTransitionSuccess> {
+        const tracked = session.creativeStatuses.get(creativeId);
+        const seeded = session.seededCreatives.get(creativeId);
+        if (tracked === undefined && seeded === undefined) {
+          throw new TestControllerError(
+            'NOT_FOUND',
+            `Creative ${creativeId} not found. Seed it first with seed_creative.`
+          );
+        }
+        const previous =
+          tracked ?? ((seeded?.status as CreativeStatus | undefined) ?? CREATIVE_STATUS_DEFAULT);
+        enforceMapCap(session.creativeStatuses, creativeId, 'creative statuses', cap);
+        session.creativeStatuses.set(creativeId, status);
+        if (status === 'rejected' && rejectionReason) {
+          enforceMapCap(
+            session.creativeRejectionReasons,
+            creativeId,
+            'creative rejection reasons',
+            cap
+          );
+          session.creativeRejectionReasons.set(creativeId, rejectionReason);
+        } else {
+          session.creativeRejectionReasons.delete(creativeId);
+        }
+        await persist(session);
+        return { success: true, previous_state: previous, current_state: status };
+      },
+
+      // ── force_account_status ──────────────────────────────
+      async forceAccountStatus(accountId, status): Promise<StateTransitionSuccess> {
+        // Accounts have no seed; upsert with 'active' default so storyboards
+        // can transition accounts without a prior setup step.
+        const previous = session.accountStatuses.get(accountId) ?? ACCOUNT_STATUS_DEFAULT;
+        enforceMapCap(session.accountStatuses, accountId, 'account statuses', cap);
+        session.accountStatuses.set(accountId, status);
+        await persist(session);
+        return { success: true, previous_state: previous, current_state: status };
+      },
+
+      // ── force_media_buy_status ────────────────────────────
+      async forceMediaBuyStatus(
+        mediaBuyId,
+        status,
+        rejectionReason
+      ): Promise<StateTransitionSuccess> {
+        const tracked = session.mediaBuyStatuses.get(mediaBuyId);
+        const seeded = session.seededMediaBuys.get(mediaBuyId);
+        if (tracked === undefined && seeded === undefined) {
+          throw new TestControllerError(
+            'NOT_FOUND',
+            `Media buy ${mediaBuyId} not found. Seed it first with seed_media_buy.`
+          );
+        }
+        const previous =
+          tracked ?? ((seeded?.status as MediaBuyStatus | undefined) ?? MEDIA_BUY_STATUS_DEFAULT);
+        enforceMapCap(session.mediaBuyStatuses, mediaBuyId, 'media buy statuses', cap);
+        session.mediaBuyStatuses.set(mediaBuyId, status);
+        if (rejectionReason) {
+          enforceMapCap(
+            session.mediaBuyRejectionReasons,
+            mediaBuyId,
+            'media buy rejection reasons',
+            cap
+          );
+          session.mediaBuyRejectionReasons.set(mediaBuyId, rejectionReason);
+        } else {
+          session.mediaBuyRejectionReasons.delete(mediaBuyId);
+        }
+        await persist(session);
+        return { success: true, previous_state: previous, current_state: status };
+      },
+
+      // ── force_session_status ──────────────────────────────
+      async forceSessionStatus(
+        sessionId,
+        status,
+        terminationReason
+      ): Promise<StateTransitionSuccess> {
+        // SI sessions have no seed; upsert with 'active' default.
+        const previous = session.sessionStatuses.get(sessionId) ?? SESSION_STATUS_DEFAULT;
+        enforceMapCap(session.sessionStatuses, sessionId, 'session statuses', cap);
+        session.sessionStatuses.set(sessionId, status);
+        if (terminationReason) {
+          enforceMapCap(
+            session.sessionTerminationReasons,
+            sessionId,
+            'session termination reasons',
+            cap
+          );
+          session.sessionTerminationReasons.set(sessionId, terminationReason);
+        } else {
+          session.sessionTerminationReasons.delete(sessionId);
+        }
+        await persist(session);
+        return { success: true, previous_state: previous, current_state: status };
+      },
+
+      // ── simulate_delivery ─────────────────────────────────
+      async simulateDelivery(mediaBuyId, params): Promise<SimulationSuccess> {
+        const delta: DeliverySimulationRecord = {
+          impressions: params.impressions,
+          clicks: params.clicks,
+          conversions: params.conversions,
+          reported_spend: params.reported_spend,
+        };
+        enforceMapCap(session.simulatedDeliveries, mediaBuyId, 'simulated deliveries', cap);
+        session.simulatedDeliveries.set(mediaBuyId, delta);
+        enforceMapCap(session.cumulativeDeliveries, mediaBuyId, 'cumulative deliveries', cap);
+        const cumulative = addDelivery(session.cumulativeDeliveries.get(mediaBuyId), delta);
+        session.cumulativeDeliveries.set(mediaBuyId, cumulative);
+        await persist(session);
+        return {
+          success: true,
+          simulated: { ...delta } as SimulationSuccess['simulated'],
+          cumulative: { ...cumulative } as SimulationSuccess['cumulative'],
+        };
+      },
+
+      // ── simulate_budget_spend ─────────────────────────────
+      async simulateBudgetSpend(params): Promise<SimulationSuccess> {
+        const record: BudgetSpendRecord = {
+          account_id: params.account_id,
+          media_buy_id: params.media_buy_id,
+          spend_percentage: params.spend_percentage,
+        };
+        const key = budgetSpendKey(record);
+        enforceMapCap(session.simulatedBudgetSpends, key, 'simulated budget spends', cap);
+        session.simulatedBudgetSpends.set(key, record);
+        await persist(session);
+        return {
+          success: true,
+          simulated: {
+            spend_percentage: record.spend_percentage,
+          } as SimulationSuccess['simulated'],
+        };
+      },
+
+      // ── seed_product ──────────────────────────────────────
+      // NOTE: wiring seeded fixtures into `get_products` is the seller's
+      // responsibility and is intentionally NOT done here. The seeded
+      // payload is stored verbatim on `session.seededProducts` — consume it
+      // from your production handler via `session.seededProducts.get(id)`.
+      async seedProduct(productId, fixture): Promise<void> {
+        enforceMapCap(session.seededProducts, productId, 'seeded products', cap);
+        session.seededProducts.set(productId, fixture ?? {});
+        await persist(session);
+      },
+
+      // ── seed_pricing_option ───────────────────────────────
+      async seedPricingOption(productId, pricingOptionId, fixture): Promise<void> {
+        const key = `${productId}:${pricingOptionId}`;
+        enforceMapCap(session.seededPricingOptions, key, 'seeded pricing options', cap);
+        session.seededPricingOptions.set(key, fixture ?? {});
+        await persist(session);
+      },
+
+      // ── seed_creative ─────────────────────────────────────
+      // Consume `session.seededCreatives` from your `sync_creatives` /
+      // `list_creatives` handler to satisfy storyboard steps that reference
+      // the seeded id.
+      async seedCreative(creativeId, fixture): Promise<void> {
+        enforceMapCap(session.seededCreatives, creativeId, 'seeded creatives', cap);
+        session.seededCreatives.set(creativeId, fixture ?? {});
+        await persist(session);
+      },
+
+      // ── seed_plan ─────────────────────────────────────────
+      async seedPlan(planId, fixture): Promise<void> {
+        enforceMapCap(session.seededPlans, planId, 'seeded plans', cap);
+        session.seededPlans.set(planId, fixture ?? {});
+        await persist(session);
+      },
+
+      // ── seed_media_buy ────────────────────────────────────
+      // Consume `session.seededMediaBuys` from your `get_media_buy` /
+      // delivery handlers so storyboard steps can reference the seeded id.
+      async seedMediaBuy(mediaBuyId, fixture): Promise<void> {
+        enforceMapCap(session.seededMediaBuys, mediaBuyId, 'seeded media buys', cap);
+        session.seededMediaBuys.set(mediaBuyId, fixture ?? {});
+        await persist(session);
+      },
+    };
+
+    if (overrides) {
+      // Apply overrides: a provided method REPLACES the default for that key.
+      // `undefined` entries suppress a default so the dispatcher returns
+      // UNKNOWN_SCENARIO for that scenario.
+      for (const key of Object.keys(overrides) as Array<keyof TestControllerStore>) {
+        const override = overrides[key];
+        if (override === undefined) {
+          delete defaults[key];
+        } else {
+          (defaults as Record<string, unknown>)[key] = override;
+        }
+      }
+    }
+
+    return defaults;
+  }
+
+  return {
+    scenarios: ALL_ADVERTISED_SCENARIOS,
+    createStore: buildStore,
+  };
+}

--- a/src/lib/testing/default-controller-store.ts
+++ b/src/lib/testing/default-controller-store.ts
@@ -57,17 +57,8 @@
  * ```
  */
 
-import type {
-  TestControllerStore,
-  TestControllerStoreFactory,
-  ControllerScenario,
-} from '../server/test-controller';
-import {
-  CONTROLLER_SCENARIOS,
-  SESSION_ENTRY_CAP,
-  TestControllerError,
-  enforceMapCap,
-} from '../server/test-controller';
+import type { TestControllerStore, TestControllerStoreFactory, ControllerScenario } from '../server/test-controller';
+import { CONTROLLER_SCENARIOS, SESSION_ENTRY_CAP, TestControllerError, enforceMapCap } from '../server/test-controller';
 import type { AccountStatus, CreativeStatus, MediaBuyStatus } from '../types/core.generated';
 import type { SimulationSuccess, StateTransitionSuccess } from '../types/tools.generated';
 
@@ -330,11 +321,7 @@ export function createDefaultTestControllerStore<S extends DefaultSessionShape>(
 
     const defaults: TestControllerStore = {
       // ── force_creative_status ─────────────────────────────
-      async forceCreativeStatus(
-        creativeId,
-        status,
-        rejectionReason
-      ): Promise<StateTransitionSuccess> {
+      async forceCreativeStatus(creativeId, status, rejectionReason): Promise<StateTransitionSuccess> {
         const tracked = session.creativeStatuses.get(creativeId);
         const seeded = session.seededCreatives.get(creativeId);
         if (tracked === undefined && seeded === undefined) {
@@ -343,17 +330,11 @@ export function createDefaultTestControllerStore<S extends DefaultSessionShape>(
             `Creative ${creativeId} not found. Seed it first with seed_creative.`
           );
         }
-        const previous =
-          tracked ?? ((seeded?.status as CreativeStatus | undefined) ?? CREATIVE_STATUS_DEFAULT);
+        const previous = tracked ?? (seeded?.status as CreativeStatus | undefined) ?? CREATIVE_STATUS_DEFAULT;
         enforceMapCap(session.creativeStatuses, creativeId, 'creative statuses', cap);
         session.creativeStatuses.set(creativeId, status);
         if (status === 'rejected' && rejectionReason) {
-          enforceMapCap(
-            session.creativeRejectionReasons,
-            creativeId,
-            'creative rejection reasons',
-            cap
-          );
+          enforceMapCap(session.creativeRejectionReasons, creativeId, 'creative rejection reasons', cap);
           session.creativeRejectionReasons.set(creativeId, rejectionReason);
         } else {
           session.creativeRejectionReasons.delete(creativeId);
@@ -374,11 +355,7 @@ export function createDefaultTestControllerStore<S extends DefaultSessionShape>(
       },
 
       // ── force_media_buy_status ────────────────────────────
-      async forceMediaBuyStatus(
-        mediaBuyId,
-        status,
-        rejectionReason
-      ): Promise<StateTransitionSuccess> {
+      async forceMediaBuyStatus(mediaBuyId, status, rejectionReason): Promise<StateTransitionSuccess> {
         const tracked = session.mediaBuyStatuses.get(mediaBuyId);
         const seeded = session.seededMediaBuys.get(mediaBuyId);
         if (tracked === undefined && seeded === undefined) {
@@ -387,17 +364,11 @@ export function createDefaultTestControllerStore<S extends DefaultSessionShape>(
             `Media buy ${mediaBuyId} not found. Seed it first with seed_media_buy.`
           );
         }
-        const previous =
-          tracked ?? ((seeded?.status as MediaBuyStatus | undefined) ?? MEDIA_BUY_STATUS_DEFAULT);
+        const previous = tracked ?? (seeded?.status as MediaBuyStatus | undefined) ?? MEDIA_BUY_STATUS_DEFAULT;
         enforceMapCap(session.mediaBuyStatuses, mediaBuyId, 'media buy statuses', cap);
         session.mediaBuyStatuses.set(mediaBuyId, status);
         if (rejectionReason) {
-          enforceMapCap(
-            session.mediaBuyRejectionReasons,
-            mediaBuyId,
-            'media buy rejection reasons',
-            cap
-          );
+          enforceMapCap(session.mediaBuyRejectionReasons, mediaBuyId, 'media buy rejection reasons', cap);
           session.mediaBuyRejectionReasons.set(mediaBuyId, rejectionReason);
         } else {
           session.mediaBuyRejectionReasons.delete(mediaBuyId);
@@ -407,22 +378,13 @@ export function createDefaultTestControllerStore<S extends DefaultSessionShape>(
       },
 
       // ── force_session_status ──────────────────────────────
-      async forceSessionStatus(
-        sessionId,
-        status,
-        terminationReason
-      ): Promise<StateTransitionSuccess> {
+      async forceSessionStatus(sessionId, status, terminationReason): Promise<StateTransitionSuccess> {
         // SI sessions have no seed; upsert with 'active' default.
         const previous = session.sessionStatuses.get(sessionId) ?? SESSION_STATUS_DEFAULT;
         enforceMapCap(session.sessionStatuses, sessionId, 'session statuses', cap);
         session.sessionStatuses.set(sessionId, status);
         if (terminationReason) {
-          enforceMapCap(
-            session.sessionTerminationReasons,
-            sessionId,
-            'session termination reasons',
-            cap
-          );
+          enforceMapCap(session.sessionTerminationReasons, sessionId, 'session termination reasons', cap);
           session.sessionTerminationReasons.set(sessionId, terminationReason);
         } else {
           session.sessionTerminationReasons.delete(sessionId);

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -154,6 +154,21 @@ export {
 } from '../server/test-controller';
 export type { ControllerScenario, SeedFixtureCache, SeedScenario } from '../server/test-controller';
 
+// Default TestControllerStore factory — ships wired defaults for every
+// force_* / simulate_* / seed_* scenario so sellers can bring a session and
+// skip the 300-line boilerplate.
+export { createDefaultTestControllerStore, createDefaultSession } from './default-controller-store';
+export type {
+  BudgetSpendRecord,
+  CreateDefaultTestControllerStoreOptions,
+  DefaultLoadSessionInput,
+  DefaultSessionShape,
+  DefaultTestControllerStoreResult,
+  DeliverySimulationRecord,
+  SeedFixture,
+  SessionTerminalStatus,
+} from './default-controller-store';
+
 // Storyboard-driven testing
 export {
   // Runner

--- a/test/lib/default-test-controller-store.test.js
+++ b/test/lib/default-test-controller-store.test.js
@@ -6,9 +6,7 @@ const {
   TestControllerError,
   CONTROLLER_SCENARIOS,
 } = require('../../dist/lib/testing');
-const {
-  handleTestControllerRequest,
-} = require('../../dist/lib/server/test-controller');
+const { handleTestControllerRequest } = require('../../dist/lib/server/test-controller');
 
 // ────────────────────────────────────────────────────────────
 // createDefaultSession

--- a/test/lib/default-test-controller-store.test.js
+++ b/test/lib/default-test-controller-store.test.js
@@ -1,0 +1,552 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  createDefaultTestControllerStore,
+  createDefaultSession,
+  TestControllerError,
+  CONTROLLER_SCENARIOS,
+} = require('../../dist/lib/testing');
+const {
+  handleTestControllerRequest,
+} = require('../../dist/lib/server/test-controller');
+
+// ────────────────────────────────────────────────────────────
+// createDefaultSession
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultSession', () => {
+  it('returns empty Maps for every field', () => {
+    const session = createDefaultSession();
+    const expectedMaps = [
+      'accountStatuses',
+      'creativeStatuses',
+      'creativeRejectionReasons',
+      'mediaBuyStatuses',
+      'mediaBuyRejectionReasons',
+      'sessionStatuses',
+      'sessionTerminationReasons',
+      'simulatedDeliveries',
+      'cumulativeDeliveries',
+      'simulatedBudgetSpends',
+      'seededProducts',
+      'seededPricingOptions',
+      'seededCreatives',
+      'seededPlans',
+      'seededMediaBuys',
+    ];
+    for (const key of expectedMaps) {
+      assert.ok(session[key] instanceof Map, `session.${key} should be a Map`);
+      assert.strictEqual(session[key].size, 0, `session.${key} should be empty`);
+    }
+  });
+
+  it('returns independent sessions on each call', () => {
+    const a = createDefaultSession();
+    const b = createDefaultSession();
+    a.accountStatuses.set('acct-1', 'active');
+    assert.strictEqual(b.accountStatuses.size, 0);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Factory shape
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — factory shape', () => {
+  it('returns a factory with scenarios populated before loadSession runs', async () => {
+    let loadSessionCalled = 0;
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        loadSessionCalled++;
+        return createDefaultSession();
+      },
+    });
+    assert.ok(Array.isArray(factory.scenarios));
+    assert.strictEqual(loadSessionCalled, 0);
+  });
+
+  it('scenarios array matches CONTROLLER_SCENARIOS length (6 advertised)', async () => {
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return createDefaultSession();
+      },
+    });
+    const advertised = Object.values(CONTROLLER_SCENARIOS);
+    assert.strictEqual(factory.scenarios.length, advertised.length);
+    assert.deepStrictEqual([...factory.scenarios].sort(), [...advertised].sort());
+  });
+
+  it('list_scenarios answers without invoking loadSession', async () => {
+    let loadSessionCalled = 0;
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        loadSessionCalled++;
+        return createDefaultSession();
+      },
+    });
+    const result = await handleTestControllerRequest(factory, { scenario: 'list_scenarios' });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(loadSessionCalled, 0);
+    assert.strictEqual(result.scenarios.length, 6);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Force scenarios
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — force_account_status', () => {
+  it('upserts an account status and returns previous/current', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'acct-1', status: 'suspended' },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.previous_state, 'active');
+    assert.strictEqual(result.current_state, 'suspended');
+    assert.strictEqual(session.accountStatuses.get('acct-1'), 'suspended');
+  });
+
+  it('second call reports the actual previous state', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'acct-1', status: 'suspended' },
+    });
+    const second = await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'acct-1', status: 'active' },
+    });
+    assert.strictEqual(second.previous_state, 'suspended');
+    assert.strictEqual(second.current_state, 'active');
+  });
+});
+
+describe('createDefaultTestControllerStore — force_creative_status', () => {
+  it('throws NOT_FOUND when creative has never been seeded or forced', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_creative_status',
+      params: { creative_id: 'cr-ghost', status: 'approved' },
+    });
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'NOT_FOUND');
+  });
+
+  it('succeeds after seed_creative has been called', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_creative',
+      params: { creative_id: 'cr-1', fixture: { status: 'pending_review' } },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_creative_status',
+      params: { creative_id: 'cr-1', status: 'approved' },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.previous_state, 'pending_review');
+    assert.strictEqual(result.current_state, 'approved');
+  });
+
+  it('stores rejection_reason only when transitioning to rejected', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_creative',
+      params: { creative_id: 'cr-1', fixture: {} },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_creative_status',
+      params: { creative_id: 'cr-1', status: 'rejected', rejection_reason: 'Brand safety' },
+    });
+    assert.strictEqual(session.creativeRejectionReasons.get('cr-1'), 'Brand safety');
+    // Transitioning away from rejected clears the reason.
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_creative_status',
+      params: { creative_id: 'cr-1', status: 'approved' },
+    });
+    assert.strictEqual(session.creativeRejectionReasons.has('cr-1'), false);
+  });
+});
+
+describe('createDefaultTestControllerStore — force_media_buy_status', () => {
+  it('throws NOT_FOUND for unseeded media_buy', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_media_buy_status',
+      params: { media_buy_id: 'mb-ghost', status: 'active' },
+    });
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'NOT_FOUND');
+  });
+
+  it('succeeds after seed_media_buy', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_media_buy',
+      params: { media_buy_id: 'mb-1', fixture: { status: 'pending_start' } },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_media_buy_status',
+      params: { media_buy_id: 'mb-1', status: 'active' },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.previous_state, 'pending_start');
+    assert.strictEqual(result.current_state, 'active');
+  });
+});
+
+describe('createDefaultTestControllerStore — force_session_status', () => {
+  it('upserts session status with active as default previous', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_session_status',
+      params: { session_id: 'sess-1', status: 'complete' },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.previous_state, 'active');
+    assert.strictEqual(result.current_state, 'complete');
+  });
+
+  it('records termination_reason when provided', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_session_status',
+      params: { session_id: 'sess-1', status: 'terminated', termination_reason: 'timeout' },
+    });
+    assert.strictEqual(session.sessionTerminationReasons.get('sess-1'), 'timeout');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Simulate scenarios
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — simulate_delivery', () => {
+  it('stores delta and builds cumulative totals', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    const first = await handleTestControllerRequest(factory, {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: 'mb-1',
+        impressions: 100,
+        clicks: 5,
+        reported_spend: { amount: 10, currency: 'USD' },
+      },
+    });
+    assert.strictEqual(first.success, true);
+    assert.strictEqual(first.cumulative.impressions, 100);
+    assert.strictEqual(first.cumulative.reported_spend.amount, 10);
+
+    const second = await handleTestControllerRequest(factory, {
+      scenario: 'simulate_delivery',
+      params: {
+        media_buy_id: 'mb-1',
+        impressions: 50,
+        reported_spend: { amount: 3, currency: 'USD' },
+      },
+    });
+    assert.strictEqual(second.cumulative.impressions, 150);
+    assert.strictEqual(second.cumulative.clicks, 5);
+    assert.strictEqual(second.cumulative.reported_spend.amount, 13);
+  });
+});
+
+describe('createDefaultTestControllerStore — simulate_budget_spend', () => {
+  it('stores the latest record keyed by media_buy_id', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'simulate_budget_spend',
+      params: { media_buy_id: 'mb-1', spend_percentage: 85 },
+    });
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.simulated.spend_percentage, 85);
+    assert.strictEqual(session.simulatedBudgetSpends.get('media_buy:mb-1').spend_percentage, 85);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Seed scenarios
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — seed scenarios', () => {
+  it('stores seeded products, pricing options, creatives, plans, media_buys', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_product',
+      params: { product_id: 'p-1', fixture: { delivery_type: 'non_guaranteed' } },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_pricing_option',
+      params: { product_id: 'p-1', pricing_option_id: 'po-1', fixture: { cpm: 5 } },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_creative',
+      params: { creative_id: 'cr-1', fixture: { type: 'banner' } },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_plan',
+      params: { plan_id: 'plan-1', fixture: { budget: 1000 } },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_media_buy',
+      params: { media_buy_id: 'mb-1', fixture: { status: 'pending_start' } },
+    });
+    assert.deepStrictEqual(session.seededProducts.get('p-1'), { delivery_type: 'non_guaranteed' });
+    assert.deepStrictEqual(session.seededPricingOptions.get('p-1:po-1'), { cpm: 5 });
+    assert.deepStrictEqual(session.seededCreatives.get('cr-1'), { type: 'banner' });
+    assert.deepStrictEqual(session.seededPlans.get('plan-1'), { budget: 1000 });
+    assert.deepStrictEqual(session.seededMediaBuys.get('mb-1'), { status: 'pending_start' });
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// saveSession / loadSession
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — saveSession', () => {
+  it('is called after each mutation', async () => {
+    const session = createDefaultSession();
+    const saveCalls = [];
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+      async saveSession(s) {
+        saveCalls.push(s.accountStatuses.get('acct-1'));
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'acct-1', status: 'suspended' },
+    });
+    assert.strictEqual(saveCalls.length, 1);
+    assert.strictEqual(saveCalls[0], 'suspended');
+  });
+
+  it('is called after seed mutations', async () => {
+    let saveCalls = 0;
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+      async saveSession() {
+        saveCalls++;
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'seed_product',
+      params: { product_id: 'p-1', fixture: {} },
+    });
+    assert.ok(saveCalls >= 1);
+  });
+});
+
+describe('createDefaultTestControllerStore — loadSession input', () => {
+  it('receives the request context unchanged', async () => {
+    let capturedContext;
+    const factory = createDefaultTestControllerStore({
+      async loadSession({ context }) {
+        capturedContext = context;
+        return createDefaultSession();
+      },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a', status: 'active' },
+      context: { session_id: 'abc' },
+    });
+    assert.deepStrictEqual(capturedContext, { session_id: 'abc' });
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Overrides
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — overrides', () => {
+  it('replace the default handler for the overridden scenario', async () => {
+    const session = createDefaultSession();
+    let called = false;
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+      overrides: {
+        async forceAccountStatus(accountId, status) {
+          called = true;
+          return {
+            success: true,
+            previous_state: 'custom_previous',
+            current_state: status,
+            message: `override handled ${accountId}`,
+          };
+        },
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'acct-1', status: 'suspended' },
+    });
+    assert.strictEqual(called, true);
+    assert.strictEqual(result.previous_state, 'custom_previous');
+    // Default path did not run — no session update.
+    assert.strictEqual(session.accountStatuses.has('acct-1'), false);
+  });
+
+  it('leaves non-overridden defaults intact', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+      overrides: {
+        async forceAccountStatus() {
+          return { success: true, previous_state: 'x', current_state: 'y' };
+        },
+      },
+    });
+    // seed_product should still work via the default handler.
+    const seedResult = await handleTestControllerRequest(factory, {
+      scenario: 'seed_product',
+      params: { product_id: 'p-1', fixture: { channels: ['web'] } },
+    });
+    assert.strictEqual(seedResult.success, true);
+    assert.deepStrictEqual(session.seededProducts.get('p-1'), { channels: ['web'] });
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Cap enforcement
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — mapCap', () => {
+  it('rejects net-new keys past the cap', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+      mapCap: 2,
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a1', status: 'active' },
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a2', status: 'active' },
+    });
+    const overflow = await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a3', status: 'active' },
+    });
+    assert.strictEqual(overflow.success, false);
+    assert.strictEqual(overflow.error, 'INVALID_STATE');
+  });
+
+  it('allows overwriting existing keys at the cap', async () => {
+    const session = createDefaultSession();
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return session;
+      },
+      mapCap: 1,
+    });
+    await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a1', status: 'active' },
+    });
+    const overwrite = await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a1', status: 'suspended' },
+    });
+    assert.strictEqual(overwrite.success, true);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// TestControllerError propagation
+// ────────────────────────────────────────────────────────────
+
+describe('createDefaultTestControllerStore — overrides can throw', () => {
+  it('surfaces TestControllerError from override as typed response', async () => {
+    const factory = createDefaultTestControllerStore({
+      async loadSession() {
+        return createDefaultSession();
+      },
+      overrides: {
+        async forceAccountStatus() {
+          throw new TestControllerError('FORBIDDEN', 'sandbox only');
+        },
+      },
+    });
+    const result = await handleTestControllerRequest(factory, {
+      scenario: 'force_account_status',
+      params: { account_id: 'a', status: 'active' },
+    });
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, 'FORBIDDEN');
+  });
+});


### PR DESCRIPTION
## Summary

- Ship `createDefaultTestControllerStore` + `createDefaultSession` from `@adcp/client/testing`. Sellers bring a `loadSession` / `saveSession` pair and get a conformance-ready `TestControllerStore` without hand-rolling 300+ lines of boilerplate.
- Wires every `force_*`, `simulate_*`, and `seed_*` scenario against a generic `DefaultSessionShape` with Maps for status tracking, simulated delivery/budget records, and seeded fixtures.
- Supports partial overrides (`opts.overrides`) so sellers can keep the default behavior for five scenarios and inject custom logic for the sixth.
- Returns the factory form (`{ scenarios, createStore }`) so `registerTestController` answers `list_scenarios` capability probes without running `loadSession`.

## Design notes

- **Force handlers for creative/media_buy require a prior seed.** They throw `TestControllerError('NOT_FOUND', ...)` otherwise, matching the existing seller-example convention (`examples/comply-controller-seller.ts`) and the AdCP spec's shape for state transitions.
- **Force handlers for account/session upsert with sensible defaults** (`'active'`) because neither entity has a corresponding `seed_*` scenario — there's nothing to "seed first."
- **simulate_delivery** accumulates cumulative totals alongside the latest delta so storyboards can assert incremental delivery. **simulate_budget_spend** stores one record per entity, keyed with `media_buy:` / `account:` prefixes so the two id spaces don't collide.
- **Seed handlers only persist the fixture** on the session; wiring fixtures into `get_products` / `sync_creatives` / `get_media_buy` remains the seller's responsibility. Handoff is noted in code comments on each seeded Map.

## Test plan

- [x] `createDefaultSession` returns empty Maps for every field, and returns independent objects per call
- [x] Factory form answers `list_scenarios` without invoking `loadSession`
- [x] Scenarios array matches `CONTROLLER_SCENARIOS` length (6 advertised force/simulate entries)
- [x] `force_account_status` upserts with sensible default previous state
- [x] `force_creative_status` and `force_media_buy_status` require prior seed (NOT_FOUND otherwise)
- [x] `rejection_reason` / `termination_reason` stored alongside status and cleared on transition
- [x] `simulate_delivery` accumulates cumulative impressions/clicks/spend across calls
- [x] `simulate_budget_spend` stores latest record keyed by media_buy_id
- [x] All 5 seed scenarios store payloads verbatim on the session
- [x] `saveSession` called after mutations (including seeds)
- [x] `overrides` replace the default handler for the overridden scenario and leave others intact
- [x] `mapCap` rejects net-new keys past the cap but permits overwrites

25 new tests, all passing. `npm run typecheck` clean. Full `npm run test:lib` run shows only pre-existing unrelated failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)