### PR TITLE
fix(testing): honor sample_request on add-shaped sync_audiences

### DIFF
--- a/.changeset/honor-sample-request-sync-audiences.md
+++ b/.changeset/honor-sample-request-sync-audiences.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+fix(testing): honor `step.sample_request` on add-shaped payloads in storyboard `sync_audiences` builder
+
+The storyboard request builder for `sync_audiences` only delegated to `step.sample_request` for delete or discovery shapes. Add-shaped payloads — where a storyboard authors `audience_id` with `add: [...]` identifiers — fell through to the generated fallback, which overwrote the authored id with `test-audience-${Date.now()}`. Downstream steps that referenced the authored id (e.g., `delete_audience` in the `audience_sync` specialism, or `$context.audience_id` substitutions) then hit `AUDIENCE_NOT_FOUND` because sync had registered a different id.
+
+The builder now delegates to `step.sample_request` whenever it's present (matching `sync_event_sources`, `sync_catalogs`, `sync_creatives`, and peers), falling back to the generated payload only when no `sample_request` is authored.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
 > Generated at: 2026-04-22
-> @adcp/client v5.12.0
+> @adcp/client v5.13.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
 > Generated at: 2026-04-22
-> Library: @adcp/client v5.12.0
+> Library: @adcp/client v5.13.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -44,9 +44,14 @@ const REQUEST_BUILDERS: Record<string, RequestBuilder> = {
   },
 
   sync_audiences(step, context, options) {
-    // Delegate to sample_request for delete/discovery patterns
-    const sampleAudiences = step.sample_request?.audiences as Array<Record<string, unknown>> | undefined;
-    if (sampleAudiences?.[0]?.delete || (step.sample_request && !step.sample_request.audiences)) {
+    // Honor hand-authored sample_request so storyboards can register a
+    // specific audience_id that downstream steps reference. Without this,
+    // add-shaped sample_request blocks (authored with audience_id + add[])
+    // fell through to the generated fallback id, and a later delete_audience
+    // or context-substitution step would hit AUDIENCE_NOT_FOUND because the
+    // sync had registered a different id. Matches the pattern used by
+    // sync_event_sources, sync_catalogs, and sync_creatives.
+    if (step.sample_request) {
       return injectContext({ ...step.sample_request, account: context.account ?? resolveAccount(options) }, context);
     }
     return {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.12.0';
+export const LIBRARY_VERSION = '5.13.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.12.0',
+  library: '5.13.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T10:29:03.662Z',
+  generatedAt: '2026-04-22T16:05:11.053Z',
 } as const;
 
 /**

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -149,6 +149,70 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('sync_audiences', () => {
+    test('generated fallback works with no sample_request', () => {
+      const result = buildRequest(step('sync_audiences'), {}, DEFAULT_OPTIONS);
+      assert.ok(result.account, 'account injected');
+      assert.ok(Array.isArray(result.audiences), 'audiences array present');
+      assert.ok(result.audiences[0].audience_id, 'generated audience_id');
+    });
+
+    test('honors step.sample_request on add-shaped payloads so authored audience_id reaches the wire', () => {
+      // Regression: the builder previously only delegated to sample_request
+      // for delete/discovery shapes. Add-shaped payloads fell through to the
+      // fallback, which overwrote the authored audience_id with a generated
+      // one. Downstream delete_audience / $context.audience_id references
+      // then hit AUDIENCE_NOT_FOUND because sync had registered a different
+      // id (observed in compliance/cache/latest/specialisms/audience-sync
+      // between create_audience and delete_audience).
+      const fixture = {
+        audiences: [
+          {
+            audience_id: 'adcp-test-audience-001',
+            name: 'AdCP test audience',
+            add: [
+              {
+                external_id: 'adcp-user-0001',
+                hashed_email: 'a000000000000000000000000000000000000000000000000000000000000000',
+              },
+            ],
+          },
+        ],
+      };
+      const result = buildRequest(step('sync_audiences', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.audiences.length, 1, 'fallback entry must not be appended');
+      assert.strictEqual(result.audiences[0].audience_id, 'adcp-test-audience-001');
+      assert.strictEqual(result.audiences[0].name, 'AdCP test audience', 'authored name must survive');
+      assert.strictEqual(result.audiences[0].add[0].external_id, 'adcp-user-0001', 'authored identifiers must survive');
+      assert.ok(result.account, 'account still injected');
+    });
+
+    test('honors step.sample_request on delete-shaped payloads', () => {
+      const fixture = {
+        audiences: [{ audience_id: 'adcp-test-audience-001', delete: true }],
+      };
+      const result = buildRequest(step('sync_audiences', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.audiences[0].audience_id, 'adcp-test-audience-001');
+      assert.strictEqual(result.audiences[0].delete, true);
+    });
+
+    test('honors discovery (no audiences array) sample_request', () => {
+      const fixture = { context: { correlation_id: 'audience_sync--discover_audiences' } };
+      const result = buildRequest(step('sync_audiences', { sample_request: fixture }), {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.context.correlation_id, 'audience_sync--discover_audiences');
+      assert.strictEqual(result.audiences, undefined, 'discovery call must not synthesize audiences');
+    });
+
+    test('injects context into sample_request', () => {
+      const fixture = {
+        audiences: [{ audience_id: '$context.audience_id', name: 'Dynamic', add: [{ external_id: 'u1' }] }],
+      };
+      const context = { audience_id: 'resolved-audience-id' };
+      const result = buildRequest(step('sync_audiences', { sample_request: fixture }), context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.audiences[0].audience_id, 'resolved-audience-id');
+    });
+  });
+
   describe('sync_catalogs', () => {
     test('builds valid catalog request', () => {
       const result = buildRequest(step('sync_catalogs'), {}, DEFAULT_OPTIONS);


### PR DESCRIPTION
## Summary
- Follow-up to #819 (issue #818). Same root-cause bug in the sibling builder `sync_audiences`.
- The builder previously only delegated to `step.sample_request` for **delete** or **discovery** shapes. Add-shaped payloads (storyboard authors `audience_id` with `add: [...]` identifiers) fell through to the generated fallback, which overwrote the authored id with `test-audience-${Date.now()}`.
- Downstream steps that reference the authored id — e.g., `delete_audience` in the `audience_sync` specialism, or any `$context.audience_id` substitution — then hit `AUDIENCE_NOT_FOUND` because sync had registered a different id.
- Confirmed latent in `compliance/cache/latest/specialisms/audience-sync/index.yaml`: `create_audience` authors `audience_id: "adcp-test-audience-001"`, `delete_audience` references the same id, but sync was sending a different generated id.
- Fix: delegate to `sample_request` whenever present (matches `sync_event_sources`, `sync_catalogs`, `sync_creatives`, peers).

## Test plan
- [x] New unit test: `honors step.sample_request on add-shaped payloads so authored audience_id reaches the wire`
- [x] New unit test: `honors step.sample_request on delete-shaped payloads` (regression guard)
- [x] New unit test: `honors discovery (no audiences array) sample_request`
- [x] New unit test: `injects context into sample_request` (`$context.audience_id` substitution)
- [x] Preserved generated-fallback test for the no-`sample_request` path
- [x] `test/lib/request-builder.test.js` — 49/49 pass

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>