### PR TITLE
fix(signing): resolve globalThis.fetch lazily in buildAgentSigningFetch (#927)

### DIFF
--- a/.changeset/927-lazy-upstream.md
+++ b/.changeset/927-lazy-upstream.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': patch
+---
+
+**Resolve `globalThis.fetch` lazily in `buildAgentSigningFetch` (#927).** The previous implementation called `defaultUpstream()` at factory-call time and bound the result; a polyfill installed between factory creation and first request was silently ignored. The factory's docstring already promised "polyfills / patches that run after this module loads still take effect" — true at the import-vs-call axis, but not at the factory-call-vs-request axis. Resolution now happens per-request inside the returned closure when `upstream` is omitted, so a late-installed polyfill takes effect on its first request.
+
+The error thrown when `globalThis.fetch` is unavailable now surfaces on the first outbound request (where it was always going to matter) rather than at factory construction. Callers passing an explicit `upstream` see no behavior change — the lazy path is taken only when the default is in use.

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -12,11 +12,12 @@ import type { SignerKey } from './signer';
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 /**
- * Resolve the default upstream fetch at call time rather than at module
- * import so (a) polyfills / patches that run after this module loads still
- * take effect, and (b) the helper throws a clear error on environments
- * lacking global `fetch` instead of binding `undefined` at import time and
- * failing cryptically on first request.
+ * Resolve `globalThis.fetch` at the moment of each outbound request — not at
+ * module import, and not at factory call. Late resolution lets a polyfill
+ * installed after `buildAgentSigningFetch` returns (but before first request)
+ * still take effect. The helper throws a clear error on environments lacking
+ * global `fetch` instead of binding `undefined` and failing cryptically inside
+ * the signing pipeline.
  */
 function defaultUpstream(): FetchLike {
   const f = (globalThis as { fetch?: FetchLike }).fetch;
@@ -182,7 +183,12 @@ export interface BuildAgentSigningFetchOptions {
  */
 export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): FetchLike {
   const { signing, getCapability } = options;
-  const upstream = options.upstream ?? defaultUpstream();
+  // Resolve `globalThis.fetch` per-call when no explicit upstream was passed
+  // so a polyfill installed between factory creation and first request still
+  // takes effect. Eager resolution would freeze whatever was global at
+  // factory-call time.
+  const explicitUpstream = options.upstream;
+  const upstream: FetchLike = explicitUpstream ?? ((input, init) => defaultUpstream()(input, init));
   const key = toSignerKey(signing);
 
   const shouldSign = (_url: string, init: RequestInit | undefined): boolean => {

--- a/test/lib/signing-defaults-and-preset.test.js
+++ b/test/lib/signing-defaults-and-preset.test.js
@@ -169,23 +169,68 @@ describe('buildAgentSigningFetch default upstream', () => {
     }
   });
 
-  it('throws a clear error when no upstream is provided and globalThis.fetch is unavailable', () => {
+  it('throws a clear error on first request when no upstream is provided and globalThis.fetch is unavailable', async () => {
+    // Lazy resolution: factory construction must NOT throw. The error surfaces
+    // on the first outbound request (when upstream is actually consulted) so
+    // that a polyfill installed between factory and first request can take
+    // effect.
     const original = globalThis.fetch;
     delete globalThis.fetch;
     try {
-      assert.throws(
+      const signedFetch = buildAgentSigningFetch({
+        signing: {
+          kid: 'test-ed25519-2026',
+          alg: 'ed25519',
+          private_key: primaryPrivate,
+          agent_url: 'https://buyer.example.com',
+        },
+        getCapability: () => undefined,
+      });
+      await assert.rejects(
         () =>
-          buildAgentSigningFetch({
-            signing: {
-              kid: 'test-ed25519-2026',
-              alg: 'ed25519',
-              private_key: primaryPrivate,
-              agent_url: 'https://buyer.example.com',
-            },
-            getCapability: () => undefined,
+          signedFetch('https://seller.example.com/mcp', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{"jsonrpc":"2.0","id":1,"method":"initialize"}',
           }),
         err => err instanceof TypeError && /globalThis\.fetch is unavailable/i.test(err.message)
       );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it('resolves globalThis.fetch lazily — polyfills installed after factory creation take effect', async () => {
+    // Build the signing fetch with NO globalThis.fetch yet. Eager resolution
+    // would either throw here or capture `undefined`; lazy resolution must
+    // defer to the first request, by which point the polyfill is installed.
+    const original = globalThis.fetch;
+    delete globalThis.fetch;
+    try {
+      const signedFetch = buildAgentSigningFetch({
+        signing: {
+          kid: 'test-ed25519-2026',
+          alg: 'ed25519',
+          private_key: primaryPrivate,
+          agent_url: 'https://buyer.example.com',
+        },
+        getCapability: () => undefined,
+      });
+
+      let captured;
+      globalThis.fetch = async (input, init) => {
+        captured = { input: String(input), init };
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+
+      const res = await signedFetch('https://seller.example.com/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{"jsonrpc":"2.0","id":1,"method":"initialize"}',
+      });
+      assert.strictEqual(res.status, 200);
+      assert.ok(captured, 'late-installed polyfill should have been invoked');
+      assert.strictEqual(captured.input, 'https://seller.example.com/mcp');
     } finally {
       globalThis.fetch = original;
     }


### PR DESCRIPTION
Closes #927 — fix 1 only. Fix 2 not addressed (rationale in "Why fix 2 was not addressed" below).

## Summary

- `buildAgentSigningFetch` now resolves `globalThis.fetch` per-request inside the returned closure when no explicit `upstream` is passed. Previously the lookup happened at factory-call time, so a polyfill installed between factory creation and first request was silently ignored — contradicting the docstring's "polyfills / patches that run after this module loads still take effect" claim.
- Explicit-`upstream` callers see no behavior change: the lazy path is taken only when the default is in use.
- The `TypeError` thrown when `globalThis.fetch` is unavailable now surfaces on the first outbound request rather than at factory construction. The existing test was updated to await on the request rather than the factory call; a new test exercises the late-polyfill scenario directly.

## Why fix 2 was not addressed

Fix 2 in #927 proposed switching `createAgentSignedFetch`'s default from `defaultCapabilityCache` to `new CapabilityCache()` per call. That would silently break the priming-coordination contract documented at \`src/lib/signing/capability-cache.ts:97-103\`:

> Process-global capability cache. Shared by the ProtocolClient priming path and the transport-level signing fetch wrappers so that a single \`get_adcp_capabilities\` call serves every subsequent signing decision for an agent.

The priming write from \`ProtocolClient\` / \`buildAgentSigningContext\` lands in \`defaultCapabilityCache\`. With a per-instance default, the signing fetch reads from a separate empty instance, \`shouldSignOperation\` falls through to \`false\` (cold cache → \`capability?.supported\` undefined), and every \`required_for\` op ships unsigned. Sellers reject. Symptom is hard to debug because the SDK side emits no error — it just decided not to sign.

The reporter's underlying concern is also weaker than it sounds. The cache key already mixes in seller URL and an auth-token hash, and the cache stores **public seller capability advertisements** — not buyer secrets. Cross-process visibility of "seller X says required_for=[create_media_buy]" isn't a security boundary; it's the entire point of caching public metadata.

If we want to do something here, the right move is option (b) from #927: keep the shared default, strengthen the JSDoc on \`createAgentSignedFetch.cache\` to call out the shared-by-design priming coordination explicitly. That's a docs PR, separate from this one.

## What was tested

- \`npm run build:lib\` — passes
- \`node --test test/lib/signing-defaults-and-preset.test.js\` — 13/13 pass (3 in the \`buildAgentSigningFetch default upstream\` block including the new lazy-polyfill test)
- \`node --test test/lib/webhook-signing-vectors.test.js test/webhook-verifier-error-codes.test.js test/webhook-verifier-factory.test.js\` — 37/37 pass (no regressions in adjacent signing surfaces)
- \`npm run format:check\` — clean

## Test additions

The new test \`resolves globalThis.fetch lazily — polyfills installed after factory creation take effect\` deletes \`globalThis.fetch\`, builds the signing fetch (must not throw), installs a polyfill, then makes the first request and asserts the polyfill was invoked. This is the regression guard for the lazy-resolution claim — without fix 1, this test fails at the factory-construction line.

The other two test gaps from #927 (replay/revocation default surviving revocation rejection; \`sellerAuthToken\` cache-key isolation) are independently valuable but unrelated to fix 1; they can be picked up separately.