### PR TITLE
fix(conformance): guard get_media_buys extractor against mid-walk pagination pages

### DIFF
--- a/.changeset/get-media-buys-extractor-has-more-guard.md
+++ b/.changeset/get-media-buys-extractor-has-more-guard.md
@@ -1,0 +1,7 @@
+---
+'@adcp/client': patch
+---
+
+**Fix `get_media_buys` convention extractor poisoning context during multi-page pagination walks (#998).** The extractor unconditionally captured `media_buys[0].media_buy_id` from every successful `get_media_buys` response. When a storyboard walks multi-page results, the page-1 response carries `pagination.has_more: true` — buys[0] is not the canonical buy, it is just the first item in a list slice. The captured ID was then picked up by the request-builder enricher on step 2 and injected as `media_buy_ids: [that_id]`, turning the pagination continuation into a single-ID lookup. The agent returned one buy with `has_more: false, total_count: 1`, failing `total_count: 3` storyboard assertions.
+
+The extractor now skips extraction when `pagination.has_more === true`, matching the conservative `=== true` convention used elsewhere in the codebase (`hasMorePages()` in `validations.ts`). When `has_more` is absent or `false` — i.e., a terminal or single-page response — extraction proceeds as before. This unblocks `get-media-buys-pagination-integrity` in `adcontextprotocol/adcp#3122` from upgrading to the seeded multi-page walk model used by `list_creatives` and other paginated storyboards.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.17.0",
+  "version": "5.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.17.0",
+      "version": "5.18.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -76,6 +76,14 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     const d = data as Record<string, unknown> | undefined;
     const buys = d?.media_buys as Array<Record<string, unknown>> | undefined;
     if (!buys?.[0]) return {};
+    // Don't extract a single-resource ID from a broad-list page. When
+    // has_more: true the caller is mid-pagination walk and buys[0] is not
+    // the canonical buy — extracting it here causes the enricher to inject
+    // media_buy_ids: [that_id] on the next step, turning a continuation into
+    // an ID-lookup. Conservative: === true matches the codebase convention
+    // (absent has_more is treated as terminal, not as a list-in-progress).
+    const pagination = d?.pagination as Record<string, unknown> | undefined;
+    if (pagination?.has_more === true) return {};
     return {
       media_buy_id: buys[0].media_buy_id,
       media_buy_status: buys[0].status,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.17.0';
+export const LIBRARY_VERSION = '5.18.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.17.0',
+  library: '5.18.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-25T09:51:32.604Z',
+  generatedAt: '2026-04-25T18:58:27.946Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-context-generate.test.js
+++ b/test/lib/storyboard-context-generate.test.js
@@ -1,6 +1,6 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
-const { injectContext, forwardAliasCache } = require('../../dist/lib/testing/storyboard/context');
+const { injectContext, forwardAliasCache, extractContext } = require('../../dist/lib/testing/storyboard/context');
 
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -77,5 +77,36 @@ describe('$generate:uuid_v4 placeholder resolution', () => {
     const b = injectContext({ idempotency_key: '$generate:uuid_v4#replay_key' }, ctx2);
 
     assert.notStrictEqual(a.idempotency_key, b.idempotency_key);
+  });
+});
+
+describe('extractContext – get_media_buys pagination guard', () => {
+  it('returns {} when pagination.has_more is true (mid-walk page)', () => {
+    const data = {
+      media_buys: [{ media_buy_id: 'buy-1', status: 'active' }],
+      pagination: { has_more: true, cursor: 'cursor-abc' },
+    };
+    assert.deepStrictEqual(extractContext('get_media_buys', data), {});
+  });
+
+  it('extracts media_buy_id when pagination.has_more is false (terminal page)', () => {
+    const data = {
+      media_buys: [{ media_buy_id: 'buy-1', status: 'active' }],
+      pagination: { has_more: false },
+    };
+    const result = extractContext('get_media_buys', data);
+    assert.strictEqual(result.media_buy_id, 'buy-1');
+    assert.strictEqual(result.media_buy_status, 'active');
+  });
+
+  it('extracts media_buy_id when no pagination block present (single-resource response)', () => {
+    const data = { media_buys: [{ media_buy_id: 'buy-2', status: 'pending' }] };
+    const result = extractContext('get_media_buys', data);
+    assert.strictEqual(result.media_buy_id, 'buy-2');
+    assert.strictEqual(result.media_buy_status, 'pending');
+  });
+
+  it('returns {} when media_buys array is empty', () => {
+    assert.deepStrictEqual(extractContext('get_media_buys', { media_buys: [] }), {});
   });
 });


### PR DESCRIPTION
Closes #998

## Summary

The `get_media_buys` convention extractor in `src/lib/testing/storyboard/context.ts` unconditionally captured `media_buys[0].media_buy_id` from every successful `get_media_buys` response. During a multi-page pagination walk, the page-1 response carries `pagination.has_more: true` — the first item is not the canonical media buy, it is just the first item in an intermediate list slice. The request-builder enricher on step 2 read that poisoned context value and injected `media_buy_ids: [that_id]`, turning the pagination continuation into an ID-lookup. The agent returned one buy with `has_more: false, total_count: 1`; the storyboard's `total_count: 3` assertion failed.

**Fix:** The extractor now returns `{}` when `pagination.has_more === true`. When `has_more` is `false` or absent (terminal or no-pagination response), extraction proceeds as before. This matches the conservative `=== true` convention used by `hasMorePages()` in `validations.ts`.

This unblocks `get-media-buys-pagination-integrity` in `adcontextprotocol/adcp#3122` from upgrading to the seeded multi-page walk model used by `list_creatives` and all other paginated storyboards.

## What was tested

- `node --test test/lib/storyboard-context-generate.test.js` — 11 tests pass (7 existing + 4 new covering: mid-walk suppressed, terminal extracted, no-pagination extracted, empty-array guard)
- `node --test test/lib/*.test.js` — baseline failures decreased from 265 to 258; no regressions introduced
- `npm run build:lib` passes

## Nits (not fixed)

- `list_creatives` and `get_signals` extractors have the same structural pattern with no `has_more` guard. No storyboard currently exercises a multi-page walk on those tools, so there is no active bug — but the gap should be tracked as a follow-up if multi-page storyboards are added for them.
- The inline `pagination?.has_more === true` cast duplicates the pattern already extracted in `hasMorePages()` (`validations.ts`). Equivalent for the inputs seen here; a nit for future cleanup.
- New tests were added to `storyboard-context-generate.test.js`; semantically they belong in a file scoped to extraction rather than generation. Minor naming mismatch, no correctness impact.

## Pre-PR review

- code-reviewer: approved — no blockers; nits noted above
- ad-tech-protocol-expert: approved — spec-correct; `has_more: true` is unambiguously an intermediate page per AdCP and OpenRTB cursor-pagination convention; `=== true` guard is consistent with `hasMorePages()`

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017TWyDQJemQ2KNew5YNGTaX

---
_Generated by [Claude Code](https://claude.ai/code/session_017TWyDQJemQ2KNew5YNGTaX)_