### PR TITLE
fix(testing): storyboard request-builders emit spec shapes for log_event + create_media_buy (#793)

### DIFF
--- a/.changeset/storyboard-request-builder-spec-shapes.md
+++ b/.changeset/storyboard-request-builder-spec-shapes.md
@@ -1,0 +1,10 @@
+---
+'@adcp/client': patch
+---
+
+Fix storyboard `REQUEST_BUILDERS` for `log_event` and `create_media_buy` so they emit spec-conformant payloads and honor hand-authored `step.sample_request` — framework-dispatch agents running zod at the MCP boundary previously rejected these with `-32602 invalid_type` (#793).
+
+- **`log_event`** now honors `step.sample_request` when present (same convention as `sync_catalogs`, `update_media_buy`, `report_usage`). The synthetic fallback emits `event_time` (was `timestamp`) and places `value` + `currency` under `custom_data` (was nested `value: { amount, currency }`). Unblocks `sales_catalog_driven` and `sales_social` storyboards whose authored events carried `event_time`, `content_ids`, and spec-shaped siblings that the builder was discarding.
+- **`create_media_buy`** now emits every authored package instead of dropping `packages[1+]`. The first package still receives context-derived `product_id` / `pricing_option_id` overrides (so single-package storyboards against arbitrary sellers keep working); additional packages pass through with context injection only, preserving per-package `product_id`, `bid_price`, `pricing_option_id`, and `creative_assignments`. Unblocks multi-package storyboards (e.g. `sales_non_guaranteed`) where `context_outputs` captured `packages[1].package_id` as `second_package_id` — the next step was being skipped with "unresolved context variables from prior steps".
+
+Surfaced while diagnosing adcontextprotocol/adcp#2872.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -133,14 +133,18 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
     // Merge any hand-authored package fields from sample_request (targeting_overlay,
     // measurement_terms, creative_assignments, performance_standards, etc.) so
-    // scenario-specific behaviors are exercised. Context-derived identifiers
-    // (product_id, pricing_option_id) still win so storyboards share context.
+    // scenario-specific behaviors are exercised. The first package receives
+    // context-derived identifiers (product_id, pricing_option_id) so single-
+    // package storyboards that test against arbitrary sellers still find a
+    // real discovered product. Additional packages pass through as-authored
+    // with context injection only — storyboards that ship multi-package
+    // sample_request blocks author specific product_ids on purpose.
     const samplePackages = (step.sample_request?.packages as Array<Record<string, unknown>> | undefined) ?? [];
     const baseSample = samplePackages[0]
       ? (injectContext({ ...samplePackages[0] }, context) as Record<string, unknown>)
       : {};
 
-    const pkg: Record<string, unknown> = {
+    const firstPkg: Record<string, unknown> = {
       ...baseSample,
       product_id: product?.product_id ?? context.product_id ?? baseSample.product_id ?? 'test-product',
       budget:
@@ -154,15 +158,19 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // Add bid_price for auction-based pricing
     if (pricingOption?.pricing_model === 'auction' || pricingOption?.pricing_model === 'cpm') {
       const floor = Number(pricingOption?.floor_price) || 5;
-      pkg.bid_price = Math.round(floor * 1.5 * 100) / 100;
+      firstPkg.bid_price = Math.round(floor * 1.5 * 100) / 100;
     }
+
+    const additionalPkgs = samplePackages
+      .slice(1)
+      .map(p => injectContext({ ...p }, context) as Record<string, unknown>);
 
     return {
       account: context.account ?? resolveAccount(options),
       brand: resolveBrand(options),
       start_time: startTime,
       end_time: endTime,
-      packages: [pkg],
+      packages: [firstPkg, ...additionalPkgs],
     };
   },
 
@@ -253,15 +261,21 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     };
   },
 
-  log_event(_step, context, _options) {
+  log_event(step, context, _options) {
+    // Storyboards routinely ship spec-conformant event payloads with
+    // event_time, content_ids, and custom_data siblings that only the
+    // author knows. Honor sample_request when present.
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       event_source_id: context.event_source_id ?? 'test-source',
       events: [
         {
           event_id: `evt-${Date.now()}`,
           event_type: 'purchase',
-          timestamp: new Date().toISOString(),
-          value: { amount: 49.99, currency: 'USD' },
+          event_time: new Date().toISOString(),
+          custom_data: { value: 49.99, currency: 'USD' },
         },
       ],
     };

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -53,6 +53,55 @@ describe('Request Builder', () => {
       assert.ok(result.end_time, 'should have end_time');
       assert.ok(new Date(result.start_time) < new Date(result.end_time), 'start should be before end');
     });
+
+    test('emits every package when sample_request authors multiple', () => {
+      // Regression: storyboards with multi-package sample_request (e.g.,
+      // sales_non_guaranteed) had packages[1+] dropped, which left
+      // context_outputs like second_package_id unresolved and caused the
+      // next step to be skipped with "unresolved context variables".
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: future,
+          end_time: new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString(),
+          packages: [
+            {
+              product_id: 'sports_display_auction',
+              budget: 10000,
+              bid_price: 8.5,
+              pricing_option_id: 'cpm_auction',
+            },
+            {
+              product_id: 'outdoor_video_auction',
+              budget: 15000,
+              bid_price: 22.0,
+              pricing_option_id: 'cpm_auction',
+            },
+          ],
+        },
+      });
+      const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages.length, 2, 'both packages emitted');
+      assert.strictEqual(result.packages[1].product_id, 'outdoor_video_auction');
+      assert.strictEqual(result.packages[1].bid_price, 22.0);
+      assert.strictEqual(result.packages[1].pricing_option_id, 'cpm_auction');
+    });
+
+    test('injects context into additional packages', () => {
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: future,
+          packages: [
+            { product_id: 'p1', budget: 1000, pricing_option_id: 'opt' },
+            { product_id: '$context.secondary_product', budget: 2000, pricing_option_id: 'opt' },
+          ],
+        },
+      });
+      const context = { secondary_product: 'resolved_product_id' };
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[1].product_id, 'resolved_product_id');
+    });
   });
 
   describe('provide_performance_feedback', () => {
@@ -160,6 +209,54 @@ describe('Request Builder', () => {
       assert.ok(Array.isArray(result.events), 'should have events array');
       assert.ok(result.events[0].event_id, 'should have event_id');
       assert.ok(result.events[0].event_type, 'should have event_type');
+    });
+
+    test('fallback event uses spec field names (event_time, custom_data)', () => {
+      // Regression: the fallback emitted `timestamp` (spec requires
+      // `event_time`) and nested `value: {amount, currency}` (spec places
+      // both under `custom_data`). Framework-dispatch agents rejected with
+      // -32602 invalid_type; legacy-dispatch permissively accepted it.
+      const result = buildRequest(step('log_event'), {}, DEFAULT_OPTIONS);
+      const event = result.events[0];
+      assert.strictEqual(typeof event.event_time, 'string', 'event_time required per event.json');
+      assert.strictEqual(event.timestamp, undefined, 'timestamp is not a spec field');
+      assert.ok(event.custom_data, 'value + currency live under custom_data per event-custom-data.json');
+      assert.strictEqual(typeof event.custom_data.value, 'number', 'custom_data.value must be number');
+      assert.strictEqual(typeof event.custom_data.currency, 'string', 'custom_data.currency must be string');
+    });
+
+    test('honors step.sample_request when present', () => {
+      // Storyboards (sales_catalog_driven, sales_social) author complete
+      // spec-conformant sample_request blocks with event_time, content_ids,
+      // and siblings. The builder must pass those through unchanged.
+      const fixture = {
+        event_source_id: 'amsterdam_website',
+        events: [
+          {
+            event_id: 'evt_001',
+            event_type: 'purchase',
+            event_time: '2026-04-15T19:30:00Z',
+            content_ids: ['ribeye_36oz'],
+            value: 89.0,
+            currency: 'USD',
+          },
+        ],
+      };
+      const result = buildRequest(step('log_event', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.event_source_id, 'amsterdam_website');
+      assert.strictEqual(result.events[0].event_time, '2026-04-15T19:30:00Z');
+      assert.deepStrictEqual(result.events[0].content_ids, ['ribeye_36oz']);
+      assert.strictEqual(result.events[0].value, 89.0);
+    });
+
+    test('injects context into sample_request', () => {
+      const fixture = {
+        event_source_id: '$context.event_source_id',
+        events: [{ event_id: 'e1', event_type: 'purchase', event_time: '2026-04-15T19:30:00Z' }],
+      };
+      const context = { event_source_id: 'resolved-source-id' };
+      const result = buildRequest(step('log_event', { sample_request: fixture }), context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.event_source_id, 'resolved-source-id');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #793 — two storyboard `REQUEST_BUILDERS` in `src/lib/testing/storyboard/request-builder.ts` emit non-spec payloads. Framework-dispatch agents running zod at the MCP boundary reject them with `-32602 invalid_type`; legacy-dispatch permissively lets them through. Surfaced while diagnosing adcontextprotocol/adcp#2872.

### Bug A — `log_event`

- Fallback emitted `timestamp` (spec: `event_time`) and `value: { amount, currency }` (spec: `custom_data.{value,currency}` per `core/event.json` + `core/event-custom-data.json`).
- Builder never consulted `step.sample_request`, so storyboards (`sales_catalog_driven`, `sales_social`) that author spec-conformant events with `event_time` / `content_ids` / siblings were silently discarded.

Fix: honor `step.sample_request` first (same convention as `sync_catalogs`, `report_usage`, `update_media_buy`, `sync_creatives`); correct the synthetic fallback's field names.

### Bug B — `create_media_buy`

- Builder always emitted `packages: [pkg]` regardless of how many packages the storyboard's `sample_request` authored. Multi-package storyboards (`sales_non_guaranteed`) lost `packages[1+]`, leaving `context_outputs` like `second_package_id` unresolved — the next step (`update_media_buy` using `$context.second_package_id`) was then skipped with "unresolved context variables from prior steps". Reproduced under both framework and legacy dispatch.

Fix: emit every authored package. First package still receives context-derived `product_id` / `pricing_option_id` (so single-package storyboards against arbitrary sellers keep working); additional packages pass through with context injection only, preserving per-package `product_id`, `bid_price`, `pricing_option_id`, and `creative_assignments`.

### Tests

Four new regression tests in `test/lib/request-builder.test.js`:
- `create_media_buy` emits every package when sample_request authors multiple.
- `create_media_buy` injects context into additional packages.
- `log_event` fallback uses spec field names (`event_time`, `custom_data`).
- `log_event` honors `step.sample_request` with context injection.

All 37 request-builder tests and 1396 storyboard-completeness tests pass.

## Deeper structural issues (filing as follow-ups)

Expert review (code-reviewer + ad-tech-protocol-expert) flagged a broader structural issue and several additional spec-violating builders that are out of scope for this PR:

- **Structural**: the runner's default is inverted. `REQUEST_BUILDERS` entries take precedence over `sample_request` unless the builder explicitly opts in with `if (step.sample_request) return injectContext(...)` — a pattern that's now duplicated in ~12 builders. The correct default is "sample_request is authoritative; builder fills discovery-derived identifiers." Will file as a separate refactor.
- **Additional spec violations** verified against `schemas/cache/latest/`:
  - `si_get_offering` emits `context` as a string, but `core/context.json` is an object ref.
  - `si_initiate_session` stuffs the intent string into `context`; schema requires `intent` + `identity` per `si-identity.json`.
  - `sync_governance` emits `credentials: "test-governance-token"` (21 chars) but schema requires `minLength: 32`; also never honors `step.sample_request`.
  - `sync_event_sources`, `sync_audiences` (narrow delegation), `list_content_standards`, `sync_accounts` — same "ignores sample_request" class as Bug A.

Both experts also suggested a schema-driven invariant test that round-trips every builder's output through the generated Zod schema. Worth adding alongside the structural refactor.

## Test plan

- [x] `node --test test/lib/request-builder.test.js` — 37 pass
- [x] `node --test test/lib/storyboard-completeness.test.js` — 1396 pass
- [x] `npm run build` — clean
- [x] `tsc --noEmit` — clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)