### PR TITLE
fix(runner): hint detector recognizes adcp_error envelope (#907)

### DIFF
--- a/.changeset/hint-detector-adcp-error-envelope.md
+++ b/.changeset/hint-detector-adcp-error-envelope.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Runner hint detector now recognizes the `adcp_error` (singular object) response envelope — what the canonical `adcpError()` SDK helper emits — alongside the `errors[]` (plural array) shape it already handled. Closes adcp-client#907. Surfaced during dogfood: agents built on the helper (the recommended pattern) were silently missing `context_value_rejected` hints because the detector only read `errors[]`. Also accepts `adcp_error: [...]` defensively. When both shapes are present in one response, the plural `errors[]` wins (spec-canonical).

--- a/src/lib/testing/storyboard/rejection-hints.ts
+++ b/src/lib/testing/storyboard/rejection-hints.ts
@@ -54,8 +54,16 @@ export function detectContextRejectionHints(
   if (!taskResult) return [];
   const data = taskResult.data as Record<string, unknown> | undefined;
   if (!data) return [];
-  const errors = data.errors;
-  if (!Array.isArray(errors)) return [];
+  // Normalize both envelope shapes the AdCP error surface produces:
+  //   - `errors: [{...}]` — plural array (AdCP core/error.json)
+  //   - `adcp_error: {...}` — singular object, what the canonical
+  //     `adcpError()` SDK helper emits. Most sellers use the helper, so
+  //     without this normalization the hint would silently never fire
+  //     against them (dogfood surfaced this; see adcp-client#907).
+  // Also accepts `adcp_error: [{...}]` defensively in case a seller
+  // ever emits the key with an array payload.
+  const errors = resolveErrorsList(data);
+  if (!errors) return [];
 
   const hints: StoryboardStepHint[] = [];
   // De-dupe: the same (context_key, rejected_value) shouldn't produce
@@ -231,6 +239,24 @@ function formatScalar(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+/**
+ * Normalize the response body's error envelope into a flat list for the
+ * hint detector. Recognizes:
+ *   - `errors: [{...}]` — AdCP core/error.json shape
+ *   - `adcp_error: {...}` — what `adcpError()` helper produces
+ *   - `adcp_error: [{...}]` — defensive; some sellers emit this
+ * Returns undefined when neither shape is present or the values aren't
+ * objects we can inspect.
+ */
+function resolveErrorsList(data: Record<string, unknown>): unknown[] | undefined {
+  const errors = data.errors;
+  if (Array.isArray(errors)) return errors;
+  const adcpError = data.adcp_error;
+  if (Array.isArray(adcpError)) return adcpError;
+  if (adcpError && typeof adcpError === 'object') return [adcpError];
+  return undefined;
 }
 
 function findAcceptedValues(

--- a/test/lib/storyboard-rejection-hints.test.js
+++ b/test/lib/storyboard-rejection-hints.test.js
@@ -351,6 +351,100 @@ describe('detectContextRejectionHints', () => {
     assert.deepEqual(hints, []);
   });
 
+  test('recognizes adcp_error singular envelope from adcpError() SDK helper', () => {
+    // `adcpError()` produces `{ adcp_error: { code, message, field, details, ... } }`
+    // (singular object). Most sellers use the helper, so the detector
+    // must treat this as a one-element errors list. Surfaced during
+    // dogfood (#907).
+    const taskResult = {
+      success: false,
+      data: {
+        adcp_error: {
+          code: 'PRODUCT_NOT_FOUND',
+          message: "Product 'prod-a' not found",
+          recovery: 'correctable',
+          field: 'packages[0].product_id',
+          details: { available: ['prod-b'] },
+        },
+      },
+    };
+    const request = { packages: [{ product_id: 'prod-a' }] };
+    const context = { first_product_id: 'prod-a' };
+    const prov = provenance({
+      first_product_id: {
+        source_step_id: 'discover',
+        source_kind: 'context_outputs',
+        response_path: 'products[0].product_id',
+        source_task: 'get_products',
+      },
+    });
+    const hints = detectContextRejectionHints(taskResult, request, context, prov);
+    assert.equal(hints.length, 1);
+    assert.equal(hints[0].error_code, 'PRODUCT_NOT_FOUND');
+    assert.equal(hints[0].context_key, 'first_product_id');
+    assert.equal(hints[0].rejected_value, 'prod-a');
+    assert.deepEqual(hints[0].accepted_values, ['prod-b']);
+  });
+
+  test('recognizes adcp_error array envelope (defensive)', () => {
+    // Some sellers have been observed emitting `adcp_error` as an array
+    // rather than the canonical singular object. Handle both.
+    const taskResult = {
+      success: false,
+      data: {
+        adcp_error: [
+          {
+            code: 'INVALID_REQUEST',
+            message: 'bad',
+            field: 'x',
+            details: { available: ['ok'] },
+          },
+        ],
+      },
+    };
+    const request = { x: 'bad' };
+    const context = { x: 'bad' };
+    const prov = provenance({
+      x: { source_step_id: 's', source_kind: 'convention' },
+    });
+    const hints = detectContextRejectionHints(taskResult, request, context, prov);
+    assert.equal(hints.length, 1);
+    assert.deepEqual(hints[0].accepted_values, ['ok']);
+  });
+
+  test('prefers errors[] when both envelope shapes are present', () => {
+    // Defensive: if an agent somehow emits BOTH (shouldn't happen but
+    // possible in a migration), read the plural array — it's the
+    // authoritative spec shape.
+    const taskResult = {
+      success: false,
+      data: {
+        errors: [
+          {
+            code: 'FROM_ARRAY',
+            message: '1',
+            field: 'x',
+            details: { available: ['ok'] },
+          },
+        ],
+        adcp_error: {
+          code: 'FROM_SINGULAR',
+          message: '2',
+          field: 'x',
+          details: { available: ['different'] },
+        },
+      },
+    };
+    const request = { x: 'bad' };
+    const context = { x: 'bad' };
+    const prov = provenance({
+      x: { source_step_id: 's', source_kind: 'convention' },
+    });
+    const hints = detectContextRejectionHints(taskResult, request, context, prov);
+    assert.equal(hints.length, 1);
+    assert.equal(hints[0].error_code, 'FROM_ARRAY');
+  });
+
   test('no hint when taskResult is undefined', () => {
     const prov = provenance({});
     const hints = detectContextRejectionHints(undefined, {}, {}, prov);


### PR DESCRIPTION
Closes #907. Surfaced during dogfood.

## Problem

The hint detector at \`src/lib/testing/storyboard/rejection-hints.ts:57\` only read \`data.errors[]\` (plural array). The canonical \`adcpError()\` SDK helper (\`src/lib/server/errors.ts\` — the pattern the SKILL files teach) produces \`data.adcp_error: {...}\` (singular object). Against any seller using the helper, hints silently never fired.

Not caught by earlier PRs because every test (unit + e2e in #896) used the \`errors[]\` shape.

## Fix

One helper (\`resolveErrorsList\`) normalizes:
- \`errors: [{...}]\` — AdCP core/error.json plural shape
- \`adcp_error: {...}\` — \`adcpError()\` helper output
- \`adcp_error: [...]\` — defensive for observed array variants
- Both present → \`errors[]\` wins (spec-canonical)

## Test plan

- [x] 3 new tests in \`test/lib/storyboard-rejection-hints.test.js\` pinning: singular adcpError path, array variant, both-shapes precedence.
- [x] Dogfood probe now fires correctly on the adcpError shape (\`[1]\` hint with all fields populated).
- [x] Full library suite: 4894 pass, 0 fail.
- [x] \`prettier --check\` + \`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)