### PR TITLE
feat(testing): per-storyboard overrides on runAgainstLocalAgent (closes #810)

### DIFF
--- a/.changeset/per-storyboard-overrides.md
+++ b/.changeset/per-storyboard-overrides.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': minor
+---
+
+Add `resolvePerStoryboard` callback to `runAgainstLocalAgent`
+
+`runAgainstLocalAgent` now accepts a `resolvePerStoryboard(storyboard, defaultAgentUrl)` callback that returns optional per-storyboard overrides. Callers can redirect a single storyboard to a different URL (e.g. route `signed_requests` at `/mcp-strict` while the rest stay on `/mcp`) and shallow-merge `StoryboardRunOptions` fields like `test_kit`, `brand`, `contracts`, or `auth` per storyboard without giving up the helper's single-serve / single-seed lifecycle. The override shape is flat — `{ agentUrl?, ...StoryboardRunOptions }` — and `webhook_receiver` stays helper-owned (typed out of the shape; re-applied after the merge). The callback may return a `Promise` for async work such as loading a test-kit YAML or minting a scoped token. Returning `undefined` keeps the run-level defaults, so existing callers are unaffected. Resolves #810.

--- a/docs/guides/VALIDATE-LOCALLY.md
+++ b/docs/guides/VALIDATE-LOCALLY.md
@@ -115,10 +115,35 @@ Your agent's `verifyBearer({ jwksUri })` can then verify fixture-minted tokens w
 
 Use capability-based resolution in CI — it mirrors what the live runner does against your production agent, so a pass locally means a pass against AdCP Verified.
 
+## Per-storyboard overrides
+
+Most runs want one agent URL and one `runStoryboardOptions` for every storyboard. Two cases need to vary per storyboard:
+
+- One storyboard targets a different route than the rest — the canonical example is `signed_requests` hitting a stricter `/mcp-strict` mount while everything else stays on `/mcp`.
+- Different storyboards declare different `test_kit` or brand (a test-kit YAML file carries the brand domain the runner stamps on the request).
+
+Supply `resolvePerStoryboard`:
+
+```ts
+const result = await runAgainstLocalAgent({
+  createAgent: () => createAdcpServer({ ..., stateStore }),
+  resolvePerStoryboard: (sb, defaultAgentUrl) => {
+    if (sb.id === 'signed_requests') {
+      return { agentUrl: defaultAgentUrl.replace(/\/mcp$/, '/mcp-strict') };
+    }
+    const kit = loadTestKit(sb); // your YAML loader
+    if (!kit) return undefined;
+    return { brand: brandFromKit(kit), test_kit: testKitFromKit(kit) };
+  },
+});
+```
+
+Return `undefined` to keep the defaults. `agentUrl` replaces the default; every other field is shallow-merged on top of the run-level `runStoryboardOptions`. `webhook_receiver` is helper-owned — the top-level `webhookReceiver` option still wins. The callback may be async if you need to load YAML or mint a scoped token per storyboard.
+
 ## What this doesn't do
 
 - **Start tunnels.** For grading a remote agent from your laptop, use the CLI with `--webhook-receiver-auto-tunnel`, which spawns ngrok/cloudflared. `runAgainstLocalAgent` is loopback-only by design.
-- **Mint tokens per-storyboard.** The `onListening` hook fires once. If a flow needs a scoped or rotated token, issue it inside `runStoryboardOptions.auth.token` as a function the runner calls per-step.
+- **Auto-mint tokens per-storyboard.** The `onListening` hook fires once. If a flow needs a scoped or rotated token, either issue it inside `runStoryboardOptions.auth.token` as a function the runner calls per-step, or return a per-storyboard `auth` from `resolvePerStoryboard`.
 - **Replace `adcp fuzz`.** Storyboards walk happy paths. Edge-case rejection is still fuzz's job. See [`VALIDATE-YOUR-AGENT.md`](./VALIDATE-YOUR-AGENT.md) for the full validation menu.
 
 ## Debugging a failing run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.11.0",
+  "version": "5.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.11.0",
+      "version": "5.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -192,7 +192,11 @@ export type {
 // One-call harness for server-side agents — composes serve() +
 // seedComplianceFixtures + createWebhookReceiver + runStoryboard.
 export { runAgainstLocalAgent } from './local-agent-runner';
-export type { LocalAgentRunResult, RunAgainstLocalAgentOptions } from './local-agent-runner';
+export type {
+  LocalAgentRunResult,
+  PerStoryboardOverride,
+  RunAgainstLocalAgentOptions,
+} from './local-agent-runner';
 
 // Storyboard-driven testing
 export {

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -192,11 +192,7 @@ export type {
 // One-call harness for server-side agents — composes serve() +
 // seedComplianceFixtures + createWebhookReceiver + runStoryboard.
 export { runAgainstLocalAgent } from './local-agent-runner';
-export type {
-  LocalAgentRunResult,
-  PerStoryboardOverride,
-  RunAgainstLocalAgentOptions,
-} from './local-agent-runner';
+export type { LocalAgentRunResult, PerStoryboardOverride, RunAgainstLocalAgentOptions } from './local-agent-runner';
 
 // Storyboard-driven testing
 export {

--- a/src/lib/testing/local-agent-runner.ts
+++ b/src/lib/testing/local-agent-runner.ts
@@ -122,6 +122,33 @@ export interface RunAgainstLocalAgentOptions {
    */
   runStoryboardOptions?: Omit<StoryboardRunOptions, 'webhook_receiver'>;
 
+  /**
+   * Produce per-storyboard overrides, called once per storyboard right
+   * before `runStoryboard`. Return `undefined` (or an empty object) to use
+   * the defaults; otherwise:
+   *
+   *   - `agentUrl` — redirect this storyboard to a different URL than the
+   *     ephemeral `http://127.0.0.1:<port>/mcp` the helper bound. Useful
+   *     when one storyboard needs to hit a stricter sibling route (e.g.
+   *     `/mcp-strict` for the `signed_requests` storyboard) while the rest
+   *     stay on the sandbox mount.
+   *   - every other `StoryboardRunOptions` field is shallow-merged on top
+   *     of the run-level `runStoryboardOptions`. Common uses: per-
+   *     storyboard `test_kit`, `brand`, or `contracts` that vary with the
+   *     storyboard under test. `webhook_receiver` is owned by the helper's
+   *     `webhookReceiver` field and is typed out of the override shape —
+   *     the helper re-applies it after the merge so overrides can't stomp
+   *     the loopback mock.
+   *
+   * Returning a `Promise` is supported so callers can do async work per
+   * storyboard (load a test-kit YAML, mint a scoped token, fetch brand
+   * metadata). The helper awaits before issuing `runStoryboard`.
+   */
+  resolvePerStoryboard?: (
+    storyboard: Storyboard,
+    defaultAgentUrl: string
+  ) => PerStoryboardOverride | undefined | Promise<PerStoryboardOverride | undefined>;
+
   /** Compliance cache overrides. */
   compliance?: ResolveOptions;
 
@@ -145,6 +172,20 @@ export interface RunAgainstLocalAgentOptions {
    */
   bail?: boolean;
 }
+
+/**
+ * Per-storyboard override returned by {@link RunAgainstLocalAgentOptions.resolvePerStoryboard}.
+ *
+ * `agentUrl` redirects the storyboard to a different URL. Every other
+ * `StoryboardRunOptions` field is shallow-merged on top of the run-level
+ * defaults. `webhook_receiver` is intentionally omitted — the helper owns
+ * that field via its `webhookReceiver` option and re-applies it after the
+ * merge.
+ */
+export type PerStoryboardOverride = { agentUrl?: string } & Omit<
+  Partial<StoryboardRunOptions>,
+  'webhook_receiver'
+>;
 
 export interface LocalAgentRunResult {
   /** True iff every storyboard passed (steps + assertions). */
@@ -227,14 +268,23 @@ export async function runAgainstLocalAgent(options: RunAgainstLocalAgentOptions)
     let skipped = 0;
 
     const webhookConfig = resolveWebhookReceiver(options.webhookReceiver);
-    const baseRunOptions: StoryboardRunOptions = {
+    const baseRunOptions: Omit<StoryboardRunOptions, 'webhook_receiver'> = {
       ...(options.runStoryboardOptions ?? {}),
-      ...(webhookConfig ? { webhook_receiver: webhookConfig } : {}),
     };
 
     for (let i = 0; i < toRun.storyboards.length; i++) {
       const sb = toRun.storyboards[i]!;
-      const result = await runStoryboard(agentUrl, sb, baseRunOptions);
+      const override = (await options.resolvePerStoryboard?.(sb, agentUrl)) ?? undefined;
+      const { agentUrl: overrideUrl, ...overrideRunOptions } = override ?? {};
+      const storyboardUrl = overrideUrl ?? agentUrl;
+      // webhook_receiver is helper-owned — re-applied after the merge so
+      // overrides can't replace the loopback mock the helper promised.
+      const storyboardOptions: StoryboardRunOptions = {
+        ...baseRunOptions,
+        ...overrideRunOptions,
+        ...(webhookConfig ? { webhook_receiver: webhookConfig } : {}),
+      };
+      const result = await runStoryboard(storyboardUrl, sb, storyboardOptions);
       results.push(result);
       passed += result.passed_count;
       failed += result.failed_count;

--- a/src/lib/testing/local-agent-runner.ts
+++ b/src/lib/testing/local-agent-runner.ts
@@ -182,10 +182,7 @@ export interface RunAgainstLocalAgentOptions {
  * that field via its `webhookReceiver` option and re-applies it after the
  * merge.
  */
-export type PerStoryboardOverride = { agentUrl?: string } & Omit<
-  Partial<StoryboardRunOptions>,
-  'webhook_receiver'
->;
+export type PerStoryboardOverride = { agentUrl?: string } & Omit<Partial<StoryboardRunOptions>, 'webhook_receiver'>;
 
 export interface LocalAgentRunResult {
   /** True iff every storyboard passed (steps + assertions). */

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.12.0';
+export const LIBRARY_VERSION = '5.13.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.12.0',
+  library: '5.13.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-22T10:29:03.662Z',
+  generatedAt: '2026-04-22T15:26:58.873Z',
 } as const;
 
 /**

--- a/test/lib/local-agent-runner.test.js
+++ b/test/lib/local-agent-runner.test.js
@@ -11,6 +11,7 @@
 
 const { test } = require('node:test');
 const assert = require('node:assert');
+const http = require('node:http');
 const { runAgainstLocalAgent } = require('../../dist/lib/testing/index.js');
 const { createAdcpServer } = require('../../dist/lib/server/index.js');
 
@@ -70,4 +71,101 @@ test('throws on unknown storyboard ids', async () => {
     }),
     /unknown storyboard or bundle id/i
   );
+});
+
+test('resolvePerStoryboard receives each storyboard and the default URL', async () => {
+  const observed = [];
+  const result = await runAgainstLocalAgent({
+    createAgent: () => makeMinimalAgent(),
+    storyboards: ['capability_discovery'],
+    webhookReceiver: false,
+    resolvePerStoryboard: (sb, defaultAgentUrl) => {
+      observed.push({ id: sb.id, defaultAgentUrl });
+      return undefined;
+    },
+  });
+
+  assert.strictEqual(observed.length, 1, 'callback fires once per storyboard');
+  assert.strictEqual(observed[0].id, 'capability_discovery');
+  assert.ok(
+    observed[0].defaultAgentUrl.endsWith('/mcp'),
+    `expected default agent URL on /mcp, got ${observed[0].defaultAgentUrl}`
+  );
+  assert.ok(result.overall_passed, 'returning undefined keeps default behavior');
+});
+
+test('resolvePerStoryboard agentUrl override routes storyboard to a different URL', async () => {
+  // Positive signal: stand up a second HTTP listener that counts hits.
+  // If the override landed, our sink server sees traffic. If the helper
+  // ignored the override, the sink sees zero hits (traffic went to the
+  // helper's real MCP mount) and the storyboard passes against the real
+  // agent — either outcome would invalidate the override claim.
+  let sinkHits = 0;
+  const sink = http.createServer((req, res) => {
+    sinkHits += 1;
+    // Drain body so Node can close cleanly, then respond with a non-MCP
+    // 404 so the storyboard fails (proves traffic reached the sink rather
+    // than bypassing it silently).
+    req.on('data', () => {}).on('end', () => {
+      res.statusCode = 404;
+      res.end('sink-not-an-agent');
+    });
+  });
+  await new Promise(resolve => sink.listen(0, '127.0.0.1', resolve));
+  const sinkPort = sink.address().port;
+  const sinkUrl = `http://127.0.0.1:${sinkPort}/mcp`;
+
+  try {
+    const result = await runAgainstLocalAgent({
+      createAgent: () => makeMinimalAgent(),
+      storyboards: ['capability_discovery'],
+      webhookReceiver: false,
+      resolvePerStoryboard: () => ({ agentUrl: sinkUrl }),
+    });
+
+    assert.ok(sinkHits > 0, 'override target received at least one request');
+    assert.strictEqual(result.results.length, 1);
+    assert.strictEqual(
+      result.results[0].overall_passed,
+      false,
+      'sink returns 404; storyboard must fail once override lands there'
+    );
+  } finally {
+    sink.closeAllConnections?.();
+    await new Promise(resolve => sink.close(resolve));
+  }
+});
+
+test('resolvePerStoryboard merges flattened StoryboardRunOptions fields', async () => {
+  const result = await runAgainstLocalAgent({
+    createAgent: () => makeMinimalAgent(),
+    storyboards: ['capability_discovery'],
+    webhookReceiver: false,
+    // Supply `contracts` via the per-storyboard override. The storyboard
+    // doesn't declare any `requires_contract:` steps, so this is a smoke
+    // test that flattened-shape fields are accepted and don't break the
+    // run. Verifying the merge against a behavior-sensitive field is
+    // covered separately by runStoryboard's own tests.
+    resolvePerStoryboard: () => ({ contracts: ['webhook_receiver_runner'] }),
+  });
+
+  assert.strictEqual(result.results.length, 1);
+  assert.ok(
+    result.overall_passed,
+    `override should not break the run: ${JSON.stringify(result.results[0].phases, null, 2)}`
+  );
+});
+
+test('resolvePerStoryboard supports async callbacks', async () => {
+  const result = await runAgainstLocalAgent({
+    createAgent: () => makeMinimalAgent(),
+    storyboards: ['capability_discovery'],
+    webhookReceiver: false,
+    resolvePerStoryboard: async (sb) => {
+      await new Promise(resolve => setImmediate(resolve));
+      return sb.id === 'capability_discovery' ? undefined : { agentUrl: 'http://unused' };
+    },
+  });
+
+  assert.ok(result.overall_passed, 'awaited callback returning undefined runs against the helper URL');
 });

--- a/test/lib/local-agent-runner.test.js
+++ b/test/lib/local-agent-runner.test.js
@@ -106,10 +106,12 @@ test('resolvePerStoryboard agentUrl override routes storyboard to a different UR
     // Drain body so Node can close cleanly, then respond with a non-MCP
     // 404 so the storyboard fails (proves traffic reached the sink rather
     // than bypassing it silently).
-    req.on('data', () => {}).on('end', () => {
-      res.statusCode = 404;
-      res.end('sink-not-an-agent');
-    });
+    req
+      .on('data', () => {})
+      .on('end', () => {
+        res.statusCode = 404;
+        res.end('sink-not-an-agent');
+      });
   });
   await new Promise(resolve => sink.listen(0, '127.0.0.1', resolve));
   const sinkPort = sink.address().port;
@@ -161,7 +163,7 @@ test('resolvePerStoryboard supports async callbacks', async () => {
     createAgent: () => makeMinimalAgent(),
     storyboards: ['capability_discovery'],
     webhookReceiver: false,
-    resolvePerStoryboard: async (sb) => {
+    resolvePerStoryboard: async sb => {
       await new Promise(resolve => setImmediate(resolve));
       return sb.id === 'capability_discovery' ? undefined : { agentUrl: 'http://unused' };
     },


### PR DESCRIPTION
## Summary

- New `resolvePerStoryboard(storyboard, defaultAgentUrl)` callback on `runAgainstLocalAgent`. Flat override shape: `{ agentUrl?, ...StoryboardRunOptions }`. Returning `undefined` keeps the run-level defaults — existing callers are unaffected.
- `webhook_receiver` stays helper-owned: typed out of the override via `Omit<…, 'webhook_receiver'>` and re-applied after the merge so overrides can't stomp the loopback mock.
- Callback may return `Promise` for async YAML loads / per-storyboard token minting. Unblocks the training-agent's `/mcp-strict` + per-storyboard `test_kit`/`brand` case from #810 — ~300 lines of hand-rolled orchestration go away.
- Doc note in `docs/guides/VALIDATE-LOCALLY.md` under "Per-storyboard overrides"; corrects the stale "can't mint tokens per-storyboard" caveat.

## Test plan

- [x] `node --test test/lib/local-agent-runner.test.js` — 7 tests, all pass (3 existing + 4 new):
  - callback fires once per storyboard with the default URL
  - `agentUrl` override routes traffic to a second listener (positive hit-count assertion, not just a connection-refused negative)
  - flattened `contracts` field merges without breaking the run
  - async callback is awaited
- [x] `npm run build` clean
- [ ] CI on PR

Resolves #810.