### PR TITLE
test(drift): redundant field_value_or_absent lint

### DIFF
--- a/.changeset/redundant-tolerance-lint.md
+++ b/.changeset/redundant-tolerance-lint.md
@@ -1,0 +1,6 @@
+---
+---
+
+Test-only — adds a drift-test lint that warns when `field_value_or_absent` is
+asserted on a schema-required path. No library code touched; this empty
+changeset is present only to satisfy the `changeset status` CI gate.

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -108,9 +108,10 @@ function isPathReachable(schema, segments) {
  * neither is a path through a `record` (any key) or a `union` branch that
  * omits the field.
  *
- * Conservative on unions: required only if ALL branches require it. Aggressive
- * on intersections: required if EITHER side requires it (matches
- * `isPathReachable` symmetry).
+ * Conservative on unions: required only if ALL branches require it. On
+ * intersections: required if EITHER side requires it — a value in
+ * `z.intersection(L, R)` must satisfy both sides, so the union of their
+ * requirements applies.
  *
  * Used to lint `field_value_or_absent` assertions: if the path the tolerant
  * matcher targets is already required by the schema, the tolerance is dead
@@ -355,7 +356,7 @@ describe('storyboard schema drift', () => {
       const schema = TOOL_RESPONSE_SCHEMAS[entry.task];
       if (!schema) continue;
 
-      it(`${entry.storyboard}/${entry.step}: ${entry.path} is not schema-required (use field_value if it is)`, () => {
+      it(`${entry.storyboard}/${entry.step}: ${entry.path} is not schema-required (use \`field_value\` if it is)`, () => {
         const segments = parsePath(entry.path);
         const required = isPathRequired(schema, segments);
         assert.ok(

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -3,12 +3,15 @@
  *
  * Catches when field_present / field_value / field_value_or_absent paths in
  * storyboard YAML reference fields that don't exist in the corresponding
- * Zod response schemas, and when context extractors reference tasks without
- * schemas.
+ * Zod response schemas, when context extractors reference tasks without
+ * schemas, and when `field_value_or_absent` is asserted on a path the
+ * response schema already marks required (the tolerance is meaningless —
+ * the storyboard author should have used `field_value`).
  */
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
+const { z } = require('zod');
 
 const { listAllComplianceStoryboards } = require('../../dist/lib/testing/storyboard/index.js');
 const { parsePath } = require('../../dist/lib/testing/storyboard/path.js');
@@ -95,6 +98,69 @@ function isPathReachable(schema, segments) {
 
   // Leaf types (string, number, boolean, enum, literal, etc.)
   // If we still have segments left, the path doesn't exist
+  return false;
+}
+
+/**
+ * Walk a Zod v4 schema along a parsed path and report whether the path is
+ * *required* — i.e. the spec guarantees the field is present. A path that
+ * traverses ANY `optional` / `nullable` / `default` wrapper is not required;
+ * neither is a path through a `record` (any key) or a `union` branch that
+ * omits the field.
+ *
+ * Conservative on unions: required only if ALL branches require it. Aggressive
+ * on intersections: required if EITHER side requires it (matches
+ * `isPathReachable` symmetry).
+ *
+ * Used to lint `field_value_or_absent` assertions: if the path the tolerant
+ * matcher targets is already required by the schema, the tolerance is dead
+ * code — the author should have used `field_value`.
+ */
+function isPathRequired(schema, segments) {
+  const type = schema?._zod?.def?.type;
+  if (!type) return false;
+
+  // Any tolerance wrapper means "not required at this level."
+  if (type === 'optional' || type === 'nullable' || type === 'default' || type === 'catch') {
+    return false;
+  }
+
+  if (type === 'pipe') {
+    return isPathRequired(schema._zod.def.in, segments);
+  }
+
+  if (type === 'union') {
+    const options = schema.options || [];
+    return options.length > 0 && options.every(opt => isPathRequired(opt, segments));
+  }
+
+  if (type === 'intersection') {
+    const { left, right } = schema._zod.def;
+    return isPathRequired(left, segments) || isPathRequired(right, segments);
+  }
+
+  if (segments.length === 0) {
+    // Reached the end of the path on a non-tolerance schema — required.
+    return true;
+  }
+
+  const [head, ...rest] = segments;
+
+  if (typeof head === 'number') {
+    if (type === 'array' && schema.element) return isPathRequired(schema.element, rest);
+    return false;
+  }
+
+  if (type === 'object' && schema.shape) {
+    const field = schema.shape[head];
+    if (!field) return false;
+    return isPathRequired(field, rest);
+  }
+
+  // Records don't guarantee any specific key.
+  if (type === 'record') return false;
+
+  // Leaf with segments remaining — path doesn't exist.
   return false;
 }
 
@@ -273,6 +339,87 @@ describe('storyboard schema drift', () => {
         );
       });
     }
+  });
+
+  // Lint: `field_value_or_absent` is meaningful only when the schema does NOT
+  // already guarantee the field is present. If a storyboard uses the tolerant
+  // matcher on a required field, the tolerance is dead code — the spec already
+  // rules out the "absent" branch. Redirect authors to `field_value` there.
+  // Envelope-tolerant paths (declared in `ENVELOPE_PATHS` above) are skipped
+  // because they target protocol-level fields not modeled on individual tool
+  // response schemas.
+  describe('field_value_or_absent is not redundantly applied to schema-required fields', () => {
+    const tolerantValidations = fieldValidations.filter(v => v.check === 'field_value_or_absent');
+
+    for (const entry of tolerantValidations) {
+      const schema = TOOL_RESPONSE_SCHEMAS[entry.task];
+      if (!schema) continue;
+
+      it(`${entry.storyboard}/${entry.step}: ${entry.path} is not schema-required (use field_value if it is)`, () => {
+        const segments = parsePath(entry.path);
+        const required = isPathRequired(schema, segments);
+        assert.ok(
+          !required,
+          `Path "${entry.path}" is required in ${entry.task} response schema — ` +
+            `the tolerance in \`field_value_or_absent\` is meaningless. Use \`field_value\` instead.`
+        );
+      });
+    }
+  });
+
+  describe('isPathRequired helper', () => {
+    it('returns true for a top-level required string field', () => {
+      const schema = z.object({ status: z.string() });
+      assert.equal(isPathRequired(schema, ['status']), true);
+    });
+
+    it('returns false for a top-level optional field', () => {
+      const schema = z.object({ replayed: z.boolean().optional() });
+      assert.equal(isPathRequired(schema, ['replayed']), false);
+    });
+
+    it('returns false for a nullable field (null is a legal value, not presence)', () => {
+      const schema = z.object({ note: z.string().nullable() });
+      assert.equal(isPathRequired(schema, ['note']), false);
+    });
+
+    it('returns false for a defaulted field (default implies absence is tolerated)', () => {
+      const schema = z.object({ currency: z.string().default('USD') });
+      assert.equal(isPathRequired(schema, ['currency']), false);
+    });
+
+    it('returns true through a nested required object', () => {
+      const schema = z.object({ envelope: z.object({ status: z.string() }) });
+      assert.equal(isPathRequired(schema, ['envelope', 'status']), true);
+    });
+
+    it('returns false when the intermediate wrapper is optional', () => {
+      const schema = z.object({ envelope: z.object({ status: z.string() }).optional() });
+      assert.equal(isPathRequired(schema, ['envelope', 'status']), false);
+    });
+
+    it('returns false for a missing field', () => {
+      const schema = z.object({ status: z.string() });
+      assert.equal(isPathRequired(schema, ['nope']), false);
+    });
+
+    it('returns true through an array element when the element schema requires the key', () => {
+      const schema = z.object({ accounts: z.array(z.object({ id: z.string() })) });
+      assert.equal(isPathRequired(schema, ['accounts', 0, 'id']), true);
+    });
+
+    it('returns false for record key access (no specific key is guaranteed)', () => {
+      const schema = z.object({ props: z.record(z.string(), z.string()) });
+      assert.equal(isPathRequired(schema, ['props', 'whatever']), false);
+    });
+
+    it('union: required only if EVERY branch requires it', () => {
+      const both = z.union([z.object({ id: z.string() }), z.object({ id: z.string(), extra: z.number() })]);
+      assert.equal(isPathRequired(both, ['id']), true);
+
+      const onlyOne = z.union([z.object({ id: z.string() }), z.object({ other: z.string() })]);
+      assert.equal(isPathRequired(onlyOne, ['id']), false);
+    });
   });
 
   describe('context extractor tasks have registered response schemas', () => {


### PR DESCRIPTION
## Summary

Follow-up to #876's review pass: warn when a storyboard asserts \`field_value_or_absent\` against a path the response schema already marks required. The tolerance is meaningless there — the spec guarantees the field is present, so the \"absent\" branch is dead code, and authors should use plain \`field_value\`.

Test-only change. No library code touched, no changeset.

## Mechanism

- New helper \`isPathRequired(schema, segments)\` mirrors the existing \`isPathReachable\` in \`test/lib/storyboard-drift.test.js\`. Walks a Zod v4 schema along the parsed path; returns \`false\` when any segment traverses a tolerance wrapper (\`optional\`, \`nullable\`, \`default\`, \`catch\`), a \`record\` (no key guaranteed), or a union branch that omits the field. Conservative on unions (required iff EVERY branch requires it), aggressive on intersections (required if EITHER side requires it — same symmetry as \`isPathReachable\`).
- New describe block walks every storyboard's \`field_value_or_absent\` assertions and fails when the path is schema-required. Zero entries today (no storyboard uses the matcher yet); engages automatically as adoption grows.
- 10 unit tests pin \`isPathRequired\` semantics against inline Zod schemas — required string, optional, nullable, default, nested required object, intermediate optional wrapper, missing field, array element, record, union (both branches / only one).

## Why test-only is the right surface

The review proposed a runner-time warning channel, but the runner has no cross-step warning surface today and nothing currently consumes one. Piggybacking on \`storyboard-drift.test.js\` is the right fit: it's already where storyboard paths meet Zod schemas, it already has an allowlist pattern (\`UPSTREAM_SCHEMA_DRIFT\`), and a CI test with an allowlist is a warning-shaped gate (fails the build, stays human-decidable). Adding a net-new runner warning channel + plumbing just for this check is speculative — revisit if other lint rules surface.

## Test plan

- [x] \`node --test test/lib/storyboard-drift.test.js\` — 399 pass / 4 skipped (pre-existing upstream drift)
- [x] \`npm run build\` clean
- [x] No storyboards break — the matcher isn't used in any existing storyboard yet (the spec-repo update at adcontextprotocol/adcp#3030 is the prerequisite for re-adding the \`replayed\` assertion that motivates it).
- [ ] CI green

## Related

- #876 — \`field_value_or_absent\` matcher (the thing being linted)
- adcontextprotocol/adcp#3030 — spec-side enum docs (blocker for any storyboard using the matcher)
- adcontextprotocol/adcp#3031 — restore \`replayed\` assertion on fresh-path \`create_media_buy\` (first real user of the matcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)