### PR TITLE
fix(server): cache strict-mode VALIDATION_ERROR to break retry-storm loop (#758)

### DIFF
--- a/.changeset/idempotency-transient-error-cache.md
+++ b/.changeset/idempotency-transient-error-cache.md
@@ -1,0 +1,13 @@
+---
+'@adcp/client': patch
+---
+
+Fix unbounded re-execution when a buyer SDK retries a mutating request against a handler whose response fails strict-mode validation (issue #758).
+
+Under the strict response-validation default, a drifted handler produced a `VALIDATION_ERROR` and released its idempotency claim on the way out, so the next retry re-entered the handler with the same drift — looping as fast as the buyer's retry budget allowed. The dispatcher now caches the `VALIDATION_ERROR` envelope under the same `(principal, key, payloadHash)` tuple for 10 seconds; retries on the same key short-circuit to the cached error instead of re-running side effects, and the cache clears itself before a handler fix would be gated on TTL expiry.
+
+A retry with a different canonical payload still produces `IDEMPOTENCY_CONFLICT` (the cache scopes on payload hash, same as the success cache), and a buyer that generates a fresh idempotency key per retry is not short-circuited — both behaviors are intentional. Same-key retry storms are the dominant failure mode; fresh-key loops already have the buyer's backoff as the correct control point.
+
+New `IdempotencyStore.saveTransientError(...)` method is optional on the interface — custom store implementations that want retry-storm protection can implement it; omitting it preserves the prior release-on-error behavior. Stores built via `createIdempotencyStore` pick it up automatically.
+
+**Operational note.** A drifted handler reachable by a hostile buyer is a cache-fill vector (every fresh key writes a 10s entry). Alert on sustained `VALIDATION_ERROR` rates per principal — steady-state should be zero.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1853,7 +1853,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // read, but belt-and-suspenders: handler-returned objects
               // can alias pieces of the formatted envelope.
               const cachedFormatted = cloneFormattedResponse(checkResult.response as McpToolResponse);
-              injectReplayed(cachedFormatted, true);
+              // Only stamp `replayed: true` on success envelopes — the
+              // field is defined for successful replays, and transient
+              // error cache entries (VALIDATION_ERROR from strict-mode
+              // drift) are retry-storm guards, not spec replays.
+              if (!isErrorResponse(cachedFormatted)) {
+                injectReplayed(cachedFormatted, true);
+              }
               return finalize(cachedFormatted);
             }
             if (checkResult.kind === 'conflict') {
@@ -1920,22 +1926,42 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 const errPayload = buildAdcpValidationErrorPayload(toolName, 'response', outcome.issues, {
                   exposeSchemaPath: exposeErrorDetails,
                 });
+                const errEnvelope = adcpError('VALIDATION_ERROR', errPayload);
                 if (idempotencyCheck && idempotency) {
+                  // Cache the VALIDATION_ERROR briefly so a buyer SDK
+                  // retrying on the same key doesn't trigger unbounded
+                  // re-execution — strict-mode drift is deterministic,
+                  // the next handler call would return the same error.
+                  // Short TTL (10s) absorbs a typical retry burst.
+                  //
+                  // Stores that pre-date #758 may not implement
+                  // `saveTransientError`; fall back to `release` so the
+                  // claim is at least freed for a fresh retry.
                   try {
-                    await idempotency.release({
-                      principal: idempotencyCheck.principal,
-                      key: idempotencyCheck.key,
-                      extraScope: idempotencyCheck.extraScope,
-                    });
+                    if (idempotency.saveTransientError) {
+                      await idempotency.saveTransientError({
+                        principal: idempotencyCheck.principal,
+                        key: idempotencyCheck.key,
+                        payloadHash: idempotencyCheck.payloadHash,
+                        response: errEnvelope,
+                        extraScope: idempotencyCheck.extraScope,
+                      });
+                    } else {
+                      await idempotency.release({
+                        principal: idempotencyCheck.principal,
+                        key: idempotencyCheck.key,
+                        extraScope: idempotencyCheck.extraScope,
+                      });
+                    }
                   } catch (err) {
                     const reason = err instanceof Error ? err.message : String(err);
-                    logger.warn('Idempotency release failed — in-flight claim will expire on TTL', {
+                    logger.warn('Idempotency transient-error cache failed — retry storm may re-execute handler', {
                       tool: toolName,
                       error: reason,
                     });
                   }
                 }
-                return finalize(adcpError('VALIDATION_ERROR', errPayload));
+                return finalize(errEnvelope);
               }
             }
           }

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -221,6 +221,41 @@ export interface IdempotencyStore {
    */
   release(params: { principal: string; key: string; extraScope?: string }): Promise<void>;
   /**
+   * Short-TTL cache for an error envelope that the handler is guaranteed
+   * to reproduce on re-execution (currently: strict-mode response
+   * VALIDATION_ERROR driven by handler drift).
+   *
+   * Optional on the interface so custom store implementations aren't
+   * forced to migrate — when absent, the dispatcher falls back to
+   * `release()` (the pre-#758 behavior). Stores backed by
+   * `createIdempotencyStore` always include it.
+   *
+   * Retry-storm guard, not a spec replay. Without it, a drifted handler
+   * under strict validation + a retrying buyer produces unbounded
+   * re-execution (release-on-error lets every retry hit the handler again
+   * with the same drift). Caching for `TRANSIENT_ERROR_TTL_SECONDS` (10s)
+   * short-circuits retries within the buyer's typical backoff window.
+   *
+   * **Operational note — DoS primitive.** A drifted handler reachable by
+   * a hostile buyer is a cache-fill vector: every fresh idempotency_key
+   * writes a new 10s-TTL entry, cheap because the handler fails fast.
+   * Alert on sustained `VALIDATION_ERROR` rates per principal — they
+   * indicate either a broken handler (deploy regression) or a buyer
+   * probing for drift. Steady-state `VALIDATION_ERROR` should be zero.
+   *
+   * **Dev-experience note — TTL opacity.** After deploying a handler fix,
+   * same-key retries within the 10s window still replay the cached error
+   * before the fix takes effect. Iterative handler authors should use a
+   * fresh `idempotency_key` to bypass the cache during development.
+   */
+  saveTransientError?(params: {
+    principal: string;
+    key: string;
+    payloadHash: string;
+    response: unknown;
+    extraScope?: string;
+  }): Promise<void>;
+  /**
    * Capability fragment for `get_adcp_capabilities` — tells buyers the
    * replay window so they can reason about retry safety. Pass to
    * `createAdcpServer` via `capabilities.idempotency`.
@@ -254,6 +289,13 @@ const DEFAULT_CLOCK_SKEW = 60;
  * holding parallel requests hostage for the full replay TTL.
  */
 const IN_FLIGHT_TTL_SECONDS = 120;
+/**
+ * How long a transient-error cache entry lives. Long enough to absorb a
+ * buyer SDK's retry storm (typical exponential backoff takes ~2–3
+ * attempts past 10s), short enough that genuine fixes by the handler
+ * author aren't gated on TTL expiry during iterative development.
+ */
+const TRANSIENT_ERROR_TTL_SECONDS = 10;
 /**
  * Payload hash for in-flight claims. Different from any real hash so a
  * parallel `check()` with the same payload sees the claim as
@@ -328,6 +370,12 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
     async release({ principal, key, extraScope }): Promise<void> {
       const scopedKey = scope(principal, key, extraScope);
       await backend.delete(scopedKey);
+    },
+
+    async saveTransientError({ principal, key, payloadHash, response, extraScope }): Promise<void> {
+      const scopedKey = scope(principal, key, extraScope);
+      const expiresAt = Math.floor(Date.now() / 1000) + TRANSIENT_ERROR_TTL_SECONDS;
+      await backend.put(scopedKey, { payloadHash, response, expiresAt });
     },
 
     capability() {

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -353,6 +353,159 @@ describe('createAdcpServer with idempotency', () => {
     assert.equal(winners.length + inFlights.length, 5);
   });
 
+  it('strict-mode VALIDATION_ERROR short-circuits retry storm on same key + payload', async () => {
+    // Regression guard for issue #758: a drifted handler under strict
+    // response validation used to release the idempotency claim and return
+    // VALIDATION_ERROR — letting a retrying buyer re-execute the handler
+    // indefinitely. The transient-error cache holds the first error so
+    // subsequent retries short-circuit instead of re-running side effects.
+    const idempotency = createIdempotencyStore({
+      backend: memoryBackend({ sweepIntervalMs: 0 }),
+    });
+    let calls = 0;
+    const server = _createAdcpServer({
+      name: 'T',
+      version: '1.0.0',
+      idempotency,
+      resolveSessionKey: () => 'tenant',
+      validation: { responses: 'strict', requests: 'off' },
+      mediaBuy: {
+        // Drifted response — violates create-media-buy-response schema.
+        createMediaBuy: async () => {
+          calls++;
+          return { media_buy_id: 'mb_1', packages: 'oops' };
+        },
+      },
+    });
+
+    const key = 'replay_storm_abcdefghij';
+    const req = { ...basePayload, idempotency_key: key };
+
+    const first = await callTool(server, 'create_media_buy', req);
+    assert.equal(first.adcp_error?.code, 'VALIDATION_ERROR');
+    assert.equal(calls, 1);
+
+    const second = await callTool(server, 'create_media_buy', req);
+    assert.equal(second.adcp_error?.code, 'VALIDATION_ERROR', 'retry must replay the cached error');
+    assert.equal(calls, 1, 'handler must not re-execute on retry within the transient-error window');
+  });
+
+  it('strict-mode transient-error cache does not mask IDEMPOTENCY_CONFLICT on different payload', async () => {
+    // Scope is (principal, key, payloadHash). A retry with a different
+    // canonical payload still bypasses the cache and hits CONFLICT — the
+    // retry-storm guard must not become a replay oracle for mismatched
+    // payloads.
+    const idempotency = createIdempotencyStore({
+      backend: memoryBackend({ sweepIntervalMs: 0 }),
+    });
+    const server = _createAdcpServer({
+      name: 'T',
+      version: '1.0.0',
+      idempotency,
+      resolveSessionKey: () => 'tenant',
+      validation: { responses: 'strict', requests: 'off' },
+      mediaBuy: {
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1', packages: 'oops' }),
+      },
+    });
+
+    const key = 'replay_conflict_abcdefgh';
+    const first = await callTool(server, 'create_media_buy', { ...basePayload, idempotency_key: key });
+    assert.equal(first.adcp_error?.code, 'VALIDATION_ERROR');
+
+    const conflict = await callTool(server, 'create_media_buy', {
+      ...basePayload,
+      idempotency_key: key,
+      start_time: '2026-06-01T00:00:00Z',
+    });
+    assert.equal(conflict.adcp_error?.code, 'IDEMPOTENCY_CONFLICT');
+  });
+
+  it('strict-mode parallel retries of a drifted handler see in-flight, not re-execution', async () => {
+    // Concurrency guard: while call A is still inside the handler
+    // producing the drifted response, a parallel call B with the same
+    // key + payload must hit the IN_FLIGHT claim (SERVICE_UNAVAILABLE)
+    // rather than re-entering the handler. Once A completes and writes
+    // the transient-error entry, a subsequent retry hits the cached
+    // VALIDATION_ERROR — not the handler.
+    const idempotency = createIdempotencyStore({
+      backend: memoryBackend({ sweepIntervalMs: 0 }),
+    });
+    let calls = 0;
+    let releaseHandler;
+    const handlerGate = new Promise(resolve => {
+      releaseHandler = resolve;
+    });
+    const server = _createAdcpServer({
+      name: 'T',
+      version: '1.0.0',
+      idempotency,
+      resolveSessionKey: () => 'tenant',
+      validation: { responses: 'strict', requests: 'off' },
+      mediaBuy: {
+        createMediaBuy: async () => {
+          calls++;
+          await handlerGate;
+          return { media_buy_id: 'mb_1', packages: 'oops' };
+        },
+      },
+    });
+
+    const key = 'replay_concurrent_abcde';
+    const req = { ...basePayload, idempotency_key: key };
+
+    const aPromise = callTool(server, 'create_media_buy', req);
+    await new Promise(r => setImmediate(r));
+    const b = await callTool(server, 'create_media_buy', req);
+
+    assert.equal(b.adcp_error?.code, 'SERVICE_UNAVAILABLE', 'parallel retry must see in-flight, not re-execute');
+    assert.equal(calls, 1, 'handler must not re-execute for parallel retry');
+
+    releaseHandler();
+    const a = await aPromise;
+    assert.equal(a.adcp_error?.code, 'VALIDATION_ERROR');
+    assert.equal(calls, 1);
+
+    const c = await callTool(server, 'create_media_buy', req);
+    assert.equal(c.adcp_error?.code, 'VALIDATION_ERROR', 'post-completion retry replays cached error');
+    assert.equal(calls, 1, 'handler still not re-executed after the in-flight window closes');
+  });
+
+  it('warn-mode response drift still releases the claim (no transient-error cache)', async () => {
+    // Only strict mode can produce a VALIDATION_ERROR from response drift;
+    // warn mode passes the response through and caches it as success.
+    // Ensure we didn't accidentally populate the transient-error cache
+    // on the warn path.
+    const idempotency = createIdempotencyStore({
+      backend: memoryBackend({ sweepIntervalMs: 0 }),
+    });
+    let calls = 0;
+    const server = _createAdcpServer({
+      name: 'T',
+      version: '1.0.0',
+      idempotency,
+      resolveSessionKey: () => 'tenant',
+      validation: { responses: 'warn', requests: 'off' },
+      mediaBuy: {
+        createMediaBuy: async () => {
+          calls++;
+          return { media_buy_id: `mb_${calls}`, packages: 'oops' };
+        },
+      },
+    });
+
+    const key = 'warn_mode_abcdefghijkl';
+    const req = { ...basePayload, idempotency_key: key };
+
+    const first = await callTool(server, 'create_media_buy', req);
+    // Drifted response passes through in warn mode — cached as success.
+    assert.ok(!first.adcp_error, 'warn mode must not turn drift into VALIDATION_ERROR');
+
+    const second = await callTool(server, 'create_media_buy', req);
+    assert.equal(calls, 1, 'warn mode caches the success response and replays it');
+    assert.equal(second.replayed, true);
+  });
+
   it('si_send_message is scoped by session_id — same key across sessions does not cross-replay', async () => {
     const idempotency = createIdempotencyStore({
       backend: memoryBackend({ sweepIntervalMs: 0 }),


### PR DESCRIPTION
## Summary

- Closes #758. Under the strict response-validation default (shipped in #757), a drifted handler returned `VALIDATION_ERROR` *and* released its idempotency claim — letting a retrying buyer re-enter the handler indefinitely with the same drift. This PR caches the `VALIDATION_ERROR` envelope under the existing `(principal, key, payloadHash)` tuple for 10 seconds so same-key retries short-circuit to the cached error instead of re-running side effects.
- New `IdempotencyStore.saveTransientError(...)` is **optional** on the interface — custom store implementations that omit it fall back to `release()` (pre-#758 behavior). Stores built via `createIdempotencyStore` pick it up automatically, so existing users get the fix for free.
- Replay path now skips `injectReplayed(true)` on cached error envelopes — `replayed` is a success-replay field.
- Scope inherits the success-cache scope: different-payload retries still hit `IDEMPOTENCY_CONFLICT`, and buyers generating fresh keys per retry are not short-circuited (backoff is the correct control point there).

## Why this shape

See `gh issue view 758` for the option matrix. Option 2 (short-TTL error cache) won over Option 1 (circuit breaker) because (a) same-key retry storms are the dominant failure mode under strict mode, (b) it reuses existing scope infrastructure, and (c) it avoids a new per-tenant/per-handler counter abstraction.

Code-reviewer and security-reviewer passes were run on this diff and their `Should Fix` items are addressed in this PR:
- Optional method on interface + fallback (code review) — keeps `patch` semver honest.
- Concurrency test: parallel retry during handler execution sees `SERVICE_UNAVAILABLE` (in-flight), not re-execution (code review).
- DoS note in JSDoc: "alert on sustained `VALIDATION_ERROR` rates per principal" — the drifted-handler-plus-hostile-buyer pair is a cache-fill vector that warrants monitoring (security review).
- Dev-experience TTL note: after deploying a handler fix, same-key retries within 10s still replay the cached error; use a fresh key to bypass (security review).

## Test plan

- [x] `npm test` — 5245 pass / 0 fail
- [x] New tests in `test/server-idempotency.test.js`:
  - same-key retry short-circuits to cached VALIDATION_ERROR (handler runs once)
  - different-payload retry still gets `IDEMPOTENCY_CONFLICT`
  - parallel retry during handler execution sees `SERVICE_UNAVAILABLE` (in-flight)
  - warn mode is unaffected (no transient-error cache populated)
- [x] Changeset: `patch` (`.changeset/idempotency-transient-error-cache.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)