### PR TITLE
fix(server): omit `replayed` on fresh execution, stamp only on replay (#857)

### DIFF
--- a/.changeset/omit-replayed-fresh.md
+++ b/.changeset/omit-replayed-fresh.md
@@ -2,10 +2,20 @@
 '@adcp/client': patch
 ---
 
-Align `replayed` envelope semantics with `protocol-envelope.json`: the field is now **omitted on fresh execution** and stamped only on replay. The envelope spec permits the field to be "omitted when the request was executed fresh", and absence-as-fresh is cleaner than emitting a pro-forma `false` on every mutating response.
+Align `replayed` envelope emission with `protocol-envelope.json`: the SDK now **omits `replayed` on fresh execution** and stamps `replayed: true` on replays only. The envelope spec explicitly permits the field to be "omitted when the request was executed fresh," and the replay stamp now mirrors into both the L3 `structuredContent` and the L2 `content[0].text` JSON body so A2A/REST transports see the same marker MCP does.
 
-- Internal: renamed `injectReplayed` to `stampReplayed` and dropped the fresh-path call site in `create-adcp-server.ts`. The replay path still stamps `replayed: true` on cached copies so buyers can distinguish cached replays from new executions.
-- Public API (`wrapEnvelope`) unchanged: sellers can still pass `replayed: false` explicitly and the helper round-trips it. Sellers that want an explicit marker in-band are free to emit one.
-- Documentation updated: `wrapEnvelope` JSDoc no longer claims conformance storyboards require `replayed: false` on fresh-path mutations.
+### What you'll see
 
-Upstream: filed [`adcp-client#857`](https://github.com/adcontextprotocol/adcp-client/issues/857) against the `idempotency.yaml` storyboard's `field_value allowed_values: [false]` assertion, which conflicts with the envelope spec's explicit allowance for omission. Until that storyboard assertion lands as `any_of` or `field_absent_or_value`, the `replay_same_payload` phase will fail on the fresh-path step — this is the storyboard being the bug, not the SDK.
+- **Seller handlers (using `createAdcpServer`)**: fresh mutating responses (`create_media_buy`, `sync_creatives`, `sync_governance`, etc.) no longer carry `replayed: false` in the envelope. Snapshot or contract tests asserting `replayed === false` on fresh will need to be updated to `replayed !== true` (or `replayed === undefined`). Replay responses still carry `replayed: true`.
+- **Buyer-side readers (using the `@adcp/client` SDK)**: no change. `ProtocolResponseParser.getReplayed` already treats absence and `false` identically, and the envelope schema's `"default": false` means schema-aware parsers materialize the same value either way.
+- **Public `wrapEnvelope` helper**: unchanged. Sellers calling `wrapEnvelope({replayed: false})` directly still round-trip the explicit marker — this release only changes the framework's internal idempotency path.
+
+### Upstream tracking
+
+The compliance storyboard `compliance/cache/latest/universal/idempotency.yaml` asserts `field_value allowed_values: [false]` on `replayed` at the fresh-path step, which conflicts with the envelope spec. The storyboard's own `description` field at that step reads "Initial execution sets replayed: false (or omits the field)" — a self-inconsistent assertion. Filed upstream as [`adcp-client#857`](https://github.com/adcontextprotocol/adcp-client/issues/857) with a fix proposal (`any_of: [field_absent, field_value: false]`). Until that lands, the `replay_same_payload` phase of the idempotency storyboard will fail on the fresh-path step for any seller on this SDK version — this is the storyboard's literal-match bug, not SDK drift. Other phases (`key_reuse_conflict`, `fresh_key_new_resource`, webhook dedup) still pass.
+
+### Internal
+
+- `create-adcp-server.ts`: `injectReplayed(response, value)` renamed to `stampReplayed(response)` (always stamps `true`); fresh-path call site dropped. Replay-path stamp now updates both L2 text and L3 structuredContent to match the `injectContextIntoResponse` / `sanitizeAdcpErrorEnvelope` lockstep pattern.
+- `wrap-envelope.ts`, `envelope-allowlist.ts`, `validation/schema-loader.ts`: documentation only.
+- `test/server-idempotency.test.js`: fresh-path assertion relaxed from `=== false` to `!== true`.

--- a/.changeset/omit-replayed-fresh.md
+++ b/.changeset/omit-replayed-fresh.md
@@ -2,20 +2,30 @@
 '@adcp/client': patch
 ---
 
-Align `replayed` envelope emission with `protocol-envelope.json`: the SDK now **omits `replayed` on fresh execution** and stamps `replayed: true` on replays only. The envelope spec explicitly permits the field to be "omitted when the request was executed fresh," and the replay stamp now mirrors into both the L3 `structuredContent` and the L2 `content[0].text` JSON body so A2A/REST transports see the same marker MCP does.
+Two independent envelope-layer fixes for mutating responses:
+
+### 1. Omit `replayed` on fresh execution (align with `protocol-envelope.json`)
+
+The SDK used to stamp `replayed: false` on every fresh-path mutating response. The envelope spec explicitly permits the field to be "omitted when the request was executed fresh" — absence now signals fresh execution, presence signals replay. Replay responses still carry `replayed: true`.
+
+### 2. Mirror the replay marker into L2 `content[0].text` (A2A/REST parity)
+
+The replay-path stamp previously only touched MCP `structuredContent` (L3). A2A and REST transports that consume `content[0].text` (L2) never saw `replayed: true` on replay — replay detection was silently broken on those transports. `stampReplayed` now updates both layers, matching the lockstep pattern used by `injectContextIntoResponse` and `sanitizeAdcpErrorEnvelope`. This is orthogonal to the envelope-semantics change and a bona fide bug fix.
 
 ### What you'll see
 
-- **Seller handlers (using `createAdcpServer`)**: fresh mutating responses (`create_media_buy`, `sync_creatives`, `sync_governance`, etc.) no longer carry `replayed: false` in the envelope. Snapshot or contract tests asserting `replayed === false` on fresh will need to be updated to `replayed !== true` (or `replayed === undefined`). Replay responses still carry `replayed: true`.
-- **Buyer-side readers (using the `@adcp/client` SDK)**: no change. `ProtocolResponseParser.getReplayed` already treats absence and `false` identically, and the envelope schema's `"default": false` means schema-aware parsers materialize the same value either way.
-- **Public `wrapEnvelope` helper**: unchanged. Sellers calling `wrapEnvelope({replayed: false})` directly still round-trip the explicit marker — this release only changes the framework's internal idempotency path.
+- **Seller handlers (`createAdcpServer`)**: fresh mutating responses no longer carry `replayed: false`. Snapshot / contract tests asserting `replayed === false` on fresh need to be updated to `replayed !== true` (or `replayed === undefined`).
+- **A2A / REST buyers**: replay responses now carry `replayed: true` on the text body where they previously didn't. Replay detection on non-MCP transports starts working.
+- **Observability / log pipelines**: dashboards that count fresh executions via `replayed === false` go silent on this version. Switch to `replayed !== true` (fresh = absent or false) or key off a different signal (e.g. tool handler invocation count).
+- **Buyer-side readers (`@adcp/client` SDK)**: no change. `ProtocolResponseParser.getReplayed` already treats absence and `false` identically, and the envelope schema's `"default": false` means schema-aware parsers materialize the same value either way.
+- **Public `wrapEnvelope` helper**: unchanged. Sellers calling `wrapEnvelope({replayed: false})` directly still round-trip the explicit marker. The asymmetry between the framework path (omits on fresh) and wrapEnvelope callers (honors explicit `false`) is intentional and documented on the option.
 
-### Upstream tracking
+### Upstream coordination
 
-The compliance storyboard `compliance/cache/latest/universal/idempotency.yaml` asserts `field_value allowed_values: [false]` on `replayed` at the fresh-path step, which conflicts with the envelope spec. The storyboard's own `description` field at that step reads "Initial execution sets replayed: false (or omits the field)" — a self-inconsistent assertion. Filed upstream as [`adcp-client#857`](https://github.com/adcontextprotocol/adcp-client/issues/857) with a fix proposal (`any_of: [field_absent, field_value: false]`). Until that lands, the `replay_same_payload` phase of the idempotency storyboard will fail on the fresh-path step for any seller on this SDK version — this is the storyboard's literal-match bug, not SDK drift. Other phases (`key_reuse_conflict`, `fresh_key_new_resource`, webhook dedup) still pass.
+Filed [`adcp-client#857`](https://github.com/adcontextprotocol/adcp-client/issues/857) against the `compliance/cache/latest/universal/idempotency.yaml` storyboard: its `field_value allowed_values: [false]` assertion on the fresh-path step conflicts with its own prose (`"Initial execution sets replayed: false (or omits the field)"`) — a literal-match bug where `any_of: [field_absent, field_value: false]` was intended. Until the storyboard fix lands, the `replay_same_payload` phase will fail on the fresh-path step for sellers on this SDK version; all other phases (`key_reuse_conflict`, `fresh_key_new_resource`, webhook dedup) still pass. Per `CLAUDE.md`'s storyboard-failure triage rule, the storyboard is the bug here — the envelope spec unambiguously permits omission.
 
 ### Internal
 
-- `create-adcp-server.ts`: `injectReplayed(response, value)` renamed to `stampReplayed(response)` (always stamps `true`); fresh-path call site dropped. Replay-path stamp now updates both L2 text and L3 structuredContent to match the `injectContextIntoResponse` / `sanitizeAdcpErrorEnvelope` lockstep pattern.
-- `wrap-envelope.ts`, `envelope-allowlist.ts`, `validation/schema-loader.ts`: documentation only.
+- `create-adcp-server.ts`: `injectReplayed(response, value)` renamed to `stampReplayed(response)`; fresh-path call site dropped; replay-path stamp mirrors into both L2 text and L3 structuredContent.
+- `wrap-envelope.ts`, `envelope-allowlist.ts`, `validation/schema-loader.ts`: documentation only. `wrap-envelope.ts` picks up a note that the framework/helper asymmetry on fresh `replayed` is intentional.
 - `test/server-idempotency.test.js`: fresh-path assertion relaxed from `=== false` to `!== true`.

--- a/.changeset/omit-replayed-fresh.md
+++ b/.changeset/omit-replayed-fresh.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': patch
+---
+
+Align `replayed` envelope semantics with `protocol-envelope.json`: the field is now **omitted on fresh execution** and stamped only on replay. The envelope spec permits the field to be "omitted when the request was executed fresh", and absence-as-fresh is cleaner than emitting a pro-forma `false` on every mutating response.
+
+- Internal: renamed `injectReplayed` to `stampReplayed` and dropped the fresh-path call site in `create-adcp-server.ts`. The replay path still stamps `replayed: true` on cached copies so buyers can distinguish cached replays from new executions.
+- Public API (`wrapEnvelope`) unchanged: sellers can still pass `replayed: false` explicitly and the helper round-trips it. Sellers that want an explicit marker in-band are free to emit one.
+- Documentation updated: `wrapEnvelope` JSDoc no longer claims conformance storyboards require `replayed: false` on fresh-path mutations.
+
+Upstream: filed [`adcp-client#857`](https://github.com/adcontextprotocol/adcp-client/issues/857) against the `idempotency.yaml` storyboard's `field_value allowed_values: [false]` assertion, which conflicts with the envelope spec's explicit allowance for omission. Until that storyboard assertion lands as `any_of` or `field_absent_or_value`, the `replay_same_payload` phase will fail on the fresh-path step — this is the storyboard being the bug, not the SDK.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1072,17 +1072,36 @@ function deepMergePlainObjects(target: unknown, source: unknown): unknown {
 }
 
 /**
- * Stamp `replayed: true` on the response envelope (MCP structuredContent)
- * for replay paths only. `protocol-envelope.json` permits the field to be
- * "omitted when the request was executed fresh" — fresh-path responses
- * therefore carry no `replayed` field, and the field's presence implies
- * `true`. Buyers read the field to distinguish cached replays from new
- * executions for billing and audit.
+ * Stamp `replayed: true` on the response envelope for replay paths only.
+ * `protocol-envelope.json` permits the field to be "omitted when the
+ * request was executed fresh" — fresh-path responses therefore carry no
+ * `replayed` field, and the field's presence implies `true`. Buyers read
+ * the field to distinguish cached replays from new executions for billing
+ * and audit.
+ *
+ * Mirrors the marker into both L3 `structuredContent` and the L2
+ * `content[0].text` JSON fallback so A2A/REST adapters that consume the
+ * text body see the same envelope MCP does — matching the lockstep
+ * pattern in `injectContextIntoResponse` / `sanitizeAdcpErrorEnvelope`.
  */
 function stampReplayed(response: McpToolResponse): void {
   if (!response.structuredContent || typeof response.structuredContent !== 'object') return;
   const sc = response.structuredContent as Record<string, unknown>;
   sc.replayed = true;
+  if (Array.isArray(response.content)) {
+    const first = response.content[0];
+    if (first && first.type === 'text' && typeof first.text === 'string') {
+      try {
+        const parsed = JSON.parse(first.text);
+        if (parsed && typeof parsed === 'object') {
+          parsed.replayed = true;
+          first.text = JSON.stringify(parsed);
+        }
+      } catch {
+        // Text isn't JSON — leave it alone (implausible for AdCP responses).
+      }
+    }
+  }
 }
 
 /**

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1072,22 +1072,17 @@ function deepMergePlainObjects(target: unknown, source: unknown): unknown {
 }
 
 /**
- * Stamp `replayed` on the response envelope (MCP structuredContent) for
- * every idempotency-gated mutating tool.
- *
- * Per `protocol-envelope.json`, `replayed` MAY be omitted on fresh exec,
- * but every 3.0 mutating-tool response schema declares the property
- * explicitly with `additionalProperties: true`, so emitting `false` is
- * spec-legal AND unambiguous for buyers. The compliance
- * `idempotency.replay_same_payload` storyboard relies on an explicit
- * `false` on the fresh call to assert idempotency is wired — omission
- * fails the `field_value, allowed_values: [false]` assertion. Emit
- * explicitly.
+ * Stamp `replayed: true` on the response envelope (MCP structuredContent)
+ * for replay paths only. `protocol-envelope.json` permits the field to be
+ * "omitted when the request was executed fresh" — fresh-path responses
+ * therefore carry no `replayed` field, and the field's presence implies
+ * `true`. Buyers read the field to distinguish cached replays from new
+ * executions for billing and audit.
  */
-function injectReplayed(response: McpToolResponse, value: boolean): void {
+function stampReplayed(response: McpToolResponse): void {
   if (!response.structuredContent || typeof response.structuredContent !== 'object') return;
   const sc = response.structuredContent as Record<string, unknown>;
-  sc.replayed = value;
+  sc.replayed = true;
 }
 
 /**
@@ -1960,7 +1955,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // error cache entries (VALIDATION_ERROR from strict-mode
               // drift) are retry-storm guards, not spec replays.
               if (!isErrorResponse(cachedFormatted)) {
-                injectReplayed(cachedFormatted, true);
+                stampReplayed(cachedFormatted);
               }
               return finalize(cachedFormatted);
             }
@@ -2152,10 +2147,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                   error: reason,
                 });
               }
-              // Stamp replayed:false AFTER caching so the cached copy has
-              // no pre-baked value. On replay we inject replayed:true
-              // from the replay path, overwriting anything.
-              injectReplayed(formatted, false);
+              // Fresh-path responses omit `replayed` — per envelope spec,
+              // absence signals fresh execution. The replay path stamps
+              // `replayed: true` on the cached copy at retrieval.
             } else {
               try {
                 await idempotency.release({

--- a/src/lib/server/envelope-allowlist.ts
+++ b/src/lib/server/envelope-allowlist.ts
@@ -56,7 +56,7 @@ export const DEFAULT_ERROR_ENVELOPE_FIELDS: ReadonlySet<string> = Object.freeze(
  * `IDEMPOTENCY_CONFLICT` deliberately excludes `replayed`: the
  * conflict path in `create-adcp-server.ts` builds its error via
  * `finalize()`, which only echoes `context` and never calls
- * `injectReplayed`. The framework's own behavior is preserved.
+ * `stampReplayed`. The framework's own behavior is preserved.
  *
  * **Invariant**: every allowlist set MUST include `'context'`.
  * `ensureContextEcho` enforces this at module load so new error codes

--- a/src/lib/server/wrap-envelope.ts
+++ b/src/lib/server/wrap-envelope.ts
@@ -30,15 +30,18 @@ import { DEFAULT_ERROR_ENVELOPE_FIELDS, ERROR_ENVELOPE_FIELD_ALLOWLIST } from '.
  * Every field is optional. When omitted, the corresponding envelope key is
  * NOT attached (as opposed to emitted with `undefined`). When `replayed`
  * is passed explicitly — including `replayed: false` — the value is
- * attached; the conformance storyboards require `replayed:false` on
- * fresh-path mutations so the field must round-trip when explicitly set.
+ * attached as-is, so sellers that want to emit an explicit marker on fresh
+ * execution can. The framework's own replay bookkeeping stamps `true` on
+ * replay and omits the field on fresh (envelope spec permits both).
  */
 export interface WrapEnvelopeOptions {
   /**
-   * Replay marker. Attached as-is when explicitly set. `false` is a
-   * meaningful value (fresh-path mutation) and MUST be emitted when
-   * passed. Dropped on error codes whose allowlist excludes it (e.g.
-   * `IDEMPOTENCY_CONFLICT`).
+   * Replay marker. Attached as-is when explicitly set. `protocol-envelope.json`
+   * permits the field to be "omitted when the request was executed fresh",
+   * so the framework's internal idempotency path omits it on fresh and
+   * stamps `true` on replay. Sellers calling this helper directly may
+   * pass `false` explicitly if they want the marker in-band. Dropped on
+   * error codes whose allowlist excludes it (e.g. `IDEMPOTENCY_CONFLICT`).
    */
   replayed?: boolean;
 
@@ -103,10 +106,9 @@ function isEchoableContext(value: unknown): boolean {
  * async function handleCreateMediaBuy(request) {
  *   try {
  *     const inner = await buyService.create(request.params);
- *     // Fresh-path success: emit replayed:false so storyboards can assert
- *     // the absence of a replay, and echo request.context for tracing.
+ *     // Fresh-path success: omit `replayed` — envelope spec reads absence
+ *     // as fresh execution. Echo request.context for correlation tracing.
  *     return wrapEnvelope(inner, {
- *       replayed: false,
  *       context: request.context,
  *       operationId: inner.operation_id,
  *     });
@@ -124,13 +126,22 @@ function isEchoableContext(value: unknown): boolean {
  * }
  * ```
  *
- * @example Success path
+ * @example Success path (fresh execution, no explicit replayed)
  * ```ts
  * const response = wrapEnvelope(
  *   { media_buy_id: 'mb_1', status: 'active' },
- *   { replayed: false, context: { correlation_id: 'abc' }, operationId: 'op_123' }
+ *   { context: { correlation_id: 'abc' }, operationId: 'op_123' }
  * );
- * // => { media_buy_id, status, replayed: false, context: {...}, operation_id: 'op_123' }
+ * // => { media_buy_id, status, context: {...}, operation_id: 'op_123' }
+ * ```
+ *
+ * @example Replay path (stamp true)
+ * ```ts
+ * const response = wrapEnvelope(
+ *   { media_buy_id: 'mb_1', status: 'active' },
+ *   { replayed: true, context: { correlation_id: 'abc' }, operationId: 'op_123' }
+ * );
+ * // => { media_buy_id, status, replayed: true, context: {...}, operation_id: 'op_123' }
  * ```
  *
  * @example Conflict error — `replayed` is dropped, `context` is echoed

--- a/src/lib/server/wrap-envelope.ts
+++ b/src/lib/server/wrap-envelope.ts
@@ -42,6 +42,12 @@ export interface WrapEnvelopeOptions {
    * stamps `true` on replay. Sellers calling this helper directly may
    * pass `false` explicitly if they want the marker in-band. Dropped on
    * error codes whose allowlist excludes it (e.g. `IDEMPOTENCY_CONFLICT`).
+   *
+   * The asymmetry between the framework path (omits on fresh) and
+   * wrapEnvelope callers (round-trip explicit `false`) is intentional:
+   * the framework optimizes for spec-clean payloads, while wrapEnvelope
+   * respects the caller's explicit intent. Don't "fix" this by collapsing
+   * `false` to absent.
    */
   replayed?: boolean;
 

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -79,7 +79,8 @@ function loadJson(file: string): LoadedSchema {
  * can ride alongside the tool-specific body — per security.mdx the
  * envelope is always extensible. Upstream bundled schemas pin
  * `additionalProperties: false` at the root on a handful of mutating
- * tools (the property-list family), which rejects `replayed: false`.
+ * tools (the property-list family), which rejects envelope fields like
+ * `replayed` that aren't declared in the tool-specific body.
  *
  * Scope is deliberately narrow: only the top-level object, plus each
  * direct branch of a root-level `oneOf` / `anyOf` / `allOf`. Nested

--- a/test/lib/wrap-envelope.test.js
+++ b/test/lib/wrap-envelope.test.js
@@ -3,7 +3,7 @@
  *
  * Covers success and error envelope construction with the sibling
  * allowlist used for error codes like IDEMPOTENCY_CONFLICT. Parity with
- * `create-adcp-server.ts`'s internal `injectReplayed` + `finalize()` path
+ * `create-adcp-server.ts`'s internal `stampReplayed` + `finalize()` path
  * is asserted via behavioral tests — the implementations stay separate
  * for now, both satisfied by this suite.
  */
@@ -24,10 +24,12 @@ describe('wrapEnvelope: success envelopes', () => {
     assert.deepEqual(out, { media_buy_id: 'mb_1', replayed: true });
   });
 
-  it('attaches replayed:false when explicitly set (storyboard-required)', () => {
-    // replayed:false is a meaningful value — fresh-path mutations MUST
-    // emit it so conformance storyboards can assert the absence of a
-    // replay. The helper must not collapse false to absent.
+  it('attaches replayed:false when explicitly set (public API round-trip)', () => {
+    // The framework's internal idempotency path omits `replayed` on fresh
+    // execution (envelope spec permits both), but the public helper MUST
+    // round-trip an explicit `false` — sellers that want the marker
+    // in-band can opt in by passing it, and the helper must not collapse
+    // false to absent.
     const out = wrapEnvelope({ media_buy_id: 'mb_1' }, { replayed: false });
     assert.deepEqual(out, { media_buy_id: 'mb_1', replayed: false });
     assert.ok('replayed' in out, 'replayed key must be present');
@@ -117,7 +119,7 @@ describe('wrapEnvelope: error envelopes', () => {
 
   it('drops replayed on IDEMPOTENCY_CONFLICT (sibling allowlist)', () => {
     // A conflict is not a replay — the framework's `finalize()` path
-    // for IDEMPOTENCY_CONFLICT never calls `injectReplayed`. The helper
+    // for IDEMPOTENCY_CONFLICT never calls `stampReplayed`. The helper
     // mirrors that by honoring the ERROR_ENVELOPE_FIELD_ALLOWLIST entry
     // for IDEMPOTENCY_CONFLICT, which excludes `replayed`.
     const err = {

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -80,12 +80,11 @@ describe('createAdcpServer with idempotency', () => {
     });
     assert.equal(calls.length, 1);
     assert.equal(result.media_buy_id, 'mb_1');
-    // Fresh exec must stamp `replayed: false` explicitly so the
-    // `idempotency.replay_same_payload` conformance storyboard's
-    // `field_value, allowed_values: [false]` assertion passes. 3.0 mutating
-    // response schemas declare `replayed` in-schema with
-    // `additionalProperties: true`, so an explicit `false` is spec-legal.
-    assert.equal(result.replayed, false, 'fresh execution must set `replayed: false` — the storyboard anchor');
+    // Fresh exec must NOT carry `replayed: true`. `protocol-envelope.json`
+    // permits the field to be "omitted when the request was executed
+    // fresh", and the framework omits it on fresh so buyers treat
+    // absence-or-false as "not a replay".
+    assert.notEqual(result.replayed, true, 'fresh execution must not set replayed:true');
   });
 
   it('replay with same key + equivalent payload returns cached response with replayed:true', async () => {


### PR DESCRIPTION
## Summary

Two independent envelope-layer fixes for mutating responses:

1. **Omit `replayed` on fresh execution** — align with `protocol-envelope.json` which explicitly permits "omitted when the request was executed fresh." Fresh = absent, replay = `true`. Replay detection semantics unchanged.
2. **Mirror the replay marker into L2 `content[0].text`** — orthogonal bug fix. `stampReplayed` previously only touched MCP `structuredContent` (L3), so A2A and REST transports reading the text body never saw `replayed: true` on replay. Replay detection on non-MCP transports was silently broken. Now mirrored in lockstep with `injectContextIntoResponse` / `sanitizeAdcpErrorEnvelope`.

Internal rename: `injectReplayed(response, value)` → `stampReplayed(response)` (one call site remains, always `true`).

Public `wrapEnvelope` API unchanged — sellers calling `wrapEnvelope({ replayed: false })` directly still round-trip the explicit marker. The asymmetry is intentional and now documented on the option.

## ⚠ Release coordination — do not merge ahead of upstream storyboard fix

Filed [adcp-client#857](https://github.com/adcontextprotocol/adcp-client/issues/857) against `idempotency.yaml`: its `field_value allowed_values: [false]` assertion on the fresh-path step is a literal-match bug (the storyboard's own prose says "or omits the field"). Once this SDK ships, the `replay_same_payload` phase fails for every downstream seller on `@adcp/client@latest` until the storyboard fix lands. Options, in order of preference:

- [ ] Land #857 storyboard fix first, then merge this PR
- [ ] Merge this PR and bundle the storyboard fix in the same release train
- [ ] Merge as-is and accept transient red for sellers mid-3.0-cert

**Blocks on:** adcontextprotocol/adcp-client#857

Per `CLAUDE.md`'s storyboard-failure triage rule the storyboard IS the bug — the envelope spec unambiguously permits omission — so the SDK change is defensible regardless of ordering. The concern is operator-reality CI friction, not correctness.

## What seller integrators will see

- Fresh `create_media_buy` / `sync_creatives` / `sync_governance` / etc. no longer carry `replayed: false`. Snapshot / contract tests asserting `replayed === false` on fresh need to be updated to `replayed !== true` (or `replayed === undefined`).
- **A2A / REST buyers** start seeing `replayed: true` on replay responses (text body) — this was previously always absent, so any downstream that already handled "absent = fresh" keeps working and replay detection now actually works.
- **Observability / log pipelines** keyed on `replayed === false` (e.g. "count fresh executions") go silent on this version. Switch to `replayed !== true`, or key off tool-handler invocation count instead.
- Buyer SDK reader side (`ProtocolResponseParser.getReplayed`) already treats absence and `false` identically. Envelope schema's `"default": false` means schema-aware parsers materialize the same value either way.

## Expert review (addressed)

Ran protocol, product, and code reviewers before the first push, plus a second human review on the opened PR:

- **Protocol**: ship-with-caveats — storyboard self-inconsistent; cross-protocol parity needed (addressed via L2 mirror).
- **Product**: mixed, lean ship — changeset needed louder migration guidance (addressed).
- **Code review**: done / ready — flagged L2 drift and `schema-loader.ts:82` comment (both addressed).
- **PR review follow-ups** (`bcba3a0f`): split changeset bullets so bisect has a clean delta; name the wrapEnvelope asymmetry as intentional in JSDoc; call out observability-pipeline impact in "What you'll see."

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 5583 / 5583 pass
- [x] `test/server-idempotency.test.js` + `test/lib/wrap-envelope.test.js` + `test/lib/idempotency-client.test.js` — 57 / 57 pass
- [x] Dogfood storyboard against local `createAdcpServer` with idempotency enabled: only `replay_same_payload` fails on the #857 assertion; `key_reuse_conflict`, `fresh_key_new_resource` still pass
- [ ] CI green
- [ ] adcp-client#857 landed or bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)