### PR TITLE
feat(testing): A2A wire-shape capture + a2a_submitted_artifact validation (#904)

### DIFF
--- a/.changeset/a2a-submitted-artifact-validation.md
+++ b/.changeset/a2a-submitted-artifact-validation.md
@@ -1,0 +1,53 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard runner: capture A2A wire shape on `protocol: 'a2a'` runs and
+add the `a2a_submitted_artifact` validation check. Closes the regression
+class from adcp-client#904 — pre-#899 A2A adapters that emitted
+`Task.state: 'submitted'` with `final: true` and `adcp_task_id` inside
+`artifact.parts[0].data` instead of `artifact.metadata` would otherwise
+pass the storyboard suite despite being non-conformant per A2A 0.3.0.
+
+The check asserts the wire-shape invariants for AdCP `submitted` arms
+over A2A:
+
+1. `Task.state === 'completed'` — A2A Task.state tracks the HTTP
+   transport call; `'submitted'` is the INITIAL state per A2A 0.3.0
+   and forbidden as a terminal value.
+2. `Task.id` and `Task.contextId` non-empty — required by A2A 0.3.0
+   for `tasks/get` addressability and follow-up correlation.
+3. `artifact.artifactId` non-empty — required for chunked-artifact
+   resumption and buyer-side caching.
+4. `artifact.metadata.adcp_task_id` carries the AdCP-level handle
+   (per A2A 0.3.0 metadata-extension convention).
+5. `artifact.parts[0]` is a DataPart with `data.status === 'submitted'`
+   — the AdCP payload preserves its native discriminator.
+6. If `data.adcp_task_id` is also present (forward-compatibility for
+   a future AdCP tool whose response schema legitimately includes
+   it), it MUST equal `metadata.adcp_task_id` — divergent or
+   solo-payload writes are the regression class.
+
+JSON-RPC error envelopes fail the check with a distinct
+`error_code: 'a2a_jsonrpc_error_envelope'` so dashboards can separate
+transport rejections from submitted-arm shape drift.
+
+The check self-skips with a `not_applicable` observation on non-A2A
+runs (MCP, raw-probe dispatch path) so storyboards can include it
+alongside MCP-shape assertions without forcing the runner to know
+which transport ran.
+
+Wires `withRawResponseCapture` around the SDK-driven A2A dispatch in
+the runner so the JSON-RPC envelope is observable for validation;
+captured response bodies pass through `redactSecrets` before landing
+in `ValidationContext.a2aEnvelope` so AdCP-style secret-shaped fields
+in DataPart payloads (`api_key`, `client_secret`, etc.) don't reach
+persisted compliance reports. `withRawResponseCapture` now surfaces
+partial captures on rejection (attached as `error.captures`) so
+storyboard validators get a wire-shape envelope even when the SDK
+threw mid-parse. Adds `A2ATaskEnvelope` to the public testing types
+and exports `getCapturesFromError` from the protocols module.
+
+The companion compliance scenario (adcontextprotocol/adcp#3083 — the
+`create_media_buy_async_submitted` storyboard) drives this check.
+Closes the runner-side half of adcp-client#904.

--- a/src/lib/protocols/rawResponseCapture.ts
+++ b/src/lib/protocols/rawResponseCapture.ts
@@ -38,6 +38,13 @@ export const rawResponseCaptureStorage = new AsyncLocalStorage<CaptureSlot>();
 /**
  * Run `fn` with a raw-response capture slot active. Every HTTP request made
  * through the wrapped fetch inside `fn` is recorded.
+ *
+ * When `fn` rejects, the rejection propagates and the partial captures
+ * are attached to the thrown error as `error.captures`. Callers that
+ * need to inspect partial captures on failure can read that property;
+ * callers that don't can ignore it. This lets storyboard validators
+ * surface "the SDK threw before the wire shape parsed" diagnostics
+ * with the actual bytes that arrived before the throw.
  */
 export async function withRawResponseCapture<T>(
   fn: () => Promise<T>,
@@ -47,8 +54,33 @@ export async function withRawResponseCapture<T>(
     captures: [],
     maxBodyBytes: options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES,
   };
-  const result = await rawResponseCaptureStorage.run(slot, fn);
-  return { result, captures: slot.captures };
+  try {
+    const result = await rawResponseCaptureStorage.run(slot, fn);
+    return { result, captures: slot.captures };
+  } catch (err) {
+    if (err && typeof err === 'object') {
+      try {
+        Object.defineProperty(err, 'captures', {
+          value: slot.captures,
+          enumerable: false,
+          configurable: true,
+          writable: true,
+        });
+      } catch {
+        // Frozen / sealed errors won't accept the property — drop the
+        // captures rather than crash on a defineProperty TypeError.
+      }
+    }
+    throw err;
+  }
+}
+
+/** Type guard for errors carrying partial captures from `withRawResponseCapture`. */
+export function getCapturesFromError(err: unknown): RawHttpCapture[] | undefined {
+  if (err && typeof err === 'object' && Array.isArray((err as { captures?: unknown }).captures)) {
+    return (err as { captures: RawHttpCapture[] }).captures;
+  }
+  return undefined;
 }
 
 /**

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -17,6 +17,7 @@ import './default-invariants';
 
 // Types
 export type {
+  A2ATaskEnvelope,
   Storyboard,
   StoryboardInvariants,
   StoryboardInvariantsObject,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -8,6 +8,7 @@
 
 import { getOrCreateClient, getOrDiscoverProfile, runStep, type TestClient } from '../client';
 import { closeConnections } from '../../protocols';
+import { getCapturesFromError, withRawResponseCapture, type RawHttpCapture } from '../../protocols/rawResponseCapture';
 import { executeStoryboardTask } from './task-map';
 import {
   extractContextWithProvenance,
@@ -52,6 +53,7 @@ interface PreSeededInput {
   attach: boolean;
 }
 import type {
+  A2ATaskEnvelope,
   AssertionResult,
   BranchSetSpec,
   ContextProvenanceEntry,
@@ -1381,6 +1383,7 @@ async function executeStep(
   let stepResult: { duration_ms: number; error?: string; passed: boolean };
   let httpResult: HttpProbeResult | undefined;
   let responseRecord: RunnerResponseRecord | undefined;
+  let a2aEnvelope: A2ATaskEnvelope | undefined;
 
   if (useRawProbe) {
     const started = Date.now();
@@ -1416,13 +1419,46 @@ async function executeStep(
       };
     }
   } else {
-    const run = await runStep(step.title, effectiveStep.task, () =>
+    // For A2A runs, wrap the SDK dispatch in `withRawResponseCapture`
+    // so storyboard validations can assert on the JSON-RPC `Task`
+    // envelope the seller emitted (e.g. `a2a_submitted_artifact`
+    // checks `Task.state` + `artifact.metadata.adcp_task_id` placement).
+    // MCP path stays unwrapped — the SDK envelope is reconstructed from
+    // `taskResult` already and capture would only add overhead.
+    //
+    // Selection note: gate on `options.protocol === 'a2a'` because
+    // that's the only signal available at this point — discovery
+    // hasn't run yet in `runStoryboardStep` (the runner branches off
+    // `agentTools` later). If a future "auto-detect protocol" flow
+    // lands, key the capture off the negotiated transport instead.
+    const captureA2a = options.protocol === 'a2a';
+    let a2aCaptures: RawHttpCapture[] | undefined;
+    const dispatch = () =>
       executeStoryboardTask(client, effectiveStep.task, request, {
         skipIdempotencyAutoInject: testsMissingIdempotencyKey,
-      })
-    );
+      });
+    const run = await runStep(step.title, effectiveStep.task, async () => {
+      if (!captureA2a) return dispatch();
+      try {
+        const { result: dispatchResult, captures } = await withRawResponseCapture(dispatch);
+        a2aCaptures = captures;
+        return dispatchResult;
+      } catch (err) {
+        // `withRawResponseCapture` attaches partial captures to the
+        // thrown error so we still get the wire-shape envelope when
+        // the SDK threw mid-parse (e.g. agent emitted malformed JSON).
+        // Bare-throw cases (network errors, no captures attached)
+        // leave `a2aCaptures` undefined and the validator self-skips.
+        const partial = getCapturesFromError(err);
+        if (partial) a2aCaptures = partial;
+        throw err;
+      }
+    });
     taskResult = run.result;
     stepResult = run.step;
+    if (captureA2a && a2aCaptures) {
+      a2aEnvelope = parseLastA2aMessageSendCapture(a2aCaptures);
+    }
     if (taskResult) {
       responseRecord = {
         transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
@@ -1508,6 +1544,7 @@ async function executeStep(
       request: requestRecord,
       ...(responseRecord && { response: responseRecord }),
       storyboardContext: context,
+      ...(a2aEnvelope && { a2aEnvelope }),
     };
     validations = runValidations(resolvedValidations, vctx);
   }
@@ -1589,7 +1626,10 @@ async function executeStep(
     passed: passed && allValidationsPassed,
     expect_error: step.expect_error,
     duration_ms: stepResult.duration_ms,
-    response: taskResult?.data,
+    // Legacy `response` field (new code reads `response_record`).
+    // Redact in case a downstream consumer still keys off it; the
+    // modern `response_record.payload` path is already redacted.
+    response: redactSecrets(taskResult?.data),
     validations,
     context: updatedContext,
     ...(runState.contextProvenance &&
@@ -1744,6 +1784,102 @@ function findPriorProbe(priorStepResults: Map<string, StoryboardStepResult>): Ht
     if (resp && typeof resp === 'object' && 'url' in resp && 'status' in resp) return resp;
   }
   return undefined;
+}
+
+/**
+ * Reduce the captured fetch traffic for an A2A step into the
+ * `A2ATaskEnvelope` validations consume. The A2A SDK fires multiple
+ * requests per call (`/.well-known/agent-card.json` discovery on
+ * fresh clients, then a `message/send` POST), and a single dispatch
+ * may also poll `tasks/get` afterwards. We pick the capture whose
+ * REQUEST body declares `method: 'message/send'`; if no capture
+ * declares the method we fall back to the last POST with a
+ * JSON-RPC-shaped body. GET captures and non-JSON bodies are
+ * skipped — `undefined` here surfaces as `not_applicable` in the
+ * validator, which is more useful than a garbage envelope.
+ *
+ * Captured response bodies pass through `redactSecrets` before
+ * landing in `ValidationContext.a2aEnvelope`. The bearer-token
+ * regex in `wrapFetchWithCapture` only catches `Bearer <token>`
+ * substrings; AdCP-style secret-shaped fields (`api_key`,
+ * `client_secret`, `access_token`) inside a DataPart payload only
+ * get redacted here. Failure paths thread the envelope into
+ * `ValidationResult.actual.failures[].actual` which lands in
+ * persisted compliance reports — redacting at capture parse time
+ * keeps that surface consistent with `responseRecord.payload`,
+ * which the runner already redacts on the success path.
+ */
+function parseLastA2aMessageSendCapture(captures: readonly RawHttpCapture[]): A2ATaskEnvelope | undefined {
+  let messageSendIdx = -1;
+  let lastPostIdx = -1;
+  for (let i = captures.length - 1; i >= 0; i--) {
+    const cap = captures[i];
+    if (!cap || cap.method !== 'POST') continue;
+    if (lastPostIdx === -1) lastPostIdx = i;
+    // The fetch wrapper doesn't capture the request body, so disambiguate
+    // by parsing the response and checking for an A2A `Task` shape on
+    // the result. `tasks/get` and `message/send` both return tasks, but
+    // only `message/send` is the immediate response we want to assert
+    // on for submitted-arm shape checks. When the runner adds polling,
+    // we'd need request-body capture to distinguish reliably; for v0
+    // the last POST is `message/send` because the SDK doesn't poll
+    // synchronously after a Task with terminal state.
+    if (messageSendIdx === -1) {
+      const env = tryParseJsonRpcEnvelope(cap.body);
+      if (env && env.result !== undefined && isTaskShape(env.result)) {
+        messageSendIdx = i;
+      }
+    }
+  }
+  const idx = messageSendIdx !== -1 ? messageSendIdx : lastPostIdx;
+  if (idx === -1) return undefined;
+  const cap = captures[idx]!;
+  const envelope = tryParseJsonRpcEnvelope(cap.body);
+  if (!envelope) return undefined;
+  // `envelope.result` mirrors the JSON-RPC envelope as observed —
+  // present when the response carried a `result`, absent when it
+  // carried `error`. The convenience `result` field at the top level
+  // coalesces undefined to `null` so validators reading the typed
+  // `A2ATaskEnvelope.result` get a stable shape; the inner
+  // `envelope.result` keeps presence-of-key fidelity for validators
+  // that need to distinguish "result was null" from "result was
+  // omitted". Both paths run through `redactSecrets`.
+  const redactedResult = envelope.result !== undefined ? redactSecrets(envelope.result) : null;
+  return {
+    result: redactedResult,
+    envelope: {
+      ...(envelope.jsonrpc !== undefined && { jsonrpc: envelope.jsonrpc }),
+      ...(envelope.id !== undefined && { id: envelope.id }),
+      ...(envelope.result !== undefined && { result: redactedResult }),
+      ...(envelope.error !== undefined && { error: redactSecrets(envelope.error) }),
+    },
+    http_status: cap.status,
+  };
+}
+
+function tryParseJsonRpcEnvelope(
+  body: string
+): { jsonrpc?: unknown; id?: unknown; result?: unknown; error?: unknown } | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return undefined;
+  }
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined;
+  const envelope = parsed as { jsonrpc?: unknown; id?: unknown; result?: unknown; error?: unknown };
+  if (envelope.jsonrpc !== '2.0') return undefined;
+  if (envelope.result === undefined && envelope.error === undefined) return undefined;
+  return envelope;
+}
+
+function isTaskShape(result: unknown): boolean {
+  return (
+    result != null &&
+    typeof result === 'object' &&
+    !Array.isArray(result) &&
+    (result as { kind?: unknown }).kind === 'task'
+  );
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -381,8 +381,56 @@ export type StoryboardValidationCheck =
   // Cross-cutting
   | 'resource_equals_agent_url'
   | 'any_of'
+  // A2A wire-shape checks (transport-specific; skipped on non-A2A runs)
+  | 'a2a_submitted_artifact'
   // Cross-step checks
   | 'refs_resolve';
+
+/**
+ * Captured A2A wire shape from a `message/send` JSON-RPC response. The
+ * runner records this when the protocol is `a2a` and a step's tool
+ * dispatch went through the SDK client; A2A wire-shape validations
+ * (`a2a_submitted_artifact`) consume it. Absent on MCP runs and on A2A
+ * runs where the capture didn't fire (raw probe path, fetch error).
+ *
+ * The `result` field is typed as `unknown` because the JSON-RPC
+ * envelope is observed at the wire — the validation engine narrows it
+ * (e.g. asserting `kind === 'task'`) and reports specific failures
+ * when the shape doesn't match. Doing the narrowing in the type would
+ * lock callers into a specific A2A SDK version; doing it in the
+ * validator preserves the runner's "report what you saw" contract.
+ *
+ * **Redaction posture.** The runner runs `redactSecrets` over `result`
+ * and `envelope` before populating this struct, matching the
+ * redaction the runner applies to `RunnerResponseRecord.payload` on
+ * the success path. AdCP-style secret-shaped fields inside the
+ * DataPart payload (`api_key`, `client_secret`, `access_token`, etc.)
+ * are replaced with `[redacted]`; bearer-token substrings in raw
+ * bodies were already redacted at fetch-capture time. Custom
+ * validators reading this field don't need to re-redact, but SHOULD
+ * avoid logging it through other channels (LLM context, debug sinks,
+ * third-party telemetry) without confirming the same redaction
+ * posture is acceptable for that channel.
+ */
+export interface A2ATaskEnvelope {
+  /**
+   * Parsed JSON-RPC `result` field — typically an A2A `Task`
+   * (`{ kind: 'task', id, status: { state }, artifacts: [...] }`) on
+   * success. Absent (set to `null`) when the JSON-RPC response was an
+   * error envelope; consumers should also inspect `envelope.error`.
+   */
+  result: unknown;
+  /**
+   * Full JSON-RPC envelope (`{ jsonrpc, id, result?, error? }`).
+   * Useful for assertions that need to distinguish a JSON-RPC error
+   * from a success-with-failure-task (e.g. `Task.state === 'failed'`
+   * is success-with-failure; `error.code === -32602` is a JSON-RPC
+   * error).
+   */
+  envelope: { jsonrpc?: unknown; id?: unknown; result?: unknown; error?: unknown };
+  /** HTTP status of the captured response (200 on JSON-RPC success). */
+  http_status: number;
+}
 
 /**
  * Set of references for `refs_resolve`. `from` picks the root object —

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -14,6 +14,7 @@ import { validateResponse, type ValidationIssue } from '../../validation/schema-
 import { ADCP_VERSION } from '../../version';
 import type { TaskResult } from '../types';
 import type {
+  A2ATaskEnvelope,
   HttpProbeResult,
   RunnerRequestRecord,
   RunnerResponseRecord,
@@ -54,6 +55,14 @@ export interface ValidationContext {
    * in the run. Single-step checks ignore it.
    */
   storyboardContext?: StoryboardContext;
+  /**
+   * Captured A2A wire shape — populated by the runner when the protocol
+   * is `a2a` and the SDK fetch was wrapped with `withRawResponseCapture`.
+   * `a2a_submitted_artifact` and other wire-shape checks read this to
+   * assert on the JSON-RPC envelope; non-A2A runs leave it undefined and
+   * those checks self-skip with `not_applicable`.
+   */
+  a2aEnvelope?: A2ATaskEnvelope;
 }
 
 /**
@@ -103,6 +112,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return requireHttpResult(ctx, validation, hr => validateResourceEqualsAgentUrl(validation, hr, ctx.agentUrl));
     case 'any_of':
       return validateAnyOf(validation, ctx.contributions);
+    case 'a2a_submitted_artifact':
+      return validateA2ASubmittedArtifact(validation, ctx);
     case 'refs_resolve':
       return validateRefsResolve(validation, ctx);
     default:
@@ -1220,6 +1231,300 @@ function validateAnyOf(validation: StoryboardValidation, contributions: Set<stri
     json_pointer: null,
     expected: flags,
     actual: Array.from(contributions),
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// a2a_submitted_artifact (A2A wire-shape regression guard)
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Assert the A2A `Task` envelope produced by the seller for an AdCP
+ * `submitted` arm matches the cross-transport contract established in
+ * adcp-client#899:
+ *
+ *   1. `Task.state === 'completed'` — A2A Task.state tracks the HTTP
+ *      transport call, not the AdCP work. The HTTP request returned
+ *      successfully with a queued AdCP task; emitting `'submitted'`
+ *      here would be a non-conformant terminal transition per A2A
+ *      0.3.0 (`submitted` is the INITIAL state, never terminal).
+ *
+ *   2. `artifact.metadata.adcp_task_id` is a non-empty string — the
+ *      AdCP-level async handle rides on the artifact's metadata field,
+ *      not buried in `data.adcp_task_id`. Buyers resume the AdCP task
+ *      by reading metadata; conflating it into the AdCP payload
+ *      pollutes the typed response shape.
+ *
+ *   3. `artifact.parts[0].data.status === 'submitted'` — the AdCP
+ *      payload preserves its native `status` discriminator so buyers
+ *      can read the ad-tech state without parsing transport metadata.
+ *
+ * The check is A2A-specific: when no `a2aEnvelope` was captured (MCP
+ * runs, or A2A runs where the SDK fetch was bypassed), the result
+ * passes with `not_applicable: true` so the validation doesn't fail
+ * the step on transports that don't carry the envelope.
+ *
+ * Failure messages name the offending field so an agent that
+ * regressed to the pre-#899 shape (`Task.state: 'submitted'` with
+ * `final: true`, `adcp_task_id` in `data` instead of `metadata`) gets
+ * a specific diagnostic, not a generic "wire-shape rejected".
+ */
+function validateA2ASubmittedArtifact(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
+  const envelope = ctx.a2aEnvelope;
+  if (!envelope) {
+    // Non-A2A transport (MCP), or A2A path where the SDK fetch wasn't
+    // wrapped. Skip without failing — the storyboard step still grades
+    // on its other validations (e.g. MCP `field_value status === submitted`).
+    return {
+      check: 'a2a_submitted_artifact',
+      passed: true,
+      description: validation.description,
+      observations: [
+        'a2a_envelope_not_captured: no JSON-RPC envelope recorded (non-A2A transport, or A2A dispatch threw before envelope was parsed)',
+      ],
+    };
+  }
+
+  const failures: Array<{ pointer: string; expected: unknown; actual: unknown; detail: string }> = [];
+
+  // JSON-RPC error envelopes never satisfy the submitted-artifact
+  // contract. We fail the check (skipping would silently hide a
+  // server-side regression where submitted arms 500 instead of
+  // returning Tasks), but emit a distinct error_code so dashboards
+  // can separate transport rejections from submitted-arm shape drift.
+  if (envelope.envelope.error !== undefined) {
+    return {
+      check: 'a2a_submitted_artifact',
+      passed: false,
+      description: validation.description,
+      error: 'Expected a JSON-RPC success envelope carrying an A2A Task; observed an error envelope.',
+      json_pointer: '/error',
+      expected: { result: { kind: 'task', status: { state: 'completed' } } },
+      actual: { error_code: 'a2a_jsonrpc_error_envelope', error: envelope.envelope.error },
+    };
+  }
+
+  const result = envelope.result;
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) {
+    return {
+      check: 'a2a_submitted_artifact',
+      passed: false,
+      description: validation.description,
+      error: 'JSON-RPC `result` is not an object — A2A `message/send` must return a Task.',
+      json_pointer: '/result',
+      expected: 'object (A2A Task)',
+      actual: result,
+    };
+  }
+  const task = result as Record<string, unknown>;
+
+  if (task.kind !== 'task') {
+    failures.push({
+      pointer: '/result/kind',
+      expected: 'task',
+      actual: task.kind,
+      detail: `Expected result.kind === 'task'; got ${JSON.stringify(task.kind)}.`,
+    });
+  }
+
+  // Task.id non-empty — buyers can't address `tasks/get` or
+  // `tasks/cancel` without it, so an empty / missing id is a
+  // wire-shape regression even if the transport call succeeded.
+  if (typeof task.id !== 'string' || task.id.length === 0) {
+    failures.push({
+      pointer: '/result/id',
+      expected: 'non-empty string',
+      actual: task.id,
+      detail:
+        'A2A `Task.id` must be a non-empty string — buyers address follow-up `tasks/get` / `tasks/cancel` calls by this id.',
+    });
+  }
+
+  // Task.contextId non-empty — A2A 0.3.0 binds follow-ups (subsequent
+  // sends, status streams) to the context; an empty contextId
+  // breaks correlation across calls.
+  if (typeof task.contextId !== 'string' || task.contextId.length === 0) {
+    failures.push({
+      pointer: '/result/contextId',
+      expected: 'non-empty string',
+      actual: task.contextId,
+      detail:
+        'A2A `Task.contextId` must be a non-empty string — A2A 0.3.0 requires it on every Task to correlate follow-up sends and status streams.',
+    });
+  }
+
+  // Invariant 1 — A2A `Task.state` for a submitted AdCP arm is
+  // `'completed'` (the HTTP call completed). Pre-#899 emitted
+  // `'submitted'` with `final: true`, which is the regression we want
+  // to catch.
+  const status = task.status;
+  const state =
+    status != null && typeof status === 'object' && !Array.isArray(status)
+      ? (status as Record<string, unknown>).state
+      : undefined;
+  if (state !== 'completed') {
+    failures.push({
+      pointer: '/result/status/state',
+      expected: 'completed',
+      actual: state,
+      detail:
+        `Expected Task.state === 'completed' (HTTP-call lifecycle); got ${JSON.stringify(state)}. ` +
+        "A2A 0.3.0 forbids 'submitted' as a terminal state — for AdCP submitted arms the transport call has completed; the AdCP task lives on artifact metadata.",
+    });
+  }
+
+  // Invariants 2 + 3 — artifact.metadata.adcp_task_id placement and
+  // artifact.parts[0].data.status preservation. Walk the artifact
+  // chain, collecting failures rather than short-circuiting so the
+  // error block names every divergence at once.
+  const artifacts = task.artifacts;
+  if (!Array.isArray(artifacts) || artifacts.length === 0) {
+    failures.push({
+      pointer: '/result/artifacts',
+      expected: 'non-empty array',
+      actual: artifacts,
+      detail: 'A2A submitted arm must produce at least one artifact carrying the AdCP response.',
+    });
+  } else {
+    const artifact = artifacts[0] as Record<string, unknown> | null;
+    if (artifact == null || typeof artifact !== 'object' || Array.isArray(artifact)) {
+      failures.push({
+        pointer: '/result/artifacts/0',
+        expected: 'object',
+        actual: artifact,
+        detail: 'First artifact must be an object.',
+      });
+    } else {
+      // artifact.artifactId non-empty — needed for chunked-artifact
+      // resumption and for buyers that key local state by artifact
+      // id (e.g. caching the AdCP payload while the task continues).
+      if (typeof artifact.artifactId !== 'string' || artifact.artifactId.length === 0) {
+        failures.push({
+          pointer: '/result/artifacts/0/artifactId',
+          expected: 'non-empty string',
+          actual: artifact.artifactId,
+          detail:
+            'A2A `Artifact.artifactId` must be a non-empty string — chunked-artifact resumption and buyer-side caching key off this id.',
+        });
+      }
+
+      // Invariant 2 — adcp_task_id on artifact.metadata.
+      const metadata = artifact.metadata;
+      const metadataTaskId =
+        metadata != null && typeof metadata === 'object' && !Array.isArray(metadata)
+          ? (metadata as Record<string, unknown>).adcp_task_id
+          : undefined;
+      if (typeof metadataTaskId !== 'string' || metadataTaskId.length === 0) {
+        failures.push({
+          pointer: '/result/artifacts/0/metadata/adcp_task_id',
+          expected: 'non-empty string',
+          actual: metadataTaskId,
+          detail:
+            'Expected `adcp_task_id` on `artifact.metadata` (per A2A 0.3.0 metadata-extension convention). Pre-#899 placed this in `artifact.parts[0].data.adcp_task_id` — that path is non-conformant; transport metadata pollutes the typed AdCP payload shape.',
+        });
+      }
+
+      // Invariant 3 — artifact.parts[0].data.status === 'submitted'.
+      const parts = artifact.parts;
+      if (!Array.isArray(parts) || parts.length === 0) {
+        failures.push({
+          pointer: '/result/artifacts/0/parts',
+          expected: 'non-empty array with a DataPart',
+          actual: parts,
+          detail: 'A2A submitted arm must include a DataPart carrying the AdCP response.',
+        });
+      } else {
+        const firstPart = parts[0] as Record<string, unknown> | null;
+        if (firstPart == null || typeof firstPart !== 'object' || Array.isArray(firstPart)) {
+          failures.push({
+            pointer: '/result/artifacts/0/parts/0',
+            expected: 'object',
+            actual: firstPart,
+            detail: 'First artifact part must be an object.',
+          });
+        } else {
+          if (firstPart.kind !== 'data') {
+            failures.push({
+              pointer: '/result/artifacts/0/parts/0/kind',
+              expected: 'data',
+              actual: firstPart.kind,
+              detail: `Expected the first artifact part to be a DataPart (kind === 'data'); got ${JSON.stringify(firstPart.kind)}.`,
+            });
+          }
+          const data = firstPart.data;
+          const dataStatus =
+            data != null && typeof data === 'object' && !Array.isArray(data)
+              ? (data as Record<string, unknown>).status
+              : undefined;
+          if (dataStatus !== 'submitted') {
+            failures.push({
+              pointer: '/result/artifacts/0/parts/0/data/status',
+              expected: 'submitted',
+              actual: dataStatus,
+              detail:
+                `Expected the AdCP payload's status to round-trip as 'submitted'; got ${JSON.stringify(dataStatus)}. ` +
+                'The DataPart must carry the AdCP tool response verbatim — buyers read the ad-tech state from `data.status`, not from `Task.state`.',
+            });
+          }
+          // Dual-write detection: catches the pre-#899 regression
+          // where the agent leaked the transport handle into the
+          // payload. A future AdCP tool whose response schema
+          // legitimately includes `adcp_task_id` is allowed to
+          // surface it inside `data` AS LONG AS it equals the
+          // metadata value — a divergent or solo-payload write is
+          // still the regression class issue #904 catches.
+          const dataAdcpTaskId =
+            data != null && typeof data === 'object' && !Array.isArray(data)
+              ? (data as Record<string, unknown>).adcp_task_id
+              : undefined;
+          if (dataAdcpTaskId !== undefined) {
+            const equalsMetadata =
+              typeof metadataTaskId === 'string' &&
+              typeof dataAdcpTaskId === 'string' &&
+              dataAdcpTaskId === metadataTaskId;
+            if (!equalsMetadata) {
+              failures.push({
+                pointer: '/result/artifacts/0/parts/0/data/adcp_task_id',
+                expected: 'absent OR equal to artifact.metadata.adcp_task_id',
+                actual: dataAdcpTaskId,
+                detail:
+                  typeof metadataTaskId === 'string'
+                    ? `Pre-#899 dual-write detected: \`data.adcp_task_id\` (${JSON.stringify(dataAdcpTaskId)}) diverges from \`artifact.metadata.adcp_task_id\` (${JSON.stringify(metadataTaskId)}).`
+                    : 'Pre-#899 shape detected: `adcp_task_id` appeared inside `artifact.parts[0].data` without a matching `artifact.metadata.adcp_task_id`. Transport metadata belongs on `artifact.metadata`.',
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (failures.length === 0) {
+    return {
+      check: 'a2a_submitted_artifact',
+      passed: true,
+      description: validation.description,
+    };
+  }
+
+  // Surface every failure at once. The first one anchors json_pointer /
+  // expected / actual for tools that read those scalar fields; the full
+  // list lands in `actual.failures` so all regressions are visible in
+  // a single grading run. Multi-failure runs prepend the first detail
+  // to the error string so consumers reading only `error` still get a
+  // pointer to the most-actionable diagnostic.
+  const first = failures[0]!;
+  return {
+    check: 'a2a_submitted_artifact',
+    passed: false,
+    description: validation.description,
+    error:
+      failures.length === 1
+        ? first.detail
+        : `${failures.length} A2A wire-shape invariants failed; first: ${first.detail}`,
+    json_pointer: first.pointer,
+    expected: first.expected,
+    actual: { failures },
   };
 }
 

--- a/test/fixtures/create_media_buy_async_submitted.yaml
+++ b/test/fixtures/create_media_buy_async_submitted.yaml
@@ -1,0 +1,253 @@
+id: media_buy_seller/create_media_buy_async_submitted
+version: "1.0.0"
+title: "Seller creates buy returning async submitted state (cross-transport)"
+category: media_buy_seller
+summary: >
+  Verifies the submitted task envelope for create_media_buy: status: submitted with task_id
+  returned on the initial response, no media_buy_id until task completion, and the final
+  active buy confirmed via get_media_buys after the test controller drives the transition.
+  Documents the cross-transport wire-shape invariants established by adcp-client#899.
+track: media_buy
+required_tools:
+  - get_products
+  - create_media_buy
+  - get_media_buys
+
+narrative: |
+  This scenario exercises the submitted async path for create_media_buy — the case where a
+  seller cannot confirm the buy before the HTTP response is emitted (for example, IO signing,
+  governance review queuing, or batch processing). The seller returns status: submitted with a
+  task_id instead of media_buy_id; the buy is not live until the task completes.
+
+  The invariants asserted here are protocol-level decisions established in the A2A serve adapter
+  (adcp-client#899). Cross-transport wire shapes:
+
+    MCP transport (asserted in validations below):
+      structuredContent.status === 'submitted'
+      structuredContent.task_id present
+
+    A2A transport (documented here; runner assertions pending adcp-client#904):
+      Task.state === 'completed'  (Task.state reflects HTTP-call completion, not AdCP task
+        completion — these are different layers. The HTTP call returned synchronously with a
+        submitted payload; the outer A2A task is therefore 'completed' even though the AdCP
+        task lifecycle is still pending.)
+      artifact.metadata.adcp_task_id === task_id  (AdCP async handle in A2A artifact metadata;
+        this is an AdCP adapter convention surfaced by adcp-client, not an A2A spec field)
+      artifact.parts[0].data.status === 'submitted'  (AdCP payload layer)
+
+  An agent that regresses to the pre-#899 shape (top-level Task.state: 'submitted' with
+  final: true, adcp_task_id in data instead of metadata) would still pass the MCP assertions
+  but fails the A2A wire-shape invariants; once adcp-client#904 lands those will be exercised.
+
+  After the initial submitted response the test controller drives the submitted → completed
+  transition. The buyer calls get_media_buys to confirm the buy is live — this mirrors what
+  a real buyer does when the push-notification webhook fires (or a tasks/get poll returns
+  completed) and the buyer queries the final state. The media_buy_id is issued by the seller
+  on task completion and is not present in the submitted envelope.
+
+agent:
+  interaction_model: media_buy_seller
+  capabilities:
+    - sells_media
+    - supports_guaranteed
+  examples:
+    - "Guaranteed seller requiring IO signing before a buy goes live"
+    - "Seller that queues create_media_buy for batch processing or internal approval"
+
+caller:
+  role: buyer_agent
+  example: "Pinnacle Agency (buyer)"
+
+prerequisites:
+  description: |
+    Seller supports create_media_buy returning status: submitted with task_id when the buy
+    cannot be confirmed synchronously. The test controller seeds an async-returning responder
+    and drives the submitted → completed transition so the completion phase can assert the
+    final active state via get_media_buys.
+  test_kit: "test-kits/acme-outdoor.yaml"
+  controller_seeding: true
+
+fixtures:
+  products:
+    - product_id: "display_async_q2"
+      delivery_type: "guaranteed"
+      channels: ["display"]
+      format_ids:
+        - id: "display_300x250"
+  pricing_options:
+    - product_id: "display_async_q2"
+      pricing_option_id: "cpm_standard"
+      pricing_model: "cpm"
+      currency: "USD"
+      fixed_price: 10.0
+
+phases:
+  - id: setup
+    title: "Discover products"
+    narrative: |
+      The buyer calls get_products to discover available inventory before creating a buy.
+      This phase confirms the seller advertises the product the scenario will purchase.
+    steps:
+      - id: get_products_brief
+        title: "Discover a display product"
+        task: get_products
+        schema_ref: "media-buy/get-products-request.json"
+        response_schema_ref: "media-buy/get-products-response.json"
+        doc_ref: "/media-buy/task-reference/get_products"
+        comply_scenario: full_sales_flow
+        stateful: false
+        expected: |
+          Return at least one display product with pricing options.
+        sample_request:
+          buying_mode: "brief"
+          brief: "Display inventory on outdoor lifestyle content. Q2 flight, $10K budget."
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          context:
+            correlation_id: "create_media_buy_async_submitted--get_products_brief"
+        validations:
+          - check: response_schema
+            description: "Response matches get-products-response.json schema"
+          - check: field_present
+            path: "products"
+            description: "Response contains at least one product"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "create_media_buy_async_submitted--get_products_brief"
+            description: "Context correlation_id returned unchanged"
+
+  - id: create_submitted
+    title: "Create buy — seller returns submitted"
+    narrative: |
+      The buyer creates a media buy. The controller-seeded seller returns status: submitted
+      with a task_id rather than media_buy_id or packages. The buyer registers a
+      push_notification_config so the seller can call back on task completion.
+
+      MCP transport: the AdCP payload has status: submitted and task_id.
+      A2A transport (documented, not yet runnable — pending adcp-client#904):
+        Task.state must be 'completed' (not 'submitted') — Task.state reflects HTTP-call
+        completion, not AdCP task lifecycle. adcp_task_id must appear in artifact.metadata,
+        not in artifact.parts[0].data. artifact.parts[0].data.status must equal 'submitted'.
+
+    steps:
+      - id: create_media_buy
+        title: "Create buy (submitted task envelope)"
+        task: create_media_buy
+        schema_ref: "media-buy/create-media-buy-request.json"
+        response_schema_ref: "media-buy/create-media-buy-response.json"
+        doc_ref: "/media-buy/task-reference/create_media_buy"
+        comply_scenario: create_media_buy
+        stateful: true
+        expected: |
+          Return the CreateMediaBuySubmitted envelope:
+          - status: submitted (discriminates this branch from the synchronous success branch)
+          - task_id: the handle the buyer polls or receives webhooks on (snake_case on the
+            AdCP payload wire; A2A adapters may surface it as taskId in the A2A task envelope,
+            but the field the agent emits in the AdCP payload is task_id)
+          - message (optional): human-readable advisory about approval timeline
+
+          Do NOT include media_buy_id or packages — those land on the task completion artifact
+          only. Do NOT use a MediaBuy.status of 'pending_approval' — that value is not in
+          MediaBuyStatus; approval workflows are modelled at the task layer.
+
+        sample_request:
+          brand:
+            domain: "acmeoutdoor.example"
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          start_time: "2026-05-01T00:00:00Z"
+          end_time: "2026-07-31T23:59:59Z"
+          packages:
+            - product_id: "display_async_q2"
+              budget: 10000
+              pricing_option_id: "cpm_standard"
+          push_notification_config:
+            url: "https://buyer.example/webhooks/adcp"
+          idempotency_key: "$generate:uuid_v4#media_buy_seller_create_submitted_create_media_buy"
+          context:
+            correlation_id: "create_media_buy_async_submitted--create_media_buy"
+        context_outputs:
+          - name: task_id
+            path: "task_id"
+        validations:
+          - check: response_schema
+            description: "Response matches create-media-buy-response.json schema (submitted branch)"
+          - check: field_value
+            path: "status"
+            value: "submitted"
+            description: "Response is the submitted task envelope, not the synchronous success branch"
+          - check: field_present
+            path: "task_id"
+            description: "task_id present for async polling or webhook correlation"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "create_media_buy_async_submitted--create_media_buy"
+            description: "Context correlation_id returned unchanged"
+
+  - id: confirm_active
+    title: "Confirm buy is active after task completion"
+    narrative: |
+      The test controller drives the submitted → completed transition and the seller issues a
+      media_buy_id. The buyer calls get_media_buys to confirm the buy is live — this mirrors
+      the buyer's behavior after receiving a push-notification webhook (or a successful
+      tasks/get poll) that signals the task completed and a media_buy_id was assigned.
+
+      The media_buy_id is not present in the submitted response; it is issued by the seller on
+      task completion. The query here does not filter by media_buy_id — the controller-seeded
+      seller will have exactly one completed buy for this account at this point.
+
+    steps:
+      - id: get_media_buys_active
+        title: "Verify buy is active after task completes"
+        task: get_media_buys
+        schema_ref: "media-buy/get-media-buys-request.json"
+        response_schema_ref: "media-buy/get-media-buys-response.json"
+        doc_ref: "/media-buy/task-reference/get_media_buys"
+        comply_scenario: media_buy_lifecycle
+        stateful: true
+        expected: |
+          Return at least one media buy with:
+          - media_buy_id: the ID issued when the task completed (this was not present in the
+            submitted response — task completion is the event that creates the MediaBuy resource)
+          - status: active, pending_creatives, or pending_start — the buy is now live
+          - packages: line items with reserved inventory
+
+          The buy must not be in any task-level state (submitted / working). Task completion
+          transitions the resource to an active MediaBuy; get_media_buys returns MediaBuy objects.
+
+        sample_request:
+          account:
+            brand:
+              domain: "acmeoutdoor.example"
+            operator: "pinnacle-agency.example"
+          context:
+            correlation_id: "create_media_buy_async_submitted--get_media_buys_active"
+        validations:
+          - check: response_schema
+            description: "Response matches get-media-buys-response.json schema"
+          - check: field_present
+            path: "media_buys"
+            description: "At least one media buy returned — the task-completed buy is now queryable"
+          - check: field_present
+            path: "media_buys[0].media_buy_id"
+            description: "Completion artifact issued a media_buy_id; the task is complete"
+          - check: field_present
+            path: "media_buys[0].status"
+            description: "Media buy has a live status after task completion"
+          - check: field_present
+            path: "context"
+            description: "Response echoes back the context object"
+          - check: field_value
+            path: "context.correlation_id"
+            value: "create_media_buy_async_submitted--get_media_buys_active"
+            description: "Context correlation_id returned unchanged"

--- a/test/storyboard-a2a-async-submitted-yaml.test.js
+++ b/test/storyboard-a2a-async-submitted-yaml.test.js
@@ -1,0 +1,359 @@
+// Pulls the upstream `create_media_buy_async_submitted` storyboard from
+// adcontextprotocol/adcp#3083 and runs each phase against a fixture A2A
+// adapter. Augments the create_media_buy step with the new
+// `a2a_submitted_artifact` check so we can confirm:
+//
+//   1. The upstream YAML parses cleanly with parseStoryboard.
+//   2. The runner's A2A wire-shape capture fires on each step.
+//   3. The new check passes against a conformant adapter and fails
+//      against a hand-rolled regressed adapter (pre-#899 shape).
+//
+// This is the end-to-end story that closes the runner-half of issue
+// #904: scenario YAML + conformant adapter = green; scenario YAML +
+// regressed adapter = red.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const express = require('express');
+
+const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { InMemoryStateStore } = require('../dist/lib/server/state-store');
+const { parseStoryboard } = require('../dist/lib/testing/storyboard/loader');
+const { runStoryboardStep } = require('../dist/lib/testing/storyboard/runner');
+
+// Snapshot of the upstream scenario YAML from adcontextprotocol/adcp#3083.
+// Refresh from the head of that PR / its merged successor when the
+// upstream YAML changes; the fixture is intentionally a copy (not a
+// fetch) so this test runs deterministically in CI without network.
+const SCENARIO_YAML_PATH = path.join(__dirname, 'fixtures', 'create_media_buy_async_submitted.yaml');
+
+function createAdcpServer(config) {
+  return _createAdcpServer({
+    ...config,
+    stateStore: config?.stateStore ?? new InMemoryStateStore(),
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
+  });
+}
+
+function fixtureAvailable() {
+  return fs.existsSync(SCENARIO_YAML_PATH);
+}
+
+function loadScenario() {
+  const yamlText = fs.readFileSync(SCENARIO_YAML_PATH, 'utf-8');
+  return parseStoryboard(yamlText);
+}
+
+/**
+ * Inject the A2A wire-shape assertion into the create_media_buy step.
+ * The upstream YAML defers this to issue #904 (this PR); we splice it
+ * in at runtime so the run exercises the full assertion set.
+ */
+function withA2aWireShapeCheck(storyboard) {
+  for (const phase of storyboard.phases) {
+    for (const step of phase.steps) {
+      if (step.id === 'create_media_buy') {
+        step.validations = [
+          ...(step.validations ?? []),
+          {
+            check: 'a2a_submitted_artifact',
+            description: 'A2A submitted arm matches adcp-client#899 wire shape',
+          },
+        ];
+      }
+    }
+  }
+  return storyboard;
+}
+
+const DISABLE_DEFAULT_INVARIANTS = {
+  disable: [
+    'status.monotonic',
+    'idempotency.conflict_no_payload_leak',
+    'context.no_secret_echo',
+    'governance.denial_blocks_mutation',
+  ],
+};
+
+/**
+ * Stateful seller fixture: tracks the active media-buy lifecycle so the
+ * scenario's three phases (get_products → submitted → confirm_active)
+ * each see consistent state. The submitted-arm responder caches a
+ * task_id and flips a flag that get_media_buys reads to surface an
+ * active buy after the (synthetic) controller transition.
+ */
+function buildSellerHandlers({ adcpTaskId = 'tk_async_seller_1' } = {}) {
+  const state = {
+    submitted: false,
+    completed: false,
+    mediaBuyId: 'mb_async_seller_1',
+  };
+  return {
+    state,
+    handlers: {
+      mediaBuy: {
+        getProducts: async () => ({
+          products: [
+            {
+              product_id: 'display_async_q2',
+              name: 'Display async fixture',
+              description: 'Display 300x250 — async submission flow',
+              delivery_type: 'guaranteed',
+              channels: ['display'],
+              format_ids: [{ agent_url: 'http://127.0.0.1:0', id: 'display_300x250' }],
+              pricing_options: [
+                {
+                  pricing_option_id: 'cpm_standard',
+                  pricing_model: 'cpm',
+                  currency: 'USD',
+                  fixed_price: 10.0,
+                },
+              ],
+            },
+          ],
+        }),
+        createMediaBuy: async () => {
+          state.submitted = true;
+          // Auto-complete on the SAME call so the next step sees the
+          // active buy without needing a controller transition. A real
+          // seller would defer this to IO signing; the fixture short-
+          // circuits it because the runner-side check fires off the
+          // submitted response, not the eventual completion.
+          state.completed = true;
+          return {
+            status: 'submitted',
+            task_id: adcpTaskId,
+            message: 'Queued for IO signature (test fixture auto-completes immediately)',
+          };
+        },
+        getMediaBuys: async () => {
+          if (!state.completed) {
+            return { media_buys: [] };
+          }
+          return {
+            media_buys: [
+              {
+                media_buy_id: state.mediaBuyId,
+                status: 'active',
+                packages: [
+                  {
+                    package_id: 'pkg_async_1',
+                    product_id: 'display_async_q2',
+                  },
+                ],
+              },
+            ],
+          };
+        },
+      },
+    },
+  };
+}
+
+async function startA2aFixture({ handlers, basePath = '/a2a' }) {
+  const adcp = createAdcpServer(handlers);
+  const app = express();
+  app.use(express.json());
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address();
+  const cardUrl = `http://127.0.0.1:${port}${basePath}`;
+  const a2a = createA2AAdapter({
+    server: adcp,
+    agentCard: {
+      name: 'Async test seller',
+      description: 'create_media_buy async submitted fixture',
+      url: cardUrl,
+      version: '1.0.0',
+      provider: { organization: 'Test', url: 'https://test.example' },
+      securitySchemes: { bearer: { type: 'http', scheme: 'bearer' } },
+    },
+  });
+  a2a.mount(app);
+  return {
+    server,
+    url: cardUrl,
+    close: () =>
+      new Promise(resolve => {
+        server.close(resolve);
+      }),
+  };
+}
+
+describe(
+  'storyboard adcp#3083: create_media_buy_async_submitted (A2A end-to-end)',
+  { skip: !fixtureAvailable() && 'YAML fixture not vendored at test/fixtures/' },
+  () => {
+    it('parses the upstream YAML cleanly via parseStoryboard', () => {
+      const sb = loadScenario();
+      assert.strictEqual(sb.id, 'media_buy_seller/create_media_buy_async_submitted');
+      assert.strictEqual(sb.phases.length, 3);
+      const stepIds = sb.phases.flatMap(p => p.steps.map(s => s.id));
+      assert.deepStrictEqual(stepIds, ['get_products_brief', 'create_media_buy', 'get_media_buys_active']);
+    });
+
+    it('runs the create_media_buy phase against a conformant A2A adapter (a2a_submitted_artifact passes)', async () => {
+      const { handlers } = buildSellerHandlers();
+      const fixture = await startA2aFixture({ handlers });
+      try {
+        const sb = withA2aWireShapeCheck(loadScenario());
+        const result = await runStoryboardStep(fixture.url, sb, 'create_media_buy', {
+          protocol: 'a2a',
+          allow_http: true,
+          invariants: DISABLE_DEFAULT_INVARIANTS,
+        });
+        // Step pass overall (the upstream YAML's MCP-level checks +
+        // the new A2A wire-shape check both succeed against the
+        // conformant adapter).
+        const a2aCheck = result.validations.find(v => v.check === 'a2a_submitted_artifact');
+        assert.ok(
+          a2aCheck,
+          `a2a_submitted_artifact ran (validations=${result.validations.map(v => v.check).join(',')})`
+        );
+        assert.strictEqual(
+          a2aCheck.passed,
+          true,
+          `a2a check should pass against the post-#899 adapter: ${JSON.stringify(a2aCheck)}`
+        );
+        // Capture must have fired — non-A2A skip path means the
+        // runner's wire-up for protocol:'a2a' regressed.
+        assert.ok(
+          !(a2aCheck.observations ?? []).some(o => /a2a_envelope_not_captured/.test(o)),
+          'wire-shape capture must fire on A2A protocol runs'
+        );
+        // The MCP-style status check (also asserted by the upstream
+        // YAML) must still see the submitted payload — confirms our
+        // runner doesn't strip the AdCP layer when capturing the A2A
+        // envelope.
+        const statusCheck = result.validations.find(v => v.check === 'field_value' && v.path === 'status');
+        assert.ok(statusCheck);
+        assert.strictEqual(
+          statusCheck.passed,
+          true,
+          `status:'submitted' check should pass: ${JSON.stringify(statusCheck)}`
+        );
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it('runs the create_media_buy phase against a regressed adapter (a2a_submitted_artifact fails specifically)', async () => {
+      // Hand-rolled Express handler that emits the pre-#899 shape so we
+      // confirm the new check catches it on the upstream YAML.
+      const app = express();
+      app.use(express.json());
+      const server = app.listen(0);
+      await new Promise(resolve => server.once('listening', resolve));
+      const { port } = server.address();
+      const baseUrl = `http://127.0.0.1:${port}`;
+      app.get('/.well-known/agent-card.json', (_req, res) => {
+        res.json({
+          name: 'Regressed seller',
+          description: 'pre-#899 wire shape',
+          url: baseUrl,
+          version: '1.0.0',
+          protocolVersion: '0.3.0',
+          defaultInputModes: ['application/json'],
+          defaultOutputModes: ['application/json'],
+          capabilities: { streaming: false, pushNotifications: false },
+          skills: [
+            { id: 'create_media_buy', name: 'create_media_buy', description: 'create', tags: ['adcp'] },
+            { id: 'get_products', name: 'get_products', description: 'discover', tags: ['adcp'] },
+            { id: 'get_adcp_capabilities', name: 'get_adcp_capabilities', description: 'caps', tags: ['adcp'] },
+          ],
+        });
+      });
+      app.post('/', (req, res) => {
+        const { id, method, params } = req.body ?? {};
+        if (method !== 'message/send') {
+          res.json({ jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } });
+          return;
+        }
+        const skill = params?.message?.parts?.[0]?.data?.skill;
+        if (skill === 'get_adcp_capabilities') {
+          res.json({
+            jsonrpc: '2.0',
+            id,
+            result: {
+              kind: 'task',
+              id: 'a2a-task-caps',
+              contextId: 'ctx-caps',
+              status: { state: 'completed', timestamp: new Date().toISOString() },
+              history: [],
+              artifacts: [
+                {
+                  artifactId: 'art-caps',
+                  name: 'result',
+                  parts: [
+                    {
+                      kind: 'data',
+                      data: {
+                        adcp_version: '3.0.0',
+                        supported_protocols: ['media-buy'],
+                        tools: [{ name: 'create_media_buy' }, { name: 'get_products' }],
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          });
+          return;
+        }
+        // Pre-#899 shape on create_media_buy — the regression #904 catches.
+        res.json({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            kind: 'task',
+            id: 'a2a-task-async',
+            contextId: 'ctx-async',
+            // Regression: terminal 'submitted' (forbidden in A2A 0.3.0)
+            status: { state: 'submitted', timestamp: new Date().toISOString() },
+            history: [],
+            artifacts: [
+              {
+                artifactId: 'art-async',
+                name: 'submitted',
+                parts: [
+                  {
+                    kind: 'data',
+                    // Regression: adcp_task_id leaked into payload
+                    data: {
+                      status: 'submitted',
+                      task_id: 'tk_async_regressed',
+                      adcp_task_id: 'tk_async_regressed',
+                    },
+                  },
+                ],
+                // Regression: no metadata at all
+              },
+            ],
+          },
+        });
+      });
+
+      try {
+        const sb = withA2aWireShapeCheck(loadScenario());
+        const result = await runStoryboardStep(baseUrl, sb, 'create_media_buy', {
+          protocol: 'a2a',
+          allow_http: true,
+          invariants: DISABLE_DEFAULT_INVARIANTS,
+        });
+        const a2aCheck = result.validations.find(v => v.check === 'a2a_submitted_artifact');
+        assert.ok(a2aCheck, 'a2a_submitted_artifact ran');
+        assert.strictEqual(a2aCheck.passed, false, 'pre-#899 shape must fail the wire-shape guard');
+        const pointers = (a2aCheck.actual?.failures ?? []).map(f => f.pointer);
+        // All three regressions surface in one validation result
+        assert.ok(pointers.includes('/result/status/state'), `pointers=${JSON.stringify(pointers)}`);
+        assert.ok(pointers.includes('/result/artifacts/0/metadata/adcp_task_id'));
+        assert.ok(pointers.includes('/result/artifacts/0/parts/0/data/adcp_task_id'));
+      } finally {
+        await new Promise(resolve => server.close(resolve));
+      }
+    });
+  }
+);

--- a/test/storyboard-a2a-submitted-artifact.test.js
+++ b/test/storyboard-a2a-submitted-artifact.test.js
@@ -1,0 +1,241 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { runValidations } = require('../dist/lib/testing/storyboard/validations.js');
+
+const VALIDATION = {
+  check: 'a2a_submitted_artifact',
+  description: 'A2A submitted arm matches adcp-client#899 wire shape',
+};
+
+function ctx(envelope) {
+  return {
+    taskName: 'create_media_buy',
+    agentUrl: 'https://example.com/a2a',
+    contributions: new Set(),
+    ...(envelope !== undefined && { a2aEnvelope: envelope }),
+  };
+}
+
+function conformantEnvelope({ adcpTaskId = 'tk_async_1' } = {}) {
+  return {
+    result: {
+      kind: 'task',
+      id: 'a2a-task-uuid',
+      contextId: 'a2a-context-uuid',
+      status: { state: 'completed', timestamp: '2026-04-25T00:00:00Z' },
+      artifacts: [
+        {
+          artifactId: 'artifact-uuid',
+          name: 'submitted',
+          parts: [{ kind: 'data', data: { status: 'submitted', task_id: adcpTaskId } }],
+          metadata: { adcp_task_id: adcpTaskId },
+        },
+      ],
+    },
+    envelope: { jsonrpc: '2.0', id: 1, result: {} },
+    http_status: 200,
+  };
+}
+
+describe('a2a_submitted_artifact', () => {
+  it('passes on the post-#899 conformant shape', () => {
+    const [result] = runValidations([VALIDATION], ctx(conformantEnvelope()));
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.check, 'a2a_submitted_artifact');
+  });
+
+  it('passes with not_applicable observation when transport is non-A2A (no envelope)', () => {
+    const [result] = runValidations([VALIDATION], ctx(undefined));
+    assert.strictEqual(result.passed, true);
+    assert.ok(Array.isArray(result.observations));
+    assert.ok(result.observations[0].includes('a2a_envelope_not_captured'));
+  });
+
+  it('fails when Task.state is "submitted" (pre-#899 regression: terminal state misuse)', () => {
+    const env = conformantEnvelope();
+    env.result.status.state = 'submitted';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/result/status/state');
+    assert.strictEqual(result.expected, 'completed');
+    assert.strictEqual(result.actual.failures[0].actual, 'submitted');
+    assert.match(result.error, /A2A 0\.3\.0 forbids 'submitted' as a terminal state/);
+  });
+
+  it('fails when adcp_task_id is missing from artifact.metadata', () => {
+    const env = conformantEnvelope();
+    delete env.result.artifacts[0].metadata;
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(
+      result.actual.failures.some(f => f.pointer === '/result/artifacts/0/metadata/adcp_task_id'),
+      'failure names the metadata path'
+    );
+  });
+
+  it('fails when data.adcp_task_id diverges from artifact.metadata.adcp_task_id (dual-write regression)', () => {
+    const env = conformantEnvelope({ adcpTaskId: 'tk_async_meta' });
+    // Divergent dual-write: data carries a different value than metadata
+    env.result.artifacts[0].parts[0].data.adcp_task_id = 'tk_async_data_DIFFERENT';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(
+      result.actual.failures.some(
+        f =>
+          f.pointer === '/result/artifacts/0/parts/0/data/adcp_task_id' && /Pre-#899 dual-write detected/.test(f.detail)
+      ),
+      `flags the divergent dual-write regression: ${JSON.stringify(result.actual.failures)}`
+    );
+  });
+
+  it('fails when data.adcp_task_id is present but metadata.adcp_task_id is missing (pre-#899 solo-payload write)', () => {
+    const env = conformantEnvelope();
+    delete env.result.artifacts[0].metadata;
+    env.result.artifacts[0].parts[0].data.adcp_task_id = 'tk_async_solo';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(
+      result.actual.failures.some(
+        f => f.pointer === '/result/artifacts/0/parts/0/data/adcp_task_id' && /Pre-#899 shape detected/.test(f.detail)
+      ),
+      'flags the solo-payload write (no matching metadata)'
+    );
+  });
+
+  it('passes when data.adcp_task_id is present and equals metadata.adcp_task_id (allowed payload duplicate)', () => {
+    const env = conformantEnvelope({ adcpTaskId: 'tk_dup' });
+    env.result.artifacts[0].parts[0].data.adcp_task_id = 'tk_dup';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, true, `equal-key dual-write should pass: ${JSON.stringify(result)}`);
+  });
+
+  it('fails when artifact.parts[0].data.status !== "submitted"', () => {
+    const env = conformantEnvelope();
+    env.result.artifacts[0].parts[0].data.status = 'completed';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.actual.failures.some(f => f.pointer === '/result/artifacts/0/parts/0/data/status'));
+  });
+
+  it('reports the full pre-#899 regression class in one validation result', () => {
+    const env = {
+      result: {
+        kind: 'task',
+        id: 'a2a-task-uuid',
+        contextId: 'a2a-context-uuid',
+        status: { state: 'submitted', timestamp: '2026-04-25T00:00:00Z' },
+        artifacts: [
+          {
+            artifactId: 'artifact-uuid',
+            name: 'submitted',
+            parts: [
+              {
+                kind: 'data',
+                data: {
+                  status: 'submitted',
+                  task_id: 'tk_async_1',
+                  adcp_task_id: 'tk_async_1',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      envelope: { jsonrpc: '2.0', id: 1, result: {} },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    const pointers = result.actual.failures.map(f => f.pointer);
+    assert.ok(pointers.includes('/result/status/state'));
+    assert.ok(pointers.includes('/result/artifacts/0/metadata/adcp_task_id'));
+    assert.ok(pointers.includes('/result/artifacts/0/parts/0/data/adcp_task_id'));
+    assert.match(result.error, /A2A wire-shape invariants failed/);
+  });
+
+  it('fails when JSON-RPC envelope carried an error instead of result', () => {
+    const env = {
+      result: null,
+      envelope: { jsonrpc: '2.0', id: 1, error: { code: -32602, message: 'Invalid params' } },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/error');
+    assert.match(result.error, /Expected a JSON-RPC success envelope/);
+  });
+
+  it('fails when result is not an object (Task expected)', () => {
+    const env = {
+      result: 'not-a-task',
+      envelope: { jsonrpc: '2.0', id: 1, result: 'not-a-task' },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/result');
+  });
+
+  it('fails when artifacts array is empty', () => {
+    const env = conformantEnvelope();
+    env.result.artifacts = [];
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.actual.failures.some(f => f.pointer === '/result/artifacts'));
+  });
+
+  it('fails when the first part is not a DataPart', () => {
+    const env = conformantEnvelope();
+    env.result.artifacts[0].parts[0] = { kind: 'text', text: 'whatever' };
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.actual.failures.some(f => f.pointer === '/result/artifacts/0/parts/0/kind'));
+  });
+
+  it('fails when Task.id is missing (buyers cannot address tasks/get without it)', () => {
+    const env = conformantEnvelope();
+    delete env.result.id;
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.actual.failures.some(f => f.pointer === '/result/id'));
+  });
+
+  it('fails when Task.contextId is empty (A2A 0.3.0 requires it for follow-up correlation)', () => {
+    const env = conformantEnvelope();
+    env.result.contextId = '';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.actual.failures.some(f => f.pointer === '/result/contextId'));
+  });
+
+  it('fails when artifact.artifactId is missing (chunked-artifact resumption breaks)', () => {
+    const env = conformantEnvelope();
+    delete env.result.artifacts[0].artifactId;
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(result.actual.failures.some(f => f.pointer === '/result/artifacts/0/artifactId'));
+  });
+
+  it('fails when Task.status is a bare string instead of an object (no /result/status/state to read)', () => {
+    const env = conformantEnvelope();
+    env.result.status = 'completed';
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.ok(
+      result.actual.failures.some(f => f.pointer === '/result/status/state'),
+      'flags a bare-string status as a missing state field'
+    );
+  });
+
+  it('JSON-RPC error envelope failure carries error_code: a2a_jsonrpc_error_envelope (distinct from shape drift)', () => {
+    const env = {
+      result: null,
+      envelope: { jsonrpc: '2.0', id: 1, error: { code: -32602, message: 'Invalid params' } },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx(env));
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.actual.error_code, 'a2a_jsonrpc_error_envelope');
+  });
+});

--- a/test/storyboard-a2a-wire-shape-capture.test.js
+++ b/test/storyboard-a2a-wire-shape-capture.test.js
@@ -1,0 +1,298 @@
+// Integration test: verifies runStoryboardStep captures the A2A wire shape
+// emitted by createA2AAdapter and feeds it to a2a_submitted_artifact
+// validations. Anchors the runner-side half of issue #904.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+
+const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { InMemoryStateStore } = require('../dist/lib/server/state-store');
+const { runStoryboardStep } = require('../dist/lib/testing/storyboard/runner');
+
+function createAdcpServer(config) {
+  // Sparse handler fixtures — opt out of strict validation for tests.
+  return _createAdcpServer({
+    ...config,
+    stateStore: config?.stateStore ?? new InMemoryStateStore(),
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
+  });
+}
+
+function agentCardFor(url) {
+  return {
+    name: 'Async Test Seller',
+    description: 'Async create_media_buy fixture for issue #904',
+    url,
+    version: '1.0.0',
+    provider: { organization: 'Test', url: 'https://test.example' },
+    securitySchemes: { bearer: { type: 'http', scheme: 'bearer' } },
+  };
+}
+
+async function startA2aFixture(handlers) {
+  const adcp = createAdcpServer(handlers);
+  const app = express();
+  app.use(express.json());
+  // Bind to port 0 first so the agent card URL can advertise the
+  // actual listening port — A2A SDK clients use the card's `url` to
+  // build their JSON-RPC endpoint.
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address();
+  // Card URL must include the basePath the adapter mounts at so the
+  // A2A SDK client (which posts to `card.url` for `message/send`)
+  // hits the JSON-RPC handler. `mount(app)` derives basePath from
+  // the URL pathname; we keep `/a2a` to match the adapter's default.
+  const cardUrl = `http://127.0.0.1:${port}/a2a`;
+  const a2a = createA2AAdapter({
+    server: adcp,
+    agentCard: agentCardFor(cardUrl),
+  });
+  a2a.mount(app);
+  return {
+    server,
+    url: cardUrl,
+    close: () =>
+      new Promise(resolve => {
+        server.close(resolve);
+      }),
+  };
+}
+
+function buildStoryboard(stepValidations) {
+  // Minimal storyboard shape — runner only requires id + phases + steps
+  // for runStoryboardStep to dispatch a single step. agent / caller /
+  // narrative blocks are validated by parseStoryboard, not the runner.
+  return {
+    id: 'a2a-wire-shape-smoke',
+    version: '1.0.0',
+    title: 'A2A wire-shape capture smoke',
+    category: 'media_buy_seller',
+    summary: 'A2A submitted-arm wire-shape regression guard',
+    narrative: 'Drives create_media_buy and asserts the A2A submitted envelope shape.',
+    agent: { interaction_model: 'media_buy_seller', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'create',
+        title: 'create',
+        steps: [
+          {
+            id: 'create_media_buy_async',
+            title: 'create_media_buy returns submitted',
+            task: 'create_media_buy',
+            stateful: true,
+            sample_request: {
+              brand: { brand_id: 'b1' },
+              account: { account_id: 'a1' },
+              start_time: '2026-05-01T00:00:00Z',
+              end_time: '2026-07-31T23:59:59Z',
+              packages: [{ product_id: 'p1', budget: 1000, pricing_option_id: 'cpm_standard' }],
+            },
+            validations: stepValidations,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('runStoryboardStep: A2A wire-shape capture (issue #904)', () => {
+  it('a2a_submitted_artifact passes against the conformant adapter shape', async () => {
+    const fixture = await startA2aFixture({
+      mediaBuy: {
+        createMediaBuy: async () => ({
+          status: 'submitted',
+          task_id: 'tk_async_1',
+          message: 'Queued for IO signature',
+        }),
+      },
+    });
+    try {
+      const storyboard = buildStoryboard([
+        {
+          check: 'a2a_submitted_artifact',
+          description: 'A2A submitted arm matches adcp-client#899 wire shape',
+        },
+        {
+          check: 'field_value',
+          path: 'status',
+          value: 'submitted',
+          description: 'AdCP payload still carries status: submitted',
+        },
+      ]);
+      const result = await runStoryboardStep(fixture.url, storyboard, 'create_media_buy_async', {
+        protocol: 'a2a',
+        allow_http: true,
+        // Disable cross-step assertions — they require a specialism context
+        // the smoke test doesn't set up.
+        invariants: {
+          disable: [
+            'status.monotonic',
+            'idempotency.conflict_no_payload_leak',
+            'context.no_secret_echo',
+            'governance.denial_blocks_mutation',
+          ],
+        },
+      });
+      assert.ok(result, 'step result returned');
+      const a2aCheck = result.validations.find(v => v.check === 'a2a_submitted_artifact');
+      assert.ok(a2aCheck, `a2a_submitted_artifact validation ran (skip=${result.skip_reason} error=${result.error})`);
+      assert.strictEqual(a2aCheck.passed, true, `validation should pass: ${JSON.stringify(a2aCheck)}`);
+      // The check should not log a "not_captured" observation — capture must have fired.
+      assert.ok(
+        !(a2aCheck.observations ?? []).some(o => /a2a_envelope_not_captured/.test(o)),
+        'capture wire-up must fire on A2A protocol runs'
+      );
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it('redacts secret-shaped fields in the captured envelope (security guard)', async () => {
+    // The runner runs `redactSecrets` over the captured envelope
+    // before populating ValidationContext.a2aEnvelope. Anchor that
+    // posture: a seller fixture that returns a payload containing
+    // secret-shaped keys must NOT surface those raw values into the
+    // validation result's `actual.failures[].actual` field, which
+    // lands in persisted compliance reports.
+    const fixture = await startA2aFixture({
+      mediaBuy: {
+        createMediaBuy: async () => ({
+          status: 'wrong', // force a wire-shape failure so the validator emits failure records
+          task_id: 'tk_async_redact_test',
+          api_key: 'sk_live_PLAINTEXT_SECRET_VALUE',
+          client_secret: 'cs_PLAINTEXT_SECRET_VALUE',
+          access_token: 'at_PLAINTEXT_SECRET_VALUE',
+        }),
+      },
+    });
+    try {
+      const storyboard = buildStoryboard([
+        {
+          check: 'a2a_submitted_artifact',
+          description: 'wire shape',
+        },
+      ]);
+      const result = await runStoryboardStep(fixture.url, storyboard, 'create_media_buy_async', {
+        protocol: 'a2a',
+        allow_http: true,
+        invariants: {
+          disable: [
+            'status.monotonic',
+            'idempotency.conflict_no_payload_leak',
+            'context.no_secret_echo',
+            'governance.denial_blocks_mutation',
+          ],
+        },
+      });
+      const a2aCheck = result.validations.find(v => v.check === 'a2a_submitted_artifact');
+      assert.ok(a2aCheck, 'check ran');
+      assert.strictEqual(a2aCheck.passed, false, 'wire-shape failure expected (status === "wrong")');
+      const serialized = JSON.stringify(result);
+      // None of the raw secret-shaped values may surface anywhere in
+      // the persisted validation result.
+      assert.doesNotMatch(serialized, /sk_live_PLAINTEXT/, 'api_key value must be redacted before reaching the report');
+      assert.doesNotMatch(serialized, /cs_PLAINTEXT/, 'client_secret value must be redacted');
+      assert.doesNotMatch(serialized, /at_PLAINTEXT/, 'access_token value must be redacted');
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it('a2a_submitted_artifact fails when the adapter is bypassed and the seller emits the pre-#899 shape', async () => {
+    // Simulate a regressed adapter by mounting a custom Express handler
+    // that ignores the SDK and emits `Task.state: 'submitted'` with
+    // `adcp_task_id` inside `data` — the exact regression class issue
+    // #904 calls out.
+    const app = express();
+    app.use(express.json());
+    let port;
+    const server = app.listen(0);
+    await new Promise(resolve => server.once('listening', resolve));
+    port = server.address().port;
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    app.get('/.well-known/agent-card.json', (_req, res) => {
+      res.json({
+        name: 'Regressed Seller',
+        description: 'Pre-#899 wire shape',
+        url: baseUrl,
+        version: '1.0.0',
+        protocolVersion: '0.3.0',
+        defaultInputModes: ['application/json'],
+        defaultOutputModes: ['application/json'],
+        capabilities: { streaming: false, pushNotifications: false },
+        skills: [{ id: 'create_media_buy', name: 'create_media_buy', description: 'create', tags: ['adcp'] }],
+      });
+    });
+    app.post('/', (req, res) => {
+      const { id, method } = req.body ?? {};
+      if (method !== 'message/send') {
+        res.json({ jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } });
+        return;
+      }
+      res.json({
+        jsonrpc: '2.0',
+        id,
+        result: {
+          kind: 'task',
+          id: 'a2a-task-uuid',
+          contextId: 'ctx-1',
+          // Regression: terminal 'submitted' state per pre-#899 wire
+          status: { state: 'submitted', timestamp: new Date().toISOString() },
+          history: [],
+          artifacts: [
+            {
+              artifactId: 'art-uuid',
+              name: 'submitted',
+              parts: [
+                {
+                  kind: 'data',
+                  // Regression: adcp_task_id leaked into payload
+                  data: { status: 'submitted', task_id: 'tk_async_1', adcp_task_id: 'tk_async_1' },
+                },
+              ],
+              // Regression: no metadata field
+            },
+          ],
+        },
+      });
+    });
+
+    try {
+      const storyboard = buildStoryboard([
+        {
+          check: 'a2a_submitted_artifact',
+          description: 'Catches pre-#899 wire-shape regression',
+        },
+      ]);
+      const result = await runStoryboardStep(baseUrl, storyboard, 'create_media_buy_async', {
+        protocol: 'a2a',
+        allow_http: true,
+        invariants: {
+          disable: [
+            'status.monotonic',
+            'idempotency.conflict_no_payload_leak',
+            'context.no_secret_echo',
+            'governance.denial_blocks_mutation',
+          ],
+        },
+      });
+      const a2aCheck = result.validations.find(v => v.check === 'a2a_submitted_artifact');
+      assert.ok(a2aCheck, 'a2a_submitted_artifact validation ran');
+      assert.strictEqual(a2aCheck.passed, false, 'regression must be caught');
+      const pointers = (a2aCheck.actual?.failures ?? []).map(f => f.pointer);
+      assert.ok(pointers.includes('/result/status/state'), 'flags Task.state regression');
+      assert.ok(pointers.includes('/result/artifacts/0/metadata/adcp_task_id'), 'flags missing artifact.metadata');
+      assert.ok(
+        pointers.includes('/result/artifacts/0/parts/0/data/adcp_task_id'),
+        'flags adcp_task_id leak into data'
+      );
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the runner-side half of #904 — a storyboard regression-class guard for the A2A submitted-arm wire shape established in #899.

Pre-#899 A2A adapters that emitted `Task.state: 'submitted'` with `final: true` and `adcp_task_id` inside `artifact.parts[0].data` (instead of `artifact.metadata`) would otherwise pass the storyboard suite despite being non-conformant per A2A 0.3.0. The new check fails-loud against that shape with specific JSON pointers naming each divergence.

## Wire-shape invariants asserted

The new `a2a_submitted_artifact` storyboard validation asserts:

1. `Task.state === 'completed'` — A2A Task.state tracks the HTTP transport call; `'submitted'` is the INITIAL state per A2A 0.3.0 and forbidden as a terminal value.
2. `Task.id` and `Task.contextId` non-empty — required by A2A 0.3.0 §6.1 for `tasks/get` addressability and follow-up correlation.
3. `artifact.artifactId` non-empty — required by §6.7 for chunked-artifact resumption and buyer-side caching.
4. `artifact.metadata.adcp_task_id` carries the AdCP-level handle (per A2A 0.3.0 metadata-extension convention).
5. `artifact.parts[0]` is a DataPart with `data.status === 'submitted'` — the AdCP payload preserves its native discriminator.
6. If `data.adcp_task_id` is also present (forward-compat for a future AdCP tool whose schema legitimately includes it), it MUST equal `metadata.adcp_task_id` — divergent or solo-payload writes are the regression class.

JSON-RPC error envelopes fail with a distinct `error_code: 'a2a_jsonrpc_error_envelope'` so dashboards can separate transport rejections from shape drift. The check self-skips with a `not_applicable` observation on non-A2A runs so storyboards can include it alongside MCP-shape assertions.

## Runner plumbing

Wires `withRawResponseCapture` around the SDK-driven A2A dispatch so the JSON-RPC envelope is observable for validation. Captured response bodies pass through `redactSecrets` before landing in `ValidationContext.a2aEnvelope` — AdCP-style secret-shaped fields in DataPart payloads (`api_key`, `client_secret`, `access_token`) get redacted before the envelope reaches persisted compliance reports.

`withRawResponseCapture` now surfaces partial captures on rejection (attached as `error.captures` via `Object.defineProperty` with `enumerable: false`) so storyboard validators get a wire-shape envelope even when the SDK threw mid-parse. Adds `getCapturesFromError` to the protocols module.

Also fixes a pre-existing un-redacted leak on the legacy `StoryboardStepResult.response` field — the modern `response_record` path was already redacted; the legacy field carried raw `taskResult.data` verbatim. Found by the new redaction integration test.

## Companion scenario

The compliance scenario at adcontextprotocol/adcp#3083 (`create_media_buy_async_submitted` storyboard) drives this check. `test/fixtures/create_media_buy_async_submitted.yaml` vendors a snapshot of that draft YAML so the runner-side end-to-end test is deterministic until the upstream YAML merges and `npm run sync-schemas` pulls it into the cache.

## Coverage

- 18 unit tests against `validateA2ASubmittedArtifact` (all wire-shape invariants + JSON-RPC error envelope path + non-A2A skip path + dual-write directions)
- 3 integration tests against `runStoryboardStep` (conformant adapter, regressed-adapter regression, secret-redaction guard)
- 3 end-to-end tests against the upstream adcp#3083 YAML

Total 24 new tests; 2434/2438 passing across the broader storyboard + uniformError + A2A test suites (4 intentional skips).

## Review path

Two rounds of expert review applied:

- **ad-tech-protocol-expert** — ship. Confirmed invariants 1–6 against A2A 0.3.0 §6.1 / §6.7 / §7.1. Suggested follow-up `a2a_context_continuity` validator for multi-step storyboards (filed separately; out of scope here).
- **security-reviewer** — ship. Verified `redactSecrets` applied at capture-parse boundary, partial-capture-on-throw safe, `defineProperty(enumerable: false)` pattern keeps captures off accidental log serialization. Caught the un-redacted legacy `response` field leak.
- **code-reviewer** — ship. Fixture pathing fixed (vendored YAML snapshot at `test/fixtures/`, graceful skip when missing); test coverage extended with non-object `task.status` case and redactSecrets envelope-path integration test.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build:lib` clean
- [x] `prettier --check` clean
- [x] All 24 new tests pass
- [x] 2434/2438 storyboard + uniformError + A2A regression battery passes (4 intentional skips, none introduced here)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)