### PR TITLE
feat(scripts): typecheck-skill-examples + fix 8 skill imports

### DIFF
--- a/.changeset/skill-example-typecheck.md
+++ b/.changeset/skill-example-typecheck.md
@@ -1,0 +1,9 @@
+---
+"@adcp/client": patch
+---
+
+Skill drift fixes (caught by `npm run typecheck:skill-examples`):
+
+- 8 SKILL.md files imported `verifyApiKey`, `verifyBearer`, `anyOf`, `bridgeFromTestControllerStore` from `@adcp/client` (top-level) — these symbols only exist under `@adcp/client/server`. Agents copy-pasting the example would get `Module has no exported member` at compile time. Fixed across all affected skills (`build-creative-agent`, `build-generative-seller-agent`, `build-governance-agent`, `build-retail-media-agent`, `build-seller-agent`, `build-si-agent`, `build-signals-agent`, `build-seller-agent/deployment.md`).
+
+Plus `scripts/typecheck-skill-examples.ts` — extracts every fenced TS block from `skills/**/*.md`, compiles each as a standalone module against the published `@adcp/client` types, and fails on new typecheck errors. Baseline mode (`scripts/skill-examples.baseline.json`) records the 142 known documentation-pattern errors (placeholder identifiers, untyped `ctx.store.list` returns) so the script ships green on day one and ratchets down over time. Run with `npm run typecheck:skill-examples`.

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "generate-agent-docs": "tsx scripts/generate-agent-docs.ts",
     "compliance:agent-skill": "tsx scripts/manual-testing/agent-skill-storyboard.ts",
     "compliance:skill-matrix": "tsx scripts/manual-testing/run-skill-matrix.ts",
+    "typecheck:skill-examples": "tsx scripts/typecheck-skill-examples.ts",
     "sync-version": "tsx scripts/sync-version.ts",
     "validate-schemas": "tsx scripts/validate-schemas.ts",
     "lint": "eslint 'src/lib/testing/**/*.ts'",

--- a/scripts/skill-examples.baseline.json
+++ b/scripts/skill-examples.baseline.json
@@ -1,0 +1,712 @@
+[
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS18046",
+    "messagePrefix": "'acc.account.brand' is of type 'unknown'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'AGENT_URL'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'AGENT_URL'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'randomUUID'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; brand_id: string; adcp_major_version?: nu"
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; idempotency_key: string; accounts: { [x: "
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '{ role: string; id: any; }' is not assignable to type 'string'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'brand' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'brand' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'length' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'operator' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'operator' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'status' does not exist on type 'GovernanceCallResult'."
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS2353",
+    "messagePrefix": "Object literal may only specify known properties, and 'findings' does not exist "
+  },
+  {
+    "source": "skills/build-brand-rights-agent/SKILL.md",
+    "errorCode": "TS7053",
+    "messagePrefix": "Element implicitly has an 'any' type because expression of type '0' can't be use"
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'creativeRepo'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'creativeRepo'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupKey'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'server'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; adcp_major_version?: number | undefined; "
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; idempotency_key: string; adcp_major_versi"
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; request_type: \"single\" | \"batch\" | \"varia"
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'id' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'id' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-creative-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'sandbox' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'FORMATS'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupKey'."
+  },
+  {
+    "source": "skills/build-generative-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'PRODUCTS'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAdcpServer'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupKey'."
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; idempotency_key: string; plans: Record<st"
+  },
+  {
+    "source": "skills/build-governance-agent/SKILL.md",
+    "errorCode": "TS2345",
+    "messagePrefix": "Argument of type 'unknown' is not assignable to parameter of type 'string'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS18048",
+    "messagePrefix": "'params.catalogs' is possibly 'undefined'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS18048",
+    "messagePrefix": "'params.event_sources' is possibly 'undefined'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupKey'."
+  },
+  {
+    "source": "skills/build-retail-media-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'PRODUCTS'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS1309",
+    "messagePrefix": "The current file is a CommonJS module and cannot use 'await' at the top level."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'AdapterConfig'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupAccount'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupAccount'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupAccount'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'MediaBuyHandlers'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'metaConfig'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'metaHandlers'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'myOAuthProvider'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'snapConfig'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'snapHandlers'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type 'string | undefined' is not assignable to type 'string'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type 'string | undefined' is not assignable to type 'string'."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2769",
+    "messagePrefix": "No overload matches this call."
+  },
+  {
+    "source": "skills/build-seller-agent/deployment.md",
+    "errorCode": "TS2769",
+    "messagePrefix": "No overload matches this call."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'accountRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'AGENT_URL'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'AGENT_URL'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'budgetRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'creativeRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'creativeRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'DEFAULT_REPORTING_CAPABILITIES'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'deliveryRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'executeBuy'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'executeBuy'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'handleGetProducts'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'humanReviewQueue'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupApiKey'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'mediaBuyRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'mediaBuyRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'planRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'productRepo'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'PRODUCTS'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'queueIoReview'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'resolveOperation'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'server'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; adcp_major_version?: number | undefined; "
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; adcp_major_version?: number | undefined; "
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; adcp_major_version?: number | undefined; "
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; idempotency_key: string; accounts: { [x: "
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '{ kid: string; alg: string; adcp_use: string; key_ops: string[]; crv?: str"
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '{}' is not assignable to type 'string'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'map' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2339",
+    "messagePrefix": "Property 'sandbox' does not exist on type '{}'."
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2345",
+    "messagePrefix": "Argument of type '{ field: string; }' is not assignable to parameter of type 'Ad"
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2345",
+    "messagePrefix": "Argument of type '{ field: string; }' is not assignable to parameter of type 'Ad"
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS2345",
+    "messagePrefix": "Argument of type '{ mediaBuy: { getProducts: any; }; testController: TestControl"
+  },
+  {
+    "source": "skills/build-seller-agent/SKILL.md",
+    "errorCode": "TS7006",
+    "messagePrefix": "Parameter 'outcome' implicitly has an 'any' type."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupKey'."
+  },
+  {
+    "source": "skills/build-si-agent/SKILL.md",
+    "errorCode": "TS2322",
+    "messagePrefix": "Type '(params: { [x: string]: unknown; idempotency_key: string; session_id: stri"
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'issuer'. Either declare one"
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS18004",
+    "messagePrefix": "No value exists in scope for the shorthand property 'jwksUri'. Either declare on"
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'createAgent'."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'db'."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'issuer'."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS2304",
+    "messagePrefix": "Cannot find name 'lookupKey'."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS7005",
+    "messagePrefix": "Variable 'signals' implicitly has an 'any[]' type."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS7005",
+    "messagePrefix": "Variable 'signals' implicitly has an 'any[]' type."
+  },
+  {
+    "source": "skills/build-signals-agent/SKILL.md",
+    "errorCode": "TS7034",
+    "messagePrefix": "Variable 'signals' implicitly has type 'any[]' in some locations where its type "
+  }
+]

--- a/scripts/typecheck-skill-examples.ts
+++ b/scripts/typecheck-skill-examples.ts
@@ -1,0 +1,426 @@
+#!/usr/bin/env tsx
+/**
+ * Typecheck every fenced TypeScript block in `skills/**\/*.md` against the
+ * published `@adcp/client` types. Catches drift between skill code samples
+ * and the actual SDK surface — the failure mode that landed PR #945
+ * (the creative skill taught a `server.registerTool` API that doesn't
+ * exist on `AdcpServer`).
+ *
+ * How it works:
+ *
+ * 1. Walks `skills/**\/*.md`.
+ * 2. Extracts every ` ```typescript ` / ` ```ts ` fenced block.
+ * 3. Writes each block to its own file under `.cache/skill-examples/`,
+ *    one file per block, so top-level imports + top-level statements
+ *    work and one block's syntax error doesn't poison the next.
+ * 4. Generates a `tsconfig.json` resolving `@adcp/client` to the local
+ *    `dist/` so we test the *published* surface — same thing a downstream
+ *    consumer sees.
+ * 5. Runs `tsc --noEmit` over the cache and reports.
+ *
+ * Skip markers (apply to one block):
+ *
+ *   <!-- skill-example-skip: <reason> -->
+ *
+ * placed on the line immediately preceding the opening fence. Use sparingly
+ * — every skipped block is a place where the harness can't catch drift.
+ *
+ * Usage:
+ *
+ *   tsx scripts/typecheck-skill-examples.ts                    # default — compare to baseline
+ *   tsx scripts/typecheck-skill-examples.ts --update-baseline  # capture current errors
+ *   tsx scripts/typecheck-skill-examples.ts --keep             # leave .cache/ around
+ *   tsx scripts/typecheck-skill-examples.ts --verbose          # show extraction + skipped
+ *
+ * Exit code: 0 = no NEW typecheck errors vs baseline. 1 = at least one new error.
+ *            2 = harness error (no skills found, dist missing, etc.).
+ *
+ * Baseline file: `scripts/skill-examples.baseline.json` records the set of
+ * error fingerprints (sourceFile:errorCode:message) currently known and
+ * accepted as documentation-pattern noise (placeholder identifiers, untyped
+ * `ctx.store.list` returns, etc.). New errors fail the run; baselined errors
+ * are reported as "known" but don't fail. Errors that disappeared since
+ * baseline are reported so the baseline can be tightened.
+ *
+ * Prerequisites: `npm run build:lib` must have run so `dist/` is populated;
+ * the script reminds you if it isn't.
+ */
+
+import { readdir, readFile, writeFile, mkdir, rm, stat } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const REPO_ROOT = resolve(__dirname, '..');
+const SKILLS_DIR = join(REPO_ROOT, 'skills');
+const CACHE_DIR = join(REPO_ROOT, '.cache/skill-examples');
+const DIST_DIR = join(REPO_ROOT, 'dist');
+
+interface CliArgs {
+  keep: boolean;
+  verbose: boolean;
+  updateBaseline: boolean;
+}
+
+const BASELINE_PATH = join(REPO_ROOT, 'scripts/skill-examples.baseline.json');
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = { keep: false, verbose: false, updateBaseline: false };
+  for (const a of argv) {
+    if (a === '--keep') out.keep = true;
+    else if (a === '--verbose') out.verbose = true;
+    else if (a === '--update-baseline') out.updateBaseline = true;
+    else if (a === '-h' || a === '--help') {
+      console.error(`Usage: typecheck-skill-examples [--keep] [--verbose] [--update-baseline]`);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+interface BaselineEntry {
+  source: string;
+  errorCode: string;
+  /** Truncated to 80 chars so cosmetic message changes don't churn the baseline. */
+  messagePrefix: string;
+}
+
+function entryKey(e: BaselineEntry): string {
+  return `${e.source}|${e.errorCode}|${e.messagePrefix}`;
+}
+
+async function loadBaseline(): Promise<BaselineEntry[]> {
+  try {
+    const raw = await readFile(BASELINE_PATH, 'utf8');
+    return JSON.parse(raw) as BaselineEntry[];
+  } catch {
+    return [];
+  }
+}
+
+async function writeBaseline(entries: BaselineEntry[]): Promise<void> {
+  // Sort for stable diffs.
+  const sorted = [...entries].sort((a, b) => entryKey(a).localeCompare(entryKey(b)));
+  await writeFile(BASELINE_PATH, JSON.stringify(sorted, null, 2) + '\n', 'utf8');
+}
+
+interface ExtractedBlock {
+  /** Path relative to repo root (e.g., `skills/build-creative-agent/SKILL.md`). */
+  sourceFile: string;
+  /** 1-based block index within the source file. */
+  index: number;
+  /** 1-based line number of the opening ``` fence in the source file. */
+  startLine: number;
+  /** Raw block content (no fences). */
+  content: string;
+  /** Skip reason, if a `<!-- skill-example-skip: ... -->` marker preceded the fence. */
+  skipReason?: string;
+}
+
+/**
+ * Determine whether a block is a "full module" (compiles standalone) or a
+ * "fragment" (object literal, partial handler block, etc. — won't parse as
+ * top-level TypeScript and isn't meant to).
+ *
+ * Rule: a block is a full module when it has BOTH (a) at least one
+ * `import ... from '...'` line AND (b) a top-level call to `serve(`,
+ * `createAdcpServer(`, `createIdempotencyStore(`, or similar entry-point
+ * that anchors it as a complete agent file.
+ *
+ * Why both checks: a fragment like `import { displayRender } from '@adcp/client'; \n
+ * buildCreative: async (params) => { ... }` has imports but is still a
+ * partial handler — the property syntax fails to parse at the top level.
+ * Requiring an entry-point call rules those out without false-skipping
+ * real agents.
+ *
+ * The drift class we're catching with this harness (`server.registerTool`
+ * and similar API drift) only shows up in full modules — by definition,
+ * the drift requires SDK symbols to be referenced *in a context that
+ * compiles*. Fragments are documentation about *shape*, not *behavior*,
+ * and trying to compile them standalone produces parser-error noise
+ * that drowns out real signal.
+ */
+const FULL_MODULE_ANCHORS = [
+  /\bserve\s*\(/,
+  /\bcreateAdcpServer\s*\(/,
+  /\bcreateIdempotencyStore\s*\(/,
+  /\bcreateComplyController\s*\(/,
+];
+
+function isFullModule(content: string): boolean {
+  const hasImport = /^[ \t]*import[ \t]+.+from[ \t]+['"]/m.test(content);
+  if (!hasImport) return false;
+  return FULL_MODULE_ANCHORS.some(re => re.test(content));
+}
+
+const FENCE_RE = /^```(typescript|ts)\s*$/;
+const SKIP_MARKER_RE = /^<!--\s*skill-example-skip:\s*(.*?)\s*-->\s*$/;
+
+function extractBlocks(sourceFile: string, content: string): ExtractedBlock[] {
+  const lines = content.split('\n');
+  const blocks: ExtractedBlock[] = [];
+  let i = 0;
+  let nextIndex = 1;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (FENCE_RE.test(line)) {
+      const startLine = i + 1; // 1-based
+      // Look back for a skip marker on the immediately preceding non-blank line.
+      let skipReason: string | undefined;
+      for (let j = i - 1; j >= 0 && j >= i - 3; j--) {
+        const prev = lines[j].trim();
+        if (prev === '') continue;
+        const m = prev.match(SKIP_MARKER_RE);
+        if (m) skipReason = m[1];
+        break;
+      }
+      // Find closing fence.
+      const inner: string[] = [];
+      let k = i + 1;
+      while (k < lines.length && lines[k].trim() !== '```') {
+        inner.push(lines[k]);
+        k++;
+      }
+      blocks.push({
+        sourceFile,
+        index: nextIndex++,
+        startLine,
+        content: inner.join('\n'),
+        skipReason,
+      });
+      i = k + 1;
+    } else {
+      i++;
+    }
+  }
+  return blocks;
+}
+
+async function walkSkillFiles(dir: string, out: string[] = []): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) await walkSkillFiles(full, out);
+    else if (e.isFile() && e.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+function blockToFilename(block: ExtractedBlock): string {
+  // Map `skills/build-creative-agent/SKILL.md` + index 3 → `build-creative-agent_SKILL_03.ts`.
+  const flat = block.sourceFile
+    .replace(/^skills\//, '')
+    .replace(/\.md$/, '')
+    .replace(/[\\/]/g, '_');
+  const padded = String(block.index).padStart(2, '0');
+  return `${flat}_${padded}.ts`;
+}
+
+async function ensureDistBuilt(): Promise<void> {
+  const s = await stat(DIST_DIR).catch(() => null);
+  if (!s?.isDirectory()) {
+    console.error(
+      `[typecheck-skill-examples] error: dist/ not found at ${DIST_DIR}. Run "npm run build:lib" first so @adcp/client resolves to the published surface.`
+    );
+    process.exit(2);
+  }
+}
+
+async function writeTsconfig(): Promise<void> {
+  // Per-block files import `@adcp/client` and `@adcp/client/server`. Map both
+  // to the built dist so we test the *exported* shape, not the in-tree source.
+  // baseUrl + paths handles the resolution; module/moduleResolution match what
+  // a downstream Node16 consumer would use.
+  const tsconfig = {
+    compilerOptions: {
+      target: 'ES2022',
+      module: 'Node16',
+      moduleResolution: 'Node16',
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      esModuleInterop: true,
+      forceConsistentCasingInFileNames: true,
+      resolveJsonModule: true,
+      allowJs: false,
+      baseUrl: '.',
+      paths: {
+        '@adcp/client': [join(REPO_ROOT, 'dist/lib/index.d.ts')],
+        '@adcp/client/server': [join(REPO_ROOT, 'dist/lib/server/index.d.ts')],
+        '@adcp/client/*': [join(REPO_ROOT, 'dist/lib/*')],
+      },
+    },
+    include: ['*.ts'],
+  };
+  await writeFile(join(CACHE_DIR, 'tsconfig.json'), JSON.stringify(tsconfig, null, 2) + '\n', 'utf8');
+}
+
+interface ManifestEntry {
+  file: string;
+  source: string;
+  startLine: number;
+  index: number;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  await ensureDistBuilt();
+
+  const skillFiles = await walkSkillFiles(SKILLS_DIR);
+  if (skillFiles.length === 0) {
+    console.error(`[typecheck-skill-examples] no skill files under ${SKILLS_DIR}`);
+    process.exit(2);
+  }
+
+  // Fresh cache every run — block extraction is cheap, leftover files would
+  // shadow real drift if a block was deleted from a skill since last run.
+  await rm(CACHE_DIR, { recursive: true, force: true });
+  await mkdir(CACHE_DIR, { recursive: true });
+
+  const manifest: ManifestEntry[] = [];
+  let totalBlocks = 0;
+  let skippedFragmentBlocks = 0;
+  let skippedMarkedBlocks = 0;
+
+  for (const skillFile of skillFiles) {
+    const content = await readFile(skillFile, 'utf8');
+    const rel = relative(REPO_ROOT, skillFile);
+    const blocks = extractBlocks(rel, content);
+    for (const b of blocks) {
+      totalBlocks++;
+      if (b.skipReason) {
+        skippedMarkedBlocks++;
+        if (args.verbose) {
+          console.error(`◇ ${rel}:${b.startLine} block #${b.index} — marker-skip: ${b.skipReason}`);
+        }
+        continue;
+      }
+      if (!isFullModule(b.content)) {
+        skippedFragmentBlocks++;
+        if (args.verbose) {
+          console.error(`◇ ${rel}:${b.startLine} block #${b.index} — fragment (no import statement)`);
+        }
+        continue;
+      }
+      const filename = blockToFilename(b);
+      const filePath = join(CACHE_DIR, filename);
+      // Prepend a one-line marker comment so tsc errors include traceable
+      // source coordinates. Each block sits at the top level of its own file —
+      // top-level imports and statements work as written.
+      const wrapped = `// source: ${b.sourceFile}:${b.startLine} (block #${b.index})\n${b.content}\n`;
+      await writeFile(filePath, wrapped, 'utf8');
+      manifest.push({ file: filename, source: b.sourceFile, startLine: b.startLine, index: b.index });
+    }
+  }
+
+  if (manifest.length === 0) {
+    console.error(
+      `[typecheck-skill-examples] no compilable blocks found (skipped: ${skippedMarkedBlocks} marker, ${skippedFragmentBlocks} fragment)`
+    );
+    process.exit(0);
+  }
+
+  await writeTsconfig();
+
+  console.error(
+    `[typecheck-skill-examples] ${manifest.length} compilable, ${skippedFragmentBlocks} fragment, ${skippedMarkedBlocks} marker-skip — of ${totalBlocks} total in ${skillFiles.length} file(s)`
+  );
+
+  const tscPath = resolve(REPO_ROOT, 'node_modules/.bin/tsc');
+  const res = spawnSync(tscPath, ['--project', join(CACHE_DIR, 'tsconfig.json'), '--pretty', 'false'], {
+    encoding: 'utf8',
+  });
+
+  const stdout = (res.stdout ?? '').trim();
+  const stderr = (res.stderr ?? '').trim();
+  if (stderr && args.verbose) console.error(stderr);
+
+  // Parse tsc output into structured entries we can compare to baseline.
+  // Each error line looks like:
+  //   .cache/skill-examples/build-creative-agent_SKILL_03.ts(12,5): error TS2304: ...
+  const cacheRe = /^([^(]+\.ts)\((\d+),(\d+)\): error (TS\d+): (.*)$/;
+  interface Diagnostic {
+    source: string;
+    sourceLine: number;
+    column: string;
+    blockIndex: number;
+    errorCode: string;
+    message: string;
+  }
+  const diagnostics: Diagnostic[] = [];
+  for (const line of stdout.split('\n')) {
+    const m = line.match(cacheRe);
+    if (!m) continue;
+    const cacheFile = m[1];
+    const cacheLine = Number(m[2]);
+    const entry = manifest.find(e => cacheFile.endsWith(e.file));
+    if (!entry) continue;
+    diagnostics.push({
+      source: entry.source,
+      // Cache-file line 1 is `// source:` marker; original-file line = startLine + (cacheLine - 1).
+      sourceLine: entry.startLine + (cacheLine - 1),
+      column: m[3],
+      blockIndex: entry.index,
+      errorCode: m[4],
+      message: m[5],
+    });
+  }
+
+  const currentEntries: BaselineEntry[] = diagnostics.map(d => ({
+    source: d.source,
+    errorCode: d.errorCode,
+    messagePrefix: d.message.slice(0, 80),
+  }));
+
+  if (args.updateBaseline) {
+    await writeBaseline(currentEntries);
+    console.error(
+      `\n[typecheck-skill-examples] wrote ${currentEntries.length} entries to ${relative(REPO_ROOT, BASELINE_PATH)}`
+    );
+    if (!args.keep) await rm(CACHE_DIR, { recursive: true, force: true });
+    process.exit(0);
+  }
+
+  const baseline = await loadBaseline();
+  const baselineKeys = new Set(baseline.map(entryKey));
+  const currentKeys = new Set(currentEntries.map(entryKey));
+
+  const newErrors = diagnostics.filter((_, i) => !baselineKeys.has(entryKey(currentEntries[i])));
+  const fixedKeys = [...baselineKeys].filter(k => !currentKeys.has(k));
+  const knownErrorCount = diagnostics.length - newErrors.length;
+
+  if (newErrors.length === 0 && diagnostics.length === 0) {
+    console.error(`✓ all ${manifest.length} skill examples typecheck — clean of all baselined and new errors`);
+    if (!args.keep) await rm(CACHE_DIR, { recursive: true, force: true });
+    process.exit(0);
+  }
+
+  if (newErrors.length === 0) {
+    console.error(`✓ no new errors (${knownErrorCount} known baselined, ${manifest.length} blocks compiled)`);
+    if (fixedKeys.length > 0) {
+      console.error(
+        `  ◇ ${fixedKeys.length} baselined error(s) no longer reproduce — run with --update-baseline to tighten`
+      );
+    }
+    if (!args.keep) await rm(CACHE_DIR, { recursive: true, force: true });
+    process.exit(0);
+  }
+
+  console.error(`\n✗ ${newErrors.length} new typecheck error(s) (not in baseline):\n`);
+  for (const d of newErrors) {
+    console.error(
+      `  ${d.source}:${d.sourceLine}:${d.column} (block #${d.blockIndex}) error ${d.errorCode}: ${d.message}`
+    );
+  }
+  console.error(
+    `\n${knownErrorCount} baselined error(s) not shown.` +
+      `\n\nTo accept these as known issues: tsx scripts/typecheck-skill-examples.ts --update-baseline` +
+      `\nTo reproduce locally: tsx scripts/typecheck-skill-examples.ts --keep --verbose`
+  );
+  if (!args.keep) await rm(CACHE_DIR, { recursive: true, force: true });
+  process.exit(1);
+}
+
+main().catch(err => {
+  console.error(`[typecheck-skill-examples] fatal: ${err?.stack ?? err}`);
+  process.exit(2);
+});

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -416,7 +416,8 @@ Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempote
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
 
 ```typescript
-import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
+import { serve } from '@adcp/client';
+import { verifyApiKey, verifyBearer, anyOf } from '@adcp/client/server';
 
 // API key — simplest, good for B2B integrations
 serve(createAgent, {

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -491,7 +491,8 @@ Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempote
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
 
 ```typescript
-import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
+import { serve } from '@adcp/client';
+import { verifyApiKey, verifyBearer, anyOf } from '@adcp/client/server';
 
 // API key — simplest, good for B2B integrations
 serve(createAgent, {

--- a/skills/build-governance-agent/SKILL.md
+++ b/skills/build-governance-agent/SKILL.md
@@ -594,7 +594,8 @@ const server = createAdcpServer({
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
 
 ```typescript
-import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
+import { serve } from '@adcp/client';
+import { verifyApiKey, verifyBearer, anyOf } from '@adcp/client/server';
 
 // API key — simplest, good for B2B integrations
 serve(createAgent, {

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -398,7 +398,8 @@ Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempote
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
 
 ```typescript
-import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
+import { serve } from '@adcp/client';
+import { verifyApiKey, verifyBearer, anyOf } from '@adcp/client/server';
 
 // API key — simplest, good for B2B integrations
 serve(createAgent, {

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -686,7 +686,8 @@ productRepo.upsert(merged.product_id, merged);
 **2. `bridgeFromTestControllerStore`** — wires your seeded `Map` into `get_products` responses automatically. Sandbox requests see seeded + handler products merged (with seeded winning collisions); production traffic (no sandbox marker, or resolved non-sandbox account) skips the bridge entirely.
 
 ```ts
-import { createAdcpServer, bridgeFromTestControllerStore } from '@adcp/client';
+import { createAdcpServer } from '@adcp/client';
+import { bridgeFromTestControllerStore } from '@adcp/client/server';
 
 const seedStore = new Map<string, unknown>();
 

--- a/skills/build-seller-agent/deployment.md
+++ b/skills/build-seller-agent/deployment.md
@@ -15,7 +15,8 @@ Companion to [`SKILL.md`](./SKILL.md). Read this only when you need deployment s
 Pass functions for `publicUrl` and `protectedResource`, branch on `ctx.host` in the factory, and turn on `trustForwardedHost` when a proxy terminates TLS:
 
 ```typescript
-import { serve, createAdcpServer, verifyBearer, UnknownHostError, hostname } from '@adcp/client';
+import { serve, createAdcpServer, UnknownHostError, hostname } from '@adcp/client';
+import { verifyBearer } from '@adcp/client/server';
 
 // Host → adapter config. Whatever shape suits your deployment (DB, env, static).
 // Cache the CONFIG (not the AdcpServer). serve() still instantiates the

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -254,7 +254,8 @@ Idempotency is wired in the example above. What the framework handles for you:
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
 
 ```typescript
-import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
+import { serve } from '@adcp/client';
+import { verifyApiKey, verifyBearer, anyOf } from '@adcp/client/server';
 
 // API key — simplest, good for B2B integrations
 serve(createAgent, {

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -336,7 +336,8 @@ Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempote
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.
 
 ```typescript
-import { serve, verifyApiKey, verifyBearer, anyOf } from '@adcp/client';
+import { serve } from '@adcp/client';
+import { verifyApiKey, verifyBearer, anyOf } from '@adcp/client/server';
 
 // API key — simplest, good for B2B integrations
 serve(createAgent, {


### PR DESCRIPTION
## Summary

Adds `scripts/typecheck-skill-examples.ts` — a deterministic CI harness that extracts every fenced TypeScript block from `skills/**/*.md`, compiles each as a standalone module against the **published** `@adcp/client` types, and fails on new typecheck errors. Catches the same class of drift that landed PR #945 (`server.registerTool`) at the cost of a single CI step (~5s, $0).

The harness paid for itself on first run: it found a real bug across **8 skill files** importing `verifyApiKey`, `verifyBearer`, `anyOf`, `bridgeFromTestControllerStore` from `@adcp/client` (top-level) — those symbols only exist under `@adcp/client/server`. The seller skill had it right; 7 others had drifted. Agents copy-pasting those examples got `Module has no exported member` at compile time.

This is dx-expert priority #2 from the matrix-v18 review. Priority #1 (`scripts/conformance-replay.ts`) shipped in #945.

## What's in this PR

- `scripts/typecheck-skill-examples.ts` — extractor, classifier, runner
- `scripts/skill-examples.baseline.json` — captured 142 currently-known errors so CI ships green and ratchets down over time
- `package.json` — `npm run typecheck:skill-examples` shortcut
- 8 skill files: import fix to `@adcp/client/server` for the affected symbols
- Patch changeset (skills are in `package.json` `files` so changes ship)

## How the harness works

1. Walks `skills/**/*.md`, extracts every ` ```typescript ` / ` ```ts ` block.
2. **Classifies** each block as full-module or fragment. Full-module = has at least one `import ... from '...'` line **and** a top-level `serve(`, `createAdcpServer(`, `createIdempotencyStore(`, or `createComplyController(` call. Fragments (single handler shapes, object literals showing field structure) are skipped — trying to compile them standalone produces parser-error noise that drowns out real signal.
3. Writes each full-module block to its own `.cache/skill-examples/<flattened>.ts`, generates a `tsconfig.json` resolving `@adcp/client` to the local `dist/` (so we test the published surface), runs `tsc --noEmit`.
4. Maps errors back to original `.md:line:col` for navigation. Compares each error against the baseline; new errors fail CI.

Skip markers: `<!-- skill-example-skip: <reason> -->` on the line before a fence skips that block. Use sparingly.

## What's not in this PR

- **CI wiring.** Same logic as #945: separate PR after this lands so reviewers see one thing at a time. Ready to wire into `.github/workflows/ci.yml` as a parallel job.
- **Baseline ratchet.** 142 baselined errors are mostly placeholder identifiers in pseudo-code patterns (`db`, `lookupKey`, `jwksUri`) and untyped `ctx.store.list` returns. Tightening these is incremental work — do it as we slim skills (task #18).
- **Coverage of fragment blocks.** 48 of 78 blocks are fragments and skipped. Cross-step context propagation (testing-expert v1 recommendation) and a "fragment-as-method-stub" wrapper would let us cover more, but trade-offs differ from the conformance-replay harness — defer.

## Verification

```bash
# Build dist/ if you haven't
npm run build:lib

# Run the harness — should pass on a clean tree
npm run typecheck:skill-examples

# Expected output:
#   [typecheck-skill-examples] 30 compilable, 48 fragment, 0 marker-skip — of 78 total in 18 file(s)
#   ✓ no new errors (142 known baselined, 30 blocks compiled)
```

To verify it actually catches drift, intentionally re-introduce one of the bad imports (`import { verifyApiKey } from '@adcp/client';` in a skill) and re-run — the harness will fail with a navigable error.

## Test plan

- [x] `npm run typecheck:skill-examples` returns exit 0 with `✓ no new errors`
- [x] `npm run typecheck` clean (project tsc unaffected)
- [x] Prettier clean
- [x] Bad-import drift is fixed (7 skills + deployment.md)
- [ ] Reviewers run `npm run typecheck:skill-examples` locally to confirm green
- [ ] CI: typecheck + unit tests + format + audit + changeset pass

## Related

- #945 — conformance-replay (dx-expert priority #1)
- #785 — matrix pickup context
- adcp#3090 — upstream spec drift epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)