### PR TITLE
fix(testing): honor sample_request in list_creative_formats builder (closes #780)

### DIFF
--- a/.changeset/fix-list-creative-formats-request-builder.md
+++ b/.changeset/fix-list-creative-formats-request-builder.md
@@ -1,0 +1,18 @@
+---
+'@adcp/client': patch
+---
+
+Storyboard runner: honor `step.sample_request` in
+`list_creative_formats` request builder.
+
+Prior behavior hardcoded `list_creative_formats() { return {}; }`, so
+any storyboard step declaring `format_ids: ["..."]` (or any other
+query param) in its sample_request hit the wire as an empty request.
+The agent returned unfiltered results and downstream round-trip /
+substitution-observer assertions failed silently (the agent looked
+non-conformant, but the filter had never been sent).
+
+Mirrors the pattern used by peer builders (`build_creative`,
+`sync_creatives`, etc.). No other API change.
+
+Closes #780.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -325,7 +325,16 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Creative ───────────────────────────────────────────
 
-  list_creative_formats() {
+  list_creative_formats(step, context) {
+    // Mirror the pattern used by peer builders (build_creative, sync_creatives,
+    // etc.): honor hand-authored sample_request so storyboards can exercise
+    // format_ids filters and other query params. Without this, any step that
+    // declares `format_ids: ["..."]` in sample_request hits the wire as an
+    // empty request and the agent returns unfiltered results — failing
+    // round-trip / substitution-observer assertions silently.
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {};
   },
 


### PR DESCRIPTION
## Summary
Fixes #780. `list_creative_formats()` in the storyboard runner's request builder hardcoded `return {}`, ignoring `step.sample_request`. Any storyboard step declaring a `format_ids` filter (or other query params) hit the wire as an empty request — the agent returned unfiltered results and downstream round-trip / substitution-observer assertions failed silently.

## Fix
Mirror peer builders (`build_creative`, `sync_creatives`, etc.):

```ts
list_creative_formats(step, context) {
  if (step.sample_request) {
    return injectContext({ ...step.sample_request }, context);
  }
  return {};
},
```

Observed at `adcontextprotocol/adcp` training-agent compliance audit — the `media_buy_seller` storyboard's substitution-observer assertion was failing because the agent never received the filter.

## Test plan
- [x] Typecheck clean
- [x] Storyboard `media_buy_seller` now reaches the substitution-observer assertion with an actual filter applied
- [ ] Full compliance suite run downstream (e.g. adcontextprotocol/adcp CI) will pick up the fix once published