### PR TITLE
fix(core): SubmittedContinuation polls with server-assigned task_id (#966)

### DIFF
--- a/.changeset/adcp-tasks-get-hardening.md
+++ b/.changeset/adcp-tasks-get-hardening.md
@@ -1,0 +1,71 @@
+---
+'@adcp/client': patch
+---
+
+Fix `TaskExecutor.getTaskStatus` to dispatch the AdCP `tasks/get` tool
+spec-conformantly. Closes #967.
+
+**Pre-fix bugs**:
+
+1. **Wrong request param**: SDK passed `{ taskId }` (camelCase). AdCP
+   3.0 schema (`schemas/cache/3.0.0/bundled/core/tasks-get-request.json`)
+   requires `{ task_id }` (snake_case). Conformant sellers reject as
+   INVALID_PARAMS.
+2. **Wrong response shape mapping**: SDK read `(response.task as TaskInfo)` —
+   expects a non-spec nested wrapper with camelCase fields. AdCP-spec
+   responses are flat snake_case (`{ task_id, task_type, status,
+created_at, updated_at, ... }`); real spec-conformant responses
+   produced `taskId: undefined` everywhere on the polled `TaskInfo`.
+3. **Wrong primary path**: SDK tried MCP `experimental.tasks.getTask`
+   first for MCP agents and fell through to the AdCP tool on
+   capability-missing. The MCP-experimental path tracks
+   transport-call lifecycle (the MCP analog of A2A `Task.state`),
+   not AdCP work lifecycle. For polling submitted-arm tasks (which
+   is what `pollTaskCompletion` does) we need work status; the two
+   interfaces are not substitutes (per protocol-expert review on
+   #966/#967).
+
+**Fix**:
+
+- Drop the MCP-experimental.tasks first attempt. Always dispatch the
+  AdCP `tasks/get` tool over the agent's transport.
+- Pass the request param as `task_id` (snake_case).
+- Map the response via a new `mapTasksGetResponseToTaskInfo` helper
+  that walks the transport-level wrappers (MCP `structuredContent`,
+  A2A `result.artifacts[0].parts[0].data`, legacy `{ task: ... }`
+  nested wrapper) and the AdCP-spec flat shape, then projects to the
+  internal `TaskInfo`.
+- Bypass `extractResponseData` for `tasks/get` — the generic
+  AdCP-error-arm detection misinterprets the spec's informational
+  `error: { code, message }` block as an error envelope and shreds
+  the response into `{ errors: [...] }`. The new helper handles
+  unwrapping directly.
+- Pass through `result` / `task_data` from `additionalProperties: true`
+  so completion data round-trips when sellers add it. (Note: AdCP
+  3.0 doesn't define a typed completion-payload field on `tasks/get`;
+  see adcp#3123 for the upstream clarification issue. Forward-compat
+  with all three possible spec resolutions.)
+
+**Behavior change**: MCP sellers that supported `experimental.tasks`
+but did NOT register an AdCP `tasks/get` tool will now see polling
+fail rather than silently use the wrong-lifecycle interface. This is
+deliberate — the previous behavior was incorrect (returned transport
+status, not work status). Sellers should register `tasks/get` as an
+AdCP tool to support buyer-side polling.
+
+Adds `test/server-tasks-get-spec-shape.test.js` with six regression
+tests:
+
+- Request param naming (snake_case `task_id`, no camelCase `taskId`)
+- AdCP-spec flat response mapping (incl. ISO 8601 timestamps)
+- Result-data passthrough via additionalProperties
+- Error-block mapping (failed status with `error: { code, message }`)
+- Legacy `{ task: ... }` nested-shape backward compat
+- No MCP-experimental.tasks first attempt
+
+Companion of #966 (server-task-id plumbing). With both PRs landed,
+MCP submitted-arm polling works end-to-end against spec-conformant
+sellers. A2A submitted-arm polling still has additional bugs at the
+parser layer (`getStatus` reads transport state, `getTaskId` extracts
+A2A Task.id instead of `artifact.metadata.adcp_task_id`); tracked in
+adcp-client#973.

--- a/.changeset/server-task-id-plumbing.md
+++ b/.changeset/server-task-id-plumbing.md
@@ -1,0 +1,44 @@
+---
+'@adcp/client': patch
+---
+
+Fix `SubmittedContinuation.taskId` and the polling cycle to use the
+server-assigned task handle instead of the SDK's runner-side
+correlation UUID. Closes #966.
+
+Pre-fix bug: `setupSubmittedTask` plumbed the local UUID generated at
+request time (`TaskState.taskId`, used for the `activeTasks` map and
+the `{operation_id}` webhook URL macro) through to the
+`SubmittedContinuation`. `track()` and `waitForCompletion()` then
+addressed `tasks/get` calls with that local UUID — which the seller
+has never seen, so any spec-conformant seller would respond with
+NOT_FOUND. Existing mock tests masked this because they ignored the
+`taskId` parameter when stubbing the polling response.
+
+Post-fix: `setupSubmittedTask` extracts the server-assigned handle via
+`responseParser.getTaskId(response)` (which already walks both the
+flat AdCP `response.task_id` shape and the A2A `result.kind === 'task'`
+→ `result.id` shape) and uses it for both the buyer-facing
+`SubmittedContinuation.taskId` field and the closures' polling calls.
+The local UUID stays internal for `activeTasks` bookkeeping and the
+webhook URL macro.
+
+When a seller violates the spec and omits the task handle entirely,
+the SDK falls back to the local UUID so callers still get a non-
+undefined `taskId` field — pollers won't be able to locate the work,
+but this matches the historical (broken) behavior surface and avoids
+introducing a hard fail at a code path that's been silently wrong.
+
+Updates `SubmittedContinuation.taskId` JSDoc to document that it
+carries the server handle and is distinct from the runner-side
+correlation id.
+
+Adds `test/server-task-id-plumbing.test.js` — five regression tests
+covering the conformant path, polling/track invocations addressing the
+right id, the spec-violation fallback, and the A2A `result.kind: 'task'`
+branch of `responseParser.getTaskId`.
+
+Companion follow-up: #967 — fix the AdCP `tasks/get` request param
+naming (`taskId` → `task_id`) and the response-shape mapping. This PR
+plumbs the right ID; #967 wires it into a spec-conformant request and
+parses the spec-conformant response.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -229,10 +229,31 @@ export interface DeferredContinuation<T> {
 }
 
 /**
- * Continuation for submitted server tasks (server needs time)
+ * Continuation for submitted server tasks (server needs time).
+ *
+ * Returned in `TaskResult.submitted` when the seller signals an AdCP
+ * `submitted` arm (long-running work that won't complete inside the
+ * transport call). The buyer either polls via {@link waitForCompletion}
+ * / {@link track} or waits for the seller's webhook callback at
+ * {@link webhookUrl}.
  */
 export interface SubmittedContinuation<T> {
-  /** Task ID for tracking */
+  /**
+   * Server-assigned task handle — the value the seller emitted in
+   * `response.task_id` (AdCP submitted-arm wire field) or surfaced via
+   * the A2A response Task. This is the identifier the seller knows; it
+   * is what the SDK passes to subsequent `tasks/get` polling calls.
+   *
+   * NOT the same as the SDK's runner-side correlation id (`TaskState.taskId`,
+   * a local UUID generated at request time and used internally for
+   * `activeTasks` map indexing and the `{operation_id}` webhook URL macro).
+   * The runner-side id never reaches the seller.
+   *
+   * If the seller violated the spec and didn't include a task handle on
+   * the submitted-arm response, this falls back to the runner-side
+   * correlation id — pollers won't be able to locate the work, but
+   * callers at least get a non-undefined value to log.
+   */
   taskId: string;
   /** Webhook URL where server will notify completion */
   webhookUrl?: string;

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -906,17 +906,38 @@ export class TaskExecutor {
 
     let webhookUrl = response.webhookUrl;
 
-    // If no webhook URL provided by server, generate one
+    // If no webhook URL provided by server, generate one. The webhook URL
+    // macro path uses the local `taskId` (the runner-side correlation id
+    // that doubles as the `{operation_id}` macro value), not the server
+    // handle — webhook URLs identify the buyer-side request, not the
+    // seller-side task.
     if (!webhookUrl && this.config.webhookManager) {
       webhookUrl = this.config.webhookManager.generateUrl(taskId);
       await this.config.webhookManager.registerWebhook(agent, taskId, webhookUrl);
     }
 
+    // Polling and the buyer-facing `SubmittedContinuation.taskId` use the
+    // SERVER-assigned task handle, not the runner's local UUID. The local
+    // UUID is the `activeTasks` map key and the `{operation_id}` webhook
+    // macro value — it never reaches the seller. The server handle comes
+    // from `response.task_id` (AdCP submitted-arm wire field) or, for A2A
+    // responses, the same handle surfaced via `result.id` / `taskId`.
+    // `responseParser.getTaskId` walks both shapes.
+    //
+    // When the seller violated the spec and didn't include a task handle
+    // we fall back to the local UUID so the buyer at least gets a
+    // non-undefined `taskId` field. This also matches the historical
+    // (broken) behavior on a wire where the server doesn't know the
+    // local UUID, so the polling cycle was already misaligned — better
+    // to keep the surface area stable than to introduce a hard fail at
+    // a place that's been silently wrong.
+    const serverTaskId = this.responseParser.getTaskId(response) ?? taskId;
+
     const submitted: SubmittedContinuation<T> = {
-      taskId,
+      taskId: serverTaskId,
       webhookUrl,
-      track: () => this.getTaskStatus(agent, taskId),
-      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, taskId, pollInterval),
+      track: () => this.getTaskStatus(agent, serverTaskId),
+      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval),
     };
 
     return {

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -4,7 +4,7 @@
 import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
 import { ProtocolClient } from '../protocols';
-import { getMCPTaskStatus, listMCPTasks } from '../protocols/mcp-tasks';
+import { listMCPTasks } from '../protocols/mcp-tasks';
 import { getAuthToken } from '../auth';
 import { is401Error, adcpErrorToTypedError } from '../errors';
 import type { ADCPError } from '../errors';
@@ -70,6 +70,114 @@ export class InputRequiredError extends Error {
     super(`Server requires input but no handler provided. Question: ${question}`);
     this.name = 'InputRequiredError';
   }
+}
+
+/**
+ * Map an AdCP `tasks/get` response (post-unwrap) to the SDK's internal
+ * `TaskInfo` shape. The AdCP 3.0 schema
+ * (`schemas/cache/3.0.0/bundled/core/tasks-get-response.json`) is flat
+ * snake_case: `{ task_id, task_type, protocol, status, created_at,
+ * updated_at, error?, progress?, history?, completed_at?, has_webhook?,
+ * context?, ext? }`. The internal `TaskInfo` is camelCase with a
+ * superset of legacy fields some pre-3.0 sellers still emit.
+ *
+ * **Result-data passthrough.** AdCP `tasks/get` doesn't define a
+ * completion-payload field — the spec leaves the result-extraction
+ * layer ambiguous (see adcp#3123 for the upstream clarification
+ * issue). Sellers MAY surface the completed task's data via
+ * `additionalProperties: true` (`result` or `task_data` are the de
+ * facto names). We pass it through so `pollTaskCompletion` can
+ * surface it on the resolved `TaskResult.data`. When the spec
+ * clarifies, this mapping refines.
+ *
+ * **Legacy nested shape.** Some pre-3.0 sellers and existing test
+ * mocks emit `{ task: { ...TaskInfo } }` — a non-spec wrapper. We
+ * unwrap it before the spec-shape mapping so the SDK stays
+ * compatible with both surfaces during the transition.
+ */
+function mapTasksGetResponseToTaskInfo(payload: unknown): TaskInfo {
+  if (payload == null || typeof payload !== 'object') {
+    return { taskId: '', status: 'unknown', taskType: 'unknown', createdAt: Date.now(), updatedAt: Date.now() };
+  }
+  const obj = payload as Record<string, unknown>;
+  // Walk the transport-level wrappers in priority order:
+  //   1. MCP `structuredContent` — the typed AdCP payload from `tools/call`
+  //   2. A2A `result.artifacts[0].parts[0].data` — the AdCP payload
+  //      surfaced via the artifact (per #899)
+  //   3. Legacy nested `{ task: TaskInfo }` — pre-3.0 sellers and
+  //      existing test mocks
+  //   4. Flat AdCP-spec shape — what AdCP 3.0 sellers emit directly
+  const flat = unwrapTasksGetEnvelope(obj);
+  const errorRaw = flat.error;
+  const errorMessage =
+    typeof errorRaw === 'string'
+      ? errorRaw
+      : errorRaw != null &&
+          typeof errorRaw === 'object' &&
+          typeof (errorRaw as { message?: unknown }).message === 'string'
+        ? (errorRaw as { message: string }).message
+        : undefined;
+  const taskInfo: TaskInfo = {
+    taskId: stringField(flat.task_id) ?? stringField(flat.taskId) ?? '',
+    status: stringField(flat.status) ?? 'unknown',
+    taskType: stringField(flat.task_type) ?? stringField(flat.taskType) ?? 'unknown',
+    createdAt: parseTimestamp(flat.created_at ?? flat.createdAt),
+    updatedAt: parseTimestamp(flat.updated_at ?? flat.updatedAt),
+  };
+  if (errorMessage !== undefined) taskInfo.error = errorMessage;
+  // Result passthrough — see JSDoc on result-data ambiguity.
+  const result = flat.result ?? flat.task_data;
+  if (result !== undefined) taskInfo.result = result;
+  return taskInfo;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function unwrapTasksGetEnvelope(obj: Record<string, unknown>): Record<string, unknown> {
+  // MCP: `tools/call` response carries the typed payload at
+  // `structuredContent`.
+  const sc = obj.structuredContent;
+  if (sc != null && typeof sc === 'object' && !Array.isArray(sc)) {
+    return unwrapTasksGetEnvelope(sc as Record<string, unknown>);
+  }
+  // A2A: `message/send` response is a JSON-RPC envelope wrapping a
+  // Task; the AdCP payload sits on the first artifact's first
+  // DataPart.
+  const result = obj.result;
+  if (result != null && typeof result === 'object' && !Array.isArray(result)) {
+    const r = result as Record<string, unknown>;
+    if (r.kind === 'task' && Array.isArray(r.artifacts) && r.artifacts.length > 0) {
+      const artifact = r.artifacts[0] as Record<string, unknown> | null;
+      if (
+        artifact != null &&
+        typeof artifact === 'object' &&
+        Array.isArray(artifact.parts) &&
+        artifact.parts.length > 0
+      ) {
+        const firstPart = artifact.parts[0] as Record<string, unknown> | null;
+        if (firstPart?.kind === 'data' && firstPart.data != null && typeof firstPart.data === 'object') {
+          return unwrapTasksGetEnvelope(firstPart.data as Record<string, unknown>);
+        }
+      }
+    }
+  }
+  // Legacy nested wrapper from pre-3.0 sellers and existing mocks.
+  if (obj.task != null && typeof obj.task === 'object' && !Array.isArray(obj.task)) {
+    return obj.task as Record<string, unknown>;
+  }
+  // Flat AdCP-spec shape — return as-is.
+  return obj;
+}
+
+function parseTimestamp(value: unknown): number {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return Date.now();
 }
 
 /**
@@ -1158,27 +1266,45 @@ export class TaskExecutor {
   }
 
   async getTaskStatus(agent: AgentConfig, taskId: string): Promise<TaskInfo> {
-    // Use MCP Tasks protocol method when available
-    if (agent.protocol === 'mcp') {
-      const authToken = getAuthToken(agent);
-      try {
-        return await getMCPTaskStatus(agent.agent_uri, taskId, authToken);
-      } catch (err) {
-        if (is401Error(err)) throw err;
-        // Fall through to tool call if protocol method is not supported
-      }
-    }
+    // AdCP `tasks/get` is the cross-protocol work-status interface
+    // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
+    // Dispatched as a buyer-callable tool over the agent's transport
+    // — `ProtocolClient.callTool` selects MCP `tools/call` or A2A
+    // `message/send` per `agent.protocol`.
+    //
+    // The previous implementation tried MCP's `experimental.tasks.getTask`
+    // first for MCP agents and fell through to the AdCP tool path on
+    // capability-missing. The native MCP path tracks the TRANSPORT-call
+    // lifecycle (MCP analog of A2A `Task.state`) — not AdCP work
+    // lifecycle. For submitted-arm polling we need work status; the
+    // two interfaces are not substitutes, so we always use the AdCP
+    // tool here. MCP sellers that haven't registered `tasks/get` as
+    // an AdCP tool will surface a tool-not-found error rather than
+    // silently polling the wrong lifecycle.
+    //
+    // The request param is `task_id` (snake_case per AdCP 3.0); the
+    // response is the spec's flat shape, mapped to `TaskInfo` via
+    // {@link mapTasksGetResponseToTaskInfo}.
     const response = (await ProtocolClient.callTool(
       agent,
       'tasks/get',
-      { taskId },
+      { task_id: taskId },
       [],
       undefined,
       undefined,
       undefined,
       this.lastKnownServerVersion
     )) as Record<string, unknown>;
-    return (response.task as TaskInfo) || (response as unknown as TaskInfo);
+    // We don't run `extractResponseData` here: that helper's
+    // generic AdCP-error-arm detection treats any top-level
+    // `error: { code, message }` as an error envelope and shreds the
+    // response into `{ errors: [...] }`. For `tasks/get` the `error`
+    // block is informational (the failed task's reason, not a
+    // request rejection), so we map the raw response directly. The
+    // mapper handles the AdCP-spec flat shape, the legacy
+    // `{ task: ... }` nested wrapper, and MCP `structuredContent` /
+    // A2A `result.artifacts[0].parts[0].data` envelopes.
+    return mapTasksGetResponseToTaskInfo(response);
   }
 
   async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000): Promise<TaskResult<T>> {

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -135,12 +135,22 @@ function stringField(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
-function unwrapTasksGetEnvelope(obj: Record<string, unknown>): Record<string, unknown> {
+/**
+ * Cap on the wrapper-unwrap recursion depth. Real-world responses
+ * have at most two layers (MCP `structuredContent` OR A2A JSON-RPC →
+ * Task → artifact → DataPart). The cap is a defense against a
+ * malformed or hostile seller emitting a deeply-nested wrapper that
+ * would otherwise stack-overflow the buyer.
+ */
+const TASKS_GET_UNWRAP_MAX_DEPTH = 8;
+
+function unwrapTasksGetEnvelope(obj: Record<string, unknown>, depth = 0): Record<string, unknown> {
+  if (depth >= TASKS_GET_UNWRAP_MAX_DEPTH) return obj;
   // MCP: `tools/call` response carries the typed payload at
   // `structuredContent`.
   const sc = obj.structuredContent;
   if (sc != null && typeof sc === 'object' && !Array.isArray(sc)) {
-    return unwrapTasksGetEnvelope(sc as Record<string, unknown>);
+    return unwrapTasksGetEnvelope(sc as Record<string, unknown>, depth + 1);
   }
   // A2A: `message/send` response is a JSON-RPC envelope wrapping a
   // Task; the AdCP payload sits on the first artifact's first
@@ -158,12 +168,15 @@ function unwrapTasksGetEnvelope(obj: Record<string, unknown>): Record<string, un
       ) {
         const firstPart = artifact.parts[0] as Record<string, unknown> | null;
         if (firstPart?.kind === 'data' && firstPart.data != null && typeof firstPart.data === 'object') {
-          return unwrapTasksGetEnvelope(firstPart.data as Record<string, unknown>);
+          return unwrapTasksGetEnvelope(firstPart.data as Record<string, unknown>, depth + 1);
         }
       }
     }
   }
   // Legacy nested wrapper from pre-3.0 sellers and existing mocks.
+  // TODO(adcp-client#967): remove once mock fixtures in
+  // `test/lib/task-executor*.test.js` migrate to the AdCP-spec flat
+  // shape. No real seller emits this; verified at PR review time.
   if (obj.task != null && typeof obj.task === 'object' && !Array.isArray(obj.task)) {
     return obj.task as Record<string, unknown>;
   }
@@ -1285,6 +1298,14 @@ export class TaskExecutor {
     // The request param is `task_id` (snake_case per AdCP 3.0); the
     // response is the spec's flat shape, mapped to `TaskInfo` via
     // {@link mapTasksGetResponseToTaskInfo}.
+    //
+    // **Known limitation (#973)**: A2A submitted-arm responses still
+    // misclassify because `responseParser.getStatus`/`getTaskId` read
+    // the transport-level `Task.state` and `Task.id` instead of the
+    // AdCP work status (`artifact.parts[0].data.status`) and AdCP
+    // work handle (`artifact.metadata.adcp_task_id`). The polling
+    // cycle never starts for A2A submitted arms in current code; the
+    // parser fix is tracked separately.
     const response = (await ProtocolClient.callTool(
       agent,
       'tasks/get',

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -926,12 +926,23 @@ export class TaskExecutor {
     //
     // When the seller violated the spec and didn't include a task handle
     // we fall back to the local UUID so the buyer at least gets a
-    // non-undefined `taskId` field. This also matches the historical
-    // (broken) behavior on a wire where the server doesn't know the
-    // local UUID, so the polling cycle was already misaligned — better
-    // to keep the surface area stable than to introduce a hard fail at
-    // a place that's been silently wrong.
-    const serverTaskId = this.responseParser.getTaskId(response) ?? taskId;
+    // non-undefined `taskId` field. The polling cycle won't be able to
+    // locate the work in this state — log an advisory so operators
+    // grepping debug logs can pinpoint the seller-side spec violation.
+    const extractedServerTaskId = this.responseParser.getTaskId(response);
+    const serverTaskId = extractedServerTaskId ?? taskId;
+    if (!extractedServerTaskId) {
+      debugLogs.push({
+        type: 'warning',
+        message:
+          'Submitted-arm response omitted task_id (spec violation). Polling will use the runner-side ' +
+          'correlation id as a fallback; the seller will not recognize it. ' +
+          'Expected: response.task_id (AdCP) or result.id with kind === "task" (A2A wrapped).',
+        timestamp: new Date().toISOString(),
+        taskName,
+        runnerTaskId: taskId,
+      });
+    }
 
     const submitted: SubmittedContinuation<T> = {
       taskId: serverTaskId,

--- a/test/server-task-id-plumbing.test.js
+++ b/test/server-task-id-plumbing.test.js
@@ -108,11 +108,13 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     assert.strictEqual(trackedId, SERVER_TASK_ID, 'track() must address the server task_id');
   });
 
-  test('falls back to runner-side UUID when seller violates spec and omits task_id', async () => {
+  test('falls back to runner-side UUID and emits debug-log advisory when seller omits task_id', async () => {
     // Spec violation: submitted arm with no task_id field. SDK can't
     // address polling at the seller's task — fall back to the local
     // UUID so callers at least get a non-undefined string to log.
-    // This tests the documented escape hatch on the JSDoc.
+    // The fallback path also writes an advisory entry to debug_logs
+    // so operators grepping for "task_id" / "spec violation" can
+    // pinpoint the offending seller call.
     ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
       if (taskName === 'tasks/get') {
         return { task: { status: 'completed', result: {} } };
@@ -125,31 +127,214 @@ describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () =>
     assert.strictEqual(result.status, 'submitted');
     assert.ok(typeof result.submitted.taskId === 'string', 'taskId is a string fallback');
     assert.ok(result.submitted.taskId.length > 0, 'taskId is non-empty');
+    const advisory = (result.debug_logs ?? []).find(
+      e => e?.type === 'warning' && /omitted task_id/i.test(e?.message ?? '')
+    );
+    assert.ok(advisory, 'fallback path emits a debug_logs advisory naming the spec violation');
   });
 
-  test('A2A response with `result.kind: "task"` extracts the A2A Task.id as the server handle', async () => {
-    // For A2A responses, the SDK extracts the server handle from
-    // `result.id` when `result.kind === 'task'`. Verifies the
-    // responseParser.getTaskId branch is what setupSubmittedTask
-    // relies on (rather than only looking at `response.task_id` flat).
+  test('A2A wrapped response with `result.kind: "task"` extracts result.id as the server handle', async () => {
+    // For A2A submitted-arm responses, the protocol client returns the
+    // JSON-RPC envelope (`{ id, jsonrpc, result: <Task> }`).
+    // responseParser walks `response.result.kind === 'task'` →
+    // `response.result.id` and returns the A2A Task.id. Distinct
+    // sentinels on `result.id` vs the flat shape ensure the test is
+    // exercising the result-branch, not silently passing because both
+    // fields carry the same value. Note: this test pins the CURRENT
+    // parser behavior; #967 will revisit this priority for A2A
+    // submitted arms (where the AdCP work handle on
+    // `artifact.metadata.adcp_task_id` is the buyer's polling key,
+    // not `result.id`).
     const A2A_TASK_ID = 'a2a-server-task-uuid-99';
+    const FLAT_TASK_ID = 'flat-task-id-should-be-ignored';
 
-    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
       if (taskName === 'tasks/get') {
         return { task: { status: 'completed', result: {} } };
       }
-      // Shape of the response the A2A protocol client returns: a
-      // JSON-RPC envelope wrapping the A2A Task. responseParser walks
-      // `response.result.kind === 'task'` → `response.result.id`.
+      // The wrapped envelope branch: `result.kind === 'task'` wins
+      // over `response.task_id` (flat) per ProtocolResponseParser
+      // priority (`response.result` checked first).
       return {
         status: 'submitted',
-        task_id: A2A_TASK_ID,
+        task_id: FLAT_TASK_ID,
         result: { kind: 'task', id: A2A_TASK_ID, status: { state: 'submitted' } },
       };
     });
 
     const executor = new TaskExecutor({ pollingInterval: 5 });
     const result = await executor.executeTask({ ...mockAgent, protocol: 'a2a' }, 'a2aSubmittedTest', {});
-    assert.strictEqual(result.submitted.taskId, A2A_TASK_ID);
+    assert.strictEqual(
+      result.submitted.taskId,
+      A2A_TASK_ID,
+      `wrapped result.id branch must take precedence over flat task_id; got ${result.submitted.taskId}`
+    );
+  });
+
+  test('MCP `structuredContent.task_id` extraction path', async () => {
+    // MCP responses surface the seller handle on
+    // `structuredContent.task_id`. Pin the path is exercised so a
+    // future parser refactor can't drop this branch silently.
+    const MCP_TASK_ID = 'mcp-structured-content-task-id';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return { task: { status: 'completed', result: {} } };
+      }
+      return { structuredContent: { status: 'submitted', task_id: MCP_TASK_ID } };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'mcpStructuredTest', {});
+    assert.strictEqual(result.submitted.taskId, MCP_TASK_ID);
+  });
+
+  test('multi-poll lifecycle: every poll addresses the server-assigned task_id (not just the first)', async () => {
+    // The pre-fix bug was "polling sends the wrong id." Single-poll
+    // tests prove the first call is correct but don't pin that
+    // subsequent calls are too. `working → working → completed` makes
+    // the regression class observable: a future refactor that fixes
+    // the first poll but regresses internal-loop polling would slip
+    // past the single-poll test.
+    const SERVER_TASK_ID = 'tk_seller_assigned_multipoll';
+    const polledIds = [];
+    const sequence = ['working', 'working', 'completed'];
+    let pollCount = 0;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        polledIds.push(params?.taskId ?? params?.task_id);
+        const state = sequence[Math.min(pollCount++, sequence.length - 1)];
+        return state === 'completed'
+          ? { task: { status: 'completed', result: { polls: pollCount } } }
+          : { task: { status: 'working' } };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'multipollTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, true);
+    assert.ok(polledIds.length >= 3, `expected ≥3 polls, got ${polledIds.length}`);
+    assert.ok(
+      polledIds.every(id => id === SERVER_TASK_ID),
+      `every poll across the working→completed lifecycle must address the server task_id; observed: ${JSON.stringify(polledIds)}`
+    );
+  });
+
+  test('concurrent submitted tasks: each continuation polls its own server task_id', async () => {
+    // Two `executeTask` calls in flight with distinct seller-side
+    // handles. Pins the activeTasks map keying — a regression that
+    // confused the local correlation UUID with the server handle
+    // could cross-pollinate concurrent polls, and that wouldn't
+    // surface on serial tests.
+    const SERVER_A = 'tk_concurrent_A';
+    const SERVER_B = 'tk_concurrent_B';
+    const polledFor = { A: [], B: [] };
+    let nextSeller = SERVER_A;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        const id = params?.taskId ?? params?.task_id;
+        if (id === SERVER_A) polledFor.A.push(id);
+        if (id === SERVER_B) polledFor.B.push(id);
+        return { task: { status: 'completed', result: { id } } };
+      }
+      const handle = nextSeller;
+      nextSeller = nextSeller === SERVER_A ? SERVER_B : SERVER_A;
+      return { status: 'submitted', task_id: handle };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const [resultA, resultB] = await Promise.all([
+      executor.executeTask({ ...mockAgent, id: 'agent-a' }, 'taskA', {}),
+      executor.executeTask({ ...mockAgent, id: 'agent-b' }, 'taskB', {}),
+    ]);
+    assert.strictEqual(resultA.submitted.taskId, SERVER_A);
+    assert.strictEqual(resultB.submitted.taskId, SERVER_B);
+
+    await Promise.all([resultA.submitted.waitForCompletion(5), resultB.submitted.waitForCompletion(5)]);
+    assert.ok(polledFor.A.length >= 1, 'task A polled at least once');
+    assert.ok(polledFor.B.length >= 1, 'task B polled at least once');
+    assert.ok(
+      polledFor.A.every(id => id === SERVER_A),
+      `task A polls must address SERVER_A; got ${JSON.stringify(polledFor.A)}`
+    );
+    assert.ok(
+      polledFor.B.every(id => id === SERVER_B),
+      `task B polls must address SERVER_B; got ${JSON.stringify(polledFor.B)}`
+    );
+  });
+
+  test('webhook URL macro uses the runner-side correlation id, not the server task_id', async () => {
+    // Documents the two-IDs-with-different-purposes invariant: the
+    // `{operation_id}` webhook URL macro is a buyer-side correlator
+    // (used in callback-URL paths the seller posts back to), so it
+    // stays on the local UUID. Conversely, `submitted.taskId` is the
+    // server's handle. A future refactor that collapses them would
+    // silently break webhook-URL stability across retries.
+    const SERVER_TASK_ID = 'tk_webhook_separation';
+    const generatedFor = [];
+    const registeredFor = [];
+    const webhookManager = {
+      generateUrl: id => {
+        generatedFor.push(id);
+        return `https://buyer.example/webhook/${id}`;
+      },
+      registerWebhook: async (_agent, id) => {
+        registeredFor.push(id);
+      },
+      processWebhook: async () => {},
+    };
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return { task: { status: 'working' } };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5, webhookManager });
+    const result = await executor.executeTask(mockAgent, 'webhookSepTest', {});
+    assert.strictEqual(result.submitted.taskId, SERVER_TASK_ID, 'continuation surfaces server handle');
+    assert.ok(generatedFor.length === 1 && registeredFor.length === 1, 'webhook manager invoked once');
+    assert.notStrictEqual(
+      generatedFor[0],
+      SERVER_TASK_ID,
+      'webhook URL macro must NOT use the server task_id — it is the buyer-side correlation id'
+    );
+    assert.strictEqual(
+      generatedFor[0],
+      registeredFor[0],
+      'generateUrl and registerWebhook receive the same id (the runner-side correlation)'
+    );
+    assert.ok(
+      result.submitted.webhookUrl?.endsWith(`/${generatedFor[0]}`),
+      'continuation webhookUrl reflects the local correlation id'
+    );
+  });
+
+  test('tasks/get error surfaces the failure on the resolved TaskResult', async () => {
+    // If the polling call itself fails (network, seller error), the
+    // SDK should surface failure rather than hang. Pinning behavior
+    // on failure prevents a future refactor from silently swallowing
+    // poll errors and looping indefinitely.
+    const SERVER_TASK_ID = 'tk_error_path';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        // Returns a failed task — within the poll loop's normal
+        // failed-status handling path.
+        return { task: { status: 'failed', error: 'simulated seller failure' } };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'errorPathTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, false, 'failed poll surfaces as completion.success === false');
+    assert.strictEqual(completion.status, 'failed');
   });
 });

--- a/test/server-task-id-plumbing.test.js
+++ b/test/server-task-id-plumbing.test.js
@@ -1,0 +1,155 @@
+// Regression test for adcp-client#966.
+//
+// Anchors the contract that `SubmittedContinuation.taskId` carries the
+// SERVER-assigned task handle (the value the seller emitted in
+// `response.task_id`), not the SDK's runner-side correlation UUID. The
+// polling cycle (`waitForCompletion` / `track`) must dispatch with the
+// server handle so the seller can locate the work.
+//
+// Pre-fix bug: `setupSubmittedTask` plumbed the runner-side correlation
+// UUID through the continuation, so polling addressed a server task the
+// seller had never minted. Existing mock tests didn't catch this
+// because they ignored the `taskId` param when stubbing the polling
+// response.
+
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('SubmittedContinuation: server-assigned task_id plumbing (#966)', () => {
+  let TaskExecutor;
+  let ProtocolClient;
+  let originalCallTool;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../dist/lib/index.js')];
+    const lib = require('../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    ProtocolClient = lib.ProtocolClient;
+    originalCallTool = ProtocolClient.callTool;
+    mockAgent = {
+      id: 'mock-agent',
+      name: 'Mock Agent',
+      agent_uri: 'https://mock.test.com',
+      protocol: 'mcp',
+    };
+  });
+
+  afterEach(() => {
+    if (originalCallTool) ProtocolClient.callTool = originalCallTool;
+  });
+
+  test('submitted continuation surfaces the server-assigned task_id, not the runner-side UUID', async () => {
+    const SERVER_TASK_ID = 'tk_seller_assigned_42';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, _params) => {
+      if (taskName === 'tasks/get') {
+        return { task: { status: 'completed', result: { ok: true } } };
+      }
+      // Initial submitted-arm response carries the seller's task handle.
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'someAsyncTask', {});
+
+    assert.strictEqual(result.status, 'submitted');
+    assert.ok(result.submitted, 'submitted continuation present');
+    assert.strictEqual(
+      result.submitted.taskId,
+      SERVER_TASK_ID,
+      'continuation must expose the server-minted task_id, not a runner-side UUID'
+    );
+  });
+
+  test('waitForCompletion polls with the server-assigned task_id', async () => {
+    const SERVER_TASK_ID = 'tk_seller_assigned_polling';
+    const polledIds = [];
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        // Capture the id the SDK polls with — that's the regression
+        // surface. Pre-fix it was the runner-side UUID; post-fix it
+        // must be the seller's task handle.
+        polledIds.push(params?.taskId ?? params?.task_id);
+        return { task: { status: 'completed', result: { polls: polledIds.length } } };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'pollingTest', {});
+    assert.strictEqual(result.status, 'submitted');
+
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, true);
+    assert.ok(polledIds.length >= 1, 'at least one poll fired');
+    assert.ok(
+      polledIds.every(id => id === SERVER_TASK_ID),
+      `every poll must address the server task_id; observed: ${JSON.stringify(polledIds)}`
+    );
+  });
+
+  test('track() uses the server-assigned task_id', async () => {
+    const SERVER_TASK_ID = 'tk_seller_assigned_track';
+    let trackedId;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        trackedId = params?.taskId ?? params?.task_id;
+        return { task: { status: 'working' } };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'trackTest', {});
+    await result.submitted.track();
+    assert.strictEqual(trackedId, SERVER_TASK_ID, 'track() must address the server task_id');
+  });
+
+  test('falls back to runner-side UUID when seller violates spec and omits task_id', async () => {
+    // Spec violation: submitted arm with no task_id field. SDK can't
+    // address polling at the seller's task — fall back to the local
+    // UUID so callers at least get a non-undefined string to log.
+    // This tests the documented escape hatch on the JSDoc.
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return { task: { status: 'completed', result: {} } };
+      }
+      return { status: 'submitted' }; // no task_id
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'malformedSubmittedTest', {});
+    assert.strictEqual(result.status, 'submitted');
+    assert.ok(typeof result.submitted.taskId === 'string', 'taskId is a string fallback');
+    assert.ok(result.submitted.taskId.length > 0, 'taskId is non-empty');
+  });
+
+  test('A2A response with `result.kind: "task"` extracts the A2A Task.id as the server handle', async () => {
+    // For A2A responses, the SDK extracts the server handle from
+    // `result.id` when `result.kind === 'task'`. Verifies the
+    // responseParser.getTaskId branch is what setupSubmittedTask
+    // relies on (rather than only looking at `response.task_id` flat).
+    const A2A_TASK_ID = 'a2a-server-task-uuid-99';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        return { task: { status: 'completed', result: {} } };
+      }
+      // Shape of the response the A2A protocol client returns: a
+      // JSON-RPC envelope wrapping the A2A Task. responseParser walks
+      // `response.result.kind === 'task'` → `response.result.id`.
+      return {
+        status: 'submitted',
+        task_id: A2A_TASK_ID,
+        result: { kind: 'task', id: A2A_TASK_ID, status: { state: 'submitted' } },
+      };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask({ ...mockAgent, protocol: 'a2a' }, 'a2aSubmittedTest', {});
+    assert.strictEqual(result.submitted.taskId, A2A_TASK_ID);
+  });
+});

--- a/test/server-tasks-get-spec-shape.test.js
+++ b/test/server-tasks-get-spec-shape.test.js
@@ -161,6 +161,150 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     assert.strictEqual(completion.status, 'failed');
   });
 
+  test('maps canceled status (peer terminal state to failed)', async () => {
+    // `pollTaskCompletion` collapses `failed` and `canceled` onto the
+    // same `TaskResult.status: 'failed'` branch (TaskExecutor.ts:1194).
+    // Pre-fix mapping bug could have regressed on `canceled` while
+    // `failed` passed; pin both branches.
+    const SERVER_TASK_ID = 'tk_canceled_test';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'canceled',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'canceledStatusTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, false, 'canceled task surfaces as completion.success === false');
+    assert.strictEqual(
+      completion.status,
+      'failed',
+      'SDK collapses canceled and failed onto the same TaskResult.status'
+    );
+  });
+
+  test('unwraps MCP `structuredContent` envelope around the AdCP-spec flat shape', async () => {
+    // Real MCP `tasks/get` responses arrive wrapped in
+    // `{ structuredContent: <AdCP payload> }` (the SDK's MCP transport
+    // surfaces the typed payload under that field). The mapper must
+    // walk past the wrapper before applying the AdCP-spec mapping.
+    const SERVER_TASK_ID = 'tk_mcp_wrapped';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          structuredContent: {
+            task_id: SERVER_TASK_ID,
+            task_type: 'create_media_buy',
+            protocol: 'media-buy',
+            status: 'completed',
+            created_at: '2026-04-25T10:00:00Z',
+            updated_at: '2026-04-25T10:05:00Z',
+          },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'mcpWrappedTest', {});
+    const status = await result.submitted.track();
+    assert.strictEqual(status.taskId, SERVER_TASK_ID, 'mapper walks past structuredContent wrapper');
+    assert.strictEqual(status.status, 'completed');
+    assert.strictEqual(status.taskType, 'create_media_buy');
+  });
+
+  test('unwraps A2A `result.kind:"task".artifacts[0].parts[0].data` envelope around the AdCP-spec flat shape', async () => {
+    // A2A `tasks/get` responses arrive as a JSON-RPC envelope
+    // wrapping a Task whose first artifact carries the AdCP payload
+    // on its first DataPart (per #899). The mapper must walk past
+    // both the JSON-RPC envelope and the artifact wrapping.
+    const SERVER_TASK_ID = 'tk_a2a_wrapped';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            kind: 'task',
+            id: 'a2a-task-uuid',
+            contextId: 'a2a-context-uuid',
+            status: { state: 'completed', timestamp: '2026-04-25T10:05:00Z' },
+            artifacts: [
+              {
+                artifactId: 'artifact-uuid',
+                name: 'tasks_get_result',
+                parts: [
+                  {
+                    kind: 'data',
+                    data: {
+                      task_id: SERVER_TASK_ID,
+                      task_type: 'create_media_buy',
+                      protocol: 'media-buy',
+                      status: 'completed',
+                      created_at: '2026-04-25T10:00:00Z',
+                      updated_at: '2026-04-25T10:05:00Z',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'a2aWrappedTest', {});
+    const status = await result.submitted.track();
+    assert.strictEqual(
+      status.taskId,
+      SERVER_TASK_ID,
+      'mapper walks past JSON-RPC + Task + artifact wrappers to find the AdCP payload'
+    );
+    assert.strictEqual(status.status, 'completed');
+  });
+
+  test('passes through `task_data` alias for completion payload', async () => {
+    // Some sellers use `task_data` instead of `result` for the
+    // completion payload (both via additionalProperties since neither
+    // is in the spec). The mapper accepts either name.
+    const SERVER_TASK_ID = 'tk_task_data_alias';
+    const COMPLETION_DATA = { foo: 'bar' };
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+          task_data: COMPLETION_DATA, // alias for `result`
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'taskDataAliasTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.deepStrictEqual(completion.data, COMPLETION_DATA);
+  });
+
   test('continues to handle the legacy { task: {...} } nested shape for backward compat', async () => {
     // Some pre-3.0 sellers and existing test fixtures emit a non-spec
     // wrapper. Until those migrate, we keep handling both shapes so
@@ -191,41 +335,49 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     assert.deepStrictEqual(completion.data, { ok: true });
   });
 
-  test('does NOT try MCP experimental.tasks.getTask before the AdCP tool', async () => {
+  test('does NOT call MCP experimental.tasks.getTask before the AdCP tool', async () => {
     // The previous implementation tried `getMCPTaskStatus` first and
     // fell through to the AdCP tool on capability-missing. The two
     // interfaces track different lifecycles (MCP-experimental =
     // transport, AdCP tasks/get = work). For submitted-arm polling
-    // we always want work status — pin it.
-    let callCount = 0;
-    let observedToolNames = [];
-
-    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
-      callCount++;
-      observedToolNames.push(taskName);
-      if (taskName === 'tasks/get') {
-        return {
-          task_id: 'tk_no_experimental',
-          task_type: 'create_media_buy',
-          protocol: 'media-buy',
-          status: 'completed',
-          created_at: '2026-04-25T10:00:00Z',
-          updated_at: '2026-04-25T10:05:00Z',
-        };
-      }
-      return { status: 'submitted', task_id: 'tk_no_experimental' };
+    // we always want work status — pin it by spying directly on the
+    // experimental-path module export. If the experimental call ever
+    // fires, the spy throws.
+    const mcpTasks = require('../dist/lib/protocols/mcp-tasks');
+    const originalGetMCPTaskStatus = mcpTasks.getMCPTaskStatus;
+    let experimentalCalls = 0;
+    mcpTasks.getMCPTaskStatus = mock.fn(async () => {
+      experimentalCalls++;
+      throw new Error(
+        'experimental.tasks.getTask must NOT be called from getTaskStatus — it tracks transport-call lifecycle, not AdCP work lifecycle'
+      );
     });
 
-    const executor = new TaskExecutor({ pollingInterval: 5 });
-    const result = await executor.executeTask(mockAgent, 'noExperimentalTest', {});
-    await result.submitted.waitForCompletion(5);
+    try {
+      ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+        if (taskName === 'tasks/get') {
+          return {
+            task_id: 'tk_no_experimental',
+            task_type: 'create_media_buy',
+            protocol: 'media-buy',
+            status: 'completed',
+            created_at: '2026-04-25T10:00:00Z',
+            updated_at: '2026-04-25T10:05:00Z',
+          };
+        }
+        return { status: 'submitted', task_id: 'tk_no_experimental' };
+      });
 
-    // Two callTool invocations expected: the initial task + one tasks/get poll
-    const tasksGetCalls = observedToolNames.filter(name => name === 'tasks/get');
-    assert.ok(tasksGetCalls.length >= 1, 'tasks/get was called for polling');
-    // No experimental.tasks.getTask reached ProtocolClient.callTool —
-    // the experimental path bypasses callTool entirely (uses the SDK's
-    // experimental subsystem), so its absence here proves the new
-    // dispatch path skipped it.
+      const executor = new TaskExecutor({ pollingInterval: 5 });
+      const result = await executor.executeTask(mockAgent, 'noExperimentalTest', {});
+      await result.submitted.waitForCompletion(5);
+      assert.strictEqual(
+        experimentalCalls,
+        0,
+        'getMCPTaskStatus (experimental.tasks.getTask) must not be invoked from the polling cycle'
+      );
+    } finally {
+      mcpTasks.getMCPTaskStatus = originalGetMCPTaskStatus;
+    }
   });
 });

--- a/test/server-tasks-get-spec-shape.test.js
+++ b/test/server-tasks-get-spec-shape.test.js
@@ -1,0 +1,231 @@
+// Regression test for adcp-client#967.
+//
+// Anchors the contract that `getTaskStatus` dispatches the AdCP
+// `tasks/get` tool with snake_case `task_id` per AdCP 3.0
+// (`schemas/cache/3.0.0/bundled/core/tasks-get-request.json`) and
+// maps the spec's flat snake_case response shape
+// (`schemas/cache/3.0.0/bundled/core/tasks-get-response.json`) to
+// the SDK's internal `TaskInfo`.
+//
+// Pre-fix bugs (caught by these tests):
+//   1. SDK passed `{ taskId }` (camelCase) — spec violation; conformant
+//      sellers reject as INVALID_PARAMS.
+//   2. SDK read `(response.task as TaskInfo)` — expects either a
+//      legacy nested wrapper or camelCase fields directly. Spec
+//      response is flat snake_case; real responses got
+//      `taskId: undefined` everywhere.
+//   3. SDK tried MCP `experimental.tasks.getTask` first for MCP
+//      agents — that's transport-call lifecycle, not AdCP work
+//      lifecycle. For polling submitted-arm tasks (which is what
+//      `pollTaskCompletion` does) we need work status; the two
+//      interfaces are not substitutes.
+
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
+  let TaskExecutor;
+  let ProtocolClient;
+  let originalCallTool;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../dist/lib/index.js')];
+    const lib = require('../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    ProtocolClient = lib.ProtocolClient;
+    originalCallTool = ProtocolClient.callTool;
+    mockAgent = {
+      id: 'mock-agent',
+      name: 'Mock Agent',
+      agent_uri: 'https://mock.test.com',
+      protocol: 'mcp',
+    };
+  });
+
+  afterEach(() => {
+    if (originalCallTool) ProtocolClient.callTool = originalCallTool;
+  });
+
+  test('dispatches tasks/get with snake_case task_id (not camelCase taskId)', async () => {
+    const SERVER_TASK_ID = 'tk_snake_case_test';
+    let observedParams;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        observedParams = params;
+        // AdCP 3.0 spec response (flat snake_case)
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'pollSnakeCaseTest', {});
+    await result.submitted.waitForCompletion(5);
+
+    assert.ok(observedParams, 'tasks/get was dispatched');
+    assert.strictEqual(observedParams.task_id, SERVER_TASK_ID, 'request must use snake_case task_id per AdCP 3.0 spec');
+    assert.strictEqual(observedParams.taskId, undefined, 'request must NOT include legacy camelCase taskId');
+  });
+
+  test('maps the AdCP-spec flat response shape correctly', async () => {
+    const SERVER_TASK_ID = 'tk_flat_shape_test';
+    const CREATED = '2026-04-25T10:00:00Z';
+    const UPDATED = '2026-04-25T10:05:30Z';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: CREATED,
+          updated_at: UPDATED,
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'flatShapeTest', {});
+    const status = await result.submitted.track();
+    assert.strictEqual(status.taskId, SERVER_TASK_ID);
+    assert.strictEqual(status.status, 'completed');
+    assert.strictEqual(status.taskType, 'create_media_buy');
+    assert.strictEqual(status.createdAt, Date.parse(CREATED));
+    assert.strictEqual(status.updatedAt, Date.parse(UPDATED));
+  });
+
+  test('passes through `result` field if seller adds it via additionalProperties', async () => {
+    // AdCP 3.0 tasks/get response schema doesn't define a `result`
+    // field for the completed task's payload (see adcp#3123). Sellers
+    // MAY surface it via additionalProperties: true. The SDK passes
+    // it through so `pollTaskCompletion` can return it as the
+    // resolved task data.
+    const SERVER_TASK_ID = 'tk_result_passthrough';
+    const COMPLETION_DATA = { media_buy_id: 'mb_42', packages: [] };
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+          result: COMPLETION_DATA, // additionalProperties passthrough
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'resultPassthroughTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, true);
+    assert.deepStrictEqual(completion.data, COMPLETION_DATA);
+  });
+
+  test('maps spec-shape error block to TaskInfo.error', async () => {
+    const SERVER_TASK_ID = 'tk_error_mapping';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'failed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+          error: { code: 'IO_REVIEW_FAILED', message: 'Sales rejected the IO terms' },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'errorMappingTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, false);
+    assert.strictEqual(completion.status, 'failed');
+  });
+
+  test('continues to handle the legacy { task: {...} } nested shape for backward compat', async () => {
+    // Some pre-3.0 sellers and existing test fixtures emit a non-spec
+    // wrapper. Until those migrate, we keep handling both shapes so
+    // we don't break ecosystem on the day this PR lands.
+    const SERVER_TASK_ID = 'tk_legacy_shape';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        // Legacy nested wrapper with camelCase TaskInfo fields
+        return {
+          task: {
+            taskId: SERVER_TASK_ID,
+            status: 'completed',
+            taskType: 'create_media_buy',
+            createdAt: 1714000000000,
+            updatedAt: 1714000300000,
+            result: { ok: true },
+          },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'legacyShapeTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, true);
+    assert.deepStrictEqual(completion.data, { ok: true });
+  });
+
+  test('does NOT try MCP experimental.tasks.getTask before the AdCP tool', async () => {
+    // The previous implementation tried `getMCPTaskStatus` first and
+    // fell through to the AdCP tool on capability-missing. The two
+    // interfaces track different lifecycles (MCP-experimental =
+    // transport, AdCP tasks/get = work). For submitted-arm polling
+    // we always want work status — pin it.
+    let callCount = 0;
+    let observedToolNames = [];
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      callCount++;
+      observedToolNames.push(taskName);
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: 'tk_no_experimental',
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+        };
+      }
+      return { status: 'submitted', task_id: 'tk_no_experimental' };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'noExperimentalTest', {});
+    await result.submitted.waitForCompletion(5);
+
+    // Two callTool invocations expected: the initial task + one tasks/get poll
+    const tasksGetCalls = observedToolNames.filter(name => name === 'tasks/get');
+    assert.ok(tasksGetCalls.length >= 1, 'tasks/get was called for polling');
+    // No experimental.tasks.getTask reached ProtocolClient.callTool —
+    // the experimental path bypasses callTool entirely (uses the SDK's
+    // experimental subsystem), so its absence here proves the new
+    // dispatch path skipped it.
+  });
+});


### PR DESCRIPTION
## Summary

Closes #966.

`setupSubmittedTask` was plumbing the SDK's runner-side correlation UUID (`TaskState.taskId`, generated at request time for `activeTasks` indexing and the `{operation_id}` webhook URL macro) all the way through to `SubmittedContinuation.taskId`. The polling closures — `track()` and `waitForCompletion()` — then addressed `tasks/get` calls with that local UUID, which the seller has never seen. Any spec-conformant seller would respond NOT_FOUND.

The existing mock tests at `test/lib/task-executor-mocking-strategy.test.js:340-353` masked the bug because they ignored the `taskId` parameter when stubbing the polling response — the SDK has been polling with the wrong ID against any real server, but the test suite was green.

## Fix

Extract the server-assigned handle via `responseParser.getTaskId(response)` (which already walks both the flat AdCP `response.task_id` shape AND the A2A `result.kind === 'task'` → `result.id` shape) and use it for the buyer-facing `SubmittedContinuation.taskId` field plus the polling closures. The local UUID stays internal — `activeTasks` map key and webhook URL macro value, both of which never reach the seller.

**Spec-violation fallback**: when the seller omits the task handle entirely on the submitted-arm response, the SDK falls back to the local UUID so callers still get a non-undefined `taskId` to log. Pollers won't be able to locate the work, but this matches the historical behavior surface and avoids a hard fail at a call site that's been silently wrong.

The buyer-facing `SubmittedContinuation.taskId` JSDoc is updated to document the corrected semantics: it carries the server handle, distinct from the runner-side correlation id.

## Why this is split from #967

The architect review on the polling redesign called out that the identifier-plumbing fix (correctness) and the AdCP `tasks/get` request/response shape fix (architecture hardening) have different review bars and rollback profiles:

- **This PR (#966)**: pure correctness — polls now address the right server task. Doesn't change which transport path is primary.
- **#967 follow-up**: AdCP `tasks/get` becomes the primary work-status path; param naming (`taskId` → `task_id`) and response-shape mapping fixed; MCP-experimental-tasks dropped from polling (wrong lifecycle for AdCP submitted arms per #899).

If #967 has to revert for an SDK quirk, this fix should not go with it.

## What we explicitly did NOT do

- A2A native `client.getTask({id})` — protocol-expert review confirmed this isn't the answer. Per #899's two-lifecycle contract (`a2a-adapter.ts:14-50`), A2A `Task.state` is `'completed'` for AdCP submitted arms, so polling A2A native returns useless data on every poll. The adapter docstring says it explicitly: *"Buyers resume the AdCP work via the `adcp_task_id` on the artifact's metadata, not by re-polling the A2A Task."*
- Renaming `TaskState.taskId` → `operationId`. Architect-suggested but invasive (50+ call sites) and pure refactor; deferred.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build:lib` clean
- [x] `prettier --check` clean (pre-existing nits format-fixed)
- [x] `eslint` 0 errors on changed files
- [x] All 5 new regression tests pass (`test/server-task-id-plumbing.test.js`)
- [x] 76/76 task-executor + error-scenarios tests pass
- [x] 2504/2508 wider regression sweep passes (4 intentional skips, none introduced here)
- [ ] CI green

## Review

- Three rounds of expert review on the broader polling redesign (architect, ad-tech-protocol, javascript-protocol) converged on this scope. Detailed synthesis lives in #966 and #967 issue descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)