### PR TITLE
docs(seller-skill): define the baseline explicitly

### DIFF
--- a/.changeset/seller-skill-baseline.md
+++ b/.changeset/seller-skill-baseline.md
@@ -1,0 +1,13 @@
+---
+'@adcp/client': patch
+---
+
+docs(seller-skill): define the baseline explicitly
+
+Follow-up to #843. The seller-agent skill referenced "the baseline" 25+ times without enumerating it. A reader (or a coding agent like Claude) hitting the skill could not find an authoritative list of tools every `sales-*` agent must implement, which is the gap that let an adapter update remove `get_products` and `create_media_buy` on the read that `sales-social` is "walled-garden-only."
+
+Adds a new top-level "The baseline: what every sales-\* agent MUST implement" section to `skills/build-seller-agent/SKILL.md` with the full 11-tool table (`get_adcp_capabilities`, `sync_accounts`, `list_accounts`, `get_products`, `list_creative_formats`, `create_media_buy`, `update_media_buy`, `get_media_buys`, `sync_creatives`, `list_creatives`, `get_media_buy_delivery`), the `createAdcpServer` handler group each belongs to, a minimum handler skeleton, and an explicit "if a specialism's storyboard doesn't exercise a baseline tool, the tool is not optional" note.
+
+Also anchors the section and wires cross-refs from the "Specialisms are additive" intro paragraph and the `sales-social` "Baseline tools still apply" block so readers have a single source of truth for the baseline surface.
+
+No code changes; skill is shipped under `files[]` so a patch bump surfaces the doc update to downstream consumers who ship CLAUDE.md-linked skill packs.

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -21,11 +21,59 @@ A seller agent receives briefs from buyers, returns products with pricing, accep
 - Serving audience segments → `skills/build-signals-agent/`
 - Rendering creatives from briefs → that's a creative agent
 
+## <a name="the-baseline-what-every-sales--agent-must-implement"></a>The baseline: what every sales-* agent MUST implement
+
+Every sales-* specialism (including `sales-social`, `sales-broadcast-tv`, `sales-retail-media`, `sales-catalog-driven`, etc.) is **additive on top of this baseline**. If you claim any `sales-*` specialism, you implement these tools regardless of the specialism-specific deltas below.
+
+**Required tools** (tested by the `media_buy_seller` storyboard bundle at `compliance/cache/3.0.0/protocols/media-buy/`):
+
+| Tool | Purpose | `createAdcpServer` group |
+|---|---|---|
+| `get_adcp_capabilities` | Declare protocols + specialisms + features | auto (framework) |
+| `sync_accounts` | Advertiser onboarding, per-tenant account creation | `accounts` |
+| `list_accounts` | Account lookup by brand/operator; buyers listing their accounts on your platform | `accounts` |
+| `get_products` | Product catalog discovery from a brief; returns `{ products: [...] }` | `mediaBuy` |
+| `list_creative_formats` | Formats your agent accepts | `mediaBuy` |
+| `create_media_buy` | Accept a campaign with packages, budget, flight dates | `mediaBuy` |
+| `update_media_buy` | Bid, budget, status, package mutations over the campaign lifecycle | `mediaBuy` |
+| `get_media_buys` | Read campaigns back with full state (status, budget, packages, targeting overlays) | `mediaBuy` |
+| `sync_creatives` | Accept creative assets and return per-asset status | `mediaBuy` |
+| `list_creatives` | Read the creative library back with pagination | `mediaBuy` |
+| `get_media_buy_delivery` | Delivery + spend reporting with `reporting_period`, per-package billing rows | `mediaBuy` |
+
+**Minimum handler skeleton** — every sales-* seller starts here, then adds specialism-specific behavior on top:
+
+```ts
+createAdcpServer({
+  name: 'my-seller',
+  version: '1.0.0',
+  stateStore,
+  idempotency: createIdempotencyStore({ backend: memoryBackend() }),
+  resolveSessionKey: ctx => ctx.account?.account_id,
+  accounts: {
+    syncAccounts: async (params, ctx) => { /* … */ },
+    listAccounts: async (params, ctx) => { /* … */ },
+  },
+  mediaBuy: {
+    getProducts: async (params, ctx) => { /* … */ },
+    listCreativeFormats: async () => ({ formats: [...] }),
+    createMediaBuy: async (params, ctx) => { /* … */ },
+    updateMediaBuy: async (params, ctx) => { /* … */ },
+    getMediaBuys: async (params, ctx) => { /* … */ },
+    syncCreatives: async (params, ctx) => { /* … */ },
+    listCreatives: async (params, ctx) => { /* … */ },
+    getMediaBuyDelivery: async (params, ctx) => { /* … */ },
+  },
+});
+```
+
+If a specialism's storyboard doesn't exercise one of these tools, the tool is **not optional** — the storyboard is just focused elsewhere (e.g. `sales-social` covers audience sync + DPA + events; the media buy flow itself is covered by `sales-non-guaranteed` or `sales-guaranteed` which you also claim). See § [Tools and Required Response Shapes](#tools-and-required-response-shapes) below for the exact response shape each tool must return.
+
 ## Specialisms This Skill Covers
 
 Your compliance obligations come from the specialisms you claim in `get_adcp_capabilities`. Each specialism has a storyboard bundle at `compliance/cache/latest/specialisms/<id>/` that the AAO compliance runner executes. Pick one or more.
 
-**Specialisms are additive on top of the baseline media-buy flow** (`get_products` → `create_media_buy` → lifecycle + creative sync + delivery reporting). A specialism's storyboard exercises the ADDITIONAL behaviors it requires; it does not displace the baseline. If the storyboard skips a baseline tool (because that tool is already covered by `sales-non-guaranteed` / `sales-guaranteed`), that doesn't mean the tool is optional for your agent — it means the test is focused elsewhere. Check the storyboard's `agent.capabilities` — if it lists `sells_media` / `accepts_briefs`, the baseline still applies.
+**Specialisms are additive on top of [the baseline](#the-baseline-what-every-sales--agent-must-implement).** A specialism's storyboard exercises the ADDITIONAL behaviors it requires; it does not displace the baseline 11-tool surface above. If the storyboard skips a baseline tool (because that tool is already covered by `sales-non-guaranteed` / `sales-guaranteed`), that doesn't mean the tool is optional for your agent — it means the test is focused elsewhere. Check the storyboard's `agent.capabilities` — if it lists `sells_media` / `accepts_briefs`, the baseline still applies.
 
 **Claim multiple specialisms.** A typical social seller claims `sales-non-guaranteed` + `sales-social`. A typical broadcast seller claims `sales-guaranteed` + `sales-broadcast-tv`. A typical social seller doing audience sync claims `sales-non-guaranteed` + `sales-social` + `audience-sync`.
 
@@ -352,7 +400,7 @@ Non-guaranteed buys are always instant confirmation.
 - **Catalog-driven** — buyer syncs product catalog via `sync_catalogs`. Common for retail media.
 - **None** — creative handled out-of-band. Omit creative tools.
 
-## Tools and Required Response Shapes
+## <a name="tools-and-required-response-shapes"></a>Tools and Required Response Shapes
 
 > **Before writing any handler's return statement, fetch [`docs/llms.txt`](../../docs/llms.txt) and grep for `#### \`<tool_name>\``(e.g.`#### \`create_media_buy\``) to read the exact required + optional field list.** The schema-derived contract lives there; this skill covers patterns, gotchas, and domain-specific examples. Strict response validation is on by default in dev — it will tell you the exact field path if you drift, so write the obvious thing and trust the contract.
 >
@@ -1429,7 +1477,7 @@ Storyboard: `social_platform` (category `sales_social`, track `audiences`).
 
 **`sales-social` is additive, not a replacement.** The storyboard's own metadata declares `interaction_model: media_buy_seller` with `capabilities: [sells_media, accepts_briefs, supports_non_guaranteed]` and lists Snap, Meta, TikTok, and Pinterest as example agents — all of which have product catalogs (ad formats, placements, audience offerings as products) AND accept media buys (campaigns with flights, budgets, ad sets). The storyboard only exercises the audience / catalog / native-creative / events / financials leg because the baseline buyer-flow is covered by `sales-non-guaranteed` (or `sales-guaranteed`). Claim BOTH specialisms and implement the full surface.
 
-**Baseline tools still apply** (these come from `sales-non-guaranteed` or `sales-guaranteed`):
+**Baseline tools still apply** — implement the full 11-tool [baseline surface](#the-baseline-what-every-sales--agent-must-implement). Highlights for social specifically:
 
 - `get_products` — return your platform's ad formats, placements, and audience-targeting products
 - `create_media_buy` — accept campaigns (ad sets / flights) with budgets, targeting, and package structure


### PR DESCRIPTION
## Summary

Follow-up to #843. Emma reported on a break: *"like there's a couple of places where it's like you do the whole flow, but I just never actually see us refer to like, what is the required baseline for the media buy protocol for a sales agent."*

She's right. The skill mentions "the baseline" 25+ times but never enumerates it. That's the same docs gap that let Claude rip `get_products`/`create_media_buy` out of the Snap adapter — without a single authoritative "here are the 11 baseline tools" section, "additive on baseline" reads as a handwave.

## Changes

Added a new top-level **"The baseline: what every sales-* agent MUST implement"** section right before the specialisms table:

1. **11-row tool table** with tool name, purpose, and `createAdcpServer` handler group. Covers the `media_buy_seller` baseline storyboard surface: `get_adcp_capabilities`, `sync_accounts`, `list_accounts`, `get_products`, `list_creative_formats`, `create_media_buy`, `update_media_buy`, `get_media_buys`, `sync_creatives`, `list_creatives`, `get_media_buy_delivery`.
2. **Minimum `createAdcpServer` handler skeleton** — concrete starting code that drops into a real agent. Includes `stateStore`, `idempotency`, `resolveSessionKey`, `accounts` + `mediaBuy` handler groups.
3. **Closing principle**: "if a specialism's storyboard doesn't exercise a baseline tool, the tool is NOT optional — the storyboard is just focused elsewhere."

Added anchors on the new section and on `§ Tools and Required Response Shapes` so cross-references resolve in rendered MDX and grep. Updated the "Specialisms are additive" intro paragraph AND the `sales-social` "Baseline tools still apply" block to link to the new section as the source of truth instead of the handwavy `get_products → create_media_buy → lifecycle` arrow.

## Why this matters

Emma's Snap failure mode was Claude reading the (now-fixed in #843) "sales-social is a walled-garden; classic path does not apply" sentence AND not having a single authoritative list to fall back to. Both surfaces needed correcting:

- #843 fixed the misleading sentence.
- This PR backs it with a concrete enumerated baseline so a reader (human or agent) doesn't need to infer the floor from scattered references.

## Test plan

- [x] `npm run format:check` clean
- [ ] Reviewer spot-check: does the new section read as authoritative enough that a future contributor won't re-introduce "does not apply" framing?
- [ ] Reviewer spot-check: are the 11 tools the right enumeration? Specifically `provide_performance_feedback` — baseline or feature-flagged?

Docs-only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)