### PR TITLE
feat(signing): SigningProvider abstraction for KMS-backed RFC 9421 signing

### DIFF
--- a/.changeset/signing-provider-kms.md
+++ b/.changeset/signing-provider-kms.md
@@ -42,6 +42,16 @@ snapshotted at context-build time so a provider object whose fields drift
 between build and outbound request cannot desynchronize the on-wire `keyid`
 from the cache key the connection was bound to.
 
+**Behavior change for non-UTF-8 byte bodies:** `createSigningFetch` and
+`createSigningFetchAsync` now throw `TypeError` on `Uint8Array` /
+`ArrayBuffer` request bodies that aren't valid UTF-8. Previously, invalid
+bytes were silently replaced with U+FFFD by `Buffer.toString('utf8')` —
+verification still passed because the wire and the digest agreed on the
+lossy string, but the seller received mangled content. Callers hitting
+this should pass a string body, ensure their bytes are UTF-8, or sign
+manually with `signRequest` / `signRequestAsync` against the exact wire
+bytes they intend to send. Error message names the escape hatch.
+
 Wire format unchanged. No AdCP version bump.
 
 A reference GCP KMS adapter ships at `examples/gcp-kms-signing-provider.ts`,

--- a/.changeset/signing-provider-kms.md
+++ b/.changeset/signing-provider-kms.md
@@ -1,0 +1,51 @@
+---
+"@adcp/client": minor
+---
+
+feat(signing): add SigningProvider abstraction for KMS-backed RFC 9421 signing
+
+Adds a pluggable `SigningProvider` interface so private keys can live in a
+managed key store (GCP KMS, AWS KMS, Azure Key Vault, HashiCorp Vault Transit)
+instead of process memory. The async `sign(payload)` boundary matches RFC
+9421 §3.1 — the SDK produces the canonical signature base, the provider
+returns wire-format signature bytes.
+
+New surface:
+- `SigningProvider` interface and `AdcpSignAlg` type (exported from
+  `@adcp/client/signing`).
+- `signRequestAsync` / `signWebhookAsync` — async variants that accept a
+  provider; sync `signRequest` / `signWebhook` are unchanged.
+- `createSigningFetchAsync(upstream, provider, options)` — async-signing
+  fetch wrapper, paired with the existing sync `createSigningFetch`. Two
+  symbols rather than one overload so the latency-cost distinction is
+  visible at integration time.
+- `derEcdsaToP1363(der, componentLen)` — DER → IEEE P1363 ECDSA signature
+  converter for KMS adapters whose `sign` API returns DER (GCP, AWS, Azure).
+- `SigningProviderAlgorithmMismatchError` — typed error adapters throw when
+  the declared algorithm doesn't match the underlying key, so misconfigurations
+  fail fast at adapter construction rather than producing signatures verifiers
+  reject downstream.
+- `@adcp/client/signing/testing` sub-path exporting `InMemorySigningProvider`
+  and `signerKeyToProvider`. Constructor refuses to instantiate when
+  `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set.
+
+`AgentRequestSigningConfig` is now a discriminated union on `kind`:
+- `kind: 'inline'` (default — `kind` is optional on this shape so existing
+  literals work unchanged) holds a private JWK in process.
+- `kind: 'provider'` delegates `sign()` to a `SigningProvider`.
+
+`buildAgentSigningContext` defensively hashes the provider-supplied
+`fingerprint` together with `algorithm` and `kid` before composing
+transport- and capability-cache keys, preserving the multi-tenant isolation
+property the in-memory path has always provided. The signing identity is
+snapshotted at context-build time so a provider object whose fields drift
+between build and outbound request cannot desynchronize the on-wire `keyid`
+from the cache key the connection was bound to.
+
+Wire format unchanged. No AdCP version bump.
+
+A reference GCP KMS adapter ships at `examples/gcp-kms-signing-provider.ts`,
+type-checked under `npm run typecheck:examples`. AWS KMS and Azure Key Vault
+adapters can mirror the same pattern; users `npm i` the cloud SDK they need.
+
+See adcontextprotocol/adcp-client#1009.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
-> Generated at: 2026-04-24
-> @adcp/client v5.15.0
+> Generated at: 2026-04-26
+> @adcp/client v5.19.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -390,7 +390,9 @@ createAdcpServer({
 });
 ```
 
-See [SIGNING-GUIDE.md](./SIGNING-GUIDE.md) for the full walkthrough: key generation, JWKS publication, brand.json, and conformance testing.
+**Production key storage.** For outbound *request* signing (calling other agents' tools), prefer a KMS-backed `SigningProvider` over in-process JWKs — `request_signing` accepts `{ kind: 'provider', provider, agent_url }` for any KMS / HSM / Vault backend. See [SIGNING-GUIDE.md § Production Key Storage](./SIGNING-GUIDE.md#step-35-production-key-storage--kms--hsm--vault) for the full walkthrough including a reference GCP KMS adapter. Server-side `webhooks.signerKey` currently accepts only an in-process `SignerKey`; KMS-backed webhook signing on the server is a follow-up.
+
+See [SIGNING-GUIDE.md](./SIGNING-GUIDE.md) for the full walkthrough: key generation, JWKS publication, brand.json, conformance testing, and KMS-backed production deployment.
 
 ### createTaskCapableServer (Low-Level)
 

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -212,6 +212,109 @@ const signingFetch = buildAgentSigningFetch({
 });
 ```
 
+## Step 3.5: Production Key Storage — KMS / HSM / Vault
+
+Holding a private JWK in process memory is fine for development and testing but it's not where you want production signing keys to live. A process compromise leaks the signing key, and the only remedy is rotation across every counterparty that's cached your public key (within their TTL). The AdCP spec recommends storing keys in a managed key store (HSM or KMS); the SDK supports this directly via the `SigningProvider` interface.
+
+### When to switch
+
+- **Stay in-process** for local development, integration tests, and pilot deployments where the signed traffic isn't financially significant.
+- **Move to KMS** before going live with mutating operations — `create_media_buy`, `acquire_*`, `sync_audiences`, anything that commits spend or changes shared state. RFC 9421 signing is recommended at AdCP 3.0 and **required for mutating ops at 3.1+**, so the threshold to care arrives soon.
+
+### The interface
+
+```typescript
+import type { SigningProvider } from '@adcp/client/signing';
+
+export interface SigningProvider {
+  sign(payload: Uint8Array): Promise<Uint8Array>;
+  readonly keyid: string;
+  readonly algorithm: 'ed25519' | 'ecdsa-p256-sha256';
+  readonly fingerprint: string;
+}
+```
+
+`sign(payload)` receives the canonical RFC 9421 signature base; the provider returns wire-format signature bytes (64-byte raw for Ed25519, 64-byte `r‖s` IEEE P1363 for ECDSA-P256 — **not** DER). `keyid` flows into `Signature-Input`; `algorithm` is the wire string; `fingerprint` is a stable opaque token (e.g., `projects/.../cryptoKeyVersions/N`) used by the SDK for transport-cache isolation. The SDK defensively hashes the fingerprint, so a buggy adapter that returns a low-entropy string can't collapse multi-tenant cache isolation.
+
+### Wiring a provider into your config
+
+`AgentRequestSigningConfig` is a discriminated union on `kind`. Existing literals continue to work — `kind` defaults to `'inline'` so adding the field isn't required. Switch to a KMS-backed signer by replacing the `private_key` block with `{ kind: 'provider', provider }`:
+
+```typescript
+import { createAgentSignedFetch } from '@adcp/client/signing';
+import { createGcpKmsSigningProvider } from './gcp-kms-signing-provider'; // see examples/
+
+const provider = await createGcpKmsSigningProvider({
+  versionName: process.env.ADCP_KMS_VERSION!,
+  kid: 'my-agent-2026',
+  algorithm: 'ed25519',
+  client: kmsClient,
+});
+
+const signedFetch = createAgentSignedFetch({
+  signing: {
+    kind: 'provider',
+    provider,
+    agent_url: 'https://agent.example.com',
+  },
+  sellerAgentUri: 'https://seller.example.com',
+});
+```
+
+The wire format is unchanged. Sellers can't tell the difference between a request signed in-process and one signed by KMS — the SDK's canonicalization is shared between the sync (in-process) and async (provider) paths via the same helpers.
+
+### GCP KMS reference adapter
+
+A complete reference lives at [`examples/gcp-kms-signing-provider.ts`](https://github.com/adcontextprotocol/adcp-client/blob/main/examples/gcp-kms-signing-provider.ts). The adapter handles two GCP-specific quirks:
+
+- **DER → IEEE P1363 conversion** for ECDSA. GCP KMS returns ECDSA signatures DER-encoded; AdCP and RFC 9421 §3.3.1 want raw `r‖s`. The SDK exports `derEcdsaToP1363(der, componentLen)` so any KMS adapter (GCP, AWS for ECDSA, Azure) can normalize at the boundary.
+- **Pre-flight algorithm check.** The adapter calls `getPublicKey` once at construction and throws `SigningProviderAlgorithmMismatchError` if the declared `algorithm` doesn't match the underlying key's algorithm. Without this, a misconfigured key produces signatures the verifier rejects with a generic `request_signature_invalid` — useless for diagnosis. Pre-flight failure is loud and specific.
+
+The published `@adcp/client` package keeps `@google-cloud/kms` out of its dependencies — copy the example into your project and `npm i @google-cloud/kms` yourself. Mirror the same shape for AWS KMS (`@aws-sdk/client-kms`), Azure Key Vault, or HashiCorp Vault Transit.
+
+### Setting up GCP KMS — the parts that actually matter
+
+1. **Key purpose.** Asymmetric sign. Algorithm: `EC_SIGN_P256_SHA256` is the well-trodden default; `EC_SIGN_ED25519` is GA but availability varies by region — verify before pinning.
+2. **Protection level.** Software is fine for AdCP — keeps the private scalar inside Google's KMS service (your process never sees it). HSM (~10× cost) is only required if you have a regulatory mandate.
+3. **IAM.** Grant `roles/cloudkms.signer` on the **key** (versions inherit the policy; per-version IAM isn't a knob GCP exposes). Treat the key as single-purpose — RFC 9421's `tag` parameter protects verifiers, not signers, so reusing the same KMS key across protocols creates a cross-protocol oracle. Bind IAM so only the AdCP signing path can call `asymmetricSign`.
+4. **JWKS publication.** Pull the public key (`gcloud kms keys versions get-public-key 1 --output-file=pub.pem`), convert PEM → JWK (the `jose` package's `importSPKI` + `exportJWK` is one line each), publish at your agent's `jwks_uri`. The `kid` you use in the `SigningProvider` must match what's published. Keep `kid` short and stable (e.g. `addie-2026-04`) — don't put the full GCP resource name on the wire; that's what `versionName` is for.
+5. **Rotation.** GCP KMS asymmetric keys don't auto-rotate. Pin `versionName` to a specific `cryptoKeyVersions/N`, redeploy when you cut a new version. This is consistent with publishing both versions in your JWKS during the transition.
+
+### Authentication when your runtime is outside GCP
+
+If your agent runs on Cloud Run / GKE / Compute Engine, ADC handles auth automatically — `new KeyManagementServiceClient()` finds credentials via the metadata service.
+
+If your agent runs **outside GCP** (Fly.io, Railway, AWS, your own VMs), you have two options, neither of them frictionless today:
+
+- **Service-account JSON key + Fly secret.** Simplest path. Create a service account, grant it `roles/cloudkms.signer` on the key, generate a JSON key, set as a Fly secret (or equivalent), construct the client with explicit credentials. The signing key still lives in KMS (never in your process); only the access credential lives in your secret store. Rotate the SA key every ~90 days as hygiene. **Caveat:** GCP orgs commonly enforce `constraints/iam.disableServiceAccountKeyCreation`, which blocks this — you'll need a temporary org-policy exception (project owner can grant themselves `orgpolicy.policyAdmin` and toggle the constraint for the project; takes seconds with the right role).
+- **Workload Identity Federation.** The right answer long-term, but requires the runtime to issue OIDC tokens GCP can trust. Fly currently issues Macaroons, not OIDC, so WIF doesn't drop in. Worth revisiting when Fly ships native OIDC.
+
+For non-GCP runtimes that lack OIDC and where the org policy blocks SA keys, the operationally clean fallback is a **Cloud Run remote-signer sidecar** — a tiny GCP-hosted service that exposes `POST /sign`, runs as the signer SA (gets ADC for free), authenticates incoming calls via shared secret. Adds 30–100 ms per signed request; no SA key in the off-cloud secret store.
+
+### Threat model upgrade — what you actually buy
+
+| Compromise | In-process key | KMS-backed signer (any auth path) |
+|---|---|---|
+| Process memory dump | Signing key gone — full impersonation until JWKS rotates everywhere | Signing key untouched — only the auth credential leaks (revocable in seconds) |
+| Recovery | Rotate the JWK + push to all counterparties + wait out their cache TTL | Revoke the SA key (or KMS access) — signing stops immediately, JWK unchanged |
+| Auditability | Whatever your app logs | Cloud audit log: every `asymmetricSign` call, by identity, with version |
+
+### Testing — `InMemorySigningProvider`
+
+The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first:
+
+```typescript
+import { InMemorySigningProvider } from '@adcp/client/signing/testing';
+
+const provider = new InMemorySigningProvider({
+  keyid: 'test-2026',
+  algorithm: 'ed25519',
+  privateKey: testJwk,
+});
+```
+
+The constructor refuses to instantiate when `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set explicitly — defense-in-depth so a copy-paste from a test file doesn't accidentally ship to prod. The gate is a self-discipline aid for the bundled implementation; the SDK can't enforce hygiene on third-party providers.
+
 ## Step 4: Verify Inbound Signatures (Seller)
 
 ### Express middleware

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-04-24
-> Library: @adcp/client v5.15.0
+> Generated at: 2026-04-26
+> Library: @adcp/client v5.19.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 

--- a/docs/migration-4.x-to-5.x.md
+++ b/docs/migration-4.x-to-5.x.md
@@ -955,6 +955,67 @@ Only the items whose subsystem you actually use.
 - [ ] **`comply_test_controller` publishers** — use `createComplyController({...}).register(server)` instead of hand-registering.
 - [ ] **Storyboard runners** — seed with `seedComplianceFixtures(server)`; wire `AdcpServer.compliance.reset()` on your reset hook; handle `CapabilityResolutionError` by `err.code` rather than regexing messages.
 
+## Part 6 — `SigningProvider` abstraction (5.20.0)
+
+_Applies to anyone signing AdCP requests in production who'd rather not hold private keys in process memory._
+
+### 6a. New: pluggable `SigningProvider` for KMS / HSM / Vault
+
+Adds a `SigningProvider` interface so private keys can live in a managed key store (GCP KMS, AWS KMS, Azure Key Vault, HashiCorp Vault Transit) instead of process memory. The async `sign(payload)` boundary matches RFC 9421 §3.1: the SDK produces the canonical signature base, the provider returns wire-format signature bytes.
+
+Existing inline literals continue to work unchanged — `AgentRequestSigningConfig` is now a discriminated union on `kind`, but `kind` defaults to `'inline'` on the existing shape:
+
+```typescript
+// Existing — still works
+request_signing: {
+  kid: 'my-agent-2026',
+  alg: 'ed25519',
+  private_key: privateJwk,
+  agent_url: 'https://agent.example.com',
+}
+
+// New — KMS-backed
+request_signing: {
+  kind: 'provider',
+  provider: await createGcpKmsSigningProvider({
+    versionName: process.env.ADCP_KMS_VERSION!,
+    kid: 'my-agent-2026',
+    algorithm: 'ed25519',
+    client: kmsClient,
+  }),
+  agent_url: 'https://agent.example.com',
+}
+```
+
+Wire format unchanged. Sellers can't tell the difference between a request signed in-process and one signed by KMS — sync and async paths share the same canonicalization helpers.
+
+New exports from `@adcp/client/signing`:
+
+- `SigningProvider` interface, `AdcpSignAlg` type
+- `signRequestAsync` / `signWebhookAsync`
+- `createSigningFetchAsync(upstream, provider, options)` — paired with the existing sync `createSigningFetch`. Two symbols rather than one overload so the latency-cost difference is visible at integration time.
+- `derEcdsaToP1363(der, componentLen)` — DER → IEEE P1363 ECDSA converter for KMS adapters
+- `SigningProviderAlgorithmMismatchError` — typed error for adapter misconfigurations
+- Reusable canonicalization helpers `prepareRequestSignature`, `prepareWebhookSignature`, `finalizeRequestSignature` — for anyone building a third signer (sigstore, custom HSM)
+
+`@adcp/client/signing/testing` sub-path: `InMemorySigningProvider` (NODE_ENV-gated against accidental production use) and `signerKeyToProvider` adapter for the conformance runner.
+
+A reference GCP KMS adapter ships at `examples/gcp-kms-signing-provider.ts` (type-checked under `npm run typecheck:examples`). AWS KMS / Azure Key Vault adapters can mirror the same shape; users `npm i` the cloud SDK they need.
+
+See [`docs/guides/SIGNING-GUIDE.md` § Production Key Storage](./guides/SIGNING-GUIDE.md#step-35-production-key-storage--kms--hsm--vault) for the full setup walkthrough including the GCP-from-non-GCP-runtime story.
+
+### 6b. **BREAKING (small)** — strict UTF-8 decoding on byte-body signing
+
+`createSigningFetch` and `createSigningFetchAsync` now throw `TypeError` on `Uint8Array` / `ArrayBuffer` request bodies that aren't valid UTF-8. Previously, invalid bytes were silently replaced with U+FFFD by `Buffer.toString('utf8')` — verification still passed because the wire and the digest agreed on the lossy string, but the seller received mangled content.
+
+If your CI starts failing here, your code was passing non-UTF-8 bytes (binary content type, encrypted payload). Pick one:
+
+- Pass a string body, ensuring valid UTF-8.
+- Ensure the `Uint8Array` contents are valid UTF-8.
+- Sign manually with `signRequest` / `signRequestAsync` against the exact wire bytes you intend to send (this bypasses the fetch wrapper's decoding step).
+
+Error message names the escape hatch.
+
 ### Tooling to adopt
 
 - [ ] Run `npm run schema-diff` after each `npm run sync-schemas` to see wire-level deltas before they bite you downstream.

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -1,0 +1,134 @@
+/**
+ * GCP KMS-backed `SigningProvider` for AdCP RFC 9421 request and webhook
+ * signing. Reference adapter — copy this file into your project and adjust
+ * IAM, region, and key-version policy to match your deployment.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { createGcpKmsSigningProvider } from './gcp-kms-signing-provider';
+ * import type { AgentConfig } from '@adcp/client';
+ *
+ * const provider = await createGcpKmsSigningProvider({
+ *   versionName: process.env.ADCP_KMS_VERSION!,
+ *   kid: 'addie-2026-04',
+ *   algorithm: 'ecdsa-p256-sha256',
+ * });
+ *
+ * const agent: AgentConfig = {
+ *   id: 'addie',
+ *   name: 'Addie',
+ *   agent_uri: 'https://seller.example.com',
+ *   protocol: 'mcp',
+ *   request_signing: {
+ *     kind: 'provider',
+ *     provider,
+ *     agent_url: 'https://addie.example.com',
+ *   },
+ * };
+ * ```
+ *
+ * Hazards:
+ * - GCP KMS returns ECDSA signatures DER-encoded; AdCP and RFC 9421 want
+ *   raw `r‖s` (IEEE P1363). The adapter converts at the boundary.
+ * - GCP KMS Ed25519 (`EC_SIGN_ED25519`) is GA but availability varies by
+ *   region/tier. Verify in your target region before pinning.
+ * - The `versionName` pins a specific `cryptoKeyVersion`. Rotation is a
+ *   redeploy. For lazy primary lookup, see the `lazyPrimary` example below.
+ *
+ * IAM (least privilege):
+ * - GCP: `roles/cloudkms.signer` scoped to the specific `cryptoKeyVersions/N`
+ *   resource. Do **not** grant `roles/cloudkms.signerVerifier` — verification
+ *   uses only the public key from `jwks_uri`.
+ * - Treat the KMS key as single-purpose: the AdCP signing path is the only
+ *   caller. Reusing the same key across protocols creates a cross-protocol
+ *   oracle.
+ */
+
+import { createHash } from 'node:crypto';
+import type { SigningProvider } from '@adcp/client/signing';
+import { derEcdsaToP1363, SigningProviderAlgorithmMismatchError } from '@adcp/client/signing';
+
+/**
+ * Minimal subset of `KeyManagementServiceClient` the adapter calls. Defined
+ * structurally so callers can stub it in tests without depending on
+ * `@google-cloud/kms`. The real client comes from
+ * `import { KeyManagementServiceClient } from '@google-cloud/kms'`.
+ */
+export interface GcpKmsClientLike {
+  asymmetricSign(request: {
+    name: string;
+    digest?: { sha256?: Buffer | Uint8Array };
+    data?: Buffer | Uint8Array;
+  }): Promise<[{ signature?: Buffer | Uint8Array | string | null }, ...unknown[]]>;
+  getPublicKey(request: { name: string }): Promise<[{ algorithm?: string | null; pem?: string | null }, ...unknown[]]>;
+}
+
+export interface GcpKmsSigningProviderOptions {
+  /** Full version resource name: `projects/.../cryptoKeyVersions/N`. */
+  versionName: string;
+  /** Short stable `kid` published in `Signature-Input`. Must match a key in the agent's `jwks_uri`. */
+  kid: string;
+  /** Wire-format algorithm. Verified against the KMS key on construction. */
+  algorithm: 'ed25519' | 'ecdsa-p256-sha256';
+  /**
+   * GCP KMS client. In production: `new KeyManagementServiceClient()`.
+   * Stubbable for tests via the {@link GcpKmsClientLike} structural type.
+   */
+  client: GcpKmsClientLike;
+}
+
+/**
+ * Construct a GCP KMS-backed `SigningProvider`. Calls `getPublicKey` once at
+ * construction to validate the declared algorithm matches the underlying
+ * key — fails fast with {@link SigningProviderAlgorithmMismatchError} rather
+ * than producing signatures verifiers would reject downstream.
+ */
+export async function createGcpKmsSigningProvider(
+  options: GcpKmsSigningProviderOptions
+): Promise<SigningProvider> {
+  const [pubResp] = await options.client.getPublicKey({ name: options.versionName });
+  const kmsAlgorithm = pubResp.algorithm ?? '';
+  const expectedKmsAlgorithm = mapDeclaredAlgorithmToKms(options.algorithm);
+  if (kmsAlgorithm !== expectedKmsAlgorithm) {
+    throw new SigningProviderAlgorithmMismatchError(options.algorithm, kmsAlgorithm, options.kid);
+  }
+
+  return {
+    keyid: options.kid,
+    algorithm: options.algorithm,
+    fingerprint: options.versionName,
+    async sign(payload: Uint8Array): Promise<Uint8Array> {
+      if (options.algorithm === 'ecdsa-p256-sha256') {
+        const digest = createHash('sha256').update(payload).digest();
+        const [resp] = await options.client.asymmetricSign({
+          name: options.versionName,
+          digest: { sha256: digest },
+        });
+        const sig = coerceSignature(resp.signature);
+        return derEcdsaToP1363(sig, 32);
+      }
+      const [resp] = await options.client.asymmetricSign({
+        name: options.versionName,
+        data: payload,
+      });
+      return coerceSignature(resp.signature);
+    },
+  };
+}
+
+function mapDeclaredAlgorithmToKms(alg: 'ed25519' | 'ecdsa-p256-sha256'): string {
+  // GCP KMS algorithm enum names per CryptoKeyVersion.CryptoKeyVersionAlgorithm.
+  return alg === 'ed25519' ? 'EC_SIGN_ED25519' : 'EC_SIGN_P256_SHA256';
+}
+
+function coerceSignature(value: Buffer | Uint8Array | string | null | undefined): Uint8Array {
+  if (value == null) {
+    throw new Error('GCP KMS asymmetricSign response did not include a signature.');
+  }
+  if (typeof value === 'string') {
+    return new Uint8Array(Buffer.from(value, 'base64'));
+  }
+  return value instanceof Uint8Array ? value : new Uint8Array(value);
+}
+

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -84,9 +84,7 @@ export interface GcpKmsSigningProviderOptions {
  * key — fails fast with {@link SigningProviderAlgorithmMismatchError} rather
  * than producing signatures verifiers would reject downstream.
  */
-export async function createGcpKmsSigningProvider(
-  options: GcpKmsSigningProviderOptions
-): Promise<SigningProvider> {
+export async function createGcpKmsSigningProvider(options: GcpKmsSigningProviderOptions): Promise<SigningProvider> {
   const [pubResp] = await options.client.getPublicKey({ name: options.versionName });
   const kmsAlgorithm = pubResp.algorithm ?? '';
   const expectedKmsAlgorithm = mapDeclaredAlgorithmToKms(options.algorithm);
@@ -131,4 +129,3 @@ function coerceSignature(value: Buffer | Uint8Array | string | null | undefined)
   }
   return value instanceof Uint8Array ? value : new Uint8Array(value);
 }
-

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -6,13 +6,21 @@
  * Usage:
  *
  * ```ts
+ * // Consumer-side wiring. The KMS client construction is the consumer's
+ * // responsibility — the SDK keeps `@google-cloud/kms` out of its deps so
+ * // non-GCP users don't pay the install cost.
+ * import { KeyManagementServiceClient } from '@google-cloud/kms';
  * import { createGcpKmsSigningProvider } from './gcp-kms-signing-provider';
  * import type { AgentConfig } from '@adcp/client';
+ *
+ * const kmsClient = new KeyManagementServiceClient(); // ADC inside GCP, or
+ *                                                     // explicit credentials elsewhere
  *
  * const provider = await createGcpKmsSigningProvider({
  *   versionName: process.env.ADCP_KMS_VERSION!,
  *   kid: 'addie-2026-04',
  *   algorithm: 'ecdsa-p256-sha256',
+ *   client: kmsClient,
  * });
  *
  * const agent: AgentConfig = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.18.0",
+  "version": "5.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.18.0",
+      "version": "5.19.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
       "require": "./dist/lib/signing/server.js",
       "types": "./dist/lib/signing/server.d.ts"
     },
+    "./signing/testing": {
+      "import": "./dist/lib/signing/testing.js",
+      "require": "./dist/lib/signing/testing.js",
+      "types": "./dist/lib/signing/testing.d.ts"
+    },
     "./schemas": {
       "import": "./dist/lib/schemas/index.js",
       "require": "./dist/lib/schemas/index.js",
@@ -102,6 +107,9 @@
       ],
       "signing/server": [
         "dist/lib/signing/server.d.ts"
+      ],
+      "signing/testing": [
+        "dist/lib/signing/testing.d.ts"
       ],
       "schemas": [
         "dist/lib/schemas/index.d.ts"

--- a/src/lib/signing/agent-context.ts
+++ b/src/lib/signing/agent-context.ts
@@ -7,6 +7,23 @@ import {
   defaultCapabilityCache,
   type CachedCapability,
 } from './capability-cache';
+import type { SigningProvider } from './provider';
+import type { AdcpSignAlg } from './types';
+
+/**
+ * Snapshot of the signing identity captured at context-build time. The
+ * transport layer reads from this snapshot rather than from `provider.*`
+ * directly so a provider object whose fields drift between context build
+ * and outbound request can't desynchronize the on-wire `keyid` from the
+ * cache key the connection was bound to. TypeScript's `readonly` modifier
+ * is compile-time only; the snapshot is the runtime defense.
+ */
+export interface AgentSigningIdentitySnapshot {
+  keyid: string;
+  algorithm: AdcpSignAlg;
+  /** Defensively hashed disambiguator — see {@link buildAgentSigningContext}. */
+  fingerprint: string;
+}
 
 /**
  * Per-call signing context passed down to the MCP/A2A transport layer. Built
@@ -14,11 +31,16 @@ import {
  * attached to the transport. Opaque to the transport helpers — they only
  * use `cacheKey` (to disambiguate connection-cache entries per signing
  * identity), `getCapability` (to read the cached seller advertisement on
- * each outbound request), and `signing` (to produce the signer key).
+ * each outbound request), and `signing` (to produce the signer key or
+ * provider).
  */
 export interface AgentSigningContext {
   /** Signing config copied from AgentConfig.request_signing. */
   signing: AgentRequestSigningConfig;
+  /** Provider when `signing.kind === 'provider'`; undefined for inline keys. */
+  provider?: SigningProvider;
+  /** Snapshot of identity fields read from the provider at build time. */
+  identity: AgentSigningIdentitySnapshot;
   /** Suffix to append to transport connection-cache keys so agents with different signing identities don't share a connection. */
   cacheKey: string;
   /** Lazy accessor for the currently cached capability for this agent. */
@@ -63,17 +85,23 @@ export function buildAgentSigningContext(
   if (!signing) return undefined;
 
   const cache = options.cache ?? defaultCapabilityCache;
-  const keyFingerprint = privateKeyFingerprint(signing);
-  const capabilityCacheKey = buildCapabilityCacheKey(agent.agent_uri, agent.auth_token, keyFingerprint);
-  // Transport-connection cache-key suffix binds to a hash of the private key,
-  // not just the advertised `kid`. Two tenants that misconfigure the same
-  // `kid` string but hold distinct private keys must not collide on a shared
-  // cached transport — that would sign one tenant's outbound requests with
-  // the other tenant's key (same `kid`, different `d`), an impersonation.
-  const cacheKey = `sig=${keyFingerprint}`;
+  const identity = snapshotIdentity(signing);
+  const cacheFingerprint = deriveCacheFingerprint(identity);
+  const capabilityCacheKey = buildCapabilityCacheKey(agent.agent_uri, agent.auth_token, cacheFingerprint);
+  // Transport-connection cache-key suffix binds to the defensively hashed
+  // identity, not just the advertised `kid`. Two tenants that misconfigure
+  // the same `kid` string but hold distinct keys must not collide on a
+  // shared cached transport — that would sign one tenant's outbound
+  // requests with the other tenant's key (same `kid`, different material),
+  // an impersonation. The hash includes `algorithm` so an Ed25519/P-256
+  // swap on the same `kid+fingerprint` doesn't alias either.
+  const cacheKey = `sig=${cacheFingerprint}`;
+  const provider = signing.kind === 'provider' ? signing.provider : undefined;
 
   return {
     signing,
+    provider,
+    identity,
     cacheKey,
     cache,
     capabilityCacheKey,
@@ -83,13 +111,56 @@ export function buildAgentSigningContext(
 }
 
 /**
- * Derive a stable per-key cache-key fragment. Hashes both `kid` and the
- * private scalar `d` so that two tenants advertising the same `kid` but
- * holding distinct private keys get different cache entries. Truncated to
- * 16 hex chars — a collision-resistance budget of 64 bits against random
- * keys is plenty for a cache disambiguator, and we never rely on this
- * value as a security boundary.
+ * Snapshot the signing identity at context-build time. For provider configs,
+ * reads `keyid` / `algorithm` / `fingerprint` once and freezes them. For
+ * inline configs, derives a fingerprint from the private scalar — same
+ * 64-bit cache disambiguator the SDK has always used.
  */
-function privateKeyFingerprint(signing: AgentRequestSigningConfig): string {
-  return createHash('sha256').update(signing.kid).update('\0').update(signing.private_key.d).digest('hex').slice(0, 16);
+function snapshotIdentity(signing: AgentRequestSigningConfig): AgentSigningIdentitySnapshot {
+  if (signing.kind === 'provider') {
+    const provider = signing.provider;
+    return {
+      keyid: provider.keyid,
+      algorithm: provider.algorithm,
+      fingerprint: provider.fingerprint,
+    };
+  }
+  return {
+    keyid: signing.kid,
+    algorithm: signing.alg,
+    fingerprint: inlineFingerprint(signing.kid, signing.private_key.d),
+  };
+}
+
+/**
+ * Defensively hash the snapshot before composing cache keys. A
+ * provider-supplied `fingerprint` is treated as untrusted input — a
+ * confused integrator could return a constant, an empty string, or a
+ * tenant-controlled value, any of which would re-enable cross-tenant
+ * collisions on the same `kid`. Including `algorithm` in the digest
+ * prevents an Ed25519/P-256 swap on identical `kid+fingerprint` from
+ * aliasing.
+ *
+ * Truncated to 16 hex chars — a 64-bit collision-resistance budget against
+ * random keys is plenty for a cache disambiguator, and we never rely on
+ * this value as a security boundary.
+ */
+function deriveCacheFingerprint(identity: AgentSigningIdentitySnapshot): string {
+  return createHash('sha256')
+    .update(identity.algorithm)
+    .update('\0')
+    .update(identity.keyid)
+    .update('\0')
+    .update(identity.fingerprint)
+    .digest('hex')
+    .slice(0, 16);
+}
+
+function inlineFingerprint(kid: string, d: string | undefined): string {
+  if (!d) {
+    throw new TypeError(
+      `AgentRequestSigningConfig (kind: 'inline', kid='${kid}') is missing 'private_key.d' — JWK must include the private scalar.`
+    );
+  }
+  return createHash('sha256').update(kid).update('\0').update(d).digest('hex').slice(0, 16);
 }

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -167,9 +167,7 @@ export function toSignerKey(config: AgentRequestSigningConfigInline): SignerKey 
 }
 
 /** Narrow predicate for the inline shape (kind absent or `'inline'`). */
-export function isInlineSigningConfig(
-  config: AgentRequestSigningConfig
-): config is AgentRequestSigningConfigInline {
+export function isInlineSigningConfig(config: AgentRequestSigningConfig): config is AgentRequestSigningConfigInline {
   return config.kind !== 'provider';
 }
 

--- a/src/lib/signing/agent-fetch.ts
+++ b/src/lib/signing/agent-fetch.ts
@@ -1,5 +1,10 @@
-import type { AgentRequestSigningConfig } from '../types/adcp';
+import type {
+  AgentRequestSigningConfig,
+  AgentRequestSigningConfigInline,
+  AgentRequestSigningConfigProvider,
+} from '../types/adcp';
 import { createSigningFetch, type CoverContentDigestPredicate } from './fetch';
+import { createSigningFetchAsync } from './fetch-async';
 import {
   buildCapabilityCacheKey,
   defaultCapabilityCache,
@@ -148,15 +153,31 @@ export function resolveCoverContentDigest(policy: ContentDigestPolicy | undefine
 }
 
 /**
- * Convert an `AgentRequestSigningConfig` into the `SignerKey` shape expected
- * by `signRequest` / `createSigningFetch`.
+ * Convert an inline `AgentRequestSigningConfig` into the `SignerKey` shape
+ * expected by `signRequest` / `createSigningFetch`. Provider-backed configs
+ * have no in-process key material — callers must route through
+ * `createSigningFetchAsync(upstream, config.provider, ...)` instead.
  */
-export function toSignerKey(config: AgentRequestSigningConfig): SignerKey {
+export function toSignerKey(config: AgentRequestSigningConfigInline): SignerKey {
   return {
     keyid: config.kid,
     alg: config.alg,
     privateKey: config.private_key as SignerKey['privateKey'],
   };
+}
+
+/** Narrow predicate for the inline shape (kind absent or `'inline'`). */
+export function isInlineSigningConfig(
+  config: AgentRequestSigningConfig
+): config is AgentRequestSigningConfigInline {
+  return config.kind !== 'provider';
+}
+
+/** Narrow predicate for the provider shape. */
+export function isProviderSigningConfig(
+  config: AgentRequestSigningConfig
+): config is AgentRequestSigningConfigProvider {
+  return config.kind === 'provider';
 }
 
 export interface BuildAgentSigningFetchOptions {
@@ -189,7 +210,6 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
   // factory-call time.
   const explicitUpstream = options.upstream;
   const upstream: FetchLike = explicitUpstream ?? ((input, init) => defaultUpstream()(input, init));
-  const key = toSignerKey(signing);
 
   const shouldSign = (_url: string, init: RequestInit | undefined): boolean => {
     const operation = extractAdcpOperation(init?.body);
@@ -202,7 +222,30 @@ export function buildAgentSigningFetch(options: BuildAgentSigningFetchOptions): 
     return resolveCoverContentDigest(entry?.requestSigning?.covers_content_digest);
   };
 
-  return createSigningFetch(upstream, key, { shouldSign, coverContentDigest });
+  if (isProviderSigningConfig(signing)) {
+    // Freeze the provider's identity fields at factory time and pass a
+    // snapshot view down to the async signer. TypeScript `readonly` on the
+    // `SigningProvider` interface is compile-time only — if a downstream
+    // adapter mutates `keyid`/`algorithm`/`fingerprint` between context
+    // build and outbound request, the wire `keyid` would drift away from
+    // the cache key the connection was bound to. The frozen view binds the
+    // wire identity to the snapshot already used for cache routing.
+    const frozen = freezeProviderIdentity(signing.provider);
+    return createSigningFetchAsync(upstream, frozen, { shouldSign, coverContentDigest });
+  }
+  return createSigningFetch(upstream, toSignerKey(signing), { shouldSign, coverContentDigest });
+}
+
+function freezeProviderIdentity(provider: AgentRequestSigningConfigProvider['provider']) {
+  const keyid = provider.keyid;
+  const algorithm = provider.algorithm;
+  const fingerprint = provider.fingerprint;
+  return {
+    keyid,
+    algorithm,
+    fingerprint,
+    sign: (payload: Uint8Array) => provider.sign(payload),
+  };
 }
 
 export interface CreateAgentSignedFetchOptions {

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -25,8 +25,13 @@ export {
   type SignRequestOptions,
   type SignWebhookOptions,
 } from './signer';
+export { signRequestAsync, signWebhookAsync } from './signer-async';
+export { derEcdsaToP1363 } from './ecdsa-encoding';
 export { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
 export { createSigningFetch, type CoverContentDigestPredicate, type SigningFetchOptions } from './fetch';
+export { createSigningFetchAsync } from './fetch-async';
+export type { SigningProvider } from './provider';
+export { SigningProviderAlgorithmMismatchError, type SigningProviderErrorCode } from './errors';
 export {
   ALLOWED_ALGS,
   CLOCK_SKEW_TOLERANCE_SECONDS,
@@ -34,6 +39,7 @@ export {
   MAX_SIGNATURE_WINDOW_SECONDS,
   REQUEST_SIGNING_TAG,
   type AdcpJsonWebKey,
+  type AdcpSignAlg,
   type ContentDigestPolicy,
   type VerifierCapability,
 } from './types';
@@ -48,11 +54,18 @@ export {
   buildAgentSigningFetch,
   createAgentSignedFetch,
   extractAdcpOperation,
+  isInlineSigningConfig,
+  isProviderSigningConfig,
   resolveCoverContentDigest,
   shouldSignOperation,
   toSignerKey,
   type BuildAgentSigningFetchOptions,
   type CreateAgentSignedFetchOptions,
 } from './agent-fetch';
-export { buildAgentSigningContext, signingContextStorage, type AgentSigningContext } from './agent-context';
+export {
+  buildAgentSigningContext,
+  signingContextStorage,
+  type AgentSigningContext,
+  type AgentSigningIdentitySnapshot,
+} from './agent-context';
 export { ensureCapabilityLoaded, CAPABILITY_OP } from './capability-priming';

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -18,8 +18,13 @@ export {
 } from './canonicalize';
 export { computeContentDigest, contentDigestMatches, parseContentDigest } from './content-digest';
 export {
+  finalizeRequestSignature,
+  prepareRequestSignature,
+  prepareWebhookSignature,
   signRequest,
   signWebhook,
+  type PreparedRequestSignature,
+  type SignatureIdentity,
   type SignedRequest,
   type SignerKey,
   type SignRequestOptions,

--- a/src/lib/signing/ecdsa-encoding.ts
+++ b/src/lib/signing/ecdsa-encoding.ts
@@ -30,19 +30,31 @@ export function derEcdsaToP1363(der: Uint8Array, componentLen: number): Uint8Arr
   }
   let cursor = 2;
   const lengthByte = readByte(1);
+  // SEQUENCE total-content length, used to validate the parsed contents
+  // don't claim more bytes than the buffer holds.
+  let sequenceContentLen: number;
   // P-256 ECDSA signatures are always short-form length encoded (<= 72 bytes
   // including header), so production callers never hit the long-form branch.
-  // We still skip the length octets defensively if present, but reject any
-  // payload that would put cursor past the buffer.
+  // We still parse long-form defensively but reject anything that would put
+  // cursor past the buffer.
   if ((lengthByte & 0x80) !== 0) {
     const skip = lengthByte & 0x7f;
     if (skip === 0 || skip > 4) {
       throw new Error('Malformed DER ECDSA signature: invalid long-form length.');
     }
+    sequenceContentLen = 0;
+    for (let i = 0; i < skip; i++) {
+      sequenceContentLen = (sequenceContentLen << 8) | readByte(2 + i);
+    }
     cursor = 2 + skip;
     if (cursor >= der.length) {
       throw new Error('Malformed DER ECDSA signature: long-form length runs past buffer.');
     }
+  } else {
+    sequenceContentLen = lengthByte;
+  }
+  if (cursor + sequenceContentLen > der.length) {
+    throw new Error('Malformed DER ECDSA signature: SEQUENCE content runs past buffer.');
   }
   if (readByte(cursor) !== 0x02) {
     throw new Error('Malformed DER ECDSA signature: missing INTEGER tag for r.');

--- a/src/lib/signing/ecdsa-encoding.ts
+++ b/src/lib/signing/ecdsa-encoding.ts
@@ -1,0 +1,75 @@
+/**
+ * Convert a DER-encoded ECDSA signature into the IEEE P1363 (`r‖s`) wire
+ * format AdCP and RFC 9421 §3.3.1 require.
+ *
+ * Most KMS providers (GCP KMS `asymmetricSign`, AWS KMS `Sign` for ECDSA,
+ * Azure Key Vault) return DER-encoded ECDSA signatures. The Node `crypto`
+ * signer used by the in-memory path produces P1363 directly via
+ * `dsaEncoding: 'ieee-p1363'`. KMS adapters need this helper to normalize
+ * to the wire format peers expect.
+ *
+ * `componentLen` is the curve's coordinate width in bytes — 32 for P-256.
+ *
+ * Each component is left-padded to `componentLen` bytes; DER's leading-zero
+ * padding (which exists to keep ASN.1 INTEGER positive) is stripped.
+ *
+ * Throws if the DER structure is malformed or a component exceeds the
+ * declared component length.
+ */
+export function derEcdsaToP1363(der: Uint8Array, componentLen: number): Uint8Array {
+  const readByte = (offset: number): number => {
+    const v = der[offset];
+    if (v === undefined) {
+      throw new Error(`Malformed DER ECDSA signature: unexpected end of input at offset ${offset}.`);
+    }
+    return v;
+  };
+
+  if (der.length < 8 || readByte(0) !== 0x30) {
+    throw new Error('Malformed DER ECDSA signature: missing SEQUENCE tag.');
+  }
+  let cursor = 2;
+  const lengthByte = readByte(1);
+  // P-256 ECDSA signatures are always short-form length encoded (<= 72 bytes
+  // including header), so production callers never hit the long-form branch.
+  // We still skip the length octets defensively if present, but reject any
+  // payload that would put cursor past the buffer.
+  if ((lengthByte & 0x80) !== 0) {
+    const skip = lengthByte & 0x7f;
+    if (skip === 0 || skip > 4) {
+      throw new Error('Malformed DER ECDSA signature: invalid long-form length.');
+    }
+    cursor = 2 + skip;
+    if (cursor >= der.length) {
+      throw new Error('Malformed DER ECDSA signature: long-form length runs past buffer.');
+    }
+  }
+  if (readByte(cursor) !== 0x02) {
+    throw new Error('Malformed DER ECDSA signature: missing INTEGER tag for r.');
+  }
+  const rLen = readByte(cursor + 1);
+  if (cursor + 2 + rLen > der.length) {
+    throw new Error('Malformed DER ECDSA signature: r INTEGER length runs past buffer.');
+  }
+  let r = der.subarray(cursor + 2, cursor + 2 + rLen);
+  cursor = cursor + 2 + rLen;
+  if (readByte(cursor) !== 0x02) {
+    throw new Error('Malformed DER ECDSA signature: missing INTEGER tag for s.');
+  }
+  const sLen = readByte(cursor + 1);
+  if (cursor + 2 + sLen > der.length) {
+    throw new Error('Malformed DER ECDSA signature: s INTEGER length runs past buffer.');
+  }
+  let s = der.subarray(cursor + 2, cursor + 2 + sLen);
+
+  if (r.length > componentLen && r[0] === 0x00) r = r.subarray(1);
+  if (s.length > componentLen && s[0] === 0x00) s = s.subarray(1);
+
+  if (r.length > componentLen || s.length > componentLen) {
+    throw new Error(`DER ECDSA component longer than expected ${componentLen}-byte wire format.`);
+  }
+  const out = new Uint8Array(componentLen * 2);
+  out.set(r, componentLen - r.length);
+  out.set(s, componentLen * 2 - s.length);
+  return out;
+}

--- a/src/lib/signing/errors.ts
+++ b/src/lib/signing/errors.ts
@@ -80,3 +80,37 @@ export class WebhookSignatureError extends ADCPError {
     this.failedStep = failedStep;
   }
 }
+
+/**
+ * SDK-side error codes for the `SigningProvider` integration path. Distinct
+ * namespace from `RequestSignatureErrorCode` / `WebhookSignatureErrorCode`
+ * because these surface during adapter setup, not during wire-level
+ * signature verification.
+ */
+export type SigningProviderErrorCode = 'signing_provider_algorithm_mismatch';
+
+/**
+ * Adapter-side error thrown when a `SigningProvider`'s declared `algorithm`
+ * doesn't match the algorithm of the underlying key material.
+ *
+ * KMS providers should detect this during construction (one-shot
+ * `getPublicKey` / `describe-key` call) so misconfigurations fail before
+ * the first signed request rather than producing signatures verifiers
+ * reject downstream with the generic `request_signature_invalid` code.
+ */
+export class SigningProviderAlgorithmMismatchError extends ADCPError {
+  readonly code: SigningProviderErrorCode = 'signing_provider_algorithm_mismatch';
+  readonly expected: string;
+  readonly actual: string;
+  readonly providerKid: string;
+
+  constructor(expected: string, actual: string, providerKid: string) {
+    super(
+      `SigningProvider declared algorithm '${expected}' but underlying key is '${actual}' (kid='${providerKid}'). ` +
+        `Reconfigure the adapter to match the key, or rotate to a key whose algorithm matches the declared one.`
+    );
+    this.expected = expected;
+    this.actual = actual;
+    this.providerKid = providerKid;
+  }
+}

--- a/src/lib/signing/fetch-async.ts
+++ b/src/lib/signing/fetch-async.ts
@@ -86,9 +86,25 @@ function headersToRecord(headers: HeadersInit | Headers | undefined): Record<str
 function bodyToString(body: RequestInit['body']): string | undefined {
   if (body === undefined || body === null) return undefined;
   if (typeof body === 'string') return body;
-  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf8');
-  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('utf8');
+  if (body instanceof Uint8Array) return decodeUtf8Strict(body);
+  if (body instanceof ArrayBuffer) return decodeUtf8Strict(new Uint8Array(body));
   throw new TypeError(
     'createSigningFetchAsync requires a string, Uint8Array, or ArrayBuffer body. FormData / Blob / ReadableStream are not supported because the signature must cover the exact wire bytes.'
   );
+}
+
+/**
+ * Decode bytes to UTF-8, throwing on invalid sequences. See the matching
+ * helper in `./fetch.ts` for the full rationale; both wrappers refuse
+ * non-UTF-8 byte bodies so callers don't get silent body corruption.
+ */
+function decodeUtf8Strict(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new TypeError(
+      'createSigningFetchAsync received a Uint8Array/ArrayBuffer body that is not valid UTF-8. ' +
+        'Pass a string body, ensure the bytes are UTF-8, or sign the request manually with `signRequestAsync` against the exact wire bytes you intend to send.'
+    );
+  }
 }

--- a/src/lib/signing/fetch-async.ts
+++ b/src/lib/signing/fetch-async.ts
@@ -1,0 +1,94 @@
+import type { CoverContentDigestPredicate, SigningFetchOptions } from './fetch';
+import type { SigningProvider } from './provider';
+import type { SignRequestOptions } from './signer';
+import { signRequestAsync } from './signer-async';
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+const SIGNING_RESERVED_HEADERS = new Set(['signature', 'signature-input', 'content-digest']);
+
+/**
+ * Async-signing variant of `createSigningFetch`. Identical request
+ * extraction and reserved-header policy; differs only in routing through a
+ * {@link SigningProvider}, which may issue a network call to a managed key
+ * store on every signed request. Returns the same `FetchLike` shape so the
+ * wrapped function is interchangeable with the sync-signed variant from
+ * the caller's point of view.
+ *
+ * The split between {@link createSigningFetch} (sync inner) and this helper
+ * is deliberate: hover docs and the function name surface the latency-cost
+ * distinction at integration time. Use the sync entry point with an
+ * in-memory `SignerKey`; use this one with a KMS-backed `SigningProvider`.
+ *
+ * Keep in sync with `createSigningFetch` in `./fetch.ts` — reserved-header
+ * policy, content-type defaulting, and `Request`-rejection are line-for-line
+ * parallel.
+ */
+export function createSigningFetchAsync(
+  upstream: FetchLike,
+  provider: SigningProvider,
+  options: SigningFetchOptions = {}
+): FetchLike {
+  return async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const method = (init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+    const shouldSign = options.shouldSign ?? (() => method !== 'GET');
+    if (!shouldSign(url, init)) return upstream(input, init);
+
+    if (input instanceof Request) {
+      throw new TypeError(
+        'createSigningFetchAsync does not accept Request objects (the body would be consumed out from under the signer). Pass a URL string and a separate init.'
+      );
+    }
+
+    const headers = headersToRecord(init?.headers);
+    for (const name of Object.keys(headers)) {
+      if (SIGNING_RESERVED_HEADERS.has(name.toLowerCase())) {
+        delete headers[name];
+      }
+    }
+    const hasContentType = Object.keys(headers).some(k => k.toLowerCase() === 'content-type');
+    if (!hasContentType && (init?.body !== undefined || method !== 'GET')) {
+      headers['content-type'] = 'application/json';
+    }
+    const body = bodyToString(init?.body);
+
+    const coverContentDigest =
+      typeof options.coverContentDigest === 'function'
+        ? (options.coverContentDigest as CoverContentDigestPredicate)(url, init)
+        : options.coverContentDigest;
+    const { coverContentDigest: _omit, ...signerOptionsBase } = options;
+    const signerOptions: SignRequestOptions = { ...signerOptionsBase, coverContentDigest };
+
+    const signed = await signRequestAsync({ method, url, headers, body }, provider, signerOptions);
+
+    const mergedInit: RequestInit = { ...init, method, headers: signed.headers };
+    if (body !== undefined && mergedInit.body === undefined) mergedInit.body = body;
+    return upstream(url, mergedInit);
+  };
+}
+
+function headersToRecord(headers: HeadersInit | Headers | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((v, k) => {
+      out[k] = v;
+    });
+    return out;
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return { ...(headers as Record<string, string>) };
+}
+
+function bodyToString(body: RequestInit['body']): string | undefined {
+  if (body === undefined || body === null) return undefined;
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf8');
+  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('utf8');
+  throw new TypeError(
+    'createSigningFetchAsync requires a string, Uint8Array, or ArrayBuffer body. FormData / Blob / ReadableStream are not supported because the signature must cover the exact wire bytes.'
+  );
+}

--- a/src/lib/signing/fetch.ts
+++ b/src/lib/signing/fetch.ts
@@ -82,9 +82,29 @@ function headersToRecord(headers: HeadersInit | Headers | undefined): Record<str
 function bodyToString(body: RequestInit['body']): string | undefined {
   if (body === undefined || body === null) return undefined;
   if (typeof body === 'string') return body;
-  if (body instanceof Uint8Array) return Buffer.from(body).toString('utf8');
-  if (body instanceof ArrayBuffer) return Buffer.from(body).toString('utf8');
+  if (body instanceof Uint8Array) return decodeUtf8Strict(body);
+  if (body instanceof ArrayBuffer) return decodeUtf8Strict(new Uint8Array(body));
   throw new TypeError(
     'createSigningFetch requires a string, Uint8Array, or ArrayBuffer body. FormData / Blob / ReadableStream are not supported because the signature must cover the exact wire bytes.'
   );
+}
+
+/**
+ * Decode bytes to UTF-8, throwing on invalid sequences. Permissive decode
+ * (the `Buffer.toString('utf8')` default) replaces invalid bytes with
+ * `U+FFFD`, which would silently corrupt binary or non-UTF-8 payloads — the
+ * signer would commit to the lossy string and the wire would carry the same
+ * lossy bytes, so verification still passes but the seller receives
+ * mangled content. Throwing forces the caller to send a string body or
+ * ensure their Uint8Array is valid UTF-8.
+ */
+function decodeUtf8Strict(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new TypeError(
+      'createSigningFetch received a Uint8Array/ArrayBuffer body that is not valid UTF-8. ' +
+        'Pass a string body, ensure the bytes are UTF-8, or sign the request manually with `signRequest` against the exact wire bytes you intend to send.'
+    );
+  }
 }

--- a/src/lib/signing/provider.ts
+++ b/src/lib/signing/provider.ts
@@ -28,6 +28,13 @@ import type { AdcpSignAlg } from './types';
  *   oracle. Bind IAM (e.g., GCP `roles/cloudkms.signer` scoped to one
  *   `cryptoKeyVersions/N`, or AWS `kms:Sign` conditioned on the key ARN) so
  *   only the AdCP signing path can invoke this key.
+ *
+ * The bundled `InMemorySigningProvider` (under `@adcp/client/signing/testing`)
+ * carries a `NODE_ENV=production` gate as a self-discipline aid for the
+ * reference implementation only — `createSigningFetchAsync` does NOT and
+ * cannot enforce hygiene on third-party providers, so a custom adapter
+ * that holds keys in process memory bypasses the gate entirely. Adapter
+ * authors are responsible for their own production-safety policy.
  */
 export interface SigningProvider {
   /**

--- a/src/lib/signing/provider.ts
+++ b/src/lib/signing/provider.ts
@@ -1,0 +1,69 @@
+import type { AdcpSignAlg } from './types';
+
+/**
+ * Pluggable signer that the AdCP request- and webhook-signing paths route
+ * through when an agent is configured with `request_signing.kind: 'provider'`.
+ *
+ * Production deployments use this to keep private key material in a managed
+ * key store (GCP KMS, AWS KMS, Azure Key Vault, HashiCorp Vault Transit) so
+ * the SDK never holds the private scalar in process memory. The `sign(bytes)`
+ * boundary matches RFC 9421 §3.1: the caller produces the canonical
+ * signature base; the provider returns raw signature bytes.
+ *
+ * **Adapter authors must:**
+ * - Return wire-format signature bytes:
+ *   - `ed25519` → 64-byte raw signature.
+ *   - `ecdsa-p256-sha256` → 64-byte `r‖s` (IEEE P1363, **not** DER).
+ *   GCP KMS returns ECDSA in DER and Ed25519 raw; AWS KMS returns DER for
+ *   both EC and Ed25519. Convert at the adapter boundary.
+ * - Throw {@link SigningProviderAlgorithmMismatchError} from `sign()` (or, ideally,
+ *   from the constructor after a one-shot key inspection) if the underlying
+ *   key's algorithm doesn't match the declared `algorithm`. KMS will happily
+ *   sign with whatever it has — silent mismatch produces signatures that
+ *   verifiers reject downstream with `request_signature_invalid`, which is
+ *   useless to the buyer in diagnosing the misconfiguration.
+ * - Treat the signer as **single-purpose**. RFC 9421's `tag` parameter
+ *   protects verifiers, not signers; reusing the same KMS key for AdCP
+ *   request-signing and any other signing protocol creates a cross-protocol
+ *   oracle. Bind IAM (e.g., GCP `roles/cloudkms.signer` scoped to one
+ *   `cryptoKeyVersions/N`, or AWS `kms:Sign` conditioned on the key ARN) so
+ *   only the AdCP signing path can invoke this key.
+ */
+export interface SigningProvider {
+  /**
+   * Sign the RFC 9421 signature base. The SDK passes canonical bytes
+   * produced by `buildSignatureBase`; the provider returns raw signature
+   * bytes in the wire format described above.
+   */
+  sign(payload: Uint8Array): Promise<Uint8Array>;
+
+  /**
+   * `kid` published in `Signature-Input`. Must match a JWK published at the
+   * agent's `jwks_uri`.
+   */
+  readonly keyid: string;
+
+  /**
+   * Wire-format algorithm identifier. Same vocabulary as `ALLOWED_ALGS`.
+   */
+  readonly algorithm: AdcpSignAlg;
+
+  /**
+   * Stable opaque identifier disambiguating this signer from others
+   * advertising the same `kid`. Used as input to the SDK's transport- and
+   * capability-cache keys.
+   *
+   * Must be deterministic across process restarts for the same logical key
+   * and MUST NOT collide between distinct private keys. Examples:
+   * - GCP KMS: `projects/.../cryptoKeyVersions/N`
+   * - AWS KMS: KMS key ARN + version
+   * - in-memory: `SHA-256(kid + '\\0' + d).slice(0, 16)`
+   *
+   * The SDK defensively hashes this value before composing cache keys, so a
+   * provider returning a low-entropy or attacker-controlled string cannot
+   * collapse multi-tenant cache isolation. The hash is a defense-in-depth
+   * measure, not a security boundary — adapter authors should still supply
+   * a high-entropy stable identifier.
+   */
+  readonly fingerprint: string;
+}

--- a/src/lib/signing/signer-async.ts
+++ b/src/lib/signing/signer-async.ts
@@ -1,0 +1,118 @@
+import { randomBytes } from 'crypto';
+import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
+import { computeContentDigest } from './content-digest';
+import type { SigningProvider } from './provider';
+import { MANDATORY_COMPONENTS, MAX_SIGNATURE_WINDOW_SECONDS, REQUEST_SIGNING_TAG } from './types';
+import type { SignedRequest, SignRequestOptions, SignWebhookOptions } from './signer';
+import { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
+
+/**
+ * Async variant of `signRequest` that delegates the actual signature
+ * production to a {@link SigningProvider}. The signature-base canonicalization
+ * is identical to the sync path — the only difference is that
+ * `provider.sign(payload)` may dispatch to KMS / HSM / Vault and adds
+ * 10–50 ms of network latency per call.
+ *
+ * Callers that hold a private JWK in process should keep using the sync
+ * `signRequest` for lower per-call cost; this entry point is for production
+ * deployments that store private keys in a managed key store.
+ *
+ * Keep in sync with `signRequest` in `./signer.ts` — the signature-base
+ * canonicalization, default windowing, nonce generation, and content-digest
+ * gating are byte-for-byte parallel. The async variant is duplicated rather
+ * than refactored to a shared core so the sync hot path stays unchanged.
+ */
+export async function signRequestAsync(
+  request: RequestLike,
+  provider: SigningProvider,
+  options: SignRequestOptions = {}
+): Promise<SignedRequest> {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+  const hasBody = (request.body ?? '').length > 0;
+
+  const coverDigest = options.coverContentDigest === true && hasBody;
+  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
+  if (coverDigest) {
+    headers['Content-Digest'] = computeContentDigest(request.body ?? '');
+  }
+
+  const components = [...MANDATORY_COMPONENTS];
+  if (hasBody) components.push('content-type');
+  if (coverDigest) components.push('content-digest');
+
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: provider.keyid,
+    alg: provider.algorithm,
+    tag: REQUEST_SIGNING_TAG,
+  };
+
+  const normalizedRequest: RequestLike = { ...request, headers };
+  const base = buildSignatureBase(components, normalizedRequest, params);
+
+  const signature = await provider.sign(Buffer.from(base, 'utf8'));
+  const sigB64 = Buffer.from(signature).toString('base64url');
+
+  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
+  headers['Signature'] = `${label}=:${sigB64}:`;
+
+  return { headers, signatureBase: base, params };
+}
+
+/**
+ * Async variant of `signWebhook`. Same five mandatory components and
+ * `adcp/webhook-signing/v1` tag as the sync path; differs only in routing
+ * the signature production through a {@link SigningProvider}.
+ *
+ * Keep in sync with `signWebhook` in `./signer.ts`.
+ */
+export async function signWebhookAsync(
+  request: RequestLike,
+  provider: SigningProvider,
+  options: SignWebhookOptions = {}
+): Promise<SignedRequest> {
+  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
+  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
+  const nonce = options.nonce ?? base64UrlRandom(16);
+  const label = options.label ?? 'sig1';
+
+  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
+  headers['Content-Digest'] = computeContentDigest(request.body ?? '');
+
+  const components = [...WEBHOOK_MANDATORY_COMPONENTS];
+  const params: SignatureParams = {
+    created: now,
+    expires: now + windowSeconds,
+    nonce,
+    keyid: provider.keyid,
+    alg: provider.algorithm,
+    tag: options.tag ?? WEBHOOK_SIGNING_TAG,
+  };
+
+  const normalizedRequest: RequestLike = { ...request, headers };
+  const base = buildSignatureBase(components, normalizedRequest, params);
+  const signature = await provider.sign(Buffer.from(base, 'utf8'));
+  const sigB64 = Buffer.from(signature).toString('base64url');
+
+  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
+  headers['Signature'] = `${label}=:${sigB64}:`;
+  return { headers, signatureBase: base, params };
+}
+
+function flattenHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v === undefined) continue;
+    out[k] = Array.isArray(v) ? v.map(entry => entry.trim()).join(', ') : v.trim();
+  }
+  return out;
+}
+
+function base64UrlRandom(byteLength: number): string {
+  return randomBytes(byteLength).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}

--- a/src/lib/signing/signer-async.ts
+++ b/src/lib/signing/signer-async.ts
@@ -1,118 +1,42 @@
-import { randomBytes } from 'crypto';
-import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
-import { computeContentDigest } from './content-digest';
+import type { RequestLike } from './canonicalize';
 import type { SigningProvider } from './provider';
-import { MANDATORY_COMPONENTS, MAX_SIGNATURE_WINDOW_SECONDS, REQUEST_SIGNING_TAG } from './types';
 import type { SignedRequest, SignRequestOptions, SignWebhookOptions } from './signer';
-import { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
+import { finalizeRequestSignature, prepareRequestSignature, prepareWebhookSignature } from './signer';
 
 /**
  * Async variant of `signRequest` that delegates the actual signature
- * production to a {@link SigningProvider}. The signature-base canonicalization
- * is identical to the sync path — the only difference is that
- * `provider.sign(payload)` may dispatch to KMS / HSM / Vault and adds
- * 10–50 ms of network latency per call.
+ * production to a {@link SigningProvider}. Reuses
+ * {@link prepareRequestSignature} and {@link finalizeRequestSignature} from
+ * the sync path so canonicalization cannot drift between the two —
+ * `provider.sign(payload)` is the only difference, and it may dispatch to
+ * KMS / HSM / Vault and add 10–50 ms of network latency per call.
  *
  * Callers that hold a private JWK in process should keep using the sync
  * `signRequest` for lower per-call cost; this entry point is for production
  * deployments that store private keys in a managed key store.
- *
- * Keep in sync with `signRequest` in `./signer.ts` — the signature-base
- * canonicalization, default windowing, nonce generation, and content-digest
- * gating are byte-for-byte parallel. The async variant is duplicated rather
- * than refactored to a shared core so the sync hot path stays unchanged.
  */
 export async function signRequestAsync(
   request: RequestLike,
   provider: SigningProvider,
   options: SignRequestOptions = {}
 ): Promise<SignedRequest> {
-  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
-  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
-  const nonce = options.nonce ?? base64UrlRandom(16);
-  const label = options.label ?? 'sig1';
-  const hasBody = (request.body ?? '').length > 0;
-
-  const coverDigest = options.coverContentDigest === true && hasBody;
-  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
-  if (coverDigest) {
-    headers['Content-Digest'] = computeContentDigest(request.body ?? '');
-  }
-
-  const components = [...MANDATORY_COMPONENTS];
-  if (hasBody) components.push('content-type');
-  if (coverDigest) components.push('content-digest');
-
-  const params: SignatureParams = {
-    created: now,
-    expires: now + windowSeconds,
-    nonce,
-    keyid: provider.keyid,
-    alg: provider.algorithm,
-    tag: REQUEST_SIGNING_TAG,
-  };
-
-  const normalizedRequest: RequestLike = { ...request, headers };
-  const base = buildSignatureBase(components, normalizedRequest, params);
-
-  const signature = await provider.sign(Buffer.from(base, 'utf8'));
-  const sigB64 = Buffer.from(signature).toString('base64url');
-
-  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
-  headers['Signature'] = `${label}=:${sigB64}:`;
-
-  return { headers, signatureBase: base, params };
+  const prepared = prepareRequestSignature(request, { keyid: provider.keyid, alg: provider.algorithm }, options);
+  const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
+  return finalizeRequestSignature(prepared, signature);
 }
 
 /**
- * Async variant of `signWebhook`. Same five mandatory components and
- * `adcp/webhook-signing/v1` tag as the sync path; differs only in routing
- * the signature production through a {@link SigningProvider}.
- *
- * Keep in sync with `signWebhook` in `./signer.ts`.
+ * Async variant of `signWebhook`. Reuses {@link prepareWebhookSignature}
+ * and {@link finalizeRequestSignature} from the sync path so the five
+ * mandatory components, `adcp/webhook-signing/v1` tag, and unconditional
+ * `Content-Digest` header stay in lockstep.
  */
 export async function signWebhookAsync(
   request: RequestLike,
   provider: SigningProvider,
   options: SignWebhookOptions = {}
 ): Promise<SignedRequest> {
-  const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
-  const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
-  const nonce = options.nonce ?? base64UrlRandom(16);
-  const label = options.label ?? 'sig1';
-
-  const headers: Record<string, string> = { ...flattenHeaders(request.headers) };
-  headers['Content-Digest'] = computeContentDigest(request.body ?? '');
-
-  const components = [...WEBHOOK_MANDATORY_COMPONENTS];
-  const params: SignatureParams = {
-    created: now,
-    expires: now + windowSeconds,
-    nonce,
-    keyid: provider.keyid,
-    alg: provider.algorithm,
-    tag: options.tag ?? WEBHOOK_SIGNING_TAG,
-  };
-
-  const normalizedRequest: RequestLike = { ...request, headers };
-  const base = buildSignatureBase(components, normalizedRequest, params);
-  const signature = await provider.sign(Buffer.from(base, 'utf8'));
-  const sigB64 = Buffer.from(signature).toString('base64url');
-
-  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
-  headers['Signature'] = `${label}=:${sigB64}:`;
-  return { headers, signatureBase: base, params };
-}
-
-function flattenHeaders(headers: Record<string, string | string[] | undefined>): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const [k, v] of Object.entries(headers)) {
-    if (v === undefined) continue;
-    out[k] = Array.isArray(v) ? v.map(entry => entry.trim()).join(', ') : v.trim();
-  }
-  return out;
-}
-
-function base64UrlRandom(byteLength: number): string {
-  return randomBytes(byteLength).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  const prepared = prepareWebhookSignature(request, { keyid: provider.keyid, alg: provider.algorithm }, options);
+  const signature = await provider.sign(Buffer.from(prepared.base, 'utf8'));
+  return finalizeRequestSignature(prepared, signature);
 }

--- a/src/lib/signing/signer.ts
+++ b/src/lib/signing/signer.ts
@@ -1,7 +1,13 @@
 import { createPrivateKey, randomBytes, sign as nodeSign, type JsonWebKey } from 'crypto';
 import { buildSignatureBase, formatSignatureParams, type RequestLike, type SignatureParams } from './canonicalize';
 import { computeContentDigest } from './content-digest';
-import { MANDATORY_COMPONENTS, MAX_SIGNATURE_WINDOW_SECONDS, REQUEST_SIGNING_TAG, type AdcpJsonWebKey } from './types';
+import {
+  MANDATORY_COMPONENTS,
+  MAX_SIGNATURE_WINDOW_SECONDS,
+  REQUEST_SIGNING_TAG,
+  type AdcpJsonWebKey,
+  type AdcpSignAlg,
+} from './types';
 import { WEBHOOK_MANDATORY_COMPONENTS, WEBHOOK_SIGNING_TAG } from './webhook-verifier';
 
 export interface SignerKey {
@@ -24,7 +30,46 @@ export interface SignedRequest {
   params: SignatureParams;
 }
 
-export function signRequest(request: RequestLike, key: SignerKey, options: SignRequestOptions = {}): SignedRequest {
+/**
+ * Identity fields needed to populate `Signature-Input` parameters. The sync
+ * `signRequest` path takes these from a {@link SignerKey}; the async path
+ * takes them from a `SigningProvider`. Centralizing the shape keeps both
+ * canonicalizations identical.
+ */
+export interface SignatureIdentity {
+  keyid: string;
+  alg: AdcpSignAlg;
+}
+
+/**
+ * Result of canonicalizing a request for signing — everything `signRequest`
+ * and `signRequestAsync` produce up to (but not including) the call into
+ * the signer/provider.
+ */
+export interface PreparedRequestSignature {
+  components: string[];
+  params: SignatureParams;
+  /**
+   * Outbound headers including `Content-Digest` when covered, but not yet
+   * including `Signature-Input` / `Signature` — those are appended by
+   * {@link finalizeRequestSignature}.
+   */
+  headers: Record<string, string>;
+  /** Canonical signature base bytes (UTF-8). Pass to the signer/provider. */
+  base: string;
+  label: string;
+}
+
+/**
+ * Canonicalize a request for RFC 9421 request-signing. Pure (no I/O); the
+ * sync and async paths share this so canonicalization can't drift between
+ * them.
+ */
+export function prepareRequestSignature(
+  request: RequestLike,
+  identity: SignatureIdentity,
+  options: SignRequestOptions = {}
+): PreparedRequestSignature {
   const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
   const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
   const nonce = options.nonce ?? base64UrlRandom(16);
@@ -45,25 +90,39 @@ export function signRequest(request: RequestLike, key: SignerKey, options: SignR
     created: now,
     expires: now + windowSeconds,
     nonce,
-    keyid: key.keyid,
-    alg: key.alg,
+    keyid: identity.keyid,
+    alg: identity.alg,
     tag: REQUEST_SIGNING_TAG,
   };
 
   const normalizedRequest: RequestLike = { ...request, headers };
   const base = buildSignatureBase(components, normalizedRequest, params);
 
-  const signature = produceSignature(key, Buffer.from(base, 'utf8'));
-  // Emit base64url without padding to match the AdCP conformance-vector
-  // format (and deterministic Ed25519 sigs are then byte-identical across
-  // SDKs). Verifiers accept either variant since Node's base64 decoder
-  // treats `+`/`-` and `/`/`_` interchangeably.
+  return { components, params, headers, base, label };
+}
+
+/**
+ * Attach `Signature` / `Signature-Input` headers given the bytes returned
+ * by the signer/provider. Shared between the sync and async paths so the
+ * base64url emission stays canonical.
+ *
+ * Emits base64url without padding to match the AdCP conformance-vector
+ * format (and deterministic Ed25519 sigs are then byte-identical across
+ * SDKs). Verifiers accept either variant since Node's base64 decoder
+ * treats `+`/`-` and `/`/`_` interchangeably.
+ */
+export function finalizeRequestSignature(prepared: PreparedRequestSignature, signature: Uint8Array): SignedRequest {
+  const headers = { ...prepared.headers };
   const sigB64 = Buffer.from(signature).toString('base64url');
+  headers['Signature-Input'] = `${prepared.label}=${formatSignatureParams(prepared.components, prepared.params)}`;
+  headers['Signature'] = `${prepared.label}=:${sigB64}:`;
+  return { headers, signatureBase: prepared.base, params: prepared.params };
+}
 
-  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
-  headers['Signature'] = `${label}=:${sigB64}:`;
-
-  return { headers, signatureBase: base, params };
+export function signRequest(request: RequestLike, key: SignerKey, options: SignRequestOptions = {}): SignedRequest {
+  const prepared = prepareRequestSignature(request, { keyid: key.keyid, alg: key.alg }, options);
+  const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
+  return finalizeRequestSignature(prepared, signature);
 }
 
 export interface SignWebhookOptions {
@@ -80,13 +139,17 @@ export interface SignWebhookOptions {
 }
 
 /**
- * Sign an outbound webhook request under the RFC 9421 webhook profile
- * (`tag=adcp/webhook-signing/v1`). Covers the five mandatory components —
+ * Canonicalize an outbound webhook request under the RFC 9421 webhook
+ * profile. Pure (no I/O); shared between sync `signWebhook` and async
+ * `signWebhookAsync` paths. Covers the five mandatory components —
  * `@method`, `@target-uri`, `@authority`, `content-type`, `content-digest` —
- * and sets `Content-Digest` on the outgoing headers. Publishers emitting
- * conformant webhooks should use this instead of hand-rolling signatures.
+ * and sets `Content-Digest` on the outgoing headers.
  */
-export function signWebhook(request: RequestLike, key: SignerKey, options: SignWebhookOptions = {}): SignedRequest {
+export function prepareWebhookSignature(
+  request: RequestLike,
+  identity: SignatureIdentity,
+  options: SignWebhookOptions = {}
+): PreparedRequestSignature {
   const now = options.now ? options.now() : Math.floor(Date.now() / 1000);
   const windowSeconds = Math.min(options.windowSeconds ?? 300, MAX_SIGNATURE_WINDOW_SECONDS);
   const nonce = options.nonce ?? base64UrlRandom(16);
@@ -100,19 +163,28 @@ export function signWebhook(request: RequestLike, key: SignerKey, options: SignW
     created: now,
     expires: now + windowSeconds,
     nonce,
-    keyid: key.keyid,
-    alg: key.alg,
+    keyid: identity.keyid,
+    alg: identity.alg,
     tag: options.tag ?? WEBHOOK_SIGNING_TAG,
   };
 
   const normalizedRequest: RequestLike = { ...request, headers };
   const base = buildSignatureBase(components, normalizedRequest, params);
-  const signature = produceSignature(key, Buffer.from(base, 'utf8'));
-  const sigB64 = Buffer.from(signature).toString('base64url');
 
-  headers['Signature-Input'] = `${label}=${formatSignatureParams(components, params)}`;
-  headers['Signature'] = `${label}=:${sigB64}:`;
-  return { headers, signatureBase: base, params };
+  return { components, params, headers, base, label };
+}
+
+/**
+ * Sign an outbound webhook request under the RFC 9421 webhook profile
+ * (`tag=adcp/webhook-signing/v1`). Covers the five mandatory components —
+ * `@method`, `@target-uri`, `@authority`, `content-type`, `content-digest` —
+ * and sets `Content-Digest` on the outgoing headers. Publishers emitting
+ * conformant webhooks should use this instead of hand-rolling signatures.
+ */
+export function signWebhook(request: RequestLike, key: SignerKey, options: SignWebhookOptions = {}): SignedRequest {
+  const prepared = prepareWebhookSignature(request, { keyid: key.keyid, alg: key.alg }, options);
+  const signature = produceSignature(key, Buffer.from(prepared.base, 'utf8'));
+  return finalizeRequestSignature(prepared, signature);
 }
 
 function produceSignature(key: SignerKey, data: Buffer): Uint8Array {

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -52,9 +52,7 @@ export class InMemorySigningProvider implements SigningProvider {
       );
     }
     if (!options.privateKey.d) {
-      throw new TypeError(
-        'InMemorySigningProvider requires a JWK with a `d` (private scalar) field.'
-      );
+      throw new TypeError('InMemorySigningProvider requires a JWK with a `d` (private scalar) field.');
     }
     this.keyid = options.keyid;
     this.algorithm = options.algorithm;

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -1,0 +1,96 @@
+import { createHash, createPrivateKey, sign as nodeSign, type JsonWebKey } from 'crypto';
+import type { SigningProvider } from './provider';
+import type { SignerKey } from './signer';
+import type { AdcpJsonWebKey, AdcpSignAlg } from './types';
+
+/**
+ * Environment variable that lets operators acknowledge an in-memory signer
+ * is intentional in a `NODE_ENV=production` deployment (CI runs with
+ * production builds, ephemeral test envs, etc.). Set to `1` to bypass the
+ * production-time guard.
+ */
+export const ALLOW_IN_MEMORY_SIGNER_ENV = 'ADCP_ALLOW_IN_MEMORY_SIGNER';
+
+export interface InMemorySigningProviderOptions {
+  /** `kid` published in `Signature-Input`. */
+  keyid: string;
+  /** Wire-format algorithm identifier — must match the JWK material. */
+  algorithm: AdcpSignAlg;
+  /** Private JWK including the `d` scalar. */
+  privateKey: AdcpJsonWebKey;
+}
+
+/**
+ * Reference {@link SigningProvider} that holds the private JWK in process
+ * memory. Useful for unit tests, conformance vectors, and local development.
+ *
+ * **Production deployments should use a KMS-backed provider** (see
+ * `examples/gcp-kms-signing-provider.ts`). To prevent accidental shipping of
+ * an in-memory signer to prod, the constructor refuses to instantiate when
+ * `NODE_ENV === 'production'` unless the operator sets
+ * `ADCP_ALLOW_IN_MEMORY_SIGNER=1` to acknowledge the choice — keeping the
+ * in-memory path grep-able in deploy manifests.
+ */
+export class InMemorySigningProvider implements SigningProvider {
+  readonly keyid: string;
+  readonly algorithm: AdcpSignAlg;
+  readonly fingerprint: string;
+  private readonly privateKey: AdcpJsonWebKey;
+
+  constructor(options: InMemorySigningProviderOptions) {
+    // The env is read once at construction. Module-init paths that
+    // instantiate `InMemorySigningProvider` before the runtime sets
+    // `NODE_ENV` will bypass the gate; orchestrators conventionally set
+    // `NODE_ENV` before the app process spawns, so this is rare in practice.
+    // Compare case-insensitively so `Production` / `PRODUCTION` don't slip
+    // through.
+    const isProduction = process.env.NODE_ENV?.toLowerCase() === 'production';
+    if (isProduction && !process.env[ALLOW_IN_MEMORY_SIGNER_ENV]) {
+      throw new Error(
+        `InMemorySigningProvider blocked in production. Set ${ALLOW_IN_MEMORY_SIGNER_ENV}=1 to acknowledge, ` +
+          `or use a KMS-backed SigningProvider (see examples/gcp-kms-signing-provider.ts).`
+      );
+    }
+    if (!options.privateKey.d) {
+      throw new TypeError(
+        'InMemorySigningProvider requires a JWK with a `d` (private scalar) field.'
+      );
+    }
+    this.keyid = options.keyid;
+    this.algorithm = options.algorithm;
+    this.privateKey = options.privateKey;
+    // Mirrors the historical `privateKeyFingerprint` derivation — same input,
+    // same 64-bit cache disambiguator, so behavior carries over for callers
+    // who switch from the inline `request_signing` shape to a provider while
+    // holding the same key material.
+    this.fingerprint = createHash('sha256')
+      .update(options.keyid)
+      .update('\0')
+      .update(options.privateKey.d as string)
+      .digest('hex')
+      .slice(0, 16);
+  }
+
+  async sign(payload: Uint8Array): Promise<Uint8Array> {
+    const privateKey = createPrivateKey({ key: this.privateKey as JsonWebKey, format: 'jwk' });
+    const data = Buffer.from(payload);
+    if (this.algorithm === 'ed25519') {
+      return new Uint8Array(nodeSign(null, data, privateKey));
+    }
+    return new Uint8Array(nodeSign('sha256', data, { key: privateKey, dsaEncoding: 'ieee-p1363' }));
+  }
+}
+
+/**
+ * Adapter from a legacy {@link SignerKey} to a {@link SigningProvider}.
+ * Lets callers (and the conformance runner) reuse private JWK material
+ * loaded for the sync-signing path against the new async-provider pipeline
+ * without rewriting key-load logic.
+ */
+export function signerKeyToProvider(key: SignerKey): SigningProvider {
+  return new InMemorySigningProvider({
+    keyid: key.keyid,
+    algorithm: key.alg,
+    privateKey: key.privateKey,
+  });
+}

--- a/src/lib/signing/types.ts
+++ b/src/lib/signing/types.ts
@@ -80,6 +80,11 @@ export type VerifyResult = ({ status: 'verified' } & VerifiedSigner) | { status:
 
 export const REQUEST_SIGNING_TAG = 'adcp/request-signing/v1';
 export const ALLOWED_ALGS = new Set(['ed25519', 'ecdsa-p256-sha256']);
+/**
+ * Wire-format algorithm identifier — the string that appears in
+ * `Signature-Input`'s `alg` parameter. Same vocabulary as `ALLOWED_ALGS`.
+ */
+export type AdcpSignAlg = 'ed25519' | 'ecdsa-p256-sha256';
 export const MAX_SIGNATURE_WINDOW_SECONDS = 300;
 export const CLOCK_SKEW_TOLERANCE_SECONDS = 60;
 export const MANDATORY_COMPONENTS: ReadonlyArray<string> = ['@method', '@target-uri', '@authority'];

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -325,8 +325,41 @@ export interface AdcpPrivateJsonWebKey {
  * advertised `covers_content_digest` policy: `required` covers, `forbidden`
  * omits, `either` (or absent) covers by default — body-binding is the safer
  * choice and a seller advertising `either` has explicitly allowed both forms.
+ *
+ * Two shapes, discriminated on `kind`:
+ * - `'inline'` (default) — private JWK held in process memory.
+ * - `'provider'` — delegates `sign()` to a {@link SigningProvider} so private
+ *   key material can live in a managed key store (GCP KMS, AWS KMS, etc.).
  */
-export interface AgentRequestSigningConfig {
+export type AgentRequestSigningConfig = AgentRequestSigningConfigInline | AgentRequestSigningConfigProvider;
+
+/** Operation-list overrides shared by both `request_signing` shapes. */
+export interface AgentRequestSigningOperationOverrides {
+  /**
+   * AdCP operation names to sign regardless of the seller's advertisement.
+   * Useful during pilots before a counterparty flips an op into `required_for`.
+   */
+  always_sign?: string[];
+  /**
+   * When true, also sign operations the seller lists in `supported_for` (but
+   * not `required_for`). Defaults to false — conservative "sign what the
+   * seller asks for" behavior.
+   */
+  sign_supported?: boolean;
+}
+
+/**
+ * In-process signing identity. The SDK loads the private JWK at request time
+ * and signs synchronously — appropriate for development, testing, and
+ * deployments where holding the private scalar in process memory is
+ * acceptable.
+ *
+ * `kind` defaults to `'inline'` so existing literals without the field
+ * continue to type-check.
+ */
+export interface AgentRequestSigningConfigInline extends AgentRequestSigningOperationOverrides {
+  /** Discriminator. Defaults to `'inline'` so legacy literals work unchanged. */
+  kind?: 'inline';
   /** Key identifier (published by the buyer at its JWKS endpoint) */
   kid: string;
   /** Signature algorithm. Must match the key material. */
@@ -349,17 +382,31 @@ export interface AgentRequestSigningConfig {
    * custom verifier wiring.
    */
   agent_url: string;
+}
+
+/**
+ * KMS-backed (or otherwise externalized) signing identity. The SDK calls
+ * `provider.sign(payload)` on every signed request — async, may dispatch
+ * to a managed key store. Use a {@link SigningProvider} for production
+ * deployments that keep private keys out of process memory.
+ *
+ * The `kid` and `alg` come from the provider itself; this shape only carries
+ * the agent's `agent_url` and the operation-list overrides.
+ */
+export interface AgentRequestSigningConfigProvider extends AgentRequestSigningOperationOverrides {
+  kind: 'provider';
   /**
-   * AdCP operation names to sign regardless of the seller's advertisement.
-   * Useful during pilots before a counterparty flips an op into `required_for`.
+   * The signing provider that produces RFC 9421 signature bytes. Imported
+   * from `@adcp/client/signing` — see `SigningProvider` for the interface
+   * contract and `examples/gcp-kms-signing-provider.ts` for a reference
+   * KMS adapter.
    */
-  always_sign?: string[];
-  /**
-   * When true, also sign operations the seller lists in `supported_for` (but
-   * not `required_for`). Defaults to false — conservative "sign what the
-   * seller asks for" behavior.
-   */
-  sign_supported?: boolean;
+  // SigningProvider is intentionally referenced by string, not imported,
+  // to avoid a forward-dependency cycle from the types module into signing.
+  // The interface lives at `src/lib/signing/provider.ts`.
+  provider: import('../signing/provider').SigningProvider;
+  /** Agent base URL — same semantics as the inline shape. */
+  agent_url: string;
 }
 
 // Agent Configuration Types

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -38,6 +38,8 @@ import type {
   SyncCreativesResponse,
 } from './core.generated';
 
+import type { SigningProvider } from '../signing/provider';
+
 export type { FrequencyCap } from './core.generated';
 
 export interface MediaBuy {
@@ -401,10 +403,7 @@ export interface AgentRequestSigningConfigProvider extends AgentRequestSigningOp
    * contract and `examples/gcp-kms-signing-provider.ts` for a reference
    * KMS adapter.
    */
-  // SigningProvider is intentionally referenced by string, not imported,
-  // to avoid a forward-dependency cycle from the types module into signing.
-  // The interface lives at `src/lib/signing/provider.ts`.
-  provider: import('../signing/provider').SigningProvider;
+  provider: SigningProvider;
   /** Agent base URL — same semantics as the inline shape. */
   agent_url: string;
 }

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -18,7 +18,6 @@ const {
   InMemoryRevocationStore,
   verifyRequestSignature,
   RequestSignatureError,
-  canonicalTargetUri,
 } = require('../dist/lib/signing/index.js');
 
 const { InMemorySigningProvider, signerKeyToProvider } = require('../dist/lib/signing/testing.js');
@@ -202,7 +201,6 @@ describe('buildAgentSigningContext: cache isolation', () => {
   });
 
   test('SDK defensively hashes provider fingerprint — low-entropy fingerprints still isolated by kid', () => {
-    const kid = 'test-ed25519-2026';
     // Two providers, same kid, both supplying a stupid `fingerprint: 'x'`.
     // SDK-side hash includes algorithm+kid so they collide ONLY if all three
     // (algorithm, kid, fingerprint) match. Demonstrate that swapping kid

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert');
 const { readFileSync } = require('node:fs');
 const path = require('node:path');
 const { createHash } = require('node:crypto');
+const fc = require('fast-check');
 
 const {
   signRequest,
@@ -117,6 +118,30 @@ describe('signWebhookAsync is functionally equivalent to signWebhook', () => {
     assert.strictEqual(async_.headers.Signature, sync.headers.Signature);
     assert.strictEqual(async_.headers['Signature-Input'], sync.headers['Signature-Input']);
     assert.strictEqual(async_.signatureBase, sync.signatureBase);
+  });
+});
+
+describe('createSigningFetchAsync rejects non-UTF-8 byte bodies', () => {
+  test('Uint8Array with invalid UTF-8 throws a clear TypeError instead of silently lossy-converting', async () => {
+    const kid = 'test-ed25519-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    const upstream = async () => new Response('ok', { status: 200 });
+    const fetchSigned = createSigningFetchAsync(upstream, provider);
+    // 0xff 0xfe is not valid UTF-8 (continuation bytes without a start).
+    const invalidUtf8 = new Uint8Array([0xff, 0xfe, 0xfd]);
+    await assert.rejects(
+      () =>
+        fetchSigned('https://seller.example.com/adcp/create_media_buy', {
+          method: 'POST',
+          headers: { 'content-type': 'application/octet-stream' },
+          body: invalidUtf8,
+        }),
+      err => err instanceof TypeError && /not valid UTF-8/.test(err.message)
+    );
   });
 });
 
@@ -379,6 +404,76 @@ describe('SigningProviderAlgorithmMismatchError', () => {
     assert.strictEqual(err.providerKid, 'addie-2026');
     assert.match(err.message, /declared algorithm 'ed25519'/);
     assert.match(err.message, /underlying key is 'EC_SIGN_P256_SHA256'/);
+  });
+});
+
+describe('property: signRequest (sync) and signRequestAsync share canonicalization', () => {
+  // Locks the parallel structure of signer.ts and signer-async.ts. If a future
+  // change adds a mandatory component, header-handling tweak, or default change
+  // to one path without the other, this property fails. Ed25519 is deterministic,
+  // so we can assert byte-identical Signature output as well as base equality.
+  const kid = 'test-ed25519-2026';
+
+  function buildArbitrary() {
+    return fc.record({
+      method: fc.constantFrom('POST', 'PUT', 'DELETE', 'PATCH'),
+      pathSegments: fc.array(
+        fc.string({ minLength: 1, maxLength: 16, unit: fc.constantFrom('a', 'b', 'c', 'media_buy', '_') }),
+        { minLength: 1, maxLength: 4 }
+      ),
+      // Body is JSON-encoded (UTF-8 by construction) — the signer covers
+      // exact wire bytes, so feeding it valid JSON bytes is the realistic case.
+      body: fc.option(
+        fc.dictionary(
+          fc.string({ minLength: 1, maxLength: 12, unit: fc.constantFrom('a', 'b', 'c', '_', '0', '1') }),
+          fc.oneof(
+            fc.string({ maxLength: 32, unit: fc.constantFrom('a', 'b', 'c', ' ', '0') }),
+            fc.integer({ min: -1000, max: 1000 })
+          ),
+          { minKeys: 0, maxKeys: 6 }
+        ),
+        { nil: undefined }
+      ),
+      coverContentDigest: fc.boolean(),
+      now: fc.integer({ min: 1700000000, max: 1900000000 }),
+      windowSeconds: fc.integer({ min: 1, max: 300 }),
+      nonce: fc.string({ minLength: 16, maxLength: 22, unit: fc.constantFrom('a', 'b', 'c', '0', '_', '-') }),
+    });
+  }
+
+  test('sync and async produce identical signatureBase, Signature-Input, and Signature for Ed25519', async () => {
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+
+    await fc.assert(
+      fc.asyncProperty(buildArbitrary(), async input => {
+        const request = {
+          method: input.method,
+          url: 'https://seller.example.com/' + input.pathSegments.join('/'),
+          headers: { 'Content-Type': 'application/json' },
+          body: input.body === undefined ? '' : JSON.stringify(input.body),
+        };
+        const opts = {
+          coverContentDigest: input.coverContentDigest,
+          now: () => input.now,
+          windowSeconds: input.windowSeconds,
+          nonce: input.nonce,
+        };
+        const sync = signRequest(request, key, opts);
+        const async_ = await signRequestAsync(request, provider, opts);
+
+        // Same canonicalization → same base, same Signature-Input, same Ed25519 sig.
+        assert.strictEqual(async_.signatureBase, sync.signatureBase);
+        assert.strictEqual(async_.headers['Signature-Input'], sync.headers['Signature-Input']);
+        assert.strictEqual(async_.headers.Signature, sync.headers.Signature);
+        return true;
+      }),
+      { numRuns: 50 }
+    );
   });
 });
 

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -592,6 +592,9 @@ describe('derEcdsaToP1363', () => {
   });
 
   test('throws on malformed DER', () => {
-    assert.throws(() => derEcdsaToP1363(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), 32), /SEQUENCE tag/);
+    assert.throws(
+      () => derEcdsaToP1363(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), 32),
+      /SEQUENCE tag/
+    );
   });
 });

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -475,6 +475,43 @@ describe('property: signRequest (sync) and signRequestAsync share canonicalizati
       { numRuns: 50 }
     );
   });
+
+  test('sync and async produce identical signatureBase + Signature-Input for ECDSA-P256 (signature bytes vary by non-determinism)', async () => {
+    const ecdsaKid = 'test-es256-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: ecdsaKid,
+      algorithm: 'ecdsa-p256-sha256',
+      privateKey: privateJwkFor(ecdsaKid),
+    });
+    const key = { keyid: ecdsaKid, alg: 'ecdsa-p256-sha256', privateKey: privateJwkFor(ecdsaKid) };
+
+    await fc.assert(
+      fc.asyncProperty(buildArbitrary(), async input => {
+        const request = {
+          method: input.method,
+          url: 'https://seller.example.com/' + input.pathSegments.join('/'),
+          headers: { 'Content-Type': 'application/json' },
+          body: input.body === undefined ? '' : JSON.stringify(input.body),
+        };
+        const opts = {
+          coverContentDigest: input.coverContentDigest,
+          now: () => input.now,
+          windowSeconds: input.windowSeconds,
+          nonce: input.nonce,
+        };
+        const sync = signRequest(request, key, opts);
+        const async_ = await signRequestAsync(request, provider, opts);
+
+        // ECDSA is non-deterministic so Signature bytes legitimately differ.
+        // The canonicalization invariant lives in the base + Signature-Input;
+        // both ECDSA branches must compute these identically.
+        assert.strictEqual(async_.signatureBase, sync.signatureBase);
+        assert.strictEqual(async_.headers['Signature-Input'], sync.headers['Signature-Input']);
+        return true;
+      }),
+      { numRuns: 50 }
+    );
+  });
 });
 
 describe('end-to-end: provider-signed request verifies under the SDK verifier', () => {

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -1,0 +1,597 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const { createHash } = require('node:crypto');
+
+const {
+  signRequest,
+  signRequestAsync,
+  signWebhook,
+  signWebhookAsync,
+  createSigningFetchAsync,
+  buildAgentSigningContext,
+  derEcdsaToP1363,
+  SigningProviderAlgorithmMismatchError,
+  StaticJwksResolver,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  verifyRequestSignature,
+  RequestSignatureError,
+  canonicalTargetUri,
+} = require('../dist/lib/signing/index.js');
+
+const { InMemorySigningProvider, signerKeyToProvider } = require('../dist/lib/signing/testing.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keysData = JSON.parse(readFileSync(KEYS_PATH, 'utf8'));
+const keysByKid = new Map(keysData.keys.map(k => [k.kid, k]));
+
+function publicJwkFor(kid) {
+  const k = keysByKid.get(kid);
+  if (!k) throw new Error(`Test key '${kid}' not in vectors`);
+  // Strip the test-only private scalar before returning a "public" JWK.
+  const { _private_d_for_test_only, ...publicPart } = k;
+  return publicPart;
+}
+
+function privateJwkFor(kid) {
+  const k = keysByKid.get(kid);
+  if (!k) throw new Error(`Test key '${kid}' not in vectors`);
+  const { _private_d_for_test_only, ...rest } = k;
+  return { ...rest, d: _private_d_for_test_only };
+}
+
+const SAMPLE_REQUEST = {
+  method: 'POST',
+  url: 'https://seller.example.com/adcp/create_media_buy',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ plan_id: 'plan_001' }),
+};
+
+const SAMPLE_OPTIONS = {
+  now: () => 1776520800,
+  nonce: 'KXYnfEfJ0PBRZXQyVXfVQA',
+  windowSeconds: 300,
+};
+
+describe('signRequestAsync produces byte-identical output to signRequest (Ed25519)', () => {
+  test('matches sync signature for the same request', async () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+
+    const sync = signRequest(SAMPLE_REQUEST, key, SAMPLE_OPTIONS);
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    const async_ = await signRequestAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+
+    assert.strictEqual(async_.headers.Signature, sync.headers.Signature);
+    assert.strictEqual(async_.headers['Signature-Input'], sync.headers['Signature-Input']);
+    assert.strictEqual(async_.signatureBase, sync.signatureBase);
+  });
+});
+
+describe('signRequestAsync produces byte-equivalent output to signRequest (ECDSA-P256)', () => {
+  test('signature is valid (ECDSA is non-deterministic, so verify-equivalence not byte-equality)', async () => {
+    const kid = 'test-es256-2026';
+    const key = { keyid: kid, alg: 'ecdsa-p256-sha256', privateKey: privateJwkFor(kid) };
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ecdsa-p256-sha256',
+      privateKey: privateJwkFor(kid),
+    });
+
+    const sync = signRequest(SAMPLE_REQUEST, key, SAMPLE_OPTIONS);
+    const async_ = await signRequestAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+
+    // Signature base is deterministic; sig bytes differ per ECDSA non-determinism.
+    assert.strictEqual(async_.signatureBase, sync.signatureBase);
+    assert.strictEqual(async_.headers['Signature-Input'], sync.headers['Signature-Input']);
+    assert.notStrictEqual(async_.headers.Signature, undefined);
+    assert.match(async_.headers.Signature, /^sig1=:[A-Za-z0-9_-]+:$/);
+  });
+});
+
+describe('signWebhookAsync is functionally equivalent to signWebhook', () => {
+  test('headers and base match for Ed25519', async () => {
+    const kid = 'test-ed25519-2026';
+    const key = { keyid: kid, alg: 'ed25519', privateKey: privateJwkFor(kid) };
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    const sync = signWebhook(SAMPLE_REQUEST, key, SAMPLE_OPTIONS);
+    const async_ = await signWebhookAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+    assert.strictEqual(async_.headers.Signature, sync.headers.Signature);
+    assert.strictEqual(async_.headers['Signature-Input'], sync.headers['Signature-Input']);
+    assert.strictEqual(async_.signatureBase, sync.signatureBase);
+  });
+});
+
+describe('createSigningFetchAsync routes through the provider', () => {
+  test('signs POST requests and forwards to upstream', async () => {
+    const kid = 'test-ed25519-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    let captured;
+    const upstream = async (url, init) => {
+      captured = { url, init };
+      return new Response('ok', { status: 200 });
+    };
+    const fetchSigned = createSigningFetchAsync(upstream, provider);
+    await fetchSigned('https://seller.example.com/adcp/create_media_buy', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ plan_id: 'p1' }),
+    });
+    assert.ok(captured.init.headers.Signature, 'Signature header was set');
+    assert.match(captured.init.headers['Signature-Input'], /keyid="test-ed25519-2026"/);
+    assert.match(captured.init.headers['Signature-Input'], /alg="ed25519"/);
+  });
+
+  test('skips GET requests by default', async () => {
+    const kid = 'test-ed25519-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+    let captured;
+    const upstream = async (url, init) => {
+      captured = init;
+      return new Response('ok', { status: 200 });
+    };
+    const fetchSigned = createSigningFetchAsync(upstream, provider);
+    await fetchSigned('https://seller.example.com/health', { method: 'GET' });
+    assert.strictEqual(captured?.headers, undefined);
+  });
+});
+
+describe('buildAgentSigningContext: cache isolation', () => {
+  test('two providers with same kid but different fingerprint get distinct cacheKeys', () => {
+    const kid = 'test-ed25519-2026';
+    const provA = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+
+    // Fabricate a second provider advertising the same kid+algorithm but a
+    // distinct fingerprint, simulating two tenants holding different KMS keys
+    // that happen to publish the same `kid` string.
+    const provB = {
+      keyid: kid,
+      algorithm: 'ed25519',
+      fingerprint: 'distinct-fingerprint-for-tenant-b',
+      sign: async () => new Uint8Array(64),
+    };
+
+    const ctxA = buildAgentSigningContext({
+      id: 'a',
+      name: 'A',
+      agent_uri: 'https://seller.example.com',
+      protocol: 'mcp',
+      request_signing: { kind: 'provider', provider: provA, agent_url: 'https://a.example.com' },
+    });
+    const ctxB = buildAgentSigningContext({
+      id: 'b',
+      name: 'B',
+      agent_uri: 'https://seller.example.com',
+      protocol: 'mcp',
+      request_signing: { kind: 'provider', provider: provB, agent_url: 'https://b.example.com' },
+    });
+
+    assert.notStrictEqual(ctxA.cacheKey, ctxB.cacheKey);
+    assert.notStrictEqual(ctxA.capabilityCacheKey, ctxB.capabilityCacheKey);
+  });
+
+  test('SDK defensively hashes provider fingerprint — low-entropy fingerprints still isolated by kid', () => {
+    const kid = 'test-ed25519-2026';
+    // Two providers, same kid, both supplying a stupid `fingerprint: 'x'`.
+    // SDK-side hash includes algorithm+kid so they collide ONLY if all three
+    // (algorithm, kid, fingerprint) match. Demonstrate that swapping kid
+    // produces a different cache key even when the fingerprint is constant.
+    const provA = {
+      keyid: 'kid-A',
+      algorithm: 'ed25519',
+      fingerprint: 'x',
+      sign: async () => new Uint8Array(64),
+    };
+    const provB = {
+      keyid: 'kid-B',
+      algorithm: 'ed25519',
+      fingerprint: 'x',
+      sign: async () => new Uint8Array(64),
+    };
+    const ctxA = buildAgentSigningContext({
+      id: 'a',
+      name: 'A',
+      agent_uri: 'https://seller.example.com',
+      protocol: 'mcp',
+      request_signing: { kind: 'provider', provider: provA, agent_url: 'https://a.example.com' },
+    });
+    const ctxB = buildAgentSigningContext({
+      id: 'b',
+      name: 'B',
+      agent_uri: 'https://seller.example.com',
+      protocol: 'mcp',
+      request_signing: { kind: 'provider', provider: provB, agent_url: 'https://b.example.com' },
+    });
+    assert.notStrictEqual(ctxA.cacheKey, ctxB.cacheKey);
+  });
+
+  test('cacheKey is deterministic across context rebuilds for the same provider', () => {
+    const kid = 'test-ed25519-2026';
+    const buildCtx = () => {
+      const provider = new InMemorySigningProvider({
+        keyid: kid,
+        algorithm: 'ed25519',
+        privateKey: privateJwkFor(kid),
+      });
+      return buildAgentSigningContext({
+        id: 'a',
+        name: 'A',
+        agent_uri: 'https://seller.example.com',
+        protocol: 'mcp',
+        request_signing: { kind: 'provider', provider, agent_url: 'https://a.example.com' },
+      });
+    };
+    const c1 = buildCtx();
+    const c2 = buildCtx();
+    assert.strictEqual(c1.cacheKey, c2.cacheKey);
+    assert.strictEqual(c1.capabilityCacheKey, c2.capabilityCacheKey);
+  });
+
+  test('algorithm flip on the same kid+fingerprint produces a different cacheKey', () => {
+    const provA = {
+      keyid: 'shared-kid',
+      algorithm: 'ed25519',
+      fingerprint: 'shared-fp',
+      sign: async () => new Uint8Array(64),
+    };
+    const provB = {
+      keyid: 'shared-kid',
+      algorithm: 'ecdsa-p256-sha256',
+      fingerprint: 'shared-fp',
+      sign: async () => new Uint8Array(64),
+    };
+    const ctxA = buildAgentSigningContext({
+      id: 'a',
+      name: 'A',
+      agent_uri: 'https://seller.example.com',
+      protocol: 'mcp',
+      request_signing: { kind: 'provider', provider: provA, agent_url: 'https://a.example.com' },
+    });
+    const ctxB = buildAgentSigningContext({
+      id: 'b',
+      name: 'B',
+      agent_uri: 'https://seller.example.com',
+      protocol: 'mcp',
+      request_signing: { kind: 'provider', provider: provB, agent_url: 'https://b.example.com' },
+    });
+    assert.notStrictEqual(ctxA.cacheKey, ctxB.cacheKey);
+  });
+});
+
+describe('InMemorySigningProvider production gate', () => {
+  test('throws when NODE_ENV=production without ack env', () => {
+    const original = { node_env: process.env.NODE_ENV, ack: process.env.ADCP_ALLOW_IN_MEMORY_SIGNER };
+    try {
+      process.env.NODE_ENV = 'production';
+      delete process.env.ADCP_ALLOW_IN_MEMORY_SIGNER;
+      assert.throws(
+        () =>
+          new InMemorySigningProvider({
+            keyid: 'k',
+            algorithm: 'ed25519',
+            privateKey: privateJwkFor('test-ed25519-2026'),
+          }),
+        /InMemorySigningProvider blocked in production/
+      );
+    } finally {
+      if (original.node_env === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original.node_env;
+      if (original.ack === undefined) delete process.env.ADCP_ALLOW_IN_MEMORY_SIGNER;
+      else process.env.ADCP_ALLOW_IN_MEMORY_SIGNER = original.ack;
+    }
+  });
+
+  test('allows when NODE_ENV=production and ack flag set', () => {
+    const original = { node_env: process.env.NODE_ENV, ack: process.env.ADCP_ALLOW_IN_MEMORY_SIGNER };
+    try {
+      process.env.NODE_ENV = 'production';
+      process.env.ADCP_ALLOW_IN_MEMORY_SIGNER = '1';
+      const p = new InMemorySigningProvider({
+        keyid: 'k',
+        algorithm: 'ed25519',
+        privateKey: privateJwkFor('test-ed25519-2026'),
+      });
+      assert.strictEqual(p.keyid, 'k');
+    } finally {
+      if (original.node_env === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original.node_env;
+      if (original.ack === undefined) delete process.env.ADCP_ALLOW_IN_MEMORY_SIGNER;
+      else process.env.ADCP_ALLOW_IN_MEMORY_SIGNER = original.ack;
+    }
+  });
+
+  test('allows in test/development environments without ack', () => {
+    const original = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = 'test';
+      const p = new InMemorySigningProvider({
+        keyid: 'k',
+        algorithm: 'ed25519',
+        privateKey: privateJwkFor('test-ed25519-2026'),
+      });
+      assert.strictEqual(p.algorithm, 'ed25519');
+    } finally {
+      if (original === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original;
+    }
+  });
+
+  test('rejects JWK without private scalar', () => {
+    assert.throws(
+      () =>
+        new InMemorySigningProvider({
+          keyid: 'k',
+          algorithm: 'ed25519',
+          privateKey: publicJwkFor('test-ed25519-2026'),
+        }),
+      /private_key.*must include.*d|private scalar/i
+    );
+  });
+});
+
+describe('signerKeyToProvider adapter', () => {
+  test('produces a provider whose fingerprint matches the legacy inline derivation', () => {
+    const kid = 'test-ed25519-2026';
+    const priv = privateJwkFor(kid);
+    const provider = signerKeyToProvider({ keyid: kid, alg: 'ed25519', privateKey: priv });
+
+    const expected = createHash('sha256').update(kid).update('\0').update(priv.d).digest('hex').slice(0, 16);
+    assert.strictEqual(provider.fingerprint, expected);
+    assert.strictEqual(provider.keyid, kid);
+    assert.strictEqual(provider.algorithm, 'ed25519');
+  });
+});
+
+describe('SigningProviderAlgorithmMismatchError', () => {
+  test('exposes expected/actual/providerKid fields', () => {
+    const err = new SigningProviderAlgorithmMismatchError('ed25519', 'EC_SIGN_P256_SHA256', 'addie-2026');
+    assert.strictEqual(err.expected, 'ed25519');
+    assert.strictEqual(err.actual, 'EC_SIGN_P256_SHA256');
+    assert.strictEqual(err.providerKid, 'addie-2026');
+    assert.match(err.message, /declared algorithm 'ed25519'/);
+    assert.match(err.message, /underlying key is 'EC_SIGN_P256_SHA256'/);
+  });
+});
+
+describe('end-to-end: provider-signed request verifies under the SDK verifier', () => {
+  function makeVerifierContext(kid) {
+    const publicJwk = publicJwkFor(kid);
+    return {
+      jwks: new StaticJwksResolver([publicJwk]),
+      replayStore: new InMemoryReplayStore(),
+      revocationStore: new InMemoryRevocationStore(),
+      capability: {
+        supported: true,
+        covers_content_digest: 'either',
+        required_for: ['create_media_buy'],
+      },
+    };
+  }
+
+  test('Ed25519 round-trip succeeds via signRequestAsync + InMemorySigningProvider', async () => {
+    const kid = 'test-ed25519-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+
+    const signed = await signRequestAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+    const ctx = makeVerifierContext(kid);
+
+    const result = await verifyRequestSignature(
+      { ...SAMPLE_REQUEST, headers: signed.headers },
+      {
+        ...ctx,
+        operation: 'create_media_buy',
+        now: SAMPLE_OPTIONS.now,
+      }
+    );
+    assert.strictEqual(result.status, 'verified');
+    assert.strictEqual(result.keyid, kid);
+  });
+
+  test('ECDSA-P256 round-trip succeeds via signRequestAsync + InMemorySigningProvider', async () => {
+    const kid = 'test-es256-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ecdsa-p256-sha256',
+      privateKey: privateJwkFor(kid),
+    });
+
+    const signed = await signRequestAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+    const ctx = makeVerifierContext(kid);
+
+    const result = await verifyRequestSignature(
+      { ...SAMPLE_REQUEST, headers: signed.headers },
+      {
+        ...ctx,
+        operation: 'create_media_buy',
+        now: SAMPLE_OPTIONS.now,
+      }
+    );
+    assert.strictEqual(result.status, 'verified');
+    assert.strictEqual(result.keyid, kid);
+  });
+
+  test('round-trip via createSigningFetchAsync + verifier (full HTTP path)', async () => {
+    const kid = 'test-ed25519-2026';
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: privateJwkFor(kid),
+    });
+
+    let captured;
+    const upstream = async (url, init) => {
+      captured = { url, init };
+      return new Response('ok', { status: 200 });
+    };
+    const fetchSigned = createSigningFetchAsync(upstream, provider, {
+      now: SAMPLE_OPTIONS.now,
+      nonce: SAMPLE_OPTIONS.nonce,
+    });
+    await fetchSigned('https://seller.example.com/adcp/create_media_buy', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ plan_id: 'plan_001' }),
+    });
+
+    const verifyRequest = {
+      method: 'POST',
+      url: captured.url,
+      headers: captured.init.headers,
+      body: captured.init.body,
+    };
+    const ctx = makeVerifierContext(kid);
+    const result = await verifyRequestSignature(verifyRequest, {
+      ...ctx,
+      operation: 'create_media_buy',
+      now: SAMPLE_OPTIONS.now,
+    });
+    assert.strictEqual(result.status, 'verified');
+  });
+
+  test('webhook async round-trip: signWebhookAsync produces signatures the webhook verifier accepts', async () => {
+    const { verifyWebhookSignature } = require('../dist/lib/signing/index.js');
+    const kid = 'test-ed25519-2026';
+    const webhookKey = keysData.keys.find(k => k.adcp_use === 'webhook-signing');
+    if (!webhookKey) {
+      // Conformance vectors don't include a separate webhook-signing key; reuse
+      // the request-signing key with a synthetic adcp_use override for the
+      // verifier's purpose check.
+      const provider = new InMemorySigningProvider({
+        keyid: kid,
+        algorithm: 'ed25519',
+        privateKey: privateJwkFor(kid),
+      });
+      const signed = await signWebhookAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+      // Just assert headers shape — full verifier round-trip needs a webhook-purpose key.
+      assert.match(signed.headers['Signature-Input'], /tag="adcp\/webhook-signing\/v1"/);
+      assert.match(signed.headers['Signature-Input'], /keyid="test-ed25519-2026"/);
+      assert.ok(signed.headers['Content-Digest'].startsWith('sha-256='));
+      return;
+    }
+    const webhookKid = webhookKey.kid;
+    const webhookPriv = { ...webhookKey, d: webhookKey._private_d_for_test_only };
+    delete webhookPriv._private_d_for_test_only;
+    const provider = new InMemorySigningProvider({
+      keyid: webhookKid,
+      algorithm: 'ed25519',
+      privateKey: webhookPriv,
+    });
+    const signed = await signWebhookAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+    const ctx = makeVerifierContext(webhookKid);
+    const result = await verifyWebhookSignature(
+      { ...SAMPLE_REQUEST, headers: signed.headers },
+      { ...ctx, now: SAMPLE_OPTIONS.now }
+    );
+    assert.strictEqual(result.status, 'verified');
+  });
+
+  test('verifier rejects when provider signs with a different private key than the JWKS publishes', async () => {
+    const kid = 'test-ed25519-2026';
+    // Sign with the wrong key but advertise the right `kid`. Verifier must
+    // reject — the signature won't validate against the JWKS public key.
+    const wrongKey = privateJwkFor('test-ed25519-2026');
+    // Mutate `d` to a different valid Ed25519 scalar (also from the test
+    // vectors): use the gov-signing key's scalar but keep `kid` advertising
+    // the request-signing identity.
+    const wrongJwk = { ...wrongKey, d: privateJwkFor('test-gov-2026').d };
+    const provider = new InMemorySigningProvider({
+      keyid: kid,
+      algorithm: 'ed25519',
+      privateKey: wrongJwk,
+    });
+
+    const signed = await signRequestAsync(SAMPLE_REQUEST, provider, SAMPLE_OPTIONS);
+    const ctx = makeVerifierContext(kid);
+
+    await assert.rejects(
+      () =>
+        verifyRequestSignature(
+          { ...SAMPLE_REQUEST, headers: signed.headers },
+          {
+            ...ctx,
+            operation: 'create_media_buy',
+            now: SAMPLE_OPTIONS.now,
+          }
+        ),
+      err => err instanceof RequestSignatureError && /signature_invalid|key_purpose|key_unknown/.test(err.code)
+    );
+  });
+});
+
+describe('derEcdsaToP1363', () => {
+  test('strips DER leading-zero padding and left-pads short components', () => {
+    // Constructed DER: SEQUENCE { INTEGER 0x00||r, INTEGER s }
+    // r has a leading zero (sign-bit guard); s is exactly 32 bytes.
+    const r = Buffer.concat([Buffer.from([0x00]), Buffer.alloc(32, 0xab)]); // 33 bytes
+    const s = Buffer.alloc(32, 0xcd); // 32 bytes
+    const der = Buffer.concat([
+      Buffer.from([0x30, 2 + r.length + 2 + s.length]),
+      Buffer.from([0x02, r.length]),
+      r,
+      Buffer.from([0x02, s.length]),
+      s,
+    ]);
+    const p1363 = derEcdsaToP1363(new Uint8Array(der), 32);
+    assert.strictEqual(p1363.length, 64);
+    // r component (after leading-zero strip) is 32 bytes of 0xab.
+    assert.deepStrictEqual(p1363.subarray(0, 32), new Uint8Array(Buffer.alloc(32, 0xab)));
+    // s component is 32 bytes of 0xcd.
+    assert.deepStrictEqual(p1363.subarray(32), new Uint8Array(Buffer.alloc(32, 0xcd)));
+  });
+
+  test('left-pads short r/s components', () => {
+    const r = Buffer.from([0x01, 0x02]); // 2 bytes
+    const s = Buffer.from([0x03]); // 1 byte
+    const der = Buffer.concat([
+      Buffer.from([0x30, 2 + r.length + 2 + s.length]),
+      Buffer.from([0x02, r.length]),
+      r,
+      Buffer.from([0x02, s.length]),
+      s,
+    ]);
+    const p1363 = derEcdsaToP1363(new Uint8Array(der), 32);
+    assert.strictEqual(p1363.length, 64);
+    assert.strictEqual(p1363[30], 0x01);
+    assert.strictEqual(p1363[31], 0x02);
+    assert.strictEqual(p1363[63], 0x03);
+  });
+
+  test('throws on malformed DER', () => {
+    assert.throws(() => derEcdsaToP1363(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), 32), /SEQUENCE tag/);
+  });
+});

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -12,6 +12,10 @@
       "@adcp/client/*": ["./dist/lib/*"]
     }
   },
-  "include": ["examples/comply-controller-seller.ts", "examples/seller-test-controller.ts"],
+  "include": [
+    "examples/comply-controller-seller.ts",
+    "examples/seller-test-controller.ts",
+    "examples/gcp-kms-signing-provider.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## What this PR does

Adds a pluggable `SigningProvider` interface so AdCP RFC 9421 private keys can live in a managed key store (GCP KMS, AWS KMS, Azure Key Vault, HashiCorp Vault Transit) instead of process memory. The async `sign(payload)` boundary matches RFC 9421 §3.1: the SDK produces the canonical signature base, the provider returns wire-format signature bytes.

Closes #1009. Sibling work tracked in #1015 (distributed `ReplayStore` for multi-instance verifiers).

**Wire format unchanged. No AdCP version bump. SDK minor: 5.19.0 → 5.20.0.**

## What's worth a second pair of eyes

### 1. Sync and async share the same canonicalization helpers

`signRequest` and `signRequestAsync` go through `prepareRequestSignature` + `finalizeRequestSignature` in `src/lib/signing/signer.ts`. Same for webhook. The only path-difference is whether the bytes go to `produceSignature` (sync, in-process Node crypto) or `await provider.sign` (async, KMS round-trip). Canonicalization can't drift between the two paths because there's only one canonicalization. The shared helpers are exported from `@adcp/client/signing` so other entry points can reuse them.

There's also a property test (`fast-check`, 50 fuzzed requests per run) asserting byte-identical `signatureBase`, `Signature-Input`, and `Signature` between sync and async for Ed25519 — defense in depth in case anyone reintroduces duplicate code paths in the future.

### 2. Discriminated `AgentRequestSigningConfig` on `kind`

```ts
type AgentRequestSigningConfig = AgentRequestSigningConfigInline | AgentRequestSigningConfigProvider;
```

`'inline'` is the default (`kind` optional on the existing shape — current literals work without changes). `'provider'` is required on the new shape. The narrowing flows through to `agent-context.ts` and `agent-fetch.ts` via the `isInlineSigningConfig` / `isProviderSigningConfig` predicates so unsafe field access is caught at compile time.

### 3. Defensive cache-key hashing for provider-supplied fingerprints

`buildAgentSigningContext` SHA-256s `algorithm + '\0' + keyid + '\0' + fingerprint` before composing transport- and capability-cache keys. A buggy adapter that returns `kid`, `''`, `'default'`, or a tenant-controlled string for `fingerprint` still produces 64-bit collision-resistant output. Two distinct keys with identical raw fingerprints don't collide because `algorithm` and `kid` are folded in. This preserves the multi-tenant isolation property that the in-memory path has always provided.

### 4. Identity snapshot at fetch construction

`buildAgentSigningFetch` wraps the provider in a frozen-identity view (`keyid` / `algorithm` / `fingerprint` snapshotted once) before passing it to `createSigningFetchAsync`. Wire `keyid`/`alg` cannot drift away from the cache key the connection was bound to even if a downstream adapter mutates fields after construction.

### 5. Non-UTF-8 byte bodies are rejected explicitly

`bodyToString` in both `fetch.ts` and `fetch-async.ts` uses `TextDecoder` fatal-mode and throws on invalid UTF-8. Previously `Buffer.from(body).toString('utf8')` silently replaced invalid bytes with U+FFFD; verification still passed because the wire and the digest agreed on the lossy string, but the seller received mangled content. Real footgun for binary payloads — KMS audience hits this faster than the inline-key audience.

### 6. `InMemorySigningProvider` NODE_ENV gate, scoped to the reference impl

Constructor refuses to instantiate when `NODE_ENV=production` (case-insensitive) unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set. Lives under `@adcp/client/signing/testing` so production imports surface the KMS path first. The interface JSDoc explicitly notes that this gate is a self-discipline aid for the bundled implementation only — the SDK can't (and doesn't try to) enforce hygiene on third-party providers.

### 7. GCP KMS reference adapter as an example, not a bundled dep

`examples/gcp-kms-signing-provider.ts` — type-checked under `npm run typecheck:examples`, demonstrates the DER → IEEE P1363 conversion (via the shared `derEcdsaToP1363` helper), pre-flight algorithm validation via one `getPublicKey` call, and the consumer-side `KeyManagementServiceClient` wiring. The published package stays free of `@google-cloud/kms`; users `npm i` the cloud SDK they need.

## Migration

Existing callers passing `{ kid, alg, private_key, agent_url }` continue to work unchanged (no `kind` field needed). New callers pass `{ kind: 'provider', provider, agent_url }`.

In-process cache-key shape changed for inline configs (`sha256(alg + kid + sha256(kid + d).slice(16))` vs old `sha256(kid + d).slice(16)`). Cache is in-process with a 5-minute TTL, no persistence boundary — entries become unreachable on upgrade and re-prime within seconds. Verified call sites (`protocols/mcp.ts`, `protocols/a2a.ts`, `capability-priming.ts`) consume `cacheKey` opaquely.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:examples` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build:lib` — clean
- [x] 25 new tests in `test/request-signing-provider.test.js`
- [x] Existing 188 signing tests pass — no regressions
- [x] Property test (fast-check, 50 runs) asserts sync/async equivalence

## Deferred follow-ups

- Distributed `ReplayStore` adapter (Redis) for multi-instance verifiers — filed as #1015, no dependency on this PR.
- AWS KMS / Azure Key Vault example adapters — pattern is identical to the GCP example; ship if/when there's demand.
- `@google-cloud/kms`'s `crc32c` integrity field on `asymmetricSign` — defensive, not required by the spec.
- `InMemorySigningProvider.sign` re-imports `createPrivateKey` per call — testing-only path, perf optimization not correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
