### PR TITLE
feat(runner): widen hint gate to validation failures (#883)

### DIFF
--- a/.changeset/hint-gate-validation-failures.md
+++ b/.changeset/hint-gate-validation-failures.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Runner hint gate now fires on any step-level failure (task-level OR validation-level), not just task failures. Closes adcp-client#883. Some sellers return 200 with an advisory `errors[]` + `available:` list (success envelope with warnings); the previous gate missed those because `passed` was true at the task level. `expect_error` semantics are unchanged — genuinely-failing expect_error steps still stay silent by design.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1534,18 +1534,28 @@ async function executeStep(
   // back to a prior-step $context.* write. Non-fatal: doesn't flip
   // pass/fail; collapses "SDK bug vs seller bug" triage to one line.
   //
-  // Gated on `!passed` (the task-level pass flag, pre-validations):
-  //   - Normal steps: hints fire only when the task reported a failure,
-  //     since that's where `errors[].available` would surface.
+  // Gate fires on any step-level failure — task-level failure OR a
+  // validation failure on a 200-OK response. Some sellers return 200 with
+  // an advisory `errors[]` + `available:` list (success envelope with
+  // warnings), and the hint is most useful on exactly that shape. Before
+  // adcp-client#883 the gate was task-level only and missed schema-
+  // rejected-but-200 flows.
+  //
+  //   - Normal steps: hints fire whenever the step failed.
   //   - `expect_error` steps: `passed` is inverted (true when the task
-  //     failed), so `!passed` means an expected error did NOT arrive —
-  //     hints stay silent, which matches intent (the caller asked for a
-  //     rejection; the runner doesn't second-guess whose fault it is).
+  //     failed), so a genuinely-failing `expect_error` step has
+  //     `passed && allValidationsPassed === true`, gate stays shut —
+  //     expected rejections don't chatter hints by design. When the
+  //     validations DO fail (the caller's assertion about the error
+  //     shape was wrong), hints fire and can point them at the source
+  //     step that supplied the rejected value.
+  //
   // Hints trace to context that existed BEFORE this step's own writes,
   // since the rejected value can't have come from this step's own
   // extraction.
+  const stepFailed = !(passed && allValidationsPassed);
   const hints =
-    !passed && runState.contextProvenance
+    stepFailed && runState.contextProvenance
       ? detectContextRejectionHints(taskResult, request, context, runState.contextProvenance)
       : [];
 

--- a/test/lib/storyboard-hint-gate-validation.test.js
+++ b/test/lib/storyboard-hint-gate-validation.test.js
@@ -1,0 +1,142 @@
+/**
+ * Hint gate: fires on validation failure even when the task reports
+ * success=200 (adcp-client#883).
+ *
+ * The original gate (adcp-client#870) checked task-level `passed` only.
+ * Sellers that return 200 with an advisory `errors[]` + `available:` list
+ * (success envelope with warnings) plus a schema-rejecting validation
+ * silently missed hints. #883 widens the gate to fire on any step-level
+ * failure — task-level OR validation-level. Uses the full `runStoryboard`
+ * path so this test lands cleanly on main without depending on #880
+ * (stateless-step provenance threading).
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+function buildStubClient(handlers) {
+  return {
+    getAgentInfo: async () => ({
+      name: 'stub',
+      tools: Object.keys(handlers).map(name => ({ name })),
+    }),
+    getSignals: async params => handlers.get_signals?.(params) ?? { success: false, error: 'no handler' },
+    activateSignal: async params => handlers.activate_signal?.(params) ?? { success: false, error: 'no handler' },
+    executeTask: async (name, params) =>
+      handlers[name]?.(params) ?? { success: false, error: `no handler for ${name}` },
+  };
+}
+
+const stubProfile = {
+  name: 'stub',
+  tools: [{ name: 'get_signals' }, { name: 'activate_signal' }],
+};
+
+function buildStoryboard(validationsForActivate) {
+  return {
+    id: 'hint_gate_sb',
+    version: '1.0.0',
+    title: 'hint-gate',
+    category: 'test',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'p1',
+        title: 'p1',
+        steps: [
+          {
+            id: 'search',
+            title: 'search',
+            task: 'get_signals',
+            sample_request: {},
+            context_outputs: [
+              {
+                key: 'first_signal_pricing_option_id',
+                path: 'signals[0].pricing_options[0].pricing_option_id',
+              },
+            ],
+          },
+          {
+            id: 'activate',
+            title: 'activate',
+            task: 'activate_signal',
+            sample_request: { pricing_option_id: '$context.first_signal_pricing_option_id' },
+            validations: validationsForActivate,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const searchResponse = {
+  signals: [{ pricing_options: [{ pricing_option_id: 'po_old' }] }],
+};
+
+// Seller returned 200 (success envelope) but embedded an advisory
+// errors[] + `available:` list and a non-activated status. The success
+// is what keeps the task-level passed flag true; the validation catches
+// the `status` mismatch. Classic 200-with-warnings shape.
+const activate200WithWarnings = {
+  status: 'rejected',
+  errors: [
+    {
+      code: 'INVALID_PRICING_MODEL',
+      message: 'Pricing option not found',
+      field: 'pricing_option_id',
+      details: { available: ['po_new'] },
+    },
+  ],
+};
+
+describe('hint gate: validation failures open the gate (#883)', () => {
+  test('200-OK success + failing validation → hint fires', async () => {
+    const storyboard = buildStoryboard([
+      { check: 'field_value', path: 'status', value: 'activated', description: 'status is activated' },
+    ]);
+    const client = buildStubClient({
+      get_signals: async () => ({ success: true, data: searchResponse }),
+      // success=true → task-level `passed` stays true. The broader gate
+      // re-opens through the validation check.
+      activate_signal: async () => ({ success: true, data: activate200WithWarnings }),
+    });
+    const result = await runStoryboard('https://stub.example/mcp', storyboard, {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+    const activateStep = result.phases[0].steps.find(s => s.step_id === 'activate');
+    assert.ok(activateStep, 'activate step present in result');
+    assert.equal(activateStep.passed, false, 'validation failure drives overall failure');
+    assert.ok(Array.isArray(activateStep.hints), `hints array present, got ${JSON.stringify(activateStep.hints)}`);
+    assert.equal(activateStep.hints.length, 1);
+    assert.equal(activateStep.hints[0].context_key, 'first_signal_pricing_option_id');
+    assert.equal(activateStep.hints[0].rejected_value, 'po_old');
+    assert.deepEqual(activateStep.hints[0].accepted_values, ['po_new']);
+  });
+
+  test('200-OK success + all validations pass → no hint (advisory only)', async () => {
+    // Same response shape but no validation that catches the issue —
+    // overall step passes, gate stays shut. Confirms the gate key is
+    // step-level failure, not presence of `errors[]` on the response.
+    const storyboard = buildStoryboard([]);
+    const client = buildStubClient({
+      get_signals: async () => ({ success: true, data: searchResponse }),
+      activate_signal: async () => ({ success: true, data: activate200WithWarnings }),
+    });
+    const result = await runStoryboard('https://stub.example/mcp', storyboard, {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+    const activateStep = result.phases[0].steps.find(s => s.step_id === 'activate');
+    assert.ok(activateStep, 'activate step present in result');
+    assert.equal(activateStep.passed, true, 'step passes when no validation catches it');
+    assert.equal(activateStep.hints, undefined, 'gate stays shut when step passes');
+  });
+});


### PR DESCRIPTION
Closes #883. Follow-up to #870 / #875.

## Problem

The hint gate in \`executeStep\` was:

\`\`\`ts
const hints = !passed && runState.contextProvenance
  ? detectContextRejectionHints(...)
  : [];
\`\`\`

where \`passed\` is the task-level flag (pre-validations). Sellers that return a 200-OK success envelope with an advisory \`errors[].details.available\` payload (common on schema-rejected-but-accepted shapes) would have \`passed=true\` — the validation catches the mismatch and fails the step, but the hint gate had already stayed closed.

## Fix

Gate on the combined step-level failure:

\`\`\`ts
const stepFailed = !(passed && allValidationsPassed);
const hints = stepFailed && runState.contextProvenance
  ? detectContextRejectionHints(...)
  : [];
\`\`\`

### Semantics pinned

- **Normal steps**: hints fire whenever the step failed (either task or validation).
- **\`expect_error\` steps**: \`passed\` is inverted (true when task failed). A genuinely-failing expect_error step has \`passed && allValidationsPassed === true\` → gate stays shut (expected rejections don't chatter). When validations DO fail (the caller's assertion about the error shape was wrong), hints fire and point at the source step.

## Test plan

2 new tests in \`test/lib/storyboard-hint-gate-validation.test.js\`:

- [x] 200-OK success + failing validation → hint fires, rejected_value and accepted_values correctly populated.
- [x] 200-OK success + all validations pass → no hint (confirms the gate key is step-level failure, not presence of \`errors[]\`).
- [x] All 2265 library storyboard tests still pass.
- [x] prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)