### PR TITLE
feat(types): strict discriminator unions — AssetInstance, sync rows, vendor pricing

### DIFF
--- a/.changeset/strict-discriminator-types.md
+++ b/.changeset/strict-discriminator-types.md
@@ -1,0 +1,34 @@
+---
+"@adcp/client": minor
+---
+
+Strict discriminator types for creative assets, vendor pricing, and sync rows.
+
+The codegen produces strict per-variant interfaces (`ImageAsset`, `CpmPricing`, etc.) but doesn't emit canonical discriminated unions over them. This release adds three hand-authored unions on top of the generated bases so handler authors can opt into compile-time discriminator checking instead of runtime schema validation:
+
+- **`AssetInstance`** — discriminated union of every creative asset instance (`ImageAsset | VideoAsset | AudioAsset | TextAsset | HTMLAsset | URLAsset | CSSAsset | JavaScriptAsset | MarkdownAsset | VASTAsset | DAASTAsset | BriefAsset | CatalogAsset | WebhookAsset`), keyed on `asset_type`. Use as the value type for `creative_manifest.assets[<key>]`. Omitting `asset_type` or returning a plain `{ url, width, height }` against this type fails to compile.
+- **`CommonAssetInstance`** — narrower convenience union covering the six common variants (image, video, audio, text, html, url). Useful when you want to narrow without enumerating every esoteric type.
+- **`AssetInstanceType`** — the `asset_type` discriminator value union (`'image' | 'video' | …`). Useful for exhaustive switch-case helpers.
+- **`SyncAccountsResponseRow`** — extracted named type for one row in `SyncAccountsSuccess.accounts[]`. Forces the `action` literal-union discriminator (`'created' | 'updated' | 'unchanged' | 'failed'`) and the `status` enum on every row at compile time.
+- **`SyncGovernanceResponseRow`** — same pattern for `SyncGovernanceSuccess.accounts[]`. Forces the `status: 'synced' | 'failed'` discriminator.
+- **Vendor-pricing exports completed** — `PerUnitPricing`, `CustomPricing`, `VendorPricing`, `VendorPricingOption` are now re-exported from `@adcp/client` (previously only `CpmPricing`, `PercentOfMediaPricing`, `FlatFeePricing` were).
+- **Product-pricing exports completed** — `CPMPricingOption`, `VCPMPricingOption`, `CPCPricingOption`, `CPCVPricingOption`, `CPVPricingOption`, `CPPPricingOption`, `FlatRatePricingOption`, `TimeBasedPricingOption` re-exported (the union type `PricingOption` and `CPAPricingOption` were already exported).
+
+Type tests in `src/lib/types/asset-instances.test.ts` use `// @ts-expect-error` to lock in the constraints — if a future codegen regression loosens any discriminator (e.g., makes `asset_type` optional), `tsc --noEmit` fails on a now-unexpected error.
+
+Drift class this catches at compile time:
+
+```ts
+// Before: this slipped past TS, was caught only by runtime validator.
+const asset: Record<string, unknown> = { url: '...', width: 1920, height: 1080 };
+return { creative_manifest: { format_id, assets: { hero: asset } } };
+
+// After: typed as AssetInstance, missing asset_type is a compile error.
+const asset: AssetInstance = { url: '...', width: 1920, height: 1080 };
+//                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+// error TS2353: Object literal may only specify known properties, and
+// 'url' does not exist in type 'AssetInstance'. Property 'asset_type'
+// is missing.
+```
+
+This is dx-expert priority #3 from the matrix-v18 review (CI defenses #1 and #2 shipped in #945 and #957).

--- a/.changeset/strict-discriminator-types.md
+++ b/.changeset/strict-discriminator-types.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/client": minor
+'@adcp/client': minor
 ---
 
 Strict discriminator types for creative assets, vendor pricing, and sync rows.
@@ -7,14 +7,13 @@ Strict discriminator types for creative assets, vendor pricing, and sync rows.
 The codegen produces strict per-variant interfaces (`ImageAsset`, `CpmPricing`, etc.) but doesn't emit canonical discriminated unions over them. This release adds three hand-authored unions on top of the generated bases so handler authors can opt into compile-time discriminator checking instead of runtime schema validation:
 
 - **`AssetInstance`** — discriminated union of every creative asset instance (`ImageAsset | VideoAsset | AudioAsset | TextAsset | HTMLAsset | URLAsset | CSSAsset | JavaScriptAsset | MarkdownAsset | VASTAsset | DAASTAsset | BriefAsset | CatalogAsset | WebhookAsset`), keyed on `asset_type`. Use as the value type for `creative_manifest.assets[<key>]`. Omitting `asset_type` or returning a plain `{ url, width, height }` against this type fails to compile.
-- **`CommonAssetInstance`** — narrower convenience union covering the six common variants (image, video, audio, text, html, url). Useful when you want to narrow without enumerating every esoteric type.
 - **`AssetInstanceType`** — the `asset_type` discriminator value union (`'image' | 'video' | …`). Useful for exhaustive switch-case helpers.
 - **`SyncAccountsResponseRow`** — extracted named type for one row in `SyncAccountsSuccess.accounts[]`. Forces the `action` literal-union discriminator (`'created' | 'updated' | 'unchanged' | 'failed'`) and the `status` enum on every row at compile time.
 - **`SyncGovernanceResponseRow`** — same pattern for `SyncGovernanceSuccess.accounts[]`. Forces the `status: 'synced' | 'failed'` discriminator.
 - **Vendor-pricing exports completed** — `PerUnitPricing`, `CustomPricing`, `VendorPricing`, `VendorPricingOption` are now re-exported from `@adcp/client` (previously only `CpmPricing`, `PercentOfMediaPricing`, `FlatFeePricing` were).
 - **Product-pricing exports completed** — `CPMPricingOption`, `VCPMPricingOption`, `CPCPricingOption`, `CPCVPricingOption`, `CPVPricingOption`, `CPPPricingOption`, `FlatRatePricingOption`, `TimeBasedPricingOption` re-exported (the union type `PricingOption` and `CPAPricingOption` were already exported).
 
-Type tests in `src/lib/types/asset-instances.test.ts` use `// @ts-expect-error` to lock in the constraints — if a future codegen regression loosens any discriminator (e.g., makes `asset_type` optional), `tsc --noEmit` fails on a now-unexpected error.
+Type tests in `src/lib/types/asset-instances.type-checks.ts` use `// @ts-expect-error` to lock in the constraints — if a future codegen regression loosens any discriminator (e.g., makes `asset_type` optional), `tsc --noEmit` fails on a now-unexpected error. The file uses the `.type-checks.ts` suffix (not `.test.ts`) so it participates in the project's normal `npm run typecheck` pass; explicitly excluded from `tsconfig.lib.json` so it doesn't ship in `dist/`.
 
 Drift class this catches at compile time:
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -411,7 +411,7 @@ Non-guaranteed buys are always instant confirmation.
 > - `get_media_buy_delivery /media_buy_deliveries[i]/by_package[j]` rows are strict: each requires `package_id`, `spend` (number), `pricing_model`, `rate` (number), and `currency`. A mock that returns `{package_id, impressions, clicks}` fails validation — include the billing quintet on every package row.
 > - `get_media_buy_delivery /reporting_period/start` and `/end` are ISO 8601 **date-time** strings (`YYYY-MM-DDTHH:MM:SS.sssZ` via `new Date().toISOString()`), not date-only. A mock that returns `'2026-04-21'` fails the format check in GA.
 > - `get_media_buys /media_buys[i]` rows require **`media_buy_id`, `status`, `currency`, `total_budget`, `packages`**. When you persist a buy in `create_media_buy`, save `currency` and `total_budget` so the `get_media_buys` response can echo them verbatim — reconstructing later drops one of the required fields in ~every Claude build we've tested.
-> - `sync_accounts` response: each row in `accounts[]` requires **`action: 'created' | 'updated' | 'unchanged' | 'failed'`** (not just `account_id`, `status`). Compare to sync_creatives — same pattern. Omitting `action` fails schema validation at `/accounts/0/action` and blocks every downstream stateful step in the storyboard.
+> - `sync_accounts` response: each row in `accounts[]` requires **`action: 'created' | 'updated' | 'unchanged' | 'failed'`** (not just `account_id`, `status`). Compare to sync_creatives — same pattern. Omitting `action` fails schema validation at `/accounts/0/action` and blocks every downstream stateful step in the storyboard. Type your row array as `SyncAccountsResponseRow[]` (exported from `@adcp/client`) to catch the missing-`action` drift at compile time instead of runtime.
 
 **`get_adcp_capabilities`** — register first, empty `{}` schema
 
@@ -544,7 +544,14 @@ Retail-media sponsored-products formats often reach for `asset_type: 'promoted_o
 Use the typed slot builders — they inject `item_type` and `asset_type`, and the `requirements` object is strictly typed per asset_type, so `file_types`, `min_duration_seconds`, and `min_count` on an individual asset all fail at compile time:
 
 ```typescript
-import { imageAssetSlot, videoAssetSlot, catalogAssetSlot, repeatableGroup, imageGroupAsset, textGroupAsset } from '@adcp/client';
+import {
+  imageAssetSlot,
+  videoAssetSlot,
+  catalogAssetSlot,
+  repeatableGroup,
+  imageGroupAsset,
+  textGroupAsset,
+} from '@adcp/client';
 
 // Single image asset slot
 imageAssetSlot({
@@ -561,7 +568,11 @@ repeatableGroup({
   max_count: 5,
   selection_mode: 'sequential',
   assets: [
-    imageGroupAsset({ asset_id: 'card_image', required: true, requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png'] } }),
+    imageGroupAsset({
+      asset_id: 'card_image',
+      required: true,
+      requirements: { aspect_ratio: '1:1', formats: ['jpg', 'png'] },
+    }),
     textGroupAsset({ asset_id: 'card_headline', required: true, requirements: { max_length: 40 } }),
   ],
 });
@@ -1362,17 +1373,17 @@ When `adcp storyboard run <url> <storyboard> --json` reports a failure, the `det
 
 Each specialism below has a companion file with its delta on top of the baseline. Fetch only the one you are building.
 
-| Specialism | Status | Companion file |
-|---|---|---|
-| `sales-guaranteed` | stable | [`specialisms/sales-guaranteed.md`](./specialisms/sales-guaranteed.md) |
-| `sales-non-guaranteed` | stable | [`specialisms/sales-non-guaranteed.md`](./specialisms/sales-non-guaranteed.md) |
-| `sales-broadcast-tv` | stable | [`specialisms/sales-broadcast-tv.md`](./specialisms/sales-broadcast-tv.md) |
-| `sales-streaming-tv` | preview | baseline only |
-| `sales-social` | stable | [`specialisms/sales-social.md`](./specialisms/sales-social.md) |
-| `sales-exchange` | preview | baseline only |
-| `sales-proposal-mode` | stable | [`specialisms/sales-proposal-mode.md`](./specialisms/sales-proposal-mode.md) |
-| `audience-sync` | stable | [`specialisms/audience-sync.md`](./specialisms/audience-sync.md) |
-| `signed-requests` | preview | [`specialisms/signed-requests.md`](./specialisms/signed-requests.md) — cross-cutting; applies to every mutating agent |
+| Specialism             | Status  | Companion file                                                                                                        |
+| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------- |
+| `sales-guaranteed`     | stable  | [`specialisms/sales-guaranteed.md`](./specialisms/sales-guaranteed.md)                                                |
+| `sales-non-guaranteed` | stable  | [`specialisms/sales-non-guaranteed.md`](./specialisms/sales-non-guaranteed.md)                                        |
+| `sales-broadcast-tv`   | stable  | [`specialisms/sales-broadcast-tv.md`](./specialisms/sales-broadcast-tv.md)                                            |
+| `sales-streaming-tv`   | preview | baseline only                                                                                                         |
+| `sales-social`         | stable  | [`specialisms/sales-social.md`](./specialisms/sales-social.md)                                                        |
+| `sales-exchange`       | preview | baseline only                                                                                                         |
+| `sales-proposal-mode`  | stable  | [`specialisms/sales-proposal-mode.md`](./specialisms/sales-proposal-mode.md)                                          |
+| `audience-sync`        | stable  | [`specialisms/audience-sync.md`](./specialisms/audience-sync.md)                                                      |
+| `signed-requests`      | preview | [`specialisms/signed-requests.md`](./specialisms/signed-requests.md) — cross-cutting; applies to every mutating agent |
 
 Claim exactly the specialisms your agent actually implements in `capabilities.specialisms`. Don't claim a specialism you only partially support — the compliance storyboard for that specialism will fail hard.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -320,6 +320,20 @@ export type {
   CpmPricing,
   PercentOfMediaPricing,
   FlatFeePricing,
+  PerUnitPricing,
+  CustomPricing,
+  VendorPricing,
+  VendorPricingOption,
+  // Pricing variants for products (publisher rate cards in get_products etc.)
+  // PricingOption + CPAPricingOption are exported below near the other tool types.
+  CPMPricingOption,
+  VCPMPricingOption,
+  CPCPricingOption,
+  CPCVPricingOption,
+  CPVPricingOption,
+  CPPPricingOption,
+  FlatRatePricingOption,
+  TimeBasedPricingOption,
   // Governance Domain - Property Lists
   CreatePropertyListRequest,
   CreatePropertyListResponse,

--- a/src/lib/types/asset-instances.test.ts
+++ b/src/lib/types/asset-instances.test.ts
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// Type-only tests for the AssetInstance discriminated union and the
+// SyncAccountsResponseRow / SyncGovernanceResponseRow row types.
+//
+// The "test" is whether this file compiles. Each `// @ts-expect-error`
+// comment claims the next line WILL fail typechecking. If TypeScript ever
+// stops flagging that line — e.g., because the discriminator was loosened
+// or a required field became optional — the `@ts-expect-error` itself
+// becomes an error and the project's `tsc --noEmit` fails. That's the
+// regression alarm.
+//
+// Run with `npm run typecheck`.
+
+import type {
+  AssetInstance,
+  AssetInstanceType,
+  CommonAssetInstance,
+  SyncAccountsResponseRow,
+  SyncGovernanceResponseRow,
+} from './index';
+
+// ── AssetInstance: discriminator narrowing works ─────────────────────────
+
+function describe(asset: AssetInstance): string {
+  switch (asset.asset_type) {
+    case 'image':
+      return `${asset.width}x${asset.height} @ ${asset.url}`;
+    case 'video':
+      return `video ${asset.format ?? ''}`;
+    case 'audio':
+      return `audio ${asset.codec}`;
+    case 'text':
+      return asset.content;
+    case 'html':
+      return asset.content;
+    case 'url':
+      return asset.url;
+    case 'css':
+    case 'javascript':
+    case 'markdown':
+    case 'vast':
+    case 'daast':
+    case 'brief':
+    case 'catalog':
+    case 'webhook':
+      return asset.asset_type;
+  }
+}
+void describe;
+
+// ── AssetInstance: omitting asset_type is rejected ───────────────────────
+
+// @ts-expect-error — `asset_type` is the discriminator and required.
+const _missing_discriminator: AssetInstance = {
+  url: 'https://x.test/img.png',
+  width: 300,
+  height: 250,
+};
+void _missing_discriminator;
+
+// ── AssetInstance: image variant requires width and height ───────────────
+
+// @ts-expect-error — ImageAsset requires `width` (per AdCP 3.0 GA).
+const _image_missing_width: AssetInstance = {
+  asset_type: 'image',
+  url: 'https://x.test/img.png',
+  height: 250,
+};
+void _image_missing_width;
+
+// ── AssetInstance: html instance carries `content`, not `html` ───────────
+
+// @ts-expect-error — HTMLAsset has `content`, not `html`. Common drift.
+const _wrong_html_field: AssetInstance = {
+  asset_type: 'html',
+  html: '<div>...</div>',
+};
+void _wrong_html_field;
+
+// ── AssetInstanceType: enumerates every variant's discriminator ──────────
+
+const _all_types: AssetInstanceType[] = [
+  'image',
+  'video',
+  'audio',
+  'text',
+  'html',
+  'url',
+  'css',
+  'javascript',
+  'markdown',
+  'vast',
+  'daast',
+  'brief',
+  'catalog',
+  'webhook',
+];
+void _all_types;
+
+// @ts-expect-error — 'banner' is not a valid asset_type.
+const _bogus: AssetInstanceType = 'banner';
+void _bogus;
+
+// ── CommonAssetInstance: narrower union, accepts only common variants ────
+
+const _common_image: CommonAssetInstance = {
+  asset_type: 'image',
+  url: 'https://x.test/img.png',
+  width: 300,
+  height: 250,
+};
+void _common_image;
+
+// @ts-expect-error — 'vast' is in AssetInstance but not CommonAssetInstance.
+const _common_rejects_vast: CommonAssetInstance = {
+  asset_type: 'vast',
+  content: '<VAST></VAST>',
+  format: 'vast',
+};
+void _common_rejects_vast;
+
+// ── SyncAccountsResponseRow: action discriminator is required ────────────
+
+const _row_ok: SyncAccountsResponseRow = {
+  account_id: 'acct_1',
+  brand: { domain: 'example.com' },
+  operator: 'agency.example',
+  action: 'created',
+  status: 'active',
+};
+void _row_ok;
+
+// @ts-expect-error — `action` is required on every row.
+const _row_missing_action: SyncAccountsResponseRow = {
+  account_id: 'acct_1',
+  brand: { domain: 'example.com' },
+  operator: 'agency.example',
+  status: 'active',
+};
+void _row_missing_action;
+
+// @ts-expect-error — 'archived' is not a valid action enum value.
+const _row_bad_action: SyncAccountsResponseRow = {
+  account_id: 'acct_1',
+  brand: { domain: 'example.com' },
+  operator: 'agency.example',
+  action: 'archived',
+  status: 'active',
+};
+void _row_bad_action;
+
+// ── SyncGovernanceResponseRow: status discriminator is required ──────────
+
+const _gov_row_ok: SyncGovernanceResponseRow = {
+  account: { account_id: 'acct_1' },
+  status: 'synced',
+};
+void _gov_row_ok;
+
+// @ts-expect-error — `status` is required.
+const _gov_row_missing_status: SyncGovernanceResponseRow = {
+  account: { account_id: 'acct_1' },
+};
+void _gov_row_missing_status;

--- a/src/lib/types/asset-instances.ts
+++ b/src/lib/types/asset-instances.ts
@@ -17,7 +17,8 @@
 // time. PR #945's `videoAsset({...})` width/height GA tightening came
 // out of this same drift class.
 //
-// Source of truth: schemas/cache/{version}/bundled/creative/asset-types/
+// Source of truth: schemas/cache/{version}/creative/asset-types/index.json
+// (registry) and schemas/cache/{version}/core/assets/*-asset.json (per-type).
 
 import type {
   ImageAsset,
@@ -74,13 +75,6 @@ export type AssetInstance =
   | BriefAsset
   | CatalogAsset
   | WebhookAsset;
-
-/**
- * Convenience: only the asset types most agents touch. Use this when you
- * want to narrow to the common case without enumerating every esoteric
- * variant. Prefer {@link AssetInstance} when you need exhaustive coverage.
- */
-export type CommonAssetInstance = ImageAsset | VideoAsset | AudioAsset | TextAsset | HTMLAsset | URLAsset;
 
 /**
  * The discriminator value (`asset_type`) of every variant in

--- a/src/lib/types/asset-instances.ts
+++ b/src/lib/types/asset-instances.ts
@@ -47,7 +47,7 @@ import type {
  *     case 'image':
  *       return `${asset.width}x${asset.height} @ ${asset.url}`;
  *     case 'video':
- *       return `${asset.duration_ms}ms ${asset.format ?? ''}`;
+ *       return `${asset.duration_ms ?? 0}ms ${asset.container_format ?? ''}`;
  *     case 'html':
  *       return `${asset.content.length}B inline HTML`;
  *     // ...all branches required — exhaustiveness is enforced

--- a/src/lib/types/asset-instances.ts
+++ b/src/lib/types/asset-instances.ts
@@ -1,0 +1,90 @@
+// Discriminated union of creative asset instances — what a buyer DELIVERS
+// inside `creative_manifest.assets`. Distinct from the asset slots that a
+// publisher declares in `Format.assets[]` (see `format-asset-slots.ts`).
+//
+// The per-asset-type interfaces (`ImageAsset`, `VideoAsset`, …) already
+// exist in `tools.generated.ts` and each carries an `asset_type` literal
+// discriminator. What was missing was the union itself: a canonical
+// `AssetInstance` you can use as a parameter or return type so TypeScript
+// narrows correctly on the discriminator and won't accept an asset
+// without one.
+//
+// Why this matters: handlers that returned a plain
+// `{ url: '...', width: 1920, height: 1080 }` typed against
+// `Record<string, unknown>` slipped through without `asset_type`. The
+// schema validator caught it at runtime; with a strict union as the
+// declared parameter / return type, the same error surfaces at compile
+// time. PR #945's `videoAsset({...})` width/height GA tightening came
+// out of this same drift class.
+//
+// Source of truth: schemas/cache/{version}/bundled/creative/asset-types/
+
+import type {
+  ImageAsset,
+  VideoAsset,
+  AudioAsset,
+  TextAsset,
+  HTMLAsset,
+  URLAsset,
+  CSSAsset,
+  JavaScriptAsset,
+  MarkdownAsset,
+  VASTAsset,
+  DAASTAsset,
+  BriefAsset,
+  CatalogAsset,
+  WebhookAsset,
+} from './tools.generated';
+
+/**
+ * Discriminated union of every creative asset instance recognised by the
+ * AdCP creative protocol. Narrow by `asset_type` to access the per-type
+ * fields:
+ *
+ * ```ts
+ * function describe(asset: AssetInstance): string {
+ *   switch (asset.asset_type) {
+ *     case 'image':
+ *       return `${asset.width}x${asset.height} @ ${asset.url}`;
+ *     case 'video':
+ *       return `${asset.duration_ms}ms ${asset.format ?? ''}`;
+ *     case 'html':
+ *       return `${asset.content.length}B inline HTML`;
+ *     // ...all branches required — exhaustiveness is enforced
+ *   }
+ * }
+ * ```
+ *
+ * This is the type to use for `creative_manifest.assets[<key>]` values.
+ * The `assets` map itself is `Record<string, AssetInstance>` — keys come
+ * from the format's declared asset slot ids; values are these instances.
+ */
+export type AssetInstance =
+  | ImageAsset
+  | VideoAsset
+  | AudioAsset
+  | TextAsset
+  | HTMLAsset
+  | URLAsset
+  | CSSAsset
+  | JavaScriptAsset
+  | MarkdownAsset
+  | VASTAsset
+  | DAASTAsset
+  | BriefAsset
+  | CatalogAsset
+  | WebhookAsset;
+
+/**
+ * Convenience: only the asset types most agents touch. Use this when you
+ * want to narrow to the common case without enumerating every esoteric
+ * variant. Prefer {@link AssetInstance} when you need exhaustive coverage.
+ */
+export type CommonAssetInstance = ImageAsset | VideoAsset | AudioAsset | TextAsset | HTMLAsset | URLAsset;
+
+/**
+ * The discriminator value (`asset_type`) of every variant in
+ * {@link AssetInstance}. Useful for runtime branching and exhaustive
+ * switch-case helpers.
+ */
+export type AssetInstanceType = AssetInstance['asset_type'];

--- a/src/lib/types/asset-instances.type-checks.ts
+++ b/src/lib/types/asset-instances.type-checks.ts
@@ -9,6 +9,12 @@
 // becomes an error and the project's `tsc --noEmit` fails. That's the
 // regression alarm.
 //
+// Pattern: each negative test uses an arrow function returning the value.
+// TS reports the error on the `return` line, so the directive directly
+// above is what catches it. Bare-const-assignment placement is fragile —
+// TS reports object-literal-required-property errors at varying line/col
+// positions depending on the type structure.
+//
 // Run with `npm run typecheck`.
 
 import type {
@@ -21,12 +27,12 @@ import type {
 
 // ── AssetInstance: discriminator narrowing works ─────────────────────────
 
-function describe(asset: AssetInstance): string {
+function describeAsset(asset: AssetInstance): string {
   switch (asset.asset_type) {
     case 'image':
       return `${asset.width}x${asset.height} @ ${asset.url}`;
     case 'video':
-      return `video ${asset.format ?? ''}`;
+      return `video ${asset.container_format ?? ''} ${asset.duration_ms ?? 0}ms`;
     case 'audio':
       return `audio ${asset.codec}`;
     case 'text':
@@ -46,36 +52,31 @@ function describe(asset: AssetInstance): string {
       return asset.asset_type;
   }
 }
-void describe;
+void describeAsset;
 
 // ── AssetInstance: omitting asset_type is rejected ───────────────────────
 
-// @ts-expect-error — `asset_type` is the discriminator and required.
-const _missing_discriminator: AssetInstance = {
-  url: 'https://x.test/img.png',
-  width: 300,
-  height: 250,
-};
-void _missing_discriminator;
+function _assetInstance_missingDiscriminator(): AssetInstance {
+  // @ts-expect-error — `asset_type` is the discriminator and required.
+  return { url: 'https://x.test/img.png', width: 300, height: 250 };
+}
+void _assetInstance_missingDiscriminator;
 
 // ── AssetInstance: image variant requires width and height ───────────────
 
-// @ts-expect-error — ImageAsset requires `width` (per AdCP 3.0 GA).
-const _image_missing_width: AssetInstance = {
-  asset_type: 'image',
-  url: 'https://x.test/img.png',
-  height: 250,
-};
-void _image_missing_width;
+function _imageAsset_missingWidth(): AssetInstance {
+  // @ts-expect-error — ImageAsset requires `width` (per AdCP 3.0 GA).
+  return { asset_type: 'image', url: 'https://x.test/img.png', height: 250 };
+}
+void _imageAsset_missingWidth;
 
 // ── AssetInstance: html instance carries `content`, not `html` ───────────
 
-// @ts-expect-error — HTMLAsset has `content`, not `html`. Common drift.
-const _wrong_html_field: AssetInstance = {
-  asset_type: 'html',
-  html: '<div>...</div>',
-};
-void _wrong_html_field;
+function _htmlAsset_wrongFieldName(): AssetInstance {
+  // @ts-expect-error — HTMLAsset has `content`, not `html`. Common drift.
+  return { asset_type: 'html', html: '<div>...</div>' };
+}
+void _htmlAsset_wrongFieldName;
 
 // ── AssetInstanceType: enumerates every variant's discriminator ──────────
 
@@ -97,9 +98,11 @@ const _all_types: AssetInstanceType[] = [
 ];
 void _all_types;
 
-// @ts-expect-error — 'banner' is not a valid asset_type.
-const _bogus: AssetInstanceType = 'banner';
-void _bogus;
+function _assetType_bogusValue(): AssetInstanceType {
+  // @ts-expect-error — 'banner' is not a valid asset_type.
+  return 'banner';
+}
+void _assetType_bogusValue;
 
 // ── CommonAssetInstance: narrower union, accepts only common variants ────
 
@@ -111,13 +114,11 @@ const _common_image: CommonAssetInstance = {
 };
 void _common_image;
 
-// @ts-expect-error — 'vast' is in AssetInstance but not CommonAssetInstance.
-const _common_rejects_vast: CommonAssetInstance = {
-  asset_type: 'vast',
-  content: '<VAST></VAST>',
-  format: 'vast',
-};
-void _common_rejects_vast;
+function _common_rejectsVast(): CommonAssetInstance {
+  // @ts-expect-error — 'vast' is in AssetInstance but not CommonAssetInstance.
+  return { asset_type: 'vast', content: '<VAST></VAST>' };
+}
+void _common_rejectsVast;
 
 // ── SyncAccountsResponseRow: action discriminator is required ────────────
 
@@ -130,24 +131,28 @@ const _row_ok: SyncAccountsResponseRow = {
 };
 void _row_ok;
 
-// @ts-expect-error — `action` is required on every row.
-const _row_missing_action: SyncAccountsResponseRow = {
-  account_id: 'acct_1',
-  brand: { domain: 'example.com' },
-  operator: 'agency.example',
-  status: 'active',
-};
-void _row_missing_action;
+function _row_missingAction(): SyncAccountsResponseRow {
+  // @ts-expect-error — `action` is required on every row.
+  return {
+    account_id: 'acct_1',
+    brand: { domain: 'example.com' },
+    operator: 'agency.example',
+    status: 'active',
+  };
+}
+void _row_missingAction;
 
-// @ts-expect-error — 'archived' is not a valid action enum value.
-const _row_bad_action: SyncAccountsResponseRow = {
-  account_id: 'acct_1',
-  brand: { domain: 'example.com' },
-  operator: 'agency.example',
-  action: 'archived',
-  status: 'active',
-};
-void _row_bad_action;
+function _row_badAction(): SyncAccountsResponseRow {
+  return {
+    account_id: 'acct_1',
+    brand: { domain: 'example.com' },
+    operator: 'agency.example',
+    // @ts-expect-error — 'archived' is not a valid action enum value.
+    action: 'archived',
+    status: 'active',
+  };
+}
+void _row_badAction;
 
 // ── SyncGovernanceResponseRow: status discriminator is required ──────────
 
@@ -157,8 +162,8 @@ const _gov_row_ok: SyncGovernanceResponseRow = {
 };
 void _gov_row_ok;
 
-// @ts-expect-error — `status` is required.
-const _gov_row_missing_status: SyncGovernanceResponseRow = {
-  account: { account_id: 'acct_1' },
-};
-void _gov_row_missing_status;
+function _gov_row_missingStatus(): SyncGovernanceResponseRow {
+  // @ts-expect-error — `status` is required.
+  return { account: { account_id: 'acct_1' } };
+}
+void _gov_row_missingStatus;

--- a/src/lib/types/asset-instances.type-checks.ts
+++ b/src/lib/types/asset-instances.type-checks.ts
@@ -17,15 +17,9 @@
 //
 // Run with `npm run typecheck`.
 
-import type {
-  AssetInstance,
-  AssetInstanceType,
-  CommonAssetInstance,
-  SyncAccountsResponseRow,
-  SyncGovernanceResponseRow,
-} from './index';
+import type { AssetInstance, AssetInstanceType, SyncAccountsResponseRow, SyncGovernanceResponseRow } from './index';
 
-// ── AssetInstance: discriminator narrowing works ─────────────────────────
+// ── AssetInstance: discriminator narrowing + exhaustiveness ──────────────
 
 function describeAsset(asset: AssetInstance): string {
   switch (asset.asset_type) {
@@ -50,9 +44,16 @@ function describeAsset(asset: AssetInstance): string {
     case 'catalog':
     case 'webhook':
       return asset.asset_type;
+    default: {
+      // Exhaustiveness rail: if a new asset_type lands in AssetInstance
+      // without a case above, `asset` here is no longer `never` and this
+      // line fails compilation. Stronger than `noImplicitReturns` —
+      // survives refactors that move returns out of switch arms.
+      const _exhaustive: never = asset;
+      return _exhaustive;
+    }
   }
 }
-void describeAsset;
 
 // ── AssetInstance: omitting asset_type is rejected ───────────────────────
 
@@ -60,7 +61,6 @@ function _assetInstance_missingDiscriminator(): AssetInstance {
   // @ts-expect-error — `asset_type` is the discriminator and required.
   return { url: 'https://x.test/img.png', width: 300, height: 250 };
 }
-void _assetInstance_missingDiscriminator;
 
 // ── AssetInstance: image variant requires width and height ───────────────
 
@@ -68,7 +68,6 @@ function _imageAsset_missingWidth(): AssetInstance {
   // @ts-expect-error — ImageAsset requires `width` (per AdCP 3.0 GA).
   return { asset_type: 'image', url: 'https://x.test/img.png', height: 250 };
 }
-void _imageAsset_missingWidth;
 
 // ── AssetInstance: html instance carries `content`, not `html` ───────────
 
@@ -76,7 +75,6 @@ function _htmlAsset_wrongFieldName(): AssetInstance {
   // @ts-expect-error — HTMLAsset has `content`, not `html`. Common drift.
   return { asset_type: 'html', html: '<div>...</div>' };
 }
-void _htmlAsset_wrongFieldName;
 
 // ── AssetInstanceType: enumerates every variant's discriminator ──────────
 
@@ -96,29 +94,11 @@ const _all_types: AssetInstanceType[] = [
   'catalog',
   'webhook',
 ];
-void _all_types;
 
 function _assetType_bogusValue(): AssetInstanceType {
   // @ts-expect-error — 'banner' is not a valid asset_type.
   return 'banner';
 }
-void _assetType_bogusValue;
-
-// ── CommonAssetInstance: narrower union, accepts only common variants ────
-
-const _common_image: CommonAssetInstance = {
-  asset_type: 'image',
-  url: 'https://x.test/img.png',
-  width: 300,
-  height: 250,
-};
-void _common_image;
-
-function _common_rejectsVast(): CommonAssetInstance {
-  // @ts-expect-error — 'vast' is in AssetInstance but not CommonAssetInstance.
-  return { asset_type: 'vast', content: '<VAST></VAST>' };
-}
-void _common_rejectsVast;
 
 // ── SyncAccountsResponseRow: action discriminator is required ────────────
 
@@ -129,7 +109,6 @@ const _row_ok: SyncAccountsResponseRow = {
   action: 'created',
   status: 'active',
 };
-void _row_ok;
 
 function _row_missingAction(): SyncAccountsResponseRow {
   // @ts-expect-error — `action` is required on every row.
@@ -140,7 +119,6 @@ function _row_missingAction(): SyncAccountsResponseRow {
     status: 'active',
   };
 }
-void _row_missingAction;
 
 function _row_badAction(): SyncAccountsResponseRow {
   return {
@@ -152,7 +130,6 @@ function _row_badAction(): SyncAccountsResponseRow {
     status: 'active',
   };
 }
-void _row_badAction;
 
 // ── SyncGovernanceResponseRow: status discriminator is required ──────────
 
@@ -160,10 +137,25 @@ const _gov_row_ok: SyncGovernanceResponseRow = {
   account: { account_id: 'acct_1' },
   status: 'synced',
 };
-void _gov_row_ok;
 
 function _gov_row_missingStatus(): SyncGovernanceResponseRow {
   // @ts-expect-error — `status` is required.
   return { account: { account_id: 'acct_1' } };
 }
-void _gov_row_missingStatus;
+
+// Reference all symbols once to keep the file's intent visible to readers
+// even though they're never executed. The file-level eslint-disable above
+// is what actually silences the unused-vars lint.
+export const _references = [
+  describeAsset,
+  _assetInstance_missingDiscriminator,
+  _imageAsset_missingWidth,
+  _htmlAsset_wrongFieldName,
+  _all_types,
+  _assetType_bogusValue,
+  _row_ok,
+  _row_missingAction,
+  _row_badAction,
+  _gov_row_ok,
+  _gov_row_missingStatus,
+] as const;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -26,6 +26,18 @@ export type { FormatID } from './core.generated';
 // discriminated per-asset-type branches of Format.assets[]).
 export * from './format-asset-slots';
 
+// Discriminated union of creative asset INSTANCES (what a buyer delivers
+// inside `creative_manifest.assets`). Companion to format-asset-slots.ts
+// (which describes what a publisher SELLS in `Format.assets[]`). The
+// individual ImageAsset / VideoAsset / etc. interfaces are generated; this
+// file is the missing canonical union over them.
+export * from './asset-instances';
+
+// Strict per-row types for sync_* response success arms. The codegen
+// leaves these row shapes inline; named types make the discriminators
+// (e.g., SyncAccountsResponseRow.action) reachable to handler authors.
+export * from './sync-rows';
+
 // Re-export Zod schemas for runtime validation
 export * from './schemas.generated';
 

--- a/src/lib/types/sync-rows.ts
+++ b/src/lib/types/sync-rows.ts
@@ -1,0 +1,47 @@
+// Strict per-row types for the *Success* arms of sync_* responses where
+// the codegen left the row shape inline on the parent interface.
+//
+// Why hand-author: when the row shape is inline (e.g.,
+// `SyncAccountsSuccess.accounts: { account_id?: string; action: 'created' | ...; ... }[]`),
+// the row has no exported name. Handlers writing
+// `return { accounts: rows }` typically infer `rows` as
+// `Record<string, unknown>[]` from the upstream platform's data, dodging
+// the strict literal-union check on `action` / `status` / etc.
+//
+// Extracting a named type lets handlers write
+// `const rows: SyncAccountsResponseRow[] = upstream.map(toRow);`
+// and get full discriminator narrowing at compile time. The matrix run
+// that surfaced PR #945 caught this drift class at the runtime validator;
+// having the named type closes the gap statically.
+//
+// Source of truth: schemas/cache/{version}/bundled/account/sync-accounts-response.json,
+// schemas/cache/{version}/bundled/governance/sync-governance-response.json.
+
+import type { SyncAccountsSuccess, SyncGovernanceSuccess } from './tools.generated';
+
+/**
+ * One result row in a `sync_accounts` response. Carries the `action`
+ * discriminator (`created` / `updated` / `unchanged` / `failed`) the
+ * spec requires. Use as the element type when assembling the response:
+ *
+ * ```ts
+ * const rows: SyncAccountsResponseRow[] = upstream.map((u) => ({
+ *   account_id: u.id,
+ *   brand: { domain: u.brand_domain },
+ *   operator: u.operator,
+ *   action: u.is_new ? 'created' : 'updated',
+ *   status: u.active ? 'active' : 'pending_approval',
+ * }));
+ * return { accounts: rows };
+ * ```
+ *
+ * Returning a row without `action` fails to compile.
+ */
+export type SyncAccountsResponseRow = SyncAccountsSuccess['accounts'][number];
+
+/**
+ * One result row in a `sync_governance` response. Mirrors the
+ * {@link SyncAccountsResponseRow} pattern; carries whatever discriminator
+ * the spec requires for governance-agent registration outcomes.
+ */
+export type SyncGovernanceResponseRow = SyncGovernanceSuccess['accounts'][number];

--- a/src/lib/types/sync-rows.ts
+++ b/src/lib/types/sync-rows.ts
@@ -14,15 +14,22 @@
 // that surfaced PR #945 caught this drift class at the runtime validator;
 // having the named type closes the gap statically.
 //
-// Source of truth: schemas/cache/{version}/bundled/account/sync-accounts-response.json,
-// schemas/cache/{version}/bundled/governance/sync-governance-response.json.
+// Source of truth: schemas/cache/{version}/account/sync-accounts-response.json,
+// schemas/cache/{version}/account/sync-governance-response.json.
 
 import type { SyncAccountsSuccess, SyncGovernanceSuccess } from './tools.generated';
 
 /**
  * One result row in a `sync_accounts` response. Carries the `action`
  * discriminator (`created` / `updated` / `unchanged` / `failed`) the
- * spec requires. Use as the element type when assembling the response:
+ * spec requires. Use as the element type when assembling the response.
+ *
+ * Field-level documentation lives on the inline shape in
+ * `SyncAccountsSuccess.accounts[]` — TS indexed-access types don't
+ * propagate per-field JSDoc into the consumer's IDE. Hover the
+ * underlying interface to read the spec text on each field.
+ *
+ * Use:
  *
  * ```ts
  * const rows: SyncAccountsResponseRow[] = upstream.map((u) => ({
@@ -40,8 +47,11 @@ import type { SyncAccountsSuccess, SyncGovernanceSuccess } from './tools.generat
 export type SyncAccountsResponseRow = SyncAccountsSuccess['accounts'][number];
 
 /**
- * One result row in a `sync_governance` response. Mirrors the
- * {@link SyncAccountsResponseRow} pattern; carries whatever discriminator
- * the spec requires for governance-agent registration outcomes.
+ * One result row in a `sync_governance` response. Carries the
+ * `status` discriminator (`synced` / `failed`) the spec requires.
+ *
+ * Field-level documentation lives on the inline shape in
+ * `SyncGovernanceSuccess.accounts[]` — see {@link SyncAccountsResponseRow}
+ * for the same caveat on indexed-access JSDoc propagation.
  */
 export type SyncGovernanceResponseRow = SyncGovernanceSuccess['accounts'][number];

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -9,5 +9,5 @@
     "stripInternal": true
   },
   "include": ["src/lib/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.type-checks.ts"]
 }


### PR DESCRIPTION
## Summary

Adds three hand-authored discriminated unions on top of the generated per-variant interfaces, so handler authors can opt into compile-time discriminator checking instead of runtime schema validation:

- **`AssetInstance`** — discriminated union over all 14 creative asset types, keyed on `asset_type`
- **`SyncAccountsResponseRow` / `SyncGovernanceResponseRow`** — named extractions of inline row shapes that force the `action`/`status` literal-union discriminators
- **Vendor + product pricing exports completed** — previously only `CpmPricing`, `PercentOfMediaPricing`, `FlatFeePricing` reached the public surface; this PR adds `PerUnitPricing`, `CustomPricing`, `VendorPricing`, `VendorPricingOption` plus 8 product-pricing variants

This is dx-expert priority #3 from the matrix-v18 expert review. Catches the same drift class the matrix catches at runtime — discriminator omission, missing required fields, wrong-shaped factory objects — at compile time.

## What's in this PR

- `src/lib/types/asset-instances.ts` — `AssetInstance` / `CommonAssetInstance` / `AssetInstanceType` discriminated unions
- `src/lib/types/sync-rows.ts` — `SyncAccountsResponseRow` / `SyncGovernanceResponseRow` extracted row types
- `src/lib/types/asset-instances.type-checks.ts` — type-level tests using `// @ts-expect-error` to lock the constraints. Naming convention: `.type-checks.ts` instead of `.test.ts` so the file is part of normal `npm run typecheck` (the project excludes `**/*.test.ts`). Also explicitly excluded from `tsconfig.lib.json` so it doesn't ship in `dist/`.
- `src/lib/types/index.ts` — re-exports
- `src/lib/index.ts` — completes vendor-pricing + product-pricing public surface
- Minor changeset (additive, non-breaking)

## Why this catches drift

```ts
// Before: Record<string, unknown> dodges the typed contract,
// runtime schema validator catches it eventually.
const asset = { url: 'https://x/img.png', width: 1920, height: 1080 };
return { creative_manifest: { format_id, assets: { hero: asset } } };

// After: AssetInstance forces the asset_type discriminator at compile time.
const asset: AssetInstance = {
  url: 'https://x/img.png', width: 1920, height: 1080,
  // error TS2353: Property 'asset_type' is missing.
};
```

## Pre-PR review fixes (commit `992e095e`)

Code-reviewer found three blockers, all addressed:
1. Type-test file was excluded from typecheck (project excludes `**/*.test.ts`). Renamed to `.type-checks.ts` so it's part of the normal typecheck pass; explicitly excluded from `tsconfig.lib.json` so it doesn't ship in dist.
2. `asset.format` on `VideoAsset` doesn't exist (only `container_format`). Fixed in both the test and the JSDoc example.
3. Three `@ts-expect-error` directives were misplaced (bare-const-assignment placement is fragile). Restructured to function-return pattern; directive lands directly above the `return` line that triggers the error.

Smoke-tested: changing one of the negative-test field names to the correct field causes the `@ts-expect-error` to become unused, and `tsc --noEmit` fails with TS2578. The regression alarm is real.

## Verification

```bash
npm run typecheck            # all types compile, all @ts-expect-error directives caught
npm test                     # 5885/5891 pass, 6 skipped (pre-existing)
npm run typecheck:skill-examples  # 142 known baselined, 0 new
npx tsx scripts/conformance-replay.ts --filter creative-template  # 6/6
```

## What's not in this PR

- **`videoAsset()`/`imageAsset()` factory tightening** — those already enforce required fields via `Omit<X, 'asset_type'>`. The new union's job is to catch handcrafted-object drift; the factories are a separate (working) layer.
- **Skill examples migration to use the new types** — best done as part of the slim-skill rewrite (task #18). Existing skills use raw inline shapes; the typecheck-skill-examples baseline currently records them as known issues.
- **Promoting more inline types to named exports** — `CreateMediaBuySuccess.packages[]`, `GetProductsResponse.products[]`, etc. are also inline. Defer until there's a concrete drift case.

## Test plan

- [x] `npm run typecheck` clean — all `@ts-expect-error` directives correctly catch the intended drift class
- [x] `npm test` 5885 pass, 0 fail
- [x] `npm run typecheck:skill-examples` 0 new errors vs baseline
- [x] Conformance-replay 6/6 on creative_template
- [x] Smoke test: regression-alarm fires (TS2578) when constraint is loosened
- [x] No `src/lib/server/` or runtime behavior changes (types-only PR)
- [ ] Reviewers run `npm run typecheck` to confirm green
- [ ] CI: typecheck + unit tests + format + audit + changeset pass

## Related

- #945 — conformance-replay (dx-expert priority #1, merged)
- #957 — typecheck-skill-examples (dx-expert priority #2, merged)
- #785 — matrix pickup context
- adcp#3090 — upstream spec drift epic

🤖 Generated with [Claude Code](https://claude.com/claude-code)