### PR TITLE
fix(testing): spec shapes for si_* + sync_governance requests (#802)

### DIFF
--- a/.changeset/fix-si-sync-governance-request-shapes.md
+++ b/.changeset/fix-si-sync-governance-request-shapes.md
@@ -1,0 +1,23 @@
+---
+'@adcp/client': patch
+---
+
+Fix spec-violating request shapes for `si_get_offering`, `si_initiate_session`,
+and `sync_governance` in both the storyboard request builders and the
+sponsored-intelligence test scenarios.
+
+- `si_get_offering`: the prose string moves from `context` (which is the core
+  context object per `si-get-offering-request.json`) to `intent`. The `identity`
+  field is dropped — it is not part of the request schema.
+- `si_initiate_session`: the prose handoff moves from `context` to `intent`
+  (required). `identity` now follows `si-identity.json` — `{ consent_granted,
+  user: { name } }` rather than the non-spec `{ principal, device_id }`.
+- `sync_governance`: the builder now honors `step.sample_request` (so
+  storyboards can pin `url: $context.governance_agent_url`) and the fallback
+  `credentials` is padded to ≥32 chars to satisfy the schema's `minLength: 32`.
+
+Framework-dispatch agents running strict validation at the MCP boundary
+previously rejected these with `-32602 invalid_type`; legacy-dispatch
+permissively accepted the wrong shapes.
+
+Closes #802.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.10.0",
+      "version": "5.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/scenarios/sponsored-intelligence.ts
+++ b/src/lib/testing/scenarios/sponsored-intelligence.ts
@@ -71,11 +71,7 @@ export async function testSISessionLifecycle(
       async () =>
         client.siGetOffering({
           offering_id: offeringId,
-          context: options.si_context || 'E2E testing - checking SI offering availability',
-          identity: {
-            principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-            device_id: 'e2e-test-device',
-          },
+          intent: options.si_context || 'E2E testing - checking SI offering availability',
         } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
     );
 
@@ -121,11 +117,11 @@ export async function testSISessionLifecycle(
         client.siInitiateSession({
           offering_id: options.si_offering_id || 'e2e-test-offering',
           offering_token: offeringToken,
+          intent: options.si_context || 'E2E testing - initiating conversation about products',
           identity: {
-            principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-            device_id: 'e2e-test-device',
+            consent_granted: true,
+            user: { name: resolveAuthPrincipal(options) || 'e2e-test-principal' },
           },
-          context: options.si_context || 'E2E testing - initiating conversation about products',
           placement: 'e2e-test-placement',
           supported_capabilities: {
             modalities: {
@@ -427,11 +423,7 @@ export async function testSIHandoff(
       async () =>
         client.siGetOffering({
           offering_id: options.si_offering_id || 'e2e-test-offering',
-          context: 'E2E testing - preparing for handoff flow',
-          identity: {
-            principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-            device_id: 'e2e-test-device',
-          },
+          intent: 'E2E testing - preparing for handoff flow',
         } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
     );
 
@@ -450,11 +442,11 @@ export async function testSIHandoff(
       client.siInitiateSession({
         offering_id: options.si_offering_id || 'e2e-test-offering',
         offering_token: offeringToken,
+        intent: options.si_context || 'E2E testing - initiating session for handoff test',
         identity: {
-          principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-          device_id: 'e2e-test-device',
+          consent_granted: true,
+          user: { name: resolveAuthPrincipal(options) || 'e2e-test-principal' },
         },
-        context: options.si_context || 'E2E testing - initiating session for handoff test',
         placement: 'e2e-test-placement',
         supported_capabilities: {
           modalities: { conversational: true },
@@ -624,11 +616,7 @@ export async function testSIAvailability(
     async () =>
       client.siGetOffering({
         offering_id: offeringId,
-        context: options.si_context || 'E2E testing - checking SI availability',
-        identity: {
-          principal: resolveAuthPrincipal(options) || 'e2e-test-principal',
-          device_id: 'e2e-test-device',
-        },
+        intent: options.si_context || 'E2E testing - checking SI availability',
       } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
   );
 
@@ -668,10 +656,7 @@ export async function testSIAvailability(
     async () =>
       client.siGetOffering({
         offering_id: 'INVALID_OFFERING_ID_DOES_NOT_EXIST_12345',
-        context: 'E2E testing - checking unavailable offering',
-        identity: {
-          principal: 'e2e-test-principal',
-        },
+        intent: 'E2E testing - checking unavailable offering',
       } as unknown as SIGetOfferingRequest) as Promise<TaskResult>
   );
 

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -446,7 +446,13 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Governance ─────────────────────────────────────────
 
-  sync_governance(_step, context, options) {
+  sync_governance(step, context, options) {
+    // Honor hand-authored sample_request so governance storyboards can
+    // pin specific governance_agent urls (e.g., $context.governance_agent_url)
+    // that downstream check_governance steps assert against.
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
     return {
       accounts: [
         {
@@ -456,7 +462,8 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
               url: 'https://governance.test.example',
               authentication: {
                 schemes: ['Bearer'],
-                credentials: 'test-governance-token',
+                // Schema enforces credentials.minLength >= 32 (sync-governance-request.json).
+                credentials: 'e2e-test-governance-token-padding-0000',
               },
               categories: ['budget_authority', 'brand_policy'],
             },
@@ -617,26 +624,33 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 
   // ── Sponsored Intelligence ─────────────────────────────
 
-  si_get_offering(_step, _context, options) {
+  si_get_offering(step, context, options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
+    // Per si-get-offering-request.json: `intent` carries the user's
+    // natural-language ask; `context` is the core context object and
+    // `identity` is not part of this request schema.
     return {
       offering_id: options.si_offering_id ?? 'e2e-test-offering',
-      context: options.si_context ?? 'E2E testing - checking SI offering availability',
-      identity: {
-        principal: resolveAuthPrincipal(options) ?? 'e2e-test-principal',
-        device_id: 'e2e-test-device',
-      },
+      intent: options.si_context ?? 'E2E testing - checking SI offering availability',
     };
   },
 
-  si_initiate_session(_step, context, options) {
+  si_initiate_session(step, context, options) {
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request }, context);
+    }
+    // Per si-initiate-session-request.json, `intent` + `identity` are required;
+    // the prose handoff string belongs in `intent`, not `context`.
     return {
       offering_id: context.offering_id ?? options.si_offering_id ?? 'e2e-test-offering',
       offering_token: context.offering_token,
+      intent: options.si_context ?? 'E2E test session',
       identity: {
         consent_granted: true,
-        user: { principal: resolveAuthPrincipal(options) ?? 'e2e-test-principal' },
+        user: { name: resolveAuthPrincipal(options) ?? 'e2e-test-principal' },
       },
-      context: options.si_context ?? 'E2E test session',
       placement: 'e2e-test',
       supported_capabilities: {
         modalities: { conversational: true, rich_media: true },

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.10.0';
+export const LIBRARY_VERSION = '5.11.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.10.0',
+  library: '5.11.0',
   adcp: 'latest',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T05:15:39.944Z',
+  generatedAt: '2026-04-22T07:57:04.475Z',
 } as const;
 
 /**

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -418,6 +418,110 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('sync_governance', () => {
+    test('fallback credentials satisfy schema minLength of 32', () => {
+      // Regression: the hardcoded 'test-governance-token' is 21 chars,
+      // shorter than the schema's minLength: 32, so strict-validation
+      // agents rejected every sync_governance step with -32602.
+      const result = buildRequest(step('sync_governance'), {}, DEFAULT_OPTIONS);
+      const credentials = result.accounts[0].governance_agents[0].authentication.credentials;
+      assert.ok(credentials.length >= 32, `credentials must be >= 32 chars, got ${credentials.length}`);
+    });
+
+    test('honors step.sample_request when present', () => {
+      // Regression: the builder never consulted sample_request, so
+      // governance storyboards authoring `url: $context.governance_agent_url`
+      // silently lost that binding and downstream check_governance steps
+      // asserted against the wrong URL.
+      const fixture = {
+        accounts: [
+          {
+            account: { account_id: 'acct_gov' },
+            governance_agents: [
+              {
+                url: '$context.governance_agent_url',
+                authentication: {
+                  schemes: ['Bearer'],
+                  credentials: 'gov-token-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const result = buildRequest(
+        step('sync_governance', { sample_request: fixture }),
+        { governance_agent_url: 'https://gov.resolved.example' },
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(
+        result.accounts[0].governance_agents[0].url,
+        'https://gov.resolved.example',
+        '$context placeholder should resolve'
+      );
+    });
+  });
+
+  describe('si_get_offering', () => {
+    test('fallback uses intent for prose and omits non-spec fields', () => {
+      // Regression: the builder passed the prose string as `context`
+      // (which is an object per spec) and included `identity`, which
+      // is not part of si-get-offering-request.json.
+      const result = buildRequest(step('si_get_offering'), {}, DEFAULT_OPTIONS);
+      assert.ok(result.offering_id, 'offering_id required');
+      assert.strictEqual(typeof result.intent, 'string', 'intent carries the prose string');
+      assert.ok(
+        result.context === undefined || typeof result.context === 'object',
+        'context must be an object or omitted, never a string'
+      );
+      assert.strictEqual(result.identity, undefined, 'identity is not in si_get_offering request schema');
+    });
+
+    test('honors step.sample_request when present', () => {
+      const fixture = {
+        offering_id: 'custom-offering',
+        intent: 'Looking for mens size 12 hiking boots',
+        include_products: true,
+      };
+      const result = buildRequest(step('si_get_offering', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.offering_id, 'custom-offering');
+      assert.strictEqual(result.intent, fixture.intent);
+      assert.strictEqual(result.include_products, true);
+    });
+  });
+
+  describe('si_initiate_session', () => {
+    test('fallback uses intent for prose string and includes required identity', () => {
+      // Regression: the builder put the prose string into `context`
+      // (an object per spec) rather than `intent` (the required field
+      // per si-initiate-session-request.json).
+      const result = buildRequest(step('si_initiate_session'), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(typeof result.intent, 'string', 'intent is required and carries the prose handoff');
+      assert.ok(result.identity, 'identity is required');
+      assert.strictEqual(typeof result.identity.consent_granted, 'boolean', 'identity.consent_granted required');
+      assert.ok(
+        result.context === undefined || typeof result.context === 'object',
+        'context must be an object or omitted, never a string'
+      );
+    });
+
+    test('honors step.sample_request when present', () => {
+      const fixture = {
+        intent: 'Help me pick a running shoe',
+        identity: { consent_granted: false, anonymous_session_id: 'anon-123' },
+        placement: 'chatgpt_search',
+      };
+      const result = buildRequest(
+        step('si_initiate_session', { sample_request: fixture }),
+        {},
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(result.intent, fixture.intent);
+      assert.deepStrictEqual(result.identity, fixture.identity);
+      assert.strictEqual(result.placement, 'chatgpt_search');
+    });
+  });
+
   describe('hasRequestBuilder', () => {
     test('returns true for tasks with builders', () => {
       const tasks = [


### PR DESCRIPTION
## Summary

Fixes three spec-violating request shapes that framework-dispatch agents running strict validation at the MCP boundary rejected with `-32602 invalid_type`. Legacy-dispatch permissively accepted them (same pattern as #793).

- **`si_get_offering`**: prose string → `intent` (per `si-get-offering-request.json`, `context` is the core context object, not a prose string); drop non-spec `identity` field.
- **`si_initiate_session`**: prose handoff → `intent` (required); `identity` now follows `si-identity.json` — `{ consent_granted, user: { name } }` rather than the non-spec `{ principal, device_id }`.
- **`sync_governance`**: builder now honors `step.sample_request` (so governance storyboards can pin `url: $context.governance_agent_url`); fallback `credentials` padded to ≥32 chars to satisfy the schema's `minLength: 32`.

Same shape bugs existed in the sponsored-intelligence test scenarios path (agent-tester orchestrator) — fixed in both places so both code paths produce spec-compliant requests.

## Test plan

- [x] Builder fallback tests: `npm run test:lib` (4575 pass)
- [x] New regression tests in `test/lib/request-builder.test.js`:
  - `sync_governance` fallback credentials ≥32 chars
  - `sync_governance` honors `$context` placeholders in sample_request
  - `si_get_offering` emits `intent` (not string `context`) and omits `identity`
  - `si_initiate_session` emits `intent` + spec-shaped `identity`
  - Both SI builders honor `step.sample_request` when present

Closes #802.

🤖 Generated with [Claude Code](https://claude.com/claude-code)