### PR TITLE
test(flake): ephemeral ports for MCP grader (#884)

### DIFF
--- a/.changeset/mcp-grader-ephemeral-ports.md
+++ b/.changeset/mcp-grader-ephemeral-ports.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: `request-signing-grader-mcp` test now binds both reference agent instances to ephemeral ports (PORT=0) instead of hardcoded 3111/3112. Fixes adcp-client#884 — parallel test workers and leftover zombies from earlier runs used to collide on port 3112, surfacing as `MCP agent exited with code 1 before signaling ready` on the rate-abuse subtest. No library change; no release needed.

--- a/test/request-signing-grader-mcp.test.js
+++ b/test/request-signing-grader-mcp.test.js
@@ -35,10 +35,13 @@ function ensureMcpAgentBuilt() {
   }
 }
 
-function startMcpAgent(port, overrides = {}) {
-  // Spread overrides first so `PORT` always wins — callers shouldn't be able
-  // to clobber the explicit `port` argument through the overrides bag.
-  const env = { ...process.env, ...overrides, PORT: String(port) };
+function startMcpAgent(overrides = {}) {
+  // PORT=0 asks the OS for a free ephemeral port so parallel test workers
+  // and leftover zombies from previous runs can't collide. The child
+  // process's `AdCP agent running at http://localhost:<port>/mcp` banner
+  // carries the actual bound port; we parse it and stash on `child.port`
+  // for the caller. Closes adcp-client#884 (rate-abuse subtest flake).
+  const env = { ...process.env, ...overrides, PORT: '0' };
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [MCP_AGENT_SCRIPT], {
       env,
@@ -51,8 +54,29 @@ function startMcpAgent(port, overrides = {}) {
       if (settled) return;
       const s = chunk.toString();
       stdoutTail.push(s);
-      if (s.includes(`listening`) || s.includes(`running at`)) {
+      // Parse the actual bound port from the banner — the banner line is
+      // authoritative because PORT=0 means the OS picked it. Fail the
+      // startup (rather than silently using port 0) if the banner arrives
+      // but we can't extract a port — that'd indicate a banner-format
+      // change the caller needs to hear about.
+      const portMatch = /running at https?:\/\/[^:]+:(\d+)/i.exec(stdoutTail.join(''));
+      if (s.includes('listening') || s.includes('running at')) {
+        if (!portMatch) {
+          settled = true;
+          try {
+            child.kill('SIGKILL');
+          } catch {
+            /* already gone */
+          }
+          reject(
+            new Error(
+              `MCP agent signaled ready but startMcpAgent could not parse a port from the banner:\n${stdoutTail.join('')}`
+            )
+          );
+          return;
+        }
         settled = true;
+        child.port = Number(portMatch[1]);
         resolve(child);
       }
     };
@@ -124,17 +148,16 @@ function stopMcpAgent(child) {
 const CAPABILITY_PROFILE_VECTORS = ['007-missing-content-digest', '018-digest-covered-when-forbidden'];
 
 describe('request-signing grader — MCP transport vs. reference MCP agent', () => {
-  // Dynamic port so the test is safe to run in parallel; fallback to 3111.
-  // The rate-abuse subtest spins up a second agent on PORT+1, so parallel
-  // runs of this file MUST set ADCP_MCP_TEST_PORT values that differ by at
-  // least 2 (e.g. 3111 and 3113) to avoid the +1 sibling colliding.
-  const PORT = Number.parseInt(process.env.ADCP_MCP_TEST_PORT ?? '3111', 10);
-  const AGENT_URL = `http://127.0.0.1:${PORT}/mcp`;
+  // Ephemeral ports (PORT=0) eliminate the parallel-worker collision and
+  // zombie-port races that used to flake the rate-abuse subtest (#884).
+  // `agent.port` is populated from the startup banner in `startMcpAgent`.
   let agent;
+  let AGENT_URL;
 
   before(async () => {
     ensureMcpAgentBuilt();
-    agent = await startMcpAgent(PORT);
+    agent = await startMcpAgent();
+    AGENT_URL = `http://127.0.0.1:${agent.port}/mcp`;
   });
 
   after(async () => {
@@ -205,10 +228,13 @@ describe('request-signing grader — MCP transport vs. reference MCP agent', () 
     // than 101. Needs `allowLiveSideEffects: true` because the reference
     // agent doesn't advertise `endpoint_scope: sandbox` — preflightSkip
     // otherwise refuses to run 020.
-    const rateAbusePort = PORT + 1;
-    const fresh = await startMcpAgent(rateAbusePort, { ADCP_REPLAY_CAP: '10' });
+    //
+    // Uses an ephemeral port (startMcpAgent binds PORT=0 and returns the
+    // OS-picked port on `child.port`) so this spawn can't collide with the
+    // `before()` agent or with a parallel test worker. Fixes #884.
+    const fresh = await startMcpAgent({ ADCP_REPLAY_CAP: '10' });
     try {
-      const report = await gradeRequestSigning(`http://127.0.0.1:${rateAbusePort}/mcp`, {
+      const report = await gradeRequestSigning(`http://127.0.0.1:${fresh.port}/mcp`, {
         allowPrivateIp: true,
         transport: 'mcp',
         onlyVectors: ['020-rate-abuse'],


### PR DESCRIPTION
Closes #884.

## Problem

\`test/request-signing-grader-mcp.test.js\` hardcoded ports \`3111\` (before-hook agent) and \`3112\` (rate-abuse subtest agent). Under Node \`--test\`'s default parallel-worker dispatch, a second test file or a leftover zombie from a prior run could bind 3112 first, and the subtest's spawn would crash with:

\`\`\`
MCP agent exited with code 1 before signaling ready:
...
Error: listen EADDRINUSE: address already in use 127.0.0.1:3112
\`\`\`

Verified as pre-existing flake during PR #875 triage (\`git stash && node --test test/request-signing-grader-mcp.test.js\` reproduced on unmodified main).

## Fix

Both agent spawns now bind \`PORT=0\` (OS-assigned ephemeral). \`startMcpAgent\` parses the actual port from the \`AdCP agent running at http://localhost:<port>/mcp\` banner \`serve()\` already emits and stashes it on \`child.port\` for the caller.

Also removes the now-irrelevant \`ADCP_MCP_TEST_PORT\` escape hatch — parallel runs are safe by default.

## Test plan

- [x] \`node --test test/request-signing-grader-mcp.test.js\` × 5 consecutive: 5/5 green (previously 1–2/5 green on the main branch).
- [x] \`npm test\` full suite: **5662 pass, 0 fail** (was 5635/1-fail with the flake).
- [x] \`prettier --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)