### PR TITLE
fix(ci): ignore version header in ci:docs-check diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "ci:validate": "node scripts/ci-validate.js",
     "ci:quick": "npm run format:check && npm run typecheck && npm run build:lib && npm test",
     "ci:schema-check": "npm run sync-schemas && npm run generate-types && npm run generate-registry-types && git diff --exit-code -I '// Generated at:' src/lib/types/ src/lib/agents/ src/lib/registry/types.generated.ts schemas/registry/registry.yaml || (echo '⚠️  Generated files are out of sync. Run: npm run sync-schemas && npm run generate-types && npm run generate-registry-types' && exit 1)",
-    "ci:docs-check": "npm run generate-agent-docs && git diff --exit-code -I '> Generated at:' docs/llms.txt docs/TYPE-SUMMARY.md || (echo '⚠️  Agent docs are out of sync. Run: npm run generate-agent-docs' && exit 1)",
+    "ci:docs-check": "npm run generate-agent-docs && git diff --exit-code -I '> Generated at:' -I '> .*@adcp/client v' docs/llms.txt docs/TYPE-SUMMARY.md || (echo '⚠️  Agent docs are out of sync. Run: npm run generate-agent-docs' && exit 1)",
     "ci:pre-push": "npm run ci:schema-check && npm run ci:quick",
     "hooks:install": "node scripts/install-hooks.js",
     "hooks:uninstall": "rm -f .git/hooks/pre-push",


### PR DESCRIPTION
Closes #881

## Summary

`ci:docs-check` uses `git diff --exit-code -I` to ignore lines that don't represent real drift. The existing filter ignores `> Generated at:` but not the library version header — so any PR that bumps `package.json` fails the check until someone regenerates agent docs.

The two header variants that change on version bumps:
- `docs/llms.txt` → `> Library: @adcp/client v5.15.0`
- `docs/TYPE-SUMMARY.md` → `> @adcp/client v5.15.0`

Added `-I '> .*@adcp/client v'` which matches both via a `.*` wildcard anchored to `> `. The pattern is surgical: `git diff -I` only ignores a hunk when **every changed line** in that hunk matches, so a real content change on a nearby line will still surface.

## What was tested

- Simulated a version-bump diff (patched version to `v5.99.0` in both files) and confirmed `git diff --exit-code -I '> Generated at:' -I '> .*@adcp/client v'` exits 0.
- Confirmed 329 pre-existing test failures are unchanged by this diff (baseline verified on `main`).
- Pre-push validation passed.

## Notes

- **Changeset:** two experts disagreed. `ci:docs-check` is a dev-only CI script with no runtime effect on package consumers — analogous to `.github/workflows/`, which CLAUDE.md explicitly exempts from changesets. No changeset included; reviewers can override.

**Pre-PR review:**
- code-reviewer: approved (1 issue raised re: changeset — surfaced above; regex is correct and surgical)
- dx-expert: approved — fix is correct, consistent with `ci:schema-check` pattern, no blocker

Session: https://claude.ai/code/session_012YMRoGrHAUYmEnou26Qry5

---
_Generated by [Claude Code](https://claude.ai/code/session_012YMRoGrHAUYmEnou26Qry5)_