### PR TITLE
fix(cli): render StoryboardStepResult.hints[] in all reporting surfaces

### DIFF
--- a/.changeset/runner-hints-cli-rendering.md
+++ b/.changeset/runner-hints-cli-rendering.md
@@ -1,0 +1,16 @@
+---
+"@adcp/client": patch
+---
+
+Render StoryboardStepResult.hints[] in CLI output and JUnit XML
+
+The storyboard runner already emits `context_value_rejected` hints when a
+seller's error traces back to a prior-step `$context.*` write, but the hints
+were silently dropped by all reporting surfaces. This patch wires them up:
+
+- `adcp storyboard run` (single and multi-instance): prints `Hint: <message>`
+  below the `Error:` line for each failing step with hints
+- `adcp storyboard step`: same, for single-step interactive debugging
+- JUnit XML (`--format junit`): appends hint messages to the `<failure>` body;
+  when `step.error` is absent, uses the first hint as the `message=` attribute
+  so CI systems that only read that attribute still surface the diagnostic

--- a/.changeset/runner-hints-cli-rendering.md
+++ b/.changeset/runner-hints-cli-rendering.md
@@ -14,3 +14,8 @@ were silently dropped by all reporting surfaces. This patch wires them up:
 - JUnit XML (`--format junit`): appends hint messages to the `<failure>` body;
   when `step.error` is absent, uses the first hint as the `message=` attribute
   so CI systems that only read that attribute still surface the diagnostic
+
+The `formatStoryboardResultsAsJUnit` formatter is extracted from `bin/adcp.js`
+into `src/lib/testing/storyboard/junit.ts` (internal; not part of the public
+`@adcp/client` API) so it can be unit-tested without bootstrapping the CLI.
+Five snapshot tests are added in `test/lib/storyboard-junit-hints.test.js`.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1599,6 +1599,9 @@ async function handleStoryboardRun(args) {
         if (step.error) {
           console.log(`   Error: ${step.error}`);
         }
+        // Runner only emits hints on failed steps (runner.ts gates on !passed),
+        // so this block is safe unconditionally. If a future hint kind fires on
+        // a passing step, revisit the UX before shipping it.
         if (step.hints?.length) {
           for (const h of step.hints) {
             console.log(`   Hint:  ${h.message}`);
@@ -2577,6 +2580,8 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
           if (step.error) {
             console.log(`   Error: ${step.error}`);
           }
+          // Runner only emits hints on failed steps; see comment in the
+          // single-storyboard printer above.
           if (step.hints?.length) {
             for (const h of step.hints) {
               console.log(`   Hint:  ${h.message}`);

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -15,6 +15,7 @@
  */
 
 const { AdCPClient, detectProtocol, usesDeprecatedAssetsField } = require('../dist/lib/index.js');
+const { formatStoryboardResultsAsJUnit } = require('../dist/lib/testing/storyboard/junit.js');
 const { readFileSync, statSync } = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
@@ -1598,6 +1599,11 @@ async function handleStoryboardRun(args) {
         if (step.error) {
           console.log(`   Error: ${step.error}`);
         }
+        if (step.hints?.length) {
+          for (const h of step.hints) {
+            console.log(`   Hint:  ${h.message}`);
+          }
+        }
         for (const v of step.validations) {
           const vIcon = v.passed ? '✅' : '❌';
           console.log(`   ${vIcon} ${v.description}`);
@@ -2314,80 +2320,6 @@ function aggregateStrictSummaries(summaries) {
   return out;
 }
 
-/**
- * Emit JUnit XML for a list of `StoryboardResult`. Each storyboard
- * becomes a `<testsuite>`; each step becomes a `<testcase>` with failures
- * attached as `<failure>` children. Matches the schema Jenkins, CircleCI,
- * and GitLab CI all consume without a plugin.
- */
-function formatStoryboardResultsAsJUnit(results) {
-  const xmlEscape = s =>
-    String(s ?? '')
-      .replace(/&/g, '&amp;')
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&apos;');
-
-  let totalTests = 0;
-  let totalFailures = 0;
-  let totalSkipped = 0;
-  let totalDuration = 0;
-  const suites = [];
-
-  for (const sb of results) {
-    const suiteCases = [];
-    for (const phase of sb.phases) {
-      for (const step of phase.steps) {
-        totalTests += 1;
-        const name = `${phase.phase_title} › ${step.title}`;
-        const time = ((step.duration_ms || 0) / 1000).toFixed(3);
-        if (step.skipped) {
-          totalSkipped += 1;
-          suiteCases.push(
-            `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(name)}" time="${time}">\n` +
-              `      <skipped message="${xmlEscape(step.skip_reason || 'skipped')}"/>\n` +
-              `    </testcase>`
-          );
-          continue;
-        }
-        if (!step.passed) {
-          totalFailures += 1;
-          const failureDetails = [
-            step.error,
-            ...step.validations.filter(v => !v.passed).map(v => `${v.description}: ${v.error || 'failed'}`),
-          ]
-            .filter(Boolean)
-            .join('\n');
-          suiteCases.push(
-            `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(name)}" time="${time}">\n` +
-              `      <failure message="${xmlEscape(step.error || 'validation failed')}" type="StoryboardFailure">${xmlEscape(failureDetails)}</failure>\n` +
-              `    </testcase>`
-          );
-          continue;
-        }
-        suiteCases.push(
-          `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(name)}" time="${time}"/>`
-        );
-      }
-    }
-    totalDuration += sb.total_duration_ms || 0;
-    const suiteTests = sb.phases.reduce((n, p) => n + p.steps.length, 0);
-    suites.push(
-      `  <testsuite name="${xmlEscape(sb.storyboard_title)}" tests="${suiteTests}" failures="${sb.failed_count}" skipped="${sb.skipped_count}" time="${((sb.total_duration_ms || 0) / 1000).toFixed(3)}" timestamp="${sb.tested_at || new Date().toISOString()}">\n` +
-        suiteCases.join('\n') +
-        `\n  </testsuite>`
-    );
-  }
-
-  return (
-    `<?xml version="1.0" encoding="UTF-8"?>\n` +
-    `<testsuites name="adcp-storyboards" tests="${totalTests}" failures="${totalFailures}" skipped="${totalSkipped}" time="${(totalDuration / 1000).toFixed(3)}">\n` +
-    suites.join('\n') +
-    `\n</testsuites>\n`
-  );
-}
-
 async function handleMultiInstanceStoryboardRun(args, opts, urls) {
   const { authToken, protocolFlag, jsonOutput, dryRun, positionalArgs, file: filePath } = opts;
 
@@ -2645,6 +2577,11 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
           if (step.error) {
             console.log(`   Error: ${step.error}`);
           }
+          if (step.hints?.length) {
+            for (const h of step.hints) {
+              console.log(`   Hint:  ${h.message}`);
+            }
+          }
           for (const v of step.validations) {
             const vIcon = v.passed ? '✅' : '❌';
             console.log(`   ${vIcon} ${v.description}`);
@@ -2880,6 +2817,11 @@ async function handleStoryboardStepCmd(args) {
 
     if (result.error) {
       console.log(`Error: ${result.error}`);
+    }
+    if (result.hints?.length) {
+      for (const h of result.hints) {
+        console.log(`Hint:  ${h.message}`);
+      }
     }
 
     for (const v of result.validations) {

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -142,6 +142,9 @@ export { buildRequest, hasRequestBuilder } from './request-builder';
 // Validations
 export { runValidations } from './validations';
 
+// JUnit XML formatter (used by CLI; exported for testing)
+export { formatStoryboardResultsAsJUnit } from './junit';
+
 // Test-kit schema validation
 export { validateTestKit, TestKitValidationError, PROBE_TASK_ALLOWLIST } from './test-kit';
 

--- a/src/lib/testing/storyboard/junit.ts
+++ b/src/lib/testing/storyboard/junit.ts
@@ -1,0 +1,82 @@
+import type { StoryboardResult } from './types';
+
+function xmlEscape(s: unknown): string {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Emit JUnit XML for a list of `StoryboardResult`. Each storyboard becomes a
+ * `<testsuite>`; each step becomes a `<testcase>` with failures attached as
+ * `<failure>` children. Matches the schema Jenkins, CircleCI, and GitLab CI
+ * all consume without a plugin.
+ *
+ * Hints (`step.hints`) are included in the `<failure>` body immediately after
+ * `step.error` so CI failure annotations carry the context-rejection diagnosis.
+ * When `step.error` is absent, the first hint message is used as the `message=`
+ * attribute so systems that only read that attribute still surface the hint.
+ */
+export function formatStoryboardResultsAsJUnit(results: StoryboardResult[]): string {
+  let totalTests = 0;
+  let totalFailures = 0;
+  let totalSkipped = 0;
+  let totalDuration = 0;
+  const suites: string[] = [];
+
+  for (const sb of results) {
+    const suiteCases: string[] = [];
+    for (const phase of sb.phases) {
+      for (const step of phase.steps) {
+        totalTests += 1;
+        const name = `${phase.phase_title} › ${step.title}`;
+        const time = ((step.duration_ms || 0) / 1000).toFixed(3);
+        if (step.skipped) {
+          totalSkipped += 1;
+          suiteCases.push(
+            `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(name)}" time="${time}">\n` +
+              `      <skipped message="${xmlEscape(step.skip_reason || 'skipped')}"/>\n` +
+              `    </testcase>`
+          );
+          continue;
+        }
+        if (!step.passed) {
+          totalFailures += 1;
+          const failureDetails = [
+            step.error,
+            ...(step.hints ?? []).map(h => `Hint: ${h.message}`),
+            ...step.validations.filter(v => !v.passed).map(v => `${v.description}: ${v.error || 'failed'}`),
+          ]
+            .filter(Boolean)
+            .join('\n');
+          suiteCases.push(
+            `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(name)}" time="${time}">\n` +
+              `      <failure message="${xmlEscape(step.error || step.hints?.[0]?.message || 'validation failed')}" type="StoryboardFailure">${xmlEscape(failureDetails)}</failure>\n` +
+              `    </testcase>`
+          );
+          continue;
+        }
+        suiteCases.push(
+          `    <testcase classname="${xmlEscape(sb.storyboard_id)}" name="${xmlEscape(name)}" time="${time}"/>`
+        );
+      }
+    }
+    totalDuration += sb.total_duration_ms || 0;
+    const suiteTests = sb.phases.reduce((n, p) => n + p.steps.length, 0);
+    suites.push(
+      `  <testsuite name="${xmlEscape(sb.storyboard_title)}" tests="${suiteTests}" failures="${sb.failed_count}" skipped="${sb.skipped_count}" time="${((sb.total_duration_ms || 0) / 1000).toFixed(3)}" timestamp="${sb.tested_at || new Date().toISOString()}">\n` +
+        suiteCases.join('\n') +
+        `\n  </testsuite>`
+    );
+  }
+
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<testsuites name="adcp-storyboards" tests="${totalTests}" failures="${totalFailures}" skipped="${totalSkipped}" time="${(totalDuration / 1000).toFixed(3)}">\n` +
+    suites.join('\n') +
+    `\n</testsuites>\n`
+  );
+}

--- a/src/lib/testing/storyboard/junit.ts
+++ b/src/lib/testing/storyboard/junit.ts
@@ -19,6 +19,9 @@ function xmlEscape(s: unknown): string {
  * `step.error` so CI failure annotations carry the context-rejection diagnosis.
  * When `step.error` is absent, the first hint message is used as the `message=`
  * attribute so systems that only read that attribute still surface the hint.
+ *
+ * @internal — CLI tooling; not part of the public `@adcp/client` API surface.
+ * Import directly from `dist/lib/testing/storyboard/junit.js` if needed.
  */
 export function formatStoryboardResultsAsJUnit(results: StoryboardResult[]): string {
   let totalTests = 0;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.15.0';
+export const LIBRARY_VERSION = '5.16.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.15.0',
+  library: '5.16.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-24T12:39:05.665Z',
+  generatedAt: '2026-04-24T14:38:57.153Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-junit-hints.test.js
+++ b/test/lib/storyboard-junit-hints.test.js
@@ -1,0 +1,141 @@
+/**
+ * Snapshot-style tests for `formatStoryboardResultsAsJUnit` to pin the
+ * behaviour added in issue #879: context_value_rejected hints must appear
+ * in the JUnit <failure> body and, when step.error is absent, in the
+ * message= attribute.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { formatStoryboardResultsAsJUnit } = require('../../dist/lib/testing/storyboard/junit.js');
+
+function makeResult({ error, hints, validations } = {}) {
+  return {
+    storyboard_id: 'test_sb',
+    storyboard_title: 'Test Storyboard',
+    agent_url: 'https://example.com/mcp',
+    tested_at: '2026-01-01T00:00:00.000Z',
+    passed: false,
+    passed_count: 0,
+    failed_count: 1,
+    skipped_count: 0,
+    total_duration_ms: 100,
+    phases: [
+      {
+        phase_id: 'phase_1',
+        phase_title: 'Phase 1',
+        passed: false,
+        duration_ms: 100,
+        steps: [
+          {
+            step_id: 'step_1',
+            title: 'Buy media',
+            task: 'create_media_buy',
+            passed: false,
+            skipped: false,
+            duration_ms: 100,
+            error: error ?? null,
+            hints: hints ?? [],
+            validations: validations ?? [],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test('hint message appears in JUnit <failure> CDATA body', () => {
+  const hint = {
+    kind: 'context_value_rejected',
+    message:
+      'Rejected `packages[0].pricing_option_id: po_prism_abandoner_cpm` was extracted from `$context.pricing_option_id` (set by step `search_step`). Accepted: [po_prism_cart_cpm].',
+    context_key: 'pricing_option_id',
+    source_step_id: 'search_step',
+    source_kind: 'convention',
+    rejected_value: 'po_prism_abandoner_cpm',
+    accepted_values: ['po_prism_cart_cpm'],
+  };
+
+  const xml = formatStoryboardResultsAsJUnit([
+    makeResult({ error: 'Pricing option not found: po_prism_abandoner_cpm', hints: [hint] }),
+  ]);
+
+  assert.match(xml, /<failure[^>]+>/, 'should have a <failure> element');
+  assert.match(xml, /Hint: Rejected `packages\[0\]\.pricing_option_id/, 'hint message should appear in failure body');
+  assert.match(xml, /Pricing option not found: po_prism_abandoner_cpm/, 'step error should appear in failure body');
+});
+
+test('hint message ordering: step.error then hints then validations', () => {
+  const hint = {
+    kind: 'context_value_rejected',
+    message: 'Hint text.',
+    context_key: 'k',
+    source_step_id: 's',
+    source_kind: 'convention',
+    rejected_value: 'v',
+    accepted_values: [],
+  };
+  const validationFailure = { passed: false, description: 'field_present: foo', error: 'missing field' };
+
+  const xml = formatStoryboardResultsAsJUnit([
+    makeResult({ error: 'Top error', hints: [hint], validations: [validationFailure] }),
+  ]);
+
+  const errorPos = xml.indexOf('Top error');
+  const hintPos = xml.indexOf('Hint text.');
+  const validationPos = xml.indexOf('field_present: foo');
+  assert.ok(errorPos < hintPos, 'error should come before hint');
+  assert.ok(hintPos < validationPos, 'hint should come before validation failure');
+});
+
+test('when step.error is absent, first hint message used as failure message= attribute', () => {
+  const hint = {
+    kind: 'context_value_rejected',
+    message: 'Context hint only.',
+    context_key: 'k',
+    source_step_id: 's',
+    source_kind: 'convention',
+    rejected_value: 'v',
+    accepted_values: [],
+  };
+
+  const xml = formatStoryboardResultsAsJUnit([makeResult({ error: null, hints: [hint] })]);
+
+  assert.match(xml, /message="Context hint only\."/, 'hint message should be the failure message= attribute');
+});
+
+test('step without hints falls through to validation failed', () => {
+  const xml = formatStoryboardResultsAsJUnit([makeResult({ error: null, hints: [], validations: [] })]);
+
+  assert.match(xml, /message="validation failed"/, 'default message should be "validation failed"');
+  assert.doesNotMatch(xml, /Hint:/, 'should not mention Hint: when no hints present');
+});
+
+test('multiple hints all appear in failure body', () => {
+  const hints = [
+    {
+      kind: 'context_value_rejected',
+      message: 'Hint A.',
+      context_key: 'a',
+      source_step_id: 's1',
+      source_kind: 'convention',
+      rejected_value: 'x',
+      accepted_values: [],
+    },
+    {
+      kind: 'context_value_rejected',
+      message: 'Hint B.',
+      context_key: 'b',
+      source_step_id: 's2',
+      source_kind: 'convention',
+      rejected_value: 'y',
+      accepted_values: [],
+    },
+  ];
+
+  const xml = formatStoryboardResultsAsJUnit([makeResult({ hints })]);
+
+  assert.match(xml, /Hint A\./, 'first hint should appear');
+  assert.match(xml, /Hint B\./, 'second hint should appear');
+});


### PR DESCRIPTION
## Summary

Wires `StoryboardStepResult.hints[]` into every human-readable and CI reporting surface that was silently dropping it. The runner already populates `hints` with `context_value_rejected` diagnostics (landed in #875/#870); this PR makes them visible.

Also extracts `formatStoryboardResultsAsJUnit` from `bin/adcp.js` into `src/lib/testing/storyboard/junit.ts` (marked `@internal`) so the formatter can be unit-tested without bootstrapping the full CLI dependency tree.

## What changed

**`bin/adcp.js`**
- `adcp storyboard run` (single + multi-instance): prints `   Hint:  <message>` below the `   Error:` line for each failing step with hints
- `adcp storyboard step`: same, matching that command's no-indent error style
- Adds comment at each hint block documenting the runner invariant (hints only emitted on failed steps)
- Removes the inline `formatStoryboardResultsAsJUnit` function (now imported from `dist/lib`)

**`src/lib/testing/storyboard/junit.ts`** (new, `@internal`)
- Hints included in `<failure>` body between `step.error` and failing validations
- `message=` attribute falls back to `step.hints?.[0]?.message` when `step.error` is absent — so CI systems that only read the attribute still surface the diagnostic
- Named export makes it reachable from tests; `@internal` JSDoc and absence from top-level barrel signal it is not part of the public `@adcp/client` API

## Test plan

- [x] `node --test test/lib/storyboard-junit-hints.test.js` — 5/5 pass (new snapshot tests)
- [x] `node --test test/lib/storyboard-rejection-hints.test.js` — 21/21 pass (existing)
- [x] `node --test test/lib/storyboard-runner-contract.test.js` — 29/30 pass (1 pre-existing skip unchanged)
- [x] `npm run format:check` — clean
- [ ] CI green

## Note for reviewer: comply path

Planning experts flagged whether to also thread hints through `ComplianceFailure` so they appear in `adcp comply` human-readable output. The dx-expert called this a follow-up concern; the protocol-expert called it out-of-scope (the comply JSON path already serializes hints verbatim). This PR takes the narrower scope per the issue's stated acceptance criteria.

## Nits noted (not fixed)

- No test for XML-special characters in hint messages (the `xmlEscape` call is correct; a test would pin it)
- `message=` attribute omits the `Hint:` prefix intentionally for brevity (pinned by test on line 108 of `storyboard-junit-hints.test.js`)

---

Closes #879

**Pre-PR review:**
- code-reviewer: approved — no blockers; documented runner invariant in CLI hint blocks per review
- dx-expert: approved after fix — resolved one blocker (`@internal` added to exported symbol to clarify public/internal boundary); 2 nits noted above

Session: https://claude.ai/code/session_01CokHw4pHKBK2v1aYVE9LfL