### PR TITLE
fix(core): AdCP tasks/get polling — spec-conformant request + response (#967)

### DIFF
--- a/.changeset/adcp-tasks-get-hardening.md
+++ b/.changeset/adcp-tasks-get-hardening.md
@@ -1,0 +1,71 @@
+---
+'@adcp/client': patch
+---
+
+Fix `TaskExecutor.getTaskStatus` to dispatch the AdCP `tasks/get` tool
+spec-conformantly. Closes #967.
+
+**Pre-fix bugs**:
+
+1. **Wrong request param**: SDK passed `{ taskId }` (camelCase). AdCP
+   3.0 schema (`schemas/cache/3.0.0/bundled/core/tasks-get-request.json`)
+   requires `{ task_id }` (snake_case). Conformant sellers reject as
+   INVALID_PARAMS.
+2. **Wrong response shape mapping**: SDK read `(response.task as TaskInfo)` —
+   expects a non-spec nested wrapper with camelCase fields. AdCP-spec
+   responses are flat snake_case (`{ task_id, task_type, status,
+created_at, updated_at, ... }`); real spec-conformant responses
+   produced `taskId: undefined` everywhere on the polled `TaskInfo`.
+3. **Wrong primary path**: SDK tried MCP `experimental.tasks.getTask`
+   first for MCP agents and fell through to the AdCP tool on
+   capability-missing. The MCP-experimental path tracks
+   transport-call lifecycle (the MCP analog of A2A `Task.state`),
+   not AdCP work lifecycle. For polling submitted-arm tasks (which
+   is what `pollTaskCompletion` does) we need work status; the two
+   interfaces are not substitutes (per protocol-expert review on
+   #966/#967).
+
+**Fix**:
+
+- Drop the MCP-experimental.tasks first attempt. Always dispatch the
+  AdCP `tasks/get` tool over the agent's transport.
+- Pass the request param as `task_id` (snake_case).
+- Map the response via a new `mapTasksGetResponseToTaskInfo` helper
+  that walks the transport-level wrappers (MCP `structuredContent`,
+  A2A `result.artifacts[0].parts[0].data`, legacy `{ task: ... }`
+  nested wrapper) and the AdCP-spec flat shape, then projects to the
+  internal `TaskInfo`.
+- Bypass `extractResponseData` for `tasks/get` — the generic
+  AdCP-error-arm detection misinterprets the spec's informational
+  `error: { code, message }` block as an error envelope and shreds
+  the response into `{ errors: [...] }`. The new helper handles
+  unwrapping directly.
+- Pass through `result` / `task_data` from `additionalProperties: true`
+  so completion data round-trips when sellers add it. (Note: AdCP
+  3.0 doesn't define a typed completion-payload field on `tasks/get`;
+  see adcp#3123 for the upstream clarification issue. Forward-compat
+  with all three possible spec resolutions.)
+
+**Behavior change**: MCP sellers that supported `experimental.tasks`
+but did NOT register an AdCP `tasks/get` tool will now see polling
+fail rather than silently use the wrong-lifecycle interface. This is
+deliberate — the previous behavior was incorrect (returned transport
+status, not work status). Sellers should register `tasks/get` as an
+AdCP tool to support buyer-side polling.
+
+Adds `test/server-tasks-get-spec-shape.test.js` with six regression
+tests:
+
+- Request param naming (snake_case `task_id`, no camelCase `taskId`)
+- AdCP-spec flat response mapping (incl. ISO 8601 timestamps)
+- Result-data passthrough via additionalProperties
+- Error-block mapping (failed status with `error: { code, message }`)
+- Legacy `{ task: ... }` nested-shape backward compat
+- No MCP-experimental.tasks first attempt
+
+Companion of #966 (server-task-id plumbing). With both PRs landed,
+MCP submitted-arm polling works end-to-end against spec-conformant
+sellers. A2A submitted-arm polling still has additional bugs at the
+parser layer (`getStatus` reads transport state, `getTaskId` extracts
+A2A Task.id instead of `artifact.metadata.adcp_task_id`); tracked in
+adcp-client#973.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -4,7 +4,7 @@
 import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
 import { ProtocolClient } from '../protocols';
-import { getMCPTaskStatus, listMCPTasks } from '../protocols/mcp-tasks';
+import { listMCPTasks } from '../protocols/mcp-tasks';
 import { getAuthToken } from '../auth';
 import { is401Error, adcpErrorToTypedError } from '../errors';
 import type { ADCPError } from '../errors';
@@ -70,6 +70,114 @@ export class InputRequiredError extends Error {
     super(`Server requires input but no handler provided. Question: ${question}`);
     this.name = 'InputRequiredError';
   }
+}
+
+/**
+ * Map an AdCP `tasks/get` response (post-unwrap) to the SDK's internal
+ * `TaskInfo` shape. The AdCP 3.0 schema
+ * (`schemas/cache/3.0.0/bundled/core/tasks-get-response.json`) is flat
+ * snake_case: `{ task_id, task_type, protocol, status, created_at,
+ * updated_at, error?, progress?, history?, completed_at?, has_webhook?,
+ * context?, ext? }`. The internal `TaskInfo` is camelCase with a
+ * superset of legacy fields some pre-3.0 sellers still emit.
+ *
+ * **Result-data passthrough.** AdCP `tasks/get` doesn't define a
+ * completion-payload field — the spec leaves the result-extraction
+ * layer ambiguous (see adcp#3123 for the upstream clarification
+ * issue). Sellers MAY surface the completed task's data via
+ * `additionalProperties: true` (`result` or `task_data` are the de
+ * facto names). We pass it through so `pollTaskCompletion` can
+ * surface it on the resolved `TaskResult.data`. When the spec
+ * clarifies, this mapping refines.
+ *
+ * **Legacy nested shape.** Some pre-3.0 sellers and existing test
+ * mocks emit `{ task: { ...TaskInfo } }` — a non-spec wrapper. We
+ * unwrap it before the spec-shape mapping so the SDK stays
+ * compatible with both surfaces during the transition.
+ */
+function mapTasksGetResponseToTaskInfo(payload: unknown): TaskInfo {
+  if (payload == null || typeof payload !== 'object') {
+    return { taskId: '', status: 'unknown', taskType: 'unknown', createdAt: Date.now(), updatedAt: Date.now() };
+  }
+  const obj = payload as Record<string, unknown>;
+  // Walk the transport-level wrappers in priority order:
+  //   1. MCP `structuredContent` — the typed AdCP payload from `tools/call`
+  //   2. A2A `result.artifacts[0].parts[0].data` — the AdCP payload
+  //      surfaced via the artifact (per #899)
+  //   3. Legacy nested `{ task: TaskInfo }` — pre-3.0 sellers and
+  //      existing test mocks
+  //   4. Flat AdCP-spec shape — what AdCP 3.0 sellers emit directly
+  const flat = unwrapTasksGetEnvelope(obj);
+  const errorRaw = flat.error;
+  const errorMessage =
+    typeof errorRaw === 'string'
+      ? errorRaw
+      : errorRaw != null &&
+          typeof errorRaw === 'object' &&
+          typeof (errorRaw as { message?: unknown }).message === 'string'
+        ? (errorRaw as { message: string }).message
+        : undefined;
+  const taskInfo: TaskInfo = {
+    taskId: stringField(flat.task_id) ?? stringField(flat.taskId) ?? '',
+    status: stringField(flat.status) ?? 'unknown',
+    taskType: stringField(flat.task_type) ?? stringField(flat.taskType) ?? 'unknown',
+    createdAt: parseTimestamp(flat.created_at ?? flat.createdAt),
+    updatedAt: parseTimestamp(flat.updated_at ?? flat.updatedAt),
+  };
+  if (errorMessage !== undefined) taskInfo.error = errorMessage;
+  // Result passthrough — see JSDoc on result-data ambiguity.
+  const result = flat.result ?? flat.task_data;
+  if (result !== undefined) taskInfo.result = result;
+  return taskInfo;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function unwrapTasksGetEnvelope(obj: Record<string, unknown>): Record<string, unknown> {
+  // MCP: `tools/call` response carries the typed payload at
+  // `structuredContent`.
+  const sc = obj.structuredContent;
+  if (sc != null && typeof sc === 'object' && !Array.isArray(sc)) {
+    return unwrapTasksGetEnvelope(sc as Record<string, unknown>);
+  }
+  // A2A: `message/send` response is a JSON-RPC envelope wrapping a
+  // Task; the AdCP payload sits on the first artifact's first
+  // DataPart.
+  const result = obj.result;
+  if (result != null && typeof result === 'object' && !Array.isArray(result)) {
+    const r = result as Record<string, unknown>;
+    if (r.kind === 'task' && Array.isArray(r.artifacts) && r.artifacts.length > 0) {
+      const artifact = r.artifacts[0] as Record<string, unknown> | null;
+      if (
+        artifact != null &&
+        typeof artifact === 'object' &&
+        Array.isArray(artifact.parts) &&
+        artifact.parts.length > 0
+      ) {
+        const firstPart = artifact.parts[0] as Record<string, unknown> | null;
+        if (firstPart?.kind === 'data' && firstPart.data != null && typeof firstPart.data === 'object') {
+          return unwrapTasksGetEnvelope(firstPart.data as Record<string, unknown>);
+        }
+      }
+    }
+  }
+  // Legacy nested wrapper from pre-3.0 sellers and existing mocks.
+  if (obj.task != null && typeof obj.task === 'object' && !Array.isArray(obj.task)) {
+    return obj.task as Record<string, unknown>;
+  }
+  // Flat AdCP-spec shape — return as-is.
+  return obj;
+}
+
+function parseTimestamp(value: unknown): number {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return Date.now();
 }
 
 /**
@@ -1158,27 +1266,45 @@ export class TaskExecutor {
   }
 
   async getTaskStatus(agent: AgentConfig, taskId: string): Promise<TaskInfo> {
-    // Use MCP Tasks protocol method when available
-    if (agent.protocol === 'mcp') {
-      const authToken = getAuthToken(agent);
-      try {
-        return await getMCPTaskStatus(agent.agent_uri, taskId, authToken);
-      } catch (err) {
-        if (is401Error(err)) throw err;
-        // Fall through to tool call if protocol method is not supported
-      }
-    }
+    // AdCP `tasks/get` is the cross-protocol work-status interface
+    // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
+    // Dispatched as a buyer-callable tool over the agent's transport
+    // — `ProtocolClient.callTool` selects MCP `tools/call` or A2A
+    // `message/send` per `agent.protocol`.
+    //
+    // The previous implementation tried MCP's `experimental.tasks.getTask`
+    // first for MCP agents and fell through to the AdCP tool path on
+    // capability-missing. The native MCP path tracks the TRANSPORT-call
+    // lifecycle (MCP analog of A2A `Task.state`) — not AdCP work
+    // lifecycle. For submitted-arm polling we need work status; the
+    // two interfaces are not substitutes, so we always use the AdCP
+    // tool here. MCP sellers that haven't registered `tasks/get` as
+    // an AdCP tool will surface a tool-not-found error rather than
+    // silently polling the wrong lifecycle.
+    //
+    // The request param is `task_id` (snake_case per AdCP 3.0); the
+    // response is the spec's flat shape, mapped to `TaskInfo` via
+    // {@link mapTasksGetResponseToTaskInfo}.
     const response = (await ProtocolClient.callTool(
       agent,
       'tasks/get',
-      { taskId },
+      { task_id: taskId },
       [],
       undefined,
       undefined,
       undefined,
       this.lastKnownServerVersion
     )) as Record<string, unknown>;
-    return (response.task as TaskInfo) || (response as unknown as TaskInfo);
+    // We don't run `extractResponseData` here: that helper's
+    // generic AdCP-error-arm detection treats any top-level
+    // `error: { code, message }` as an error envelope and shreds the
+    // response into `{ errors: [...] }`. For `tasks/get` the `error`
+    // block is informational (the failed task's reason, not a
+    // request rejection), so we map the raw response directly. The
+    // mapper handles the AdCP-spec flat shape, the legacy
+    // `{ task: ... }` nested wrapper, and MCP `structuredContent` /
+    // A2A `result.artifacts[0].parts[0].data` envelopes.
+    return mapTasksGetResponseToTaskInfo(response);
   }
 
   async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000): Promise<TaskResult<T>> {

--- a/test/server-tasks-get-spec-shape.test.js
+++ b/test/server-tasks-get-spec-shape.test.js
@@ -1,0 +1,231 @@
+// Regression test for adcp-client#967.
+//
+// Anchors the contract that `getTaskStatus` dispatches the AdCP
+// `tasks/get` tool with snake_case `task_id` per AdCP 3.0
+// (`schemas/cache/3.0.0/bundled/core/tasks-get-request.json`) and
+// maps the spec's flat snake_case response shape
+// (`schemas/cache/3.0.0/bundled/core/tasks-get-response.json`) to
+// the SDK's internal `TaskInfo`.
+//
+// Pre-fix bugs (caught by these tests):
+//   1. SDK passed `{ taskId }` (camelCase) — spec violation; conformant
+//      sellers reject as INVALID_PARAMS.
+//   2. SDK read `(response.task as TaskInfo)` — expects either a
+//      legacy nested wrapper or camelCase fields directly. Spec
+//      response is flat snake_case; real responses got
+//      `taskId: undefined` everywhere.
+//   3. SDK tried MCP `experimental.tasks.getTask` first for MCP
+//      agents — that's transport-call lifecycle, not AdCP work
+//      lifecycle. For polling submitted-arm tasks (which is what
+//      `pollTaskCompletion` does) we need work status; the two
+//      interfaces are not substitutes.
+
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
+  let TaskExecutor;
+  let ProtocolClient;
+  let originalCallTool;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../dist/lib/index.js')];
+    const lib = require('../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    ProtocolClient = lib.ProtocolClient;
+    originalCallTool = ProtocolClient.callTool;
+    mockAgent = {
+      id: 'mock-agent',
+      name: 'Mock Agent',
+      agent_uri: 'https://mock.test.com',
+      protocol: 'mcp',
+    };
+  });
+
+  afterEach(() => {
+    if (originalCallTool) ProtocolClient.callTool = originalCallTool;
+  });
+
+  test('dispatches tasks/get with snake_case task_id (not camelCase taskId)', async () => {
+    const SERVER_TASK_ID = 'tk_snake_case_test';
+    let observedParams;
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
+      if (taskName === 'tasks/get') {
+        observedParams = params;
+        // AdCP 3.0 spec response (flat snake_case)
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'pollSnakeCaseTest', {});
+    await result.submitted.waitForCompletion(5);
+
+    assert.ok(observedParams, 'tasks/get was dispatched');
+    assert.strictEqual(observedParams.task_id, SERVER_TASK_ID, 'request must use snake_case task_id per AdCP 3.0 spec');
+    assert.strictEqual(observedParams.taskId, undefined, 'request must NOT include legacy camelCase taskId');
+  });
+
+  test('maps the AdCP-spec flat response shape correctly', async () => {
+    const SERVER_TASK_ID = 'tk_flat_shape_test';
+    const CREATED = '2026-04-25T10:00:00Z';
+    const UPDATED = '2026-04-25T10:05:30Z';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: CREATED,
+          updated_at: UPDATED,
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'flatShapeTest', {});
+    const status = await result.submitted.track();
+    assert.strictEqual(status.taskId, SERVER_TASK_ID);
+    assert.strictEqual(status.status, 'completed');
+    assert.strictEqual(status.taskType, 'create_media_buy');
+    assert.strictEqual(status.createdAt, Date.parse(CREATED));
+    assert.strictEqual(status.updatedAt, Date.parse(UPDATED));
+  });
+
+  test('passes through `result` field if seller adds it via additionalProperties', async () => {
+    // AdCP 3.0 tasks/get response schema doesn't define a `result`
+    // field for the completed task's payload (see adcp#3123). Sellers
+    // MAY surface it via additionalProperties: true. The SDK passes
+    // it through so `pollTaskCompletion` can return it as the
+    // resolved task data.
+    const SERVER_TASK_ID = 'tk_result_passthrough';
+    const COMPLETION_DATA = { media_buy_id: 'mb_42', packages: [] };
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+          result: COMPLETION_DATA, // additionalProperties passthrough
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'resultPassthroughTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, true);
+    assert.deepStrictEqual(completion.data, COMPLETION_DATA);
+  });
+
+  test('maps spec-shape error block to TaskInfo.error', async () => {
+    const SERVER_TASK_ID = 'tk_error_mapping';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: SERVER_TASK_ID,
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'failed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+          error: { code: 'IO_REVIEW_FAILED', message: 'Sales rejected the IO terms' },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'errorMappingTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, false);
+    assert.strictEqual(completion.status, 'failed');
+  });
+
+  test('continues to handle the legacy { task: {...} } nested shape for backward compat', async () => {
+    // Some pre-3.0 sellers and existing test fixtures emit a non-spec
+    // wrapper. Until those migrate, we keep handling both shapes so
+    // we don't break ecosystem on the day this PR lands.
+    const SERVER_TASK_ID = 'tk_legacy_shape';
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      if (taskName === 'tasks/get') {
+        // Legacy nested wrapper with camelCase TaskInfo fields
+        return {
+          task: {
+            taskId: SERVER_TASK_ID,
+            status: 'completed',
+            taskType: 'create_media_buy',
+            createdAt: 1714000000000,
+            updatedAt: 1714000300000,
+            result: { ok: true },
+          },
+        };
+      }
+      return { status: 'submitted', task_id: SERVER_TASK_ID };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'legacyShapeTest', {});
+    const completion = await result.submitted.waitForCompletion(5);
+    assert.strictEqual(completion.success, true);
+    assert.deepStrictEqual(completion.data, { ok: true });
+  });
+
+  test('does NOT try MCP experimental.tasks.getTask before the AdCP tool', async () => {
+    // The previous implementation tried `getMCPTaskStatus` first and
+    // fell through to the AdCP tool on capability-missing. The two
+    // interfaces track different lifecycles (MCP-experimental =
+    // transport, AdCP tasks/get = work). For submitted-arm polling
+    // we always want work status — pin it.
+    let callCount = 0;
+    let observedToolNames = [];
+
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+      callCount++;
+      observedToolNames.push(taskName);
+      if (taskName === 'tasks/get') {
+        return {
+          task_id: 'tk_no_experimental',
+          task_type: 'create_media_buy',
+          protocol: 'media-buy',
+          status: 'completed',
+          created_at: '2026-04-25T10:00:00Z',
+          updated_at: '2026-04-25T10:05:00Z',
+        };
+      }
+      return { status: 'submitted', task_id: 'tk_no_experimental' };
+    });
+
+    const executor = new TaskExecutor({ pollingInterval: 5 });
+    const result = await executor.executeTask(mockAgent, 'noExperimentalTest', {});
+    await result.submitted.waitForCompletion(5);
+
+    // Two callTool invocations expected: the initial task + one tasks/get poll
+    const tasksGetCalls = observedToolNames.filter(name => name === 'tasks/get');
+    assert.ok(tasksGetCalls.length >= 1, 'tasks/get was called for polling');
+    // No experimental.tasks.getTask reached ProtocolClient.callTool —
+    // the experimental path bypasses callTool entirely (uses the SDK's
+    // experimental subsystem), so its absence here proves the new
+    // dispatch path skipped it.
+  });
+});


### PR DESCRIPTION
## Summary

Closes #967. **Stacked on #971** (#966 — server-task-id plumbing).

\`TaskExecutor.getTaskStatus\` had three spec-conformance bugs that prevented submitted-arm polling from working against any real AdCP 3.0 seller:

1. **Wrong request param**: SDK passed \`{ taskId }\` (camelCase). AdCP 3.0 requires \`{ task_id }\` (snake_case). Conformant sellers reject as INVALID_PARAMS.
2. **Wrong response shape**: SDK read \`(response.task as TaskInfo)\` — non-spec nested camelCase wrapper. AdCP-spec responses are flat snake_case; real responses produced \`taskId: undefined\` everywhere on the polled \`TaskInfo\`.
3. **Wrong primary path**: SDK tried MCP \`experimental.tasks.getTask\` first. That path tracks transport-call lifecycle (analog of A2A \`Task.state\`), not AdCP work lifecycle. For polling submitted-arm tasks we need work status — the two interfaces are not substitutes.

## Fix

- AdCP \`tasks/get\` tool becomes the only path. Dispatched over the agent's transport (\`tools/call\` for MCP, \`message/send\` for A2A).
- Request: \`{ task_id }\` (snake_case).
- New \`mapTasksGetResponseToTaskInfo\` helper walks transport wrappers (MCP \`structuredContent\`, A2A \`result.artifacts[0].parts[0].data\` per #899, legacy \`{ task: ... }\` for backward-compat) and projects the AdCP-spec flat shape onto the internal \`TaskInfo\`.
- Bypass \`extractResponseData\` for \`tasks/get\`: its generic AdCP-error-arm detection misinterprets the spec's informational \`error: { code, message }\` block as an error envelope and shreds the response. The new helper handles unwrapping directly.
- \`result\` / \`task_data\` round-trips via \`additionalProperties: true\` so completion data surfaces when sellers add it.

## Behavior change

MCP sellers that supported \`experimental.tasks\` but did NOT register an AdCP \`tasks/get\` tool will now see polling fail rather than silently use the wrong-lifecycle interface. This is deliberate — the previous behavior was incorrect.

## Spec ambiguity flagged upstream

AdCP 3.0 doesn't define a typed completion-payload field on \`tasks/get\`. Filed adcontextprotocol/adcp#3123 for clarification. Current implementation is forward-compatible with all three possible spec resolutions (webhook-only, additionalProperties passthrough, future typed field).

## Out of scope (tracked separately)

- A2A submitted-arm parser fixes (\`getStatus\` misclassifies, \`getTaskId\` extracts wrong handle): #973
- A2A end-to-end submitted-arm round-trip (depends on #973)

## Test plan

- [x] 6 new regression tests in \`test/server-tasks-get-spec-shape.test.js\` — all pass
- [x] 133/133 task-executor + A2A test sweep
- [x] 2378/2382 storyboard + uniform-error sweep (4 intentional skips)
- [x] \`tsc --noEmit\` clean
- [x] \`prettier --check\` clean
- [x] \`eslint\` 0 errors on changed files
- [ ] CI green

## Stacking note

This PR's base is \`bokelley/server-task-id-plumbing\` (#971), not \`main\`. Once #971 merges, this rebases to \`main\` and the diff narrows to just the dispatch + mapping changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)