### PR TITLE
refactor(conformance): introduce StoryboardStepHintBase for kind+message invariant

### DIFF
--- a/.changeset/storyboard-step-hint-base.md
+++ b/.changeset/storyboard-step-hint-base.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+Add `StoryboardStepHintBase<K extends string>` interface that every `StoryboardStepHint` union member extends, enforcing the `kind` discriminator and `message` fallback contract at compile time. Non-breaking — existing fields are unchanged; the interface is additive.

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -263,6 +263,7 @@ export {
   type StoryboardStepPreview,
   type StoryboardStepResult,
   type StoryboardStepHint,
+  type StoryboardStepHintBase,
   type ContextValueRejectedHint,
   type ContextProvenanceEntry,
   type StoryboardPhaseResult,

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -32,6 +32,7 @@ export type {
   ContextInput,
   ContextProvenanceEntry,
   ContextValueRejectedHint,
+  StoryboardStepHintBase,
   StoryboardContext,
   StoryboardRunOptions,
   ValidationResult,

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1049,6 +1049,18 @@ export interface ContextProvenanceEntry {
 }
 
 /**
+ * Shared contract for every StoryboardStepHint discriminated-union member.
+ * Renderers that don't recognise a `kind` should still display `message` verbatim.
+ * Pass `StoryboardStepHintBase<string>` when you need a supertype that accepts any kind.
+ */
+export interface StoryboardStepHintBase<K extends string> {
+  /** Discriminator. Always a string literal at the kind-interface level. */
+  kind: K;
+  /** Human-readable summary. Always present so unknown-kind renderers still work. */
+  message: string;
+}
+
+/**
  * Non-fatal hint attached to a step result. Today the runner only emits
  * `context_value_rejected` — more kinds may be added over time. The
  * discriminator lives on `kind` so consumers that only know how to render
@@ -1063,10 +1075,7 @@ export type StoryboardStepHint = ContextValueRejectedHint;
  * identical to an SDK bug; with it, the caller can see the substitution
  * chain (step → context key → response path) and go talk to the seller.
  */
-export interface ContextValueRejectedHint {
-  kind: 'context_value_rejected';
-  /** Pre-formatted human-readable message suitable for a console line. */
-  message: string;
+export interface ContextValueRejectedHint extends StoryboardStepHintBase<'context_value_rejected'> {
   /** Context key whose value matched the rejected request field. */
   context_key: string;
   /** Step id that wrote the context key. */


### PR DESCRIPTION
Closes #950

## Summary

- Adds `StoryboardStepHintBase<K extends string>` interface (no `= string` default) to `src/lib/testing/storyboard/types.ts`
- `ContextValueRejectedHint` extends `StoryboardStepHintBase<'context_value_rejected'>`, removing the duplicate `kind` and `message` declarations
- Exports `StoryboardStepHintBase` from `storyboard/index.ts` and `src/lib/testing/index.ts` alongside `StoryboardStepHint` and `ContextValueRejectedHint`
- Includes patch changeset

## What was tested

- `tsc --noEmit` on the lib tsconfig shows only pre-existing environment errors (`@types/node` missing, deprecated `moduleResolution`); zero new type errors introduced
- `ContextValueRejectedHint` extends the base with a concrete literal — discriminated union narrowing confirmed unaffected
- `buildHint` object literal in `rejection-hints.ts` continues to typecheck (explicit `kind: 'context_value_rejected'` satisfies the base + concrete fields)

## Notes

- Wire format unchanged — TypeScript-only structural change
- `StoryboardStepHintBase<string>` is the recommended supertype for fallback renderers (see JSDoc on the interface)
- The `= string` default was intentionally omitted: callers must supply the literal type argument, preventing future kinds from accidentally inheriting `kind: string` and losing discriminant narrowing

**Pre-PR review:**
- code-reviewer: approved — no breaking change, discriminated union narrowing intact, buildHint typechecks; nit on `type` keyword in inner barrel unfounded (already inside `export type {` block)
- dx-expert: approved — export placement correct, `StoryboardStepHintBase<string>` supertype pattern is sound; two nits (inline JSDoc example, comment explaining absent default) noted for follow-up

Session: https://claude.ai/code/session_01P4h7SnRH8N5djMswLnFzf7

---
_Generated by [Claude Code](https://claude.ai/code/session_01P4h7SnRH8N5djMswLnFzf7)_