### PR TITLE
feat(runner): thread context_provenance through runStoryboardStep (#880)

### DIFF
--- a/.changeset/runstoryboardstep-provenance-threading.md
+++ b/.changeset/runstoryboardstep-provenance-threading.md
@@ -1,0 +1,10 @@
+---
+"@adcp/client": minor
+---
+
+`runStoryboardStep` now accepts and emits `context_provenance` so LLM-orchestrated step-by-step runs can thread rejection-hint provenance across calls the same way `context` already flows. Closes adcp-client#880. Before this, stateless step calls always initialized an empty provenance map and `context_value_rejected` hints never fired on that surface.
+
+- `StoryboardRunOptions.context_provenance?: Record<string, ContextProvenanceEntry>` — seeds the map.
+- `StoryboardStepResult.context_provenance?: Record<string, ContextProvenanceEntry>` — full accumulated map after this step's own writes are applied. Absent when empty.
+
+Full `runStoryboard` behavior is unchanged (it builds the map internally; the field still surfaces on each step result for consumers reading compliance reports).

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1130,6 +1130,10 @@ export async function runStoryboardStep(
     );
   }
 
+  // Seed provenance from the caller-supplied map (threaded through from a
+  // previous step's result). Storyboard-level runs build this internally;
+  // here the caller owns accumulation across stateless invocations.
+  const contextProvenance = new Map<string, ContextProvenanceEntry>(Object.entries(options.context_provenance ?? {}));
   const result = await executeStep(client, found.step, found.phaseId, context, allSteps, options, {
     contributions: new Set(),
     priorStepResults: new Map(),
@@ -1137,7 +1141,7 @@ export async function runStoryboardStep(
     agentUrl,
     webhookReceiver,
     runnerVars,
-    contextProvenance: new Map(),
+    contextProvenance,
   });
 
   if (!options._client) {
@@ -1563,6 +1567,10 @@ async function executeStep(
     response: taskResult?.data,
     validations,
     context: updatedContext,
+    ...(runState.contextProvenance &&
+      runState.contextProvenance.size > 0 && {
+        context_provenance: Object.fromEntries(runState.contextProvenance),
+      }),
     error: step.expect_error ? undefined : truncateError(stepResult.error || taskResult?.error),
     next,
     request: requestRecord,

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -545,6 +545,16 @@ export type StoryboardContext = Record<string, unknown>;
 export interface StoryboardRunOptions extends TestOptions {
   /** Initial context (e.g., from a previous step invocation) */
   context?: StoryboardContext;
+  /**
+   * Initial context-provenance map, typically threaded from a prior
+   * `runStoryboardStep` invocation's `StoryboardStepResult.context_provenance`.
+   * Lets LLM-orchestrated step-by-step runs accumulate the per-key write
+   * history the runner needs to emit `context_value_rejected` hints when a
+   * later step's seller rejects a value an earlier step extracted. Ignored by
+   * `runStoryboard` (full run builds its own map internally). Closes
+   * adcp-client#880.
+   */
+  context_provenance?: Record<string, ContextProvenanceEntry>;
   /** Override the step's sample_request with a custom request */
   request?: Record<string, unknown>;
   /** Agent's available tools (for requires_tool filtering) */
@@ -956,6 +966,15 @@ export interface StoryboardStepResult {
   validations: ValidationResult[];
   /** Accumulated context after this step */
   context: StoryboardContext;
+  /**
+   * Accumulated context-provenance after this step. Each entry records which
+   * step wrote the matching context key and how (convention extractor vs
+   * author-provided `context_outputs` path). Thread back into
+   * `StoryboardRunOptions.context_provenance` on the next `runStoryboardStep`
+   * invocation so hints fire across the stateless step-by-step surface the
+   * same way they do inside `runStoryboard`. adcp-client#880.
+   */
+  context_provenance?: Record<string, ContextProvenanceEntry>;
   error?: string;
   /** Preview of the next step (for LLM consumption) */
   next?: StoryboardStepPreview;

--- a/test/lib/storyboard-step-provenance-threading.test.js
+++ b/test/lib/storyboard-step-provenance-threading.test.js
@@ -1,0 +1,213 @@
+/**
+ * runStoryboardStep: context-provenance threading across stateless calls
+ * (adcp-client#880).
+ *
+ * The stateless single-step primitive is the core of LLM-friendly step-by-
+ * step orchestration. Before #880 it initialized a fresh empty provenance
+ * map each call, so hints from #870 / #875 never fired on that surface
+ * even when the caller threaded `context` across calls. This test pins
+ * the round-trip: `StoryboardRunOptions.context_provenance` in →
+ * `StoryboardStepResult.context_provenance` out → feed back into the next
+ * call → hints emit on the rejection step.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
+
+// Minimal stub that mimics the AdcpClient surface `executeStoryboardTask`
+// expects: typed methods by camelCase name (TASK_TO_METHOD), a getAgentInfo
+// for profile discovery if needed. Returns deterministic task results the
+// test controls per invocation.
+function buildStubClient(handlers) {
+  return {
+    getAgentInfo: async () => ({
+      name: 'stub',
+      tools: Object.keys(handlers).map(name => ({ name })),
+    }),
+    // Runner prefers typed methods when TASK_TO_METHOD has an entry; falls
+    // back to executeTask otherwise. Covering both avoids branching on
+    // whether the task we pick is in the map.
+    getSignals: async params => handlers.get_signals?.(params) ?? { success: false, error: 'no handler' },
+    activateSignal: async params => handlers.activate_signal?.(params) ?? { success: false, error: 'no handler' },
+    executeTask: async (name, params) =>
+      handlers[name]?.(params) ?? { success: false, error: `no handler for ${name}` },
+  };
+}
+
+const stubProfile = {
+  name: 'stub',
+  tools: [{ name: 'get_signals' }, { name: 'activate_signal' }],
+};
+
+const twoStepStoryboard = {
+  id: 'prov_threading_sb',
+  version: '1.0.0',
+  title: 'Provenance threading',
+  category: 'test',
+  summary: '',
+  narrative: '',
+  agent: { interaction_model: '*', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  phases: [
+    {
+      id: 'p1',
+      title: 'phase 1',
+      steps: [
+        {
+          id: 'search',
+          title: 'search signals',
+          task: 'get_signals',
+          sample_request: { signal_spec: 'bogus' },
+          context_outputs: [
+            { key: 'first_signal_id', path: 'signals[0].signal_agent_segment_id' },
+            { key: 'first_signal_pricing_option_id', path: 'signals[0].pricing_options[0].pricing_option_id' },
+          ],
+        },
+        {
+          id: 'activate',
+          title: 'activate signal',
+          task: 'activate_signal',
+          sample_request: {
+            signal_agent_segment_id: '$context.first_signal_id',
+            pricing_option_id: '$context.first_signal_pricing_option_id',
+          },
+          // Note: deliberately NOT `expect_error` — we want the step to
+          // fail so the hint gate (!passed) opens. An expect_error step
+          // treats seller rejection as a PASS and silences hints by design.
+        },
+      ],
+    },
+  ],
+};
+
+const searchResponse = {
+  signals: [
+    {
+      signal_agent_segment_id: 'sig_prism_abandoner',
+      pricing_options: [{ pricing_option_id: 'po_prism_abandoner_cpm' }],
+    },
+  ],
+};
+
+const activateRejection = {
+  errors: [
+    {
+      code: 'INVALID_PRICING_MODEL',
+      message: 'Pricing option not found: po_prism_abandoner_cpm',
+      field: 'pricing_option_id',
+      details: { available: ['po_prism_cart_cpm'] },
+    },
+  ],
+};
+
+describe('runStoryboardStep: context-provenance threading (#880)', () => {
+  test('step 1 result carries context_provenance shaped for threading', async () => {
+    const client = buildStubClient({
+      get_signals: async () => ({ success: true, data: searchResponse }),
+    });
+    const r1 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'search', {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['get_signals', 'activate_signal'],
+      _client: client,
+      _profile: stubProfile,
+    });
+    assert.equal(r1.passed, true, 'step 1 should pass');
+    assert.ok(r1.context_provenance, 'result carries context_provenance');
+    assert.equal(r1.context_provenance.first_signal_pricing_option_id.source_step_id, 'search');
+    assert.equal(r1.context_provenance.first_signal_pricing_option_id.source_kind, 'context_outputs');
+    assert.equal(
+      r1.context_provenance.first_signal_pricing_option_id.response_path,
+      'signals[0].pricing_options[0].pricing_option_id'
+    );
+    assert.equal(r1.context.first_signal_pricing_option_id, 'po_prism_abandoner_cpm');
+  });
+
+  test('threading context + provenance → step 2 emits context_value_rejected hint', async () => {
+    const client = buildStubClient({
+      get_signals: async () => ({ success: true, data: searchResponse }),
+      activate_signal: async () => ({ success: false, data: activateRejection }),
+    });
+    const r1 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'search', {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['get_signals', 'activate_signal'],
+      _client: client,
+      _profile: stubProfile,
+    });
+    const r2 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'activate', {
+      protocol: 'mcp',
+      allow_http: true,
+      agentTools: ['get_signals', 'activate_signal'],
+      _client: client,
+      _profile: stubProfile,
+      context: r1.context,
+      context_provenance: r1.context_provenance,
+    });
+
+    assert.ok(Array.isArray(r2.hints) && r2.hints.length === 1, `expected one hint, got ${JSON.stringify(r2.hints)}`);
+    const [hint] = r2.hints;
+    assert.equal(hint.kind, 'context_value_rejected');
+    assert.equal(hint.context_key, 'first_signal_pricing_option_id');
+    assert.equal(hint.source_step_id, 'search');
+    assert.equal(hint.rejected_value, 'po_prism_abandoner_cpm');
+    assert.deepEqual(hint.accepted_values, ['po_prism_cart_cpm']);
+  });
+
+  test('WITHOUT threading provenance → no hint even when context threaded', async () => {
+    // Regression guard: proves the threading is load-bearing. Threading
+    // only `context` (without `context_provenance`) matches how callers
+    // wrote step-by-step orchestration before #880 — they shouldn't
+    // silently lose hints once they migrate, but they won't GET hints
+    // until they also thread provenance. Pinning that contract.
+    const client = buildStubClient({
+      get_signals: async () => ({ success: true, data: searchResponse }),
+      activate_signal: async () => ({ success: false, data: activateRejection }),
+    });
+    const r1 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'search', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+    const r2 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'activate', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      context: r1.context,
+      // context_provenance intentionally omitted
+    });
+    assert.equal(r2.hints, undefined, 'no hints without provenance threading');
+  });
+
+  test('threaded provenance round-trips unchanged when this step writes nothing', async () => {
+    // `runStoryboardStep` accumulates writes into its own map seeded from
+    // the options, then emits the full accumulated map. If step 2 writes
+    // nothing (common for mutating failures), the map should still reflect
+    // what step 1 wrote — otherwise callers can't continue threading
+    // across step 3+.
+    const client = buildStubClient({
+      get_signals: async () => ({ success: true, data: searchResponse }),
+      activate_signal: async () => ({ success: false, data: activateRejection }),
+    });
+    const r1 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'search', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+    const r2 = await runStoryboardStep('https://stub.example/mcp', twoStepStoryboard, 'activate', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      context: r1.context,
+      context_provenance: r1.context_provenance,
+    });
+    assert.ok(r2.context_provenance, 'provenance is surfaced on step 2 result');
+    assert.equal(
+      r2.context_provenance.first_signal_pricing_option_id.source_step_id,
+      'search',
+      'step 1 provenance preserved through step 2'
+    );
+  });
+});


### PR DESCRIPTION
Closes #880. Follow-up to #870 / #875 / #879.

## Problem

\`runStoryboardStep\` is the stateless single-step primitive for LLM-friendly orchestration. Before this PR it initialized a fresh empty \`contextProvenance\` map on every call, so \`context_value_rejected\` hints never fired on that surface — even for callers who correctly threaded \`context\` across calls. The feature was effectively \`runStoryboard\`-only.

## Fix

Mirror how \`context\` already flows:

- New \`StoryboardRunOptions.context_provenance?: Record<string, ContextProvenanceEntry>\` seeds the map.
- New \`StoryboardStepResult.context_provenance?: Record<string, ContextProvenanceEntry>\` exposes the accumulated map (this step's writes included) so the caller can roll it forward to the next invocation.

Callers now thread both:

\`\`\`ts
const r1 = await runStoryboardStep(url, sb, 'search', opts);
const r2 = await runStoryboardStep(url, sb, 'activate', {
  ...opts,
  context: r1.context,
  context_provenance: r1.context_provenance,
});
// r2.hints[0] now fires on the rejection
\`\`\`

Full \`runStoryboard\` flow is unchanged — the field lands on every step result for consumers reading compliance reports.

## Test plan

4 new tests in \`test/lib/storyboard-step-provenance-threading.test.js\`:

- [x] Step 1 result carries \`context_provenance\` shaped for threading (source_step_id, source_kind, response_path).
- [x] Threading context + provenance → step 2 emits \`context_value_rejected\` hint end-to-end.
- [x] Regression guard: threading \`context\` WITHOUT \`context_provenance\` → no hint (pins that provenance is load-bearing).
- [x] Provenance round-trips unchanged when step 2 writes nothing itself.

All 2284 library tests pass, formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)