### PR TITLE
fix: flat-tree schema cross-refs + create_media_buy fixture precedence (#862)

### DIFF
--- a/.changeset/storyboard-regressions-862.md
+++ b/.changeset/storyboard-regressions-862.md
@@ -42,17 +42,27 @@ discovered product's `pricing_options[0]` — e.g. a seller's
 `pinnacle_news_video_premium_pricing_0` replaced the fixture's
 `cpm_guaranteed`, failing create-buy with `INVALID_REQUEST`.
 
-Fixture now wins on every per-package identifier. Discovery still
-gap-fills when the author omits per-package ids — the behavior
-generic single-package storyboards rely on. Auction/CPM `bid_price`
-synthesis only fires when the fixture didn't author one, so
-bid-floor-boundary tests keep their explicit values.
+Real seller ids in the fixture now win over discovery. Discovery
+still gap-fills when the author omits per-package ids — the
+behavior generic single-package storyboards rely on. Auction/CPM
+`bid_price` synthesis only fires when the fixture didn't author
+one, so bid-floor-boundary tests keep their explicit values.
 
-**Migration note.** If a storyboard was intentionally relying on
-discovery overriding an authored `product_id` / `pricing_option_id` /
-`bid_price` (e.g. `pricing_option_id: "placeholder"` expecting the
-enricher to rewrite it), remove the fixture value so gap-fill kicks
-in, or align the fixture value with the seller's catalog.
+**Sentinel placeholders pass through to discovery.** The upstream
+universal compliance storyboards (`adcontextprotocol/adcp`:
+`universal/deterministic-testing.yaml`, `error-compliance.yaml`,
+`idempotency.yaml`, `domains/media-buy/state-machine.yaml`) ship
+`packages[0]` fixtures with `product_id: "test-product"` and
+`pricing_option_id: "test-pricing"` expecting the runner to
+substitute the seller's discovered identifiers. The enricher
+recognizes those two literals as sentinels and defers to discovery
+when either appears. Real seller ids (`cpm_guaranteed`,
+`sports_display_auction`, any non-sentinel string) keep winning.
+
+If your storyboard wants placeholder-then-discovery semantics for a
+new field, author `$context.<key>` substitution rather than a magic
+literal — the intent is explicit at the fixture level and the
+sentinel allowlist stays small.
 
 ### Out of scope
 
@@ -62,7 +72,7 @@ enricher is not `FIXTURE_AWARE` — the outer merge lets the storyboard's
 and both resolve from the same `signals[0].pricing_options[0]`. The
 mismatch reporters saw (`po_prism_abandoner_cpm` sent,
 `po_prism_cart_cpm` accepted) traces to seller catalog inconsistency
-between `get_signals` and `activate_signal`, not SDK synthesis. A
-follow-up to have the storyboard runner emit a hint when a response's
-`available:` list excludes a context-derived `pricing_option_id` will
-land separately.
+between `get_signals` and `activate_signal`, not SDK synthesis.
+Follow-up in #870: have the storyboard runner emit a hint when a
+response's `available:` list excludes a context-derived value, so the
+reporter-facing symptom stops looking identical to an SDK bug.

--- a/.changeset/storyboard-regressions-862.md
+++ b/.changeset/storyboard-regressions-862.md
@@ -2,36 +2,67 @@
 '@adcp/client': patch
 ---
 
-Two storyboard regressions from the 5.14 train (closes #862).
+Two regressions from the 5.14 train (closes #862). Both restore documented
+behavior — no new surface, no new policy. **5.14.0 consumers should upgrade
+directly to this release; no code changes required.**
 
-- **Schema loader**: `sync_plans`, `check_governance`, `acquire_rights`,
-  `create_property_list`, and every other tool whose request schema
-  lives in a flat-tree domain directory (`governance/`, `brand/`,
-  `property/`, `collection/`, `content-standards/`, `account/`, …) now
-  compiles cleanly regardless of sibling `$ref`s. Previously the loader
-  pre-registered only `core/` and `enums/` before compile; refs like
-  `governance/sync-plans-request.json` → `governance/audience-constraints.json`
-  threw `can't resolve reference` at AJV compile time.
+### (1) Schema loader: flat-tree domain `$ref` resolution
 
-  `ensureCoreLoaded` now walks every directory outside `bundled/` and
-  pre-registers non-tool JSON fragments — covering `core/`, `enums/`,
-  `pricing-options/`, `error-details/`, `extensions/`, and every
-  flat-tree domain's sibling building blocks. Tool request/response
-  files stay lazy-compiled so `relaxResponseRoot` still applies.
+`ensureCoreLoaded` pre-registered only `core/` and `enums/` before AJV
+compile. Tool schemas in flat-tree domain directories — `governance/`,
+`brand/`, `property/`, `collection/`, `content-standards/`, `account/`,
+`signals/` — ship alongside sibling building-block fragments they `$ref`,
+and those siblings were never registered. First compile of e.g.
+`governance/sync-plans-request.json` threw `can't resolve reference
+/schemas/3.0.0/governance/audience-constraints.json`.
 
-- **`create_media_buy` enricher**: fixture package identifiers now win
-  over discovery-derived values. When a storyboard authors
-  `packages[0].product_id`, `packages[0].pricing_option_id`, or
-  `packages[0].bid_price`, the enricher no longer overrides them with
-  the first discovered product's fields. Discovery still fills gaps
-  when the author omits per-package identifiers — the behavior
-  single-package storyboards against arbitrary sellers rely on. Closes
-  the 5.14 regression where a seller's `get_products`-returned
-  `pricing_options[0].pricing_option_id` (e.g.
-  `pinnacle_news_video_premium_pricing_0`) replaced the fixture's
-  explicit value (e.g. `cpm_guaranteed`) and created-buy failed with
-  `INVALID_REQUEST`.
+The loader now walks every directory outside `bundled/` and pre-registers
+non-tool JSON fragments — covering `core/`, `enums/`, `pricing-options/`,
+`error-details/`, `extensions/`, and every flat-tree domain's sibling
+building blocks. Tool request/response files stay lazy-compiled so
+`relaxResponseRoot` still applies to response variants.
 
-  The fixture-authoritative refactor (#816) set this direction for
-  top-level fields but the `create_media_buy` nested-package merge
-  kept the prior builder-authoritative precedence. Now aligned.
+**Blast radius is broader than storyboards.** The same `getValidator` is
+wired into strict-mode request/response validation
+(`AdcpClient({ strict: true })`, `createAdcpServer` default validation,
+`validateOutgoingRequest` / `validateIncomingResponse`, the dispatcher
+middleware, and `TaskExecutor`). Any 5.14.0 server-side adopter running
+strict validation on governance/brand/property/signals/collection/
+content-standards/account tools was silently throwing on first call;
+those paths are fixed by this release too.
+
+### (2) `create_media_buy` enricher: fixture-per-package precedence
+
+The fixture-authoritative refactor in 5.14 (#816) set every task's
+top-level merge to fixture-wins, but the nested-package merge in
+`create_media_buy` kept the prior builder-authoritative precedence.
+Storyboards that authored explicit `product_id` / `pricing_option_id` /
+`bid_price` on `packages[0]` had those values overridden by the first
+discovered product's `pricing_options[0]` — e.g. a seller's
+`pinnacle_news_video_premium_pricing_0` replaced the fixture's
+`cpm_guaranteed`, failing create-buy with `INVALID_REQUEST`.
+
+Fixture now wins on every per-package identifier. Discovery still
+gap-fills when the author omits per-package ids — the behavior
+generic single-package storyboards rely on. Auction/CPM `bid_price`
+synthesis only fires when the fixture didn't author one, so
+bid-floor-boundary tests keep their explicit values.
+
+**Migration note.** If a storyboard was intentionally relying on
+discovery overriding an authored `product_id` / `pricing_option_id` /
+`bid_price` (e.g. `pricing_option_id: "placeholder"` expecting the
+enricher to rewrite it), remove the fixture value so gap-fill kicks
+in, or align the fixture value with the seller's catalog.
+
+### Out of scope
+
+Issue #862 also flagged `activate_signal` as "same pattern". The
+enricher is not `FIXTURE_AWARE` — the outer merge lets the storyboard's
+`$context.first_signal_pricing_option_id` overlay the enricher's pick,
+and both resolve from the same `signals[0].pricing_options[0]`. The
+mismatch reporters saw (`po_prism_abandoner_cpm` sent,
+`po_prism_cart_cpm` accepted) traces to seller catalog inconsistency
+between `get_signals` and `activate_signal`, not SDK synthesis. A
+follow-up to have the storyboard runner emit a hint when a response's
+`available:` list excludes a context-derived `pricing_option_id` will
+land separately.

--- a/.changeset/storyboard-regressions-862.md
+++ b/.changeset/storyboard-regressions-862.md
@@ -1,0 +1,37 @@
+---
+'@adcp/client': patch
+---
+
+Two storyboard regressions from the 5.14 train (closes #862).
+
+- **Schema loader**: `sync_plans`, `check_governance`, `acquire_rights`,
+  `create_property_list`, and every other tool whose request schema
+  lives in a flat-tree domain directory (`governance/`, `brand/`,
+  `property/`, `collection/`, `content-standards/`, `account/`, …) now
+  compiles cleanly regardless of sibling `$ref`s. Previously the loader
+  pre-registered only `core/` and `enums/` before compile; refs like
+  `governance/sync-plans-request.json` → `governance/audience-constraints.json`
+  threw `can't resolve reference` at AJV compile time.
+
+  `ensureCoreLoaded` now walks every directory outside `bundled/` and
+  pre-registers non-tool JSON fragments — covering `core/`, `enums/`,
+  `pricing-options/`, `error-details/`, `extensions/`, and every
+  flat-tree domain's sibling building blocks. Tool request/response
+  files stay lazy-compiled so `relaxResponseRoot` still applies.
+
+- **`create_media_buy` enricher**: fixture package identifiers now win
+  over discovery-derived values. When a storyboard authors
+  `packages[0].product_id`, `packages[0].pricing_option_id`, or
+  `packages[0].bid_price`, the enricher no longer overrides them with
+  the first discovered product's fields. Discovery still fills gaps
+  when the author omits per-package identifiers — the behavior
+  single-package storyboards against arbitrary sellers rely on. Closes
+  the 5.14 regression where a seller's `get_products`-returned
+  `pricing_options[0].pricing_option_id` (e.g.
+  `pinnacle_news_video_premium_pricing_0`) replaced the fixture's
+  explicit value (e.g. `cpm_guaranteed`) and created-buy failed with
+  `INVALID_REQUEST`.
+
+  The fixture-authoritative refactor (#816) set this direction for
+  top-level fields but the `create_media_buy` nested-package merge
+  kept the prior builder-authoritative precedence. Now aligned.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -201,14 +201,15 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     const startTime = sampleStart && Date.parse(sampleStart) >= now ? sampleStart : defaultStart;
     const endTime = sampleEnd && Date.parse(sampleEnd) >= now ? sampleEnd : defaultEnd;
 
-    // Merge any hand-authored package fields from sample_request (targeting_overlay,
+    // Merge hand-authored package fields from sample_request (targeting_overlay,
     // measurement_terms, creative_assignments, performance_standards, etc.) so
-    // scenario-specific behaviors are exercised. The first package receives
-    // context-derived identifiers (product_id, pricing_option_id) so single-
-    // package storyboards that test against arbitrary sellers still find a
-    // real discovered product. Additional packages pass through as-authored
-    // with context injection only — storyboards that ship multi-package
-    // sample_request blocks author specific product_ids on purpose.
+    // scenario-specific behaviors are exercised. The fixture wins on every
+    // field it authors — storyboards that name a specific `product_id` +
+    // `pricing_option_id` are asserting against a seller that ships those
+    // identifiers, and discovery-derived values must never override them.
+    // Discovery fills the gaps for generic storyboards that omit the first
+    // package's identifiers. Additional packages pass through as-authored
+    // with context injection only.
     const samplePackages = (step.sample_request?.packages as Array<Record<string, unknown>> | undefined) ?? [];
     const baseSample = samplePackages[0]
       ? (injectContext({ ...samplePackages[0] }, context) as Record<string, unknown>)
@@ -216,17 +217,27 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
 
     const firstPkg: Record<string, unknown> = {
       ...baseSample,
-      product_id: product?.product_id ?? context.product_id ?? baseSample.product_id ?? 'test-product',
+      product_id: (baseSample.product_id as string | undefined) ?? product?.product_id ?? context.product_id ?? 'test-product',
       budget:
         (baseSample.budget as number | undefined) ??
         options.budget ??
         Math.max(1000, (pricingOption?.min_spend_per_package as number) ?? 1000),
       pricing_option_id:
-        pricingOption?.pricing_option_id ?? context.pricing_option_id ?? baseSample.pricing_option_id ?? 'default',
+        (baseSample.pricing_option_id as string | undefined) ??
+        pricingOption?.pricing_option_id ??
+        context.pricing_option_id ??
+        'default',
     };
 
-    // Add bid_price for auction-based pricing
-    if (pricingOption?.pricing_model === 'auction' || pricingOption?.pricing_model === 'cpm') {
+    // Synthesize a bid_price for auction/cpm pricing only when the fixture
+    // didn't author one. Storyboards that test auction flows (e.g.
+    // sales-non-guaranteed) author explicit bid_prices the seller validates
+    // against floor_price; discovery-synthesized values would silently
+    // override intentional bid-floor-boundary tests.
+    if (
+      baseSample.bid_price === undefined &&
+      (pricingOption?.pricing_model === 'auction' || pricingOption?.pricing_model === 'cpm')
+    ) {
       const floor = Number(pricingOption?.floor_price) || 5;
       firstPkg.bid_price = Math.round(floor * 1.5 * 100) / 100;
     }

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -217,7 +217,8 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
 
     const firstPkg: Record<string, unknown> = {
       ...baseSample,
-      product_id: (baseSample.product_id as string | undefined) ?? product?.product_id ?? context.product_id ?? 'test-product',
+      product_id:
+        (baseSample.product_id as string | undefined) ?? product?.product_id ?? context.product_id ?? 'test-product',
       budget:
         (baseSample.budget as number | undefined) ??
         options.budget ??

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -75,6 +75,26 @@ const FIXTURE_AWARE_ENRICHERS = new Set<string>([
   'comply_test_controller', // forces account.sandbox: true regardless of fixture
 ]);
 
+/**
+ * Placeholder identifiers that the upstream universal compliance
+ * storyboards ship inside `create_media_buy.packages[0]` expecting the
+ * runner to substitute the seller's discovered identifiers. The fixtures
+ * live in `adcontextprotocol/adcp` and can't be rewritten from the SDK,
+ * so the enricher treats these literals as "defer to discovery" while
+ * real seller ids (e.g. `cpm_guaranteed`) win over discovery per the
+ * fixture-authoritative contract. If a future storyboard wants
+ * placeholder-then-discovery semantics for another value, author it as
+ * a `$context.<key>` substitution rather than a magic literal so the
+ * intent is explicit at the fixture level.
+ */
+const PRODUCT_ID_SENTINELS = new Set(['test-product']);
+const PRICING_OPTION_ID_SENTINELS = new Set(['test-pricing']);
+
+function asNonSentinel(value: unknown, sentinels: Set<string>): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  return sentinels.has(value) ? undefined : value;
+}
+
 const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   // ── Account & Audience ─────────────────────────────────
 
@@ -203,31 +223,41 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
 
     // Merge hand-authored package fields from sample_request (targeting_overlay,
     // measurement_terms, creative_assignments, performance_standards, etc.) so
-    // scenario-specific behaviors are exercised. The fixture wins on every
-    // field it authors — storyboards that name a specific `product_id` +
-    // `pricing_option_id` are asserting against a seller that ships those
-    // identifiers, and discovery-derived values must never override them.
-    // Discovery fills the gaps for generic storyboards that omit the first
-    // package's identifiers. Additional packages pass through as-authored
-    // with context injection only.
+    // scenario-specific behaviors are exercised. The first package's
+    // identifiers (product_id, pricing_option_id) follow a two-tier rule:
+    //
+    //   - Real seller ids in the fixture win over discovery — storyboards
+    //     that name `cpm_guaranteed` (or any seller-specific identifier)
+    //     are asserting that specific id reaches the wire. Discovery must
+    //     not override.
+    //   - Well-known sentinel placeholders (`test-product`, `test-pricing`)
+    //     from the upstream universal compliance storyboards defer to
+    //     discovery. Those storyboards ship package fixtures with
+    //     `product_id: "test-product"` expecting the runner to substitute
+    //     the seller's discovered product — they'd fail against every
+    //     seller that doesn't literally ship a "test-product" catalog
+    //     entry if the fixture value survived to the wire.
+    //
+    // The sentinel list is conservative. If a future storyboard wants
+    // placeholder-then-discovery semantics for another field, author it
+    // as `$context.<key>` substitution instead of a magic literal.
     const samplePackages = (step.sample_request?.packages as Array<Record<string, unknown>> | undefined) ?? [];
     const baseSample = samplePackages[0]
       ? (injectContext({ ...samplePackages[0] }, context) as Record<string, unknown>)
       : {};
 
+    const fixtureProductId = asNonSentinel(baseSample.product_id, PRODUCT_ID_SENTINELS);
+    const fixturePricingOptionId = asNonSentinel(baseSample.pricing_option_id, PRICING_OPTION_ID_SENTINELS);
+
     const firstPkg: Record<string, unknown> = {
       ...baseSample,
-      product_id:
-        (baseSample.product_id as string | undefined) ?? product?.product_id ?? context.product_id ?? 'test-product',
+      product_id: fixtureProductId ?? product?.product_id ?? context.product_id ?? 'test-product',
       budget:
         (baseSample.budget as number | undefined) ??
         options.budget ??
         Math.max(1000, (pricingOption?.min_spend_per_package as number) ?? 1000),
       pricing_option_id:
-        (baseSample.pricing_option_id as string | undefined) ??
-        pricingOption?.pricing_option_id ??
-        context.pricing_option_id ??
-        'default',
+        fixturePricingOptionId ?? pricingOption?.pricing_option_id ?? context.pricing_option_id ?? 'default',
     };
 
     // Synthesize a bid_price for auction/cpm pricing only when the fixture

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -199,18 +199,36 @@ function ensureInit(): LoaderState {
 }
 
 /**
- * Lazily load `core/` and `enums/` schemas on first compile of a schema
- * that may $ref them. Async response variants and flat-tree domain schemas
- * (governance, brand, content-standards, account, property, collection)
- * both dereference into these shared trees; bundled/ pre-resolves its own
- * refs and doesn't need them. Deferring the load keeps cold-start cheap
- * for consumers that only touch bundled/ tools.
+ * Lazily pre-register every non-tool JSON schema shipped with the SDK so
+ * cross-domain `$ref`s compile. Async response variants and flat-tree
+ * domain schemas `$ref` out to three classes of building-block schemas:
+ *
+ *   - `core/` + `enums/` — shared primitives referenced by every domain.
+ *   - `pricing-options/`, `error-details/`, `extensions/` — stand-alone
+ *     fragment trees.
+ *   - Sibling fragments inside each domain directory — e.g.
+ *     `governance/audience-constraints.json` referenced by
+ *     `governance/sync-plans-request.json`, or `signals/*` fragments
+ *     referenced by `signals/activate-signal-*.json`.
+ *
+ * Walk every directory except `bundled/` (pre-resolved schemas with refs
+ * already inlined). Skip files that `buildFileIndex` registered as tool
+ * request/response — those compile via `getValidator` with
+ * `relaxResponseRoot` applied to the response variant, and pre-registering
+ * the raw schema would short-circuit the relaxation. The fileIndex check
+ * is stricter than a filename-suffix match: building-block fragments like
+ * `core/pagination-response.json` end in `-response.json` but aren't tools,
+ * so suffix-matching would wrongly exclude them.
  */
 function ensureCoreLoaded(s: LoaderState): void {
   if (s.coreLoaded) return;
-  for (const dir of ['core', 'enums']) {
-    const abs = path.join(s.root, dir);
+  const toolFiles = new Set(s.fileIndex.values());
+  for (const entry of readdirSync(s.root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === 'bundled') continue;
+    const abs = path.join(s.root, entry.name);
     for (const file of walkJsonFiles(abs)) {
+      if (toolFiles.has(file)) continue;
       const schema = loadJson(file);
       if (typeof schema.$id === 'string' && !s.ajv.getSchema(schema.$id)) {
         s.ajv.addSchema(schema);

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -102,6 +102,84 @@ describe('Request Builder', () => {
       const result = buildRequest(s, context, DEFAULT_OPTIONS);
       assert.strictEqual(result.packages[1].product_id, 'resolved_product_id');
     });
+
+    test('fixture pricing_option_id wins over discovered product pricing (regression #862)', () => {
+      // Storyboards that author an explicit pricing_option_id on the first
+      // package are asserting against a seller that ships that identifier.
+      // Discovery may return unrelated pricing_options[0] values — the
+      // enricher must not override the fixture's intent.
+      const context = {
+        products: [
+          {
+            product_id: 'discovered-product',
+            pricing_options: [{ pricing_option_id: 'discovered-pricing-id', pricing_model: 'cpm' }],
+          },
+        ],
+      };
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: future,
+          packages: [{ product_id: 'fixture-product', pricing_option_id: 'cpm_guaranteed', budget: 5000 }],
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[0].pricing_option_id, 'cpm_guaranteed', 'fixture pricing_option_id wins');
+      assert.strictEqual(result.packages[0].product_id, 'fixture-product', 'fixture product_id wins');
+      assert.strictEqual(result.packages[0].budget, 5000, 'fixture budget wins');
+    });
+
+    test('fixture bid_price wins over discovered floor-based synthesis (regression #862)', () => {
+      // Storyboards that assert bid-floor boundary behavior author explicit
+      // bid_prices the seller validates. Discovery-derived floor math must
+      // not silently override those values.
+      const context = {
+        products: [
+          {
+            product_id: 'auction-product',
+            pricing_options: [{ pricing_option_id: 'opt', pricing_model: 'auction', floor_price: 10 }],
+          },
+        ],
+      };
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: future,
+          packages: [{ product_id: 'auction-product', pricing_option_id: 'opt', bid_price: 2.5 }],
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[0].bid_price, 2.5, 'fixture bid_price wins over floor * 1.5');
+    });
+
+    test('discovered pricing fills gaps when fixture omits the first package package-level ids', () => {
+      // Generic storyboards that ship a sample_request body without
+      // per-package identifiers rely on discovery — this behavior is what
+      // lets single-package storyboards run against arbitrary sellers.
+      const context = {
+        products: [
+          {
+            product_id: 'discovered',
+            pricing_options: [{ pricing_option_id: 'discovered-pricing', pricing_model: 'cpm' }],
+          },
+        ],
+      };
+      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: future,
+          packages: [{ targeting_overlay: { geo_targets: { countries: ['US'] } } }],
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[0].product_id, 'discovered', 'discovery fills missing product_id');
+      assert.strictEqual(result.packages[0].pricing_option_id, 'discovered-pricing', 'discovery fills missing pricing_option_id');
+      assert.deepStrictEqual(
+        result.packages[0].targeting_overlay,
+        { geo_targets: { countries: ['US'] } },
+        'fixture fields outside the id set pass through'
+      );
+    });
   });
 
   describe('provide_performance_feedback', () => {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -173,7 +173,11 @@ describe('Request Builder', () => {
       });
       const result = buildRequest(s, context, DEFAULT_OPTIONS);
       assert.strictEqual(result.packages[0].product_id, 'discovered', 'discovery fills missing product_id');
-      assert.strictEqual(result.packages[0].pricing_option_id, 'discovered-pricing', 'discovery fills missing pricing_option_id');
+      assert.strictEqual(
+        result.packages[0].pricing_option_id,
+        'discovered-pricing',
+        'discovery fills missing pricing_option_id'
+      );
       assert.deepStrictEqual(
         result.packages[0].targeting_overlay,
         { geo_targets: { countries: ['US'] } },

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -19,8 +19,8 @@ const DEFAULT_OPTIONS = {
 // The create_media_buy enricher replaces past-dated sample_request.start_time
 // / end_time with dynamic defaults; these literals skip that path so
 // fixture-precedence tests stay deterministic across CI wall-clock drift.
-const FUTURE_START = '2099-01-01T00:00:00Z';
-const FUTURE_END = '2099-02-01T00:00:00Z';
+const FUTURE_START = '9999-01-01T00:00:00Z';
+const FUTURE_END = '9999-02-01T00:00:00Z';
 
 function step(task, overrides = {}) {
   return { id: `test-${task}`, title: `Test ${task}`, task, ...overrides };
@@ -185,6 +185,59 @@ describe('Request Builder', () => {
         { geo_targets: { countries: ['US'] } },
         'fixture fields outside the id set pass through'
       );
+    });
+
+    test('sentinel `test-product` / `test-pricing` fixture defers to discovery (upstream universal storyboards)', () => {
+      // The upstream compliance storyboards (adcontextprotocol/adcp:
+      // universal/deterministic-testing.yaml, error-compliance.yaml,
+      // idempotency.yaml, domains/media-buy/state-machine.yaml) ship
+      // fixture `packages[0]` with `product_id: "test-product"` and
+      // `pricing_option_id: "test-pricing"` expecting the runner to
+      // substitute the seller's discovered identifiers. Those fixtures
+      // live in the spec repo and can't be rewritten from the SDK —
+      // the enricher must recognize these sentinels and defer.
+      const context = {
+        products: [
+          {
+            product_id: 'real_seller_product',
+            pricing_options: [{ pricing_option_id: 'real_seller_cpm', pricing_model: 'cpm' }],
+          },
+        ],
+      };
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          packages: [{ product_id: 'test-product', budget: 5000, pricing_option_id: 'test-pricing' }],
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[0].product_id, 'real_seller_product', 'sentinel product_id → discovery');
+      assert.strictEqual(
+        result.packages[0].pricing_option_id,
+        'real_seller_cpm',
+        'sentinel pricing_option_id → discovery'
+      );
+      assert.strictEqual(result.packages[0].budget, 5000, 'non-sentinel fixture fields pass through');
+    });
+
+    test('empty fixture package object {} falls back to discovery cleanly', () => {
+      // Some storyboards ship `packages: [{}]` for defaults-only scenarios
+      // where every field should come from discovery / enricher synthesis.
+      const context = {
+        products: [
+          {
+            product_id: 'discovered',
+            pricing_options: [{ pricing_option_id: 'discovered-pricing', pricing_model: 'cpm' }],
+          },
+        ],
+      };
+      const s = step('create_media_buy', {
+        sample_request: { start_time: FUTURE_START, packages: [{}] },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[0].product_id, 'discovered');
+      assert.strictEqual(result.packages[0].pricing_option_id, 'discovered-pricing');
+      assert.ok(result.packages[0].budget > 0, 'budget synthesized from min_spend_per_package or default');
     });
   });
 

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -15,6 +15,13 @@ const DEFAULT_OPTIONS = {
   account: { brand: { domain: 'acmeoutdoor.example' }, operator: 'acmeoutdoor.example' },
 };
 
+// Fixture dates past the enricher's stale-date substitution boundary.
+// The create_media_buy enricher replaces past-dated sample_request.start_time
+// / end_time with dynamic defaults; these literals skip that path so
+// fixture-precedence tests stay deterministic across CI wall-clock drift.
+const FUTURE_START = '2099-01-01T00:00:00Z';
+const FUTURE_END = '2099-02-01T00:00:00Z';
+
 function step(task, overrides = {}) {
   return { id: `test-${task}`, title: `Test ${task}`, task, ...overrides };
 }
@@ -59,11 +66,10 @@ describe('Request Builder', () => {
       // sales_non_guaranteed) had packages[1+] dropped, which left
       // context_outputs like second_package_id unresolved and caused the
       // next step to be skipped with "unresolved context variables".
-      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
       const s = step('create_media_buy', {
         sample_request: {
-          start_time: future,
-          end_time: new Date(Date.now() + 8 * 24 * 60 * 60 * 1000).toISOString(),
+          start_time: FUTURE_START,
+          end_time: FUTURE_END,
           packages: [
             {
               product_id: 'sports_display_auction',
@@ -88,10 +94,9 @@ describe('Request Builder', () => {
     });
 
     test('injects context into additional packages', () => {
-      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
       const s = step('create_media_buy', {
         sample_request: {
-          start_time: future,
+          start_time: FUTURE_START,
           packages: [
             { product_id: 'p1', budget: 1000, pricing_option_id: 'opt' },
             { product_id: '$context.secondary_product', budget: 2000, pricing_option_id: 'opt' },
@@ -116,10 +121,9 @@ describe('Request Builder', () => {
           },
         ],
       };
-      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
       const s = step('create_media_buy', {
         sample_request: {
-          start_time: future,
+          start_time: FUTURE_START,
           packages: [{ product_id: 'fixture-product', pricing_option_id: 'cpm_guaranteed', budget: 5000 }],
         },
       });
@@ -141,10 +145,9 @@ describe('Request Builder', () => {
           },
         ],
       };
-      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
       const s = step('create_media_buy', {
         sample_request: {
-          start_time: future,
+          start_time: FUTURE_START,
           packages: [{ product_id: 'auction-product', pricing_option_id: 'opt', bid_price: 2.5 }],
         },
       });
@@ -164,10 +167,9 @@ describe('Request Builder', () => {
           },
         ],
       };
-      const future = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
       const s = step('create_media_buy', {
         sample_request: {
-          start_time: future,
+          start_time: FUTURE_START,
           packages: [{ targeting_overlay: { geo_targets: { countries: ['US'] } } }],
         },
       });

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -14,6 +14,7 @@ const {
   resolveValidationModes,
 } = require('../../dist/lib/validation');
 const { validateOutgoingRequest, validateIncomingResponse } = require('../../dist/lib/validation/client-hooks.js');
+const { _resetValidationLoader } = require('../../dist/lib/validation/schema-loader.js');
 const { ValidationError } = require('../../dist/lib/errors');
 
 describe('schema-driven validation', () => {
@@ -206,6 +207,38 @@ describe('schema-driven validation', () => {
       for (const key of ['get_products::request', 'get_products::sync', 'create_media_buy::submitted']) {
         assert.ok(keys.includes(key), `missing ${key}`);
       }
+    });
+  });
+
+  describe('ensureCoreLoaded ordering (regression #862)', () => {
+    // Belt-and-braces guard: when a flat-tree tool compile fires
+    // `ensureCoreLoaded` FIRST, every non-tool fragment across the whole
+    // schema tree gets pre-registered raw. That pre-registration must not
+    // accidentally short-circuit the later `relaxResponseRoot` compile for
+    // a bundled tool whose response has root-level `additionalProperties:
+    // false`. Path-normalization drift between `fileIndex.values()` (the
+    // tool-file skip list) and `walkJsonFiles` (the registration walker)
+    // would cause this silent strict-mode flip — `create_property_list`
+    // below would start rejecting `replayed` at the root instead of
+    // passing it through as envelope.
+    test('flat-tree compile before bundled compile still preserves relaxResponseRoot', () => {
+      _resetValidationLoader();
+      // Compile a flat-tree-only tool first; this fires `ensureCoreLoaded`
+      // and walks every non-bundled directory.
+      const flat = validateResponse('sync_plans', {
+        plans: [{ plan_id: 'p1', status: 'active', version: 1 }],
+      });
+      assert.notStrictEqual(flat.variant, 'skipped', 'sync_plans must have a compiled validator');
+      // Now compile a bundled tool whose root needs relaxation.
+      const bundled = validateResponse('create_property_list', { replayed: false });
+      const rootAdditional = bundled.issues.filter(
+        i => i.keyword === 'additionalProperties' && (i.pointer === '' || i.pointer === '/')
+      );
+      assert.deepStrictEqual(
+        rootAdditional,
+        [],
+        `relaxResponseRoot must still apply after ensureCoreLoaded pre-registers fragments: ${JSON.stringify(rootAdditional)}`
+      );
     });
   });
 

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -209,6 +209,36 @@ describe('schema-driven validation', () => {
     });
   });
 
+  describe('cross-domain $ref resolution (regression #862)', () => {
+    // sync-plans-request.json lives in governance/ and $refs three sibling
+    // building-block fragments in the same directory:
+    //   - governance/audience-constraints.json
+    //   - governance/policy-entry.json
+    //   - enums/restricted-attribute.json
+    // Before the loader pre-registered flat-tree domain fragments, AJV could
+    // not resolve the governance/* siblings and threw at compile time. This
+    // guard compiles each validator and runs it against a minimal payload;
+    // a $ref resolution regression would show up as a thrown exception.
+    for (const tool of [
+      'sync_plans',
+      'check_governance',
+      'acquire_rights',
+      'update_rights',
+      'get_rights',
+      'create_content_standards',
+      'create_property_list',
+      'create_collection_list',
+      'activate_signal',
+    ]) {
+      test(`${tool} request schema compiles + runs without $ref errors`, () => {
+        assert.doesNotThrow(() => validateRequest(tool, {}));
+      });
+      test(`${tool} response schema compiles + runs without $ref errors`, () => {
+        assert.doesNotThrow(() => validateResponse(tool, {}));
+      });
+    }
+  });
+
   describe('client hooks', () => {
     test('validateOutgoingRequest strict throws a ValidationError', () => {
       assert.throws(

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -231,10 +231,42 @@ describe('schema-driven validation', () => {
       'activate_signal',
     ]) {
       test(`${tool} request schema compiles + runs without $ref errors`, () => {
-        assert.doesNotThrow(() => validateRequest(tool, {}));
+        let outcome;
+        assert.doesNotThrow(() => {
+          outcome = validateRequest(tool, {});
+        });
+        // Guard against silent-regression where a refactor drops the tool
+        // from the catalog and the doesNotThrow assertion becomes trivial.
+        assert.notStrictEqual(
+          outcome.variant,
+          'skipped',
+          `${tool} must have a compiled request validator — got variant:skipped`
+        );
+        // Even if AJV ever demoted unresolved-$ref to a soft error instead
+        // of throwing, the issue list would surface it.
+        for (const issue of outcome.issues) {
+          assert.ok(
+            !/can't resolve reference/i.test(issue.message),
+            `${tool} request compile leaked unresolved-$ref: ${issue.message}`
+          );
+        }
       });
       test(`${tool} response schema compiles + runs without $ref errors`, () => {
-        assert.doesNotThrow(() => validateResponse(tool, {}));
+        let outcome;
+        assert.doesNotThrow(() => {
+          outcome = validateResponse(tool, {});
+        });
+        assert.notStrictEqual(
+          outcome.variant,
+          'skipped',
+          `${tool} must have a compiled response validator — got variant:skipped`
+        );
+        for (const issue of outcome.issues) {
+          assert.ok(
+            !/can't resolve reference/i.test(issue.message),
+            `${tool} response compile leaked unresolved-$ref: ${issue.message}`
+          );
+        }
       });
     }
   });


### PR DESCRIPTION
## Summary

Two storyboard regressions reported in #862 from the 5.14 train.

- **Schema loader**: `sync_plans`, `check_governance`, `acquire_rights`, `create_property_list`, and every other tool whose request lives in a flat-tree domain directory now compiles cleanly. `ensureCoreLoaded` pre-registered only `core/` and `enums/`; sibling `$ref`s (e.g. `governance/sync-plans-request.json` → `governance/audience-constraints.json`) threw `can't resolve reference` at AJV compile time. Fixed by walking every non-`bundled/` directory and registering non-tool fragments.
- **`create_media_buy`**: fixture-aware enricher now honors `sample_request.packages[0].{product_id,pricing_option_id,bid_price}` over discovery-derived values. Aligns with the fixture-authoritative contract from #816; previously the nested-package merge still inverted precedence and overrode fixture ids with the first discovered product's pricing options.

## Out of scope

Issue #862 also flags `activate_signal` as "same pattern". After tracing the enricher, context_outputs extraction, and top-level fixture merge, the symptom (`po_prism_abandoner_cpm` sent, `po_prism_cart_cpm` accepted) doesn't point at SDK-side synthesis — `activate_signal` is not `FIXTURE_AWARE` and the outer merge lets the storyboard's `$context.first_signal_pricing_option_id` win. The mismatch tracks to the seller's discovery/activation catalog consistency. Happy to re-open if I'm missing an SDK path.

## Test plan

- [x] `node --test test/lib/schema-validation.test.js test/lib/request-builder.test.js` — **95/95 pass**
  - 18 new cross-domain `$ref` compile guards (request + response for 9 flat-tree tools)
  - 3 new fixture-precedence regression tests on `create_media_buy`
- [x] `npm run test:lib` — **4810/4810 pass** (6 environment skips, governance E2E needs training agent)
- [x] `node --test test/lib/storyboard-*.test.js` — **2251/2251 pass**
- [x] Reproduced via local script: `getValidator` now compiles request + response for 16 flat-tree tools (governance, brand, property, collection, content-standards, signals, media-buy) without throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)