### PR TITLE
feat(testing,server): shape-drift hint + helper for get_plan_audit_logs (#856)

### DIFF
--- a/.changeset/plan-audit-logs-shape-drift.md
+++ b/.changeset/plan-audit-logs-shape-drift.md
@@ -1,0 +1,11 @@
+---
+'@adcp/client': minor
+---
+
+feat(testing,server): shape-drift hint + response helper for `get_plan_audit_logs`
+
+The storyboard runner's `LIST_WRAPPER_TOOLS` table now covers `get_plan_audit_logs`, so a handler that returns a bare `[{plan_id, …}]` array instead of `{ plans: [...] }` gets the targeted hint (`Use getPlanAuditLogsResponse() from @adcp/client/server`) alongside the AJV error.
+
+`getPlanAuditLogsResponse(data, summary?)` is now exported from `@adcp/client/server` and `@adcp/client`, mirroring the existing list-tool helpers (`listPropertyListsResponse`, `listContentStandardsResponse`, …).
+
+Note: the wrapper key is `plans`, not `logs` as issue #856's body claimed. Verified against `schemas/cache/3.0.0/governance/get-plan-audit-logs-response.json` and `tools.generated.ts:11542` — audit entries are bundled under each `plans[].entries[]` record. Closes #856.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -542,6 +542,7 @@ export {
   listPropertyListsResponse,
   listCollectionListsResponse,
   listContentStandardsResponse,
+  getPlanAuditLogsResponse,
   syncCreativesResponse,
   getSignalsResponse,
   activateSignalResponse,

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -29,6 +29,7 @@ export {
   listPropertyListsResponse,
   listCollectionListsResponse,
   listContentStandardsResponse,
+  getPlanAuditLogsResponse,
   syncCreativesResponse,
   getSignalsResponse,
   activateSignalResponse,

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -55,6 +55,7 @@ import type {
   ListPropertyListsResponse,
   ListCollectionListsResponse,
   ListContentStandardsResponse,
+  GetPlanAuditLogsResponse,
   ReportUsageRequest,
   ReportUsageResponse,
   SyncAccountsResponse,
@@ -375,6 +376,23 @@ export function listContentStandardsResponse(data: ListContentStandardsResponse,
       : 'Content standards lookup error';
   return {
     content: [{ type: 'text', text: summary ?? defaultSummary }],
+    structuredContent: toStructuredContent(data),
+  };
+}
+
+/**
+ * Build a get_plan_audit_logs response. Wraps the audit data array under
+ * the required `plans` key — handlers that return a bare array trip the
+ * storyboard runner's shape-drift hint.
+ */
+export function getPlanAuditLogsResponse(data: GetPlanAuditLogsResponse, summary?: string): McpToolResponse {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: summary ?? `Audit data for ${data.plans.length} plan${data.plans.length === 1 ? '' : 's'}`,
+      },
+    ],
     structuredContent: toStructuredContent(data),
   };
 }

--- a/src/lib/testing/storyboard/shape-drift-hints.ts
+++ b/src/lib/testing/storyboard/shape-drift-hints.ts
@@ -42,6 +42,7 @@ export const LIST_WRAPPER_TOOLS: Record<string, { wrapperKey: string; helper: st
   list_property_lists: { wrapperKey: 'lists', helper: 'listPropertyListsResponse' },
   list_collection_lists: { wrapperKey: 'lists', helper: 'listCollectionListsResponse' },
   list_content_standards: { wrapperKey: 'standards', helper: 'listContentStandardsResponse' },
+  get_plan_audit_logs: { wrapperKey: 'plans', helper: 'getPlanAuditLogsResponse' },
 };
 
 /**

--- a/test/lib/shape-drift-hint.test.js
+++ b/test/lib/shape-drift-hint.test.js
@@ -337,6 +337,17 @@ test('list_content_standards with bare array → hint suggests { standards: [...
   assert.match(hint, /listContentStandardsResponse/);
 });
 
+test('get_plan_audit_logs with bare array → hint suggests { plans: [...] }', () => {
+  // Wrapper key is `plans`, not `logs` — the schema bundles audit entries
+  // under each plan record (`plans[].entries[]`), and the response root
+  // exposes `plans`. Issue #856's body said `logs`; verified against
+  // schemas/cache/3.0.0/governance/get-plan-audit-logs-response.json.
+  const hint = detectShapeDriftHint('get_plan_audit_logs', [{ plan_id: 'plan1', plan_version: 1, status: 'active' }]);
+  assert.ok(hint);
+  assert.match(hint, /\{ plans: \[\.\.\.\] \}/);
+  assert.match(hint, /getPlanAuditLogsResponse/);
+});
+
 test('null / primitive payloads → no hint (detector exits cleanly)', () => {
   // Defensive: the detector must handle `null`, strings, numbers without
   // throwing — they're not a shape-drift pattern but they'd otherwise crash

--- a/test/lib/storyboard-shape-drift-hints.test.js
+++ b/test/lib/storyboard-shape-drift-hints.test.js
@@ -38,6 +38,21 @@ describe('detectShapeDriftHints: bare-array → list-tool wrapper', () => {
     assert.match(hint.message, /productsResponse/);
   });
 
+  test('get_plan_audit_logs bare array → expected_variant names the plans wrapper', () => {
+    // Schema wraps plan audit data under `plans`, not `logs` — issue #856
+    // body's `logs` claim is incorrect; the response shape is
+    // `{ plans: [{ plan_id, ..., entries: [...] }] }` per
+    // schemas/cache/3.0.0/governance/get-plan-audit-logs-response.json.
+    const [hint] = detectShapeDriftHints('get_plan_audit_logs', [{ plan_id: 'p1' }]);
+    assert.ok(hint, 'expected exactly one hint');
+    assert.equal(hint.kind, 'shape_drift');
+    assert.equal(hint.tool, 'get_plan_audit_logs');
+    assert.equal(hint.observed_variant, 'bare_array');
+    assert.equal(hint.expected_variant, '{ plans: [...] }');
+    assert.equal(hint.instance_path, '');
+    assert.match(hint.message, /getPlanAuditLogsResponse/);
+  });
+
   test('unknown tool with bare array → no hint (avoids false positives)', () => {
     const hints = detectShapeDriftHints('unknown_tool', [{ id: 1 }]);
     assert.deepEqual(hints, []);

--- a/test/server-responses.test.js
+++ b/test/server-responses.test.js
@@ -18,6 +18,7 @@ const {
   listPropertyListsResponse,
   listCollectionListsResponse,
   listContentStandardsResponse,
+  getPlanAuditLogsResponse,
   syncCreativesResponse,
   getSignalsResponse,
   activateSignalResponse,
@@ -582,5 +583,54 @@ describe('listContentStandardsResponse', () => {
     const result = listContentStandardsResponse(data);
     assert.match(result.content[0].text, /Found 1 content standard\b/);
     assert.doesNotMatch(result.content[0].text, /error/i);
+  });
+});
+
+describe('getPlanAuditLogsResponse', () => {
+  it('wraps plans under the required envelope with a counted default summary', () => {
+    const data = {
+      plans: [
+        {
+          plan_id: 'plan_1',
+          plan_version: 1,
+          status: 'active',
+          budget: {},
+          governed_actions: [],
+          summary: {},
+        },
+        {
+          plan_id: 'plan_2',
+          plan_version: 3,
+          status: 'completed',
+          budget: {},
+          governed_actions: [],
+          summary: {},
+        },
+      ],
+    };
+    const result = getPlanAuditLogsResponse(data);
+    assert.match(result.content[0].text, /Audit data for 2 plans/);
+    assert.deepStrictEqual(result.structuredContent.plans, data.plans);
+  });
+
+  it('handles the singular case without the plural "s"', () => {
+    const result = getPlanAuditLogsResponse({
+      plans: [
+        {
+          plan_id: 'plan_1',
+          plan_version: 1,
+          status: 'active',
+          budget: {},
+          governed_actions: [],
+          summary: {},
+        },
+      ],
+    });
+    assert.match(result.content[0].text, /Audit data for 1 plan\b/);
+  });
+
+  it('honours an explicit summary override', () => {
+    const result = getPlanAuditLogsResponse({ plans: [] }, 'Audit pulled');
+    assert.strictEqual(result.content[0].text, 'Audit pulled');
   });
 });


### PR DESCRIPTION
## Summary

Closes #856.

- Add \`getPlanAuditLogsResponse(data, summary?)\` to \`@adcp/client/server\` (and re-export from \`@adcp/client\`), mirroring \`listPropertyListsResponse\` / \`listContentStandardsResponse\`.
- Register \`get_plan_audit_logs\` in \`LIST_WRAPPER_TOOLS\` so a bare \`[{plan_id, …}]\` array trips the storyboard runner's targeted shape-drift hint (\`Use getPlanAuditLogsResponse() from @adcp/client/server\`) alongside the AJV pointer.

## Wrapper key correction

Issue #856's body said the wrapper key was \`logs\`. It's \`plans\` — verified against the schema and the generated TS:

- \`schemas/cache/3.0.0/governance/get-plan-audit-logs-response.json\` → \`properties.plans\` (array of plan records, each with its own \`entries[]\`)
- \`src/lib/types/tools.generated.ts:11542\` → \`plans: { plan_id, plan_version, status, …, entries?: [...] }[]\`

Audit entries are bundled per-plan under \`plans[].entries[]\` rather than at the response root, so wrapping under \`logs\` would have produced a hint that names a key the schema doesn't have. Tests + the changeset call this out so future readers don't repeat the mistake.

## Test plan

- [x] Build clean (\`npm run build\`)
- [x] Lint clean — 0 errors (\`npm run lint\`)
- [x] Format clean (\`npm run format\`)
- [x] All 117 tests pass for shape-drift + responses suites
  - New: \`storyboard-shape-drift-hints.test.js\` — structured hint asserts \`expected_variant: "{ plans: [...] }"\`, \`tool: "get_plan_audit_logs"\`, \`instance_path: ""\`
  - New: \`shape-drift-hint.test.js\` — string-shim hint mentions \`getPlanAuditLogsResponse\`
  - New: \`server-responses.test.js\` — \`getPlanAuditLogsResponse\` covers singular/plural/empty + summary override
- [x] Changeset: \`@adcp/client\` minor — calls out the API addition and the issue-body correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)