### PR TITLE
feat(testing): pre-flight controller seeding from storyboard fixtures (#778)

### DIFF
--- a/.changeset/storyboard-controller-seeding.md
+++ b/.changeset/storyboard-controller-seeding.md
@@ -1,0 +1,27 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard runner auto-fires `comply_test_controller` seed scenarios from the `fixtures:` block (adcp-client#778).
+
+When a storyboard declares `prerequisites.controller_seeding: true` and carries a top-level `fixtures:` block, the runner now issues a `comply_test_controller` call per fixture entry before phase 1:
+
+- `fixtures.products[]` → `seed_product`
+- `fixtures.pricing_options[]` → `seed_pricing_option`
+- `fixtures.creatives[]` → `seed_creative`
+- `fixtures.plans[]` → `seed_plan`
+- `fixtures.media_buys[]` → `seed_media_buy`
+
+Each entry's id field(s) ride on `params`; every other field is forwarded verbatim as `params.fixture`. The seed pass surfaces as a synthetic `__controller_seeding__` phase in `StoryboardResult.phases[]` so compliance reports distinguish pre-flight setup from per-step buyer behavior.
+
+**Grading semantics:**
+
+- Seed failure cascade-skips remaining phases with **detailed** `skip_reason: 'controller_seeding_failed'` and **canonical** `skip.reason: 'prerequisite_failed'` — respects the runner-output-contract's six canonical skip reasons (`controller_seeding_failed` is a new `RunnerDetailedSkipReason`, not a new canonical value).
+- Agent not advertising `comply_test_controller` → cascade-skips with canonical `skip.reason: 'missing_test_controller'`, implementing the spec's `fixture_seed_unsupported` not_applicable grade. No wire calls are issued.
+- Multi-pass mode seeds exactly once at the run level (inside `runMultiPass`) instead of N times inside each pass — avoids inflating `failed_count` / `skipped_count` by N when a fixture breaks.
+
+**Closes the spec-side/seller-side gap.** The `fixtures:` block (adcontextprotocol/adcp#2585, rolled out in adcontextprotocol/adcp#2743) and the `seed_*` scenarios (adcontextprotocol/adcp#2584, implemented here as `SEED_SCENARIOS` + `createSeedFixtureCache`) shipped without runner glue. Storyboards like `sales_non_guaranteed`, `creative_ad_server`, `governance_delivery_monitor`, `media_buy_governance_escalation`, and `governance_spend_authority` go from red to green against sellers that implement the matching `seed*` adapters.
+
+**New `StoryboardRunOptions.skip_controller_seeding`.** Opt out of the pre-flight for agents that load fixtures via a non-MCP path (HTTP admin, test bootstrap, inline Node state) — the runner then skips the seed loop even when the storyboard declares it.
+
+**Types.** `Storyboard.prerequisites.controller_seeding?: boolean`, `Storyboard.fixtures?: StoryboardFixtures`, and `StoryboardFixtures` are now part of the public type. `RunnerDetailedSkipReason` gains `'controller_seeding_failed'` mapped to canonical `'prerequisite_failed'` via `DETAILED_SKIP_TO_CANONICAL`.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -837,6 +837,7 @@ _Response (success branch):_
 {
   list: Property List  // required
   auth_token: string  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -863,6 +864,7 @@ _Response (success branch):_
 ```
 {
   list: Property List  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -931,6 +933,7 @@ _Response (success branch):_
 {
   deleted: boolean  // required
   list_id: string  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -956,6 +959,7 @@ _Response (success branch):_
 {
   list: Collection List  // required
   auth_token: string  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -982,6 +986,7 @@ _Response (success branch):_
 ```
 {
   list: Collection List  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -1050,6 +1055,7 @@ _Response (success branch):_
 {
   deleted: boolean  // required
   list_id: string  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -1250,6 +1256,7 @@ _Response (success branch):_
 ```
 {
   plans: object[]  // required
+  replayed: boolean
   context: Context
 }
 ```
@@ -1280,6 +1287,7 @@ _Response (success branch):_
   committed_budget: number
   findings: object[]
   plan_summary: object
+  replayed: boolean
   context: Context
 }
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -490,7 +490,7 @@ Request parameters for creating a new property list.
 
 **Response (success branch):**
 - Required: `list: Property List`, `auth_token: string`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `update_property_list`
 
@@ -502,7 +502,7 @@ Request parameters for updating an existing property list.
 
 **Response (success branch):**
 - Required: `list: Property List`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `get_property_list`
 
@@ -537,7 +537,7 @@ Request parameters for deleting a property list.
 
 **Response (success branch):**
 - Required: `deleted: boolean`, `list_id: string`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `create_collection_list`
 
@@ -549,7 +549,7 @@ Request parameters for creating a new collection list.
 
 **Response (success branch):**
 - Required: `list: Collection List`, `auth_token: string`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `update_collection_list`
 
@@ -561,7 +561,7 @@ Request parameters for updating an existing collection list.
 
 **Response (success branch):**
 - Required: `list: Collection List`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `get_collection_list`
 
@@ -596,7 +596,7 @@ Request parameters for deleting a collection list.
 
 **Response (success branch):**
 - Required: `deleted: boolean`, `list_id: string`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `list_content_standards`
 
@@ -702,7 +702,7 @@ Push campaign plans to the governance agent.
 
 **Response (success branch):**
 - Required: `plans: object[]`
-- Optional: `context: Context`
+- Optional: `replayed: boolean`, `context: Context`
 
 #### `report_plan_outcome`
 
@@ -714,7 +714,7 @@ Report the outcome of an action to the governance agent.
 
 **Response (success branch):**
 - Required: `outcome_id: string`, `status: 'accepted' | 'findings'`
-- Optional: `committed_budget: number`, `findings: object[]`, `plan_summary: object`, `context: Context`
+- Optional: `committed_budget: number`, `findings: object[]`, `plan_summary: object`, `replayed: boolean`, `context: Context`
 
 #### `get_plan_audit_logs`
 
@@ -951,7 +951,7 @@ Flow: `get_adcp_capabilities → get_brand_identity → get_rights → acquire_r
 Flow: `get_adcp_capabilities`
 
 **Deterministic testing** — Uses comply_test_controller to force state transitions and simulate delivery/budget, verifying state machines and reporting.
-Flow: `get_adcp_capabilities → comply_test_controller → sync_accounts → list_accounts → comply_test_controller → create_media_buy → comply_test_controller → get_media_buys → comply_test_controller → sync_creatives → comply_test_controller → si_initiate_session → comply_test_controller → si_send_message → create_media_buy → comply_test_controller → get_media_buy_delivery → create_media_buy → comply_test_controller`
+Flow: `get_adcp_capabilities → comply_test_controller → sync_accounts → list_accounts → comply_test_controller → create_media_buy → comply_test_controller → get_media_buys → comply_test_controller → sync_creatives → comply_test_controller → sync_creatives → comply_test_controller → si_initiate_session → comply_test_controller → si_send_message → create_media_buy → comply_test_controller → get_media_buy_delivery → create_media_buy → comply_test_controller`
 
 **Idempotency enforcement** — Validates that mutating requests enforce idempotency_key — replays return cached responses, key reuse with a different payload returns IDEMPOTENCY_CONFLICT, and fresh keys create new resources.
 Flow: `get_adcp_capabilities → create_media_buy → expect_webhook → create_media_buy → get_media_buys`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.9.1",
+      "version": "5.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -35,6 +35,21 @@ import { validateStoryboardShape } from './loader';
 import { probeRequestSigningVector } from './request-signing/probe-dispatch';
 import { createWebhookReceiver, type WebhookReceiver } from './webhook-receiver';
 import { WEBHOOK_ASSERTION_TASKS, armWebhookAssertions, executeWebhookAssertionStep } from './webhook-assertions';
+import { CONTROLLER_SEEDING_PHASE_ID, runControllerSeeding, type ControllerSeedingResult } from './seeding';
+
+/**
+ * Pre-computed controller-seeding outcome passed into `executeStoryboardPass`.
+ * Populated by `runMultiPass` so seeding fires once at the run level instead
+ * of once per pass (which would inflate `failed_count`/`skipped_count` when
+ * the aggregator sums per-pass counts). `attach: true` on the first pass so
+ * the synthetic `__controller_seeding__` phase appears in `phaseResults`
+ * exactly once; subsequent passes inherit `allPassed` for cascade-skip
+ * semantics but don't double-attach.
+ */
+interface PreSeededInput {
+  result: ControllerSeedingResult | null;
+  attach: boolean;
+}
 import type {
   AssertionResult,
   BranchSetSpec,
@@ -76,6 +91,9 @@ const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
   peer_branch_taken: 'Skipped: a peer branch in the same any_of branch set already contributed the aggregation flag.',
 };
 
+const CONTROLLER_SEEDING_FAILED_DETAIL =
+  'Skipped: pre-flight comply_test_controller seeding failed; the agent was not populated with the storyboard fixtures the remaining phases depend on.';
+
 const OAUTH_NOT_ADVERTISED_DETAIL =
   'Skipped: agent does not advertise OAuth — /.well-known/oauth-protected-resource returned 404 (RFC 9728 §3). API-key path must carry auth_mechanism_verified for this storyboard to pass.';
 
@@ -86,6 +104,7 @@ const OAUTH_NOT_ADVERTISED_DETAIL =
  */
 const DETAILED_SKIP_DETAILS: Partial<Record<RunnerDetailedSkipReason, string>> = {
   oauth_not_advertised: OAUTH_NOT_ADVERTISED_DETAIL,
+  controller_seeding_failed: CONTROLLER_SEEDING_FAILED_DETAIL,
 };
 
 function buildSkip(reason: RunnerSkipReason, detail?: string): { reason: RunnerSkipReason; detail: string } {
@@ -356,7 +375,8 @@ async function executeStoryboardPass(
   agentUrls: string[],
   storyboard: Storyboard,
   options: StoryboardRunOptions,
-  dispatchOffset: number
+  dispatchOffset: number,
+  preSeeded?: PreSeededInput
 ): Promise<StoryboardResult> {
   const start = Date.now();
   const isMultiInstance = agentUrls.length > 1;
@@ -479,6 +499,52 @@ async function executeStoryboardPass(
     skippedCount++;
   }
 
+  // Pre-flight controller seeding (adcp-client#778). When the storyboard
+  // declares `prerequisites.controller_seeding: true` and carries a
+  // `fixtures:` block, fire the corresponding `seed_*` scenarios on
+  // `comply_test_controller` so the seller's catalog / ledger holds every
+  // fixture id the downstream phases reference. On any seed failure we
+  // cascade-skip the remaining phases with `controller_seeding_failed` so
+  // the report shows "setup broke" instead of a thicket of per-step
+  // PRODUCT_NOT_FOUND / VALIDATION_ERROR failures. Runs against the first
+  // client only: in multi-instance mode the seller is expected to share
+  // state across replicas (that is what multi-instance tests exist to
+  // verify). Sellers that hold per-replica state must opt out via
+  // `skip_controller_seeding`.
+  //
+  // The seeding phase is held in a sidecar rather than pushed into
+  // `phaseResults` up-front so every downstream consumer that indexes
+  // `phaseResults[i]` against `storyboard.phases[i]` (branch-set grading,
+  // `requiredPhasesPassed`) keeps working. It is spliced to the front of
+  // `phaseResults` at the end so the report reads top-to-bottom in the
+  // order the runner actually executed things.
+  //
+  // Multi-pass mode populates `preSeeded` so seeding fires exactly once
+  // across all passes — see `runMultiPass`. Without the sidecar, every
+  // pass would re-seed and the aggregator's cross-pass sum would inflate
+  // `failed_count`/`skipped_count` by N when a single fixture broke.
+  let seedingPhaseResult: StoryboardPhaseResult | null = null;
+  let seedingFailed = false;
+  let seedingMissingController = false;
+  {
+    const seeding =
+      preSeeded !== undefined ? preSeeded.result : await runControllerSeeding(clients[0]!, storyboard, options, context);
+    if (seeding) {
+      const attach = preSeeded === undefined || preSeeded.attach;
+      if (attach) {
+        seedingPhaseResult = seeding.phase;
+        passedCount += seeding.passedCount;
+        failedCount += seeding.failedCount;
+        if (seeding.missingController) skippedCount += seeding.phase.steps.length;
+      }
+      if (seeding.missingController) {
+        seedingMissingController = true;
+      } else if (!seeding.allPassed) {
+        seedingFailed = true;
+      }
+    }
+  }
+
   for (const phase of storyboard.phases) {
     const phaseStart = Date.now();
     const stepResults: StoryboardStepResult[] = [];
@@ -502,6 +568,50 @@ async function executeStoryboardPass(
         steps: [],
         duration_ms: 0,
       });
+      continue;
+    }
+
+    // Seeding-cascade skip: either the pre-flight seed phase failed (setup
+    // break) or the agent doesn't advertise `comply_test_controller`
+    // (coverage gap). Both paths emit skipped steps; the reasons differ so
+    // compliance reports distinguish "agent misconfigured" from "agent not
+    // graded against this storyboard". `controller_seeding_failed` is a
+    // detailed reason mapped to canonical `prerequisite_failed`;
+    // `missing_test_controller` is canonical on its own. Emits full step
+    // rows (not an empty phase) so implementors see exactly which
+    // buyer-side operations were elided.
+    if (seedingMissingController || seedingFailed) {
+      const cascadeSkip: Pick<StoryboardStepResult, 'skip_reason' | 'skip'> = seedingMissingController
+        ? {
+            skip_reason: 'missing_test_controller',
+            skip: { reason: 'missing_test_controller', detail: SKIP_DETAILS.missing_test_controller },
+          }
+        : {
+            skip_reason: 'controller_seeding_failed',
+            skip: { reason: 'prerequisite_failed', detail: CONTROLLER_SEEDING_FAILED_DETAIL },
+          };
+      const cascadeSteps: StoryboardStepResult[] = phase.steps.map(step => ({
+        storyboard_id: storyboard.id,
+        step_id: step.id,
+        phase_id: phase.id,
+        title: step.title,
+        task: step.task,
+        passed: true,
+        skipped: true,
+        ...cascadeSkip,
+        duration_ms: 0,
+        validations: [],
+        context,
+        extraction: { path: 'none' },
+      }));
+      phaseResults.push({
+        phase_id: phase.id,
+        phase_title: phase.title,
+        passed: true,
+        steps: cascadeSteps,
+        duration_ms: 0,
+      });
+      skippedCount += cascadeSteps.length;
       continue;
     }
 
@@ -701,6 +811,10 @@ async function executeStoryboardPass(
     if (!phaseDef || phaseDef.optional || !p.passed) return false;
     return p.steps.some(s => !s.skipped && s.passed);
   });
+  // Prepend the pre-flight seeding phase now that every consumer that
+  // index-aligns `phaseResults` with `storyboard.phases` has run. Reader
+  // order matches execution order.
+  if (seedingPhaseResult) phaseResults.unshift(seedingPhaseResult);
   const schemasUsed = collectSchemasUsed(phaseResults);
   const result: StoryboardResult = {
     storyboard_id: storyboard.id,
@@ -764,10 +878,22 @@ async function runMultiPass(
   options: StoryboardRunOptions
 ): Promise<StoryboardResult> {
   const start = Date.now();
+
+  // Run pre-flight controller seeding ONCE at the run level (adcp-client#778)
+  // so the aggregator doesn't sum N redundant seed batches into
+  // `failed_count` / `skipped_count`. Every pass inherits the same outcome;
+  // only the first pass attaches the synthetic `__controller_seeding__`
+  // phase to its `phaseResults`, so the aggregated top-level counts reflect
+  // a single seeding pass across the whole run.
+  const preSeedClients = agentUrls.map(url => getOrCreateClient(url, options));
+  const preSeedContext: StoryboardContext = { ...options.context };
+  const preSeededResult = await runControllerSeeding(preSeedClients[0]!, storyboard, options, preSeedContext);
+
   const passes: StoryboardPassResult[] = [];
   const passResults: StoryboardResult[] = [];
   for (let passIdx = 0; passIdx < agentUrls.length; passIdx++) {
-    const result = await executeStoryboardPass(agentUrls, storyboard, options, passIdx);
+    const passSeeded: PreSeededInput = { result: preSeededResult, attach: passIdx === 0 };
+    const result = await executeStoryboardPass(agentUrls, storyboard, options, passIdx, passSeeded);
     passResults.push(result);
     passes.push({
       pass_index: passIdx + 1,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -528,7 +528,9 @@ async function executeStoryboardPass(
   let seedingMissingController = false;
   {
     const seeding =
-      preSeeded !== undefined ? preSeeded.result : await runControllerSeeding(clients[0]!, storyboard, options, context);
+      preSeeded !== undefined
+        ? preSeeded.result
+        : await runControllerSeeding(clients[0]!, storyboard, options, context);
     if (seeding) {
       const attach = preSeeded === undefined || preSeeded.attach;
       if (attach) {

--- a/src/lib/testing/storyboard/seeding.ts
+++ b/src/lib/testing/storyboard/seeding.ts
@@ -1,0 +1,340 @@
+/**
+ * Pre-flight `comply_test_controller` seeding.
+ *
+ * Spec: adcontextprotocol/adcp#2585 (fixtures block + `controller_seeding`
+ * flag) + adcontextprotocol/adcp#2584 (seed_* scenarios on
+ * `comply_test_controller`). Storyboards such as `sales_non_guaranteed`,
+ * `creative_ad_server`, `governance_delivery_monitor`,
+ * `media_buy_governance_escalation`, and `governance_spend_authority`
+ * reference fixture IDs (product_ids, pricing_option_ids, creative_ids,
+ * plan_ids, media_buy_ids) that the seller must already hold before the
+ * buyer-side flow runs. This module fires the `seed_*` scenarios derived
+ * from the storyboard's top-level `fixtures:` block before the first real
+ * phase, so the seller's catalog is populated ahead of any `create_media_buy`
+ * / `sync_creatives` / etc. call that would otherwise fail with
+ * `PRODUCT_NOT_FOUND`.
+ *
+ * Failures here surface as a dedicated synthetic phase (`__controller_seeding__`)
+ * so an implementor reading the report can distinguish "setup broke" from
+ * "buyer did something wrong" — the runner short-circuits the rest of the
+ * phases on any seed failure, emitting a cascade skip with reason
+ * `controller_seeding_failed`.
+ */
+
+import type { TestClient } from '../client';
+import { callControllerRaw } from '../test-controller';
+import type {
+  Storyboard,
+  StoryboardContext,
+  StoryboardFixtures,
+  StoryboardPhaseResult,
+  StoryboardRunOptions,
+  StoryboardStepResult,
+} from './types';
+
+/** Synthetic phase id used in `StoryboardResult.phases[]` for the seed pass. */
+export const CONTROLLER_SEEDING_PHASE_ID = '__controller_seeding__';
+
+/** Seed scenario names. Kept local — the server-side `SEED_SCENARIOS`
+ * constant from `src/lib/server/test-controller.ts` is authoritative, but
+ * importing it here would cross the testing ⇄ server module boundary. */
+type SeedScenario = 'seed_product' | 'seed_pricing_option' | 'seed_creative' | 'seed_plan' | 'seed_media_buy';
+
+interface SeedCall {
+  step_id: string;
+  title: string;
+  scenario: SeedScenario;
+  params: Record<string, unknown>;
+  /** Authoring error (e.g. missing required id). When set, the call fails at
+   * build time — no controller request is issued. */
+  authoring_error?: string;
+}
+
+/**
+ * Translate a storyboard `fixtures:` block into an ordered list of seed
+ * calls. Each entry's id field(s) are lifted into the scenario params; every
+ * remaining field rides in `params.fixture` verbatim. Missing required ids
+ * produce an authoring-error marker the runner surfaces as a failed seed
+ * step (rather than crashing or silently skipping).
+ */
+// Top-level fixture keys are forwarded to the server verbatim inside
+// `params.fixture`. Prototype-pollution rejection (`__proto__`, `constructor`,
+// `prototype`) is enforced by the server-side `dispatchSeed` at a single
+// canonical point (`src/lib/server/test-controller.ts`), NOT re-guarded here:
+// surfacing the rejection through the normal seed-error path keeps one source
+// of truth for the check, and the server-side handler is where a seed request
+// can actually land from any client implementation. A future refactor that
+// removes the server check must add the client guard before removing it.
+export function buildSeedCalls(fixtures: StoryboardFixtures | undefined): SeedCall[] {
+  if (!fixtures) return [];
+  const calls: SeedCall[] = [];
+
+  (fixtures.products ?? []).forEach((entry, i) => {
+    const { product_id, ...fixture } = entry;
+    const label = product_id ?? `#${i}`;
+    if (typeof product_id !== 'string' || product_id.length === 0) {
+      calls.push({
+        step_id: `seed_product.${label}`,
+        title: `Seed product ${label}`,
+        scenario: 'seed_product',
+        params: { fixture },
+        authoring_error: `fixtures.products[${i}] requires a non-empty string 'product_id'`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_product.${product_id}`,
+      title: `Seed product ${product_id}`,
+      scenario: 'seed_product',
+      params: { product_id, fixture },
+    });
+  });
+
+  (fixtures.pricing_options ?? []).forEach((entry, i) => {
+    const { product_id, pricing_option_id, ...fixture } = entry;
+    const label =
+      pricing_option_id && product_id
+        ? `${product_id}:${pricing_option_id}`
+        : (pricing_option_id ?? product_id ?? `#${i}`);
+    const missing: string[] = [];
+    if (typeof product_id !== 'string' || product_id.length === 0) missing.push('product_id');
+    if (typeof pricing_option_id !== 'string' || pricing_option_id.length === 0) missing.push('pricing_option_id');
+    if (missing.length > 0) {
+      calls.push({
+        step_id: `seed_pricing_option.${label}`,
+        title: `Seed pricing option ${label}`,
+        scenario: 'seed_pricing_option',
+        params: { ...(product_id && { product_id }), ...(pricing_option_id && { pricing_option_id }), fixture },
+        authoring_error: `fixtures.pricing_options[${i}] requires non-empty string(s) for: ${missing.join(', ')}`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_pricing_option.${product_id}.${pricing_option_id}`,
+      title: `Seed pricing option ${pricing_option_id} on ${product_id}`,
+      scenario: 'seed_pricing_option',
+      params: { product_id, pricing_option_id, fixture },
+    });
+  });
+
+  (fixtures.creatives ?? []).forEach((entry, i) => {
+    const { creative_id, ...fixture } = entry;
+    const label = creative_id ?? `#${i}`;
+    if (typeof creative_id !== 'string' || creative_id.length === 0) {
+      calls.push({
+        step_id: `seed_creative.${label}`,
+        title: `Seed creative ${label}`,
+        scenario: 'seed_creative',
+        params: { fixture },
+        authoring_error: `fixtures.creatives[${i}] requires a non-empty string 'creative_id'`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_creative.${creative_id}`,
+      title: `Seed creative ${creative_id}`,
+      scenario: 'seed_creative',
+      params: { creative_id, fixture },
+    });
+  });
+
+  (fixtures.plans ?? []).forEach((entry, i) => {
+    const { plan_id, ...fixture } = entry;
+    const label = plan_id ?? `#${i}`;
+    if (typeof plan_id !== 'string' || plan_id.length === 0) {
+      calls.push({
+        step_id: `seed_plan.${label}`,
+        title: `Seed plan ${label}`,
+        scenario: 'seed_plan',
+        params: { fixture },
+        authoring_error: `fixtures.plans[${i}] requires a non-empty string 'plan_id'`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_plan.${plan_id}`,
+      title: `Seed plan ${plan_id}`,
+      scenario: 'seed_plan',
+      params: { plan_id, fixture },
+    });
+  });
+
+  (fixtures.media_buys ?? []).forEach((entry, i) => {
+    const { media_buy_id, ...fixture } = entry;
+    const label = media_buy_id ?? `#${i}`;
+    if (typeof media_buy_id !== 'string' || media_buy_id.length === 0) {
+      calls.push({
+        step_id: `seed_media_buy.${label}`,
+        title: `Seed media buy ${label}`,
+        scenario: 'seed_media_buy',
+        params: { fixture },
+        authoring_error: `fixtures.media_buys[${i}] requires a non-empty string 'media_buy_id'`,
+      });
+      return;
+    }
+    calls.push({
+      step_id: `seed_media_buy.${media_buy_id}`,
+      title: `Seed media buy ${media_buy_id}`,
+      scenario: 'seed_media_buy',
+      params: { media_buy_id, fixture },
+    });
+  });
+
+  return calls;
+}
+
+export interface ControllerSeedingResult {
+  /** Synthetic pre-flight phase to prepend to `StoryboardResult.phases[]`. */
+  phase: StoryboardPhaseResult;
+  /** True when every seed call succeeded; false means downstream phases must cascade-skip. */
+  allPassed: boolean;
+  /** Step counts to fold into the storyboard-level totals. */
+  passedCount: number;
+  failedCount: number;
+  /**
+   * Agent didn't advertise `comply_test_controller` — the storyboard can't
+   * be graded against this seller. The runner cascade-skips real phases
+   * with canonical `missing_test_controller` instead of the seeding-failed
+   * path. Implements the spec's `fixture_seed_unsupported` not_applicable
+   * grade (storyboard-schema.yaml `skip_reasons`).
+   */
+  missingController?: boolean;
+}
+
+/**
+ * Fire every seed call for this storyboard. Returns `null` when seeding is
+ * not applicable (opt-out, no declaration, empty fixtures) so the runner can
+ * treat a no-op identically to a non-seeding storyboard.
+ */
+export async function runControllerSeeding(
+  client: TestClient,
+  storyboard: Storyboard,
+  options: StoryboardRunOptions,
+  context: StoryboardContext
+): Promise<ControllerSeedingResult | null> {
+  if (options.skip_controller_seeding === true) return null;
+  if (storyboard.prerequisites?.controller_seeding !== true) return null;
+  const calls = buildSeedCalls(storyboard.fixtures);
+  if (calls.length === 0) return null;
+
+  // If we can see the agent's tool list and `comply_test_controller` is
+  // absent, grade as not_applicable rather than issuing calls that are
+  // guaranteed to fail on the wire. Spec: `fixture_seed_unsupported` in
+  // storyboard-schema.yaml — missing test-controller is a coverage gap, not
+  // a setup break. `options.agentTools` is discovered from the agent profile
+  // or passed explicitly by the caller; we don't enforce when it's absent
+  // because some harnesses skip tool discovery.
+  if (options.agentTools && !options.agentTools.includes('comply_test_controller')) {
+    return buildMissingControllerResult(storyboard, calls, context);
+  }
+
+  const start = Date.now();
+  const steps: StoryboardStepResult[] = [];
+  let passedCount = 0;
+  let failedCount = 0;
+  let allPassed = true;
+
+  for (const call of calls) {
+    const stepStart = Date.now();
+    let passed = false;
+    let error: string | undefined;
+
+    if (call.authoring_error) {
+      error = call.authoring_error;
+    } else {
+      try {
+        const raw = await callControllerRaw(client, { scenario: call.scenario, params: call.params }, options);
+        const data = raw.data as { success?: boolean; error?: string; error_detail?: string } | undefined;
+        if (raw.success && data?.success === true) {
+          passed = true;
+        } else {
+          error = formatControllerError(call.scenario, raw, data);
+        }
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    const step: StoryboardStepResult = {
+      storyboard_id: storyboard.id,
+      step_id: call.step_id,
+      phase_id: CONTROLLER_SEEDING_PHASE_ID,
+      title: call.title,
+      task: 'comply_test_controller',
+      passed,
+      duration_ms: Date.now() - stepStart,
+      validations: [],
+      context,
+      extraction: { path: 'none' },
+      ...(error !== undefined && { error }),
+    };
+    steps.push(step);
+    if (passed) {
+      passedCount++;
+    } else {
+      failedCount++;
+      allPassed = false;
+    }
+  }
+
+  return {
+    phase: {
+      phase_id: CONTROLLER_SEEDING_PHASE_ID,
+      phase_title: 'Controller seeding (pre-flight)',
+      passed: allPassed,
+      steps,
+      duration_ms: Date.now() - start,
+    },
+    allPassed,
+    passedCount,
+    failedCount,
+  };
+}
+
+function formatControllerError(
+  scenario: SeedScenario,
+  raw: { success: boolean; error?: string },
+  data: { success?: boolean; error?: string; error_detail?: string } | undefined
+): string {
+  if (data?.error_detail) return data.error ? `${data.error}: ${data.error_detail}` : data.error_detail;
+  if (data?.error) return data.error;
+  return raw.error ?? `comply_test_controller ${scenario} call failed`;
+}
+
+const MISSING_CONTROLLER_DETAIL =
+  'Skipped: agent did not advertise comply_test_controller, so fixture seeding (`fixture_seed_unsupported`) cannot run. Storyboard grades not_applicable — the buyer-side flow depends on pre-seeded state the agent has no way to accept.';
+
+function buildMissingControllerResult(
+  storyboard: Storyboard,
+  calls: Array<{ step_id: string; title: string }>,
+  context: StoryboardContext
+): ControllerSeedingResult {
+  const steps: StoryboardStepResult[] = calls.map(call => ({
+    storyboard_id: storyboard.id,
+    step_id: call.step_id,
+    phase_id: CONTROLLER_SEEDING_PHASE_ID,
+    title: call.title,
+    task: 'comply_test_controller',
+    passed: true,
+    skipped: true,
+    skip_reason: 'missing_test_controller',
+    skip: { reason: 'missing_test_controller', detail: MISSING_CONTROLLER_DETAIL },
+    duration_ms: 0,
+    validations: [],
+    context,
+    extraction: { path: 'none' },
+  }));
+  return {
+    phase: {
+      phase_id: CONTROLLER_SEEDING_PHASE_ID,
+      phase_title: 'Controller seeding (pre-flight) — agent lacks comply_test_controller',
+      passed: true,
+      steps,
+      duration_ms: 0,
+    },
+    allPassed: true,
+    passedCount: 0,
+    failedCount: 0,
+    missingController: true,
+  };
+}

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -45,7 +45,25 @@ export interface Storyboard {
   prerequisites?: {
     description: string;
     test_kit?: string;
+    /**
+     * When true and the storyboard carries a top-level `fixtures:` block,
+     * the runner fires `comply_test_controller` seed_* calls for each fixture
+     * entry before phase 1. Spec: adcontextprotocol/adcp#2585 (fixtures block)
+     * + adcontextprotocol/adcp#2584 (seed_* scenarios). Opts-out per run via
+     * `StoryboardRunOptions.skip_controller_seeding` (for agents that seed via
+     * tests or HTTP admin rather than the MCP controller).
+     */
+    controller_seeding?: boolean;
   };
+  /**
+   * Fixture entries consumed by the runner's pre-flight controller seeding
+   * (see `prerequisites.controller_seeding`). Each entry is split into id
+   * params + a `fixture` body before being issued as a `seed_*` scenario on
+   * `comply_test_controller`. Entries are spec-shaped objects drawn from the
+   * source storyboard YAML; the runner preserves every field besides the id
+   * field(s) into `params.fixture` verbatim.
+   */
+  fixtures?: StoryboardFixtures;
   phases: StoryboardPhase[];
   /**
    * Cross-step assertion ids that apply to this storyboard. Each entry names
@@ -57,6 +75,30 @@ export interface Storyboard {
    * error). See `./assertions.ts` for the registry API.
    */
   invariants?: string[];
+}
+
+/**
+ * Fixture entries the runner seeds into the seller via `comply_test_controller`
+ * pre-flight (adcp#2585, adcp#2743). Each array entry carries its id field(s)
+ * alongside the body the runner forwards into `params.fixture` for the
+ * corresponding `seed_*` scenario.
+ *
+ *   - `products[]`      → `seed_product`         — requires `product_id`
+ *   - `pricing_options[]` → `seed_pricing_option` — requires `product_id` + `pricing_option_id`
+ *   - `creatives[]`     → `seed_creative`        — requires `creative_id`
+ *   - `plans[]`         → `seed_plan`            — requires `plan_id`
+ *   - `media_buys[]`    → `seed_media_buy`       — requires `media_buy_id`
+ *
+ * Every other field on the entry is forwarded verbatim as `params.fixture`.
+ * Entries without their required id field produce a pre-flight error so the
+ * authoring mistake is surfaced before any real step runs.
+ */
+export interface StoryboardFixtures {
+  products?: Array<Record<string, unknown> & { product_id?: string }>;
+  pricing_options?: Array<Record<string, unknown> & { product_id?: string; pricing_option_id?: string }>;
+  creatives?: Array<Record<string, unknown> & { creative_id?: string }>;
+  plans?: Array<Record<string, unknown> & { plan_id?: string }>;
+  media_buys?: Array<Record<string, unknown> & { media_buy_id?: string }>;
 }
 
 export interface StoryboardPhase {
@@ -539,6 +581,16 @@ export interface StoryboardRunOptions extends TestOptions {
    */
   contracts?: string[];
   /**
+   * Opt out of the runner's pre-flight `comply_test_controller` seeding
+   * (adcp-client#778). When true, the runner skips the seed_* loop even if
+   * the storyboard declares `prerequisites.controller_seeding: true` and a
+   * `fixtures:` block. Intended for agents that load fixtures via a non-MCP
+   * path (HTTP admin, test bootstrap, inline Node state) — set the flag so
+   * the runner doesn't race the external seeding or fail against an agent
+   * that doesn't host `comply_test_controller`.
+   */
+  skip_controller_seeding?: boolean;
+  /**
    * Dependencies for `expect_webhook_signature_valid`. When omitted the step
    * grades `not_applicable` — matches the spec's "pending" gate. Supply the
    * publisher's JWKS resolver (typically fetched via `brand.json`
@@ -658,7 +710,17 @@ export type RunnerDetailedSkipReason =
   /** Request-signing grader's MCP-transport mode collapses URL-edge vectors (#617). */
   | 'mcp_mode_flattens_url_edges'
   /** RFC 9728 protected-resource metadata returned 404 → agent is not advertising OAuth, cascade-skip oauth_discovery (#677). */
-  | 'oauth_not_advertised';
+  | 'oauth_not_advertised'
+  /**
+   * Pre-flight `comply_test_controller` seeding failed (adcp-client#778), so
+   * every real phase cascade-skipped rather than run against an unseeded
+   * agent. The structured `skip.reason` resolves to the canonical
+   * `prerequisite_failed` per `DETAILED_SKIP_TO_CANONICAL` — the detailed
+   * form stays on the legacy `skip_reason` field so report consumers can
+   * still distinguish setup breaks from stateful-chain breaks within a
+   * phase.
+   */
+  | 'controller_seeding_failed';
 
 /**
  * Map detailed grader skip reasons onto the six canonical spec values so
@@ -675,6 +737,7 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
   missing_test_kit_contract: 'unsatisfied_contract',
   live_side_effect_opt_in_required: 'unsatisfied_contract',
   operator_skip: 'unsatisfied_contract',
+  controller_seeding_failed: 'prerequisite_failed',
 };
 
 export interface RunnerSkipResult {

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas vlatest
-// Generated at: 2026-04-22T04:09:05.446Z
+// Generated at: 2026-04-22T06:59:39.972Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -11231,6 +11231,10 @@ export interface SyncAudiencesRequest {
  */
 export type SyncAudiencesResponse = SyncAudiencesSuccess | SyncAudiencesError;
 /**
+ * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed.
+ */
+export type AudienceStatus = 'processing' | 'ready' | 'too_small';
+/**
  * Identifier type. Combines hashed PII types (hashed_email, hashed_phone) with universal ID types (rampid, uid2, maid, etc.).
  */
 export type MatchIDType =
@@ -11268,10 +11272,7 @@ export interface SyncAudiencesSuccess {
      * Action taken for this audience. 'status' is present when action is created, updated, or unchanged. 'status' is absent when action is deleted or failed.
      */
     action: 'created' | 'updated' | 'unchanged' | 'deleted' | 'failed';
-    /**
-     * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed. 'processing': platform is still matching members against its user base. 'ready': audience is available for targeting, matched_count is populated. 'too_small': matched audience is below the platform's minimum size — add more members and re-sync.
-     */
-    status?: 'processing' | 'ready' | 'too_small';
+    status?: AudienceStatus;
     /**
      * Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.
      */
@@ -11940,6 +11941,10 @@ export interface CreatePropertyListResponse {
    * Token that can be shared with sellers to authorize fetching this list. Store this - it is only returned at creation time.
    */
   auth_token: string;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -12027,6 +12032,10 @@ export interface DeletePropertyListResponse {
    * ID of the deleted list
    */
   list_id: string;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -12172,6 +12181,10 @@ export interface UpdatePropertyListRequest {
  */
 export interface UpdatePropertyListResponse {
   list: PropertyList;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-04-22T04:09:10.844Z
+// Generated at: 2026-04-22T06:59:44.443Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2553,6 +2553,8 @@ export const SyncAudiencesErrorSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const AudienceStatusSchema = z.union([z.literal("processing"), z.literal("ready"), z.literal("too_small")]);
+
 export const MatchIDTypeSchema = z.union([z.literal("hashed_email"), z.literal("hashed_phone"), z.literal("rampid"), z.literal("id5"), z.literal("uid2"), z.literal("euid"), z.literal("pairid"), z.literal("maid"), z.literal("other")]);
 
 export const SyncAudiencesSuccessSchema = z.object({
@@ -2561,7 +2563,7 @@ export const SyncAudiencesSuccessSchema = z.object({
         name: z.string().optional(),
         seller_id: z.string().optional(),
         action: z.union([z.literal("created"), z.literal("updated"), z.literal("unchanged"), z.literal("deleted"), z.literal("failed")]),
-        status: z.union([z.literal("processing"), z.literal("ready"), z.literal("too_small")]).optional(),
+        status: AudienceStatusSchema.optional(),
         uploaded_count: z.number().optional(),
         total_uploaded_count: z.number().optional(),
         matched_count: z.number().optional(),
@@ -2682,6 +2684,7 @@ export const DeletePropertyListRequestSchema = z.object({
 export const DeletePropertyListResponseSchema = z.object({
     deleted: z.boolean(),
     list_id: z.string(),
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4653,6 +4656,7 @@ export const PropertyListSchema = z.object({
 
 export const UpdatePropertyListResponseSchema = z.object({
     list: PropertyListSchema,
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4720,6 +4724,7 @@ export const UpdateCollectionListRequestSchema = z.object({
 
 export const UpdateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4790,6 +4795,7 @@ export const DeleteCollectionListRequestSchema = z.object({
 export const DeleteCollectionListResponseSchema = z.object({
     deleted: z.boolean(),
     list_id: z.string(),
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4901,6 +4907,7 @@ export const SyncPlansResponseSchema = z.object({
             reason: z.string().optional()
         }).passthrough()).optional()
     }).passthrough()),
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4955,6 +4962,7 @@ export const ReportPlanOutcomeResponseSchema = z.object({
         total_committed: z.number().optional(),
         budget_remaining: z.number().optional()
     }).passthrough().optional(),
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6019,6 +6027,7 @@ export const CreativeAsset1Schema = z.object({
 export const CreatePropertyListResponseSchema = z.object({
     list: PropertyListSchema,
     auth_token: z.string(),
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -6242,6 +6251,7 @@ export const CreateMediaBuyResponseSchema = z.union([CreateMediaBuySuccessSchema
 export const CreateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,
     auth_token: z.string(),
+    replayed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -7238,6 +7238,10 @@ export interface SyncAudiencesRequest {
  */
 export type SyncAudiencesResponse = SyncAudiencesSuccess | SyncAudiencesError;
 /**
+ * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed.
+ */
+export type AudienceStatus = 'processing' | 'ready' | 'too_small';
+/**
  * Identifier type. Combines hashed PII types (hashed_email, hashed_phone) with universal ID types (rampid, uid2, maid, etc.).
  */
 export type MatchIDType =
@@ -7275,10 +7279,7 @@ export interface SyncAudiencesSuccess {
      * Action taken for this audience. 'status' is present when action is created, updated, or unchanged. 'status' is absent when action is deleted or failed.
      */
     action: 'created' | 'updated' | 'unchanged' | 'deleted' | 'failed';
-    /**
-     * Matching status. Present when action is created, updated, or unchanged; absent when action is deleted or failed. 'processing': platform is still matching members against its user base. 'ready': audience is available for targeting, matched_count is populated. 'too_small': matched audience is below the platform's minimum size — add more members and re-sync.
-     */
-    status?: 'processing' | 'ready' | 'too_small';
+    status?: AudienceStatus;
     /**
      * Number of members submitted in this sync operation (delta, not cumulative). In discovery-only calls (no audiences array), this is 0.
      */
@@ -9398,6 +9399,10 @@ export interface CreatePropertyListResponse {
    * Token that can be shared with sellers to authorize fetching this list. Store this - it is only returned at creation time.
    */
   auth_token: string;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -9496,6 +9501,10 @@ export interface UpdatePropertyListRequest {
  */
 export interface UpdatePropertyListResponse {
   list: PropertyList;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -9632,6 +9641,10 @@ export interface DeletePropertyListResponse {
    * ID of the deleted list
    */
   list_id: string;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -9819,6 +9832,10 @@ export interface CreateCollectionListResponse {
    * Token that authorizes sellers to fetch this list via get_collection_list. Only returned at creation time — buyers MUST store it in a secret manager. Scoped to this one list_id; MUST NOT be reused across lists. Governance agents MUST issue a distinct token per seller so per-relationship revocation is possible. Tokens MUST NOT be logged, appear in cache keys, or echo in error responses. delete_collection_list MUST revoke the token immediately; compromise-driven revocation MUST also signal cache invalidation to sellers (reduced cache_valid_until or a list-changed webhook). See Security considerations in docs/governance/collection/tasks/collection_lists.
    */
   auth_token: string;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -9913,6 +9930,10 @@ export interface UpdateCollectionListRequest {
  */
 export interface UpdateCollectionListResponse {
   list: CollectionList;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -10084,6 +10105,10 @@ export interface DeleteCollectionListResponse {
    * ID of the deleted list
    */
   list_id: string;
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -11294,6 +11319,10 @@ export interface SyncPlansResponse {
       reason?: string;
     }[];
   }[];
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }
@@ -11459,6 +11488,10 @@ export interface ReportPlanOutcomeResponse {
      */
     budget_remaining?: number;
   };
+  /**
+   * Set to true when this response is a cached replay returned for an idempotency_key that was already processed. Set to false (or omitted) when the request was executed fresh. Buyers use this to distinguish cached replays from new executions — matters for billing reconciliation, audit logs, and any downstream system that assumes exactly-once event semantics. Only present on responses to mutating requests that carry idempotency_key.
+   */
+  replayed?: boolean;
   context?: ContextObject;
   ext?: ExtensionObject;
 }

--- a/test/lib/storyboard-controller-seeding.test.js
+++ b/test/lib/storyboard-controller-seeding.test.js
@@ -1,0 +1,428 @@
+/**
+ * Pre-flight `comply_test_controller` seeding (adcp-client#778).
+ *
+ * Covers the runner glue between the spec's `fixtures:` block +
+ * `prerequisites.controller_seeding: true` (adcontextprotocol/adcp#2585,
+ * #2743) and the SDK's `seed_*` scenarios (adcontextprotocol/adcp#2584).
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { buildSeedCalls, runControllerSeeding } = require('../../dist/lib/testing/storyboard/seeding');
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+// ────────────────────────────────────────────────────────────
+// buildSeedCalls — pure translation from fixtures block to seed calls
+// ────────────────────────────────────────────────────────────
+
+describe('buildSeedCalls', () => {
+  test('returns empty array for missing or empty fixtures', () => {
+    assert.deepStrictEqual(buildSeedCalls(undefined), []);
+    assert.deepStrictEqual(buildSeedCalls({}), []);
+    assert.deepStrictEqual(buildSeedCalls({ products: [] }), []);
+  });
+
+  test('products → seed_product with product_id lifted into params and rest in fixture', () => {
+    const calls = buildSeedCalls({
+      products: [
+        { product_id: 'sports_display_auction', delivery_type: 'non_guaranteed', channels: ['display'] },
+        { product_id: 'outdoor_video_auction', delivery_type: 'non_guaranteed', channels: ['video'] },
+      ],
+    });
+    assert.strictEqual(calls.length, 2);
+    assert.strictEqual(calls[0].scenario, 'seed_product');
+    assert.deepStrictEqual(calls[0].params, {
+      product_id: 'sports_display_auction',
+      fixture: { delivery_type: 'non_guaranteed', channels: ['display'] },
+    });
+    assert.strictEqual(calls[1].params.product_id, 'outdoor_video_auction');
+  });
+
+  test('pricing_options → seed_pricing_option with product_id + pricing_option_id lifted', () => {
+    const calls = buildSeedCalls({
+      pricing_options: [
+        {
+          product_id: 'sports_display_auction',
+          pricing_option_id: 'cpm_auction',
+          pricing_model: 'cpm',
+          floor_price: 5.0,
+        },
+      ],
+    });
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].scenario, 'seed_pricing_option');
+    assert.deepStrictEqual(calls[0].params, {
+      product_id: 'sports_display_auction',
+      pricing_option_id: 'cpm_auction',
+      fixture: { pricing_model: 'cpm', floor_price: 5.0 },
+    });
+  });
+
+  test('creatives → seed_creative, plans → seed_plan, media_buys → seed_media_buy', () => {
+    const calls = buildSeedCalls({
+      creatives: [{ creative_id: 'cr-1', format_id: 'display_300x250' }],
+      plans: [{ plan_id: 'plan-1', brand_domain: 'acme.example' }],
+      media_buys: [{ media_buy_id: 'mb-1', status: 'pending_approval' }],
+    });
+    assert.strictEqual(calls.length, 3);
+    const byScenario = Object.fromEntries(calls.map(c => [c.scenario, c]));
+    assert.deepStrictEqual(byScenario.seed_creative.params, {
+      creative_id: 'cr-1',
+      fixture: { format_id: 'display_300x250' },
+    });
+    assert.deepStrictEqual(byScenario.seed_plan.params, {
+      plan_id: 'plan-1',
+      fixture: { brand_domain: 'acme.example' },
+    });
+    assert.deepStrictEqual(byScenario.seed_media_buy.params, {
+      media_buy_id: 'mb-1',
+      fixture: { status: 'pending_approval' },
+    });
+  });
+
+  test('emits ordering: products → pricing_options → creatives → plans → media_buys', () => {
+    const calls = buildSeedCalls({
+      media_buys: [{ media_buy_id: 'mb-1' }],
+      products: [{ product_id: 'p-1' }],
+      creatives: [{ creative_id: 'c-1' }],
+      plans: [{ plan_id: 'pl-1' }],
+      pricing_options: [{ product_id: 'p-1', pricing_option_id: 'po-1' }],
+    });
+    assert.deepStrictEqual(
+      calls.map(c => c.scenario),
+      ['seed_product', 'seed_pricing_option', 'seed_creative', 'seed_plan', 'seed_media_buy']
+    );
+  });
+
+  test('flags authoring error when a required id field is missing — seed is not issued', () => {
+    const calls = buildSeedCalls({
+      products: [{ delivery_type: 'non_guaranteed' }],
+      pricing_options: [{ product_id: 'p-1' }],
+      creatives: [{ format_id: 'x' }],
+    });
+    assert.strictEqual(calls.length, 3);
+    assert.match(calls[0].authoring_error, /product_id/);
+    assert.match(calls[1].authoring_error, /pricing_option_id/);
+    assert.match(calls[2].authoring_error, /creative_id/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// runControllerSeeding — opt-out, no-op, success, failure
+// ────────────────────────────────────────────────────────────
+
+function makeMockClient(responder) {
+  const calls = [];
+  const client = {
+    async executeTask(name, params) {
+      calls.push({ name, params });
+      return responder({ name, params });
+    },
+  };
+  return { client, calls };
+}
+
+function successResponse() {
+  return {
+    success: true,
+    data: { content: [{ type: 'text', text: JSON.stringify({ success: true, previous_state: 'none', current_state: 'seeded' }) }] },
+  };
+}
+
+describe('runControllerSeeding', () => {
+  const storyboardWithFixtures = {
+    id: 'test_sb',
+    version: '1.0',
+    title: '',
+    category: '',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '', capabilities: [] },
+    caller: { role: '' },
+    prerequisites: { description: '', controller_seeding: true },
+    fixtures: {
+      products: [{ product_id: 'p-1', delivery_type: 'guaranteed' }],
+    },
+    phases: [],
+  };
+
+  test('returns null when skip_controller_seeding opt-out is set', async () => {
+    const { client, calls } = makeMockClient(successResponse);
+    const result = await runControllerSeeding(client, storyboardWithFixtures, { skip_controller_seeding: true }, {});
+    assert.strictEqual(result, null);
+    assert.strictEqual(calls.length, 0);
+  });
+
+  test('returns null when prerequisites.controller_seeding is not true', async () => {
+    const { client, calls } = makeMockClient(successResponse);
+    const noDecl = { ...storyboardWithFixtures, prerequisites: { description: '' } };
+    const result = await runControllerSeeding(client, noDecl, {}, {});
+    assert.strictEqual(result, null);
+    assert.strictEqual(calls.length, 0);
+  });
+
+  test('returns null when fixtures block is empty or absent', async () => {
+    const { client, calls } = makeMockClient(successResponse);
+    const noFixtures = { ...storyboardWithFixtures, fixtures: undefined };
+    assert.strictEqual(await runControllerSeeding(client, noFixtures, {}, {}), null);
+    const emptyFixtures = { ...storyboardWithFixtures, fixtures: {} };
+    assert.strictEqual(await runControllerSeeding(client, emptyFixtures, {}, {}), null);
+    assert.strictEqual(calls.length, 0);
+  });
+
+  test('happy path: issues one comply_test_controller call per fixture entry, all pass', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      fixtures: {
+        products: [{ product_id: 'p-1' }, { product_id: 'p-2' }],
+        creatives: [{ creative_id: 'cr-1' }],
+      },
+    };
+    const { client, calls } = makeMockClient(successResponse);
+    const result = await runControllerSeeding(client, storyboard, {}, {});
+    assert.ok(result, 'seeding result should exist');
+    assert.strictEqual(calls.length, 3);
+    for (const call of calls) {
+      assert.strictEqual(call.name, 'comply_test_controller');
+      assert.match(String(call.params.scenario), /seed_/);
+    }
+    assert.strictEqual(result.allPassed, true);
+    assert.strictEqual(result.passedCount, 3);
+    assert.strictEqual(result.failedCount, 0);
+    assert.strictEqual(result.phase.phase_id, '__controller_seeding__');
+    assert.strictEqual(result.phase.steps.length, 3);
+    for (const step of result.phase.steps) {
+      assert.strictEqual(step.passed, true);
+      assert.strictEqual(step.task, 'comply_test_controller');
+    }
+  });
+
+  test('failure path: controller returns an error for one seed — phase fails, allPassed is false', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      fixtures: {
+        products: [{ product_id: 'p-1' }, { product_id: 'p-broken' }],
+      },
+    };
+    const { client } = makeMockClient(({ params }) => {
+      if (params.params?.product_id === 'p-broken') {
+        return {
+          success: true,
+          data: {
+            content: [
+              { type: 'text', text: JSON.stringify({ success: false, error: 'INVALID_PARAMS', error_detail: 'bad fixture' }) },
+            ],
+          },
+        };
+      }
+      return successResponse();
+    });
+    const result = await runControllerSeeding(client, storyboard, {}, {});
+    assert.ok(result);
+    assert.strictEqual(result.allPassed, false);
+    assert.strictEqual(result.passedCount, 1);
+    assert.strictEqual(result.failedCount, 1);
+    const failed = result.phase.steps.find(s => !s.passed);
+    assert.ok(failed, 'one step must be failed');
+    assert.match(failed.error, /INVALID_PARAMS/);
+  });
+
+  test('authoring errors (missing id) produce a failed step without issuing a controller call', async () => {
+    const storyboard = {
+      ...storyboardWithFixtures,
+      fixtures: {
+        products: [{ delivery_type: 'guaranteed' /* missing product_id */ }],
+      },
+    };
+    const { client, calls } = makeMockClient(successResponse);
+    const result = await runControllerSeeding(client, storyboard, {}, {});
+    assert.strictEqual(calls.length, 0, 'no controller call when id is missing');
+    assert.strictEqual(result.allPassed, false);
+    assert.match(result.phase.steps[0].error, /product_id/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// runStoryboard — runner integration
+// ────────────────────────────────────────────────────────────
+
+describe('runStoryboard: controller seeding integration', () => {
+  function makeRunnerClient(responder) {
+    const calls = [];
+    return {
+      calls,
+      client: {
+        async executeTask(name, params) {
+          calls.push({ name, params });
+          return responder({ name, params });
+        },
+        async getAgentInfo() {
+          return { name: 'Test', tools: [{ name: 'comply_test_controller' }, { name: 'get_products' }] };
+        },
+      },
+    };
+  }
+
+  const baseStoryboard = {
+    id: 'seed_runner_sb',
+    version: '1.0.0',
+    title: 'Seeding runner',
+    category: 'compliance',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    prerequisites: { description: 'needs seeds', controller_seeding: true },
+    fixtures: {
+      products: [{ product_id: 'sports_display', delivery_type: 'non_guaranteed' }],
+    },
+    phases: [
+      {
+        id: 'discovery',
+        title: 'discovery',
+        steps: [
+          {
+            id: 'get_caps',
+            title: 'get caps',
+            task: 'get_products',
+            sample_request: { brief: 'test' },
+            validations: [],
+          },
+        ],
+      },
+    ],
+  };
+
+  test('fires seed_* calls before the first phase and prepends the seeding phase to phaseResults', async () => {
+    const { client, calls } = makeRunnerClient(successResponse);
+    const result = await runStoryboard('https://example.invalid/mcp', baseStoryboard, {
+      protocol: 'mcp',
+      allow_http: false,
+      agentTools: ['comply_test_controller', 'get_products'],
+      _profile: { name: 'Test', tools: ['comply_test_controller', 'get_products'] },
+      _client: client,
+    });
+
+    const seedCalls = calls.filter(c => c.name === 'comply_test_controller');
+    const productCalls = calls.filter(c => c.name === 'get_products');
+    assert.strictEqual(seedCalls.length, 1, 'exactly one seed_product call');
+    assert.strictEqual(seedCalls[0].params.scenario, 'seed_product');
+    assert.strictEqual(seedCalls[0].params.params.product_id, 'sports_display');
+    assert.ok(productCalls.length >= 1, 'real phase should run after seeding');
+
+    const seedPhase = result.phases.find(p => p.phase_id === '__controller_seeding__');
+    assert.ok(seedPhase, 'seeding phase must be in phaseResults');
+    assert.strictEqual(result.phases[0].phase_id, '__controller_seeding__', 'seeding phase must be first');
+  });
+
+  test('seed failure cascade-skips every real phase with controller_seeding_failed', async () => {
+    const { client, calls } = makeRunnerClient(({ name }) => {
+      if (name === 'comply_test_controller') {
+        return {
+          success: true,
+          data: {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({ success: false, error: 'UNKNOWN_SCENARIO', error_detail: 'no seedProduct' }),
+              },
+            ],
+          },
+        };
+      }
+      return successResponse();
+    });
+    const result = await runStoryboard('https://example.invalid/mcp', baseStoryboard, {
+      protocol: 'mcp',
+      agentTools: ['comply_test_controller', 'get_products'],
+      _profile: { name: 'Test', tools: ['comply_test_controller', 'get_products'] },
+      _client: client,
+    });
+
+    assert.strictEqual(result.overall_passed, false);
+    assert.ok(result.failed_count >= 1, 'seed failure must count as failed');
+    const realPhaseCalls = calls.filter(c => c.name === 'get_products');
+    assert.strictEqual(realPhaseCalls.length, 0, 'real phases must not run after seed failure');
+
+    const realPhase = result.phases.find(p => p.phase_id === 'discovery');
+    assert.ok(realPhase);
+    for (const step of realPhase.steps) {
+      assert.strictEqual(step.skipped, true, `step ${step.step_id} should be skipped`);
+      // Detailed skip reason stays on the legacy field so report consumers
+      // can distinguish setup break from stateful chain break.
+      assert.strictEqual(step.skip_reason, 'controller_seeding_failed');
+      // Canonical skip reason must be one of the six spec-required values —
+      // controller_seeding_failed collapses to prerequisite_failed per
+      // DETAILED_SKIP_TO_CANONICAL.
+      assert.strictEqual(step.skip.reason, 'prerequisite_failed');
+    }
+  });
+
+  test('agent missing comply_test_controller grades as not_applicable via missing_test_controller cascade', async () => {
+    const { client, calls } = makeRunnerClient(successResponse);
+    const result = await runStoryboard('https://example.invalid/mcp', baseStoryboard, {
+      protocol: 'mcp',
+      // agentTools does NOT include comply_test_controller — spec says
+      // fixture_seed_unsupported grades not_applicable, not setup-failed.
+      agentTools: ['get_products'],
+      _profile: { name: 'Test', tools: ['get_products'] },
+      _client: client,
+    });
+
+    // No MCP calls should be issued — the runner detected the missing tool
+    // before firing any seed.
+    const seedCalls = calls.filter(c => c.name === 'comply_test_controller');
+    assert.strictEqual(seedCalls.length, 0, 'no seed calls when controller is missing');
+
+    const seedPhase = result.phases.find(p => p.phase_id === '__controller_seeding__');
+    assert.ok(seedPhase);
+    for (const step of seedPhase.steps) {
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.skip_reason, 'missing_test_controller');
+      assert.strictEqual(step.skip.reason, 'missing_test_controller');
+    }
+
+    const realPhase = result.phases.find(p => p.phase_id === 'discovery');
+    assert.ok(realPhase);
+    for (const step of realPhase.steps) {
+      assert.strictEqual(step.skipped, true);
+      assert.strictEqual(step.skip_reason, 'missing_test_controller');
+      assert.strictEqual(step.skip.reason, 'missing_test_controller');
+    }
+    // No failures — missing controller is a coverage gap, not a setup break.
+    assert.strictEqual(result.failed_count, 0);
+  });
+
+  test('skip_controller_seeding opt-out bypasses seeding entirely — real phase still runs', async () => {
+    const { client, calls } = makeRunnerClient(successResponse);
+    const result = await runStoryboard('https://example.invalid/mcp', baseStoryboard, {
+      protocol: 'mcp',
+      agentTools: ['comply_test_controller', 'get_products'],
+      _profile: { name: 'Test', tools: ['comply_test_controller', 'get_products'] },
+      _client: client,
+      skip_controller_seeding: true,
+    });
+
+    const seedCalls = calls.filter(c => c.name === 'comply_test_controller');
+    assert.strictEqual(seedCalls.length, 0, 'opt-out must suppress seed calls');
+    const seedPhase = result.phases.find(p => p.phase_id === '__controller_seeding__');
+    assert.strictEqual(seedPhase, undefined, 'no seeding phase when opted out');
+  });
+
+  test('no-op when storyboard omits controller_seeding declaration', async () => {
+    const storyboardNoDecl = {
+      ...baseStoryboard,
+      prerequisites: { description: 'no seeding needed' },
+    };
+    const { client, calls } = makeRunnerClient(successResponse);
+    await runStoryboard('https://example.invalid/mcp', storyboardNoDecl, {
+      protocol: 'mcp',
+      agentTools: ['comply_test_controller', 'get_products'],
+      _profile: { name: 'Test', tools: ['comply_test_controller', 'get_products'] },
+      _client: client,
+    });
+    const seedCalls = calls.filter(c => c.name === 'comply_test_controller');
+    assert.strictEqual(seedCalls.length, 0);
+  });
+});

--- a/test/lib/storyboard-controller-seeding.test.js
+++ b/test/lib/storyboard-controller-seeding.test.js
@@ -126,7 +126,11 @@ function makeMockClient(responder) {
 function successResponse() {
   return {
     success: true,
-    data: { content: [{ type: 'text', text: JSON.stringify({ success: true, previous_state: 'none', current_state: 'seeded' }) }] },
+    data: {
+      content: [
+        { type: 'text', text: JSON.stringify({ success: true, previous_state: 'none', current_state: 'seeded' }) },
+      ],
+    },
   };
 }
 
@@ -211,7 +215,10 @@ describe('runControllerSeeding', () => {
           success: true,
           data: {
             content: [
-              { type: 'text', text: JSON.stringify({ success: false, error: 'INVALID_PARAMS', error_detail: 'bad fixture' }) },
+              {
+                type: 'text',
+                text: JSON.stringify({ success: false, error: 'INVALID_PARAMS', error_detail: 'bad fixture' }),
+              },
             ],
           },
         };


### PR DESCRIPTION
## Summary

Closes #778. Bridges the spec-side `fixtures:` block + `prerequisites.controller_seeding` flag (adcontextprotocol/adcp#2585, rolled out in adcontextprotocol/adcp#2743) to the SDK-side `seed_*` scenarios on `comply_test_controller` (adcontextprotocol/adcp#2584). The runner glue between these two halves was missing — both ends shipped, nothing connected them. Now:

- When a storyboard declares `prerequisites.controller_seeding: true` and a `fixtures:` block, the runner fires one `comply_test_controller` call per fixture entry before phase 1.
- Each entry's id field(s) ride on `params`; everything else is forwarded verbatim as `params.fixture`.
- The seed pass surfaces as a synthetic `__controller_seeding__` phase in `StoryboardResult.phases[]`.

**Unblocks:** `sales_non_guaranteed`, `creative_ad_server` (campaign_hero_video), `governance_delivery_monitor`, `media_buy_governance_escalation`, `governance_spend_authority` against any seller that implements the matching `seed*` adapters.

## Grading semantics (per runner-output-contract)

The runner-output-contract enumerates six canonical skip reasons; this PR does **not** add a seventh.

- **Seed failure** → cascade-skip with detailed `skip_reason: 'controller_seeding_failed'` and canonical `skip.reason: 'prerequisite_failed'`. Adds `'controller_seeding_failed'` to `RunnerDetailedSkipReason` and `DETAILED_SKIP_TO_CANONICAL`.
- **Agent missing `comply_test_controller`** → cascade-skip with canonical `'missing_test_controller'` (no wire calls fired). Implements the spec's `fixture_seed_unsupported` not_applicable grade from `storyboard-schema.yaml`.
- **Multi-pass dedup** → seeding fires once at the `runMultiPass` level so cross-pass aggregation doesn't inflate `failed_count` / `skipped_count` by N when a fixture breaks. Each pass attaches the synthetic phase only on pass 0.

## Public type additions

- `Storyboard.prerequisites.controller_seeding?: boolean`
- `Storyboard.fixtures?: StoryboardFixtures`
- `StoryboardFixtures` interface (typed arrays per fixture category)
- `StoryboardRunOptions.skip_controller_seeding?: boolean` — opt-out for agents that load fixtures via non-MCP paths

## Test plan

- [x] 17 new tests in `test/lib/storyboard-controller-seeding.test.js` cover `buildSeedCalls` translation, opt-out paths, happy path, failure cascade, missing-controller cascade, authoring errors, and end-to-end runner integration
- [x] 87/87 tests pass across new file + adjacent storyboard tests (runner-contract, skip-counting, idempotency-invariant, multi-instance, branch-set-grading)
- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)