### PR TITLE
ci: ignore library-version header in docs-check diff (#881)

### DIFF
--- a/.changeset/docs-check-ignore-version-header.md
+++ b/.changeset/docs-check-ignore-version-header.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+CI: `ci:docs-check` now ignores the `> @adcp/client v<version>` / `> Library: @adcp/client v<version>` header when diffing generated agent docs, matching how the `> Generated at:` header is already ignored. Closes #881 — previously every version bump forced a doc regeneration commit even when no real content changed.

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "ci:validate": "node scripts/ci-validate.js",
     "ci:quick": "npm run format:check && npm run typecheck && npm run build:lib && npm test",
     "ci:schema-check": "npm run sync-schemas && npm run generate-types && npm run generate-registry-types && git diff --exit-code -I '// Generated at:' src/lib/types/ src/lib/agents/ src/lib/registry/types.generated.ts schemas/registry/registry.yaml || (echo '⚠️  Generated files are out of sync. Run: npm run sync-schemas && npm run generate-types && npm run generate-registry-types' && exit 1)",
-    "ci:docs-check": "npm run generate-agent-docs && git diff --exit-code -I '> Generated at:' docs/llms.txt docs/TYPE-SUMMARY.md || (echo '⚠️  Agent docs are out of sync. Run: npm run generate-agent-docs' && exit 1)",
+    "ci:docs-check": "npm run generate-agent-docs && git diff --exit-code -I '> Generated at:' -I '> (Library: )?@adcp/client v' docs/llms.txt docs/TYPE-SUMMARY.md || (echo '⚠️  Agent docs are out of sync. Run: npm run generate-agent-docs' && exit 1)",
     "ci:pre-push": "npm run ci:schema-check && npm run ci:quick",
     "hooks:install": "node scripts/install-hooks.js",
     "hooks:uninstall": "rm -f .git/hooks/pre-push",


### PR DESCRIPTION
Closes #881.

## Summary

\`ci:docs-check\` regenerates \`docs/llms.txt\` + \`docs/TYPE-SUMMARY.md\` from \`npm run generate-agent-docs\` and diffs them against committed copies. The existing \`-I '> Generated at:'\` flag ignores the date header, but not the library-version header — so any PR that bumps \`package.json\` fails the check with a noise diff:

\`\`\`
- > @adcp/client v5.13.0
+ > @adcp/client v5.15.0
\`\`\`

This happened twice on #875; surfaced in the follow-up punch list.

## Fix

One-line change to \`ci:docs-check\` — add a second \`-I\` pattern that matches both header shapes (\`docs/llms.txt\` uses \`> Library: @adcp/client v…\`, \`docs/TYPE-SUMMARY.md\` uses \`> @adcp/client v…\`):

\`\`\`diff
- -I '> Generated at:'
+ -I '> Generated at:' -I '> (Library: )?@adcp/client v'
\`\`\`

Git's \`-I\` flag is additive (any line matching any pattern is ignored, hunk skipped only when every line in the hunk is ignored), so real content drift still fails the check.

## Test plan

- [x] Real content drift still fails (\`sed 's/AdCP/AdCP-MANGLED/'\` → exit 1).
- [x] Version-only drift passes (exit 0).
- [x] Date + version combined drift passes (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)