### PR TITLE
feat(testing): a2a_context_continuity validator for multi-step storyboards (#962)

### DIFF
--- a/.changeset/a2a-context-continuity-validator.md
+++ b/.changeset/a2a-context-continuity-validator.md
@@ -1,0 +1,62 @@
+---
+'@adcp/client': minor
+---
+
+Storyboard runner: add the `a2a_context_continuity` validation check
+plus cross-step A2A envelope tracking. Closes #962.
+
+A2A 0.3.0 §7.1 binds follow-up `message/send` calls to a server-side
+conversation via `Message.contextId`; the server MUST echo it on the
+response Task. The `@a2a-js/sdk`'s `DefaultRequestHandler` does this
+automatically — `createA2AAdapter` (#899) passes through
+`requestContext.contextId`, so a passing seller built on the SDK
+won't trip a single-call check. The regression class is sellers that
+bypass the SDK's request handler and stamp their own `contextId` on
+the response, breaking buyer-side correlation across multi-turn flows
+(proposal refinement, IO signing, async approval). This kind of bug
+is only surface-able on **multi-step** storyboards where step N+1
+sends with the contextId returned by step N.
+
+The new check runs at step N+1 and compares
+`a2aEnvelope.result.contextId` against the most recent prior step's
+captured envelope. Skip semantics:
+
+- Non-A2A run (no envelope captured) → skip with `not_applicable`
+  observation
+- First A2A step in a run (no prior to compare) → skip
+- Either envelope has no extractable `contextId` → skip
+- JSON-RPC error envelope (transport rejection) → skip — continuity
+  is undefined when the call didn't reach the work layer
+- Skip cases tag the observation so triage can distinguish
+  "validator self-skipped" from "validator passed because contexts
+  matched"
+
+Failure cases:
+
+- Current step's response has no `contextId` (empty/missing) on a
+  non-first send → fail with a pointer to `/result/contextId`
+- Current step's response `contextId` differs from prior step's →
+  fail with both values surfaced and the prior step id named in
+  the diagnostic
+
+**Runner-side plumbing**: per-step A2A envelopes are now tracked in
+a long-lived `priorA2aEnvelopes` map on `ExecutionState`, populated
+after each capture. The validator reads the most recent insertion-
+order entry as the comparison baseline. Probe steps, MCP steps, and
+capture-bypass paths don't insert, so cross-step comparisons walk
+back to the most recent A2A step automatically.
+
+Suggested by the ad-tech-protocol-expert review on #952. Filed as
+#962, scoped as a separate validator since the failure mode and
+fix surface are distinct from `a2a_submitted_artifact`'s single-call
+wire-shape check.
+
+**Coverage**:
+
+- 10 unit tests against `validateA2AContextContinuity` (synthetic
+  envelopes covering match, divergence, missing contextId, every
+  skip path)
+- 2 integration tests against `runStoryboard` driving multi-step
+  storyboards: one against a conformant `createA2AAdapter` (passes),
+  one against a hand-rolled regressed adapter that stamps a fresh
+  contextId per send (fails)

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -536,6 +536,7 @@ async function executeStoryboardPass(
   const priorStepResults = new Map<string, StoryboardStepResult>();
   const priorProbes = new Map<string, HttpProbeResult>();
   const contextProvenance = new Map<string, ContextProvenanceEntry>();
+  const priorA2aEnvelopes = new Map<string, A2ATaskEnvelope>();
   const phaseResults: StoryboardPhaseResult[] = [];
   let passedCount = 0;
   let failedCount = 0;
@@ -814,6 +815,7 @@ async function executeStoryboardPass(
         webhookReceiver,
         runnerVars,
         contextProvenance,
+        priorA2aEnvelopes,
       });
       const result: StoryboardStepResult = { ...rawResult, storyboard_id: storyboard.id };
       if (isMultiInstance) {
@@ -1283,6 +1285,7 @@ export async function runStoryboardStep(
     webhookReceiver,
     runnerVars,
     contextProvenance,
+    priorA2aEnvelopes: new Map(),
   });
 
   if (!options._client) {
@@ -1314,6 +1317,19 @@ interface ExecutionState {
    * the shallow-merge semantics of the context itself.
    */
   contextProvenance?: Map<string, ContextProvenanceEntry>;
+  /**
+   * Per-step A2A envelopes captured during the run, keyed by step id.
+   * Cross-step A2A validators (`a2a_context_continuity`) read this to
+   * compare consecutive `Task.contextId` values. The map is mutated
+   * by `executeStep` after each step's capture; reads pick the most
+   * recently inserted entry to seed `priorA2aEnvelope` on the
+   * ValidationContext for the next step. Issue adcp-client#962.
+   *
+   * Map shared by reference across `executeStep` invocations — like
+   * `priorStepResults`, this is the state that has to live one level
+   * up from the per-step `ExecutionState` literal.
+   */
+  priorA2aEnvelopes?: Map<string, A2ATaskEnvelope>;
 }
 
 async function executeStep(
@@ -1669,11 +1685,39 @@ async function executeStep(
       ...(responseRecord && { response: responseRecord }),
       storyboardContext: context,
       ...(a2aEnvelope && { a2aEnvelope }),
+      ...(() => {
+        // Walk back through the run's captured A2A envelopes and use
+        // the most recent prior step's envelope as the comparison
+        // baseline. The map preserves insertion order, so the last
+        // entry is the most recent prior step's capture.
+        const map = runState.priorA2aEnvelopes;
+        if (!map || map.size === 0) return {};
+        let priorStepId: string | undefined;
+        let priorEnv: A2ATaskEnvelope | undefined;
+        for (const [stepId, env] of map) {
+          priorStepId = stepId;
+          priorEnv = env;
+        }
+        return {
+          ...(priorEnv && { priorA2aEnvelope: priorEnv }),
+          ...(priorStepId && { priorA2aStepId: priorStepId }),
+        };
+      })(),
     };
     validations = runValidations(resolvedValidations, vctx);
   }
 
   const allValidationsPassed = validations.every(v => v.passed);
+
+  // Persist the captured A2A envelope keyed by step id so cross-step
+  // validators (`a2a_context_continuity`) on subsequent steps can
+  // compare against it. Only fires when this step actually captured
+  // an envelope — probe steps, MCP steps, and capture-bypass paths
+  // don't insert, so cross-step comparisons walk back to the most
+  // recent A2A step automatically via insertion-order iteration.
+  if (a2aEnvelope && runState.priorA2aEnvelopes) {
+    runState.priorA2aEnvelopes.set(step.id, a2aEnvelope);
+  }
 
   // Extract context from responses. Forward the alias cache so
   // `$generate:uuid_v4#<alias>` placeholders in subsequent steps resolve

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -402,6 +402,7 @@ export type StoryboardValidationCheck =
   | 'any_of'
   // A2A wire-shape checks (transport-specific; skipped on non-A2A runs)
   | 'a2a_submitted_artifact'
+  | 'a2a_context_continuity'
   // Cross-step checks
   | 'refs_resolve';
 

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -64,6 +64,23 @@ export interface ValidationContext {
    * those checks self-skip with `not_applicable`.
    */
   a2aEnvelope?: A2ATaskEnvelope;
+  /**
+   * Most recent A2A envelope captured by a PRIOR step in the same run.
+   * Cross-step checks (`a2a_context_continuity`) read this to compare
+   * the current step's `Task.contextId` against the prior step's
+   * `Task.contextId` — A2A 0.3.0 mandates the server echo the
+   * client-supplied `contextId` on follow-up sends. Absent on the
+   * first A2A step in a run, on non-A2A runs, and when no prior step
+   * captured an envelope (e.g. all priors were probe steps).
+   */
+  priorA2aEnvelope?: A2ATaskEnvelope;
+  /**
+   * Step id of the prior step whose A2A envelope `priorA2aEnvelope`
+   * came from. Used by cross-step diagnostics to point operators at
+   * the exact prior step the continuity assertion is comparing
+   * against.
+   */
+  priorA2aStepId?: string;
 }
 
 /**
@@ -115,6 +132,8 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return validateAnyOf(validation, ctx.contributions);
     case 'a2a_submitted_artifact':
       return validateA2ASubmittedArtifact(validation, ctx);
+    case 'a2a_context_continuity':
+      return validateA2AContextContinuity(validation, ctx);
     case 'refs_resolve':
       return validateRefsResolve(validation, ctx);
     default:
@@ -1386,6 +1405,95 @@ function validateA2ASubmittedArtifact(validation: StoryboardValidation, ctx: Val
 // ────────────────────────────────────────────────────────────
 // refs_resolve (cross-step integrity check)
 // ────────────────────────────────────────────────────────────
+
+// ────────────────────────────────────────────────────────────
+// a2a_context_continuity (cross-step A2A session-binding guard)
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Assert that the A2A `Task.contextId` on this step's response
+ * matches the prior step's response. A2A 0.3.0 §7.1 binds follow-up
+ * sends to a server-side conversation via `Message.contextId`; the
+ * server MUST echo it on the response Task. The `@a2a-js/sdk`'s
+ * `DefaultRequestHandler` does this automatically — `createA2AAdapter`
+ * passes through `requestContext.contextId`, so a passing seller built
+ * on the SDK won't trip a single-call check. The regression class is
+ * sellers that bypass the SDK's request handler and stamp their own
+ * `contextId` on the response, breaking buyer-side correlation across
+ * a multi-turn flow (proposal refinement, IO signing, async approval).
+ *
+ * The check compares the current step's
+ * `ctx.a2aEnvelope.result.contextId` against the prior step's
+ * `ctx.priorA2aEnvelope.result.contextId`. Skip semantics:
+ *
+ *   - Non-A2A run (`a2aEnvelope` undefined) → skip
+ *   - First A2A step in a run (`priorA2aEnvelope` undefined) → skip
+ *   - Either envelope had no extractable `contextId` → skip
+ *   - JSON-RPC error envelope (`envelope.error` present) → skip
+ *
+ * Skips emit a single observation noting which condition triggered so
+ * triage can distinguish "validator self-skipped" from "validator
+ * passed because contexts matched".
+ */
+function validateA2AContextContinuity(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
+  const current = ctx.a2aEnvelope;
+  const prior = ctx.priorA2aEnvelope;
+  const passResult = (observation: string): ValidationResult => ({
+    check: 'a2a_context_continuity',
+    passed: true,
+    description: validation.description,
+    observations: [observation],
+  });
+
+  if (!current)
+    return passResult('a2a_envelope_not_captured: skipped on non-A2A transport (or capture-bypassing dispatch path)');
+  if (!prior) return passResult('first_a2a_step: no prior A2A envelope to compare against; skipped');
+  if (current.envelope.error !== undefined || prior.envelope.error !== undefined) {
+    return passResult('jsonrpc_error_envelope: skipped — continuity is undefined for transport-rejected calls');
+  }
+
+  const currentContextId = extractContextIdFromEnvelope(current);
+  const priorContextId = extractContextIdFromEnvelope(prior);
+
+  if (priorContextId == null)
+    return passResult('prior_contextId_absent: prior step did not surface a Task.contextId; skipped');
+  if (currentContextId == null) {
+    return {
+      check: 'a2a_context_continuity',
+      passed: false,
+      description: validation.description,
+      error:
+        `Current step's response Task is missing \`contextId\` (prior step had ${JSON.stringify(priorContextId)}). ` +
+        'A2A 0.3.0 requires the server to echo the client-supplied contextId on every follow-up send; an empty/missing ' +
+        'contextId on a non-first send breaks buyer-side session correlation.',
+      json_pointer: '/result/contextId',
+      expected: priorContextId,
+      actual: currentContextId,
+    };
+  }
+  if (currentContextId !== priorContextId) {
+    const priorStepNote = ctx.priorA2aStepId ? ` (prior step: ${ctx.priorA2aStepId})` : '';
+    return {
+      check: 'a2a_context_continuity',
+      passed: false,
+      description: validation.description,
+      error:
+        `A2A \`Task.contextId\` diverged across steps${priorStepNote}: expected ${JSON.stringify(priorContextId)}, got ${JSON.stringify(currentContextId)}. ` +
+        "Per A2A 0.3.0 §7.1 the server MUST echo the client-supplied contextId on follow-up sends. A divergent value indicates the seller bypassed the SDK's request handler and stamped its own contextId — buyer-side session correlation is broken.",
+      json_pointer: '/result/contextId',
+      expected: priorContextId,
+      actual: currentContextId,
+    };
+  }
+  return { check: 'a2a_context_continuity', passed: true, description: validation.description };
+}
+
+function extractContextIdFromEnvelope(envelope: A2ATaskEnvelope): string | undefined {
+  const result = envelope.result;
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) return undefined;
+  const ctxId = (result as Record<string, unknown>).contextId;
+  return typeof ctxId === 'string' && ctxId.length > 0 ? ctxId : undefined;
+}
 
 /**
  * Assert every ref in a source set resolves to a member of a target set.

--- a/test/storyboard-a2a-context-continuity-integration.test.js
+++ b/test/storyboard-a2a-context-continuity-integration.test.js
@@ -1,0 +1,246 @@
+// Integration test: verifies runStoryboardStep / runStoryboard
+// captures consecutive A2A envelopes and feeds the prior one to
+// `a2a_context_continuity` validations on follow-up steps. Anchors
+// the runner-side cross-step plumbing for adcp-client#962.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+
+const { createAdcpServer: _createAdcpServer } = require('../dist/lib/server/create-adcp-server');
+const { createA2AAdapter } = require('../dist/lib/server/a2a-adapter');
+const { InMemoryStateStore } = require('../dist/lib/server/state-store');
+const { runStoryboard } = require('../dist/lib/testing/storyboard/runner');
+
+function createAdcpServer(config) {
+  return _createAdcpServer({
+    ...config,
+    stateStore: config?.stateStore ?? new InMemoryStateStore(),
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
+  });
+}
+
+async function startConformantA2aFixture(handlers) {
+  const adcp = createAdcpServer(handlers);
+  const app = express();
+  app.use(express.json());
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address();
+  const cardUrl = `http://127.0.0.1:${port}/a2a`;
+  const a2a = createA2AAdapter({
+    server: adcp,
+    agentCard: {
+      name: 'Conformant Seller',
+      description: 'A2A SDK auto-echoes contextId',
+      url: cardUrl,
+      version: '1.0.0',
+      provider: { organization: 'Test', url: 'https://test.example' },
+      securitySchemes: { bearer: { type: 'http', scheme: 'bearer' } },
+    },
+  });
+  a2a.mount(app);
+  return {
+    server,
+    url: cardUrl,
+    close: () => new Promise(resolve => server.close(resolve)),
+  };
+}
+
+/**
+ * Build an Express handler that emits a non-conformant A2A response —
+ * the seller stamps a fresh contextId on every send rather than
+ * echoing the buyer's. This is the regression the validator catches.
+ */
+async function startRegressedA2aFixture() {
+  const app = express();
+  app.use(express.json());
+  const server = app.listen(0);
+  await new Promise(resolve => server.once('listening', resolve));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  let sendCount = 0;
+
+  app.get('/.well-known/agent-card.json', (_req, res) => {
+    res.json({
+      name: 'Regressed Seller',
+      description: 'stamps own contextId, ignores buyer-supplied',
+      url: baseUrl,
+      version: '1.0.0',
+      protocolVersion: '0.3.0',
+      defaultInputModes: ['application/json'],
+      defaultOutputModes: ['application/json'],
+      capabilities: { streaming: false, pushNotifications: false },
+      skills: [
+        { id: 'get_products', name: 'get_products', description: 'discover', tags: ['adcp'] },
+        { id: 'list_creative_formats', name: 'list_creative_formats', description: 'formats', tags: ['adcp'] },
+        { id: 'get_adcp_capabilities', name: 'get_adcp_capabilities', description: 'caps', tags: ['adcp'] },
+      ],
+    });
+  });
+  app.post('/', (req, res) => {
+    const { id, method, params } = req.body ?? {};
+    if (method !== 'message/send') {
+      res.json({ jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } });
+      return;
+    }
+    const skill = params?.message?.parts?.[0]?.data?.skill;
+    sendCount += 1;
+    const freshContextId = `ctx-stamped-${sendCount}`;
+    if (skill === 'get_adcp_capabilities') {
+      res.json({
+        jsonrpc: '2.0',
+        id,
+        result: {
+          kind: 'task',
+          id: `t-caps-${sendCount}`,
+          contextId: freshContextId,
+          status: { state: 'completed', timestamp: new Date().toISOString() },
+          artifacts: [
+            {
+              artifactId: 'a',
+              parts: [{ kind: 'data', data: { adcp_version: '3.0.0', supported_protocols: ['media-buy'], tools: [] } }],
+            },
+          ],
+        },
+      });
+      return;
+    }
+    res.json({
+      jsonrpc: '2.0',
+      id,
+      result: {
+        kind: 'task',
+        id: `t-${sendCount}`,
+        contextId: freshContextId,
+        status: { state: 'completed', timestamp: new Date().toISOString() },
+        artifacts: [
+          {
+            artifactId: 'a',
+            parts: [{ kind: 'data', data: skill === 'get_products' ? { products: [] } : { formats: [] } }],
+          },
+        ],
+      },
+    });
+  });
+  return {
+    server,
+    url: baseUrl,
+    close: () => new Promise(resolve => server.close(resolve)),
+  };
+}
+
+function buildTwoStepStoryboard() {
+  return {
+    id: 'a2a-context-continuity-smoke',
+    version: '1.0.0',
+    title: 'A2A context continuity smoke',
+    category: 'media_buy_seller',
+    summary: 'Two A2A sends; second asserts contextId echo',
+    narrative: 'first send mints context; second send must echo it.',
+    agent: { interaction_model: 'media_buy_seller', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'establish',
+        title: 'establish',
+        steps: [
+          {
+            id: 'first_send',
+            title: 'establish session',
+            task: 'get_products',
+            stateful: false,
+            sample_request: { brief: 'first send' },
+          },
+        ],
+      },
+      {
+        id: 'follow_up',
+        title: 'follow_up',
+        steps: [
+          {
+            id: 'second_send',
+            title: 'continue session',
+            task: 'list_creative_formats',
+            stateful: true,
+            sample_request: {},
+            validations: [
+              {
+                check: 'a2a_context_continuity',
+                description: 'follow-up send echoes the buyer-supplied contextId',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+const DISABLE_DEFAULT_INVARIANTS = {
+  disable: [
+    'status.monotonic',
+    'idempotency.conflict_no_payload_leak',
+    'context.no_secret_echo',
+    'governance.denial_blocks_mutation',
+  ],
+};
+
+describe('a2a_context_continuity (runner integration, #962)', () => {
+  it('passes against an SDK-conformant adapter that echoes contextId', async () => {
+    const fixture = await startConformantA2aFixture({
+      mediaBuy: {
+        getProducts: async () => ({ products: [] }),
+      },
+      creative: {
+        listCreativeFormats: async () => ({ formats: [] }),
+      },
+    });
+    try {
+      const sb = buildTwoStepStoryboard();
+      const result = await runStoryboard(fixture.url, sb, {
+        protocol: 'a2a',
+        allow_http: true,
+        invariants: DISABLE_DEFAULT_INVARIANTS,
+      });
+      const followUp = result.phases.flatMap(p => p.steps).find(s => s.step_id === 'second_send');
+      assert.ok(followUp, 'follow-up step ran');
+      const continuityCheck = followUp.validations.find(v => v.check === 'a2a_context_continuity');
+      assert.ok(continuityCheck, 'continuity validator ran');
+      assert.strictEqual(
+        continuityCheck.passed,
+        true,
+        `conformant adapter must pass continuity: ${JSON.stringify(continuityCheck)}`
+      );
+      // Did not emit the not-captured / first-step skip observations
+      const obs = continuityCheck.observations ?? [];
+      assert.ok(
+        !obs.some(o => /a2a_envelope_not_captured|first_a2a_step|prior_contextId_absent/.test(o)),
+        `conformant pass should not surface skip observations: ${JSON.stringify(obs)}`
+      );
+    } finally {
+      await fixture.close();
+    }
+  });
+
+  it('fails against a regressed adapter that stamps fresh contextId per send', async () => {
+    const fixture = await startRegressedA2aFixture();
+    try {
+      const sb = buildTwoStepStoryboard();
+      const result = await runStoryboard(fixture.url, sb, {
+        protocol: 'a2a',
+        allow_http: true,
+        invariants: DISABLE_DEFAULT_INVARIANTS,
+      });
+      const followUp = result.phases.flatMap(p => p.steps).find(s => s.step_id === 'second_send');
+      assert.ok(followUp, 'follow-up step ran');
+      const continuityCheck = followUp.validations.find(v => v.check === 'a2a_context_continuity');
+      assert.ok(continuityCheck, 'continuity validator ran');
+      assert.strictEqual(continuityCheck.passed, false, 'regressed adapter must fail continuity');
+      assert.strictEqual(continuityCheck.json_pointer, '/result/contextId');
+      assert.match(continuityCheck.error, /diverged across steps/);
+    } finally {
+      await fixture.close();
+    }
+  });
+});

--- a/test/storyboard-a2a-context-continuity.test.js
+++ b/test/storyboard-a2a-context-continuity.test.js
@@ -1,0 +1,148 @@
+// Regression tests for adcp-client#962.
+//
+// Anchors the contract that `a2a_context_continuity` catches sellers
+// that bypass the @a2a-js/sdk DefaultRequestHandler and stamp their
+// own contextId on the response. Per A2A 0.3.0 §7.1 the server MUST
+// echo the client-supplied contextId on every follow-up send; a
+// divergent value indicates the seller broke the SDK's automatic
+// contextId echo.
+//
+// Single-call tests pin the validator's logic against synthetic
+// envelopes; the runner-level integration is covered separately by
+// stacking step results in `priorA2aEnvelope`.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { runValidations } = require('../dist/lib/testing/storyboard/validations.js');
+
+const VALIDATION = {
+  check: 'a2a_context_continuity',
+  description: 'A2A Task.contextId carries through across steps',
+};
+
+function envelope(contextId, opts = {}) {
+  return {
+    result: {
+      kind: 'task',
+      id: opts.taskId ?? 'task-uuid',
+      contextId,
+      status: { state: 'completed', timestamp: '2026-04-25T12:00:00Z' },
+      artifacts: [],
+    },
+    envelope: { jsonrpc: '2.0', id: 1, result: {} },
+    http_status: 200,
+  };
+}
+
+function ctx({ current, prior, priorStepId } = {}) {
+  return {
+    taskName: 'follow_up_step',
+    agentUrl: 'https://example.com/a2a',
+    contributions: new Set(),
+    ...(current && { a2aEnvelope: current }),
+    ...(prior && { priorA2aEnvelope: prior }),
+    ...(priorStepId && { priorA2aStepId: priorStepId }),
+  };
+}
+
+describe('a2a_context_continuity', () => {
+  it('passes when current and prior contextIds match', () => {
+    const SHARED_CTX = 'ctx-shared-123';
+    const [result] = runValidations(
+      [VALIDATION],
+      ctx({ current: envelope(SHARED_CTX), prior: envelope(SHARED_CTX, { taskId: 'prior-task' }) })
+    );
+    assert.strictEqual(result.passed, true);
+    assert.strictEqual(result.check, 'a2a_context_continuity');
+  });
+
+  it('fails when current contextId diverges from prior — seller stamped their own', () => {
+    const [result] = runValidations(
+      [VALIDATION],
+      ctx({
+        current: envelope('ctx-seller-stamped'),
+        prior: envelope('ctx-original'),
+        priorStepId: 'create_media_buy',
+      })
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.json_pointer, '/result/contextId');
+    assert.strictEqual(result.expected, 'ctx-original');
+    assert.strictEqual(result.actual, 'ctx-seller-stamped');
+    assert.match(result.error, /diverged across steps.*create_media_buy/);
+    assert.match(result.error, /A2A 0\.3\.0 §7\.1/);
+  });
+
+  it('fails when current Task is missing contextId entirely', () => {
+    const cur = envelope('whatever');
+    delete cur.result.contextId;
+    const [result] = runValidations([VALIDATION], ctx({ current: cur, prior: envelope('ctx-prior') }));
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /missing `contextId`/);
+  });
+
+  it('passes with skip-observation on non-A2A transport (no envelope)', () => {
+    const [result] = runValidations([VALIDATION], ctx({}));
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.observations?.[0]?.includes('a2a_envelope_not_captured'));
+  });
+
+  it('passes with skip-observation on first A2A step (no prior to compare)', () => {
+    const [result] = runValidations([VALIDATION], ctx({ current: envelope('ctx-first') }));
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.observations?.[0]?.includes('first_a2a_step'));
+  });
+
+  it('passes with skip-observation when prior step had no contextId', () => {
+    const priorEnv = envelope('discarded');
+    delete priorEnv.result.contextId;
+    const [result] = runValidations([VALIDATION], ctx({ current: envelope('ctx-current'), prior: priorEnv }));
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.observations?.[0]?.includes('prior_contextId_absent'));
+  });
+
+  it('passes with skip-observation when current envelope is a JSON-RPC error', () => {
+    const errEnvelope = {
+      result: null,
+      envelope: { jsonrpc: '2.0', id: 1, error: { code: -32602, message: 'Invalid params' } },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx({ current: errEnvelope, prior: envelope('ctx-prior') }));
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.observations?.[0]?.includes('jsonrpc_error_envelope'));
+  });
+
+  it('passes with skip-observation when prior envelope is a JSON-RPC error', () => {
+    const errEnvelope = {
+      result: null,
+      envelope: { jsonrpc: '2.0', id: 1, error: { code: -32602, message: 'Invalid params' } },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx({ current: envelope('ctx-current'), prior: errEnvelope }));
+    assert.strictEqual(result.passed, true);
+    assert.ok(result.observations?.[0]?.includes('jsonrpc_error_envelope'));
+  });
+
+  it('treats empty-string contextId as missing', () => {
+    const cur = envelope('');
+    const [result] = runValidations([VALIDATION], ctx({ current: cur, prior: envelope('ctx-prior') }));
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /missing `contextId`/);
+  });
+
+  it('extracts contextId from `result` (the post-redaction envelope shape)', () => {
+    // Defensive — confirms the validator reads from envelope.result.contextId,
+    // not from envelope.envelope.result.contextId or some other path. The
+    // capture pipeline writes both result and envelope.result, but the
+    // validator should consult the canonical location.
+    const SHARED = 'ctx-from-result';
+    const env = {
+      result: { kind: 'task', id: 't', contextId: SHARED, status: { state: 'completed' }, artifacts: [] },
+      envelope: { jsonrpc: '2.0', id: 1, result: { kind: 'task', id: 't', contextId: SHARED } },
+      http_status: 200,
+    };
+    const [result] = runValidations([VALIDATION], ctx({ current: env, prior: env }));
+    assert.strictEqual(result.passed, true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #962. Suggested by the ad-tech-protocol-expert review on #952 — sibling validator to `a2a_submitted_artifact`, but for cross-step session continuity instead of single-call wire shape.

A2A 0.3.0 §7.1 binds follow-up `message/send` calls to a server-side conversation via `Message.contextId`; the server MUST echo it on the response Task. The `@a2a-js/sdk`'s `DefaultRequestHandler` does this automatically — `createA2AAdapter` (#899) passes through `requestContext.contextId`, so a passing seller built on the SDK won't trip a single-call check.

**Regression class caught**: sellers that bypass the SDK's request handler and stamp their own `contextId` on the response, breaking buyer-side correlation across multi-turn flows (proposal refinement, IO signing, async approval). Only surface-able on multi-step storyboards where step N+1 sends with the contextId returned by step N.

## Validator behavior

Runs at step N+1, compares `a2aEnvelope.result.contextId` against the most recent prior step's captured envelope.

**Skip cases** (pass with observation):
- Non-A2A run (no envelope) — observation: `a2a_envelope_not_captured`
- First A2A step in run (no prior) — observation: `first_a2a_step`
- Either envelope has no extractable `contextId` — observation: `prior_contextId_absent`
- JSON-RPC error envelope on either side — observation: `jsonrpc_error_envelope`

**Failure cases**:
- Current step's response has no `contextId` on a non-first send → fail with `/result/contextId` json_pointer
- Current step's `contextId` differs from prior step's → fail with both values surfaced and prior step id named

## Runner-side plumbing

Per-step A2A envelopes are tracked in a long-lived `priorA2aEnvelopes` map on `ExecutionState` — mirroring the pattern used for `priorStepResults`/`priorProbes` since the per-step state literal is a fresh object on each `executeStep` call and can't hold mutations. The validator reads the most recent insertion-order entry as the comparison baseline. Probe steps, MCP steps, and capture-bypass paths don't insert, so cross-step comparisons walk back to the most recent A2A step automatically.

## Tests

- 10 unit tests against `validateA2AContextContinuity` (synthetic envelopes covering match, divergence, missing/empty contextId, every skip path including JSON-RPC error envelopes on either side)
- 2 integration tests against `runStoryboard` driving real multi-step storyboards: one against a conformant `createA2AAdapter` (passes without skip observations); one against a hand-rolled regressed adapter that stamps a fresh contextId per send (fails with the expected diagnostic)

## Test plan

- [x] 12/12 new tests pass
- [x] 2440/2444 wider sweep (storyboard + a2a-* + adapter tests) passes — 4 intentional skips, none introduced
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] `eslint` 0 errors
- [ ] CI green

## Independent of #971

This PR doesn't depend on PR1/PR2 (#971) merging — it touches `src/lib/testing/storyboard/` exclusively, no overlap with the polling cycle work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)