### PR TITLE
feat(signing): default stores + upstream, add createAgentSignedFetch preset

### DIFF
--- a/.changeset/signing-defaults-and-preset.md
+++ b/.changeset/signing-defaults-and-preset.md
@@ -1,0 +1,19 @@
+---
+"@adcp/client": minor
+---
+
+Three ergonomic upgrades to the RFC 9421 signing surface — all backwards compatible, all opt-in via omission:
+
+- **`verifySignatureAsAuthenticator`** now defaults `replayStore` and `revocationStore` to fresh `InMemoryReplayStore` / `InMemoryRevocationStore` instances when omitted. Every authenticator instance gets its own default stores (no cross-talk). Wire explicit stores in multi-replica deployments where replay state must be shared.
+- **`buildAgentSigningFetch`** now defaults `upstream` to `globalThis.fetch` when omitted. Throws a clear `TypeError` if `globalThis.fetch` isn't available, rather than binding `undefined` and failing cryptically on first request.
+- **`createAgentSignedFetch(options)`** — new preset for the single-seller buyer case. Bundles `buildAgentSigningFetch` with a `CapabilityCache` lookup keyed by the target seller's `agent_uri`. One call replaces the four-object `buildAgentSigningFetch` + `CapabilityCache` + explicit `getCapability` wire-up:
+
+  ```typescript
+  // fetch.ts
+  export const signedFetch = createAgentSignedFetch({
+    signing: { kid, alg: 'ed25519', private_key: privateJwk, agent_url: 'https://agent.example.com' },
+    sellerAgentUri: 'https://seller.example.com',
+  });
+  ```
+
+  For multi-seller adapters, build one preset per seller or drop to `buildAgentSigningFetch` with a URL-dispatching `getCapability`.

--- a/.changeset/signing-defaults-and-preset.md
+++ b/.changeset/signing-defaults-and-preset.md
@@ -2,9 +2,10 @@
 "@adcp/client": minor
 ---
 
-Three ergonomic upgrades to the RFC 9421 signing surface — all backwards compatible, all opt-in via omission:
+Four ergonomic upgrades to the RFC 9421 signing surface — all backwards compatible, all opt-in via omission:
 
 - **`verifySignatureAsAuthenticator`** now defaults `replayStore` and `revocationStore` to fresh `InMemoryReplayStore` / `InMemoryRevocationStore` instances when omitted. Every authenticator instance gets its own default stores (no cross-talk). Wire explicit stores in multi-replica deployments where replay state must be shared.
+- **`createExpressVerifier`** gets the same defaults — symmetric with `verifySignatureAsAuthenticator` so both the `serve()` and raw-Express paths have identical ergonomics.
 - **`buildAgentSigningFetch`** now defaults `upstream` to `globalThis.fetch` when omitted. Throws a clear `TypeError` if `globalThis.fetch` isn't available, rather than binding `undefined` and failing cryptically on first request.
 - **`createAgentSignedFetch(options)`** — new preset for the single-seller buyer case. Bundles `buildAgentSigningFetch` with a `CapabilityCache` lookup keyed by the target seller's `agent_uri`. One call replaces the four-object `buildAgentSigningFetch` + `CapabilityCache` + explicit `getCapability` wire-up:
 

--- a/src/lib/server/auth-signature.ts
+++ b/src/lib/server/auth-signature.ts
@@ -41,8 +41,8 @@ import type { IncomingMessage } from 'http';
 import type { RequestLike } from '../signing/canonicalize';
 import { RequestSignatureError } from '../signing/errors';
 import type { JwksResolver } from '../signing/jwks';
-import type { ReplayStore } from '../signing/replay';
-import type { RevocationStore } from '../signing/revocation';
+import { InMemoryReplayStore, type ReplayStore } from '../signing/replay';
+import { InMemoryRevocationStore, type RevocationStore } from '../signing/revocation';
 import type { VerifiedSigner, VerifierCapability, VerifyResult } from '../signing/types';
 import { verifyRequestSignature } from '../signing/verifier';
 import {
@@ -62,10 +62,21 @@ export interface VerifySignatureAsAuthenticatorOptions {
   capability: VerifierCapability;
   /** Resolves verification keys by `keyid`. */
   jwks: JwksResolver;
-  /** Stores `(keyid, signature-bytes, expires)` tuples for replay detection. */
-  replayStore: ReplayStore;
-  /** Consulted for revoked `kid` / `jti` before accepting a signature. */
-  revocationStore: RevocationStore;
+  /**
+   * Stores `(keyid, signature-bytes, expires)` tuples for replay detection.
+   * Defaults to a fresh {@link InMemoryReplayStore} — fine for single-process
+   * deployments. Wire a shared store (Redis, Postgres, etc.) for multi-replica
+   * setups where a signature accepted on one replica must be rejected on the
+   * others.
+   */
+  replayStore?: ReplayStore;
+  /**
+   * Consulted for revoked `kid` / `jti` before accepting a signature.
+   * Defaults to a fresh {@link InMemoryRevocationStore}. Most agents don't
+   * revoke at runtime; when you do, swap in a store backed by your secrets
+   * manager or admin tooling.
+   */
+  revocationStore?: RevocationStore;
   /** Override clock for tests. */
   now?: () => number;
   /**
@@ -110,6 +121,12 @@ export interface VerifySignatureAsAuthenticatorOptions {
  * same side-channel state as the Express-shaped middleware.
  */
 export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthenticatorOptions): Authenticator {
+  // Instantiate defaults once at wire-up time so every request on this
+  // authenticator shares the same replay/revocation state — lazy
+  // per-request construction would defeat replay detection entirely.
+  const replayStore = options.replayStore ?? new InMemoryReplayStore();
+  const revocationStore = options.revocationStore ?? new InMemoryRevocationStore();
+
   const authenticator: Authenticator = async req => {
     if (!hasSignatureHeader(req)) return null;
 
@@ -127,8 +144,8 @@ export function verifySignatureAsAuthenticator(options: VerifySignatureAsAuthent
       result = await verifyRequestSignature(requestLike, {
         capability: options.capability,
         jwks: options.jwks,
-        replayStore: options.replayStore,
-        revocationStore: options.revocationStore,
+        replayStore,
+        revocationStore,
         now: options.now,
         operation: options.resolveOperation(req as IncomingMessage & { rawBody?: string }),
         agentUrlForKeyid: options.agentUrlForKeyid,

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -1,10 +1,32 @@
 import type { AgentRequestSigningConfig } from '../types/adcp';
 import { createSigningFetch, type CoverContentDigestPredicate } from './fetch';
-import type { CachedCapability, CapabilityCache } from './capability-cache';
+import {
+  buildCapabilityCacheKey,
+  defaultCapabilityCache,
+  type CachedCapability,
+  type CapabilityCache,
+} from './capability-cache';
 import type { ContentDigestPolicy, VerifierCapability } from './types';
 import type { SignerKey } from './signer';
 
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Resolve the default upstream fetch at call time rather than at module
+ * import so (a) polyfills / patches that run after this module loads still
+ * take effect, and (b) the helper throws a clear error on environments
+ * lacking global `fetch` instead of binding `undefined` at import time and
+ * failing cryptically on first request.
+ */
+function defaultUpstream(): FetchLike {
+  const f = (globalThis as { fetch?: FetchLike }).fetch;
+  if (typeof f !== 'function') {
+    throw new TypeError(
+      'buildAgentSigningFetch: no upstream fetch provided and globalThis.fetch is unavailable. Pass `upstream: yourFetch` explicitly.'
+    );
+  }
+  return f;
+}
 
 function bodyToUtf8(body: unknown): string | undefined {
   if (body === undefined || body === null) return undefined;
@@ -137,7 +159,12 @@ export function toSignerKey(config: AgentRequestSigningConfig): SignerKey {
 }
 
 export interface BuildAgentSigningFetchOptions {
-  upstream: FetchLike;
+  /**
+   * Upstream fetch to wrap. Defaults to `globalThis.fetch` when omitted —
+   * use a Node 18+ / browser / worker global, or pass a polyfill / a
+   * decorated fetch (retries, telemetry) to compose.
+   */
+  upstream?: FetchLike;
   signing: AgentRequestSigningConfig;
   /** Lazy accessor for the current cached capability — re-read on every call. */
   getCapability: () => CachedCapability | undefined;
@@ -154,7 +181,8 @@ export interface BuildAgentSigningFetchOptions {
  *   4. Delegate to `createSigningFetch` with the decision baked in.
  */
 export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): FetchLike {
-  const { upstream, signing, getCapability } = options;
+  const { signing, getCapability } = options;
+  const upstream = options.upstream ?? defaultUpstream();
   const key = toSignerKey(signing);
 
   const shouldSign = (_url: string, init: RequestInit | undefined): boolean => {
@@ -169,4 +197,81 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
   };
 
   return createSigningFetch(upstream, key, { shouldSign, coverContentDigest });
+}
+
+export interface CreateAgentSignedFetchOptions {
+  /** This agent's RFC 9421 signing identity (kid, alg, private_key, agent_url). */
+  signing: AgentRequestSigningConfig;
+  /**
+   * Target seller's `agent_uri` — the base URL whose `get_adcp_capabilities`
+   * response gates whether each operation gets signed. The preset keys a
+   * capability-cache entry off this URL so repeat calls reuse the same
+   * advertisement.
+   *
+   * For multi-seller buyers, build one signed fetch per seller (or use
+   * {@link buildAgentSigningFetch} directly and supply your own
+   * `getCapability` that dispatches on the target URL).
+   */
+  sellerAgentUri: string;
+  /**
+   * Optional auth token the seller expects alongside the signing headers.
+   * Included in the capability cache key so a token rotation naturally
+   * invalidates the cached advertisement.
+   */
+  sellerAuthToken?: string;
+  /** Capability cache. Defaults to the shared {@link defaultCapabilityCache}. */
+  cache?: CapabilityCache;
+  /** Upstream fetch. Defaults to `globalThis.fetch`. */
+  upstream?: FetchLike;
+}
+
+/**
+ * One-call preset for the single-seller case: bundles
+ * {@link buildAgentSigningFetch} with a {@link CapabilityCache} lookup keyed
+ * by `sellerAgentUri`, so adapter authors don't have to wire the cache and
+ * capability accessor themselves.
+ *
+ * ```ts
+ * // fetch.ts
+ * import { createAgentSignedFetch } from '@adcp/client/signing';
+ *
+ * export const signedFetch = createAgentSignedFetch({
+ *   signing: {
+ *     kid: 'my-agent-2026',
+ *     alg: 'ed25519',
+ *     private_key: JSON.parse(process.env.ADCP_PRIV_KEY!),
+ *     agent_url: 'https://agent.example.com',
+ *   },
+ *   sellerAgentUri: 'https://seller.example.com',
+ * });
+ * ```
+ *
+ * ```ts
+ * // any other module
+ * import { signedFetch } from './fetch';
+ *
+ * await signedFetch('https://seller.example.com/mcp', {
+ *   method: 'POST',
+ *   headers: { 'Content-Type': 'application/json' },
+ *   body: JSON.stringify(payload),
+ * });
+ * ```
+ *
+ * Signing only happens on operations the seller advertises as
+ * `required_for` / `warn_for` (or `supported_for` when the buyer config
+ * opts in) — so the `get_adcp_capabilities` priming call itself is always
+ * unsigned, as the spec requires.
+ *
+ * For multi-seller adapters, construct one preset per seller, or use
+ * {@link buildAgentSigningFetch} directly with a request-dispatching
+ * `getCapability` callback.
+ */
+export function createAgentSignedFetch(options: CreateAgentSignedFetchOptions): FetchLike {
+  const cache = options.cache ?? defaultCapabilityCache;
+  const cacheKey = buildCapabilityCacheKey(options.sellerAgentUri, options.sellerAuthToken);
+  return buildAgentSigningFetch({
+    signing: options.signing,
+    upstream: options.upstream,
+    getCapability: () => cache.get(cacheKey),
+  });
 }

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -46,11 +46,13 @@ export {
 } from './capability-cache';
 export {
   buildAgentSigningFetch,
+  createAgentSignedFetch,
   extractAdcpOperation,
   resolveCoverContentDigest,
   shouldSignOperation,
   toSignerKey,
   type BuildAgentSigningFetchOptions,
+  type CreateAgentSignedFetchOptions,
 } from './agent-fetch';
 export { buildAgentSigningContext, signingContextStorage, type AgentSigningContext } from './agent-context';
 export { ensureCapabilityLoaded, CAPABILITY_OP } from './capability-priming';

--- a/src/lib/signing/middleware.ts
+++ b/src/lib/signing/middleware.ts
@@ -31,7 +31,10 @@ export interface ExpressLike {
   [key: string]: unknown;
 }
 
-export interface ExpressMiddlewareOptions extends Omit<VerifyRequestOptions, 'operation' | 'replayStore' | 'revocationStore'> {
+export interface ExpressMiddlewareOptions extends Omit<
+  VerifyRequestOptions,
+  'operation' | 'replayStore' | 'revocationStore'
+> {
   /**
    * Stores `(keyid, signature-bytes, expires)` tuples for replay detection.
    * Defaults to a fresh {@link InMemoryReplayStore} — fine for single-process

--- a/src/lib/signing/middleware.ts
+++ b/src/lib/signing/middleware.ts
@@ -1,6 +1,8 @@
 import type { RequestLike } from './canonicalize';
 import { getHeaderValue } from './canonicalize';
 import { RequestSignatureError } from './errors';
+import { InMemoryReplayStore } from './replay';
+import { InMemoryRevocationStore } from './revocation';
 import { verifyRequestSignature, type VerifyRequestOptions } from './verifier';
 import type { VerifiedSigner } from './types';
 
@@ -29,7 +31,22 @@ export interface ExpressLike {
   [key: string]: unknown;
 }
 
-export interface ExpressMiddlewareOptions extends Omit<VerifyRequestOptions, 'operation'> {
+export interface ExpressMiddlewareOptions extends Omit<VerifyRequestOptions, 'operation' | 'replayStore' | 'revocationStore'> {
+  /**
+   * Stores `(keyid, signature-bytes, expires)` tuples for replay detection.
+   * Defaults to a fresh {@link InMemoryReplayStore} — fine for single-process
+   * deployments. Wire a shared store (Redis, Postgres, etc.) for multi-replica
+   * setups where a signature accepted on one replica must be rejected on the
+   * others.
+   */
+  replayStore?: VerifyRequestOptions['replayStore'];
+  /**
+   * Consulted for revoked `kid` / `jti` before accepting a signature.
+   * Defaults to a fresh {@link InMemoryRevocationStore}. Most agents don't
+   * revoke at runtime; when you do, swap in a store backed by your secrets
+   * manager or admin tooling.
+   */
+  revocationStore?: VerifyRequestOptions['revocationStore'];
   /**
    * Extract the AdCP operation name from the incoming request so the verifier
    * can consult `capability.required_for`. Return `undefined` for requests
@@ -58,6 +75,12 @@ export interface ExpressMiddlewareOptions extends Omit<VerifyRequestOptions, 'op
 type NextFn = (err?: unknown) => void;
 
 export function createExpressVerifier(options: ExpressMiddlewareOptions) {
+  // Instantiate defaults once at wire-up so every request on this middleware
+  // shares the same replay/revocation state — lazy per-request construction
+  // would defeat replay detection entirely.
+  const replayStore = options.replayStore ?? new InMemoryReplayStore();
+  const revocationStore = options.revocationStore ?? new InMemoryRevocationStore();
+
   return async function requestSignatureMiddleware(
     req: ExpressLike,
     res: { status: (code: number) => { set: (k: string, v: string) => { json: (body: unknown) => void } } },
@@ -74,6 +97,8 @@ export function createExpressVerifier(options: ExpressMiddlewareOptions) {
       };
       const result = await verifyRequestSignature(requestLike, {
         ...options,
+        replayStore,
+        revocationStore,
         operation: options.resolveOperation(req),
       });
       if (result.status === 'verified') {

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -14,7 +14,6 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const { readFileSync } = require('node:fs');
 const path = require('node:path');
-const { generateKeyPairSync } = require('node:crypto');
 
 const { AuthError, verifySignatureAsAuthenticator, mcpToolNameResolver } = require('../../dist/lib/server/index.js');
 const {

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -1,0 +1,268 @@
+/**
+ * Defaults + presets shipped alongside the RFC 9421 signing surface:
+ *
+ *   - `verifySignatureAsAuthenticator` defaults `replayStore` and
+ *     `revocationStore` to in-memory stores.
+ *   - `buildAgentSigningFetch` defaults `upstream` to `globalThis.fetch`.
+ *   - `createAgentSignedFetch` bundles capability-cache wiring for the
+ *     single-seller case.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const { generateKeyPairSync } = require('node:crypto');
+
+const {
+  AuthError,
+  verifySignatureAsAuthenticator,
+  mcpToolNameResolver,
+} = require('../../dist/lib/server/index.js');
+const {
+  signRequest,
+  StaticJwksResolver,
+  CapabilityCache,
+  defaultCapabilityCache,
+  buildAgentSigningFetch,
+  createAgentSignedFetch,
+} = require('../../dist/lib/signing/index.js');
+
+// ---------------------------------------------------------------------------
+// Key + request helpers
+// ---------------------------------------------------------------------------
+
+const keysPath = path.join(
+  __dirname,
+  '..',
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const { keys } = JSON.parse(readFileSync(keysPath, 'utf8'));
+const primary = keys.find(k => k.kid === 'test-ed25519-2026');
+const primaryPublic = { ...primary };
+delete primaryPublic._private_d_for_test_only;
+delete primaryPublic.d;
+const primaryPrivate = { ...primary, d: primary._private_d_for_test_only };
+delete primaryPrivate._private_d_for_test_only;
+
+function signedReq({ now, url, body, nonce }) {
+  const signed = signRequest(
+    { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body },
+    { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: primaryPrivate },
+    { now: () => now, windowSeconds: 300, nonce }
+  );
+  const headers = { host: 'seller.example.com' };
+  for (const [k, v] of Object.entries(signed.headers)) {
+    headers[k.toLowerCase()] = v;
+  }
+  const parsed = new URL(url);
+  return {
+    method: 'POST',
+    url: parsed.pathname + parsed.search,
+    headers,
+    rawBody: body,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// verifySignatureAsAuthenticator — default stores
+// ---------------------------------------------------------------------------
+
+describe('verifySignatureAsAuthenticator default stores', () => {
+  const now = 1_776_520_800;
+  const body = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_media_buy","arguments":{}}}';
+  const url = 'https://seller.example.com/mcp';
+
+  function baseOptionsWithoutStores(overrides = {}) {
+    return {
+      jwks: new StaticJwksResolver([primaryPublic]),
+      capability: { supported: true, covers_content_digest: 'either', required_for: [] },
+      resolveOperation: mcpToolNameResolver,
+      getUrl: req => `https://seller.example.com${req.url ?? '/mcp'}`,
+      now: () => now,
+      ...overrides,
+    };
+  }
+
+  it('accepts a valid signature when replayStore/revocationStore are omitted', async () => {
+    const auth = verifySignatureAsAuthenticator(baseOptionsWithoutStores());
+    const req = signedReq({ now, url, body, nonce: 'default-stores-01' });
+    const result = await auth(req);
+    assert.ok(result, 'should return a principal');
+    assert.strictEqual(result.principal, 'signing:test-ed25519-2026');
+  });
+
+  it('the default replay store actually rejects replayed nonces', async () => {
+    // Single authenticator instance means a single default InMemoryReplayStore
+    // shared across requests — same as wiring an explicit store once at boot.
+    const auth = verifySignatureAsAuthenticator(baseOptionsWithoutStores());
+    const nonce = 'default-stores-replay-01';
+
+    const firstReq = signedReq({ now, url, body, nonce });
+    const first = await auth(firstReq);
+    assert.ok(first, 'first request should verify');
+
+    // Re-sign the same nonce: new request object, identical replay fingerprint.
+    const replayedReq = signedReq({ now, url, body, nonce });
+    await assert.rejects(
+      () => auth(replayedReq),
+      err => err instanceof AuthError && /replay/i.test(err.publicMessage ?? err.message ?? '')
+    );
+  });
+
+  it('every new authenticator instance gets its own default stores (no cross-talk)', async () => {
+    const nonce = 'default-stores-isolation-01';
+
+    const authA = verifySignatureAsAuthenticator(baseOptionsWithoutStores());
+    const authB = verifySignatureAsAuthenticator(baseOptionsWithoutStores());
+
+    const req1 = signedReq({ now, url, body, nonce });
+    const resultA = await authA(req1);
+    assert.ok(resultA, 'authA should verify');
+
+    // authB must accept the same nonce — its default store is independent.
+    const req2 = signedReq({ now, url, body, nonce });
+    const resultB = await authB(req2);
+    assert.ok(resultB, 'authB should verify (separate default store from authA)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentSigningFetch default upstream
+// ---------------------------------------------------------------------------
+
+describe('buildAgentSigningFetch default upstream', () => {
+  it('falls back to globalThis.fetch when upstream is omitted', async () => {
+    const original = globalThis.fetch;
+    let captured;
+    globalThis.fetch = async (input, init) => {
+      captured = { input: String(input), init };
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+    try {
+      // Minimal signing config; capability cache empty so the request passes
+      // through unsigned — we only need to confirm the default upstream was
+      // called.
+      const signedFetch = buildAgentSigningFetch({
+        signing: {
+          kid: 'test-ed25519-2026',
+          alg: 'ed25519',
+          private_key: primaryPrivate,
+          agent_url: 'https://buyer.example.com',
+        },
+        getCapability: () => undefined,
+      });
+      const res = await signedFetch('https://seller.example.com/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"jsonrpc":"2.0","id":1,"method":"initialize"}',
+      });
+      assert.strictEqual(res.status, 200);
+      assert.ok(captured, 'default upstream (globalThis.fetch) should have been invoked');
+      assert.strictEqual(captured.input, 'https://seller.example.com/mcp');
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('throws a clear error when no upstream is provided and globalThis.fetch is unavailable', () => {
+    const original = globalThis.fetch;
+    delete globalThis.fetch;
+    try {
+      assert.throws(
+        () =>
+          buildAgentSigningFetch({
+            signing: {
+              kid: 'test-ed25519-2026',
+              alg: 'ed25519',
+              private_key: primaryPrivate,
+              agent_url: 'https://buyer.example.com',
+            },
+            getCapability: () => undefined,
+          }),
+        err => err instanceof TypeError && /globalThis\.fetch is unavailable/i.test(err.message)
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createAgentSignedFetch preset
+// ---------------------------------------------------------------------------
+
+describe('createAgentSignedFetch preset', () => {
+  const signing = {
+    kid: 'test-ed25519-2026',
+    alg: 'ed25519',
+    private_key: primaryPrivate,
+    agent_url: 'https://buyer.example.com',
+  };
+  const sellerAgentUri = 'https://seller.example.com';
+
+  function makeCapturingUpstream() {
+    const captured = {};
+    const upstream = async (input, init) => {
+      captured.input = String(input);
+      captured.init = init;
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+    return { captured, upstream };
+  }
+
+  it('returns a FetchLike function', () => {
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache: new CapabilityCache() });
+    assert.strictEqual(typeof signedFetch, 'function');
+  });
+
+  it('passes through unsigned when the capability cache is cold', async () => {
+    const cache = new CapabilityCache();
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_media_buy","arguments":{}}}',
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.strictEqual(headers.get('signature-input'), null, 'cold cache should not sign');
+  });
+
+  it('signs when the capability cache lists the operation as required_for', async () => {
+    const cache = new CapabilityCache();
+    const { buildCapabilityCacheKey } = require('../../dist/lib/signing/index.js');
+    const cacheKey = buildCapabilityCacheKey(sellerAgentUri);
+    cache.set(cacheKey, {
+      agentUri: sellerAgentUri,
+      requestSigning: {
+        supported: true,
+        required_for: ['create_media_buy'],
+        covers_content_digest: 'either',
+      },
+      cachedAt: Date.now(),
+    });
+    const { captured, upstream } = makeCapturingUpstream();
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri, cache, upstream });
+    await signedFetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_media_buy","arguments":{}}}',
+    });
+    const headers = new Headers(captured.init?.headers);
+    assert.ok(headers.get('signature-input'), 'required_for op should be signed');
+    assert.ok(headers.get('signature'), 'Signature header should be present');
+  });
+
+  it('defaults to defaultCapabilityCache when no cache is passed', () => {
+    const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri });
+    assert.strictEqual(typeof signedFetch, 'function');
+    assert.ok(defaultCapabilityCache, 'defaultCapabilityCache should be exported');
+  });
+});

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -3,6 +3,8 @@
  *
  *   - `verifySignatureAsAuthenticator` defaults `replayStore` and
  *     `revocationStore` to in-memory stores.
+ *   - `createExpressVerifier` defaults `replayStore` and `revocationStore`
+ *     to in-memory stores (symmetric with the authenticator shape).
  *   - `buildAgentSigningFetch` defaults `upstream` to `globalThis.fetch`.
  *   - `createAgentSignedFetch` bundles capability-cache wiring for the
  *     single-seller case.
@@ -26,6 +28,7 @@ const {
   defaultCapabilityCache,
   buildAgentSigningFetch,
   createAgentSignedFetch,
+  createExpressVerifier,
 } = require('../../dist/lib/signing/index.js');
 
 // ---------------------------------------------------------------------------
@@ -264,5 +267,127 @@ describe('createAgentSignedFetch preset', () => {
     const signedFetch = createAgentSignedFetch({ signing, sellerAgentUri });
     assert.strictEqual(typeof signedFetch, 'function');
     assert.ok(defaultCapabilityCache, 'defaultCapabilityCache should be exported');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createExpressVerifier — default stores
+// ---------------------------------------------------------------------------
+
+describe('createExpressVerifier default stores', () => {
+  const now = 1_776_520_800;
+  const body = '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"create_media_buy","arguments":{}}}';
+  const url = 'https://seller.example.com/mcp';
+
+  function baseOptionsWithoutStores(overrides = {}) {
+    return {
+      jwks: new StaticJwksResolver([primaryPublic]),
+      capability: { supported: true, covers_content_digest: 'either', required_for: [] },
+      resolveOperation: req => {
+        try {
+          const parsed = JSON.parse(req.rawBody ?? '');
+          if (parsed.method === 'tools/call') return parsed.params?.name;
+        } catch {}
+        return undefined;
+      },
+      getUrl: req => `https://seller.example.com${req.originalUrl ?? req.url ?? '/mcp'}`,
+      now: () => now,
+      ...overrides,
+    };
+  }
+
+  function expressReq(signed, bodyStr) {
+    const headers = { host: 'seller.example.com' };
+    for (const [k, v] of Object.entries(signed.headers)) {
+      headers[k.toLowerCase()] = v;
+    }
+    return {
+      method: 'POST',
+      url: '/mcp',
+      originalUrl: '/mcp',
+      protocol: 'https',
+      headers,
+      rawBody: bodyStr,
+      get(name) {
+        return headers[name.toLowerCase()];
+      },
+    };
+  }
+
+  function sign(nonce, bodyStr) {
+    return signRequest(
+      { method: 'POST', url, headers: { 'Content-Type': 'application/json' }, body: bodyStr },
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: primaryPrivate },
+      { now: () => now, windowSeconds: 300, nonce }
+    );
+  }
+
+  function fakeRes() {
+    const state = { status: undefined, headers: {}, body: undefined };
+    const chain = {
+      set(k, v) {
+        state.headers[k] = v;
+        return chain;
+      },
+      json(b) {
+        state.body = b;
+        return chain;
+      },
+    };
+    return {
+      status(code) {
+        state.status = code;
+        return chain;
+      },
+      state,
+    };
+  }
+
+  it('accepts a valid signature when replayStore/revocationStore are omitted', async () => {
+    const middleware = createExpressVerifier(baseOptionsWithoutStores());
+    const req = expressReq(sign('express-default-stores-01', body), body);
+    const res = fakeRes();
+    let nextCalled = false;
+    await middleware(req, res, err => {
+      if (err) throw err;
+      nextCalled = true;
+    });
+    assert.strictEqual(nextCalled, true, 'next() should be called on verified request');
+    assert.ok(req.verifiedSigner, 'req.verifiedSigner should be populated');
+    assert.strictEqual(req.verifiedSigner.keyid, 'test-ed25519-2026');
+  });
+
+  it('the default replay store rejects replayed nonces', async () => {
+    const middleware = createExpressVerifier(baseOptionsWithoutStores());
+    const nonce = 'express-default-stores-replay-01';
+
+    const req1 = expressReq(sign(nonce, body), body);
+    const res1 = fakeRes();
+    await middleware(req1, res1, () => {});
+    assert.ok(req1.verifiedSigner, 'first request should verify');
+
+    const req2 = expressReq(sign(nonce, body), body);
+    const res2 = fakeRes();
+    await middleware(req2, res2, () => {});
+    assert.strictEqual(res2.state.status, 401, 'replay should yield 401');
+    assert.ok(
+      res2.state.headers['WWW-Authenticate']?.startsWith('Signature error="'),
+      'should carry Signature WWW-Authenticate challenge'
+    );
+  });
+
+  it('every new middleware instance gets its own default stores', async () => {
+    const mwA = createExpressVerifier(baseOptionsWithoutStores());
+    const mwB = createExpressVerifier(baseOptionsWithoutStores());
+    const nonce = 'express-default-stores-isolation-01';
+
+    const reqA = expressReq(sign(nonce, body), body);
+    await mwA(reqA, fakeRes(), () => {});
+    assert.ok(reqA.verifiedSigner, 'mwA should verify');
+
+    // Same nonce on an independent middleware instance must verify — default stores don't leak across instances.
+    const reqB = expressReq(sign(nonce, body), body);
+    await mwB(reqB, fakeRes(), () => {});
+    assert.ok(reqB.verifiedSigner, 'mwB should verify (independent default store)');
   });
 });

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -16,11 +16,7 @@ const { readFileSync } = require('node:fs');
 const path = require('node:path');
 const { generateKeyPairSync } = require('node:crypto');
 
-const {
-  AuthError,
-  verifySignatureAsAuthenticator,
-  mcpToolNameResolver,
-} = require('../../dist/lib/server/index.js');
+const { AuthError, verifySignatureAsAuthenticator, mcpToolNameResolver } = require('../../dist/lib/server/index.js');
 const {
   signRequest,
   StaticJwksResolver,


### PR DESCRIPTION
## Summary

Four ergonomic upgrades to the RFC 9421 signing surface. All backwards compatible — existing callers that pass explicit stores or an upstream fetch are unaffected. Lands on top of #916 (`mcpToolNameResolver`).

- **`verifySignatureAsAuthenticator`** — defaults `replayStore` and `revocationStore` to fresh `InMemoryReplayStore` / `InMemoryRevocationStore` instances when omitted. The defaults are constructed once at authenticator wire-up so replay detection actually works across requests on a single instance. Wire explicit stores for multi-replica deployments where replay state must be shared.

- **`createExpressVerifier`** — gets the same defaults, symmetric with `verifySignatureAsAuthenticator`. Previously the `serve()` path could omit both stores while the raw-Express path required them — same underlying verifier, asymmetric ergonomics. Now both shapes behave identically on omission.

- **`buildAgentSigningFetch`** — defaults `upstream` to `globalThis.fetch` when omitted. Throws a clear `TypeError` if `globalThis.fetch` isn't available at wire-up, rather than binding `undefined` and failing cryptically on first request.

- **`createAgentSignedFetch(options)`** — new single-seller buyer preset. Bundles `buildAgentSigningFetch` with a `CapabilityCache` lookup keyed by the target seller's `agent_uri`, so adapter authors write one call instead of wiring the cache and capability accessor by hand:

  ```typescript
  // fetch.ts
  import { createAgentSignedFetch } from '@adcp/client/signing';

  export const signedFetch = createAgentSignedFetch({
    signing: {
      kid: 'my-agent-2026',
      alg: 'ed25519',
      private_key: JSON.parse(process.env.ADCP_PRIV_KEY!),
      agent_url: 'https://agent.example.com',
    },
    sellerAgentUri: 'https://seller.example.com',
  });
  ```

  Multi-seller buyers still use `buildAgentSigningFetch` directly with a URL-dispatching `getCapability`.

## Motivation

Follow-up from the [PR #914](https://github.com/adcontextprotocol/adcp-client/pull/914) signing-guide review — ported to the spec repo at [adcp#3064](https://github.com/adcontextprotocol/adcp/pull/3064). Ben asked for "base tooling setup as defaults with override capability" plus an `init()` entrypoint that configures a shared `signedFetch` importable anywhere.

Module-level `init()` would regress [host-aware multi-agent `serve()`](https://github.com/adcontextprotocol/adcp-client/pull/897) (5.16) — one process running N agents with N signing keys can't use a singleton. This PR takes the defaults-with-override half directly and ships the "import once, use anywhere" ergonomic via a factory preset instead of a singleton. The usage pattern Ben wants works identically — module-level `export const signedFetch = createAgentSignedFetch({...})` — but stays multi-tenant-safe, testable, and consistent with every other SDK config surface (`createAdcpServer`, `serve`, `createSigningFetch`, `createExpressVerifier`).

Once this merges, the [adcp#3064 signing guide](https://github.com/adcontextprotocol/adcp/pull/3064) can drop the explicit `new InMemoryReplayStore()` / `new InMemoryRevocationStore()` lines from its Step 4 `createExpressVerifier` and `requireAuthenticatedOrSigned` examples, and the Step 3 capability-aware fetch example can collapse into a single `createAgentSignedFetch({ signing, sellerAgentUri })` call.

## Test plan

- [x] New tests: `test/lib/signing-defaults-and-preset.test.js` — 12/12 pass
  - 3 for `verifySignatureAsAuthenticator` default stores (accepts valid signature, default replay store rejects replays, separate authenticator instances get isolated stores)
  - 3 for `createExpressVerifier` default stores (accepts valid signature, default replay store rejects replays with 401 `WWW-Authenticate: Signature`, separate middleware instances get isolated stores)
  - 2 for `buildAgentSigningFetch` default upstream (falls back to `globalThis.fetch`, throws `TypeError` when `globalThis.fetch` is unavailable)
  - 4 for `createAgentSignedFetch` preset (returns FetchLike, cold-cache no-sign, required_for sign, default cache wiring)
- [x] Regression: existing `auth-signature-compose.test.js` + `webhook-signing-vectors.test.js` + `storyboard-webhook-signature.test.js` + `request-signing-runner-integration.test.js` + `request-signing-e2e.test.js` still green (84/84)
- [x] `npm run build` clean
- [x] `tsc --noEmit` clean (pre-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)