### PR TITLE
fix(testing): storyboard builders emit spec shapes for si_* + sync_governance (closes #802)

### DIFF
--- a/.changeset/fix-si-gov-storyboard-builders.md
+++ b/.changeset/fix-si-gov-storyboard-builders.md
@@ -2,18 +2,26 @@
 '@adcp/client': patch
 ---
 
-Storyboard runner: fix spec-violating shapes emitted by three request
-builders. All three now honor `step.sample_request` first (matching peer
-builders) and their synthetic fallbacks conform to the generated Zod
-schemas, so framework-dispatch agents running strict validation at the
-MCP boundary no longer reject them with `-32602 invalid_type`.
+Storyboard runner: fix spec-violating shapes and `sample_request`
+precedence across the SI + governance request builders. All affected
+builders now honor `step.sample_request` first (matching peer builders),
+and their synthetic fallbacks conform to the generated Zod schemas so
+framework-dispatch agents running strict validation at the MCP boundary
+no longer reject them with `-32602 invalid_type`.
 
 - `si_get_offering`: drop the string `context` and the out-of-schema
-  `identity`; emit the prose string as `intent` (optional per
-  `si-get-offering-request.json`).
-- `si_initiate_session`: move the prose string from `context` (which
-  must be an object per `core/context.json`) to the required `intent`
-  field.
+  `identity`; emit the prose string as optional `intent` (per
+  `si-get-offering-request.json`, `context` is a ref to an object).
+- `si_initiate_session`: move prose from `context` (which must be an
+  object) to required `intent`; default the identity fallback to the
+  realistic anonymous handoff shape (`consent_granted: false` +
+  `anonymous_session_id`) instead of `consent_granted: true` with an
+  empty consented user — spec-legal either way, but the anonymous shape
+  is what a host that hasn't obtained PII consent actually sends.
+- `si_send_message` / `si_terminate_session`: honor `sample_request` so
+  storyboards can drive `action_response`, `handoff_transaction`,
+  `termination_context`, and non-default `reason` paths without the
+  fallback stomping the scenario.
 - `sync_governance`: lengthen default `authentication.credentials` to
   meet `minLength: 32`, and honor `sample_request` so fixtures like
   `signal-marketplace/scenarios/governance_denied.yaml` that author

--- a/.changeset/fix-si-gov-storyboard-builders.md
+++ b/.changeset/fix-si-gov-storyboard-builders.md
@@ -1,0 +1,22 @@
+---
+'@adcp/client': patch
+---
+
+Storyboard runner: fix spec-violating shapes emitted by three request
+builders. All three now honor `step.sample_request` first (matching peer
+builders) and their synthetic fallbacks conform to the generated Zod
+schemas, so framework-dispatch agents running strict validation at the
+MCP boundary no longer reject them with `-32602 invalid_type`.
+
+- `si_get_offering`: drop the string `context` and the out-of-schema
+  `identity`; emit the prose string as `intent` (optional per
+  `si-get-offering-request.json`).
+- `si_initiate_session`: move the prose string from `context` (which
+  must be an object per `core/context.json`) to the required `intent`
+  field.
+- `sync_governance`: lengthen default `authentication.credentials` to
+  meet `minLength: 32`, and honor `sample_request` so fixtures like
+  `signal-marketplace/scenarios/governance_denied.yaml` that author
+  `url: $context.governance_agent_url` flow through.
+
+Closes #802.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -826,7 +826,7 @@ Flow: `get_adcp_capabilities → list_creative_formats → sync_creatives → li
 **Sales agent with creative capabilities** — Stateful sales agent that accepts pushed creative assets and renders them in its environment.
 Flow: `get_adcp_capabilities → list_creative_formats → sync_creatives → preview_creative`
 
-**Creative ad server** — Stateful ad server with pre-loaded creatives. Generates serving tags per media buy with pricing and billing.
+**Creative ad server** — Stateful ad server with pre-loaded creatives. Generates serving tags per media buy. Optionally bills through AdCP.
 Flow: `get_adcp_capabilities → list_creatives → list_creative_formats → build_creative → get_creative_delivery → report_usage`
 
 **Creative template and transformation agent** — Stateless creative agent that takes assets in, applies templates, and produces tags or rendered output.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -838,7 +838,7 @@ Flow: `get_adcp_capabilities → list_creative_formats → preview_creative → 
 Flow: `get_adcp_capabilities → sync_accounts → sync_governance → sync_plans → get_products → check_governance → create_media_buy → report_plan_outcome → get_plan_audit_logs`
 
 **Campaign governance — delivery monitoring with drift detection** — Governance agent monitors delivery, detects budget drift past thresholds, and triggers re-evaluation.
-Flow: `get_adcp_capabilities → sync_plans → check_governance → get_media_buy_delivery → check_governance`
+Flow: `get_adcp_capabilities → sync_plans → check_governance → create_media_buy → get_media_buy_delivery → check_governance`
 
 **Campaign governance — denied** — Governance agent denies a media buy that exceeds the agent's spending authority. No human escalation — the buy is blocked.
 Flow: `get_adcp_capabilities → sync_plans → check_governance`

--- a/src/lib/testing/scenarios/sponsored-intelligence.ts
+++ b/src/lib/testing/scenarios/sponsored-intelligence.ts
@@ -9,7 +9,7 @@
  */
 
 import type { TestOptions, TestStepResult, AgentProfile, TaskResult } from '../types';
-import { getOrCreateClient, runStep, getOrDiscoverProfile, resolveAuthPrincipal } from '../client';
+import { getOrCreateClient, runStep, getOrDiscoverProfile } from '../client';
 import { SPONSORED_INTELLIGENCE_TOOLS } from '../../utils/capabilities';
 import type {
   SIGetOfferingRequest,
@@ -71,11 +71,7 @@ export async function testSISessionLifecycle(
       async () =>
         client.siGetOffering({
           offering_id: offeringId,
-          context: options.si_context || 'E2E testing - checking SI offering availability',
-          identity: {
-            principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-            device_id: 'e2e-test-device',
-          },
+          intent: options.si_context || 'E2E testing - checking SI offering availability',
         } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
     );
 
@@ -121,11 +117,11 @@ export async function testSISessionLifecycle(
         client.siInitiateSession({
           offering_id: options.si_offering_id || 'e2e-test-offering',
           offering_token: offeringToken,
+          intent: options.si_context || 'E2E testing - initiating conversation about products',
           identity: {
-            principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-            device_id: 'e2e-test-device',
+            consent_granted: false,
+            anonymous_session_id: `e2e-anon-${Date.now()}`,
           },
-          context: options.si_context || 'E2E testing - initiating conversation about products',
           placement: 'e2e-test-placement',
           supported_capabilities: {
             modalities: {
@@ -427,11 +423,7 @@ export async function testSIHandoff(
       async () =>
         client.siGetOffering({
           offering_id: options.si_offering_id || 'e2e-test-offering',
-          context: 'E2E testing - preparing for handoff flow',
-          identity: {
-            principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-            device_id: 'e2e-test-device',
-          },
+          intent: 'E2E testing - preparing for handoff flow',
         } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
     );
 
@@ -450,11 +442,11 @@ export async function testSIHandoff(
       client.siInitiateSession({
         offering_id: options.si_offering_id || 'e2e-test-offering',
         offering_token: offeringToken,
+        intent: options.si_context || 'E2E testing - initiating session for handoff test',
         identity: {
-          principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-          device_id: 'e2e-test-device',
+          consent_granted: false,
+          anonymous_session_id: `e2e-anon-${Date.now()}`,
         },
-        context: options.si_context || 'E2E testing - initiating session for handoff test',
         placement: 'e2e-test-placement',
         supported_capabilities: {
           modalities: { conversational: true },
@@ -624,11 +616,7 @@ export async function testSIAvailability(
     async () =>
       client.siGetOffering({
         offering_id: offeringId,
-        context: options.si_context || 'E2E testing - checking SI availability',
-        identity: {
-          principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-          device_id: 'e2e-test-device',
-        },
+        intent: options.si_context || 'E2E testing - checking SI availability',
       } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
   );
 
@@ -668,10 +656,7 @@ export async function testSIAvailability(
     async () =>
       client.siGetOffering({
         offering_id: 'INVALID_OFFERING_ID_DOES_NOT_EXIST_12345',
-        context: 'E2E testing - checking unavailable offering',
-        identity: {
-          principal: 'e2e-test-principal',
-        },
+        intent: 'E2E testing - checking unavailable offering',
       } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
   );
 

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -10,7 +10,7 @@
  * fallback when no builder exists for a task.
  */
 
-import { resolveBrand, resolveAccount, resolveAuthPrincipal } from '../client';
+import { resolveBrand, resolveAccount } from '../client';
 import type { TestOptions } from '../types';
 import type { StoryboardContext, StoryboardStep } from './types';
 import { injectContext } from './context';
@@ -638,8 +638,8 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
       offering_id: context.offering_id ?? options.si_offering_id ?? 'e2e-test-offering',
       offering_token: context.offering_token,
       identity: {
-        consent_granted: true,
-        user: { principal: resolveAuthPrincipal(options) ?? 'e2e-test-principal' },
+        consent_granted: false,
+        anonymous_session_id: `e2e-anon-${Date.now()}`,
       },
       intent: options.si_context ?? 'E2E test session',
       placement: 'e2e-test',
@@ -649,14 +649,20 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     };
   },
 
-  si_send_message(_step, context, _options) {
+  si_send_message(step, context, _options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       session_id: context.session_id ?? 'unknown',
       message: 'Tell me more about this product.',
     };
   },
 
-  si_terminate_session(_step, context, _options) {
+  si_terminate_session(step, context, _options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       session_id: context.session_id ?? 'unknown',
       reason: 'user_exit',

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -446,7 +446,10 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Governance ─────────────────────────────────────────
 
-  sync_governance(_step, context, options) {
+  sync_governance(step, context, options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       accounts: [
         {
@@ -456,7 +459,7 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
               url: 'https://governance.test.example',
               authentication: {
                 schemes: ['Bearer'],
-                credentials: 'test-governance-token',
+                credentials: 'test-governance-token-padded-to-meet-min-length-32',
               },
               categories: ['budget_authority', 'brand_policy'],
             },
@@ -617,18 +620,20 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Sponsored Intelligence ─────────────────────────────
 
-  si_get_offering(_step, _context, options) {
+  si_get_offering(step, context, options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       offering_id: options.si_offering_id ?? 'e2e-test-offering',
-      context: options.si_context ?? 'E2E testing - checking SI offering availability',
-      identity: {
-        principal: resolveAuthPrincipal(options) ?? 'e2e-test-principal',
-        device_id: 'e2e-test-device',
-      },
+      intent: options.si_context ?? 'E2E testing - checking SI offering availability',
     };
   },
 
-  si_initiate_session(_step, context, options) {
+  si_initiate_session(step, context, options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       offering_id: context.offering_id ?? options.si_offering_id ?? 'e2e-test-offering',
       offering_token: context.offering_token,
@@ -636,7 +641,7 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
         consent_granted: true,
         user: { principal: resolveAuthPrincipal(options) ?? 'e2e-test-principal' },
       },
-      context: options.si_context ?? 'E2E test session',
+      intent: options.si_context ?? 'E2E test session',
       placement: 'e2e-test',
       supported_capabilities: {
         modalities: { conversational: true, rich_media: true },

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.10.0';
+export const LIBRARY_VERSION = '5.11.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.10.0',
+  library: '5.11.0',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T05:15:39.944Z',
+  generatedAt: '2026-04-22T08:06:42.838Z',
 } as const;
 
 /**

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -516,11 +516,7 @@ describe('Request Builder', () => {
         identity: { consent_granted: false, anonymous_session_id: 'anon-123' },
         placement: 'chatgpt_search',
       };
-      const result = buildRequest(
-        step('si_initiate_session', { sample_request: fixture }),
-        {},
-        DEFAULT_OPTIONS
-      );
+      const result = buildRequest(step('si_initiate_session', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
       assert.strictEqual(result.intent, fixture.intent);
       assert.deepStrictEqual(result.identity, fixture.identity);
       assert.strictEqual(result.placement, 'chatgpt_search');

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -418,6 +418,115 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('sync_governance', () => {
+    test('fallback credentials satisfy schema minLength of 32', () => {
+      // Regression: the hardcoded 'test-governance-token' is 21 chars,
+      // shorter than the schema's minLength: 32, so strict-validation
+      // agents rejected every sync_governance step with -32602.
+      const result = buildRequest(step('sync_governance'), {}, DEFAULT_OPTIONS);
+      const credentials = result.accounts[0].governance_agents[0].authentication.credentials;
+      assert.ok(credentials.length >= 32, `credentials must be >= 32 chars, got ${credentials.length}`);
+    });
+
+    test('honors step.sample_request when present', () => {
+      // Regression: the builder never consulted sample_request, so
+      // governance storyboards authoring `url: $context.governance_agent_url`
+      // silently lost that binding and downstream check_governance steps
+      // asserted against the wrong URL.
+      const fixture = {
+        accounts: [
+          {
+            account: { account_id: 'acct_gov' },
+            governance_agents: [
+              {
+                url: '$context.governance_agent_url',
+                authentication: {
+                  schemes: ['Bearer'],
+                  credentials: 'gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = buildRequest(
+        step('sync_governance', { sample_request: fixture }),
+        { governance_agent_url: 'https://gov.resolved.example' },
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(
+        result.accounts[0].governance_agents[0].url,
+        'https://gov.resolved.example',
+        '$context placeholder should resolve'
+      );
+    });
+  });
+
+  describe('si_get_offering', () => {
+    test('fallback uses intent for prose and omits non-spec fields', () => {
+      // Regression: the builder passed the prose string as `context`
+      // (which is an object per spec) and included `identity`, which
+      // is not part of si-get-offering-request.json.
+      const result = buildRequest(step('si_get_offering'), {}, DEFAULT_OPTIONS);
+      assert.ok(result.offering_id, 'offering_id required');
+      assert.strictEqual(typeof result.intent, 'string', 'intent carries the prose string');
+      assert.ok(
+        result.context === undefined || typeof result.context === 'object',
+        'context must be an object or omitted, never a string'
+      );
+      assert.strictEqual(result.identity, undefined, 'identity is not in si_get_offering request schema');
+    });
+
+    test('honors step.sample_request when present', () => {
+      const fixture = {
+        offering_id: 'custom-offering',
+        intent: 'Looking for mens size 12 hiking boots',
+        include_products: true,
+      };
+      const result = buildRequest(step('si_get_offering', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.offering_id, 'custom-offering');
+      assert.strictEqual(result.intent, fixture.intent);
+      assert.strictEqual(result.include_products, true);
+    });
+  });
+
+  describe('si_initiate_session', () => {
+    test('fallback uses intent for prose string and anonymous identity', () => {
+      // Regression: the builder put the prose string into `context`
+      // (an object per spec) rather than `intent` (the required field
+      // per si-initiate-session-request.json), and used a non-spec
+      // `{ principal, device_id }` identity shape.
+      const result = buildRequest(step('si_initiate_session'), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(typeof result.intent, 'string', 'intent is required and carries the prose handoff');
+      assert.ok(result.identity, 'identity is required');
+      assert.strictEqual(result.identity.consent_granted, false, 'default is anonymous (no PII consent)');
+      assert.ok(
+        typeof result.identity.anonymous_session_id === 'string',
+        'anonymous identity must carry an anonymous_session_id'
+      );
+      assert.ok(
+        result.context === undefined || typeof result.context === 'object',
+        'context must be an object or omitted, never a string'
+      );
+    });
+
+    test('honors step.sample_request when present', () => {
+      const fixture = {
+        intent: 'Help me pick a running shoe',
+        identity: { consent_granted: false, anonymous_session_id: 'anon-123' },
+        placement: 'chatgpt_search',
+      };
+      const result = buildRequest(
+        step('si_initiate_session', { sample_request: fixture }),
+        {},
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(result.intent, fixture.intent);
+      assert.deepStrictEqual(result.identity, fixture.identity);
+      assert.strictEqual(result.placement, 'chatgpt_search');
+    });
+  });
+
   describe('hasRequestBuilder', () => {
     test('returns true for tasks with builders', () => {
       const tasks = [


### PR DESCRIPTION
## Summary
Closes #802. Three storyboard `REQUEST_BUILDERS` emitted payloads the generated Zod schema rejects; strict-validation (framework-dispatch) agents surface this as `-32602 invalid_type`, while legacy-dispatch accepts them permissively and masks the bug.

- `si_get_offering`: drop the string `context` and the out-of-schema `identity`; emit the prose string as optional `intent` (`core/context.json` is an object, not a string).
- `si_initiate_session`: move the prose string from `context` to the required `intent` field. Schema requires `idempotency_key` + `intent` + `identity`; the first is handled by `applyIdempotencyInvariant`.
- `sync_governance`: lengthen default `authentication.credentials` to meet `minLength: 32`; honor `step.sample_request` so fixtures like `signal-marketplace/scenarios/governance_denied.yaml` that author `url: $context.governance_agent_url` flow through.

All three now honor `step.sample_request` first, matching peer builders (`build_creative`, `sync_creatives`, `sync_plans`, `check_governance`, `list_creative_formats`, etc.). Same bug class as #789 and #793.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Pre-push validation passed
- [ ] Downstream compliance suite (adcontextprotocol/adcp CI) picks up the fix once published — Group C storyboards touching SI + governance should stop failing the strict-validation dispatch with `invalid_type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)