### PR TITLE
fix(server): symmetric MCP/A2A request validation (#909)

### DIFF
--- a/.changeset/909-validation-symmetry.md
+++ b/.changeset/909-validation-symmetry.md
@@ -1,0 +1,19 @@
+---
+'@adcp/client': minor
+---
+
+**Fix MCP/A2A validation asymmetry (#909).** Before this change, the MCP SDK's Zod validator ran only on the MCP transport — A2A bypassed it via `AdcpServer.invoke()`, so the same malformed request could be rejected on MCP (with a raw `-32602` JSON-RPC error) while silently reaching the handler on A2A. The framework AJV validator now runs authoritatively on both transports, producing a single structured `adcp_error` envelope with the same pointer-level `issues[]` regardless of transport.
+
+**Implementation:**
+
+- Framework-registered tools (`create-adcp-server.ts`) now pass `z.object({}).passthrough()` as `inputSchema` instead of per-tool Zod shapes. The passthrough shape preserves handler arguments (the SDK's `validateToolInput` returns `undefined` when no schema is registered, which would have destroyed args on MCP); the empty declared-properties make the framework AJV validator the sole enforcer for both transports.
+- `requests` validation mode default flipped from `'warn'` to `'strict'` outside production. Matches the existing `responses: 'strict'` default and ensures A2A malformed payloads are rejected before reaching handlers (previously the MCP SDK's Zod filled this role; that safety net is gone).
+- Client-side field-stripping in `SingleAgentClient.adaptRequestForServerVersion` treats an empty-properties schema as "fail open" instead of "strip everything" (JSON Schema semantics). Required because the server's post-#909 `tools/list` publishes `{ type: 'object', properties: {} }` for every tool — the previous code would have stripped every buyer-supplied field.
+
+**Wire format change:**
+
+- MCP clients no longer receive raw `-32602 Input validation error: <Zod text>` on malformed requests. They receive the framework's structured `adcp_error` envelope (`code: 'VALIDATION_ERROR'`, `issues: [{ pointer, message, keyword }]`) — same shape A2A clients always get. Clients that parsed `-32602` text need to migrate to reading `structuredContent.adcp_error`.
+- `tools/list` over MCP returns `{ type: 'object', properties: {} }` per tool (no per-tool parameter schemas). AdCP-native discovery (`get_adcp_capabilities`) already works over both transports; upstream [adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057) proposes `get_schema` as a capability tool for per-tool shape discovery.
+- Test seller fixtures using sparse payloads now need explicit `validation: { requests: 'off' }` alongside `responses: 'off'`. The seven in-tree test helpers were updated accordingly.
+
+**New test:** `test/server-validation-symmetry.test.js` sends the same malformed request to one `AdcpServer` over MCP and A2A; asserts `adcp_error.code`, `recovery`, and sorted issue-pointer lists match. Locks #909 against regression.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -309,6 +309,8 @@ createAdcpServer({
 
 Modes per side: `'strict' | 'warn' | 'off'`. Default is `'off'` — enable explicitly. `VALIDATION_ERROR` envelopes carry the full issue list (pointer, message, keyword, schema path) at the top level `adcp_error.issues` (and mirrored at `details.issues` for spec-convention compatibility) so buyers can surface each offending field without drilling into nested metadata.
 
+**Note on MCP `tools/list` introspection**: `@adcp/client` agents register framework tools with a passthrough input schema so the framework AJV validator is authoritative on both MCP and A2A (see [#909](https://github.com/adcontextprotocol/adcp-client/issues/909)). One visible consequence: MCP `tools/list` publishes `{ type: 'object', properties: {}, additionalProperties: {} }` for every framework tool — not the per-tool parameter schema. Generic MCP discovery clients that lean on `tools/list` inputSchema for field-level introspection will see an untyped surface. AdCP-native discovery via `get_adcp_capabilities` is unaffected; upstream [adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057) proposes a `get_schema` capability tool for per-tool shape discovery across transports.
+
 The same validator runs on the `AdcpClient` side — storyboards and third-party clients configure it via `validation: { requests, responses }` on the client config. Request default is `warn` (so existing callers that send partial payloads still work); response default is `strict` in dev/test, `warn` in production. Set either side to `'off'` for zero overhead.
 
 ### createTaskCapableServer (Low-Level)

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1180,11 +1180,15 @@ export class SingleAgentClient {
     // This handles partial implementations (agents that omit some fields)
     // and prevents unknown fields from causing validation errors on the
     // remote server.
-    // Fails open when no schema is cached — better to send unknown fields and
-    // let the agent respond than to silently drop data that might be required.
+    // Fails open when no schema is cached OR when the schema declares no
+    // properties (JSON Schema semantics: an object with no properties
+    // and no `additionalProperties: false` accepts any shape). Post-#909,
+    // framework-registered agents publish `{ type: 'object', properties: {} }`
+    // on tools/list — treating that as "strip everything" would silently
+    // drop every field the buyer sent.
     // MCP-only in practice: A2A agents don't populate cachedToolSchemas.
     const toolSchema = this.cachedToolSchemas?.get(taskType);
-    if (!toolSchema) return adapted;
+    if (!toolSchema || Object.keys(toolSchema).length === 0) return adapted;
 
     const declaredFields = new Set(Object.keys(toolSchema));
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -35,7 +35,7 @@
  * ```
  */
 
-import type { z } from 'zod';
+import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ZodRawShapeCompat, AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
@@ -1445,6 +1445,13 @@ const MUT: ToolAnnotation = { readOnlyHint: false, destructiveHint: false };
 const DEST: ToolAnnotation = { readOnlyHint: false, destructiveHint: true };
 const IDEMP: ToolAnnotation = { readOnlyHint: false, idempotentHint: true };
 
+// Passthrough schema for every framework-registered tool (#909). See
+// the comment at the registerTool call sites for rationale — short
+// version: makes our AJV validator authoritative on both transports
+// without destroying args on MCP when the SDK's tool dispatcher would
+// otherwise coerce `undefined` into the handler for schemaless tools.
+const PASSTHROUGH_INPUT_SCHEMA = z.object({}).passthrough();
+
 const TOOL_META: Record<string, ToolMeta> = {
   // Media Buy
   get_products: { wrap: productsResponse, annotations: RO },
@@ -1997,21 +2004,22 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     testController: testControllerBridge,
   } = config;
 
-  // Asymmetric defaults, gated on `process.env.NODE_ENV`:
+  // Defaults gated on `process.env.NODE_ENV`:
   //   - Production → both sides `'off'` (zero AJV overhead; trust the
   //     handler after its test suite has exercised it).
-  //   - Dev/test/CI → `requests: 'warn'` (log incoming payloads that don't
-  //     match the bundled AdCP schema but still dispatch, so upstream
-  //     schema tightenings surface as diagnostics rather than hard
-  //     breakage); `responses: 'strict'` (handler drift fails with
-  //     VALIDATION_ERROR and the offending field path — catches
-  //     sparse-response bugs at development time).
+  //   - Dev/test/CI → BOTH sides `'strict'`. Request validation is now
+  //     authoritative on both transports (#909) — we dropped the SDK
+  //     Zod from `registerTool` inputSchema, so if our framework validator
+  //     doesn't reject malformed payloads they reach the handler
+  //     unchecked over A2A. Matching responses' existing `'strict'`
+  //     default keeps behavior consistent across the wire in both
+  //     directions.
   // Explicit `validation: { requests, responses }` on the config always
   // wins. `process.env.NODE_ENV` matches the convention every other SDK
   // consumer already tunes (Express, React, etc.); containers/CI that
   // want prod-like behavior set NODE_ENV=production before start.
   const isProduction = process.env.NODE_ENV === 'production';
-  const requestValidationMode = validationConfig?.requests ?? (isProduction ? 'off' : 'warn');
+  const requestValidationMode = validationConfig?.requests ?? (isProduction ? 'off' : 'strict');
   const responseValidationMode = validationConfig?.responses ?? (isProduction ? 'off' : 'strict');
 
   // Enforce lock-step between the `signed-requests` specialism claim and the
@@ -2589,24 +2597,31 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         }
       };
 
-      // When idempotency is wired and the tool is mutating, relax
-      // `idempotency_key` to optional in the MCP-level input schema. The
-      // middleware is authoritative for this field and returns a properly-
-      // shaped `adcp_error` (with `code`, `field`, `recovery`) on missing
-      // or malformed keys. If we let the MCP SDK's schema validator
-      // reject the request first, buyers get a text-only `-32602` error
-      // instead of the structured compliance error — breaking the
-      // idempotency storyboard's `error_code` validation.
-      const registersAsMutating = isMutatingTask(toolName);
-      const idempKeyField = (schema.shape as any).idempotency_key;
-      const toolShape =
-        idempotency && registersAsMutating && typeof idempKeyField?.optional === 'function'
-          ? { ...(schema.shape as any), idempotency_key: idempKeyField.optional() }
-          : schema.shape;
+      // Register a PASSTHROUGH input schema (#909). The MCP SDK's Zod
+      // validator only fires on the MCP transport — A2A calls the
+      // handler via AdcpServer.invoke(), bypassing it. Registering the
+      // real per-tool Zod schema meant MCP and A2A produced different
+      // verdicts and different error shapes for the same malformed
+      // request. Our framework request validator (AJV, loaded from
+      // schemas/cache/<version>/) runs inside the handler closure on
+      // BOTH transports and produces a structured adcp_error envelope;
+      // make it authoritative.
+      //
+      // Passthrough (not omit): the SDK's `validateToolInput` returns
+      // `undefined` when `inputSchema` is absent (see @modelcontextprotocol/sdk
+      // server/mcp.js), and passes that `undefined` verbatim to the
+      // handler — destroying the actual arguments. `z.object({}).passthrough()`
+      // keeps every key intact, so args still reach the closure.
+      //
+      // Trade-off: MCP `tools/list` publishes `{ type: 'object' }` for
+      // every tool (no per-tool parameter schema). AdCP-native
+      // discovery via `get_adcp_capabilities` already works over both
+      // transports; upstream #3057 proposes a `get_schema` capability
+      // tool for per-tool shape discovery.
       server.registerTool(
         toolName,
         {
-          inputSchema: toolShape as Parameters<typeof server.registerTool>[1]['inputSchema'],
+          inputSchema: PASSTHROUGH_INPUT_SCHEMA,
           ...(meta?.annotations != null && { annotations: meta.annotations }),
         },
         toolHandler as Parameters<typeof server.registerTool>[2]
@@ -2766,11 +2781,12 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     applyCapabilityOverrides(capabilitiesData, capConfig.overrides);
   }
 
-  const capSchema = TOOL_REQUEST_SCHEMAS['get_adcp_capabilities'] as { shape: Record<string, unknown> } | undefined;
+  // Passthrough inputSchema — framework validation is authoritative on
+  // both transports (#909). Same rationale as the domain-tool loop above.
   server.registerTool(
     'get_adcp_capabilities',
     {
-      inputSchema: (capSchema?.shape ?? {}) as Parameters<typeof server.registerTool>[1]['inputSchema'],
+      inputSchema: PASSTHROUGH_INPUT_SCHEMA,
       annotations: { readOnlyHint: true },
     },
     (async (params: any) => {

--- a/test/lib/conformance-seeder.test.js
+++ b/test/lib/conformance-seeder.test.js
@@ -25,7 +25,7 @@ function startAgent(config) {
         name: 'Seed Test Agent',
         version: '1.0.0',
         ...config,
-        validation: { responses: 'off', ...(config?.validation ?? {}) },
+        validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
       }),
     { port: 0, onListening: () => {} }
   );

--- a/test/lib/uniform-error-invariant.test.js
+++ b/test/lib/uniform-error-invariant.test.js
@@ -31,6 +31,10 @@ function makeAgent(shape) {
       createAdcpServer({
         name: 'Uniform Error Test Agent',
         version: '1.0.0',
+        // These tests probe seller misbehavior (id echo, code-leak) — the
+        // framework must NOT short-circuit to VALIDATION_ERROR on the probe
+        // payload, or the invariant never sees the seller's response.
+        validation: { requests: 'off', responses: 'off' },
         governance: {
           getPropertyList: async (params, ctx) => {
             const token = ctx.authInfo?.token;

--- a/test/server-a2a-adapter.test.js
+++ b/test/server-a2a-adapter.test.js
@@ -13,7 +13,7 @@ function createAdcpServer(config) {
   return _createAdcpServer({
     ...config,
     stateStore: config?.stateStore ?? new InMemoryStateStore(),
-    validation: { responses: 'off', ...(config?.validation ?? {}) },
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
   });
 }
 

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -18,7 +18,7 @@ const { adcpError } = require('../dist/lib/server/errors');
 function createAdcpServer(config) {
   return _createAdcpServer({
     ...config,
-    validation: { responses: 'off', ...(config?.validation ?? {}) },
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
   });
 }
 

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -11,7 +11,7 @@ const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/id
 function createAdcpServer(config) {
   return _createAdcpServer({
     ...config,
-    validation: { responses: 'off', ...(config?.validation ?? {}) },
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
   });
 }
 

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -289,10 +289,14 @@ describe('resolveSessionKey', () => {
       params: { name: toolName, arguments: params ?? {} },
     });
   }
+  // Sparse fixtures — opt out of strict request validation (#909 made
+  // it the default for correctness over the A2A path). These tests
+  // exercise session-key wiring, not schema compliance.
+  const newServer = config => createAdcpServer({ ...config, validation: { requests: 'off' } });
 
   it('populates ctx.sessionKey before the handler runs', async () => {
     let seenSessionKey;
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       resolveSessionKey: ({ toolName }) => `tenant_${toolName}`,
@@ -310,7 +314,7 @@ describe('resolveSessionKey', () => {
 
   it('can derive sessionKey from resolved account', async () => {
     let seenSessionKey;
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       resolveAccount: async () => ({ tenant_id: 'tnt_42' }),
@@ -337,7 +341,7 @@ describe('resolveSessionKey', () => {
     // so dev-mode matrix runs stop wasting hours on opaque internal errors;
     // production deployments that want the redaction still get it by default
     // (NODE_ENV=production) or by setting `exposeErrorDetails: false` explicitly.
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       exposeErrorDetails: false,
@@ -354,7 +358,7 @@ describe('resolveSessionKey', () => {
   });
 
   it('includes details.reason when exposeErrorDetails: true', async () => {
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       exposeErrorDetails: true,
@@ -374,7 +378,7 @@ describe('resolveSessionKey', () => {
     // buyers see the typed code (CREATIVE_NOT_FOUND) rather than the
     // opaque SERVICE_UNAVAILABLE: [object Object] that thrown objects
     // otherwise produce.
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       exposeErrorDetails: false,
@@ -399,7 +403,7 @@ describe('resolveSessionKey', () => {
     // Guard: the unwrap path must only fire for actual `adcpError(...)`
     // envelopes. A TypeError or a bare object that happens to carry a
     // `structuredContent` field should still surface as SERVICE_UNAVAILABLE.
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       exposeErrorDetails: true,
@@ -422,7 +426,7 @@ describe('resolveSessionKey', () => {
 
   it('leaves ctx.sessionKey undefined when resolver returns undefined', async () => {
     let seenSessionKey = 'sentinel';
-    const server = createAdcpServer({
+    const server = newServer({
       name: 'Test',
       version: '1.0.0',
       resolveSessionKey: () => undefined,

--- a/test/server-validation-symmetry.test.js
+++ b/test/server-validation-symmetry.test.js
@@ -185,11 +185,23 @@ describe('cross-transport validation symmetry (#909)', () => {
       // Missing EVERYTHING except idempotency_key.
       const badArgs = { idempotency_key: '22222222-2222-2222-2222-222222222222' };
 
-      await mcpCall(baseUrl, 'create_media_buy', badArgs);
+      const mcpRes = await mcpCall(baseUrl, 'create_media_buy', badArgs);
       assert.strictEqual(handlerRan, false, 'MCP path must reject before handler');
+      // Additional assertion guards against a route-regression false-positive
+      // (e.g. a 404 on the MCP path would leave handlerRan=false too).
+      assert.strictEqual(
+        mcpAdcpError(mcpRes)?.code,
+        'VALIDATION_ERROR',
+        'MCP rejection must be the framework VALIDATION_ERROR, not a transport error'
+      );
 
-      await a2aCall(baseUrl, 'create_media_buy', badArgs);
+      const a2aRes = await a2aCall(baseUrl, 'create_media_buy', badArgs);
       assert.strictEqual(handlerRan, false, 'A2A path must reject before handler');
+      assert.strictEqual(
+        a2aAdcpError(a2aRes)?.code,
+        'VALIDATION_ERROR',
+        'A2A rejection must be the framework VALIDATION_ERROR'
+      );
     } finally {
       await new Promise(r => server.close(r));
     }

--- a/test/server-validation-symmetry.test.js
+++ b/test/server-validation-symmetry.test.js
@@ -1,0 +1,197 @@
+// Cross-transport validation symmetry (#909). Sends the same malformed
+// create_media_buy over MCP and A2A against one AdcpServer; asserts the
+// framework's AJV validator produces the same adcp_error envelope on
+// both transports — same code, same JSON-pointer issue list, same
+// recovery classification. Locks the fix against regression.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
+const { Client: McpClient } = require('@modelcontextprotocol/sdk/client/index.js');
+const { createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { getSdkServer } = require('../dist/lib/server/adcp-server');
+const { createIdempotencyStore, memoryBackend } = require('../dist/lib/server/idempotency');
+
+function randomUuid() {
+  const bytes = require('node:crypto').randomBytes(16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function buildDualTransportApp() {
+  const adcp = createAdcpServer({
+    name: 'Test',
+    version: '0.1.0',
+    idempotency: createIdempotencyStore({ backend: memoryBackend() }),
+    resolveSessionKey: () => 'tenant_test',
+    mediaBuy: {
+      createMediaBuy: async () => ({ media_buy_id: 'mb_ok', packages: [] }),
+    },
+  });
+  const a2a = createA2AAdapter({
+    server: adcp,
+    agentCard: {
+      name: 'Symmetry',
+      description: 'MCP+A2A validation symmetry',
+      url: 'http://127.0.0.1/a2a',
+      version: '0.1.0',
+    },
+  });
+  const app = express();
+  app.use(express.json());
+  app.post('/mcp', async (req, res) => {
+    const sdk = getSdkServer(adcp);
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await sdk.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } finally {
+      await sdk.close().catch(() => {});
+    }
+  });
+  a2a.mount(app);
+  return app;
+}
+
+async function mcpCall(baseUrl, toolName, args) {
+  const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
+  const client = new McpClient({ name: 'sym', version: '0' }, { capabilities: {} });
+  await client.connect(transport);
+  try {
+    return await client.callTool({ name: toolName, arguments: args });
+  } finally {
+    await client.close().catch(() => {});
+  }
+}
+
+async function a2aCall(baseUrl, skill, input) {
+  const body = {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'message/send',
+    params: {
+      message: {
+        kind: 'message',
+        messageId: randomUuid(),
+        role: 'user',
+        parts: [{ kind: 'data', data: { skill, input } }],
+      },
+    },
+  };
+  const res = await fetch(`${baseUrl}/a2a`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+function mcpAdcpError(callToolResult) {
+  return callToolResult?.structuredContent?.adcp_error;
+}
+
+function a2aAdcpError(jsonRpcResponse) {
+  return jsonRpcResponse?.result?.artifacts?.[0]?.parts?.[0]?.data?.adcp_error;
+}
+
+describe('cross-transport validation symmetry (#909)', () => {
+  it('malformed create_media_buy produces identical adcp_error shape on MCP and A2A', async () => {
+    const app = buildDualTransportApp();
+    const server = app.listen(0);
+    try {
+      const port = server.address().port;
+      const baseUrl = `http://127.0.0.1:${port}`;
+
+      const badArgs = {
+        account: { account_id: 'a1' },
+        brand: { brand_id: 'acme' }, // invalid: should be `domain`
+        start_time: '2026-05-01T00:00:00Z',
+        end_time: '2026-05-31T23:59:59Z',
+        packages: [{ product_id: 'p1', budget: { amount: 100, currency: 'USD' } }], // budget must be number, missing pricing_option_id
+        idempotency_key: '11111111-1111-1111-1111-111111111111',
+      };
+
+      const mcpRes = await mcpCall(baseUrl, 'create_media_buy', badArgs);
+      const a2aRes = await a2aCall(baseUrl, 'create_media_buy', badArgs);
+
+      const mcpErr = mcpAdcpError(mcpRes);
+      const a2aErr = a2aAdcpError(a2aRes);
+
+      assert.ok(mcpErr, 'MCP must carry structured adcp_error (not raw -32602)');
+      assert.ok(a2aErr, 'A2A must carry structured adcp_error');
+
+      assert.strictEqual(mcpErr.code, 'VALIDATION_ERROR');
+      assert.strictEqual(a2aErr.code, 'VALIDATION_ERROR');
+      assert.strictEqual(mcpErr.code, a2aErr.code, 'error codes must match');
+
+      assert.strictEqual(mcpErr.recovery, a2aErr.recovery, 'recovery classification must match');
+
+      // JSON pointers identify which fields failed — same bad payload,
+      // same pointers. Sort to compare irrespective of emission order.
+      const mcpPointers = (mcpErr.issues ?? []).map(i => i.pointer).sort();
+      const a2aPointers = (a2aErr.issues ?? []).map(i => i.pointer).sort();
+      assert.deepStrictEqual(
+        mcpPointers,
+        a2aPointers,
+        `pointers must match across transports: MCP=${JSON.stringify(mcpPointers)} A2A=${JSON.stringify(a2aPointers)}`
+      );
+      assert.ok(mcpPointers.length > 0, 'at least one validation issue expected');
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  });
+
+  it('malformed request is rejected BEFORE reaching the handler on both transports', async () => {
+    let handlerRan = false;
+    const adcp = createAdcpServer({
+      name: 'Test',
+      version: '0.1.0',
+      idempotency: createIdempotencyStore({ backend: memoryBackend() }),
+      resolveSessionKey: () => 'tenant',
+      mediaBuy: {
+        createMediaBuy: async () => {
+          handlerRan = true;
+          return { media_buy_id: 'should-not-happen', packages: [] };
+        },
+      },
+    });
+    const a2a = createA2AAdapter({
+      server: adcp,
+      agentCard: { name: 'T', description: 't', url: 'http://127.0.0.1/a2a', version: '0.1.0' },
+    });
+    const app = express();
+    app.use(express.json());
+    app.post('/mcp', async (req, res) => {
+      const sdk = getSdkServer(adcp);
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      try {
+        await sdk.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+      } finally {
+        await sdk.close().catch(() => {});
+      }
+    });
+    a2a.mount(app);
+    const server = app.listen(0);
+    try {
+      const port = server.address().port;
+      const baseUrl = `http://127.0.0.1:${port}`;
+
+      // Missing EVERYTHING except idempotency_key.
+      const badArgs = { idempotency_key: '22222222-2222-2222-2222-222222222222' };
+
+      await mcpCall(baseUrl, 'create_media_buy', badArgs);
+      assert.strictEqual(handlerRan, false, 'MCP path must reject before handler');
+
+      await a2aCall(baseUrl, 'create_media_buy', badArgs);
+      assert.strictEqual(handlerRan, false, 'A2A path must reject before handler');
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #909. Before this change, the MCP SDK's Zod validator ran only on the MCP transport; A2A bypassed it via `AdcpServer.invoke()`. Same malformed request → rejected on MCP, silently accepted on A2A. After this change the framework AJV validator is the sole enforcement path on both transports, emitting the same structured \`adcp_error\` envelope with pointer-level \`issues[]\`.

## Changes

- **`src/lib/server/create-adcp-server.ts`** — framework-registered tools pass \`z.object({}).passthrough()\` as inputSchema instead of per-tool Zod shapes. Key subtlety: the SDK's \`validateToolInput\` returns \`undefined\` when no inputSchema is registered, which would destroy args on MCP. Passthrough keeps every key intact while declaring no properties, so AJV is the sole enforcer on both paths.
- **Request validation default flipped to \`'strict'\`** outside production (matches the existing \`responses: 'strict'\` default). Necessary because dropping the SDK's Zod means malformed A2A payloads would otherwise reach handlers unchecked.
- **`src/lib/core/SingleAgentClient.ts`** — \`adaptRequestForServerVersion\` treats empty-properties schemas as "fail open" per JSON Schema semantics. MCP \`tools/list\` post-fix publishes \`{ type: 'object', properties: {} }\` per tool; the old code would have interpreted that as "strip every buyer-supplied field."

## Wire format changes (intentional)

- MCP clients receive structured \`adcp_error\` envelopes on malformed requests instead of raw \`-32602 Input validation error: <Zod text>\`. Same shape A2A clients always got.
- \`tools/list\` over MCP no longer publishes per-tool parameter schemas. AdCP-native discovery (\`get_adcp_capabilities\`) stays; upstream [adcontextprotocol/adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057) proposes a \`get_schema\` capability tool.
- Test seller fixtures using sparse payloads now need \`validation: { requests: 'off' }\` alongside \`responses: 'off'\`. Seven in-tree helpers updated.

## Test plan

- [x] New test: \`test/server-validation-symmetry.test.js\` — sends identical malformed \`create_media_buy\` to one \`AdcpServer\` over both transports; asserts \`adcp_error.code\`, \`recovery\`, and sorted JSON-pointer issue lists match. Also asserts the handler does NOT run on either transport for malformed input.
- [x] 189 tests pass across touched areas (server dispatcher, A2A adapter, idempotency, state store extensions, uniform-error invariants on MCP + A2A, conformance seeder)
- [x] tsc clean, build clean, prettier clean
- [x] Stood up end-to-end; MCP + A2A produce identical \`VALIDATION_ERROR\` envelopes with matching pointer lists (\`["/brand/domain", "/packages/0/budget", "/packages/0/pricing_option_id"]\`)
- [ ] CI green

## Related

- Closes #909 (this)
- Builds on PR #899 (A2A adapter that exposed the asymmetry)
- Upstream #3057 (AdCP \`get_schema\` spec proposal, the forward path for per-tool schema discovery now that MCP \`tools/list\` is schemaless)
- Related #911 (docs fix — BUILD-AN-AGENT example payload + VALIDATE-YOUR-AGENT A2A examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)