### PR TITLE
docs(server): explain why tools/list inputSchema is intentionally empty

### DIFF
--- a/.changeset/tools-list-design-comment.md
+++ b/.changeset/tools-list-design-comment.md
@@ -1,0 +1,5 @@
+---
+'@adcp/client': patch
+---
+
+**Docs (in-source): clarify why `tools/list` publishes empty `inputSchema`.** The framework intentionally registers tools with `PASSTHROUGH_INPUT_SCHEMA` so MCP `tools/list` returns `{ type: 'object', properties: {} }` per tool — full per-tool schemas would balloon the context window for LLM consumers, who are the primary readers of MCP discovery. Tool shapes live in `docs/llms.txt`, the SKILL.md files, and `schemas/cache/`. Comment-only change at `create-adcp-server.ts` (registration + `PASSTHROUGH_INPUT_SCHEMA` definition) and `SingleAgentClient.adaptRequestForServerVersion` (consumer side) so future engineers don't try to "fix" the empty schemas by inlining them. Points downstream consumers at `schema-loader.ts` / `schemaAllowsTopLevelField` (#940) as the canonical pattern when they need a tool's shape.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1187,6 +1187,16 @@ export class SingleAgentClient {
     // on tools/list — treating that as "strip everything" would silently
     // drop every field the buyer sent.
     // MCP-only in practice: A2A agents don't populate cachedToolSchemas.
+    //
+    // Note: the empty-properties state from framework agents is intentional
+    // (LLM context-window economy — see `PASSTHROUGH_INPUT_SCHEMA` in
+    // `create-adcp-server.ts`). Don't try to "fix" it by wiring per-tool
+    // schemas into `tools/list`. If you genuinely need to know a tool's
+    // shape (gating, validation, version adaptation), read raw JSON from
+    // `schemas/cache/{version}/` via `schema-loader.ts`. The right defense
+    // against unknown-field errors is to gate at the *injection site*
+    // (e.g. `applyBrandInvariant` in the storyboard runner — see #940),
+    // not to lean on this strip path as a backstop.
     const toolSchema = this.cachedToolSchemas?.get(taskType);
     if (!toolSchema || Object.keys(toolSchema).length === 0) return adapted;
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1459,6 +1459,8 @@ const IDEMP: ToolAnnotation = { readOnlyHint: false, idempotentHint: true };
 // version: makes our AJV validator authoritative on both transports
 // without destroying args on MCP when the SDK's tool dispatcher would
 // otherwise coerce `undefined` into the handler for schemaless tools.
+// This also keeps `tools/list` payloads small for LLM consumers (full
+// schemas live in `docs/llms.txt`, SKILL.md files, and `schemas/cache/`).
 const PASSTHROUGH_INPUT_SCHEMA = z.object({}).passthrough();
 
 const TOOL_META: Record<string, ToolMeta> = {
@@ -2702,10 +2704,23 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       // keeps every key intact, so args still reach the closure.
       //
       // Trade-off: MCP `tools/list` publishes `{ type: 'object' }` for
-      // every tool (no per-tool parameter schema). AdCP-native
-      // discovery via `get_adcp_capabilities` already works over both
-      // transports; upstream #3057 proposes a `get_schema` capability
-      // tool for per-tool shape discovery.
+      // every tool (no per-tool parameter schema). This is intentional,
+      // not a wiring gap — inlining ~50 full request schemas in
+      // `tools/list` would balloon the context window for LLM consumers,
+      // who are the primary readers of MCP discovery. Tool shapes live
+      // in `docs/llms.txt`, the SKILL.md files, and `schemas/cache/`,
+      // which curated agents read on demand instead of paying the cost
+      // every connection. AdCP-native discovery via `get_adcp_capabilities`
+      // already works over both transports; upstream #3057 proposes a
+      // `get_schema` capability tool for programmatic per-tool shape
+      // discovery.
+      //
+      // Implication for downstream consumers: if you need a tool's shape
+      // (cross-version field-stripping, gating, validation), read raw
+      // JSON from `schemas/cache/{version}/` via `schema-loader.ts` —
+      // see `schemaAllowsTopLevelField` for the canonical pattern (#940).
+      // Don't try to recover the shape from `tools/list`; it's empty by
+      // design and will fail open.
       server.registerTool(
         toolName,
         {


### PR DESCRIPTION
## Summary

Adds inline comments at the three sites engineers are most likely to read when wondering whether the empty `inputSchema` published on `tools/list` is a bug:

- `PASSTHROUGH_INPUT_SCHEMA` definition (`create-adcp-server.ts:1457`)
- Domain-tool `registerTool` call site (`create-adcp-server.ts:2688`)
- `adaptRequestForServerVersion` consumer (`SingleAgentClient.ts:1179`)

The comments capture the LLM context-window-economy rationale (full schemas would balloon `tools/list` payloads for LLM consumers, who use `SKILL.md` and `docs/llms.txt` instead of MCP discovery for tool shapes) and point future engineers at `schema-loader.ts` / `schemaAllowsTopLevelField` (#940) as the canonical pattern when they need a tool's shape.

## Why

Closed issue #954 was filed (by me) framing the empty `inputSchema` as a wiring gap. It isn't — it's a deliberate trade-off that wasn't discoverable from the code. The next engineer to triage a related symptom would re-litigate the same design unless we record the intent in the source. These comments make the rationale visible at every relevant site and direct downstream consumers to the right pattern (read raw JSON from `schemas/cache/` via `schema-loader.ts`) rather than trying to inline schemas back into `tools/list`.

## What this is **not**

- No behavior change
- No new exports / API additions
- No test changes (none needed — comments only)

## Test plan

- [x] `npm run build` — passes
- [x] `npm run format:check` — clean
- [x] Inspect commit: 3 files (2 source + 1 changeset), all comment-only / additive

Refs: #940, #909, #954, upstream adcontextprotocol/adcp#3057

🤖 Generated with [Claude Code](https://claude.com/claude-code)