### PR TITLE
feat(testing): field_value_or_absent check matcher (closes #873)

### DIFF
--- a/.changeset/field-value-or-absent.md
+++ b/.changeset/field-value-or-absent.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": minor
+---
+
+Added `field_value_or_absent` storyboard check matcher. Passes when the field is absent OR present with a value in `allowed_values` / matching `value`; fails only when present with a disallowed value. Use it for envelope-tolerant assertions (e.g. fresh-path `replayed`) where the spec allows omission but forbids a wrong value. Closes #873.

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -371,6 +371,7 @@ export type StoryboardValidationCheck =
   | 'response_schema'
   | 'field_present'
   | 'field_value'
+  | 'field_value_or_absent'
   | 'status_code'
   | 'error_code'
   // HTTP-probe checks (for raw_probe tasks)

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -87,6 +87,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return validateFieldPresent(validation, resolveTarget(ctx));
     case 'field_value':
       return validateFieldValue(validation, resolveTarget(ctx));
+    case 'field_value_or_absent':
+      return validateFieldValueOrAbsent(validation, resolveTarget(ctx));
     case 'status_code':
       return requireTaskResult(ctx, validation, tr => validateStatusCode(validation, tr));
     case 'error_code':
@@ -721,6 +723,89 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
     json_pointer: pointer,
     expected: validation.value,
     actual: actual ?? null,
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// field_value_or_absent: envelope-tolerant variant of field_value
+//
+// Pass when the field is absent OR present-and-matching. Fail only when the
+// field is present with a disallowed value. Lets a storyboard keep positive
+// coverage on a spec-optional field without penalizing agents that omit it.
+// Spec: adcontextprotocol/adcp #3013 envelope `replayed` semantics.
+// ────────────────────────────────────────────────────────────
+
+function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
+  if (!validation.path) {
+    return {
+      check: 'field_value_or_absent',
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: 'No path specified for field_value_or_absent validation',
+      json_pointer: null,
+      expected: 'path must be set in storyboard validation entry',
+      actual: null,
+    };
+  }
+
+  const actual = resolvePath(taskResult.data, validation.path);
+  const pointer = toJsonPointer(validation.path);
+
+  // Absent → pass. The check only fires when the field is present.
+  if (actual === undefined) {
+    return {
+      check: 'field_value_or_absent',
+      passed: true,
+      description: validation.description,
+      path: validation.path,
+      json_pointer: pointer,
+    };
+  }
+
+  // Present → fall through to the same value / allowed_values semantics as field_value.
+  if (validation.allowed_values?.length) {
+    const passed = validation.allowed_values.some(v => valuesMatch(actual, v));
+    if (passed) {
+      return {
+        check: 'field_value_or_absent',
+        passed: true,
+        description: validation.description,
+        path: validation.path,
+        json_pointer: pointer,
+      };
+    }
+    return {
+      check: 'field_value_or_absent',
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `Expected absent or one of ${JSON.stringify(validation.allowed_values)}, got ${JSON.stringify(actual)}`,
+      json_pointer: pointer,
+      expected: validation.allowed_values,
+      actual,
+    };
+  }
+
+  const passed = valuesMatch(actual, validation.value);
+  if (passed) {
+    return {
+      check: 'field_value_or_absent',
+      passed: true,
+      description: validation.description,
+      path: validation.path,
+      json_pointer: pointer,
+    };
+  }
+  return {
+    check: 'field_value_or_absent',
+    passed: false,
+    description: validation.description,
+    path: validation.path,
+    error: `Expected absent or ${JSON.stringify(validation.value)}, got ${JSON.stringify(actual)}`,
+    json_pointer: pointer,
+    expected: validation.value,
+    actual,
   };
 }
 

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -1,9 +1,10 @@
 /**
  * Schema drift detection for storyboard YAML validations.
  *
- * Catches when field_present / field_value paths in storyboard YAML
- * reference fields that don't exist in the corresponding Zod response
- * schemas, and when context extractors reference tasks without schemas.
+ * Catches when field_present / field_value / field_value_or_absent paths in
+ * storyboard YAML reference fields that don't exist in the corresponding
+ * Zod response schemas, and when context extractors reference tasks without
+ * schemas.
  */
 
 const { describe, it } = require('node:test');
@@ -136,7 +137,10 @@ function collectFieldValidations(storyboards) {
         const isErrorStep = step.validations.some(v => v.check === 'is_error');
         if (isErrorStep) continue;
         for (const v of step.validations) {
-          if ((v.check === 'field_present' || v.check === 'field_value') && v.path) {
+          if (
+            (v.check === 'field_present' || v.check === 'field_value' || v.check === 'field_value_or_absent') &&
+            v.path
+          ) {
             if (ENVELOPE_PATHS.has(v.path)) continue; // protocol-level, not per-schema
             entries.push({
               storyboard: sb.id,
@@ -166,7 +170,10 @@ describe('storyboard schema drift', () => {
   });
 
   it('found field validations to check', () => {
-    assert.ok(fieldValidations.length > 0, 'Expected at least one field_present or field_value validation');
+    assert.ok(
+      fieldValidations.length > 0,
+      'Expected at least one field_present, field_value, or field_value_or_absent validation'
+    );
   });
 
   // Drift entries cleared by upstream fixes that haven't shipped in the
@@ -230,6 +237,27 @@ describe('storyboard schema drift', () => {
     const valueValidations = fieldValidations.filter(v => v.check === 'field_value');
 
     for (const entry of valueValidations) {
+      const schema = TOOL_RESPONSE_SCHEMAS[entry.task];
+      if (!schema) continue;
+
+      const key = `${entry.storyboard}/${entry.step}:${entry.path}`;
+      const skip = skipReason(key);
+      it(`${entry.storyboard}/${entry.step}: ${entry.path} exists in ${entry.task} schema`, { skip }, () => {
+        const segments = parsePath(entry.path);
+        const reachable = isPathReachable(schema, segments);
+        assert.ok(
+          reachable,
+          `Path "${entry.path}" is not reachable in ${entry.task} response schema. ` +
+            `Segments: ${JSON.stringify(segments)}`
+        );
+      });
+    }
+  });
+
+  describe('field_value_or_absent paths are reachable in response schemas', () => {
+    const tolerantValidations = fieldValidations.filter(v => v.check === 'field_value_or_absent');
+
+    for (const entry of tolerantValidations) {
       const schema = TOOL_RESPONSE_SCHEMAS[entry.task];
       if (!schema) continue;
 

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -71,6 +71,90 @@ describe('runner-output contract: validation_result', () => {
     assert.strictEqual(result.actual, 'canceled');
   });
 
+  test('field_value_or_absent passes when the field is absent', () => {
+    const result = runOne(
+      {
+        check: 'field_value_or_absent',
+        path: 'replayed',
+        allowed_values: [false],
+        description: 'replayed is either absent or false on fresh execution',
+      },
+      { taskResult: { success: true, data: {} } }
+    );
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.json_pointer, '/replayed');
+    assert.strictEqual(result.check, 'field_value_or_absent');
+  });
+
+  test('field_value_or_absent passes when present and in allowed_values', () => {
+    const result = runOne(
+      {
+        check: 'field_value_or_absent',
+        path: 'replayed',
+        allowed_values: [false],
+        description: 'replayed is either absent or false on fresh execution',
+      },
+      { taskResult: { success: true, data: { replayed: false } } }
+    );
+    assert.strictEqual(result.passed, true);
+  });
+
+  test('field_value_or_absent fails when present with a disallowed value', () => {
+    const result = runOne(
+      {
+        check: 'field_value_or_absent',
+        path: 'replayed',
+        allowed_values: [false],
+        description: 'replayed is either absent or false on fresh execution',
+      },
+      { taskResult: { success: true, data: { replayed: true } } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/replayed');
+    assert.deepStrictEqual(result.expected, [false]);
+    assert.strictEqual(result.actual, true);
+  });
+
+  test('field_value_or_absent with scalar value fails only on present-mismatch', () => {
+    const present = runOne(
+      {
+        check: 'field_value_or_absent',
+        path: 'status',
+        value: 'active',
+        description: 'status is either absent or active',
+      },
+      { taskResult: { success: true, data: { status: 'paused' } } }
+    );
+    assert.strictEqual(present.passed, false);
+    assert.strictEqual(present.expected, 'active');
+    assert.strictEqual(present.actual, 'paused');
+
+    const absent = runOne(
+      {
+        check: 'field_value_or_absent',
+        path: 'status',
+        value: 'active',
+        description: 'status is either absent or active',
+      },
+      { taskResult: { success: true, data: {} } }
+    );
+    assert.strictEqual(absent.passed, true);
+  });
+
+  test('field_value_or_absent with a null field fails (null is present, not absent)', () => {
+    const result = runOne(
+      {
+        check: 'field_value_or_absent',
+        path: 'replayed',
+        allowed_values: [false],
+        description: 'replayed is either absent or false',
+      },
+      { taskResult: { success: true, data: { replayed: null } } }
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.actual, null);
+  });
+
   test('response_schema failure carries schema_id, schema_url, AJV-shaped actual', () => {
     const result = runOne(
       { check: 'response_schema', description: 'Response matches get-adcp-capabilities-response.json schema' },

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -71,88 +71,153 @@ describe('runner-output contract: validation_result', () => {
     assert.strictEqual(result.actual, 'canceled');
   });
 
-  test('field_value_or_absent passes when the field is absent', () => {
-    const result = runOne(
-      {
-        check: 'field_value_or_absent',
-        path: 'replayed',
-        allowed_values: [false],
-        description: 'replayed is either absent or false on fresh execution',
-      },
-      { taskResult: { success: true, data: {} } }
-    );
-    assert.strictEqual(result.passed, true);
-    assert.strictEqual(result.json_pointer, '/replayed');
-    assert.strictEqual(result.check, 'field_value_or_absent');
-  });
+  describe('field_value_or_absent', () => {
+    test('passes when the field is absent', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'replayed',
+          allowed_values: [false],
+          description: 'replayed is either absent or false on fresh execution',
+        },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(result.passed, true);
+      assert.strictEqual(result.json_pointer, '/replayed');
+      assert.strictEqual(result.check, 'field_value_or_absent');
+    });
 
-  test('field_value_or_absent passes when present and in allowed_values', () => {
-    const result = runOne(
-      {
-        check: 'field_value_or_absent',
-        path: 'replayed',
-        allowed_values: [false],
-        description: 'replayed is either absent or false on fresh execution',
-      },
-      { taskResult: { success: true, data: { replayed: false } } }
-    );
-    assert.strictEqual(result.passed, true);
-  });
+    test('passes when present and in allowed_values', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'replayed',
+          allowed_values: [false],
+          description: 'replayed is either absent or false on fresh execution',
+        },
+        { taskResult: { success: true, data: { replayed: false } } }
+      );
+      assert.strictEqual(result.passed, true);
+    });
 
-  test('field_value_or_absent fails when present with a disallowed value', () => {
-    const result = runOne(
-      {
-        check: 'field_value_or_absent',
-        path: 'replayed',
-        allowed_values: [false],
-        description: 'replayed is either absent or false on fresh execution',
-      },
-      { taskResult: { success: true, data: { replayed: true } } }
-    );
-    assert.strictEqual(result.passed, false);
-    assert.strictEqual(result.json_pointer, '/replayed');
-    assert.deepStrictEqual(result.expected, [false]);
-    assert.strictEqual(result.actual, true);
-  });
+    test('fails when present with a disallowed value', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'replayed',
+          allowed_values: [false],
+          description: 'replayed is either absent or false on fresh execution',
+        },
+        { taskResult: { success: true, data: { replayed: true } } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.json_pointer, '/replayed');
+      assert.deepStrictEqual(result.expected, [false]);
+      assert.strictEqual(result.actual, true);
+    });
 
-  test('field_value_or_absent with scalar value fails only on present-mismatch', () => {
-    const present = runOne(
-      {
-        check: 'field_value_or_absent',
-        path: 'status',
-        value: 'active',
-        description: 'status is either absent or active',
-      },
-      { taskResult: { success: true, data: { status: 'paused' } } }
-    );
-    assert.strictEqual(present.passed, false);
-    assert.strictEqual(present.expected, 'active');
-    assert.strictEqual(present.actual, 'paused');
+    test('with scalar value fails only on present-mismatch', () => {
+      const present = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'status',
+          value: 'active',
+          description: 'status is either absent or active',
+        },
+        { taskResult: { success: true, data: { status: 'paused' } } }
+      );
+      assert.strictEqual(present.passed, false);
+      assert.strictEqual(present.expected, 'active');
+      assert.strictEqual(present.actual, 'paused');
 
-    const absent = runOne(
-      {
-        check: 'field_value_or_absent',
-        path: 'status',
-        value: 'active',
-        description: 'status is either absent or active',
-      },
-      { taskResult: { success: true, data: {} } }
-    );
-    assert.strictEqual(absent.passed, true);
-  });
+      const absent = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'status',
+          value: 'active',
+          description: 'status is either absent or active',
+        },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(absent.passed, true);
+    });
 
-  test('field_value_or_absent with a null field fails (null is present, not absent)', () => {
-    const result = runOne(
-      {
-        check: 'field_value_or_absent',
-        path: 'replayed',
-        allowed_values: [false],
-        description: 'replayed is either absent or false',
-      },
-      { taskResult: { success: true, data: { replayed: null } } }
-    );
-    assert.strictEqual(result.passed, false);
-    assert.strictEqual(result.actual, null);
+    test('with a null field fails (null is present, not absent)', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'replayed',
+          allowed_values: [false],
+          description: 'replayed is either absent or false',
+        },
+        { taskResult: { success: true, data: { replayed: null } } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.actual, null);
+    });
+
+    // `resolvePath` returns `undefined` whether the key is truly missing or
+    // present with an explicit `undefined` value (JSON cannot encode this case
+    // anyway, but native handlers can produce it). The matcher treats both
+    // the same — absent semantics win. Pinning this disambiguates for any
+    // implementor walking the runner against a non-JSON transport.
+    test('treats an explicit `undefined` value the same as a missing key', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'replayed',
+          allowed_values: [false],
+          description: 'replayed is either absent or false',
+        },
+        { taskResult: { success: true, data: { replayed: undefined } } }
+      );
+      assert.strictEqual(result.passed, true);
+    });
+
+    // A broken chain mid-path (intermediate segment missing) resolves to
+    // `undefined`, which the matcher routes to the absent-passes branch.
+    // Same outcome as the leaf being missing — the whole chain "is absent."
+    test('broken chain in the middle of the path is treated as absent', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'envelope.status.replayed',
+          allowed_values: [false],
+          description: 'envelope.status.replayed is either absent or false',
+        },
+        { taskResult: { success: true, data: { envelope: {} } } }
+      );
+      assert.strictEqual(result.passed, true);
+    });
+
+    // Empty `allowed_values` falls through to the scalar `value` branch, same
+    // as `field_value`. With neither set, the matcher compares against
+    // `undefined`. Storyboards shouldn't emit this shape, but pinning the
+    // behavior means a silent authoring bug surfaces as a failing check
+    // rather than silently passing.
+    test('empty allowed_values falls through to `value` comparison (same as field_value)', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: 'status',
+          allowed_values: [],
+          value: 'active',
+          description: 'status is either absent or active',
+        },
+        { taskResult: { success: true, data: { status: 'active' } } }
+      );
+      assert.strictEqual(result.passed, true);
+    });
+
+    test('missing `path` returns a structured error', () => {
+      const result = runOne(
+        { check: 'field_value_or_absent', allowed_values: [false], description: 'no path supplied' },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.json_pointer, null);
+      assert.match(result.error, /No path specified for field_value_or_absent/);
+    });
   });
 
   test('response_schema failure carries schema_id, schema_url, AJV-shaped actual', () => {


### PR DESCRIPTION
## Summary

Adds a new storyboard check matcher `field_value_or_absent` that mirrors `field_value` but treats an absent field as a pass. Fails only when the field is present with a disallowed value.

Closes #873.

## Why

Today a storyboard can't positively assert a value on a field the envelope spec explicitly allows to be omitted — `field_value` fires when the field is missing, so authors either drop the assertion (losing positive coverage) or keep it (penalizing spec-compliant agents). This matcher encodes the real intent: *"if you report the value, it must be X; if you omit it, that's fine."*

First target is fresh-path `replayed` (adcontextprotocol/adcp#3013): envelope spec says MAY omit, MUST NOT be `true` on fresh execution.

## Semantics

```yaml
- check: field_value_or_absent
  path: "replayed"
  allowed_values: [false]
  description: "If replayed is present on a fresh execution, it must be false"
```

- **Absent** (field missing, resolved `undefined`) → pass
- **Present + matches `value` / in `allowed_values`** → pass
- **Present + doesn't match** → fail (with `json_pointer`, `expected`, `actual` per the runner-output contract)
- `null` is treated as present, not absent — matches `field_present` precedent

`field_value` stays strict: authors opt into tolerance explicitly via the new matcher, same as the issue suggests.

## Changes

- `src/lib/testing/storyboard/types.ts` — add `field_value_or_absent` to the `StoryboardValidationCheck` union.
- `src/lib/testing/storyboard/validations.ts` — new `validateFieldValueOrAbsent` matcher + switch case. Shares `valuesMatch`, `resolvePath`, `toJsonPointer` with `field_value` — no duplication of path resolution or pointer generation.
- `test/lib/storyboard-runner-contract.test.js` — 5 new contract tests covering absent→pass, present-allowed→pass, present-disallowed→fail (with `json_pointer` / `expected` / `actual`), scalar `value` fallback, and `null` fails (present, not absent).
- `test/lib/storyboard-drift.test.js` — schema-drift path reachability now also walks `field_value_or_absent` paths, so a storyboard using the new matcher against a drifted path fails the same drift gate.
- `.changeset/field-value-or-absent.md` — minor bump.

## Not done (intentionally)

The issue also floats a lint rule: "warn when `field_value_or_absent` is asserted on a field that is required in the response schema." Left as a follow-up — the matcher is useful on its own, and the issue explicitly labels the lint rule as belt-and-suspenders. The upstream storyboard schema in `compliance/cache/3.0.0/universal/storyboard-schema.yaml` is also not updated here because that file is synced from `adcontextprotocol/adcp` via `npm run sync-schemas`; the check list there needs a PR against the spec repo.

## Test plan

- [x] `node --test test/lib/storyboard-runner-contract.test.js` — 24/24 pass (5 new)
- [x] `node --test test/lib/storyboard-drift.test.js` — 389/389 pass, 4 skipped (pre-existing upstream drift allowlist)
- [x] `node --test --test-force-exit test/lib/storyboard-security.test.js` — 85/85 pass
- [x] `npm run build` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)