### PR TITLE
fix(protocols): use native A2A tasks/get JSON-RPC for polling (#963)

### DIFF
--- a/.changeset/a2a-native-tasks-get-polling.md
+++ b/.changeset/a2a-native-tasks-get-polling.md
@@ -1,0 +1,11 @@
+---
+"@adcp/client": patch
+---
+
+fix(protocols): A2A polling now uses native `tasks/get` JSON-RPC instead of `callTool/message/send`
+
+`TaskExecutor.getTaskStatus` was routing A2A task polling through `ProtocolClient.callTool('tasks/get', …)`, which dispatched `message/send { skill: 'tasks/get' }`. Conformant A2A sellers (running `createA2AAdapter`) reject this because `tasks/get` is a native A2A JSON-RPC method, not an AdCP tool name — causing the polling loop to surface a false task-failed result.
+
+**Fix:** Added `getA2ATaskStatus` to `src/lib/protocols/a2a.ts` (parallel to `getMCPTaskStatus`) that calls `client.getTask({ id })` on the `@a2a-js/sdk` `A2AClient`. `TaskExecutor.getTaskStatus` now dispatches to this for `protocol: 'a2a'` agents. `setupSubmittedTask` extracts the server-assigned A2A `Task.id` from the initial `message/send` response and threads it into the `track`/`waitForCompletion` closures — using it instead of the client-minted correlation UUID that `tasks/get` would not recognize.
+
+**Status mapping:** `Task.status.state` is always `'completed'` for submitted AdCP arms (the transport call finished, not the AdCP work). The real AdCP lifecycle status is now read from `artifact.parts[last-data-part].data.status`, with A2A terminal states (`failed`/`rejected`) as the fallback when no artifact payload is present.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -5,6 +5,7 @@ import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
 import { ProtocolClient } from '../protocols';
 import { getMCPTaskStatus, listMCPTasks } from '../protocols/mcp-tasks';
+import { getA2ATaskStatus } from '../protocols/a2a';
 import { getAuthToken } from '../auth';
 import { is401Error, adcpErrorToTypedError } from '../errors';
 import type { ADCPError } from '../errors';
@@ -912,11 +913,19 @@ export class TaskExecutor {
       await this.config.webhookManager.registerWebhook(agent, taskId, webhookUrl);
     }
 
+    // For A2A agents, `tasks/get` is a native JSON-RPC method keyed on the
+    // server-assigned Task.id — not the client-minted correlation UUID. Extract
+    // it from the initial message/send response so the polling closures below
+    // can pass it to getA2ATaskStatus.
+    const a2aServerTaskId =
+      agent.protocol === 'a2a' ? (this.responseParser.getTaskId(response) ?? undefined) : undefined;
+
     const submitted: SubmittedContinuation<T> = {
       taskId,
       webhookUrl,
-      track: () => this.getTaskStatus(agent, taskId),
-      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, taskId, pollInterval),
+      track: () => this.getTaskStatus(agent, taskId, a2aServerTaskId),
+      waitForCompletion: (pollInterval = 60000) =>
+        this.pollTaskCompletion<T>(agent, taskId, pollInterval, a2aServerTaskId),
     };
 
     return {
@@ -1125,7 +1134,7 @@ export class TaskExecutor {
     }
   }
 
-  async getTaskStatus(agent: AgentConfig, taskId: string): Promise<TaskInfo> {
+  async getTaskStatus(agent: AgentConfig, taskId: string, a2aServerTaskId?: string): Promise<TaskInfo> {
     // Use MCP Tasks protocol method when available
     if (agent.protocol === 'mcp') {
       const authToken = getAuthToken(agent);
@@ -1135,6 +1144,20 @@ export class TaskExecutor {
         if (is401Error(err)) throw err;
         // Fall through to tool call if protocol method is not supported
       }
+    }
+    // Use the native A2A tasks/get JSON-RPC method for A2A agents. The A2A
+    // protocol's tasks/get is distinct from the AdCP tool of the same name —
+    // routing it through callTool/message/send causes conformant sellers to
+    // reject with A2AInvocationError (no such AdCP tool registered).
+    if (agent.protocol === 'a2a') {
+      if (!a2aServerTaskId) {
+        throw new Error(
+          `A2A polling requires the server-assigned Task.id from the initial message/send response. ` +
+            `Ensure the A2A seller returns a Task with a non-empty id on the submitted arm. ` +
+            `(client task id: ${taskId})`
+        );
+      }
+      return await getA2ATaskStatus(agent.agent_uri, a2aServerTaskId, getAuthToken(agent));
     }
     const response = (await ProtocolClient.callTool(
       agent,
@@ -1149,9 +1172,14 @@ export class TaskExecutor {
     return (response.task as TaskInfo) || (response as unknown as TaskInfo);
   }
 
-  async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000): Promise<TaskResult<T>> {
+  async pollTaskCompletion<T>(
+    agent: AgentConfig,
+    taskId: string,
+    pollInterval = 60000,
+    a2aServerTaskId?: string
+  ): Promise<TaskResult<T>> {
     while (true) {
-      const status = await this.getTaskStatus(agent, taskId);
+      const status = await this.getTaskStatus(agent, taskId, a2aServerTaskId);
 
       if (status.status === ADCP_STATUS.COMPLETED) {
         const pollSuccess = this.isOperationSuccess(status.result);

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1219,7 +1219,11 @@ export class TaskExecutor {
         });
       }
 
-      if (status.status === ADCP_STATUS.FAILED || status.status === ADCP_STATUS.CANCELED) {
+      if (
+        status.status === ADCP_STATUS.FAILED ||
+        status.status === ADCP_STATUS.CANCELED ||
+        status.status === ADCP_STATUS.REJECTED
+      ) {
         const asyncFailedErr = extractAdcpErrorInfo(status.result);
         return attachMatch({
           success: false as const,

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -13,6 +13,7 @@ import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
+import type { TaskInfo } from '../core/ConversationTypes';
 
 if (!A2AClient) {
   throw new Error('A2A SDK client is required. Please install @a2a-js/sdk');
@@ -372,4 +373,78 @@ async function callA2AToolImpl(
 
     throw error;
   }
+}
+
+/**
+ * Poll an A2A task's current state via the native `tasks/get` JSON-RPC method.
+ * Parallel to `getMCPTaskStatus`. Intentionally not signed — `tasks/get` is a
+ * read-only lifecycle method, matching the convention in `getMCPTaskStatus`.
+ *
+ * The `a2aTaskId` must be the server-assigned A2A `Task.id` from the initial
+ * `message/send` response — NOT the client-minted correlation UUID.
+ */
+export async function getA2ATaskStatus(
+  agentUrl: string,
+  a2aTaskId: string,
+  authToken: string | undefined
+): Promise<TaskInfo> {
+  if (!a2aTaskId || typeof a2aTaskId !== 'string' || a2aTaskId.length > 256) {
+    throw new Error(`Invalid a2aTaskId: expected non-empty string (max 256 chars)`);
+  }
+  const client = await getOrCreateA2AClient(agentUrl, authToken);
+  try {
+    const task = await client.getTask({ id: a2aTaskId });
+    return mapA2ATaskToTaskInfo(task);
+  } catch (error: unknown) {
+    if (is401Error(error)) {
+      a2aClientCache.delete(a2aCacheKey(agentUrl, authToken));
+      const oauthMetadata = await discoverOAuthMetadata(agentUrl);
+      throw new AuthenticationRequiredError(agentUrl, oauthMetadata || undefined);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Map an A2A `Task` returned by `tasks/get` to the AdCP `TaskInfo` shape.
+ *
+ * Key invariant: A2A `Task.status.state` is always `'completed'` for submitted
+ * AdCP arms because the adapter marks the transport call as done while the AdCP
+ * work is queued (see a2a-adapter.ts commentary). The real AdCP lifecycle status
+ * lives in `artifact.parts[last-data-part].data.status`; `Task.state` is only
+ * reliable for distinguishing terminal transport failures (`'failed'`/`'canceled'`).
+ */
+function mapA2ATaskToTaskInfo(task: {
+  id: string;
+  status: { state: string; timestamp?: string };
+  artifacts?: Array<{
+    parts: Array<{ kind: string; data?: Record<string, unknown> }>;
+    metadata?: Record<string, unknown>;
+  }>;
+}): TaskInfo {
+  const lastArtifact = task.artifacts?.[task.artifacts.length - 1];
+  const lastDataPart = lastArtifact?.parts.filter(p => p.kind === 'data').slice(-1)[0] as
+    | { kind: 'data'; data: Record<string, unknown> }
+    | undefined;
+
+  const adcpStatus = lastDataPart?.data?.status as string | undefined;
+  const a2aState = task.status.state;
+
+  // Prefer the AdCP-level status embedded in the artifact payload; fall back to
+  // the A2A transport state (working, submitted, failed, canceled, etc.) when
+  // no artifact payload is present yet.
+  const status = adcpStatus ?? a2aState;
+
+  const timestampMs = task.status.timestamp ? new Date(task.status.timestamp).getTime() : Date.now();
+
+  return {
+    taskId: task.id,
+    status,
+    // A2A tasks/get does not carry the originating AdCP tool name.
+    taskType: 'unknown',
+    createdAt: timestampMs,
+    updatedAt: Date.now(),
+    result: lastDataPart?.data,
+    error: a2aState === 'failed' || a2aState === 'rejected' ? `A2A task ${task.id} ${a2aState}` : undefined,
+  };
 }

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -430,7 +430,8 @@ function mapA2ATaskToTaskInfo(task: {
     | { kind: 'data'; data: Record<string, unknown> }
     | undefined;
 
-  const adcpStatus = lastDataPart?.data?.status as string | undefined;
+  const rawStatus = lastDataPart?.data?.status;
+  const adcpStatus = typeof rawStatus === 'string' ? rawStatus : undefined;
   const a2aState = task.status.state;
 
   // Prefer the AdCP-level status embedded in the artifact payload; fall back to

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -397,7 +397,10 @@ export async function getA2ATaskStatus(
     return mapA2ATaskToTaskInfo(task);
   } catch (error: unknown) {
     if (is401Error(error)) {
+      // Evict both the unsigned entry (used by this call) and any signed entry
+      // that may exist from a prior callA2ATool call for the same agent.
       a2aClientCache.delete(a2aCacheKey(agentUrl, authToken));
+      a2aClientCache.delete(a2aCacheKey(agentUrl, authToken, signingContextStorage.getStore()?.cacheKey));
       const oauthMetadata = await discoverOAuthMetadata(agentUrl);
       throw new AuthenticationRequiredError(agentUrl, oauthMetadata || undefined);
     }
@@ -445,6 +448,8 @@ function mapA2ATaskToTaskInfo(task: {
     createdAt: timestampMs,
     updatedAt: Date.now(),
     result: lastDataPart?.data,
+    // 'canceled' is omitted: it's a deliberate stop, not an unexpected failure, so
+    // TaskResult callers can surface it via status without treating it as an error.
     error: a2aState === 'failed' || a2aState === 'rejected' ? `A2A task ${task.id} ${a2aState}` : undefined,
   };
 }

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -16,7 +16,7 @@ export async function closeConnections(protocol: 'mcp' | 'a2a' = 'mcp'): Promise
   }
 }
 export type { MCPCallOptions, MCPConnectionResult } from './mcp';
-export { callA2ATool } from './a2a';
+export { callA2ATool, getA2ATaskStatus } from './a2a';
 export {
   callMCPToolWithTasks,
   getMCPTaskStatus,

--- a/test/lib/a2a-task-status.test.js
+++ b/test/lib/a2a-task-status.test.js
@@ -1,0 +1,203 @@
+// Tests for the native A2A tasks/get polling path added in issue #963.
+//
+// The bug: TaskExecutor.getTaskStatus fell through to ProtocolClient.callTool
+// for A2A agents, dispatching `message/send { skill: 'tasks/get' }`. Conformant
+// sellers reject that because tasks/get is a native A2A JSON-RPC method, not an
+// AdCP tool. The fix adds getA2ATaskStatus which calls client.getTask() directly.
+//
+// Key invariant under test: A2A Task.state is always 'completed' for submitted
+// AdCP arms; the real AdCP status is read from artifact.parts[0].data.status.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+// Load from dist — tests run against the compiled output.
+const { getA2ATaskStatus, closeA2AConnections } = require('../../dist/lib/protocols/a2a.js');
+
+const AGENT_URL = 'https://seller.example.com/a2a';
+const SERVER_TASK_ID = 'srv-task-abc123';
+const TS = '2026-04-25T12:00:00.000Z';
+
+// ─── stub helpers ────────────────────────────────────────────────────────────
+
+function makeA2ATask({ state = 'completed', artifacts = undefined, timestamp = TS } = {}) {
+  return {
+    kind: 'task',
+    id: SERVER_TASK_ID,
+    contextId: 'ctx-xyz',
+    status: { state, timestamp },
+    ...(artifacts !== undefined ? { artifacts } : {}),
+  };
+}
+
+function submittedArtifact(extra = {}) {
+  return [
+    {
+      artifactId: 'art-1',
+      name: 'submitted',
+      parts: [{ kind: 'data', data: { status: 'submitted', task_id: 'adcp-task-001', ...extra } }],
+      metadata: { adcp_task_id: 'adcp-task-001' },
+    },
+  ];
+}
+
+function completedArtifact(resultData = {}) {
+  return [
+    {
+      artifactId: 'art-2',
+      name: 'result',
+      parts: [{ kind: 'data', data: { status: 'completed', ...resultData } }],
+    },
+  ];
+}
+
+/**
+ * Stubs A2AClient so getTask() returns controlled Task objects.
+ * Returns { getTaskCalls, enqueue, restore }.
+ */
+function installGetTaskStub() {
+  closeA2AConnections();
+
+  const getTaskCalls = [];
+  const queue = [];
+
+  const stubClient = {
+    sendMessage: async () => {
+      throw new Error('sendMessage should not be called during tasks/get polling');
+    },
+    getTask: async params => {
+      getTaskCalls.push(params);
+      if (queue.length === 0) throw new Error('No responses enqueued for getTask');
+      return queue.shift();
+    },
+  };
+
+  const { A2AClient } = require('@a2a-js/sdk/client');
+  const originalFromCardUrl = A2AClient.fromCardUrl;
+  A2AClient.fromCardUrl = async () => stubClient;
+
+  return {
+    getTaskCalls,
+    enqueue(task) {
+      queue.push(task);
+    },
+    restore() {
+      A2AClient.fromCardUrl = originalFromCardUrl;
+      closeA2AConnections();
+    },
+  };
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('getA2ATaskStatus', () => {
+  let stub;
+
+  beforeEach(() => {
+    stub = installGetTaskStub();
+  });
+
+  afterEach(() => {
+    stub.restore();
+  });
+
+  test('reads AdCP status from artifact data, not Task.state', async () => {
+    // Task.state is 'completed' (transport done) but AdCP status is 'submitted'
+    stub.enqueue(makeA2ATask({ state: 'completed', artifacts: submittedArtifact() }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'submitted', 'must read status from artifact.data.status');
+    assert.strictEqual(info.taskId, SERVER_TASK_ID);
+    assert.strictEqual(info.taskType, 'unknown');
+    assert.ok(info.result, 'result must be populated from artifact data');
+    assert.strictEqual(info.result.task_id, 'adcp-task-001');
+  });
+
+  test('maps completed artifact with full result', async () => {
+    stub.enqueue(
+      makeA2ATask({
+        state: 'completed',
+        artifacts: completedArtifact({ media_buy_id: 'mb-001', status: 'completed' }),
+      })
+    );
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'completed');
+    assert.strictEqual(info.result?.media_buy_id, 'mb-001');
+    assert.ok(!info.error, 'no error on completed task');
+  });
+
+  test('maps A2A failed state to status: failed with error field', async () => {
+    stub.enqueue(makeA2ATask({ state: 'failed', artifacts: [] }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'failed');
+    assert.ok(info.error, 'error field must be set for failed tasks');
+    assert.ok(info.error.includes(SERVER_TASK_ID));
+  });
+
+  test('maps A2A rejected state to status: rejected with error field', async () => {
+    stub.enqueue(makeA2ATask({ state: 'rejected', artifacts: [] }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'rejected');
+    assert.ok(info.error?.includes('rejected'));
+  });
+
+  test('converts ISO timestamp to epoch milliseconds in createdAt', async () => {
+    stub.enqueue(makeA2ATask({ state: 'completed', artifacts: completedArtifact() }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    const expected = new Date(TS).getTime();
+    assert.strictEqual(info.createdAt, expected, 'createdAt must be epoch ms, not ISO string');
+    assert.ok(typeof info.createdAt === 'number');
+  });
+
+  test('dispatches getTask with the server-assigned task id', async () => {
+    stub.enqueue(makeA2ATask({ state: 'completed', artifacts: completedArtifact() }));
+
+    await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(stub.getTaskCalls.length, 1);
+    assert.strictEqual(stub.getTaskCalls[0].id, SERVER_TASK_ID);
+  });
+
+  test('never calls sendMessage (not routed through callTool/message/send)', async () => {
+    stub.enqueue(makeA2ATask({ state: 'completed', artifacts: completedArtifact() }));
+
+    // The stub throws if sendMessage is called — this test implicitly passes if no throw.
+    await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+  });
+
+  test('rejects empty taskId before network call', async () => {
+    await assert.rejects(() => getA2ATaskStatus(AGENT_URL, '', undefined), /Invalid a2aTaskId/);
+    assert.strictEqual(stub.getTaskCalls.length, 0, 'no network call made for invalid id');
+  });
+
+  test('rejects taskId longer than 256 chars', async () => {
+    const longId = 'x'.repeat(257);
+    await assert.rejects(() => getA2ATaskStatus(AGENT_URL, longId, undefined), /Invalid a2aTaskId/);
+  });
+
+  test('handles task with no artifacts — falls back to A2A state', async () => {
+    stub.enqueue(makeA2ATask({ state: 'working', artifacts: [] }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'working');
+    assert.ok(!info.result, 'no result when artifacts array is empty');
+  });
+
+  test('handles task with no artifacts field — falls back to A2A state', async () => {
+    stub.enqueue(makeA2ATask({ state: 'submitted' }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'submitted');
+  });
+});

--- a/test/lib/a2a-task-status.test.js
+++ b/test/lib/a2a-task-status.test.js
@@ -148,6 +148,15 @@ describe('getA2ATaskStatus', () => {
     assert.ok(info.error?.includes('rejected'));
   });
 
+  test('maps A2A canceled state to status: canceled with no error field', async () => {
+    stub.enqueue(makeA2ATask({ state: 'canceled', artifacts: [] }));
+
+    const info = await getA2ATaskStatus(AGENT_URL, SERVER_TASK_ID, undefined);
+
+    assert.strictEqual(info.status, 'canceled');
+    assert.ok(!info.error, 'canceled is a deliberate stop, not an error');
+  });
+
   test('converts ISO timestamp to epoch milliseconds in createdAt', async () => {
     stub.enqueue(makeA2ATask({ state: 'completed', artifacts: completedArtifact() }));
 


### PR DESCRIPTION
## Problem

`TaskExecutor.getTaskStatus` fell through to `ProtocolClient.callTool` for A2A agents, dispatching `message/send { skill: 'tasks/get' }`. Conformant sellers reject this because `tasks/get` is a native A2A JSON-RPC method, not an AdCP tool name. Separately, the polling closures in `setupSubmittedTask` used the client-minted correlation UUID as the task ID, but `tasks/get` requires the server-assigned `Task.id` from the `message/send` response.

Fixes #963.

## Changes

**`src/lib/protocols/a2a.ts`**
- New `getA2ATaskStatus(agentUrl, a2aTaskId, authToken)` — calls `client.getTask({ id })` directly via the `@a2a-js/sdk` transport, bypassing `message/send`
- New `mapA2ATaskToTaskInfo` — maps A2A `Task` to `TaskInfo`; prefers `artifact.parts[last-data].data.status` over `Task.state` (state is always `'completed'` for submitted AdCP arms; real lifecycle lives in the artifact)
- 401 cache eviction evicts both the unsigned cache entry (used by `getA2ATaskStatus`) and any signed entry that may exist from a prior `callA2ATool` call
- `getA2ATaskStatus` exported from `src/lib/protocols/index.ts`

**`src/lib/core/TaskExecutor.ts`**
- `getTaskStatus`: new A2A branch calls `getA2ATaskStatus` with the server-assigned task ID instead of routing through `callTool`
- `setupSubmittedTask`: extracts A2A server Task.id via `responseParser.getTaskId(response)` and threads it through the `track` / `waitForCompletion` closures
- `pollTaskCompletion`: accepts optional `a2aServerTaskId` and threads it into `getTaskStatus`; also adds `REJECTED` as a terminal exit condition (pre-existing gap, now reachable for A2A)

**`test/lib/a2a-task-status.test.js`** (new, 12 tests)
- Verifies status is read from artifact data, not `Task.state`
- Verifies `failed`/`rejected` set `error`; `canceled` does not
- Verifies ISO timestamp → epoch ms conversion
- Verifies `getTask` is called with the server-assigned ID
- Verifies `sendMessage` is never called
- Validates empty/oversized `taskId` input
- Verifies fallback to A2A state when no artifacts are present

**`.changeset/a2a-native-tasks-get-polling.md`** — patch changeset

## Key invariant

A2A `Task.status.state` is always `'completed'` for submitted AdCP arms because the adapter marks the transport call done while AdCP work is queued. The real AdCP lifecycle status (`submitted`, `working`, `completed`, …) lives in `artifact.parts[last-data-part].data.status`. `Task.state` is only used as a fallback when no artifact payload is present yet, and to surface transport-level terminal failures (`failed`, `rejected`).

## Test plan

- [x] `npm run build:lib` — clean build
- [x] `node --test test/lib/a2a-task-status.test.js` — 12/12 pass
- [x] `npx prettier --check` — no formatting issues

https://claude.ai/code/session_015ga1KhzvR7DbWvwsqDVSaW — Tracked at #997