### PR TITLE
docs(server): clarify AuthPrincipal.claims dual-source semantics

### DIFF
--- a/.changeset/introspection-claims-doc.md
+++ b/.changeset/introspection-claims-doc.md
@@ -1,0 +1,14 @@
+---
+'@adcp/client': patch
+---
+
+`verifyIntrospection`: drop the `as Record<string, unknown>` cast on the
+introspection response stored in `AuthPrincipal.claims`. `JWTPayload`'s
+`[propName: string]: unknown` index signature already accepts the RFC 7662
+response shape structurally, so the cast was hiding the real relationship
+between the two types. Adds a JSDoc callout on `AuthPrincipal.claims` that
+the field carries either a decoded JWT (verifyBearer) or an RFC 7662
+introspection response (verifyIntrospection), and that adapter handlers
+passing claim values (`sub`, `username`, `client_id`) into an LLM context
+must narrow and validate — an upstream IdP that controls those fields can
+inject prompt content otherwise.

--- a/src/lib/server/auth-introspection.ts
+++ b/src/lib/server/auth-introspection.ts
@@ -224,7 +224,7 @@ export function verifyIntrospection(options: VerifyIntrospectionOptions): Authen
             : 'unknown',
       token,
       scopes,
-      claims: response as Record<string, unknown>,
+      claims: response,
     };
     if (typeof response.exp === 'number') principal.expiresAt = response.exp;
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -59,6 +59,19 @@ export interface AuthPrincipal {
   /** Raw credential that authenticated the request. Propagated into `req.auth.token` for MCP tool handlers. */
   token?: string;
   scopes?: string[];
+  /**
+   * Parsed identity claims. Source depends on the authenticator:
+   * - {@link verifyBearer} populates the decoded JWT payload (RFC 7519).
+   * - {@link verifyIntrospection} populates the RFC 7662 introspection response
+   *   — same shape for the overlap fields (`iss`, `sub`, `aud`, `exp`, `iat`,
+   *   `nbf`, `jti`), plus introspection-only fields (`active`, `client_id`,
+   *   `username`, `scope`, `token_type`) typed as `unknown` via the index
+   *   signature. Narrow with a type guard before passing to an LLM context —
+   *   an upstream IdP that controls `sub`, `username`, `client_id`, or
+   *   `scope` can inject prompt content if those values reach a model
+   *   unvalidated (adapters often reflect granted scopes into UI / system
+   *   prompts, so the scope string is a real injection surface).
+   */
   claims?: JWTPayload;
   /** Token expiry (seconds since epoch) when known — propagated to MCP `AuthInfo.expiresAt`. */
   expiresAt?: number;


### PR DESCRIPTION
Follow-up to #897 (which closed #902). Addresses the convergent code-reviewer + security-reviewer concern about a "type-lie" on `AuthPrincipal.claims` when populated by `verifyIntrospection` instead of `verifyBearer`.

## Summary

- **Drops the `as Record<string, unknown>` cast** on the introspection response stored in `claims` (`src/lib/server/auth-introspection.ts:227`). `JWTPayload`'s `[propName: string]: unknown` index signature (jose) already accepts the RFC 7662 response shape structurally — the cast was a confused widening that obscured the real type relationship.
- **JSDoc on `AuthPrincipal.claims`** documenting the dual sources (RFC 7519 JWT payload via `verifyBearer`, RFC 7662 introspection response via `verifyIntrospection`) plus a prompt-injection callout for adapter handlers passing `sub` / `username` / `client_id` / `scope` into LLM contexts.

No runtime behavior change. Patch-level changeset.

## Why doc instead of a separate `introspectionClaims` field

The original code-reviewer suggestion was to add a separate field. With the structural-assignability fact established (cast was unnecessary), `JWTPayload` is just an open-shape claims bag — it doesn't *misrepresent* introspection data, and a separate field would (1) break existing test access patterns at `test/server-auth-introspection.test.js:484-492`, (2) force `serve.ts:825` to spread two fields into `AuthInfo.extra`, (3) double the surface area for the same conceptual slot. Documentation lands the concern at the right layer.

The other security-reviewer asks (`clientSecret` as callable, HMAC-salted cache key, runtime claims allowlist) are intentionally not addressed — see commit message for rationale. None warrant a follow-up issue per security-reviewer.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `node --test test/server-auth-introspection.test.js` — 30/30 pass
- [x] `node --test test/server-auth.test.js` — 39/39 pass
- [x] Reviewed by code-reviewer (LGTM), security-reviewer (OK to merge), ad-tech-protocol-expert (LGTM with edits — `scope` callout incorporated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)