### PR TITLE
fix(conformance): omit media_buy_ids when context ID absent in get_media_buys enricher

### DIFF
--- a/.changeset/get-media-buys-enricher-broad-list.md
+++ b/.changeset/get-media-buys-enricher-broad-list.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': patch
+---
+
+**Fix `get_media_buys` and `get_media_buy_delivery` storyboard enrichers injecting `media_buy_ids: ["unknown"]` when no context ID is present (#983).** Both enrichers unconditionally built `media_buy_ids: [context.media_buy_id ?? 'unknown']`. When a storyboard tests the broad-list/pagination path (no IDs in `sample_request`), the fixture-wins merge (`{ ...enriched, ...fixture }`) could not clear the injected placeholder because the fixture simply omitted the key. Agents received `media_buy_ids: ["unknown"]`, returned 0 matches, and storyboard `pagination.has_more` assertions failed.
+
+Both enrichers now omit `media_buy_ids` entirely when `context.media_buy_id` is absent, matching the pattern used by `list_creatives` and `list_accounts`. When a real ID is present the behavior is unchanged. This unblocks the `get-media-buys-pagination-integrity` storyboard in `adcontextprotocol/adcp#3122` from upgrading to its intended multi-page seeded walk.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@opentelemetry/api": "^1.9.0",
         "@types/express": "4.17.25",
-        "@types/node": "^20.19.13",
+        "@types/node": "^20.19.39",
         "@types/pg": "^8.20.0",
         "@types/tar": "^6.1.13",
         "eslint": "^10.0.3",
@@ -1199,6 +1199,8 @@
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@opentelemetry/api": "^1.9.0",
     "@types/express": "4.17.25",
-    "@types/node": "^20.19.13",
+    "@types/node": "^20.19.39",
     "@types/pg": "^8.20.0",
     "@types/tar": "^6.1.13",
     "eslint": "^10.0.3",

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -328,6 +328,8 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   },
 
   get_media_buy_delivery(_step, context, _options) {
+    // Same as get_media_buys: omit media_buy_ids when absent so storyboards
+    // that don't provide a context ID don't reach the agent with ["unknown"].
     if (!context.media_buy_id) return {};
     return { media_buy_ids: [context.media_buy_id] };
   },

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -318,15 +318,18 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   },
 
   get_media_buys(_step, context, _options) {
-    return {
-      media_buy_ids: [context.media_buy_id ?? 'unknown'],
-    };
+    // Omit media_buy_ids when no context ID is present so storyboards that
+    // test the broad-list/pagination path receive a spec-conformant request
+    // (media_buy_ids is optional per the schema; omitting it returns all
+    // accessible media buys). Injecting ["unknown"] breaks pagination
+    // assertions — agents return 0 results for the placeholder ID.
+    if (!context.media_buy_id) return {};
+    return { media_buy_ids: [context.media_buy_id] };
   },
 
   get_media_buy_delivery(_step, context, _options) {
-    return {
-      media_buy_ids: [context.media_buy_id ?? 'unknown'],
-    };
+    if (!context.media_buy_id) return {};
+    return { media_buy_ids: [context.media_buy_id] };
   },
 
   // provide_performance_feedback intentionally has no builder — storyboard

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -318,19 +318,18 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   },
 
   get_media_buys(_step, context, _options) {
-    // Omit media_buy_ids when no context ID is present so storyboards that
-    // test the broad-list/pagination path receive a spec-conformant request
-    // (media_buy_ids is optional per the schema; omitting it returns all
-    // accessible media buys). Injecting ["unknown"] breaks pagination
-    // assertions — agents return 0 results for the placeholder ID.
-    if (!context.media_buy_id) return {};
+    // media_buy_ids is optional per the request schema; omitting it returns
+    // the broad/paginated set. Inject only when context carries a real ID
+    // so storyboards exercising the list path don't reach the agent with a
+    // synthesized lookup that filters out every result.
+    if (context.media_buy_id == null) return {};
     return { media_buy_ids: [context.media_buy_id] };
   },
 
   get_media_buy_delivery(_step, context, _options) {
-    // Same as get_media_buys: omit media_buy_ids when absent so storyboards
-    // that don't provide a context ID don't reach the agent with ["unknown"].
-    if (!context.media_buy_id) return {};
+    // Same omission rule as get_media_buys — media_buy_ids is optional on
+    // get_media_buy_delivery's request schema.
+    if (context.media_buy_id == null) return {};
     return { media_buy_ids: [context.media_buy_id] };
   },
 

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -740,6 +740,36 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('get_media_buys', () => {
+    test('omits media_buy_ids when context.media_buy_id is absent (broad-list path)', () => {
+      const result = buildRequest(step('get_media_buys'), {}, DEFAULT_OPTIONS);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(result, 'media_buy_ids'),
+        'media_buy_ids must be absent so agent receives a broad-list request'
+      );
+    });
+
+    test('injects media_buy_ids when context.media_buy_id is present', () => {
+      const result = buildRequest(step('get_media_buys'), { media_buy_id: 'buy-42' }, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.media_buy_ids, ['buy-42']);
+    });
+  });
+
+  describe('get_media_buy_delivery', () => {
+    test('omits media_buy_ids when context.media_buy_id is absent', () => {
+      const result = buildRequest(step('get_media_buy_delivery'), {}, DEFAULT_OPTIONS);
+      assert.ok(
+        !Object.prototype.hasOwnProperty.call(result, 'media_buy_ids'),
+        'media_buy_ids must be absent when no context ID is available'
+      );
+    });
+
+    test('injects media_buy_ids when context.media_buy_id is present', () => {
+      const result = buildRequest(step('get_media_buy_delivery'), { media_buy_id: 'buy-99' }, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.media_buy_ids, ['buy-99']);
+    });
+  });
+
   describe('hasRequestBuilder', () => {
     test('returns true for tasks with builders', () => {
       const tasks = [


### PR DESCRIPTION
Closes #983

## Summary

- `get_media_buys` and `get_media_buy_delivery` request enrichers in `request-builder.ts` unconditionally injected `media_buy_ids: [context.media_buy_id ?? 'unknown']` even when no context ID was present.
- The fixture-wins merge (`{ ...enriched, ...fixture }`) can't clear an enricher-injected key when the storyboard's `sample_request` simply omits it — so `["unknown"]` reached the agent, which returned 0 results, and `pagination.has_more=true` assertions failed.
- Both enrichers now omit `media_buy_ids` entirely when `context.media_buy_id` is absent, matching the `list_creatives` / `list_accounts` pattern. When a real context ID is present, behavior is unchanged.
- Unblocks `get-media-buys-pagination-integrity` in `adcontextprotocol/adcp#3122` from upgrading to its intended multi-page seeded walk.

## What was tested

- `node --test test/lib/request-builder.test.js` — 58 tests pass (4 new: absent-context + present-context for each enricher)
- `npm run build` passes
- Pre-existing test-suite failures (312) are unchanged — all pre-exist on `main`

## Scope note

`update_media_buy` (line 299) still uses `context.media_buy_id ?? 'unknown'` — intentionally, since `media_buy_id` is a **required** field on `UpdateMediaBuyRequest` and sending `'unknown'` produces a clean `MEDIA_BUY_NOT_FOUND` rather than a schema-validation failure. That is a different situation from the optional-field read enrichers fixed here.

`get_media_buy_delivery` returning `{}` when no context ID is present is spec-conformant: `media_buy_ids` is optional and the delivery endpoint has no `pagination` field (it is not a paginated endpoint by design). Downstream storyboards that invoke `get_media_buy_delivery` without a context ID will now receive delivery data for all accessible buys rather than 0 results — this is the correct broad-scoped behavior per the spec.

## Nits (not fixed)

None.

## Pre-PR review

- code-reviewer: approved — no blockers
- ad-tech-protocol-expert: approved — non-breaking per spec; `media_buy_ids` optional on both request types; `{}` is fully spec-conformant for `get_media_buy_delivery`

Session: https://claude.ai/code/session_01EbKBi9ZSKfXYHKJofYNsL1

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbKBi9ZSKfXYHKJofYNsL1)_