### PR TITLE
ci(ipr): allowlist `claude` for triage-routine PRs

### DIFF
--- a/.github/workflows/ipr-agreement.yml
+++ b/.github/workflows/ipr-agreement.yml
@@ -28,7 +28,12 @@ jobs:
           branch: 'ipr-signatures'
           remote-organization-name: 'adcontextprotocol'
           remote-repository-name: 'adcp'
-          allowlist: 'bot*,dependabot*,renovate*,github-actions*'
+          # `claude` is the GitHub user the Claude triage routine commits as
+          # (`noreply@anthropic.com` resolves to user `claude`, id 81847).
+          # Triage-routine PRs are opened on behalf of a signed repo
+          # contributor (the `/triage` invoker or issue author), and we
+          # don't ask the Claude account to sign the IPR Policy itself.
+          allowlist: 'bot*,dependabot*,renovate*,github-actions*,claude'
 
           custom-notsigned-prcomment: |
             ## IPR Policy Agreement Required


### PR DESCRIPTION
## Summary

The Claude triage routine commits as GitHub user `claude` (the account that owns `noreply@anthropic.com`, id 81847). That user hasn't signed the IPR Policy, so `contributor-assistant/github-action` fails the IPR check on every push to a Claude-triaged PR.

This was masked in #922 by an accidental bypass: the workflow's `if:` clause only evaluates the check on `pull_request_target` events or comments matching the exact phrase `I have read the IPR Policy`. Any other comment (e.g. `recheck`) skips the step, and a skipped step appears as green in the PR status rollup. So the most-recent `ipr-check` was a no-op that displayed as success — that's how #922 merged. The actual underlying check kept failing.

## What changes

One line in `.github/workflows/ipr-agreement.yml`:

```diff
- allowlist: 'bot*,dependabot*,renovate*,github-actions*'
+ allowlist: 'bot*,dependabot*,renovate*,github-actions*,claude'
```

## Why allowlisting is the right call

Triage-routine PRs are opened on behalf of a signed repo contributor: the `/triage` invoker, or the issue author. See `.github/workflows/claude-issue-triage.yml` — that workflow gates manual triage behind a slash-dispatch permission check and passes the human author through. The IPR coverage is established by the human PR opener; the `claude` account is just the worker identity that pushes commits on their delegation.

Asking the `claude` account itself to sign the IPR Policy isn't workable — it's a service account whose comment access we don't control.

## Test plan

- [x] Workflow change is syntactically valid (one allowlist entry appended)
- [ ] Verify on the next Claude-triaged PR that `ipr-check` passes on `pull_request_target.synchronize` without needing the `recheck` bypass

## What's NOT in this PR

- Fix for the skip-as-success display quirk (the `if:` gate that lets `recheck` masquerade as a green check). That's a separate workflow design issue — could tighten the gate or move the check to always-run with stricter `continue-on-error: false`. Tracked as a follow-up; out of scope for the immediate fix.

No library/CLI impact, no changeset.