### PR TITLE
feat(conformance): add MissingRequiredFieldHint to StoryboardStepHint taxonomy

### DIFF
--- a/.changeset/missing-required-field-hint.md
+++ b/.changeset/missing-required-field-hint.md
@@ -1,0 +1,21 @@
+---
+"@adcp/client": minor
+---
+
+feat(conformance): add MissingRequiredFieldHint to StoryboardStepHint taxonomy
+
+Extends `StoryboardStepHint` with a new `MissingRequiredFieldHint` member — a
+structured hint the runner emits when the strict AJV validator detects a
+`required`-field violation in the agent's response.
+
+The runner already surfaced these conditions via `ValidationResult.warning`
+(prose only). `MissingRequiredFieldHint` carries the same diagnosis in
+machine-readable fields (`tool`, `field_path`, `schema_ref`) so downstream
+renderers (Addie, CLI, JUnit) can build per-field fix plans (locate → fill →
+verify) without parsing the warning string.
+
+`field_path` uses RFC 6901 JSON Pointer conventions, matching the
+`instance_path` convention adopted by `ShapeDriftHint` in #937.
+`message` is always present as a human-readable fallback; renderers that don't
+recognise the new `kind` continue to work verbatim. Pass/fail is unaffected —
+hints remain non-fatal. Closes #946.

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -264,6 +264,7 @@ export {
   type StoryboardStepResult,
   type StoryboardStepHint,
   type ContextValueRejectedHint,
+  type MissingRequiredFieldHint,
   type ContextProvenanceEntry,
   type StoryboardPhaseResult,
   type StoryboardResult,

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -32,6 +32,7 @@ export type {
   ContextInput,
   ContextProvenanceEntry,
   ContextValueRejectedHint,
+  MissingRequiredFieldHint,
   StoryboardContext,
   StoryboardRunOptions,
   ValidationResult,

--- a/src/lib/testing/storyboard/missing-required-hints.ts
+++ b/src/lib/testing/storyboard/missing-required-hints.ts
@@ -1,0 +1,66 @@
+/**
+ * Missing-required-field hint detection.
+ *
+ * Parallel to `shape-drift-hints.ts` — pure function that reads the strict
+ * AJV verdict already computed by `validateResponseSchema` (via
+ * `ValidationResult.strict`) and emits one `MissingRequiredFieldHint` per
+ * `required`-keyword violation.
+ *
+ * The runner (`runner.ts`) calls this after `runValidations` and merges the
+ * result into `StoryboardStepResult.hints[]`. Fires unconditionally (same
+ * gate as `ValidationResult.warning`) — hints are non-fatal and informational
+ * even on passing steps (a strict-only violation does not flip `passed`).
+ */
+import type { MissingRequiredFieldHint, ValidationResult } from './types';
+
+// AJV formats the message for `required` keyword violations as:
+//   must have required property '<name>'
+// Capture group 1 is the field name.
+const REQUIRED_MSG_RE = /required property ['"]([^'"]+)['"]/;
+
+/**
+ * Scan the strict AJV verdicts in `validations` and emit one hint per
+ * required-field violation. Returns an empty array when no AJV schemas
+ * are available or no required-field issues are present.
+ *
+ * @param taskName - tool name (snake_case) the storyboard dispatched under
+ * @param validations - result array from `runValidations` for this step
+ */
+export function detectMissingRequiredHints(
+  taskName: string,
+  validations: ValidationResult[]
+): MissingRequiredFieldHint[] {
+  const hints: MissingRequiredFieldHint[] = [];
+
+  for (const result of validations) {
+    const strict = result.strict;
+    if (!strict || strict.valid || !strict.issues) continue;
+
+    for (const issue of strict.issues) {
+      if (issue.keyword !== 'required') continue;
+
+      const match = issue.message.match(REQUIRED_MSG_RE);
+      const fieldName = match?.[1];
+      if (!fieldName) continue;
+
+      // Build RFC 6901 path: parent instance_path + "/" + field name.
+      // instance_path is "" for root-level required violations (AJV points
+      // at the parent object, not the missing child), so "" + "/" + name
+      // collapses to "/name" which is the correct RFC 6901 form.
+      const parentPath = issue.instance_path ?? '';
+      const fieldPath = `${parentPath}/${fieldName}`;
+
+      hints.push({
+        kind: 'missing_required_field',
+        tool: taskName,
+        field_path: fieldPath,
+        schema_ref: issue.schema_path || undefined,
+        message:
+          `${taskName} strict validation: missing required property '${fieldName}'` +
+          (parentPath ? ` at ${parentPath}` : ''),
+      });
+    }
+  }
+
+  return hints;
+}

--- a/src/lib/testing/storyboard/missing-required-hints.ts
+++ b/src/lib/testing/storyboard/missing-required-hints.ts
@@ -13,15 +13,15 @@
  */
 import type { MissingRequiredFieldHint, ValidationResult } from './types';
 
-// AJV formats the message for `required` keyword violations as:
-//   must have required property '<name>'
-// Capture group 1 is the field name.
-const REQUIRED_MSG_RE = /required property ['"]([^'"]+)['"]/;
-
 /**
  * Scan the strict AJV verdicts in `validations` and emit one hint per
  * required-field violation. Returns an empty array when no AJV schemas
  * are available or no required-field issues are present.
+ *
+ * `field_path` is taken directly from `SchemaValidationError.instance_path`,
+ * which `ajvIssueToSchemaError` (via `formatIssue` in schema-validator.ts)
+ * already encodes as `"${instancePath}/${missingProperty}"` — so the field
+ * pointer is fully built before it reaches this detector.
  *
  * @param taskName - tool name (snake_case) the storyboard dispatched under
  * @param validations - result array from `runValidations` for this step
@@ -31,33 +31,30 @@ export function detectMissingRequiredHints(
   validations: ValidationResult[]
 ): MissingRequiredFieldHint[] {
   const hints: MissingRequiredFieldHint[] = [];
+  // De-duplicate across multiple ValidationResult entries (e.g. two
+  // response_schema checks on the same step that share overlapping schemas).
+  const seen = new Set<string>();
 
   for (const result of validations) {
     const strict = result.strict;
-    if (!strict || strict.valid || !strict.issues) continue;
+    if (!strict?.issues?.length) continue;
 
     for (const issue of strict.issues) {
       if (issue.keyword !== 'required') continue;
 
-      const match = issue.message.match(REQUIRED_MSG_RE);
-      const fieldName = match?.[1];
-      if (!fieldName) continue;
-
-      // Build RFC 6901 path: parent instance_path + "/" + field name.
-      // instance_path is "" for root-level required violations (AJV points
-      // at the parent object, not the missing child), so "" + "/" + name
-      // collapses to "/name" which is the correct RFC 6901 form.
-      const parentPath = issue.instance_path ?? '';
-      const fieldPath = `${parentPath}/${fieldName}`;
+      // instance_path already contains the full pointer to the missing field
+      // (formatIssue in schema-validator.ts: pointer = instancePath + "/" +
+      // missingProperty). Use it directly — do not reconstruct from message.
+      const fieldPath = issue.instance_path || '/';
+      if (seen.has(fieldPath)) continue;
+      seen.add(fieldPath);
 
       hints.push({
         kind: 'missing_required_field',
         tool: taskName,
         field_path: fieldPath,
         schema_ref: issue.schema_path || undefined,
-        message:
-          `${taskName} strict validation: missing required property '${fieldName}'` +
-          (parentPath ? ` at ${parentPath}` : ''),
+        message: `${taskName} strict validation: ${issue.message}`,
       });
     }
   }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -19,6 +19,7 @@ import {
   type RunnerVariables,
 } from './context';
 import { detectContextRejectionHints } from './rejection-hints';
+import { detectMissingRequiredHints } from './missing-required-hints';
 import { runValidations, type ValidationContext } from './validations';
 import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
@@ -1685,10 +1686,15 @@ async function executeStep(
   // since the rejected value can't have come from this step's own
   // extraction.
   const stepFailed = !(passed && allValidationsPassed);
-  const hints =
+  const contextRejectionHints =
     stepFailed && runState.contextProvenance
       ? detectContextRejectionHints(taskResult, request, context, runState.contextProvenance, effectiveStep.task)
       : [];
+  // Missing-required-field hints fire unconditionally (same gate as
+  // ValidationResult.warning) — strict-only violations don't flip `passed`,
+  // but builders still need the per-field pointer to locate the fix.
+  const missingRequiredHints = detectMissingRequiredHints(effectiveStep.task, validations);
+  const hints = [...contextRejectionHints, ...missingRequiredHints];
 
   // Build next step preview
   const next = getNextStepPreview(step.id, allSteps, updatedContext, runState.runnerVars);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1049,12 +1049,12 @@ export interface ContextProvenanceEntry {
 }
 
 /**
- * Non-fatal hint attached to a step result. Today the runner only emits
- * `context_value_rejected` — more kinds may be added over time. The
- * discriminator lives on `kind` so consumers that only know how to render
- * a subset can ignore the rest without losing them.
+ * Non-fatal hint attached to a step result. More kinds may be added over
+ * time. The discriminator lives on `kind` so consumers that only know how
+ * to render a subset can ignore the rest; `message` is always present as a
+ * human-readable fallback.
  */
-export type StoryboardStepHint = ContextValueRejectedHint;
+export type StoryboardStepHint = ContextValueRejectedHint | MissingRequiredFieldHint;
 
 /**
  * A seller rejected a request value that the runner traced back to a
@@ -1090,6 +1090,34 @@ export interface ContextValueRejectedHint {
   accepted_values: unknown[];
   /** Error code from the seller's error (if present). */
   error_code?: string;
+}
+
+/**
+ * The runner detected that the agent's response is missing a field the
+ * spec marks as `required` — surfaced via the strict AJV verdict that runs
+ * alongside the lenient Zod check in `validateResponseSchema`.
+ *
+ * Non-fatal: step pass/fail is unchanged (driven by the Zod path).
+ * `message` is always present as a human-readable fallback; renderers that
+ * understand the structured fields (`field_path`, `tool`) can build per-field
+ * fix plans (locate → fill → verify) instead of parsing the warning string.
+ *
+ * `field_path` uses RFC 6901 JSON Pointer conventions with a leading slash
+ * pointing at the missing field itself — e.g. `/field_name` for a root-level
+ * field, `/nested/field_name` for a nested one. Contrast with
+ * `ShapeDriftHint.instance_path` which points at the drift site (parent
+ * object), so root drift is `""`.
+ */
+export interface MissingRequiredFieldHint {
+  kind: 'missing_required_field';
+  /** Pre-formatted human-readable message (same text as ValidationResult.warning). */
+  message: string;
+  /** AdCP tool name (snake_case) that produced the missing-field failure. */
+  tool: string;
+  /** RFC 6901 JSON Pointer to the missing field; e.g. `/field_name` for root-level. */
+  field_path: string;
+  /** Optional `$ref` or schema id naming the schema that flagged it. */
+  schema_ref?: string;
 }
 
 export interface StoryboardPhaseResult {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1116,7 +1116,7 @@ export interface MissingRequiredFieldHint {
   tool: string;
   /** RFC 6901 JSON Pointer to the missing field; e.g. `/field_name` for root-level. */
   field_path: string;
-  /** Optional `$ref` or schema id naming the schema that flagged it. */
+  /** AJV `schema_path` JSON Pointer identifying the schema keyword that flagged it (e.g. `#/required`). */
   schema_ref?: string;
 }
 

--- a/test/lib/storyboard-missing-required-hints.test.js
+++ b/test/lib/storyboard-missing-required-hints.test.js
@@ -1,0 +1,106 @@
+/**
+ * Tests for missing-required-field hint detection (issue #946).
+ *
+ * The runner emits a non-fatal hint when the strict AJV validator flags a
+ * required-field violation. Hints are additive — step pass/fail is unchanged.
+ */
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { detectMissingRequiredHints } = require('../../dist/lib/testing/storyboard/missing-required-hints');
+
+function makeValidation(issues) {
+  return {
+    check: 'response_schema',
+    passed: true,
+    description: 'response schema',
+    strict: {
+      valid: false,
+      variant: 'sync',
+      issues,
+    },
+  };
+}
+
+function requiredIssue(fieldPath, fieldName) {
+  return {
+    instance_path: fieldPath,
+    schema_path: '#/required',
+    keyword: 'required',
+    message: `must have required property '${fieldName}'`,
+  };
+}
+
+describe('detectMissingRequiredHints', () => {
+  test('returns empty array when validations is empty', () => {
+    assert.deepEqual(detectMissingRequiredHints('get_products', []), []);
+  });
+
+  test('returns empty array when no strict issues', () => {
+    const validations = [{ check: 'response_schema', passed: true, description: 'd' }];
+    assert.deepEqual(detectMissingRequiredHints('get_products', validations), []);
+  });
+
+  test('returns empty array when strict.valid is true', () => {
+    const validations = [makeValidation(undefined)];
+    validations[0].strict.valid = true;
+    validations[0].strict.issues = undefined;
+    assert.deepEqual(detectMissingRequiredHints('get_products', validations), []);
+  });
+
+  test('emits hint for root-level missing required field', () => {
+    const validations = [makeValidation([requiredIssue('/products', 'products')])];
+    const hints = detectMissingRequiredHints('get_products', validations);
+    assert.equal(hints.length, 1);
+    const h = hints[0];
+    assert.equal(h.kind, 'missing_required_field');
+    assert.equal(h.tool, 'get_products');
+    assert.equal(h.field_path, '/products');
+    assert.equal(h.schema_ref, '#/required');
+    assert.ok(h.message.includes('get_products'));
+    assert.ok(h.message.includes("'products'"));
+  });
+
+  test('emits hint for nested missing required field', () => {
+    const validations = [makeValidation([requiredIssue('/account/brand', 'brand')])];
+    const hints = detectMissingRequiredHints('create_media_buy', validations);
+    assert.equal(hints.length, 1);
+    assert.equal(hints[0].field_path, '/account/brand');
+    assert.equal(hints[0].tool, 'create_media_buy');
+  });
+
+  test('ignores non-required keyword issues', () => {
+    const validations = [makeValidation([
+      {
+        instance_path: '/budget',
+        schema_path: '#/properties/budget/type',
+        keyword: 'type',
+        message: 'must be number',
+      },
+    ])];
+    assert.deepEqual(detectMissingRequiredHints('create_media_buy', validations), []);
+  });
+
+  test('emits multiple hints for multiple required violations', () => {
+    const validations = [makeValidation([
+      requiredIssue('/name', 'name'),
+      requiredIssue('/budget', 'budget'),
+    ])];
+    const hints = detectMissingRequiredHints('create_media_buy', validations);
+    assert.equal(hints.length, 2);
+    assert.equal(hints[0].field_path, '/name');
+    assert.equal(hints[1].field_path, '/budget');
+  });
+
+  test('deduplicates the same field_path across multiple ValidationResult entries', () => {
+    const issue = requiredIssue('/name', 'name');
+    const validations = [makeValidation([issue]), makeValidation([issue])];
+    const hints = detectMissingRequiredHints('create_media_buy', validations);
+    assert.equal(hints.length, 1);
+  });
+
+  test('fallback: passes when strict.issues is empty array', () => {
+    const validations = [makeValidation([])];
+    assert.deepEqual(detectMissingRequiredHints('get_products', validations), []);
+  });
+});


### PR DESCRIPTION
Closes #946

## Summary

Extends `StoryboardStepHint` with a new `MissingRequiredFieldHint` discriminated union member. When the strict AJV validator flags a `required`-field violation in a storyboard step's response, the runner now emits a structured hint with `tool` + `field_path` so renderers (Addie, CLI, JUnit) can produce per-field fix plans instead of paraphrasing prose.

**What changed:**
- `types.ts` — `StoryboardStepHint` union extended; `MissingRequiredFieldHint` interface added
- `missing-required-hints.ts` — new pure detector that reads `ValidationResult[].strict.issues` (already computed by `validateResponseSchema`); no AJV re-invocation
- `runner.ts` — `detectMissingRequiredHints` wired after `runValidations`, unconditional (same gate as `ValidationResult.warning`)
- `storyboard/index.ts` + `testing/index.ts` — `MissingRequiredFieldHint` exported from public surface
- `test/lib/storyboard-missing-required-hints.test.js` — 8 unit tests mirroring `storyboard-rejection-hints.test.js`
- `.changeset/missing-required-field-hint.md` — minor bump

**What's not changing:**
- `hints[]` non-fatal contract — pass/fail is Zod-driven and unchanged
- `message` always present as fallback; renderers that don't know `missing_required_field` continue working verbatim
- No protocol-side change; no generated files touched

**`field_path` note:** `SchemaValidationError.instance_path` already encodes the full pointer to the missing field (`formatIssue` in `schema-validator.ts` bakes in `instancePath + "/" + missingProperty`). The detector uses it directly — no regex reconstruction. Root-level missing field `foo` → `field_path: "/foo"`. This differs from `ShapeDriftHint.instance_path` (which points at the drift *site*, so root drift is `""`).

**Merge order:** This PR targets `main` and is independent of #937 (ShapeDriftHint). When both land, the union becomes `ContextValueRejectedHint | MissingRequiredFieldHint | ShapeDriftHint` — trivial merge conflict at the type alias line.

## What was tested

- `tsc --project tsconfig.lib.json --noEmit` clean (pre-existing env-only errors unchanged)
- `prettier --check` passes
- 8 unit tests in `test/lib/storyboard-missing-required-hints.test.js` cover: root/nested `field_path`, non-required keyword filtering, multi-violation emission, deduplication across `ValidationResult` entries, empty/valid-strict edge cases

## Pre-PR review

**Pass 1:**
- code-reviewer: **2 blockers** — `field_path` double-appended field name (fixed: use `issue.instance_path` directly); `MissingRequiredFieldHint` missing from `storyboard/index.ts` (fixed: added). Also flagged missing unit tests (fixed: added).
- ad-tech-protocol-expert: approved — no protocol-side change; discriminated union extension backward-compatible via `message` fallback; `field_path` semantics (`/field_name` for root) confirmed correct

**Pass 2 (after fixes):**
- code-reviewer: **blockers resolved** — remaining nits below

## Nits (not fixed, documented here)

- `instance_path || '/'` fallback produces `field_path: '/'` in an edge case that cannot fire given AJV's `required`-keyword behavior; a future cleanup could use empty string instead
- Changeset says "`message` carries same text as `ValidationResult.warning`" — slightly imprecise: `warning` groups multiple required issues by parent path into one sentence, while `hint.message` is per-issue

---

Session: https://claude.ai/code/session_01U1kgmDYuNkWRdwvoqU2o5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01U1kgmDYuNkWRdwvoqU2o5i)_