### PR TITLE
fix(core): poll with server-assigned task ID, not local UUID

### DIFF
--- a/.changeset/poll-server-task-id-fix.md
+++ b/.changeset/poll-server-task-id-fix.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": patch
+---
+
+Fixed `pollTaskCompletion` using the client-minted local UUID instead of the server-assigned task ID when polling `tasks/get` (#966).
+
+`setupSubmittedTask` now extracts the server-assigned task ID from the initial response via `responseParser.getTaskId()` and passes it to the polling closures. The buyer-facing `SubmittedContinuation.taskId` field now holds the server-assigned ID (matching its JSDoc), while the new `SubmittedContinuation.operationId` field carries the SDK-internal local UUID used for webhook URL macros and activity events. Before this fix, every `submitted.track()` and `submitted.waitForCompletion()` call against a spec-conformant seller returned NOT_FOUND.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -232,8 +232,19 @@ export interface DeferredContinuation<T> {
  * Continuation for submitted server tasks (server needs time)
  */
 export interface SubmittedContinuation<T> {
-  /** Task ID for tracking */
+  /**
+   * Server-assigned task ID — the handle the seller uses to identify this task.
+   * Pass this to the seller's `tasks/get` endpoint for manual status polling.
+   * Distinct from the SDK-internal operation ID (`operationId`) which is a
+   * local UUID used for webhook URL macros and the `activeTasks` bookkeeping map.
+   */
   taskId: string;
+  /**
+   * SDK-internal operation ID — the local UUID minted by the client for this
+   * call's lifecycle tracking. Used in `{operation_id}` webhook URL macros and
+   * `activity` event payloads. Not meaningful to the seller.
+   */
+  operationId: string;
   /** Webhook URL where server will notify completion */
   webhookUrl?: string;
   /** Get current task status */

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -912,11 +912,17 @@ export class TaskExecutor {
       await this.config.webhookManager.registerWebhook(agent, taskId, webhookUrl);
     }
 
+    // Use the server-assigned task ID for polling. The local `taskId` is an
+    // SDK-internal UUID the server has never seen — passing it to tasks/get
+    // returns NOT_FOUND on any spec-conformant seller (#966).
+    const serverTaskId = this.responseParser.getTaskId(response) ?? taskId;
+
     const submitted: SubmittedContinuation<T> = {
-      taskId,
+      taskId: serverTaskId,
+      operationId: taskId,
       webhookUrl,
-      track: () => this.getTaskStatus(agent, taskId),
-      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, taskId, pollInterval),
+      track: () => this.getTaskStatus(agent, serverTaskId),
+      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval),
     };
 
     return {
@@ -1125,12 +1131,12 @@ export class TaskExecutor {
     }
   }
 
-  async getTaskStatus(agent: AgentConfig, taskId: string): Promise<TaskInfo> {
+  async getTaskStatus(agent: AgentConfig, serverTaskId: string): Promise<TaskInfo> {
     // Use MCP Tasks protocol method when available
     if (agent.protocol === 'mcp') {
       const authToken = getAuthToken(agent);
       try {
-        return await getMCPTaskStatus(agent.agent_uri, taskId, authToken);
+        return await getMCPTaskStatus(agent.agent_uri, serverTaskId, authToken);
       } catch (err) {
         if (is401Error(err)) throw err;
         // Fall through to tool call if protocol method is not supported
@@ -1139,7 +1145,7 @@ export class TaskExecutor {
     const response = (await ProtocolClient.callTool(
       agent,
       'tasks/get',
-      { taskId },
+      { taskId: serverTaskId },
       [],
       undefined,
       undefined,
@@ -1149,9 +1155,9 @@ export class TaskExecutor {
     return (response.task as TaskInfo) || (response as unknown as TaskInfo);
   }
 
-  async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000): Promise<TaskResult<T>> {
+  async pollTaskCompletion<T>(agent: AgentConfig, serverTaskId: string, pollInterval = 60000): Promise<TaskResult<T>> {
     while (true) {
-      const status = await this.getTaskStatus(agent, taskId);
+      const status = await this.getTaskStatus(agent, serverTaskId);
 
       if (status.status === ADCP_STATUS.COMPLETED) {
         const pollSuccess = this.isOperationSuccess(status.result);
@@ -1162,7 +1168,7 @@ export class TaskExecutor {
             status: 'completed' as const,
             data: status.result,
             metadata: this.buildMetadata({
-              taskId,
+              taskId: serverTaskId,
               taskName: status.taskType,
               agent,
               responseTimeMs: Date.now() - status.createdAt,
@@ -1178,10 +1184,10 @@ export class TaskExecutor {
           data: status.result,
           error: this.extractOperationError(status.result),
           adcpError: asyncResultErr,
-          errorInstance: this.buildErrorInstance(taskId, asyncResultErr),
+          errorInstance: this.buildErrorInstance(serverTaskId, asyncResultErr),
           correlationId: extractCorrelationId(status.result),
           metadata: this.buildMetadata({
-            taskId,
+            taskId: serverTaskId,
             taskName: status.taskType,
             agent,
             responseTimeMs: Date.now() - status.createdAt,
@@ -1199,10 +1205,10 @@ export class TaskExecutor {
           data: status.result,
           error: status.error || `Task ${status.status}`,
           adcpError: asyncFailedErr,
-          errorInstance: this.buildErrorInstance(taskId, asyncFailedErr),
+          errorInstance: this.buildErrorInstance(serverTaskId, asyncFailedErr),
           correlationId: extractCorrelationId(status.result),
           metadata: this.buildMetadata({
-            taskId,
+            taskId: serverTaskId,
             taskName: status.taskType,
             agent,
             responseTimeMs: Date.now() - status.createdAt,

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -915,14 +915,26 @@ export class TaskExecutor {
     // Use the server-assigned task ID for polling. The local `taskId` is an
     // SDK-internal UUID the server has never seen — passing it to tasks/get
     // returns NOT_FOUND on any spec-conformant seller (#966).
-    const serverTaskId = this.responseParser.getTaskId(response) ?? taskId;
+    const extractedTaskId = this.responseParser.getTaskId(response);
+    if (!extractedTaskId) {
+      console.warn(
+        '[adcp-client] submitted response did not include a server-assigned task ID ' +
+          '(task_id / Task.id). Polling will use the SDK-internal operation ID, which ' +
+          'the seller has never seen and may return NOT_FOUND. Ensure the seller ' +
+          'includes task_id in its submitted response.'
+      );
+    }
+    const serverTaskId = extractedTaskId ?? taskId;
 
     const submitted: SubmittedContinuation<T> = {
       taskId: serverTaskId,
       operationId: taskId,
       webhookUrl,
       track: () => this.getTaskStatus(agent, serverTaskId),
-      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval),
+      // Pass `taskId` (local UUID) as `operationId` so `buildMetadata` inside the
+      // polling loop can look up idempotency keys from the `activeTasks` map.
+      waitForCompletion: (pollInterval = 60000) =>
+        this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval, taskId),
     };
 
     return {
@@ -1155,7 +1167,17 @@ export class TaskExecutor {
     return (response.task as TaskInfo) || (response as unknown as TaskInfo);
   }
 
-  async pollTaskCompletion<T>(agent: AgentConfig, serverTaskId: string, pollInterval = 60000): Promise<TaskResult<T>> {
+  async pollTaskCompletion<T>(
+    agent: AgentConfig,
+    serverTaskId: string,
+    pollInterval = 60000,
+    operationId?: string
+  ): Promise<TaskResult<T>> {
+    // `operationId` is the SDK-internal local UUID used as the `activeTasks` map
+    // key for idempotency-key lookup. When absent (external callers of the public
+    // method), falls back to `serverTaskId` which won't match the map, so
+    // idempotency_key will simply be absent from the metadata — acceptable.
+    const metaTaskId = operationId ?? serverTaskId;
     while (true) {
       const status = await this.getTaskStatus(agent, serverTaskId);
 
@@ -1168,7 +1190,7 @@ export class TaskExecutor {
             status: 'completed' as const,
             data: status.result,
             metadata: this.buildMetadata({
-              taskId: serverTaskId,
+              taskId: metaTaskId,
               taskName: status.taskType,
               agent,
               responseTimeMs: Date.now() - status.createdAt,
@@ -1184,10 +1206,10 @@ export class TaskExecutor {
           data: status.result,
           error: this.extractOperationError(status.result),
           adcpError: asyncResultErr,
-          errorInstance: this.buildErrorInstance(serverTaskId, asyncResultErr),
+          errorInstance: this.buildErrorInstance(metaTaskId, asyncResultErr),
           correlationId: extractCorrelationId(status.result),
           metadata: this.buildMetadata({
-            taskId: serverTaskId,
+            taskId: metaTaskId,
             taskName: status.taskType,
             agent,
             responseTimeMs: Date.now() - status.createdAt,
@@ -1205,10 +1227,10 @@ export class TaskExecutor {
           data: status.result,
           error: status.error || `Task ${status.status}`,
           adcpError: asyncFailedErr,
-          errorInstance: this.buildErrorInstance(serverTaskId, asyncFailedErr),
+          errorInstance: this.buildErrorInstance(metaTaskId, asyncFailedErr),
           correlationId: extractCorrelationId(status.result),
           metadata: this.buildMetadata({
-            taskId: serverTaskId,
+            taskId: metaTaskId,
             taskName: status.taskType,
             agent,
             responseTimeMs: Date.now() - status.createdAt,

--- a/test/lib/task-executor-mocking-strategy.test.js
+++ b/test/lib/task-executor-mocking-strategy.test.js
@@ -326,6 +326,54 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
   });
 
   describe('Timing and Polling Mocking', () => {
+    test('pollTaskCompletion uses server-assigned task ID, not the local UUID (#966)', async () => {
+      // Regression guard: the initial submitted response carries a server-assigned
+      // task_id. The SDK must poll tasks/get with that ID, not the local UUID it
+      // minted internally. A conformant seller returns NOT_FOUND for an unknown ID.
+      const SERVER_TASK_ID = 'server-task-abc-123';
+      const polledIds = [];
+
+      ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
+        if (taskName === 'tasks/get') {
+          polledIds.push(params.taskId);
+          return {
+            task: {
+              status: 'completed',
+              result: { done: true },
+              taskType: 'pollIdTask',
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        // Initial submission response carries the server-assigned task ID.
+        return { status: 'submitted', task_id: SERVER_TASK_ID };
+      });
+
+      const executor = new TaskExecutor({ workingTimeout: 10000 });
+      const result = await executor.executeTask(mockAgent, 'pollIdTask', {});
+
+      assert.strictEqual(result.status, 'submitted');
+      assert(result.submitted, 'Expected submitted continuation');
+      // The buyer-facing taskId must be the server-assigned ID.
+      assert.strictEqual(
+        result.submitted.taskId,
+        SERVER_TASK_ID,
+        'submitted.taskId must be server-assigned, not local UUID'
+      );
+
+      await result.submitted.waitForCompletion(0);
+
+      assert(polledIds.length > 0, 'Expected at least one tasks/get call');
+      for (const polled of polledIds) {
+        assert.strictEqual(
+          polled,
+          SERVER_TASK_ID,
+          `tasks/get was called with local UUID instead of server task ID: ${polled}`
+        );
+      }
+    });
+
     test('should control polling intervals with submitted task polling', async () => {
       // Since working status is returned immediately (no polling), this test uses
       // the submitted pattern where polling happens via waitForCompletion.

--- a/test/lib/task-executor-mocking-strategy.test.js
+++ b/test/lib/task-executor-mocking-strategy.test.js
@@ -326,54 +326,6 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
   });
 
   describe('Timing and Polling Mocking', () => {
-    test('pollTaskCompletion uses server-assigned task ID, not the local UUID (#966)', async () => {
-      // Regression guard: the initial submitted response carries a server-assigned
-      // task_id. The SDK must poll tasks/get with that ID, not the local UUID it
-      // minted internally. A conformant seller returns NOT_FOUND for an unknown ID.
-      const SERVER_TASK_ID = 'server-task-abc-123';
-      const polledIds = [];
-
-      ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
-        if (taskName === 'tasks/get') {
-          polledIds.push(params.taskId);
-          return {
-            task: {
-              status: 'completed',
-              result: { done: true },
-              taskType: 'pollIdTask',
-              createdAt: Date.now(),
-              updatedAt: Date.now(),
-            },
-          };
-        }
-        // Initial submission response carries the server-assigned task ID.
-        return { status: 'submitted', task_id: SERVER_TASK_ID };
-      });
-
-      const executor = new TaskExecutor({ workingTimeout: 10000 });
-      const result = await executor.executeTask(mockAgent, 'pollIdTask', {});
-
-      assert.strictEqual(result.status, 'submitted');
-      assert(result.submitted, 'Expected submitted continuation');
-      // The buyer-facing taskId must be the server-assigned ID.
-      assert.strictEqual(
-        result.submitted.taskId,
-        SERVER_TASK_ID,
-        'submitted.taskId must be server-assigned, not local UUID'
-      );
-
-      await result.submitted.waitForCompletion(0);
-
-      assert(polledIds.length > 0, 'Expected at least one tasks/get call');
-      for (const polled of polledIds) {
-        assert.strictEqual(
-          polled,
-          SERVER_TASK_ID,
-          `tasks/get was called with local UUID instead of server task ID: ${polled}`
-        );
-      }
-    });
-
     test('should control polling intervals with submitted task polling', async () => {
       // Since working status is returned immediately (no polling), this test uses
       // the submitted pattern where polling happens via waitForCompletion.

--- a/test/lib/task-executor-poll-server-id.test.js
+++ b/test/lib/task-executor-poll-server-id.test.js
@@ -1,0 +1,135 @@
+// Regression guard for #966: pollTaskCompletion must use the server-assigned
+// task ID, not the SDK-internal local UUID.
+// Runs in CI (no skip guard) because this is a correctness regression, not a
+// slow timing test.
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('TaskExecutor — server task ID plumbing (#966)', () => {
+  let TaskExecutor;
+  let ProtocolClient;
+  let originalCallTool;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../../dist/lib/index.js')];
+    const lib = require('../../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    ProtocolClient = lib.ProtocolClient;
+    originalCallTool = ProtocolClient.callTool;
+
+    mockAgent = {
+      id: 'mock-agent',
+      name: 'Mock Agent',
+      agent_uri: 'https://mock.test.com',
+      protocol: 'mcp',
+    };
+  });
+
+  afterEach(() => {
+    if (originalCallTool) {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('submitted.taskId carries the server-assigned ID, not the local UUID', async () => {
+    const SERVER_TASK_ID = 'server-task-abc-123';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, _params) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task: {
+            status: 'completed',
+            result: { done: true },
+            taskType: 'pollIdTask',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ workingTimeout: 10000 });
+    const result = await executor.executeTask(mockAgent, 'pollIdTask', {});
+
+    assert.strictEqual(result.status, 'submitted');
+    assert(result.submitted, 'Expected submitted continuation');
+    assert.strictEqual(
+      result.submitted.taskId,
+      SERVER_TASK_ID,
+      'submitted.taskId must be server-assigned, not the local UUID'
+    );
+    // operationId is the local UUID — must differ from the server-assigned ID
+    assert.notStrictEqual(
+      result.submitted.operationId,
+      SERVER_TASK_ID,
+      'submitted.operationId should be the SDK-internal local UUID, not the server ID'
+    );
+  });
+
+  test('tasks/get is called with the server-assigned ID, not the local UUID', async () => {
+    const SERVER_TASK_ID = 'server-task-xyz-789';
+    const polledIds = [];
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        polledIds.push(params.taskId);
+        return {
+          task: {
+            status: 'completed',
+            result: { done: true },
+            taskType: 'pollIdTask',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+          },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ workingTimeout: 10000 });
+    const result = await executor.executeTask(mockAgent, 'pollIdTask', {});
+    assert.strictEqual(result.status, 'submitted');
+
+    await result.submitted.waitForCompletion(0);
+
+    assert(polledIds.length > 0, 'Expected at least one tasks/get call');
+    for (const polled of polledIds) {
+      assert.strictEqual(
+        polled,
+        SERVER_TASK_ID,
+        `tasks/get called with wrong ID "${polled}" — expected server-assigned "${SERVER_TASK_ID}"`
+      );
+    }
+  });
+
+  test('falls back to local UUID when server omits task_id (emits console.warn)', async () => {
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(' '));
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, _params) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task: { status: 'completed', result: {}, taskType: 't', createdAt: Date.now(), updatedAt: Date.now() },
+        };
+      }
+      // No task_id in submitted response
+      return { status: 'submitted' };
+    });
+
+    try {
+      const executor = new TaskExecutor({ workingTimeout: 10000 });
+      const result = await executor.executeTask(mockAgent, 'noIdTask', {});
+      assert.strictEqual(result.status, 'submitted');
+      // A warning must have been emitted about the missing server task ID
+      assert(
+        warnings.some(w => w.includes('server-assigned task ID') || w.includes('task_id')),
+        `Expected a warning about missing task_id, got: ${JSON.stringify(warnings)}`
+      );
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+});


### PR DESCRIPTION
Refs #966

## Summary

`TaskExecutor.setupSubmittedTask` was populating `SubmittedContinuation.taskId` — and the `track()`/`waitForCompletion()` polling closures — with the SDK-internal local UUID minted by `randomUUID()`. The server has never seen this ID. Every `submitted.track()` or `submitted.waitForCompletion()` call against a spec-conformant seller returned NOT_FOUND.

The fix is three lines: extract the server-assigned task ID from the initial response via `responseParser.getTaskId()` and use it everywhere the seller needs to identify the task. Falls back to the local UUID for backward compat with non-conformant sellers, with a `console.warn` so developers can identify the gap.

### What changed

- **`TaskExecutor.setupSubmittedTask`** — calls `responseParser.getTaskId(response)` to get the server-assigned task ID; passes it to `SubmittedContinuation.taskId` and the polling closures. Emits `console.warn` when the submitted response carries no task ID.
- **`SubmittedContinuation`** (additive, non-breaking) — new `operationId: string` field exposes the SDK-internal local UUID so buyers have both handles in one place. `taskId` JSDoc updated to make clear it is the server-assigned ID.
- **`pollTaskCompletion`** — optional `operationId?: string` parameter added; used as the `activeTasks` map key in `buildMetadata`/`buildErrorInstance` so idempotency-key lookup continues to work on polled completions.
- **`getTaskStatus` / `pollTaskCompletion`** — parameter renamed `taskId → serverTaskId` for call-site clarity (non-breaking: TS positional params).
- **New test file `test/lib/task-executor-poll-server-id.test.js`** — three tests, no CI skip: asserts `submitted.taskId` is the server-assigned ID, asserts `tasks/get` is called with the server ID, asserts the console.warn fires when the seller omits `task_id`.

### Out of scope (explicitly deferred)

`TaskState.taskId → operationId` rename: `TaskState` is publicly exported (`src/lib/index.ts:131`), so this is a breaking API change requiring a separate major-bump PR. The issue proposes it; this PR skips it and documents why.

## What was tested

- TypeScript: no new errors (`tsc --noEmit`, filtered for pre-existing `node` typedefs environment issue)
- Prettier: clean
- Regression tests in new `test/lib/task-executor-poll-server-id.test.js` verified to detect the bug against the pre-fix dist (all three fail on old dist, confirming the guards work)
- Pre-existing test failure count unchanged (44 failures before/after in `test/*.test.js`, all pre-existing environment issues)

## Pre-PR review

**Round 1 (plan review):**
- code-reviewer: approved non-breaking subset; flagged `TaskState` rename as breaking (deferred per spec)
- dx-expert: confirmed `operationId` companion field improves buyer discoverability without breaking `taskId`

**Round 2 (diff review):**
- code-reviewer: two blockers fixed — `buildMetadata` idempotency-key lookup (now passes `operationId ?? serverTaskId` as `metaTaskId`); regression test moved to non-skipped CI file
- ad-tech-protocol-expert: one blocker fixed — silent fallback now emits `console.warn`; confirmed `getTaskId()` fallback chain covers both A2A and AdCP-shim paths; `tasks/get` polling mechanism is correct for both transports; `operationId` field naming is consistent with existing `{operation_id}` webhook URL macro convention

Nits surfaced (not fixed in this PR, tracked separately):
- MCP Tasks `pollTaskCompletion` returns `data: undefined` on completion because `mapMCPTaskToTaskInfo` doesn't call `getTaskResult()` — pre-existing, separate issue
- `webhookManager.registerWebhook` is passed the local UUID; webhook reconciliation by task ID remains unaddressed — pre-existing

Session: https://claude.ai/code/session_01ThENaCC4Y1KHCio2BStUD6

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThENaCC4Y1KHCio2BStUD6)_