### PR TITLE
docs(guides): fix create_media_buy example payload + add --protocol a2a examples

### DIFF
--- a/.changeset/fix-docs-create-media-buy-example.md
+++ b/.changeset/fix-docs-create-media-buy-example.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Fix docs/guides/BUILD-AN-AGENT.md create_media_buy CLI example to match current schema: PackageRequest uses `product_id` + `budget` (plain number) + `pricing_option_id`; `brand` uses `{domain}` discriminator; `idempotency_key` is required. Adds `--protocol a2a` usage examples to VALIDATE-YOUR-AGENT.md.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -502,17 +502,18 @@ npx @adcp/client@latest http://localhost:3001/mcp get_signals '{}' --json
 
 ```bash
 # Create a media buy (mutating tool — requires idempotency_key)
-# Schema traps: package-level budget is a plain number (not {amount,currency}); brand uses {domain} (not {brand_id});
+# Schema traps: idempotency_key must be 16-255 chars (UUID v4 recommended);
+# package-level budget is a plain number (not {amount,currency}); brand uses {domain} (not {brand_id});
 # packages require product_id, budget, and pricing_option_id
 npx @adcp/client@latest http://localhost:3001/mcp create_media_buy '{
+  "idempotency_key": "550e8400-e29b-41d4-a716-446655440000",
   "account": { "account_id": "acct_123" },
   "brand": { "domain": "acme.example" },
   "start_time": "2026-05-01T00:00:00Z",
   "end_time": "2026-05-31T23:59:59Z",
   "packages": [
     { "product_id": "p_sports_ctv", "budget": 10000, "pricing_option_id": "po_cpm_35" }
-  ],
-  "idempotency_key": "test-buy-001"
+  ]
 }'
 ```
 

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -474,50 +474,6 @@ const httpServer = createServer(async (req, res) => {
 });
 ```
 
-### A2A transport (preview)
-
-To serve A2A alongside MCP from the same process, use `createA2AAdapter`. Both transports share the same `AdcpServer` instance — handlers, idempotency store, and `resolveAccount` are all shared; no duplication required.
-
-```typescript
-import express from 'express';
-import { createAdcpServer, serve, createA2AAdapter } from '@adcp/client';
-
-const adcp = createAdcpServer({
-  name: 'My Publisher',
-  version: '1.0.0',
-  mediaBuy: { /* handlers */ },
-});
-
-// MCP — as today
-serve(() => adcp);
-
-// A2A — preview, same handlers
-const a2a = createA2AAdapter({
-  server: adcp,
-  agentCard: {
-    name: 'My Publisher',
-    description: 'Display and video inventory',
-    url: 'https://publisher.example/a2a',
-    version: '1.0.0',
-    provider: { organization: 'My Co', url: 'https://publisher.example' },
-    securitySchemes: { bearer: { type: 'http', scheme: 'bearer' } },
-  },
-  async authenticate(req) {
-    const token = req.headers.authorization?.replace(/^Bearer\s+/, '');
-    return token ? { token, clientId: 'buyer' } : null;
-  },
-});
-
-const app = express();
-app.use(express.json());
-// A2A spec requires the agent card at both the origin root and /.well-known/agent-card.json
-app.use('/.well-known/agent-card.json', a2a.agentCardHandler);
-app.use('/a2a', a2a.jsonRpcHandler);
-app.listen(3001);
-```
-
-`createA2AAdapter` seeds `skills[]`, `capabilities`, and `defaultInputModes` from `get_adcp_capabilities` automatically — supply only identity fields (`name`, `description`, `url`, `provider`, `securitySchemes`). Validators running `--protocol a2a` point at the base URL (`http://localhost:3001`), not the `/a2a` sub-path. For A2A validation, see [VALIDATE-YOUR-AGENT.md § Serving both transports](./VALIDATE-YOUR-AGENT.md#serving-both-transports-mcp--a2a).
-
 ## Testing Your Agent
 
 ### Tool Discovery

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -4,7 +4,7 @@
 
 This guide walks through building an AdCP agent (server) using `@adcp/client`. While most documentation covers the client side — calling existing agents — this guide covers the server side: implementing an agent that other clients can discover and call.
 
-We'll build a **signals agent** that serves audience segments via the `get_signals` tool. The same patterns apply to any AdCP tool (`get_products`, `create_media_buy`, etc.).
+We'll build a **signals agent** that serves audience segments via the `get_signals` tool. The same patterns apply to any AdCP tool (`get_products`, `create_media_buy`, etc.) — for mutating tools, see the `create_media_buy` example in the Calling Tools section below.
 
 ## Prerequisites
 
@@ -474,6 +474,50 @@ const httpServer = createServer(async (req, res) => {
 });
 ```
 
+### A2A transport (preview)
+
+To serve A2A alongside MCP from the same process, use `createA2AAdapter`. Both transports share the same `AdcpServer` instance — handlers, idempotency store, and `resolveAccount` are all shared; no duplication required.
+
+```typescript
+import express from 'express';
+import { createAdcpServer, serve, createA2AAdapter } from '@adcp/client';
+
+const adcp = createAdcpServer({
+  name: 'My Publisher',
+  version: '1.0.0',
+  mediaBuy: { /* handlers */ },
+});
+
+// MCP — as today
+serve(() => adcp);
+
+// A2A — preview, same handlers
+const a2a = createA2AAdapter({
+  server: adcp,
+  agentCard: {
+    name: 'My Publisher',
+    description: 'Display and video inventory',
+    url: 'https://publisher.example/a2a',
+    version: '1.0.0',
+    provider: { organization: 'My Co', url: 'https://publisher.example' },
+    securitySchemes: { bearer: { type: 'http', scheme: 'bearer' } },
+  },
+  async authenticate(req) {
+    const token = req.headers.authorization?.replace(/^Bearer\s+/, '');
+    return token ? { token, clientId: 'buyer' } : null;
+  },
+});
+
+const app = express();
+app.use(express.json());
+// A2A spec requires the agent card at both the origin root and /.well-known/agent-card.json
+app.use('/.well-known/agent-card.json', a2a.agentCardHandler);
+app.use('/a2a', a2a.jsonRpcHandler);
+app.listen(3001);
+```
+
+`createA2AAdapter` seeds `skills[]`, `capabilities`, and `defaultInputModes` from `get_adcp_capabilities` automatically — supply only identity fields (`name`, `description`, `url`, `provider`, `securitySchemes`). Validators running `--protocol a2a` point at the base URL (`http://localhost:3001`), not the `/a2a` sub-path. For A2A validation, see [VALIDATE-YOUR-AGENT.md § Serving both transports](./VALIDATE-YOUR-AGENT.md#serving-both-transports-mcp--a2a).
+
 ## Testing Your Agent
 
 ### Tool Discovery
@@ -498,6 +542,22 @@ npx @adcp/client@latest http://localhost:3001/mcp get_signals '{"filters":{"cata
 
 # JSON output for scripting
 npx @adcp/client@latest http://localhost:3001/mcp get_signals '{}' --json
+```
+
+```bash
+# Create a media buy (mutating tool — requires idempotency_key)
+# Schema traps: budget is a plain number (not {amount,currency}); brand uses {domain} (not {brand_id});
+# packages require buyer_ref and pricing_option_id
+npx @adcp/client@latest http://localhost:3001/mcp create_media_buy '{
+  "account": { "account_id": "acct_123" },
+  "brand": { "domain": "acme.example" },
+  "start_time": "2026-05-01T00:00:00Z",
+  "end_time": "2026-05-31T23:59:59Z",
+  "packages": [
+    { "buyer_ref": "pkg_1", "product_id": "p_sports_ctv", "budget": 10000, "pricing_option_id": "po_cpm_35" }
+  ],
+  "idempotency_key": "test-buy-001"
+}'
 ```
 
 ### Compliance Check

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -502,15 +502,15 @@ npx @adcp/client@latest http://localhost:3001/mcp get_signals '{}' --json
 
 ```bash
 # Create a media buy (mutating tool — requires idempotency_key)
-# Schema traps: budget is a plain number (not {amount,currency}); brand uses {domain} (not {brand_id});
-# packages require buyer_ref and pricing_option_id
+# Schema traps: package-level budget is a plain number (not {amount,currency}); brand uses {domain} (not {brand_id});
+# packages require product_id, budget, and pricing_option_id
 npx @adcp/client@latest http://localhost:3001/mcp create_media_buy '{
   "account": { "account_id": "acct_123" },
   "brand": { "domain": "acme.example" },
   "start_time": "2026-05-01T00:00:00Z",
   "end_time": "2026-05-31T23:59:59Z",
   "packages": [
-    { "buyer_ref": "pkg_1", "product_id": "p_sports_ctv", "budget": 10000, "pricing_option_id": "po_cpm_35" }
+    { "product_id": "p_sports_ctv", "budget": 10000, "pricing_option_id": "po_cpm_35" }
   ],
   "idempotency_key": "test-buy-001"
 }'

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -28,7 +28,7 @@ npx @adcp/client@latest storyboard run \
 
 If all five pass and your skill's specialism-specific checks below pass, you're conformant. The rest of this page explains why each check exists and how to debug failures.
 
-**Serving both transports (MCP + A2A)?** If your agent mounts MCP and A2A on the same process (via `serve()` + `createA2AAdapter`), run command sets 1–2 against both endpoints — storyboards and capability checks are protocol-independent. MCP validators target the `/mcp` sub-path; A2A validators target the base URL. See [BUILD-AN-AGENT.md § A2A transport](./BUILD-AN-AGENT.md#a2a-transport-preview) for the dual-mount setup.
+**Serving both transports (MCP + A2A)?** If your agent mounts MCP and A2A on the same process (via `serve()` + `createA2AAdapter`), run command sets 1–2 against both endpoints — storyboards and capability checks are protocol-independent. MCP validators target the `/mcp` sub-path; A2A validators target the base URL. See [BUILD-AN-AGENT.md § Exposing your agent over A2A](./BUILD-AN-AGENT.md#exposing-your-agent-over-a2a-preview) for the dual-mount setup.
 
 **Working on the agent locally?** Before you reach for the remote-agent commands above, see [`VALIDATE-LOCALLY.md`](./VALIDATE-LOCALLY.md) — the same storyboards, zero tunnel setup, ten lines of code. Point `--local-agent <module>` at your handlers or call `runAgainstLocalAgent` directly from a test file.
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -6,10 +6,12 @@ Your checklist to get from "agent boots" to "agent ships." Every tool below is a
 
 ```bash
 # 1. Does it answer at all? (60s)
-npx @adcp/client@latest http://localhost:3001/mcp get_adcp_capabilities '{}'
+npx @adcp/client@latest http://localhost:3001/mcp get_adcp_capabilities '{}'              # MCP
+npx @adcp/client@latest --protocol a2a http://localhost:3001 get_adcp_capabilities '{}'   # A2A (preview)
 
 # 2. Does it walk the golden path? (2–5 min)
-npx @adcp/client@latest storyboard run http://localhost:3001/mcp --auth $TOKEN
+npx @adcp/client@latest storyboard run http://localhost:3001/mcp --auth $TOKEN            # MCP
+npx @adcp/client@latest storyboard run --protocol a2a http://localhost:3001 --auth $TOKEN # A2A (preview)
 
 # 3. Does it crash on weird inputs? (1–3 min)
 npx @adcp/client@latest fuzz http://localhost:3001/mcp --auth-token $TOKEN
@@ -25,6 +27,8 @@ npx @adcp/client@latest storyboard run \
 ```
 
 If all five pass and your skill's specialism-specific checks below pass, you're conformant. The rest of this page explains why each check exists and how to debug failures.
+
+**Serving both transports (MCP + A2A)?** If your agent mounts MCP and A2A on the same process (via `serve()` + `createA2AAdapter`), run command sets 1–2 against both endpoints — storyboards and capability checks are protocol-independent. MCP validators target the `/mcp` sub-path; A2A validators target the base URL. See [BUILD-AN-AGENT.md § A2A transport](./BUILD-AN-AGENT.md#a2a-transport-preview) for the dual-mount setup.
 
 **Working on the agent locally?** Before you reach for the remote-agent commands above, see [`VALIDATE-LOCALLY.md`](./VALIDATE-LOCALLY.md) — the same storyboards, zero tunnel setup, ten lines of code. Point `--local-agent <module>` at your handlers or call `runAgainstLocalAgent` directly from a test file.
 


### PR DESCRIPTION
Closes #911

## Summary

- **BUILD-AN-AGENT.md** — adds a `create_media_buy` CLI example to the "Calling Tools" section with accurate `PackageRequest` shape: `product_id` + `budget` (plain number, not `{amount,currency}`) + `pricing_option_id`; `brand` uses `{domain}` discriminator; `idempotency_key` required. Inline schema-trap comments prevent the three most common copy-paste errors. Also updates the guide intro to forward-reference this new example.
- **VALIDATE-YOUR-AGENT.md** — adds `--protocol a2a` variants for commands 1 and 2 in the TL;DR block, plus a "Serving both transports (MCP + A2A)?" callout paragraph cross-linking to the A2A section added by PR #899.

No generated files edited. Docs-only change — no changeset required per CLAUDE.md.

## What was tested

- Verified `PackageRequest` type at `src/lib/types/tools.generated.ts:3767` — required fields are `product_id`, `budget`, `pricing_option_id`. No `buyer_ref` field exists; removed from earlier draft.
- Verified `BrandReference` discriminator: `{domain}` not `{brand_id}` against `docs/TYPE-SUMMARY.md`.
- Verified `createA2AAdapter` is exported from `@adcp/client` (`src/lib/index.ts:589`, `src/lib/server/index.ts:244`, `src/lib/server/a2a-adapter.ts:707`) — added by PR #899 (`42a66f3`).
- Verified anchor `#exposing-your-agent-over-a2a-preview` matches the PR #899 heading `### Exposing your agent over A2A (preview)` (GitHub slug algorithm: lowercase, strip parens, spaces→dashes).
- Confirmed no duplicate A2A sections — the redundant section (with wrong `/.well-known/agent-card.json` path) was removed; PR #899's `a2a.mount(app)` section is the single authoritative example.

## Pre-PR review

- **code-reviewer**: approved after 1 fix — removed non-existent `buyer_ref` from `PackageRequest` example; clarified comment to "package-level budget". Nit noted: intro sentence could link `[Calling Tools](#calling-tools)` rather than "below" in prose.
- **docs-expert**: pending second-pass result (first pass approved shape and anchors; second pass in flight at PR creation time).

## Out of scope (noted for follow-up)

- `REAL-WORLD-EXAMPLES.md` uses deprecated 4.x `ADCPMultiAgentClient` API throughout; `budget` shape there is also wrong, but fixing budget alone would mislead — the whole file needs a 5.x rewrite.
- Commands 3–5 in VALIDATE-YOUR-AGENT.md TL;DR (fuzz, webhook, multi-instance) don't have A2A variants yet — issue #911 only asked for 1–2.

---

Session: https://claude.ai/code/session_01MEfTvEQZL46ufGdZ8SvkCW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEfTvEQZL46ufGdZ8SvkCW)_