### PR TITLE
fix(testing): allow recovery paths after expected governance denial (#811)

### DIFF
--- a/.changeset/governance-denial-recovery.md
+++ b/.changeset/governance-denial-recovery.md
@@ -1,0 +1,24 @@
+---
+'@adcp/client': patch
+---
+
+Fix `governance.denial_blocks_mutation` to allow expected-denial recovery
+paths.
+
+The invariant anchored any governance denial (`GOVERNANCE_DENIED`,
+`TERMS_REJECTED`, `POLICY_VIOLATION`, etc.) and then flagged any later
+successful mutation in the same run as a silent bypass. That fired on
+first-party storyboards whose whole purpose is to test recovery —
+`media_buy_seller/governance_denied_recovery` (buyer shrinks the buy
+and retries) and `media_buy_seller/measurement_terms_rejected` (buyer
+relaxes terms and retries) — because the retry step succeeded against
+the same plan and tripped the anchor.
+
+A denial step that the storyboard marks `expect_error: true` is the
+author explicitly acknowledging the denial. The subsequent mutation is
+a recovery path, not a silent bypass, so the invariant no longer
+anchors when the denial step is expected. The silent-bypass signal is
+preserved for `check_governance` 200s with `status: denied` and for
+`adcp_error` responses the author did not declare expected.
+
+Closes #811.

--- a/.changeset/governance-denial-recovery.md
+++ b/.changeset/governance-denial-recovery.md
@@ -21,4 +21,10 @@ anchors when the denial step is expected. The silent-bypass signal is
 preserved for `check_governance` 200s with `status: denied` and for
 `adcp_error` responses the author did not declare expected.
 
+When the invariant does fire on a wire-error denial, the failure
+message now points the author at the `expect_error: true` escape so
+the next author doesn't have to re-derive it from source. The hint is
+suppressed on `check_governance` 200 denials where the flag has no
+effect.
+
 Closes #811.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -288,6 +288,15 @@ registerOnce('governance.denial_blocks_mutation', {
     const anchor = (planId && state.deniedPlans.get(planId)) ?? state.runDenial;
     if (!anchor) return [];
 
+    // The `expect_error: true` escape only applies to wire-error denials
+    // (adcp_error responses). `check_governance` 200 with `status: denied`
+    // is not a wire error, so expect_error semantics don't cover it — don't
+    // misdirect the author to a flag that would have no effect.
+    const escapeHint =
+      anchor.signal === 'CHECK_GOVERNANCE_DENIED'
+        ? ''
+        : ` — if the denial at step "${anchor.stepId}" is an intentional recovery-path setup, mark it \`expect_error: true\` so the invariant does not anchor on it`;
+
     return [
       {
         passed: false,
@@ -298,7 +307,8 @@ registerOnce('governance.denial_blocks_mutation', {
           (planId ? ` for plan_id=${planId}` : ' (run-wide)') +
           `; subsequent step "${stepResult.step_id}" (task=${stepResult.task}) ` +
           `acquired ${acquired.field}=${acquired.id}` +
-          (planId ? ' for the same plan' : ''),
+          (planId ? ' for the same plan' : '') +
+          escapeHint,
       },
     ];
   },

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -267,6 +267,12 @@ registerOnce('governance.denial_blocks_mutation', {
     // Denial observation is never itself a failure — record and return.
     const denial = detectGovernanceDenial(stepResult);
     if (denial) {
+      // A step marked `expect_error: true` is the storyboard author explicitly
+      // acknowledging the denial. Subsequent mutations in the same run are a
+      // recovery path, not a silent bypass — don't anchor. The invariant still
+      // catches silent denials (check_governance 200 `status: denied`, or
+      // adcp_error responses the author did not expect).
+      if (stepResult.expect_error) return [];
       const anchor: GovernanceDenialAnchor = { stepId: stepResult.step_id, signal: denial };
       if (planId) {
         if (!state.deniedPlans.has(planId)) state.deniedPlans.set(planId, anchor);

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -109,11 +109,23 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     };
   }
 
-  function denialStep(planId, code = 'GOVERNANCE_DENIED', { expectError = false } = {}) {
+  // Two helpers split by intent: a "silent" denial is one the storyboard
+  // author did NOT declare expected — the invariant's primary target.
+  // An "expected" denial is `expect_error: true` — a recovery-path setup.
+  function silentDenialStep(planId, code = 'GOVERNANCE_DENIED') {
     return makeStep({
       step_id: 'deny',
       task: 'check_governance',
-      expect_error: expectError,
+      expect_error: false,
+      response: { plan_id: planId, adcp_error: { code, message: 'denied' } },
+    });
+  }
+
+  function expectedDenialStep(planId, code = 'GOVERNANCE_DENIED') {
+    return makeStep({
+      step_id: 'deny_expected',
+      task: 'check_governance',
+      expect_error: true,
       response: { plan_id: planId, adcp_error: { code, message: 'denied' } },
     });
   }
@@ -140,7 +152,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
   });
 
   test('fires when a mutation follows a plan-scoped denial', () => {
-    const out = run([denialStep('plan-a'), mutateStep({ planId: 'plan-a' })]);
+    const out = run([silentDenialStep('plan-a'), mutateStep({ planId: 'plan-a' })]);
     const v = out[1].output[0];
     assert.strictEqual(v.passed, false);
     assert.match(v.error, /GOVERNANCE_DENIED/);
@@ -150,7 +162,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
 
   test('is plan-scoped — denial on plan A does not block mutation on plan B', () => {
     const out = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       mutateStep({ planId: 'plan-b', response: { media_buy_id: 'mb-b', status: 'active' } }),
     ]);
     assert.strictEqual(out[1].output.length, 0);
@@ -158,7 +170,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
 
   test('reads plan_id from the runner-recorded request payload when the response omits it', () => {
     const out = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       mutateStep({ requestPlanId: 'plan-a', response: { media_buy_id: 'mb-new', status: 'active' } }),
     ]);
     assert.strictEqual(out[1].output[0].passed, false);
@@ -171,7 +183,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     // bind this to plan-a; the assertion must stay silent.
     const step = mutateStep({ response: { media_buy_id: 'mb-new', status: 'active' } });
     step.context = { plan_id: 'plan-a' };
-    const out = run([denialStep('plan-a'), step]);
+    const out = run([silentDenialStep('plan-a'), step]);
     assert.strictEqual(out[1].output.length, 0);
   });
 
@@ -188,7 +200,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
 
   test('treats rejected media_buy status as NOT acquired', () => {
     const out = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       makeStep({
         step_id: 'rejected_mb',
         task: 'create_media_buy',
@@ -200,7 +212,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
 
   test('ignores read tasks even if they echo resource ids', () => {
     const out = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       makeStep({
         step_id: 'lookup',
         task: 'get_media_buys',
@@ -212,7 +224,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
 
   test('denial state is sticky — later passing check_governance does not clear it', () => {
     const out = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       makeStep({
         step_id: 'recheck',
         task: 'check_governance',
@@ -226,8 +238,8 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
 
   test('records only the first anchor on a plan', () => {
     const out = run([
-      denialStep('plan-a', 'GOVERNANCE_DENIED'),
-      denialStep('plan-a', 'CAMPAIGN_SUSPENDED'),
+      silentDenialStep('plan-a', 'GOVERNANCE_DENIED'),
+      silentDenialStep('plan-a', 'CAMPAIGN_SUSPENDED'),
       mutateStep({ planId: 'plan-a' }),
     ]);
     const err = out[2].output[0].error;
@@ -267,7 +279,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     'COMPLIANCE_UNSATISFIED',
   ]) {
     test(`triggers on error code ${code}`, () => {
-      const out = run([denialStep('plan-a', code), mutateStep({ planId: 'plan-a' })]);
+      const out = run([silentDenialStep('plan-a', code), mutateStep({ planId: 'plan-a' })]);
       assert.strictEqual(out[1].output[0].passed, false);
       assert.match(out[1].output[0].error, new RegExp(code));
     });
@@ -280,13 +292,13 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
       passed: false,
       response: { plan_id: 'plan-a', adcp_error: { code: 'VALIDATION_ERROR', message: 'bad input' } },
     });
-    const out = run([denialStep('plan-a'), failed]);
+    const out = run([silentDenialStep('plan-a'), failed]);
     assert.strictEqual(out[1].output.length, 0);
   });
 
   test('counts acquire_rights and activate_signal as mutations', () => {
     const acq = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       makeStep({
         step_id: 'acq',
         task: 'acquire_rights',
@@ -295,7 +307,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     ]);
     assert.strictEqual(acq[1].output[0].passed, false);
     const act = run([
-      denialStep('plan-a'),
+      silentDenialStep('plan-a'),
       makeStep({
         step_id: 'act',
         task: 'activate_signal',
@@ -306,29 +318,29 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
   });
 
   test('expected denial (expect_error: true) does not anchor — recovery path is allowed', () => {
-    // Models `media_buy_seller/governance_denied_recovery`: the denial step
-    // declares the error was expected, the retry step corrects the payload
-    // and legitimately mints a media_buy. The invariant must stay silent.
+    // Mirrors `media_buy_seller/governance_denied_recovery` (in
+    // `compliance/cache/latest/protocols/media-buy/scenarios/`): the denial
+    // step declares the error was expected, the retry step corrects the
+    // payload and legitimately mints a media_buy.
     const out = run([
-      denialStep('plan-a', 'GOVERNANCE_DENIED', { expectError: true }),
+      expectedDenialStep('plan-a', 'GOVERNANCE_DENIED'),
       mutateStep({ planId: 'plan-a', response: { media_buy_id: 'mb-recovered', status: 'active' } }),
     ]);
-    assert.strictEqual(out[1].output.length, 0);
+    assert.deepStrictEqual(out[1].output, []);
   });
 
   test('expected TERMS_REJECTED does not anchor either', () => {
-    // Mirror of `media_buy_seller/measurement_terms_rejected`.
+    // Mirrors `media_buy_seller/measurement_terms_rejected`.
     const out = run([
-      denialStep('plan-b', 'TERMS_REJECTED', { expectError: true }),
+      expectedDenialStep('plan-b', 'TERMS_REJECTED'),
       mutateStep({ planId: 'plan-b', response: { media_buy_id: 'mb-relaxed', status: 'pending_start' } }),
     ]);
-    assert.strictEqual(out[1].output.length, 0);
+    assert.deepStrictEqual(out[1].output, []);
   });
 
-  test('expected denial on plan A does not bleed into run-wide anchor', () => {
-    // If an expected denial lacked plan linkage, it must still not anchor
-    // run-wide — otherwise the whole run would be tainted by a single
-    // expected error.
+  test('expected denial without plan linkage does not create a run-wide anchor', () => {
+    // A run-wide denial on an expect_error step would otherwise taint every
+    // subsequent mutation in the run.
     const step = makeStep({
       step_id: 'deny_no_plan',
       task: 'get_products',
@@ -336,7 +348,39 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
       response: { adcp_error: { code: 'POLICY_VIOLATION', message: 'refused' } },
     });
     const out = run([step, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } })]);
-    assert.strictEqual(out[1].output.length, 0);
+    assert.deepStrictEqual(out[1].output, []);
+  });
+
+  test('expected denial on a plan does not mask a later silent denial on the same plan', () => {
+    // Regression guard: the expect_error skip must be scoped to the
+    // expected step itself, not to the whole plan. If a later unexpected
+    // denial on the same plan fires, the invariant must still anchor on
+    // it and trip the subsequent mutation.
+    const out = run([
+      expectedDenialStep('plan-a', 'GOVERNANCE_DENIED'),
+      silentDenialStep('plan-a', 'CAMPAIGN_SUSPENDED'),
+      mutateStep({ planId: 'plan-a' }),
+    ]);
+    assert.strictEqual(out[2].output[0].passed, false);
+    assert.match(out[2].output[0].error, /CAMPAIGN_SUSPENDED/);
+  });
+
+  test('expected denial does not mask a later silent run-wide denial', () => {
+    // Plan-scoped expected denial then an unrelated run-wide silent denial
+    // must still anchor run-wide and catch a subsequent acquisition.
+    const runWideDenial = makeStep({
+      step_id: 'deny_run_wide',
+      task: 'get_products',
+      expect_error: false,
+      response: { adcp_error: { code: 'POLICY_VIOLATION', message: 'refused' } },
+    });
+    const out = run([
+      expectedDenialStep('plan-a', 'GOVERNANCE_DENIED'),
+      runWideDenial,
+      mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } }),
+    ]);
+    assert.strictEqual(out[2].output[0].passed, false);
+    assert.match(out[2].output[0].error, /run-wide/);
   });
 
   test('onStart resets runDenial so stale state does not bleed across runs', () => {

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -109,11 +109,11 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     };
   }
 
-  function denialStep(planId, code = 'GOVERNANCE_DENIED') {
+  function denialStep(planId, code = 'GOVERNANCE_DENIED', { expectError = false } = {}) {
     return makeStep({
       step_id: 'deny',
       task: 'check_governance',
-      expect_error: true,
+      expect_error: expectError,
       response: { plan_id: planId, adcp_error: { code, message: 'denied' } },
     });
   }
@@ -250,7 +250,7 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     const step = makeStep({
       step_id: 'deny_no_plan',
       task: 'get_products',
-      expect_error: true,
+      expect_error: false,
       response: { adcp_error: { code: 'POLICY_VIOLATION', message: 'refused' } },
     });
     const out = run([step, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } })]);
@@ -303,6 +303,40 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
       }),
     ]);
     assert.strictEqual(act[1].output[0].passed, false);
+  });
+
+  test('expected denial (expect_error: true) does not anchor — recovery path is allowed', () => {
+    // Models `media_buy_seller/governance_denied_recovery`: the denial step
+    // declares the error was expected, the retry step corrects the payload
+    // and legitimately mints a media_buy. The invariant must stay silent.
+    const out = run([
+      denialStep('plan-a', 'GOVERNANCE_DENIED', { expectError: true }),
+      mutateStep({ planId: 'plan-a', response: { media_buy_id: 'mb-recovered', status: 'active' } }),
+    ]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('expected TERMS_REJECTED does not anchor either', () => {
+    // Mirror of `media_buy_seller/measurement_terms_rejected`.
+    const out = run([
+      denialStep('plan-b', 'TERMS_REJECTED', { expectError: true }),
+      mutateStep({ planId: 'plan-b', response: { media_buy_id: 'mb-relaxed', status: 'pending_start' } }),
+    ]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  test('expected denial on plan A does not bleed into run-wide anchor', () => {
+    // If an expected denial lacked plan linkage, it must still not anchor
+    // run-wide — otherwise the whole run would be tainted by a single
+    // expected error.
+    const step = makeStep({
+      step_id: 'deny_no_plan',
+      task: 'get_products',
+      expect_error: true,
+      response: { adcp_error: { code: 'POLICY_VIOLATION', message: 'refused' } },
+    });
+    const out = run([step, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } })]);
+    assert.strictEqual(out[1].output.length, 0);
   });
 
   test('onStart resets runDenial so stale state does not bleed across runs', () => {

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -158,6 +158,9 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     assert.match(v.error, /GOVERNANCE_DENIED/);
     assert.match(v.error, /plan_id=plan-a/);
     assert.match(v.error, /media_buy_id=mb-1/);
+    // Wire-error denial: error message should point authors at the
+    // expect_error: true escape so they don't have to file an issue.
+    assert.match(v.error, /expect_error: true/);
   });
 
   test('is plan-scoped — denial on plan A does not block mutation on plan B', () => {
@@ -196,6 +199,10 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     });
     const out = run([step, mutateStep({ planId: 'plan-b' })]);
     assert.match(out[1].output[0].error, /CHECK_GOVERNANCE_DENIED/);
+    // 200-status denials are not wire errors — `expect_error: true` has no
+    // effect on them, so the escape hint must NOT appear (it would send
+    // authors down a dead end).
+    assert.doesNotMatch(out[1].output[0].error, /expect_error: true/);
   });
 
   test('treats rejected media_buy status as NOT acquired', () => {


### PR DESCRIPTION
## Summary

Closes #811. The default `governance.denial_blocks_mutation` invariant anchored every denial signal and then flagged any later successful mutation in the same run as a silent bypass. That false-positived on two first-party storyboards whose whole purpose is testing buyer recovery:

- `media_buy_seller/governance_denied_recovery` — `GOVERNANCE_DENIED` then a corrected (smaller) retry
- `media_buy_seller/measurement_terms_rejected` — `TERMS_REJECTED` then a corrected (relaxed terms) retry

The invariant fired on the retry because the anchor it set on the denial observation persisted for the rest of the run.

## Fix (option A from the issue)

A denial step marked `expect_error: true` is the storyboard author explicitly acknowledging the denial. The subsequent mutation is the recovery path, not a silent bypass — so when we observe a denial on an `expect_error: true` step, we don't anchor.

Silent-bypass detection is preserved for:
- `check_governance` 200 with `status: denied` (no wire error to mark expected)
- `adcp_error` responses the author did not declare expected (`expect_error: false`)

When the invariant **does** fire on a wire-error denial, the failure message now points the author at the `expect_error: true` escape so they don't have to re-derive it from source. The hint is suppressed on `check_governance` 200 denials (see edge note below).

## Intentional edge — `check_governance` 200 `status: denied` has no escape hatch

The `expect_error: true` opt-out only applies to **wire-error** denials (`adcp_error` responses). A `check_governance` 200 with `status: denied` is not a wire error, so `expect_error` is semantically inapplicable.

A storyboard shaped like `check_governance → denied → correct → check_governance → approved → create_media_buy` currently has no way to tell the invariant the first denial was intentional. This PR leaves that path anchoring — no current storyboards hit it, so closing off a legitimate-but-unused pattern is the conservative call.

Filed **#815** to track either documenting that constraint or adding a step-level escape hatch (e.g. `invariants: { acknowledge: [...] }`). Not blocking this PR.

## Test plan

- [x] `node --test test/lib/storyboard-default-invariants.test.js` — all 104 tests pass
- [x] `npm test` — 5440 pass, 0 fail, 6 skipped (pre-existing)
- [x] Helper split: `silentDenialStep` (`expect_error: false`, invariant's primary target) and `expectedDenialStep` (`expect_error: true`, recovery setup). Every call site is explicit about which shape it's testing.
- [x] New tests cover:
  - Recovery path for `GOVERNANCE_DENIED`
  - Recovery path for `TERMS_REJECTED`
  - Expected denial without plan linkage does not create a run-wide anchor
  - Expected denial on plan A does **not** mask a later silent denial on the same plan (regression guard)
  - Expected denial does **not** mask a later silent run-wide denial (regression guard)
  - Error-message hint appears for wire-error anchors
  - Error-message hint is **suppressed** for `check_governance` 200-denied anchors (no dead-end advice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)