### PR TITLE
feat(types): strict per-asset-type slot types for Format.assets[]

### DIFF
--- a/.changeset/format-asset-slot-types.md
+++ b/.changeset/format-asset-slot-types.md
@@ -1,0 +1,15 @@
+---
+'@adcp/client': minor
+---
+
+**Strict types and builders for `Format.assets[]`.** The codegen collapses the discriminated union under `Format.assets[]` to `BaseIndividualAsset` — no per-asset-type branches, no `requirements` field. That means a platform emitting a loose literal like `{ asset_type: 'image', requirements: { file_types: ['jpg'] } }` compiled clean but failed strict response validation, because the real spec field is `formats`, not `file_types`. `scope3data/agentic-adapters#118` hit this across five adapters (Pinterest, TikTok, UniversalAds, Criteo, CitrusAd) on four independent axes: `file_types` vs `formats`/`containers`, `min_duration_seconds` vs `min_duration_ms`, comma-joined `aspect_ratio`, and `min_count`/`max_count` placed on an individual asset instead of a `repeatable_group` wrapper.
+
+**New types** — per-asset-type slot shapes that wire the existing `ImageAssetRequirements` / `VideoAssetRequirements` / `AudioAssetRequirements` / `TextAssetRequirements` / `MarkdownAssetRequirements` / `HTMLAssetRequirements` / `CSSAssetRequirements` / `JavaScriptAssetRequirements` / `VASTAssetRequirements` / `DAASTAssetRequirements` / `URLAssetRequirements` / `WebhookAssetRequirements` / `CatalogRequirements` interfaces into a discriminated `IndividualAssetSlot` union, plus `RepeatableGroupSlot` and a top-level `FormatAssetSlot = IndividualAssetSlot | RepeatableGroupSlot`. `GroupAssetSlot` variants parallel the individual slots for use inside `RepeatableGroupSlot.assets[]`. Exported from `@adcp/client`.
+
+**New builders** — `imageAssetSlot`, `videoAssetSlot`, `audioAssetSlot`, `textAssetSlot`, `markdownAssetSlot`, `htmlAssetSlot`, `cssAssetSlot`, `javascriptAssetSlot`, `vastAssetSlot`, `daastAssetSlot`, `urlAssetSlot`, `webhookAssetSlot`, `briefAssetSlot`, `catalogAssetSlot`, `repeatableGroup`, and per-asset-type `*GroupAsset` helpers. Each injects `item_type` and `asset_type` so callers write the meaningful fields only. A `FormatAsset` namespace groups all of them for single-import use (`FormatAsset.image(...)`, `FormatAsset.group(...)`).
+
+**What this catches.** With the generated types, `{ requirements: { file_types: ['jpg'] } }` was `{ [k: string]: unknown }` and passed the compiler. With the new slot types, it fails at the authorship site — the compiler knows the spec's field names and closed enums. The type-test file `src/type-tests/format-asset-slots.type-test.ts` asserts via `@ts-expect-error` that `file_types`, `min_duration_seconds`, out-of-enum `containers`/`formats`, and `min_count`/`max_count` on an individual asset are all rejected — CI's typecheck fails if any of those regress.
+
+**Skills updated.** `skills/build-seller-agent/SKILL.md`, `skills/build-generative-seller-agent/SKILL.md`, and `skills/build-creative-agent/SKILL.md` each gained a "format asset slot" section with the four translation footguns and concrete builder-based examples framed for that audience (social/retail sales, generative DSPs, ad servers/CMPs).
+
+Additive change — existing `Format.assets[]` literals continue to compile; the new surface is available for authors who want compile-time protection for requirement shapes.

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -214,6 +214,11 @@ const formats = [
   },
 ];
 
+// The plain literal above works, but creative agents declaring richer
+// acceptance specs (technical `requirements`, carousel/collection wrappers)
+// should use the typed slot builders — see "Format asset slot builders"
+// below.
+
 // Idempotency — required for v3 compliance on any agent with mutating
 // handlers. `sync_creatives`, `build_creative`, and `calibrate_content`
 // are all mutating for creative agents.
@@ -331,6 +336,85 @@ serve(() => {
 Use `ctx.store` to persist synced creatives. The framework provides `InMemoryStateStore` by default — no need for module-level Maps or external state management.
 
 The `sync_creatives` handler adds/updates entries via `ctx.store.put('creatives', id, data)`. The `list_creatives` handler queries via `ctx.store.list('creatives')` (include `created_date` and `updated_date` in each creative). The `preview_creative` handler previews the `creative_manifest` sent in the request (no library lookup needed). The `build_creative` handler finds a synced creative by `target_format_id` (matching the format), then builds a serving tag from it.
+
+### Format asset slot builders
+
+Ad servers and creative management platforms declare the technical acceptance contract in `Format.assets[]` — what a buyer must submit for a creative to be accepted. The spec's closed enums and field shapes are easy to get slightly wrong in a handwritten literal; strict response validation then rejects the format even when it's structurally close.
+
+Four recurring mistakes:
+
+1. **Image** uses `formats: ('jpg' | 'png' | 'gif' | 'webp' | 'svg' | 'avif' | 'tiff' | 'pdf' | 'eps')[]` — not `file_types`. Image `aspect_ratio` matches `^\d+(\.\d+)?:\d+(\.\d+)?$` (single-valued).
+2. **Video** uses `containers: ('mp4' | 'webm' | 'mov' | 'avi' | 'mkv')[]` and `codecs: ('h264' | 'h265' | 'vp8' | 'vp9' | 'av1' | 'prores')[]`. Video `aspect_ratio` is integer-only `^\d+:\d+$`. Durations are `min_duration_ms` / `max_duration_ms`.
+3. **Audio** uses `formats: ('mp3' | 'aac' | 'wav' | 'ogg' | 'flac')[]`. Durations are `*_duration_ms`.
+4. **`min_count` / `max_count`** live on the `repeatable_group` wrapper. Formats that render multiple items (galleries, story frames, product showcases) declare an `item_type: 'repeatable_group'` slot with `assets[]` inside — never put counts on an individual asset.
+
+Use the typed slot builders when declaring acceptance specs. `requirements` is strictly typed per `asset_type`, so misnamed fields and wrong units fail at compile time:
+
+```typescript
+import {
+  imageAssetSlot,
+  videoAssetSlot,
+  repeatableGroup,
+  imageGroupAsset,
+  textGroupAsset,
+} from '@adcp/client';
+
+// MRec banner with typed image requirements
+{
+  format_id: { agent_url: AGENT_URL, id: 'display_banner_300x250' },
+  name: 'Display Banner 300x250',
+  renders: [{ role: 'primary', dimensions: { width: 300, height: 250 } }],
+  assets: [
+    imageAssetSlot({
+      asset_id: 'image',
+      required: true,
+      requirements: { formats: ['jpg', 'png', 'webp'], max_file_size_kb: 200 },
+    }),
+  ],
+}
+
+// In-stream video, 6–30s
+{
+  format_id: { agent_url: AGENT_URL, id: 'video_instream_16x9' },
+  name: 'In-Stream Video 16:9',
+  renders: [{ role: 'primary', dimensions: { width: 1920, height: 1080 } }],
+  assets: [
+    videoAssetSlot({
+      asset_id: 'video',
+      required: true,
+      requirements: {
+        aspect_ratio: '16:9',
+        containers: ['mp4', 'webm'],
+        codecs: ['h264', 'h265'],
+        min_duration_ms: 6000,
+        max_duration_ms: 30000,
+      },
+    }),
+  ],
+}
+
+// Gallery format — 3 to 8 image+headline pairs. Counts on the GROUP.
+{
+  format_id: { agent_url: AGENT_URL, id: 'gallery_1x1' },
+  name: 'Image Gallery',
+  renders: [{ role: 'primary', dimensions: { width: 1080, height: 1080 } }],
+  assets: [
+    repeatableGroup({
+      asset_group_id: 'cards',
+      required: true,
+      min_count: 3,
+      max_count: 8,
+      selection_mode: 'sequential',
+      assets: [
+        imageGroupAsset({ asset_id: 'card_image', required: true, requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png'] } }),
+        textGroupAsset({ asset_id: 'card_headline', required: true, requirements: { max_length: 40 } }),
+      ],
+    }),
+  ],
+}
+```
+
+Ad servers whose output is a serving-tag (VAST, display tag HTML) declare those via `vastAssetSlot`, `htmlAssetSlot`, or `javascriptAssetSlot` with their respective requirement shapes (`vast_version`, `sandbox`, `module_type`).
 
 ## Idempotency
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -184,6 +184,80 @@ listCreativeFormatsResponse({
 })
 ```
 
+#### Format requirements as generation constraints
+
+Generative sellers consume `requirements` as the input spec the generator must satisfy. When you declare a format, its requirements are the contract for what your generator will produce — so the field names and units have to match the spec exactly or downstream validators will reject what you generate even when the bytes are correct.
+
+Four constraints that recur on every generative format declaration:
+
+1. **Image** uses `formats: ('jpg' | 'png' | 'gif' | 'webp' | 'svg' | 'avif' | 'tiff' | 'pdf' | 'eps')[]` — not `file_types`. Image `aspect_ratio` matches `^\d+(\.\d+)?:\d+(\.\d+)?$` (decimals allowed, e.g. `1.91:1`), single-valued.
+2. **Video** uses `containers: ('mp4' | 'webm' | 'mov' | 'avi' | 'mkv')[]` — not `file_types`. Video `aspect_ratio` is integer-only `^\d+:\d+$`. Durations are `min_duration_ms` / `max_duration_ms`.
+3. **Audio** uses `formats: ('mp3' | 'aac' | 'wav' | 'ogg' | 'flac')[]`. Durations are `min_duration_ms` / `max_duration_ms`.
+4. **`min_count` / `max_count`** live on the `repeatable_group` wrapper for formats that generate multiple items (carousel packs, product collections). Never on an individual asset.
+
+Use the typed slot builders to declare format slots — the `requirements` object is strictly typed per `asset_type`, so misnamed fields and wrong units fail at compile time:
+
+```typescript
+import {
+  briefAssetSlot,
+  imageAssetSlot,
+  videoAssetSlot,
+  repeatableGroup,
+  imageGroupAsset,
+  textGroupAsset,
+} from '@adcp/client';
+
+// Generative display format — brief in, spec-compliant image out
+{
+  format_id: { agent_url, id: 'display_300x250_generative' },
+  name: 'Generated Display 300x250',
+  renders: [{ role: 'primary', dimensions: { width: 300, height: 250 } }],
+  assets: [
+    briefAssetSlot({ asset_id: 'brief', required: true }),
+  ],
+}
+
+// Generative carousel pack — generator produces 3–6 image+headline cards
+{
+  format_id: { agent_url, id: 'carousel_generative' },
+  name: 'Generated Product Carousel',
+  renders: [{ role: 'primary', dimensions: { width: 1080, height: 1080 } }],
+  assets: [
+    briefAssetSlot({ asset_id: 'brief', required: true }),
+    repeatableGroup({
+      asset_group_id: 'cards',
+      required: true,
+      min_count: 3,
+      max_count: 6,
+      selection_mode: 'sequential',
+      assets: [
+        imageGroupAsset({ asset_id: 'card_image', required: true, requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png'] } }),
+        textGroupAsset({ asset_id: 'card_headline', required: true, requirements: { max_length: 40 } }),
+      ],
+    }),
+  ],
+}
+```
+
+Reading requirements on the generation path — discriminate by `asset_type` to narrow to the correct requirements shape, then feed it to the generator:
+
+```typescript
+import type { IndividualAssetSlot } from '@adcp/client';
+
+function constraintsFor(slot: IndividualAssetSlot) {
+  switch (slot.asset_type) {
+    case 'image':
+      return slot.requirements; // ImageAssetRequirements — formats, aspect_ratio, max_file_size_kb
+    case 'video':
+      return slot.requirements; // VideoAssetRequirements — containers, *_duration_ms, aspect_ratio
+    case 'audio':
+      return slot.requirements; // AudioAssetRequirements — formats, *_duration_ms
+    default:
+      return undefined;
+  }
+}
+```
+
 **`sync_creatives`** — `SyncCreativesRequestSchema.shape`
 
 Handle both brief-based and standard creatives:

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -529,6 +529,57 @@ listCreativeFormatsResponse({
 })
 ```
 
+#### Format asset slots — translating platform-native constraints to AdCP
+
+Social and retail-media sellers translate platform-native format catalogs (Meta, Pinterest, TikTok, Criteo, CitrusAd, UniversalAds) into AdCP's `Format.assets[]`. Four recurring footguns fail strict response validation even when the data is "there":
+
+1. **Wrong field name for file types.** The spec uses `formats` on image requirements and `containers` on video requirements — NOT `file_types`. Platforms commonly carry `file_types: ['mp4']`; remap to `containers: ['mp4']` for video, `formats: ['jpg', 'png']` for image.
+2. **Wrong unit on duration.** AdCP uses `min_duration_ms` / `max_duration_ms` (milliseconds). Platforms often carry `min_duration_seconds`. Multiply by 1000 on translation.
+3. **Aspect ratios are single-valued per format.** Image pattern `^\d+(\.\d+)?:\d+(\.\d+)?$` allows decimals (`1.91:1`); video is integer-only `^\d+:\d+$`. Comma-joined values (`"1:1,16:9"`) fail — emit separate format variants per ratio.
+4. **`min_count` / `max_count` live on the repeatable_group wrapper.** Carousels, collections, story-pin frames, product showcases are `repeatable_group` assets with `assets[]` inside. Putting counts on an individual asset slot is a spec violation that strict validation rejects.
+
+Retail-media sponsored-products formats often reach for `asset_type: 'promoted_offerings'`. That value isn't in the AdCP enum — the correct choice is `asset_type: 'catalog'` with a `CatalogRequirements` object declaring `catalog_type: 'product'` (or `offering`, etc.), `min_items`, `max_items`, and the expected `feed_formats`.
+
+Use the typed slot builders — they inject `item_type` and `asset_type`, and the `requirements` object is strictly typed per asset_type, so `file_types`, `min_duration_seconds`, and `min_count` on an individual asset all fail at compile time:
+
+```typescript
+import { imageAssetSlot, videoAssetSlot, catalogAssetSlot, repeatableGroup, imageGroupAsset, textGroupAsset } from '@adcp/client';
+
+// Single image asset slot
+imageAssetSlot({
+  asset_id: 'hero_image',
+  required: true,
+  requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png', 'webp'], max_file_size_kb: 5120 },
+});
+
+// Carousel: 2–5 images. Counts on the GROUP, not the individual image.
+repeatableGroup({
+  asset_group_id: 'carousel_items',
+  required: true,
+  min_count: 2,
+  max_count: 5,
+  selection_mode: 'sequential',
+  assets: [
+    imageGroupAsset({ asset_id: 'card_image', required: true, requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png'] } }),
+    textGroupAsset({ asset_id: 'card_headline', required: true, requirements: { max_length: 40 } }),
+  ],
+});
+
+// Sponsored-products: catalog slot, not 'promoted_offerings'
+catalogAssetSlot({
+  asset_id: 'products',
+  required: true,
+  requirements: {
+    catalog_type: 'product',
+    min_items: 3,
+    max_items: 10,
+    feed_formats: ['google_merchant_center'],
+  },
+});
+```
+
+Grouped namespace `FormatAsset.image(...)`, `FormatAsset.group(...)`, etc. is available when constructing several slot types together.
+
 **`sync_creatives`** — `SyncCreativesRequestSchema.shape`
 
 ```

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -849,6 +849,47 @@ export {
   webhookAsset,
 } from './utils/asset-builders';
 
+// ====== FORMAT ASSET SLOT BUILDERS ======
+// Typed factories for the slot definitions inside `Format.assets[]` — what a
+// seller/publisher declares it accepts. Each builder injects the `item_type`
+// and `asset_type` discriminators, and the `requirements` object is strictly
+// typed per asset_type: misnamed fields (`file_types` vs `formats`) and wrong
+// units (`min_duration_seconds` vs `min_duration_ms`) fail type-check.
+// Use `repeatableGroup({...})` (or `FormatAsset.group(...)`) to wrap assets
+// that repeat — that's the correct home for `min_count` / `max_count`.
+export {
+  FormatAsset,
+  imageAssetSlot,
+  videoAssetSlot,
+  audioAssetSlot,
+  textAssetSlot,
+  markdownAssetSlot,
+  htmlAssetSlot,
+  cssAssetSlot,
+  javascriptAssetSlot,
+  vastAssetSlot,
+  daastAssetSlot,
+  urlAssetSlot,
+  webhookAssetSlot,
+  briefAssetSlot,
+  catalogAssetSlot,
+  repeatableGroup,
+  imageGroupAsset,
+  videoGroupAsset,
+  audioGroupAsset,
+  textGroupAsset,
+  markdownGroupAsset,
+  htmlGroupAsset,
+  cssGroupAsset,
+  javascriptGroupAsset,
+  vastGroupAsset,
+  daastGroupAsset,
+  urlGroupAsset,
+  webhookGroupAsset,
+  briefGroupAsset,
+  catalogGroupAsset,
+} from './utils/format-asset-slot-builders';
+
 // ====== PREVIEW RENDER BUILDERS ======
 // Typed factories that inject the `output_format` discriminator on
 // `PreviewRender` objects. `urlRender({ render_id, preview_url, role })`

--- a/src/lib/types/format-asset-slots.ts
+++ b/src/lib/types/format-asset-slots.ts
@@ -1,0 +1,205 @@
+// Strict types for the asset slots inside a Format definition (Format.assets[]).
+//
+// These describe what a publisher/platform SELLS — the slots buyers must fill
+// when building a creative for the format. They are distinct from the creative
+// instance types (ImageAsset, VideoAsset, …) in `tools.generated.ts`, which
+// describe the assets a buyer DELIVERS.
+//
+// The generated `Format.assets[]` collapses to `BaseIndividualAsset` (no
+// per-asset-type discriminator, no `requirements` field) — the json-schema-to-
+// typescript codegen loses the `oneOf` branching when all branches share a
+// `$ref` base. The per-asset-type `*AssetRequirements` interfaces already
+// exist in `core.generated.ts`; these hand-authored slot types wire them in
+// so misnamed fields (`file_types` vs `formats`), wrong units (`_seconds` vs
+// `_ms`), and misplaced `min_count` (on an individual asset instead of a
+// repeatable_group) become TypeScript errors at the authorship site.
+//
+// Source of truth: schemas/cache/{version}/bundled/{creative,media-buy}/list-creative-formats-response.json
+
+import type {
+  AudioAssetRequirements,
+  CSSAssetRequirements,
+  CatalogRequirements,
+  DAASTAssetRequirements,
+  HTMLAssetRequirements,
+  ImageAssetRequirements,
+  JavaScriptAssetRequirements,
+  MarkdownAssetRequirements,
+  TextAssetRequirements,
+  URLAssetRequirements,
+  VASTAssetRequirements,
+  VideoAssetRequirements,
+  WebhookAssetRequirements,
+} from './core.generated';
+import type { Overlay } from './tools.generated';
+
+// ---------- Shared base ----------
+
+export interface BaseIndividualAssetSlot {
+  item_type: 'individual';
+  /** Unique identifier for this asset. Creative manifests MUST use this exact value as the key in the assets object. */
+  asset_id: string;
+  /** Descriptive label for this asset's purpose (for documentation / UI only). */
+  asset_role?: string;
+  /** Whether this asset is required for a valid creative. */
+  required: boolean;
+  /** Publisher-controlled overlay elements rendered over buyer content at this asset's position. */
+  overlays?: Overlay[];
+}
+
+export interface BaseGroupAssetSlot {
+  /** Identifier within the group. */
+  asset_id: string;
+  asset_role?: string;
+  /** Whether this asset is required within each repetition of the group. */
+  required: boolean;
+  overlays?: Overlay[];
+}
+
+// ---------- Per-asset-type individual slot shapes ----------
+
+export interface IndividualImageAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'image';
+  requirements?: ImageAssetRequirements;
+}
+
+export interface IndividualVideoAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'video';
+  requirements?: VideoAssetRequirements;
+}
+
+export interface IndividualAudioAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'audio';
+  requirements?: AudioAssetRequirements;
+}
+
+export interface IndividualTextAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'text';
+  requirements?: TextAssetRequirements;
+}
+
+export interface IndividualMarkdownAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'markdown';
+  requirements?: MarkdownAssetRequirements;
+}
+
+export interface IndividualHtmlAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'html';
+  requirements?: HTMLAssetRequirements;
+}
+
+export interface IndividualCssAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'css';
+  requirements?: CSSAssetRequirements;
+}
+
+export interface IndividualJavascriptAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'javascript';
+  requirements?: JavaScriptAssetRequirements;
+}
+
+export interface IndividualVastAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'vast';
+  requirements?: VASTAssetRequirements;
+}
+
+export interface IndividualDaastAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'daast';
+  requirements?: DAASTAssetRequirements;
+}
+
+export interface IndividualUrlAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'url';
+  requirements?: URLAssetRequirements;
+}
+
+export interface IndividualWebhookAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'webhook';
+  requirements?: WebhookAssetRequirements;
+}
+
+export interface IndividualBriefAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'brief';
+}
+
+export interface IndividualCatalogAssetSlot extends BaseIndividualAssetSlot {
+  asset_type: 'catalog';
+  requirements?: CatalogRequirements;
+}
+
+export type IndividualAssetSlot =
+  | IndividualImageAssetSlot
+  | IndividualVideoAssetSlot
+  | IndividualAudioAssetSlot
+  | IndividualTextAssetSlot
+  | IndividualMarkdownAssetSlot
+  | IndividualHtmlAssetSlot
+  | IndividualCssAssetSlot
+  | IndividualJavascriptAssetSlot
+  | IndividualVastAssetSlot
+  | IndividualDaastAssetSlot
+  | IndividualUrlAssetSlot
+  | IndividualWebhookAssetSlot
+  | IndividualBriefAssetSlot
+  | IndividualCatalogAssetSlot;
+
+// ---------- Group asset slot shapes (inside a repeatable_group) ----------
+
+type GroupSlotOf<T extends IndividualAssetSlot> = Omit<T, 'item_type' | 'overlays'> & BaseGroupAssetSlot;
+
+export type GroupImageAssetSlot = GroupSlotOf<IndividualImageAssetSlot>;
+export type GroupVideoAssetSlot = GroupSlotOf<IndividualVideoAssetSlot>;
+export type GroupAudioAssetSlot = GroupSlotOf<IndividualAudioAssetSlot>;
+export type GroupTextAssetSlot = GroupSlotOf<IndividualTextAssetSlot>;
+export type GroupMarkdownAssetSlot = GroupSlotOf<IndividualMarkdownAssetSlot>;
+export type GroupHtmlAssetSlot = GroupSlotOf<IndividualHtmlAssetSlot>;
+export type GroupCssAssetSlot = GroupSlotOf<IndividualCssAssetSlot>;
+export type GroupJavascriptAssetSlot = GroupSlotOf<IndividualJavascriptAssetSlot>;
+export type GroupVastAssetSlot = GroupSlotOf<IndividualVastAssetSlot>;
+export type GroupDaastAssetSlot = GroupSlotOf<IndividualDaastAssetSlot>;
+export type GroupUrlAssetSlot = GroupSlotOf<IndividualUrlAssetSlot>;
+export type GroupWebhookAssetSlot = GroupSlotOf<IndividualWebhookAssetSlot>;
+export type GroupBriefAssetSlot = GroupSlotOf<IndividualBriefAssetSlot>;
+export type GroupCatalogAssetSlot = GroupSlotOf<IndividualCatalogAssetSlot>;
+
+export type GroupAssetSlot =
+  | GroupImageAssetSlot
+  | GroupVideoAssetSlot
+  | GroupAudioAssetSlot
+  | GroupTextAssetSlot
+  | GroupMarkdownAssetSlot
+  | GroupHtmlAssetSlot
+  | GroupCssAssetSlot
+  | GroupJavascriptAssetSlot
+  | GroupVastAssetSlot
+  | GroupDaastAssetSlot
+  | GroupUrlAssetSlot
+  | GroupWebhookAssetSlot
+  | GroupBriefAssetSlot
+  | GroupCatalogAssetSlot;
+
+// ---------- Repeatable group ----------
+
+/**
+ * Wrapper for asset groups that repeat (carousels, collections, story-pin
+ * frames, product showcases). `min_count` and `max_count` live here — NOT on
+ * individual assets inside `assets[]`. Putting count constraints on an
+ * individual asset slot violates the spec.
+ */
+export interface RepeatableGroupSlot {
+  item_type: 'repeatable_group';
+  /** Identifier for this asset group (e.g., 'product', 'slide', 'card'). */
+  asset_group_id: string;
+  /** Whether this asset group is required. If true, at least `min_count` repetitions must be provided. */
+  required: boolean;
+  /** Minimum number of repetitions. */
+  min_count: number;
+  /** Maximum number of repetitions. */
+  max_count: number;
+  /** Display semantics: 'sequential' (carousel) or 'optimize' (platform selects best-performing). */
+  selection_mode?: 'sequential' | 'optimize';
+  /** Assets within each repetition of this group. */
+  assets: GroupAssetSlot[];
+}
+
+export type FormatAssetSlot = IndividualAssetSlot | RepeatableGroupSlot;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -22,5 +22,9 @@ export type {
 // Re-export FormatID from generated core types
 export type { FormatID } from './core.generated';
 
+// Strict format asset slot types (hand-authored — the codegen drops the
+// discriminated per-asset-type branches of Format.assets[]).
+export * from './format-asset-slots';
+
 // Re-export Zod schemas for runtime validation
 export * from './schemas.generated';

--- a/src/lib/utils/format-asset-slot-builders.ts
+++ b/src/lib/utils/format-asset-slot-builders.ts
@@ -1,0 +1,207 @@
+// Typed factory helpers for format asset slots. Companion to
+// `asset-builders.ts` (which builds creative INSTANCES). These build the slot
+// definitions inside `Format.assets[]` — what a publisher declares it accepts.
+//
+// Each helper injects `item_type: 'individual'` plus the per-asset-type
+// `asset_type` discriminator so callers only supply the meaningful fields.
+// The slot's `requirements` object is strictly typed per asset type — misnamed
+// fields like `file_types` or wrong units like `min_duration_seconds` become
+// compile-time errors, and the Zod schemas catch runtime drift (e.g.
+// comma-joined aspect ratios) at validation time.
+
+import type {
+  GroupAudioAssetSlot,
+  GroupBriefAssetSlot,
+  GroupCatalogAssetSlot,
+  GroupCssAssetSlot,
+  GroupDaastAssetSlot,
+  GroupHtmlAssetSlot,
+  GroupImageAssetSlot,
+  GroupJavascriptAssetSlot,
+  GroupMarkdownAssetSlot,
+  GroupTextAssetSlot,
+  GroupUrlAssetSlot,
+  GroupVastAssetSlot,
+  GroupVideoAssetSlot,
+  GroupWebhookAssetSlot,
+  IndividualAudioAssetSlot,
+  IndividualBriefAssetSlot,
+  IndividualCatalogAssetSlot,
+  IndividualCssAssetSlot,
+  IndividualDaastAssetSlot,
+  IndividualHtmlAssetSlot,
+  IndividualImageAssetSlot,
+  IndividualJavascriptAssetSlot,
+  IndividualMarkdownAssetSlot,
+  IndividualTextAssetSlot,
+  IndividualUrlAssetSlot,
+  IndividualVastAssetSlot,
+  IndividualVideoAssetSlot,
+  IndividualWebhookAssetSlot,
+  RepeatableGroupSlot,
+} from '../types/format-asset-slots';
+
+type IndividualFields<T> = Omit<T, 'item_type' | 'asset_type'>;
+type GroupFields<T> = Omit<T, 'asset_type'>;
+
+// ---------- Individual asset slot builders ----------
+
+export function imageAssetSlot(fields: IndividualFields<IndividualImageAssetSlot>): IndividualImageAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'image' };
+}
+
+export function videoAssetSlot(fields: IndividualFields<IndividualVideoAssetSlot>): IndividualVideoAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'video' };
+}
+
+export function audioAssetSlot(fields: IndividualFields<IndividualAudioAssetSlot>): IndividualAudioAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'audio' };
+}
+
+export function textAssetSlot(fields: IndividualFields<IndividualTextAssetSlot>): IndividualTextAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'text' };
+}
+
+export function markdownAssetSlot(
+  fields: IndividualFields<IndividualMarkdownAssetSlot>,
+): IndividualMarkdownAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'markdown' };
+}
+
+export function htmlAssetSlot(fields: IndividualFields<IndividualHtmlAssetSlot>): IndividualHtmlAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'html' };
+}
+
+export function cssAssetSlot(fields: IndividualFields<IndividualCssAssetSlot>): IndividualCssAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'css' };
+}
+
+export function javascriptAssetSlot(
+  fields: IndividualFields<IndividualJavascriptAssetSlot>,
+): IndividualJavascriptAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'javascript' };
+}
+
+export function vastAssetSlot(fields: IndividualFields<IndividualVastAssetSlot>): IndividualVastAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'vast' };
+}
+
+export function daastAssetSlot(fields: IndividualFields<IndividualDaastAssetSlot>): IndividualDaastAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'daast' };
+}
+
+export function urlAssetSlot(fields: IndividualFields<IndividualUrlAssetSlot>): IndividualUrlAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'url' };
+}
+
+export function webhookAssetSlot(
+  fields: IndividualFields<IndividualWebhookAssetSlot>,
+): IndividualWebhookAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'webhook' };
+}
+
+export function briefAssetSlot(fields: IndividualFields<IndividualBriefAssetSlot>): IndividualBriefAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'brief' };
+}
+
+export function catalogAssetSlot(
+  fields: IndividualFields<IndividualCatalogAssetSlot>,
+): IndividualCatalogAssetSlot {
+  return { ...fields, item_type: 'individual', asset_type: 'catalog' };
+}
+
+// ---------- Group asset slot builders (for use inside repeatableGroup) ----------
+
+export function imageGroupAsset(fields: GroupFields<GroupImageAssetSlot>): GroupImageAssetSlot {
+  return { ...fields, asset_type: 'image' };
+}
+export function videoGroupAsset(fields: GroupFields<GroupVideoAssetSlot>): GroupVideoAssetSlot {
+  return { ...fields, asset_type: 'video' };
+}
+export function audioGroupAsset(fields: GroupFields<GroupAudioAssetSlot>): GroupAudioAssetSlot {
+  return { ...fields, asset_type: 'audio' };
+}
+export function textGroupAsset(fields: GroupFields<GroupTextAssetSlot>): GroupTextAssetSlot {
+  return { ...fields, asset_type: 'text' };
+}
+export function markdownGroupAsset(fields: GroupFields<GroupMarkdownAssetSlot>): GroupMarkdownAssetSlot {
+  return { ...fields, asset_type: 'markdown' };
+}
+export function htmlGroupAsset(fields: GroupFields<GroupHtmlAssetSlot>): GroupHtmlAssetSlot {
+  return { ...fields, asset_type: 'html' };
+}
+export function cssGroupAsset(fields: GroupFields<GroupCssAssetSlot>): GroupCssAssetSlot {
+  return { ...fields, asset_type: 'css' };
+}
+export function javascriptGroupAsset(fields: GroupFields<GroupJavascriptAssetSlot>): GroupJavascriptAssetSlot {
+  return { ...fields, asset_type: 'javascript' };
+}
+export function vastGroupAsset(fields: GroupFields<GroupVastAssetSlot>): GroupVastAssetSlot {
+  return { ...fields, asset_type: 'vast' };
+}
+export function daastGroupAsset(fields: GroupFields<GroupDaastAssetSlot>): GroupDaastAssetSlot {
+  return { ...fields, asset_type: 'daast' };
+}
+export function urlGroupAsset(fields: GroupFields<GroupUrlAssetSlot>): GroupUrlAssetSlot {
+  return { ...fields, asset_type: 'url' };
+}
+export function webhookGroupAsset(fields: GroupFields<GroupWebhookAssetSlot>): GroupWebhookAssetSlot {
+  return { ...fields, asset_type: 'webhook' };
+}
+export function briefGroupAsset(fields: GroupFields<GroupBriefAssetSlot>): GroupBriefAssetSlot {
+  return { ...fields, asset_type: 'brief' };
+}
+export function catalogGroupAsset(fields: GroupFields<GroupCatalogAssetSlot>): GroupCatalogAssetSlot {
+  return { ...fields, asset_type: 'catalog' };
+}
+
+// ---------- Repeatable group builder ----------
+
+/**
+ * Wrap asset slots in a `repeatable_group` — the correct home for
+ * `min_count` / `max_count`. Use for carousels, collections, story-pin
+ * frames, product showcases. The platform repeats the inner `assets` once
+ * per item; each repetition must provide all required assets within it.
+ */
+export function repeatableGroup(
+  fields: Omit<RepeatableGroupSlot, 'item_type'>,
+): RepeatableGroupSlot {
+  return { ...fields, item_type: 'repeatable_group' };
+}
+
+/**
+ * Grouped accessor for format-slot builders. `FormatAsset.image({...})`
+ * reads well in format declarations. The individual named exports remain
+ * the primary entry points.
+ */
+export const FormatAsset = {
+  image: imageAssetSlot,
+  video: videoAssetSlot,
+  audio: audioAssetSlot,
+  text: textAssetSlot,
+  markdown: markdownAssetSlot,
+  html: htmlAssetSlot,
+  css: cssAssetSlot,
+  javascript: javascriptAssetSlot,
+  vast: vastAssetSlot,
+  daast: daastAssetSlot,
+  url: urlAssetSlot,
+  webhook: webhookAssetSlot,
+  brief: briefAssetSlot,
+  catalog: catalogAssetSlot,
+  group: repeatableGroup,
+  groupImage: imageGroupAsset,
+  groupVideo: videoGroupAsset,
+  groupAudio: audioGroupAsset,
+  groupText: textGroupAsset,
+  groupMarkdown: markdownGroupAsset,
+  groupHtml: htmlGroupAsset,
+  groupCss: cssGroupAsset,
+  groupJavascript: javascriptGroupAsset,
+  groupVast: vastGroupAsset,
+  groupDaast: daastGroupAsset,
+  groupUrl: urlGroupAsset,
+  groupWebhook: webhookGroupAsset,
+  groupBrief: briefGroupAsset,
+  groupCatalog: catalogGroupAsset,
+} as const;

--- a/src/lib/utils/format-asset-slot-builders.ts
+++ b/src/lib/utils/format-asset-slot-builders.ts
@@ -6,8 +6,7 @@
 // `asset_type` discriminator so callers only supply the meaningful fields.
 // The slot's `requirements` object is strictly typed per asset type — misnamed
 // fields like `file_types` or wrong units like `min_duration_seconds` become
-// compile-time errors, and the Zod schemas catch runtime drift (e.g.
-// comma-joined aspect ratios) at validation time.
+// compile-time errors at the authorship site.
 
 import type {
   GroupAudioAssetSlot,
@@ -62,9 +61,7 @@ export function textAssetSlot(fields: IndividualFields<IndividualTextAssetSlot>)
   return { ...fields, item_type: 'individual', asset_type: 'text' };
 }
 
-export function markdownAssetSlot(
-  fields: IndividualFields<IndividualMarkdownAssetSlot>,
-): IndividualMarkdownAssetSlot {
+export function markdownAssetSlot(fields: IndividualFields<IndividualMarkdownAssetSlot>): IndividualMarkdownAssetSlot {
   return { ...fields, item_type: 'individual', asset_type: 'markdown' };
 }
 
@@ -77,7 +74,7 @@ export function cssAssetSlot(fields: IndividualFields<IndividualCssAssetSlot>): 
 }
 
 export function javascriptAssetSlot(
-  fields: IndividualFields<IndividualJavascriptAssetSlot>,
+  fields: IndividualFields<IndividualJavascriptAssetSlot>
 ): IndividualJavascriptAssetSlot {
   return { ...fields, item_type: 'individual', asset_type: 'javascript' };
 }
@@ -94,9 +91,7 @@ export function urlAssetSlot(fields: IndividualFields<IndividualUrlAssetSlot>): 
   return { ...fields, item_type: 'individual', asset_type: 'url' };
 }
 
-export function webhookAssetSlot(
-  fields: IndividualFields<IndividualWebhookAssetSlot>,
-): IndividualWebhookAssetSlot {
+export function webhookAssetSlot(fields: IndividualFields<IndividualWebhookAssetSlot>): IndividualWebhookAssetSlot {
   return { ...fields, item_type: 'individual', asset_type: 'webhook' };
 }
 
@@ -104,9 +99,7 @@ export function briefAssetSlot(fields: IndividualFields<IndividualBriefAssetSlot
   return { ...fields, item_type: 'individual', asset_type: 'brief' };
 }
 
-export function catalogAssetSlot(
-  fields: IndividualFields<IndividualCatalogAssetSlot>,
-): IndividualCatalogAssetSlot {
+export function catalogAssetSlot(fields: IndividualFields<IndividualCatalogAssetSlot>): IndividualCatalogAssetSlot {
   return { ...fields, item_type: 'individual', asset_type: 'catalog' };
 }
 
@@ -163,9 +156,7 @@ export function catalogGroupAsset(fields: GroupFields<GroupCatalogAssetSlot>): G
  * frames, product showcases. The platform repeats the inner `assets` once
  * per item; each repetition must provide all required assets within it.
  */
-export function repeatableGroup(
-  fields: Omit<RepeatableGroupSlot, 'item_type'>,
-): RepeatableGroupSlot {
+export function repeatableGroup(fields: Omit<RepeatableGroupSlot, 'item_type'>): RepeatableGroupSlot {
   return { ...fields, item_type: 'repeatable_group' };
 }
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.15.0';
+export const LIBRARY_VERSION = '5.16.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.15.0',
+  library: '5.16.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-24T12:39:05.665Z',
+  generatedAt: '2026-04-24T21:53:15.899Z',
 } as const;
 
 /**

--- a/src/type-tests/format-asset-slots.type-test.ts
+++ b/src/type-tests/format-asset-slots.type-test.ts
@@ -1,0 +1,150 @@
+// Type-level gate for the format asset slot types.
+//
+// This file is type-checked by `npm run typecheck` (root tsconfig includes
+// `src/**/*`) but NOT emitted to dist — the library build uses
+// `tsconfig.lib.json` with `rootDir: src/lib`, so this path sits outside the
+// build surface on purpose.
+//
+// Each `@ts-expect-error` below asserts that the types reject the exact
+// failure modes that scope3data/agentic-adapters#118 surfaced in the five
+// social/retail adapters. If any of these stop erroring, the types regressed
+// and CI will fail here first.
+
+import type {
+  IndividualImageAssetSlot,
+  IndividualVideoAssetSlot,
+  IndividualAudioAssetSlot,
+  RepeatableGroupSlot,
+} from '../lib/types/format-asset-slots';
+
+// --- Image: the field is `formats`, not `file_types` ---
+const goodImage: IndividualImageAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'image',
+  asset_id: 'hero',
+  required: true,
+  requirements: { formats: ['jpg', 'png'], aspect_ratio: '1:1' },
+};
+void goodImage;
+
+const badImage: IndividualImageAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'image',
+  asset_id: 'hero',
+  required: true,
+  requirements: {
+    // @ts-expect-error — `file_types` is not a spec field; the correct name is `formats`
+    file_types: ['jpg'],
+  },
+};
+void badImage;
+
+// --- Video: unit is milliseconds, not seconds ---
+const goodVideo: IndividualVideoAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'video',
+  asset_id: 'ad',
+  required: true,
+  requirements: { min_duration_ms: 6000, max_duration_ms: 30000, containers: ['mp4'] },
+};
+void goodVideo;
+
+const badVideoMinSeconds: IndividualVideoAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'video',
+  asset_id: 'ad',
+  required: true,
+  // @ts-expect-error — use `min_duration_ms` (spec is milliseconds, not seconds)
+  requirements: { min_duration_seconds: 6 },
+};
+void badVideoMinSeconds;
+
+const badVideoMaxSeconds: IndividualVideoAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'video',
+  asset_id: 'ad',
+  required: true,
+  // @ts-expect-error — use `max_duration_ms`
+  requirements: { max_duration_seconds: 30 },
+};
+void badVideoMaxSeconds;
+
+// --- Video: containers, not file_types ---
+const badVideoFileTypes: IndividualVideoAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'video',
+  asset_id: 'ad',
+  required: true,
+  requirements: {
+    // @ts-expect-error — the field is `containers` for video, not `file_types`
+    file_types: ['mp4'],
+  },
+};
+void badVideoFileTypes;
+
+// --- Video: container enum is closed ---
+const badVideoContainer: IndividualVideoAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'video',
+  asset_id: 'ad',
+  required: true,
+  requirements: {
+    // @ts-expect-error — 'flv' is not in the spec enum (mp4|webm|mov|avi|mkv)
+    containers: ['flv'],
+  },
+};
+void badVideoContainer;
+
+// --- Audio: formats enum is closed ---
+const badAudio: IndividualAudioAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'audio',
+  asset_id: 'spot',
+  required: true,
+  requirements: {
+    // @ts-expect-error — 'm4a' is not in the spec enum (mp3|aac|wav|ogg|flac)
+    formats: ['m4a'],
+  },
+};
+void badAudio;
+
+// --- min_count / max_count belong on the repeatable_group wrapper ---
+// Correct: counts on the group.
+const goodGroup: RepeatableGroupSlot = {
+  item_type: 'repeatable_group',
+  asset_group_id: 'carousel',
+  required: true,
+  min_count: 2,
+  max_count: 5,
+  assets: [
+    {
+      asset_type: 'image',
+      asset_id: 'card_image',
+      required: true,
+      requirements: { aspect_ratio: '1:1' },
+    },
+  ],
+};
+void goodGroup;
+
+// Wrong: counts on an individual image slot. Pinterest/TikTok carousels in
+// PR #118 tried this shape before the repeatable_group fix.
+const badMinCountOnIndividual: IndividualImageAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'image',
+  asset_id: 'card_image',
+  required: true,
+  // @ts-expect-error — min_count is only valid on a repeatable_group wrapper
+  min_count: 2,
+};
+void badMinCountOnIndividual;
+
+const badMaxCountOnIndividual: IndividualImageAssetSlot = {
+  item_type: 'individual',
+  asset_type: 'image',
+  asset_id: 'card_image',
+  required: true,
+  // @ts-expect-error — max_count is only valid on a repeatable_group wrapper
+  max_count: 5,
+};
+void badMaxCountOnIndividual;

--- a/test/lib/format-asset-slot-builders.test.js
+++ b/test/lib/format-asset-slot-builders.test.js
@@ -1,0 +1,155 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  FormatAsset,
+  imageAssetSlot,
+  videoAssetSlot,
+  audioAssetSlot,
+  textAssetSlot,
+  catalogAssetSlot,
+  repeatableGroup,
+  imageGroupAsset,
+  textGroupAsset,
+} = require('../../dist/lib/index.js');
+
+// These tests cover the exact shapes that scope3data/agentic-adapters#118
+// had to fix post-merge: image/video/audio requirements on Format.assets[],
+// and min_count/max_count on a repeatable_group wrapper rather than on
+// individual asset slots. TypeScript blocks the wrong shapes at compile time
+// (see format-asset-slots.ts). These runtime tests prove the builders emit
+// the right wire shape for the right shape.
+
+test('format asset slot builders', async t => {
+  await t.test('imageAssetSlot injects item_type and asset_type with nested requirements', () => {
+    const slot = imageAssetSlot({
+      asset_id: 'hero_image',
+      required: true,
+      requirements: {
+        aspect_ratio: '1:1',
+        formats: ['jpg', 'png', 'webp'],
+        max_file_size_kb: 5120,
+      },
+    });
+
+    assert.deepStrictEqual(slot, {
+      asset_id: 'hero_image',
+      required: true,
+      requirements: {
+        aspect_ratio: '1:1',
+        formats: ['jpg', 'png', 'webp'],
+        max_file_size_kb: 5120,
+      },
+      item_type: 'individual',
+      asset_type: 'image',
+    });
+  });
+
+  await t.test('videoAssetSlot uses containers + min_duration_ms (not file_types, not _seconds)', () => {
+    const slot = videoAssetSlot({
+      asset_id: 'video_ad',
+      required: true,
+      requirements: {
+        aspect_ratio: '16:9',
+        containers: ['mp4', 'webm'],
+        min_duration_ms: 6000,
+        max_duration_ms: 30000,
+      },
+    });
+
+    assert.strictEqual(slot.item_type, 'individual');
+    assert.strictEqual(slot.asset_type, 'video');
+    assert.deepStrictEqual(slot.requirements.containers, ['mp4', 'webm']);
+    assert.strictEqual(slot.requirements.min_duration_ms, 6000);
+    assert.strictEqual(slot.requirements.max_duration_ms, 30000);
+    assert.strictEqual(slot.requirements.file_types, undefined);
+    assert.strictEqual(slot.requirements.min_duration_seconds, undefined);
+  });
+
+  await t.test('audioAssetSlot accepts duration in milliseconds', () => {
+    const slot = audioAssetSlot({
+      asset_id: 'audio_ad',
+      required: true,
+      requirements: { min_duration_ms: 10000, max_duration_ms: 60000, formats: ['mp3', 'aac'] },
+    });
+    assert.strictEqual(slot.asset_type, 'audio');
+    assert.strictEqual(slot.requirements.min_duration_ms, 10000);
+  });
+
+  await t.test('textAssetSlot with character_pattern + length limits', () => {
+    const slot = textAssetSlot({
+      asset_id: 'headline',
+      required: true,
+      requirements: { max_length: 40, min_lines: 1, max_lines: 1 },
+    });
+    assert.strictEqual(slot.asset_type, 'text');
+    assert.strictEqual(slot.requirements.max_length, 40);
+  });
+
+  await t.test('catalogAssetSlot carries CatalogRequirements', () => {
+    const slot = catalogAssetSlot({
+      asset_id: 'products',
+      required: true,
+      requirements: {
+        catalog_type: 'product',
+        min_items: 3,
+        max_items: 10,
+        feed_formats: ['google_merchant_center'],
+      },
+    });
+    assert.strictEqual(slot.asset_type, 'catalog');
+    assert.strictEqual(slot.requirements.catalog_type, 'product');
+  });
+
+  await t.test('repeatableGroup places min_count and max_count on the wrapper, not on individual assets', () => {
+    // Pinterest carousel: 2-5 images. The counts live on the group, NOT on the
+    // image asset inside — that was the spec-violation bug in PR #118.
+    const group = repeatableGroup({
+      asset_group_id: 'carousel_items',
+      required: true,
+      min_count: 2,
+      max_count: 5,
+      selection_mode: 'sequential',
+      assets: [
+        imageGroupAsset({
+          asset_id: 'card_image',
+          required: true,
+          requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png'] },
+        }),
+        textGroupAsset({ asset_id: 'card_headline', required: true, requirements: { max_length: 40 } }),
+      ],
+    });
+
+    assert.strictEqual(group.item_type, 'repeatable_group');
+    assert.strictEqual(group.min_count, 2);
+    assert.strictEqual(group.max_count, 5);
+    assert.strictEqual(group.asset_group_id, 'carousel_items');
+    assert.strictEqual(group.assets.length, 2);
+    assert.strictEqual(group.assets[0].asset_type, 'image');
+    // Group assets don't carry item_type — they sit inside the group wrapper.
+    assert.strictEqual(group.assets[0].item_type, undefined);
+  });
+
+  await t.test('FormatAsset namespace exposes every slot builder', () => {
+    // Sanity: the top-level helpers are reachable under FormatAsset.*.
+    assert.strictEqual(FormatAsset.image, imageAssetSlot);
+    assert.strictEqual(FormatAsset.video, videoAssetSlot);
+    assert.strictEqual(FormatAsset.audio, audioAssetSlot);
+    assert.strictEqual(FormatAsset.text, textAssetSlot);
+    assert.strictEqual(FormatAsset.catalog, catalogAssetSlot);
+    assert.strictEqual(FormatAsset.group, repeatableGroup);
+    assert.strictEqual(FormatAsset.groupImage, imageGroupAsset);
+  });
+
+  await t.test('discriminator spread order prevents casted input from overriding asset_type', () => {
+    const smuggled = {
+      asset_id: 'x',
+      required: true,
+      requirements: {},
+      asset_type: 'image', // bypasses TS via cast in a misbehaving caller
+      item_type: 'repeatable_group', // also a cast bypass
+    };
+    const slot = videoAssetSlot(smuggled);
+    assert.strictEqual(slot.asset_type, 'video');
+    assert.strictEqual(slot.item_type, 'individual');
+  });
+});


### PR DESCRIPTION
## Summary

The codegen collapses the discriminated union under `Format.assets[]` to `BaseIndividualAsset` with no `asset_type` and no `requirements` field. Authors had no compile-time signal on misnamed requirement fields, wrong units, or misplaced count constraints. [scope3data/agentic-adapters#118](https://github.com/scope3data/agentic-adapters/pull/118) hit all four failure modes post-merge across five social/retail adapters (Pinterest, TikTok, UniversalAds, Criteo, CitrusAd):

1. `file_types` instead of `formats` (image) / `containers` (video)
2. `min_duration_seconds` instead of `min_duration_ms`
3. Comma-joined `aspect_ratio` (`"1:1,16:9"`) instead of single-valued matching the spec regex
4. `min_count` / `max_count` on individual asset slots instead of the `repeatable_group` wrapper

This PR adds:

- **Types** (`src/lib/types/format-asset-slots.ts`) — `IndividualImageAssetSlot`, `IndividualVideoAssetSlot`, `IndividualAudioAssetSlot`, `IndividualTextAssetSlot`, `IndividualMarkdownAssetSlot`, `IndividualHtmlAssetSlot`, `IndividualCssAssetSlot`, `IndividualJavascriptAssetSlot`, `IndividualVastAssetSlot`, `IndividualDaastAssetSlot`, `IndividualUrlAssetSlot`, `IndividualWebhookAssetSlot`, `IndividualBriefAssetSlot`, `IndividualCatalogAssetSlot`, `RepeatableGroupSlot`, plus matching `Group*` variants for use inside repeatable groups. Wires the existing `*AssetRequirements` interfaces from `core.generated.ts` into a proper discriminated union.
- **Builders** (`src/lib/utils/format-asset-slot-builders.ts`) — `imageAssetSlot`, `videoAssetSlot`, …, `repeatableGroup`, plus per-asset-type group helpers and a `FormatAsset` namespace for grouped imports.
- **Type-test gate** (`src/type-tests/format-asset-slots.type-test.ts`) — `@ts-expect-error` directives covering each PR #118 failure mode. Outside `tsconfig.lib` so it doesn't ship to dist; root tsconfig type-checks it. Regressions block CI's typecheck.
- **Runtime tests** (`test/lib/format-asset-slot-builders.test.js`) — 9 tests confirming the builders emit the right wire shape.
- **Skill updates** — `build-seller-agent`, `build-generative-seller-agent`, and `build-creative-agent` each gained a "format asset slot" section framed for that audience (social/retail sales, generative DSPs, ad servers/CMPs).
- **Changeset** — minor bump.

## Spec-side companion

Filed [adcontextprotocol/adcp#3069](https://github.com/adcontextprotocol/adcp/issues/3069) requesting `title` on the `oneOf` branches in `list-creative-formats-response`. Once that lands and codegen produces named per-asset-type interfaces natively, the hand-authored shim in this PR retires.

Additive change — existing `Format.assets[]` literals continue to compile.

## Test plan

- [x] `npm run build` clean
- [x] `npm run typecheck` clean (the type-test file's `@ts-expect-error` directives all fire)
- [x] 44/44 builder tests pass
- [x] `npx biome check` clean on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)