### PR TITLE
fix(testing): governance.denial_blocks_mutation skips anchor on expect_error recovery steps (#811)

### DIFF
--- a/.changeset/governance-denial-recovery.md
+++ b/.changeset/governance-denial-recovery.md
@@ -1,0 +1,31 @@
+---
+'@adcp/client': patch
+---
+
+Fix `governance.denial_blocks_mutation` false-positives on denial-recovery
+storyboards.
+
+A step authored with `expect_error: true` is the storyboard declaring
+"this denial is a planned part of the flow" — the canonical shape for
+denial-recovery scenarios where the buyer reads the findings, corrects
+the payload (shrink the buy, relax the terms), and retries. The
+subsequent successful mutation is the recovery path, not a silent
+bypass, and the invariant no longer anchors on it.
+
+Unacknowledged denials — e.g. a `check_governance` 200 with
+`status: "denied"`, or an `adcp_error` denial code on a step the author
+did not mark `expect_error` — continue to anchor as before. That is the
+real silent-bypass shape the invariant guards.
+
+Narrowed scope: the invariant no longer catches a buggy mutation that
+fires immediately after an author-acknowledged denial. Correctness of
+the recovery payload itself (right budget, relaxed terms, etc.) is a
+storyboard-level concern — covered by per-step `validations` and status
+checks on the retry, not by this run-wide guard.
+
+Unblocks two first-party storyboards whose whole point is exercising
+denial-recovery:
+- `media_buy_seller/governance_denied_recovery`
+- `media_buy_seller/measurement_terms_rejected`
+
+Closes #811.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -267,6 +267,21 @@ registerOnce('governance.denial_blocks_mutation', {
     // Denial observation is never itself a failure — record and return.
     const denial = detectGovernanceDenial(stepResult);
     if (denial) {
+      // A step authored with `expect_error: true` is the storyboard declaring
+      // "this denial is a planned part of the flow." First-party storyboards
+      // use this shape to test denial-recovery — the buyer reads the denial
+      // findings, corrects the payload (shrink the buy, relax the terms), and
+      // retries. The retry SHOULD succeed; it is not a silent bypass. Skip
+      // anchoring so the subsequent mutation is not flagged.
+      //
+      // The invariant's value-add is catching UN-acknowledged denials being
+      // ignored downstream — e.g. `check_governance` 200 with `status:
+      // "denied"` (expect_error is false; the 200 is not a wire error) that a
+      // buggy seller mutates past. Those still anchor below. Post-recovery
+      // mutation correctness after an acknowledged denial is a storyboard-
+      // level concern (payload assertions, status checks on the retry), not
+      // this invariant's scope. See issue #811.
+      if (stepResult.expect_error) return [];
       const anchor: GovernanceDenialAnchor = { stepId: stepResult.step_id, signal: denial };
       if (planId) {
         if (!state.deniedPlans.has(planId)) state.deniedPlans.set(planId, anchor);

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -110,10 +110,15 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
   }
 
   function denialStep(planId, code = 'GOVERNANCE_DENIED') {
+    // `expect_error` intentionally NOT set — this models an unacknowledged
+    // denial (e.g. a handler returning GOVERNANCE_DENIED on a step whose
+    // author did not plan for it, or a `check_governance` 200 with
+    // `status: "denied"` that the flow continues past). That's the scenario
+    // the invariant guards: silent mutation after an un-anchored denial.
+    // Acknowledged denials (`expect_error: true`) are covered separately below.
     return makeStep({
       step_id: 'deny',
       task: 'check_governance',
-      expect_error: true,
       response: { plan_id: planId, adcp_error: { code, message: 'denied' } },
     });
   }
@@ -250,7 +255,6 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     const step = makeStep({
       step_id: 'deny_no_plan',
       task: 'get_products',
-      expect_error: true,
       response: { adcp_error: { code: 'POLICY_VIOLATION', message: 'refused' } },
     });
     const out = run([step, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } })]);
@@ -311,6 +315,102 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     spec.onStart(ctx);
     const out = spec.onStep(ctx, mutateStep({ response: { media_buy_id: 'mb-1', status: 'active' } }));
     assert.strictEqual(out.length, 0);
+  });
+
+  // ── issue #811: denial-recovery storyboards ─────────────────────────
+  //
+  // A step authored with `expect_error: true` is the storyboard declaring
+  // "this denial is planned — the subsequent corrected request is the
+  // recovery path." Two first-party storyboards rely on this shape:
+  // `media_buy_seller/governance_denied_recovery` (GOVERNANCE_DENIED → shrink
+  // budget → retry) and `media_buy_seller/measurement_terms_rejected`
+  // (TERMS_REJECTED → relax terms → retry). The invariant previously fired on
+  // the retry; that was the false positive reported in #811.
+
+  test('acknowledged denial (expect_error: true) does not anchor — retry may succeed', () => {
+    const acknowledgedDenial = makeStep({
+      step_id: 'create_media_buy_denied',
+      task: 'create_media_buy',
+      expect_error: true,
+      response: { adcp_error: { code: 'GOVERNANCE_DENIED', message: 'exceeds plan' } },
+    });
+    const retry = makeStep({
+      step_id: 'create_media_buy_retry',
+      task: 'create_media_buy',
+      response: { media_buy_id: 'mb-corrected', status: 'active' },
+    });
+    const out = run([acknowledgedDenial, retry]);
+    assert.strictEqual(out[0].output.length, 0, 'denial observation itself never emits a finding');
+    assert.strictEqual(
+      out[1].output.length,
+      0,
+      'retry after an acknowledged denial must not trip the invariant — it is the recovery path'
+    );
+  });
+
+  test('acknowledged denial with plan linkage does not anchor on that plan', () => {
+    // Same as above but with plan_id surfacing from the response body —
+    // ensures the "don't anchor" rule applies to plan-scoped anchors too,
+    // not just run-wide.
+    const acknowledgedDenial = makeStep({
+      step_id: 'denied',
+      task: 'create_media_buy',
+      expect_error: true,
+      response: { plan_id: 'plan-a', adcp_error: { code: 'TERMS_REJECTED', message: 'terms too aggressive' } },
+    });
+    const retry = makeStep({
+      step_id: 'retry',
+      task: 'create_media_buy',
+      response: { plan_id: 'plan-a', media_buy_id: 'mb-relaxed', status: 'active' },
+    });
+    const out = run([acknowledgedDenial, retry]);
+    assert.strictEqual(out[1].output.length, 0);
+  });
+
+  for (const code of [
+    'GOVERNANCE_DENIED',
+    'CAMPAIGN_SUSPENDED',
+    'PERMISSION_DENIED',
+    'POLICY_VIOLATION',
+    'TERMS_REJECTED',
+    'COMPLIANCE_UNSATISFIED',
+  ]) {
+    test(`acknowledged ${code} allows a subsequent successful mutation`, () => {
+      const acknowledgedDenial = makeStep({
+        step_id: 'denied',
+        task: 'create_media_buy',
+        expect_error: true,
+        response: { adcp_error: { code, message: 'denied' } },
+      });
+      const retry = makeStep({
+        step_id: 'retry',
+        task: 'create_media_buy',
+        response: { media_buy_id: 'mb-corrected', status: 'active' },
+      });
+      const out = run([acknowledgedDenial, retry]);
+      assert.strictEqual(out[1].output.length, 0);
+    });
+  }
+
+  test('unacknowledged denial still anchors even when a later step is expect_error: true', () => {
+    // Guard: the "acknowledgment" only applies to the denial-bearing step
+    // itself. An unrelated expect_error step downstream must not retroactively
+    // clear a legitimate anchor established by a silent-bypass scenario.
+    const silentDenial = makeStep({
+      step_id: 'check',
+      task: 'check_governance',
+      response: { status: 'denied', plan_id: 'plan-a' },
+    });
+    const unrelatedFailure = makeStep({
+      step_id: 'unrelated_err',
+      task: 'get_products',
+      expect_error: true,
+      response: { adcp_error: { code: 'INVALID_REQUEST', message: 'unrelated' } },
+    });
+    const mutation = mutateStep({ planId: 'plan-a' });
+    const out = run([silentDenial, unrelatedFailure, mutation]);
+    assert.strictEqual(out[2].output[0].passed, false);
+    assert.match(out[2].output[0].error, /CHECK_GOVERNANCE_DENIED/);
   });
 });
 


### PR DESCRIPTION
## Summary

- `governance.denial_blocks_mutation` now skips anchoring when the denial-bearing step is authored with `expect_error: true`, treating it as an acknowledged denial rather than a latent anchor
- Unblocks two first-party denial-recovery storyboards that were being false-positived: `media_buy_seller/governance_denied_recovery` and `media_buy_seller/measurement_terms_rejected`
- Silent-bypass detection is preserved for `check_governance` 200 `status: "denied"` and any adcp_error denial code on a step the author did not mark `expect_error`

## Rationale

A step authored with `expect_error: true` is the storyboard declaring "this denial is a planned part of the flow" — the canonical shape for denial-recovery scenarios where the buyer reads the findings, corrects the payload (shrink the buy, relax the terms), and retries. Before this fix, the invariant anchored on the acknowledged denial and then flagged the corrected retry as a post-denial resource acquisition — a false positive on two shipping storyboards.

The narrowed scope is principled: `check_governance` 200 with `status: "denied"` is HTTP-200 on the wire and cannot be marked `expect_error: true` (that flag inverts the pass/fail check for WIRE-level errors). So the silent-bypass shape the invariant actually guards — downstream mutation after an un-acknowledged denial — remains fully covered. Correctness of the recovery PAYLOAD itself (right budget, relaxed terms, etc.) is a storyboard-level concern handled by per-step `validations`.

## Test plan

- [x] `node --test test/lib/storyboard-default-invariants.test.js` — 106 / 106 pass, including:
  - New: acknowledged denial (`expect_error: true`) followed by a retry mutation does NOT fire
  - New: parameterized coverage over all six denial codes on the acknowledged-recovery path
  - New: un-acknowledged `check_governance` 200 status:denied still anchors even when an UNRELATED `expect_error` step sits between it and the mutation (guard against too-broad anchor clearing)
- [x] `npm test` — 5413 / 5413 pass
- [x] `npm run build` + `npm run typecheck` clean
- [x] Independent code-review by the `code-reviewer` agent — "Ship it. No Must-Fix."

Closes #811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)