### PR TITLE
docs(signing): explain why createAgentSignedFetch.cache defaults to shared (#927)

### DIFF
--- a/.changeset/927-cache-jsdoc.md
+++ b/.changeset/927-cache-jsdoc.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': patch
+---
+
+**Document why `createAgentSignedFetch.cache` defaults to the shared `defaultCapabilityCache` (#927).** The shared default is load-bearing: `ProtocolClient` / `buildAgentSigningContext` writes the seller's `get_adcp_capabilities` response into `defaultCapabilityCache`, and the signing fetch reads from the same instance so a single priming call serves every subsequent signing decision. Passing a fresh `new CapabilityCache()` without priming it silently disables `required_for` enforcement — cold cache → `shouldSignOperation` returns `false` → required ops ship unsigned → seller rejects, with no error from the SDK side. JSDoc on the `cache` field now spells this out, plus when an explicit cache is appropriate (primed in tests, out-of-band capability discovery), plus the security framing (cached entries are public seller advertisements, not buyer secrets).
+
+No behavior change.

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -238,15 +238,18 @@ export interface CreateAgentSignedFetchOptions {
    * unsigned → seller rejects. The SDK emits no error on this path because
    * "decided not to sign" is the spec-correct behavior on a cold cache.
    *
-   * Pass an explicit cache only when you've also primed it (test isolation,
-   * out-of-band capability discovery), or when you genuinely want each
-   * caller to re-fetch the seller's capability block.
+   * Pass an explicit cache only when you've also primed it — call
+   * {@link ensureCapabilityLoaded} against your cache instance after
+   * construction, or seed it via `cache.set(buildCapabilityCacheKey(uri,
+   * token), entry)` — or when you genuinely want each caller to re-fetch
+   * the seller's capability block.
    *
    * Note: the cache stores **public** seller capability advertisements
    * (the contents of `get_adcp_capabilities` responses), not buyer
    * credentials. The shared default is not a multi-tenant security
-   * boundary — different sellers and different auth tokens already get
-   * separate keys via {@link buildCapabilityCacheKey}.
+   * boundary — different sellers, different auth tokens, and different
+   * signing keys already get separate entries via
+   * {@link buildCapabilityCacheKey}.
    */
   cache?: CapabilityCache;
   /** Upstream fetch. Defaults to `globalThis.fetch`. */

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -225,7 +225,29 @@ export interface CreateAgentSignedFetchOptions {
    * invalidates the cached advertisement.
    */
   sellerAuthToken?: string;
-  /** Capability cache. Defaults to the shared {@link defaultCapabilityCache}. */
+  /**
+   * Capability cache. Defaults to the shared {@link defaultCapabilityCache}.
+   *
+   * **The shared default is load-bearing.** `ProtocolClient` and
+   * `buildAgentSigningContext` write the seller's `get_adcp_capabilities`
+   * response into `defaultCapabilityCache`; this preset reads from the same
+   * instance so a single priming call serves every subsequent signing
+   * decision. Passing a fresh `new CapabilityCache()` here without also
+   * priming it will silently disable `required_for` enforcement: cold cache
+   * → `shouldSignOperation` returns `false` → every required op ships
+   * unsigned → seller rejects. The SDK emits no error on this path because
+   * "decided not to sign" is the spec-correct behavior on a cold cache.
+   *
+   * Pass an explicit cache only when you've also primed it (test isolation,
+   * out-of-band capability discovery), or when you genuinely want each
+   * caller to re-fetch the seller's capability block.
+   *
+   * Note: the cache stores **public** seller capability advertisements
+   * (the contents of `get_adcp_capabilities` responses), not buyer
+   * credentials. The shared default is not a multi-tenant security
+   * boundary — different sellers and different auth tokens already get
+   * separate keys via {@link buildCapabilityCacheKey}.
+   */
   cache?: CapabilityCache;
   /** Upstream fetch. Defaults to `globalThis.fetch`. */
   upstream?: FetchLike;


### PR DESCRIPTION
Closes #927 — option (b). Companion to #929 (fix 1).

## Summary

Beef up the JSDoc on `CreateAgentSignedFetchOptions.cache` to make the shared-by-design priming-coordination contract visible. The previous one-line comment ("Capability cache. Defaults to the shared `defaultCapabilityCache`") didn't make clear that switching to a per-instance `new CapabilityCache()` silently disables `required_for` enforcement — exactly the trap fix 2 in #927 walked into.

The new docstring spells out:

- **The priming coordination contract.** `ProtocolClient` and `buildAgentSigningContext` write the seller's `get_adcp_capabilities` response into `defaultCapabilityCache`; this preset reads from the same instance so a single priming call serves every signing decision.
- **The exact failure mode.** Cold cache → `shouldSignOperation` returns `false` → required ops ship unsigned → seller rejects. No SDK-side error, because "decided not to sign" is spec-correct on a cold cache.
- **When explicit caches are appropriate.** Test isolation, out-of-band discovery, intentionally per-caller re-fetching.
- **The security framing.** Cached entries are *public* seller advertisements, not buyer secrets. The shared default isn't a multi-tenant security boundary; different sellers and different auth tokens already get separate keys via `buildCapabilityCacheKey`.

## What was tested

- `npm run format:check` — clean
- `tsc --noEmit -p tsconfig.lib.json` — clean

No code paths changed, so the existing test suite already covers the surface. Patch changeset included (the JSDoc ships in `.d.ts`).