### PR TITLE
feat(testing): extend shape-drift hint to list-shaped tools (bare-array)

### DIFF
--- a/.changeset/shape-drift-list-tools.md
+++ b/.changeset/shape-drift-list-tools.md
@@ -1,0 +1,16 @@
+---
+'@adcp/client': patch
+---
+
+Extend `detectShapeDriftHint` in the storyboard runner to cover list-shaped tools (closes #852):
+
+- `list_creatives` — handler returns bare `[{...}]` instead of `{ creatives, query_summary, pagination }`
+- `list_creative_formats` — bare array instead of `{ formats: [...] }`
+- `list_accounts` — bare array instead of `{ accounts: [...] }`
+- `get_products` — bare array instead of `{ products: [...] }`
+
+The detector now accepts `unknown` rather than `Record<string, unknown>` so it can recognize bare-array responses at the root — a common drift class where AJV's error ("expected object, got array") doesn't name the required wrapper key. Each known list tool gets a pointed hint naming the wrapper and the response helper (`listCreativesResponse`, `listCreativeFormatsResponse`, `listAccountsResponse`, `productsResponse`) from `@adcp/client/server`.
+
+Bare arrays for unknown task names pass through silently — the detector only fires on registered list tools to avoid false positives on APIs that legitimately return top-level arrays.
+
+8 new tests covering each tool, the wrapper-present negative case, unknown-task pass-through, empty-array handling, and null/primitive defensive cases.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -267,9 +267,17 @@ function validateResponseSchema(
     };
   }
 
-  // Strip _message from data before validation — it's added by the response
-  // unwrapper as a text summary and is not part of the AdCP response schema.
-  const { _message, ...dataWithoutMessage } = (taskResult.data ?? {}) as Record<string, unknown>;
+  // Keep the raw payload separately from the object-form one below so the
+  // shape-drift detector can recognize bare-array responses (a common drift
+  // pattern for list tools). Strip _message when it's a top-level property —
+  // bare arrays don't carry that field.
+  const rawData = taskResult.data ?? {};
+  const dataWithoutMessage = Array.isArray(rawData)
+    ? rawData
+    : (() => {
+        const { _message, ...rest } = rawData as Record<string, unknown>;
+        return rest;
+      })();
   const parseResult = schema.safeParse(dataWithoutMessage);
 
   // Strict (AJV) verdict runs alongside the lenient Zod check so the run
@@ -277,7 +285,9 @@ function validateResponseSchema(
   // enforces `format` keywords and `additionalProperties: false` that Zod's
   // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
   // overall pass/fail stays Zod-driven to preserve backwards compatibility.
-  const strict = computeStrictVerdict(taskName, dataWithoutMessage);
+  // Cast the array case to Record for the strict validator — its underlying
+  // AJV call accepts any JSON value but the type annotation expects an object.
+  const strict = computeStrictVerdict(taskName, dataWithoutMessage as Record<string, unknown>);
 
   // Shape-drift hint runs regardless of strict/lenient outcome — a
   // platform-native `build_creative` response typically fails Zod, but the
@@ -401,37 +411,80 @@ function buildStrictWarning(strict: StrictValidationVerdict): string | undefined
 }
 
 /**
+ * List-shaped tools where handlers commonly return the bare inner array
+ * (`[{...}]`) at the root instead of wrapping it in the required object
+ * envelope. Each entry names the wrapper key and the response helper that
+ * builds the correct shape.
+ *
+ * `get_products` uses `productsResponse` (not `getProductsResponse`) —
+ * matches the helper name in `src/lib/server/responses.ts`.
+ */
+const LIST_WRAPPER_TOOLS: Record<string, { wrapperKey: string; helper: string }> = {
+  list_creatives: { wrapperKey: 'creatives', helper: 'listCreativesResponse' },
+  list_creative_formats: { wrapperKey: 'formats', helper: 'listCreativeFormatsResponse' },
+  list_accounts: { wrapperKey: 'accounts', helper: 'listAccountsResponse' },
+  get_products: { wrapperKey: 'products', helper: 'productsResponse' },
+};
+
+/**
  * Recognize common payload-shape mistakes and emit an actionable hint
  * alongside the generic schema-error message. Keeps the fix-recipe next
  * to the failure signal so implementors don't have to cross-reference
  * docs from a bare AJV pointer like `/ must have required property
  * 'creative_manifest'`.
  *
- * Covers three shape-inversion patterns observed in real integrations:
+ * Covers four shape-inversion patterns observed in real integrations:
  *   - `build_creative` returning platform-native fields at the top level
  *     (scope3 agentic-adapters#100 — `tag_url`, `creative_id`, `media_type`)
  *   - `sync_creatives` returning a single creative's inner shape bubbled
- *     up without the `creatives` array wrapper
+ *     up without the `creatives` array wrapper, OR the wrong wrapper key
+ *     (`{ results: [...] }` instead of `{ creatives: [...] }`)
  *   - `preview_creative` returning raw render fields (`preview_url`,
  *     `preview_html`) at the top level without the `previews[].renders[]`
  *     nesting and `response_type` discriminator
+ *   - List tools (`list_creatives`, `list_creative_formats`, `list_accounts`,
+ *     `get_products`) returning a bare array at the root instead of the
+ *     `{ <key>: [...] }` envelope
  *
  * The detector is a switch on taskName — narrow by design. Add a branch
  * here when a new top-level-key drift pattern shows up in the field.
+ *
+ * Takes `unknown` rather than `Record<string, unknown>` so bare-array
+ * responses (a common list-shape drift) can be recognized at the root.
+ * Object-path branches guard with `typeof payload === 'object'`.
  *
  * Exported for direct unit testing; consumers should rely on the hint
  * reaching `ValidationResult.warning` through the normal run path rather
  * than calling this directly.
  */
-export function detectShapeDriftHint(taskName: string, payload: Record<string, unknown>): string | undefined {
+export function detectShapeDriftHint(taskName: string, payload: unknown): string | undefined {
+  // Bare array at the root — common list-shape drift. Fire a pointed hint
+  // only when the handler is a known list tool; an unknown tool with a
+  // bare array might be legitimate (some APIs do return top-level arrays)
+  // and we don't want a false positive.
+  if (Array.isArray(payload)) {
+    const listMeta = LIST_WRAPPER_TOOLS[taskName];
+    if (listMeta) {
+      return (
+        `${taskName} returned a bare array at the root. ` +
+        `Required: { ${listMeta.wrapperKey}: [...] }. ` +
+        `Use ${listMeta.helper}() from @adcp/client/server.`
+      );
+    }
+    return undefined;
+  }
+
+  // Object branches — require a plain object. null and primitives exit here.
+  if (typeof payload !== 'object' || payload === null) return undefined;
+  const p = payload as Record<string, unknown>;
   // Short and actionable — a developer hitting this is in their terminal
   // looking for the fix, not reading docs. The @adcp/client/server
   // breadcrumb is enough to lead them to the typed helpers.
 
   if (taskName === 'build_creative') {
-    const hasManifest = 'creative_manifest' in payload || 'creative_manifests' in payload;
+    const hasManifest = 'creative_manifest' in p || 'creative_manifests' in p;
     const platformNativeKeys = ['tag_url', 'creative_id', 'media_type', 'tag_type'];
-    const platformNativePresent = platformNativeKeys.filter(k => k in payload);
+    const platformNativePresent = platformNativeKeys.filter(k => k in p);
     if (!hasManifest && platformNativePresent.length > 0) {
       return (
         `build_creative returned platform-native fields at the top level (${platformNativePresent.join(', ')}). ` +
@@ -449,12 +502,12 @@ export function detectShapeDriftHint(taskName: string, payload: Record<string, u
     // `task_id`) deliberately short-circuits before we look at the per-
     // item keys, so a response with BOTH a wrapper AND a top-level
     // `creative_id` (valid, schema-additive extension) stays silent.
-    const hasValidWrapper = 'creatives' in payload || 'errors' in payload || 'task_id' in payload;
+    const hasValidWrapper = 'creatives' in p || 'errors' in p || 'task_id' in p;
 
     // Drift A: per-item shape bubbled up to the top level — the handler
     // forgot to wrap per-creative results in the `creatives` array.
     const perItemKeys = ['creative_id', 'platform_id', 'action'];
-    const perItemPresent = perItemKeys.filter(k => k in payload);
+    const perItemPresent = perItemKeys.filter(k => k in p);
     if (!hasValidWrapper && perItemPresent.length > 0) {
       return (
         `sync_creatives returned a single creative's inner shape at the top level (${perItemPresent.join(', ')}). ` +
@@ -468,7 +521,7 @@ export function detectShapeDriftHint(taskName: string, payload: Record<string, u
     // instead of `{ creatives: [...] }`. Only fire when `results` contains
     // per-item sync shapes, so a legitimate preview handler misrouted to
     // sync_creatives doesn't spuriously trigger.
-    const results = payload.results;
+    const results = p.results;
     if (!hasValidWrapper && Array.isArray(results) && results.length > 0) {
       const firstRow = results[0];
       const looksLikeCreativeRow =
@@ -492,9 +545,9 @@ export function detectShapeDriftHint(taskName: string, payload: Record<string, u
     // (schema/3.0.0/creative/preview-creative-response.json — PreviewCreativeVariantResponse),
     // so deliberately NOT a trigger key. We key only on render-shape fields
     // that only belong inside previews[].renders[] entries.
-    const hasValidWrapper = 'response_type' in payload || 'previews' in payload || 'results' in payload;
+    const hasValidWrapper = 'response_type' in p || 'previews' in p || 'results' in p;
     const rawRenderKeys = ['preview_url', 'preview_html', 'interactive_url'];
-    const rawRenderPresent = rawRenderKeys.filter(k => k in payload);
+    const rawRenderPresent = rawRenderKeys.filter(k => k in p);
     // interactive_url is a legal top-level field on the single-variant branch,
     // so it alone doesn't signal drift — only count it when no wrapper and at
     // least one of the more-specific render fields is also present.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -285,9 +285,7 @@ function validateResponseSchema(
   // enforces `format` keywords and `additionalProperties: false` that Zod's
   // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
   // overall pass/fail stays Zod-driven to preserve backwards compatibility.
-  // Cast the array case to Record for the strict validator — its underlying
-  // AJV call accepts any JSON value but the type annotation expects an object.
-  const strict = computeStrictVerdict(taskName, dataWithoutMessage as Record<string, unknown>);
+  const strict = computeStrictVerdict(taskName, dataWithoutMessage);
 
   // Shape-drift hint runs regardless of strict/lenient outcome — a
   // platform-native `build_creative` response typically fails Zod, but the
@@ -352,7 +350,7 @@ function validateResponseSchema(
  * the SDK — notably the brand-rights and governance schemas that live
  * outside the `bundled/` tree the loader walks today).
  */
-function computeStrictVerdict(taskName: string, payload: Record<string, unknown>): StrictValidationVerdict | undefined {
+function computeStrictVerdict(taskName: string, payload: unknown): StrictValidationVerdict | undefined {
   const outcome = validateResponse(taskName, payload);
   // `variant: 'skipped'` means no AJV validator compiled for this task (no
   // strictness signal to emit); treat the same as "no AJV schema available".
@@ -412,18 +410,28 @@ function buildStrictWarning(strict: StrictValidationVerdict): string | undefined
 
 /**
  * List-shaped tools where handlers commonly return the bare inner array
- * (`[{...}]`) at the root instead of wrapping it in the required object
- * envelope. Each entry names the wrapper key and the response helper that
- * builds the correct shape.
+ * (`[{...}]`) at the top level instead of wrapping it in the required
+ * object envelope. Each entry names the wrapper key and the response
+ * helper that builds the correct shape.
  *
- * `get_products` uses `productsResponse` (not `getProductsResponse`) —
- * matches the helper name in `src/lib/server/responses.ts`.
+ * Helper names aren't uniformly prefixed — `get_products` uses
+ * `productsResponse` (no `get` prefix) while `get_media_buys` uses
+ * `getMediaBuysResponse`. Names match the exports in
+ * `src/lib/server/responses.ts` verbatim so a developer can grep
+ * straight from the hint.
+ *
+ * Tools whose response helpers don't exist yet
+ * (`list_property_lists`, `list_collection_lists`, `list_content_standards`)
+ * are tracked separately — extending the detector to them depends on those
+ * helpers landing first so the hint can name a real SDK symbol.
  */
 const LIST_WRAPPER_TOOLS: Record<string, { wrapperKey: string; helper: string }> = {
   list_creatives: { wrapperKey: 'creatives', helper: 'listCreativesResponse' },
   list_creative_formats: { wrapperKey: 'formats', helper: 'listCreativeFormatsResponse' },
   list_accounts: { wrapperKey: 'accounts', helper: 'listAccountsResponse' },
   get_products: { wrapperKey: 'products', helper: 'productsResponse' },
+  get_media_buys: { wrapperKey: 'media_buys', helper: 'getMediaBuysResponse' },
+  get_signals: { wrapperKey: 'signals', helper: 'getSignalsResponse' },
 };
 
 /**
@@ -443,19 +451,24 @@ const LIST_WRAPPER_TOOLS: Record<string, { wrapperKey: string; helper: string }>
  *     `preview_html`) at the top level without the `previews[].renders[]`
  *     nesting and `response_type` discriminator
  *   - List tools (`list_creatives`, `list_creative_formats`, `list_accounts`,
- *     `get_products`) returning a bare array at the root instead of the
- *     `{ <key>: [...] }` envelope
+ *     `get_products`, `get_media_buys`, `get_signals`) returning a bare
+ *     array at the top level instead of the `{ <key>: [...] }` envelope
  *
- * The detector is a switch on taskName — narrow by design. Add a branch
- * here when a new top-level-key drift pattern shows up in the field.
- *
- * Takes `unknown` rather than `Record<string, unknown>` so bare-array
- * responses (a common list-shape drift) can be recognized at the root.
- * Object-path branches guard with `typeof payload === 'object'`.
+ * The detector is a switch on taskName — narrow by design. Add an entry
+ * to `LIST_WRAPPER_TOOLS` for a new list tool, or a new `if (taskName === ...)`
+ * branch for a new object-shape drift pattern. A registry refactor that
+ * unifies the two halves into one data table is tracked as follow-up once
+ * the branch count justifies it.
  *
  * Exported for direct unit testing; consumers should rely on the hint
  * reaching `ValidationResult.warning` through the normal run path rather
  * than calling this directly.
+ *
+ * @param taskName — tool name (snake_case) the storyboard dispatched under
+ * @param payload — raw response payload. `unknown` rather than
+ *   `Record<string, unknown>` so bare-array payloads are recognizable at
+ *   the top level. Object-path branches guard internally with
+ *   `typeof payload === 'object' && payload !== null`.
  */
 export function detectShapeDriftHint(taskName: string, payload: unknown): string | undefined {
   // Bare array at the root — common list-shape drift. Fire a pointed hint
@@ -466,7 +479,7 @@ export function detectShapeDriftHint(taskName: string, payload: unknown): string
     const listMeta = LIST_WRAPPER_TOOLS[taskName];
     if (listMeta) {
       return (
-        `${taskName} returned a bare array at the root. ` +
+        `${taskName} returned a bare array at the top level. ` +
         `Required: { ${listMeta.wrapperKey}: [...] }. ` +
         `Use ${listMeta.helper}() from @adcp/client/server.`
       );

--- a/test/lib/shape-drift-hint.test.js
+++ b/test/lib/shape-drift-hint.test.js
@@ -226,3 +226,83 @@ test('preview_creative with ONLY interactive_url and no wrapper → no hint', ()
 test('preview_creative empty payload → no hint', () => {
   assert.strictEqual(detectShapeDriftHint('preview_creative', {}), undefined);
 });
+
+// ────────────────────────────────────────────────────────────
+// List-shaped tools — bare array at the root instead of the wrapper envelope
+// ────────────────────────────────────────────────────────────
+
+test('list_creatives with bare array at the root → hint suggests { creatives: [...] }', () => {
+  // Handler returned the inner array directly instead of wrapping it in the
+  // envelope. AJV's error ("expected object, got array") doesn't name the
+  // required wrapper key — this hint does.
+  const hint = detectShapeDriftHint('list_creatives', [
+    { creative_id: 'c1', format_id: { agent_url: 'https://x', id: 'f1' } },
+  ]);
+  assert.ok(hint, 'expected a hint for bare-array list_creatives response');
+  assert.match(hint, /bare array at the root/);
+  assert.match(hint, /\{ creatives: \[\.\.\.\] \}/);
+  assert.match(hint, /listCreativesResponse/);
+  assert.match(hint, /@adcp\/client\/server/);
+});
+
+test('list_creative_formats with bare array → hint suggests { formats: [...] }', () => {
+  const hint = detectShapeDriftHint('list_creative_formats', [
+    { format_id: { agent_url: 'https://x', id: 'f1' }, name: 'Display 300x250' },
+  ]);
+  assert.ok(hint);
+  assert.match(hint, /\{ formats: \[\.\.\.\] \}/);
+  assert.match(hint, /listCreativeFormatsResponse/);
+});
+
+test('list_accounts with bare array → hint suggests { accounts: [...] }', () => {
+  const hint = detectShapeDriftHint('list_accounts', [{ account_id: 'a1', name: 'Acme' }]);
+  assert.ok(hint);
+  assert.match(hint, /\{ accounts: \[\.\.\.\] \}/);
+  assert.match(hint, /listAccountsResponse/);
+});
+
+test('get_products with bare array → hint suggests { products: [...] }', () => {
+  const hint = detectShapeDriftHint('get_products', [{ product_id: 'p1', name: 'Awareness' }]);
+  assert.ok(hint);
+  assert.match(hint, /\{ products: \[\.\.\.\] \}/);
+  assert.match(hint, /productsResponse/);
+});
+
+test('list tools with proper object wrapper → no hint', () => {
+  // A valid list response (object with the wrapper key populated) must not
+  // trigger the bare-array branch.
+  assert.strictEqual(
+    detectShapeDriftHint('list_creatives', {
+      creatives: [{ creative_id: 'c1' }],
+      query_summary: { total_matching: 1, returned: 1 },
+      pagination: { has_more: false },
+    }),
+    undefined
+  );
+  assert.strictEqual(detectShapeDriftHint('get_products', { products: [{ product_id: 'p1' }] }), undefined);
+});
+
+test('bare array for an unknown tool → no hint (avoids false positives)', () => {
+  // Some APIs legitimately return top-level arrays. The detector must not
+  // fire on unknown task names — only on the known list tools in
+  // LIST_WRAPPER_TOOLS.
+  assert.strictEqual(detectShapeDriftHint('unknown_tool', [{ id: 1 }]), undefined);
+  assert.strictEqual(detectShapeDriftHint('create_media_buy', [{ media_buy_id: 'mb1' }]), undefined);
+});
+
+test('empty bare array for a list tool → still a hint (shape is still wrong)', () => {
+  // An empty array is the same shape mistake as a populated one — the
+  // handler forgot the wrapper. Hint fires regardless of length.
+  const hint = detectShapeDriftHint('list_creatives', []);
+  assert.ok(hint);
+  assert.match(hint, /bare array at the root/);
+});
+
+test('null / primitive payloads → no hint (detector exits cleanly)', () => {
+  // Defensive: the detector must handle `null`, strings, numbers without
+  // throwing — they're not a shape-drift pattern but they'd otherwise crash
+  // the object-branch guards.
+  assert.strictEqual(detectShapeDriftHint('list_creatives', null), undefined);
+  assert.strictEqual(detectShapeDriftHint('build_creative', 'oops'), undefined);
+  assert.strictEqual(detectShapeDriftHint('sync_creatives', 42), undefined);
+});

--- a/test/lib/shape-drift-hint.test.js
+++ b/test/lib/shape-drift-hint.test.js
@@ -239,7 +239,7 @@ test('list_creatives with bare array at the root → hint suggests { creatives: 
     { creative_id: 'c1', format_id: { agent_url: 'https://x', id: 'f1' } },
   ]);
   assert.ok(hint, 'expected a hint for bare-array list_creatives response');
-  assert.match(hint, /bare array at the root/);
+  assert.match(hint, /bare array at the top level/);
   assert.match(hint, /\{ creatives: \[\.\.\.\] \}/);
   assert.match(hint, /listCreativesResponse/);
   assert.match(hint, /@adcp\/client\/server/);
@@ -295,7 +295,21 @@ test('empty bare array for a list tool → still a hint (shape is still wrong)',
   // handler forgot the wrapper. Hint fires regardless of length.
   const hint = detectShapeDriftHint('list_creatives', []);
   assert.ok(hint);
-  assert.match(hint, /bare array at the root/);
+  assert.match(hint, /bare array at the top level/);
+});
+
+test('get_media_buys with bare array → hint suggests { media_buys: [...] }', () => {
+  const hint = detectShapeDriftHint('get_media_buys', [{ media_buy_id: 'mb1', status: 'active' }]);
+  assert.ok(hint);
+  assert.match(hint, /\{ media_buys: \[\.\.\.\] \}/);
+  assert.match(hint, /getMediaBuysResponse/);
+});
+
+test('get_signals with bare array → hint suggests { signals: [...] }', () => {
+  const hint = detectShapeDriftHint('get_signals', [{ signal_id: { agent_url: 'x', id: 's1' } }]);
+  assert.ok(hint);
+  assert.match(hint, /\{ signals: \[\.\.\.\] \}/);
+  assert.match(hint, /getSignalsResponse/);
 });
 
 test('null / primitive payloads → no hint (detector exits cleanly)', () => {


### PR DESCRIPTION
## Summary

Closes #852. Extends the \`detectShapeDriftHint\` framework from #845/#848/#851 to cover list-shaped tools where handlers return a bare array at the root instead of wrapping it in the required \`{ <key>: [...] }\` envelope.

### What's detected

| Tool | Wrong shape | Required shape | Helper named |
|---|---|---|---|
| \`list_creatives\` | \`[{...}]\` | \`{ creatives, query_summary, pagination }\` | \`listCreativesResponse\` |
| \`list_creative_formats\` | \`[{...}]\` | \`{ formats: [...] }\` | \`listCreativeFormatsResponse\` |
| \`list_accounts\` | \`[{...}]\` | \`{ accounts: [...] }\` | \`listAccountsResponse\` |
| \`get_products\` | \`[{...}]\` | \`{ products: [...] }\` | \`productsResponse\` |

### Why

AJV's error on a bare-array response is "expected object, got array" — accurate but doesn't name the required wrapper. A developer sees the error, doesn't know \`creatives\` vs \`results\` vs \`data\`, and has to dig into the schema. The hint tells them in one line.

The \`LIST_WRAPPER_TOOLS\` map is the single extension point — add a row, ship a helper reference, done.

### Signature change

\`detectShapeDriftHint\` now accepts \`unknown\` rather than \`Record<string, unknown>\` so it can recognize bare-array payloads at the root. Object-branch logic guards with \`typeof payload === 'object' && payload !== null\` at the top, keeping existing behavior intact. The caller in \`validateResponseSchema\` also no longer destructures \`_message\` off array-valued payloads (bare arrays don't carry that field).

### Safety

Bare arrays for **unknown** task names pass through silently. Some APIs legitimately return top-level arrays; the detector only fires on tools in \`LIST_WRAPPER_TOOLS\`. Defensive tests cover null / primitive payloads (detector exits cleanly), empty arrays (still wrong shape, hint fires), and the wrapper-present negative case.

## Test plan

- [x] 29/29 shape-drift-hint tests pass (21 pre-existing + 8 new)
- [x] \`npm run typecheck\` — clean
- [x] \`npm run prettier --check\` — clean

## Still deferred

- **#841** \`--no-sandbox\` — blocked on convention RFC
- **#850** version-staleness hint suffix — next tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)