### PR TITLE
feat(server): PostgresTaskStore.createTask accepts optional caller-supplied taskId

### DIFF
--- a/.changeset/postgres-task-store-caller-id.md
+++ b/.changeset/postgres-task-store-caller-id.md
@@ -8,6 +8,21 @@ Compliance storyboard controller scenarios (`force_create_media_buy_arm`,
 `force_task_completion`) need to inject buyer-supplied task IDs for storyboard
 determinism. `PostgresTaskStore.createTask` now accepts an optional `taskId`
 field on its first argument: when supplied, the ID is used verbatim; when
-omitted, a random hex ID is generated as before. Throws with a descriptive
-message if the supplied ID already exists (detected via PG uniqueness
-constraint, not a pre-check race).
+omitted, a random hex ID is generated as before. Throws if the supplied ID is
+empty, longer than 128 characters, or already exists (the collision is detected
+via PG uniqueness constraint, not a pre-check race).
+
+**Caveats and follow-ups:**
+- `InMemoryTaskStore` (re-exported from the upstream MCP SDK) does NOT honor
+  caller-supplied `taskId` — sellers running without `DATABASE_URL` (e.g., test
+  paths) get random IDs even when one is supplied. Filing an upstream MCP SDK
+  issue to add `taskId?: string` to `CreateTaskOptions` so both stores can honor
+  it cleanly is the right durable fix; this PR is the Postgres-only shim until
+  upstream lands.
+- The `task_id` namespace on `PostgresTaskStore` is process-global today (no
+  tenant scoping in the schema). Callers using caller-supplied IDs are
+  responsible for namespace isolation. A future migration to a composite
+  `(tenant_id, task_id)` key would close this for production use.
+- The storyboard runner does not yet send caller-supplied IDs through to the
+  controller tool's input schema. That wiring (runner → tool input → task
+  store) is a separate change tracked in the parent issue.

--- a/.changeset/postgres-task-store-caller-id.md
+++ b/.changeset/postgres-task-store-caller-id.md
@@ -1,0 +1,13 @@
+---
+"@adcp/client": minor
+---
+
+feat(server): PostgresTaskStore.createTask accepts optional caller-supplied taskId
+
+Compliance storyboard controller scenarios (`force_create_media_buy_arm`,
+`force_task_completion`) need to inject buyer-supplied task IDs for storyboard
+determinism. `PostgresTaskStore.createTask` now accepts an optional `taskId`
+field on its first argument: when supplied, the ID is used verbatim; when
+omitted, a random hex ID is generated as before. Throws with a descriptive
+message if the supplied ID already exists (detected via PG uniqueness
+constraint, not a pre-check race).

--- a/src/lib/server/postgres-task-store.ts
+++ b/src/lib/server/postgres-task-store.ts
@@ -159,7 +159,13 @@ export class PostgresTaskStore implements TaskStore {
    * Create a new task. Pass `taskParams.taskId` to use a caller-supplied ID verbatim
    * (useful for compliance-controller scenarios where the runner needs deterministic
    * task IDs). If omitted, a random hex ID is generated. Throws if the supplied ID
-   * already exists.
+   * is empty / longer than 128 chars, or already exists.
+   *
+   * The `task_id` namespace on this store is global (no tenant scoping in the schema
+   * today). Callers using caller-supplied IDs are responsible for namespace isolation;
+   * cross-tenant collisions surface as `already exists`. Track the schema fix
+   * (composite key on tenant + task_id) in a future SDK migration if production paths
+   * ever wire caller-supplied IDs.
    */
   async createTask(
     taskParams: CreateTaskOptions & { taskId?: string },
@@ -167,6 +173,14 @@ export class PostgresTaskStore implements TaskStore {
     request: Request,
     _sessionId?: string
   ): Promise<Task> {
+    if (taskParams.taskId !== undefined) {
+      if (typeof taskParams.taskId !== 'string' || taskParams.taskId.length === 0) {
+        throw new Error('taskId must be a non-empty string when supplied');
+      }
+      if (taskParams.taskId.length > 128) {
+        throw new Error(`taskId must be 128 characters or fewer (got ${taskParams.taskId.length})`);
+      }
+    }
     const taskId = taskParams.taskId ?? randomBytes(16).toString('hex');
     const ttl = taskParams.ttl ?? null;
     const pollInterval = taskParams.pollInterval ?? 1000;

--- a/src/lib/server/postgres-task-store.ts
+++ b/src/lib/server/postgres-task-store.ts
@@ -155,27 +155,43 @@ export class PostgresTaskStore implements TaskStore {
     }
   }
 
+  /**
+   * Create a new task. Pass `taskParams.taskId` to use a caller-supplied ID verbatim
+   * (useful for compliance-controller scenarios where the runner needs deterministic
+   * task IDs). If omitted, a random hex ID is generated. Throws if the supplied ID
+   * already exists.
+   */
   async createTask(
-    taskParams: CreateTaskOptions,
+    taskParams: CreateTaskOptions & { taskId?: string },
     requestId: RequestId,
     request: Request,
     _sessionId?: string
   ): Promise<Task> {
-    const taskId = randomBytes(16).toString('hex');
+    const taskId = taskParams.taskId ?? randomBytes(16).toString('hex');
     const ttl = taskParams.ttl ?? null;
     const pollInterval = taskParams.pollInterval ?? 1000;
 
-    const { rows } = await this.db.query(
-      `INSERT INTO ${this.table} (task_id, status, ttl, poll_interval, request_id, request, expires_at)
-       VALUES ($1, 'working', $2, $3, $4, $5,
-               CASE WHEN $2::integer IS NOT NULL
-                    THEN NOW() + ($2::integer || ' milliseconds')::interval
-                    ELSE NULL END)
-       RETURNING *`,
-      [taskId, ttl, pollInterval, String(requestId), JSON.stringify(request)]
-    );
+    try {
+      const { rows } = await this.db.query(
+        `INSERT INTO ${this.table} (task_id, status, ttl, poll_interval, request_id, request, expires_at)
+         VALUES ($1, 'working', $2, $3, $4, $5,
+                 CASE WHEN $2::integer IS NOT NULL
+                      THEN NOW() + ($2::integer || ' milliseconds')::interval
+                      ELSE NULL END)
+         RETURNING *`,
+        [taskId, ttl, pollInterval, String(requestId), JSON.stringify(request)]
+      );
 
-    return rowToTask(rows[0] as unknown as TaskRow);
+      return rowToTask(rows[0] as unknown as TaskRow);
+    } catch (err) {
+      // Unique constraint violation — a task with this ID already exists.
+      if (typeof err === 'object' && err !== null && (err as { code?: unknown }).code === '23505') {
+        throw new Error(
+          `Task with ID ${taskId.slice(0, 256)} already exists. Use a different taskId or retrieve the existing task via getTask().`
+        );
+      }
+      throw err;
+    }
   }
 
   async getTask(taskId: string, _sessionId?: string): Promise<Task | null> {

--- a/src/lib/server/postgres-task-store.ts
+++ b/src/lib/server/postgres-task-store.ts
@@ -159,7 +159,9 @@ export class PostgresTaskStore implements TaskStore {
    * Create a new task. Pass `taskParams.taskId` to use a caller-supplied ID verbatim
    * (useful for compliance-controller scenarios where the runner needs deterministic
    * task IDs). If omitted, a random hex ID is generated. Throws if the supplied ID
-   * is empty / longer than 128 chars, or already exists.
+   * is empty / longer than 128 chars, or already exists. The 128-char ceiling is an
+   * SDK policy (matches typical request-id / session-id field lengths and keeps
+   * the task_id index efficient) — Postgres TEXT itself imposes no limit.
    *
    * The `task_id` namespace on this store is global (no tenant scoping in the schema
    * today). Callers using caller-supplied IDs are responsible for namespace isolation;
@@ -201,7 +203,7 @@ export class PostgresTaskStore implements TaskStore {
       // Unique constraint violation — a task with this ID already exists.
       if (typeof err === 'object' && err !== null && (err as { code?: unknown }).code === '23505') {
         throw new Error(
-          `Task with ID ${taskId.slice(0, 256)} already exists. Use a different taskId or retrieve the existing task via getTask().`
+          `Task with ID ${taskId} already exists. Use a different taskId or retrieve the existing task via getTask().`
         );
       }
       throw err;

--- a/test/lib/postgres-task-store.test.js
+++ b/test/lib/postgres-task-store.test.js
@@ -144,18 +144,12 @@ describe('PostgresTaskStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' },
   });
 
   test('createTask rejects empty-string taskId', async () => {
-    await assert.rejects(
-      () => store.createTask({ taskId: '' }, '1', fakeRequest),
-      /non-empty string/,
-    );
+    await assert.rejects(() => store.createTask({ taskId: '' }, '1', fakeRequest), /non-empty string/);
   });
 
   test('createTask rejects taskId longer than 128 characters', async () => {
     const tooLong = 'x'.repeat(129);
-    await assert.rejects(
-      () => store.createTask({ taskId: tooLong }, '1', fakeRequest),
-      /128 characters or fewer/,
-    );
+    await assert.rejects(() => store.createTask({ taskId: tooLong }, '1', fakeRequest), /128 characters or fewer/);
   });
 
   test('createTask accepts taskId at the 128-character boundary', async () => {

--- a/test/lib/postgres-task-store.test.js
+++ b/test/lib/postgres-task-store.test.js
@@ -119,6 +119,30 @@ describe('PostgresTaskStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' },
     assert.strictEqual(task.pollInterval, 1000);
   });
 
+  test('createTask accepts caller-supplied taskId', async () => {
+    const suppliedId = 'storyboard-deterministic-id-001';
+    const task = await store.createTask({ taskId: suppliedId, ttl: 60000 }, '1', fakeRequest);
+
+    assert.strictEqual(task.taskId, suppliedId);
+    assert.strictEqual(task.status, 'working');
+
+    const fetched = await store.getTask(suppliedId);
+    assert.strictEqual(fetched.taskId, suppliedId);
+  });
+
+  test('createTask throws on duplicate caller-supplied taskId', async () => {
+    const suppliedId = 'duplicate-id-test';
+    await store.createTask({ taskId: suppliedId }, '1', fakeRequest);
+
+    await assert.rejects(() => store.createTask({ taskId: suppliedId }, '2', fakeRequest), /already exists/);
+  });
+
+  test('createTask with no taskId generates a random id each call', async () => {
+    const t1 = await store.createTask({}, '1', fakeRequest);
+    const t2 = await store.createTask({}, '2', fakeRequest);
+    assert.notStrictEqual(t1.taskId, t2.taskId);
+  });
+
   test('getTask returns created task', async () => {
     const created = await store.createTask({ ttl: 60000 }, '1', fakeRequest);
     const fetched = await store.getTask(created.taskId);

--- a/test/lib/postgres-task-store.test.js
+++ b/test/lib/postgres-task-store.test.js
@@ -143,6 +143,27 @@ describe('PostgresTaskStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' },
     assert.notStrictEqual(t1.taskId, t2.taskId);
   });
 
+  test('createTask rejects empty-string taskId', async () => {
+    await assert.rejects(
+      () => store.createTask({ taskId: '' }, '1', fakeRequest),
+      /non-empty string/,
+    );
+  });
+
+  test('createTask rejects taskId longer than 128 characters', async () => {
+    const tooLong = 'x'.repeat(129);
+    await assert.rejects(
+      () => store.createTask({ taskId: tooLong }, '1', fakeRequest),
+      /128 characters or fewer/,
+    );
+  });
+
+  test('createTask accepts taskId at the 128-character boundary', async () => {
+    const boundary = 'x'.repeat(128);
+    const task = await store.createTask({ taskId: boundary }, '1', fakeRequest);
+    assert.strictEqual(task.taskId, boundary);
+  });
+
   test('getTask returns created task', async () => {
     const created = await store.createTask({ ttl: 60000 }, '1', fakeRequest);
     const fetched = await store.getTask(created.taskId);


### PR DESCRIPTION
Refs #994

## Summary

- Adds an optional `taskId?: string` field to `PostgresTaskStore.createTask`'s first parameter. When supplied, the ID is used verbatim; when omitted, a random 32-char hex ID is generated (existing behavior unchanged).
- Collision detection relies on PostgreSQL's `23505` uniqueness constraint caught on INSERT — no TOCTOU check-then-insert race.
- Error message includes recovery guidance consistent with the file's existing style.

**Does not ship Gap 2** (the `tasks/get` response shape mismatch). See the triage comment on #994 for expert synthesis and recommended design. That gap requires architectural discussion about where `task_type` is sourced and whether the `tasks/get` tool should be auto-registered.

## What was tested

- TypeScript: no new errors introduced (pre-existing `@types/node` absent errors are environment-only)
- Prettier: passes `format:check`
- Unit tests: three new cases added to `test/lib/postgres-task-store.test.js` (skipped without `DATABASE_URL`): caller-supplied ID round-trip, duplicate collision throws, auto-generated IDs are distinct

## Nits from pre-PR review (not blocking)

- Empty-string `taskId` accepted by PG as a valid TEXT key; callers should avoid it. A future hardening pass could add explicit validation, but it's not a SQL injection risk (parameterized query).

## Pre-PR review

- code-reviewer: approved — fixed PG error code type guard (`typeof`/`instanceof` double-cast → plain object check); bumped changeset from `patch` to `minor`; renamed one test name for accuracy
- ad-tech-protocol-expert: approved — non-breaking per spec; change is additive on the concrete class, not the interface

Session: https://claude.ai/code/session_01Xwm3Ed1SRCjKFvjQhSzz5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xwm3Ed1SRCjKFvjQhSzz5M)_