### PR TITLE
feat(testing): fixture-authoritative storyboard runner + fallback fixes (#805, #820)

### DIFF
--- a/.changeset/check-governance-caller-uri.md
+++ b/.changeset/check-governance-caller-uri.md
@@ -2,26 +2,49 @@
 '@adcp/client': patch
 ---
 
-Fix storyboard `check_governance` builder fallback: emit a URI-formatted
-`caller` instead of a bare domain.
+Fix storyboard request-builder fallback shapes: every fallback now
+satisfies the upstream JSON schema it pairs with, unblocking strict-mode
+agents that reject non-conforming payloads at the MCP boundary.
 
-`governance/check-governance-request.json` declares `caller` as
-`format: uri`; the fallback was passing `resolveBrand(options).domain`
-directly, which fails strict JSON-schema validation (framework-dispatch
-agents reject with `-32602 invalid_type`; legacy-dispatch accepts
-permissively). The generated Zod schema does not enforce `format`
-keywords, so the existing Zod round-trip invariant did not catch it.
+**Builder fixes** (all only take effect when `step.sample_request` is
+absent — authored fixtures are unaffected):
 
-Adds `test/lib/request-builder-jsonschema-roundtrip.test.js` — an AJV
-round-trip invariant that validates every builder fallback against the
-upstream JSON schema, catching `format` violations and strict
-`additionalProperties` regressions that Zod misses. The suite ships
-with a small `KNOWN_NONCONFORMING` allowlist for six pre-existing
-fallback bugs (format_id.agent_url placeholders, missing required
-fields on `update_media_buy` / `get_signals` / `create_content_standards`);
-a companion guard test fails if any listed task starts passing, forcing
-the allowlist to stay minimal as fixes land.
+- `check_governance` — `caller` now emits `https://${brand.domain}`
+  instead of a bare domain. Schema declares `caller: format: uri`. (#805)
+- `build_creative`, `preview_creative`, `sync_creatives` — the
+  `format_id` placeholder for a missing format now carries a
+  URI-formatted `agent_url` (`https://unknown.example.com/`) instead of
+  the string `"unknown"`. Schema (`core/format-id.json`) declares
+  `agent_url: format: uri`.
+- `update_media_buy` — fallback now injects
+  `account: context.account ?? resolveAccount(options)`; schema lists
+  `account` as required. Matches the pattern peer builders
+  (`sync_creatives`, `sync_catalogs`, `report_usage`) already use.
+- `get_signals` — when neither `options.brief` nor
+  `sample_request.signal_ids` is present, fallback now emits
+  `{ signal_spec: 'E2E fallback signal discovery' }` instead of `{}`.
+  Schema `anyOf: [signal_spec | signal_ids]`.
+- `create_content_standards` — fallback now emits a minimal inline
+  bespoke policy (`policies: [{policy_id, enforcement: 'must', policy}]`)
+  alongside `scope`. Schema `anyOf: [policies | registry_policy_ids]`.
 
-Closes #805 (check_governance half; the creative_approval half was
-already fixed by prior work on the builder and is covered by the new
-invariant).
+**New test**: `test/lib/request-builder-jsonschema-roundtrip.test.js` —
+AJV round-trip invariant that validates every builder fallback against
+the upstream JSON schema. Complements the existing Zod round-trip test
+(`request-builder-schema-roundtrip.test.js`), which does not enforce
+`format` keywords or strict `additionalProperties`. `KNOWN_NONCONFORMING`
+allowlist is empty; self-pruning guard tests fire if a new fallback
+regresses or an allowlisted task starts passing.
+
+**Observable-behavior notes**:
+
+- Callers importing `buildRequest` who asserted on `get_signals` returning
+  `{}` will need to update — it now returns `{ signal_spec }`.
+- `update_media_buy` fallback now carries an `account`. Storyboards
+  relying on a seller resolving account from `media_buy_id` alone via the
+  fallback will now send a canonical account; if the seller is strict
+  about account consistency across lifecycle, this is the correct signal.
+  No shipping first-party storyboards hit this path (all author
+  `sample_request.account`).
+
+Closes #805.

--- a/.changeset/check-governance-caller-uri.md
+++ b/.changeset/check-governance-caller-uri.md
@@ -1,0 +1,27 @@
+---
+'@adcp/client': patch
+---
+
+Fix storyboard `check_governance` builder fallback: emit a URI-formatted
+`caller` instead of a bare domain.
+
+`governance/check-governance-request.json` declares `caller` as
+`format: uri`; the fallback was passing `resolveBrand(options).domain`
+directly, which fails strict JSON-schema validation (framework-dispatch
+agents reject with `-32602 invalid_type`; legacy-dispatch accepts
+permissively). The generated Zod schema does not enforce `format`
+keywords, so the existing Zod round-trip invariant did not catch it.
+
+Adds `test/lib/request-builder-jsonschema-roundtrip.test.js` — an AJV
+round-trip invariant that validates every builder fallback against the
+upstream JSON schema, catching `format` violations and strict
+`additionalProperties` regressions that Zod misses. The suite ships
+with a small `KNOWN_NONCONFORMING` allowlist for six pre-existing
+fallback bugs (format_id.agent_url placeholders, missing required
+fields on `update_media_buy` / `get_signals` / `create_content_standards`);
+a companion guard test fails if any listed task starts passing, forcing
+the allowlist to stay minimal as fixes land.
+
+Closes #805 (check_governance half; the creative_approval half was
+already fixed by prior work on the builder and is covered by the new
+invariant).

--- a/.changeset/fixture-authoritative-runner.md
+++ b/.changeset/fixture-authoritative-runner.md
@@ -1,0 +1,77 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard runner: fixture-authoritative request construction (closes #820).
+
+The runner's request-construction priority is inverted. `sample_request`
+is now the authoritative base payload — when authored, every top-level
+key the author wrote reaches the wire verbatim. The per-task enricher
+(formerly "request builder") runs alongside, filling fields the fixture
+left unset — typically discovery-derived identifiers, envelope fields,
+or context-substituted placeholders.
+
+The previous behavior silently fabricated payloads and discarded author
+fixtures on ~20 tasks whose enrichers didn't opt into a fixture-honoring
+early return. That false-green failure mode produced five consecutive
+fallback-shape bugs (#780 / #792 / #793 / #802 / #805) before anyone
+noticed the architecture was backward.
+
+### New contract
+
+- **`sample_request` (authored)** — base payload. Context placeholders
+  (`$context.*`, `$generate:uuid_v4`, `{{runner.*}}`) resolve as before.
+- **Enricher (per-task)** — produces fields that gap-fill the fixture.
+  Fixture wins every top-level conflict.
+- **Fixture-aware enrichers** (`create_media_buy`, `comply_test_controller`) —
+  declared in `FIXTURE_AWARE_ENRICHERS` because they splice
+  discovery-derived fields INTO nested fixture structures (array-level
+  merges the generic overlay can't express). The runner passes their
+  output verbatim; envelope fields from the fixture (`context`, `ext`,
+  `push_notification_config`, `idempotency_key`) still flow through.
+
+### Load-time hard-fail
+
+Mutating tasks (per `MUTATING_TASKS`) now throw at storyboard load when
+`sample_request` is absent and `expect_error !== true`. The runner no
+longer fabricates write payloads. Error messages point at the task,
+step id, storyboard id, and suggest the concrete author action. Synthesized
+phases (request-signing, controller seeding) are unaffected — their
+runtime-generated steps don't pass through `parseStoryboard`.
+
+### Rename (compat preserved)
+
+- `buildRequest` → `enrichRequest` (old name kept as deprecated alias)
+- `hasRequestBuilder` → `hasRequestEnricher` (old name kept)
+- `REQUEST_BUILDERS` → `REQUEST_ENRICHERS` (internal)
+
+External consumers pinned to the old names continue to work for one
+release. Migrate to the new names at your own pace.
+
+### Observable-behavior changes
+
+- Mutating storyboards that omitted `sample_request` fail loudly at load
+  instead of silently shipping fabricated payloads. This is the
+  intentional correctness improvement.
+- **Fixture `account` now wins** on four tasks whose pre-inversion
+  builders injected `context.account` OVER the fixture's authored
+  `account` via the hybrid `{ ...sample_request, account: context.account }`
+  pattern: `sync_catalogs`, `sync_creatives`, `report_usage`,
+  `sync_audiences`. Storyboards that relied on the runner silently
+  substituting `context.account` over their authored value will now send
+  the authored value. Audit these fixtures if your tests depend on a
+  specific account on these tasks.
+- Under fixture-wins merge, options-derived fields (e.g.
+  `options.brief` → `signal_spec`) now coexist with authored fields
+  (`sample_request.signal_ids`) instead of replacing them. A storyboard
+  authoring signal_ids and being invoked with `--brief X` now sends
+  both; agents receive a richer query. Schema-valid under
+  `anyOf: [signal_spec | signal_ids]`.
+- Enricher-derived identity fields (e.g. `get_rights.brand_id` from
+  `resolveBrand(options)`) gap-fill when fixture omits them. A
+  storyboard that specifically needs an identity field absent must
+  author it explicitly or opt out via `expect_error: true`.
+
+Strict-vs-lenient run reporting (the fourth proposal in #820) is
+deferred to a separate issue — it's a reporting-subsystem concern
+orthogonal to the request-construction flow.

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -9,6 +9,7 @@
 import { readFileSync } from 'fs';
 import { parse } from 'yaml';
 import type { Storyboard } from './types';
+import { MUTATING_TASKS } from '../../utils/idempotency';
 
 /**
  * Supported `branch_set.semantics` values. Extend when AdCP adds `all_of`,
@@ -62,8 +63,42 @@ export function validateStoryboardShape(storyboard: Storyboard): void {
     if (!phase.steps) continue;
     for (const step of phase.steps) {
       resolveContributesShorthand(storyboard.id, phase, step);
+      validateFixtureForMutatingStep(storyboard.id, phase, step);
     }
   }
+}
+
+/**
+ * Issue #820: mutating tasks (per {@link MUTATING_TASKS}) must have a
+ * `sample_request` authored. The fixture is authoritative at run time —
+ * there's no sane default payload for a write, and silently fabricating
+ * one was the bug factory that produced #780 / #792 / #793 / #802 / #805.
+ *
+ * Error messages point at the task name, the step id, the storyboard, and
+ * suggest the concrete author action.
+ *
+ * Opt-out: steps with `expect_error: true` that deliberately exercise
+ * missing-fixture / malformed-payload seller behavior skip this check —
+ * the author is signaling the payload is the test condition.
+ *
+ * Synthesized phases (`request-signing/synthesize.ts`, controller seeding)
+ * start with `phase.steps = []` in YAML and the loader doesn't see the
+ * runtime-generated steps, so those paths are not affected.
+ */
+function validateFixtureForMutatingStep(
+  storyboardId: string,
+  phase: Storyboard['phases'][number],
+  step: Storyboard['phases'][number]['steps'][number]
+): void {
+  if (!MUTATING_TASKS.has(step.task)) return;
+  if (step.sample_request !== undefined) return;
+  if (step.expect_error === true) return;
+  throw new Error(
+    `[${storyboardId}] phase '${phase.id}' step '${step.id}' (task=${step.task}): ` +
+      `mutating tasks require a sample_request fixture — the runner no longer fabricates ` +
+      `write payloads. Author sample_request in the step or, for intentionally malformed ` +
+      `payloads, set expect_error: true.`
+  );
 }
 
 function validateBranchSet(storyboardId: string, phase: Storyboard['phases'][number]): void {

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -1,25 +1,41 @@
 /**
- * Request builder for storyboard steps.
+ * Request enrichers for storyboard steps.
  *
- * Builds valid requests from discovered context rather than using
- * raw sample_request YAML payloads. Each task has a builder that
- * constructs a minimal valid request from the accumulated context
- * (discovered products, accounts, formats, etc.) and TestOptions.
+ * Contract (see issue #820):
+ *   - `sample_request` (when authored) is the authoritative base payload.
+ *     The runner injects context placeholders into it and passes it through
+ *     to the agent under test.
+ *   - An enricher fills top-level fields the fixture didn't specify —
+ *     typically discovery-derived identifiers (`product_id`, `format_id`,
+ *     `account`, `media_buy_id`) or envelope fields that only the harness
+ *     knows.
+ *   - For conflicts at the top level, the fixture wins — storyboard authors'
+ *     intent is not silently overridden.
  *
- * sample_request from YAML is used only as documentation and as a
- * fallback when no builder exists for a task.
+ * A short list of tasks need to splice discovery-derived fields INTO
+ * nested structures in the fixture (e.g. `create_media_buy` injects
+ * `product_id` into `packages[0]`) and can't be expressed by a top-level
+ * overlay. Those enrichers declare themselves fixture-aware via
+ * `FIXTURE_AWARE_ENRICHERS` below and the runner uses their output as-is.
+ *
+ * `sample_request` from YAML, when a task has no enricher, is used directly
+ * after context injection — preserves the "no handler, fixture is the wire
+ * payload" pattern.
  */
 
 import { resolveBrand, resolveAccount } from '../client';
 import type { TestOptions } from '../types';
 import type { StoryboardContext, StoryboardStep } from './types';
-import { injectContext } from './context';
+import { injectContext, type RunnerVariables } from './context';
 
-type RequestBuilder = (
+type RequestEnricher = (
   step: StoryboardStep,
   context: StoryboardContext,
   options: TestOptions
 ) => Record<string, unknown>;
+
+/** Legacy alias kept for external consumers pinned to the old terminology. */
+type RequestBuilder = RequestEnricher;
 
 /**
  * Placeholder `format_id` used when neither `list_creative_formats` discovery
@@ -46,7 +62,20 @@ const UNKNOWN_FORMAT_ID = Object.freeze({ agent_url: 'https://unknown.example.co
  */
 const FALLBACK_CALLER_AGENT_URL = 'https://e2e-orchestrator.adcontextprotocol.org/';
 
-const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
+/**
+ * Tasks whose enricher must see `sample_request` to produce the final
+ * payload — typically because it needs to splice discovery-derived fields
+ * INTO nested structures the fixture owns (arrays, object trees). For
+ * these, the runner uses the enricher's output verbatim and does not
+ * layer the fixture on top; the enricher is responsible for fixture
+ * precedence internally.
+ */
+const FIXTURE_AWARE_ENRICHERS = new Set<string>([
+  'create_media_buy', // merges discovery-derived product_id / pricing_option_id INTO fixture packages[0]
+  'comply_test_controller', // forces account.sandbox: true regardless of fixture
+]);
+
+const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   // ── Account & Audience ─────────────────────────────────
 
   sync_accounts(_step, _context, options) {
@@ -112,9 +141,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // $context.rights_id doesn't resolve, and downstream acquire_rights
     // steps fail with rights_not_found instead of the error the
     // storyboard is actually asserting (e.g., GOVERNANCE_DENIED).
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     const brand = resolveBrand(options);
     return {
       query: 'available rights for advertising',
@@ -218,9 +244,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // are hand-authored to exercise specific seller behaviors (creative
     // assignment, targeting overlay swaps, pause/resume/cancel, etc.) and the
     // builder should not override the intent.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
 
     // `account` is required per bundled/media-buy/update-media-buy-request.json —
     // sellers enforce governance and account resolution against it.
@@ -273,9 +296,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // ('json') is NOT in the spec's 5-literal union and its `type` is
     // missing entirely, so any agent running the generated Zod schema
     // rejects the fallback with -32602 on both fields.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
-    }
     return {
       account: context.account ?? resolveAccount(options),
       catalogs: [
@@ -307,9 +327,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // Storyboards routinely ship spec-conformant event payloads with
     // event_time, content_ids, and custom_data siblings that only the
     // author knows. Honor sample_request when present.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       event_source_id: context.event_source_id ?? 'test-source',
       events: [
@@ -328,9 +345,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // specialisms carry per-usage-entry fields (vendor_cost, currency,
     // pricing_option_id) that the hardcoded fallback here omits, causing
     // agents running the generated Zod schema to reject every step.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
-    }
     const now = new Date();
     const monthAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
     return {
@@ -360,18 +374,12 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // declares `format_ids: ["..."]` in sample_request hits the wire as an
     // empty request and the agent returns unfiltered results — failing
     // round-trip / substitution-observer assertions silently.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {};
   },
 
   build_creative(step, context, options) {
     // Hand-authored sample_request can exercise slot-specific briefs, target
     // format overrides, or multi-format requests — honor it when present.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     const format = selectFormat(context);
     return {
       target_format_id: format?.format_id ?? context.format_id ?? UNKNOWN_FORMAT_ID,
@@ -397,9 +405,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   sync_creatives(step, context, options) {
     // Honor hand-authored sample_request for scenarios that require specific
     // creative shapes (delete/patch flows, format-scoped uploads, etc).
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
-    }
     const formats = (context.formats as Array<Record<string, unknown>> | undefined) ?? [];
     const now = Date.now();
 
@@ -481,9 +486,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   // ── Governance ─────────────────────────────────────────
 
   sync_governance(step, context, options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       accounts: [
         {
@@ -514,9 +516,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   calibrate_content(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       standards_id: context.content_standards_id ?? 'unknown',
       artifact: {
@@ -531,9 +530,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // Governance storyboards define scenario-specific plans in sample_request
     // (e.g., custom_policies for conditions, reallocation_threshold for denied).
     // Delegate to sample_request when present.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     const now = Date.now();
     const startDate = new Date(now + 24 * 60 * 60 * 1000).toISOString();
     const endDate = new Date(now + 90 * 24 * 60 * 60 * 1000).toISOString();
@@ -552,9 +548,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   check_governance(step, context, options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     // `caller` names the CALLER-AGENT's URL, not the brand — governance agents
     // use it for agent identity (rate limits, audit, JWS issuer correlation).
     // The brand belongs inside `payload`, where governance rules about the
@@ -579,9 +572,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   create_content_standards(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     // `anyOf: [{required: [policies]}, {required: [registry_policy_ids]}]` —
     // one must be present. Emit a minimal inline bespoke policy rather than
     // pinning a registry id the agent may not carry; storyboards that want
@@ -608,18 +598,12 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   update_content_standards(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       standards_id: context.content_standards_id ?? 'unknown',
     };
   },
 
   validate_content_delivery(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       standards_id: context.content_standards_id ?? 'unknown',
       records: [
@@ -636,9 +620,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   acquire_rights(step, context, options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       rights_id: context.rights_id ?? 'unknown',
       pricing_option_id: 'standard',
@@ -658,18 +639,12 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   update_rights(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       rights_id: context.rights_id ?? 'unknown',
     };
   },
 
   creative_approval(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       rights_id: context.rights_id ?? 'unknown',
       creative_id: context.creative_id ?? 'test-creative',
@@ -682,9 +657,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   // ── Sponsored Intelligence ─────────────────────────────
 
   si_get_offering(step, context, options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       offering_id: options.si_offering_id ?? 'e2e-test-offering',
       intent: options.si_context ?? 'E2E testing - checking SI offering availability',
@@ -696,9 +668,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // semantically plausible one so agents that dispatch on intent still
     // behave sensibly; storyboards override via sample_request when
     // testing intent-specific paths.
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       offering_id: context.offering_id ?? options.si_offering_id ?? 'e2e-test-offering',
       offering_token: context.offering_token,
@@ -715,9 +684,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   si_send_message(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       session_id: context.session_id ?? 'unknown',
       message: 'Tell me more about this product.',
@@ -725,9 +691,6 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   si_terminate_session(step, context, _options) {
-    if (step.sample_request) {
-      return injectContext({ ...step.sample_request }, context);
-    }
     return {
       session_id: context.session_id ?? 'unknown',
       reason: 'user_exit',
@@ -750,34 +713,94 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
 };
 
 /**
- * Build a request for a storyboard step.
+ * Enrich a storyboard step's request payload.
  *
- * Priority:
- * 1. User-provided --request override (from StoryboardRunOptions)
- * 2. Request builder for the task (builds from context + options)
- * 3. sample_request from YAML with context injection (fallback)
- * 4. Empty object
+ * Contract (issue #820):
+ *   - `sample_request`, when authored, is the authoritative base. The runner
+ *     injects context placeholders into it before calling here.
+ *   - An enricher (if registered for the task) produces fields that should
+ *     fill gaps the fixture left unset — discovery-derived identifiers,
+ *     envelope fields the author couldn't know at YAML-authoring time.
+ *   - Top-level merge: fixture wins on key conflicts. Fixture-aware
+ *     enrichers (see `FIXTURE_AWARE_ENRICHERS`) skip the generic merge and
+ *     return the final payload themselves.
+ *
+ * Returns `{}` when the task has no enricher and no `sample_request` — the
+ * runner's load-time validator prevents this for mutating tasks, so the
+ * empty return is reachable only for read tasks that have no fixture and
+ * no registered enricher (rare).
  */
-export function buildRequest(
+/**
+ * Envelope fields that live on every AdCP request and are owned by the
+ * storyboard author — `context.correlation_id`, runner-supplied
+ * `idempotency_key` aliases, webhook pointers, per-request extensions.
+ * Fixture-aware enrichers (`create_media_buy`, `comply_test_controller`)
+ * build their body from scratch and don't re-copy these fields, so the
+ * outer `enrichRequest` overlays them from sample_request after the
+ * enricher runs. Non-fixture-aware enrichers get these via the generic
+ * top-level merge below.
+ *
+ * If a future fixture-aware enricher starts emitting an envelope field
+ * itself (e.g. a scenario where the enricher needs to inject a specific
+ * `idempotency_key` independent of the fixture), the `=== undefined`
+ * guard below keeps the enricher's value — intentional, not a bug.
+ * Fixture envelope fields only flow through for fields the enricher
+ * didn't set.
+ */
+const ENVELOPE_FIELDS = ['context', 'ext', 'push_notification_config', 'idempotency_key'] as const;
+
+export function enrichRequest(
   step: StoryboardStep,
   context: StoryboardContext,
-  options: TestOptions
+  options: TestOptions,
+  runnerVars?: RunnerVariables
 ): Record<string, unknown> {
-  const builder = REQUEST_BUILDERS[step.task];
-  if (builder) {
-    return builder(step, context, options);
+  const enricher = REQUEST_ENRICHERS[step.task];
+  const fixture =
+    step.sample_request !== undefined
+      ? (injectContext(
+          { ...(step.sample_request as Record<string, unknown>) },
+          context,
+          runnerVars
+        ) as Record<string, unknown>)
+      : undefined;
+
+  if (!enricher) return fixture ?? {};
+
+  const enriched = enricher(step, context, options);
+
+  // Fixture-aware enrichers already did the body merge internally and know
+  // the array/nested shapes better than a generic top-level overlay can.
+  // Envelope fields still flow through from sample_request.
+  if (FIXTURE_AWARE_ENRICHERS.has(step.task)) {
+    if (!fixture) return enriched;
+    const out: Record<string, unknown> = { ...enriched };
+    for (const field of ENVELOPE_FIELDS) {
+      if (fixture[field] !== undefined && out[field] === undefined) out[field] = fixture[field];
+    }
+    return out;
   }
 
-  // No builder — fall through to sample_request (handled by runner)
-  return {};
+  // Generic fixture-authoritative merge: fixture keys overlay enricher keys.
+  return fixture ? { ...enriched, ...fixture } : enriched;
 }
 
-/**
- * Check if a request builder exists for a task.
- */
-export function hasRequestBuilder(taskName: string): boolean {
-  return taskName in REQUEST_BUILDERS;
+/** True iff a request enricher is registered for this task. */
+export function hasRequestEnricher(taskName: string): boolean {
+  return taskName in REQUEST_ENRICHERS;
 }
+
+// ────────────────────────────────────────────────────────────
+// Legacy aliases — pre-#820 terminology. Kept for one release so
+// external consumers (repo greps found none, but public exports may
+// have downstream users) migrate at their own pace.
+// ────────────────────────────────────────────────────────────
+
+/** @deprecated Renamed to `enrichRequest`. Same behavior. */
+export const buildRequest = enrichRequest;
+
+/** @deprecated Renamed to `hasRequestEnricher`. Same behavior. */
+export const hasRequestBuilder = hasRequestEnricher;
 
 // ────────────────────────────────────────────────────────────
 // Selection helpers: pick the best item from discovered data

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -34,6 +34,18 @@ type RequestBuilder = (
  */
 const UNKNOWN_FORMAT_ID = Object.freeze({ agent_url: 'https://unknown.example.com/', id: 'unknown' });
 
+/**
+ * Placeholder `caller` URL for tasks whose schema names the CALLER-AGENT's
+ * URL (not the brand or the seller). `check_governance.caller` is the canonical
+ * case: governance agents bind this field to agent identity for rate limiting,
+ * audit trails, and (with `signed-requests`) JWS issuer correlation — emitting
+ * the brand domain here names the wrong entity and will confuse strict
+ * governance agents. Storyboards that care about a specific caller identity
+ * author sample_request; this is the fallback when neither fixture nor
+ * harness-supplied agent URL is present.
+ */
+const FALLBACK_CALLER_AGENT_URL = 'https://e2e-orchestrator.adcontextprotocol.org/';
+
 const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   // ── Account & Audience ─────────────────────────────────
 
@@ -543,19 +555,18 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     if (step.sample_request) {
       return injectContext({ ...step.sample_request }, context);
     }
-    // `caller` is `format: uri` per governance/check-governance-request.json
-    // — a bare domain fails strict JSON-schema validation. Prefix with
-    // `https://` so the fallback payload round-trips through the upstream
-    // schema when no sample_request is authored. Scheme-check defends against
-    // a future change to `resolveBrand` that could return a URL instead of a
-    // bare hostname (would otherwise produce `https://https://…`).
-    const brandDomain = resolveBrand(options).domain;
+    // `caller` names the CALLER-AGENT's URL, not the brand — governance agents
+    // use it for agent identity (rate limits, audit, JWS issuer correlation).
+    // The brand belongs inside `payload`, where governance rules about the
+    // advertised entity are evaluated. Using the fallback harness-orchestrator
+    // URL keeps the semantics honest when no sample_request is authored.
     return {
       plan_id: context.plan_id ?? 'unknown',
-      caller: brandDomain.includes('://') ? brandDomain : `https://${brandDomain}`,
+      caller: FALLBACK_CALLER_AGENT_URL,
       payload: {
         type: 'media_buy',
         account: context.account ?? resolveAccount(options),
+        brand: resolveBrand(options),
         total_budget: options.budget ?? 10000,
       },
     };
@@ -574,17 +585,23 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     // `anyOf: [{required: [policies]}, {required: [registry_policy_ids]}]` —
     // one must be present. Emit a minimal inline bespoke policy rather than
     // pinning a registry id the agent may not carry; storyboards that want
-    // real governance coverage will author sample_request.
+    // real governance coverage author sample_request.
+    //
+    // Contamination safeguards for the rare case a fallback hits a shared
+    // sandbox: `enforcement: "should"` keeps this from hardening into a deny
+    // rule against real content, and the ephemeral `policy_id` (timestamped
+    // + "e2e-fallback-" prefix) guarantees uniqueness per run so a stale
+    // policy can't be matched by accident.
     return {
       scope: {
         languages_any: ['en'],
-        description: 'E2E Test Content Standards',
+        description: 'E2E fallback content standards — replace via sample_request for real governance coverage',
       },
       policies: [
         {
-          policy_id: 'e2e_test_policy',
-          enforcement: 'must',
-          policy: 'E2E fallback policy — replace via sample_request for real governance coverage.',
+          policy_id: `e2e-fallback-${Date.now()}`,
+          enforcement: 'should',
+          policy: 'E2E fallback policy — storyboard author did not supply sample_request.',
         },
       ],
     };

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -522,9 +522,16 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     if (step.sample_request) {
       return injectContext({ ...step.sample_request }, context);
     }
+    // `caller` is `format: uri` per governance/check-governance-request.json
+    // — a bare domain fails strict JSON-schema validation. Prefix with
+    // `https://` so the fallback payload round-trips through the upstream
+    // schema when no sample_request is authored. Scheme-check defends against
+    // a future change to `resolveBrand` that could return a URL instead of a
+    // bare hostname (would otherwise produce `https://https://…`).
+    const brandDomain = resolveBrand(options).domain;
     return {
       plan_id: context.plan_id ?? 'unknown',
-      caller: resolveBrand(options).domain,
+      caller: brandDomain.includes('://') ? brandDomain : `https://${brandDomain}`,
       payload: {
         type: 'media_buy',
         account: context.account ?? resolveAccount(options),

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -21,6 +21,19 @@ type RequestBuilder = (
   options: TestOptions
 ) => Record<string, unknown>;
 
+/**
+ * Placeholder `format_id` used when neither `list_creative_formats` discovery
+ * nor accumulated `context.format_id` supplied one. Schema
+ * (core/format-id.json) requires `agent_url` in URI form, so a bare
+ * `"unknown"` string fails validation. `example.com` is reserved for
+ * documentation per RFC 2606 — an obvious fixture that strict JSON-schema
+ * validators accept and that downstream handlers resolve to a clean
+ * format-not-found error rather than an unrelated crash. Frozen so a
+ * builder that accidentally spread-mutates the shared constant hits a
+ * TypeError instead of silently corrupting sibling calls.
+ */
+const UNKNOWN_FORMAT_ID = Object.freeze({ agent_url: 'https://unknown.example.com/', id: 'unknown' });
+
 const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   // ── Account & Audience ─────────────────────────────────
 
@@ -188,7 +201,7 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     };
   },
 
-  update_media_buy(step, context, _options) {
+  update_media_buy(step, context, options) {
     // If the storyboard provides a sample_request, honor it — these requests
     // are hand-authored to exercise specific seller behaviors (creative
     // assignment, targeting overlay swaps, pause/resume/cancel, etc.) and the
@@ -197,7 +210,10 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
       return injectContext({ ...step.sample_request }, context);
     }
 
+    // `account` is required per bundled/media-buy/update-media-buy-request.json —
+    // sellers enforce governance and account resolution against it.
     const request: Record<string, unknown> = {
+      account: context.account ?? resolveAccount(options),
       media_buy_id: context.media_buy_id ?? 'unknown',
     };
 
@@ -346,7 +362,7 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     }
     const format = selectFormat(context);
     return {
-      target_format_id: format?.format_id ?? context.format_id ?? { agent_url: 'unknown', id: 'unknown' },
+      target_format_id: format?.format_id ?? context.format_id ?? UNKNOWN_FORMAT_ID,
       brand: resolveBrand(options),
       message: 'Create a test advertisement for an e-commerce brand promoting a summer sale.',
       quality: 'draft',
@@ -359,7 +375,7 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     return {
       request_type: 'single',
       creative_manifest: {
-        format_id: format?.format_id ?? context.format_id ?? { agent_url: 'unknown', id: 'unknown' },
+        format_id: format?.format_id ?? context.format_id ?? UNKNOWN_FORMAT_ID,
         name: 'E2E Test Creative',
         assets: {},
       },
@@ -382,14 +398,14 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
         ? formats.map((fmt, i) => ({
             creative_id: `test-creative-${now}-${i}`,
             name: `E2E Test Creative ${i + 1}`,
-            format_id: fmt.format_id ?? context.format_id ?? { agent_url: 'unknown', id: 'unknown' },
+            format_id: fmt.format_id ?? context.format_id ?? UNKNOWN_FORMAT_ID,
             assets: buildAssetsForFormat(fmt),
           }))
         : [
             {
               creative_id: `test-creative-${now}`,
               name: 'E2E Test Creative',
-              format_id: context.format_id ?? { agent_url: 'unknown', id: 'unknown' },
+              format_id: context.format_id ?? UNKNOWN_FORMAT_ID,
               assets: {
                 primary: {
                   asset_type: 'image',
@@ -421,7 +437,12 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     if (step.sample_request?.signal_ids) {
       return injectContext({ signal_ids: step.sample_request.signal_ids }, context);
     }
-    return {};
+    // `anyOf: [{required: [signal_spec]}, {required: [signal_ids]}]` — the
+    // schema rejects an empty object. Default to a discovery-style
+    // `signal_spec` so storyboards that omit `options.brief` still send a
+    // conforming request. A real test should author sample_request or pass
+    // options.brief; this is the minimally valid fallback.
+    return { signal_spec: 'E2E fallback signal discovery' };
   },
 
   activate_signal(step, context, _options) {
@@ -550,11 +571,22 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     if (step.sample_request) {
       return injectContext({ ...step.sample_request }, context);
     }
+    // `anyOf: [{required: [policies]}, {required: [registry_policy_ids]}]` —
+    // one must be present. Emit a minimal inline bespoke policy rather than
+    // pinning a registry id the agent may not carry; storyboards that want
+    // real governance coverage will author sample_request.
     return {
       scope: {
         languages_any: ['en'],
         description: 'E2E Test Content Standards',
       },
+      policies: [
+        {
+          policy_id: 'e2e_test_policy',
+          enforcement: 'must',
+          policy: 'E2E fallback policy — replace via sample_request for real governance coverage.',
+        },
+      ],
     };
   },
 

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -758,11 +758,10 @@ export function enrichRequest(
   const enricher = REQUEST_ENRICHERS[step.task];
   const fixture =
     step.sample_request !== undefined
-      ? (injectContext(
-          { ...(step.sample_request as Record<string, unknown>) },
-          context,
-          runnerVars
-        ) as Record<string, unknown>)
+      ? (injectContext({ ...(step.sample_request as Record<string, unknown>) }, context, runnerVars) as Record<
+          string,
+          unknown
+        >)
       : undefined;
 
   if (!enricher) return fixture ?? {};

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -19,7 +19,7 @@ import {
   type RunnerVariables,
 } from './context';
 import { runValidations, type ValidationContext } from './validations';
-import { buildRequest, hasRequestBuilder } from './request-builder';
+import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask, generateIdempotencyKey } from '../../utils/idempotency';
 import {
@@ -1142,51 +1142,19 @@ async function executeStep(
     };
   }
 
-  // Build request — priority:
+  // Build request — priority (issue #820, fixture-authoritative):
   // 1. User-provided --request override
-  // 2. For expect_error steps: use sample_request directly (preserves intentionally invalid input)
-  // 3. Request builder (builds from context + options, like hand-written scenarios)
-  // 4. sample_request from YAML with context injection (fallback)
+  // 2. For expect_error steps: sample_request directly (preserves intentionally invalid input)
+  // 3. enrichRequest — fixture is the base, enricher fills gaps (fixture wins conflicts)
+  // 4. sample_request with context injection when no enricher is registered
+  // 5. Empty object (only reachable for non-mutating tasks with neither fixture nor enricher)
   let request: Record<string, unknown>;
   if (options.request) {
     request = { ...options.request };
   } else if (step.expect_error && step.sample_request) {
     request = injectContext({ ...step.sample_request }, context, runState.runnerVars);
-  } else if (hasRequestBuilder(effectiveStep.task)) {
-    request = buildRequest(effectiveStep, context, options);
-    // Merge pass-through envelope fields from sample_request — builders
-    // don't include these, but storyboards define them for compliance
-    // testing. `context` and `ext` are opaque pass-through. `idempotency_key`
-    // must be forwarded so compliance storyboards can test replay semantics:
-    // the same `$generate:uuid_v4#<alias>` across two steps resolves to the
-    // same UUID, and the server sees both calls with that UUID (no auto-
-    // generated UUID overriding it at the client layer).
-    if (step.sample_request) {
-      if (step.sample_request.context !== undefined && request.context === undefined) {
-        request.context = injectContext({ context: step.sample_request.context }, context, runState.runnerVars).context;
-      }
-      if (step.sample_request.ext !== undefined && request.ext === undefined) {
-        request.ext = step.sample_request.ext;
-      }
-      if (
-        step.sample_request.push_notification_config !== undefined &&
-        request.push_notification_config === undefined
-      ) {
-        request.push_notification_config = injectContext(
-          { push_notification_config: step.sample_request.push_notification_config },
-          context,
-          runState.runnerVars
-        ).push_notification_config;
-      }
-      if (step.sample_request.idempotency_key !== undefined && request.idempotency_key === undefined) {
-        const resolved = injectContext(
-          { idempotency_key: step.sample_request.idempotency_key },
-          context,
-          runState.runnerVars
-        ).idempotency_key;
-        if (typeof resolved === 'string') request.idempotency_key = resolved;
-      }
-    }
+  } else if (hasRequestEnricher(effectiveStep.task)) {
+    request = enrichRequest(effectiveStep, context, options, runState.runnerVars);
   } else if (step.sample_request) {
     request = injectContext({ ...step.sample_request }, context, runState.runnerVars);
   } else {

--- a/test/lib/request-builder-jsonschema-roundtrip.test.js
+++ b/test/lib/request-builder-jsonschema-roundtrip.test.js
@@ -1,0 +1,185 @@
+/**
+ * JSON-schema round-trip invariant for storyboard request builders.
+ *
+ * Companion to `request-builder-schema-roundtrip.test.js`. That suite validates
+ * against generated Zod schemas, which do not enforce `format` keywords (e.g.
+ * `format: "uri"`) and use `passthrough()` instead of `additionalProperties:
+ * false`. This suite runs the same builder fallbacks through AJV against the
+ * upstream JSON schemas so format violations and strict-additionalProperties
+ * regressions surface as test failures.
+ *
+ * Walks every request JSON schema under `schemas/cache/latest/<domain>/*-request.json`,
+ * builds the fallback for any task that has a matching request builder, and
+ * asserts AJV validation succeeds. Issue #805 surfaced the bug class this
+ * guards: builder fallbacks whose shape is Zod-valid but JSON-schema-invalid.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const Ajv = require('ajv').default;
+const addFormats = require('ajv-formats').default;
+
+const { buildRequest, hasRequestBuilder } = require('../../dist/lib/testing/storyboard/request-builder.js');
+const { MUTATING_TASKS } = require('../../dist/lib/utils/idempotency.js');
+const { ADCP_VERSION } = require('../../dist/lib/version.js');
+
+const SCHEMA_ROOT = path.resolve(__dirname, '..', '..', 'schemas', 'cache', ADCP_VERSION);
+
+// Tasks whose schema requires idempotency_key but which aren't in
+// MUTATING_TASKS because they ship as webhooks, not MCP tools (so the Zod
+// schema lives outside TOOL_REQUEST_SCHEMAS). The runner still injects on
+// these; mirror that here.
+const EXTRA_MUTATING = new Set(['creative_approval', 'update_rights']);
+
+// Builders whose fallback is known to fail JSON-schema validation today.
+// Skipping these keeps the invariant focused on catching NEW regressions —
+// each entry is a separately-filable fix that doesn't belong in the same
+// change as the two #805 bugs. The `covered` guard below asserts the
+// intersection with actual builders is stable, so adding a builder to the
+// code without re-evaluating this list still fails the suite.
+const KNOWN_NONCONFORMING = new Map([
+  // All three use `agent_url: "unknown"` as a placeholder — schema requires URI.
+  ['build_creative', 'target_format_id.agent_url fallback is "unknown"; schema requires format: uri'],
+  ['preview_creative', 'creative_manifest.format_id.agent_url fallback is "unknown"; schema requires format: uri'],
+  ['sync_creatives', 'creatives[].format_id.agent_url fallback is "unknown"; schema requires format: uri'],
+  // Required fields missing from the fallback body.
+  ['create_content_standards', 'missing required `policies` / `registry_policy_ids` (anyOf unsatisfied)'],
+  ['get_signals', 'empty fallback; schema requires `signal_spec` or `signal_ids` (anyOf unsatisfied)'],
+  ['update_media_buy', 'missing required `account`'],
+]);
+
+const SYNTHETIC_IDEMPOTENCY_KEY = 'roundtrip_test_key_0000000000';
+
+const DEFAULT_OPTIONS = {
+  brand: { domain: 'acmeoutdoor.example' },
+  account: { brand: { domain: 'acmeoutdoor.example' }, operator: 'acmeoutdoor.example' },
+};
+
+function isMutating(task) {
+  return MUTATING_TASKS.has(task) || EXTRA_MUTATING.has(task);
+}
+
+function step(task) {
+  return { id: `test-${task}`, title: `Test ${task}`, task };
+}
+
+function walkJsonFiles(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkJsonFiles(full));
+    else if (entry.isFile() && entry.name.endsWith('.json')) out.push(full);
+  }
+  return out;
+}
+
+function loadAjv() {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  // Pre-register every schema so $ref resolution works regardless of lookup
+  // order. Skip duplicates silently — some schemas are reachable via both the
+  // flat per-domain tree and the bundled tree.
+  for (const file of walkJsonFiles(SCHEMA_ROOT)) {
+    let raw;
+    try {
+      raw = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch {
+      continue;
+    }
+    const id = raw.$id;
+    if (typeof id === 'string' && !ajv.getSchema(id)) {
+      ajv.addSchema(raw);
+    }
+  }
+  return ajv;
+}
+
+function collectRequestSchemas() {
+  // Walk the flat per-domain tree rather than `bundled/` so domains like
+  // `governance/` and `brand/` (which ship their schemas outside the bundled
+  // tree) are covered.
+  const out = [];
+  for (const entry of fs.readdirSync(SCHEMA_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'bundled' || entry.name === 'core') continue;
+    const domainDir = path.join(SCHEMA_ROOT, entry.name);
+    for (const file of walkJsonFiles(domainDir)) {
+      const base = path.basename(file, '.json');
+      if (!base.endsWith('-request')) continue;
+      const task = base.slice(0, -'-request'.length).replace(/-/g, '_');
+      out.push({ task, file });
+    }
+  }
+  return out;
+}
+
+function formatAjvErrors(errors) {
+  return (errors ?? [])
+    .slice(0, 5)
+    .map(e => `  path=${e.instancePath || '(root)'} keyword=${e.keyword} msg=${e.message}`)
+    .join('\n');
+}
+
+describe('Request builder JSON-schema round-trip', () => {
+  const ajv = loadAjv();
+  const pairs = collectRequestSchemas().filter(({ task }) => hasRequestBuilder(task));
+
+  for (const { task, file } of pairs) {
+    if (KNOWN_NONCONFORMING.has(task)) continue;
+
+    test(`${task} fallback round-trips through JSON schema`, () => {
+      const schema = JSON.parse(fs.readFileSync(file, 'utf-8'));
+      const validate = (typeof schema.$id === 'string' && ajv.getSchema(schema.$id)) || ajv.compile(schema);
+
+      const request = buildRequest(step(task), {}, DEFAULT_OPTIONS);
+
+      // Mirror the runner: inject an idempotency_key on mutating tasks when
+      // the builder didn't mint one. Non-mutating tasks (e.g. check_governance)
+      // must NOT receive one — the schema's `additionalProperties: false`
+      // would reject it, and that would be a genuine test failure.
+      if (isMutating(task) && request.idempotency_key === undefined) {
+        request.idempotency_key = SYNTHETIC_IDEMPOTENCY_KEY;
+      }
+
+      const ok = validate(request);
+      assert.ok(
+        ok,
+        ok
+          ? ''
+          : `${task} fallback fails JSON-schema validation:\n${formatAjvErrors(validate.errors)}\nrequest=${JSON.stringify(request, null, 2)}`
+      );
+    });
+  }
+
+  test('KNOWN_NONCONFORMING entries still reference real builders (stale-allowlist guard)', () => {
+    const covered = new Set(pairs.map(p => p.task));
+    const stale = [...KNOWN_NONCONFORMING.keys()].filter(t => !covered.has(t));
+    assert.deepStrictEqual(
+      stale,
+      [],
+      `KNOWN_NONCONFORMING lists task(s) with no matching builder+schema pair — delete these entries: ${stale.join(', ')}`
+    );
+  });
+
+  test('KNOWN_NONCONFORMING entries still fail (remove any that now pass)', () => {
+    const stillPassing = [];
+    for (const [task, reason] of KNOWN_NONCONFORMING) {
+      const match = pairs.find(p => p.task === task);
+      if (!match) continue;
+      const schema = JSON.parse(fs.readFileSync(match.file, 'utf-8'));
+      const validate = (typeof schema.$id === 'string' && ajv.getSchema(schema.$id)) || ajv.compile(schema);
+      const request = buildRequest(step(task), {}, DEFAULT_OPTIONS);
+      if (isMutating(task) && request.idempotency_key === undefined) {
+        request.idempotency_key = SYNTHETIC_IDEMPOTENCY_KEY;
+      }
+      if (validate(request)) stillPassing.push(`${task} (was: ${reason})`);
+    }
+    assert.deepStrictEqual(
+      stillPassing,
+      [],
+      `Builder(s) now PASS JSON-schema validation — remove from KNOWN_NONCONFORMING:\n  ${stillPassing.join('\n  ')}`
+    );
+  });
+});

--- a/test/lib/request-builder-jsonschema-roundtrip.test.js
+++ b/test/lib/request-builder-jsonschema-roundtrip.test.js
@@ -34,21 +34,12 @@ const SCHEMA_ROOT = path.resolve(__dirname, '..', '..', 'schemas', 'cache', ADCP
 const EXTRA_MUTATING = new Set(['creative_approval', 'update_rights']);
 
 // Builders whose fallback is known to fail JSON-schema validation today.
-// Skipping these keeps the invariant focused on catching NEW regressions —
-// each entry is a separately-filable fix that doesn't belong in the same
-// change as the two #805 bugs. The `covered` guard below asserts the
-// intersection with actual builders is stable, so adding a builder to the
-// code without re-evaluating this list still fails the suite.
-const KNOWN_NONCONFORMING = new Map([
-  // All three use `agent_url: "unknown"` as a placeholder — schema requires URI.
-  ['build_creative', 'target_format_id.agent_url fallback is "unknown"; schema requires format: uri'],
-  ['preview_creative', 'creative_manifest.format_id.agent_url fallback is "unknown"; schema requires format: uri'],
-  ['sync_creatives', 'creatives[].format_id.agent_url fallback is "unknown"; schema requires format: uri'],
-  // Required fields missing from the fallback body.
-  ['create_content_standards', 'missing required `policies` / `registry_policy_ids` (anyOf unsatisfied)'],
-  ['get_signals', 'empty fallback; schema requires `signal_spec` or `signal_ids` (anyOf unsatisfied)'],
-  ['update_media_buy', 'missing required `account`'],
-]);
+// Kept as an explicit allowlist so this invariant stays useful the moment a
+// future fallback drifts out of spec — add it here with a reason, fix it,
+// then remove the entry. Empty today; the guard tests below still run so any
+// newly-documented-and-then-fixed entry would surface via the "still-fail"
+// guard.
+const KNOWN_NONCONFORMING = new Map([]);
 
 const SYNTHETIC_IDEMPOTENCY_KEY = 'roundtrip_test_key_0000000000';
 

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -125,27 +125,25 @@ describe('Request Builder', () => {
       assert.strictEqual(result.brand_id, 'acmeoutdoor.example');
     });
 
-    test('honors step.sample_request when present', () => {
-      // Regression: the builder previously ignored sample_request for
-      // everything except brand_id, so a storyboard declaring specific
-      // query text / uses / countries hit the wire with the generic
-      // fallback. That silently broke scenarios like
-      // brand_rights/governance_denied where the buyer query matters
-      // for the rights-holder roster to return a non-empty list.
+    test('honors step.sample_request when present (fixture wins top-level conflicts)', () => {
+      // Under #820 (fixture-authoritative), every field the author specified
+      // in sample_request takes precedence over the enricher's fabrication.
+      // Fields the author omitted (brand_id here) are gap-filled by the
+      // enricher from resolveBrand(options) — the harness's run-scoped
+      // brand. Storyboards that specifically require brand_id to NOT be
+      // sent must omit it from the fixture and opt out of the enricher
+      // (not possible today without authoring an explicit null, tracked
+      // as a possible #820+ follow-up).
       const fixture = {
         buyer: { domain: 'pinnacle-agency.example' },
         query: 'licensed commercial rights for a regional outdoor retail campaign',
         uses: ['commercial', 'endorsement'],
       };
       const result = buildRequest(step('get_rights', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
-      assert.strictEqual(result.query, fixture.query);
-      assert.deepStrictEqual(result.uses, fixture.uses);
-      assert.deepStrictEqual(result.buyer, fixture.buyer);
-      assert.strictEqual(
-        result.brand_id,
-        undefined,
-        'brand_id from caller domain must not leak when sample_request omits it'
-      );
+      assert.strictEqual(result.query, fixture.query, 'fixture query wins');
+      assert.deepStrictEqual(result.uses, fixture.uses, 'fixture uses wins');
+      assert.deepStrictEqual(result.buyer, fixture.buyer, 'fixture buyer preserved');
+      assert.strictEqual(result.brand_id, 'acmeoutdoor.example', 'brand_id gap-filled from options.brand');
     });
   });
 
@@ -335,7 +333,12 @@ describe('Request Builder', () => {
       assert.strictEqual(result.signal_spec, undefined);
     });
 
-    test('brief takes priority over signal_ids', () => {
+    test('fixture signal_ids coexist with options.brief (both present; author-authored fields preserved)', () => {
+      // Under #820 (fixture-authoritative), the author's signal_ids are
+      // preserved; the enricher's `signal_spec` derived from `options.brief`
+      // is additive. `anyOf: [signal_spec, signal_ids]` accepts either or
+      // both, so the downstream agent receives a richer query (authored
+      // exact signal_ids plus the caller's natural-language brief).
       const s = step('get_signals', {
         sample_request: {
           signal_ids: [{ source: 'catalog', data_provider_domain: 'x.example', id: 'seg1' }],
@@ -343,8 +346,12 @@ describe('Request Builder', () => {
       });
       const options = { ...DEFAULT_OPTIONS, brief: 'override brief' };
       const result = buildRequest(s, {}, options);
-      assert.strictEqual(result.signal_spec, 'override brief');
-      assert.strictEqual(result.signal_ids, undefined);
+      assert.strictEqual(result.signal_spec, 'override brief', 'enricher gap-fills signal_spec from options.brief');
+      assert.deepStrictEqual(
+        result.signal_ids,
+        [{ source: 'catalog', data_provider_domain: 'x.example', id: 'seg1' }],
+        'fixture signal_ids are preserved (author wins)'
+      );
     });
 
     test('falls back to a minimal discovery signal_spec when no brief and no signal_ids', () => {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -347,9 +347,15 @@ describe('Request Builder', () => {
       assert.strictEqual(result.signal_ids, undefined);
     });
 
-    test('returns empty object when no brief and no signal_ids', () => {
+    test('falls back to a minimal discovery signal_spec when no brief and no signal_ids', () => {
+      // The get-signals-request schema requires anyOf [signal_spec, signal_ids];
+      // an empty object fails strict JSON-schema validation. With no brief
+      // and no authored signal_ids, emit a synthetic signal_spec so the
+      // request stays schema-conforming.
       const result = buildRequest(step('get_signals'), {}, DEFAULT_OPTIONS);
-      assert.deepStrictEqual(result, {});
+      assert.strictEqual(typeof result.signal_spec, 'string');
+      assert.ok(result.signal_spec.length > 0);
+      assert.strictEqual(result.signal_ids, undefined);
     });
 
     test('injects context placeholders in signal_ids', () => {

--- a/test/lib/storyboard-contributes-shorthand.test.js
+++ b/test/lib/storyboard-contributes-shorthand.test.js
@@ -41,7 +41,7 @@ describe('storyboard loader: branch_set + contributes shorthand', () => {
     steps:
       - id: create_buy_past_start_reject
         title: Reject
-        task: create_media_buy
+        task: get_media_buys
         contributes: true`
     );
     const parsed = parseStoryboard(yamlContent);
@@ -61,7 +61,7 @@ describe('storyboard loader: branch_set + contributes shorthand', () => {
     steps:
       - id: s
         title: S
-        task: create_media_buy
+        task: get_media_buys
         contributes: false`
     );
     const parsed = parseStoryboard(yamlContent);
@@ -81,7 +81,7 @@ describe('storyboard loader: branch_set + contributes shorthand', () => {
     steps:
       - id: s
         title: S
-        task: create_media_buy
+        task: get_media_buys
         contributes_to: f`
     );
     const parsed = parseStoryboard(yamlContent);
@@ -99,7 +99,7 @@ describe('storyboard loader: branch_set + contributes shorthand', () => {
     steps:
       - id: s
         title: S
-        task: create_media_buy
+        task: get_media_buys
         contributes: true
         contributes_to: f`
     );
@@ -114,7 +114,7 @@ describe('storyboard loader: branch_set + contributes shorthand', () => {
     steps:
       - id: s
         title: S
-        task: create_media_buy
+        task: get_media_buys
         contributes: true`
     );
     assert.throws(() => parseStoryboard(yamlContent), /only legal inside a phase that declares branch_set/);
@@ -131,7 +131,7 @@ describe('storyboard loader: branch_set + contributes shorthand', () => {
     steps:
       - id: s
         title: S
-        task: create_media_buy
+        task: get_media_buys
         contributes_to: other_flag`
     );
     assert.throws(() => parseStoryboard(yamlContent), /must equal enclosing phase's branch_set\.id/);


### PR DESCRIPTION
## Summary

Two related improvements that started as a #805 bug fix and grew into an architectural cleanup (#820):

- **#805 (floor):** every storyboard request-builder fallback now satisfies its upstream JSON schema. Adds an AJV round-trip invariant that catches `format` violations and strict `additionalProperties` regressions Zod misses.
- **#820 (ceiling):** storyboard runner is now fixture-authoritative. `sample_request` is the base payload; per-task "enricher" (formerly "builder") fills fields the fixture left unset. Mutating tasks without `sample_request` hard-fail at load time.

## Why both in one PR

Five consecutive fallback-shape bugs (#780 / #792 / #793 / #802 / #805) were all symptoms of the same root cause: the runner ran builders first and silently discarded authored fixtures on ~20 tasks. Fixing the floor (AJV) without fixing the ceiling (builder-first → fixture-first) would just reset the clock until the next drift. Three independent expert reviews converged on this framing; #820 was filed as the explicit architectural target before we decided to land both together.

## What changed

### Runner (`src/lib/testing/storyboard/runner.ts`)

New priority:
1. `options.request` override
2. `expect_error` + `sample_request` → sample_request verbatim (preserves intentionally invalid input)
3. `enrichRequest` — fixture is the base, enricher fills gaps (fixture wins every top-level conflict)
4. `sample_request` with context injection when no enricher is registered
5. Empty object (only reachable for non-mutating tasks with neither fixture nor enricher; load-time validator catches mutating)

Collapsed ~50 lines of builder-then-envelope-merge into a single `enrichRequest` call.

### Enricher engine (`src/lib/testing/storyboard/request-builder.ts`)

- `enrichRequest` replaces `buildRequest` (old export kept as `@deprecated` alias).
- `FIXTURE_AWARE_ENRICHERS` escape hatch for two tasks that splice discovery-derived fields into nested fixture structures: `create_media_buy` (array-level merge) and `comply_test_controller` (forces `account.sandbox: true`). Envelope fields (`context`, `ext`, `push_notification_config`, `idempotency_key`) flow through from the fixture after these enrichers run.
- Stripped ~20 early-return `if (step.sample_request) return injectContext(...)` blocks from simple passthrough enrichers — the runner handles that now via fixture-authoritative merge.

### Load-time hard-fail (`src/lib/testing/storyboard/loader.ts`)

`validateStoryboardShape` now rejects mutating tasks without `sample_request`. Opt-out: `expect_error: true` (author signals payload IS the test condition). Synthesized phases (request-signing, controller seeding) unaffected because their runtime-generated steps don't pass through `parseStoryboard`. Verified: 73/73 shipping compliance storyboards load clean.

### Six fallback shape fixes (from #805, before the architectural cleanup)

- `check_governance.caller` → URI-formatted (expert follow-up: now the harness-orchestrator URL, not the brand — brand moved into `payload` where it belongs)
- `build_creative` / `preview_creative` / `sync_creatives` → shared frozen `UNKNOWN_FORMAT_ID` with URI `agent_url`
- `update_media_buy` → required `account` injected
- `get_signals` → minimal `signal_spec` default instead of `{}`
- `create_content_standards` → minimal inline `policies[]` with `enforcement: 'should'` (expert follow-up: downgrade from `'must'` to prevent sandbox contamination; ephemeral `policy_id`)

### AJV round-trip invariant

`test/lib/request-builder-jsonschema-roundtrip.test.js` — validates every builder fallback against the upstream JSON schema. Complements the existing Zod round-trip test. `KNOWN_NONCONFORMING` allowlist is empty; self-pruning guard tests fire if any allowlisted task starts passing or an entry references a removed builder.

## Observable-behavior changes (call out for downstream reviewers)

1. **Fixture `account` now wins on four tasks** that previously had the hybrid `{ ...sample_request, account: context.account }` override pattern: `sync_catalogs`, `sync_creatives`, `report_usage`, `sync_audiences`. Audit fixtures on these if your tests depended on runner-substituted account.
2. **Mutating tasks without `sample_request` throw at load.** Any programmatic storyboard that omitted `sample_request` on a mutating step needs an `expect_error: true` opt-out or an authored fixture.
3. **Gap-filling is now real.** Fields the fixture omits get filled by the enricher (e.g. `get_rights.brand_id` from `resolveBrand(options)`). Storyboards that specifically need a field absent must author it explicitly.
4. **Co-existence:** under fixture-wins merge, options-derived fields (e.g. `options.brief` → `signal_spec`) and authored fields (`sample_request.signal_ids`) coexist in the request; they used to replace each other.

## Test plan

- [x] `node --test test/lib/request-builder-jsonschema-roundtrip.test.js` — 43 / 43 pass (AJV schema-strict, no allowlist)
- [x] `node --test test/lib/request-builder-schema-roundtrip.test.js` — 41 / 41 pass (Zod invariant, unchanged)
- [x] `node --test test/lib/request-builder.test.js` — 44 / 44 pass (unit tests; two updated for new semantics)
- [x] `node --test test/lib/storyboard-envelope-passthrough.test.js` — 4 / 4 pass (fixture-aware envelope pass-through preserved)
- [x] `node --test test/lib/storyboard-contributes-shorthand.test.js` — 9 / 9 pass (fixtures switched to read task; test was always about contributes semantics, not request construction)
- [x] Corpus load: 73 / 73 real compliance storyboards parse cleanly (one-off script: walks `compliance/cache/latest/` recursively, parses every YAML; 11 non-storyboard configs like `test-kits/*` fail pre-existing `id + phases` check)
- [x] `npm test` — **5407 / 5413** pass, 6 pre-existing skipped, 0 fail
- [x] `npm run build` + `npm run typecheck` clean
- [x] Three expert readouts on the #820 architecture (product / protocol / DX), plus a code-reviewer pass on the final diff — all "Ship it"

## Follow-ups

- Strict-vs-lenient run reporting (fourth proposal in #820) — orthogonal reporting-subsystem concern; tracked as a separate follow-up.
- Remove compat aliases (`buildRequest`, `hasRequestBuilder`) in the next major.

Closes #805. Closes #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)