### PR TITLE
feat(signing): PostgresReplayStore for distributed verifier deployments

### DIFF
--- a/.changeset/postgres-replay-store.md
+++ b/.changeset/postgres-replay-store.md
@@ -1,0 +1,21 @@
+---
+"@adcp/client": minor
+---
+
+feat(signing): PostgresReplayStore for distributed verifier deployments
+
+Adds a Postgres-backed `ReplayStore` so multi-instance verifier deployments share replay-protection state. The default `InMemoryReplayStore` is per-process; on a fleet, an attacker who captures a signed request can replay it against a sibling whose cache hasn't seen the nonce — RFC 9421's 5-minute expiry bounds the window but that's plenty of time for an in-flight replay. `PostgresReplayStore` closes that hole using a `(keyid, scope, nonce)` primary key the verifier checks on every signed request.
+
+New exports from `@adcp/client/signing/server`:
+
+- `PostgresReplayStore` — `ReplayStore` implementation against the structural `PgQueryable` interface (same pattern as `PostgresTaskStore` and `PostgresStateStore`; the SDK stays free of a hard `pg` dependency).
+- `getReplayStoreMigration(tableName?)` — idempotent DDL for the cache table plus indexes on `expires_at` and `(keyid, scope, expires_at)`.
+- `sweepExpiredReplays(pool, options?)` — exported helper for callers to schedule (cron, app timer, `pg_cron`, etc.); Postgres has no native row-level TTL, so expired rows have to be deleted explicitly.
+
+The insert path is a single CTE statement that handles replay/cap/insert decision atomically. `ON CONFLICT DO UPDATE WHERE existing-is-expired` recycles expired rows in place — a same-nonce insert after the previous registration's TTL elapsed (but before the sweeper ran) correctly returns `'ok'` rather than falsely reporting `'replayed'`. Concurrent same-nonce inserts (10 parallel) consistently produce exactly one `'ok'` and the rest `'replayed'`, matching `InMemoryReplayStore` semantics.
+
+Wire format unchanged. No AdCP version bump.
+
+See [`docs/guides/SIGNING-GUIDE.md` § Verify Inbound Signatures](./guides/SIGNING-GUIDE.md#step-4-verify-inbound-signatures-seller) for the multi-instance failure mode and the wire-up.
+
+Closes #1015.

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -339,7 +339,35 @@ app.post(
 );
 ```
 
-`replayStore` and `revocationStore` default to in-memory implementations — fine for single-process deployments. Replace with a shared store (Redis-backed, etc.) for horizontally scaled fleets so replay detection works across instances.
+`replayStore` and `revocationStore` default to in-memory implementations — fine for single-process deployments.
+
+**For multi-instance verifier deployments, the in-memory default is a real gap.** Each process has its own cache; an attacker who captures a signed request can replay it against a sibling instance whose cache hasn't seen the nonce. The replay-protection invariant is "this `(keyid, scope, nonce)` tuple has not been seen before" — that has to hold across the fleet, not per-process. RFC 9421 expiry bounds the window to 5 minutes, but that's plenty of time for an in-flight replay. Use a shared backend.
+
+The SDK ships `PostgresReplayStore` for this:
+
+```typescript
+import { Pool } from 'pg';
+import { PostgresReplayStore, getReplayStoreMigration, sweepExpiredReplays } from '@adcp/client/signing/server';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+await pool.query(getReplayStoreMigration());                    // run once at boot
+
+const replayStore = new PostgresReplayStore(pool);
+
+// Postgres has no native TTL — schedule the sweeper somewhere to delete
+// expired rows. Once a minute is fine for moderate traffic; tune down if
+// the verifier sees thousands of signed requests per second.
+setInterval(() => sweepExpiredReplays(pool).catch(console.error), 60_000);
+
+app.use(createExpressVerifier({
+  capability: { ... },
+  jwks,
+  replayStore,                                                  // <-- shared across instances
+  resolveOperation: mcpToolNameResolver,
+}));
+```
+
+The schema is one table with `(keyid, scope, nonce)` as the primary key plus indexes on `expires_at` and `(keyid, scope, expires_at)`. Lookups are O(log n) on the composite index; insert is one round-trip CTE that handles the replay/cap/insert decision atomically. The sweeper exists because Postgres has no native row-level TTL — it's a `DELETE FROM replay_cache WHERE expires_at <= now()` you call on a schedule. Other backends (Redis, KeyDB, anything supporting atomic insert-if-absent with TTL) can implement the `ReplayStore` interface the same way.
 
 On successful verification, `req.verifiedSigner` contains `{ keyid, agent_url?, verified_at }`. On failure, the middleware returns `401` with `WWW-Authenticate: Signature error="<code>"`.
 

--- a/src/lib/signing/postgres-replay-store.ts
+++ b/src/lib/signing/postgres-replay-store.ts
@@ -1,0 +1,257 @@
+/**
+ * PostgreSQL-backed `ReplayStore` for distributed AdCP verifier deployments.
+ *
+ * Replaces `InMemoryReplayStore` when running multiple verifier instances
+ * behind a load balancer. The default in-memory store is per-process; a
+ * signature captured by an attacker can be replayed against a sibling
+ * instance whose cache hasn't seen the nonce. Sharing replay state via
+ * Postgres closes that hole using a `(keyid, scope, nonce)` primary key
+ * the verifier checks on every signed request.
+ *
+ * @example
+ * ```typescript
+ * import { Pool } from 'pg';
+ * import { PostgresReplayStore, getReplayStoreMigration } from '@adcp/client/signing/server';
+ *
+ * const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+ * await pool.query(getReplayStoreMigration());          // run once at boot
+ *
+ * const replayStore = new PostgresReplayStore(pool);
+ *
+ * app.use(createExpressVerifier({
+ *   capability: { ... },
+ *   jwks,
+ *   replayStore,                                        // <-- shared across instances
+ *   resolveOperation: mcpToolNameResolver,
+ * }));
+ *
+ * // Schedule the sweeper somewhere (cron, app timer, pg_cron, etc.):
+ * setInterval(() => sweepExpiredReplays(pool).catch(console.error), 60_000);
+ * ```
+ *
+ * Reuses the structural `PgQueryable` interface from `postgres-task-store`
+ * so the SDK stays free of a hard `pg` dependency — callers pass any
+ * pg-compatible query executor.
+ */
+
+import type { PgQueryable } from '../server/postgres-task-store';
+import type { ReplayInsertResult, ReplayStore } from './replay';
+
+const DEFAULT_TABLE = 'adcp_replay_cache';
+const DEFAULT_CAP = 100_000;
+const VALID_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+export interface PostgresReplayStoreOptions {
+  /** Table name. Lowercase letters, digits, underscores only. Defaults to `adcp_replay_cache`. */
+  tableName?: string;
+  /**
+   * Max retained (unexpired) nonces per `(keyid, scope)` pair before
+   * `insert` returns `'rate_abuse'`. Mirrors `InMemoryReplayStore`'s
+   * `maxEntriesPerKeyid`. Defaults to 100,000.
+   */
+  cap?: number;
+}
+
+/**
+ * Generate the SQL DDL for the replay-cache table. Idempotent — safe to
+ * run on existing tables. Run once at server startup, before constructing
+ * `PostgresReplayStore`.
+ *
+ * Schema:
+ * - `(keyid, scope, nonce)` is the primary key, so concurrent inserts of
+ *   the same tuple serialize against the unique index — the second insert
+ *   silently fails via `ON CONFLICT DO NOTHING`, which the adapter detects
+ *   to return `'replayed'`.
+ * - `expires_at` carries the per-row TTL since Postgres has no native TTL.
+ *   Lookups filter `expires_at > now()`; expired rows are deleted by the
+ *   exported {@link sweepExpiredReplays} helper which callers schedule
+ *   themselves.
+ */
+export function getReplayStoreMigration(tableName: string = DEFAULT_TABLE): string {
+  if (!VALID_IDENTIFIER.test(tableName)) {
+    throw new Error(`Invalid table name: "${tableName}". Must match /^[a-z_][a-z0-9_]*$/.`);
+  }
+  return `
+    CREATE TABLE IF NOT EXISTS ${tableName} (
+      keyid       TEXT NOT NULL,
+      scope       TEXT NOT NULL,
+      nonce       TEXT NOT NULL,
+      expires_at  TIMESTAMPTZ NOT NULL,
+      PRIMARY KEY (keyid, scope, nonce)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_${tableName}_expires_at
+      ON ${tableName}(expires_at);
+
+    CREATE INDEX IF NOT EXISTS idx_${tableName}_keyid_scope_active
+      ON ${tableName}(keyid, scope, expires_at);
+  `;
+}
+
+export class PostgresReplayStore implements ReplayStore {
+  private readonly db: PgQueryable;
+  private readonly tableName: string;
+  private readonly cap: number;
+
+  constructor(db: PgQueryable, options: PostgresReplayStoreOptions = {}) {
+    const tableName = options.tableName ?? DEFAULT_TABLE;
+    if (!VALID_IDENTIFIER.test(tableName)) {
+      throw new Error(`Invalid table name: "${tableName}". Must match /^[a-z_][a-z0-9_]*$/.`);
+    }
+    this.db = db;
+    this.tableName = tableName;
+    this.cap = options.cap ?? DEFAULT_CAP;
+  }
+
+  async has(keyid: string, scope: string, nonce: string, now: number): Promise<boolean> {
+    const result = await this.db.query(
+      `SELECT 1 FROM ${this.tableName}
+       WHERE keyid = $1 AND scope = $2 AND nonce = $3 AND expires_at > to_timestamp($4)
+       LIMIT 1`,
+      [keyid, scope, nonce, now]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async isCapHit(keyid: string, scope: string, now: number): Promise<boolean> {
+    const result = await this.db.query(
+      `SELECT count(*)::bigint AS active FROM ${this.tableName}
+       WHERE keyid = $1 AND scope = $2 AND expires_at > to_timestamp($3)`,
+      [keyid, scope, now]
+    );
+    const row = result.rows[0] as { active: string | number } | undefined;
+    if (!row) return false;
+    // count(*)::bigint returns string in node-postgres by default; coerce.
+    const active = typeof row.active === 'string' ? Number(row.active) : row.active;
+    return active >= this.cap;
+  }
+
+  /**
+   * Atomically check replay → cap → insert in a single MVCC-snapshotted
+   * statement. Result precedence matches `InMemoryReplayStore`: replay
+   * wins over rate_abuse wins over ok.
+   *
+   * Recycles expired rows in place via `ON CONFLICT DO UPDATE WHERE
+   * existing-is-expired`. Without that, a same-nonce insert *after* the
+   * previous registration's TTL elapsed (but before the sweeper ran)
+   * would falsely report `'replayed'` — the sync `InMemoryReplayStore`
+   * prunes expired entries before the existence check, so we have to
+   * achieve the same semantics here without a separate prune step.
+   *
+   * The `RETURNING 1` is empty when (a) the cap blocked the insert
+   * (`WHERE` clause filtered the conditional INSERT to zero rows) or
+   * (b) the concurrent-same-nonce race lost — another transaction
+   * inserted the same `(keyid, scope, nonce)` between this statement's
+   * snapshot and our `ON CONFLICT`. Both branches are handled by the
+   * outer `CASE`.
+   */
+  async insert(
+    keyid: string,
+    scope: string,
+    nonce: string,
+    ttlSeconds: number,
+    now: number
+  ): Promise<ReplayInsertResult> {
+    const expiresAt = now + ttlSeconds;
+    const result = await this.db.query(
+      `WITH
+        existing AS (
+          SELECT 1 FROM ${this.tableName}
+          WHERE keyid = $1 AND scope = $2 AND nonce = $3 AND expires_at > to_timestamp($4)
+        ),
+        active AS (
+          SELECT count(*)::bigint AS n FROM ${this.tableName}
+          WHERE keyid = $1 AND scope = $2 AND expires_at > to_timestamp($4)
+        ),
+        upsert AS (
+          INSERT INTO ${this.tableName} (keyid, scope, nonce, expires_at)
+          SELECT $1, $2, $3, to_timestamp($5)
+          WHERE NOT EXISTS (SELECT 1 FROM existing)
+            AND (SELECT n FROM active) < $6::bigint
+          ON CONFLICT (keyid, scope, nonce) DO UPDATE
+            SET expires_at = EXCLUDED.expires_at
+            WHERE ${this.tableName}.expires_at <= to_timestamp($4)
+          RETURNING 1
+        )
+      SELECT
+        CASE
+          WHEN EXISTS (SELECT 1 FROM existing) THEN 'replayed'
+          WHEN (SELECT n FROM active) >= $6::bigint THEN 'rate_abuse'
+          WHEN EXISTS (SELECT 1 FROM upsert) THEN 'ok'
+          ELSE 'replayed'
+        END AS result`,
+      [keyid, scope, nonce, now, expiresAt, this.cap]
+    );
+    const row = result.rows[0] as { result: ReplayInsertResult } | undefined;
+    if (!row) {
+      throw new Error('PostgresReplayStore.insert: query returned no rows');
+    }
+    return row.result;
+  }
+}
+
+export interface SweepExpiredReplaysOptions {
+  /** Table name. Defaults to `adcp_replay_cache`. */
+  tableName?: string;
+  /** Current time in seconds (UNIX epoch). Defaults to `Date.now() / 1000`. */
+  now?: number;
+  /**
+   * Limit the number of rows deleted per call. Useful for very large
+   * tables where a single `DELETE` would lock the table too long. When
+   * unset, deletes all expired rows in one statement.
+   */
+  batchSize?: number;
+}
+
+/**
+ * Delete expired rows from the replay-cache table. Postgres has no native
+ * TTL; callers schedule this helper themselves (cron, an app-side timer,
+ * a `pg_cron` job, etc.).
+ *
+ * Returns the count of rows deleted, so callers can tune sweep frequency
+ * against observed accumulation. A typical schedule is once per minute
+ * for moderate-traffic verifiers; a hot-path verifier signing thousands
+ * per second may want every 10–15 seconds.
+ *
+ * @example
+ * ```typescript
+ * setInterval(async () => {
+ *   const { deleted } = await sweepExpiredReplays(pool);
+ *   if (deleted > 0) metrics.replayCacheSweep(deleted);
+ * }, 60_000);
+ * ```
+ */
+export async function sweepExpiredReplays(
+  db: PgQueryable,
+  options: SweepExpiredReplaysOptions = {}
+): Promise<{ deleted: number }> {
+  const tableName = options.tableName ?? DEFAULT_TABLE;
+  if (!VALID_IDENTIFIER.test(tableName)) {
+    throw new Error(`Invalid table name: "${tableName}". Must match /^[a-z_][a-z0-9_]*$/.`);
+  }
+  const now = options.now ?? Math.floor(Date.now() / 1000);
+  const batchSize = options.batchSize;
+
+  if (batchSize === undefined) {
+    const result = await db.query(`DELETE FROM ${tableName} WHERE expires_at <= to_timestamp($1)`, [now]);
+    return { deleted: result.rowCount ?? 0 };
+  }
+  // Bounded sweep — use a CTE to delete only `batchSize` rows. Useful when
+  // the table has accumulated a long tail and a single DELETE would
+  // hold a long table lock.
+  const result = await db.query(
+    `WITH expired AS (
+      SELECT keyid, scope, nonce
+      FROM ${tableName}
+      WHERE expires_at <= to_timestamp($1)
+      LIMIT $2
+    )
+    DELETE FROM ${tableName}
+    USING expired
+    WHERE ${tableName}.keyid = expired.keyid
+      AND ${tableName}.scope = expired.scope
+      AND ${tableName}.nonce = expired.nonce`,
+    [now, batchSize]
+  );
+  return { deleted: result.rowCount ?? 0 };
+}

--- a/src/lib/signing/postgres-replay-store.ts
+++ b/src/lib/signing/postgres-replay-store.ts
@@ -41,6 +41,21 @@ const DEFAULT_TABLE = 'adcp_replay_cache';
 const DEFAULT_CAP = 100_000;
 const VALID_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
 
+/**
+ * Reject non-finite or out-of-range timestamps before they reach Postgres.
+ * `to_timestamp(NaN)` raises a parse error and `to_timestamp(±Infinity)`
+ * silently produces an `infinity` timestamp — neither would lapse replay
+ * protection, but a buggy `options.now()` injection point could DoS the
+ * verifier with PG errors. Bound to JS-safe-integer territory; verifiers
+ * pass UNIX seconds, not microseconds, so the upper bound is effectively
+ * "year 9999 plus epsilon."
+ */
+function assertFiniteSeconds(label: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0 || value > Number.MAX_SAFE_INTEGER) {
+    throw new TypeError(`PostgresReplayStore: ${label} must be a finite non-negative number; received ${value}`);
+  }
+}
+
 export interface PostgresReplayStoreOptions {
   /** Table name. Lowercase letters, digits, underscores only. Defaults to `adcp_replay_cache`. */
   tableName?: string;
@@ -48,9 +63,23 @@ export interface PostgresReplayStoreOptions {
    * Max retained (unexpired) nonces per `(keyid, scope)` pair before
    * `insert` returns `'rate_abuse'`. Mirrors `InMemoryReplayStore`'s
    * `maxEntriesPerKeyid`. Defaults to 100,000.
+   *
+   * The cap is **best-effort** under concurrency: two simultaneous inserts
+   * at `cap-1` can both observe `n = cap-1` from the same MVCC snapshot
+   * and both insert, briefly overshooting by one. This matches
+   * `InMemoryReplayStore` semantics — the cap is a soft DoS guard, not a
+   * hard invariant.
    */
   cap?: number;
 }
+
+/**
+ * Pre-baked migration SQL for the default `adcp_replay_cache` table. Use
+ * when callers don't need a custom table name. Mirrors the convention of
+ * `MCP_TASKS_MIGRATION` (`postgres-task-store.ts`) and `ADCP_STATE_MIGRATION`
+ * (`postgres-state-store.ts`).
+ */
+export const REPLAY_CACHE_MIGRATION: string = renderReplayStoreMigration(DEFAULT_TABLE);
 
 /**
  * Generate the SQL DDL for the replay-cache table. Idempotent — safe to
@@ -68,6 +97,10 @@ export interface PostgresReplayStoreOptions {
  *   themselves.
  */
 export function getReplayStoreMigration(tableName: string = DEFAULT_TABLE): string {
+  return renderReplayStoreMigration(tableName);
+}
+
+function renderReplayStoreMigration(tableName: string): string {
   if (!VALID_IDENTIFIER.test(tableName)) {
     throw new Error(`Invalid table name: "${tableName}". Must match /^[a-z_][a-z0-9_]*$/.`);
   }
@@ -104,6 +137,7 @@ export class PostgresReplayStore implements ReplayStore {
   }
 
   async has(keyid: string, scope: string, nonce: string, now: number): Promise<boolean> {
+    assertFiniteSeconds('now', now);
     const result = await this.db.query(
       `SELECT 1 FROM ${this.tableName}
        WHERE keyid = $1 AND scope = $2 AND nonce = $3 AND expires_at > to_timestamp($4)
@@ -114,6 +148,7 @@ export class PostgresReplayStore implements ReplayStore {
   }
 
   async isCapHit(keyid: string, scope: string, now: number): Promise<boolean> {
+    assertFiniteSeconds('now', now);
     const result = await this.db.query(
       `SELECT count(*)::bigint AS active FROM ${this.tableName}
        WHERE keyid = $1 AND scope = $2 AND expires_at > to_timestamp($3)`,
@@ -152,6 +187,8 @@ export class PostgresReplayStore implements ReplayStore {
     ttlSeconds: number,
     now: number
   ): Promise<ReplayInsertResult> {
+    assertFiniteSeconds('now', now);
+    assertFiniteSeconds('ttlSeconds', ttlSeconds);
     const expiresAt = now + ttlSeconds;
     const result = await this.db.query(
       `WITH

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -42,6 +42,13 @@ export {
   type ReplayInsertResult,
   type ReplayStore,
 } from './replay';
+export {
+  PostgresReplayStore,
+  getReplayStoreMigration,
+  sweepExpiredReplays,
+  type PostgresReplayStoreOptions,
+  type SweepExpiredReplaysOptions,
+} from './postgres-replay-store';
 export { InMemoryRevocationStore, type RevocationStore } from './revocation';
 export { HttpsRevocationStore, type HttpsRevocationStoreOptions } from './revocation-https';
 export {

--- a/src/lib/signing/server.ts
+++ b/src/lib/signing/server.ts
@@ -44,6 +44,7 @@ export {
 } from './replay';
 export {
   PostgresReplayStore,
+  REPLAY_CACHE_MIGRATION,
   getReplayStoreMigration,
   sweepExpiredReplays,
   type PostgresReplayStoreOptions,

--- a/test/lib/postgres-replay-store.test.js
+++ b/test/lib/postgres-replay-store.test.js
@@ -1,0 +1,281 @@
+/**
+ * PostgresReplayStore integration tests.
+ *
+ * Requires a running PostgreSQL instance. Set DATABASE_URL to run:
+ *   DATABASE_URL=postgres://localhost/test node --test test/lib/postgres-replay-store.test.js
+ *
+ * Skipped entirely when DATABASE_URL is not set.
+ */
+
+const { test, describe, before, afterEach, after } = require('node:test');
+const assert = require('node:assert');
+
+const DATABASE_URL = process.env.DATABASE_URL;
+
+const TABLE = 'adcp_replay_cache';
+
+describe('PostgresReplayStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' }, () => {
+  let Pool, pool;
+  let PostgresReplayStore, getReplayStoreMigration, sweepExpiredReplays;
+
+  before(async () => {
+    Pool = require('pg').Pool;
+    pool = new Pool({ connectionString: DATABASE_URL });
+
+    const lib = require('../../dist/lib/signing/server.js');
+    PostgresReplayStore = lib.PostgresReplayStore;
+    getReplayStoreMigration = lib.getReplayStoreMigration;
+    sweepExpiredReplays = lib.sweepExpiredReplays;
+
+    await pool.query(`DROP TABLE IF EXISTS ${TABLE} CASCADE`);
+    await pool.query(getReplayStoreMigration());
+  });
+
+  afterEach(async () => {
+    await pool.query(`DELETE FROM ${TABLE}`);
+  });
+
+  after(async () => {
+    if (pool) await pool.end();
+  });
+
+  // ====== Migration / configuration ======
+
+  test('default migration creates the canonical schema', () => {
+    const sql = getReplayStoreMigration();
+    assert.ok(sql.includes('CREATE TABLE IF NOT EXISTS adcp_replay_cache'));
+    assert.ok(sql.includes('PRIMARY KEY (keyid, scope, nonce)'));
+    assert.ok(sql.includes('idx_adcp_replay_cache_expires_at'));
+    assert.ok(sql.includes('idx_adcp_replay_cache_keyid_scope_active'));
+  });
+
+  test('custom table name flows through migration and queries', async () => {
+    const customTable = 'custom_replay';
+    await pool.query(`DROP TABLE IF EXISTS ${customTable} CASCADE`);
+    await pool.query(getReplayStoreMigration(customTable));
+
+    const customStore = new PostgresReplayStore(pool, { tableName: customTable });
+    const now = 1_700_000_000;
+    const result = await customStore.insert('kid-A', 'https://x/op', 'n1', 60, now);
+    assert.strictEqual(result, 'ok');
+    assert.strictEqual(await customStore.has('kid-A', 'https://x/op', 'n1', now), true);
+
+    await pool.query(`DROP TABLE ${customTable}`);
+  });
+
+  test('rejects SQL-injection-shaped table names', () => {
+    assert.throws(() => getReplayStoreMigration('DROP TABLE; --'), /Invalid table name/);
+    assert.throws(() => new PostgresReplayStore(pool, { tableName: 'Mixed' }), /Invalid table name/);
+    assert.throws(() => new PostgresReplayStore(pool, { tableName: '1bad' }), /Invalid table name/);
+  });
+
+  // ====== Core insert / has / replay-vs-rate_abuse ======
+
+  test('insert returns ok the first time and replayed the second time for the same nonce', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_100;
+
+    const first = await store.insert('kid-A', 'https://seller/op1', 'nonce-1', 60, now);
+    assert.strictEqual(first, 'ok');
+
+    const second = await store.insert('kid-A', 'https://seller/op1', 'nonce-1', 60, now);
+    assert.strictEqual(second, 'replayed');
+
+    assert.strictEqual(await store.has('kid-A', 'https://seller/op1', 'nonce-1', now), true);
+  });
+
+  test('partitions storage by (keyid, scope) — same nonce on different scope is not a replay', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_200;
+
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op1', 'shared', 60, now), 'ok');
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op2', 'shared', 60, now), 'ok');
+    assert.strictEqual(await store.insert('kid-B', 'https://seller/op1', 'shared', 60, now), 'ok');
+  });
+
+  test('expired entries are not seen by has() — TTL boundary respected', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_300;
+
+    await store.insert('kid-A', 'https://seller/op', 'n1', 30, now);
+    assert.strictEqual(await store.has('kid-A', 'https://seller/op', 'n1', now + 10), true);
+    assert.strictEqual(await store.has('kid-A', 'https://seller/op', 'n1', now + 60), false);
+  });
+
+  test('insert returns ok for a previously-expired same-nonce — TTL bounds replay protection', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_400;
+
+    await store.insert('kid-A', 'https://seller/op', 'recycled', 30, now);
+    // After expiry the same nonce can be inserted again — replay protection
+    // is bounded by the signature's expiry, matching InMemoryReplayStore.
+    const second = await store.insert('kid-A', 'https://seller/op', 'recycled', 30, now + 60);
+    assert.strictEqual(second, 'ok');
+  });
+
+  test('rate_abuse fires once cap is hit; existing nonces still report replayed (precedence)', async () => {
+    const store = new PostgresReplayStore(pool, { cap: 3 });
+    const now = 1_700_000_500;
+
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op', 'n1', 60, now), 'ok');
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op', 'n2', 60, now), 'ok');
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op', 'n3', 60, now), 'ok');
+
+    // At cap. New nonce → rate_abuse.
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op', 'n4', 60, now), 'rate_abuse');
+
+    // Replay of an existing nonce — replay wins over rate_abuse.
+    assert.strictEqual(await store.insert('kid-A', 'https://seller/op', 'n2', 60, now), 'replayed');
+  });
+
+  test('isCapHit reflects active count vs configured cap', async () => {
+    const store = new PostgresReplayStore(pool, { cap: 2 });
+    const now = 1_700_000_600;
+
+    assert.strictEqual(await store.isCapHit('kid-A', 'https://seller/op', now), false);
+    await store.insert('kid-A', 'https://seller/op', 'n1', 60, now);
+    assert.strictEqual(await store.isCapHit('kid-A', 'https://seller/op', now), false);
+    await store.insert('kid-A', 'https://seller/op', 'n2', 60, now);
+    assert.strictEqual(await store.isCapHit('kid-A', 'https://seller/op', now), true);
+
+    // Once entries expire, cap is no longer hit.
+    assert.strictEqual(await store.isCapHit('kid-A', 'https://seller/op', now + 120), false);
+  });
+
+  // ====== Sweeper ======
+
+  test('sweepExpiredReplays deletes only expired rows', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_700;
+
+    await store.insert('kid-A', 'https://seller/op', 'short-lived', 30, now);
+    await store.insert('kid-A', 'https://seller/op', 'long-lived', 600, now);
+
+    const before = await pool.query(`SELECT count(*)::int AS n FROM ${TABLE}`);
+    assert.strictEqual(before.rows[0].n, 2);
+
+    const { deleted } = await sweepExpiredReplays(pool, { now: now + 60 });
+    assert.strictEqual(deleted, 1);
+
+    const after = await pool.query(`SELECT count(*)::int AS n FROM ${TABLE}`);
+    assert.strictEqual(after.rows[0].n, 1);
+
+    // Long-lived survives.
+    assert.strictEqual(await store.has('kid-A', 'https://seller/op', 'long-lived', now + 60), true);
+  });
+
+  test('sweepExpiredReplays with batchSize bounds work per call', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_800;
+
+    for (let i = 0; i < 5; i++) {
+      await store.insert('kid-A', 'https://seller/op', `n${i}`, 30, now);
+    }
+
+    const first = await sweepExpiredReplays(pool, { now: now + 60, batchSize: 3 });
+    assert.strictEqual(first.deleted, 3);
+
+    const second = await sweepExpiredReplays(pool, { now: now + 60, batchSize: 10 });
+    assert.strictEqual(second.deleted, 2);
+  });
+
+  // ====== Concurrency ======
+
+  test('concurrent inserts of the same nonce — exactly one returns ok, others return replayed', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_900;
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => store.insert('kid-A', 'https://seller/op', 'race-nonce', 60, now))
+    );
+
+    const okCount = results.filter(r => r === 'ok').length;
+    const replayedCount = results.filter(r => r === 'replayed').length;
+    assert.strictEqual(okCount, 1, 'exactly one concurrent insert succeeds');
+    assert.strictEqual(replayedCount, 9, 'the rest report replayed');
+  });
+
+  // ====== Wiring with the verifier ======
+
+  test('end-to-end: signed request → verifier with PostgresReplayStore → second attempt rejected as replay', async () => {
+    const {
+      signRequest,
+      verifyRequestSignature,
+      InMemoryRevocationStore,
+      StaticJwksResolver,
+    } = require('../../dist/lib/signing/index.js');
+    const { readFileSync } = require('node:fs');
+    const path = require('node:path');
+
+    const KEYS_PATH = path.join(
+      __dirname,
+      '..',
+      '..',
+      'compliance',
+      'cache',
+      'latest',
+      'test-vectors',
+      'request-signing',
+      'keys.json'
+    );
+    const keys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys;
+    const ed = keys.find(k => k.kid === 'test-ed25519-2026');
+    const privateJwk = { ...ed, d: ed._private_d_for_test_only };
+    delete privateJwk._private_d_for_test_only;
+    const publicJwk = { ...ed };
+    delete publicJwk._private_d_for_test_only;
+
+    const replayStore = new PostgresReplayStore(pool);
+    const revocationStore = new InMemoryRevocationStore();
+    const jwks = new StaticJwksResolver([publicJwk]);
+
+    const now = 1_700_001_000;
+    const request = {
+      method: 'POST',
+      url: 'https://seller.example.com/adcp/create_media_buy',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan_id: 'p1' }),
+    };
+    const signed = signRequest(
+      request,
+      { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk },
+      {
+        now: () => now,
+        nonce: 'pg-replay-test-nonce',
+      }
+    );
+
+    const verified = await verifyRequestSignature(
+      { ...request, headers: signed.headers },
+      {
+        capability: { supported: true, covers_content_digest: 'either', required_for: ['create_media_buy'] },
+        jwks,
+        replayStore,
+        revocationStore,
+        operation: 'create_media_buy',
+        now: () => now,
+      }
+    );
+    assert.strictEqual(verified.status, 'verified');
+
+    // Second attempt with the same signature must be rejected as a replay
+    // — even though this is a "second instance" simulation, the shared
+    // PostgresReplayStore caught it.
+    const { RequestSignatureError } = require('../../dist/lib/signing/index.js');
+    await assert.rejects(
+      () =>
+        verifyRequestSignature(
+          { ...request, headers: signed.headers },
+          {
+            capability: { supported: true, covers_content_digest: 'either', required_for: ['create_media_buy'] },
+            jwks,
+            replayStore,
+            revocationStore,
+            operation: 'create_media_buy',
+            now: () => now,
+          }
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_replayed'
+    );
+  });
+});

--- a/test/lib/postgres-replay-store.test.js
+++ b/test/lib/postgres-replay-store.test.js
@@ -128,6 +128,49 @@ describe('PostgresReplayStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' 
     assert.strictEqual(await store.insert('kid-A', 'https://seller/op', 'n2', 60, now), 'replayed');
   });
 
+  test('cap clears once entries pass expiry — no sweeper required', async () => {
+    // The invariant: every store query filters `expires_at > now`, so an
+    // expired-but-not-yet-swept entry doesn't count toward the cap. This
+    // matches InMemoryReplayStore's prune-then-check semantics. Locking
+    // this in a test so a future schema change can't quietly regress it.
+    const store = new PostgresReplayStore(pool, { cap: 2 });
+    const now = 1_700_000_550;
+
+    await store.insert('kid-A', 'https://seller/op', 'a', 30, now);
+    await store.insert('kid-A', 'https://seller/op', 'b', 30, now);
+    assert.strictEqual(await store.isCapHit('kid-A', 'https://seller/op', now), true);
+
+    // Advance past expiry — without running the sweeper.
+    assert.strictEqual(await store.isCapHit('kid-A', 'https://seller/op', now + 60), false);
+
+    // A fresh insert should now succeed (cap is no longer hit).
+    const after = await store.insert('kid-A', 'https://seller/op', 'c', 30, now + 60);
+    assert.strictEqual(after, 'ok');
+  });
+
+  test('concurrent recycle of an expired same-nonce — exactly one ok, others replayed', async () => {
+    // Variant of the same-nonce concurrency test, but this time the row
+    // already exists and is expired. Both the InMemory and Postgres stores
+    // must serialize the recycle so only one caller observes the fresh
+    // registration.
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_650;
+
+    await store.insert('kid-A', 'https://seller/op', 'recycle-race', 30, now);
+
+    // 10 concurrent attempts to register the same nonce, all at a time
+    // past the original entry's expiry.
+    const recycleAt = now + 60;
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => store.insert('kid-A', 'https://seller/op', 'recycle-race', 30, recycleAt))
+    );
+
+    const okCount = results.filter(r => r === 'ok').length;
+    const replayedCount = results.filter(r => r === 'replayed').length;
+    assert.strictEqual(okCount, 1, 'exactly one concurrent recycle wins');
+    assert.strictEqual(replayedCount, 9, 'losers report replayed');
+  });
+
   test('isCapHit reflects active count vs configured cap', async () => {
     const store = new PostgresReplayStore(pool, { cap: 2 });
     const now = 1_700_000_600;
@@ -164,6 +207,22 @@ describe('PostgresReplayStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' 
     assert.strictEqual(await store.has('kid-A', 'https://seller/op', 'long-lived', now + 60), true);
   });
 
+  test('sweepExpiredReplays with batchSize larger than expired count returns actual count', async () => {
+    const store = new PostgresReplayStore(pool);
+    const now = 1_700_000_750;
+
+    await store.insert('kid-A', 'https://seller/op', 'short-1', 30, now);
+    await store.insert('kid-A', 'https://seller/op', 'short-2', 30, now);
+    await store.insert('kid-A', 'https://seller/op', 'long', 600, now);
+
+    // batchSize 100, but only 2 are expired at the sweep time.
+    const { deleted } = await sweepExpiredReplays(pool, { now: now + 60, batchSize: 100 });
+    assert.strictEqual(deleted, 2);
+
+    const remaining = await pool.query(`SELECT count(*)::int AS n FROM ${TABLE}`);
+    assert.strictEqual(remaining.rows[0].n, 1);
+  });
+
   test('sweepExpiredReplays with batchSize bounds work per call', async () => {
     const store = new PostgresReplayStore(pool);
     const now = 1_700_000_800;
@@ -196,6 +255,94 @@ describe('PostgresReplayStore', { skip: !DATABASE_URL && 'DATABASE_URL not set' 
   });
 
   // ====== Wiring with the verifier ======
+
+  test('rejects non-finite or negative `now` / `ttlSeconds` — defense vs PG to_timestamp DoS', async () => {
+    const store = new PostgresReplayStore(pool);
+    await assert.rejects(() => store.insert('kid-A', 'scope', 'n1', 30, Number.NaN), /finite non-negative/);
+    await assert.rejects(
+      () => store.insert('kid-A', 'scope', 'n1', 30, Number.POSITIVE_INFINITY),
+      /finite non-negative/
+    );
+    await assert.rejects(() => store.insert('kid-A', 'scope', 'n1', 30, -1), /finite non-negative/);
+    await assert.rejects(() => store.insert('kid-A', 'scope', 'n1', Number.NaN, 1_700_000_000), /finite non-negative/);
+    await assert.rejects(() => store.has('kid-A', 'scope', 'n1', Number.NaN), /finite non-negative/);
+    await assert.rejects(() => store.isCapHit('kid-A', 'scope', Number.POSITIVE_INFINITY), /finite non-negative/);
+  });
+
+  test('end-to-end rate-abuse: cap hit at the verifier boundary surfaces request_signature_rate_abuse', async () => {
+    const {
+      signRequest,
+      verifyRequestSignature,
+      InMemoryRevocationStore,
+      StaticJwksResolver,
+      RequestSignatureError,
+    } = require('../../dist/lib/signing/index.js');
+    const { readFileSync } = require('node:fs');
+    const path = require('node:path');
+
+    const KEYS_PATH = path.join(
+      __dirname,
+      '..',
+      '..',
+      'compliance',
+      'cache',
+      'latest',
+      'test-vectors',
+      'request-signing',
+      'keys.json'
+    );
+    const keys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys;
+    const ed = keys.find(k => k.kid === 'test-ed25519-2026');
+    const privateJwk = { ...ed, d: ed._private_d_for_test_only };
+    delete privateJwk._private_d_for_test_only;
+    const publicJwk = { ...ed };
+    delete publicJwk._private_d_for_test_only;
+
+    // Cap of 2 — third unique signed request should be rejected as rate_abuse,
+    // exercising the same rejection path the conformance vector
+    // `negative/020-rate-abuse.json` covers.
+    const replayStore = new PostgresReplayStore(pool, { cap: 2 });
+    const revocationStore = new InMemoryRevocationStore();
+    const jwks = new StaticJwksResolver([publicJwk]);
+    const capability = {
+      supported: true,
+      covers_content_digest: 'either',
+      required_for: ['create_media_buy'],
+    };
+    const now = 1_700_001_500;
+    const baseRequest = {
+      method: 'POST',
+      url: 'https://seller.example.com/adcp/create_media_buy',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ plan_id: 'p1' }),
+    };
+
+    const signWithNonce = nonce =>
+      signRequest(
+        baseRequest,
+        { keyid: 'test-ed25519-2026', alg: 'ed25519', privateKey: privateJwk },
+        { now: () => now, nonce }
+      );
+
+    for (const nonce of ['rate-test-1', 'rate-test-2']) {
+      const signed = signWithNonce(nonce);
+      const result = await verifyRequestSignature(
+        { ...baseRequest, headers: signed.headers },
+        { capability, jwks, replayStore, revocationStore, operation: 'create_media_buy', now: () => now }
+      );
+      assert.strictEqual(result.status, 'verified');
+    }
+
+    const signed = signWithNonce('rate-test-3');
+    await assert.rejects(
+      () =>
+        verifyRequestSignature(
+          { ...baseRequest, headers: signed.headers },
+          { capability, jwks, replayStore, revocationStore, operation: 'create_media_buy', now: () => now }
+        ),
+      err => err instanceof RequestSignatureError && err.code === 'request_signature_rate_abuse'
+    );
+  });
 
   test('end-to-end: signed request → verifier with PostgresReplayStore → second attempt rejected as replay', async () => {
     const {


### PR DESCRIPTION
## Summary

Adds a Postgres-backed `ReplayStore` so multi-instance verifier deployments share replay-protection state. Closes #1015.

The default `InMemoryReplayStore` is per-process. On a fleet, an attacker who captures a signed request can replay it against a sibling instance whose cache hasn't seen the nonce — RFC 9421's 5-minute expiry bounds the window but that's plenty of time for an in-flight replay. `PostgresReplayStore` closes the hole using a `(keyid, scope, nonce)` primary key the verifier checks on every signed request.

**This PR's changeset accumulates into Release PR #1014, which currently bumps to 5.20.0 from #1017.** Merging this lands the work on `main`; nothing publishes to npm until you merge the Release PR.

## What's worth a second pair of eyes

### 1. The single-statement insert handles replay → cap → insert atomically

`src/lib/signing/postgres-replay-store.ts:148` — one CTE that:
- Returns `'replayed'` if an unexpired row already exists for `(keyid, scope, nonce)`
- Returns `'rate_abuse'` if the active count for `(keyid, scope)` is at the cap
- Otherwise inserts (or refreshes an expired row in place) and returns `'ok'`
- Falls through to `'replayed'` on the concurrent-same-nonce loser branch

Result precedence matches `InMemoryReplayStore`: replay > rate_abuse > ok.

### 2. Expired-row recycling — the bug I caught with the integration test

The first version of the SQL used `ON CONFLICT DO NOTHING` and inferred `'replayed'` from an empty `RETURNING`. That broke the "previously-expired same-nonce" case: the row was still on disk (sweeper hadn't run), `ON CONFLICT` fired, `RETURNING` was empty, adapter returned `'replayed'` — but the InMemory store returns `'ok'` for that case (it prunes-then-checks). Switched to `ON CONFLICT DO UPDATE WHERE existing-is-expired`, which refreshes the row in place when its previous TTL has elapsed. Now both stores agree.

### 3. Sweeper is an exported helper, not a background timer

`sweepExpiredReplays(pool, options?)` is exported and callers schedule it themselves (cron, app timer, `pg_cron`, etc.). Deliberately avoiding a constructor-injected timer — those surprise people in tests and serverless. Doc shows three ways to schedule.

### 4. Reuses `PgQueryable` structural type

Imports from `src/lib/server/postgres-task-store.ts` so the SDK stays free of a hard `pg` dependency. Matches the `PostgresTaskStore` / `PostgresStateStore` pattern already in the codebase.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build:lib` — clean
- [x] 13 new integration tests in `test/lib/postgres-replay-store.test.js` (run with `DATABASE_URL=postgres://...`):
  - Default migration + custom table names + SQL-injection-shaped name rejection
  - First insert `'ok'`, second insert same nonce `'replayed'`
  - `(keyid, scope)` partitioning — same nonce on different scopes is not a replay
  - TTL boundary respected by `has()` and by `insert()` (expired same-nonce recycles correctly)
  - Cap precedence: replay > rate_abuse > ok
  - `isCapHit` reflects active count vs cap; expires-out properly
  - Sweeper: full sweep + batched sweep
  - Concurrency: 10 parallel same-nonce inserts produce exactly 1 `'ok'` and 9 `'replayed'`
  - E2E: signed request → verifier wired with `PostgresReplayStore` → first request verifies, second is rejected as `request_signature_replayed`
- [x] All existing 175 signing tests still pass — no regressions

## Deferred follow-ups

- Redis adapter (`@upstash/redis` or `ioredis`-shaped) as a sibling example — pattern is identical, no SDK interface change.
- `pg_cron` schema helper for users who'd rather have Postgres run the sweep — small follow-up doc, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)