### PR TITLE
feat(cli): render StoryboardStepResult.hints in console + JUnit (#879)

### DIFF
--- a/.changeset/cli-render-runner-hints.md
+++ b/.changeset/cli-render-runner-hints.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": patch
+---
+
+CLI now renders runner hints (`StoryboardStepResult.hints[]`) in both the human console output and JUnit `<failure>` body. Previously #875 added the detector and populated the field but the CLI was a no-op for the feature — triage output still looked identical to a bare seller error. Closes #879.
+
+Console output prefixes each hint with `💡 Hint:` at the same 3-space indent as `Error:` and validations. JUnit failure bodies append `Hint (<kind>): <message>` lines so CI dashboards and test reporters pick them up.

--- a/bin/adcp-step-hints.js
+++ b/bin/adcp-step-hints.js
@@ -1,0 +1,38 @@
+/**
+ * Runner-hint rendering helpers for the CLI (adcp-client#879).
+ *
+ * Extracted from bin/adcp.js so the single-purpose formatting logic is
+ * unit-testable without spawning the CLI. Consumers: the human console
+ * printer (`printStepHints`) and the JUnit XML failure-body composer
+ * (`formatHintsForFailureBody`).
+ *
+ * The runner populates `StoryboardStepResult.hints[]` when it can trace a
+ * seller rejection back to a prior-step `$context.*` write. Rendering
+ * them in CI output collapses the "SDK bug vs seller bug" triage to a
+ * single line. See adcp-client#870 for the detection logic.
+ */
+
+/**
+ * Print each hint on its own line, prefixed with the hint icon and
+ * indented to align with the step's `Error:` line. No-op when `hints`
+ * is absent or empty.
+ */
+function printStepHints(hints) {
+  if (!Array.isArray(hints) || hints.length === 0) return;
+  for (const h of hints) {
+    console.log(`   💡 Hint: ${h.message}`);
+  }
+}
+
+/**
+ * Format hints as plain-text lines suitable for appending to a JUnit
+ * `<failure>` body. Mirrors `printStepHints` but returns an array of
+ * strings so the caller can concatenate them with other failure detail
+ * lines.
+ */
+function formatHintsForFailureBody(hints) {
+  if (!Array.isArray(hints) || hints.length === 0) return [];
+  return hints.map(h => `Hint (${h.kind}): ${h.message}`);
+}
+
+module.exports = { printStepHints, formatHintsForFailureBody };

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -32,6 +32,7 @@ const {
 } = require('./adcp-config.js');
 const { handleRegistryCommand } = require('./adcp-registry.js');
 const { captureStdoutLogs, writeJsonOutput } = require('./adcp-json-stdout.js');
+const { printStepHints, formatHintsForFailureBody } = require('./adcp-step-hints.js');
 const { scheduleVersionCheck } = require('./adcp-version-check.js');
 const { LIBRARY_VERSION } = require('../dist/lib/version.js');
 const {
@@ -1598,6 +1599,7 @@ async function handleStoryboardRun(args) {
         if (step.error) {
           console.log(`   Error: ${step.error}`);
         }
+        printStepHints(step.hints);
         for (const v of step.validations) {
           const vIcon = v.passed ? '✅' : '❌';
           console.log(`   ${vIcon} ${v.description}`);
@@ -2356,6 +2358,10 @@ function formatStoryboardResultsAsJUnit(results) {
           const failureDetails = [
             step.error,
             ...step.validations.filter(v => !v.passed).map(v => `${v.description}: ${v.error || 'failed'}`),
+            // Runner hints (adcp-client#870) are diagnostic, not fatal, but
+            // they're the piece that collapses triage from "SDK bug vs seller
+            // bug" to one line — worth propagating into the CI report body.
+            ...formatHintsForFailureBody(step.hints),
           ]
             .filter(Boolean)
             .join('\n');
@@ -2645,6 +2651,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
           if (step.error) {
             console.log(`   Error: ${step.error}`);
           }
+          printStepHints(step.hints);
           for (const v of step.validations) {
             const vIcon = v.passed ? '✅' : '❌';
             console.log(`   ${vIcon} ${v.description}`);

--- a/test/lib/cli-step-hints.test.js
+++ b/test/lib/cli-step-hints.test.js
@@ -1,0 +1,104 @@
+/**
+ * CLI renderers for runner hints (adcp-client#879).
+ *
+ * The runner populates `StoryboardStepResult.hints[]` with
+ * `context_value_rejected` hints (#870/#875). This test fixes the
+ * formatting the CLI uses for both the human console path and the JUnit
+ * XML failure body so regressions in either renderer surface here
+ * instead of in downstream CI dashboards.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { printStepHints, formatHintsForFailureBody } = require('../../bin/adcp-step-hints.js');
+
+const sampleHint = {
+  kind: 'context_value_rejected',
+  message:
+    'Rejected `packages[0].pricing_option_id: po_prism_abandoner_cpm` was extracted from ' +
+    '`$context.first_signal_pricing_option_id` (set by step `search_by_spec` from ' +
+    'response path `signals[0].pricing_options[0].pricing_option_id`). ' +
+    "Seller's accepted values: [po_prism_cart_cpm].",
+  context_key: 'first_signal_pricing_option_id',
+  source_step_id: 'search_by_spec',
+  source_kind: 'context_outputs',
+  response_path: 'signals[0].pricing_options[0].pricing_option_id',
+  rejected_value: 'po_prism_abandoner_cpm',
+  request_field: 'packages[0].pricing_option_id',
+  accepted_values: ['po_prism_cart_cpm'],
+  error_code: 'INVALID_PRICING_MODEL',
+};
+
+function captureLogs(fn) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(' '));
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+describe('printStepHints', () => {
+  test('renders one line per hint prefixed with the Hint marker', () => {
+    const lines = captureLogs(() => printStepHints([sampleHint]));
+    assert.equal(lines.length, 1);
+    assert.match(lines[0], /^ {3}💡 Hint: /);
+    assert.match(lines[0], /\$context\.first_signal_pricing_option_id/);
+    assert.match(lines[0], /po_prism_cart_cpm/);
+  });
+
+  test('renders multiple hints on separate lines', () => {
+    const second = { ...sampleHint, message: 'second hint body' };
+    const lines = captureLogs(() => printStepHints([sampleHint, second]));
+    assert.equal(lines.length, 2);
+    assert.match(lines[1], /second hint body/);
+  });
+
+  test('no-op when hints is undefined', () => {
+    const lines = captureLogs(() => printStepHints(undefined));
+    assert.equal(lines.length, 0);
+  });
+
+  test('no-op when hints is an empty array', () => {
+    const lines = captureLogs(() => printStepHints([]));
+    assert.equal(lines.length, 0);
+  });
+
+  test('no-op when hints is not an array', () => {
+    const lines = captureLogs(() => printStepHints('not an array'));
+    assert.equal(lines.length, 0);
+  });
+
+  test('aligns with the 3-space indent used for `Error:` and validations', () => {
+    // The CLI prints `   Error: ...` and `   ✅ ...` at 3-space indent.
+    // Hint lines use the same so they group visually.
+    const [line] = captureLogs(() => printStepHints([sampleHint]));
+    assert.ok(line.startsWith('   '), `expected 3-space indent, got ${JSON.stringify(line.slice(0, 6))}`);
+  });
+});
+
+describe('formatHintsForFailureBody', () => {
+  test('formats each hint as a prefixed line with its kind', () => {
+    const lines = formatHintsForFailureBody([sampleHint]);
+    assert.deepEqual(lines, [`Hint (context_value_rejected): ${sampleHint.message}`]);
+  });
+
+  test('returns empty array when hints is absent', () => {
+    assert.deepEqual(formatHintsForFailureBody(undefined), []);
+    assert.deepEqual(formatHintsForFailureBody(null), []);
+    assert.deepEqual(formatHintsForFailureBody([]), []);
+  });
+
+  test('returns one entry per hint (order preserved)', () => {
+    const second = { ...sampleHint, kind: 'context_value_rejected', message: 'B' };
+    const third = { ...sampleHint, kind: 'context_value_rejected', message: 'C' };
+    const lines = formatHintsForFailureBody([sampleHint, second, third]);
+    assert.equal(lines.length, 3);
+    assert.ok(lines[1].endsWith(': B'));
+    assert.ok(lines[2].endsWith(': C'));
+  });
+});


### PR DESCRIPTION
Closes #879. Follow-up to #870 / #875.

## Summary

#875 landed the runner hint detector and populated \`StoryboardStepResult.hints[]\` with \`context_value_rejected\` diagnostics. The CLI never read the field — \`grep \\.hints bin/adcp.js\` returned zero matches — so triage output looked identical to a plain seller error. This PR renders hints in both surfaces:

**Human console** (both the main and multi-instance printers):
\`\`\`
❌ activate PII signal (123ms)
   Task: activate_signal
   Error: Pricing option not found: po_prism_abandoner_cpm
   💡 Hint: Rejected \`packages[0].pricing_option_id: po_prism_abandoner_cpm\` was extracted from \`\$context.first_signal_pricing_option_id\` (set by step \`search_by_spec\` from response path \`signals[0].pricing_options[0].pricing_option_id\`). Seller's accepted values: [po_prism_cart_cpm].
\`\`\`

**JUnit \`<failure>\` body**: \`Hint (context_value_rejected): <message>\` lines appended after validation detail.

## Implementation

Extracted \`printStepHints\` + \`formatHintsForFailureBody\` to \`bin/adcp-step-hints.js\` (following the sibling-file pattern used by \`adcp-async-handler.js\`, \`adcp-json-stdout.js\`, etc.). \`bin/adcp.js\` requires them at three call sites: the two step printers (lines ~1601, ~2649) and the JUnit failure composer (line ~2359).

## Test plan

- [x] 9 new unit tests in \`test/lib/cli-step-hints.test.js\` covering formatting, alignment, multi-hint ordering, and no-op edges (undefined / empty / non-array / null).
- [x] All existing CLI tests (67) still pass.
- [x] \`node bin/adcp.js --help\` smoke check.
- [x] \`prettier --check\` clean on modified files.

An end-to-end integration test (full \`runStoryboard\` → CLI → stdout) remains open as #882, blocked on MCP stub plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)