### PR TITLE
feat(testing): add rawA2aProbe for A2A transport-layer storyboard diagnostics

### DIFF
--- a/.changeset/raw-a2a-probe.md
+++ b/.changeset/raw-a2a-probe.md
@@ -1,0 +1,12 @@
+---
+"@adcp/client": minor
+---
+
+feat(testing): add rawA2aProbe for A2A transport-layer storyboard diagnostics
+
+Adds `rawA2aProbe({ agentUrl, method, params?, headers?, allowPrivateIp? })` to
+`src/lib/testing/storyboard/probes.ts`, mirroring `rawMcpProbe` for agents
+exposed over the A2A transport. Returns `{ httpResult: HttpProbeResult;
+taskResult?: TaskResult }` so the storyboard `ValidationContext` can consume both
+probes interchangeably. Surfaces raw JSON-RPC error codes (including A2A-specific
+`-32002 TaskNotCancelable`) without protocol aliasing.

--- a/src/lib/testing/storyboard/probes.ts
+++ b/src/lib/testing/storyboard/probes.ts
@@ -447,8 +447,7 @@ export async function rawA2aProbe(options: {
     }
 
     const data = rpc.result;
-    const extractionPath: 'text_fallback' | 'none' =
-      data !== undefined && data !== null ? 'text_fallback' : 'none';
+    const extractionPath: 'text_fallback' | 'none' = data !== undefined && data !== null ? 'text_fallback' : 'none';
     return { httpResult, taskResult: { success: true, data, _extraction_path: extractionPath } };
   } catch (err) {
     httpResult.error = err instanceof Error ? err.message : String(err);

--- a/src/lib/testing/storyboard/probes.ts
+++ b/src/lib/testing/storyboard/probes.ts
@@ -324,6 +324,138 @@ export async function rawMcpProbe(options: {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Raw-A2A probe (transport-layer diagnostics for A2A agents)
+// ---------------------------------------------------------------------------
+
+/**
+ * POST a JSON-RPC 2.0 request to an A2A agent endpoint with caller-provided
+ * headers. Bypasses the A2A SDK so raw HTTP status, headers, and JSON-RPC
+ * error codes can be captured by storyboard diagnostics.
+ *
+ * Mirrors `rawMcpProbe` in structure and SSRF-safety contract. Key
+ * differences from the MCP variant:
+ *
+ * - The caller supplies `method` + optional `params` (not a fixed `tools/call`
+ *   body). A2A has no single canonical method — use `"message/send"` for most
+ *   auth and error-code probes, `"tasks/get"` / `"tasks/cancel"` for lifecycle
+ *   checks. **Note:** `message/send` requires `params.message` (a full A2A
+ *   `Message` object with `messageId`, `role`, `kind`, `parts`). Passing
+ *   `params: {}` will produce `-32602 Invalid params` from a conformant server,
+ *   masking auth rejections — supply a minimal message when probing auth paths.
+ * - A2A JSON-RPC error codes differ from MCP's. Notably `-32002` means
+ *   `TaskNotCancelable` in A2A (not session-not-initialized). The probe
+ *   surfaces raw numeric codes without protocol-specific aliasing so
+ *   storyboards can assert on the exact code.
+ * - SSE (streaming) responses are handled the same way as `rawMcpProbe`:
+ *   `Accept: application/json` is sent; non-JSON bodies surface a distinct
+ *   error so callers don't mistake an event-stream for a silent success.
+ *
+ * **Args are not secret** — must not contain credentials or PII. The
+ * server's response body lands in `httpResult.body` and is written to
+ * compliance reports.
+ *
+ * Returns an `HttpProbeResult` plus an optional `TaskResult` (same shape as
+ * `rawMcpProbe`) so the storyboard `ValidationContext` can consume both probes
+ * interchangeably. The A2A success `_extraction_path` is `'text_fallback'`
+ * (not `'structured_content'`) because A2A's `result` field is a plain object,
+ * not an MCP structured-content envelope.
+ */
+export async function rawA2aProbe(options: {
+  /** Base URL of the A2A agent endpoint (e.g. `https://agent.example.com/a2a`). */
+  agentUrl: string;
+  /** A2A/JSON-RPC 2.0 method name (e.g. `"message/send"`, `"tasks/get"`). */
+  method: string;
+  /** JSON-RPC params. Defaults to `{}` so the probe always emits a valid envelope. */
+  params?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  /** Allow http:// and private-IP agent URLs (dev loops). Default false. */
+  allowPrivateIp?: boolean;
+}): Promise<{ httpResult: HttpProbeResult; taskResult?: TaskResult }> {
+  const { agentUrl, method, params, headers = {}, allowPrivateIp = false } = options;
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: ++probeRequestId,
+    method,
+    params: params ?? {},
+  });
+
+  const httpResult: HttpProbeResult = { url: agentUrl, status: 0, headers: {}, body: null };
+  try {
+    const res = await ssrfSafeFetch(agentUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json',
+        ...headers,
+      },
+      body,
+      allowPrivateIp,
+    });
+    httpResult.status = res.status;
+    httpResult.headers = res.headers;
+
+    const text = Buffer.from(res.body.buffer, res.body.byteOffset, res.body.byteLength).toString('utf8');
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      httpResult.body = text;
+      return {
+        httpResult,
+        taskResult: {
+          success: false,
+          data: undefined,
+          error: `Non-JSON response body (content-type: ${httpResult.headers['content-type'] ?? 'unknown'}).`,
+          _extraction_path: 'error',
+        },
+      };
+    }
+    httpResult.body = parsed;
+
+    const rpc = parsed as {
+      result?: unknown;
+      error?: { message?: string; code?: number };
+    };
+
+    if (httpResult.status >= 400) {
+      return {
+        httpResult,
+        taskResult: {
+          success: false,
+          data: undefined,
+          error: rpc.error?.message ?? `HTTP ${httpResult.status}`,
+          _extraction_path: 'error',
+        },
+      };
+    }
+
+    if (rpc.error) {
+      const code = rpc.error.code;
+      return {
+        httpResult,
+        taskResult: {
+          success: false,
+          data: undefined,
+          error:
+            code !== undefined
+              ? `JSON-RPC error ${code}: ${rpc.error.message ?? 'no message'}`
+              : (rpc.error.message ?? 'JSON-RPC error (no code)'),
+          _extraction_path: 'error',
+        },
+      };
+    }
+
+    const data = rpc.result;
+    const extractionPath: 'text_fallback' | 'none' =
+      data !== undefined && data !== null ? 'text_fallback' : 'none';
+    return { httpResult, taskResult: { success: true, data, _extraction_path: extractionPath } };
+  } catch (err) {
+    httpResult.error = err instanceof Error ? err.message : String(err);
+    return { httpResult };
+  }
+}
+
 // IP classifiers live in `src/lib/net/address-guards.ts` so the SSRF-safe
 // fetch primitive can use them without depending on the testing module.
 // Re-exported here for existing import sites (storyboard-security test + any

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -11,6 +11,7 @@ const {
   generateRandomInvalidApiKey,
   generateRandomInvalidJwt,
   rawMcpProbe,
+  rawA2aProbe,
 } = require('../../dist/lib/testing/storyboard/probes');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
 const { loadStoryboardFile } = require('../../dist/lib/testing/storyboard/loader');
@@ -472,6 +473,217 @@ describe('rawMcpProbe', () => {
     });
     assert.strictEqual(httpResult.status, 0);
     assert.match(httpResult.error ?? '', /non-HTTPS/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// rawA2aProbe end-to-end (against a generated A2A agent server)
+// ────────────────────────────────────────────────────────────
+
+describe('rawA2aProbe', () => {
+  it('sends JSON-RPC message/send and surfaces HTTP 200 + text_fallback extraction', async () => {
+    let seenBody, seenAuth, seenAccept;
+    const server = http.createServer(async (req, res) => {
+      seenAuth = req.headers.authorization ?? null;
+      seenAccept = req.headers.accept ?? null;
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      seenBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: seenBody.id,
+          result: { kind: 'task', id: 'task_abc', status: { state: 'submitted' } },
+        })
+      );
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawA2aProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/a2a`,
+        method: 'message/send',
+        params: {
+          message: {
+            messageId: 'msg_1',
+            role: 'user',
+            kind: 'message',
+            parts: [{ kind: 'text', text: 'ping' }],
+          },
+        },
+        headers: { authorization: 'Bearer sk_test' },
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 200);
+      assert.strictEqual(seenAuth, 'Bearer sk_test');
+      assert.strictEqual(seenAccept, 'application/json');
+      assert.strictEqual(seenBody.jsonrpc, '2.0');
+      assert.strictEqual(seenBody.method, 'message/send');
+      assert.strictEqual(taskResult.success, true);
+      // A2A result is plain object, not structured-content envelope
+      assert.strictEqual(taskResult._extraction_path, 'text_fallback');
+      assert.deepStrictEqual(taskResult.data, {
+        kind: 'task',
+        id: 'task_abc',
+        status: { state: 'submitted' },
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  it('defaults params to {} when caller omits them', async () => {
+    let seenBody;
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      seenBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: seenBody.id, result: {} }));
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      await rawA2aProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/a2a`,
+        method: 'tasks/get',
+        allowPrivateIp: true,
+      });
+      assert.deepStrictEqual(seenBody.params, {});
+    } finally {
+      server.close();
+    }
+  });
+
+  it('surfaces 401 + WWW-Authenticate from the agent', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(401, {
+        'content-type': 'application/json',
+        'www-authenticate': 'Bearer realm="agent", error="invalid_token"',
+      });
+      res.end(JSON.stringify({ error: 'unauthorized' }));
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawA2aProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/a2a`,
+        method: 'message/send',
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 401);
+      assert.match(httpResult.headers['www-authenticate'], /Bearer realm/);
+      assert.strictEqual(taskResult.success, false);
+      assert.strictEqual(taskResult._extraction_path, 'error');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('surfaces A2A -32002 (TaskNotCancelable) as-is, without MCP session-init aliasing', async () => {
+    // Distinct from rawMcpProbe: in A2A, -32002 is TaskNotCancelable.
+    // The probe must not relabel it as "session not initialized."
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: rpc.id,
+          error: { code: -32002, message: 'Task is not in a cancelable state' },
+        })
+      );
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawA2aProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/a2a`,
+        method: 'tasks/cancel',
+        params: { id: 'task_abc' },
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 200);
+      assert.strictEqual(taskResult.success, false);
+      assert.strictEqual(taskResult.error, 'JSON-RPC error -32002: Task is not in a cancelable state');
+      // Full raw code is preserved in the error string
+      // Must NOT be labeled as MCP-session-init
+      assert.doesNotMatch(taskResult.error, /session.*(?:not.*)?initialized/i);
+      assert.strictEqual(httpResult.body.error.code, -32002, 'raw numeric code preserved on httpResult.body');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('refuses https:// loopback agent URLs by default (no allowPrivateIp)', async () => {
+    const { httpResult } = await rawA2aProbe({
+      agentUrl: 'https://127.0.0.1:1/a2a',
+      method: 'message/send',
+    });
+    assert.strictEqual(httpResult.status, 0);
+    assert.match(httpResult.error ?? '', /private\/loopback/);
+  });
+
+  it('refuses IMDS (169.254.169.254) even when allowPrivateIp is on', async () => {
+    const { httpResult } = await rawA2aProbe({
+      agentUrl: 'http://169.254.169.254/a2a',
+      method: 'message/send',
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(httpResult.status, 0);
+    assert.match(httpResult.error ?? '', /always-blocked/);
+  });
+
+  it('refuses non-HTTPS URLs by default', async () => {
+    const { httpResult } = await rawA2aProbe({
+      agentUrl: 'http://example.com/a2a',
+      method: 'message/send',
+    });
+    assert.strictEqual(httpResult.status, 0);
+    assert.match(httpResult.error ?? '', /non-HTTPS/);
+  });
+
+  it('surfaces distinct error on non-JSON response body (e.g., SSE leaking through)', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'text/event-stream' });
+      res.end('event: message\ndata: {"foo":"bar"}\n\n');
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const { httpResult, taskResult } = await rawA2aProbe({
+        agentUrl: `http://127.0.0.1:${server.address().port}/a2a`,
+        method: 'message/send',
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(httpResult.status, 200);
+      assert.strictEqual(taskResult.success, false);
+      assert.strictEqual(taskResult._extraction_path, 'error');
+      assert.match(taskResult.error, /Non-JSON response body/);
+      assert.match(taskResult.error, /text\/event-stream/);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('uses a per-call incrementing id (no collision with prior calls)', async () => {
+    const seenIds = [];
+    const server = http.createServer(async (req, res) => {
+      const chunks = [];
+      for await (const c of req) chunks.push(c);
+      const rpc = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      seenIds.push(rpc.id);
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: rpc.id, result: {} }));
+    });
+    await new Promise(r => server.listen(0, r));
+    try {
+      const agentUrl = `http://127.0.0.1:${server.address().port}/a2a`;
+      await rawA2aProbe({ agentUrl, method: 'tasks/get', allowPrivateIp: true });
+      await rawA2aProbe({ agentUrl, method: 'tasks/get', allowPrivateIp: true });
+      assert.strictEqual(seenIds.length, 2);
+      assert.notStrictEqual(seenIds[0], seenIds[1]);
+    } finally {
+      server.close();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #905

## Summary

- Adds `rawA2aProbe({ agentUrl, method, params?, headers?, allowPrivateIp? })` to `src/lib/testing/storyboard/probes.ts`
- Returns `{ httpResult: HttpProbeResult; taskResult?: TaskResult }` — same shape as `rawMcpProbe` so the storyboard `ValidationContext` consumes both probes interchangeably
- Constructs the JSON-RPC 2.0 envelope internally (uses shared `probeRequestId` counter, no id collisions)
- Surfaces raw A2A error codes without protocol aliasing — `-32002` means `TaskNotCancelable` in A2A (not session-not-initialized as in MCP)
- `_extraction_path` on success is `'text_fallback'` (not `'structured_content'`) since A2A's `result` is a plain object, not an MCP structured-content envelope
- Includes `allowPrivateIp` parity with `rawMcpProbe` for dev-loop localhost agents

## What tested

- Verified pre-existing CI env failures (missing `@types/node`, deprecated `moduleResolution`) predate this PR — confirmed by `git stash` + retest
- `rawA2aProbe` is structurally identical to `rawMcpProbe`; all SSRF guards, body-cap, and timeout behavior inherited from `ssrfSafeFetch`
- Runner wiring (`runner.ts`) is intentional follow-up: the runner currently skips raw-probe dispatch for A2A (`options.protocol !== 'a2a'`); `rawA2aProbe` is available as a direct storyboard utility until that integration ships

## Pre-PR review

- **code-reviewer:** approved — fixed `_extraction_path` misnomer (`'structured_content'` → `'text_fallback'`), removed unused `data?` from error cast, added `message/send` params warning to JSDoc
- **ad-tech-protocol-expert:** approved — JSON-RPC 2.0 envelope matches A2A 0.3.0 wire format; SSE-avoidance strategy consistent with spec; A2A error code disambiguation correct

## Nits surfaced (not fixed, not blockers)

- `Buffer.from(...)` body decode could reuse `decodeBodyAsJsonOrText` for future-proof consistency — deferred to avoid scope creep
- `rawAgentCardProbe` follow-up (noted in issue) deferred; `buildCardUrls` + `A2A_CARD_PATHS` from `src/lib/utils/a2a-discovery.ts` make it trivial when ready

Session: https://claude.ai/code/session_01HWXiPZ34tLttJH2uQrHmuy

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWXiPZ34tLttJH2uQrHmuy)_