### PR TITLE
feat(core): pollTaskCompletion handles all non-progressing task statuses (#977)

### DIFF
--- a/.changeset/poll-rejected-terminal.md
+++ b/.changeset/poll-rejected-terminal.md
@@ -1,0 +1,9 @@
+---
+'@adcp/client': patch
+---
+
+fix(core): pollTaskCompletion now exits immediately on `rejected` status instead of spinning until timeout
+
+`TaskExecutor.pollTaskCompletion` previously only exited the polling loop for `completed`, `failed`, and `canceled` statuses. When a server returned `rejected` (task refused before starting), the loop would spin until the caller's timeout. The `rejected` status is now treated as terminal — consistent with how `handleAsyncResponse` handles it — and returns `{ success: false, status: 'failed' }` immediately.
+
+Also fixes the error-message fallback: the polling path now checks `status.message` before falling back to the generic `"Task rejected"` string, matching the behavior of the synchronous dispatch path. `TaskInfo` gains an optional `message` field for this. `TaskStatus` now includes `'rejected'` and `'canceled'` for metadata fidelity.

--- a/.changeset/poll-rejected-terminal.md
+++ b/.changeset/poll-rejected-terminal.md
@@ -49,3 +49,15 @@ covers all three new exit paths plus regressions for `failed` /
 `canceled`. 9 tests; mocks dispatch via `protocol: 'a2a'` so polls
 route directly through `ProtocolClient.callTool` without the MCP
 Tasks protocol fast path.
+
+**adcp#3126 alignment** (typed `tasks/get` result field):
+adcontextprotocol/adcp#3126 closed the spec ambiguity flagged in
+adcp#3123 by adding a typed `result` field on `tasks/get` responses
+(gated by `include_result: true` on the request, populated when
+`status: 'completed'`). The SDK now sets `include_result: true` on
+every polling request so spec-conformant 3.1.0+ sellers populate
+the typed field; pre-3.1.0 sellers ignore the unknown request
+field, and the response mapper continues to read `result` (the
+typed and informal paths share the same field name). Dropped the
+informal `task_data` alias from the mapper — `result` is the
+canonical name.

--- a/.changeset/poll-rejected-terminal.md
+++ b/.changeset/poll-rejected-terminal.md
@@ -2,8 +2,50 @@
 '@adcp/client': patch
 ---
 
-fix(core): pollTaskCompletion now exits immediately on `rejected` status instead of spinning until timeout
+`TaskExecutor.pollTaskCompletion`: handle every non-progressing AdCP
+task status. Closes #977 (both halves).
 
-`TaskExecutor.pollTaskCompletion` previously only exited the polling loop for `completed`, `failed`, and `canceled` statuses. When a server returned `rejected` (task refused before starting), the loop would spin until the caller's timeout. The `rejected` status is now treated as terminal — consistent with how `handleAsyncResponse` handles it — and returns `{ success: false, status: 'failed' }` immediately.
+**Pre-fix**: `pollTaskCompletion` only exited on `completed`, `failed`,
+and `canceled`. Three non-progressing statuses caused the loop to spin
+until the caller's timeout:
 
-Also fixes the error-message fallback: the polling path now checks `status.message` before falling back to the generic `"Task rejected"` string, matching the behavior of the synchronous dispatch path. `TaskInfo` gains an optional `message` field for this. `TaskStatus` now includes `'rejected'` and `'canceled'` for metadata fidelity.
+- **`rejected`** — definitively terminal per the AdCP `task-status`
+  enum ("Task was rejected by the agent and was not started"). Now
+  collapses onto the same `failed`/`canceled` exit branch with
+  `{ success: false, status: 'failed' }`.
+- **`input-required`** — paused state. Polling alone can't advance it;
+  the buyer must satisfy the paused condition (supply input) and
+  retry the original tool call. Now returns a
+  `TaskResultIntermediate` with `status: 'input-required'`,
+  `success: true` (mirrors the synchronous `handleInputRequired`
+  no-handler path).
+- **`auth-required`** — paused state. Same handling as
+  `input-required`. Also added to `TaskResultIntermediate`'s status
+  union and the `TaskStatus` type.
+
+**Error fallback**: the polling path now checks `status.message`
+before the generic `Task <status>` template, matching the
+synchronous dispatch path. `TaskInfo` gains an optional `message`
+field; the `tasks/get` response mapper preserves the top-level
+`message` field through to it.
+
+**Side fixes** caught by review:
+
+- `mcp-tasks.mapMCPTaskToTaskInfo`: the `statusMessage → error`
+  projection now checks against the AdCP-mapped status (post-
+  `mapMCPTaskStatus`) instead of the MCP-side raw status. The prior
+  check used `['failed', 'rejected', 'canceled']` against the
+  pre-mapping string — but MCP Tasks emits `'cancelled'` (British)
+  and never `'rejected'` as a standard status, so MCP-cancelled
+  tasks weren't surfacing `statusMessage` as `error`.
+- `onTaskEvents`: `'canceled'` was falling through to
+  `onTaskUpdated`. Now joins `'failed'` and `'rejected'` on the
+  `onTaskFailed` branch.
+- `TaskStatus` union: adds `'rejected'`, `'canceled'`, and
+  `'auth-required'` for metadata fidelity.
+
+**Tests**: `test/lib/poll-task-completion-terminal-states.test.js`
+covers all three new exit paths plus regressions for `failed` /
+`canceled`. 9 tests; mocks dispatch via `protocol: 'a2a'` so polls
+route directly through `ProtocolClient.callTool` without the MCP
+Tasks protocol fast path.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -112,6 +112,8 @@ export type TaskStatus =
   | 'input-required'
   | 'completed'
   | 'failed'
+  | 'rejected'
+  | 'canceled'
   | 'deferred'
   | 'aborted'
   | 'submitted'
@@ -212,6 +214,8 @@ export interface TaskInfo {
   result?: any;
   /** Error message (if failed) */
   error?: string;
+  /** Human-readable message from agent (alternative to error field) */
+  message?: string;
   /** Webhook URL (if applicable) */
   webhookUrl?: string;
 }

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -110,6 +110,7 @@ export type TaskStatus =
   | 'working'
   | 'needs_input'
   | 'input-required'
+  | 'auth-required'
   | 'completed'
   | 'failed'
   | 'rejected'
@@ -394,7 +395,14 @@ export interface TaskResultCompleted<T> extends TaskResultBase<T> {
 /** Task is still progressing (working, submitted, input-required, deferred). */
 export interface TaskResultIntermediate<T> extends TaskResultBase<T> {
   success: true;
-  status: 'working' | 'submitted' | 'input-required' | 'deferred';
+  /**
+   * Task is progressing but not yet final. `'auth-required'` and
+   * `'input-required'` are paused states surfaced by the polling
+   * cycle (`pollTaskCompletion`) — the buyer must satisfy the
+   * paused condition (refresh auth / supply input) and retry the
+   * original tool call. Polling alone won't advance them.
+   */
+  status: 'working' | 'submitted' | 'input-required' | 'auth-required' | 'deferred';
   data?: T;
   error?: undefined;
   adcpError?: undefined;

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1370,13 +1370,17 @@ export class TaskExecutor {
         });
       }
 
-      if (status.status === ADCP_STATUS.FAILED || status.status === ADCP_STATUS.CANCELED) {
+      if (
+        status.status === ADCP_STATUS.FAILED ||
+        status.status === ADCP_STATUS.CANCELED ||
+        status.status === ADCP_STATUS.REJECTED
+      ) {
         const asyncFailedErr = extractAdcpErrorInfo(status.result);
         return attachMatch({
           success: false as const,
           status: 'failed' as const,
           data: status.result,
-          error: status.error || `Task ${status.status}`,
+          error: status.error || status.message || `Task ${status.status}`,
           adcpError: asyncFailedErr,
           errorInstance: this.buildErrorInstance(taskId, asyncFailedErr),
           correlationId: extractCorrelationId(status.result),

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -81,14 +81,15 @@ export class InputRequiredError extends Error {
  * context?, ext? }`. The internal `TaskInfo` is camelCase with a
  * superset of legacy fields some pre-3.0 sellers still emit.
  *
- * **Result-data passthrough.** AdCP `tasks/get` doesn't define a
- * completion-payload field — the spec leaves the result-extraction
- * layer ambiguous (see adcp#3123 for the upstream clarification
- * issue). Sellers MAY surface the completed task's data via
- * `additionalProperties: true` (`result` or `task_data` are the de
- * facto names). We pass it through so `pollTaskCompletion` can
- * surface it on the resolved `TaskResult.data`. When the spec
- * clarifies, this mapping refines.
+ * **Result-data extraction.** AdCP 3.1.0 defines a typed `result`
+ * field on `tasks/get` responses (per adcontextprotocol/adcp#3126,
+ * which closed adcp#3123). Sellers populate it when the buyer's
+ * request set `include_result: true` and the task reached
+ * `completed`. The mapper reads it directly into `TaskInfo.result`
+ * so `pollTaskCompletion` surfaces it on the resolved
+ * `TaskResult.data`. Pre-3.1.0 sellers that emitted `result` via
+ * `additionalProperties: true` continue to work — the typed and
+ * informal paths share the same field name.
  *
  * **Legacy nested shape.** Some pre-3.0 sellers and existing test
  * mocks emit `{ task: { ...TaskInfo } }` — a non-spec wrapper. We
@@ -134,9 +135,11 @@ function mapTasksGetResponseToTaskInfo(payload: unknown): TaskInfo {
   // object).
   const messageField = stringField(flat.message);
   if (messageField !== undefined) taskInfo.message = messageField;
-  // Result passthrough — see JSDoc on result-data ambiguity.
-  const result = flat.result ?? flat.task_data;
-  if (result !== undefined) taskInfo.result = result;
+  // Result extraction — see JSDoc. AdCP 3.1.0 defines `result` as
+  // the canonical typed field; pre-3.1.0 sellers using
+  // `additionalProperties: true` shared the same field name, so the
+  // mapping is unchanged across versions.
+  if (flat.result !== undefined) taskInfo.result = flat.result;
   return taskInfo;
 }
 
@@ -1308,17 +1311,17 @@ export class TaskExecutor {
     // response is the spec's flat shape, mapped to `TaskInfo` via
     // {@link mapTasksGetResponseToTaskInfo}.
     //
-    // **Known limitation (#973)**: A2A submitted-arm responses still
-    // misclassify because `responseParser.getStatus`/`getTaskId` read
-    // the transport-level `Task.state` and `Task.id` instead of the
-    // AdCP work status (`artifact.parts[0].data.status`) and AdCP
-    // work handle (`artifact.metadata.adcp_task_id`). The polling
-    // cycle never starts for A2A submitted arms in current code; the
-    // parser fix is tracked separately.
+    //
+    // Request includes `include_result: true` so spec-conformant
+    // sellers (AdCP 3.1.0+) populate the typed `result` field on
+    // `completed` responses (per adcontextprotocol/adcp#3126). Older
+    // sellers ignore the unknown request field; the response mapper
+    // falls back to the informal `additionalProperties` passthrough
+    // for those.
     const response = (await ProtocolClient.callTool(
       agent,
       'tasks/get',
-      { task_id: taskId },
+      { task_id: taskId, include_result: true },
       [],
       undefined,
       undefined,

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1404,6 +1404,31 @@ export class TaskExecutor {
         });
       }
 
+      // Paused states: `input-required` and `auth-required`. Polling
+      // alone can't advance these — the buyer must satisfy the paused
+      // condition (supply input / refresh auth) and retry the
+      // original tool call. Return a `TaskResultIntermediate` so the
+      // caller can branch on `result.status`; this mirrors the
+      // synchronous `handleInputRequired` no-handler path
+      // (`success: true` because the task is progressing, not failed).
+      // Without this branch the loop would spin until timeout — the
+      // paused-state regression class flagged by adcp-client#977.
+      if (status.status === ADCP_STATUS.INPUT_REQUIRED || status.status === ADCP_STATUS.AUTH_REQUIRED) {
+        return attachMatch({
+          success: true as const,
+          status: status.status,
+          data: status.result as T,
+          metadata: this.buildMetadata({
+            taskId,
+            taskName: status.taskType,
+            agent,
+            responseTimeMs: Date.now() - status.createdAt,
+            status: status.status,
+            response: status.result,
+          }),
+        });
+      }
+
       await this.sleep(pollInterval);
     }
   }
@@ -1662,7 +1687,8 @@ export class TaskExecutor {
           break;
         case 'failed':
         case 'rejected':
-          callbacks.onTaskFailed?.(task, task.error || 'Task failed');
+        case 'canceled':
+          callbacks.onTaskFailed?.(task, task.error || `Task ${task.status}`);
           break;
         default:
           callbacks.onTaskUpdated?.(task);

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -125,6 +125,15 @@ function mapTasksGetResponseToTaskInfo(payload: unknown): TaskInfo {
     updatedAt: parseTimestamp(flat.updated_at ?? flat.updatedAt),
   };
   if (errorMessage !== undefined) taskInfo.error = errorMessage;
+  // Top-level `message` field: the AdCP envelope's human-readable
+  // status descriptor (advisory string accompanying any status —
+  // e.g. "Budget cap exceeded — task not started" on a `rejected`
+  // task). `pollTaskCompletion` falls back to this when the
+  // `error.message` block is absent on a terminal failure. Distinct
+  // from `error.message` (which lives under the structured `error`
+  // object).
+  const messageField = stringField(flat.message);
+  if (messageField !== undefined) taskInfo.message = messageField;
   // Result passthrough — see JSDoc on result-data ambiguity.
   const result = flat.result ?? flat.task_data;
   if (result !== undefined) taskInfo.result = result;

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -87,13 +87,23 @@ function mapMCPTaskToTaskInfo(
   },
   toolName?: string
 ): TaskInfo {
+  // Project `statusMessage → TaskInfo.error` against the
+  // POST-MAPPING AdCP status (not the raw MCP-side status). MCP
+  // Tasks emits `'cancelled'` (British) and never `'rejected'` as a
+  // standard status; checking against the AdCP set after mapping
+  // catches all terminal failures uniformly. Sellers that extend
+  // MCP with custom statuses (e.g. emit `'rejected'` via spec
+  // extension) flow through unchanged via the `default` arm of
+  // {@link mapMCPTaskStatus}.
+  const adcpStatus = mapMCPTaskStatus(task.status);
+  const isTerminalFailure = adcpStatus === 'failed' || adcpStatus === 'rejected' || adcpStatus === 'canceled';
   return {
     taskId: task.taskId,
-    status: mapMCPTaskStatus(task.status),
+    status: adcpStatus,
     taskType: toolName ?? 'unknown',
     createdAt: new Date(task.createdAt).getTime(),
     updatedAt: new Date(task.lastUpdatedAt).getTime(),
-    error: ['failed', 'rejected', 'canceled'].includes(task.status) ? task.statusMessage : undefined,
+    error: isTerminalFailure ? task.statusMessage : undefined,
   };
 }
 

--- a/src/lib/protocols/mcp-tasks.ts
+++ b/src/lib/protocols/mcp-tasks.ts
@@ -93,7 +93,7 @@ function mapMCPTaskToTaskInfo(
     taskType: toolName ?? 'unknown',
     createdAt: new Date(task.createdAt).getTime(),
     updatedAt: new Date(task.lastUpdatedAt).getTime(),
-    error: task.status === 'failed' ? task.statusMessage : undefined,
+    error: ['failed', 'rejected', 'canceled'].includes(task.status) ? task.statusMessage : undefined,
   };
 }
 

--- a/test/lib/poll-task-completion-terminal-states.test.js
+++ b/test/lib/poll-task-completion-terminal-states.test.js
@@ -1,0 +1,119 @@
+// Tests that pollTaskCompletion exits immediately on terminal/paused states
+// instead of spinning until timeout.
+//
+// Calls pollTaskCompletion directly (bypassing executeTask) to isolate the
+// polling loop behavior from schema validation on the initial call.
+
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('pollTaskCompletion terminal state handling', () => {
+  let TaskExecutor;
+  let ProtocolClient;
+  let originalCallTool;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../../dist/lib/index.js')];
+    const lib = require('../../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    ProtocolClient = lib.ProtocolClient;
+    originalCallTool = ProtocolClient.callTool;
+
+    mockAgent = {
+      id: 'test-agent',
+      name: 'Test Agent',
+      agent_uri: 'https://test.example.com',
+      protocol: 'mcp',
+    };
+  });
+
+  afterEach(() => {
+    if (originalCallTool) {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('exits loop and returns failure when tasks/get returns rejected (error field)', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-abc',
+        status: 'rejected',
+        error: 'Request rejected by agent policy',
+        taskType: 'create_media_buy',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-abc', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.ok(
+      result.error.includes('rejected by agent policy'),
+      `Expected error to include rejection message, got: ${result.error}`
+    );
+  });
+
+  test('preserves message field as error fallback when error field is absent on rejection', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-def',
+        status: 'rejected',
+        message: 'Budget cap exceeded — task not started',
+        taskType: 'create_media_buy',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-def', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error.includes('Budget cap exceeded'), `Expected error from message field, got: ${result.error}`);
+  });
+
+  test('exits on first poll without retries when tasks/get returns rejected', async () => {
+    let pollCount = 0;
+
+    ProtocolClient.callTool = mock.fn(async () => {
+      pollCount++;
+      return {
+        task: {
+          taskId: 'task-ghi',
+          status: 'rejected',
+          error: 'Rejected immediately',
+          taskType: 'create_media_buy',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      };
+    });
+
+    const executor = new TaskExecutor();
+    await executor.pollTaskCompletion(mockAgent, 'task-ghi', 10);
+
+    assert.strictEqual(pollCount, 1, 'Should exit after exactly one poll on rejected');
+  });
+
+  test('generic error string when no error or message field on rejection', async () => {
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-jkl',
+        status: 'rejected',
+        taskType: 'create_media_buy',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-jkl', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error.includes('rejected'), `Expected fallback error to mention status, got: ${result.error}`);
+  });
+});

--- a/test/lib/poll-task-completion-terminal-states.test.js
+++ b/test/lib/poll-task-completion-terminal-states.test.js
@@ -20,11 +20,13 @@ describe('pollTaskCompletion terminal state handling', () => {
     ProtocolClient = lib.ProtocolClient;
     originalCallTool = ProtocolClient.callTool;
 
+    // Use 'a2a' protocol so getTaskStatus goes directly to ProtocolClient.callTool
+    // (the 'mcp' path tries getMCPTaskStatus first, which requires a live server).
     mockAgent = {
       id: 'test-agent',
       name: 'Test Agent',
       agent_uri: 'https://test.example.com',
-      protocol: 'mcp',
+      protocol: 'a2a',
     };
   });
 

--- a/test/lib/poll-task-completion-terminal-states.test.js
+++ b/test/lib/poll-task-completion-terminal-states.test.js
@@ -101,6 +101,56 @@ describe('pollTaskCompletion terminal state handling', () => {
     assert.strictEqual(pollCount, 1, 'Should exit after exactly one poll on rejected');
   });
 
+  test('exits on failed status (regression — pre-existing branch, now in shared FAILED|CANCELED|REJECTED block)', async () => {
+    let pollCount = 0;
+    ProtocolClient.callTool = mock.fn(async () => {
+      pollCount++;
+      return {
+        task: {
+          taskId: 'task-failed',
+          status: 'failed',
+          error: 'Internal error',
+          taskType: 'create_media_buy',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      };
+    });
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-failed', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.ok(result.error.includes('Internal error'));
+    assert.strictEqual(pollCount, 1, 'failed exits on first poll, like rejected');
+  });
+
+  test('exits on canceled status (regression — pre-existing branch)', async () => {
+    let pollCount = 0;
+    ProtocolClient.callTool = mock.fn(async () => {
+      pollCount++;
+      return {
+        task: {
+          taskId: 'task-canceled',
+          status: 'canceled',
+          message: 'Buyer canceled before activation',
+          taskType: 'create_media_buy',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      };
+    });
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-canceled', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.ok(result.error.includes('Buyer canceled'), `expected message-field fallback, got: ${result.error}`);
+    assert.strictEqual(pollCount, 1);
+  });
+
   test('generic error string when no error or message field on rejection', async () => {
     ProtocolClient.callTool = mock.fn(async () => ({
       task: {
@@ -117,5 +167,88 @@ describe('pollTaskCompletion terminal state handling', () => {
 
     assert.strictEqual(result.success, false);
     assert.ok(result.error.includes('rejected'), `Expected fallback error to mention status, got: ${result.error}`);
+  });
+
+  // ────────────────────────────────────────────────────────────
+  // Paused states (#977 part 2): input-required / auth-required.
+  //
+  // Polling alone can't advance these — the buyer must satisfy the
+  // paused condition (supply input / refresh auth) and retry the
+  // original tool call. The polling loop returns a
+  // TaskResultIntermediate so callers can branch on `result.status`,
+  // matching the synchronous handleInputRequired no-handler path
+  // (`success: true` because the task is progressing, not failed).
+  //
+  // Pre-fix: pollTaskCompletion ignored these statuses and looped
+  // until timeout — a worse failure mode than a clean paused-state
+  // result.
+  // ────────────────────────────────────────────────────────────
+
+  test('exits with TaskResultIntermediate when status === input-required', async () => {
+    let pollCount = 0;
+    ProtocolClient.callTool = mock.fn(async () => {
+      pollCount++;
+      return {
+        task: {
+          taskId: 'task-input',
+          status: 'input-required',
+          taskType: 'create_media_buy',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      };
+    });
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-input', 10);
+
+    assert.strictEqual(result.success, true, 'task is progressing, not failed');
+    assert.strictEqual(result.status, 'input-required');
+    assert.strictEqual(pollCount, 1, 'should not loop on paused state');
+  });
+
+  test('exits with TaskResultIntermediate when status === auth-required', async () => {
+    let pollCount = 0;
+    ProtocolClient.callTool = mock.fn(async () => {
+      pollCount++;
+      return {
+        task: {
+          taskId: 'task-auth',
+          status: 'auth-required',
+          taskType: 'create_media_buy',
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+        },
+      };
+    });
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-auth', 10);
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.status, 'auth-required');
+    assert.strictEqual(pollCount, 1, 'should not loop on paused state');
+  });
+
+  test('paused-state result preserves the wire status (not collapsed)', async () => {
+    // Distinct from `failed`/`canceled`/`rejected` which all collapse
+    // to `status: 'failed'` on TaskResultFailure. Paused states
+    // preserve their wire status so callers can pattern-match.
+    ProtocolClient.callTool = mock.fn(async () => ({
+      task: {
+        taskId: 'task-distinct',
+        status: 'auth-required',
+        taskType: 'create_media_buy',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    }));
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-distinct', 10);
+
+    assert.notStrictEqual(result.status, 'failed');
+    assert.notStrictEqual(result.status, 'completed');
+    assert.strictEqual(result.status, 'auth-required');
   });
 });

--- a/test/server-tasks-get-spec-shape.test.js
+++ b/test/server-tasks-get-spec-shape.test.js
@@ -277,15 +277,19 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
     assert.strictEqual(status.status, 'completed');
   });
 
-  test('passes through `task_data` alias for completion payload', async () => {
-    // Some sellers use `task_data` instead of `result` for the
-    // completion payload (both via additionalProperties since neither
-    // is in the spec). The mapper accepts either name.
-    const SERVER_TASK_ID = 'tk_task_data_alias';
-    const COMPLETION_DATA = { foo: 'bar' };
+  test('polling request includes `include_result: true` (adcp#3126)', async () => {
+    // AdCP 3.1.0 (adcontextprotocol/adcp#3126) makes `result` a typed
+    // optional field on `tasks/get` responses, gated by an
+    // `include_result: true` flag on the request. The SDK always sets
+    // it on polling so spec-conformant sellers populate the typed
+    // field on `completed` responses; older sellers ignore the
+    // unknown request field.
+    const SERVER_TASK_ID = 'tk_include_result';
+    let observedParams;
 
-    ProtocolClient.callTool = mock.fn(async (_agent, taskName) => {
+    ProtocolClient.callTool = mock.fn(async (_agent, taskName, params) => {
       if (taskName === 'tasks/get') {
+        observedParams = params;
         return {
           task_id: SERVER_TASK_ID,
           task_type: 'create_media_buy',
@@ -293,16 +297,21 @@ describe('getTaskStatus: AdCP tasks/get spec-shape mapping (#967)', () => {
           status: 'completed',
           created_at: '2026-04-25T10:00:00Z',
           updated_at: '2026-04-25T10:05:00Z',
-          task_data: COMPLETION_DATA, // alias for `result`
         };
       }
       return { status: 'submitted', task_id: SERVER_TASK_ID };
     });
 
     const executor = new TaskExecutor({ pollingInterval: 5 });
-    const result = await executor.executeTask(mockAgent, 'taskDataAliasTest', {});
-    const completion = await result.submitted.waitForCompletion(5);
-    assert.deepStrictEqual(completion.data, COMPLETION_DATA);
+    const result = await executor.executeTask(mockAgent, 'includeResultTest', {});
+    await result.submitted.waitForCompletion(5);
+
+    assert.strictEqual(
+      observedParams?.include_result,
+      true,
+      'request must include `include_result: true` per adcp#3126'
+    );
+    assert.strictEqual(observedParams?.task_id, SERVER_TASK_ID);
   });
 
   test('continues to handle the legacy { task: {...} } nested shape for backward compat', async () => {


### PR DESCRIPTION
## Summary

Refs #977

`TaskExecutor.pollTaskCompletion` only exited the polling loop for `completed`, `failed`, and `canceled`. When a server returned `rejected` (task refused before starting), the loop would spin until the caller's timeout — a worse failure mode than a clean error.

- **Add `ADCP_STATUS.REJECTED` to the terminal-state exit condition** — consistent with how `handleAsyncResponse` already handles `rejected` in the synchronous dispatch path (line 627).
- **Fix error-message fallback** — the polling path now checks `status.message` before the generic `"Task rejected"` string, matching the synchronous dispatch path. `TaskInfo` gains `message?: string` for this.
- **Fix `mcp-tasks.ts`** — `mapMCPTaskToTaskInfo` was only mapping `statusMessage → error` for `failed` status; extended to cover `rejected` and `canceled` (pre-existing gap surfaced by this fix).
- **Add `'rejected'` and `'canceled'` to `TaskStatus`** — the type union was missing these, limiting metadata fidelity.
- **New test file** `test/lib/poll-task-completion-terminal-states.test.js` — 4 tests covering error-field path, message-field fallback, single-poll exit, and generic fallback string. Tests use `protocol: 'a2a'` so `getTaskStatus` routes to the `ProtocolClient.callTool` mock directly (not the MCP Tasks protocol path which requires a live server).

## What's deferred (#977 part 2)

`input-required` and `auth-required` paused states are intentionally out of scope. Polling alone can't advance them, but the right surface (typed error vs. continuation) needs a design decision — the two expert reviewers disagreed (code-reviewer: return `TaskResultIntermediate`; dx-expert: throw typed error). Leaving for a follow-up so this fix ships cleanly.

## What was tested

- 4 new unit tests: all pass (`npm run test -- --test test/lib/poll-task-completion-terminal-states.test.js`)
- Pre-push validation: TypeScript typecheck + build pass
- Format: Prettier clean

## Pre-PR review

- **code-reviewer:** approved after two-pass fix — flagged MCP `statusMessage` mapping gap (fixed in commit 2) and test protocol path issue (fixed in commit 2); nits: `require.cache` bust is redundant per-test after first, missing regression tests for `failed`/`canceled` (pre-existing coverage exists in `task-executor-async-patterns.test.js`)
- **ad-tech-protocol-expert:** approved — `rejected` is definitively terminal per AdCP 3.0 GA `task-status.json`; noted `status: 'failed'` collapsing loses `rejected` signal (pre-existing pattern matching `handleAsyncResponse`; `TaskResultFailure.status` extension left as follow-up); confirmed `message?` is defensive tolerance, not a spec contract

## Known follow-ons (not blocking this PR)

- Extend `TaskResultFailure.status` to `'failed' | 'canceled' | 'rejected' | 'governance-denied'` for caller-visible signal fidelity
- `input-required` / `auth-required` handling in `pollTaskCompletion` (design decision needed)

Session: https://claude.ai/code/session_01AzgwdsUqsi7EbD8nWxLHXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzgwdsUqsi7EbD8nWxLHXd)_