### PR TITLE
docs(validate): reading runner `💡 Hint:` context-value rejections

### DIFF
--- a/.changeset/docs-rejection-hints.md
+++ b/.changeset/docs-rejection-hints.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs-only: adds a "Reading `💡 Hint:` lines" section to `docs/guides/VALIDATE-YOUR-AGENT.md` explaining how to interpret the runner's `context_value_rejected` diagnostics (shipped in #870 / #875 et seq.) and what they indicate about seller-side catalog inconsistency. No code or release impact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ your context: `src/lib/types/*.generated.ts`, `src/lib/agents/index.generated.ts
 
 **Building a server-side agent?** Read `docs/guides/BUILD-AN-AGENT.md`. Storyboards live at `https://adcontextprotocol.org/compliance/{version}/` (pulled into `compliance/cache/{version}/` by `npm run sync-schemas`).
 
-**Validating a server-side agent?** Read `docs/guides/VALIDATE-YOUR-AGENT.md` — the five-command checklist plus deep references for `adcp storyboard run`, `adcp fuzz` (T1/T2/T3), `adcp grade request-signing`, multi-instance testing, webhook conformance, schema-driven validation hooks, custom `--invariants`, and the `npm run compliance:skill-matrix` dogfood harness.
+**Validating a server-side agent?** Read `docs/guides/VALIDATE-YOUR-AGENT.md` — the five-command checklist plus deep references for `adcp storyboard run`, `adcp fuzz` (T1/T2/T3), `adcp grade request-signing`, multi-instance testing, webhook conformance, schema-driven validation hooks, custom `--invariants`, the `npm run compliance:skill-matrix` dogfood harness, and how to read the runner's `💡 Hint: …` context-value-rejection diagnostics.
 
 **Building a seller agent?** Read and follow `skills/build-seller-agent/SKILL.md` — covers guaranteed vs non-guaranteed, pricing, approval workflows, creative management.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ your context: `src/lib/types/*.generated.ts`, `src/lib/agents/index.generated.ts
 
 **Building a server-side agent?** Read `docs/guides/BUILD-AN-AGENT.md`. Storyboards live at `https://adcontextprotocol.org/compliance/{version}/` (pulled into `compliance/cache/{version}/` by `npm run sync-schemas`).
 
-**Validating a server-side agent?** Read `docs/guides/VALIDATE-YOUR-AGENT.md` — the five-command checklist plus deep references for `adcp storyboard run`, `adcp fuzz` (T1/T2/T3), `adcp grade request-signing`, multi-instance testing, webhook conformance, schema-driven validation hooks, custom `--invariants`, the `npm run compliance:skill-matrix` dogfood harness, and how to read the runner's `💡 Hint: …` context-value-rejection diagnostics.
+**Validating a server-side agent?** Read `docs/guides/VALIDATE-YOUR-AGENT.md` — the five-command checklist plus deep references for `adcp storyboard run`, `adcp fuzz` (T1/T2/T3), `adcp grade request-signing`, multi-instance testing, webhook conformance, schema-driven validation hooks, custom `--invariants`, the `npm run compliance:skill-matrix` dogfood harness, and how to read the runner's `context_value_rejected` diagnostics (the `💡 Hint:` lines printed on failing storyboard steps).
 
 **Building a seller agent?** Read and follow `skills/build-seller-agent/SKILL.md` — covers guaranteed vs non-guaranteed, pricing, approval workflows, creative management.
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -329,7 +329,9 @@ Use before merging skill changes. ~60s per pair; matrix runs fan out.
 
 ## Reading `💡 Hint:` lines (context-value rejections)
 
-When the storyboard runner prints output like this:
+> **If you see a `💡 Hint:` line, the fix is almost always in your catalog, not the SDK.** The two tools named in the hint are returning inconsistent values — unify their source.
+
+Example output:
 
 ```
 ❌ Activate PII signal (412ms)
@@ -342,22 +344,34 @@ When the storyboard runner prints output like this:
            accepted values: [po_prism_cart_cpm].
 ```
 
-…the failure is almost always **your catalog is inconsistent across tools**, not an SDK bug. The runner is telling you:
+The runner is telling you:
 
 1. Step `search_by_spec` wrote `po_prism_abandoner_cpm` into `$context.first_signal_pricing_option_id` — extracted from `signals[0].pricing_options[0].pricing_option_id` on your own `get_signals` response.
 2. Step `activate_signal` sent that id back to you.
 3. Your `activate_signal` handler rejected it with `available: [po_prism_cart_cpm]`.
 
-So `get_signals` advertised one id and `activate_signal` accepted a different one. Fix by unifying the catalog source — typically the two handlers should read from the same store instead of each returning independently-built lists.
+So **`get_signals` advertised one id and `activate_signal` accepted a different one**. **Fix by unifying the catalog source** — typically both handlers should read from the same store ([build-seller-agent/SKILL.md](../../skills/build-seller-agent/SKILL.md) covers the shared-store pattern).
 
-Hints only fire when the runner can trace the rejected value back to a prior-step `$context.*` write. If you see the rejection message with **no** `💡 Hint:` line, the mismatch came from somewhere else (hardcoded sample_request, stale fixture, user-provided `--request` override) and the fix lives closer to the storyboard itself.
+The runner only prints a hint when it can trace the rejected value back to a prior-step `$context.*` write. **No hint?** The mismatch came from somewhere else — a hardcoded `sample_request` in the storyboard, a stale fixture, or a `--request` override. Fix the storyboard, not the handler.
 
-The hint is diagnostic-only; pass/fail is decided by the step result, not by the presence of hints. Hints also land in:
+Hints are diagnostic-only; pass/fail is decided by the step result, not by hint presence.
 
-- **JUnit XML** — appended to the `<failure>` body as `Hint (context_value_rejected): …`, and used as the `message=` attribute when `step.error` is empty (e.g. validation-only failures on 200-OK responses).
-- **JSON report** (`--format json`) — on `StoryboardStepResult.hints[]`.
+### For CI dashboards
 
-Each hint carries structured fields (`context_key`, `source_step_id`, `source_kind`, `response_path`, `rejected_value`, `accepted_values`, `error_code`) so CI dashboards can aggregate rejections by source step / context key to spot systemic catalog-drift.
+Hints also land in machine-readable output:
+
+- **JUnit XML** — appended to the `<failure>` body as `Hint (context_value_rejected): …`, and used as the `message=` attribute when `step.error` is empty (e.g. validation-only failures on 200-OK responses):
+
+  ```xml
+  <failure message="Rejected `pricing_option_id: po_prism_abandoner_cpm` …" type="StoryboardFailure">
+  Pricing option not found: po_prism_abandoner_cpm
+  Hint (context_value_rejected): Rejected `pricing_option_id: po_prism_abandoner_cpm` …
+  </failure>
+  ```
+
+- **JSON report** (`--format json`) — on `StoryboardStepResult.hints[]` as `ContextValueRejectedHint` objects. Fields: `kind`, `context_key`, `source_step_id`, `source_kind`, `response_path`, `source_task`, `rejected_value`, `request_field`, `accepted_values`, `error_code`, `message`. Dashboards can aggregate rejections by `source_step_id` or `context_key` to spot systemic catalog-drift. See `StoryboardStepHint` / `ContextValueRejectedHint` types exported from `@adcp/client/testing`.
+
+> The rejection-envelope shape (`errors[].details.available` etc.) is tracked in [adcontextprotocol/adcp#3049](https://github.com/adcontextprotocol/adcp/issues/3049); field names here may evolve as the spec pins a canonical key.
 
 ---
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -327,6 +327,40 @@ Use before merging skill changes. ~60s per pair; matrix runs fan out.
 
 ---
 
+## Reading `💡 Hint:` lines (context-value rejections)
+
+When the storyboard runner prints output like this:
+
+```
+❌ Activate PII signal (412ms)
+   Task: activate_signal
+   Error: Pricing option not found: po_prism_abandoner_cpm
+   💡 Hint: Rejected `pricing_option_id: po_prism_abandoner_cpm` was extracted
+           from `$context.first_signal_pricing_option_id` (set by step
+           `search_by_spec` from response path
+           `signals[0].pricing_options[0].pricing_option_id`). Seller's
+           accepted values: [po_prism_cart_cpm].
+```
+
+…the failure is almost always **your catalog is inconsistent across tools**, not an SDK bug. The runner is telling you:
+
+1. Step `search_by_spec` wrote `po_prism_abandoner_cpm` into `$context.first_signal_pricing_option_id` — extracted from `signals[0].pricing_options[0].pricing_option_id` on your own `get_signals` response.
+2. Step `activate_signal` sent that id back to you.
+3. Your `activate_signal` handler rejected it with `available: [po_prism_cart_cpm]`.
+
+So `get_signals` advertised one id and `activate_signal` accepted a different one. Fix by unifying the catalog source — typically the two handlers should read from the same store instead of each returning independently-built lists.
+
+Hints only fire when the runner can trace the rejected value back to a prior-step `$context.*` write. If you see the rejection message with **no** `💡 Hint:` line, the mismatch came from somewhere else (hardcoded sample_request, stale fixture, user-provided `--request` override) and the fix lives closer to the storyboard itself.
+
+The hint is diagnostic-only; pass/fail is decided by the step result, not by the presence of hints. Hints also land in:
+
+- **JUnit XML** — appended to the `<failure>` body as `Hint (context_value_rejected): …`, and used as the `message=` attribute when `step.error` is empty (e.g. validation-only failures on 200-OK responses).
+- **JSON report** (`--format json`) — on `StoryboardStepResult.hints[]`.
+
+Each hint carries structured fields (`context_key`, `source_step_id`, `source_kind`, `response_path`, `rejected_value`, `accepted_values`, `error_code`) so CI dashboards can aggregate rejections by source step / context key to spot systemic catalog-drift.
+
+---
+
 ## When each check fails: debug first-lookups
 
 | Failure | First lookup |
@@ -334,6 +368,7 @@ Use before merging skill changes. ~60s per pair; matrix runs fan out.
 | `storyboard run` skips steps with "no webhook_receiver_runner" | Add `--webhook-receiver` |
 | `storyboard run` fails on `security_baseline` | You skipped `authenticate` in `serve()` — see [build-seller-agent/SKILL.md § signed-requests](../../skills/build-seller-agent/SKILL.md) |
 | `storyboard run` reports `Agent requires OAuth` / exits without running | Save tokens once with `adcp --save-auth <alias> <url> --oauth`, or pass `--oauth` to `storyboard run` to complete auth inline |
+| `storyboard run` prints `💡 Hint: Rejected …` below an error | Catalog inconsistency between the two tools — see [§ Reading hint lines](#reading--hint-lines-context-value-rejections) above |
 | `fuzz` reports `500` status with stack trace | Validate inputs and return `adcpError('REFERENCE_NOT_FOUND', ...)` instead |
 | `fuzz` reports `response_shape_mismatch` | Response drifted from schema — regen with `npm run sync-schemas` + check your handler |
 | Multi-instance fails with `NOT_FOUND` on read-after-write | State keyed by session ID instead of `(brand, account)` — see multi-instance guide |


### PR DESCRIPTION
Follow-up to #870 / #875 / #891 / #900.

## Summary

The hint feature shipped across eight PRs without user-facing docs. This adds a section to \`docs/guides/VALIDATE-YOUR-AGENT.md\` walking through:

- A concrete \`activate_signal\` rejection example with the hint output
- What each field of the hint means (\`context_key\`, \`source_step_id\`, \`response_path\`, \`rejected_value\`, \`accepted_values\`)
- What the hint implies: seller-side catalog inconsistency between two tools (e.g. \`get_signals\` + \`activate_signal\` disagreeing), almost never an SDK bug
- Where hints land in JUnit XML and JSON report output
- A row in the existing "debug first-lookups" table pointing at the new section

Also updates the \`CLAUDE.md\` validate-agent pointer so the hint docs are advertised.

No code / behavior changes. Empty changeset attached.

## Test plan

- [x] Markdown-only diff; renders correctly on github.com.
- [x] No broken links (the section anchors are self-referential).

🤖 Generated with [Claude Code](https://claude.com/claude-code)