### PR TITLE
fix(release): sync version.ts when changeset bumps package.json

### DIFF
--- a/.changeset/version-ts-sync-on-release.md
+++ b/.changeset/version-ts-sync-on-release.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+**Fix `version.ts` drift on release.** Changesets bumps `package.json` for the Release PR but doesn't know about `src/lib/version.ts`, so every release left the in-repo `version.ts` stale (e.g., `package.json: 5.17.0` while `version.ts: 5.16.0`). The npm tarball was always correct because `build:lib` runs `sync-version` on the CI runner — but the git tree drifted.
+
+Fix: chain `npm run sync-version` after `changeset version` so the Release PR includes the synced `version.ts`. When merged, both files stay in lockstep.
+
+No runtime behavior change. The published package's `LIBRARY_VERSION` was already correct via the build-time sync; this just keeps the git source-of-truth honest.

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "test:e2e": "node test/e2e/adcp-e2e.test.js",
     "test:protocols": "node test/run-protocol-tests.js",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && npm run sync-version",
     "release": "changeset publish",
     "test:protocol-compliance": "node test/run-protocol-tests.js --only compliance",
     "test:protocol-schema": "node test/run-protocol-tests.js --only schema",

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.16.0';
+export const LIBRARY_VERSION = '5.17.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.16.0',
+  library: '5.17.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-24T21:53:15.899Z',
+  generatedAt: '2026-04-25T09:51:32.604Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

`src/lib/version.ts` has been persistently out of sync with `package.json` after every release — `package.json` bumps to the new version, `version.ts` stays at the previous one. Trace:

1. Developer merges a PR with a changeset
2. Changesets bot creates a Release PR that bumps `package.json` and updates `CHANGELOG.md`
3. **Release PR doesn't touch `src/lib/version.ts`** — `changeset version` only knows about `package.json`
4. Release PR merges to main; release workflow runs `npm run build:lib` which runs `sync-version` and rewrites `version.ts` **on the CI runner only**
5. npm tarball ships with correct `LIBRARY_VERSION` ✅
6. Git tree on `main` still has the stale `version.ts` ❌

The drift was harmless to consumers (npm got the right value) but visible on every fresh checkout — `npm run build:lib` would silently rewrite `version.ts` and developers would have a "modified" file they couldn't usefully commit.

## Fix

Chain `sync-version` after `changeset version` in the `version` npm script. Now the Release PR includes the synced `version.ts`, and merging keeps both files in lockstep.

```diff
- "version": "changeset version",
+ "version": "changeset version && npm run sync-version",
```

Also includes a one-time catch-up: `version.ts` bumped from `5.16.0` to `5.17.0` to match the published package and clear the existing drift on main.

## Why now

The drift surfaced repeatedly during PRs #931, #934, #938 — every fresh checkout had `version.ts` modified after `npm run build:lib`. Each PR had to either include the catch-up bump (mixing it with unrelated changes) or `git checkout --` it before commit (just deferring the problem).

## Test plan

- [x] Local dry-run: `npx tsx scripts/sync-version.ts` rewrites `version.ts` to match `package.json`'s `5.17.0`
- [x] No behavior change at runtime — published npm package's `LIBRARY_VERSION` was always correct via build-time sync
- [ ] Verified on next release: when the next changeset Release PR opens, it will include `version.ts` updates alongside `package.json`/`CHANGELOG.md`

## Tradeoffs

Ties Release-PR creation to `sync-version`'s correctness. `sync-version` already runs on every `build:lib` today, so its blast radius is unchanged. The new failure mode: a malformed `ADCP_VERSION` file would break Release PR creation instead of silently shipping drift — which is what we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)