### PR TITLE
feat(signing): SigningProvider abstraction for KMS/HSM/Vault

### DIFF
--- a/.changeset/signing-provider-kms-abstraction.md
+++ b/.changeset/signing-provider-kms-abstraction.md
@@ -1,0 +1,32 @@
+---
+"@adcp/client": minor
+---
+
+Add `SigningProvider` abstraction for external key management (KMS/HSM/Vault)
+
+Operators who want to keep private keys in AWS KMS / GCP KMS / Azure Key Vault /
+Vault Transit can now implement the new `SigningProvider` interface and pass it
+directly to the SDK — the private scalar never needs to be loaded into process memory.
+
+New exports from `@adcp/client/signing/client`:
+- `SigningProvider` interface — async `sign(Uint8Array): Promise<Uint8Array>` contract
+- `AdcpSignAlg` type — shared `'ed25519' | 'ecdsa-p256-sha256'` union (replaces ad-hoc duplicates)
+- `signRequestAsync(req, provider, opts)` — async variant of `signRequest`
+- `signWebhookAsync(req, provider, opts)` — async variant of `signWebhook`
+- `createSigningFetch` now accepts `SignerKey | SigningProvider` via overload
+- `buildAgentSigningContextFromConfig(signing, agentUri, authToken?, opts?)` — builds a signing context directly from `AnyAgentSigningConfig`
+- `isProviderConfig(signing)` — type guard for the provider arm
+
+New exports from `@adcp/client/signing/testing`:
+- `InMemorySigningProvider` — test double backed by a raw JWK; byte-identical to the sync path
+
+New types in `@adcp/client/types`:
+- `AgentProviderSigningConfig` — KMS-backed sibling of `AgentRequestSigningConfig`
+- `AnyAgentSigningConfig = AgentRequestSigningConfig | AgentProviderSigningConfig`
+
+`AgentConfig.request_signing` now accepts `AnyAgentSigningConfig`.
+
+All existing `AgentRequestSigningConfig`, `signRequest`, `signWebhook`, and
+`createSigningFetch(upstream, key)` call sites are unbroken.
+
+See `examples/gcp-kms-signing-provider.ts` for a GCP Cloud KMS adapter.

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -1,0 +1,151 @@
+/**
+ * GCP Cloud KMS adapter for `SigningProvider`.
+ *
+ * This file is an example — it is NOT bundled with `@adcp/client`. Users must
+ * install `@google-cloud/kms` themselves:
+ *
+ *   npm install @google-cloud/kms
+ *
+ * ## Algorithm support
+ *
+ * | Algorithm          | GCP KMS algorithm name      | Supported |
+ * |--------------------|----------------------------|-----------|
+ * | ecdsa-p256-sha256  | EC_SIGN_P256_SHA256         | ✅        |
+ * | ed25519            | (not available in GCP KMS)  | ❌        |
+ *
+ * GCP Cloud KMS does not offer Ed25519 asymmetric signing. Use
+ * `InMemorySigningProvider` from `@adcp/client/signing/testing` for Ed25519
+ * test keys, or use a different KMS provider that supports Ed25519.
+ *
+ * ## Wire-format note (ECDSA)
+ *
+ * GCP KMS returns ECDSA signatures in DER format. The AdCP verifier expects
+ * IEEE P1363 (64-byte r‖s). This adapter converts DER → P1363 automatically.
+ *
+ * ## Pre-hash note
+ *
+ * GCP's `EC_SIGN_P256_SHA256` API requires the caller to supply the pre-computed
+ * SHA-256 digest (32 bytes). GCP applies ECDSA to the digest without hashing it
+ * again. The result is a valid ECDSA signature over SHA256(signature_base),
+ * which is exactly what the AdCP verifier expects (`nodeVerify('sha256', ...)`).
+ * Do NOT hash the payload twice — pass `SHA256(payload)` as the digest, not
+ * `SHA256(SHA256(payload))`.
+ *
+ * @example
+ * ```ts
+ * import { createGcpKmsSigningProvider } from './gcp-kms-signing-provider';
+ * import { buildAgentSigningContextFromConfig } from '@adcp/client/signing/client';
+ *
+ * const provider = createGcpKmsSigningProvider({
+ *   versionName: 'projects/my-project/locations/us-east1/keyRings/adcp/cryptoKeys/buyer-signing/cryptoKeyVersions/1',
+ *   kid: 'buyer-signing-2026',
+ *   algorithm: 'ecdsa-p256-sha256',
+ * });
+ *
+ * const signingContext = buildAgentSigningContextFromConfig(
+ *   { provider, agent_url: 'https://buyer.example.com' },
+ *   'https://seller.example.com'
+ * );
+ * ```
+ */
+
+import { createHash } from 'node:crypto';
+// @ts-expect-error — peer dependency not installed in the SDK itself
+import { KeyManagementServiceClient } from '@google-cloud/kms';
+import type { SigningProvider } from '@adcp/client/signing/client';
+
+export interface GcpKmsSigningProviderOptions {
+  /**
+   * Full CryptoKeyVersion resource name:
+   * `projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY/cryptoKeyVersions/VERSION`
+   *
+   * This is used as the `fingerprint` — it is stable, deterministic, and
+   * unique per key version, satisfying the `SigningProvider.fingerprint` contract.
+   * Do NOT use the key name (without version) — two key versions share a key name
+   * but have different private keys and must not collide in the capability cache.
+   */
+  versionName: string;
+  /**
+   * Short, stable `kid` published in your JWKS. Must match the key at
+   * `{agent_url}/.well-known/adcp-jwks.json`. Do NOT use the full
+   * `versionName` as the `kid` — `kid` is a public identifier and the
+   * resource path leaks internal GCP project structure.
+   */
+  kid: string;
+  /** Only `ecdsa-p256-sha256` is supported by GCP KMS. */
+  algorithm: 'ecdsa-p256-sha256';
+  /** Optionally inject a pre-constructed client (useful in tests). */
+  client?: InstanceType<typeof KeyManagementServiceClient>;
+}
+
+export function createGcpKmsSigningProvider(opts: GcpKmsSigningProviderOptions): SigningProvider {
+  if (opts.algorithm !== 'ecdsa-p256-sha256') {
+    // GCP KMS does not offer Ed25519. Fail at construction rather than at
+    // first sign() call so the misconfiguration surfaces immediately.
+    throw new Error(
+      `GCP KMS does not support algorithm "${opts.algorithm}". ` +
+        'Only "ecdsa-p256-sha256" is available. ' +
+        'For Ed25519 test keys use InMemorySigningProvider from @adcp/client/signing/testing.'
+    );
+  }
+
+  const client: InstanceType<typeof KeyManagementServiceClient> =
+    opts.client ?? new KeyManagementServiceClient();
+
+  return {
+    keyid: opts.kid,
+    algorithm: opts.algorithm,
+    // versionName is a stable, unique identifier for this key version —
+    // satisfies the fingerprint uniqueness and determinism requirements.
+    fingerprint: opts.versionName,
+
+    async sign(payload: Uint8Array): Promise<Uint8Array> {
+      // Compute SHA-256 of the RFC 9421 signature base. GCP's
+      // EC_SIGN_P256_SHA256 expects the pre-computed digest (32 bytes);
+      // GCP applies ECDSA directly to those bytes without hashing again.
+      // Result: signature over SHA256(payload), matching nodeVerify('sha256').
+      const digest = createHash('sha256').update(payload).digest();
+
+      const [resp] = await client.asymmetricSign({
+        name: opts.versionName,
+        digest: { sha256: digest },
+      });
+
+      const derBytes = resp.signature instanceof Buffer ? resp.signature : Buffer.from(resp.signature);
+      return derEcdsaToP1363(derBytes, 32);
+    },
+  };
+}
+
+/**
+ * Convert a DER-encoded ECDSA signature to IEEE P1363 (r‖s).
+ *
+ * DER layout for ECDSA: 0x30 [total-len] 0x02 [r-len] [r-bytes] 0x02 [s-len] [s-bytes]
+ * P1363 layout: fixed-width r‖s, each component zero-padded to `coordBytes`.
+ */
+function derEcdsaToP1363(der: Buffer, coordBytes: number): Uint8Array {
+  let offset = 0;
+  if (der[offset++] !== 0x30) throw new Error('GCP KMS: expected DER SEQUENCE tag 0x30');
+  // Skip length (may be 1 or 2 bytes).
+  if (der[offset] & 0x80) offset += (der[offset] & 0x7f) + 1;
+  else offset++;
+
+  function readInt(): Buffer {
+    if (der[offset++] !== 0x02) throw new Error('GCP KMS: expected DER INTEGER tag 0x02');
+    const len = der[offset++];
+    const value = der.subarray(offset, offset + len);
+    offset += len;
+    return Buffer.from(value);
+  }
+
+  const r = readInt();
+  const s = readInt();
+
+  const out = Buffer.alloc(coordBytes * 2);
+  // Strip leading zero byte that DER adds to keep the sign bit clear.
+  const rStripped = r[0] === 0x00 ? r.subarray(1) : r;
+  const sStripped = s[0] === 0x00 ? s.subarray(1) : s;
+  rStripped.copy(out, coordBytes - rStripped.length);
+  sStripped.copy(out, coordBytes * 2 - sStripped.length);
+  return new Uint8Array(out);
+}

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -78,6 +78,9 @@ export interface GcpKmsSigningProviderOptions {
   client?: InstanceType<typeof KeyManagementServiceClient>;
 }
 
+const GCP_VERSION_NAME_RE =
+  /^projects\/[^/]+\/locations\/[^/]+\/keyRings\/[^/]+\/cryptoKeys\/[^/]+\/cryptoKeyVersions\/\d+$/;
+
 export function createGcpKmsSigningProvider(opts: GcpKmsSigningProviderOptions): SigningProvider {
   if (opts.algorithm !== 'ecdsa-p256-sha256') {
     // GCP KMS does not offer Ed25519. Fail at construction rather than at
@@ -86,6 +89,14 @@ export function createGcpKmsSigningProvider(opts: GcpKmsSigningProviderOptions):
       `GCP KMS does not support algorithm "${opts.algorithm}". ` +
         'Only "ecdsa-p256-sha256" is available. ' +
         'For Ed25519 test keys use InMemorySigningProvider from @adcp/client/signing/testing.'
+    );
+  }
+
+  if (!GCP_VERSION_NAME_RE.test(opts.versionName)) {
+    throw new Error(
+      `GCP KMS: versionName does not match expected resource path format ` +
+        `"projects/P/locations/L/keyRings/R/cryptoKeys/K/cryptoKeyVersions/N". ` +
+        `Got: ${JSON.stringify(opts.versionName)}`
     );
   }
 
@@ -133,6 +144,7 @@ function derEcdsaToP1363(der: Buffer, coordBytes: number): Uint8Array {
   function readInt(): Buffer {
     if (der[offset++] !== 0x02) throw new Error('GCP KMS: expected DER INTEGER tag 0x02');
     const len = der[offset++];
+    if (len & 0x80) throw new Error('GCP KMS: unexpected long-form INTEGER length in DER signature');
     const value = der.subarray(offset, offset + len);
     offset += len;
     return Buffer.from(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.18.0",
+      "version": "5.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
       "require": "./dist/lib/signing/server.js",
       "types": "./dist/lib/signing/server.d.ts"
     },
+    "./signing/testing": {
+      "import": "./dist/lib/signing/testing.js",
+      "require": "./dist/lib/signing/testing.js",
+      "types": "./dist/lib/signing/testing.d.ts"
+    },
     "./schemas": {
       "import": "./dist/lib/schemas/index.js",
       "require": "./dist/lib/schemas/index.js",
@@ -102,6 +107,9 @@
       ],
       "signing/server": [
         "dist/lib/signing/server.d.ts"
+      ],
+      "signing/testing": [
+        "dist/lib/signing/testing.d.ts"
       ],
       "schemas": [
         "dist/lib/schemas/index.d.ts"

--- a/src/lib/signing/agent-context.ts
+++ b/src/lib/signing/agent-context.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { createHash } from 'node:crypto';
-import type { AgentConfig, AgentRequestSigningConfig } from '../types/adcp';
+import type { AgentConfig, AgentProviderSigningConfig, AgentRequestSigningConfig, AnyAgentSigningConfig } from '../types/adcp';
 import {
   buildCapabilityCacheKey,
   CapabilityCache,
@@ -17,8 +17,8 @@ import {
  * each outbound request), and `signing` (to produce the signer key).
  */
 export interface AgentSigningContext {
-  /** Signing config copied from AgentConfig.request_signing. */
-  signing: AgentRequestSigningConfig;
+  /** Signing config — raw-key or provider arm. */
+  signing: AnyAgentSigningConfig;
   /** Suffix to append to transport connection-cache keys so agents with different signing identities don't share a connection. */
   cacheKey: string;
   /** Lazy accessor for the currently cached capability for this agent. */
@@ -61,15 +61,28 @@ export function buildAgentSigningContext(
 ): AgentSigningContext | undefined {
   const signing = agent.request_signing;
   if (!signing) return undefined;
+  return buildAgentSigningContextFromConfig(signing, agent.agent_uri, agent.auth_token, options);
+}
 
+/**
+ * Build an `AgentSigningContext` directly from an {@link AnyAgentSigningConfig}.
+ * Use when the config comes from outside an `AgentConfig` — for example, when
+ * wiring a KMS-backed provider without loading a full agent config.
+ */
+export function buildAgentSigningContextFromConfig(
+  signing: AnyAgentSigningConfig,
+  agentUri: string,
+  authToken?: string,
+  options: { cache?: CapabilityCache } = {}
+): AgentSigningContext {
   const cache = options.cache ?? defaultCapabilityCache;
-  const keyFingerprint = privateKeyFingerprint(signing);
-  const capabilityCacheKey = buildCapabilityCacheKey(agent.agent_uri, agent.auth_token, keyFingerprint);
-  // Transport-connection cache-key suffix binds to a hash of the private key,
-  // not just the advertised `kid`. Two tenants that misconfigure the same
-  // `kid` string but hold distinct private keys must not collide on a shared
-  // cached transport — that would sign one tenant's outbound requests with
-  // the other tenant's key (same `kid`, different `d`), an impersonation.
+  const keyFingerprint = resolveFingerprint(signing);
+  const capabilityCacheKey = buildCapabilityCacheKey(agentUri, authToken, keyFingerprint);
+  // Transport-connection cache-key suffix binds to a fingerprint that
+  // uniquely identifies the private key. Two tenants that advertise the same
+  // `kid` but hold distinct private keys must not collide on a shared cached
+  // transport — that would sign one tenant's outbound requests with the other
+  // tenant's key (same `kid`, different key material), an impersonation.
   const cacheKey = `sig=${keyFingerprint}`;
 
   return {
@@ -82,14 +95,24 @@ export function buildAgentSigningContext(
   };
 }
 
-/**
- * Derive a stable per-key cache-key fragment. Hashes both `kid` and the
- * private scalar `d` so that two tenants advertising the same `kid` but
- * holding distinct private keys get different cache entries. Truncated to
- * 16 hex chars — a collision-resistance budget of 64 bits against random
- * keys is plenty for a cache disambiguator, and we never rely on this
- * value as a security boundary.
- */
-function privateKeyFingerprint(signing: AgentRequestSigningConfig): string {
+/** Derive a stable per-key cache-key fragment from whichever config arm is supplied. */
+function resolveFingerprint(signing: AnyAgentSigningConfig): string {
+  if (isProviderConfig(signing)) {
+    const fp = signing.provider.fingerprint;
+    if (!fp || fp.length < 16) {
+      throw new Error(
+        `SigningProvider.fingerprint must be at least 16 characters to provide adequate cache-isolation entropy (got ${JSON.stringify(fp)}). ` +
+          'Use the KMS resource path (e.g. projects/…/cryptoKeyVersions/N) or a SHA-256 hex prefix.'
+      );
+    }
+    return fp;
+  }
+  // Raw-key path: derive from kid + private scalar so two tenants with the
+  // same kid but distinct keys get different cache entries.
   return createHash('sha256').update(signing.kid).update('\0').update(signing.private_key.d).digest('hex').slice(0, 16);
+}
+
+/** Type guard distinguishing the provider arm from the raw-key arm. */
+export function isProviderConfig(signing: AnyAgentSigningConfig): signing is AgentProviderSigningConfig {
+  return 'provider' in signing;
 }

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -1,4 +1,5 @@
-import type { AgentRequestSigningConfig } from '../types/adcp';
+import type { AnyAgentSigningConfig, AgentRequestSigningConfig } from '../types/adcp';
+import { isProviderConfig } from './agent-context';
 import { createSigningFetch, type CoverContentDigestPredicate } from './fetch';
 import {
   buildCapabilityCacheKey,
@@ -122,7 +123,7 @@ export function extractAdcpOperation(body: unknown): string | undefined {
 export function shouldSignOperation(
   operation: string | undefined,
   capability: VerifierCapability | undefined,
-  config: AgentRequestSigningConfig
+  config: AnyAgentSigningConfig
 ): boolean {
   if (!operation) return false;
   if (config.always_sign?.includes(operation)) return true;
@@ -148,8 +149,9 @@ export function resolveCoverContentDigest(policy: ContentDigestPolicy | undefine
 }
 
 /**
- * Convert an `AgentRequestSigningConfig` into the `SignerKey` shape expected
- * by `signRequest` / `createSigningFetch`.
+ * Convert an {@link AgentRequestSigningConfig} into the `SignerKey` shape
+ * expected by `signRequest` / `createSigningFetch`. Only valid on the
+ * raw-key arm — call site must guard with `!isProviderConfig(config)`.
  */
 export function toSignerKey(config: AgentRequestSigningConfig): SignerKey {
   return {
@@ -166,7 +168,7 @@ export interface BuildAgentSigningFetchOptions {
    * decorated fetch (retries, telemetry) to compose.
    */
   upstream?: FetchLike;
-  signing: AgentRequestSigningConfig;
+  signing: AnyAgentSigningConfig;
   /** Lazy accessor for the current cached capability — re-read on every call. */
   getCapability: () => CachedCapability | undefined;
 }
@@ -189,7 +191,6 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
   // factory-call time.
   const explicitUpstream = options.upstream;
   const upstream: FetchLike = explicitUpstream ?? ((input, init) => defaultUpstream()(input, init));
-  const key = toSignerKey(signing);
 
   const shouldSign = (_url: string, init: RequestInit | undefined): boolean => {
     const operation = extractAdcpOperation(init?.body);
@@ -202,12 +203,15 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
     return resolveCoverContentDigest(entry?.requestSigning?.covers_content_digest);
   };
 
-  return createSigningFetch(upstream, key, { shouldSign, coverContentDigest });
+  if (isProviderConfig(signing)) {
+    return createSigningFetch(upstream, signing.provider, { shouldSign, coverContentDigest });
+  }
+  return createSigningFetch(upstream, toSignerKey(signing), { shouldSign, coverContentDigest });
 }
 
 export interface CreateAgentSignedFetchOptions {
-  /** This agent's RFC 9421 signing identity (kid, alg, private_key, agent_url). */
-  signing: AgentRequestSigningConfig;
+  /** This agent's RFC 9421 signing identity — raw JWK or KMS provider. */
+  signing: AnyAgentSigningConfig;
   /**
    * Target seller's `agent_uri` — the base URL whose `get_adcp_capabilities`
    * response gates whether each operation gets signed. The preset keys a

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -19,7 +19,9 @@ export {
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
 export {
   signRequest,
+  signRequestAsync,
   signWebhook,
+  signWebhookAsync,
   type SignedRequest,
   type SignerKey,
   type SignRequestOptions,
@@ -34,9 +36,11 @@ export {
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
   type AdcpJsonWebKey,
+  type AdcpSignAlg,
   type ContentDigestPolicy,
   type VerifierCapability,
 } from './types';
+export { type SigningProvider } from './provider';
 export {
   CapabilityCache,
   buildCapabilityCacheKey,
@@ -54,5 +58,11 @@ export {
   type BuildAgentSigningFetchOptions,
   type CreateAgentSignedFetchOptions,
 } from './agent-fetch';
-export { buildAgentSigningContext, signingContextStorage, type AgentSigningContext } from './agent-context';
+export {
+  buildAgentSigningContext,
+  buildAgentSigningContextFromConfig,
+  isProviderConfig,
+  signingContextStorage,
+  type AgentSigningContext,
+} from './agent-context';
 export { ensureCapabilityLoaded, CAPABILITY_OP } from './capability-priming';

--- a/src/lib/signing/fetch.ts
+++ b/src/lib/signing/fetch.ts
@@ -1,4 +1,5 @@
-import { signRequest, type SignerKey, type SignRequestOptions } from './signer';
+import type { SigningProvider } from './provider';
+import { signRequest, signRequestAsync, type SignerKey, type SignRequestOptions } from './signer';
 
 /** Callback form for `coverContentDigest` — lets the wrapper decide per call. */
 export type CoverContentDigestPredicate = (url: string, init: RequestInit | undefined) => boolean;
@@ -24,7 +25,13 @@ type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<
  */
 const SIGNING_RESERVED_HEADERS = new Set(['signature', 'signature-input', 'content-digest']);
 
-export function createSigningFetch(upstream: FetchLike, key: SignerKey, options: SigningFetchOptions = {}): FetchLike {
+export function createSigningFetch(upstream: FetchLike, signer: SignerKey, options?: SigningFetchOptions): FetchLike;
+export function createSigningFetch(upstream: FetchLike, signer: SigningProvider, options?: SigningFetchOptions): FetchLike;
+export function createSigningFetch(
+  upstream: FetchLike,
+  signer: SignerKey | SigningProvider,
+  options: SigningFetchOptions = {}
+): FetchLike {
   return async (input, init) => {
     const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
@@ -56,7 +63,10 @@ export function createSigningFetch(upstream: FetchLike, key: SignerKey, options:
     const { coverContentDigest: _omit, ...signerOptionsBase } = options;
     const signerOptions: SignRequestOptions = { ...signerOptionsBase, coverContentDigest };
 
-    const signed = signRequest({ method, url, headers, body }, key, signerOptions);
+    const requestLike = { method, url, headers, body };
+    const signed = 'privateKey' in signer
+      ? signRequest(requestLike, signer, signerOptions)
+      : await signRequestAsync(requestLike, signer, signerOptions);
 
     const mergedInit: RequestInit = { ...init, method, headers: signed.headers };
     if (body !== undefined && mergedInit.body === undefined) mergedInit.body = body;

--- a/src/lib/signing/fetch.ts
+++ b/src/lib/signing/fetch.ts
@@ -64,9 +64,9 @@ export function createSigningFetch(
     const signerOptions: SignRequestOptions = { ...signerOptionsBase, coverContentDigest };
 
     const requestLike = { method, url, headers, body };
-    const signed = 'privateKey' in signer
-      ? signRequest(requestLike, signer, signerOptions)
-      : await signRequestAsync(requestLike, signer, signerOptions);
+    const signed = 'sign' in signer
+      ? await signRequestAsync(requestLike, signer, signerOptions)
+      : signRequest(requestLike, signer, signerOptions);
 
     const mergedInit: RequestInit = { ...init, method, headers: signed.headers };
     if (body !== undefined && mergedInit.body === undefined) mergedInit.body = body;

--- a/src/lib/signing/provider.ts
+++ b/src/lib/signing/provider.ts
@@ -1,0 +1,58 @@
+import type { AdcpSignAlg } from './types';
+
+/**
+ * Pluggable signing backend for RFC 9421 request signatures.
+ *
+ * Implement this interface to delegate signing to an external key store
+ * (KMS, HSM, Vault Transit) without ever loading the private scalar into
+ * process memory.
+ *
+ * Wire-format contract for `sign(payload)`:
+ *   - `payload` is the raw UTF-8 bytes of the RFC 9421 signature base.
+ *     The SDK builds this string; the provider only handles the final
+ *     signing step.
+ *   - For `ed25519`: sign `payload` directly — Ed25519 handles
+ *     prehashing internally. Return the 64-byte raw signature.
+ *   - For `ecdsa-p256-sha256`: compute SHA-256(`payload`) yourself
+ *     (or pass `payload` to a KMS API that applies SHA-256 internally),
+ *     then return the 64-byte r‖s in IEEE P1363 format (NOT DER).
+ *     KMS adapters that return DER-encoded signatures MUST convert to
+ *     P1363 before resolving. Do NOT hash twice.
+ */
+export interface SigningProvider {
+  /**
+   * Sign the RFC 9421 signature base. See wire-format contract above.
+   * KMS latency (10–50 ms) is expected; the SDK awaits this Promise on
+   * every signed outbound request.
+   */
+  sign(payload: Uint8Array): Promise<Uint8Array>;
+
+  /** `kid` published in `Signature-Input`. Must match a key in `jwks_uri`. */
+  readonly keyid: string;
+
+  /** Wire-format algorithm — same vocabulary as `ALLOWED_ALGS`. */
+  readonly algorithm: AdcpSignAlg;
+
+  /**
+   * Stable opaque token that uniquely identifies this private key.
+   *
+   * Used to isolate transport- and capability-cache entries so two
+   * tenants advertising the same `kid` but holding distinct private
+   * keys never share a cache entry. Requirements:
+   *   - Deterministic across process restarts.
+   *   - MUST NOT collide between distinct private keys.
+   *   - Must be at least 16 characters to provide adequate cache
+   *     isolation entropy (the SDK throws at construction time if
+   *     shorter).
+   *   - MUST NOT be the raw private key material.
+   *
+   * Good examples:
+   *   - GCP KMS:  `projects/…/cryptoKeyVersions/N` (resource path)
+   *   - AWS KMS:  KMS key ARN + "/" + key version
+   *   - In-memory: SHA-256(kid + "\0" + d).hex().slice(0, 16)
+   *
+   * Bad examples (too short or non-unique):
+   *   - `"test"`, `kid` alone, `"1"`
+   */
+  readonly fingerprint: string;
+}

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -1,12 +1,13 @@
 import { createPrivateKey, randomBytes, sign as nodeSign, type JsonWebKey } from 'crypto';
 import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
 import { computeContentDigest } from './content-digest';
-import { MANDATORY_COMPONENTS, MAX_SIGNATURE_WINDOW_SECONDS, REQUEST_SIGNING_TAG, type AdcpJsonWebKey } from './types';
+import type { SigningProvider } from './provider';
+import { MANDATORY_COMPONENTS, MAX_SIGNATURE_WINDOW_SECONDS, REQUEST_SIGNING_TAG, type AdcpJsonWebKey, type AdcpSignAlg } from './types';
 import { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
 
 export interface SignerKey {
   keyid: string;
-  alg: 'ed25519' | 'ecdsa-p256-sha256';
+  alg: AdcpSignAlg;
   privateKey: AdcpJsonWebKey;
 }
 
@@ -108,6 +109,83 @@ export function signWebhook(request: RequestLike, key: SignerKey, options: SignW
   const normalizedRequest: RequestLike = { ...request, headers };
   const base = buildSignatureBase(components, normalizedRequest, params);
   const signature = produceSignature(key, Buffer.from(base, 'utf8'));
+  const sigB64 = Buffer.from(signature).toString('base64url');
+
+  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
+  headers['Signature'] = `${label}=:${sigB64}:`;
+  return { headers, signatureBase: base, params };
+}
+
+/** Async variant of {@link signRequest} for use with a {@link SigningProvider}. */
+export async function signRequestAsync(
+  request: RequestLike,
+  provider: SigningProvider,
+  options: SignRequestOptions = {}
+): Promise<SignedRequest> {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+  const hasBody = (request.body ?? '').length > 0;
+
+  const coverDigest = options.coverContentDigest === true && hasBody;
+  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
+  if (coverDigest) {
+    headers['Content-Digest'] = computeContentDigest(request.body ?? '');
+  }
+
+  const components = [...MANDATORY_COMPONENTS];
+  if (hasBody) components.push('content-type');
+  if (coverDigest) components.push('content-digest');
+
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: provider.keyid,
+    alg: provider.algorithm,
+    tag: REQUEST_SIGNING_TAG,
+  };
+
+  const normalizedRequest: RequestLike = { ...request, headers };
+  const base = buildSignatureBase(components, normalizedRequest, params);
+
+  const signature = await provider.sign(Buffer.from(base, 'utf8'));
+  const sigB64 = Buffer.from(signature).toString('base64url');
+
+  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
+  headers['Signature'] = `${label}=:${sigB64}:`;
+
+  return { headers, signatureBase: base, params };
+}
+
+/** Async variant of {@link signWebhook} for use with a {@link SigningProvider}. */
+export async function signWebhookAsync(
+  request: RequestLike,
+  provider: SigningProvider,
+  options: SignWebhookOptions = {}
+): Promise<SignedRequest> {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+
+  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
+  headers['Content-Digest'] = computeContentDigest(request.body ?? '');
+
+  const components = [...WEBHOOK_MANDATORY_COMPONENTS];
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: provider.keyid,
+    alg: provider.algorithm,
+    tag: options.tag ?? WEBHOOK_SIGNING_TAG,
+  };
+
+  const normalizedRequest: RequestLike = { ...request, headers };
+  const base = buildSignatureBase(components, normalizedRequest, params);
+  const signature = await provider.sign(Buffer.from(base, 'utf8'));
   const sigB64 = Buffer.from(signature).toString('base64url');
 
   headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -1,0 +1,62 @@
+/**
+ * Test-only signing utilities. Import from `@adcp/client/signing/testing`.
+ *
+ * @remarks
+ * `InMemorySigningProvider` stores the private scalar in process memory —
+ * the same security model as `AgentRequestSigningConfig`. It is provided
+ * so tests can exercise the `SigningProvider` interface without a real KMS.
+ *
+ * **Do not use in production.** For KMS-backed signing, implement
+ * `SigningProvider` with your KMS client (see
+ * `examples/gcp-kms-signing-provider.ts`).
+ */
+import { createHash, createPrivateKey, sign as nodeSign, type JsonWebKey } from 'node:crypto';
+import type { SigningProvider } from './provider';
+import type { SignerKey } from './signer';
+import type { AdcpSignAlg } from './types';
+
+export type { SigningProvider };
+
+/**
+ * In-memory `SigningProvider` backed by a raw private JWK. Delegates to
+ * the same Node.js crypto path as `signRequest`, so RFC 9421 test vectors
+ * produce byte-identical signatures on both the sync and provider paths.
+ *
+ * Fingerprint is derived deterministically from `kid + '\0' + d`, matching
+ * the legacy `AgentRequestSigningConfig` cache-key derivation — two
+ * instances constructed from the same JWK get the same fingerprint and
+ * share a cache entry.
+ *
+ * @example
+ * ```ts
+ * import { InMemorySigningProvider } from '@adcp/client/signing/testing';
+ *
+ * const provider = new InMemorySigningProvider({
+ *   keyid: 'test-key-1',
+ *   algorithm: 'ed25519',
+ *   privateKey: JSON.parse(process.env.TEST_PRIV_KEY!),
+ * });
+ * ```
+ */
+export class InMemorySigningProvider implements SigningProvider {
+  readonly keyid: string;
+  readonly algorithm: AdcpSignAlg;
+  readonly fingerprint: string;
+  private readonly _key: SignerKey;
+
+  constructor(opts: { keyid: string; algorithm: AdcpSignAlg; privateKey: SignerKey['privateKey'] }) {
+    this.keyid = opts.keyid;
+    this.algorithm = opts.algorithm;
+    this._key = { keyid: opts.keyid, alg: opts.algorithm, privateKey: opts.privateKey };
+    const d = opts.privateKey.d ?? '';
+    this.fingerprint = createHash('sha256').update(opts.keyid).update('\0').update(d).digest('hex').slice(0, 16);
+  }
+
+  async sign(payload: Uint8Array): Promise<Uint8Array> {
+    const pk = createPrivateKey({ key: this._key.privateKey as JsonWebKey, format: 'jwk' });
+    if (this._key.alg === 'ed25519') {
+      return new Uint8Array(nodeSign(null, payload, pk));
+    }
+    return new Uint8Array(nodeSign('sha256', payload, { key: pk, dsaEncoding: 'ieee-p1363' }));
+  }
+}

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -79,7 +79,9 @@ export interface VerifiedSigner {
 export type VerifyResult = ({ status: 'verified' } & VerifiedSigner) | { status: 'unsigned'; verified_at: number };
 
 export const REQUEST_SIGNING_TAG = 'adcp/request-signing/v1';
-export const ALLOWED_ALGS = new Set(['ed25519', 'ecdsa-p256-sha256']);
+/** Wire-format algorithm strings that AdCP verifiers accept. */
+export type AdcpSignAlg = 'ed25519' | 'ecdsa-p256-sha256';
+export const ALLOWED_ALGS = new Set<string>(['ed25519', 'ecdsa-p256-sha256']);
 export const MAX_SIGNATURE_WINDOW_SECONDS = 300;
 export const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
 export const MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@method', '@target-uri', '@authority'];

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -17,6 +17,8 @@ export const ADCP_ENVELOPE_FIELDS = new Set([
 ]);
 
 // Import structured FormatID from generated core types
+import type { SigningProvider } from '../signing/provider';
+
 import type {
   CreateMediaBuyAsyncInputRequired,
   CreateMediaBuyAsyncSubmitted,
@@ -362,6 +364,37 @@ export interface AgentRequestSigningConfig {
   sign_supported?: boolean;
 }
 
+/**
+ * KMS/HSM-backed signing configuration. Use instead of
+ * {@link AgentRequestSigningConfig} when the private key is managed by an
+ * external key store and must never be loaded into process memory.
+ *
+ * Supply a `SigningProvider` whose `sign()` delegates to your KMS. The SDK
+ * never calls `private_key.d` on this path.
+ */
+export interface AgentProviderSigningConfig {
+  /** Signing backend — KMS, HSM, Vault Transit, or an in-memory test double. */
+  provider: SigningProvider;
+  /**
+   * Agent's base URL. Sellers derive the JWKS endpoint from this via the
+   * conventional well-known suffix (`{agent_url}/.well-known/adcp-jwks.json`).
+   */
+  agent_url: string;
+  /** AdCP operation names to sign regardless of the seller's advertisement. */
+  always_sign?: string[];
+  /**
+   * When true, also sign operations the seller lists in `supported_for`.
+   * Defaults to false.
+   */
+  sign_supported?: boolean;
+}
+
+/**
+ * Either form of signing configuration accepted by the SDK. Pass to
+ * `buildAgentSigningContext` / `buildAgentSigningFetch`.
+ */
+export type AnyAgentSigningConfig = AgentRequestSigningConfig | AgentProviderSigningConfig;
+
 // Agent Configuration Types
 export interface AgentConfig {
   id: string;
@@ -420,9 +453,11 @@ export interface AgentConfig {
    * Optional — when set, outbound requests to this agent are signed per
    * RFC 9421 for operations the agent advertises in its `request_signing`
    * capability block (fetched once via `get_adcp_capabilities` and cached
-   * by the client). See {@link AgentRequestSigningConfig}.
+   * by the client). Accepts either {@link AgentRequestSigningConfig} (raw
+   * JWK in process memory) or {@link AgentProviderSigningConfig} (KMS/HSM
+   * backend via {@link SigningProvider}).
    */
-  request_signing?: AgentRequestSigningConfig;
+  request_signing?: AnyAgentSigningConfig;
 
   /**
    * Pre-connected MCP `Client` for in-process testing without an HTTP loopback server.

--- a/test/signing-provider.test.js
+++ b/test/signing-provider.test.js
@@ -38,10 +38,12 @@ const { InMemorySigningProvider } = require('../dist/lib/signing/testing.js');
 // ---------------------------------------------------------------------------
 // Key fixtures — generated fresh per process, self-contained
 // ---------------------------------------------------------------------------
-let privateJwk;    // request-signing key
+let privateJwk;    // request-signing key (ed25519)
 let publicJwk;
-let webhookPrivJwk; // webhook-signing key
+let webhookPrivJwk; // webhook-signing key (ed25519)
 let webhookPubJwk;
+let ecPrivJwk;     // request-signing key (ecdsa-p256-sha256)
+let ecPubJwk;
 
 before(() => {
   function makeKeypair(kid, adcp_use) {
@@ -51,12 +53,21 @@ before(() => {
     const pub  = { ...publicKey.export({ format: 'jwk' }),  kid, kty: 'OKP', crv: 'Ed25519', alg: 'EdDSA', adcp_use, key_ops: ['verify'] };
     return { priv, pub };
   }
+  function makeEcKeypair(kid, adcp_use) {
+    const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const priv = { ...privateKey.export({ format: 'jwk' }), kid, kty: 'EC', crv: 'P-256', alg: 'ES256', adcp_use, key_ops: ['sign'] };
+    const pub  = { ...publicKey.export({ format: 'jwk' }),  kid, kty: 'EC', crv: 'P-256', alg: 'ES256', adcp_use, key_ops: ['verify'] };
+    return { priv, pub };
+  }
   const req = makeKeypair('test-gen-ed25519', 'request-signing');
   privateJwk = req.priv;
   publicJwk  = req.pub;
   const wh = makeKeypair('test-gen-webhook', 'webhook-signing');
   webhookPrivJwk = wh.priv;
   webhookPubJwk  = wh.pub;
+  const ec = makeEcKeypair('test-gen-ec-p256', 'request-signing');
+  ecPrivJwk = ec.priv;
+  ecPubJwk  = ec.pub;
 });
 
 function makeReq(opts = {}) {
@@ -217,6 +228,28 @@ describe('buildAgentSigningContextFromConfig fingerprint validation', () => {
       'https://seller.example.com'
     );
     assert.ok(ctx.cacheKey.startsWith('sig='));
+  });
+});
+
+describe('ECDSA-P256 round-trip with InMemorySigningProvider', () => {
+  it('signed with ecdsa-p256-sha256 provider verifies successfully', async () => {
+    const provider = new InMemorySigningProvider({
+      keyid: ecPubJwk.kid,
+      algorithm: 'ecdsa-p256-sha256',
+      privateKey: ecPrivJwk,
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const req = makeReq();
+    const signed = await signRequestAsync(req, provider, { now: () => now });
+
+    const verifier = makeVerifier(ecPubJwk);
+    const result = await verifyRequestSignature(
+      { method: req.method, url: req.url, headers: { ...req.headers, ...signed.headers }, body: req.body },
+      { ...verifier, now: () => now }
+    );
+    assert.strictEqual(result.status, 'verified');
+    assert.strictEqual(result.keyid, ecPubJwk.kid);
   });
 });
 

--- a/test/signing-provider.test.js
+++ b/test/signing-provider.test.js
@@ -1,0 +1,254 @@
+/**
+ * Tests for the SigningProvider abstraction:
+ *   - InMemorySigningProvider produces byte-identical output to signRequest
+ *   - signRequestAsync + InMemorySigningProvider round-trips through verifyRequestSignature
+ *   - signWebhookAsync produces a verifiable webhook signature
+ *   - createSigningFetch accepts a SigningProvider
+ *   - buildAgentSigningContext: fingerprint < 16 chars throws
+ *   - Cache-isolation: two providers with same kid but distinct fingerprints get distinct cache keys
+ */
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert');
+const { generateKeyPairSync } = require('node:crypto');
+
+const {
+  signRequest,
+  signRequestAsync,
+  signWebhookAsync,
+  createSigningFetch,
+} = require('../dist/lib/signing/client.js');
+
+const {
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  StaticJwksResolver,
+  verifyRequestSignature,
+  verifyWebhookSignature,
+} = require('../dist/lib/signing/server.js');
+
+const {
+  buildAgentSigningContext,
+  buildAgentSigningContextFromConfig,
+  CapabilityCache,
+  buildCapabilityCacheKey,
+} = require('../dist/lib/signing/client.js');
+
+const { InMemorySigningProvider } = require('../dist/lib/signing/testing.js');
+
+// ---------------------------------------------------------------------------
+// Key fixtures — generated fresh per process, self-contained
+// ---------------------------------------------------------------------------
+let privateJwk;    // request-signing key
+let publicJwk;
+let webhookPrivJwk; // webhook-signing key
+let webhookPubJwk;
+
+before(() => {
+  function makeKeypair(kid, adcp_use) {
+    const { privateKey, publicKey } = generateKeyPairSync('ed25519');
+    // alg must be the JOSE name (EdDSA), not the AdCP wire name (ed25519)
+    const priv = { ...privateKey.export({ format: 'jwk' }), kid, kty: 'OKP', crv: 'Ed25519', alg: 'EdDSA', adcp_use, key_ops: ['sign'] };
+    const pub  = { ...publicKey.export({ format: 'jwk' }),  kid, kty: 'OKP', crv: 'Ed25519', alg: 'EdDSA', adcp_use, key_ops: ['verify'] };
+    return { priv, pub };
+  }
+  const req = makeKeypair('test-gen-ed25519', 'request-signing');
+  privateJwk = req.priv;
+  publicJwk  = req.pub;
+  const wh = makeKeypair('test-gen-webhook', 'webhook-signing');
+  webhookPrivJwk = wh.priv;
+  webhookPubJwk  = wh.pub;
+});
+
+function makeReq(opts = {}) {
+  return {
+    method: opts.method ?? 'POST',
+    url: opts.url ?? 'https://seller.example.com/mcp',
+    headers: { 'content-type': 'application/json', host: 'seller.example.com', ...opts.headers },
+    body: opts.body ?? '{"method":"tools/call","params":{"name":"create_media_buy"}}',
+  };
+}
+
+function makeVerifier(pubJwk) {
+  return {
+    jwks: new StaticJwksResolver([pubJwk]),
+    replayStore: new InMemoryReplayStore(),
+    revocationStore: new InMemoryRevocationStore(),
+    capability: { supported: true, covers_content_digest: 'either', required_for: [] },
+  };
+}
+
+describe('InMemorySigningProvider', () => {
+  it('sign() produces byte-identical output to signRequest for ed25519', async () => {
+    const now = 1700000000;
+    const nonce = 'test-nonce-abc';
+    const req = makeReq();
+
+    // Use privateJwk for signing; adcp_use scoping only affects the verifier.
+    const signerKey = { keyid: privateJwk.kid, alg: 'ed25519', privateKey: privateJwk };
+    const syncResult = signRequest(req, signerKey, { now: () => now, nonce });
+
+    const provider = new InMemorySigningProvider({
+      keyid: privateJwk.kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwk,
+    });
+    const asyncResult = await signRequestAsync(req, provider, { now: () => now, nonce });
+
+    assert.strictEqual(asyncResult.headers['Signature'], syncResult.headers['Signature'],
+      'async provider signature must match sync signRequest output');
+    assert.strictEqual(asyncResult.headers['Signature-Input'], syncResult.headers['Signature-Input']);
+    assert.strictEqual(asyncResult.signatureBase, syncResult.signatureBase);
+  });
+
+  it('fingerprint matches legacy AgentRequestSigningConfig derivation', () => {
+    const provider = new InMemorySigningProvider({
+      keyid: 'my-key',
+      algorithm: 'ed25519',
+      privateKey: { d: 'secret-scalar', kty: 'OKP', crv: 'Ed25519' },
+    });
+    const { createHash } = require('node:crypto');
+    const expected = createHash('sha256').update('my-key').update('\0').update('secret-scalar').digest('hex').slice(0, 16);
+    assert.strictEqual(provider.fingerprint, expected);
+  });
+});
+
+describe('signRequestAsync round-trip through verifyRequestSignature', () => {
+  it('signed with InMemorySigningProvider verifies successfully', async () => {
+    const provider = new InMemorySigningProvider({
+      keyid: publicJwk.kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwk,
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const req = makeReq();
+    const signed = await signRequestAsync(req, provider, { now: () => now });
+
+    const verifier = makeVerifier(publicJwk);
+    const result = await verifyRequestSignature(
+      { method: req.method, url: req.url, headers: { ...req.headers, ...signed.headers }, body: req.body },
+      { ...verifier, now: () => now }
+    );
+    assert.strictEqual(result.status, 'verified');
+    assert.strictEqual(result.keyid, publicJwk.kid);
+  });
+});
+
+describe('signWebhookAsync round-trip', () => {
+  it('webhook signed with InMemorySigningProvider verifies successfully', async () => {
+    const provider = new InMemorySigningProvider({
+      keyid: webhookPubJwk.kid,
+      algorithm: 'ed25519',
+      privateKey: webhookPrivJwk,
+    });
+
+    const now = Math.floor(Date.now() / 1000);
+    const req = { method: 'POST', url: 'https://buyer.example.com/webhooks', headers: { host: 'buyer.example.com', 'content-type': 'application/json' }, body: '{"event":"delivery"}' };
+    const signed = await signWebhookAsync(req, provider, { now: () => now });
+
+    const result = await verifyWebhookSignature(
+      { method: req.method, url: req.url, headers: { ...req.headers, ...signed.headers }, body: req.body },
+      {
+        jwks: new StaticJwksResolver([webhookPubJwk]),
+        replayStore: new InMemoryReplayStore(),
+        revocationStore: new InMemoryRevocationStore(),
+        now: () => now,
+      }
+    );
+    assert.strictEqual(result.status, 'verified');
+  });
+});
+
+describe('createSigningFetch with SigningProvider', () => {
+  it('sends signed request and upstream receives correct Signature header', async () => {
+    const provider = new InMemorySigningProvider({
+      keyid: publicJwk.kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwk,
+    });
+
+    let capturedHeaders;
+    const fakeUpstream = async (_url, init) => {
+      capturedHeaders = init.headers;
+      return new Response('{}', { status: 200 });
+    };
+
+    const fetch = createSigningFetch(fakeUpstream, provider);
+    await fetch('https://seller.example.com/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"method":"tools/call"}',
+    });
+
+    assert.ok(capturedHeaders['Signature'], 'Signature header must be set');
+    assert.ok(capturedHeaders['Signature-Input'], 'Signature-Input header must be set');
+    assert.match(capturedHeaders['Signature'], /^sig1=:/);
+  });
+});
+
+describe('buildAgentSigningContextFromConfig fingerprint validation', () => {
+  it('throws when provider fingerprint is shorter than 16 characters', () => {
+    const shortFpProvider = {
+      keyid: 'k1',
+      algorithm: 'ed25519',
+      fingerprint: 'tooshort',
+      async sign() { return new Uint8Array(64); },
+    };
+
+    assert.throws(
+      () => buildAgentSigningContextFromConfig(
+        { provider: shortFpProvider, agent_url: 'https://buyer.example.com' },
+        'https://seller.example.com'
+      ),
+      err => err.message.includes('at least 16 characters')
+    );
+  });
+
+  it('succeeds when fingerprint is exactly 16 characters', () => {
+    const provider = new InMemorySigningProvider({
+      keyid: 'k1',
+      algorithm: 'ed25519',
+      privateKey: { d: 'aaaaaaaaaaaaaaaa', kty: 'OKP', crv: 'Ed25519' },
+    });
+    assert.ok(provider.fingerprint.length >= 16);
+
+    const ctx = buildAgentSigningContextFromConfig(
+      { provider, agent_url: 'https://buyer.example.com' },
+      'https://seller.example.com'
+    );
+    assert.ok(ctx.cacheKey.startsWith('sig='));
+  });
+});
+
+describe('cache-isolation: two providers, same kid, distinct fingerprints', () => {
+  it('get distinct cacheKey and capabilityCacheKey entries', () => {
+    const providerA = new InMemorySigningProvider({
+      keyid: 'shared-kid',
+      algorithm: 'ed25519',
+      privateKey: { d: 'key-material-tenant-a', kty: 'OKP', crv: 'Ed25519' },
+    });
+    const providerB = new InMemorySigningProvider({
+      keyid: 'shared-kid',
+      algorithm: 'ed25519',
+      privateKey: { d: 'key-material-tenant-b', kty: 'OKP', crv: 'Ed25519' },
+    });
+
+    assert.notStrictEqual(providerA.fingerprint, providerB.fingerprint,
+      'distinct private keys must produce distinct fingerprints');
+
+    const sellerUri = 'https://seller.example.com';
+    const ctxA = buildAgentSigningContextFromConfig(
+      { provider: providerA, agent_url: 'https://buyer-a.example.com' },
+      sellerUri
+    );
+    const ctxB = buildAgentSigningContextFromConfig(
+      { provider: providerB, agent_url: 'https://buyer-b.example.com' },
+      sellerUri
+    );
+
+    assert.notStrictEqual(ctxA.cacheKey, ctxB.cacheKey,
+      'transport cache keys must differ for distinct key material');
+    assert.notStrictEqual(ctxA.capabilityCacheKey, ctxB.capabilityCacheKey,
+      'capability cache keys must differ for distinct key material');
+  });
+});


### PR DESCRIPTION
Closes #1009

## Summary

Adds a pluggable `SigningProvider` interface so operators can delegate RFC 9421 signing to AWS KMS / GCP KMS / Azure Key Vault / Vault Transit without ever loading private key material into process memory. The change is fully non-breaking — all existing `signRequest`, `signWebhook`, and `createSigningFetch(upstream, key)` call sites continue to work unchanged.

**New exports from `@adcp/client/signing/client`:**
- `SigningProvider` interface — `sign(Uint8Array): Promise<Uint8Array>` with `keyid`, `algorithm`, `fingerprint`
- `AdcpSignAlg` type — shared `'ed25519' | 'ecdsa-p256-sha256'` union (was duplicated ad-hoc)
- `signRequestAsync(req, provider, opts)` — async variant of `signRequest`
- `signWebhookAsync(req, provider, opts)` — async variant of `signWebhook`
- `createSigningFetch` now accepts `SignerKey | SigningProvider` via overload
- `buildAgentSigningContextFromConfig(signing, agentUri, authToken?, opts?)` — wire a provider without a full `AgentConfig`
- `isProviderConfig(signing)` — type guard for the provider arm

**New exports from `@adcp/client/signing/testing`:**
- `InMemorySigningProvider` — test double backed by a raw JWK; byte-identical to the sync path

**New types in `@adcp/client/types`:**
- `AgentProviderSigningConfig` — KMS-backed sibling of `AgentRequestSigningConfig`
- `AnyAgentSigningConfig = AgentRequestSigningConfig | AgentProviderSigningConfig`

`AgentConfig.request_signing` now accepts `AnyAgentSigningConfig`. `AgentRequestSigningConfig` is unchanged.

**Example:** `examples/gcp-kms-signing-provider.ts` — GCP Cloud KMS adapter (ECDSA-P256, DER→P1363 conversion, pre-hash contract documented).

## Key design decisions (per #1009)

- **Discriminant**: `isProviderConfig` uses `'provider' in signing`; `createSigningFetch` uses `'sign' in signer` (positive check on the required interface method, not absence of `privateKey`).
- **Multi-tenant cache isolation**: `fingerprint` (≥16 chars, enforced at construction) replaces the `.d` hash for the provider arm. `resolveFingerprint` throws with a clear message if the constraint is violated.
- **Non-breaking union**: `AnyAgentSigningConfig` is an additive alias; the existing raw-key arm is structurally unchanged.
- **Pre-hash contract (GCP KMS)**: `EC_SIGN_P256_SHA256` takes a pre-computed SHA-256 digest. The adapter hashes once and documents the invariant explicitly.

## Pre-PR review sign-offs

Two expert reviews were run before opening this PR (design pass + code/security pass). All blocker findings were addressed before this PR was opened:

| Finding | Location | Fix |
|---|---|---|
| Wrong discriminant (`'privateKey' in signer`) | `fetch.ts:67` | Changed to `'sign' in signer` |
| `readInt` no long-form DER guard | `gcp-kms-signing-provider.ts` | Added `if (len & 0x80) throw` |
| `versionName` unvalidated before KMS call | `gcp-kms-signing-provider.ts` | GCP resource path regex at construction |
| No ECDSA round-trip test | `test/signing-provider.test.js` | Added P-256 round-trip via `verifyRequestSignature` |

## Test plan

- [ ] `node --test test/signing-provider.test.js` — 9 tests, 0 failures (Ed25519 + ECDSA-P256 round-trips, `createSigningFetch` with provider, fingerprint validation, cache isolation)
- [ ] `npm run build` passes (TypeScript strict, no `tsc` errors)
- [ ] Existing signing tests unaffected (`test/signing.test.js`, `test/webhook-signing.test.js`)
- [ ] Review `examples/gcp-kms-signing-provider.ts` for accuracy against GCP KMS docs

https://claude.ai/code/session_01VsmjQXjQrapZq8qniBrFmu

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsmjQXjQrapZq8qniBrFmu)_