### PR TITLE
fix(hints): drop AJV-prose fallback in groupRequiredIssues

### DIFF
--- a/.changeset/fix-missing-fields-ajv-prose.md
+++ b/.changeset/fix-missing-fields-ajv-prose.md
@@ -1,0 +1,9 @@
+---
+"@adcp/client": patch
+---
+
+fix(hints): drop AJV-prose fallback in `groupRequiredIssues`
+
+`MissingRequiredFieldHint.missing_fields` is documented as "Field name(s) the parent object was required to carry." When the field-name extraction regex did not match an AJV `required` error message (e.g. a reworded or locale-variant message), the fallback `?? issue.message` wrote the entire AJV prose string into `missing_fields[]` as if it were a field name. Downstream renderers (CLI, Addie, JUnit) wrap entries in backticks and generate "add the X field" coaching, so they would produce nonsense output for these entries.
+
+The fallback is now removed. When the regex does not match, the issue is skipped — `missing_fields` contains only clean field identifiers. Unextractable issues remain visible via `ValidationResult.warning`.

--- a/src/lib/testing/storyboard/strict-validation-hints.ts
+++ b/src/lib/testing/storyboard/strict-validation-hints.ts
@@ -93,7 +93,11 @@ function groupRequiredIssues(
   for (const issue of issues) {
     const at = issue.instance_path || '';
     const match = issue.message.match(/required property ['"]([^'"]+)['"]/);
-    const field = match?.[1] ?? issue.message;
+    // When the regex doesn't match (e.g. compound AJV messages), skip rather
+    // than falling back to raw AJV prose — missing_fields must contain only
+    // clean field identifiers per its documented contract.
+    if (!match) continue;
+    const field = match[1];
     const entry = grouped.get(at);
     if (entry) {
       entry.fields.push(field);

--- a/src/lib/testing/storyboard/strict-validation-hints.ts
+++ b/src/lib/testing/storyboard/strict-validation-hints.ts
@@ -98,6 +98,10 @@ function groupRequiredIssues(
     // clean field identifiers per its documented contract.
     if (!match) continue;
     const field = match[1];
+    // TypeScript noUncheckedIndexedAccess types `match[1]` as `string |
+    // undefined` even though a successful regex match with one capture
+    // group always has it. Narrow defensively rather than assert.
+    if (field === undefined) continue;
     const entry = grouped.get(at);
     if (entry) {
       entry.fields.push(field);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1212,7 +1212,16 @@ export interface MissingRequiredFieldHint extends StoryboardStepHintBase {
   instance_path: string;
   /** Pointer into the JSON schema that named the requirement. */
   schema_path: string;
-  /** Field name(s) the parent object was required to carry. */
+  /**
+   * Field name(s) the parent object was required to carry. Every entry is a
+   * bare identifier extracted from the AJV error message (via the pattern
+   * `required property 'X'`). AJV issues whose message does not match that
+   * pattern — e.g. a reworded or locale-variant message from a future AJV
+   * major or a custom AJV instance — are omitted rather than included
+   * verbatim. Callers can rely on every entry being a plain field name.
+   * The raw AJV issue message may still appear in `ValidationResult.warning`
+   * prose for human readers.
+   */
   missing_fields: string[];
   /** Resolvable schema URL (when the runner could attribute one). */
   schema_url?: string;

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.18.0';
+export const LIBRARY_VERSION = '5.19.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.18.0',
+  library: '5.19.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-25T18:58:27.946Z',
+  generatedAt: '2026-04-25T23:27:37.876Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-strict-validation-hints.test.js
+++ b/test/lib/storyboard-strict-validation-hints.test.js
@@ -179,6 +179,91 @@ describe('detectStrictValidationHints', () => {
     }
   });
 
+  test('skips a required issue when the AJV message does not match the field-name regex', () => {
+    // A future AJV rewording or locale variant may not carry the
+    // `required property 'X'` pattern. The entire message must not leak into
+    // missing_fields as a "field name".
+    const out = detectStrictValidationHints(
+      'get_products',
+      withStrict('get_products', {
+        valid: false,
+        variant: 'sync',
+        issues: [
+          {
+            instance_path: '/products/0',
+            schema_path: '#/properties/products/items/required',
+            keyword: 'required',
+            message: "must have required 'foo'",  // missing the word "property" — regex won't match
+          },
+        ],
+      })
+    );
+    const hints = out.filter(h => h.kind === 'missing_required_field');
+    assert.equal(hints.length, 0, 'no hint when field name cannot be cleanly extracted');
+  });
+
+  test('emits no hint when all required issues at a path fail regex extraction', () => {
+    const out = detectStrictValidationHints(
+      'get_products',
+      withStrict('get_products', {
+        valid: false,
+        variant: 'sync',
+        issues: [
+          {
+            instance_path: '/products/0',
+            schema_path: '#/properties/products/items/required',
+            keyword: 'required',
+            message: 'some unrecognised AJV message format without field markers',
+          },
+          {
+            instance_path: '/products/0',
+            schema_path: '#/properties/products/items/required',
+            keyword: 'required',
+            message: "the 'foo' field is required",
+          },
+        ],
+      })
+    );
+    const hints = out.filter(h => h.kind === 'missing_required_field');
+    assert.equal(hints.length, 0, 'no hint emitted when every issue in the group fails extraction');
+    for (const h of out) {
+      assert.ok(
+        typeof h.missing_fields === 'undefined' || h.missing_fields.every(f => !/\s/.test(f)),
+        'missing_fields must not contain prose strings with spaces'
+      );
+    }
+  });
+
+  test('emits only extractable field names when a path has mixed matching/non-matching issues', () => {
+    const out = detectStrictValidationHints(
+      'get_products',
+      withStrict('get_products', {
+        valid: false,
+        variant: 'sync',
+        issues: [
+          {
+            instance_path: '/products/0',
+            schema_path: '#/properties/products/items/required',
+            keyword: 'required',
+            message: "must have required property 'title'",
+          },
+          {
+            instance_path: '/products/0',
+            schema_path: '#/properties/products/items/required',
+            keyword: 'required',
+            // Missing "property" keyword — regex won't match; this issue is dropped.
+            message: "must have required 'price'",
+          },
+        ],
+      })
+    );
+    const hints = out.filter(h => h.kind === 'missing_required_field');
+    assert.equal(hints.length, 1, 'one grouped hint for the path');
+    assert.deepEqual(hints[0].missing_fields, ['title'], 'only the extractable field name appears');
+    assert.match(hints[0].message, /title/, 'message reflects only the extractable field');
+    assert.ok(!hints[0].missing_fields.some(f => f.includes('must have')), 'no AJV prose in missing_fields');
+  });
+
   test('schema_url field absent when ValidationResult does not carry one', () => {
     const out = detectStrictValidationHints(
       'list_creative_formats',

--- a/test/lib/storyboard-strict-validation-hints.test.js
+++ b/test/lib/storyboard-strict-validation-hints.test.js
@@ -193,7 +193,7 @@ describe('detectStrictValidationHints', () => {
             instance_path: '/products/0',
             schema_path: '#/properties/products/items/required',
             keyword: 'required',
-            message: "must have required 'foo'",  // missing the word "property" — regex won't match
+            message: "must have required 'foo'", // missing the word "property" — regex won't match
           },
         ],
       })


### PR DESCRIPTION
Closes #1011

## Summary

`MissingRequiredFieldHint.missing_fields` is documented as "Field name(s) the parent object was required to carry." When the field-name extraction regex (`required property 'X'`) didn't match an AJV `required` error message, the fallback `?? issue.message` wrote the entire AJV prose string into `missing_fields[]` as if it were a field name. Downstream renderers (CLI, Addie, JUnit) wrap entries in backticks and generate "add the X field" coaching — so unextractable AJV prose produced output like:

> Diagnose — missing required fields: `must have required property 'bid_floor'`, `status`.

The fix: drop the fallback. When the regex misses, `continue` — the issue is skipped and `missing_fields` contains only clean field identifiers. Unextractable AJV messages remain visible in `ValidationResult.warning` prose for human readers.

**Nit (not fixed in this PR, surfaced by pre-PR review):** `buildStrictWarning` in `validations.ts` has the same `match?.[1] ?? issue.message` pattern for the prose `warning` field. That path is intentionally left alone — prose warnings may include raw AJV text and that is acceptable — but the two code paths are now asymmetric.

## What was tested

- `node --test test/lib/storyboard-strict-validation-hints.test.js` — 11/11 pass (3 new regression tests added)
- `npm run build:lib --noEmitOnError false` — compiles cleanly (2 pre-existing TS infra errors unrelated to this change: missing `@types/node`, deprecated `moduleResolution`)
- Full `node --test test/lib/*.test.js` — 471 pre-existing failures unchanged, 3 new tests added (821 pass vs 818 baseline)

## Pre-PR review

- **code-reviewer:** approved — no blockers; JSDoc example updated per nit feedback
- **ad-tech-protocol-expert:** approved — non-breaking per spec; `missing_fields` invariant is correct and consistent with runner-output-contract.yaml

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0175S3zFzpbzfEC97CtqG3VZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0175S3zFzpbzfEC97CtqG3VZ)_