### PR TITLE
docs(skill): replay semantics + symptom→fix table on call-adcp-agent

### DIFF
--- a/.changeset/call-adcp-agent-skill-polish.md
+++ b/.changeset/call-adcp-agent-skill-polish.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': patch
+---
+
+`skills/call-adcp-agent/SKILL.md`: two dx-driven additions for naive LLM callers.
+
+1. **Replay semantics on `idempotency_key`.** The skill now spells out what "same key → cached response" actually means in practice — same `task_id`, same `media_buy_id`, byte-for-byte identical — and warns against the most common doubling pattern (generating a fresh UUID on retry). Async flows replay against the same `task_id`, so polling continues against the same task instead of forking.
+
+2. **Symptom → fix table.** A quick lookup of the most common `adcp_error.issues[*]` shapes mapped to their one-line fix: merged `oneOf` variants, missing `idempotency_key`, `budget` as object, `format_id` as string, made-up `destinations[*].type`, async `status: 'submitted'`, the three `recovery` modes (`retryable` / `correctable` / `unsupported`), and HTTP 401. Designed to short-circuit the recovery loop before the caller has to read the whole envelope schema.
+
+Docs-only — no library/CLI behavior change. Pairs with the `variants[]` enrichment shipped in [#919](https://github.com/adcontextprotocol/adcp-client/pull/919).

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -29,7 +29,14 @@ Walk these in order on first contact:
 
 ### `idempotency_key` is required on every mutating tool
 
-UUID format. Same key on retry → replay cached response. Required on: `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_audiences`, `sync_accounts`, `sync_catalogs`, `sync_event_sources`, `sync_plans`, `sync_governance`, `activate_signal`, `acquire_rights`, `log_event`, `report_usage`, `provide_performance_feedback`, `report_plan_outcome`, `create_property_list`, `update_property_list`, `delete_property_list`, `create_collection_list`, `update_collection_list`, `delete_collection_list`, `create_content_standards`, `update_content_standards`, `calibrate_content`, `si_initiate_session`, `si_send_message`.
+UUID format. The key is your retry-safety guarantee — and the most common way naive callers create duplicate media buys is by misunderstanding it:
+
+- **Same key on retry → replay.** The server returns the SAME response — same `task_id`, same `media_buy_id`, same shape, byte-for-byte. Use this for transport-level retries (timeout, 5xx, dropped connection).
+- **Fresh key on retry → NEW operation.** Generating a new UUID because the previous attempt failed is how you double-book. Reuse the key until you've seen a terminal response (success, error, or non-retryable error).
+- **Same key, different body → server-defined.** Most agents return the original cached response and ignore the body change. Don't rely on it — pick a fresh key only when you genuinely want a new operation.
+- For async flows, the replayed response carries the **same `task_id`**, so polling continues against the same task instead of forking a duplicate.
+
+Required on: `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_audiences`, `sync_accounts`, `sync_catalogs`, `sync_event_sources`, `sync_plans`, `sync_governance`, `activate_signal`, `acquire_rights`, `log_event`, `report_usage`, `provide_performance_feedback`, `report_plan_outcome`, `create_property_list`, `update_property_list`, `delete_property_list`, `create_collection_list`, `update_collection_list`, `delete_collection_list`, `create_content_standards`, `update_content_standards`, `calibrate_content`, `si_initiate_session`, `si_send_message`.
 
 Missing the key → `adcp_error.code: 'VALIDATION_ERROR'` with `/idempotency_key` in `issues`.
 
@@ -208,6 +215,26 @@ Both transports share: idempotency, error shape, schema enforcement, and handler
 4. **Forgetting `idempotency_key`**: required on every mutating tool; see the list above.
 5. **Treating A2A `Task.state: 'completed'` as AdCP completion**: A2A task state = transport call lifecycle. AdCP-level completion is in the artifact's payload (`structuredContent.status` or `data.status`). A `completed` A2A task can still carry a `submitted` AdCP response.
 6. **`format_id` as a string**: `format_id` is always an object `{ agent_url, id }` (and sometimes `{ width, height, duration_ms }` for dimensions). Sending `"format_id": "video_1920x1080"` fails with an `additionalProperties` / `type` error — pass the object.
+
+## Symptom → fix
+
+Quick lookup before reading the full envelope. Match what you see in `adcp_error.issues[*]`, apply the fix:
+
+| Symptom | What it means | Fix |
+|---|---|---|
+| `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
+| 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants ({account_id, brand, operator, …}) | Drop to one variant. Don't keep "extra" fields "for completeness". |
+| `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
+| `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |
+| `additionalProperties` at `/format_id` (string passed) | Sent `"format_id": "video_..."` | `format_id` is `{agent_url, id}` — always an object. |
+| `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
+| Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
+| `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
+| `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
+| `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
+| HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |
+
+If your symptom isn't here, fall through to the next section.
 
 ## If you get stuck
 


### PR DESCRIPTION
## Summary

Two dx-driven additions to `skills/call-adcp-agent/SKILL.md` (#918) that the dx-expert flagged during the original review:

### 1. Replay semantics on `idempotency_key`

The pre-existing one-liner ("same key on retry → replay cached response") didn't tell a naive caller what would actually come back, or what NOT to do. Now spelled out:

- **Same key on retry → replay.** Same `task_id`, same `media_buy_id`, byte-for-byte. Use this for transport-level retries.
- **Fresh key on retry → NEW operation.** This is how callers double-book. Reuse the key until you've seen a terminal response.
- **Same key, different body → server-defined.** Most agents return the cached response. Don't rely on it.
- For async flows, the replayed response carries the **same `task_id`**, so polling continues against the same task instead of forking.

### 2. Symptom → fix table

Quick lookup before reading the full envelope. Maps the common `adcp_error.issues[*]` shapes to their one-line fix:

| Symptom | What it means | Fix |
|---|---|---|
| `keyword: 'oneOf'` with `variants[]` | Discriminated union | Pick ONE variant from `variants[]` |
| 2-3 `additionalProperties` at same pointer | Merged variants | Drop to one |
| `keyword: 'required'`, `pointer: '/idempotency_key'` | No UUID | Generate fresh UUID per logical operation |
| `additionalProperties` at `/format_id` (string) | String passed | Object: `{agent_url, id}` |
| Response carries `status: 'submitted'` and `task_id` | Async, not done | Poll via `tasks/get` (A2A) or MCP async ext |
| `recovery: 'transient' \| 'correctable' \| 'terminal'` | Three classes | Verified against `schemas/cache/3.0.0/core/error.json` |
| HTTP 401 with `WWW-Authenticate` | Missing/expired cred | Add `Authorization` |

Plus a few more (full list in the diff). The three `recovery` enum values were verified against the spec's `core/error.json` — earlier draft had wrong names (`retryable`/`unsupported`/`permanent`); fixed before commit.

## Why now

Pairs with the `variants[]` enrichment shipped in #919: the table teaches what to do with the field; the runtime carries the data. Together they close the discoverability loop for naive LLM clients on the most common stalls.

## Test plan

- [x] Spec-verify enum values (`recovery`: transient/correctable/terminal; `destinations[*].type`: platform/agent)
- [x] Verify field paths (`idempotency_key`, `pricing_option_id`, `format_id`) against `schemas/cache/3.0.0/bundled/`
- [ ] Empirical: re-run a naive-LLM probe against a stub seller with the polished skill loaded, confirm symptom→fix table cuts hop count further on `recovery`-driven retries

Patch bump, docs-only.