### PR TITLE
feat(client): storyboard invariants default-on + enriched status.monotonic error

### DIFF
--- a/.changeset/invariants-default-on.md
+++ b/.changeset/invariants-default-on.md
@@ -1,0 +1,16 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard cross-step invariants are now default-on. Bundled assertions (`status.monotonic`, `idempotency.conflict_no_payload_leak`, `context.no_secret_echo`, `governance.denial_blocks_mutation`) apply to every run unless a storyboard opts out — forks and new specialisms no longer ship with zero cross-step gating silently.
+
+- `Storyboard.invariants` now accepts an object form `{ disable?: string[]; enable?: string[] }`. `disable` is the escape hatch that removes a specific default; `enable` adds a consumer-registered (non-default) assertion on top of the baseline. The legacy `invariants: [id, ...]` array form still works and is treated as additive on top of the defaults.
+- **Behavior change for direct-API callers**: `resolveAssertions(['id'])` now returns `[...defaults, ...named]` instead of exactly the named ids. Callers that relied on the array-only return shape (e.g., snapshotting `resolveAssertions([...]).length`) should switch to `resolveAssertions({ enable: [...], disable: listDefaultAssertions() })` to reproduce the old semantics.
+- `AssertionSpec` gained an optional `default?: boolean` flag. Consumers registering custom assertions via `registerAssertion(...)` can opt their own specs into the default-on path.
+- `resolveAssertions(...)` fails fast on unknown ids in `enable` / the legacy array, and on `disable` ids that aren't registered as defaults (typo guard — a silent no-op would mask coverage gaps). Errors name the registered set and emit a `Did you mean "..."?` suggestion when one of the unknown ids is within Levenshtein distance 2 of a known id.
+- Unknown top-level keys on the object form (e.g. `invariants: { disabled: [...] }` — trailing `d` typo) throw instead of silently normalising to an empty disable set.
+- New export `listDefaultAssertions()` (re-exported from `@adcp/client/testing`) enumerates the default-on set for tooling / diagnostics.
+
+`status.monotonic` failure messages now include the legal next states from the anchor status and a link to the canonical enum schema, e.g.
+`media_buy mb-1: active → pending_creatives (step "create" → step "regress") is not in the lifecycle graph. Legal next states from "active": "canceled", "completed", "paused". See https://adcontextprotocol.org/schemas/latest/enums/media-buy-status.json for the canonical lifecycle.`
+Terminal states render as `(none — terminal state)` so the message is unambiguous.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.9.1",
+      "version": "5.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -195,6 +195,7 @@ export {
   registerAssertion,
   getAssertion,
   listAssertions,
+  listDefaultAssertions,
   clearAssertionRegistry,
   resolveAssertions,
   type AssertionSpec,
@@ -203,6 +204,8 @@ export {
   type RegisterAssertionOptions,
   // Types
   type Storyboard,
+  type StoryboardInvariants,
+  type StoryboardInvariantsObject,
   type StoryboardPhase,
   type StoryboardStep,
   type StoryboardValidation,

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -21,7 +21,13 @@
  * See adcontextprotocol/adcp#2639 for the originating design.
  */
 
-import type { AssertionResult, Storyboard, StoryboardRunOptions, StoryboardStepResult } from './types';
+import type {
+  AssertionResult,
+  Storyboard,
+  StoryboardInvariants,
+  StoryboardRunOptions,
+  StoryboardStepResult,
+} from './types';
 
 // ────────────────────────────────────────────────────────────
 // Public types
@@ -61,6 +67,17 @@ export interface AssertionContext {
 export interface AssertionSpec {
   id: string;
   description: string;
+  /**
+   * When true, the assertion runs on every storyboard unless explicitly
+   * disabled via `storyboard.invariants.disable`. Defaults to `false` —
+   * non-default assertions are opt-in through `invariants.enable` (object
+   * form) or `invariants: [id, ...]` (legacy additive array form). The
+   * bundled assertions in `default-invariants.ts` all set this to `true`
+   * so forks and new specialisms inherit baseline cross-step gating
+   * automatically; consumers registering custom assertions can opt in by
+   * setting it on their own specs.
+   */
+  default?: boolean;
   onStart?(ctx: AssertionContext): void | Promise<void>;
   onStep?(
     ctx: AssertionContext,
@@ -114,6 +131,20 @@ export function listAssertions(): string[] {
 }
 
 /**
+ * List every assertion id registered with `default: true`. Used by
+ * `resolveAssertions` to build the baseline set that applies when a
+ * storyboard omits `invariants:` entirely or uses the object form's
+ * `disable: [...]` escape hatch.
+ */
+export function listDefaultAssertions(): string[] {
+  const out: string[] = [];
+  for (const [id, spec] of registry) {
+    if (spec.default) out.push(id);
+  }
+  return out;
+}
+
+/**
  * Remove all registrations. Scoped for tests — production runs rely on
  * module-init registration, and clearing the registry mid-run would break
  * any in-flight storyboard.
@@ -123,24 +154,132 @@ export function clearAssertionRegistry(): void {
 }
 
 /**
- * Resolve a list of ids to their registered specs. Throws with a single
- * aggregated error naming every unknown id — fails fast at runner start
- * rather than silently dropping ids.
+ * Resolve a storyboard's `invariants` declaration to the ordered list of
+ * `AssertionSpec`s the runner will drive. Every assertion registered with
+ * `default: true` is in the result unless the object form explicitly
+ * disables it; any ids supplied (legacy array form, or the object form's
+ * `enable`) are merged in on top.
+ *
+ * Fails fast at runner start on:
+ *   - any unknown id in the caller-supplied enable / legacy-array list,
+ *   - any id in `disable` that is not registered as a default (typo guard —
+ *     silently no-opping would mask real coverage gaps).
+ *
+ * The return order is: default specs (in registration order, with disabled
+ * ones filtered out) followed by the enable / legacy-array specs in the
+ * order the caller supplied them. Duplicates are collapsed.
+ *
+ * Accepts `string[]` (legacy additive form) and the `{ disable?, enable? }`
+ * object form from `Storyboard.invariants`; `undefined` means "apply all
+ * defaults". The looser `StoryboardInvariants | undefined` parameter type
+ * exists so callers can forward `storyboard.invariants` directly.
  */
-export function resolveAssertions(ids: string[] | undefined): AssertionSpec[] {
-  if (!ids || ids.length === 0) return [];
-  const resolved: AssertionSpec[] = [];
-  const missing: string[] = [];
-  for (const id of ids) {
-    const spec = registry.get(id);
-    if (spec) resolved.push(spec);
-    else missing.push(id);
+export function resolveAssertions(invariants: StoryboardInvariants | undefined): AssertionSpec[] {
+  const { disable, enable } = normaliseInvariants(invariants);
+
+  const resolved = new Map<string, AssertionSpec>();
+  const defaultIds: string[] = [];
+  for (const [id, spec] of registry) {
+    if (!spec.default) continue;
+    defaultIds.push(id);
+    if (!disable.includes(id)) resolved.set(id, spec);
   }
-  if (missing.length > 0) {
+
+  const unknownEnable: string[] = [];
+  for (const id of enable) {
+    const spec = registry.get(id);
+    if (!spec) unknownEnable.push(id);
+    else resolved.set(id, spec);
+  }
+
+  const defaultIdSet = new Set(defaultIds);
+  const unknownDisable: string[] = disable.filter(id => !defaultIdSet.has(id));
+
+  if (unknownEnable.length > 0 || unknownDisable.length > 0) {
+    const lines: string[] = [];
+    if (unknownEnable.length > 0) {
+      const registered = [...registry.keys()].sort().join(', ') || '(none registered)';
+      lines.push(
+        `Storyboard references unregistered assertion${unknownEnable.length > 1 ? 's' : ''}: ${unknownEnable.join(', ')}. ` +
+          suggestionClause(unknownEnable, [...registry.keys()]) +
+          `Registered ids: ${registered}. ` +
+          `Import the module that calls registerAssertion(...) for each id before running the storyboard.`
+      );
+    }
+    if (unknownDisable.length > 0) {
+      const known = defaultIds.slice().sort().join(', ') || '(none registered)';
+      lines.push(
+        `Storyboard invariants.disable names id${unknownDisable.length > 1 ? 's' : ''} that are not default-on: ${unknownDisable.join(', ')}. ` +
+          suggestionClause(unknownDisable, defaultIds) +
+          `Known default-on ids: ${known}. Non-default assertions don't need to be disabled — omit them instead.`
+      );
+    }
+    throw new Error(lines.join(' '));
+  }
+
+  return [...resolved.values()];
+}
+
+interface NormalisedInvariants {
+  disable: string[];
+  enable: string[];
+}
+
+// Object form keys. Any other top-level key (common typo: `disabled`) is a
+// silent-no-op trap under the permissive spread, so we catch it at parse-time.
+const INVARIANTS_OBJECT_KEYS: ReadonlySet<string> = new Set(['disable', 'enable']);
+
+function normaliseInvariants(invariants: StoryboardInvariants | undefined): NormalisedInvariants {
+  if (!invariants) return { disable: [], enable: [] };
+  if (Array.isArray(invariants)) return { disable: [], enable: invariants };
+  const unknown = Object.keys(invariants).filter(k => !INVARIANTS_OBJECT_KEYS.has(k));
+  if (unknown.length > 0) {
     throw new Error(
-      `Storyboard references unregistered assertion${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}. ` +
-        `Import the module that calls registerAssertion(...) for each id before running the storyboard.`
+      `Storyboard invariants has unknown field${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}. ` +
+        `Supported fields are: ${[...INVARIANTS_OBJECT_KEYS].sort().join(', ')}.`
     );
   }
-  return resolved;
+  return { disable: invariants.disable ?? [], enable: invariants.enable ?? [] };
+}
+
+/**
+ * Render a `Did you mean "X"?` clause when one of the unknown ids has a
+ * close Levenshtein match in the candidate set. Kept narrow (distance ≤ 2,
+ * first hit wins) so typo suggestions don't bleed into legitimate near-
+ * collisions between registered ids.
+ */
+function suggestionClause(unknown: string[], candidates: string[]): string {
+  for (const id of unknown) {
+    const hit = closestMatch(id, candidates);
+    if (hit) return `Did you mean "${hit}"? `;
+  }
+  return '';
+}
+
+function closestMatch(input: string, candidates: string[]): string | null {
+  let best: { id: string; distance: number } | null = null;
+  for (const c of candidates) {
+    const d = levenshtein(input, c);
+    if (d === 0) continue;
+    if (d > 2) continue;
+    if (!best || d < best.distance) best = { id: c, distance: d };
+  }
+  return best ? best.id : null;
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let curr = new Array<number>(b.length + 1).fill(0);
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1]! + 1, prev[j]! + 1, prev[j - 1]! + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length]!;
 }

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -883,9 +883,7 @@ registerOnce('status.monotonic', {
         // fine, just not this one".
         const legalTargets = [...allowedTargets].sort();
         const legalDescription =
-          legalTargets.length > 0
-            ? legalTargets.map(t => `"${t}"`).join(', ')
-            : '(none — terminal state)';
+          legalTargets.length > 0 ? legalTargets.map(t => `"${t}"`).join(', ') : '(none — terminal state)';
         return [
           {
             passed: false,

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -657,6 +657,7 @@ const AUDIENCE_TRANSITIONS: TransitionGraph = {
     ['ready', new Set(['processing', 'too_small'])],
     ['too_small', new Set(['processing', 'ready'])],
   ]),
+  enumFile: 'audience-status.json',
 };
 
 /**

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -33,6 +33,7 @@
  *     enum schemas in `static/schemas/source/enums/*-status.json`.
  */
 
+import { ADCP_VERSION } from '../../version';
 import { registerAssertion } from './assertions';
 
 // Register only once per process. `registerAssertion` throws on duplicates —
@@ -68,6 +69,7 @@ const CONFLICT_ALLOWED_ENVELOPE_KEYS = new Set([
 
 registerOnce('idempotency.conflict_no_payload_leak', {
   id: 'idempotency.conflict_no_payload_leak',
+  default: true,
   description:
     'IDEMPOTENCY_CONFLICT errors MUST NOT echo the prior request payload or response (stolen-key read oracle).',
   onStep: (_ctx, stepResult) => {
@@ -130,6 +132,7 @@ const SECRET_MIN_LENGTH = 16;
 
 registerOnce('context.no_secret_echo', {
   id: 'context.no_secret_echo',
+  default: true,
   description: 'Response bodies MUST NOT echo bearer tokens, API keys, or auth header values back to the caller.',
   onStart: ctx => {
     // Stash caller-supplied secrets worth hunting verbatim. `auth` is the
@@ -267,6 +270,7 @@ interface GovernanceDenialAnchor {
 
 registerOnce('governance.denial_blocks_mutation', {
   id: 'governance.denial_blocks_mutation',
+  default: true,
   description:
     'Once a governance signal denies a plan, no subsequent step in the run may acquire a resource for that plan.',
   onStart: ctx => {
@@ -520,6 +524,19 @@ function extractAuthSecrets(auth: unknown): string[] {
  */
 interface TransitionGraph {
   readonly transitions: ReadonlyMap<string, ReadonlySet<string>>;
+  /**
+   * Filename of the canonical enum schema this graph mirrors, relative to
+   * `/schemas/<adcp-version>/enums/`. Used to render a deep-link in the
+   * assertion failure message so implementors can jump straight to the
+   * spec's lifecycle doc instead of grep-searching for it.
+   */
+  readonly enumFile: string;
+}
+
+const SCHEMA_URL_BASE = 'https://adcontextprotocol.org';
+
+function buildEnumSchemaUrl(enumFile: string): string {
+  return `${SCHEMA_URL_BASE}/schemas/${ADCP_VERSION}/enums/${enumFile}`;
 }
 
 const MEDIA_BUY_TRANSITIONS: TransitionGraph = {
@@ -540,6 +557,7 @@ const MEDIA_BUY_TRANSITIONS: TransitionGraph = {
     ['rejected', new Set()],
     ['canceled', new Set()],
   ]),
+  enumFile: 'media-buy-status.json',
 };
 
 const CREATIVE_ASSET_TRANSITIONS: TransitionGraph = {
@@ -561,6 +579,7 @@ const CREATIVE_ASSET_TRANSITIONS: TransitionGraph = {
     ['archived', new Set(['approved'])],
     ['rejected', new Set(['processing', 'pending_review'])],
   ]),
+  enumFile: 'creative-status.json',
 };
 
 const CREATIVE_APPROVAL_TRANSITIONS: TransitionGraph = {
@@ -572,6 +591,7 @@ const CREATIVE_APPROVAL_TRANSITIONS: TransitionGraph = {
     ['approved', new Set(['rejected'])],
     ['rejected', new Set(['pending_review'])],
   ]),
+  enumFile: 'creative-approval-status.json',
 };
 
 const ACCOUNT_TRANSITIONS: TransitionGraph = {
@@ -588,6 +608,7 @@ const ACCOUNT_TRANSITIONS: TransitionGraph = {
     ['rejected', new Set()],
     ['closed', new Set()],
   ]),
+  enumFile: 'account-status.json',
 };
 
 const SI_SESSION_TRANSITIONS: TransitionGraph = {
@@ -599,6 +620,7 @@ const SI_SESSION_TRANSITIONS: TransitionGraph = {
     ['complete', new Set()],
     ['terminated', new Set()],
   ]),
+  enumFile: 'si-session-status.json',
 };
 
 const CATALOG_ITEM_TRANSITIONS: TransitionGraph = {
@@ -611,6 +633,7 @@ const CATALOG_ITEM_TRANSITIONS: TransitionGraph = {
     ['warning', new Set(['approved', 'rejected'])],
     ['rejected', new Set(['pending'])],
   ]),
+  enumFile: 'catalog-item-status.json',
 };
 
 const PROPOSAL_TRANSITIONS: TransitionGraph = {
@@ -619,6 +642,7 @@ const PROPOSAL_TRANSITIONS: TransitionGraph = {
     ['draft', new Set(['committed'])],
     ['committed', new Set()],
   ]),
+  enumFile: 'proposal-status.json',
 };
 
 /**
@@ -806,6 +830,7 @@ interface MonotonicState {
 
 registerOnce('status.monotonic', {
   id: 'status.monotonic',
+  default: true,
   description:
     'Observed resource statuses (media_buy, creative, account, si_session, catalog_item, proposal, creative_approval) MUST only transition along edges in the spec lifecycle graph.',
   onStart: ctx => {
@@ -850,6 +875,17 @@ registerOnce('status.monotonic', {
         continue;
       }
       if (!allowedTargets.has(ob.status)) {
+        // Surface the legal next states + a canonical enum URL so implementors
+        // can self-diagnose without grepping the SDK source for the
+        // lifecycle table. `allowedTargets` is empty for terminal states
+        // (completed / rejected / canceled / etc.) — call that out explicitly
+        // rather than rendering an empty list that reads as "any target is
+        // fine, just not this one".
+        const legalTargets = [...allowedTargets].sort();
+        const legalDescription =
+          legalTargets.length > 0
+            ? legalTargets.map(t => `"${t}"`).join(', ')
+            : '(none — terminal state)';
         return [
           {
             passed: false,
@@ -857,7 +893,9 @@ registerOnce('status.monotonic', {
             step_id: stepResult.step_id,
             error:
               `${ob.resource_type} ${ob.resource_id}: ${prev.status} → ${ob.status} ` +
-              `(step "${prev.stepId}" → step "${stepResult.step_id}") is not in the lifecycle graph.`,
+              `(step "${prev.stepId}" → step "${stepResult.step_id}") is not in the lifecycle graph. ` +
+              `Legal next states from "${prev.status}": ${legalDescription}. ` +
+              `See ${buildEnumSchemaUrl(ob.graph.enumFile)} for the canonical lifecycle.`,
           },
         ];
       }

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -18,6 +18,8 @@ import './default-invariants';
 // Types
 export type {
   Storyboard,
+  StoryboardInvariants,
+  StoryboardInvariantsObject,
   StoryboardPhase,
   StoryboardStep,
   StoryboardValidation,
@@ -43,6 +45,7 @@ export {
   registerAssertion,
   getAssertion,
   listAssertions,
+  listDefaultAssertions,
   clearAssertionRegistry,
   resolveAssertions,
 } from './assertions';

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -48,15 +48,54 @@ export interface Storyboard {
   };
   phases: StoryboardPhase[];
   /**
-   * Cross-step assertion ids that apply to this storyboard. Each entry names
-   * an assertion registered via `registerAssertion(...)`; the runner resolves
-   * them at start and fails fast on unknown ids. Per-step checks live inline
-   * on steps — assertions encode specialism- or protocol-wide properties
-   * that must hold across the full run (governance denial never mutates,
-   * idempotency dedup, status monotonicity, context never echoes secrets on
-   * error). See `./assertions.ts` for the registry API.
+   * Cross-step assertions that apply to this storyboard. Every assertion
+   * registered with `default: true` (the bundled set: `status.monotonic`,
+   * `idempotency.conflict_no_payload_leak`, `context.no_secret_echo`,
+   * `governance.denial_blocks_mutation`) runs by default — omit the field
+   * entirely and the full default set applies. Per-step checks live inline
+   * on steps; assertions encode specialism- or protocol-wide properties
+   * that must hold across the full run.
+   *
+   * Three shapes are accepted:
+   *   - `undefined` (or field omitted) — run every default-on assertion.
+   *   - `string[]` — legacy additive form. Defaults still run; any ids in
+   *     the list register on top for storyboards that want extra non-default
+   *     assertions registered by the consumer. Every id MUST resolve.
+   *   - `{ disable?: string[]; enable?: string[] }` — object form. `disable`
+   *     removes default-on assertions by id (typo-guarded: unknown ids throw
+   *     at runner start); `enable` adds non-default assertions registered by
+   *     the consumer on top.
+   *
+   * See `./assertions.ts` for the registry API and `./default-invariants.ts`
+   * for the bundled set.
    */
-  invariants?: string[];
+  invariants?: StoryboardInvariants;
+}
+
+/**
+ * Storyboard-level invariants declaration. `undefined` / array / object
+ * shapes all map onto the same "resolve to AssertionSpec[]" path in
+ * `resolveAssertions(...)`. See `Storyboard.invariants` for the full
+ * semantics (bundled defaults are always applied unless explicitly
+ * disabled via the object form).
+ */
+export type StoryboardInvariants = string[] | StoryboardInvariantsObject;
+
+export interface StoryboardInvariantsObject {
+  /**
+   * Default-on assertion ids to suppress for this storyboard. Each id MUST
+   * match an assertion registered with `default: true` — an unknown or
+   * non-default id is a typo and fails fast at runner start rather than
+   * silently no-opping (which would mask genuine coverage gaps).
+   */
+  disable?: string[];
+  /**
+   * Additional (non-default) assertion ids to enable for this storyboard on
+   * top of the default-on set. Consumers use this to attach custom
+   * assertions they've registered via `registerAssertion(...)`. Every id
+   * MUST resolve; unknown ids fail fast at runner start.
+   */
+  enable?: string[];
 }
 
 export interface StoryboardPhase {

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -112,27 +112,35 @@ describe('resolveAssertions: default-on semantics', () => {
   test('undefined invariants runs every default-on assertion', () => {
     registerTwoDefaults();
     registerAssertion({ id: 'custom.only', description: 'custom, not default' });
-    const resolved = resolveAssertions(undefined).map(s => s.id).sort();
+    const resolved = resolveAssertions(undefined)
+      .map(s => s.id)
+      .sort();
     assert.deepStrictEqual(resolved, ['default.one', 'default.two']);
   });
 
   test('empty object invariants runs every default-on assertion', () => {
     registerTwoDefaults();
-    const resolved = resolveAssertions({}).map(s => s.id).sort();
+    const resolved = resolveAssertions({})
+      .map(s => s.id)
+      .sort();
     assert.deepStrictEqual(resolved, ['default.one', 'default.two']);
   });
 
   test('legacy array form is additive on top of defaults', () => {
     registerTwoDefaults();
     registerAssertion({ id: 'custom.extra', description: 'extra' });
-    const resolved = resolveAssertions(['custom.extra']).map(s => s.id).sort();
+    const resolved = resolveAssertions(['custom.extra'])
+      .map(s => s.id)
+      .sort();
     assert.deepStrictEqual(resolved, ['custom.extra', 'default.one', 'default.two']);
   });
 
   test('object form enable is additive on top of defaults', () => {
     registerTwoDefaults();
     registerAssertion({ id: 'custom.extra', description: 'extra' });
-    const resolved = resolveAssertions({ enable: ['custom.extra'] }).map(s => s.id).sort();
+    const resolved = resolveAssertions({ enable: ['custom.extra'] })
+      .map(s => s.id)
+      .sort();
     assert.deepStrictEqual(resolved, ['custom.extra', 'default.one', 'default.two']);
   });
 
@@ -186,18 +194,12 @@ describe('resolveAssertions: default-on semantics', () => {
 
   test('unknown object-form top-level key ("disabled" typo) throws instead of silent no-op', () => {
     registerTwoDefaults();
-    assert.throws(
-      () => resolveAssertions({ disabled: ['default.one'] }),
-      /invariants has unknown field: disabled/
-    );
+    assert.throws(() => resolveAssertions({ disabled: ['default.one'] }), /invariants has unknown field: disabled/);
   });
 
   test('disable typo triggers a "Did you mean" suggestion against the default-on set', () => {
     registerTwoDefaults();
-    assert.throws(
-      () => resolveAssertions({ disable: ['default.onee'] }),
-      /Did you mean "default\.one"\?/
-    );
+    assert.throws(() => resolveAssertions({ disable: ['default.onee'] }), /Did you mean "default\.one"\?/);
   });
 
   test('unknown enable id names registered ids symmetric to unknown disable', () => {

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -14,6 +14,7 @@ const {
   registerAssertion,
   getAssertion,
   listAssertions,
+  listDefaultAssertions,
   clearAssertionRegistry,
   resolveAssertions,
 } = require('../../dist/lib/testing/storyboard/assertions.js');
@@ -84,9 +85,128 @@ describe('assertion registry', () => {
     assert.throws(() => resolveAssertions(['known.one', 'missing.a', 'missing.b']), /missing\.a, missing\.b/);
   });
 
-  test('resolveAssertions returns [] on undefined or empty', () => {
+  test('resolveAssertions returns [] on undefined or empty when no defaults are registered', () => {
     assert.deepStrictEqual(resolveAssertions(undefined), []);
     assert.deepStrictEqual(resolveAssertions([]), []);
+  });
+});
+
+// Default-on resolution is the big product change here: storyboards that omit
+// `invariants:` entirely used to ship with zero cross-step gating, which made
+// forks and new specialisms silently coverage-free. Default-on flips that so
+// the bundled set runs unless explicitly opted out.
+describe('resolveAssertions: default-on semantics', () => {
+  beforeEach(() => clearAssertionRegistry());
+
+  function registerTwoDefaults() {
+    registerAssertion({ id: 'default.one', description: 'one', default: true });
+    registerAssertion({ id: 'default.two', description: 'two', default: true });
+  }
+
+  test('listDefaultAssertions enumerates only default:true specs', () => {
+    registerAssertion({ id: 'plain', description: 'no default flag' });
+    registerTwoDefaults();
+    assert.deepStrictEqual(listDefaultAssertions().sort(), ['default.one', 'default.two']);
+  });
+
+  test('undefined invariants runs every default-on assertion', () => {
+    registerTwoDefaults();
+    registerAssertion({ id: 'custom.only', description: 'custom, not default' });
+    const resolved = resolveAssertions(undefined).map(s => s.id).sort();
+    assert.deepStrictEqual(resolved, ['default.one', 'default.two']);
+  });
+
+  test('empty object invariants runs every default-on assertion', () => {
+    registerTwoDefaults();
+    const resolved = resolveAssertions({}).map(s => s.id).sort();
+    assert.deepStrictEqual(resolved, ['default.one', 'default.two']);
+  });
+
+  test('legacy array form is additive on top of defaults', () => {
+    registerTwoDefaults();
+    registerAssertion({ id: 'custom.extra', description: 'extra' });
+    const resolved = resolveAssertions(['custom.extra']).map(s => s.id).sort();
+    assert.deepStrictEqual(resolved, ['custom.extra', 'default.one', 'default.two']);
+  });
+
+  test('object form enable is additive on top of defaults', () => {
+    registerTwoDefaults();
+    registerAssertion({ id: 'custom.extra', description: 'extra' });
+    const resolved = resolveAssertions({ enable: ['custom.extra'] }).map(s => s.id).sort();
+    assert.deepStrictEqual(resolved, ['custom.extra', 'default.one', 'default.two']);
+  });
+
+  test('object form disable removes specific defaults', () => {
+    registerTwoDefaults();
+    const resolved = resolveAssertions({ disable: ['default.one'] }).map(s => s.id);
+    assert.deepStrictEqual(resolved, ['default.two']);
+  });
+
+  test('object form disable + enable combine (defaults minus disable plus enable)', () => {
+    registerTwoDefaults();
+    registerAssertion({ id: 'custom.extra', description: 'extra' });
+    const resolved = resolveAssertions({
+      disable: ['default.one'],
+      enable: ['custom.extra'],
+    })
+      .map(s => s.id)
+      .sort();
+    assert.deepStrictEqual(resolved, ['custom.extra', 'default.two']);
+  });
+
+  test('unknown enable id throws and names every missing id', () => {
+    registerTwoDefaults();
+    assert.throws(
+      () => resolveAssertions({ enable: ['missing.a', 'missing.b'] }),
+      /unregistered assertions: missing\.a, missing\.b/
+    );
+  });
+
+  test('unknown disable id throws with "non default-on" guidance and lists known defaults', () => {
+    registerTwoDefaults();
+    registerAssertion({ id: 'not.default', description: 'plain, registered' });
+    assert.throws(
+      () => resolveAssertions({ disable: ['not.default'] }),
+      /invariants\.disable names id.*not\.default.*Known default-on ids: default\.one, default\.two/s
+    );
+  });
+
+  test('disable + enable unknowns surface both errors in one throw', () => {
+    registerTwoDefaults();
+    let caught;
+    try {
+      resolveAssertions({ disable: ['not.registered'], enable: ['also.missing'] });
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught, 'resolveAssertions must throw on any unknown id');
+    assert.match(caught.message, /unregistered assertion: also\.missing/);
+    assert.match(caught.message, /invariants\.disable names id.*not\.registered/);
+  });
+
+  test('unknown object-form top-level key ("disabled" typo) throws instead of silent no-op', () => {
+    registerTwoDefaults();
+    assert.throws(
+      () => resolveAssertions({ disabled: ['default.one'] }),
+      /invariants has unknown field: disabled/
+    );
+  });
+
+  test('disable typo triggers a "Did you mean" suggestion against the default-on set', () => {
+    registerTwoDefaults();
+    assert.throws(
+      () => resolveAssertions({ disable: ['default.onee'] }),
+      /Did you mean "default\.one"\?/
+    );
+  });
+
+  test('unknown enable id names registered ids symmetric to unknown disable', () => {
+    registerTwoDefaults();
+    registerAssertion({ id: 'not.default', description: 'plain, registered' });
+    assert.throws(
+      () => resolveAssertions({ enable: ['missing.x'] }),
+      /Registered ids: default\.one, default\.two, not\.default/
+    );
   });
 });
 

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -59,7 +59,9 @@ describe('default-invariants: auto-registration', () => {
   });
 
   it('resolveAssertions(undefined) returns the full bundled default set (default-on, not opt-in)', () => {
-    const resolved = resolveAssertions(undefined).map(s => s.id).sort();
+    const resolved = resolveAssertions(undefined)
+      .map(s => s.id)
+      .sort();
     assert.deepStrictEqual(resolved, [
       'context.no_secret_echo',
       'governance.denial_blocks_mutation',

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -42,6 +42,42 @@ describe('default-invariants: auto-registration', () => {
       ])
     );
   });
+
+  it('all four bundled assertion ids register with default:true so they apply by default', () => {
+    for (const id of [
+      'idempotency.conflict_no_payload_leak',
+      'context.no_secret_echo',
+      'governance.denial_blocks_mutation',
+      'status.monotonic',
+    ]) {
+      assert.strictEqual(
+        getAssertion(id).default,
+        true,
+        `assertion "${id}" must be default:true — storyboards that omit invariants: would otherwise silently skip it`
+      );
+    }
+  });
+
+  it('resolveAssertions(undefined) returns the full bundled default set (default-on, not opt-in)', () => {
+    const resolved = resolveAssertions(undefined).map(s => s.id).sort();
+    assert.deepStrictEqual(resolved, [
+      'context.no_secret_echo',
+      'governance.denial_blocks_mutation',
+      'idempotency.conflict_no_payload_leak',
+      'status.monotonic',
+    ]);
+  });
+
+  it('resolveAssertions({ disable: [...] }) is the escape hatch — drops the named default, keeps the rest', () => {
+    const resolved = resolveAssertions({ disable: ['status.monotonic'] })
+      .map(s => s.id)
+      .sort();
+    assert.deepStrictEqual(resolved, [
+      'context.no_secret_echo',
+      'governance.denial_blocks_mutation',
+      'idempotency.conflict_no_payload_leak',
+    ]);
+  });
 });
 
 describe('default-invariants: governance.denial_blocks_mutation', () => {
@@ -755,7 +791,7 @@ describe('default-invariants: status.monotonic', () => {
     assert.ok(out.every(r => r.output.every(o => o.passed)));
   });
 
-  test('media_buy backward transition fails with actionable error', () => {
+  test('media_buy backward transition fails with actionable error (legal targets + enum URL)', () => {
     const out = run([
       step({ step_id: 'create', task: 'create_media_buy', response: mb('mb-1', 'active') }),
       step({ step_id: 'regress', task: 'get_media_buys', response: { media_buys: [mb('mb-1', 'pending_creatives')] } }),
@@ -765,15 +801,43 @@ describe('default-invariants: status.monotonic', () => {
     assert.match(fail.error, /media_buy mb-1/);
     assert.match(fail.error, /active → pending_creatives/);
     assert.match(fail.error, /step "create" → step "regress"/);
+    // Legal targets from `active` are the other edges in the graph — sorted
+    // alphabetically, quoted, comma-separated. Anchors the enrichment so a
+    // regression that drops any one of them gets caught.
+    assert.match(fail.error, /Legal next states from "active": "canceled", "completed", "paused"/);
+    // Canonical enum URL points implementors straight at the spec lifecycle.
+    assert.match(fail.error, /adcontextprotocol\.org\/schemas\/.+\/enums\/media-buy-status\.json/);
   });
 
-  test('media_buy terminal is terminal — no exit transitions allowed', () => {
+  test('media_buy terminal is terminal — error names "(none — terminal state)" and the enum URL', () => {
     const out = run([
       step({ step_id: 'done', task: 'get_media_buys', response: { media_buys: [mb('mb-1', 'completed')] } }),
       step({ step_id: 'revive', task: 'get_media_buys', response: { media_buys: [mb('mb-1', 'active')] } }),
     ]);
-    assert.strictEqual(out[1].output[0].passed, false);
-    assert.match(out[1].output[0].error, /completed → active/);
+    const fail = out[1].output[0];
+    assert.strictEqual(fail.passed, false);
+    assert.match(fail.error, /completed → active/);
+    assert.match(fail.error, /Legal next states from "completed": \(none — terminal state\)/);
+    assert.match(fail.error, /enums\/media-buy-status\.json/);
+  });
+
+  test('creative asset error references the creative-status enum URL, not media-buy-status', () => {
+    // Sanity check that the per-resource enumFile routes to the right schema
+    // — otherwise a single regression in the graph table would be invisible
+    // from the message.
+    const creativeOf = (id, status) => ({ creative_id: id, status });
+    const out = run([
+      step({ step_id: 'first', task: 'sync_creatives', response: { creatives: [creativeOf('cr-1', 'approved')] } }),
+      step({
+        step_id: 'illegal_back_to_processing',
+        task: 'sync_creatives',
+        response: { creatives: [creativeOf('cr-1', 'processing')] },
+      }),
+    ]);
+    const fail = out[1].output[0];
+    assert.strictEqual(fail.passed, false);
+    assert.match(fail.error, /enums\/creative-status\.json/);
+    assert.doesNotMatch(fail.error, /media-buy-status/);
   });
 
   test('scope is per-(resource_type, resource_id) — two media buys independent', () => {


### PR DESCRIPTION
## Summary

- **Invariants are default-on.** The four bundled cross-step assertions (`status.monotonic`, `idempotency.conflict_no_payload_leak`, `context.no_secret_echo`, `governance.denial_blocks_mutation`) now apply to every storyboard run automatically. Before this change, only 5 of 88 bundled storyboards explicitly listed `invariants: [...]`; forks and new specialisms inherited zero cross-step gating silently.
- **Escape hatch**: `invariants: { disable: [id, ...] }` opts a storyboard out of specific defaults. The legacy `invariants: [id, ...]` array form still works and is additive on top of the defaults.
- **Enriched `status.monotonic` failure**: the error now names the legal next states from the anchor status and links to the canonical enum schema URL, so implementors can self-diagnose without grepping the SDK.
- **Better fail-fast errors**: unknown ids in `enable`/the legacy array or non-default ids in `disable` throw, listing the registered set and suggesting `Did you mean "..."?` on Levenshtein ≤ 2 matches. Unknown top-level object keys (`{ disabled: [...] }` typo) also throw instead of silent no-op.
- **New export**: `listDefaultAssertions()` from `@adcp/client/testing` for tooling / diagnostics.

Example before → after on a bad transition:

    media_buy mb-1: active → pending_creatives (step "create" → step "regress") is not in the lifecycle graph.

→

    media_buy mb-1: active → pending_creatives (step "create" → step "regress") is not in the lifecycle graph. Legal next states from "active": "canceled", "completed", "paused". See https://adcontextprotocol.org/schemas/latest/enums/media-buy-status.json for the canonical lifecycle.

## Behavior change for direct-API callers

`resolveAssertions(['id'])` now returns `[...defaults, ...named]` instead of exactly the named ids. Callers that relied on the array-only return shape should switch to `resolveAssertions({ enable: [...], disable: listDefaultAssertions() })` to reproduce the old semantics. Flagged in the changeset.

## Test plan

- [x] Unit: `test/lib/storyboard-assertion-registry.test.js` — 11 new tests covering default-on semantics (`undefined → all defaults`, empty object, legacy-array additive, object-form `disable`/`enable`, combined, unknown-enable, unknown-disable, unknown-top-level-key typo guard, Levenshtein suggestion, registered-id listing).
- [x] Unit: `test/lib/storyboard-default-invariants.test.js` — confirms all 4 bundled specs set `default:true`, `resolveAssertions(undefined)` returns the full set, `disable` escape hatch drops named defaults, enriched `status.monotonic` error includes legal targets + enum URL and the terminal-state case renders `(none — terminal state)`, per-resource enum URLs route correctly (creative vs media-buy).
- [x] All 119 tests in the two files pass. Full storyboard test suite passes (pre-existing timeouts in `storyboard-security`/`uniform-error-invariant` reproduce on main, unrelated).
- [x] Type check clean (`tsc --noEmit`).
- [x] Enum URL confirmed live: `curl -I https://adcontextprotocol.org/schemas/latest/enums/media-buy-status.json` → HTTP 200.
- [x] Code-review + security-review passes, all Must/Should-fix items applied.

## Follow-ups (not in this PR)

- Spec PR to adcontextprotocol/adcp making default-on a runner requirement (otherwise another implementation could ship opt-in semantics and silently pass agents this runner would fail — real interop gap).
- Upstream tarball cleanup of the 5 now-redundant `invariants: [id]` declarations in bundled storyboards.
- `StoryboardResult.invariants_applied` / `invariants_disabled` observability fields for compliance reports.
- Docs pass in `docs/guides/VALIDATE-YOUR-AGENT.md` and the `build-*-agent` SKILL.md files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)