### PR TITLE
fix(testing): prototype-key guard on scalar resolvePath

### DIFF
--- a/.changeset/resolvepath-proto-guard.md
+++ b/.changeset/resolvepath-proto-guard.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Hardened `resolvePath` in the storyboard runner to apply the same `FORBIDDEN_KEYS` + `hasOwnProperty` guard that `resolvePathAll` and `setPath` already use. A storyboard path like `__proto__.polluted`, `constructor`, or `hasOwnProperty` now resolves to `undefined` (not-found) instead of projecting `Object.prototype` state into validation results. No call site relied on the permissive behavior. Surfaced by the security review on #876.

--- a/src/lib/testing/storyboard/path.ts
+++ b/src/lib/testing/storyboard/path.ts
@@ -97,7 +97,12 @@ export function resolvePath(obj: unknown, path: string): unknown {
       if (!Array.isArray(current)) return undefined;
       current = current[segment];
     } else {
+      if (FORBIDDEN_KEYS.has(segment)) return undefined;
       if (typeof current !== 'object') return undefined;
+      // Own-property gate keeps `Object.prototype` accessors (`toString`,
+      // `hasOwnProperty`, …) from surfacing into compliance reports as
+      // "agent returned X." Matches `resolvePathAll` / `setPath`.
+      if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
       current = (current as Record<string, unknown>)[segment];
     }
   }

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -280,8 +280,7 @@ describe('runner-output contract: validation_result', () => {
 
     // Own properties named like prototype accessors are also blocked by
     // FORBIDDEN_KEYS — the guard errs on the side of safety over an esoteric
-    // "I literally have a field named __proto__" storyboard (which wouldn't
-    // survive JSON round-tripping anyway).
+    // "I literally have a field named __proto__" storyboard.
     test('field_value on an own-property `__proto__` is still blocked', () => {
       const data = Object.create(null);
       Object.defineProperty(data, '__proto__', { value: { x: 1 }, enumerable: true, configurable: true });

--- a/test/lib/storyboard-runner-contract.test.js
+++ b/test/lib/storyboard-runner-contract.test.js
@@ -220,6 +220,80 @@ describe('runner-output contract: validation_result', () => {
     });
   });
 
+  // Prototype-key guard on the scalar resolver: `__proto__`, `constructor`,
+  // and `prototype` must not surface `Object.prototype` state into validation
+  // results. Asserting through `field_present` / `field_value` / the tolerant
+  // matcher exercises all three matchers' call into `resolvePath`, so a
+  // regression here would fail on any of them.
+  describe('resolvePath prototype-key guard', () => {
+    test('field_present on __proto__ returns not-found', () => {
+      const result = runOne(
+        { check: 'field_present', path: '__proto__', description: 'prototype must not surface' },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.actual, null);
+    });
+
+    test('field_present on a nested __proto__ segment returns not-found', () => {
+      const result = runOne(
+        { check: 'field_present', path: 'accounts.__proto__.polluted', description: 'nested prototype' },
+        { taskResult: { success: true, data: { accounts: {} } } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.actual, null);
+    });
+
+    test('field_value on constructor returns not-found, not Object itself', () => {
+      const result = runOne(
+        { check: 'field_value', path: 'constructor', value: 'anything', description: 'constructor ≠ Object' },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.actual, null);
+    });
+
+    test('field_value_or_absent on __proto__ passes (treated as absent)', () => {
+      const result = runOne(
+        {
+          check: 'field_value_or_absent',
+          path: '__proto__',
+          allowed_values: [false],
+          description: 'prototype chain is absent from the agent response',
+        },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(result.passed, true);
+    });
+
+    // Inherited-but-own-named keys (e.g. `hasOwnProperty` on a plain object)
+    // also must not surface — the guard is hasOwnProperty, not just the
+    // forbidden-list.
+    test('field_present on an inherited method name returns not-found', () => {
+      const result = runOne(
+        { check: 'field_present', path: 'hasOwnProperty', description: 'inherited methods must not surface' },
+        { taskResult: { success: true, data: {} } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.actual, null);
+    });
+
+    // Own properties named like prototype accessors are also blocked by
+    // FORBIDDEN_KEYS — the guard errs on the side of safety over an esoteric
+    // "I literally have a field named __proto__" storyboard (which wouldn't
+    // survive JSON round-tripping anyway).
+    test('field_value on an own-property `__proto__` is still blocked', () => {
+      const data = Object.create(null);
+      Object.defineProperty(data, '__proto__', { value: { x: 1 }, enumerable: true, configurable: true });
+      const result = runOne(
+        { check: 'field_value', path: '__proto__.x', value: 1, description: 'forbidden-key takes precedence' },
+        { taskResult: { success: true, data } }
+      );
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.actual, null);
+    });
+  });
+
   test('response_schema failure carries schema_id, schema_url, AJV-shaped actual', () => {
     const result = runOne(
       { check: 'response_schema', description: 'Response matches get-adcp-capabilities-response.json schema' },


### PR DESCRIPTION
## Summary

Brings `resolvePath` into consistency with its siblings `resolvePathAll` and `setPath` by applying the same `FORBIDDEN_KEYS` + `hasOwnProperty` guard. A storyboard path like `__proto__.polluted` or `constructor` now resolves to `undefined` (not-found) instead of projecting `Object.prototype` state into validation results.

Surfaced by the security review on #876. Read-only exposure — paths are storyboard-authored and trusted — but wrong to surface prototype-chain values as "agent returned X" in compliance reports.

## Scope

- `src/lib/testing/storyboard/path.ts` — one block added to the string-segment branch of `resolvePath` (mirrors `resolvePathAll`'s existing lines).
- `test/lib/storyboard-runner-contract.test.js` — 6 new tests under a `describe('resolvePath prototype-key guard')` block, exercising `field_present` / `field_value` / `field_value_or_absent` (all three route through `resolvePath`, so the guard is covered end-to-end).
- `.changeset/resolvepath-proto-guard.md` — patch bump.

## Why it's safe

- No call site relied on the permissive behavior. The wider storyboard suite (534 pass / 4 pre-existing skips) is unchanged.
- `resolvePathAll` and `setPath` already enforce these exact guards; inheriting their behavior is strictly narrowing.
- Existing prototype-safety tests for `resolvePathAll` (`test/lib/storyboard-validations-refs-resolve.test.js:331`, `:893`) confirm the pattern is well-established — this PR extends symmetry to the scalar resolver.

## Test plan

- [x] `node --test test/lib/storyboard-runner-contract.test.js` — 34/34 pass (6 new)
- [x] `node --test --test-force-exit test/lib/storyboard-{validations,validations-refs-resolve,security,drift,context-provenance}.test.js` — 534 pass / 4 skipped (pre-existing upstream drift)
- [x] `npm run build` clean
- [ ] CI green

## Related

- #876 — `field_value_or_absent` matcher; security review there flagged this inconsistency as pre-existing, out of scope for that PR. This is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)