### PR TITLE
feat(testing): strict/lenient response-schema reporting (closes #820)

### DIFF
--- a/.changeset/strict-validation-reporting.md
+++ b/.changeset/strict-validation-reporting.md
@@ -1,0 +1,42 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard runner: strict/lenient response-schema reporting (closes the
+final proposal from #820).
+
+`response_schema` validations now run the strict AJV path alongside the
+existing lenient Zod check and record the strict verdict on each
+`ValidationResult.strict` (new optional field). The step's pass/fail is
+unchanged — it remains Zod-driven so existing tests and downstream
+reporting stay backward-compatible. The strict verdict is additive
+signal.
+
+The runner aggregates the verdicts into a new
+`StoryboardResult.strict_validation_summary`:
+
+```ts
+{
+  checked: number;  // response_schema checks with an AJV validator available
+  passed: number;   // of checked, how many the agent passed under strict semantics
+  failed: number;   // checked - passed
+  delta: number;    // lenient-pass ∧ strict-fail — the agent's strictness gap
+}
+```
+
+`delta` is the signal agent developers need: responses that cleared Zod
+passthrough but fail AJV's `format: uri`, pattern, and other keywords Zod
+doesn't enforce on generated schemas. A green lenient run with `delta > 0`
+tells the developer their agent isn't yet production-ready for strict
+dispatchers, even though it passes today's test suite.
+
+Helper `summarizeStrictValidation(phases)` is exported from
+`@adcp/client/testing` so dashboards and CI formatters can compute the
+same summary over a filtered subset of phases without re-running
+validation.
+
+Absent when a run has no AJV-checkable `response_schema` validations —
+typical for storyboards dominated by `field_present` / `error_code` /
+`assertion` checks, and for tasks whose schema ships outside the
+`bundled/` tree the AJV loader walks today (notably brand-rights and
+governance schemas).

--- a/.changeset/strict-validation-reporting.md
+++ b/.changeset/strict-validation-reporting.md
@@ -12,31 +12,66 @@ unchanged — it remains Zod-driven so existing tests and downstream
 reporting stay backward-compatible. The strict verdict is additive
 signal.
 
-The runner aggregates the verdicts into a new
-`StoryboardResult.strict_validation_summary`:
+### Per-run summary
+
+Every `StoryboardResult` now carries a `strict_validation_summary`:
 
 ```ts
 {
-  checked: number;  // response_schema checks with an AJV validator available
-  passed: number;   // of checked, how many the agent passed under strict semantics
-  failed: number;   // checked - passed
-  delta: number;    // lenient-pass ∧ strict-fail — the agent's strictness gap
+  observable: boolean;         // false = no strict-eligible checks ran
+  checked: number;             // response_schema checks with AJV coverage
+  passed: number;              // of checked, how many cleared strict AJV
+  failed: number;              // checked - passed
+  strict_only_failures: number; // lenient-pass ∧ strict-fail — the #820 signal
+  lenient_also_failed: number;  // failed - strict_only_failures
 }
 ```
 
-`delta` is the signal agent developers need: responses that cleared Zod
-passthrough but fail AJV's `format: uri`, pattern, and other keywords Zod
-doesn't enforce on generated schemas. A green lenient run with `delta > 0`
-tells the developer their agent isn't yet production-ready for strict
-dispatchers, even though it passes today's test suite.
+`strict_only_failures` is the actionable number. Responses that cleared
+Zod passthrough but strict AJV rejected — typically `format: uri` or
+pattern violations Zod's generated `z.string()` doesn't enforce. A green
+lenient run with `strict_only_failures > 0` tells the developer their
+agent isn't production-ready for strict dispatchers.
 
-Helper `summarizeStrictValidation(phases)` is exported from
-`@adcp/client/testing` so dashboards and CI formatters can compute the
-same summary over a filtered subset of phases without re-running
-validation.
+`observable: false` with zeroed counters signals "run had no
+strict-eligible checks" (distinct from strict-clean). Dashboards and
+JUnit formatters MUST check `observable` before rendering counts.
 
-Absent when a run has no AJV-checkable `response_schema` validations —
-typical for storyboards dominated by `field_present` / `error_code` /
-`assertion` checks, and for tasks whose schema ships outside the
-`bundled/` tree the AJV loader walks today (notably brand-rights and
-governance schemas).
+### New helpers exported from `@adcp/client/testing`
+
+- `summarizeStrictValidation(phases)` — compute the summary over a
+  filtered subset of phases (e.g. render per-phase rollups in a
+  dashboard without re-running validation).
+- `listStrictOnlyFailures(phases)` — flat drill-down list of every
+  `strict_only_failure` with `{phase_id, step_id, task, variant,
+  issues}` for triage. Direct path from `strict_only_failures: 7` to
+  the seven offending responses without walking four levels of nested
+  arrays.
+
+### AJV coverage extended to flat-tree domains
+
+The AJV schema loader now indexes `governance/`, `brand/`,
+`content-standards/`, `account/`, `property/`, and `collection/`
+alongside `bundled/`. This closes a coverage gap where
+`strict_validation_summary` systematically under-reported for mutating
+tasks whose schemas ship outside the bundled tree —
+`check_governance`, `acquire_rights`, `creative_approval`,
+`sync_governance`, `sync_plans`, CRUD on property_list / collection_list,
+etc. Previously those validations returned `strict: undefined` and
+didn't count toward `checked`; now they grade strict-eligible, so
+`format: uri` violations on `caller` and `idempotency_key` pattern
+mismatches (protocol-wide requirements per AdCP 3.0 GA) surface in the
+strictness delta where they belong.
+
+### Out of scope — tracked as follow-ups
+
+- CLI summary line (`adcp storyboard run` prints the JSON field but no
+  human-readable summary yet).
+- `warning` field on strict-only failures so step-level output surfaces
+  the top issue instead of only the nested `strict.issues[]`.
+- Distinct signal when `selectResponseVariant` picks an async variant
+  that has no schema and falls back to sync (protocol reviewer's
+  follow-up #2).
+- Per-field envelope validation (`replayed`, `operation_id`, `context`,
+  `ext` value shapes) as a separate check type.
+- Opt-in `--strict` CLI flag that gates CI on `strict_only_failures == 0`.

--- a/.changeset/strict-validation-reporting.md
+++ b/.changeset/strict-validation-reporting.md
@@ -63,15 +63,53 @@ didn't count toward `checked`; now they grade strict-eligible, so
 mismatches (protocol-wide requirements per AdCP 3.0 GA) surface in the
 strictness delta where they belong.
 
-### Out of scope — tracked as follow-ups
+### CLI summary line
 
-- CLI summary line (`adcp storyboard run` prints the JSON field but no
-  human-readable summary yet).
-- `warning` field on strict-only failures so step-level output surfaces
-  the top issue instead of only the nested `strict.issues[]`.
-- Distinct signal when `selectResponseVariant` picks an async variant
-  that has no schema and falls back to sync (protocol reviewer's
-  follow-up #2).
+`adcp storyboard run` now prints a single human-readable line under the
+lenient pass/fail tally when `observable: true`:
+
+```
+✅ 32 passed, 0 failed, 3 skipped (1240ms)
+⚠️  strict: 11/18 passed (7 lenient-only — strict dispatcher would reject)
+```
+
+Silent when the run had no strict-eligible checks. The multi-storyboard
+local-agent mode aggregates across results before printing.
+
+### `ValidationResult.warning` on strict-only failures
+
+When Zod passes and AJV rejects, the step stays `passed: true` but a new
+`warning` field carries the top AJV issue:
+
+```
+"warning": "strict JSON-schema rejected /caller: must match format \"uri\" (+2 more AJV issues)"
+```
+
+This closes the loop for LLM-driven self-correction and CI graphs that
+scan `error`/`warning` fields — they can act on the strict signal
+without the runner flipping step pass/fail and breaking existing tests.
+
+### Async variant fallback signal
+
+When the agent's response advertises an async variant (`status:
+submitted` / `working` / `input-required`) but the tool schema doesn't
+ship a variant schema, validation falls back to the sync response
+schema. The fallback is now surfaced:
+
+- `StrictValidationVerdict.variant_fallback_applied: true`
+- `StrictValidationVerdict.requested_variant: 'working'`
+- `ValidationResult.warning` names the gap
+
+A conformance signal that was previously invisible (the tool accepts
+sync-shaped validation even though the agent sent an async shape) now
+tells the author: "this tool doesn't schema the variant your agent is
+using." AJV acceptance of the sync fallback doesn't mask the signal.
+
+### Out of scope — tracked follow-ups (#832)
+
 - Per-field envelope validation (`replayed`, `operation_id`, `context`,
-  `ext` value shapes) as a separate check type.
-- Opt-in `--strict` CLI flag that gates CI on `strict_only_failures == 0`.
+  `ext` value shapes) as a separate check type — needs a spec
+  contribution for `core/envelope.json`.
+- Opt-in `--strict` CLI flag that gates CI on
+  `strict_only_failures == 0` — waiting for real-world delta telemetry
+  before calibrating the gating policy.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1559,6 +1559,7 @@ async function handleStoryboardRun(args) {
     console.log(
       `${overallIcon} ${result.passed_count} passed, ${result.failed_count} failed, ${result.skipped_count} skipped (${result.total_duration_ms}ms)`
     );
+    printStrictSummary(result.strict_validation_summary);
   }
 
   process.exit(result.overall_passed ? 0 : 3);
@@ -2210,7 +2211,51 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
   console.log(
     `\n${overallIcon} ${result.passed_count} passed, ${result.failed_count} failed, ${result.skipped_count} skipped across ${result.results.length} storyboard(s)`
   );
+  printStrictSummary(aggregateStrictSummaries(result.results.map(r => r.strict_validation_summary)));
   process.exit(result.overall_passed ? 0 : 3);
+}
+
+/**
+ * Print the strict/lenient response-schema summary as a one-liner beneath
+ * the lenient pass/fail tally. Silent when the run had no strict-eligible
+ * checks (observable: false); visible only when something was graded.
+ * `strict_only_failures > 0` is the production-readiness signal — tint
+ * the icon to reflect it so scrolling eyes catch it.
+ */
+function printStrictSummary(summary) {
+  if (!summary || !summary.observable) return;
+  const { checked, passed, strict_only_failures: strictOnly } = summary;
+  const icon = strictOnly > 0 ? '⚠️ ' : '✅';
+  const tail = strictOnly > 0 ? ` (${strictOnly} lenient-only — strict dispatcher would reject)` : '';
+  console.log(`${icon} strict: ${passed}/${checked} passed${tail}`);
+}
+
+/**
+ * Aggregate per-storyboard strict summaries into one. Runs are
+ * independent grading passes against the same SDK; summing their
+ * counters produces the run-total signal the CLI summary needs.
+ * Returns a summary with `observable: true` iff any input was
+ * observable.
+ */
+function aggregateStrictSummaries(summaries) {
+  const out = {
+    observable: false,
+    checked: 0,
+    passed: 0,
+    failed: 0,
+    strict_only_failures: 0,
+    lenient_also_failed: 0,
+  };
+  for (const s of summaries) {
+    if (!s) continue;
+    if (s.observable) out.observable = true;
+    out.checked += s.checked;
+    out.passed += s.passed;
+    out.failed += s.failed;
+    out.strict_only_failures += s.strict_only_failures;
+    out.lenient_also_failed += s.lenient_also_failed;
+  }
+  return out;
 }
 
 /**

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -72,7 +72,13 @@ export type { RunnerVariables } from './context';
 export { WEBHOOK_ASSERTION_TASKS } from './webhook-assertions';
 
 // Runner
-export { runStoryboard, runStoryboardStep, getFirstStepPreview, summarizeStrictValidation } from './runner';
+export {
+  runStoryboard,
+  runStoryboardStep,
+  getFirstStepPreview,
+  summarizeStrictValidation,
+  listStrictOnlyFailures,
+} from './runner';
 
 // Parser (single-file load for spec evolution / targeted testing)
 export { parseStoryboard, loadStoryboardFile } from './loader';

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -37,6 +37,8 @@ export type {
   StoryboardPhaseResult,
   StoryboardResult,
   AssertionResult,
+  StrictValidationSummary,
+  StrictValidationVerdict,
 } from './types';
 export { WEBHOOK_IDEMPOTENCY_KEY_PATTERN } from './types';
 
@@ -70,7 +72,7 @@ export type { RunnerVariables } from './context';
 export { WEBHOOK_ASSERTION_TASKS } from './webhook-assertions';
 
 // Runner
-export { runStoryboard, runStoryboardStep, getFirstStepPreview } from './runner';
+export { runStoryboard, runStoryboardStep, getFirstStepPreview, summarizeStrictValidation } from './runner';
 
 // Parser (single-file load for spec evolution / targeted testing)
 export { parseStoryboard, loadStoryboardFile } from './loader';

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -70,6 +70,7 @@ import type {
   StoryboardPhaseResult,
   StoryboardStepResult,
   StoryboardStepPreview,
+  StrictValidationSummary,
   ValidationResult,
 } from './types';
 import { DETAILED_SKIP_TO_CANONICAL } from './types';
@@ -818,6 +819,7 @@ async function executeStoryboardPass(
   // order matches execution order.
   if (seedingPhaseResult) phaseResults.unshift(seedingPhaseResult);
   const schemasUsed = collectSchemasUsed(phaseResults);
+  const strictSummary = summarizeStrictValidation(phaseResults);
   const result: StoryboardResult = {
     storyboard_id: storyboard.id,
     storyboard_title: storyboard.title,
@@ -837,6 +839,7 @@ async function executeStoryboardPass(
     tested_at: new Date().toISOString(),
     ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
     ...(assertionResults.length > 0 ? { assertions: assertionResults } : {}),
+    ...(strictSummary ? { strict_validation_summary: strictSummary } : {}),
   };
 
   // Close protocol connections when the runner created its own client. The
@@ -961,6 +964,43 @@ function collectSchemasUsed(phases: StoryboardPhaseResult[]): Array<{ schema_id:
     }
   }
   return out;
+}
+
+/**
+ * Walk every response_schema validation and aggregate the strict/lenient
+ * delta. Returns undefined when no AJV schema was available on any check
+ * (nothing to summarize). See issue #820 follow-up.
+ *
+ * `checked` = validations with a `strict` verdict attached.
+ * `passed` / `failed` partition `checked` by `strict.valid`.
+ * `delta` = #(lenient-pass ∧ strict-fail) — the strictness gap the agent
+ * slipped past Zod that strict JSON-schema would have caught.
+ *
+ * Exported so callers post-processing a `StoryboardResult` (dashboards,
+ * CI formatters) can compute the same summary over a subset of phases
+ * without re-running validation.
+ */
+export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): StrictValidationSummary | undefined {
+  let checked = 0;
+  let passed = 0;
+  let delta = 0;
+  for (const phase of phases) {
+    for (const step of phase.steps) {
+      for (const v of step.validations) {
+        if (v.check !== 'response_schema' || v.strict === undefined) continue;
+        checked++;
+        if (v.strict.valid) {
+          passed++;
+        } else if (v.passed) {
+          // Lenient Zod accepted this response; strict AJV rejected it.
+          // That's the agent's strictness gap — the signal #820 wants.
+          delta++;
+        }
+      }
+    }
+  }
+  if (checked === 0) return undefined;
+  return { checked, passed, failed: checked - passed, delta };
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -71,6 +71,7 @@ import type {
   StoryboardStepResult,
   StoryboardStepPreview,
   StrictValidationSummary,
+  SchemaValidationError,
   ValidationResult,
 } from './types';
 import { DETAILED_SKIP_TO_CANONICAL } from './types';
@@ -839,7 +840,7 @@ async function executeStoryboardPass(
     tested_at: new Date().toISOString(),
     ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
     ...(assertionResults.length > 0 ? { assertions: assertionResults } : {}),
-    ...(strictSummary ? { strict_validation_summary: strictSummary } : {}),
+    strict_validation_summary: strictSummary,
   };
 
   // Close protocol connections when the runner created its own client. The
@@ -968,22 +969,71 @@ function collectSchemasUsed(phases: StoryboardPhaseResult[]): Array<{ schema_id:
 
 /**
  * Walk every response_schema validation and aggregate the strict/lenient
- * delta. Returns undefined when no AJV schema was available on any check
- * (nothing to summarize). See issue #820 follow-up.
+ * delta. Always returns a summary; `observable: false` signals "run had
+ * no strict-eligible checks" (distinct from strict-clean with zero
+ * findings). See issue #820 follow-up.
  *
- * `checked` = validations with a `strict` verdict attached.
+ * `checked` counts validations with a `strict` verdict attached.
  * `passed` / `failed` partition `checked` by `strict.valid`.
- * `delta` = #(lenient-pass ∧ strict-fail) — the strictness gap the agent
- * slipped past Zod that strict JSON-schema would have caught.
+ * `strict_only_failures` = #(lenient-pass ∧ strict-fail) — the agent's
+ * production-readiness gap.
+ * `lenient_also_failed` = #(lenient-fail ∧ strict-fail) — step already
+ * broken, strict-rejection isn't new signal.
  *
  * Exported so callers post-processing a `StoryboardResult` (dashboards,
  * CI formatters) can compute the same summary over a subset of phases
  * without re-running validation.
  */
-export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): StrictValidationSummary | undefined {
+/**
+ * Flatten every `strict_only_failure` (lenient-pass ∧ strict-fail) into a
+ * dashboard-friendly row list. Each row carries the step/phase context
+ * needed for triage without re-walking the nested result tree:
+ *
+ *   { phase_id, step_id, task, variant, issues }
+ *
+ * Exported because the ValidationResult tree is four levels deep
+ * (`phases[].steps[].validations[].strict.issues[]`) and a consumer
+ * seeing `strict_only_failures: 7` in the summary needs a direct path
+ * to the seven offending responses. This is that path.
+ *
+ * Returns `[]` on runs with no strict-only failures OR no AJV coverage
+ * (both cases produce zero rows). Inspect `strict_validation_summary`
+ * for the total counts.
+ */
+export function listStrictOnlyFailures(
+  phases: StoryboardPhaseResult[]
+): Array<{ phase_id: string; step_id: string; task: string; variant: string; issues: SchemaValidationError[] }> {
+  const rows: Array<{
+    phase_id: string;
+    step_id: string;
+    task: string;
+    variant: string;
+    issues: SchemaValidationError[];
+  }> = [];
+  for (const phase of phases) {
+    for (const step of phase.steps) {
+      for (const v of step.validations) {
+        if (v.check !== 'response_schema') continue;
+        if (v.strict === undefined) continue;
+        if (v.strict.valid) continue;
+        if (!v.passed) continue; // already counted by lenient path
+        rows.push({
+          phase_id: phase.phase_id,
+          step_id: step.step_id,
+          task: step.task,
+          variant: v.strict.variant,
+          issues: v.strict.issues ?? [],
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): StrictValidationSummary {
   let checked = 0;
   let passed = 0;
-  let delta = 0;
+  let strictOnlyFailures = 0;
   for (const phase of phases) {
     for (const step of phase.steps) {
       for (const v of step.validations) {
@@ -994,13 +1044,20 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
         } else if (v.passed) {
           // Lenient Zod accepted this response; strict AJV rejected it.
           // That's the agent's strictness gap — the signal #820 wants.
-          delta++;
+          strictOnlyFailures++;
         }
       }
     }
   }
-  if (checked === 0) return undefined;
-  return { checked, passed, failed: checked - passed, delta };
+  const failed = checked - passed;
+  return {
+    observable: checked > 0,
+    checked,
+    passed,
+    failed,
+    strict_only_failures: strictOnlyFailures,
+    lenient_also_failed: failed - strictOnlyFailures,
+  };
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -830,6 +830,16 @@ export interface ValidationResult {
    */
   observations?: unknown[];
   /**
+   * Non-fatal human-readable warning attached when a check `passed` but
+   * detected a softer issue the caller should still see — today used only
+   * by `response_schema` to surface the top strict-AJV issue when Zod
+   * accepts and AJV rejects (the "lenient-passes ∧ strict-fails" subset
+   * of issue #820). LLM-driven self-correction and CI graphs that scan
+   * `error`/`warning` fields can act on this without the runner flipping
+   * step pass/fail and breaking existing tests.
+   */
+  warning?: string;
+  /**
    * Issue #820 follow-up — strict JSON-schema (AJV) verdict for
    * `response_schema` checks. `passed` remains the lenient Zod outcome
    * (runner's historical pass/fail semantics); `strict` carries the
@@ -851,10 +861,20 @@ export interface ValidationResult {
  */
 export interface StrictValidationVerdict {
   valid: boolean;
-  /** Response variant AJV selected, e.g. `"sync"`, `"submitted"`, `"working"`, `"input-required"`. */
+  /** Response variant AJV ultimately validated against. After fallback: `"sync"`. */
   variant: string;
   /** Concrete AJV issues (RFC 6901 pointers) when `valid: false`. Absent when valid. */
   issues?: SchemaValidationError[];
+  /**
+   * True when the agent's response `status` field named an async variant
+   * (`submitted` / `working` / `input-required`) but no compiled schema
+   * existed for that variant, so validation fell back to the sync
+   * response schema. Conformance signal: the agent advertised an async
+   * shape this tool doesn't explicitly schema. Present only on fallback.
+   */
+  variant_fallback_applied?: boolean;
+  /** Variant requested by payload shape before fallback. Set iff `variant_fallback_applied`. */
+  requested_variant?: string;
 }
 
 export interface StoryboardStepPreview {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -829,6 +829,32 @@ export interface ValidationResult {
    * when the check has something to report; absent otherwise.
    */
   observations?: unknown[];
+  /**
+   * Issue #820 follow-up — strict JSON-schema (AJV) verdict for
+   * `response_schema` checks. `passed` remains the lenient Zod outcome
+   * (runner's historical pass/fail semantics); `strict` carries the
+   * AJV-with-formats-and-additionalProperties verdict separately so
+   * agent developers can see the strict/lenient delta without the
+   * runner failing a step that the Zod path accepts. Absent on non-
+   * response_schema checks or when no AJV schema is available.
+   */
+  strict?: StrictValidationVerdict;
+}
+
+/**
+ * Strict (AJV JSON-schema) verdict attached to a response_schema
+ * validation result. Informational — the step's pass/fail is driven by
+ * the lenient Zod path. `valid: false` with `valid_lenient: true`
+ * indicates the strict/lenient delta: the agent's response passes the
+ * generated Zod shape but fails strict JSON-schema (typically a
+ * `format` violation or an `additionalProperties: false` breach).
+ */
+export interface StrictValidationVerdict {
+  valid: boolean;
+  /** Response variant AJV selected, e.g. `"sync"`, `"submitted"`, `"working"`, `"input-required"`. */
+  variant: string;
+  /** Concrete AJV issues (RFC 6901 pointers) when `valid: false`. Absent when valid. */
+  issues?: SchemaValidationError[];
 }
 
 export interface StoryboardStepPreview {
@@ -938,6 +964,39 @@ export interface StoryboardResult {
    * failed.
    */
   assertions?: AssertionResult[];
+  /**
+   * Issue #820 follow-up — strict/lenient `response_schema` delta.
+   * `checked` counts `response_schema` validations that had an AJV schema
+   * available (the strict path); `passed` is how many of those the agent's
+   * response cleared under strict JSON-schema semantics (format enforcement
+   * on ref'd core schemas, required-field checks AJV runs alongside Zod).
+   * `delta` is the count of validations where lenient Zod accepted AND
+   * strict AJV rejected — the agent's risk surface when an upstream
+   * dispatcher turns on strict mode.
+   *
+   * Absent when the run had zero AJV-checkable `response_schema`
+   * validations. Absence means "unobservable" (e.g. the storyboard only
+   * exercised governance / brand-rights tasks whose schemas ship outside
+   * the AJV loader's bundled tree), NOT "strict-clean with zero findings".
+   * Downstream dashboards should distinguish the two states.
+   */
+  strict_validation_summary?: StrictValidationSummary;
+}
+
+export interface StrictValidationSummary {
+  /** Response-schema checks that had an AJV validator compiled (strict-eligible). */
+  checked: number;
+  /** Of `checked`, how many passed strict AJV. */
+  passed: number;
+  /** Of `checked`, how many failed strict AJV. Equals `checked - passed`. */
+  failed: number;
+  /**
+   * Count of validations where `passed` (lenient Zod) is true AND strict
+   * AJV rejected the response — the "lenient passes, strict fails" subset
+   * of `failed`. This is the agent's strictness gap: responses the Zod
+   * path waved through that a strict dispatcher would reject.
+   */
+  delta: number;
 }
 
 /**

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -965,38 +965,48 @@ export interface StoryboardResult {
    */
   assertions?: AssertionResult[];
   /**
-   * Issue #820 follow-up — strict/lenient `response_schema` delta.
-   * `checked` counts `response_schema` validations that had an AJV schema
-   * available (the strict path); `passed` is how many of those the agent's
-   * response cleared under strict JSON-schema semantics (format enforcement
-   * on ref'd core schemas, required-field checks AJV runs alongside Zod).
-   * `delta` is the count of validations where lenient Zod accepted AND
-   * strict AJV rejected — the agent's risk surface when an upstream
-   * dispatcher turns on strict mode.
-   *
-   * Absent when the run had zero AJV-checkable `response_schema`
-   * validations. Absence means "unobservable" (e.g. the storyboard only
-   * exercised governance / brand-rights tasks whose schemas ship outside
-   * the AJV loader's bundled tree), NOT "strict-clean with zero findings".
-   * Downstream dashboards should distinguish the two states.
+   * Issue #820 follow-up — strict/lenient `response_schema` delta. Always
+   * emitted by the runner; inspect `observable` first to distinguish
+   * "observed zero strict-eligible checks" from "observed N and graded
+   * them". Storyboards dominated by non-`response_schema` validations
+   * (`field_present`, `error_code`, pure `assertion` runs) will have
+   * `observable: false` and zeroed counters.
    */
   strict_validation_summary?: StrictValidationSummary;
 }
 
 export interface StrictValidationSummary {
-  /** Response-schema checks that had an AJV validator compiled (strict-eligible). */
+  /**
+   * True when at least one `response_schema` validation had an AJV
+   * validator compiled (the strict path could actually grade something).
+   * False means "unobservable": the run exercised only tasks whose JSON
+   * schema isn't registered, or only non-`response_schema` validations —
+   * NOT "strict-clean with zero findings". Downstream dashboards and
+   * CI formatters MUST check this before rendering the counts.
+   */
+  observable: boolean;
+  /** Response-schema checks that had an AJV validator compiled. */
   checked: number;
   /** Of `checked`, how many passed strict AJV. */
   passed: number;
   /** Of `checked`, how many failed strict AJV. Equals `checked - passed`. */
   failed: number;
   /**
-   * Count of validations where `passed` (lenient Zod) is true AND strict
-   * AJV rejected the response — the "lenient passes, strict fails" subset
-   * of `failed`. This is the agent's strictness gap: responses the Zod
-   * path waved through that a strict dispatcher would reject.
+   * Count of validations where lenient Zod accepted AND strict AJV
+   * rejected — the "silent failures" the agent ships today that a strict
+   * dispatcher would block. Subset of `failed`. This is the actionable
+   * production-readiness signal for agent developers: a green lenient run
+   * with `strict_only_failures > 0` is a migration trap.
    */
-  delta: number;
+  strict_only_failures: number;
+  /**
+   * Count of validations where BOTH lenient Zod AND strict AJV rejected —
+   * the step already failed under today's semantics, so strict rejection
+   * isn't new signal. Equals `failed - strict_only_failures`. Useful for
+   * dashboards that want to distinguish "already-failing" from
+   * "silently-failing" in the same run.
+   */
+  lenient_also_failed: number;
 }
 
 /**

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -287,7 +287,17 @@ function validateResponseSchema(
       schema_id,
       schema_url,
     };
-    return strict ? { ...base, strict } : base;
+    if (!strict) return base;
+    // Surface two kinds of strict-only signal via `warning` so step-level
+    // output (and LLM-driven self-correction that scans `error`/`warning`
+    // fields) sees something without flipping `passed`:
+    //   1. Strict-only FAILURE — Zod accepted but AJV rejected. Top issue.
+    //   2. Variant FALLBACK — agent advertised an async variant the tool
+    //      doesn't schema, so validation fell back to sync. AJV may still
+    //      accept, but the conformance signal is that the tool hasn't
+    //      declared the variant schema the agent is using.
+    const warning = buildStrictWarning(strict);
+    return warning ? { ...base, strict, warning } : { ...base, strict };
   }
 
   const schemaErrors = zodIssuesToSchemaErrors(parseResult.error.issues);
@@ -324,13 +334,18 @@ function computeStrictVerdict(taskName: string, payload: Record<string, unknown>
   // `variant: 'skipped'` means no AJV validator compiled for this task (no
   // strictness signal to emit); treat the same as "no AJV schema available".
   if (outcome.variant === 'skipped') return undefined;
+  const fallbackFields: Pick<StrictValidationVerdict, 'variant_fallback_applied' | 'requested_variant'> =
+    outcome.variant_fallback_applied
+      ? { variant_fallback_applied: true, requested_variant: outcome.requested_variant }
+      : {};
   if (outcome.valid) {
-    return { valid: true, variant: outcome.variant };
+    return { valid: true, variant: outcome.variant, ...fallbackFields };
   }
   return {
     valid: false,
     variant: outcome.variant,
     issues: outcome.issues.slice(0, 10).map(ajvIssueToSchemaError),
+    ...fallbackFields,
   };
 }
 
@@ -341,6 +356,35 @@ function ajvIssueToSchemaError(issue: ValidationIssue): SchemaValidationError {
     keyword: issue.keyword,
     message: issue.message,
   };
+}
+
+/**
+ * Render the strict verdict into a non-fatal warning for step-level
+ * output. Two cases produce signal (both preserve `passed`):
+ *   - Strict-only failure: Zod accepted, AJV rejected. Top AJV issue.
+ *   - Variant fallback: agent advertised an async variant without a
+ *     compiled schema; validation fell back to sync. Conformance gap
+ *     worth flagging even when AJV ultimately accepted.
+ * When both apply, both are joined. Returns undefined when neither
+ * applies (strict accepted and no fallback).
+ */
+function buildStrictWarning(strict: StrictValidationVerdict): string | undefined {
+  const parts: string[] = [];
+  if (strict.variant_fallback_applied && strict.requested_variant) {
+    parts.push(
+      `agent advertised status="${strict.requested_variant}" but the tool has no schema for that variant — validated against sync fallback`
+    );
+  }
+  if (!strict.valid && strict.issues && strict.issues.length > 0) {
+    const top = strict.issues[0];
+    if (top) {
+      const pointer = top.instance_path || '/';
+      const remaining = strict.issues.length - 1;
+      const more = remaining > 0 ? ` (+${remaining} more AJV issue${remaining === 1 ? '' : 's'})` : '';
+      parts.push(`strict JSON-schema rejected ${pointer}: ${top.message}${more}`);
+    }
+  }
+  return parts.length > 0 ? parts.join('; ') : undefined;
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -10,6 +10,7 @@
 
 import { TOOL_RESPONSE_SCHEMAS } from '../../utils/response-schemas';
 import { TRANSPORT_SUFFIX_REGEX } from '../../utils/a2a-discovery';
+import { validateResponse, type ValidationIssue } from '../../validation/schema-validator';
 import { ADCP_VERSION } from '../../version';
 import type { TaskResult } from '../types';
 import type {
@@ -19,6 +20,7 @@ import type {
   SchemaValidationError,
   StoryboardContext,
   StoryboardValidation,
+  StrictValidationVerdict,
   ValidationResult,
 } from './types';
 import { resolvePath, resolvePathAll, toJsonPointer } from './path';
@@ -269,14 +271,23 @@ function validateResponseSchema(
   // unwrapper as a text summary and is not part of the AdCP response schema.
   const { _message, ...dataWithoutMessage } = (taskResult.data ?? {}) as Record<string, unknown>;
   const parseResult = schema.safeParse(dataWithoutMessage);
+
+  // Strict (AJV) verdict runs alongside the lenient Zod check so the run
+  // report surfaces strictness deltas (issue #820 follow-up). The AJV path
+  // enforces `format` keywords and `additionalProperties: false` that Zod's
+  // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
+  // overall pass/fail stays Zod-driven to preserve backwards compatibility.
+  const strict = computeStrictVerdict(taskName, dataWithoutMessage);
+
   if (parseResult.success) {
-    return {
+    const base: ValidationResult = {
       check: 'response_schema',
       passed: true,
       description: validation.description,
       schema_id,
       schema_url,
     };
+    return strict ? { ...base, strict } : base;
   }
 
   const schemaErrors = zodIssuesToSchemaErrors(parseResult.error.issues);
@@ -287,7 +298,7 @@ function validateResponseSchema(
     .map(i => `${i.path.join('.')}: ${i.message}`)
     .join('; ');
 
-  return {
+  const failed: ValidationResult = {
     check: 'response_schema',
     passed: false,
     description: validation.description,
@@ -297,6 +308,38 @@ function validateResponseSchema(
     actual: schemaErrors,
     schema_id,
     schema_url,
+  };
+  return strict ? { ...failed, strict } : failed;
+}
+
+/**
+ * Run the strict AJV validator for `taskName` against the response payload.
+ * Returns undefined when no AJV schema is available (the client can't
+ * observe a strictness delta for tools whose JSON-schema doesn't ship with
+ * the SDK — notably the brand-rights and governance schemas that live
+ * outside the `bundled/` tree the loader walks today).
+ */
+function computeStrictVerdict(taskName: string, payload: Record<string, unknown>): StrictValidationVerdict | undefined {
+  const outcome = validateResponse(taskName, payload);
+  // `variant: 'skipped'` means no AJV validator compiled for this task (no
+  // strictness signal to emit); treat the same as "no AJV schema available".
+  if (outcome.variant === 'skipped') return undefined;
+  if (outcome.valid) {
+    return { valid: true, variant: outcome.variant };
+  }
+  return {
+    valid: false,
+    variant: outcome.variant,
+    issues: outcome.issues.slice(0, 10).map(ajvIssueToSchemaError),
+  };
+}
+
+function ajvIssueToSchemaError(issue: ValidationIssue): SchemaValidationError {
+  return {
+    instance_path: issue.pointer,
+    schema_path: issue.schemaPath,
+    keyword: issue.keyword,
+    message: issue.message,
   };
 }
 

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -132,8 +132,22 @@ function buildFileIndex(root: string): Map<string, string> {
     }
   }
 
-  // Async variants aren't bundled upstream — they live in the flat per-domain
-  // directory with $refs to core/context.json and core/ext.json.
+  // Async variants AND domain schemas that ship flat (not pre-bundled) both
+  // live in the per-domain directories. Walk each for sync request/response
+  // files and async variant files. Skip `bundled/` (already indexed above)
+  // and `core/` (pure $ref targets, no tools).
+  //
+  // Flat-tree domains include `governance/`, `brand/`, `account/`,
+  // `content-standards/`, `property/`, `collection/` — their schemas are
+  // NOT pre-resolved into `bundled/`, so a bundled-only walk would miss
+  // every `check_governance` / `acquire_rights` / `creative_approval` /
+  // `sync_governance` / `*_property_list` request-response pair. That gap
+  // (flagged by the ad-tech-protocol reviewer on PR #831) would leave
+  // protocol-wide-requirement-bearing tasks (idempotency_key pattern,
+  // `format: uri` on `caller`) invisible to the strict-validation signal.
+  // Register flat-tree sync pairs only when `bundled/` didn't already
+  // index them, so pre-resolved schemas (with $refs already inlined) win
+  // for any domain that ships both.
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     if (entry.name === 'bundled' || entry.name === 'core') continue;
@@ -149,6 +163,12 @@ function buildFileIndex(root: string): Map<string, string> {
       } else if (base.endsWith('-async-response-input-required')) {
         const tool = base.slice(0, -'-async-response-input-required'.length).replace(/-/g, '_');
         record(tool, 'input-required', file);
+      } else if (base.endsWith('-request')) {
+        const tool = base.slice(0, -'-request'.length).replace(/-/g, '_');
+        if (!index.has(`${tool}::request`)) record(tool, 'request', file);
+      } else if (base.endsWith('-response')) {
+        const tool = base.slice(0, -'-response'.length).replace(/-/g, '_');
+        if (!index.has(`${tool}::sync`)) record(tool, 'sync', file);
       }
     }
   }
@@ -178,16 +198,22 @@ function ensureInit(): LoaderState {
 }
 
 /**
- * Lazily load `core/` schemas on first compile of an async response variant.
- * Deferring keeps cold-start cheap for the common case (sync request/response).
+ * Lazily load `core/` and `enums/` schemas on first compile of a schema
+ * that may $ref them. Async response variants and flat-tree domain schemas
+ * (governance, brand, content-standards, account, property, collection)
+ * both dereference into these shared trees; bundled/ pre-resolves its own
+ * refs and doesn't need them. Deferring the load keeps cold-start cheap
+ * for consumers that only touch bundled/ tools.
  */
 function ensureCoreLoaded(s: LoaderState): void {
   if (s.coreLoaded) return;
-  const coreDir = path.join(s.root, 'core');
-  for (const file of walkJsonFiles(coreDir)) {
-    const schema = loadJson(file);
-    if (typeof schema.$id === 'string' && !s.ajv.getSchema(schema.$id)) {
-      s.ajv.addSchema(schema);
+  for (const dir of ['core', 'enums']) {
+    const abs = path.join(s.root, dir);
+    for (const file of walkJsonFiles(abs)) {
+      const schema = loadJson(file);
+      if (typeof schema.$id === 'string' && !s.ajv.getSchema(schema.$id)) {
+        s.ajv.addSchema(schema);
+      }
     }
   }
   s.coreLoaded = true;
@@ -207,11 +233,12 @@ export function getValidator(toolName: string, direction: Direction): ValidateFu
   const file = s.fileIndex.get(cacheKey);
   if (!file) return undefined;
 
-  // Async response variants $ref into core/ — only pay that load cost when
-  // we're actually about to compile one.
-  if (direction !== 'request' && direction !== 'sync') {
-    ensureCoreLoaded(s);
-  }
+  // Schemas that $ref into core/ and enums/ need those trees registered
+  // before compile. Async response variants always do; flat-tree domain
+  // schemas (anything outside `bundled/`) do too — their $refs weren't
+  // pre-resolved at spec-publish time.
+  const fromBundled = file.includes(`${path.sep}bundled${path.sep}`);
+  if (!fromBundled) ensureCoreLoaded(s);
 
   const rawSchema = loadJson(file);
   const schema = direction === 'request' ? rawSchema : relaxResponseRoot(rawSchema);

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -29,6 +29,18 @@ export interface ValidationOutcome {
   issues: ValidationIssue[];
   /** Which schema variant was selected — useful for logging/debugging. */
   variant: Direction | 'skipped';
+  /**
+   * True when the response's `status` field named an async variant
+   * (`submitted` / `working` / `input-required`) but no compiled schema
+   * existed for that variant, so validation fell back to the sync
+   * response schema. The agent is using an async shape that this tool
+   * doesn't explicitly schema — a conformance signal the sync-fallback
+   * validation can't render by itself. Absent on normal sync or
+   * fully-schema-covered async flows.
+   */
+  variant_fallback_applied?: boolean;
+  /** Variant requested by payload shape before fallback. Set iff `variant_fallback_applied`. */
+  requested_variant?: ResponseVariant;
 }
 
 const OK: ValidationOutcome = Object.freeze({ valid: true, issues: [], variant: 'skipped' });
@@ -89,11 +101,16 @@ export function validateResponse(toolName: string, payload: unknown): Validation
   if (!effective) return OK;
   const valid = effective(payload) as boolean;
   const usedVariant: Direction = validator ? variant : 'sync';
-  if (valid) return { valid: true, issues: [], variant: usedVariant };
+  const variantFallback = !validator && variant !== 'sync';
+  const fallbackFields: Pick<ValidationOutcome, 'variant_fallback_applied' | 'requested_variant'> = variantFallback
+    ? { variant_fallback_applied: true, requested_variant: variant }
+    : {};
+  if (valid) return { valid: true, issues: [], variant: usedVariant, ...fallbackFields };
   return {
     valid: false,
     issues: (effective.errors ?? []).map(formatIssue),
     variant: usedVariant,
+    ...fallbackFields,
   };
 }
 

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -1,0 +1,251 @@
+/**
+ * Strict/lenient response-schema validation + run-level aggregation (issue
+ * #820, fourth proposal). `runValidations` must attach an AJV-based strict
+ * verdict to every `response_schema` ValidationResult without flipping the
+ * step's pass/fail (which stays Zod-driven for backwards compatibility).
+ *
+ * Tests hit the storyboard validation layer directly — `runValidations`
+ * with a synthetic `ValidationContext`. No runner boot or network needed.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { runValidations } = require('../../dist/lib/testing/storyboard/validations.js');
+const { summarizeStrictValidation } = require('../../dist/lib/testing/storyboard/runner.js');
+
+function ctx(taskName, data, responseSchemaRef) {
+  return {
+    taskName,
+    taskResult: { data },
+    agentUrl: 'http://agent.example/mcp',
+    contributions: new Set(),
+    responseSchemaRef,
+  };
+}
+
+describe('storyboard validations: strict/lenient response_schema delta', () => {
+  test('clean response: strict.valid=true, passed=true, no issues emitted', () => {
+    // Minimal valid list_creative_formats response — `formats` is the only
+    // required field at the root; an empty array satisfies both Zod and AJV.
+    const response = { formats: [] };
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', response, 'creative/list-creative-formats-response.json')
+    );
+    assert.strictEqual(results.length, 1);
+    const v = results[0];
+    assert.strictEqual(v.passed, true, 'Zod path accepts');
+    assert.ok(v.strict, 'strict verdict attached');
+    assert.strictEqual(v.strict.valid, true, 'AJV path accepts');
+    assert.strictEqual(v.strict.issues, undefined, 'no issues on a valid response');
+  });
+
+  test('response missing a required field: Zod and AJV both fail; strict.valid=false', () => {
+    // list_creative_formats requires `formats` per the response schema.
+    // Emitting `{}` fails both Zod and AJV.
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', {}, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, false, 'Zod rejects — step fails');
+    assert.ok(v.strict, 'strict verdict attached on failed step too');
+    assert.strictEqual(v.strict.valid, false);
+    assert.ok(Array.isArray(v.strict.issues), 'strict issues list present');
+    assert.ok(v.strict.issues.length > 0, 'at least one AJV issue');
+    for (const issue of v.strict.issues) {
+      assert.ok(issue.keyword, 'every AJV issue carries a keyword');
+      assert.ok(typeof issue.message === 'string', 'every AJV issue has a message');
+    }
+  });
+
+  test('strictness-delta scenario: Zod accepts a bad URI, AJV rejects format: uri', () => {
+    // Zod's generated `z.string()` doesn't enforce `format` keywords. AJV
+    // does. A response where `format_id.agent_url` is a bare word rather
+    // than a URI is the canonical "lenient passes, strict fails" case —
+    // the delta signal #820 wants agent developers to see.
+    const response = {
+      formats: [
+        {
+          // agent_url is declared `format: uri` per core/format-id.json.
+          // "not-a-uri" satisfies z.string() but fails AJV's URI check.
+          format_id: { agent_url: 'not-a-uri', id: 'display_static' },
+          name: 'Display Static',
+          description: 'Static display format',
+          assets: [],
+        },
+      ],
+    };
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', response, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, true, 'Zod path accepts bare string (lenient-pass)');
+    assert.ok(v.strict);
+    assert.strictEqual(v.strict.valid, false, 'AJV rejects bare string where format: uri is required');
+    assert.ok(v.strict.issues);
+    const hasFormat = v.strict.issues.some(i => i.keyword === 'format');
+    assert.ok(hasFormat, `expected a format issue, got: ${JSON.stringify(v.strict.issues)}`);
+  });
+
+  test('no AJV schema registered: strict verdict absent (not a failure)', () => {
+    // Some task schemas live outside the bundled/ tree and aren't compiled
+    // by the AJV loader. The runner must NOT emit a strict verdict in that
+    // case — there's no signal to report. The lenient Zod path still runs.
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('check_governance', { status: 'approved', plan_id: 'plan-1' }, 'governance/check-governance-response.json')
+    );
+    const v = results[0];
+    // Either passes Zod cleanly (no strict emitted) or fails Zod (still no
+    // strict emitted because there's no AJV schema). Either way `strict`
+    // is absent.
+    assert.strictEqual(v.strict, undefined, 'no strict verdict when AJV has no schema for this task');
+  });
+
+  test('strict verdict caps issues at 10 (diagnostic stability)', () => {
+    // A pathological response with many simultaneously-invalid siblings
+    // exercises AJV's cascade mode — every bad format_id.agent_url surfaces
+    // as its own issue. Without the cap the result object would bloat
+    // proportionally to the payload size; with it, consumers get the first
+    // 10 signals and a predictable size. Fifteen entries ensures the cap
+    // trips even if AJV dedupes in some future version.
+    const response = {
+      formats: Array.from({ length: 15 }, (_, i) => ({
+        format_id: { agent_url: `not-a-uri-${i}`, id: `fmt_${i}` },
+        name: `Format ${i}`,
+        description: 'bad URI on every entry',
+        assets: [],
+      })),
+    };
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', response, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.ok(v.strict, 'strict verdict attached');
+    assert.strictEqual(v.strict.valid, false);
+    assert.ok(v.strict.issues, 'issues list present');
+    assert.ok(v.strict.issues.length <= 10, `expected ≤ 10 issues, got ${v.strict.issues.length}`);
+    assert.strictEqual(v.strict.issues.length, 10, 'cap should trip with 15 violations on the wire');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Run-level strict_validation_summary aggregation (issue #820)
+// ─────────────────────────────────────────────────────────────
+
+function makePhase(steps) {
+  return { phase_id: 'p1', phase_title: 't', passed: true, steps, duration_ms: 0 };
+}
+
+function makeStep(validations) {
+  return {
+    step_id: 's',
+    phase_id: 'p1',
+    title: 't',
+    task: 'list_creative_formats',
+    passed: true,
+    duration_ms: 0,
+    validations,
+    context: {},
+    extraction: { path: 'none' },
+  };
+}
+
+describe('summarizeStrictValidation: run-level aggregation', () => {
+  test('returns undefined when no response_schema validation has a strict verdict', () => {
+    // A run that only exercises non-schema checks (field_present, etc.)
+    // emits no strict signal; the summary field must be absent.
+    const phases = [makePhase([makeStep([{ check: 'field_present', passed: true, description: 'x' }])])];
+    assert.strictEqual(summarizeStrictValidation(phases), undefined);
+  });
+
+  test('counts a run with all-clean strict verdicts', () => {
+    const phases = [
+      makePhase([
+        makeStep([
+          { check: 'response_schema', passed: true, description: 'x', strict: { valid: true, variant: 'sync' } },
+        ]),
+        makeStep([
+          { check: 'response_schema', passed: true, description: 'y', strict: { valid: true, variant: 'sync' } },
+        ]),
+      ]),
+    ];
+    const summary = summarizeStrictValidation(phases);
+    assert.deepStrictEqual(summary, { checked: 2, passed: 2, failed: 0, delta: 0 });
+  });
+
+  test('counts a strict/lenient delta (lenient-pass, strict-fail)', () => {
+    // Canonical #820 case: agent passes Zod but slips past AJV (format or
+    // additionalProperties violation). `delta` counts exactly these.
+    const phases = [
+      makePhase([
+        makeStep([
+          {
+            check: 'response_schema',
+            passed: true,
+            description: 'lenient accepts format violation',
+            strict: {
+              valid: false,
+              variant: 'sync',
+              issues: [
+                {
+                  instance_path: '/x/agent_url',
+                  schema_path: '#',
+                  keyword: 'format',
+                  message: 'must match format uri',
+                },
+              ],
+            },
+          },
+        ]),
+      ]),
+    ];
+    const summary = summarizeStrictValidation(phases);
+    assert.deepStrictEqual(summary, { checked: 1, passed: 0, failed: 1, delta: 1 });
+  });
+
+  test('does not count strict-fail as a delta when Zod also rejected', () => {
+    // When the step already failed Zod (passed=false), strict-fail is
+    // not a NEW signal — the lenient path already blocked it. Delta
+    // should be 0; failed still counts.
+    const phases = [
+      makePhase([
+        makeStep([
+          {
+            check: 'response_schema',
+            passed: false,
+            description: 'both reject',
+            strict: { valid: false, variant: 'sync', issues: [] },
+          },
+        ]),
+      ]),
+    ];
+    const summary = summarizeStrictValidation(phases);
+    assert.deepStrictEqual(summary, { checked: 1, passed: 0, failed: 1, delta: 0 });
+  });
+
+  test('ignores checks without a strict verdict (no AJV schema)', () => {
+    // response_schema validations whose task has no compiled AJV
+    // validator don't contribute to the summary — they're invisible
+    // to the strict/lenient signal.
+    const phases = [
+      makePhase([
+        makeStep([
+          { check: 'response_schema', passed: true, description: 'no ajv' }, // strict absent
+          {
+            check: 'response_schema',
+            passed: true,
+            description: 'has ajv',
+            strict: { valid: true, variant: 'sync' },
+          },
+        ]),
+      ]),
+    ];
+    const summary = summarizeStrictValidation(phases);
+    assert.deepStrictEqual(summary, { checked: 1, passed: 1, failed: 0, delta: 0 });
+  });
+});

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -88,6 +88,57 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
     assert.ok(v.strict.issues);
     const hasFormat = v.strict.issues.some(i => i.keyword === 'format');
     assert.ok(hasFormat, `expected a format issue, got: ${JSON.stringify(v.strict.issues)}`);
+    // Warning must be populated on strict-only failure so LLM-driven
+    // self-correction and CI graphs that scan error/warning fields see
+    // something — the runner shouldn't flip passed (backwards compat)
+    // but also shouldn't leave the strict finding only in nested arrays.
+    assert.ok(typeof v.warning === 'string', 'warning surfaced on strict-only failure');
+    assert.match(v.warning, /strict JSON-schema rejected/);
+    assert.match(v.warning, /format/);
+  });
+
+  test('warning absent when both Zod and AJV pass cleanly', () => {
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', { formats: [] }, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, true);
+    assert.ok(v.strict && v.strict.valid);
+    assert.strictEqual(v.warning, undefined, 'no warning on a clean pass');
+  });
+
+  test('warning absent when Zod rejects (failure already carries error)', () => {
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', {}, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.strictEqual(v.passed, false);
+    assert.ok(typeof v.error === 'string', 'error message populated by the Zod failure path');
+    assert.strictEqual(v.warning, undefined, 'warning reserved for the strict-only case');
+  });
+
+  test('variant fallback surfaces as a warning when the tool has no async schema', () => {
+    // `list_creative_formats` has no async-response-working schema, so an
+    // agent advertising `status: "working"` triggers the sync-fallback
+    // validation path. AJV may still accept, but the conformance signal
+    // — "agent advertised an async shape the tool hasn't schema'd" — is
+    // otherwise invisible. Warning surfaces it with the requested variant
+    // named so the author knows what to author.
+    const response = { status: 'working', formats: [] };
+    const results = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctx('list_creative_formats', response, 'creative/list-creative-formats-response.json')
+    );
+    const v = results[0];
+    assert.ok(v.strict, 'strict verdict attached');
+    assert.strictEqual(v.strict.variant_fallback_applied, true, 'fallback flag set');
+    assert.strictEqual(v.strict.requested_variant, 'working', 'requested variant recorded');
+    assert.strictEqual(v.strict.variant, 'sync', 'AJV validated against sync after fallback');
+    assert.ok(typeof v.warning === 'string', 'warning surfaces the fallback');
+    assert.match(v.warning, /status="working"/);
+    assert.match(v.warning, /sync fallback/);
   });
 
   test('no AJV schema registered: strict verdict absent (not a failure)', () => {

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -12,7 +12,7 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
 const { runValidations } = require('../../dist/lib/testing/storyboard/validations.js');
-const { summarizeStrictValidation } = require('../../dist/lib/testing/storyboard/runner.js');
+const { summarizeStrictValidation, listStrictOnlyFailures } = require('../../dist/lib/testing/storyboard/runner.js');
 
 function ctx(taskName, data, responseSchemaRef) {
   return {
@@ -91,17 +91,18 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
   });
 
   test('no AJV schema registered: strict verdict absent (not a failure)', () => {
-    // Some task schemas live outside the bundled/ tree and aren't compiled
-    // by the AJV loader. The runner must NOT emit a strict verdict in that
-    // case — there's no signal to report. The lenient Zod path still runs.
+    // Schemas outside both `bundled/` and the flat per-domain trees — e.g.
+    // a custom tool the consumer registered through their own storyboard
+    // without shipping a JSON schema — don't get an AJV validator. The
+    // runner must NOT emit a strict verdict in that case; there's no
+    // signal to report. The lenient Zod path is also absent for such
+    // tasks (no Zod schema), so the validation falls through with
+    // passed=false and no strict field.
     const results = runValidations(
       [{ check: 'response_schema', description: 'response conforms' }],
-      ctx('check_governance', { status: 'approved', plan_id: 'plan-1' }, 'governance/check-governance-response.json')
+      ctx('custom_consumer_tool_without_schema', { any: 'payload' }, 'custom/custom-tool-response.json')
     );
     const v = results[0];
-    // Either passes Zod cleanly (no strict emitted) or fails Zod (still no
-    // strict emitted because there's no AJV schema). Either way `strict`
-    // is absent.
     assert.strictEqual(v.strict, undefined, 'no strict verdict when AJV has no schema for this task');
   });
 
@@ -156,11 +157,20 @@ function makeStep(validations) {
 }
 
 describe('summarizeStrictValidation: run-level aggregation', () => {
-  test('returns undefined when no response_schema validation has a strict verdict', () => {
+  test('observable: false when no response_schema validation has a strict verdict', () => {
     // A run that only exercises non-schema checks (field_present, etc.)
-    // emits no strict signal; the summary field must be absent.
+    // emits no strict signal; the summary is still present with
+    // `observable: false` so dashboards can distinguish "unobservable"
+    // from "strict-clean with zero findings".
     const phases = [makePhase([makeStep([{ check: 'field_present', passed: true, description: 'x' }])])];
-    assert.strictEqual(summarizeStrictValidation(phases), undefined);
+    assert.deepStrictEqual(summarizeStrictValidation(phases), {
+      observable: false,
+      checked: 0,
+      passed: 0,
+      failed: 0,
+      strict_only_failures: 0,
+      lenient_also_failed: 0,
+    });
   });
 
   test('counts a run with all-clean strict verdicts', () => {
@@ -174,13 +184,19 @@ describe('summarizeStrictValidation: run-level aggregation', () => {
         ]),
       ]),
     ];
-    const summary = summarizeStrictValidation(phases);
-    assert.deepStrictEqual(summary, { checked: 2, passed: 2, failed: 0, delta: 0 });
+    assert.deepStrictEqual(summarizeStrictValidation(phases), {
+      observable: true,
+      checked: 2,
+      passed: 2,
+      failed: 0,
+      strict_only_failures: 0,
+      lenient_also_failed: 0,
+    });
   });
 
-  test('counts a strict/lenient delta (lenient-pass, strict-fail)', () => {
+  test('counts strict_only_failures (lenient-pass ∧ strict-fail) — the #820 signal', () => {
     // Canonical #820 case: agent passes Zod but slips past AJV (format or
-    // additionalProperties violation). `delta` counts exactly these.
+    // pattern violation). `strict_only_failures` counts exactly these.
     const phases = [
       makePhase([
         makeStep([
@@ -204,14 +220,20 @@ describe('summarizeStrictValidation: run-level aggregation', () => {
         ]),
       ]),
     ];
-    const summary = summarizeStrictValidation(phases);
-    assert.deepStrictEqual(summary, { checked: 1, passed: 0, failed: 1, delta: 1 });
+    assert.deepStrictEqual(summarizeStrictValidation(phases), {
+      observable: true,
+      checked: 1,
+      passed: 0,
+      failed: 1,
+      strict_only_failures: 1,
+      lenient_also_failed: 0,
+    });
   });
 
-  test('does not count strict-fail as a delta when Zod also rejected', () => {
-    // When the step already failed Zod (passed=false), strict-fail is
-    // not a NEW signal — the lenient path already blocked it. Delta
-    // should be 0; failed still counts.
+  test('lenient_also_failed partitions failed from strict_only_failures', () => {
+    // When the step already failed Zod (passed=false), strict-fail isn't
+    // a new signal — the lenient path already blocked it. Counts against
+    // `lenient_also_failed`, not `strict_only_failures`.
     const phases = [
       makePhase([
         makeStep([
@@ -224,8 +246,14 @@ describe('summarizeStrictValidation: run-level aggregation', () => {
         ]),
       ]),
     ];
-    const summary = summarizeStrictValidation(phases);
-    assert.deepStrictEqual(summary, { checked: 1, passed: 0, failed: 1, delta: 0 });
+    assert.deepStrictEqual(summarizeStrictValidation(phases), {
+      observable: true,
+      checked: 1,
+      passed: 0,
+      failed: 1,
+      strict_only_failures: 0,
+      lenient_also_failed: 1,
+    });
   });
 
   test('ignores checks without a strict verdict (no AJV schema)', () => {
@@ -245,7 +273,82 @@ describe('summarizeStrictValidation: run-level aggregation', () => {
         ]),
       ]),
     ];
-    const summary = summarizeStrictValidation(phases);
-    assert.deepStrictEqual(summary, { checked: 1, passed: 1, failed: 0, delta: 0 });
+    assert.deepStrictEqual(summarizeStrictValidation(phases), {
+      observable: true,
+      checked: 1,
+      passed: 1,
+      failed: 0,
+      strict_only_failures: 0,
+      lenient_also_failed: 0,
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// listStrictOnlyFailures drill-down helper
+// ─────────────────────────────────────────────────────────────
+
+describe('listStrictOnlyFailures: drill-down into the #820 signal', () => {
+  test('returns empty on runs with no strict-only failures', () => {
+    const phases = [
+      makePhase([
+        makeStep([
+          { check: 'response_schema', passed: true, description: 'clean', strict: { valid: true, variant: 'sync' } },
+        ]),
+      ]),
+    ];
+    assert.deepStrictEqual(listStrictOnlyFailures(phases), []);
+  });
+
+  test('flattens every strict-only failure with step / task / variant / issues', () => {
+    const phases = [
+      makePhase([
+        makeStep([
+          {
+            check: 'response_schema',
+            passed: true, // lenient accepted
+            description: 'format violation',
+            strict: {
+              valid: false,
+              variant: 'sync',
+              issues: [
+                {
+                  instance_path: '/caller',
+                  schema_path: '#/properties/caller/format',
+                  keyword: 'format',
+                  message: 'must match format "uri"',
+                },
+              ],
+            },
+          },
+        ]),
+      ]),
+    ];
+    const rows = listStrictOnlyFailures(phases);
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].phase_id, 'p1');
+    assert.strictEqual(rows[0].step_id, 's');
+    assert.strictEqual(rows[0].task, 'list_creative_formats');
+    assert.strictEqual(rows[0].variant, 'sync');
+    assert.strictEqual(rows[0].issues.length, 1);
+    assert.strictEqual(rows[0].issues[0].keyword, 'format');
+  });
+
+  test('excludes lenient-also-failed rows (not strict-only signal)', () => {
+    // A step that failed BOTH Zod and AJV isn't a strict-only failure —
+    // today's suite already blocks it. Don't put it in the drill-down.
+    const phases = [
+      makePhase([
+        makeStep([
+          {
+            check: 'response_schema',
+            passed: false, // lenient also rejected
+            description: 'both reject',
+            strict: { valid: false, variant: 'sync', issues: [] },
+          },
+        ]),
+      ]),
+    ];
+    assert.deepStrictEqual(listStrictOnlyFailures(phases), []);
   });
 });


### PR DESCRIPTION
## Summary

Landing the fourth proposal from #820 (strict-vs-lenient reporting), deferred from the merged PR #816. Completes the #820 architectural cleanup.

Every \`response_schema\` validation now runs the strict AJV path alongside the existing lenient Zod check. The strict verdict attaches to \`ValidationResult.strict\` (new optional field) without flipping the step's pass/fail — Zod-driven pass/fail stays for backward compat, and strict is additive signal.

## The signal

A new \`StoryboardResult.strict_validation_summary\`:

\`\`\`ts
{
  checked: number;  // response_schema checks with an AJV validator compiled
  passed: number;   // of checked, how many cleared strict AJV
  failed: number;   // checked - passed
  delta: number;    // lenient-pass ∧ strict-fail — the agent's strictness gap
}
\`\`\`

\`delta\` is the actionable number. Responses that cleared Zod's \`passthrough()\` but a strict dispatcher would reject — typically \`format: uri\` violations or other keywords the generated \`z.string()\` doesn't enforce. A green lenient run with \`delta > 0\` tells agent authors they aren't production-ready for strict dispatchers, even though today's test suite is green.

## Why informational, not gating

Strict AJV failure does **not** flip step \`passed\`. Reasons:
1. Existing storyboards pass Zod; making strict gating would break shipping tests retroactively.
2. Agents need to see the delta BEFORE deciding to act on it — gating without telemetry is a migration trap.
3. A future \`--strict\` CLI flag / \`StoryboardRunOptions.strict\` option can opt in to gating once telemetry calibrates the real-world gap.

Tracked as a #820+ follow-up.

## Output contract

- \`ValidationResult.strict\` present on every \`response_schema\` check that had an AJV validator compiled; absent for tasks whose schemas ship outside the loader's \`bundled/\` tree (brand-rights, governance).
- Issues list capped at 10 per validation (diagnostic stability on cascading failures).
- \`variant\` field carries the async variant AJV selected (\`sync\` / \`submitted\` / \`working\` / \`input-required\`) — diagnostic signal for routing mismatches.
- \`strict_validation_summary\` absent when zero AJV-checkable checks ran. **Absence ≠ zero findings** — dashboards should treat absence as "unobservable" (storyboard exercised only no-AJV tasks).

## Test plan

- [x] \`node --test test/lib/storyboard-strict-validation.test.js\` — **10 / 10** pass
  - Per-validation layer: clean / both-reject / lenient-pass-strict-fail (format: uri) / no-AJV-schema / issue cap trips at 10 on a 15-violation payload
  - Aggregation layer: no-signal / all-clean / delta / already-failed-no-delta / mixed-coverage
- [x] \`npm test\` — **5450 / 5456** pass, 6 pre-existing skipped, 0 fail
- [x] \`npm run build\` + \`npm run typecheck\` + \`prettier --check\` clean
- [x] Independent code-reviewer pass — ship it, JSDoc tightening applied (distinguishing absent vs zero findings, explicit \`failed = checked - passed\`)

## Public API additions

Re-exported from \`@adcp/client/testing\`:

- type \`StrictValidationVerdict\` — the per-validation verdict shape
- type \`StrictValidationSummary\` — the run-level aggregate shape
- \`summarizeStrictValidation(phases)\` — helper for dashboards / CI formatters that want to recompute over a filtered subset

Closes #820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)