### PR TITLE
feat(conformance): add MonotonicViolationHint to StoryboardStepHint taxonomy

### DIFF
--- a/.changeset/monotonic-violation-hint.md
+++ b/.changeset/monotonic-violation-hint.md
@@ -1,0 +1,9 @@
+---
+"@adcp/client": minor
+---
+
+Add `MonotonicViolationHint` to `StoryboardStepHint` taxonomy (issue #948).
+
+When the `status.monotonic` cross-step assertion detects a lifecycle-status regression, it now emits a structured `MonotonicViolationHint` into `StoryboardStepResult.hints[]` alongside the existing prose `AssertionResult`. The hint carries `task`, `step_id`, `resource_type`, `resource_id`, `previous_status`, `observed_status`, and `enum_schema_url` so renderers (Addie, CLI, JUnit) can build deterministic fix plans without parsing the prose error string.
+
+Also adds an optional `getStepHints?(ctx, step): StoryboardStepHint[]` hook to `AssertionSpec` — the runner calls it after `onStep` so assertions can emit non-fatal structured hints as a side channel without changing the `AssertionResult[]` return type.

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -26,6 +26,7 @@ import type {
   Storyboard,
   StoryboardInvariants,
   StoryboardRunOptions,
+  StoryboardStepHint,
   StoryboardStepResult,
   StepInvariantsObject,
 } from './types';
@@ -87,6 +88,23 @@ export interface AssertionSpec {
   onEnd?(
     ctx: AssertionContext
   ): Omit<AssertionResult, 'assertion_id' | 'scope'>[] | Promise<Omit<AssertionResult, 'assertion_id' | 'scope'>[]>;
+  /**
+   * Optional hook called by the runner immediately after `onStep` to collect
+   * non-fatal `StoryboardStepHint`s. Unlike `onStep` results (which gate
+   * pass/fail), hints are advisory — they survive even when the assertion
+   * marks the step as failed, giving renderers structured fields to build
+   * fix plans without parsing the prose `AssertionResult.error`.
+   *
+   * Implementations typically store pending hints in `ctx.state` during
+   * `onStep` and retrieve + clear them here. The runner merges returned hints
+   * into `StoryboardStepResult.hints[]` so they reach the same surface as
+   * the `context_value_rejected` hints emitted by the rejection-hint detector.
+   *
+   * Called only when the assertion's `onStep` was also called for this step
+   * (respects per-step `invariants.disable` opt-outs). Synchronous-only —
+   * hint collection must be a pure state read, not an async operation.
+   */
+  getStepHints?(ctx: AssertionContext, stepResult: StoryboardStepResult): StoryboardStepHint[];
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -103,6 +103,14 @@ export interface AssertionSpec {
    * Called only when the assertion's `onStep` was also called for this step
    * (respects per-step `invariants.disable` opt-outs). Synchronous-only —
    * hint collection must be a pure state read, not an async operation.
+   *
+   * **Implementations MUST clear any pending hint state from `ctx.state` on
+   * every `onStep` call** (both on violation and on clean passes) — not only
+   * when a violation is detected. Failing to clear on a passing `onStep` would
+   * leave stale state that `getStepHints` would then drain on the NEXT step,
+   * emitting a hint that belongs to a prior step's violation. The `status.monotonic`
+   * implementation clears `s.pendingHint = undefined` at the top of every
+   * `onStep` call as the reference pattern.
    */
   getStepHints?(ctx: AssertionContext, stepResult: StoryboardStepResult): StoryboardStepHint[];
 }

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -36,6 +36,7 @@
 import { ADCP_VERSION } from '../../version';
 import { CONFLICT_ADCP_ERROR_ALLOWLIST } from '../../server/envelope-allowlist';
 import { registerAssertion } from './assertions';
+import type { MonotonicViolationHint } from './types';
 
 // Register only once per process. `registerAssertion` throws on duplicates —
 // consumers who import `@adcp/client/testing` multiple times would hit that.
@@ -860,9 +861,19 @@ function pushAudience(obs: StatusObservation[], record: Record<string, unknown>)
   }
 }
 
-interface MonotonicState {
+interface MonotonicObservationState {
   stepId: string;
   status: string;
+}
+
+interface MonotonicAssertionState {
+  history: Map<string, MonotonicObservationState>;
+  /** Hint from the most recent violation detected in `onStep`. Cleared by `getStepHints`. */
+  pendingHint: MonotonicViolationHint | undefined;
+}
+
+function getMonotonicState(ctx: { state: Record<string, unknown> }): MonotonicAssertionState {
+  return ctx.state as unknown as MonotonicAssertionState;
 }
 
 registerOnce('status.monotonic', {
@@ -873,7 +884,9 @@ registerOnce('status.monotonic', {
   onStart: ctx => {
     // `${resource_type}:${resource_id}` → last-observed state. Tuple key
     // disambiguates the unlikely `media_buy_id` / `creative_id` collision.
-    ctx.state.history = new Map<string, MonotonicState>();
+    const s = getMonotonicState(ctx);
+    s.history = new Map<string, MonotonicObservationState>();
+    s.pendingHint = undefined;
   },
   onStep: (ctx, stepResult) => {
     // Skip error / skipped / negative-path steps. An errored read doesn't
@@ -886,15 +899,16 @@ registerOnce('status.monotonic', {
     if (!body || typeof body !== 'object') return [];
     if (extractAdcpError(stepResult)) return [];
 
-    const history = ctx.state.history as Map<string, MonotonicState>;
+    const s = getMonotonicState(ctx);
+    s.pendingHint = undefined;
     const observations = extractStatusObservations(stepResult.task, body as Record<string, unknown>);
     const description = 'Resource statuses transition only along spec lifecycle edges';
 
     for (const ob of observations) {
       const key = `${ob.resource_type}:${ob.resource_id}`;
-      const prev = history.get(key);
+      const prev = s.history.get(key);
       if (!prev) {
-        history.set(key, { stepId: stepResult.step_id, status: ob.status });
+        s.history.set(key, { stepId: stepResult.step_id, status: ob.status });
         continue;
       }
       if (prev.status === ob.status) {
@@ -908,7 +922,7 @@ registerOnce('status.monotonic', {
         // Unknown previous status (enum drift or we missed a state in the
         // table). Don't fail — `response_schema` catches enum violations;
         // reset the anchor so downstream transitions still get checked.
-        history.set(key, { stepId: stepResult.step_id, status: ob.status });
+        s.history.set(key, { stepId: stepResult.step_id, status: ob.status });
         continue;
       }
       if (!allowedTargets.has(ob.status)) {
@@ -921,24 +935,46 @@ registerOnce('status.monotonic', {
         const legalTargets = [...allowedTargets].sort();
         const legalDescription =
           legalTargets.length > 0 ? legalTargets.map(t => `"${t}"`).join(', ') : '(none — terminal state)';
+        const enumSchemaUrl = buildEnumSchemaUrl(ob.graph.enumFile);
+        const errorMsg =
+          `${ob.resource_type} ${ob.resource_id}: ${prev.status} → ${ob.status} ` +
+          `(step "${prev.stepId}" → step "${stepResult.step_id}") is not in the lifecycle graph. ` +
+          `Legal next states from "${prev.status}": ${legalDescription}. ` +
+          `See ${enumSchemaUrl} for the canonical lifecycle.`;
+        // Store structured hint for `getStepHints`. First violation per step wins;
+        // subsequent violations in the same step do not overwrite (assertion already
+        // short-circuits via return so only one violation fires per onStep call).
+        s.pendingHint = {
+          kind: 'monotonic_violation',
+          message: errorMsg,
+          task: stepResult.task,
+          step_id: stepResult.step_id,
+          resource_type: ob.resource_type,
+          resource_id: ob.resource_id,
+          previous_status: prev.status,
+          observed_status: ob.status,
+          enum_schema_url: enumSchemaUrl,
+        };
         return [
           {
             passed: false,
             description,
             step_id: stepResult.step_id,
-            error:
-              `${ob.resource_type} ${ob.resource_id}: ${prev.status} → ${ob.status} ` +
-              `(step "${prev.stepId}" → step "${stepResult.step_id}") is not in the lifecycle graph. ` +
-              `Legal next states from "${prev.status}": ${legalDescription}. ` +
-              `See ${buildEnumSchemaUrl(ob.graph.enumFile)} for the canonical lifecycle.`,
+            error: errorMsg,
           },
         ];
       }
-      history.set(key, { stepId: stepResult.step_id, status: ob.status });
+      s.history.set(key, { stepId: stepResult.step_id, status: ob.status });
     }
 
     if (observations.length === 0) return [];
     return [{ passed: true, description, step_id: stepResult.step_id }];
+  },
+  getStepHints: ctx => {
+    const s = getMonotonicState(ctx);
+    const hint = s.pendingHint;
+    s.pendingHint = undefined;
+    return hint ? [hint] : [];
   },
 });
 

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -32,6 +32,7 @@ export type {
   ContextInput,
   ContextProvenanceEntry,
   ContextValueRejectedHint,
+  MonotonicViolationHint,
   StoryboardContext,
   StoryboardRunOptions,
   ValidationResult,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -845,6 +845,16 @@ async function executeStoryboardPass(
             assertionsFailed = true;
           }
         }
+        // Collect non-fatal structured hints from the assertion (e.g.
+        // MonotonicViolationHint from status.monotonic). Called after onStep
+        // so assertions can populate ctx.state during onStep and drain it here.
+        // Respects the same per-step disable opt-out as onStep above.
+        if (spec.getStepHints) {
+          const assertionHints = spec.getStepHints(assertionContexts.get(spec.id)!, result);
+          if (assertionHints.length > 0) {
+            result.hints = [...(result.hints ?? []), ...assertionHints];
+          }
+        }
       }
 
       // PRM presence accounting — must happen after the step result lands so

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1049,12 +1049,11 @@ export interface ContextProvenanceEntry {
 }
 
 /**
- * Non-fatal hint attached to a step result. Today the runner only emits
- * `context_value_rejected` — more kinds may be added over time. The
- * discriminator lives on `kind` so consumers that only know how to render
- * a subset can ignore the rest without losing them.
+ * Non-fatal hint attached to a step result. The discriminator lives on `kind`
+ * so consumers that only know how to render a subset can ignore unknown kinds
+ * and display `message` verbatim as a fallback.
  */
-export type StoryboardStepHint = ContextValueRejectedHint;
+export type StoryboardStepHint = ContextValueRejectedHint | MonotonicViolationHint;
 
 /**
  * A seller rejected a request value that the runner traced back to a
@@ -1090,6 +1089,41 @@ export interface ContextValueRejectedHint {
   accepted_values: unknown[];
   /** Error code from the seller's error (if present). */
   error_code?: string;
+}
+
+/**
+ * The status-monotonic invariant observed a lifecycle regression: a resource
+ * transitioned along an edge not in the spec's lifecycle graph. Emitted
+ * alongside the failing `AssertionResult` (which already sets `passed: false`)
+ * so renderers can build a deterministic fix plan from structured fields
+ * instead of parsing the prose `AssertionResult.error` string.
+ *
+ * `message` preserves the human-readable prose surface so renderers that do
+ * not recognise `kind: 'monotonic_violation'` can still display it verbatim.
+ */
+export interface MonotonicViolationHint {
+  kind: 'monotonic_violation';
+  /** Human-readable summary of the violation. */
+  message: string;
+  /** AdCP task name (snake_case) dispatched at the step where the violation was observed. */
+  task: string;
+  /** Storyboard step id where the violation was observed. */
+  step_id: string;
+  /** Resource type scoping the status observation (e.g. `'media_buy'`, `'creative'`). */
+  resource_type: string;
+  /** Resource id scoping the status observation. */
+  resource_id: string;
+  /** The resource's status at the last valid observation (transition source). */
+  previous_status: string;
+  /** The resource's status observed at this step (the illegal transition target). */
+  observed_status: string;
+  /**
+   * Canonical enum schema URL for this resource type's lifecycle.
+   * Points at `https://adcontextprotocol.org/schemas/<version>/enums/<file>`
+   * so renderers can deep-link to the spec lifecycle table without re-deriving
+   * the URL from `resource_type`.
+   */
+  enum_schema_url: string;
 }
 
 export interface StoryboardPhaseResult {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.16.0';
+export const LIBRARY_VERSION = '5.17.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.16.0',
+  library: '5.17.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-24T21:53:15.899Z',
+  generatedAt: '2026-04-25T10:07:28.765Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -1365,3 +1365,152 @@ describe('default-invariants: status.monotonic', () => {
     assert.ok(out[1].output.every(o => o.passed));
   });
 });
+
+// ────────────────────────────────────────────────────────────
+// status.monotonic — MonotonicViolationHint emission (issue #948)
+// ────────────────────────────────────────────────────────────
+
+describe('default-invariants: status.monotonic — MonotonicViolationHint', () => {
+  const spec = getAssertion('status.monotonic');
+
+  function makeCtx() {
+    return { storyboard: {}, agentUrl: 'x', options: {}, state: {} };
+  }
+
+  function step(overrides) {
+    return {
+      step_id: 's1',
+      phase_id: 'p',
+      title: 't',
+      task: 'get_media_buys',
+      passed: true,
+      duration_ms: 0,
+      validations: [],
+      context: {},
+      extraction: { path: 'none' },
+      ...overrides,
+    };
+  }
+
+  function mb(id, status) {
+    return { media_buy_id: id, status, packages: [] };
+  }
+
+  test('getStepHints returns empty array when no violation occurred', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    const s1 = step({ step_id: 'create', task: 'create_media_buy', response: mb('mb-1', 'active') });
+    spec.onStep(ctx, s1);
+    const hints = spec.getStepHints(ctx, s1);
+    assert.deepStrictEqual(hints, []);
+  });
+
+  test('getStepHints returns MonotonicViolationHint on backward transition', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    const s1 = step({ step_id: 'create', task: 'create_media_buy', response: mb('mb-1', 'active') });
+    const s2 = step({
+      step_id: 'regress',
+      task: 'get_media_buys',
+      response: { media_buys: [mb('mb-1', 'pending_creatives')] },
+    });
+    spec.onStep(ctx, s1);
+    const assertionResults = spec.onStep(ctx, s2);
+    assert.strictEqual(assertionResults[0].passed, false, 'assertion must have failed');
+
+    const hints = spec.getStepHints(ctx, s2);
+    assert.strictEqual(hints.length, 1);
+    const hint = hints[0];
+    assert.strictEqual(hint.kind, 'monotonic_violation');
+    assert.strictEqual(hint.task, 'get_media_buys');
+    assert.strictEqual(hint.step_id, 'regress');
+    assert.strictEqual(hint.resource_type, 'media_buy');
+    assert.strictEqual(hint.resource_id, 'mb-1');
+    assert.strictEqual(hint.previous_status, 'active');
+    assert.strictEqual(hint.observed_status, 'pending_creatives');
+    assert.ok(
+      hint.enum_schema_url.includes('media-buy-status.json'),
+      `expected enum URL to include media-buy-status.json, got: ${hint.enum_schema_url}`
+    );
+    assert.ok(typeof hint.message === 'string' && hint.message.length > 0, 'message must be a non-empty string');
+    assert.ok(hint.message.includes('active → pending_creatives'), 'message must describe the transition');
+  });
+
+  test('getStepHints clears pendingHint after first call (no double-emit)', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    const s1 = step({ step_id: 'create', task: 'create_media_buy', response: mb('mb-1', 'active') });
+    const s2 = step({
+      step_id: 'regress',
+      task: 'get_media_buys',
+      response: { media_buys: [mb('mb-1', 'pending_creatives')] },
+    });
+    spec.onStep(ctx, s1);
+    spec.onStep(ctx, s2);
+    const first = spec.getStepHints(ctx, s2);
+    const second = spec.getStepHints(ctx, s2);
+    assert.strictEqual(first.length, 1, 'first call must return the hint');
+    assert.strictEqual(second.length, 0, 'second call must return empty — hint already consumed');
+  });
+
+  test('getStepHints returns empty when previous step had violation but current step is clean', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    const s1 = step({ step_id: 'create', task: 'create_media_buy', response: mb('mb-1', 'active') });
+    const s2 = step({
+      step_id: 'regress',
+      task: 'get_media_buys',
+      response: { media_buys: [mb('mb-1', 'pending_creatives')] },
+    });
+    // Run a third step that makes a valid forward observation on a different resource
+    // (so onStep runs but produces no violation) — pendingHint must be clear.
+    const s3 = step({
+      step_id: 'ok',
+      task: 'create_media_buy',
+      response: mb('mb-2', 'pending_creatives'),
+    });
+    spec.onStep(ctx, s1);
+    spec.onStep(ctx, s2);
+    // Consume s2's hint so state is clean
+    spec.getStepHints(ctx, s2);
+    spec.onStep(ctx, s3);
+    const hints = spec.getStepHints(ctx, s3);
+    assert.deepStrictEqual(hints, []);
+  });
+
+  test('terminal-state violation hint carries correct enum URL', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    const s1 = step({ step_id: 'done', task: 'get_media_buys', response: { media_buys: [mb('mb-1', 'completed')] } });
+    const s2 = step({ step_id: 'revive', task: 'get_media_buys', response: { media_buys: [mb('mb-1', 'active')] } });
+    spec.onStep(ctx, s1);
+    spec.onStep(ctx, s2);
+    const hints = spec.getStepHints(ctx, s2);
+    assert.strictEqual(hints.length, 1);
+    assert.strictEqual(hints[0].previous_status, 'completed');
+    assert.strictEqual(hints[0].observed_status, 'active');
+    assert.ok(hints[0].enum_schema_url.includes('media-buy-status.json'));
+  });
+
+  test('creative violation hint carries creative-status enum URL', () => {
+    const ctx = makeCtx();
+    spec.onStart(ctx);
+    const creativeOf = (id, status) => ({ creative_id: id, status });
+    const s1 = step({
+      step_id: 's1',
+      task: 'sync_creatives',
+      response: { creatives: [creativeOf('cr-1', 'approved')] },
+    });
+    const s2 = step({
+      step_id: 's2',
+      task: 'sync_creatives',
+      response: { creatives: [creativeOf('cr-1', 'processing')] },
+    });
+    spec.onStep(ctx, s1);
+    spec.onStep(ctx, s2);
+    const hints = spec.getStepHints(ctx, s2);
+    assert.strictEqual(hints.length, 1);
+    assert.strictEqual(hints[0].resource_type, 'creative');
+    assert.ok(hints[0].enum_schema_url.includes('creative-status.json'));
+  });
+});


### PR DESCRIPTION
Closes #948

## Summary

- Adds `MonotonicViolationHint` as the fourth member of the `StoryboardStepHint` discriminated union (`kind: 'monotonic_violation'`)
- When `status.monotonic` detects a lifecycle-status regression, emits a structured hint into `StoryboardStepResult.hints[]` alongside the existing prose `AssertionResult` — pass/fail unchanged
- Hint carries `task`, `step_id`, `resource_type`, `resource_id`, `previous_status`, `observed_status`, `enum_schema_url` so renderers (Addie, CLI, JUnit) can build deterministic fix plans without parsing the prose error string
- Adds optional `getStepHints?(ctx, step): StoryboardStepHint[]` hook to `AssertionSpec` so assertions can emit non-fatal structured hints as a side channel without changing the `AssertionResult[]` return type

## What tested

- 6 new unit tests in `test/lib/storyboard-default-invariants.test.js`: no-violation empty return, correct fields on backward transition, clear-after-consume (no double-emit), clean-step produces no hint, terminal-state enum URL, creative-status enum URL
- All 104 tests in `storyboard-default-invariants.test.js` pass
- Build compiles cleanly against lib tsconfig

## Nits (not fixed, noted for record)

- `getStepHints` is gated behind `if (!spec.onStep) continue` in the runner — a hypothetical hints-only `AssertionSpec` without `onStep` would silently emit nothing. Documented in the JSDoc as the expected contract; not a concern for any current assertion.
- Protocol expert noted `enum_file` (bare filename) as a potentially useful field for consumers who want to construct version-independent URLs. Deferred — no current consumer needs it, and `enum_schema_url` carries the fully-formed canonical URL. Can be added in a follow-up without a breaking change.

**Pre-PR review:**
- code-reviewer: approved — no blockers, one structural nit noted above
- ad-tech-protocol-expert: approved — non-breaking per spec, `string` status fields correct, `enum_schema_url` sufficient

Session: https://claude.ai/code/session_01F23rtd57PTgCbdUMsAAHHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01F23rtd57PTgCbdUMsAAHHD)_