### PR TITLE
feat(sdk): address 5.15.0 DX feedback on handler types, error shape, extraction

### DIFF
--- a/.changeset/sdk-feedback-5-15-0.md
+++ b/.changeset/sdk-feedback-5-15-0.md
@@ -1,0 +1,23 @@
+---
+'@adcp/client': minor
+---
+
+SDK ergonomics fixes addressing feedback on 5.15.0.
+
+**Root re-exports.** The `Success` / `Error` / `Submitted` arms of every `*Response` discriminated union now export from the `@adcp/client` root (previously only the full `*Response` unions did). `AdcpServer` handler returns no longer need `as any` to narrow off the union. Covered arms include `SyncCreativesSuccess`, `SyncAudiencesSuccess`, `CreateMediaBuy{Success,Error,Submitted}`, `UpdateMediaBuy{Success,Error}`, `BuildCreative{Success,MultiSuccess,Error}`, `ActivateSignal{Success,Error}`, `ProvidePerformanceFeedback{Success,Error}`, `SyncEventSources{Success,Error}`, `LogEvent{Success,Error}`, `SyncAccounts{Success,Error}`, `SyncGovernance{Success,Error}`, `UpdateContentStandards{Success,Error}`, `SyncAudiences{Success,Error}`, and `SyncCreatives{Success,Error,Submitted}`.
+
+**Idempotency store dual-export.** `createIdempotencyStore`, `memoryBackend`, `pgBackend`, `getIdempotencyMigration`, `IDEMPOTENCY_MIGRATION`, `cleanupExpiredIdempotency`, `hashPayload`, plus `IdempotencyStore` / `IdempotencyStoreConfig` / `IdempotencyBackend` / `IdempotencyCacheEntry` / `IdempotencyCheckResult` / `MemoryBackendOptions` / `PgBackendOptions` now re-export from the `@adcp/client` root (previously only `@adcp/client/server`), matching the dual-export treatment of `createAdcpServer`.
+
+**Widened handler return types + response-union narrowing.** `DomainHandler<K>` now accepts `Promise<AdcpToolMap[K]['result'] | AdcpToolMap[K]['response'] | McpToolResponse>`. Adapter-style handlers that return `Result<CreateMediaBuyResponse, ...>` where `CreateMediaBuyResponse = Success | Error | Submitted` type-check without `as any`. The dispatcher narrows at runtime:
+
+- `status === 'submitted' && typeof task_id === 'string'` → Submitted envelope. Framework wraps without the Success-builder defaults (`revision`, `confirmed_at`, `valid_actions`) so async-task shapes round-trip correctly.
+- `errors: Error[]` with no Success-arm fields → Error arm. Framework wraps as `{ isError: true, structuredContent: { errors: [...] } }`, preserving the typed-union shape the spec defines.
+- Otherwise → Success arm, response builder applies as before.
+
+`AdcpToolMap` entries gained a `response` field (full union) alongside the existing `result` (narrow Success). Handlers and response builders continue to type-check against `result`; callers that want the permissive shape reach for `response`.
+
+**`extractResult(toolCallResult)` helper.** New lightweight companion to `unwrapProtocolResponse` — prefers `structuredContent`, falls back to JSON-parsing `content[0].text`, returns `undefined` otherwise. Use it on the client side of `mcpClient.callTool(...)` instead of writing the extraction by hand. `unwrapProtocolResponse` remains available when you also want schema validation and extraction-path provenance.
+
+**`VALIDATION_ERROR.issues` surfaced at top level.** Strict-mode validation errors now expose `adcp_error.issues` (RFC 6901 pointer list) at the top level of the envelope so operators see it on the first render. The same list is still mirrored at `adcp_error.details.issues` for buyers that index into `details` per AdCP spec convention — existing `details.issues` readers continue to work, no migration required. `adcp_error.details` also gains the `{ tool, side }` metadata. `schemaPath` gating is unchanged: stripped when `exposeErrorDetails` is off; request-side and response-side now thread the same `exposeSchemaPath` policy (previously request-side stripped schemaPath even in dev).
+
+Handlers that return a tool's *Error arm with spec-violating items (missing `code` or `message`) get a dev-log warning at dispatch — the envelope still ships unchanged, matching the handler's intent, but drift is surfaced in logs.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -96,6 +96,34 @@ serve(() => createAdcpServer({
 - **Catches handler errors** — unhandled exceptions return `SERVICE_UNAVAILABLE` instead of crashing
 - **Sets tool annotations** — `readOnlyHint`, `destructiveHint`, `idempotentHint` per tool
 - **Warns on incoherent tool sets** — e.g., `create_media_buy` without `get_products`
+- **Narrows response unions** — a handler may return the Success arm *or* the full response union (`Success | Error | Submitted`). Adapter-style handlers that already produce `Result<CreateMediaBuyResponse, ...>` don't need to pre-narrow: the dispatcher detects the arm by shape and routes accordingly. Error arms surface as `{ isError: true, structuredContent: { errors: [...] } }`; Submitted arms surface as `{ structuredContent: { status: 'submitted', task_id, ... } }` without the Success-only `revision` / `confirmed_at` defaults. You can still call `adcpError('CODE', ...)` directly for framework-style error envelopes.
+
+### Reading tool results (client side)
+
+The framework emits responses with typed data in `structuredContent` (MCP L3) and a human-readable summary in `content[0].text` (L2). When calling an AdCP agent from client code, prefer `structuredContent`; only fall back to parsing the text block for pre-`structuredContent` servers. The SDK ships two helpers with different failure modes:
+
+```typescript
+import { extractResult, unwrapProtocolResponse } from '@adcp/client';
+
+const res = await mcpClient.callTool({ name: 'get_products', arguments: { brief: '...' } });
+
+// Happy-path: returns structuredContent (or JSON-parsed text); undefined if neither yields data.
+const payload = extractResult<GetProductsResponse>(res);
+
+// Validated read: narrows against the tool schema, throws on missing / drifted payloads.
+const validated = unwrapProtocolResponse(res, 'get_products', 'mcp');
+```
+
+Pick based on the caller: `extractResult` when you just want the payload and can handle `undefined`; `unwrapProtocolResponse` when you want a schema-narrowed AdCP response or an explicit throw.
+
+### Returning errors from handlers
+
+Two shapes round-trip as errors, and they mean different things:
+
+- **Spec-defined tool failure** — return the tool's `*Error` arm directly: `return { errors: [{ code: 'PRODUCT_NOT_FOUND', message: 'no such product' }] }`. The dispatcher detects the Error arm by shape, sets `isError: true`, and preserves the `errors[]` / `context` / `ext` fields on `structuredContent`. Use this when the AdCP spec defines a per-tool error variant for the condition you're surfacing.
+- **Framework / infra failure** — return `adcpError('CODE', { message: '...' })`. Use this for validation drift, idempotency conflicts, authentication failures, rate-limits, `SERVICE_UNAVAILABLE`, and anything else the spec classifies via the standard `code` vocabulary. The envelope lands at `structuredContent.adcp_error`.
+
+Both surface as `isError: true` on the wire, and both skip response-schema validation. Buyers that need to distinguish can look for `structuredContent.adcp_error` (framework) vs `structuredContent.errors` (tool Error arm).
 
 **7 domain groups:**
 
@@ -217,7 +245,7 @@ createAdcpServer({
 });
 ```
 
-Modes per side: `'strict' | 'warn' | 'off'`. Default is `'off'` — enable explicitly. `VALIDATION_ERROR` envelopes carry the full issue list (pointer, message, keyword, schema path) under `details.issues` so buyers can surface each offending field.
+Modes per side: `'strict' | 'warn' | 'off'`. Default is `'off'` — enable explicitly. `VALIDATION_ERROR` envelopes carry the full issue list (pointer, message, keyword, schema path) at the top level `adcp_error.issues` (and mirrored at `details.issues` for spec-convention compatibility) so buyers can surface each offending field without drilling into nested metadata.
 
 The same validator runs on the `AdcpClient` side — storyboards and third-party clients configure it via `validation: { requests, responses }` on the client config. Request default is `warn` (so existing callers that send partial payloads still work); response default is `strict` in dev/test, `warn` in production. Set either side to `'off'` for zero overhead.
 

--- a/docs/migration-4.x-to-5.x.md
+++ b/docs/migration-4.x-to-5.x.md
@@ -563,8 +563,9 @@ policy), or wrap with a response builder (`productsResponse`,
 
 `createAdcpServer({ validation: { responses } })` now defaults to
 `'strict'` when `NODE_ENV !== 'production'`. Handler-returned schema
-drift fails with `VALIDATION_ERROR` (field path in `details.issues`)
-instead of logging a warning you can silently ignore.
+drift fails with `VALIDATION_ERROR` (field path in `adcp_error.issues`,
+mirrored at `details.issues`) instead of logging a warning you can
+silently ignore.
 
 Production stays `'off'`. Pass `validation: { responses: 'warn' }` to
 restore the previous dev behavior; `'off'` opts out entirely.
@@ -576,10 +577,11 @@ server. **Node's test runner does not set `NODE_ENV`, so `node --test`
 suites fall into the dev/test bucket and start validating responses**
 — this is intentional.
 
-`VALIDATION_ERROR.details.issues[].schemaPath` is now gated behind
-`exposeErrorDetails` (same policy as `SERVICE_UNAVAILABLE.details.reason`).
-Production responses no longer leak `#/oneOf/<n>/properties/...` paths
-that fingerprint internal `oneOf` branch selection.
+`VALIDATION_ERROR.issues[].schemaPath` (and its `details.issues[].schemaPath`
+mirror) is now gated behind `exposeErrorDetails` (same policy as
+`SERVICE_UNAVAILABLE.details.reason`). Production responses no longer leak
+`#/oneOf/<n>/properties/...` paths that fingerprint internal `oneOf`
+branch selection.
 
 ### 4d. Request validation defaults to `'warn'` outside production
 
@@ -591,8 +593,8 @@ server to opt out.
 
 ### 4e. `exposeErrorDetails` defaults to `true` outside production
 
-`SERVICE_UNAVAILABLE.details.reason` and
-`VALIDATION_ERROR.details.issues[].schemaPath` ship to callers in
+`SERVICE_UNAVAILABLE.details.reason` and the per-issue `schemaPath` on
+`VALIDATION_ERROR.issues[]` (and `details.issues[]`) ship to callers in
 dev/test/CI. Production stays opted out.
 
 ### 4f. `McpServer.tool()` → `registerTool()` migration

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -285,10 +285,22 @@ export type {
   ListCreativeFormatsResponse,
   CreateMediaBuyRequest,
   CreateMediaBuyResponse,
+  CreateMediaBuySuccess,
+  CreateMediaBuyError,
+  CreateMediaBuySubmitted,
   UpdateMediaBuyRequest,
   UpdateMediaBuyResponse,
+  UpdateMediaBuySuccess,
+  UpdateMediaBuyError,
   SyncCreativesRequest,
   SyncCreativesResponse,
+  SyncCreativesSuccess,
+  SyncCreativesError,
+  SyncCreativesSubmitted,
+  SyncAudiencesRequest,
+  SyncAudiencesResponse,
+  SyncAudiencesSuccess,
+  SyncAudiencesError,
   ListCreativesRequest,
   ListCreativesResponse,
   CreativeFilters,
@@ -296,11 +308,15 @@ export type {
   GetMediaBuyDeliveryResponse,
   ProvidePerformanceFeedbackRequest,
   ProvidePerformanceFeedbackResponse,
+  ProvidePerformanceFeedbackSuccess,
+  ProvidePerformanceFeedbackError,
   // Signals Domain
   GetSignalsRequest,
   GetSignalsResponse,
   ActivateSignalRequest,
   ActivateSignalResponse,
+  ActivateSignalSuccess,
+  ActivateSignalError,
   CpmPricing,
   PercentOfMediaPricing,
   FlatFeePricing,
@@ -326,6 +342,8 @@ export type {
   CreateContentStandardsResponse,
   UpdateContentStandardsRequest,
   UpdateContentStandardsResponse,
+  UpdateContentStandardsSuccess,
+  UpdateContentStandardsError,
   CalibrateContentRequest,
   CalibrateContentResponse,
   ValidateContentDeliveryRequest,
@@ -335,6 +353,10 @@ export type {
   // Governance Domain - Campaign Governance
   SyncPlansRequest,
   SyncPlansResponse,
+  SyncGovernanceRequest,
+  SyncGovernanceResponse,
+  SyncGovernanceSuccess,
+  SyncGovernanceError,
   CheckGovernanceRequest,
   CheckGovernanceResponse,
   ReportPlanOutcomeRequest,
@@ -367,8 +389,12 @@ export type {
   // Event Tracking Domain
   SyncEventSourcesRequest,
   SyncEventSourcesResponse,
+  SyncEventSourcesSuccess,
+  SyncEventSourcesError,
   LogEventRequest,
   LogEventResponse,
+  LogEventSuccess,
+  LogEventError,
   // Enums
   CanceledBy,
   // Core data structures used within requests and responses
@@ -413,6 +439,9 @@ export type {
   CreativeVariable,
   BuildCreativeRequest,
   BuildCreativeResponse,
+  BuildCreativeSuccess,
+  BuildCreativeMultiSuccess,
+  BuildCreativeError,
   PreviewCreativeRequest,
   PreviewCreativeResponse,
   GetMediaBuysRequest,
@@ -446,6 +475,8 @@ export type {
   ListAccountsResponse,
   SyncAccountsRequest,
   SyncAccountsResponse,
+  SyncAccountsSuccess,
+  SyncAccountsError,
   GetAccountFinancialsRequest,
   GetAccountFinancialsResponse,
   GetAccountFinancialsSuccess,
@@ -548,6 +579,13 @@ export {
   requireSessionKey,
   structuredSerialize,
   structuredDeserialize,
+  createIdempotencyStore,
+  memoryBackend,
+  pgBackend,
+  getIdempotencyMigration,
+  IDEMPOTENCY_MIGRATION,
+  cleanupExpiredIdempotency,
+  hashPayload,
 } from './server';
 export type {
   AdcpErrorOptions,
@@ -611,6 +649,13 @@ export type {
   PatchWithRetryOptions,
   StateErrorCode,
   SessionKeyContext,
+  IdempotencyStore,
+  IdempotencyStoreConfig,
+  IdempotencyBackend,
+  IdempotencyCacheEntry,
+  IdempotencyCheckResult,
+  MemoryBackendOptions,
+  PgBackendOptions,
 } from './server';
 
 // ====== ERROR HANDLING & RETRY ======
@@ -745,6 +790,7 @@ export {
 // ====== RESPONSE UTILITIES ======
 // Public utilities for working with AdCP responses
 export { getStandardFormats, unwrapProtocolResponse, isAdcpError, isAdcpSuccess } from './utils';
+export { extractResult, type ToolCallResultLike } from './utils';
 export { REQUEST_TIMEOUT, MAX_CONCURRENT, STANDARD_FORMATS } from './utils';
 export { detectProtocol, detectProtocolWithTimeout } from './utils';
 export { A2A_CARD_PATHS, isAgentCardPath, isWellKnownAgentCardUrl, buildCardUrls, stripAgentCardPath } from './utils';

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -182,19 +182,25 @@ import type {
 import type {
   GetProductsResponse,
   CreateMediaBuySuccess,
+  CreateMediaBuyResponse,
   UpdateMediaBuySuccess,
+  UpdateMediaBuyResponse,
   GetMediaBuysResponse,
   GetMediaBuyDeliveryResponse,
   ListAccountsResponse,
   ListCreativeFormatsResponse,
   ProvidePerformanceFeedbackSuccess,
+  ProvidePerformanceFeedbackResponse,
   BuildCreativeSuccess,
   BuildCreativeMultiSuccess,
+  BuildCreativeResponse,
   GetCreativeDeliveryResponse,
   ListCreativesResponse,
   SyncCreativesSuccess,
+  SyncCreativesResponse,
   GetSignalsResponse,
   ActivateSignalSuccess,
+  ActivateSignalResponse,
   GetAdCPCapabilitiesResponse,
   CreatePropertyListResponse,
   UpdatePropertyListResponse,
@@ -210,12 +216,19 @@ import type {
   SISendMessageResponse,
   SITerminateSessionResponse,
   SyncEventSourcesSuccess,
+  SyncEventSourcesResponse,
   LogEventSuccess,
+  LogEventResponse,
   SyncAudiencesSuccess,
+  SyncAudiencesResponse,
   SyncCatalogsSuccess,
+  SyncCatalogsResponse,
   SyncAccountsSuccess,
+  SyncAccountsResponse,
   SyncGovernanceSuccess,
+  SyncGovernanceResponse,
   GetAccountFinancialsSuccess,
+  GetAccountFinancialsResponse,
   GetCreativeFeaturesResponse,
   ReportUsageResponse,
   PreviewCreativeResponse,
@@ -360,96 +373,253 @@ export function requireSessionKey<TAccount = unknown>(ctx: HandlerContext<TAccou
 // Tool → type mapping (kept from v1 for type-level handler signatures)
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-tool param / result / response types.
+ *
+ * `result` is the narrow success arm — what the framework's response
+ * builders (`mediaBuyResponse`, `syncCreativesResponse`, ...) expect.
+ * `response` is the full AdCP response union (Success | Error | Submitted).
+ * Handlers can return either shape: adapter patterns that produce
+ * `Result<FooResponse, ...>` now type-check without `as any`, and the
+ * dispatcher narrows Error / Submitted arms at runtime so the response
+ * builder only fires on the Success arm.
+ */
 export interface AdcpToolMap {
-  get_products: { params: z.input<typeof GetProductsRequestSchema>; result: GetProductsResponse };
-  create_media_buy: { params: z.input<typeof CreateMediaBuyRequestSchema>; result: CreateMediaBuySuccess };
-  update_media_buy: { params: z.input<typeof UpdateMediaBuyRequestSchema>; result: UpdateMediaBuySuccess };
-  get_media_buys: { params: z.input<typeof GetMediaBuysRequestSchema>; result: GetMediaBuysResponse };
+  get_products: {
+    params: z.input<typeof GetProductsRequestSchema>;
+    result: GetProductsResponse;
+    response: GetProductsResponse;
+  };
+  create_media_buy: {
+    params: z.input<typeof CreateMediaBuyRequestSchema>;
+    result: CreateMediaBuySuccess;
+    response: CreateMediaBuyResponse;
+  };
+  update_media_buy: {
+    params: z.input<typeof UpdateMediaBuyRequestSchema>;
+    result: UpdateMediaBuySuccess;
+    response: UpdateMediaBuyResponse;
+  };
+  get_media_buys: {
+    params: z.input<typeof GetMediaBuysRequestSchema>;
+    result: GetMediaBuysResponse;
+    response: GetMediaBuysResponse;
+  };
   get_media_buy_delivery: {
     params: z.input<typeof GetMediaBuyDeliveryRequestSchema>;
     result: GetMediaBuyDeliveryResponse;
+    response: GetMediaBuyDeliveryResponse;
   };
   provide_performance_feedback: {
     params: z.input<typeof ProvidePerformanceFeedbackRequestSchema>;
     result: ProvidePerformanceFeedbackSuccess;
+    response: ProvidePerformanceFeedbackResponse;
   };
   list_creative_formats: {
     params: z.input<typeof ListCreativeFormatsRequestSchema>;
     result: ListCreativeFormatsResponse;
+    response: ListCreativeFormatsResponse;
   };
   build_creative: {
     params: z.input<typeof BuildCreativeRequestSchema>;
     result: BuildCreativeSuccess | BuildCreativeMultiSuccess;
+    response: BuildCreativeResponse;
   };
-  preview_creative: { params: z.input<typeof PreviewCreativeRequestSchema>; result: PreviewCreativeResponse };
+  preview_creative: {
+    params: z.input<typeof PreviewCreativeRequestSchema>;
+    result: PreviewCreativeResponse;
+    response: PreviewCreativeResponse;
+  };
   get_creative_delivery: {
     params: z.input<typeof GetCreativeDeliveryRequestSchema>;
     result: GetCreativeDeliveryResponse;
+    response: GetCreativeDeliveryResponse;
   };
-  list_creatives: { params: z.input<typeof ListCreativesRequestSchema>; result: ListCreativesResponse };
-  sync_creatives: { params: z.input<typeof SyncCreativesRequestSchema>; result: SyncCreativesSuccess };
-  get_signals: { params: z.input<typeof GetSignalsRequestSchema>; result: GetSignalsResponse };
-  activate_signal: { params: z.input<typeof ActivateSignalRequestSchema>; result: ActivateSignalSuccess };
-  list_accounts: { params: z.input<typeof ListAccountsRequestSchema>; result: ListAccountsResponse };
-  sync_accounts: { params: z.input<typeof SyncAccountsRequestSchema>; result: SyncAccountsSuccess };
-  sync_governance: { params: z.input<typeof SyncGovernanceRequestSchema>; result: SyncGovernanceSuccess };
+  list_creatives: {
+    params: z.input<typeof ListCreativesRequestSchema>;
+    result: ListCreativesResponse;
+    response: ListCreativesResponse;
+  };
+  sync_creatives: {
+    params: z.input<typeof SyncCreativesRequestSchema>;
+    result: SyncCreativesSuccess;
+    response: SyncCreativesResponse;
+  };
+  get_signals: {
+    params: z.input<typeof GetSignalsRequestSchema>;
+    result: GetSignalsResponse;
+    response: GetSignalsResponse;
+  };
+  activate_signal: {
+    params: z.input<typeof ActivateSignalRequestSchema>;
+    result: ActivateSignalSuccess;
+    response: ActivateSignalResponse;
+  };
+  list_accounts: {
+    params: z.input<typeof ListAccountsRequestSchema>;
+    result: ListAccountsResponse;
+    response: ListAccountsResponse;
+  };
+  sync_accounts: {
+    params: z.input<typeof SyncAccountsRequestSchema>;
+    result: SyncAccountsSuccess;
+    response: SyncAccountsResponse;
+  };
+  sync_governance: {
+    params: z.input<typeof SyncGovernanceRequestSchema>;
+    result: SyncGovernanceSuccess;
+    response: SyncGovernanceResponse;
+  };
   get_account_financials: {
     params: z.input<typeof GetAccountFinancialsRequestSchema>;
     result: GetAccountFinancialsSuccess;
+    response: GetAccountFinancialsResponse;
   };
-  report_usage: { params: z.input<typeof ReportUsageRequestSchema>; result: ReportUsageResponse };
-  sync_event_sources: { params: z.input<typeof SyncEventSourcesRequestSchema>; result: SyncEventSourcesSuccess };
-  log_event: { params: z.input<typeof LogEventRequestSchema>; result: LogEventSuccess };
-  sync_audiences: { params: z.input<typeof SyncAudiencesRequestSchema>; result: SyncAudiencesSuccess };
-  sync_catalogs: { params: z.input<typeof SyncCatalogsRequestSchema>; result: SyncCatalogsSuccess };
-  create_property_list: { params: z.input<typeof CreatePropertyListRequestSchema>; result: CreatePropertyListResponse };
-  update_property_list: { params: z.input<typeof UpdatePropertyListRequestSchema>; result: UpdatePropertyListResponse };
-  get_property_list: { params: z.input<typeof GetPropertyListRequestSchema>; result: GetPropertyListResponse };
-  list_property_lists: { params: z.input<typeof ListPropertyListsRequestSchema>; result: ListPropertyListsResponse };
-  delete_property_list: { params: z.input<typeof DeletePropertyListRequestSchema>; result: DeletePropertyListResponse };
+  report_usage: {
+    params: z.input<typeof ReportUsageRequestSchema>;
+    result: ReportUsageResponse;
+    response: ReportUsageResponse;
+  };
+  sync_event_sources: {
+    params: z.input<typeof SyncEventSourcesRequestSchema>;
+    result: SyncEventSourcesSuccess;
+    response: SyncEventSourcesResponse;
+  };
+  log_event: {
+    params: z.input<typeof LogEventRequestSchema>;
+    result: LogEventSuccess;
+    response: LogEventResponse;
+  };
+  sync_audiences: {
+    params: z.input<typeof SyncAudiencesRequestSchema>;
+    result: SyncAudiencesSuccess;
+    response: SyncAudiencesResponse;
+  };
+  sync_catalogs: {
+    params: z.input<typeof SyncCatalogsRequestSchema>;
+    result: SyncCatalogsSuccess;
+    response: SyncCatalogsResponse;
+  };
+  create_property_list: {
+    params: z.input<typeof CreatePropertyListRequestSchema>;
+    result: CreatePropertyListResponse;
+    response: CreatePropertyListResponse;
+  };
+  update_property_list: {
+    params: z.input<typeof UpdatePropertyListRequestSchema>;
+    result: UpdatePropertyListResponse;
+    response: UpdatePropertyListResponse;
+  };
+  get_property_list: {
+    params: z.input<typeof GetPropertyListRequestSchema>;
+    result: GetPropertyListResponse;
+    response: GetPropertyListResponse;
+  };
+  list_property_lists: {
+    params: z.input<typeof ListPropertyListsRequestSchema>;
+    result: ListPropertyListsResponse;
+    response: ListPropertyListsResponse;
+  };
+  delete_property_list: {
+    params: z.input<typeof DeletePropertyListRequestSchema>;
+    result: DeletePropertyListResponse;
+    response: DeletePropertyListResponse;
+  };
   list_content_standards: {
     params: z.input<typeof ListContentStandardsRequestSchema>;
     result: ListContentStandardsResponse;
+    response: ListContentStandardsResponse;
   };
   get_content_standards: {
     params: z.input<typeof GetContentStandardsRequestSchema>;
     result: GetContentStandardsResponse;
+    response: GetContentStandardsResponse;
   };
   create_content_standards: {
     params: z.input<typeof CreateContentStandardsRequestSchema>;
     result: CreateContentStandardsResponse;
+    response: CreateContentStandardsResponse;
   };
   update_content_standards: {
     params: z.input<typeof UpdateContentStandardsRequestSchema>;
     result: UpdateContentStandardsResponse;
+    response: UpdateContentStandardsResponse;
   };
-  calibrate_content: { params: z.input<typeof CalibrateContentRequestSchema>; result: CalibrateContentResponse };
+  calibrate_content: {
+    params: z.input<typeof CalibrateContentRequestSchema>;
+    result: CalibrateContentResponse;
+    response: CalibrateContentResponse;
+  };
   validate_content_delivery: {
     params: z.input<typeof ValidateContentDeliveryRequestSchema>;
     result: ValidateContentDeliveryResponse;
+    response: ValidateContentDeliveryResponse;
   };
   get_media_buy_artifacts: {
     params: z.input<typeof GetMediaBuyArtifactsRequestSchema>;
     result: GetMediaBuyArtifactsResponse;
+    response: GetMediaBuyArtifactsResponse;
   };
   get_creative_features: {
     params: z.input<typeof GetCreativeFeaturesRequestSchema>;
     result: GetCreativeFeaturesResponse;
+    response: GetCreativeFeaturesResponse;
   };
-  sync_plans: { params: z.input<typeof SyncPlansRequestSchema>; result: SyncPlansResponse };
-  check_governance: { params: z.input<typeof CheckGovernanceRequestSchema>; result: CheckGovernanceResponse };
-  report_plan_outcome: { params: z.input<typeof ReportPlanOutcomeRequestSchema>; result: ReportPlanOutcomeResponse };
-  get_plan_audit_logs: { params: z.input<typeof GetPlanAuditLogsRequestSchema>; result: GetPlanAuditLogsResponse };
-  si_get_offering: { params: z.input<typeof SIGetOfferingRequestSchema>; result: SIGetOfferingResponse };
-  si_initiate_session: { params: z.input<typeof SIInitiateSessionRequestSchema>; result: SIInitiateSessionResponse };
-  si_send_message: { params: z.input<typeof SISendMessageRequestSchema>; result: SISendMessageResponse };
-  si_terminate_session: { params: z.input<typeof SITerminateSessionRequestSchema>; result: SITerminateSessionResponse };
+  sync_plans: {
+    params: z.input<typeof SyncPlansRequestSchema>;
+    result: SyncPlansResponse;
+    response: SyncPlansResponse;
+  };
+  check_governance: {
+    params: z.input<typeof CheckGovernanceRequestSchema>;
+    result: CheckGovernanceResponse;
+    response: CheckGovernanceResponse;
+  };
+  report_plan_outcome: {
+    params: z.input<typeof ReportPlanOutcomeRequestSchema>;
+    result: ReportPlanOutcomeResponse;
+    response: ReportPlanOutcomeResponse;
+  };
+  get_plan_audit_logs: {
+    params: z.input<typeof GetPlanAuditLogsRequestSchema>;
+    result: GetPlanAuditLogsResponse;
+    response: GetPlanAuditLogsResponse;
+  };
+  si_get_offering: {
+    params: z.input<typeof SIGetOfferingRequestSchema>;
+    result: SIGetOfferingResponse;
+    response: SIGetOfferingResponse;
+  };
+  si_initiate_session: {
+    params: z.input<typeof SIInitiateSessionRequestSchema>;
+    result: SIInitiateSessionResponse;
+    response: SIInitiateSessionResponse;
+  };
+  si_send_message: {
+    params: z.input<typeof SISendMessageRequestSchema>;
+    result: SISendMessageResponse;
+    response: SISendMessageResponse;
+  };
+  si_terminate_session: {
+    params: z.input<typeof SITerminateSessionRequestSchema>;
+    result: SITerminateSessionResponse;
+    response: SITerminateSessionResponse;
+  };
 
-  get_brand_identity: { params: z.input<typeof GetBrandIdentityRequestSchema>; result: GetBrandIdentitySuccess };
-  get_rights: { params: z.input<typeof GetRightsRequestSchema>; result: GetRightsSuccess };
+  get_brand_identity: {
+    params: z.input<typeof GetBrandIdentityRequestSchema>;
+    result: GetBrandIdentitySuccess;
+    response: GetBrandIdentitySuccess;
+  };
+  get_rights: {
+    params: z.input<typeof GetRightsRequestSchema>;
+    result: GetRightsSuccess;
+    response: GetRightsSuccess;
+  };
   acquire_rights: {
     params: z.input<typeof AcquireRightsRequestSchema>;
     result: AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected;
+    response: AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected;
   };
 }
 
@@ -460,12 +630,20 @@ export type AdcpServerToolName = keyof AdcpToolMap;
 // ---------------------------------------------------------------------------
 
 /** Handler that receives validated params and a resolved context.
- *  Return the tool's typed success shape, or an error envelope via
- *  `adcpError(...)` (typed as `McpToolResponse`). */
+ *
+ *  Return any of:
+ *  - The narrow Success arm (`result`) — framework applies the response builder.
+ *  - The full response union (`response` = Success | Error | Submitted) — the
+ *    dispatcher narrows Error / Submitted arms at runtime. Useful for adapters
+ *    that already produce a `Result<FooResponse, ...>` and don't want to
+ *    pre-narrow.
+ *  - A pre-formatted `McpToolResponse` (e.g. from `adcpError(...)`) — passed
+ *    through unchanged.
+ */
 type DomainHandler<K extends AdcpServerToolName, TAccount> = (
   params: AdcpToolMap[K]['params'],
   ctx: HandlerContext<TAccount>
-) => Promise<AdcpToolMap[K]['result'] | McpToolResponse>;
+) => Promise<AdcpToolMap[K]['result'] | AdcpToolMap[K]['response'] | McpToolResponse>;
 
 export interface MediaBuyHandlers<TAccount = unknown> {
   getProducts?: DomainHandler<'get_products', TAccount>;
@@ -1488,6 +1666,79 @@ function isFormattedResponse(value: unknown): value is McpToolResponse {
 }
 
 /**
+ * Detect an AdCP Submitted envelope (async task acknowledgement).
+ *
+ * Every *Submitted arm in the generated types has `status: 'submitted'`
+ * plus a required `task_id: string`. The discriminant is stable enough
+ * to use for routing at dispatch time without per-tool knowledge.
+ */
+function isSubmittedEnvelope(value: unknown): value is { status: 'submitted'; task_id: string; message?: string } {
+  if (value == null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return obj.status === 'submitted' && typeof obj.task_id === 'string';
+}
+
+/**
+ * Detect an AdCP *Error arm (union member, not the framework `adcp_error`
+ * envelope). Every *Error interface in the generated types carries a
+ * required `errors: Error[]` and a narrow set of allowed siblings
+ * (`context`, `ext`, plus a couple of tool-specific extras). Success
+ * arms may have optional advisory fields but never a required `errors`
+ * array — the `status === 'submitted'` exclusion keeps us from
+ * confusing a Submitted envelope that advisory-echoes errors as an
+ * Error arm. The set of allowed sibling keys is intentionally narrow:
+ * any other top-level key means the payload carries Success-only fields
+ * (`media_buy_id`, `creatives`, `signal_id`, ...) and should fall
+ * through to the response builder.
+ */
+const ERROR_ARM_ALLOWED_KEYS = new Set(['errors', 'context', 'ext', 'success', 'conflicting_standards_id']);
+function isErrorArm(value: unknown): value is { errors: unknown[]; context?: unknown; ext?: unknown } {
+  if (value == null || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  if (!Array.isArray(obj.errors)) return false;
+  if ('status' in obj) return false;
+  for (const key of Object.keys(obj)) {
+    if (!ERROR_ARM_ALLOWED_KEYS.has(key)) return false;
+  }
+  return true;
+}
+
+/**
+ * Wrap a Submitted envelope returned directly by a handler. Skips the
+ * Success-builder defaults (`revision`, `confirmed_at`, `valid_actions`)
+ * — those fields are specific to `CreateMediaBuySuccess` and would
+ * corrupt the async-task shape if applied.
+ */
+function wrapSubmittedEnvelope(value: { status: 'submitted'; task_id: string; message?: string }): McpToolResponse {
+  const summary = value.message ?? `Task ${value.task_id} submitted`;
+  return {
+    content: [{ type: 'text', text: summary }],
+    structuredContent: value as unknown as Record<string, unknown>,
+  };
+}
+
+/**
+ * Wrap an *Error arm returned directly by a handler. Preserves the
+ * generated-type shape (`errors: Error[]`) on `structuredContent` so
+ * buyers reading the typed response union see the exact branch the
+ * spec defines; also sets `isError: true` so the MCP-level signal
+ * matches `adcp_error` envelopes, which keeps `isErrorResponse()` and
+ * `response-validation: strict` consistent across both error paths.
+ */
+function wrapErrorArm(value: { errors: unknown[] }): McpToolResponse {
+  const firstError = value.errors[0] as { code?: unknown; message?: unknown } | undefined;
+  const summary =
+    firstError && typeof firstError === 'object'
+      ? `${typeof firstError.code === 'string' ? firstError.code : 'ERROR'}: ${typeof firstError.message === 'string' ? firstError.message : 'operation failed'}`
+      : 'operation failed';
+  return {
+    content: [{ type: 'text', text: summary }],
+    isError: true,
+    structuredContent: value as unknown as Record<string, unknown>,
+  };
+}
+
+/**
  * Defence-in-depth sanitizer for handler-returned error envelopes.
  *
  * `adcpError()` filters its own output against `ADCP_ERROR_FIELD_ALLOWLIST`,
@@ -1892,7 +2143,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           const outcome = validateRequest(toolName, params);
           if (!outcome.valid) {
             if (requestValidationMode === 'strict') {
-              const payload = buildAdcpValidationErrorPayload(toolName, 'request', outcome.issues);
+              // Thread `exposeSchemaPath` the same way response-side does
+              // so request-side schemaPath also ships in dev and stays
+              // gated in production. Prior to this, request-side silently
+              // stripped schemaPath even in dev — asymmetric with response-side.
+              const payload = buildAdcpValidationErrorPayload(toolName, 'request', outcome.issues, {
+                exposeSchemaPath: exposeErrorDetails,
+              });
               return finalize(adcpError('VALIDATION_ERROR', payload));
             }
             logger.warn(`Schema validation warning (request) for ${toolName}: ${formatIssues(outcome.issues)}`, {
@@ -2063,7 +2320,43 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // --- Handler ---
         try {
           const result = await handler(params, ctx);
-          let formatted: McpToolResponse = isFormattedResponse(result) ? result : wrap(result);
+          // Narrow Error / Submitted arms of the *Response union before
+          // reaching the success-arm builder: wrap() on an Error payload
+          // would still serialize it but apply success-shaped defaults
+          // (revision, confirmed_at, 'Media buy undefined created') to
+          // a shape that doesn't have those fields. Routing here keeps
+          // the wire shape correct regardless of which arm the handler
+          // chose to return.
+          let formatted: McpToolResponse;
+          if (isFormattedResponse(result)) {
+            formatted = result;
+          } else if (isSubmittedEnvelope(result)) {
+            formatted = wrapSubmittedEnvelope(result);
+          } else if (isErrorArm(result)) {
+            // Log-warn (always) on spec-violating Error items — required
+            // `code`/`message` are spec-mandatory on core/error.json. We
+            // don't fail the response: response-schema validation is
+            // already skipped for `isError: true` envelopes and flipping
+            // a handler-returned Error arm into a framework VALIDATION_ERROR
+            // would obscure the seller's intended error. A steady-state
+            // warn is enough to surface drift in dev/test logs.
+            const malformed = (result.errors as unknown[]).some(
+              e =>
+                e == null ||
+                typeof e !== 'object' ||
+                typeof (e as Record<string, unknown>).code !== 'string' ||
+                typeof (e as Record<string, unknown>).message !== 'string'
+            );
+            if (malformed) {
+              logger.warn(`Handler returned ${toolName} Error arm with spec-violating errors[]`, {
+                tool: toolName,
+                errors: result.errors,
+              });
+            }
+            formatted = wrapErrorArm(result);
+          } else {
+            formatted = wrap(result);
+          }
 
           // --- Test-controller bridge: augment get_products with seeded fixtures. ---
           // Only runs when the seller opted in via `testController.getSeededProducts`

--- a/src/lib/server/errors.ts
+++ b/src/lib/server/errors.ts
@@ -11,6 +11,7 @@ import {
   type StandardErrorCode,
   type ErrorRecovery,
 } from '../types/error-codes';
+import type { ValidationIssue } from '../validation/schema-validator';
 import { ADCP_ERROR_FIELD_ALLOWLIST } from './envelope-allowlist';
 
 export interface AdcpErrorOptions {
@@ -50,6 +51,15 @@ export interface AdcpErrorOptions {
    * prior request payload or cached response body).
    */
   details?: Record<string, unknown>;
+  /**
+   * Schema validation issues surfaced at the top level of `adcp_error`
+   * so operators see JSON Pointers on the first render. Primary use is
+   * `VALIDATION_ERROR`; framework validation hooks populate this
+   * automatically and also mirror the same array to `details.issues`
+   * for buyers that already index into `details` per AdCP spec
+   * convention.
+   */
+  issues?: Array<Omit<ValidationIssue, 'schemaPath'> & { schemaPath?: string }>;
 }
 
 export interface AdcpErrorPayload {
@@ -68,6 +78,13 @@ export interface AdcpErrorPayload {
   suggestion?: string;
   retry_after?: number;
   details?: Record<string, unknown>;
+  /**
+   * Schema validation issues (`VALIDATION_ERROR`) exposed at the top
+   * level so the list is the first thing a reader sees when inspecting
+   * the envelope. Also mirrored at `details.issues` for spec-convention
+   * compatibility.
+   */
+  issues?: Array<Omit<ValidationIssue, 'schemaPath'> & { schemaPath?: string }>;
 }
 
 export interface AdcpErrorResponse {
@@ -124,6 +141,7 @@ export function adcpError(code: StandardErrorCode | (string & {}), options: Adcp
     ...(options.field != null && { field: options.field }),
     ...(options.suggestion != null && { suggestion: options.suggestion }),
     ...(options.retry_after != null && { retry_after: options.retry_after }),
+    ...(options.issues != null && { issues: options.issues }),
     ...(options.details != null && { details: options.details }),
   };
 

--- a/src/lib/utils/extract-result.ts
+++ b/src/lib/utils/extract-result.ts
@@ -1,0 +1,65 @@
+/**
+ * Extract structured data from an MCP `CallToolResult`.
+ *
+ * AdCP servers put the typed tool response in `structuredContent` (MCP L3);
+ * `content[0].text` carries a human-readable summary (MCP L2). Prefer
+ * `structuredContent` when present, fall back to JSON-parsing a text block
+ * for servers that haven't adopted `structuredContent` yet.
+ *
+ * **Returns `undefined`** when neither surface yields usable data. This
+ * is the ergonomic happy-path helper — the companion
+ * `unwrapProtocolResponse` **throws** on missing/invalid payloads and
+ * additionally validates against a per-tool schema, handling protocol
+ * detection and extraction-path provenance. Pick based on the caller:
+ *
+ * - `extractResult<T>(res)` — "I just want the payload; `undefined` if
+ *   there's nothing to extract." No throw, no validation.
+ * - `unwrapProtocolResponse(res, toolName, 'mcp')` — "Give me a
+ *   validated, schema-narrowed AdCP response or throw." Heavier, tool-aware.
+ *
+ * `content[]` entries that aren't text blocks (image / audio / resource
+ * per the MCP `CallToolResult.content` schema) are intentionally
+ * skipped — AdCP's typed payload always rides on `structuredContent`
+ * or the first JSON-parseable text block.
+ *
+ * @example
+ * ```ts
+ * import { extractResult } from '@adcp/client';
+ *
+ * const res = await mcpClient.callTool({ name: 'get_products', arguments: {} });
+ * const payload = extractResult<GetProductsResponse>(res);
+ * if (payload && 'products' in payload) {
+ *   // payload is the Success arm — narrow further if it's a Success|Error union
+ * }
+ * ```
+ */
+export interface ToolCallResultLike {
+  structuredContent?: unknown;
+  content?: Array<{ type?: string; text?: string } | null | undefined>;
+  isError?: boolean;
+}
+
+export function extractResult<T = unknown>(result: ToolCallResultLike | null | undefined): T | undefined {
+  if (result == null || typeof result !== 'object') return undefined;
+
+  const structured = result.structuredContent;
+  if (structured != null && typeof structured === 'object') {
+    return structured as T;
+  }
+
+  if (Array.isArray(result.content)) {
+    for (const block of result.content) {
+      // Non-text blocks (image/audio/resource) carry no AdCP payload —
+      // skip silently rather than throwing on an unknown block type.
+      if (block && block.type === 'text' && typeof block.text === 'string') {
+        try {
+          return JSON.parse(block.text) as T;
+        } catch {
+          // Not JSON — keep scanning for another text block.
+        }
+      }
+    }
+  }
+
+  return undefined;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -138,6 +138,9 @@ export function getStandardFormats(): CreativeFormat[] {
 export { unwrapProtocolResponse, isAdcpError, isAdcpSuccess } from './response-unwrapper';
 export type { AdCPResponse } from './response-unwrapper';
 
+// Lightweight MCP CallToolResult extractor (prefers structuredContent, falls back to JSON text).
+export { extractResult, type ToolCallResultLike } from './extract-result';
+
 // Re-export retry utilities
 export { isRetryable, getRetryDelay } from './retry';
 

--- a/src/lib/validation/schema-errors.ts
+++ b/src/lib/validation/schema-errors.ts
@@ -36,10 +36,12 @@ export function buildValidationError(
 
 /**
  * Shape of `adcp_error.details` inside a server-side `VALIDATION_ERROR`
- * envelope. Shipped so buyers can index every pointer programmatically
- * instead of parsing the free-text message. `schemaPath` is optional
- * per-issue — the builder drops it by default in production so
- * `oneOf` branch selection doesn't leak to buyers.
+ * envelope. The issue list is ALSO promoted to the top level
+ * (`adcp_error.issues`) so operators see JSON Pointers on the first
+ * render; `details.issues` is kept as a spec-convention mirror for
+ * buyers that index into `details`. `schemaPath` is optional per-issue
+ * — the builder drops it by default in production so `oneOf` branch
+ * selection doesn't leak to buyers.
  */
 export interface AdcpValidationErrorDetails {
   tool: string;
@@ -50,28 +52,47 @@ export interface AdcpValidationErrorDetails {
 /**
  * Serialize issues for the server-side `adcpError('VALIDATION_ERROR', ...)` call.
  *
+ * Issues appear at BOTH `adcp_error.issues` (top level, so operators
+ * and debuggers see them on first render) AND `adcp_error.details.issues`
+ * (the spec-convention location, so buyers that already index into
+ * `details` continue to work). Future buyers should prefer
+ * `adcp_error.issues`; the `details.issues` mirror is maintained for
+ * compatibility across the AdCP ecosystem until a spec decision settles
+ * where issues should canonically live.
+ *
  * `exposeSchemaPath` controls whether each issue's AJV `schemaPath`
  * (e.g. `#/oneOf/2/properties/status/enum`) crosses the wire. When
- * false, schemaPath is stripped from the emitted details.issues[] —
- * buyers still get `pointer`, `message`, and `keyword`, which is
- * enough to fix their payload, but the internal branch shape of the
- * seller's handler isn't leaked. Defaults to the same policy as
- * `exposeErrorDetails`: on in dev/test, off in production.
+ * false, schemaPath is stripped from the emitted `issues` (both
+ * copies) — buyers still get `pointer`, `message`, and `keyword`,
+ * which is enough to fix their payload, but the internal branch
+ * shape of the seller's handler isn't leaked. Defaults to the same
+ * policy as `exposeErrorDetails`: on in dev/test, off in production.
  */
 export function buildAdcpValidationErrorPayload(
   tool: string,
   side: 'request' | 'response',
   issues: ValidationIssue[],
   options: { exposeSchemaPath?: boolean } = {}
-): { message: string; field?: string; details: Record<string, unknown> } {
+): {
+  message: string;
+  field?: string;
+  issues: Array<Omit<ValidationIssue, 'schemaPath'> & { schemaPath?: string }>;
+  details: Record<string, unknown>;
+} {
   const first = issues[0];
   const message =
     first != null
       ? `${tool} ${side} failed schema validation at ${first.pointer}: ${first.message}`
       : `${tool} ${side} failed schema validation`;
   const emittedIssues = options.exposeSchemaPath ? issues : issues.map(({ schemaPath: _schemaPath, ...rest }) => rest);
-  const payload: { message: string; field?: string; details: Record<string, unknown> } = {
+  const payload: {
+    message: string;
+    field?: string;
+    issues: Array<Omit<ValidationIssue, 'schemaPath'> & { schemaPath?: string }>;
+    details: Record<string, unknown>;
+  } = {
     message,
+    issues: emittedIssues,
     details: { tool, side, issues: emittedIssues } satisfies AdcpValidationErrorDetails as unknown as Record<
       string,
       unknown

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -11,7 +11,8 @@ import { getValidator, type Direction, type ResponseVariant } from './schema-loa
 /**
  * A single validation failure with a JSON Pointer to the offending field,
  * the AJV message, and the schema path that rejected it. Mirrors the
- * format a `VALIDATION_ERROR` carries in its `details.issues`.
+ * format a `VALIDATION_ERROR` carries at `adcp_error.issues` (top level)
+ * and `adcp_error.details.issues` (spec-convention mirror).
  */
 export interface ValidationIssue {
   /** RFC 6901 JSON Pointer to the offending field in the payload. */

--- a/test/lib/schema-validation-server.test.js
+++ b/test/lib/schema-validation-server.test.js
@@ -234,8 +234,15 @@ describe('createAdcpServer validation middleware', () => {
         });
         const res = await callTool(server, 'get_products', VALID_GET_PRODUCTS);
         assert.strictEqual(res.structuredContent.adcp_error.code, 'VALIDATION_ERROR');
-        const issues = res.structuredContent.adcp_error.details.issues;
-        assert.ok(Array.isArray(issues) && issues.length > 0);
+        const issues = res.structuredContent.adcp_error.issues;
+        assert.ok(Array.isArray(issues) && issues.length > 0, 'issues must live at top level of adcp_error');
+        // Spec convention: issues also mirrored inside details for buyers that
+        // index details.issues today. See src/lib/validation/schema-errors.ts.
+        assert.deepStrictEqual(
+          res.structuredContent.adcp_error.details.issues,
+          issues,
+          'details.issues must mirror top-level issues'
+        );
         for (const issue of issues) {
           assert.strictEqual(issue.schemaPath, undefined, 'schemaPath must not leak when exposeErrorDetails is off');
           assert.ok(issue.pointer, 'pointer still present');
@@ -258,7 +265,7 @@ describe('createAdcpServer validation middleware', () => {
           mediaBuy: { getProducts: async () => ({ products: 'oops' }) },
         });
         const res = await callTool(server, 'get_products', VALID_GET_PRODUCTS);
-        const issues = res.structuredContent.adcp_error.details.issues;
+        const issues = res.structuredContent.adcp_error.issues;
         assert.ok(issues.some(i => typeof i.schemaPath === 'string' && i.schemaPath.length > 0));
       } finally {
         if (originalEnv === undefined) delete process.env.NODE_ENV;

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -187,15 +187,22 @@ describe('schema-driven validation', () => {
       assert.deepStrictEqual(err.details.issues, issues);
     });
 
-    test('builds an L3 error payload for adcpError()', () => {
+    test('builds an L3 error payload for adcpError() with dual-location issues', () => {
       const issues = [
         { pointer: '/media_buy_id', message: 'is required', keyword: 'required', schemaPath: '#/required' },
       ];
       const payload = buildAdcpValidationErrorPayload('create_media_buy', 'response', issues);
       assert.ok(payload.message.includes('/media_buy_id'));
       assert.strictEqual(payload.field, '/media_buy_id');
+      // Issues land at the top level AND inside details (spec-convention mirror).
+      assert.ok(Array.isArray(payload.issues), 'issues must be a top-level array');
+      assert.strictEqual(payload.issues.length, 1);
+      assert.strictEqual(payload.issues[0].pointer, '/media_buy_id');
+      assert.strictEqual(payload.issues[0].keyword, 'required');
       assert.strictEqual(payload.details.tool, 'create_media_buy');
       assert.strictEqual(payload.details.side, 'response');
+      assert.ok(Array.isArray(payload.details.issues), 'details.issues mirrors for spec compatibility');
+      assert.deepStrictEqual(payload.details.issues, payload.issues);
     });
   });
 

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -464,9 +464,7 @@ describe('createAdcpServer', () => {
         version: '1.0.0',
         mediaBuy: {
           createMediaBuy: async () => ({
-            errors: [
-              { code: 'PRODUCT_NOT_FOUND', message: 'no such product', field: 'packages[0].product_id' },
-            ],
+            errors: [{ code: 'PRODUCT_NOT_FOUND', message: 'no such product', field: 'packages[0].product_id' }],
           }),
         },
       });
@@ -658,8 +656,7 @@ describe('createAdcpServer', () => {
         name: 'Test',
         version: '1.0.0',
         mediaBuy: {
-          getProducts: async () =>
-            adcpError('RATE_LIMITED', { message: 'slow down', retry_after: 30 }),
+          getProducts: async () => adcpError('RATE_LIMITED', { message: 'slow down', retry_after: 30 }),
         },
       });
       const result = await callToolRaw(server, 'get_products', {

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -457,6 +457,225 @@ describe('createAdcpServer', () => {
     });
   });
 
+  describe('response-union narrowing (handler returns full Response)', () => {
+    it('handler that returns create_media_buy Error arm → isError + errors preserved', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          createMediaBuy: async () => ({
+            errors: [
+              { code: 'PRODUCT_NOT_FOUND', message: 'no such product', field: 'packages[0].product_id' },
+            ],
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.strictEqual(result.isError, true, 'Error arm must surface as MCP isError');
+      assert.ok(Array.isArray(result.structuredContent.errors), 'errors array preserved on wire');
+      assert.strictEqual(result.structuredContent.errors[0].code, 'PRODUCT_NOT_FOUND');
+      // Must NOT apply Success-arm defaults to an Error payload.
+      assert.strictEqual(result.structuredContent.revision, undefined);
+      assert.strictEqual(result.structuredContent.confirmed_at, undefined);
+      assert.strictEqual(result.structuredContent.media_buy_id, undefined);
+    });
+
+    it('handler that returns create_media_buy Submitted arm → no success defaults, structuredContent preserved', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          createMediaBuy: async () => ({
+            status: 'submitted',
+            task_id: 'tk_123',
+            message: 'Awaiting IO signature',
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.notStrictEqual(result.isError, true, 'submitted is not an error');
+      assert.strictEqual(result.structuredContent.status, 'submitted');
+      assert.strictEqual(result.structuredContent.task_id, 'tk_123');
+      // Success defaults must not leak onto an async-task envelope.
+      assert.strictEqual(result.structuredContent.revision, undefined);
+      assert.strictEqual(result.structuredContent.confirmed_at, undefined);
+      assert.ok(result.content[0].text.includes('tk_123') || result.content[0].text.includes('signature'));
+    });
+
+    it('handler that returns sync_creatives Error arm → errors preserved, no creatives/summary corruption', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        creative: {
+          syncCreatives: async () => ({
+            errors: [{ code: 'AUTHENTICATION_FAILED', message: 'bad token' }],
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'sync_creatives', {
+        account: { account_id: 'a1' },
+        creatives: [],
+        idempotency_key: '11111111-1111-1111-1111-111111111111',
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.creatives, undefined, 'Success-only field absent on Error arm');
+      assert.strictEqual(result.structuredContent.errors[0].code, 'AUTHENTICATION_FAILED');
+    });
+
+    it('handler that returns Success arm still gets response-builder defaults', async () => {
+      // Regression: narrowing must not change the Success-path behavior.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          createMediaBuy: async () => ({ media_buy_id: 'mb_1', packages: [] }),
+        },
+      });
+      const result = await callToolRaw(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.strictEqual(result.structuredContent.media_buy_id, 'mb_1');
+      assert.strictEqual(result.structuredContent.revision, 1);
+      assert.ok(result.structuredContent.confirmed_at);
+    });
+
+    it('sync_creatives Submitted with advisory errors routes as submitted, not error', async () => {
+      // SyncCreativesSubmitted has optional `errors: Error[]` for advisory warnings
+      // (e.g. throttled_severity). The isSubmittedEnvelope check must fire BEFORE
+      // isErrorArm so the payload doesn't accidentally flip to isError: true.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        creative: {
+          syncCreatives: async () => ({
+            status: 'submitted',
+            task_id: 'tk_batch_1',
+            message: 'Batch ingestion queued',
+            errors: [{ code: 'THROTTLED_SEVERITY', message: 'rate-limited severity advisory' }],
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'sync_creatives', {
+        account: { account_id: 'a1' },
+        creatives: [],
+        idempotency_key: '22222222-2222-2222-2222-222222222222',
+      });
+      assert.notStrictEqual(result.isError, true, 'submitted-with-advisories must not flip to isError');
+      assert.strictEqual(result.structuredContent.status, 'submitted');
+      assert.strictEqual(result.structuredContent.task_id, 'tk_batch_1');
+      assert.strictEqual(result.structuredContent.errors[0].code, 'THROTTLED_SEVERITY');
+    });
+
+    it('Error arm preserves context and ext siblings on structuredContent', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          createMediaBuy: async () => ({
+            errors: [{ code: 'PRODUCT_NOT_FOUND', message: 'gone' }],
+            context: { correlation_id: 'corr_xyz' },
+            ext: { seller_note: 'see knowledge base kb_1234' },
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.errors[0].code, 'PRODUCT_NOT_FOUND');
+      assert.strictEqual(result.structuredContent.context.correlation_id, 'corr_xyz');
+      assert.strictEqual(result.structuredContent.ext.seller_note, 'see knowledge base kb_1234');
+    });
+
+    it('empty errors[] still flips isError and emits a generic summary', async () => {
+      // Spec violation at the handler, but the dispatcher must not throw.
+      // Operators see the warn log; the wire shape stays consistent.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          createMediaBuy: async () => ({ errors: [] }),
+        },
+      });
+      const result = await callToolRaw(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.strictEqual(result.isError, true);
+      assert.deepStrictEqual(result.structuredContent.errors, []);
+      assert.ok(result.content[0].text.length > 0);
+    });
+
+    it('errors[] alongside a Success-only field falls through to the Success builder', async () => {
+      // Unknown sibling keys mean this is NOT a pure Error arm — the shape
+      // carries Success fields (media_buy_id) so isErrorArm returns false.
+      // Success builder runs. Response validation (off by default in this
+      // file) would reject this drift in strict mode, which is correct.
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          createMediaBuy: async () => ({
+            errors: [{ code: 'WARNING', message: 'partial success' }],
+            media_buy_id: 'mb_partial_1',
+            packages: [],
+          }),
+        },
+      });
+      const result = await callToolRaw(server, 'create_media_buy', {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'b1' },
+        start_time: '2026-01-01T00:00:00Z',
+        end_time: '2026-02-01T00:00:00Z',
+      });
+      assert.notStrictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.media_buy_id, 'mb_partial_1');
+      assert.strictEqual(result.structuredContent.revision, 1, 'Success defaults applied');
+    });
+  });
+
+  describe('adcpError() does not carry issues on non-VALIDATION_ERROR codes', () => {
+    it('RATE_LIMITED envelope has no top-level issues field', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: {
+          getProducts: async () =>
+            adcpError('RATE_LIMITED', { message: 'slow down', retry_after: 30 }),
+        },
+      });
+      const result = await callToolRaw(server, 'get_products', {
+        buying_mode: 'brief',
+        brief: 'test',
+      });
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'RATE_LIMITED');
+      // issues is conditional-spread in adcpError; undefined options.issues
+      // must not materialize an empty key.
+      assert.ok(
+        !('issues' in result.structuredContent.adcp_error),
+        'issues must be absent when caller did not pass options.issues'
+      );
+    });
+  });
+
   describe('account resolution', () => {
     it('resolves account and passes to handler context', async () => {
       let receivedCtx;


### PR DESCRIPTION
## Summary

Addresses five user-reported DX issues on @adcp/client 5.15.0 ([full feedback here](#)). All changes additive on the wire; no breaking migrations required.

- **Root re-exports for Success/Error/Submitted arms** of every `*Response` union (`SyncCreativesSuccess`, `SyncAudiencesSuccess`, `CreateMediaBuySuccess`, `BuildCreativeSuccess`, `BuildCreativeMultiSuccess`, `ActivateSignalSuccess`, `SyncAccountsSuccess`, `SyncGovernanceSuccess`, `UpdateContentStandardsSuccess`, `ProvidePerformanceFeedbackSuccess`, `SyncEventSourcesSuccess`, `LogEventSuccess`, etc., plus Error and Submitted variants) — `AdcpServer` handler returns no longer need `as any`.
- **Dual-export idempotency helpers** (`createIdempotencyStore`, `memoryBackend`, `pgBackend`, plus types) from `@adcp/client` root, matching `createAdcpServer`.
- **Widened `DomainHandler` return type** to accept `Promise<Success | FullResponseUnion | McpToolResponse>`. The dispatcher narrows Submitted (`status: 'submitted' && task_id`) and Error arms (`{errors, context, ext, success, conflicting_standards_id}`) at runtime so success-arm response builders only run on actual Success payloads. Adapter patterns returning `Result<CreateMediaBuyResponse, ...>` type-check without casts.
- **`extractResult<T>(result)` helper** — prefers `structuredContent`, falls back to JSON-parsing `content[0].text`, returns `undefined`. Lightweight companion to `unwrapProtocolResponse` (which throws and schema-validates).
- **`VALIDATION_ERROR.issues` surfaced at top level** of `adcp_error` so operators see JSON Pointers immediately. Same list mirrored at `details.issues` for spec-convention compatibility. Request-side `schemaPath` gating now threads `exposeSchemaPath` the same way response-side does.

Also: lightweight dev-log warning on handler-returned Error arms whose `errors[]` items violate the spec (missing `code`/`message`).

## Changes

- `src/lib/index.ts` — root re-exports (types + idempotency helpers)
- `src/lib/server/create-adcp-server.ts` — `AdcpToolMap` gains `response` field; `DomainHandler` widened; new `isSubmittedEnvelope` / `isErrorArm` / `wrapSubmittedEnvelope` / `wrapErrorArm`; aligned schemaPath gating
- `src/lib/server/errors.ts` — `AdcpErrorOptions` / `AdcpErrorPayload` gain top-level `issues`
- `src/lib/validation/schema-errors.ts` — emits `issues` at both top-level and `details.issues`
- `src/lib/utils/extract-result.ts` — new helper
- `docs/guides/BUILD-AN-AGENT.md` — response-union narrowing, extractor asymmetry, Error-arm vs `adcpError` guidance
- `docs/migration-4.x-to-5.x.md` — refresh the three `details.issues` callouts

## Review

Addressed feedback from code-reviewer, security-reviewer, ad-tech-protocol-expert, dx-expert, and nodejs-testing-expert. Key decisions:

- **Error arm vs adcp_error envelope**: kept separate. Spec-defined per-tool failures → return the Error arm directly. Framework/infra failures → `adcpError('CODE', ...)`. Documented side-by-side in BUILD-AN-AGENT.
- **VALIDATION_ERROR wire shape**: rather than moving `issues` (which would have broken buyers reading `details.issues`), added a top-level copy AND kept the `details.issues` mirror. Additive, not breaking.
- **Error-arm shape check**: dev-log warning, not a framework-level flip to VALIDATION_ERROR. Preserves the seller's intent while surfacing drift.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] 606/606 targeted regression battery passes (server dispatcher, idempotency, responses, errors, envelope wrap, schema validation, response unwrapper, type safety, discriminated unions, uniform-error comparator)
- [x] 10 new dispatcher tests covering: Error/Submitted/Success arm narrowing, Submitted-with-advisory-errors (ordering), Error arm with `context`/`ext` siblings, empty `errors[]`, unknown-key fallthrough, `adcpError()` on non-VALIDATION_ERROR code not emitting `issues`, and dual-location `issues` on the wire
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)