### PR TITLE
fix(testing): honor sample_request in sync_event_sources builder (#818)

### DIFF
--- a/.changeset/honor-sample-request-sync-event-sources.md
+++ b/.changeset/honor-sample-request-sync-event-sources.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+fix(testing): honor `step.sample_request` in storyboard `sync_event_sources` builder
+
+The storyboard request builder for `sync_event_sources` ignored `step.sample_request` and always emitted a generated `test-source-${Date.now()}` id. Storyboards (e.g., `sales_catalog_driven`) that author a specific `event_source_id` hit the wire with the generated id on sync, while downstream `log_event` / `provide_performance_feedback` steps sent the authored id — producing `EVENT_SOURCE_NOT_FOUND` even though the handler was implemented correctly.
+
+The builder now delegates to `step.sample_request` when present, matching the pattern used by `log_event`, `sync_catalogs`, `report_usage`, `list_creative_formats`, `get_rights`, and `sync_governance`.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-22
-> @adcp/client v5.12.0
+> @adcp/client v5.13.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-22
-> Library: @adcp/client v5.12.0
+> Library: @adcp/client v5.13.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.11.0",
+  "version": "5.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -262,7 +262,15 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
     };
   },
 
-  sync_event_sources(_step, context, options) {
+  sync_event_sources(step, context, options) {
+    // Honor hand-authored sample_request so storyboards can register a
+    // specific event_source_id that downstream log_event /
+    // provide_performance_feedback steps reference. Without this, the
+    // generated fallback id is synced while later steps send the authored
+    // id, producing EVENT_SOURCE_NOT_FOUND.
+    if (step.sample_request) {
+      return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
+    }
     return {
       account: context.account ?? resolveAccount(options),
       event_sources: [

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.12.0';
+export const LIBRARY_VERSION = '5.13.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.12.0',
+  library: '5.13.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T10:29:03.662Z',
+  generatedAt: '2026-04-22T15:25:17.137Z',
 } as const;
 
 /**

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -238,7 +238,14 @@ describe('Request Builder', () => {
         ],
       };
       const result = buildRequest(step('sync_event_sources', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.event_sources.length, 1, 'fallback entry must not be appended');
       assert.strictEqual(result.event_sources[0].event_source_id, 'amsterdam_website');
+      assert.strictEqual(result.event_sources[0].name, 'Amsterdam Website', 'authored name must survive');
+      assert.deepStrictEqual(
+        result.event_sources[0].event_types,
+        ['purchase', 'add_to_cart'],
+        'authored event_types must survive'
+      );
       assert.ok(result.account, 'account still injected');
     });
 

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -222,6 +222,48 @@ describe('Request Builder', () => {
       assert.ok(result.event_sources[0].event_source_id, 'should have event_source_id');
       assert.ok(Array.isArray(result.event_sources[0].event_types), 'should have event_types');
     });
+
+    test('honors step.sample_request so authored event_source_id reaches the wire', () => {
+      // Regression: the fallback generated `test-source-${Date.now()}` and
+      // ignored the authored id. Downstream log_event steps then referenced
+      // the authored id (e.g., "amsterdam_website") and agents returned
+      // EVENT_SOURCE_NOT_FOUND because no such source had been synced.
+      const fixture = {
+        event_sources: [
+          {
+            event_source_id: 'amsterdam_website',
+            name: 'Amsterdam Website',
+            event_types: ['purchase', 'add_to_cart'],
+          },
+        ],
+      };
+      const result = buildRequest(
+        step('sync_event_sources', { sample_request: fixture }),
+        {},
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(result.event_sources[0].event_source_id, 'amsterdam_website');
+      assert.ok(result.account, 'account still injected');
+    });
+
+    test('injects context into sample_request', () => {
+      const fixture = {
+        event_sources: [
+          {
+            event_source_id: '$context.event_source_id',
+            name: 'Dynamic Source',
+            event_types: ['purchase'],
+          },
+        ],
+      };
+      const context = { event_source_id: 'resolved-source-id' };
+      const result = buildRequest(
+        step('sync_event_sources', { sample_request: fixture }),
+        context,
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(result.event_sources[0].event_source_id, 'resolved-source-id');
+    });
   });
 
   describe('log_event', () => {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -237,11 +237,7 @@ describe('Request Builder', () => {
           },
         ],
       };
-      const result = buildRequest(
-        step('sync_event_sources', { sample_request: fixture }),
-        {},
-        DEFAULT_OPTIONS
-      );
+      const result = buildRequest(step('sync_event_sources', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
       assert.strictEqual(result.event_sources[0].event_source_id, 'amsterdam_website');
       assert.ok(result.account, 'account still injected');
     });
@@ -257,11 +253,7 @@ describe('Request Builder', () => {
         ],
       };
       const context = { event_source_id: 'resolved-source-id' };
-      const result = buildRequest(
-        step('sync_event_sources', { sample_request: fixture }),
-        context,
-        DEFAULT_OPTIONS
-      );
+      const result = buildRequest(step('sync_event_sources', { sample_request: fixture }), context, DEFAULT_OPTIONS);
       assert.strictEqual(result.event_sources[0].event_source_id, 'resolved-source-id');
     });
   });


### PR DESCRIPTION
## Summary
- Fixes #818: storyboard `sync_event_sources` request builder ignored `step.sample_request` and always sent a generated `test-source-${Date.now()}` id.
- Storyboards that author a specific `event_source_id` (e.g., `sales_catalog_driven` → `amsterdam_website`) synced the generated id while downstream `log_event` / `provide_performance_feedback` steps sent the authored id, producing `EVENT_SOURCE_NOT_FOUND`.
- Builder now delegates to `sample_request` when present, matching the pattern used by `log_event`, `sync_catalogs`, `report_usage`, `list_creative_formats`, `get_rights`, and `sync_governance`.

## Test plan
- [x] New unit test: `sync_event_sources honors step.sample_request so authored event_source_id reaches the wire`
- [x] New unit test: `sync_event_sources injects context into sample_request`
- [x] Existing fallback test still passes
- [x] `test/lib/request-builder.test.js` — 46/46 pass
- [x] `test/lib/request-builder-schema-roundtrip.test.js` — 41/41 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>