### PR TITLE
fix(server): add pgBackend probe + readinessCheck for fail-fast pool validation

### DIFF
--- a/.changeset/pgbackend-probe-at-boot.md
+++ b/.changeset/pgbackend-probe-at-boot.md
@@ -1,0 +1,28 @@
+---
+"@adcp/client": minor
+---
+
+Add `pgBackend.probe()` and `serve({ readinessCheck })` for fail-fast pool validation
+
+Sellers wiring `createIdempotencyStore({ backend: pgBackend(pool) })` from a `DATABASE_URL` env var previously got a silent failure mode: a bad URL (typo, deprovisioned DB, missing creds) lets the server boot successfully, advertise `IdempotencySupported`, then fail every mutating call indefinitely.
+
+This release adds:
+
+- **`pgBackend.probe()`** — runs `SELECT 1 FROM "<table>" LIMIT 0` at startup, validating both connectivity and that the idempotency table has been migrated. Throws a descriptive error naming the table, root cause, and remediation steps.
+- **`IdempotencyStore.probe()`** — delegates to `backend.probe()` when the backend implements it; no-ops for `memoryBackend`.
+- **`probeIdempotencyStore(store)`** — convenience export for callers that manage their own lifecycle (Lambda, custom HTTP frameworks).
+- **`ServeOptions.readinessCheck?: () => Promise<void>`** — called before `httpServer.listen()`. The server never accepts connections if the check throws, so a misconfigured pool crashes the process at deploy time rather than silently failing live traffic.
+
+Wire the probe in `serve()`:
+
+```ts
+const store = createIdempotencyStore({ backend: pgBackend(pool), ttlSeconds: 86400 });
+pool.on('error', (err) => console.error('pg pool error', err)); // prevent crash on idle-client errors
+serve(createAgent, {
+  readinessCheck: () => store.probe(),
+});
+```
+
+`readinessCheck` is general-purpose — use it for any startup dependency check, not just idempotency.
+
+**Non-breaking.** `createIdempotencyStore` remains synchronous. Existing callers require no changes. Option A (async constructor) is tracked separately as a future major-version enhancement.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -261,8 +261,9 @@ import {
   serve,
 } from '@adcp/client/server';
 
+// Development — in-process store, resets on restart:
 const idempotency = createIdempotencyStore({
-  backend: memoryBackend(),       // or pgBackend(pool) — run getIdempotencyMigration() once
+  backend: memoryBackend(),
   ttlSeconds: 86400,              // 1h–7d, clamped to spec bounds
 });
 
@@ -278,6 +279,24 @@ serve(() => createAdcpServer({
     }),
   },
 }));
+```
+
+**Production (pgBackend).** `pg.Pool` is lazy — a bad `DATABASE_URL` lets the server boot, advertise `IdempotencySupported`, then silently fail every mutating call. Wire `readinessCheck` so the server never accepts traffic with a broken pool:
+
+```typescript
+import { createIdempotencyStore, pgBackend, getIdempotencyMigration, serve } from '@adcp/client/server';
+import { Pool } from 'pg';
+
+// Run getIdempotencyMigration() once before first boot to create the table —
+// readinessCheck below queries it to catch missing migrations, not just connectivity.
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+pool.on('error', (err) => console.error('pg pool error', err)); // prevent crash on idle-client errors
+const idempotency = createIdempotencyStore({ backend: pgBackend(pool), ttlSeconds: 86400 });
+
+serve(createAdcpServer, {
+  readinessCheck: () => idempotency.probe(), // throws with a descriptive error if pool/table is broken
+});
 ```
 
 The framework auto-handles:

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -1193,6 +1193,16 @@ If the validation can only run after a partial write (rare), make the write itse
 
 The quick-start uses `memoryBackend()` + `InMemoryStateStore` — both reset on process restart and don't scale across replicas. Production swaps three pieces: `createIdempotencyStore({ backend: pgBackend(pool) })`, `PostgresStateStore(pool)`, `PostgresTaskStore(pool)`. Run the three migrations at boot (`getIdempotencyMigration()`, `getAdcpStateMigration()`, `MCP_TASKS_MIGRATION`), wire `cleanupExpiredIdempotency(pool)` on an hourly cron, and set `resolveAccount` to hit your real DB instead of `InMemoryStateStore`. Full worked example with Pool sizing and multi-tenant principal resolution lives in [`docs/guides/BUILD-AN-AGENT.md`](../../docs/guides/BUILD-AN-AGENT.md) § Going to Production.
 
+**Critical: probe the pool at boot.** `pg.Pool` is lazy — `new Pool({ connectionString })` does not validate the URL. A bad `DATABASE_URL` lets the server start, advertise `IdempotencySupported`, and then silently fail every mutating call. Wire `readinessCheck` on `serve()` so the server never accepts traffic with a broken pool:
+
+```ts
+const store = createIdempotencyStore({ backend: pgBackend(pool), ttlSeconds: 86400 });
+pool.on('error', (err) => console.error('pg pool error', err)); // prevent crash on idle-client errors
+serve(createAgent, {
+  readinessCheck: () => store.probe(), // throws with a descriptive error if pool/table is broken
+});
+```
+
 Auth is not wired in the example — see [§ Protecting your agent](#protecting-your-agent) below.
 
 ## Deployment beyond single-host HTTP

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -331,6 +331,16 @@ AdCP v3 requires an `idempotency_key` on every mutating request — for signals 
 
 Scoping is per-principal via `resolveSessionKey` (override with `resolveIdempotencyPrincipal` for custom scoping). `ttlSeconds` must be 3600–604800 — out of range throws at construction. If you register mutating handlers without wiring `idempotency`, the framework logs an error at server-creation time.
 
+**Critical: probe the pool at boot (pgBackend).** `pg.Pool` is lazy — `new Pool({ connectionString })` does not validate the URL. A bad `DATABASE_URL` lets the server start, advertise `IdempotencySupported`, and then silently fail every `activate_signal` call. Wire `readinessCheck` on `serve()` so the server never accepts traffic with a broken pool:
+
+```ts
+const store = createIdempotencyStore({ backend: pgBackend(pool), ttlSeconds: 86400 });
+pool.on('error', (err) => console.error('pg pool error', err)); // prevent crash on idle-client errors
+serve(createAgent, {
+  readinessCheck: () => store.probe(), // throws with a descriptive error if pool/table is broken
+});
+```
+
 ## Protecting your agent
 
 **An AdCP agent that accepts unauthenticated requests is non-compliant** (see `security_baseline` in the universal storyboard bundle). Ask the operator: "API key, OAuth, or both?" — then wire one of these into `serve()`.

--- a/src/lib/server/idempotency/backends/pg.ts
+++ b/src/lib/server/idempotency/backends/pg.ts
@@ -85,11 +85,45 @@ export const IDEMPOTENCY_MIGRATION = getIdempotencyMigration();
  * Pass a connection pool (or any `PgQueryable`) and optionally a custom
  * table name. Run `getIdempotencyMigration()` once per deployment to
  * create the table.
+ *
+ * **Startup probe.** Call `store.probe()` (or `probeIdempotencyStore(store)`)
+ * before your server starts accepting traffic to catch a bad `DATABASE_URL`
+ * at boot rather than on the first mutating request. Wire it via:
+ *
+ * ```ts
+ * serve(createAgent, {
+ *   readinessCheck: () => store.probe(),
+ * });
+ * ```
+ *
+ * **Idle-client errors.** `pg.Pool` re-emits network drop / PG restart
+ * errors on the pool itself. Without a listener, Node's `EventEmitter`
+ * default-throws and crashes the process. Add one in your bootstrap:
+ *
+ * ```ts
+ * pool.on('error', (err) => console.error('pg pool error', err));
+ * ```
  */
 export function pgBackend(db: PgQueryable, options: PgBackendOptions = {}): IdempotencyBackend {
+  // tableName is trusted SDK config (compile-time / startup), not user input —
+  // quoteIdent validates the identifier shape and is safe to interpolate.
   const table = quoteIdent(options.tableName ?? DEFAULT_TABLE);
 
   return {
+    async probe(): Promise<void> {
+      try {
+        await db.query(`SELECT 1 FROM ${table} LIMIT 0`);
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err);
+        throw new Error(
+          `idempotency backend probe failed: cannot reach the "${options.tableName ?? DEFAULT_TABLE}" table. ` +
+            `The pool is unreachable or the table has not been migrated — the server would advertise ` +
+            `IdempotencySupported but every mutating call would fail. ` +
+            `Run getIdempotencyMigration() to create the table, or check DATABASE_URL. Cause: ${cause}`
+        );
+      }
+    },
+
     async get(scopedKey: string): Promise<IdempotencyCacheEntry | null> {
       const result = await db.query(
         `SELECT payload_hash, response, EXTRACT(EPOCH FROM expires_at)::BIGINT AS expires_at FROM ${table} WHERE scoped_key = $1`,

--- a/src/lib/server/idempotency/index.ts
+++ b/src/lib/server/idempotency/index.ts
@@ -1,4 +1,4 @@
-export { createIdempotencyStore, hashPayload } from './store';
+export { createIdempotencyStore, hashPayload, probeIdempotencyStore } from './store';
 export type {
   IdempotencyStore,
   IdempotencyStoreConfig,

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -114,6 +114,15 @@ export interface IdempotencyBackend {
    */
   delete(scopedKey: string): Promise<void>;
   /**
+   * Optional startup probe. Implementations that wrap an external store
+   * (e.g., `pgBackend`) should implement this to eagerly validate the
+   * connection before the server starts accepting traffic. Called by
+   * `probeIdempotencyStore()` and by `serve()` when `readinessCheck` is
+   * wired. Throws a descriptive error when the backend is unreachable or
+   * the required schema is missing.
+   */
+  probe?(): Promise<void>;
+  /**
    * Optional hook for implementations that need to release resources
    * (close pools, clear timers). Called by `store.close()`.
    */
@@ -256,6 +265,13 @@ export interface IdempotencyStore {
     extraScope?: string;
   }): Promise<void>;
   /**
+   * Probe the backend at server startup. Delegates to `backend.probe()` if
+   * the backend implements it; otherwise resolves immediately. Wire into
+   * `serve()` via `readinessCheck: () => store.probe()` so the server
+   * never accepts traffic with a broken pool.
+   */
+  probe?(): Promise<void>;
+  /**
    * Capability fragment for `get_adcp_capabilities` — tells buyers the
    * replay window so they can reason about retry safety. Pass to
    * `createAdcpServer` via `capabilities.idempotency`.
@@ -391,6 +407,10 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
       await backend.put(scopedKey, { payloadHash, response, expiresAt });
     },
 
+    async probe() {
+      if (backend.probe) await backend.probe();
+    },
+
     capability() {
       return { replay_ttl_seconds: ttlSeconds };
     },
@@ -466,6 +486,23 @@ function scope(principal: string, key: string, extraScope?: string): string {
   return extraScope
     ? `${principal}${SCOPE_SEPARATOR}${extraScope}${SCOPE_SEPARATOR}${key}`
     : `${principal}${SCOPE_SEPARATOR}${key}`;
+}
+
+/**
+ * Escape-hatch for callers that manage their own lifecycle (Lambda, custom
+ * HTTP frameworks) and cannot use `serve({ readinessCheck })`. Delegates to
+ * `store.probe()`. For servers built with `serve()`, prefer:
+ *
+ * ```ts
+ * serve(createAgent, { readinessCheck: () => store.probe() });
+ * ```
+ *
+ * Resolves immediately when the backend has no `probe()` (e.g., `memoryBackend`).
+ * Throws with a descriptive error when the backend is unreachable or its
+ * required schema is missing.
+ */
+export async function probeIdempotencyStore(store: IdempotencyStore): Promise<void> {
+  if (store.probe) await store.probe();
 }
 
 function validateTtl(seconds: number): number {

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -236,6 +236,7 @@ export type {
 
 export {
   createIdempotencyStore,
+  probeIdempotencyStore,
   memoryBackend,
   pgBackend,
   getIdempotencyMigration,

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -107,6 +107,22 @@ export interface ServeOptions {
   /** Called when the server starts listening. */
   onListening?: (url: string) => void;
   /**
+   * Async check called before the server begins accepting connections.
+   * Throw to abort boot — `serve()` logs the error and calls `process.exit(1)`,
+   * so the server never enters listen mode and no traffic arrives during the
+   * check. Use to validate external dependencies (database pools, credential
+   * fetches) so a misconfigured deployment fails loudly at startup rather than
+   * silently on the first live request.
+   *
+   * @example
+   * ```ts
+   * serve(createAgent, {
+   *   readinessCheck: () => store.probe(),
+   * });
+   * ```
+   */
+  readinessCheck?: () => Promise<void>;
+  /**
    * Custom task store. Defaults to a shared InMemoryTaskStore.
    *
    * The default InMemoryTaskStore only evicts tasks that have a TTL set.
@@ -635,16 +651,31 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
     }
   });
 
-  httpServer.listen(port, () => {
-    const actualPort = (httpServer.address() as { port: number }).port;
-    const url = `http://localhost:${actualPort}${mountPath}`;
-    if (options?.onListening) {
-      options.onListening(url);
-    } else {
-      console.log(`AdCP agent running at ${url}`);
-      console.log(`\nTest with:\n  npx @adcp/client@latest ${url}`);
-    }
-  });
+  const doListen = () => {
+    httpServer.listen(port, () => {
+      const actualPort = (httpServer.address() as { port: number }).port;
+      const url = `http://localhost:${actualPort}${mountPath}`;
+      if (options?.onListening) {
+        options.onListening(url);
+      } else {
+        console.log(`AdCP agent running at ${url}`);
+        console.log(`\nTest with:\n  npx @adcp/client@latest ${url}`);
+      }
+    });
+  };
+
+  if (options?.readinessCheck) {
+    options
+      .readinessCheck()
+      .then(doListen)
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error('[adcp/serve] readinessCheck failed — aborting boot:', message);
+        process.exit(1);
+      });
+  } else {
+    doListen();
+  }
 
   return httpServer;
 }


### PR DESCRIPTION
Closes #1004

## Summary

`pg.Pool` is lazy — `new Pool({ connectionString })` doesn't open a connection on construction, so a bad `DATABASE_URL` lets the server boot successfully, advertise `IdempotencySupported`, then silently fail every mutating call indefinitely. This PR adds non-breaking fail-fast protection: a `probe()` method on `pgBackend` (validates connectivity + table existence via `SELECT 1 FROM "<table>" LIMIT 0`) and a `readinessCheck` option on `serve()` that defers `httpServer.listen()` until the check resolves — so a misconfigured pool crashes the process at deploy time with a descriptive error, not silently at runtime.

## Changes

**Library:**
- `IdempotencyBackend.probe?(): Promise<void>` — optional; implementations that wrap an external store should implement to validate at boot
- `pgBackend` implements `probe()` with `SELECT 1 FROM "<table>" LIMIT 0` — catches bad credentials, unreachable host, and missing migration in one shot
- `IdempotencyStore.probe?(): Promise<void>` — delegates to `backend.probe()` when present; no-ops for `memoryBackend`
- `createIdempotencyStore` wires the delegation
- `probeIdempotencyStore(store)` — escape-hatch export for callers that manage their own lifecycle (Lambda, custom HTTP frameworks); servers using `serve()` should prefer `readinessCheck: () => store.probe()`
- `ServeOptions.readinessCheck?: () => Promise<void>` — called before `httpServer.listen()`; on failure, logs the error and calls `process.exit(1)` so the descriptive probe message always surfaces

**Docs:**
- `pgBackend` JSDoc: startup probe + pool error handler guidance
- `docs/guides/BUILD-AN-AGENT.md`: separate production code block with live (uncommented) pgBackend + readinessCheck wiring
- `skills/build-seller-agent/SKILL.md`: "Critical: probe the pool at boot" callout with full example
- `skills/build-signals-agent/SKILL.md`: same callout (signals agents face the same `activate_signal` footgun)

## Nits flagged by reviewers (not fixed — out of scope for this PR)

- No new unit tests for `readinessCheck` boot behavior or `store.probe()` delegation (test env has no node_modules; CI will gate; tracking as follow-up)
- `docs/llms.txt` server-side idempotency section not updated (buyer-focused document; separate PR recommended)

## What was tested

- `npx tsc --project tsconfig.lib.json --noEmit` — passes (only pre-existing env errors: missing `@types/node`, deprecated `moduleResolution` — both present on `main` before this PR)
- `prettier --check` — passes
- Full test suite could not run locally (no `node_modules` in this environment); CI will validate

**Pre-PR review:**
- code-reviewer: approved after two blockers fixed (1. `probe()` required on `IdempotencyStore` → made optional `probe?()`; 2. `httpServer.emit('error')` with no listener window → replaced with `console.error + process.exit(1)`)
- dx-expert: approved after two blockers fixed (1. BUILD-AN-AGENT.md commented-out pattern without pgBackend context → replaced with separate live production example; 2. `build-signals-agent/SKILL.md` missing probe callout → added)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0175Ghha8PE7jR28vxVwHxDe

---
_Generated by [Claude Code](https://claude.ai/code/session_0175Ghha8PE7jR28vxVwHxDe)_