### PR TITLE
fix(conformance): runner no longer fails agents on empty-phases storyboards

### DIFF
--- a/.changeset/runner-no-phases-sentinel-fix.md
+++ b/.changeset/runner-no-phases-sentinel-fix.md
@@ -1,0 +1,14 @@
+---
+'@adcp/client': patch
+---
+
+**Fix: storyboard runner no longer fails agents on empty-phases storyboards.**
+
+When a storyboard had `phases: []` (e.g., a placeholder or a `requires_scenarios:`-composed storyboard), the runner emitted a synthetic phase with `passed: false` even though its only step was `skipped: true`. This caused agents to appear to fail on that storyboard in the compliance report, producing a confusing `__no_phases__` entry in the output — a string not in the storyboard-schema's documented grading vocabulary.
+
+Changes:
+- Synthetic phase `passed` corrected from `false` → `true` (a skipped step is neutral, not a failure).
+- Internal sentinel strings `'__no_phases__'` replaced with `'no_phases'` in `step_id` and `phase_id`, consistent with the documented `RunnerSkipReason` vocabulary.
+- When `storyboard.requires_scenarios` is populated, the detail message now explains the structural reason (scenario composition) rather than the generic placeholder message.
+
+Fixes #921.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -490,7 +490,7 @@ async function executeStoryboardPass(
   if (!hasExecutableSteps) {
     const isScenarioComposed = (storyboard.requires_scenarios?.length ?? 0) > 0;
     const detail = isScenarioComposed
-      ? `Storyboard "${storyboard.id}" has no local phases — its test surface is fully composed from the scenarios listed in \`requires_scenarios\`. Run via \`comply()\` to execute the composed scenarios.`
+      ? `Storyboard "${storyboard.id}" has no local phases — its test surface is fully composed from the scenarios listed in \`requires_scenarios\`.`
       : `Storyboard "${storyboard.id}" has no executable phases — populate \`phases[].steps\` or remove the storyboard.`;
     const syntheticStep: StoryboardStepResult = {
       storyboard_id: storyboard.id,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -834,11 +834,19 @@ async function executeStoryboardPass(
   // required_tools filtered out everything) would pass vacuously. (c) makes
   // assertions gating — a run with all validations green but a cross-step
   // invariant broken is not conformant.
-  const requiredPhasesPassed = phaseResults.some((p, idx) => {
-    const phaseDef = storyboard.phases[idx];
-    if (!phaseDef || phaseDef.optional || !p.passed) return false;
-    return p.steps.some(s => !s.skipped && s.passed);
-  });
+  // When no phases had executable steps the storyboard result is a skip, not a
+  // failure. The index-aligned guard below would hit storyboard.phases[0] ===
+  // undefined for an empty-phases storyboard and force requiredPhasesPassed to
+  // false, flipping overall_passed to false. Short-circuit to true so the
+  // no-phases sentinel produces overall_passed: true (consistent with how
+  // buildNotApplicableStoryboardResult shapes its result in comply.ts).
+  const requiredPhasesPassed =
+    !hasExecutableSteps ||
+    phaseResults.some((p, idx) => {
+      const phaseDef = storyboard.phases[idx];
+      if (!phaseDef || phaseDef.optional || !p.passed) return false;
+      return p.steps.some(s => !s.skipped && s.passed);
+    });
   // Prepend the pre-flight seeding phase now that every consumer that
   // index-aligns `phaseResults` with `storyboard.phases` has run. Reader
   // order matches execution order.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -488,11 +488,15 @@ async function executeStoryboardPass(
   // "everything passed".
   const hasExecutableSteps = storyboard.phases.some(p => p.steps.length > 0);
   if (!hasExecutableSteps) {
-    const detail = `Storyboard "${storyboard.id}" has no executable phases — populate \`phases[].steps\` or remove the storyboard.`;
+    const isScenarioComposed = (storyboard.requires_scenarios?.length ?? 0) > 0;
+    const detail = isScenarioComposed
+      ? `Storyboard "${storyboard.id}" has no local phases — its test surface is fully composed from the scenarios listed in \`requires_scenarios\`. Run via \`comply()\` to execute the composed scenarios.`
+      : `Storyboard "${storyboard.id}" has no executable phases — populate \`phases[].steps\` or remove the storyboard.`;
     const syntheticStep: StoryboardStepResult = {
       storyboard_id: storyboard.id,
-      step_id: '__no_phases__',
-      phase_id: '__no_phases__',
+      // Synthetic sentinel — cannot collide with real phase/step ids since phases is empty or has no steps.
+      step_id: 'no_phases',
+      phase_id: 'no_phases',
       title: 'Storyboard has no executable phases',
       task: '',
       passed: true,
@@ -506,9 +510,10 @@ async function executeStoryboardPass(
       extraction: { path: 'none' },
     };
     phaseResults.push({
-      phase_id: '__no_phases__',
+      // Synthetic sentinel — cannot collide with real phase ids since phases is empty or has no steps.
+      phase_id: 'no_phases',
       phase_title: 'No phases',
-      passed: false,
+      passed: true, // skipped step is neutral — phase must not fail
       steps: [syntheticStep],
       duration_ms: 0,
     });

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -494,7 +494,10 @@ async function executeStoryboardPass(
       : `Storyboard "${storyboard.id}" has no executable phases — populate \`phases[].steps\` or remove the storyboard.`;
     const syntheticStep: StoryboardStepResult = {
       storyboard_id: storyboard.id,
-      // Synthetic sentinel — cannot collide with real phase/step ids since phases is empty or has no steps.
+      // Synthetic sentinel. Functionally non-colliding because downstream
+      // consumers (CLI report, storyboard-tracks) key on `skip_reason`,
+      // not `phase_id`/`step_id`. Matches the documented `RunnerSkipReason`
+      // vocabulary in storyboard/types.ts.
       step_id: 'no_phases',
       phase_id: 'no_phases',
       title: 'Storyboard has no executable phases',
@@ -510,7 +513,6 @@ async function executeStoryboardPass(
       extraction: { path: 'none' },
     };
     phaseResults.push({
-      // Synthetic sentinel — cannot collide with real phase ids since phases is empty or has no steps.
       phase_id: 'no_phases',
       phase_title: 'No phases',
       passed: true, // skipped step is neutral — phase must not fail

--- a/test/lib/storyboard-no-phases.test.js
+++ b/test/lib/storyboard-no-phases.test.js
@@ -1,0 +1,90 @@
+/**
+ * Regression test for #921 / PR #922.
+ *
+ * When a storyboard has `phases: []` the runner emits a synthetic
+ * skipped phase. The shape must satisfy three invariants:
+ *
+ *   1. `overall_passed: true` — vacuous skip is not a failure
+ *   2. `skip_reason: 'no_phases'` — value from the documented
+ *      `RunnerSkipReason` vocabulary (not the `__no_phases__`
+ *      sentinel that leaked in earlier versions)
+ *   3. `requires_scenarios`-composed storyboards get a detail message
+ *      that points at the composition mechanism, not a misleading
+ *      "populate phases" hint
+ *
+ * Without these, agents look like they're failing compliance on
+ * placeholder / scenario-composed storyboards even though they're
+ * meant to skip cleanly.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
+
+const FAKE_AGENT_URL = 'http://127.0.0.1:1/mcp'; // never reached — phases is empty
+const FAKE_CLIENT = { getAgentInfo: async () => ({ name: 'Test', tools: [] }) };
+const FAKE_PROFILE = { name: 'Test', tools: [] };
+
+function emptyStoryboard(overrides = {}) {
+  return {
+    id: 'placeholder_sb',
+    version: '1.0.0',
+    title: 'Placeholder',
+    category: 'compliance',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [],
+    ...overrides,
+  };
+}
+
+describe('runStoryboard: empty-phases storyboard (regression for #921)', () => {
+  it('passes vacuously and exposes the documented `no_phases` skip reason', async () => {
+    const result = await runStoryboard(FAKE_AGENT_URL, emptyStoryboard(), {
+      protocol: 'mcp',
+      allow_http: true,
+      _client: FAKE_CLIENT,
+      _profile: FAKE_PROFILE,
+    });
+
+    assert.strictEqual(result.overall_passed, true, 'empty-phases storyboard must not fail the agent');
+    assert.strictEqual(result.passed_count, 0);
+    assert.strictEqual(result.failed_count, 0);
+    assert.strictEqual(result.skipped_count, 1, 'one synthetic skipped step');
+
+    const phase = result.phases.find(p => p.phase_id === 'no_phases');
+    assert.ok(phase, 'synthetic phase must use the documented `no_phases` id, not `__no_phases__`');
+    assert.strictEqual(phase.passed, true, 'phase with only skipped steps must not be marked failed');
+    assert.strictEqual(phase.steps.length, 1);
+
+    const step = phase.steps[0];
+    assert.strictEqual(step.step_id, 'no_phases');
+    assert.strictEqual(step.skipped, true);
+    assert.strictEqual(step.passed, true);
+    assert.strictEqual(step.skip_reason, 'no_phases');
+    // Default detail message for a placeholder storyboard.
+    assert.match(step.skip?.detail ?? step.error ?? '', /populate `phases\[\]\.steps`|remove the storyboard/);
+  });
+
+  it('uses a scenario-composition detail when `requires_scenarios` is populated', async () => {
+    const result = await runStoryboard(
+      FAKE_AGENT_URL,
+      emptyStoryboard({
+        id: 'composed_sb',
+        requires_scenarios: ['scenario_a', 'scenario_b'],
+      }),
+      { protocol: 'mcp', allow_http: true, _client: FAKE_CLIENT, _profile: FAKE_PROFILE }
+    );
+
+    assert.strictEqual(result.overall_passed, true);
+    const step = result.phases[0]?.steps[0];
+    assert.ok(step, 'synthetic step must exist');
+    assert.strictEqual(step.skip_reason, 'no_phases');
+    const detail = step.skip?.detail ?? step.error ?? '';
+    assert.match(detail, /requires_scenarios/, 'detail must reference the composition mechanism');
+    assert.doesNotMatch(detail, /populate `phases/, 'must not echo the placeholder hint when scenarios compose the surface');
+  });
+});

--- a/test/lib/storyboard-no-phases.test.js
+++ b/test/lib/storyboard-no-phases.test.js
@@ -85,6 +85,10 @@ describe('runStoryboard: empty-phases storyboard (regression for #921)', () => {
     assert.strictEqual(step.skip_reason, 'no_phases');
     const detail = step.skip?.detail ?? step.error ?? '';
     assert.match(detail, /requires_scenarios/, 'detail must reference the composition mechanism');
-    assert.doesNotMatch(detail, /populate `phases/, 'must not echo the placeholder hint when scenarios compose the surface');
+    assert.doesNotMatch(
+      detail,
+      /populate `phases/,
+      'must not echo the placeholder hint when scenarios compose the surface'
+    );
   });
 });


### PR DESCRIPTION
Closes #921

## Summary

When a storyboard had `phases: []`, the runner produced a result that made agents appear to **fail** even though the storyboard should have been a neutral skip. A real seller with 68/69 passing media-buy scenarios was failing compliance solely on `governance_aware_seller` with `__no_phases__` — a string not in the storyboard-schema's grading vocabulary.

Three interlinked bugs:

1. **`passed: false` on the synthetic phase** — the phase result was `false` even though its only step had `passed: true, skipped: true`. Per the runner-output contract (`steps.every(s => s.passed || s.skipped)`), a skipped step is neutral; the phase must not fail.
2. **`__no_phases__` leaking externally** — the sentinel strings appeared as `step_id` and `phase_id` in user-facing reports, but `'__no_phases__'` was never in the documented `RunnerSkipReason` vocabulary.
3. **`requiredPhasesPassed` guard not short-circuited** — the guard indexes `storyboard.phases[idx]`, which is `undefined` for an empty-phases storyboard, so `requiredPhasesPassed` stayed `false` and `overall_passed` stayed `false` even after fixing (1).

## What changed (`src/lib/testing/storyboard/runner.ts`)

- Synthetic phase `passed`: `false` → `true`
- Synthetic sentinel IDs: `'__no_phases__'` → `'no_phases'` (matches the documented `RunnerSkipReason` and `SKIP_DETAILS` entry; consistent with `buildNotApplicableStoryboardResult` precedent in `comply.ts`)
- `requiredPhasesPassed`: added `!hasExecutableSteps ||` short-circuit so the index-aligned guard is bypassed when phases is empty, producing `overall_passed: true`
- `requires_scenarios`-composed storyboards get a distinct detail message that explains the structural situation without incorrectly prescribing a call path

## What was tested

- `npm run build:lib` passes (pre-existing `tsx: not found` in env prevents full `ci:quick`; confirmed pre-existing on `main`)
- `npm test`: 61 passing, 548 failing — same pass count as `main`, one fewer failure (the `Compliance result types` test that imports `dist/lib/testing/compliance/index.js` now passes because the fix is reflected in the rebuilt dist)
- Pre-existing test failures are infrastructure-related (no compiled dist, no running agents)

## What is NOT in this PR (follow-up)

Issue #921 also asks about emitting `not_applicable` instead of `no_phases` when `requires_scenarios` is populated. Both experts flagged this as a design decision: `not_applicable` currently means "agent didn't declare the protocol or specialism", which is different from "storyboard delegates to scenario composition". A new `RunnerSkipReason` value (`scenario_composed` or similar) would be the right surgical fix — tracked as a follow-up to avoid conflating the two cases and breaking `storyboard-tracks.ts`'s label disambiguation.

## Known gaps

- No unit tests for the `phases: []` path. The test suite has almost no runner unit coverage (systemic gap, not introduced here). Adding regression tests for this path is tracked.

## Pre-PR review

- **code-reviewer**: approved — no blockers; noted `error: detail` on a skipped step is semantically odd (pre-existing pattern, not introduced here) and the duplicate sentinel comments
- **ad-tech-protocol-expert**: approved — `passed: true` correct per spec formula; `'no_phases'` rename non-breaking (undocumented → documented vocabulary); `requiredPhasesPassed` short-circuit aligns with `buildNotApplicableStoryboardResult` precedent

Session: https://claude.ai/code/session_01N7UFtzFS6q2ACWTfzqBZdG

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7UFtzFS6q2ACWTfzqBZdG)_