### PR TITLE
feat(server): auth context on resolveAccount, MCP envelope fix, alt-transport docs

### DIFF
--- a/.changeset/resolve-account-authinfo-scope3-asks.md
+++ b/.changeset/resolve-account-authinfo-scope3-asks.md
@@ -1,0 +1,15 @@
+---
+'@adcp/client': minor
+---
+
+`resolveAccount` now receives auth context, `checkGovernance` parses MCP envelope shapes correctly, and the seller skill documents alternative transports.
+
+**`resolveAccount(ref, ctx)` now receives `{ toolName, authInfo }`.** Adapters that front an upstream platform API (Snap, Meta, TikTok, retail media networks) need the caller's OAuth token to look up the upstream account. Previously `authInfo` was only available inside handlers, forcing resolvers to return a thin stub and re-resolve the platform account on every handler call. Single-arg resolvers (`async (ref) => ...`) remain valid — TypeScript allows a shorter parameter list.
+
+**`dispatchTestRequest(request, { authInfo })`.** Test harnesses can simulate the `authInfo` that `serve({ authenticate })` would populate, so `resolveAccount` and handler tests cover auth-sensitive paths without spinning up HTTP. Never mount this behind an HTTP route — `extras.authInfo` bypasses `authenticate`.
+
+**`checkGovernance` now extracts from `structuredContent` or `content[0].text` before falling back to top-level fields.** Fixes a latent bug where the helper returned "missing required fields" when the governance agent responded with a conformant MCP `CallToolResult` envelope rather than spreading the payload at the root. The single-agent JSDoc example no longer references a fabricated `ctx.account.governanceAgentUrl` field — it now shows the real `sync_governance` → `Account.governance_agents[]` flow.
+
+**Multi-agent governance helper is deferred** pending spec resolution on adcontextprotocol/adcp#3010 — `sync_governance` allows up to 10 governance agents per account but the `check_governance` request and the protocol envelope only thread a single `governance_context` per lifecycle. The SDK will ship an aggregation helper once the spec picks an interpretation.
+
+**Skill docs.** `skills/build-seller-agent/SKILL.md` gains an Alternative Transports section covering the `createAdcpServer().connect(transport)` pattern — multi-host HTTP on a single process and stdio — for cases where `serve()`'s single-`publicUrl`-per-process model doesn't fit.

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -1131,6 +1131,71 @@ The quick-start uses `memoryBackend()` + `InMemoryStateStore` — both reset on 
 
 Auth is not wired in the example — see [§ Protecting your agent](#protecting-your-agent) below.
 
+## Alternative Transports
+
+`serve()` is the supported path for HTTP-hosted seller agents: one process, one `publicUrl`, one MCP mount. Two setups need something else:
+
+- **Multi-host routing on a single process.** Fronting many hostnames (white-label publishers, multi-brand operators) from one Fly machine or pod — one `publicUrl` per incoming host, resolved from `Host` / `Forwarded`.
+- **Stdio transport.** Running as a local subprocess of a buyer agent (CLI tools, desktop clients) instead of an HTTP server.
+
+The escape hatch for both is the same: `createAdcpServer()` returns a handle with a `connect(transport)` method. Skip `serve()` and drive the transport yourself.
+
+### Multi-host HTTP
+
+```typescript
+import { createServer } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { createAdcpServer } from '@adcp/client/server';
+
+// One AdcpServer per host — build lazily and cache.
+const servers = new Map<string, ReturnType<typeof createAdcpServer>>();
+function getServer(host: string) {
+  let s = servers.get(host);
+  if (!s) {
+    s = createAdcpServer({
+      name: `Seller for ${host}`,
+      version: '1.0.0',
+      resolveAccount: async (ref, { authInfo }) => lookupAccount(host, ref, authInfo),
+      mediaBuy: { /* ... */ },
+    });
+    servers.set(host, s);
+  }
+  return s;
+}
+
+createServer(async (req, res) => {
+  const host = req.headers['x-forwarded-host'] ?? req.headers.host ?? '';
+  const server = getServer(String(host));
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  try {
+    await server.connect(transport);
+    await transport.handleRequest(req, res);
+  } finally {
+    transport.close();
+  }
+}).listen(3001);
+```
+
+Things `serve()` does that you now own: auth verification, RFC 9421 request-signature verification (if you claim `signed-requests`), `/.well-known/oauth-protected-resource/<path>` publishing, request-body buffering for signature hashing, and idempotency+governance composition. Most of those helpers are exported — see `verifyApiKey`, `verifyBearer`, `requireSignatureWhenPresent`, and `createExpressAdapter` if you want a partial shortcut. Only go this route if you genuinely need multi-host; a separate process per host with `serve()` is the simpler answer.
+
+### Stdio
+
+```typescript
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createAdcpServer } from '@adcp/client/server';
+
+const server = createAdcpServer({
+  name: 'Local Seller',
+  version: '1.0.0',
+  resolveAccount: async (ref) => lookupAccount(ref),
+  mediaBuy: { /* ... */ },
+});
+
+await server.connect(new StdioServerTransport());
+```
+
+Stdio agents skip the entire HTTP stack — no `authenticate`, no `publicUrl`, no OAuth discovery. The host process (a CLI or local buyer agent) establishes trust by launching the subprocess, so `authenticate` on `serve()` doesn't apply. Your handlers still run the same way; `ctx.authInfo` is simply undefined.
+
 <a name="protecting-your-agent"></a>
 
 ## Protecting your agent

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -89,6 +89,26 @@ export interface AdcpTestToolsCallRequest {
 export type AdcpTestResponse = unknown;
 
 /**
+ * Optional per-call overrides for `dispatchTestRequest()`. Lets tests
+ * simulate transport-level state — most importantly the `authInfo` that
+ * `serve()` populates from its `authenticate` hook — without spinning up
+ * a real HTTP transport.
+ */
+export interface AdcpTestRequestExtras {
+  /**
+   * Auth principal visible to handlers and `resolveAccount`. Mirrors the
+   * shape `serve()` produces from its `authenticate` hook.
+   */
+  authInfo?: {
+    token: string;
+    clientId: string;
+    scopes: string[];
+    expiresAt?: number;
+    extra?: Record<string, unknown>;
+  };
+}
+
+/**
  * Test-harness hooks attached to every `AdcpServer`. Namespaced under
  * `compliance` so production code paths don't accidentally reach for
  * them — `reset()` drops cached state and is intended for storyboard
@@ -161,6 +181,12 @@ export interface AdcpServer {
    * error from the tool's input schema (not from dispatch) is the
    * expected failure mode for a missing required field.
    *
+   * **Never mount this behind an HTTP route.** `extras.authInfo` is
+   * written directly onto the MCP handler's `extra` without any check
+   * against `serve({ authenticate })` — exposing it externally lets a
+   * caller impersonate any principal. This API is for in-process test
+   * harnesses and storyboard runners only.
+   *
    * @example
    * ```typescript
    * const result = await server.dispatchTestRequest({
@@ -172,8 +198,8 @@ export interface AdcpServer {
    * });
    * ```
    */
-  dispatchTestRequest(request: AdcpTestToolsCallRequest): Promise<CallToolResult>;
-  dispatchTestRequest(request: AdcpTestRequest): Promise<AdcpTestResponse>;
+  dispatchTestRequest(request: AdcpTestToolsCallRequest, extras?: AdcpTestRequestExtras): Promise<CallToolResult>;
+  dispatchTestRequest(request: AdcpTestRequest, extras?: AdcpTestRequestExtras): Promise<AdcpTestResponse>;
 }
 
 /**
@@ -307,8 +333,14 @@ export function wrapMcpServer(
       );
     },
   };
-  const dispatch = async (request: AdcpTestRequest): Promise<AdcpTestResponse> => {
-    const extra = { signal: new AbortController().signal };
+  const dispatch = async (
+    request: AdcpTestRequest,
+    extras?: AdcpTestRequestExtras
+  ): Promise<AdcpTestResponse> => {
+    const extra: { signal: AbortSignal; authInfo?: AdcpTestRequestExtras['authInfo'] } = {
+      signal: new AbortController().signal,
+    };
+    if (extras?.authInfo) extra.authInfo = extras.authInfo;
 
     if (request.method === 'tools/call') {
       const params = (request.params ?? {}) as { name?: string; arguments?: Record<string, unknown> };

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -333,10 +333,7 @@ export function wrapMcpServer(
       );
     },
   };
-  const dispatch = async (
-    request: AdcpTestRequest,
-    extras?: AdcpTestRequestExtras
-  ): Promise<AdcpTestResponse> => {
+  const dispatch = async (request: AdcpTestRequest, extras?: AdcpTestRequestExtras): Promise<AdcpTestResponse> => {
     const extra: { signal: AbortSignal; authInfo?: AdcpTestRequestExtras['authInfo'] } = {
       signal: new AbortController().signal,
     };

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -18,7 +18,11 @@
  *   name: 'My Publisher',
  *   version: '1.0.0',
  *
- *   resolveAccount: async (ref) => db.findAccount(ref),
+ *   // Second argument carries `toolName` and (when `authenticate` is wired
+ *   // on `serve()`) the caller's `authInfo`. Adapters that front an
+ *   // upstream platform API can use the caller's token here to resolve
+ *   // the platform account in one pass.
+ *   resolveAccount: async (ref, { authInfo }) => db.findAccount(ref, authInfo),
  *
  *   mediaBuy: {
  *     getProducts: async (params, ctx) => ({ products: catalog.search(params) }),
@@ -310,6 +314,25 @@ export interface SessionKeyContext<TAccount = unknown> {
   toolName: AdcpServerToolName;
   params: Record<string, unknown>;
   account?: TAccount;
+}
+
+/**
+ * Request context passed to `resolveAccount` so the resolver can inspect the
+ * authenticated principal at resolution time. This matters for adapters that
+ * front an upstream platform API (Snap, Meta, TikTok, retail media networks)
+ * where the upstream account lookup requires the caller's platform OAuth
+ * token — forwarding `authInfo` into `resolveAccount` lets the resolver put
+ * platform identifiers (ad_account_id, upstream token state) directly on the
+ * resolved `TAccount` rather than re-resolving inside every handler.
+ */
+export interface ResolveAccountContext {
+  /** The AdCP tool being called. */
+  toolName: AdcpServerToolName;
+  /**
+   * Authentication info for the caller, populated from `extra.authInfo` on the
+   * MCP request. Undefined when no `authenticate` is configured on `serve()`.
+   */
+  authInfo?: HandlerContext['authInfo'];
 }
 
 /**
@@ -779,8 +802,22 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * Resolve an account from an AccountReference.
    * Called on every request that has an `account` field.
    * Return null if the account doesn't exist — framework responds ACCOUNT_NOT_FOUND.
+   *
+   * The second argument carries the AdCP `toolName` and, when `serve()` is
+   * configured with `authenticate`, the caller's `authInfo`. Adapters that
+   * need the caller's upstream platform token to look up the account can
+   * read it from `ctx.authInfo` here and attach anything they want to the
+   * resolved account.
+   *
+   * Single-argument resolvers (`async (ref) => ...`) are valid — TypeScript
+   * allows a shorter parameter list.
+   *
+   * **Do not persist `authInfo` outside the returned account object.** The
+   * framework makes no isolation guarantees about values closed over by the
+   * resolver; caching `authInfo` into shared state can leak the caller's
+   * principal across requests.
    */
-  resolveAccount?: (ref: AccountReference) => Promise<TAccount | null>;
+  resolveAccount?: (ref: AccountReference, ctx: ResolveAccountContext) => Promise<TAccount | null>;
 
   /**
    * Derive a session-scoping key from the request. Populates `ctx.sessionKey`
@@ -1868,7 +1905,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // --- Account resolution ---
         if (hasAccount && params.account != null && resolveAccount) {
           try {
-            const account = await resolveAccount(params.account);
+            const account = await resolveAccount(params.account, {
+              toolName: toolName as AdcpServerToolName,
+              authInfo: ctx.authInfo,
+            });
             if (account == null) {
               logger.warn('Account not found', { tool: toolName, account: params.account });
               return finalize(

--- a/src/lib/server/governance.ts
+++ b/src/lib/server/governance.ts
@@ -5,28 +5,48 @@
  * (create_media_buy, update_media_buy, activate_signal). The seller controls
  * when and how governance is checked — the framework doesn't intercept.
  *
+ * ## Where the governance agent URL comes from
+ *
+ * Buyers register governance agents against their accounts via `sync_governance`.
+ * The seller persists each entry (URL + write-only credentials + optional
+ * categories) and reads it back on every lifecycle event. Account's public
+ * shape (`Account.governance_agents`) carries `{ url, categories? }[]` —
+ * credentials are write-only on the wire, so sellers pair each stored URL
+ * with its stored auth token from their own storage when calling this helper.
+ *
+ * Multi-agent semantics for a single lifecycle event are currently
+ * under-specified (see adcontextprotocol/adcp#3010). Until the spec
+ * resolves, the recommended usage is one governance agent per
+ * category/scope per plan — pick the agent whose `categories` matches the
+ * lifecycle event and call it directly.
+ *
  * @example
  * ```typescript
- * import { createAdcpServer, checkGovernance, adcpError } from '@adcp/client/server';
+ * import { createAdcpServer, checkGovernance, governanceDeniedError } from '@adcp/client/server';
  *
  * const server = createAdcpServer({
  *   name: 'My Publisher', version: '1.0.0',
  *   resolveAccount: async (ref) => db.findAccount(ref),
  *   mediaBuy: {
  *     createMediaBuy: async (params, ctx) => {
- *       // Check governance before committing spend
- *       const gov = await checkGovernance({
- *         agentUrl: ctx.account.governanceAgentUrl,
- *         planId: params.plan_id,
- *         caller: 'https://my-publisher.com/mcp',
- *         tool: 'create_media_buy',
- *         payload: params,
- *       });
- *       if (!gov.approved) {
- *         return adcpError('GOVERNANCE_DENIED', { message: gov.explanation });
+ *       // Look up the governance agent (url + stored credentials) from your
+ *       // storage. The public `ctx.account.governance_agents` readback
+ *       // carries URL + categories; auth credentials live in your DB.
+ *       const agent = await db.governanceAgentForPlan(ctx.account.id, params.plan_id);
+ *       if (agent) {
+ *         const gov = await checkGovernance({
+ *           agentUrl: agent.url,
+ *           authToken: agent.authToken,
+ *           planId: params.plan_id!,
+ *           caller: 'https://my-publisher.com/mcp',
+ *           tool: 'create_media_buy',
+ *           payload: params,
+ *         });
+ *         if (!gov.approved) return governanceDeniedError(gov);
+ *         // Thread gov.governanceContext through the media buy lifecycle —
+ *         // persist it and forward verbatim on subsequent checks.
  *       }
- *       // governance_context threads through the media buy lifecycle
- *       return { media_buy_id: '...', governance_context: gov.governanceContext };
+ *       return { media_buy_id: '...' };
  *     },
  *   },
  * });
@@ -37,6 +57,47 @@ import { callMCPTool } from '../protocols/mcp';
 import type { CheckGovernanceResponse } from '../types/tools.generated';
 import type { McpToolResponse } from './responses';
 import { adcpError } from './errors';
+
+/**
+ * Extract a tool's JSON payload from an MCP `CallToolResult` envelope.
+ *
+ * Handles the three shapes the SDK might see in the wild:
+ *   - `structuredContent` (AdCP convention — preferred, always an object)
+ *   - `content[0]` with `type: 'text'` carrying a JSON string
+ *   - the payload already spread at top level (legacy / non-conformant)
+ *
+ * Returns `null` when no payload can be extracted.
+ */
+function extractMcpPayload(raw: unknown): Record<string, unknown> | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const envelope = raw as Record<string, unknown>;
+
+  // Error envelopes can carry structuredContent with shapes that accidentally
+  // include `status` — refuse to mis-type them as a successful response.
+  if (envelope.isError === true) return null;
+
+  if (envelope.structuredContent && typeof envelope.structuredContent === 'object') {
+    return envelope.structuredContent as Record<string, unknown>;
+  }
+
+  const content = envelope.content;
+  if (Array.isArray(content) && content.length > 0) {
+    const first = content[0] as { type?: string; text?: unknown };
+    if (first?.type === 'text' && typeof first.text === 'string') {
+      try {
+        const parsed = JSON.parse(first.text);
+        if (parsed && typeof parsed === 'object') return parsed as Record<string, unknown>;
+      } catch {
+        // fall through
+      }
+    }
+  }
+
+  // Legacy: caller spread the payload at top level.
+  if ('status' in envelope || 'check_id' in envelope) return envelope;
+
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -117,16 +178,16 @@ export async function checkGovernance(options: CheckGovernanceOptions): Promise<
   if (governanceContext != null) args.governance_context = governanceContext;
   if (purchaseType != null) args.purchase_type = purchaseType;
 
-  const raw = (await callMCPTool(agentUrl, 'check_governance', args, authToken)) as Record<string, unknown>;
+  const raw = await callMCPTool(agentUrl, 'check_governance', args, authToken);
+  const extracted = extractMcpPayload(raw);
 
-  // Validate required fields from governance response
-  if (!raw || typeof raw !== 'object' || !('status' in raw) || !('check_id' in raw) || !('explanation' in raw)) {
+  if (!extracted || !('status' in extracted) || !('check_id' in extracted) || !('explanation' in extracted)) {
     throw new Error(
       `Invalid check_governance response from ${agentUrl}: ` +
         `missing required fields (status, check_id, explanation). Got: ${JSON.stringify(raw)?.slice(0, 200)}`
     );
   }
-  const response = raw as unknown as CheckGovernanceResponse;
+  const response = extracted as unknown as CheckGovernanceResponse;
 
   if (response.status === 'approved') {
     return {
@@ -151,7 +212,6 @@ export async function checkGovernance(options: CheckGovernanceOptions): Promise<
     };
   }
 
-  // denied
   return {
     approved: false,
     checkId: response.check_id,

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -204,6 +204,7 @@ export type {
   AccountHandlers,
   EventTrackingHandlers,
   SponsoredIntelligenceHandlers,
+  ResolveAccountContext,
 } from './create-adcp-server';
 
 export { DEFAULT_REPORTING_CAPABILITIES } from './product-defaults';

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -591,6 +591,71 @@ describe('createAdcpServer', () => {
       assert.strictEqual(result.isError, true);
       assert.strictEqual(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
     });
+
+    it('passes toolName and authInfo to resolveAccount via the second argument', async () => {
+      let resolverCtx;
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        resolveAccount: async (ref, ctx) => {
+          resolverCtx = ctx;
+          return { id: ref.account_id, upstreamToken: ctx.authInfo?.extra?.upstreamToken };
+        },
+        mediaBuy: {
+          getProducts: async (_params, ctx) => {
+            assert.strictEqual(ctx.account.upstreamToken, 'upstream-xyz');
+            return { products: [] };
+          },
+        },
+      });
+
+      const authInfo = {
+        token: 'caller-token',
+        clientId: 'buyer-1',
+        scopes: ['adcp.media_buy'],
+        extra: { upstreamToken: 'upstream-xyz' },
+      };
+
+      await server.dispatchTestRequest(
+        {
+          method: 'tools/call',
+          params: {
+            name: 'get_products',
+            arguments: { buying_mode: 'brief', brief: 'test', account: { account_id: 'a1' } },
+          },
+        },
+        { authInfo }
+      );
+
+      assert.ok(resolverCtx);
+      assert.strictEqual(resolverCtx.toolName, 'get_products');
+      assert.strictEqual(resolverCtx.authInfo.token, 'caller-token');
+      assert.deepStrictEqual(resolverCtx.authInfo.extra, { upstreamToken: 'upstream-xyz' });
+    });
+
+    it('single-argument resolvers remain compatible', async () => {
+      // A pre-existing `async (ref) => ...` must still be callable. TS widens
+      // a 1-arg callback to fit the 2-arg resolver signature; the runtime
+      // just ignores the extra argument.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        resolveAccount: async ref => ({ id: ref.account_id }),
+        mediaBuy: {
+          getProducts: async (_params, ctx) => {
+            assert.strictEqual(ctx.account.id, 'legacy-1');
+            return { products: [] };
+          },
+        },
+      });
+
+      const result = await callToolRaw(server, 'get_products', {
+        buying_mode: 'brief',
+        brief: 'test',
+        account: { account_id: 'legacy-1' },
+      });
+      assert.strictEqual(result.isError, undefined);
+    });
   });
 
   describe('governance helper', () => {


### PR DESCRIPTION
## Summary

Three of the Scope3 agentic-adapters 5.x migration asks land here; a fourth (multi-agent governance aggregation) is deferred pending spec resolution on adcontextprotocol/adcp#3010.

- **`resolveAccount(ref, ctx)` receives `{ toolName, authInfo }`.** Adapters fronting an upstream platform API (Snap, Meta, TikTok, retail media networks) can now resolve the upstream account using the caller's OAuth token in one pass instead of re-resolving lazily inside every handler. Single-arg resolvers (`async (ref) => ...`) remain valid — TypeScript allows a shorter parameter list.
- **`dispatchTestRequest(request, { authInfo })`.** Test harnesses can simulate the auth principal `serve({ authenticate })` would populate without standing up HTTP + auth. JSDoc warns never to mount behind an HTTP route (`extras.authInfo` bypasses `authenticate`).
- **`checkGovernance` MCP envelope fix.** The helper now extracts from `structuredContent` → `content[0].text` → top-level, with an `isError` gate so error envelopes carrying a `status`/`check_id`-shaped payload can't be mis-typed as a successful response. The JSDoc example replaces the fabricated `ctx.account.governanceAgentUrl` with the real `sync_governance` → `Account.governance_agents[]` flow.
- **Seller skill docs.** New Alternative Transports section covering `createAdcpServer().connect(transport)` for multi-host HTTP (single process fronting many hostnames) and stdio (local subprocess of a buyer agent).

## Deferred

The multi-agent `checkGovernanceForAccount` helper was staged and then pulled back: `sync_governance` registers up to 10 governance agents per account, but `check_governance` request/response and the protocol envelope thread only a single `governance_context` per lifecycle action. Filed adcontextprotocol/adcp#3010 to get a spec decision on intended semantics before locking the SDK surface.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 5583 pass / 0 fail / 6 pre-existing skips / 5 pre-existing cancellations in `request-signing-grader-mcp.test.js` (flaky `EADDRINUSE :3111`, reproduces on main, unrelated)
- [x] Two new tests in `test/server-create-adcp-server.test.js` for the two-arg resolver signature and single-arg backward compat
- [x] Code review (clean)
- [x] Security review (clean) — `authInfo` persistence warning on `resolveAccount`, "never mount" warning on `dispatchTestRequest`, `isError` gate on `extractMcpPayload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)