### PR TITLE
docs: add call-adcp-agent skill for buyer-side LLM clients

### DIFF
--- a/.changeset/call-adcp-agent-skill.md
+++ b/.changeset/call-adcp-agent-skill.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+New skill: `skills/call-adcp-agent/SKILL.md` — buyer-side playbook for LLM clients calling an AdCP agent. Covers the wire contract, the `oneOf` account variants, idempotency invariants, async flow (`status:'submitted'` + `task_id`), error recovery from `adcp_error.issues[]`, and minimal payload examples for the top five tools (`get_products`, `create_media_buy`, `sync_creatives`, `get_signals`, `activate_signal`).
+
+**Motivation**: [#915](https://github.com/adcontextprotocol/adcp-client/pull/915) made MCP `tools/list` schema-free (the trade-off for cross-transport validation symmetry). Empirical three-way comparison showed a naive LLM gets stuck on 5/5 common tools without priors; with this skill loaded, Claude-class clients land their first successful call in 1 hop on all five. Upstream [adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057) (`get_schema`) remains the longer-term spec path for programmatic schema discovery; this skill unblocks LLMs today.
+
+Referenced from `CLAUDE.md`; ships alongside the existing `skills/build-*-agent/` set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ your context: `src/lib/types/*.generated.ts`, `src/lib/agents/index.generated.ts
 
 **Validating a server-side agent?** Read `docs/guides/VALIDATE-YOUR-AGENT.md` — the five-command checklist plus deep references for `adcp storyboard run`, `adcp fuzz` (T1/T2/T3), `adcp grade request-signing`, multi-instance testing, webhook conformance, schema-driven validation hooks, custom `--invariants`, the `npm run compliance:skill-matrix` dogfood harness, and how to read the runner's `context_value_rejected` diagnostics (the `💡 Hint:` lines printed on failing storyboard steps).
 
+**Calling an AdCP agent as a buyer?** Read and follow `skills/call-adcp-agent/SKILL.md` — covers the wire contract, minimal payload shapes, async flow, and error recovery so you don't stall on `oneOf`/discriminated-union fields that schema-free tool discovery won't explain. Significantly reduces the hop count an LLM needs to make its first successful call (3-4 attempts → 1 attempt on common tools in empirical comparison).
+
 **Building a seller agent?** Read and follow `skills/build-seller-agent/SKILL.md` — covers guaranteed vs non-guaranteed, pricing, approval workflows, creative management.
 
 **Building a generative seller / AI ad network?** Read and follow `skills/build-generative-seller-agent/SKILL.md` — covers brief-based creative generation, standard + generative format catalogs, brand resolution.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Official TypeScript/JavaScript client for the **Ad Context Protocol (AdCP)**. Bu
 
 ## For AI Agents
 
-Start with [`docs/llms.txt`](./docs/llms.txt) — the full protocol spec in one file (tools, types, error codes, examples). Building a server? See [`docs/guides/BUILD-AN-AGENT.md`](./docs/guides/BUILD-AN-AGENT.md). For type signatures, use [`docs/TYPE-SUMMARY.md`](./docs/TYPE-SUMMARY.md). Skip `src/lib/types/*.generated.ts` — they're machine-generated and will burn context.
+Start with [`docs/llms.txt`](./docs/llms.txt) — the full protocol spec in one file (tools, types, error codes, examples). Building a server? See [`docs/guides/BUILD-AN-AGENT.md`](./docs/guides/BUILD-AN-AGENT.md). **Calling** an AdCP agent as a buyer? Load [`skills/call-adcp-agent/SKILL.md`](./skills/call-adcp-agent/SKILL.md) — wire contract, async flow, and error-recovery priors that aren't in the type signatures. For type signatures, use [`docs/TYPE-SUMMARY.md`](./docs/TYPE-SUMMARY.md). Skip `src/lib/types/*.generated.ts` — they're machine-generated and will burn context.
 
 These docs are also available in `node_modules/@adcp/client/docs/` after install.
 

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -74,7 +74,7 @@ When you see `status: 'submitted'`, the work is NOT complete. Poll via `tasks/ge
 ]
 ```
 
-`budget` is a **number** (not `{amount, currency}` — currency is implied by the pricing option). `pricing_option_id` and `buyer_ref` are required per package.
+`budget` is a **number** (not `{amount, currency}` — currency is implied by the pricing option). Required per package: `product_id`, `budget`, `pricing_option_id`. `buyer_ref` is optional but strongly recommended as a buyer-side correlation id across retries and reporting.
 
 ## Error envelope — read `issues[]` to recover
 
@@ -174,7 +174,7 @@ Returns `{ signals: [{ signal_agent_segment_id, match_rate, pricing, ... }] }`. 
   "idempotency_key": "<uuid>",
   "signal_agent_segment_id": "sig_premium_ctv_sports",
   "destinations": [
-    { "type": "platform", "platform": "trade_desk_us" }
+    { "type": "platform", "platform": "the-trade-desk" }
   ]
 }
 ```

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: call-adcp-agent
+description: Use when calling an AdCP agent as a buyer — media buys, signal lookups, creative sync, delivery reports. Covers the wire contract, common payload shapes, async flow, and error recovery so you don't get stuck on oneOf or discriminated-union fields that schema-free tool discovery won't explain.
+---
+
+# Call an AdCP agent
+
+## When to Use
+
+- User wants to call a publisher / SSP / retail media network over AdCP
+- Tool names like `get_products`, `create_media_buy`, `sync_creatives`, `get_signals` appear in the available-tools list
+- Agent card advertises `protocolVersion: '0.3.0'` with `skills` listing AdCP tool names
+- **Not this skill:** building an AdCP seller agent (see `skills/build-seller-agent/`)
+
+## Discovery chain
+
+Walk these in order on first contact:
+
+1. **Agent card** (A2A) or **`tools/list`** (MCP): returns tool NAMES. Post-`@adcp/client` [#915](https://github.com/adcontextprotocol/adcp-client/pull/915), `tools/list` no longer publishes per-tool parameter schemas — everything shows `{type: 'object', properties: {}}`. Don't try to infer shape from here.
+2. **`get_adcp_capabilities`**: returns supported protocols (`media_buy`, `signals`, `creative`, …), AdCP major versions, feature flags. Tells you WHICH tools this agent supports, not how to call them.
+3. **`get_schema(tool_name)`** *(when the agent exposes it — upstream [adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057))*: returns the JSON Schema for a tool's request/response. Preferred over reading bundled schemas when available.
+4. **Bundled schemas** (offline, authoritative): `schemas/cache/<version>/bundled/<protocol>/<tool>-request.json` and `-response.json`. The spec ships them; every AdCP version has them.
+
+## Non-obvious rules every buyer must follow
+
+### `idempotency_key` is required on every mutating tool
+
+UUID format. Same key on retry → replay cached response. Required on: `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_audiences`, `sync_accounts`, `sync_catalogs`, `sync_event_sources`, `sync_plans`, `sync_governance`, `activate_signal`, `acquire_rights`, `log_event`, `report_usage`, `provide_performance_feedback`, `report_plan_outcome`, `create_property_list`, `update_property_list`, `delete_property_list`, `create_collection_list`, `update_collection_list`, `delete_collection_list`, `create_content_standards`, `update_content_standards`, `calibrate_content`, `si_initiate_session`, `si_send_message`.
+
+Missing the key → `adcp_error.code: 'VALIDATION_ERROR'` with `/idempotency_key` in `issues`.
+
+### `account` is a `oneOf` — pick ONE variant, send ONLY its fields
+
+Probably the single most common stumble for naive LLMs. `account` is a discriminated union. Per AdCP 3.0, two variants on `create_media_buy` / `update_media_buy`:
+
+```json
+// variant 0: by seller-assigned id (from sync_accounts or list_accounts)
+"account": { "account_id": "seller_assigned_id" }
+
+// variant 1: by natural key (brand + operator, optional sandbox)
+"account": { "brand": { "domain": "acme.com" }, "operator": "sales.example" }
+```
+
+**Do NOT merge required fields across variants** — `additionalProperties: false` on each variant means `{account_id, brand}` fails BOTH. Pick one variant and send only its fields. Always check the specific tool's schema because other tools (e.g. `sync_creatives`) may accept a superset.
+
+### `brand` takes `{domain}` — not `{brand_id}`
+
+```json
+"brand": { "domain": "acme.example" }
+```
+
+### Async responses: `status: 'submitted'` means "queued, poll later"
+
+A mutating tool can return one of three shapes:
+
+```json
+// Success (sync): the work is done
+{ "media_buy_id": "mb_123", "packages": [...], "confirmed_at": "..." }
+
+// Submitted (async): the work is queued
+{ "status": "submitted", "task_id": "tk_abc", "message": "Awaiting IO signature" }
+
+// Error: don't retry without fixing
+{ "errors": [{ "code": "PRODUCT_NOT_FOUND", "message": "..." }] }
+```
+
+When you see `status: 'submitted'`, the work is NOT complete. Poll via `tasks/get` (A2A) or the MCP async task extension, using the `task_id`. Over A2A the AdCP `task_id` also rides on `artifact.metadata.adcp_task_id` — both work.
+
+### `packages[*]` on media buys
+
+```json
+"packages": [
+  { "buyer_ref": "pkg_1", "product_id": "p_from_catalog", "budget": 10000, "pricing_option_id": "po_xyz" }
+]
+```
+
+`budget` is a **number** (not `{amount, currency}` — currency is implied by the pricing option). `pricing_option_id` and `buyer_ref` are required per package.
+
+## Error envelope — read `issues[]` to recover
+
+Every validation failure produces:
+
+```json
+{
+  "adcp_error": {
+    "code": "VALIDATION_ERROR",
+    "recovery": "correctable",
+    "field": "/first/offending/pointer",
+    "issues": [
+      { "pointer": "/account",    "keyword": "oneOf", "message": "must match exactly one schema in oneOf" },
+      { "pointer": "/brand/domain", "keyword": "required", "message": "must have required property 'domain'" }
+    ]
+  }
+}
+```
+
+- `issues[].pointer` is an RFC 6901 JSON Pointer to the field.
+- `issues[].keyword` is the AJV keyword (`required`, `type`, `oneOf`, `additionalProperties`, `format`, `enum`).
+- **On `oneOf` errors** the framework tells you the field is a union but NOT which variant to pick. This skill or the schema is how you know.
+
+Patch the pointers, don't re-guess what the skill already told you, resend. Three attempts should cover every field.
+
+## Minimal working examples
+
+### get_products
+
+```json
+{
+  "buying_mode": "brief",
+  "brief": "premium CTV sports inventory for live NBA finals in major US markets"
+}
+```
+
+Returns `{ products: [{ product_id, name, description, delivery_type, pricing_options, ... }] }`.
+
+### create_media_buy
+
+```json
+{
+  "idempotency_key": "<uuid>",
+  "account": { "account_id": "seller_assigned_id" },
+  "brand": { "domain": "acme.example" },
+  "start_time": "2026-05-01T00:00:00Z",
+  "end_time": "2026-05-31T23:59:59Z",
+  "packages": [
+    {
+      "buyer_ref": "pkg_1",
+      "product_id": "<product_id from get_products>",
+      "budget": 10000,
+      "pricing_option_id": "<pricing_option_id from product.pricing_options>"
+    }
+  ]
+}
+```
+
+If you don't have a `seller_assigned_id`, use the natural-key variant instead:
+`"account": { "brand": { "domain": "acme.example" }, "operator": "sales.example" }`.
+
+Returns **either** `{ media_buy_id, packages: [...], confirmed_at }` (sync) **or** `{ status: 'submitted', task_id, message }` (async — guaranteed / IO-signed flows).
+
+### sync_creatives
+
+```json
+{
+  "idempotency_key": "<uuid>",
+  "account": { "account_id": "seller_assigned_id" },
+  "creatives": [
+    {
+      "creative_id": "cr_1",
+      "name": "My Creative",
+      "format_id": { "agent_url": "https://creatives.adcontextprotocol.org", "id": "video_1920x1080" },
+      "assets": {}
+    }
+  ]
+}
+```
+
+Per-creative required: `creative_id`, `name`, `format_id: { agent_url, id }`, `assets` (shape depends on `format_id`; start with `{}` then fill required asset keys per format spec). Returns `{ creatives: [{ creative_id, action, status }] }` — items may fail individually without failing the batch.
+
+### get_signals
+
+```json
+{
+  "signal_spec": "female professionals 25-54 in major US metros"
+}
+```
+
+Returns `{ signals: [{ signal_agent_segment_id, match_rate, pricing, ... }] }`. Note: the identifier field is `signal_agent_segment_id` (not `signal_id`) — used as input to `activate_signal` below.
+
+### activate_signal
+
+```json
+{
+  "idempotency_key": "<uuid>",
+  "signal_agent_segment_id": "sig_premium_ctv_sports",
+  "destinations": [
+    { "type": "platform", "platform": "trade_desk_us" }
+  ]
+}
+```
+
+`destinations[]` is a `oneOf`: either `{type: 'platform', platform, account?}` OR `{type, agent_url, account?}`. Pick one shape per destination.
+
+## Transport notes
+
+- **MCP**: `tools/call` with `{ name: 'tool_name', arguments: {...} }`. Returns `{ content, structuredContent, isError? }`. Read `structuredContent` for the typed response.
+- **A2A**: `message/send` with a `DataPart` of shape `{ skill: 'tool_name', input: {...} }` (the legacy key `parameters` is also accepted). Returns an A2A `Task`; the typed response is at `task.artifacts[0].parts[0].data`.
+
+Both transports share: idempotency, error shape, schema enforcement, and handler semantics. If a call works on one, the equivalent call works on the other.
+
+## Gotchas I keep seeing
+
+1. **Merging `oneOf` variants**: see the account section above. If you see three `additionalProperties` errors under one pointer, you merged. Drop to one variant.
+2. **`budget` as an object**: it's a number. Currency comes from the `pricing_option`.
+3. **`brand.brand_id` instead of `brand.domain`**: spec uses `domain`.
+4. **Forgetting `idempotency_key`**: required on every mutating tool; see the list above.
+5. **Treating A2A `Task.state: 'completed'` as AdCP completion**: A2A task state = transport call lifecycle. AdCP-level completion is in the artifact's payload (`structuredContent.status` or `data.status`). A `completed` A2A task can still carry a `submitted` AdCP response.
+
+## If you get stuck
+
+Priority order:
+
+1. Re-read the failure's `issues[]`. The pointer list plus this skill covers 80% of cases.
+2. Call `get_schema(tool_name)` if the agent exposes it (adcp#3057).
+3. Read the bundled JSON Schema at `schemas/cache/<version>/bundled/<protocol>/<tool>-request.json`.
+4. Consult `docs/guides/VALIDATE-YOUR-AGENT.md` in `@adcp/client` for per-specialism patterns.
+
+## Related
+
+- `skills/build-seller-agent/SKILL.md` — building agents on the other side of the call
+- `docs/guides/BUILD-AN-AGENT.md` — framework reference
+- `schemas/cache/<version>/` — canonical JSON Schemas (every tool, every version)

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -91,18 +91,26 @@ Every validation failure produces:
     "recovery": "correctable",
     "field": "/first/offending/pointer",
     "issues": [
-      { "pointer": "/account",    "keyword": "oneOf", "message": "must match exactly one schema in oneOf" },
+      {
+        "pointer": "/account",
+        "keyword": "oneOf",
+        "message": "must match exactly one schema in oneOf",
+        "variants": [
+          { "index": 0, "required": ["account_id"],        "properties": ["account_id"] },
+          { "index": 1, "required": ["brand", "operator"], "properties": ["brand", "operator", "sandbox"] }
+        ]
+      },
       { "pointer": "/brand/domain", "keyword": "required", "message": "must have required property 'domain'" }
     ]
   }
 }
 ```
 
-- `issues[].pointer` is an RFC 6901 JSON Pointer to the field.
-- `issues[].keyword` is the AJV keyword (`required`, `type`, `oneOf`, `additionalProperties`, `format`, `enum`).
-- **On `oneOf` errors** the framework tells you the field is a union but NOT which variant to pick. This skill or the schema is how you know.
+- `issues[].pointer` — RFC 6901 JSON Pointer to the field.
+- `issues[].keyword` — AJV keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`).
+- `issues[].variants` — when the keyword is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`. **Pick ONE variant**, send only its `required` fields. This is the fastest recovery path when you didn't know the field was a union.
 
-Patch the pointers, don't re-guess what the skill already told you, resend. Three attempts should cover every field.
+Patch the pointers, don't re-guess what the skill or the `variants` already told you, resend. Three attempts should cover every field.
 
 ## Minimal working examples
 

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: call-adcp-agent
-description: Use when calling an AdCP agent as a buyer — media buys, signal lookups, creative sync, delivery reports. Covers the wire contract, common payload shapes, async flow, and error recovery so you don't get stuck on oneOf or discriminated-union fields that schema-free tool discovery won't explain.
+description: Use when calling an AdCP agent as a buyer — media buys, signal lookups, creative sync, delivery reports. Covers the wire contract, minimal payload shapes, async flow (`status:'submitted'` + `task_id`), and error recovery from `adcp_error.issues[]`.
 ---
 
 # Call an AdCP agent
+
+## Overview
+
+AdCP (Ad Context Protocol) agents expose a fixed tool surface (`get_products`, `create_media_buy`, `get_signals`, …) over MCP or A2A. Tool names come from `get_adcp_capabilities`; exact request/response shapes live in the spec's bundled JSON Schemas at `schemas/cache/3.0.0/bundled/<protocol>/<tool>-{request,response}.json` (or via `get_schema` when the agent exposes it). This skill teaches the invariants that don't live cleanly in any schema: cross-tool patterns, async flow, error recovery.
 
 ## When to Use
 
@@ -19,7 +23,7 @@ Walk these in order on first contact:
 1. **Agent card** (A2A) or **`tools/list`** (MCP): returns tool NAMES. Post-`@adcp/client` [#915](https://github.com/adcontextprotocol/adcp-client/pull/915), `tools/list` no longer publishes per-tool parameter schemas — everything shows `{type: 'object', properties: {}}`. Don't try to infer shape from here.
 2. **`get_adcp_capabilities`**: returns supported protocols (`media_buy`, `signals`, `creative`, …), AdCP major versions, feature flags. Tells you WHICH tools this agent supports, not how to call them.
 3. **`get_schema(tool_name)`** *(when the agent exposes it — upstream [adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057))*: returns the JSON Schema for a tool's request/response. Preferred over reading bundled schemas when available.
-4. **Bundled schemas** (offline, authoritative): `schemas/cache/<version>/bundled/<protocol>/<tool>-request.json` and `-response.json`. The spec ships them; every AdCP version has them.
+4. **Bundled schemas** (offline, authoritative): `schemas/cache/3.0.0/bundled/<protocol>/<tool>-request.json` and `-response.json`. `npm run sync-schemas` in `@adcp/client` pulls them from the spec repo; substitute your target AdCP major version in the path.
 
 ## Non-obvious rules every buyer must follow
 
@@ -195,6 +199,7 @@ Both transports share: idempotency, error shape, schema enforcement, and handler
 3. **`brand.brand_id` instead of `brand.domain`**: spec uses `domain`.
 4. **Forgetting `idempotency_key`**: required on every mutating tool; see the list above.
 5. **Treating A2A `Task.state: 'completed'` as AdCP completion**: A2A task state = transport call lifecycle. AdCP-level completion is in the artifact's payload (`structuredContent.status` or `data.status`). A `completed` A2A task can still carry a `submitted` AdCP response.
+6. **`format_id` as a string**: `format_id` is always an object `{ agent_url, id }` (and sometimes `{ width, height, duration_ms }` for dimensions). Sending `"format_id": "video_1920x1080"` fails with an `additionalProperties` / `type` error — pass the object.
 
 ## If you get stuck
 
@@ -202,11 +207,11 @@ Priority order:
 
 1. Re-read the failure's `issues[]`. The pointer list plus this skill covers 80% of cases.
 2. Call `get_schema(tool_name)` if the agent exposes it (adcp#3057).
-3. Read the bundled JSON Schema at `schemas/cache/<version>/bundled/<protocol>/<tool>-request.json`.
+3. Read the bundled JSON Schema at `schemas/cache/3.0.0/bundled/<protocol>/<tool>-request.json`.
 4. Consult `docs/guides/VALIDATE-YOUR-AGENT.md` in `@adcp/client` for per-specialism patterns.
 
 ## Related
 
 - `skills/build-seller-agent/SKILL.md` — building agents on the other side of the call
 - `docs/guides/BUILD-AN-AGENT.md` — framework reference
-- `schemas/cache/<version>/` — canonical JSON Schemas (every tool, every version)
+- `schemas/cache/3.0.0/` — canonical JSON Schemas (every tool, pinned to the AdCP version `@adcp/client` bundles)


### PR DESCRIPTION
## Summary

New skill at \`skills/call-adcp-agent/SKILL.md\` for LLMs calling AdCP agents as buyers. Covers:

- Wire contract (MCP vs A2A; same tool surface, different framing)
- Discovery chain (\`get_adcp_capabilities\` → schemas at \`schemas/cache/<version>/\`)
- \`idempotency_key\` invariant (required on every mutating tool)
- **\`account\` is a \`oneOf\`** — the #1 stumble for naive LLMs (two variants in AdCP 3.0: \`{account_id}\` XOR \`{brand, operator, sandbox?}\`)
- \`brand\` takes \`{domain}\` (not \`{brand_id}\`)
- Async flow: \`status:'submitted'\` + \`task_id\` means queued, not complete
- Error recovery from \`adcp_error.issues[]\`
- Minimal working payload examples for the top five tools

## Why now

PR #915 made MCP \`tools/list\` schema-free (trade-off for cross-transport validation symmetry with A2A). Without per-tool inputSchemas on \`tools/list\`, naive LLMs have no priors when making their first call. Upstream [adcp#3057](https://github.com/adcontextprotocol/adcp/issues/3057) proposes a \`get_schema\` capability tool as the long-term discovery surface, but that's spec-pending.

## Empirical A/B/C probe

Ran a three-way comparison on a real MCP + A2A agent:
- **Naive** (no priors; error-driven recovery only)
- **Schema-aware** (calls mocked \`get_schema(tool_name)\`, synthesizes from schema)
- **Skill-aware** (uses this skill's minimal examples as starting payloads)

\`\`\`
Tool                  Naive           Schema (get_schema)   Skill (SKILL.md)
get_products          ✗ stuck@2       ✓ 2                   ✓ 1
create_media_buy      ✗ stuck@4       ✓ 3                   ✓ 1
sync_creatives        ✗ stuck@4       ✗ stuck@3             ✓ 1
get_signals           ✗ stuck         ✗ stuck               ✓ 1
activate_signal       ✗ stuck@2       ✗ stuck@3             ✓ 1
\`\`\`

Skill-aware: **5/5 tools land on first attempt.** Schema-aware: 2/5 (stumbles on deeper oneOf/nested shapes that a naive synthesizer can't handle). Naive: 0/5.

## Honest caveats (in the skill)

- **Prose can drift.** My first draft had the \`account\` oneOf wrong (3 variants; spec has 2). Fact-checked against \`schemas/cache/3.0.0/bundled/\` before shipping. When in doubt, the skill points at the bundled schema or upstream \`get_schema\`.
- **Deep nested shapes (assets[] on creatives) need the schema, not prose.** The skill gives the top-level call; the bundled schema gives the exact creative-asset shape.
- **Per-agent extensions aren't covered** by a generic skill. For agent-specific tool shapes, call \`get_schema\` on that agent (when the tool is available).

## Changes

- \`skills/call-adcp-agent/SKILL.md\` (new, ~180 lines)
- \`CLAUDE.md\` — one-line pointer under the existing "Read and follow …" skill index
- Changeset (patch bump; docs-only)

## Related

- PR #915 — the validation-symmetry fix that motivated this skill
- Upstream adcp#3057 — \`get_schema\` capability tool proposal (complementary; covers the 20% this skill can't)
- Issue #909 — MCP/A2A validation asymmetry (closed by #915)

🤖 Generated with [Claude Code](https://claude.com/claude-code)