### PR TITLE
fix(runner): hint closing cites source + current task, not key fragment

### DIFF
--- a/.changeset/hint-tail-polish.md
+++ b/.changeset/hint-tail-polish.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Runner `context_value_rejected` hint closing sentence now cites the two tool names involved in the catalog drift (e.g. "Check that the seller's `get_signals` and `activate_signal` catalogs agree.") instead of deriving an identifier fragment from the context key. The previous phrasing ("Check that the seller's catalogs agree on the id for this `first_signal_pricing_option` across steps.") read awkwardly when the key was multi-word — surfaced during dogfood. Falls back to the single-task form when only the source tool is known, and to a generic closing when neither is known. The detector now accepts an optional `currentTask` argument; existing callers keep working unchanged (generic closing).

--- a/src/lib/testing/storyboard/rejection-hints.ts
+++ b/src/lib/testing/storyboard/rejection-hints.ts
@@ -49,7 +49,15 @@ export function detectContextRejectionHints(
   taskResult: TaskResult | undefined,
   request: Record<string, unknown>,
   context: StoryboardContext,
-  provenance: ReadonlyMap<string, ContextProvenanceEntry>
+  provenance: ReadonlyMap<string, ContextProvenanceEntry>,
+  /**
+   * Current step's AdCP task name (e.g. `activate_signal`). Used only to
+   * produce a human-readable closing sentence that cites both tools
+   * involved in the catalog drift — "Check that `get_signals` and
+   * `activate_signal` catalogs agree." Optional for backwards
+   * compatibility; callers that can't supply it get a generic closing.
+   */
+  currentTask?: string
 ): StoryboardStepHint[] {
   if (!taskResult) return [];
   const data = taskResult.data as Record<string, unknown> | undefined;
@@ -95,6 +103,7 @@ export function detectContextRejectionHints(
         context,
         provenance,
         emitted,
+        ...(currentTask !== undefined && { currentTask }),
       });
       if (hint) hints.push(hint);
       continue;
@@ -118,6 +127,7 @@ export function detectContextRejectionHints(
           rejectedValue: contextValue,
           acceptedValues,
           ...(errorCode !== undefined && { errorCode }),
+          ...(currentTask !== undefined && { currentTask }),
         })
       );
     }
@@ -134,6 +144,7 @@ interface BuildForValueInput {
   context: StoryboardContext;
   provenance: ReadonlyMap<string, ContextProvenanceEntry>;
   emitted: Set<string>;
+  currentTask?: string;
 }
 
 /**
@@ -145,7 +156,7 @@ interface BuildForValueInput {
  * to author distinct context keys to disambiguate.
  */
 function buildHintForValue(input: BuildForValueInput): StoryboardStepHint | undefined {
-  const { rejectedValue, fieldPath, acceptedValues, errorCode, context, provenance, emitted } = input;
+  const { rejectedValue, fieldPath, acceptedValues, errorCode, context, provenance, emitted, currentTask } = input;
   if (rejectedValue === undefined || rejectedValue === null) return undefined;
   // If the seller claims to accept the value they rejected, the error
   // shape is inconsistent — skip rather than emit a confusing hint.
@@ -164,6 +175,7 @@ function buildHintForValue(input: BuildForValueInput): StoryboardStepHint | unde
       acceptedValues,
       requestField: fieldPath,
       ...(errorCode !== undefined && { errorCode }),
+      ...(currentTask !== undefined && { currentTask }),
     });
   }
   return undefined;
@@ -176,16 +188,18 @@ interface BuildHintInput {
   acceptedValues: unknown[];
   requestField?: string;
   errorCode?: string;
+  currentTask?: string;
 }
 
 function buildHint(input: BuildHintInput): ContextValueRejectedHint {
-  const { contextKey, entry, rejectedValue, acceptedValues, requestField, errorCode } = input;
+  const { contextKey, entry, rejectedValue, acceptedValues, requestField, errorCode, currentTask } = input;
   const message = formatMessage({
     contextKey,
     entry,
     rejectedValue,
     acceptedValues,
     ...(requestField !== undefined && { requestField }),
+    ...(currentTask !== undefined && { currentTask }),
   });
   return {
     kind: 'context_value_rejected',
@@ -208,10 +222,11 @@ interface FormatMessageInput {
   rejectedValue: unknown;
   acceptedValues: unknown[];
   requestField?: string;
+  currentTask?: string;
 }
 
 function formatMessage(input: FormatMessageInput): string {
-  const { contextKey, entry, rejectedValue, acceptedValues, requestField } = input;
+  const { contextKey, entry, rejectedValue, acceptedValues, requestField, currentTask } = input;
   const valueRepr = formatScalar(rejectedValue);
   const fieldRepr = requestField ? `\`${requestField}: ${valueRepr}\`` : `\`${valueRepr}\``;
   const sourceDetail =
@@ -221,13 +236,31 @@ function formatMessage(input: FormatMessageInput): string {
         ? `set by step \`${entry.source_step_id}\` (convention extractor for \`${entry.source_task}\`)`
         : `set by step \`${entry.source_step_id}\``;
   const acceptedRepr = `[${acceptedValues.map(formatScalar).join(', ')}]`;
+  // Closing sentence prefers the two-task form ("`get_signals` and
+  // `activate_signal` catalogs agree") when both source and current task
+  // are known — reads naturally regardless of how the context key was
+  // named. Falls back to the single-task form ("the `get_signals`
+  // catalog") when only the source is known, and to a generic nudge when
+  // neither is known. The earlier context-key-derived phrasing read
+  // awkwardly for multi-word keys (`first_signal_pricing_option_id` →
+  // "for this first_signal_pricing_option"); cited by dogfood findings.
+  const closing = buildClosing(entry.source_task, currentTask);
   return (
     `Rejected ${fieldRepr} was extracted from \`$context.${contextKey}\` ` +
     `(${sourceDetail}). ` +
     `Seller's accepted values: ${acceptedRepr}. ` +
-    `Check that the seller's catalogs agree on the id for this ` +
-    `${contextKey.replace(/_id$/, '')} across steps.`
+    closing
   );
+}
+
+function buildClosing(sourceTask: string | undefined, currentTask: string | undefined): string {
+  if (sourceTask && currentTask && sourceTask !== currentTask) {
+    return `Check that the seller's \`${sourceTask}\` and \`${currentTask}\` catalogs agree.`;
+  }
+  if (sourceTask) {
+    return `Check that the seller's \`${sourceTask}\` catalog agrees with other tools.`;
+  }
+  return `Check that the seller's catalogs agree across tools.`;
 }
 
 function formatScalar(value: unknown): string {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1560,7 +1560,7 @@ async function executeStep(
   const stepFailed = !(passed && allValidationsPassed);
   const hints =
     stepFailed && runState.contextProvenance
-      ? detectContextRejectionHints(taskResult, request, context, runState.contextProvenance)
+      ? detectContextRejectionHints(taskResult, request, context, runState.contextProvenance, effectiveStep.task)
       : [];
 
   // Build next step preview

--- a/test/lib/storyboard-rejection-hints.test.js
+++ b/test/lib/storyboard-rejection-hints.test.js
@@ -662,6 +662,69 @@ describe('detectContextRejectionHints', () => {
     assert.match(hints[0].message, /convention extractor for `get_products`/);
   });
 
+  describe('currentTask → closing sentence (tail polish)', () => {
+    const baseTaskResult = {
+      success: false,
+      data: {
+        errors: [{ code: 'X', message: 'x', field: 'pricing_option_id', details: { available: ['po_b'] } }],
+      },
+    };
+    const request = { pricing_option_id: 'po_a' };
+    const context = { first_signal_pricing_option_id: 'po_a' };
+    const prov = provenance({
+      first_signal_pricing_option_id: {
+        source_step_id: 'discover',
+        source_kind: 'context_outputs',
+        response_path: 'signals[0].pricing_options[0].pricing_option_id',
+        source_task: 'get_signals',
+      },
+    });
+
+    test('both tasks known → closes with both tool names', () => {
+      const [hint] = detectContextRejectionHints(baseTaskResult, request, context, prov, 'activate_signal');
+      assert.match(hint.message, /Check that the seller's `get_signals` and `activate_signal` catalogs agree\.$/);
+    });
+
+    test('same source and current task → collapses to the single-task form', () => {
+      // A self-rejection (context written by and rejected by the same
+      // task) shouldn't produce "X and X catalogs agree" — fall through
+      // to single-task wording.
+      const [hint] = detectContextRejectionHints(baseTaskResult, request, context, prov, 'get_signals');
+      assert.match(hint.message, /Check that the seller's `get_signals` catalog agrees with other tools\.$/);
+    });
+
+    test('no currentTask passed → single-task form using source_task', () => {
+      const [hint] = detectContextRejectionHints(baseTaskResult, request, context, prov);
+      assert.match(hint.message, /Check that the seller's `get_signals` catalog agrees with other tools\.$/);
+    });
+
+    test('no source_task and no currentTask → generic closing', () => {
+      const bareProv = provenance({
+        first_signal_pricing_option_id: {
+          source_step_id: 'discover',
+          source_kind: 'context_outputs',
+          response_path: 'signals[0].pricing_options[0].pricing_option_id',
+          // no source_task
+        },
+      });
+      const [hint] = detectContextRejectionHints(baseTaskResult, request, context, bareProv);
+      assert.match(hint.message, /Check that the seller's catalogs agree across tools\.$/);
+    });
+
+    test('no key-derived identifier fragment ever appears in the closing', () => {
+      // Regression guard for the original bug — the previous formatter
+      // produced "for this first_signal_pricing_option across steps"
+      // (key minus _id suffix embedded as prose). The literal context
+      // key still appears earlier (in the `$context.<key>` substring);
+      // the guard scopes to the closing sentence, which starts after
+      // "Seller's accepted values: [...]."
+      const [hint] = detectContextRejectionHints(baseTaskResult, request, context, prov, 'activate_signal');
+      const closing = hint.message.split(/Seller's accepted values: \[[^\]]*\]\.\s*/)[1] ?? '';
+      assert.doesNotMatch(closing, /first_signal_pricing_option/);
+      assert.doesNotMatch(closing, /for this [a-z_]+\b across/);
+    });
+  });
+
   test('empty provenance map yields no hints (provenance gate, not value absence)', () => {
     // With the request carrying `a: "c"` and the error rejecting "c",
     // the only thing holding the hint back is the empty provenance map —


### PR DESCRIPTION
Dogfood found the existing closing sentence reads awkwardly on multi-word context keys. This replaces the key-derived identifier fragment with actual tool names.

## Before / after

\`\`\`
BEFORE: "Check that the seller's catalogs agree on the id for this
         first_signal_pricing_option across steps."

AFTER:  "Check that the seller's \`get_signals\` and \`activate_signal\`
         catalogs agree."
\`\`\`

## How

\`detectContextRejectionHints\` accepts an optional \`currentTask\` argument (the runner passes \`effectiveStep.task\`). The closing has four forms, picked by which tasks are known:

- source + current, different → \`Check that the seller's \`X\` and \`Y\` catalogs agree.\`
- source == current (self-rejection) → \`Check that the seller's \`X\` catalog agrees with other tools.\`
- only source known → same single-task form
- neither known → \`Check that the seller's catalogs agree across tools.\`

## Test plan

- [x] 5 new tests pinning each fallback variant + a regression guard against the old identifier-fragment phrasing reappearing (scoped to the closing sentence — the literal \`\$context.<key>\` substring still appears earlier in the message).
- [x] Existing 24 hint tests still pass (they didn't pin the closing).
- [x] Full lib suite: 4852 pass, 0 fail.
- [x] \`prettier\` + \`tsc\` clean.
- [x] Live dogfood confirms new closing renders as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)