### PR TITLE
feat(server): add mcpToolNameResolver helper for signature auth

### DIFF
--- a/.changeset/mcp-tool-name-resolver.md
+++ b/.changeset/mcp-tool-name-resolver.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": minor
+---
+
+Add `mcpToolNameResolver` export on `@adcp/client/server` — a default `resolveOperation` for MCP agents wiring RFC 9421 signature auth. Parses the buffered JSON-RPC body on `req.rawBody` and returns `params.name` when `method === 'tools/call'`; returns `undefined` otherwise so the downstream handler produces a precise error instead of the pre-check rejecting every unsigned call.
+
+Use directly as `resolveOperation` on `verifySignatureAsAuthenticator`, `requireSignatureWhenPresent`, or `requireAuthenticatedOrSigned` instead of hand-rolling the same JSON-RPC parser in every seller agent.

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -14,7 +14,13 @@
  * rejected" rather than falling through.
  *
  * ```ts
- * import { serve, verifyApiKey, anyOf, verifySignatureAsAuthenticator } from '@adcp/client/server';
+ * import {
+ *   serve,
+ *   verifyApiKey,
+ *   anyOf,
+ *   verifySignatureAsAuthenticator,
+ *   mcpToolNameResolver,
+ * } from '@adcp/client/server';
  *
  * serve(createAgent, {
  *   authenticate: anyOf(
@@ -22,13 +28,7 @@
  *     verifySignatureAsAuthenticator({
  *       jwks, replayStore, revocationStore,
  *       capability: { supported: true, required_for: [], covers_content_digest: 'either' },
- *       resolveOperation: req => {
- *         try {
- *           const body = JSON.parse(req.rawBody ?? '');
- *           if (body.method === 'tools/call') return body.params?.name;
- *         } catch {}
- *         return undefined;
- *       },
+ *       resolveOperation: mcpToolNameResolver,
  *     }),
  *   ),
  * });
@@ -276,18 +276,9 @@ export interface RequireSignatureWhenPresentOptions {
    * Extract the AdCP operation name (or any identifier that can be
    * matched against `requiredFor`) from the incoming request.
    *
-   * For MCP agents, this usually parses `req.rawBody` as JSON-RPC and
-   * pulls `params.name` when `method === 'tools/call'`:
-   *
-   * ```ts
-   * resolveOperation: (req) => {
-   *   try {
-   *     const body = JSON.parse(req.rawBody ?? '');
-   *     if (body?.method === 'tools/call') return body.params?.name;
-   *   } catch {}
-   *   return undefined;
-   * }
-   * ```
+   * For MCP agents, pass the exported {@link mcpToolNameResolver} — it
+   * implements the standard `tools/call` → `params.name` parse. For A2A
+   * agents (or other non-JSON-RPC envelopes), supply a bespoke resolver.
    *
    * When `requiredFor` is set but `resolveOperation` is omitted OR
    * returns `undefined`, the pre-check is skipped — better to let the
@@ -433,21 +424,19 @@ export interface RequireAuthenticatedOrSignedOptions {
  *   anyOf,
  *   verifySignatureAsAuthenticator,
  *   requireAuthenticatedOrSigned,
+ *   mcpToolNameResolver,
  *   MUTATING_TASKS,
  * } from '@adcp/client/server';
  *
  * serve(createAgent, {
  *   authenticate: requireAuthenticatedOrSigned({
- *     signature: verifySignatureAsAuthenticator({ jwks, replayStore, revocationStore, capability, resolveOperation }),
+ *     signature: verifySignatureAsAuthenticator({
+ *       jwks, replayStore, revocationStore, capability,
+ *       resolveOperation: mcpToolNameResolver,
+ *     }),
  *     fallback: anyOf(verifyApiKey({ keys }), verifyBearer({ jwksUri, issuer, audience })),
  *     requiredFor: [...MUTATING_TASKS],
- *     resolveOperation: req => {
- *       try {
- *         const body = JSON.parse(req.rawBody ?? '');
- *         if (body?.method === 'tools/call') return body.params?.name;
- *       } catch {}
- *       return undefined;
- *     },
+ *     resolveOperation: mcpToolNameResolver,
  *   }),
  * });
  * ```
@@ -457,6 +446,46 @@ export function requireAuthenticatedOrSigned(options: RequireAuthenticatedOrSign
     requiredFor: options.requiredFor,
     resolveOperation: options.resolveOperation,
   });
+}
+
+/**
+ * Default `resolveOperation` for MCP agents. Parses the buffered JSON-RPC
+ * body on `req.rawBody` and returns `params.name` when `method === 'tools/call'`.
+ * Returns `undefined` for non-`tools/call` methods, a missing body, or
+ * malformed JSON — the same "skip the pre-check and let the handler produce
+ * a precise error" semantics every other `resolveOperation` in the SDK
+ * uses.
+ *
+ * Pass directly as `resolveOperation` on {@link verifySignatureAsAuthenticator},
+ * {@link requireSignatureWhenPresent}, or {@link requireAuthenticatedOrSigned}:
+ *
+ * ```ts
+ * serve(createAgent, {
+ *   authenticate: requireAuthenticatedOrSigned({
+ *     signature: verifySignatureAsAuthenticator({
+ *       jwks, replayStore, revocationStore, capability,
+ *       resolveOperation: mcpToolNameResolver,
+ *     }),
+ *     fallback: anyOf(verifyApiKey({ keys }), verifyBearer({ jwksUri, issuer, audience })),
+ *     requiredFor: [...MUTATING_TASKS],
+ *     resolveOperation: mcpToolNameResolver,
+ *   }),
+ * });
+ * ```
+ *
+ * A2A agents use a different envelope — write a bespoke resolver there.
+ */
+export function mcpToolNameResolver(req: IncomingMessage & { rawBody?: string }): string | undefined {
+  const raw = req.rawBody;
+  if (!raw) return undefined;
+  try {
+    const body = JSON.parse(raw) as { method?: unknown; params?: unknown };
+    if (body?.method !== 'tools/call') return undefined;
+    const params = body.params as { name?: unknown } | undefined;
+    return typeof params?.name === 'string' ? params.name : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 const SAFE_KEYID = /^[A-Za-z0-9._-]{1,256}$/;

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -142,6 +142,7 @@ export {
   verifySignatureAsAuthenticator,
   requireSignatureWhenPresent,
   requireAuthenticatedOrSigned,
+  mcpToolNameResolver,
 } from './auth-signature';
 export type {
   VerifySignatureAsAuthenticatorOptions,

--- a/test/lib/mcp-tool-name-resolver.test.js
+++ b/test/lib/mcp-tool-name-resolver.test.js
@@ -1,0 +1,54 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { mcpToolNameResolver } = require('../../dist/lib/server/index.js');
+
+function makeReq(rawBody) {
+  return {
+    method: 'POST',
+    url: '/mcp',
+    headers: { 'content-type': 'application/json' },
+    rawBody,
+  };
+}
+
+describe('mcpToolNameResolver', () => {
+  it('returns the tool name for a tools/call JSON-RPC request', () => {
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'create_media_buy', arguments: { plan_id: 'p_1' } },
+    });
+    assert.strictEqual(mcpToolNameResolver(makeReq(body)), 'create_media_buy');
+  });
+
+  it('returns undefined for non-tools/call methods', () => {
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' });
+    assert.strictEqual(mcpToolNameResolver(makeReq(body)), undefined);
+  });
+
+  it('returns undefined when params.name is missing', () => {
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: {} });
+    assert.strictEqual(mcpToolNameResolver(makeReq(body)), undefined);
+  });
+
+  it('returns undefined when params.name is not a string', () => {
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 42 } });
+    assert.strictEqual(mcpToolNameResolver(makeReq(body)), undefined);
+  });
+
+  it('returns undefined for malformed JSON', () => {
+    assert.strictEqual(mcpToolNameResolver(makeReq('{ not json')), undefined);
+  });
+
+  it('returns undefined when rawBody is missing or empty', () => {
+    assert.strictEqual(mcpToolNameResolver(makeReq(undefined)), undefined);
+    assert.strictEqual(mcpToolNameResolver(makeReq('')), undefined);
+  });
+
+  it('returns undefined when params is absent on a tools/call request', () => {
+    const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call' });
+    assert.strictEqual(mcpToolNameResolver(makeReq(body)), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

- Export `mcpToolNameResolver` from `@adcp/client/server` — a default `resolveOperation` callback for MCP agents wiring RFC 9421 signature auth. Parses `req.rawBody` as JSON-RPC and returns `params.name` when `method === 'tools/call'`.
- Rewrite the four JSDoc examples in `src/lib/server/auth-signature.ts` to use the helper instead of copy-pasting the same 6-line parser.
- Unit tests cover the happy path plus every undefined-returning case (non-`tools/call` method, missing params, non-string name, malformed JSON, missing/empty rawBody).

## Motivation

The RFC 9421 signing composition helpers (`verifySignatureAsAuthenticator`, `requireSignatureWhenPresent`, `requireAuthenticatedOrSigned`) take a `resolveOperation` callback whose MCP implementation is identical across every seller agent:

```typescript
resolveOperation: req => {
  try {
    const body = JSON.parse(req.rawBody ?? '');
    if (body.method === 'tools/call') return body.params?.name;
  } catch {}
  return undefined;
}
```

That block appears four times in `auth-signature.ts` JSDoc alone, plus once verbatim in `test/auth-signature-compose.test.js`, plus every time it's pasted into a new adapter. Ships as a one-line import instead:

```typescript
resolveOperation: mcpToolNameResolver,
```

A2A agents use a different envelope and still need a bespoke resolver — the helper is explicitly MCP.

Follow-up to #914 (docs-only signing guide): once this lands I'll propose a rewrite of Step 4 of `SIGNING-GUIDE.md` using `requireAuthenticatedOrSigned` + `mcpToolNameResolver`, collapsing the ~25-line manual composition to ~8 lines.

## Test plan

- [x] New tests: `node --test test/lib/mcp-tool-name-resolver.test.js` (7/7 pass locally)
- [x] Regression: existing `auth-signature-compose.test.js` still green (37/37)
- [x] `npm run build` clean
- [x] `tsc --noEmit` clean (ran in pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)