### PR TITLE
feat(cli): pin @latest in docs + startup staleness check

### DIFF
--- a/.changeset/major-eyes-allow.md
+++ b/.changeset/major-eyes-allow.md
@@ -1,5 +1,9 @@
 ---
-'@adcp/client': patch
+'@adcp/client': minor
 ---
 
-Pin `@latest` in all documented `npx @adcp/client` invocations. Unpinned `npx` reuses stale cached versions indefinitely, so users silently run old CLI code and miss bug fixes.
+Catch stale CLI installs before users spend hours debugging phantom behavior.
+
+- **Docs:** pin `@latest` in every documented `npx @adcp/client` invocation. Unpinned `npx` reuses whatever version is cached in `~/.npm/_npx/` — users can have six different versions co-existing and not know which one runs. `@latest` forces npx to re-resolve against the registry each invocation.
+- **CLI:** add a startup staleness check. On every run, the CLI hits `registry.npmjs.org/@adcp/client/latest` (cached for 24h at `~/.adcp/version-check.json`, 800ms timeout, fire-and-forget) and prints a one-time stderr warning if the running version is behind the published latest. Catches every stale-install path, not just the npx copy-paste one: global installs, pinned `package.json`, corporate forks, `pnpm dlx` caches.
+- **Silenced in:** CI (`CI=true`), non-TTY stderr, `--json` mode, and `ADCP_SKIP_VERSION_CHECK=1`.

--- a/.changeset/major-eyes-allow.md
+++ b/.changeset/major-eyes-allow.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': patch
+---
+
+Pin `@latest` in all documented `npx @adcp/client` invocations. Unpinned `npx` reuses stale cached versions indefinitely, so users silently run old CLI code and miss bug fixes.

--- a/.claude/skills/build-creative-agent/SKILL.md
+++ b/.claude/skills/build-creative-agent/SKILL.md
@@ -244,7 +244,7 @@ The `sync_creatives` handler adds/updates entries. The `list_creatives` handler 
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_lifecycle --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp creative_lifecycle --json
 ```
 
 **Sandbox validation** (if ports are blocked):

--- a/.claude/skills/build-generative-seller-agent/SKILL.md
+++ b/.claude/skills/build-generative-seller-agent/SKILL.md
@@ -308,7 +308,7 @@ The sync_creatives handler must check the format_id to decide how to process:
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_generative_seller --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_generative_seller --json
 ```
 
 **Sandbox validation** (if ports are blocked):

--- a/.claude/skills/build-retail-media-agent/SKILL.md
+++ b/.claude/skills/build-retail-media-agent/SKILL.md
@@ -258,7 +258,7 @@ The skill contains everything you need. Do not read additional docs before writi
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_catalog_creative --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_catalog_creative --json
 ```
 
 **Keep iterating until all steps pass.**

--- a/.claude/skills/build-seller-agent/SKILL.md
+++ b/.claude/skills/build-seller-agent/SKILL.md
@@ -680,7 +680,7 @@ Two things the example doesn't wire (app-specific):
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
 **Sandbox validation** (if ports are blocked):

--- a/.claude/skills/build-signals-agent/SKILL.md
+++ b/.claude/skills/build-signals-agent/SKILL.md
@@ -203,8 +203,8 @@ The skill contains everything you need. Do not read additional docs before writi
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_owned --json       # for owned data
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace --json  # for marketplace
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp signal_owned --json       # for owned data
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp signal_marketplace --json  # for marketplace
 ```
 
 **Sandbox validation** (if ports are blocked):

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -119,7 +119,7 @@ npm run test:all          # Full test suite
 ### CLI Async Operations
 
 ```bash
-npx @adcp/client agent-url get_products '{"brief":"test"}' --webhook --timeout 30
+npx @adcp/client@latest agent-url get_products '{"brief":"test"}' --webhook --timeout 30
 # Automatically starts webhook handler with ngrok tunnel
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Pick the specialisms you want to claim in `get_adcp_capabilities`. Each maps to 
 - ❌ Configuration files (`.eslintrc`, `tsconfig.json`, etc.)
 
 **Why CLI changes need changesets:**
-The CLI (`bin/adcp.js`) is bundled with the npm package. Users who run `npx @adcp/client` or install the package globally need version bumps to get CLI fixes. Without a changeset, the fix won't be published to npm.
+The CLI (`bin/adcp.js`) is bundled with the npm package. Users who run `npx @adcp/client@latest` or install the package globally need version bumps to get CLI fixes. Without a changeset, the fix won't be published to npm.
 
 ### 🚨 REQUIRED: Make Changeset Check a Required Status Check 🚨
 

--- a/README.md
+++ b/README.md
@@ -624,13 +624,13 @@ Save agents for quick access:
 
 ```bash
 # Save an agent with an alias
-npx @adcp/client --save-auth test https://test-agent.adcontextprotocol.org
+npx @adcp/client@latest --save-auth test https://test-agent.adcontextprotocol.org
 
 # Use the alias
-npx @adcp/client test get_products '{"brief":"Coffee brands"}'
+npx @adcp/client@latest test get_products '{"brief":"Coffee brands"}'
 
 # List saved agents
-npx @adcp/client --list-agents
+npx @adcp/client@latest --list-agents
 ```
 
 ### Direct URL Usage
@@ -639,20 +639,20 @@ Auto-detect protocol and call directly:
 
 ```bash
 # Protocol auto-detection (default)
-npx @adcp/client https://test-agent.adcontextprotocol.org get_products '{"brief":"Coffee"}'
+npx @adcp/client@latest https://test-agent.adcontextprotocol.org get_products '{"brief":"Coffee"}'
 
 # Force specific protocol with --protocol flag
-npx @adcp/client https://agent.example.com get_products '{"brief":"Coffee"}' --protocol mcp
-npx @adcp/client https://agent.example.com list_authorized_properties --protocol a2a
+npx @adcp/client@latest https://agent.example.com get_products '{"brief":"Coffee"}' --protocol mcp
+npx @adcp/client@latest https://agent.example.com list_authorized_properties --protocol a2a
 
 # List available tools
-npx @adcp/client https://agent.example.com
+npx @adcp/client@latest https://agent.example.com
 
 # Use a file for payload
-npx @adcp/client https://agent.example.com create_media_buy @payload.json
+npx @adcp/client@latest https://agent.example.com create_media_buy @payload.json
 
 # JSON output for scripting
-npx @adcp/client https://agent.example.com get_products '{"brief":"..."}' --json | jq '.products'
+npx @adcp/client@latest https://agent.example.com get_products '{"brief":"..."}' --json | jq '.products'
 ```
 
 ### Authentication
@@ -661,44 +661,44 @@ Three ways to provide auth tokens (priority order):
 
 ```bash
 # 1. Explicit flag (highest priority)
-npx @adcp/client test get_products '{"brief":"..."}' --auth your-token
+npx @adcp/client@latest test get_products '{"brief":"..."}' --auth your-token
 
 # 2. Saved in agent config (recommended)
-npx @adcp/client --save-auth prod https://prod-agent.com
+npx @adcp/client@latest --save-auth prod https://prod-agent.com
 # Will prompt for auth token securely
 
 # 3. Environment variable (fallback)
 export ADCP_AUTH_TOKEN=your-token
-npx @adcp/client test get_products '{"brief":"..."}'
+npx @adcp/client@latest test get_products '{"brief":"..."}'
 ```
 
 ### Agent Management
 
 ```bash
 # Save agent with auth
-npx @adcp/client --save-auth prod https://prod-agent.com mcp
+npx @adcp/client@latest --save-auth prod https://prod-agent.com mcp
 
 # List all saved agents
-npx @adcp/client --list-agents
+npx @adcp/client@latest --list-agents
 
 # Remove an agent
-npx @adcp/client --remove-agent test
+npx @adcp/client@latest --remove-agent test
 
 # Show config file location
-npx @adcp/client --show-config
+npx @adcp/client@latest --show-config
 ```
 
 ### Testing & Compliance
 
 ```bash
 # Run test scenarios against an agent
-npx @adcp/client test test-mcp full_sales_flow
-npx @adcp/client test test-mcp --list-scenarios
+npx @adcp/client@latest test test-mcp full_sales_flow
+npx @adcp/client@latest test test-mcp --list-scenarios
 
 # Run compliance assessment
-npx @adcp/client comply test-mcp
-npx @adcp/client comply test-mcp --platform-type social_platform
-npx @adcp/client comply --list-platform-types
+npx @adcp/client@latest comply test-mcp
+npx @adcp/client@latest comply test-mcp --platform-type social_platform
+npx @adcp/client@latest comply --list-platform-types
 ```
 
 **Protocol Auto-Detection**: The CLI automatically detects whether an endpoint uses MCP or A2A by checking URL patterns and discovery endpoints. Override with `--protocol mcp` or `--protocol a2a` if needed.
@@ -798,7 +798,7 @@ The skill guides domain decisions, scaffolds code, and tells you how to validate
 
 ```bash
 npx tsx agent.ts
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --json
 ```
 
 Available skills:

--- a/bin/adcp-version-check.js
+++ b/bin/adcp-version-check.js
@@ -49,11 +49,7 @@ function writeCache(latestVersion) {
     if (!fs.existsSync(CONFIG_DIR)) {
       fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
     }
-    fs.writeFileSync(
-      CACHE_FILE,
-      JSON.stringify({ latestVersion, checkedAt: Date.now() }),
-      'utf8'
-    );
+    fs.writeFileSync(CACHE_FILE, JSON.stringify({ latestVersion, checkedAt: Date.now() }), 'utf8');
   } catch {
     /* fail silent */
   }
@@ -61,32 +57,28 @@ function writeCache(latestVersion) {
 
 function fetchLatest() {
   return new Promise(resolve => {
-    const req = https.get(
-      REGISTRY_URL,
-      { headers: { accept: 'application/json' }, timeout: FETCH_TIMEOUT_MS },
-      res => {
-        if (res.statusCode !== 200) {
-          res.resume();
-          resolve(null);
-          return;
-        }
-        let body = '';
-        res.setEncoding('utf8');
-        res.on('data', chunk => {
-          body += chunk;
-          // Abort runaway responses — the registry's `latest` entry is ~2KB.
-          if (body.length > 64 * 1024) req.destroy();
-        });
-        res.on('end', () => {
-          try {
-            const parsed = JSON.parse(body);
-            resolve(typeof parsed.version === 'string' ? parsed.version : null);
-          } catch {
-            resolve(null);
-          }
-        });
+    const req = https.get(REGISTRY_URL, { headers: { accept: 'application/json' }, timeout: FETCH_TIMEOUT_MS }, res => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        resolve(null);
+        return;
       }
-    );
+      let body = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => {
+        body += chunk;
+        // Abort runaway responses — the registry's `latest` entry is ~2KB.
+        if (body.length > 64 * 1024) req.destroy();
+      });
+      res.on('end', () => {
+        try {
+          const parsed = JSON.parse(body);
+          resolve(typeof parsed.version === 'string' ? parsed.version : null);
+        } catch {
+          resolve(null);
+        }
+      });
+    });
     req.on('error', () => resolve(null));
     req.on('timeout', () => {
       req.destroy();
@@ -100,7 +92,11 @@ function fetchLatest() {
 // which is the right call for a staleness nudge — we don't want to tell a
 // user on 5.13.0 that 5.14.0-next.3 is "newer" and they should upgrade.
 function compareVersions(a, b) {
-  const parse = v => v.split('-')[0].split('.').map(n => parseInt(n, 10));
+  const parse = v =>
+    v
+      .split('-')[0]
+      .split('.')
+      .map(n => parseInt(n, 10));
   const aa = parse(a);
   const bb = parse(b);
   for (let i = 0; i < 3; i++) {

--- a/bin/adcp-version-check.js
+++ b/bin/adcp-version-check.js
@@ -1,0 +1,154 @@
+/**
+ * CLI startup staleness check.
+ *
+ * Unpinned `npx @adcp/client` reuses whatever version is cached in
+ * ~/.npm/_npx/ — users run months-old code without knowing. Doc pins
+ * to `@latest` fix the copy-paste path; this catches every other way
+ * stale code lands (global installs, locked package.json, corporate
+ * forks, pnpm dlx cache).
+ *
+ * Runs once per 24h via a cache file. Fails silent on any network or
+ * filesystem hiccup — a staleness warning must never break a CLI call.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const https = require('https');
+
+const CONFIG_DIR = path.join(os.homedir(), '.adcp');
+const CACHE_FILE = path.join(CONFIG_DIR, 'version-check.json');
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 800;
+const REGISTRY_URL = 'https://registry.npmjs.org/@adcp/client/latest';
+
+function shouldSkipCheck() {
+  if (process.env.ADCP_SKIP_VERSION_CHECK === '1') return true;
+  if (process.env.CI === 'true' || process.env.CI === '1') return true;
+  if (!process.stderr.isTTY) return true;
+  if (process.argv.includes('--json')) return true;
+  return false;
+}
+
+function readCache() {
+  try {
+    const raw = fs.readFileSync(CACHE_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.latestVersion !== 'string') return null;
+    if (typeof parsed?.checkedAt !== 'number') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(latestVersion) {
+  try {
+    if (!fs.existsSync(CONFIG_DIR)) {
+      fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+    }
+    fs.writeFileSync(
+      CACHE_FILE,
+      JSON.stringify({ latestVersion, checkedAt: Date.now() }),
+      'utf8'
+    );
+  } catch {
+    /* fail silent */
+  }
+}
+
+function fetchLatest() {
+  return new Promise(resolve => {
+    const req = https.get(
+      REGISTRY_URL,
+      { headers: { accept: 'application/json' }, timeout: FETCH_TIMEOUT_MS },
+      res => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          resolve(null);
+          return;
+        }
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', chunk => {
+          body += chunk;
+          // Abort runaway responses — the registry's `latest` entry is ~2KB.
+          if (body.length > 64 * 1024) req.destroy();
+        });
+        res.on('end', () => {
+          try {
+            const parsed = JSON.parse(body);
+            resolve(typeof parsed.version === 'string' ? parsed.version : null);
+          } catch {
+            resolve(null);
+          }
+        });
+      }
+    );
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(null);
+    });
+  });
+}
+
+// Semver ordering without a dep: compare numeric segments of the leading
+// `x.y.z`. Pre-release suffixes are treated as equal to the base release,
+// which is the right call for a staleness nudge — we don't want to tell a
+// user on 5.13.0 that 5.14.0-next.3 is "newer" and they should upgrade.
+function compareVersions(a, b) {
+  const parse = v => v.split('-')[0].split('.').map(n => parseInt(n, 10));
+  const aa = parse(a);
+  const bb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    const x = aa[i] ?? 0;
+    const y = bb[i] ?? 0;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+function printStaleWarning(current, latest) {
+  process.stderr.write(
+    `\n⚠️  Running @adcp/client ${current} — latest is ${latest}.\n` +
+      `   Upgrade with \`npx @adcp/client@latest …\` (or clear \`~/.npm/_npx\` if you copy-pasted commands without the @latest pin).\n` +
+      `   Silence this check with ADCP_SKIP_VERSION_CHECK=1.\n\n`
+  );
+}
+
+/**
+ * Schedule a staleness check. Returns immediately — the actual network
+ * fetch (if needed) runs on `process.nextTick` so command dispatch is
+ * never blocked. The warning, if any, prints to stderr before the
+ * process exits naturally.
+ */
+function scheduleVersionCheck(currentVersion) {
+  if (shouldSkipCheck()) return;
+
+  const cache = readCache();
+  const fresh = cache && Date.now() - cache.checkedAt < CACHE_TTL_MS;
+
+  if (fresh) {
+    if (compareVersions(currentVersion, cache.latestVersion) < 0) {
+      printStaleWarning(currentVersion, cache.latestVersion);
+    }
+    return;
+  }
+
+  // Stale cache or no cache — fetch in the background. The command is
+  // already running; we just want to catch the warning before exit if
+  // we can, and otherwise refresh the cache for the next invocation.
+  process.nextTick(async () => {
+    const latest = await fetchLatest();
+    if (!latest) return;
+    writeCache(latest);
+    if (compareVersions(currentVersion, latest) < 0) {
+      printStaleWarning(currentVersion, latest);
+    }
+  });
+}
+
+module.exports = { scheduleVersionCheck };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -32,6 +32,8 @@ const {
 } = require('./adcp-config.js');
 const { handleRegistryCommand } = require('./adcp-registry.js');
 const { captureStdoutLogs, writeJsonOutput } = require('./adcp-json-stdout.js');
+const { scheduleVersionCheck } = require('./adcp-version-check.js');
+const { LIBRARY_VERSION } = require('../dist/lib/version.js');
 const {
   createCLIOAuthProvider,
   hasValidOAuthTokens,
@@ -3165,6 +3167,11 @@ function formatVerdict(verdict) {
 
 async function main() {
   const args = process.argv.slice(2);
+
+  // Fire a staleness check in the background so a months-old cached
+  // CLI doesn't run silently. Fails silent on any network/FS hiccup;
+  // skipped in CI, non-TTY, --json, and when ADCP_SKIP_VERSION_CHECK=1.
+  scheduleVersionCheck(LIBRARY_VERSION);
 
   // Global: suppress the v2-sunset warning before any subcommand runs.
   // v2 went unsupported on 2026-04-20 (AdCP 3.0 GA, adcp#2220) — the library

--- a/docs/examples/multi-instance/README.md
+++ b/docs/examples/multi-instance/README.md
@@ -25,7 +25,7 @@ Two replicas of an AdCP agent sharing one Postgres store, fronted by a round-rob
 
    **Runner-level round-robin** (client alternates per step, distinct MCP sessions per replica):
    ```bash
-   npx @adcp/client storyboard run \
+   npx @adcp/client@latest storyboard run \
      --url http://localhost:4100/mcp/ \
      --url http://localhost:4101/mcp/ \
      property_lists --auth "$AGENT_TOKEN" --allow-http
@@ -33,7 +33,7 @@ Two replicas of an AdCP agent sharing one Postgres store, fronted by a round-rob
 
    **LB-level rotation** (single MCP session; Caddy round-robins per request; matches production fronting):
    ```bash
-   npx @adcp/client storyboard run http://localhost:4099/mcp/ \
+   npx @adcp/client@latest storyboard run http://localhost:4099/mcp/ \
      property_lists --auth "$AGENT_TOKEN" --allow-http
    ```
 
@@ -53,7 +53,7 @@ Either is valid. The docker-compose here gives you both on the same stack so you
 The multi-instance failure mode only surfaces on storyboards that have write→read chains. List them with:
 
 ```bash
-npx @adcp/client storyboard list --stateful
+npx @adcp/client@latest storyboard list --stateful
 ```
 
 That returns the ~40 compliance storyboards with at least one step marked `stateful: true`. Run those; stateless probes (capability discovery, schema validation, auth rejection) don't exercise the cross-replica invariant.

--- a/docs/examples/multi-instance/docker-compose.yml
+++ b/docs/examples/multi-instance/docker-compose.yml
@@ -3,7 +3,7 @@
 # Two replicas of your agent (agent-a, agent-b) share one Postgres store.
 # Caddy fronts both with round-robin routing for the "single LB endpoint"
 # test path. You can also hit the replicas directly via their host ports
-# (4100, 4101) and pass both to `npx @adcp/client storyboard run --url`.
+# (4100, 4101) and pass both to `npx @adcp/client@latest storyboard run --url`.
 #
 # Swap `image: CHANGEME/your-adcp-agent:latest` for your own image (or a
 # build context). Everything else is reusable.
@@ -16,7 +16,7 @@
 #
 #   # (A) Runner-level round-robin across two direct URLs. Each request
 #   # gets a distinct MCP session and round-robins at the client.
-#   npx @adcp/client storyboard run \
+#   npx @adcp/client@latest storyboard run \
 #     --url http://localhost:4100/mcp/ \
 #     --url http://localhost:4101/mcp/ \
 #     property_lists --auth $AGENT_TOKEN --allow-http
@@ -24,7 +24,7 @@
 #   # (B) LB-level rotation at Caddy. Single MCP session; Caddy round-robins
 #   # per request. This matches what a production Fly.io / K8s deployment
 #   # looks like from the outside.
-#   npx @adcp/client storyboard run http://localhost:4099/mcp/ \
+#   npx @adcp/client@latest storyboard run http://localhost:4099/mcp/ \
 #     property_lists --auth $AGENT_TOKEN --allow-http
 #
 # Both shapes exercise cross-replica state persistence. (A) gives you

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -51,8 +51,8 @@ Start it and test immediately:
 
 ```bash
 npx tsx agent.ts
-npx @adcp/client http://localhost:3001/mcp                    # discover tools
-npx @adcp/client http://localhost:3001/mcp get_signals '{}'   # call get_signals
+npx @adcp/client@latest http://localhost:3001/mcp                    # discover tools
+npx @adcp/client@latest http://localhost:3001/mcp get_signals '{}'   # call get_signals
 ```
 
 ## Key Concepts
@@ -389,7 +389,7 @@ const httpServer = createServer(async (req, res) => {
 ### Tool Discovery
 
 ```bash
-npx @adcp/client http://localhost:3001/mcp
+npx @adcp/client@latest http://localhost:3001/mcp
 ```
 
 This lists all tools your agent exposes, their descriptions, and parameters. If `get_signals` appears with the correct schema, your agent is wired up correctly.
@@ -398,22 +398,22 @@ This lists all tools your agent exposes, their descriptions, and parameters. If 
 
 ```bash
 # All segments
-npx @adcp/client http://localhost:3001/mcp get_signals '{"signal_spec":"audience segments"}'
+npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"signal_spec":"audience segments"}'
 
 # Filtered by text
-npx @adcp/client http://localhost:3001/mcp get_signals '{"signal_spec":"shoppers"}'
+npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"signal_spec":"shoppers"}'
 
 # Filtered by catalog type
-npx @adcp/client http://localhost:3001/mcp get_signals '{"filters":{"catalog_types":["marketplace"]}}'
+npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"filters":{"catalog_types":["marketplace"]}}'
 
 # JSON output for scripting
-npx @adcp/client http://localhost:3001/mcp get_signals '{}' --json
+npx @adcp/client@latest http://localhost:3001/mcp get_signals '{}' --json
 ```
 
 ### Compliance Check
 
 ```bash
-npx @adcp/client storyboard run http://localhost:3001/mcp
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp
 ```
 
 This runs a standard validation suite against your agent to check AdCP compliance. For the full validation picture — storyboard runner, property-based fuzzing (`adcp fuzz`), multi-instance testing, webhook conformance, request-signing, schema-driven validation, and the skill→agent→grader dogfood harness — see [**VALIDATE-YOUR-AGENT.md**](./VALIDATE-YOUR-AGENT.md).

--- a/docs/guides/MULTI-INSTANCE-TESTING.md
+++ b/docs/guides/MULTI-INSTANCE-TESTING.md
@@ -20,7 +20,7 @@ A single-URL storyboard never sees this. Multi-instance mode round-robins steps 
 ## Usage
 
 ```
-npx @adcp/client storyboard run \
+npx @adcp/client@latest storyboard run \
   --url https://a.your-agent.example/mcp/ \
   --url https://b.your-agent.example/mcp/ \
   account_and_audience \
@@ -67,7 +67,7 @@ For local dev without Docker, the simplest setup is two `node` processes listeni
 Quick way to verify the multi-instance code path end-to-end against the AdCP public test agent:
 
 ```bash
-npx @adcp/client storyboard run \
+npx @adcp/client@latest storyboard run \
   --url "https://test-agent.adcontextprotocol.org/mcp/?replica=a" \
   --url "https://test-agent.adcontextprotocol.org/mcp/?replica=b" \
   property_lists \

--- a/docs/guides/VALIDATE-LOCALLY.md
+++ b/docs/guides/VALIDATE-LOCALLY.md
@@ -56,10 +56,10 @@ Prefer a one-shot from the shell? Point the CLI at a module file:
 
 ```bash
 # agent.mjs exports `createAgent`
-npx @adcp/client storyboard run --local-agent ./agent.mjs
+npx @adcp/client@latest storyboard run --local-agent ./agent.mjs
 
 # Single storyboard, CI-friendly JUnit output
-npx @adcp/client storyboard run --local-agent ./agent.mjs capability_discovery \
+npx @adcp/client@latest storyboard run --local-agent ./agent.mjs capability_discovery \
   --format junit > junit.xml
 ```
 
@@ -144,7 +144,7 @@ for (const sb of result.results) {
 Or emit JSON for richer tooling:
 
 ```bash
-npx @adcp/client storyboard run --local-agent ./agent.mjs --json | jq '.results[] | select(.overall_passed | not)'
+npx @adcp/client@latest storyboard run --local-agent ./agent.mjs --json | jq '.results[] | select(.overall_passed | not)'
 ```
 
 ## Related

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -6,20 +6,20 @@ Your checklist to get from "agent boots" to "agent ships." Every tool below is a
 
 ```bash
 # 1. Does it answer at all? (60s)
-npx @adcp/client http://localhost:3001/mcp get_adcp_capabilities '{}'
+npx @adcp/client@latest http://localhost:3001/mcp get_adcp_capabilities '{}'
 
 # 2. Does it walk the golden path? (2–5 min)
-npx @adcp/client storyboard run http://localhost:3001/mcp --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp --auth $TOKEN
 
 # 3. Does it crash on weird inputs? (1–3 min)
-npx @adcp/client fuzz http://localhost:3001/mcp --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --auth-token $TOKEN
 
 # 4. Does webhook/async conformance pass? (2–5 min)
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --webhook-receiver --auth $TOKEN
 
 # 5. Does it survive horizontal scaling? (same as 2, two URLs)
-npx @adcp/client storyboard run \
+npx @adcp/client@latest storyboard run \
   --url https://a.agent.example/mcp --url https://b.agent.example/mcp \
   sales-guaranteed --auth $TOKEN
 ```
@@ -54,19 +54,19 @@ The main compliance entry point. Runs every storyboard that applies to your agen
 
 ```bash
 # Full capability-driven run — resolves bundles from your capabilities
-npx @adcp/client storyboard run http://localhost:3001/mcp --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp --auth $TOKEN
 
 # Single bundle or storyboard by id
-npx @adcp/client storyboard run http://localhost:3001/mcp sales-guaranteed --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp sales-guaranteed --auth $TOKEN
 
 # Specific tracks only (faster feedback when iterating)
-npx @adcp/client storyboard run http://localhost:3001/mcp --tracks core,products --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp --tracks core,products --auth $TOKEN
 
 # Ad-hoc YAML (new storyboards under development)
-npx @adcp/client storyboard run http://localhost:3001/mcp --file ./my-wip.yaml --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp --file ./my-wip.yaml --auth $TOKEN
 
 # JSON report for CI / tooling
-npx @adcp/client storyboard run http://localhost:3001/mcp --json > report.json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp --json > report.json
 ```
 
 **Flags you'll actually use:**
@@ -85,12 +85,12 @@ npx @adcp/client storyboard run http://localhost:3001/mcp --json > report.json
 
 ```bash
 # (a) pre-save tokens
-npx @adcp/client --save-auth my-agent https://agent.example.com/mcp --oauth
-npx @adcp/client storyboard run my-agent
+npx @adcp/client@latest --save-auth my-agent https://agent.example.com/mcp --oauth
+npx @adcp/client@latest storyboard run my-agent
 
 # (b) inline on first run
-npx @adcp/client --save-auth my-agent https://agent.example.com/mcp --no-auth
-npx @adcp/client storyboard run my-agent --oauth
+npx @adcp/client@latest --save-auth my-agent https://agent.example.com/mcp --no-auth
+npx @adcp/client@latest storyboard run my-agent --oauth
 ```
 
 Either way, subsequent runs reuse the cached tokens (auto-refresh on expiry via the stored `refresh_token`). Raw URLs don't support `--oauth` — save an alias first.
@@ -105,27 +105,27 @@ Generates schema-valid requests, calls your agent, checks every response under t
 
 ```bash
 # Tier 1 + Tier 2 stateless + referential (safe, no mutation)
-npx @adcp/client fuzz http://localhost:3001/mcp --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --auth-token $TOKEN
 
 # Reproducible (rerun with same seed to repro a failure)
-npx @adcp/client fuzz http://localhost:3001/mcp --seed 42 --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --seed 42 --auth-token $TOKEN
 
 # Pre-seeded ID pools for referential tools (Tier 2)
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --fixture creative_ids=cre_a,cre_b \
   --fixture media_buy_ids=mb_1
 
 # Auto-seed + Tier 3 update-tool fuzzing (mutates agent state — SANDBOX ONLY)
-npx @adcp/client fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
 
 # Uniform-error-response invariant in full cross-tenant mode
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --auto-seed \
   --auth-token            $TENANT_A_TOKEN \
   --auth-token-cross-tenant $TENANT_B_TOKEN
 
 # Inspect the tool list + tier classification
-npx @adcp/client fuzz --list-tools
+npx @adcp/client@latest fuzz --list-tools
 ```
 
 See [`docs/guides/CONFORMANCE.md`](./CONFORMANCE.md) for the fixture map, tier-by-tier tool list, and failure interpretation.
@@ -172,16 +172,16 @@ If you claim the `signed-requests` specialism, run the RFC 9421 grader. The grad
 
 ```bash
 # All 38 vectors
-npx @adcp/client grade request-signing https://sandbox.agent.example/mcp
+npx @adcp/client@latest grade request-signing https://sandbox.agent.example/mcp
 
 # Skip rate-abuse (vector 020 fires cap+1 requests; skip in dev loops)
-npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --skip-rate-abuse
+npx @adcp/client@latest grade request-signing https://sandbox.agent.example/mcp --skip-rate-abuse
 
 # MCP transport (wraps vectors in JSON-RPC envelopes)
-npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --transport mcp
+npx @adcp/client@latest grade request-signing https://sandbox.agent.example/mcp --transport mcp
 
 # Isolate a single vector
-npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --only 016-replayed-nonce
+npx @adcp/client@latest grade request-signing https://sandbox.agent.example/mcp --only 016-replayed-nonce
 ```
 
 ### Multi-instance testing
@@ -189,7 +189,7 @@ npx @adcp/client grade request-signing https://sandbox.agent.example/mcp --only 
 Exposes `(brand, account)`-scoped state that lives per-process instead of in a shared store — a class of bug that single-URL runs never catch. See [`docs/guides/MULTI-INSTANCE-TESTING.md`](./MULTI-INSTANCE-TESTING.md).
 
 ```bash
-npx @adcp/client storyboard run \
+npx @adcp/client@latest storyboard run \
   --url https://a.agent.example/mcp \
   --url https://b.agent.example/mcp \
   sales-guaranteed --auth $TOKEN
@@ -270,7 +270,7 @@ Use `--invariants` to load modules that assert properties across storyboard step
 
 ```bash
 # Load ./my-invariants.js (relative path) or a bare specifier (npm package)
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --invariants ./assertions/idempotency.js,@my-org/adcp-invariants
 ```
 
@@ -346,18 +346,18 @@ Use before merging skill changes. ~60s per pair; matrix runs fan out.
 
 ```yaml
 - name: Storyboard (core + products)
-  run: npx @adcp/client storyboard run $AGENT_URL --tracks core,products --auth $TOKEN
+  run: npx @adcp/client@latest storyboard run $AGENT_URL --tracks core,products --auth $TOKEN
 - name: Fuzz (fixed seed)
-  run: npx @adcp/client fuzz $AGENT_URL --seed 42 --auth-token $TOKEN --format json
+  run: npx @adcp/client@latest fuzz $AGENT_URL --seed 42 --auth-token $TOKEN --format json
 ```
 
 ### Nightly (slow, broader coverage)
 
 ```yaml
 - name: Fuzz (random seed, auto-seed)
-  run: npx @adcp/client fuzz $AGENT_URL --auto-seed --auth-token $TOKEN
+  run: npx @adcp/client@latest fuzz $AGENT_URL --auto-seed --auth-token $TOKEN
 - name: Full storyboard assessment
-  run: npx @adcp/client storyboard run $AGENT_URL --auth $TOKEN --json > report.json
+  run: npx @adcp/client@latest storyboard run $AGENT_URL --auth $TOKEN --json > report.json
 ```
 
 Random seed on nightly broadens the surface; fixed seed on per-PR keeps reproducibility.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -28,6 +28,8 @@ If all five pass and your skill's specialism-specific checks below pass, you're 
 
 **Working on the agent locally?** Before you reach for the remote-agent commands above, see [`VALIDATE-LOCALLY.md`](./VALIDATE-LOCALLY.md) — the same storyboards, zero tunnel setup, ten lines of code. Point `--local-agent <module>` at your handlers or call `runAgainstLocalAgent` directly from a test file.
 
+**Why `@latest` in every `npx` command?** Without the pin, `npx` reuses whatever version happens to be cached in `~/.npm/_npx/` — and it never re-checks. If you ran `npx @adcp/client` six months ago, you're still on that version today. `npx @adcp/client@latest` forces npx to resolve the `latest` dist-tag against the registry on every run. If an old cache is causing confusing behavior, `rm -rf ~/.npm/_npx` clears all cached CLI versions.
+
 ---
 
 ## What catches what

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1145,4 +1145,4 @@ JSON schemas (source of truth): `schemas/cache/latest/index.json` (local only)
 - Documentation: https://adcontextprotocol.github.io/adcp-client/
 - npm: https://www.npmjs.com/package/@adcp/client
 - Spec: https://adcontextprotocol.org
-- CLI: `npx @adcp/client`
+- CLI: `npx @adcp/client@latest`

--- a/docs/proposals/server-builder-quick-start.md
+++ b/docs/proposals/server-builder-quick-start.md
@@ -157,11 +157,11 @@ The response must include the full media buy object with packages array. Comply 
 
 ```bash
 # Run all tracks
-npx @adcp/client storyboard run http://localhost:3456/mcp
+npx @adcp/client@latest storyboard run http://localhost:3456/mcp
 
 # Run one track
-npx @adcp/client storyboard run http://localhost:3456/mcp --track core
+npx @adcp/client@latest storyboard run http://localhost:3456/mcp --track core
 
 # JSON output for debugging
-npx @adcp/client storyboard run http://localhost:3456/mcp --format json
+npx @adcp/client@latest storyboard run http://localhost:3456/mcp --format json
 ```

--- a/examples/comply-controller-seller.ts
+++ b/examples/comply-controller-seller.ts
@@ -13,16 +13,16 @@
  * Then drive the controller from another terminal:
  *
  *   # List advertised scenarios (force_/simulate_ only — seeds are universal)
- *   npx @adcp/client call http://localhost:3456/mcp comply_test_controller \
+ *   npx @adcp/client@latest call http://localhost:3456/mcp comply_test_controller \
  *     --scenario list_scenarios
  *
  *   # Seed a product so storyboards can reference `test-product` by id
- *   npx @adcp/client call http://localhost:3456/mcp comply_test_controller \
+ *   npx @adcp/client@latest call http://localhost:3456/mcp comply_test_controller \
  *     --scenario seed_product \
  *     --params '{"product_id":"test-product","fixture":{"delivery_type":"non_guaranteed"}}'
  *
  *   # Force a creative into `rejected` to drive the rejection branch
- *   npx @adcp/client call http://localhost:3456/mcp comply_test_controller \
+ *   npx @adcp/client@latest call http://localhost:3456/mcp comply_test_controller \
  *     --scenario force_creative_status \
  *     --params '{"creative_id":"cr-1","status":"rejected","rejection_reason":"Brand safety"}'
  */

--- a/examples/error-compliant-server.ts
+++ b/examples/error-compliant-server.ts
@@ -8,7 +8,7 @@
  *
  * Then test with:
  *
- *   npx @adcp/client comply http://localhost:3456/mcp
+ *   npx @adcp/client@latest comply http://localhost:3456/mcp
  */
 
 import {

--- a/examples/signals-agent.ts
+++ b/examples/signals-agent.ts
@@ -10,10 +10,10 @@
  *
  * Then test with:
  *
- *   npx @adcp/client http://localhost:3001/mcp
- *   npx @adcp/client http://localhost:3001/mcp get_signals '{"signal_spec":"audience segments"}'
- *   npx @adcp/client http://localhost:3001/mcp get_signals '{"signal_spec":"shoppers"}'
- *   npx @adcp/client http://localhost:3001/mcp get_signals '{"filters":{"catalog_types":["marketplace"]}}'
+ *   npx @adcp/client@latest http://localhost:3001/mcp
+ *   npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"signal_spec":"audience segments"}'
+ *   npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"signal_spec":"shoppers"}'
+ *   npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"filters":{"catalog_types":["marketplace"]}}'
  */
 
 import { createAdcpServer, serve } from '@adcp/client';

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -924,7 +924,7 @@ function generateLlmsTxt(
   ln(`- Documentation: ${DOCS_BASE_URL}/`);
   ln(`- npm: https://www.npmjs.com/package/@adcp/client`);
   ln(`- Spec: https://adcontextprotocol.org`);
-  ln(`- CLI: \`npx @adcp/client\``);
+  ln(`- CLI: \`npx @adcp/client@latest\``);
   ln();
 
   return lines.join('\n');

--- a/skills/adcp/SKILL.md
+++ b/skills/adcp/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash, Read
 
 # AdCP CLI
 
-Use `adcp` (or `npx @adcp/client`) to interact with AdCP advertising agents, run compliance tests, and query the AdCP registry.
+Use `adcp` (or `npx @adcp/client@latest`) to interact with AdCP advertising agents, run compliance tests, and query the AdCP registry.
 
 ## Quick start — zero config
 
@@ -285,9 +285,9 @@ Remote `--wait` requires ngrok: `brew install ngrok`
 
 ### Step 1: Check installation
 ```bash
-which adcp 2>/dev/null && echo "installed" || echo "use npx @adcp/client"
+which adcp 2>/dev/null && echo "installed" || echo "use npx @adcp/client@latest"
 ```
-If not installed, prefix all commands with `npx @adcp/client`. Requires Node.js 18+.
+If not installed, prefix all commands with `npx @adcp/client@latest`. Requires Node.js 18+.
 
 ### Step 2: Route the request
 

--- a/skills/build-brand-rights-agent/SKILL.md
+++ b/skills/build-brand-rights-agent/SKILL.md
@@ -477,18 +477,18 @@ For OAuth, `anyOf(verifyApiKey, verifyBearer)` composition, or `publicUrl` + `pr
 npx tsx agent.ts &
 
 # Happy path — brand_rights bundle (includes governance_denied sub-scenario)
-npx @adcp/client storyboard run http://localhost:3001/mcp brand_rights --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp brand_rights --auth $TOKEN
 
 # Cross-cutting obligations
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation --auth $TOKEN
 
 # Revocation webhook conformance (if you emit revocations)
-npx @adcp/client storyboard run http://localhost:3001/mcp webhook_emission \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp webhook_emission \
   --webhook-receiver --auth $TOKEN
 
 # Rejection-surface fuzz
-npx @adcp/client fuzz http://localhost:3001/mcp --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --auth-token $TOKEN
 ```
 
 Common failure decoder:

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -416,16 +416,16 @@ Validate with: `adcp storyboard run <agent> deterministic_testing --auth $TOKEN`
 npx tsx agent.ts &
 
 # Happy path — the archetype you're claiming
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_ad_server --auth $TOKEN     # stateful
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_template --auth $TOKEN      # stateless
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_generative --auth $TOKEN    # brief-to-creative
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp creative_ad_server --auth $TOKEN     # stateful
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp creative_template --auth $TOKEN      # stateless
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp creative_generative --auth $TOKEN    # brief-to-creative
 
 # Cross-cutting obligations (all creative agents)
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
 
 # Rejection-surface fuzz — includes preview_creative (referential, fixture-eligible)
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --tools list_creative_formats,list_creatives,get_creative_features,preview_creative \
   --fixture creative_ids=cre_a,cre_b \
   --auth-token $TOKEN

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -459,15 +459,15 @@ The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on fai
 npx tsx agent.ts &
 
 # Happy paths — sells inventory AND generates creatives
-npx @adcp/client storyboard run http://localhost:3001/mcp creative_generative/seller --auth $TOKEN
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp creative_generative/seller --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --auth $TOKEN
 
 # Cross-cutting obligations
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
 
 # Rejection-surface fuzz
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --tools get_products,list_creative_formats,get_creative_features,preview_creative \
   --auth-token $TOKEN
 ```

--- a/skills/build-governance-agent/SKILL.md
+++ b/skills/build-governance-agent/SKILL.md
@@ -636,19 +636,19 @@ The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on fai
 npx tsx agent.ts &
 
 # Happy paths — run the storyboards matching your claimed specialisms
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards governance_spend_authority,governance_spend_authority/denied,governance_delivery_monitor \
   --auth $TOKEN
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards property_lists,collection_lists,content_standards \
   --auth $TOKEN
 
 # Cross-cutting obligations
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
 
 # Rejection-surface fuzz — includes update_property_list / update_content_standards (Tier 3)
-npx @adcp/client fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --auto-seed --auth-token $TOKEN
 ```
 
 Common failure decoder:

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -440,14 +440,14 @@ The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on fai
 npx tsx agent.ts &
 
 # Happy path — catalog-driven creative + conversion tracking
-npx @adcp/client storyboard run http://localhost:3001/mcp sales_catalog_driven --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp sales_catalog_driven --auth $TOKEN
 
 # Cross-cutting obligations
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
 
 # Rejection-surface fuzz — includes the catalog surface
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --tools get_products,list_creative_formats \
   --auth-token $TOKEN
 ```

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -1175,25 +1175,25 @@ npx tsx agent.ts &
 
 ```bash
 # Full seller lifecycle
-npx @adcp/client storyboard run http://localhost:3001/mcp media_buy_seller --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp media_buy_seller --auth $TOKEN
 
 # Your specialism bundle (one of: sales_guaranteed, sales_non_guaranteed,
 # sales_broadcast_tv, sales_streaming_tv, sales_social, sales_proposal_mode)
-npx @adcp/client storyboard run http://localhost:3001/mcp sales_guaranteed --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp sales_guaranteed --auth $TOKEN
 
 # Cross-cutting obligations — every seller must pass these
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards idempotency,security_baseline,schema_validation,error_compliance --auth $TOKEN
 
 # Webhook conformance (if you claim async task lifecycles)
-npx @adcp/client storyboard run http://localhost:3001/mcp webhook_emission \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp webhook_emission \
   --webhook-receiver --auth $TOKEN
 ```
 
 **Rejection-surface conformance (property-based fuzzer — catches crashes on edge inputs):**
 
 ```bash
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --tools get_products,get_media_buys,list_creative_formats \
   --auth-token $TOKEN
 ```
@@ -1629,7 +1629,7 @@ const revocationStore = new InMemoryRevocationStore({
 
 ```bash
 npx tsx agent.ts &
-npx @adcp/client storyboard run http://localhost:3001/mcp signed_requests --json
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp signed_requests --json
 ```
 
 Every negative vector must return the exact `expected_outcome.error_code` in `WWW-Authenticate: Signature error="<code>"`. A non-claiming agent is not graded against this specialism.

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -297,14 +297,14 @@ The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on fai
 npx tsx agent.ts &
 
 # Happy path — session lifecycle
-npx @adcp/client storyboard run http://localhost:3001/mcp si_baseline --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp si_baseline --auth $TOKEN
 
 # Cross-cutting obligations
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
 
 # Rejection-surface fuzz
-npx @adcp/client fuzz http://localhost:3001/mcp \
+npx @adcp/client@latest fuzz http://localhost:3001/mcp \
   --tools si_get_offering --auth-token $TOKEN
 ```
 

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -379,18 +379,18 @@ The framework produces RFC 6750-compliant `WWW-Authenticate: Bearer` 401s on fai
 npx tsx agent.ts &
 
 # Happy path — the specialism you're claiming
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_owned --auth $TOKEN        # owned data
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace --auth $TOKEN  # marketplace
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp signal_owned --auth $TOKEN        # owned data
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp signal_marketplace --auth $TOKEN  # marketplace
 
 # Marketplace governance sub-scenario (if you claim signal_marketplace)
-npx @adcp/client storyboard run http://localhost:3001/mcp signal_marketplace/governance_denied --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp signal_marketplace/governance_denied --auth $TOKEN
 
 # Cross-cutting obligations
-npx @adcp/client storyboard run http://localhost:3001/mcp \
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp \
   --storyboards security_baseline,idempotency,schema_validation,error_compliance --auth $TOKEN
 
 # Rejection-surface fuzz
-npx @adcp/client fuzz http://localhost:3001/mcp --tools get_signals --auth-token $TOKEN
+npx @adcp/client@latest fuzz http://localhost:3001/mcp --tools get_signals --auth-token $TOKEN
 ```
 
 Common failure decoder:

--- a/src/lib/conformance/schemaLoader.ts
+++ b/src/lib/conformance/schemaLoader.ts
@@ -54,7 +54,7 @@ function findBundledDir(): string {
 
   throw new Error(
     `Conformance schema bundle not found. Looked in ${distCandidate} and ${srcCandidate}. ` +
-      `Run \`npm run sync-schemas && npm run build:lib\`, or reinstall @adcp/client.`
+      `Run \`npm run sync-schemas && npm run build:lib\`, or install the current package: \`npm i @adcp/client@latest\`.`
   );
 }
 

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -378,7 +378,7 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
       options.onListening(url);
     } else {
       console.log(`AdCP agent running at ${url}`);
-      console.log(`\nTest with:\n  npx @adcp/client ${url}`);
+      console.log(`\nTest with:\n  npx @adcp/client@latest ${url}`);
     }
   });
 

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -176,7 +176,7 @@ function readAdcpVersion(): string {
 function complianceMissingMessage(what: string, path: string): string {
   return (
     `${what} not found at ${path}. ` +
-    `The compliance cache ships with @adcp/client — try reinstalling the package. ` +
+    `The compliance cache ships with @adcp/client — run \`npm i @adcp/client@latest\` (or \`npx @adcp/client@latest …\`) to pick up the current cache. ` +
     `If developing locally, run \`npm run sync-schemas\` to populate the cache.`
   );
 }


### PR DESCRIPTION
## Summary

`npx @adcp/client` silently reuses stale cached versions from `~/.npm/_npx/` indefinitely. Users run old CLI code, miss bug fixes, and don't realize they're on a stale version — mine has six different `@adcp/client` versions cached (4.14 → 5.13) and npx will happily reuse any of them. Two-pronged fix:

### 1. Pin `@latest` in every documented invocation (149 refs, 31 files)

- `README.md` (22 refs) · `docs/guides/VALIDATE-YOUR-AGENT.md` (30 refs)
- All 8 skill files + their `.claude/skills/` mirrors, `copilot-instructions.md`, root `CLAUDE.md`
- `docs/llms.txt`, multi-instance guide, examples, proposal docs
- One runtime string: the "Test with: npx …" hint emitted by `serve.ts` after a local agent boots
- Error-message hints in `compliance.ts` and `schemaLoader.ts` that previously said "reinstall @adcp/client"
- New paragraph in `VALIDATE-YOUR-AGENT.md` explaining the npx cache trap and how to clear it (`rm -rf ~/.npm/_npx`)

### 2. CLI startup staleness check (`bin/adcp-version-check.js`)

Pins only fix copy-paste. They don't help users on stale global installs, locked `package.json`, corporate forks, or `pnpm dlx` caches. A startup check catches everything:

- Hits `registry.npmjs.org/@adcp/client/latest` once per 24h (cached at `~/.adcp/version-check.json`)
- 800ms timeout · fails silent on any network/FS error · fire-and-forget (`process.nextTick`, never blocks command dispatch)
- Warns to stderr when running version is behind: `⚠️  Running @adcp/client 4.25.0 — latest is 5.13.0. Upgrade with \`npx @adcp/client@latest …\``
- **Silenced in:** CI (`CI=true`), non-TTY stderr, `--json` mode, and `ADCP_SKIP_VERSION_CHECK=1`
- Pre-release versions on the same base (e.g. `5.13.0-rc.1` vs `5.13.0`) don't nag

Changeset bumped to `minor` since this adds a CLI feature. Paired doc-repo PR: adcontextprotocol/adcp#2932.

## Test plan

- [x] `grep -r "npx @adcp/client[^@]"` returns zero unpinned refs under tracked docs/code
- [x] `npm run build:lib` succeeds
- [x] Stale version triggers warning with network fetch (verified: 4.25.0 → warns about 5.13.0)
- [x] Current version produces no warning with cached result
- [x] CI / non-TTY / `--json` / `ADCP_SKIP_VERSION_CHECK=1` all silent
- [x] Garbage cache file recovers gracefully (refetches + overwrites)
- [x] Pre-release version on the same base doesn't false-nag
- [x] `./bin/adcp.js --help` runs successfully with the check wired in

🤖 Generated with [Claude Code](https://claude.com/claude-code)