### PR TITLE
feat(agents): triage runs pre-PR build+test gate before expert review

### DIFF
--- a/.agents/routines/triage-prompt.md
+++ b/.agents/routines/triage-prompt.md
@@ -313,6 +313,28 @@ related fixes, or "items 1-5 after PR #N" — decide:
 A single cohesive PR is easier to review than three PRs with
 dependencies. The bot reduces maintainer clicks, not multiplies them.
 
+## Pre-PR build + test gate — mandatory before expert review
+
+The expert review is expensive; don't run it on broken code. Before
+spawning experts, make sure the diff actually compiles and the
+unit tests pass.
+
+1. Run the repo's build + fast test tier (see PR constraints below
+   for exact commands). If the diff only touches docs/markdown, skip
+   build and run the relevant doc check instead.
+2. **If build or tests fail:** read the errors, fix the code,
+   re-run. Cap at **2 build→fix iterations.** If still failing,
+   abandon the PR and Flag for human review with the build log
+   in the comment.
+3. Do **not** skip tests locally because "CI will run them." The
+   point of this gate is to not ship known-broken code even as a
+   draft, because (a) review noise, (b) a human reviewer may
+   admin-merge a draft that looks fine, (c) a green CI on push
+   is the baseline for the auto-fix loop — a red PR at push time
+   is indistinguishable from drift after the fact.
+4. Only once build + tests pass on the final diff: proceed to
+   pre-PR expert review.
+
 ## Pre-PR expert review — mandatory before `gh pr create`
 
 After the branch is pushed but **before** opening the PR, run a

--- a/.changeset/triage-build-test-gate.md
+++ b/.changeset/triage-build-test-gate.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Triage routine now runs a mandatory pre-PR build+test gate (npm run ci:quick) before expert review, capped at 2 build→fix iterations.


### PR DESCRIPTION
## Summary

Mirrors [adcontextprotocol/adcp#3023](https://github.com/adcontextprotocol/adcp/pull/3023).

Routine now runs the repo's build + fast-test tier **before** the pre-PR expert review. Expert spawns are expensive; no point running them on broken code. Also keeps the planned auto-fix loop's "red PR at push = drift" signal clean.

Capped at 2 build→fix iterations. If still failing → abandon and Flag for human review with the log.

## Test plan
- [ ] CI green
- [ ] Next triage-opened PR from this repo includes a visible build-gate outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)