### PR TITLE
feat(testing): step-level invariants.disable escape hatch (#815)

### DIFF
--- a/.changeset/step-level-invariants-disable.md
+++ b/.changeset/step-level-invariants-disable.md
@@ -1,0 +1,42 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard steps can now opt out of a default invariant for that step
+only. New `StoryboardStep.invariants.disable: string[]` mirrors the
+existing storyboard-level `invariants.disable` but scoped to one step:
+the runner skips calling the named invariants' `onStep` for that step
+and leaves every other invariant (and every other step) untouched.
+
+```yaml
+- id: check_plan_first_pass
+  task: check_governance
+  invariants:
+    disable: [governance.denial_blocks_mutation]
+```
+
+Motivating case: storyboards that exercise buyer recovery from a
+`check_governance` 200 `status: denied`. The `expect_error: true`
+escape introduced in 5.12.1 only covers wire-error denials
+(`adcp_error` responses). A 200 with `status: denied` is not a wire
+error, so the flag was semantically inapplicable — the invariant would
+anchor and flag every subsequent mutation in the run as a silent
+bypass. `invariants.disable` covers both shapes uniformly.
+
+Validation is fail-fast at runner start (matches the storyboard-level
+precedent):
+- unknown assertion id in step `invariants.disable` throws;
+- id already disabled storyboard-wide throws (dead code — remove one);
+- unknown top-level key (e.g. `disabled`) throws.
+
+The `governance.denial_blocks_mutation` failure message now names this
+field and renders the exact YAML snippet to paste, for every anchor
+shape. The previous message branched on anchor kind and suppressed the
+hint for 200-status denials — that suppression pointed authors at
+nothing. Unified under the one escape that works for both.
+
+`expect_error: true`'s implicit skip is unchanged. It remains the
+zero-ceremony path for expected-error contracts; `invariants.disable`
+is the explicit surface for everything else.
+
+Closes #815.

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -246,6 +246,7 @@ export {
   type Storyboard,
   type StoryboardInvariants,
   type StoryboardInvariantsObject,
+  type StepInvariantsObject,
   type StoryboardPhase,
   type StoryboardStep,
   type StoryboardValidation,

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -27,6 +27,7 @@ import type {
   StoryboardInvariants,
   StoryboardRunOptions,
   StoryboardStepResult,
+  StepInvariantsObject,
 } from './types';
 
 // ────────────────────────────────────────────────────────────
@@ -228,6 +229,86 @@ interface NormalisedInvariants {
 // Object form keys. Any other top-level key (common typo: `disabled`) is a
 // silent-no-op trap under the permissive spread, so we catch it at parse-time.
 const INVARIANTS_OBJECT_KEYS: ReadonlySet<string> = new Set(['disable', 'enable']);
+
+// Step-level form accepts only `disable`. Enabling an assertion for one step
+// has no coherent meaning (assertions reason across steps), so `enable` at
+// this scope is a parse-time authoring error.
+const STEP_INVARIANTS_OBJECT_KEYS: ReadonlySet<string> = new Set(['disable']);
+
+/**
+ * Validate every step's `invariants.disable` against the resolved assertion
+ * set for this run, and against the storyboard-level disable. Throws on
+ * unknown fields, unknown ids, and ids that are dead code because they're
+ * already disabled storyboard-wide. Called once at runner start so
+ * authoring mistakes surface before the first step runs.
+ *
+ * Accepts the resolved specs rather than the registry so a step can only
+ * reference assertions that actually run for this storyboard — same
+ * principle as the storyboard-level check.
+ */
+export function validateStepInvariants(
+  storyboard: Storyboard,
+  resolvedAssertions: AssertionSpec[]
+): void {
+  const resolvedIds = new Set(resolvedAssertions.map(spec => spec.id));
+  const storyboardDisable = new Set<string>();
+  if (storyboard.invariants && !Array.isArray(storyboard.invariants)) {
+    for (const id of storyboard.invariants.disable ?? []) storyboardDisable.add(id);
+  }
+
+  const problems: string[] = [];
+  for (const phase of storyboard.phases) {
+    for (const step of phase.steps) {
+      const stepInvariants = step.invariants;
+      if (!stepInvariants) continue;
+      const unknownField = Object.keys(stepInvariants).filter(k => !STEP_INVARIANTS_OBJECT_KEYS.has(k));
+      if (unknownField.length > 0) {
+        problems.push(
+          `Step "${step.id}" invariants has unknown field${unknownField.length > 1 ? 's' : ''}: ${unknownField.join(', ')}. ` +
+            `Supported step-level fields are: ${[...STEP_INVARIANTS_OBJECT_KEYS].sort().join(', ')}.`
+        );
+        continue;
+      }
+      for (const id of stepInvariants.disable ?? []) {
+        // Check the run-wide `disable` first — an id there is filtered out
+        // of the resolved set, so without this the "dead code" case would
+        // fall through to the more generic "not in resolved set" message.
+        if (storyboardDisable.has(id)) {
+          problems.push(
+            `Step "${step.id}" invariants.disable names "${id}", but the storyboard already disables it run-wide. ` +
+              `The step-level directive is dead code — remove one.`
+          );
+          continue;
+        }
+        if (!resolvedIds.has(id)) {
+          const candidates = [...resolvedIds];
+          const suggestion = suggestionClause([id], candidates);
+          problems.push(
+            `Step "${step.id}" invariants.disable names "${id}", which is not in the resolved assertion set for this run. ` +
+              suggestion +
+              `Resolved ids: ${candidates.sort().join(', ') || '(none)'}.`
+          );
+        }
+      }
+    }
+  }
+
+  if (problems.length > 0) throw new Error(problems.join(' '));
+}
+
+/**
+ * Test whether a step's `invariants.disable` names the given assertion id.
+ * Used by the runner to skip calling `onStep` for disabled invariants on
+ * the step — a single choke point that keeps individual assertion code
+ * unaware of the escape hatch.
+ */
+export function stepDisablesAssertion(
+  stepInvariants: StepInvariantsObject | undefined,
+  assertionId: string
+): boolean {
+  if (!stepInvariants?.disable) return false;
+  return stepInvariants.disable.includes(assertionId);
+}
 
 function normaliseInvariants(invariants: StoryboardInvariants | undefined): NormalisedInvariants {
   if (!invariants) return { disable: [], enable: [] };

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -246,10 +246,7 @@ const STEP_INVARIANTS_OBJECT_KEYS: ReadonlySet<string> = new Set(['disable']);
  * reference assertions that actually run for this storyboard — same
  * principle as the storyboard-level check.
  */
-export function validateStepInvariants(
-  storyboard: Storyboard,
-  resolvedAssertions: AssertionSpec[]
-): void {
+export function validateStepInvariants(storyboard: Storyboard, resolvedAssertions: AssertionSpec[]): void {
   const resolvedIds = new Set(resolvedAssertions.map(spec => spec.id));
   const storyboardDisable = new Set<string>();
   if (storyboard.invariants && !Array.isArray(storyboard.invariants)) {
@@ -302,10 +299,7 @@ export function validateStepInvariants(
  * the step — a single choke point that keeps individual assertion code
  * unaware of the escape hatch.
  */
-export function stepDisablesAssertion(
-  stepInvariants: StepInvariantsObject | undefined,
-  assertionId: string
-): boolean {
+export function stepDisablesAssertion(stepInvariants: StepInvariantsObject | undefined, assertionId: string): boolean {
   if (!stepInvariants?.disable) return false;
   return stepInvariants.disable.includes(assertionId);
 }

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -288,14 +288,14 @@ registerOnce('governance.denial_blocks_mutation', {
     const anchor = (planId && state.deniedPlans.get(planId)) ?? state.runDenial;
     if (!anchor) return [];
 
-    // The `expect_error: true` escape only applies to wire-error denials
-    // (adcp_error responses). `check_governance` 200 with `status: denied`
-    // is not a wire error, so expect_error semantics don't cover it — don't
-    // misdirect the author to a flag that would have no effect.
+    // Always surface the step-level escape hatch — it's the one hint that
+    // works for both wire-error denials and `check_governance` 200
+    // `status: denied`. Names the step, names the field, shows the YAML so
+    // the author doesn't have to re-derive the escape from source.
     const escapeHint =
-      anchor.signal === 'CHECK_GOVERNANCE_DENIED'
-        ? ''
-        : ` — if the denial at step "${anchor.stepId}" is an intentional recovery-path setup, mark it \`expect_error: true\` so the invariant does not anchor on it`;
+      `. If the denial at step "${anchor.stepId}" is an intentional recovery-path setup, add to that step:\n` +
+      `  invariants:\n` +
+      `    disable: [governance.denial_blocks_mutation]`;
 
     return [
       {

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -20,6 +20,7 @@ export type {
   Storyboard,
   StoryboardInvariants,
   StoryboardInvariantsObject,
+  StepInvariantsObject,
   StoryboardPhase,
   StoryboardStep,
   StoryboardValidation,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -74,7 +74,13 @@ import type {
 } from './types';
 import { DETAILED_SKIP_TO_CANONICAL } from './types';
 import type { TaskResult } from '../types';
-import { type AssertionContext, type AssertionSpec, resolveAssertions } from './assertions';
+import {
+  type AssertionContext,
+  type AssertionSpec,
+  resolveAssertions,
+  stepDisablesAssertion,
+  validateStepInvariants,
+} from './assertions';
 
 // ────────────────────────────────────────────────────────────
 // Runner-output contract helpers
@@ -450,6 +456,11 @@ async function executeStoryboardPass(
   // `resolveAssertions` throws on unknown ids — fail fast here rather than
   // silently skip, since a missing assertion means unknown conformance gaps.
   const assertions = resolveAssertions(storyboard.invariants);
+  // Step-level `invariants.disable` uses the resolved set as its universe:
+  // an id is only a valid step-level opt-out if it actually runs on this
+  // storyboard. Typos and dead-code references (already disabled run-wide)
+  // fail fast here for the same reason.
+  validateStepInvariants(storyboard, assertions);
   const assertionContexts = new Map<string, AssertionContext>();
   for (const spec of assertions) {
     assertionContexts.set(spec.id, {
@@ -690,6 +701,10 @@ async function executeStoryboardPass(
       // failure — that's what makes assertions gating, not advisory.
       for (const spec of assertions) {
         if (!spec.onStep) continue;
+        // Per-step opt-out: authors use `step.invariants.disable: [id]` to
+        // suppress a default invariant on a step that deliberately models
+        // behavior the invariant would flag (validated at runner start).
+        if (stepDisablesAssertion(step.invariants, spec.id)) continue;
         const raw = await spec.onStep(assertionContexts.get(spec.id)!, result);
         for (const r of raw) {
           const full: AssertionResult = { ...r, assertion_id: spec.id, scope: 'step', step_id: step.id };

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -133,6 +133,15 @@ export interface StoryboardInvariantsObject {
  * Every id in `disable` MUST be in the assertion set resolved for this
  * run. An unknown id, or an id already suppressed storyboard-wide, is
  * dead code and fails fast at runner start rather than silently no-op.
+ *
+ * Semantics for stateful invariants: disable means the invariant does
+ * not OBSERVE the step. Invariants that accumulate per-step state
+ * (e.g. `status.monotonic`'s last-observed transition anchor) will
+ * therefore miss any observation the disabling step would have
+ * contributed. That's the point for `governance.denial_blocks_mutation`
+ * (a deliberate setup is not an anchor); for accumulator-style
+ * invariants, prefer disabling run-wide if the missed observation
+ * would hide later violations.
  */
 export interface StepInvariantsObject {
   disable?: string[];

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -117,6 +117,28 @@ export interface StoryboardInvariantsObject {
 }
 
 /**
+ * Per-step invariant opt-out. Mirrors `StoryboardInvariantsObject.disable`
+ * but scoped to a single step — the runner skips calling the named
+ * assertions' `onStep` for that step only. Use when a step deliberately
+ * models behavior a default invariant would otherwise flag (e.g. a
+ * `check_governance` 200 `status: denied` setting up a buyer-recovery
+ * sequence that the `governance.denial_blocks_mutation` invariant would
+ * anchor).
+ *
+ * Step-level is narrower on purpose — there is no `enable`. Enabling an
+ * assertion for a single step makes no sense at this scope (assertions
+ * reason across steps), and disallowing it at the type level removes a
+ * footgun. Only `disable` is accepted.
+ *
+ * Every id in `disable` MUST be in the assertion set resolved for this
+ * run. An unknown id, or an id already suppressed storyboard-wide, is
+ * dead code and fails fast at runner start rather than silently no-op.
+ */
+export interface StepInvariantsObject {
+  disable?: string[];
+}
+
+/**
  * Fixture entries the runner seeds into the seller via `comply_test_controller`
  * pre-flight (adcp#2585, adcp#2743). Each array entry carries its id field(s)
  * alongside the body the runner forwards into `params.fixture` for the
@@ -244,6 +266,14 @@ export interface StoryboardStep {
   stateful?: boolean;
   /** When true, the step passes if the task returns an error */
   expect_error?: boolean;
+  /**
+   * Per-step invariant opt-out. See `StepInvariantsObject`. Use when a
+   * specific step deliberately trips a default invariant (e.g. a
+   * `check_governance` 200 `status: denied` that is the setup for a
+   * buyer-recovery sequence, which `governance.denial_blocks_mutation`
+   * would otherwise anchor for the remainder of the run).
+   */
+  invariants?: StepInvariantsObject;
   /**
    * When true, suppress the runner's `idempotency_key` auto-injection on a
    * mutating step so the storyboard can exercise the server's missing-key

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -458,3 +458,133 @@ describe('runStoryboard: assertion hooks', () => {
     assert.ok(withAssertion.assertions.every(a => a.passed));
   });
 });
+
+describe('runStoryboard: step-level invariants.disable', () => {
+  beforeEach(() => clearAssertionRegistry());
+
+  function buildStoryboardWithStepDisable(stepInvariants, { rootInvariants } = {}) {
+    const sb = buildStoryboard(rootInvariants ? { invariants: rootInvariants } : undefined);
+    sb.phases[0].steps[1].invariants = stepInvariants;
+    return sb;
+  }
+
+  it('skips onStep only for the named assertion on the disabling step', async () => {
+    const stepIds = [];
+    registerAssertion({
+      id: 'obs.per_step',
+      description: 'observes every step',
+      default: true,
+      onStep(_ctx, stepResult) {
+        stepIds.push(stepResult.step_id);
+        return [];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    try {
+      await runStoryboard(
+        url,
+        buildStoryboardWithStepDisable({ disable: ['obs.per_step'] }),
+        runnerOptions
+      );
+    } finally {
+      server.close();
+    }
+    // Step s2 disabled the assertion — s1 must still have fired.
+    assert.deepStrictEqual(stepIds, ['s1']);
+  });
+
+  it('leaves other assertions running on the disabling step', async () => {
+    const observed = [];
+    registerAssertion({
+      id: 'obs.disabled',
+      description: 'observes every step (disabled on s2)',
+      default: true,
+      onStep(_ctx, stepResult) {
+        observed.push(['disabled', stepResult.step_id]);
+        return [];
+      },
+    });
+    registerAssertion({
+      id: 'obs.untouched',
+      description: 'also observes every step (never disabled)',
+      default: true,
+      onStep(_ctx, stepResult) {
+        observed.push(['untouched', stepResult.step_id]);
+        return [];
+      },
+    });
+    const { server, url } = await startStubAgent();
+    try {
+      await runStoryboard(
+        url,
+        buildStoryboardWithStepDisable({ disable: ['obs.disabled'] }),
+        runnerOptions
+      );
+    } finally {
+      server.close();
+    }
+    // The untouched assertion fires on both steps. The disabled one fires on s1 only.
+    assert.deepStrictEqual(observed, [
+      ['disabled', 's1'],
+      ['untouched', 's1'],
+      ['untouched', 's2'],
+    ]);
+  });
+
+  it('throws at run start when a step disables an assertion not in the resolved set', async () => {
+    registerAssertion({ id: 'registered.default', description: '', default: true });
+    const { server, url } = await startStubAgent();
+    try {
+      await assert.rejects(
+        () =>
+          runStoryboard(
+            url,
+            buildStoryboardWithStepDisable({ disable: ['never.registered'] }),
+            runnerOptions
+          ),
+        /Step "s2" invariants\.disable names "never\.registered".*not in the resolved assertion set/s
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it('throws at run start when a step disables an id the storyboard already disables run-wide', async () => {
+    registerAssertion({ id: 'will.be.root.disabled', description: '', default: true });
+    const { server, url } = await startStubAgent();
+    try {
+      await assert.rejects(
+        () =>
+          runStoryboard(
+            url,
+            buildStoryboardWithStepDisable(
+              { disable: ['will.be.root.disabled'] },
+              { rootInvariants: { disable: ['will.be.root.disabled'] } }
+            ),
+            runnerOptions
+          ),
+        /already disables it run-wide.*dead code/s
+      );
+    } finally {
+      server.close();
+    }
+  });
+
+  it('throws at run start on unknown step-level field (common typo: `disabled`)', async () => {
+    registerAssertion({ id: 'some.default', description: '', default: true });
+    const { server, url } = await startStubAgent();
+    try {
+      await assert.rejects(
+        () =>
+          runStoryboard(
+            url,
+            buildStoryboardWithStepDisable({ disabled: ['some.default'] }),
+            runnerOptions
+          ),
+        /Step "s2" invariants has unknown field: disabled/
+      );
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -515,7 +515,10 @@ describe('runStoryboard: step-level invariants.disable', () => {
     } finally {
       server.close();
     }
-    // The untouched assertion fires on both steps. The disabled one fires on s1 only.
+    // Observation order is the runner's documented contract (assertions.ts:
+    // registration order) × the per-step loop (runner.ts:702). Outer axis is
+    // the step, inner axis is the spec in registration order. A breaking
+    // change to either loop should trip this test.
     assert.deepStrictEqual(observed, [
       ['disabled', 's1'],
       ['untouched', 's1'],
@@ -568,5 +571,88 @@ describe('runStoryboard: step-level invariants.disable', () => {
     } finally {
       server.close();
     }
+  });
+
+  // Integration — the feature's motivating use case end-to-end. A stateful
+  // invariant anchors in onStep and fires on any later step when anchored;
+  // disabling it on the anchoring step must prevent the anchor from ever
+  // being set, so the later step passes cleanly. Models the shape
+  // `governance.denial_blocks_mutation` takes on a `check_governance` 200
+  // `status: denied` recovery-setup storyboard — #815.
+  function registerAnchorInvariant() {
+    registerAssertion({
+      id: 'test.denial_anchor',
+      description: 'anchors on s1, fires on any step while anchored',
+      default: true,
+      onStart: ctx => {
+        ctx.state.anchored = false;
+      },
+      onStep: (ctx, stepResult) => {
+        const state = ctx.state;
+        if (stepResult.step_id === 's1') {
+          state.anchored = true;
+          return [];
+        }
+        if (state.anchored) {
+          return [{ passed: false, description: 'fired while anchored' }];
+        }
+        return [];
+      },
+    });
+  }
+
+  // Helper: gather every per-step assertion validation the runner emitted
+  // for a given assertion id across the whole run. `overall_passed` isn't
+  // useful here — the stub intentionally doesn't implement executeTask, so
+  // steps fail at the transport layer regardless. What we care about is
+  // whether our invariant's onStep contributed a validation row.
+  function assertionValidations(result, assertionId) {
+    const hits = [];
+    for (const phase of result.phases ?? []) {
+      for (const step of phase.steps ?? []) {
+        for (const v of step.validations ?? []) {
+          if (v.check === 'assertion' && v.description?.startsWith(`${assertionId}:`)) {
+            hits.push({ step_id: step.step_id, passed: v.passed, description: v.description });
+          }
+        }
+      }
+    }
+    return hits;
+  }
+
+  it('disabling the invariant on the anchoring step prevents it from firing on a later step', async () => {
+    registerAnchorInvariant();
+    const { server, url } = await startStubAgent();
+    let result;
+    try {
+      // Disable `test.denial_anchor` on s1 (the anchoring step). s2 runs
+      // normally but has nothing to fire on because onStep never saw s1.
+      const sb = buildStoryboard();
+      sb.phases[0].steps[0].invariants = { disable: ['test.denial_anchor'] };
+      result = await runStoryboard(url, sb, runnerOptions);
+    } finally {
+      server.close();
+    }
+    assert.deepStrictEqual(
+      assertionValidations(result, 'test.denial_anchor'),
+      [],
+      'invariant must not contribute any validation — anchor was never set'
+    );
+  });
+
+  it('without the step-level disable, the same invariant does fire on the later step (negative control)', async () => {
+    registerAnchorInvariant();
+    const { server, url } = await startStubAgent();
+    let result;
+    try {
+      // Same storyboard, no step-level disable. s1 anchors, s2 fires.
+      result = await runStoryboard(url, buildStoryboard(), runnerOptions);
+    } finally {
+      server.close();
+    }
+    const hits = assertionValidations(result, 'test.denial_anchor');
+    assert.strictEqual(hits.length, 1, 'exactly one invariant contribution expected');
+    assert.strictEqual(hits[0].step_id, 's2');
+    assert.strictEqual(hits[0].passed, false);
   });
 });

--- a/test/lib/storyboard-assertion-registry.test.js
+++ b/test/lib/storyboard-assertion-registry.test.js
@@ -481,11 +481,7 @@ describe('runStoryboard: step-level invariants.disable', () => {
     });
     const { server, url } = await startStubAgent();
     try {
-      await runStoryboard(
-        url,
-        buildStoryboardWithStepDisable({ disable: ['obs.per_step'] }),
-        runnerOptions
-      );
+      await runStoryboard(url, buildStoryboardWithStepDisable({ disable: ['obs.per_step'] }), runnerOptions);
     } finally {
       server.close();
     }
@@ -515,11 +511,7 @@ describe('runStoryboard: step-level invariants.disable', () => {
     });
     const { server, url } = await startStubAgent();
     try {
-      await runStoryboard(
-        url,
-        buildStoryboardWithStepDisable({ disable: ['obs.disabled'] }),
-        runnerOptions
-      );
+      await runStoryboard(url, buildStoryboardWithStepDisable({ disable: ['obs.disabled'] }), runnerOptions);
     } finally {
       server.close();
     }
@@ -536,12 +528,7 @@ describe('runStoryboard: step-level invariants.disable', () => {
     const { server, url } = await startStubAgent();
     try {
       await assert.rejects(
-        () =>
-          runStoryboard(
-            url,
-            buildStoryboardWithStepDisable({ disable: ['never.registered'] }),
-            runnerOptions
-          ),
+        () => runStoryboard(url, buildStoryboardWithStepDisable({ disable: ['never.registered'] }), runnerOptions),
         /Step "s2" invariants\.disable names "never\.registered".*not in the resolved assertion set/s
       );
     } finally {
@@ -575,12 +562,7 @@ describe('runStoryboard: step-level invariants.disable', () => {
     const { server, url } = await startStubAgent();
     try {
       await assert.rejects(
-        () =>
-          runStoryboard(
-            url,
-            buildStoryboardWithStepDisable({ disabled: ['some.default'] }),
-            runnerOptions
-          ),
+        () => runStoryboard(url, buildStoryboardWithStepDisable({ disabled: ['some.default'] }), runnerOptions),
         /Step "s2" invariants has unknown field: disabled/
       );
     } finally {

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -158,9 +158,10 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     assert.match(v.error, /GOVERNANCE_DENIED/);
     assert.match(v.error, /plan_id=plan-a/);
     assert.match(v.error, /media_buy_id=mb-1/);
-    // Wire-error denial: error message should point authors at the
-    // expect_error: true escape so they don't have to file an issue.
-    assert.match(v.error, /expect_error: true/);
+    // The error message points future authors at the step-level escape so
+    // they don't have to re-derive it from source. One hint for every
+    // anchor shape (wire-error AND check_governance 200 `status: denied`).
+    assert.match(v.error, /invariants:\s*\n\s*disable: \[governance\.denial_blocks_mutation\]/);
   });
 
   test('is plan-scoped — denial on plan A does not block mutation on plan B', () => {
@@ -199,10 +200,9 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     });
     const out = run([step, mutateStep({ planId: 'plan-b' })]);
     assert.match(out[1].output[0].error, /CHECK_GOVERNANCE_DENIED/);
-    // 200-status denials are not wire errors — `expect_error: true` has no
-    // effect on them, so the escape hint must NOT appear (it would send
-    // authors down a dead end).
-    assert.doesNotMatch(out[1].output[0].error, /expect_error: true/);
+    // 200-status denials get the same step-level escape hint as wire-error
+    // anchors — `invariants.disable` works for both shapes.
+    assert.match(out[1].output[0].error, /invariants:\s*\n\s*disable: \[governance\.denial_blocks_mutation\]/);
   });
 
   test('treats rejected media_buy status as NOT acquired', () => {
@@ -388,6 +388,22 @@ describe('default-invariants: governance.denial_blocks_mutation', () => {
     ]);
     assert.strictEqual(out[2].output[0].passed, false);
     assert.match(out[2].output[0].error, /run-wide/);
+  });
+
+  test('step-level invariants.disable short-circuits onStep so no anchor forms', () => {
+    // This simulates what the runner does when a step carries
+    // `invariants: { disable: [governance.denial_blocks_mutation] }` — it
+    // skips calling onStep entirely for that step. Verifies the contract
+    // from the invariant's side: no hidden state is set, so a subsequent
+    // mutation is not flagged.
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    // Denial step: runner does NOT call spec.onStep because the step
+    // disables this invariant. The invariant therefore never sees the
+    // denial and has no anchor to trip on later.
+    const mutation = mutateStep({ planId: 'plan-a' });
+    const out = spec.onStep(ctx, mutation);
+    assert.deepStrictEqual(out, []);
   });
 
   test('onStart resets runDenial so stale state does not bleed across runs', () => {


### PR DESCRIPTION
## Summary

Closes #815. Storyboard steps can now opt out of a default invariant for that step only via `StoryboardStep.invariants.disable`.

```yaml
- id: check_plan_first_pass
  task: check_governance
  invariants:
    disable: [governance.denial_blocks_mutation]
```

Shape mirrors the existing storyboard-level `invariants.disable`, scoped to one step. The runner skips calling the named invariants' `onStep` for that step and leaves every other invariant (and every other step) untouched — a single choke point, so no per-invariant code changes.

## Motivation

#813 fixed the false positive where `governance.denial_blocks_mutation` fired on buyer-recovery storyboards. Fix: skip anchoring when the denial step has `expect_error: true`. That only covers **wire-error** denials (`adcp_error` responses).

A `check_governance` 200 with `status: denied` is not a wire error, so `expect_error` was semantically inapplicable. A storyboard shaped like `check_governance → denied → correct → check_governance → approved → create_media_buy` had no opt-out. #815 filed the gap; this PR closes it with a uniform escape that works for both shapes and extends to any future invariant.

## DX decisions (per dx-expert review)

- **Spelling.** `invariants.disable` (not `acknowledge`/`skip`/`suppress`). Reuses the word storyboard-level authors already learned; only new concept is scope (step vs run).
- **Scope.** Only `disable` is accepted at step-level. `enable` at step scope has no coherent meaning (assertions reason across steps) — rejected at the type level and at parse time.
- **Error message.** Unified the `governance.denial_blocks_mutation` failure message to always render the exact YAML snippet to paste. Dropped the previous branching that suppressed the hint for 200-denied anchors — that suppression pointed authors at nothing.
- **`expect_error: true` is not folded in.** It remains a per-step *contract* ("this call should fail"); `invariants.disable` is a per-step *escape* ("don't run this check here"). Different questions, kept separate.

## Validation (fail-fast at runner start)

- Unknown id in step `invariants.disable` — named with a "Did you mean" suggestion.
- Id already disabled storyboard-wide — dead code, throws with "remove one".
- Unknown top-level key on step `invariants` (e.g. the `disabled` typo) — throws with the supported field list.

## Test plan

- [x] `npm test` — 5439 pass, 0 fail, 6 skipped (pre-existing).
- [x] `test/lib/storyboard-default-invariants.test.js`: error-message assertions updated; new test exercises the contract from the invariant side (runner skips onStep → no anchor → no trip).
- [x] `test/lib/storyboard-assertion-registry.test.js`: five new end-to-end tests against the stub MCP agent:
  - skips onStep for the named assertion on the disabling step only
  - leaves other assertions running on the same step
  - throws on unknown id in step-level disable
  - throws on dead-code id (already disabled run-wide)
  - throws on unknown top-level key (`disabled` typo)

## Files

- `src/lib/testing/storyboard/types.ts` — new `StepInvariantsObject`; `StoryboardStep.invariants` field.
- `src/lib/testing/storyboard/assertions.ts` — `validateStepInvariants()` + `stepDisablesAssertion()` helpers.
- `src/lib/testing/storyboard/runner.ts` — validation call + per-step skip in the assertion loop.
- `src/lib/testing/storyboard/default-invariants.ts` — unified error-message hint.
- `src/lib/testing/{index,storyboard/index}.ts` — export `StepInvariantsObject`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)