### PR TITLE
feat(testing): adcp grade signer — validate a signer before going live

### DIFF
--- a/.changeset/signer-conformance-grader.md
+++ b/.changeset/signer-conformance-grader.md
@@ -1,0 +1,18 @@
+---
+"@adcp/client": minor
+---
+
+feat(testing): `adcp grade signer` — validate a signer end-to-end before going live
+
+Adds a CLI grader and matching library function that exercises a signer (typically KMS-backed) end-to-end: produces a sample signed AdCP request through the operator's signer, then verifies the result against the operator's published JWKS via the SDK's RFC 9421 verifier. Pass means a counterparty verifier will accept your signatures; fail produces a specific `error_code` + step matching the verifier-checklist semantics, so DER-vs-P1363 / kid-mismatch / wrong-key / algorithm-mismatch each surface as a distinct diagnostic instead of the generic `request_signature_invalid` you'd see in the seller's monitoring after pushing live traffic.
+
+Two signer-source modes:
+
+- `--key-file <path>` — local JWK file. Easy path for local dev / non-KMS testing.
+- `--signer-url <url>` — HTTP signing oracle for KMS-backed signers. Wire contract is intentionally minimal — `POST {payload_b64, kid, alg}` returns `{signature_b64}` (raw wire-format bytes, not DER) — so any KMS adapter can put a small handler in front of `provider.sign()` for grading without exposing the underlying KMS to the grader.
+
+Programmatic API: `gradeSigner(options)` exported from `@adcp/client/testing/storyboard/signer-grader`. Returns a `SignerGradeReport` with `passed`, `step.{status,error_code,diagnostic}`, the JWKS URI it resolved against, and the sample request the signer produced headers for (useful for operator-side diagnostics).
+
+Pairs with the `SigningProvider` abstraction (also in 5.20.0) — that release added the surface for KMS-backed signing; this one closes the loop by giving operators a way to validate their adapter before going live.
+
+Closes #610.

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -75,6 +75,14 @@ Required:
 Options:
   --operation <name>         AdCP operation in the sample request body.
                              Default: \`create_media_buy\`.
+  --covers-content-digest    Content-digest policy your verifier advertises
+    <required|forbidden|either>
+                             (\`request_signing.covers_content_digest\`).
+                             Default: \`required\` — recommended posture for
+                             spend-committing operations. A signer that
+                             skips \`Content-Digest\` against \`required\`
+                             surfaces here as step 6
+                             \`request_signature_components_incomplete\`.
   --signer-auth <header>     Authorization header attached to --signer-url
                              POSTs (e.g. \`Bearer <secret>\`).
   --allow-http               Allow http:// signer / JWKS URLs + private-IP
@@ -255,6 +263,17 @@ async function runSignerGrader(args) {
       case '--operation':
         options.operation = args[++i];
         break;
+      case '--covers-content-digest': {
+        const policy = args[++i];
+        if (policy !== 'required' && policy !== 'forbidden' && policy !== 'either') {
+          console.error(
+            `ERROR: --covers-content-digest must be \"required\", \"forbidden\", or \"either\", got \"${policy}\"\n`
+          );
+          process.exit(2);
+        }
+        options.coversContentDigest = policy;
+        break;
+      }
       case '--allow-http':
         options.allowPrivateIp = true;
         break;
@@ -287,6 +306,15 @@ async function runSignerGrader(args) {
   }
   if (options.keyFilePath && options.signerUrl) {
     errExit('Pass exactly one of --key-file or --signer-url, not both', USAGE_SIGNER);
+  }
+  // Surface the in-process key-file path on stderr so CI logs make the
+  // dev-tool nature of the run visible — operators reviewing the log can
+  // confirm the file isn't checked in / shipped to prod.
+  if (options.keyFilePath) {
+    process.stderr.write(
+      `[adcp grade signer] in-process key loaded from ${options.keyFilePath} — ` +
+        `ensure this file is not checked in or shipped to production.\n`
+    );
   }
 
   try {
@@ -329,15 +357,24 @@ function printSignerReport(report) {
     console.log();
     console.log('Sample request the signer produced headers for:');
     console.log(`  ${report.sample.method} ${report.sample.url}`);
-    if (report.sample.headers['Signature-Input']) {
-      console.log(`  Signature-Input: ${report.sample.headers['Signature-Input']}`);
+    const sigInput = headerCaseInsensitive(report.sample.headers, 'signature-input');
+    if (sigInput) {
+      console.log(`  Signature-Input: ${sigInput}`);
     }
-    if (report.sample.headers['Signature']) {
-      const sig = report.sample.headers['Signature'];
-      console.log(`  Signature: ${sig.length > 100 ? sig.slice(0, 80) + '...' : sig}`);
+    const signature = headerCaseInsensitive(report.sample.headers, 'signature');
+    if (signature) {
+      console.log(`  Signature: ${signature.length > 100 ? signature.slice(0, 80) + '...' : signature}`);
     }
   }
   console.log();
+}
+
+function headerCaseInsensitive(headers, name) {
+  const lower = name.toLowerCase();
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === lower) return headers[key];
+  }
+  return undefined;
 }
 
 function parseVectorList(raw, flagName) {

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 const { gradeRequestSigning } = require('../dist/lib/testing/storyboard/request-signing/index.js');
+const { gradeSigner } = require('../dist/lib/testing/storyboard/signer-grader/index.js');
 
-const USAGE = `Usage: adcp grade request-signing <agent-url> [options]
+const USAGE_REQUEST_SIGNING = `Usage: adcp grade request-signing <agent-url> [options]
 
 Runs the RFC 9421 conformance grader against an agent's request-signing
 verifier. Returns a PASS/FAIL report with per-vector diagnostics.
@@ -45,20 +46,90 @@ Examples:
   adcp grade request-signing https://sandbox.seller.com/adcp --json | jq
 `;
 
+const USAGE_SIGNER = `Usage: adcp grade signer <agent-url> [options]
+
+Grades an AdCP signer end-to-end: produces a sample signed request through
+your signer, then verifies it against your agent's published JWKS via the
+SDK's RFC 9421 verifier. Surfaces algorithm-mismatch / kid-mismatch /
+DER-vs-P1363 / wrong-key failures as specific verifier error codes — the
+same codes a real counterparty would reject with — rather than the generic
+\`request_signature_invalid\` you'd see in the seller's monitoring after
+pushing live traffic.
+
+Pick exactly ONE signer source:
+  --key-file <path>          Local JWK file (must include \`d\`). For local
+                             dev / non-KMS testing.
+  --signer-url <url>         HTTP signing oracle for KMS-backed signers.
+                             POSTs JSON {payload_b64, kid, alg}; expects
+                             {signature_b64} back. Lets you grade without
+                             handing the grader your private key.
+
+Required:
+  --kid <id>                 Key identifier the signer asserts in
+                             \`Signature-Input\`. Must match a JWK at the
+                             agent's \`jwks_uri\`.
+  --alg <alg>                Algorithm — \`ed25519\` or \`ecdsa-p256-sha256\`.
+                             Must match \`ALLOWED_ALGS\` and the JWK \`alg\`.
+  --jwks-url <url>           JWKS endpoint to verify against.
+
+Options:
+  --operation <name>         AdCP operation in the sample request body.
+                             Default: \`create_media_buy\`.
+  --signer-auth <header>     Authorization header attached to --signer-url
+                             POSTs (e.g. \`Bearer <secret>\`).
+  --allow-http               Allow http:// signer / JWKS URLs + private-IP
+                             targets (dev only).
+  --timeout <ms>             Per-probe timeout (default 10000).
+  --json                     Emit the report as JSON.
+  -h, --help                 Show this help.
+
+Exit code:
+  0   signer produces valid AdCP signatures (verifier accepted)
+  1   verifier rejected — see error_code / step in the report
+  2   argument / configuration error
+
+Examples:
+  # Grade a KMS-backed signer via a signing oracle
+  adcp grade signer https://addie.example.com \\
+    --signer-url https://signer.internal/sign \\
+    --signer-auth "Bearer \${SIGNER_TOKEN}" \\
+    --kid addie-2026-04 \\
+    --alg ed25519 \\
+    --jwks-url https://addie.example.com/.well-known/jwks.json
+
+  # Grade an in-process signer with a local JWK
+  adcp grade signer https://agent.example.com \\
+    --key-file ./signing-key.jwk \\
+    --kid my-agent-2026 \\
+    --alg ed25519 \\
+    --jwks-url https://agent.example.com/.well-known/jwks.json
+`;
+
 async function handleGradeCommand(argv) {
   if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h') {
-    process.stdout.write(USAGE);
+    process.stdout.write(USAGE_REQUEST_SIGNING);
+    process.stdout.write('\n');
+    process.stdout.write(USAGE_SIGNER);
     return;
   }
-  if (argv[0] !== 'request-signing') {
-    console.error(`Unknown grade subject: ${argv[0]}\n`);
-    process.stderr.write(USAGE);
-    process.exit(2);
+  const subject = argv[0];
+  if (subject === 'request-signing') {
+    return await runRequestSigningGrader(argv.slice(1));
   }
-  const args = argv.slice(1);
+  if (subject === 'signer') {
+    return await runSignerGrader(argv.slice(1));
+  }
+  console.error(`Unknown grade subject: ${subject}\n`);
+  process.stderr.write(USAGE_REQUEST_SIGNING);
+  process.stderr.write('\n');
+  process.stderr.write(USAGE_SIGNER);
+  process.exit(2);
+}
+
+async function runRequestSigningGrader(args) {
   if (args.length === 0 || args[0].startsWith('-')) {
     console.error('ERROR: agent URL is required\n');
-    process.stderr.write(USAGE);
+    process.stderr.write(USAGE_REQUEST_SIGNING);
     process.exit(2);
   }
 
@@ -112,11 +183,11 @@ async function handleGradeCommand(argv) {
         break;
       case '-h':
       case '--help':
-        process.stdout.write(USAGE);
+        process.stdout.write(USAGE_REQUEST_SIGNING);
         return;
       default:
         console.error(`Unknown flag: ${a}\n`);
-        process.stderr.write(USAGE);
+        process.stderr.write(USAGE_REQUEST_SIGNING);
         process.exit(2);
     }
   }
@@ -133,6 +204,140 @@ async function handleGradeCommand(argv) {
     console.error(`grade-request-signing failed: ${err instanceof Error ? err.message : String(err)}`);
     process.exit(2);
   }
+}
+
+async function runSignerGrader(args) {
+  if (args.length === 0) {
+    console.error('ERROR: agent URL is required\n');
+    process.stderr.write(USAGE_SIGNER);
+    process.exit(2);
+  }
+  if (args[0] === '-h' || args[0] === '--help') {
+    process.stdout.write(USAGE_SIGNER);
+    return;
+  }
+  if (args[0].startsWith('-')) {
+    console.error('ERROR: agent URL is required (must come before flags)\n');
+    process.stderr.write(USAGE_SIGNER);
+    process.exit(2);
+  }
+  const agentUrl = args[0];
+  const options = { agentUrl };
+  let emitJson = false;
+
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    switch (a) {
+      case '--key-file':
+        options.keyFilePath = args[++i];
+        break;
+      case '--signer-url':
+        options.signerUrl = args[++i];
+        break;
+      case '--signer-auth':
+        options.signerAuth = args[++i];
+        break;
+      case '--kid':
+        options.kid = args[++i];
+        break;
+      case '--alg': {
+        const alg = args[++i];
+        if (alg !== 'ed25519' && alg !== 'ecdsa-p256-sha256') {
+          console.error(`ERROR: --alg must be \"ed25519\" or \"ecdsa-p256-sha256\", got \"${alg}\"\n`);
+          process.exit(2);
+        }
+        options.algorithm = alg;
+        break;
+      }
+      case '--jwks-url':
+        options.jwksUrl = args[++i];
+        break;
+      case '--operation':
+        options.operation = args[++i];
+        break;
+      case '--allow-http':
+        options.allowPrivateIp = true;
+        break;
+      case '--timeout':
+        options.timeoutMs = Number.parseInt(args[++i], 10);
+        if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1) {
+          console.error('ERROR: --timeout requires a positive integer (ms)\n');
+          process.exit(2);
+        }
+        break;
+      case '--json':
+        emitJson = true;
+        break;
+      case '-h':
+      case '--help':
+        process.stdout.write(USAGE_SIGNER);
+        return;
+      default:
+        console.error(`Unknown flag: ${a}\n`);
+        process.stderr.write(USAGE_SIGNER);
+        process.exit(2);
+    }
+  }
+
+  if (!options.kid) errExit('--kid is required', USAGE_SIGNER);
+  if (!options.algorithm) errExit('--alg is required', USAGE_SIGNER);
+  if (!options.jwksUrl) errExit('--jwks-url is required', USAGE_SIGNER);
+  if (!options.keyFilePath && !options.signerUrl) {
+    errExit('Pass exactly one of --key-file or --signer-url', USAGE_SIGNER);
+  }
+  if (options.keyFilePath && options.signerUrl) {
+    errExit('Pass exactly one of --key-file or --signer-url, not both', USAGE_SIGNER);
+  }
+
+  try {
+    const report = await gradeSigner(options);
+    if (emitJson) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    } else {
+      printSignerReport(report);
+    }
+    process.exit(report.passed ? 0 : 1);
+  } catch (err) {
+    console.error(`grade-signer failed: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(2);
+  }
+}
+
+function errExit(message, usage) {
+  console.error(`ERROR: ${message}\n`);
+  process.stderr.write(usage);
+  process.exit(2);
+}
+
+function printSignerReport(report) {
+  console.log();
+  console.log(`Agent:     ${report.agent_url}`);
+  console.log(`JWKS:      ${report.jwks_uri}`);
+  console.log(`kid:       ${report.kid}`);
+  console.log(`algorithm: ${report.algorithm}`);
+  console.log(`duration:  ${report.duration_ms}ms`);
+  console.log();
+  const status = report.step.status === 'pass' ? 'PASS' : 'FAIL';
+  console.log(`Result: ${status}`);
+  if (report.step.error_code) {
+    console.log(`  error_code: ${report.step.error_code}`);
+  }
+  if (report.step.diagnostic) {
+    console.log(`  diagnostic: ${report.step.diagnostic}`);
+  }
+  if (!report.passed) {
+    console.log();
+    console.log('Sample request the signer produced headers for:');
+    console.log(`  ${report.sample.method} ${report.sample.url}`);
+    if (report.sample.headers['Signature-Input']) {
+      console.log(`  Signature-Input: ${report.sample.headers['Signature-Input']}`);
+    }
+    if (report.sample.headers['Signature']) {
+      const sig = report.sample.headers['Signature'];
+      console.log(`  Signature: ${sig.length > 100 ? sig.slice(0, 80) + '...' : sig}`);
+    }
+  }
+  console.log();
 }
 
 function parseVectorList(raw, flagName) {

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -315,6 +315,26 @@ const provider = new InMemorySigningProvider({
 
 The constructor refuses to instantiate when `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set explicitly — defense-in-depth so a copy-paste from a test file doesn't accidentally ship to prod. The gate is a self-discipline aid for the bundled implementation; the SDK can't enforce hygiene on third-party providers.
 
+### Validating a signer before going live — `adcp grade signer`
+
+Before pushing live signed traffic from a KMS-backed signer, exercise the full signing path through the SDK's verifier so misconfigurations surface as specific RFC 9421 error codes (the same codes a counterparty would reject with) rather than the generic `request_signature_invalid` you'd see in the seller's monitoring after the fact.
+
+```bash
+# KMS-backed signer via an HTTPS signing oracle (no private key handed to the CLI):
+adcp grade signer https://addie.example.com \
+  --signer-url https://signer.internal/sign \
+  --signer-auth "Bearer ${SIGNER_TOKEN}" \
+  --kid addie-2026-04 \
+  --alg ed25519 \
+  --jwks-url https://addie.example.com/.well-known/jwks.json
+```
+
+The grader produces a sample signed AdCP request through your signer, then verifies it against your published JWKS. PASS means a counterparty verifier will accept your signatures. FAIL produces a specific `error_code` and `step` matching the verifier-checklist semantics, so DER-vs-P1363 / kid-mismatch / wrong-key / algorithm-mismatch each surface as a distinct diagnostic.
+
+The signing-oracle protocol is intentionally minimal — `POST {payload_b64, kid, alg}` returns `{signature_b64}` — so any KMS adapter can put a small handler in front of `provider.sign()` for grading without exposing the underlying KMS.
+
+For local dev / non-KMS testing, `--key-file <jwk-path>` accepts an in-process JWK directly. Same grader, same report.
+
 ## Step 4: Verify Inbound Signatures (Seller)
 
 ### Express middleware

--- a/src/lib/testing/storyboard/signer-grader/grader.ts
+++ b/src/lib/testing/storyboard/signer-grader/grader.ts
@@ -1,0 +1,296 @@
+import { readFile } from 'node:fs/promises';
+import { createPrivateKey, sign as nodeSign, type JsonWebKey } from 'node:crypto';
+import {
+  HttpsJwksResolver,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+  RequestSignatureError,
+  signRequestAsync,
+  verifyRequestSignature,
+  type AdcpJsonWebKey,
+  type AdcpSignAlg,
+  type JwksResolver,
+  type SigningProvider,
+} from '../../../signing';
+import type { SignerGradeReport, SignerGradeStep } from './types';
+
+export interface GradeSignerOptions {
+  /** Agent URL of the signer being graded — used as `agent_url` in the report and as the host for the sample signed request. */
+  agentUrl: string;
+  /** `kid` the signer advertises in `Signature-Input`. Must match a JWK at the agent's `jwks_uri`. */
+  kid: string;
+  /** Algorithm the signer advertises. Must match `ALLOWED_ALGS` and the JWK's `alg`. */
+  algorithm: AdcpSignAlg;
+  /**
+   * Local JWK file (must include the private scalar `d`). Pick this OR
+   * `signerUrl` — the grader produces a `SigningProvider` from whichever
+   * is set.
+   */
+  keyFilePath?: string;
+  /**
+   * HTTP signing-oracle endpoint for KMS-backed signers. The grader POSTs
+   * `{ payload_b64, kid, alg }` and expects `{ signature_b64 }` back. The
+   * payload is the canonical RFC 9421 signature base; the response is raw
+   * wire-format signature bytes (Ed25519: 64-byte raw; ECDSA-P256:
+   * 64-byte `r‖s` IEEE P1363, NOT DER).
+   */
+  signerUrl?: string;
+  /** Optional `Authorization` header for the signer-url POSTs. */
+  signerAuth?: string;
+  /** JWKS endpoint to verify against. Required (no brand.json discovery in v1). */
+  jwksUrl: string;
+  /** AdCP operation to embed in the sample request body. Defaults to `create_media_buy`. */
+  operation?: string;
+  /** Allow http:// signer / JWKS URLs for development. Off by default. */
+  allowPrivateIp?: boolean;
+  /** Per-probe timeout. Defaults to 10000 ms. */
+  timeoutMs?: number;
+}
+
+/**
+ * Grade a signer end-to-end: produce a sample signed AdCP request through
+ * the operator's signer, verify the signature against the JWKS the
+ * operator publishes, report verifier-pipeline results step-by-step.
+ *
+ * Useful before pushing live signed traffic from a KMS-backed signer —
+ * surfaces algorithm-mismatch / kid-mismatch / DER-vs-P1363 / wrong-key
+ * failures as specific verifier error codes (the same codes a real
+ * counterparty would reject with), rather than a generic
+ * `request_signature_invalid` from the seller's monitoring.
+ */
+export async function gradeSigner(options: GradeSignerOptions): Promise<SignerGradeReport> {
+  const start = Date.now();
+  const operation = options.operation ?? 'create_media_buy';
+  const sampleUrl = new URL(`/adcp/${operation}`, options.agentUrl).toString();
+  const sampleBody = JSON.stringify({ probe: 'adcp-signer-grade', operation });
+  const sample = {
+    method: 'POST',
+    url: sampleUrl,
+    body: sampleBody,
+    headers: {} as Record<string, string>,
+  };
+
+  let provider: SigningProvider;
+  try {
+    provider = await buildProviderFromOptions(options);
+  } catch (err) {
+    return failReport(options, sample, start, {
+      status: 'fail',
+      error_code: 'signer_setup_failed',
+      diagnostic: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Sign a sample request with the user's signer. Wire format is the
+  // verifier's only contact surface — if this step throws, the user's
+  // signer raised before producing a signature (e.g., KMS auth failure,
+  // network timeout).
+  let signed;
+  try {
+    signed = await signRequestAsync(
+      { method: 'POST', url: sampleUrl, headers: { 'Content-Type': 'application/json' }, body: sampleBody },
+      provider
+    );
+  } catch (err) {
+    return failReport(options, sample, start, {
+      status: 'fail',
+      error_code: 'signer_invocation_failed',
+      diagnostic: err instanceof Error ? err.message : String(err),
+    });
+  }
+  sample.headers = signed.headers;
+
+  // Verify against the user's JWKS. The verifier returns step + code on
+  // failure; pass that straight through to the report so the operator
+  // sees exactly which spec check rejected.
+  const jwks = buildJwksResolver(options);
+  const replayStore = new InMemoryReplayStore();
+  const revocationStore = new InMemoryRevocationStore();
+  const verifyRequest = {
+    method: sample.method,
+    url: sample.url,
+    headers: signed.headers,
+    body: sample.body,
+  };
+
+  let step: SignerGradeStep;
+  try {
+    const result = await verifyRequestSignature(verifyRequest, {
+      capability: { supported: true, covers_content_digest: 'either', required_for: [operation] },
+      jwks,
+      replayStore,
+      revocationStore,
+      operation,
+    });
+    if (result.status === 'verified') {
+      step = { status: 'pass', diagnostic: 'Signature verified end-to-end against JWKS.' };
+    } else {
+      step = {
+        status: 'fail',
+        error_code: 'verifier_returned_unsigned',
+        diagnostic: 'Verifier reported `unsigned` — signer produced no signature headers.',
+      };
+    }
+  } catch (err) {
+    if (err instanceof RequestSignatureError) {
+      step = {
+        status: 'fail',
+        error_code: err.code,
+        diagnostic: `step ${err.failedStep}: ${err.message}`,
+      };
+    } else {
+      step = {
+        status: 'fail',
+        error_code: 'verifier_threw_unexpected',
+        diagnostic: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  return {
+    agent_url: options.agentUrl,
+    jwks_uri: options.jwksUrl,
+    kid: options.kid,
+    algorithm: options.algorithm,
+    duration_ms: Date.now() - start,
+    passed: step.status === 'pass',
+    step,
+    sample,
+  };
+}
+
+function failReport(
+  options: GradeSignerOptions,
+  sample: SignerGradeReport['sample'],
+  start: number,
+  step: SignerGradeStep
+): SignerGradeReport {
+  return {
+    agent_url: options.agentUrl,
+    jwks_uri: options.jwksUrl,
+    kid: options.kid,
+    algorithm: options.algorithm,
+    duration_ms: Date.now() - start,
+    passed: false,
+    step,
+    sample,
+  };
+}
+
+async function buildProviderFromOptions(options: GradeSignerOptions): Promise<SigningProvider> {
+  const hasKey = options.keyFilePath !== undefined;
+  const hasUrl = options.signerUrl !== undefined;
+  if (hasKey === hasUrl) {
+    throw new Error('gradeSigner: pass exactly one of keyFilePath or signerUrl');
+  }
+  if (hasKey) {
+    return await keyFileProvider(options.keyFilePath as string, options.kid, options.algorithm);
+  }
+  return httpOracleProvider({
+    url: options.signerUrl as string,
+    authorization: options.signerAuth,
+    kid: options.kid,
+    algorithm: options.algorithm,
+    timeoutMs: options.timeoutMs ?? 10_000,
+  });
+}
+
+async function keyFileProvider(filePath: string, kid: string, algorithm: AdcpSignAlg): Promise<SigningProvider> {
+  const raw = await readFile(filePath, 'utf8');
+  let jwk: AdcpJsonWebKey;
+  try {
+    jwk = JSON.parse(raw);
+  } catch {
+    throw new Error(`gradeSigner: --key-file ${filePath} is not valid JSON`);
+  }
+  if (!jwk.d) {
+    throw new Error(`gradeSigner: --key-file ${filePath} is missing the private scalar 'd'`);
+  }
+  // Build a minimal in-process SigningProvider directly. We can't use
+  // InMemorySigningProvider here because its production-NODE_ENV gate
+  // would refuse to construct in a CI environment running the grader.
+  // The grader is dev / pre-deployment tooling; bypass the gate
+  // intentionally with a clear note.
+  return {
+    keyid: kid,
+    algorithm,
+    fingerprint: `key-file:${kid}`,
+    async sign(payload: Uint8Array): Promise<Uint8Array> {
+      const privateKey = createPrivateKey({ key: jwk as JsonWebKey, format: 'jwk' });
+      const data = Buffer.from(payload);
+      if (algorithm === 'ed25519') {
+        return new Uint8Array(nodeSign(null, data, privateKey));
+      }
+      return new Uint8Array(nodeSign('sha256', data, { key: privateKey, dsaEncoding: 'ieee-p1363' }));
+    },
+  };
+}
+
+interface HttpOracleOptions {
+  url: string;
+  authorization?: string;
+  kid: string;
+  algorithm: AdcpSignAlg;
+  timeoutMs: number;
+}
+
+/**
+ * SigningProvider that delegates `sign(payload)` to an HTTP signing
+ * oracle. The oracle protocol is intentionally minimal — bytes in,
+ * bytes out — so any KMS-backed signer can put it in front of
+ * `provider.sign()` without exposing the underlying KMS to the grader.
+ *
+ * Wire contract:
+ *   POST <url>
+ *     Content-Type: application/json
+ *     Authorization: <signerAuth?>             // optional shared-secret
+ *     Body: { "payload_b64": "...",
+ *             "kid": "...",
+ *             "alg": "ed25519" | "ecdsa-p256-sha256" }
+ *
+ *   Response:
+ *     200 OK
+ *     Content-Type: application/json
+ *     Body: { "signature_b64": "..." }         // raw wire-format bytes
+ */
+function httpOracleProvider(options: HttpOracleOptions): SigningProvider {
+  return {
+    keyid: options.kid,
+    algorithm: options.algorithm,
+    fingerprint: `oracle:${options.url}#${options.kid}`,
+    async sign(payload: Uint8Array): Promise<Uint8Array> {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+      try {
+        const headers: Record<string, string> = { 'content-type': 'application/json' };
+        if (options.authorization) headers.authorization = options.authorization;
+        const response = await fetch(options.url, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            payload_b64: Buffer.from(payload).toString('base64'),
+            kid: options.kid,
+            alg: options.algorithm,
+          }),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`signing oracle ${options.url} responded ${response.status} ${response.statusText}`);
+        }
+        const body = (await response.json()) as { signature_b64?: unknown };
+        if (typeof body.signature_b64 !== 'string') {
+          throw new Error(`signing oracle response missing 'signature_b64' string field`);
+        }
+        return new Uint8Array(Buffer.from(body.signature_b64, 'base64'));
+      } finally {
+        clearTimeout(timer);
+      }
+    },
+  };
+}
+
+function buildJwksResolver(options: GradeSignerOptions): JwksResolver {
+  return new HttpsJwksResolver(options.jwksUrl, {
+    allowPrivateIp: options.allowPrivateIp ?? false,
+  });
+}

--- a/src/lib/testing/storyboard/signer-grader/grader.ts
+++ b/src/lib/testing/storyboard/signer-grader/grader.ts
@@ -9,9 +9,11 @@ import {
   verifyRequestSignature,
   type AdcpJsonWebKey,
   type AdcpSignAlg,
+  type ContentDigestPolicy,
   type JwksResolver,
   type SigningProvider,
 } from '../../../signing';
+import { ssrfSafeFetch } from '../../../net/ssrf-fetch';
 import type { SignerGradeReport, SignerGradeStep } from './types';
 
 export interface GradeSignerOptions {
@@ -41,6 +43,15 @@ export interface GradeSignerOptions {
   jwksUrl: string;
   /** AdCP operation to embed in the sample request body. Defaults to `create_media_buy`. */
   operation?: string;
+  /**
+   * Content-digest policy the operator's verifier advertises. The grader
+   * exercises the same policy locally so a signer that fails to emit
+   * `Content-Digest` against a `'required'` policy surfaces here as
+   * `request_signature_components_incomplete` (step 6) — the same code a
+   * real counterparty would reject with. Defaults to `'required'`, which
+   * is the recommended posture for spend-committing operations.
+   */
+  coversContentDigest?: ContentDigestPolicy;
   /** Allow http:// signer / JWKS URLs for development. Off by default. */
   allowPrivateIp?: boolean;
   /** Per-probe timeout. Defaults to 10000 ms. */
@@ -61,6 +72,7 @@ export interface GradeSignerOptions {
 export async function gradeSigner(options: GradeSignerOptions): Promise<SignerGradeReport> {
   const start = Date.now();
   const operation = options.operation ?? 'create_media_buy';
+  const coversContentDigest = options.coversContentDigest ?? 'required';
   const sampleUrl = new URL(`/adcp/${operation}`, options.agentUrl).toString();
   const sampleBody = JSON.stringify({ probe: 'adcp-signer-grade', operation });
   const sample = {
@@ -84,12 +96,17 @@ export async function gradeSigner(options: GradeSignerOptions): Promise<SignerGr
   // Sign a sample request with the user's signer. Wire format is the
   // verifier's only contact surface — if this step throws, the user's
   // signer raised before producing a signature (e.g., KMS auth failure,
-  // network timeout).
+  // network timeout). When `coversContentDigest === 'required'` the signer
+  // must emit a `Content-Digest` header; the verifier then exercises step
+  // 11 (digest recompute) end-to-end.
   let signed;
   try {
     signed = await signRequestAsync(
       { method: 'POST', url: sampleUrl, headers: { 'Content-Type': 'application/json' }, body: sampleBody },
-      provider
+      provider,
+      // Cover Content-Digest unless the operator's policy is `'forbidden'`,
+      // matching `resolveCoverContentDigest`'s posture at the agent layer.
+      { coverContentDigest: coversContentDigest !== 'forbidden' }
     );
   } catch (err) {
     return failReport(options, sample, start, {
@@ -102,7 +119,9 @@ export async function gradeSigner(options: GradeSignerOptions): Promise<SignerGr
 
   // Verify against the user's JWKS. The verifier returns step + code on
   // failure; pass that straight through to the report so the operator
-  // sees exactly which spec check rejected.
+  // sees exactly which spec check rejected. The capability passed here is
+  // the operator's (not a permissive default) so digest-policy
+  // misconfigurations surface as step 6 rejections.
   const jwks = buildJwksResolver(options);
   const replayStore = new InMemoryReplayStore();
   const revocationStore = new InMemoryRevocationStore();
@@ -116,27 +135,28 @@ export async function gradeSigner(options: GradeSignerOptions): Promise<SignerGr
   let step: SignerGradeStep;
   try {
     const result = await verifyRequestSignature(verifyRequest, {
-      capability: { supported: true, covers_content_digest: 'either', required_for: [operation] },
+      capability: { supported: true, covers_content_digest: coversContentDigest, required_for: [operation] },
       jwks,
       replayStore,
       revocationStore,
       operation,
     });
-    if (result.status === 'verified') {
-      step = { status: 'pass', diagnostic: 'Signature verified end-to-end against JWKS.' };
-    } else {
-      step = {
-        status: 'fail',
-        error_code: 'verifier_returned_unsigned',
-        diagnostic: 'Verifier reported `unsigned` — signer produced no signature headers.',
-      };
+    if (result.status !== 'verified') {
+      // Defensive — `signRequestAsync` always emits `Signature` /
+      // `Signature-Input` so a successful sign-then-verify can't reach
+      // here. Throw rather than silently report a custom code so an SDK
+      // bug that produces empty headers surfaces loudly.
+      throw new Error(
+        `gradeSigner internal: verifier returned status='${result.status}' on a freshly-signed request — likely SDK bug`
+      );
     }
+    step = { status: 'pass', diagnostic: 'Signature verified end-to-end against JWKS.' };
   } catch (err) {
     if (err instanceof RequestSignatureError) {
       step = {
         status: 'fail',
         error_code: err.code,
-        diagnostic: `step ${err.failedStep}: ${err.message}`,
+        diagnostic: buildVerifierDiagnostic(err, options.algorithm),
       };
     } else {
       step = {
@@ -157,6 +177,27 @@ export async function gradeSigner(options: GradeSignerOptions): Promise<SignerGr
     step,
     sample,
   };
+}
+
+/**
+ * Layer a hint on top of the verifier's raw error message for the
+ * common KMS-adapter misconfigurations operators hit. Today the only
+ * one with a unique signature is DER-vs-P1363 for ECDSA — the verifier
+ * surfaces it as the generic `request_signature_invalid` at step 10,
+ * but the most likely cause is a KMS adapter that didn't run output
+ * through `derEcdsaToP1363`. Surfacing this inline is cheap and saves
+ * an operator a debugging cycle.
+ */
+function buildVerifierDiagnostic(err: RequestSignatureError, algorithm: AdcpSignAlg): string {
+  const base = `step ${err.failedStep}: ${err.message}`;
+  if (err.code === 'request_signature_invalid' && algorithm === 'ecdsa-p256-sha256') {
+    return (
+      `${base}\n  Common cause: signing oracle returned a DER-encoded signature.` +
+      ` AdCP / RFC 9421 §3.3.1 require raw r‖s (IEEE P1363, 64 bytes for P-256).` +
+      ` See \`derEcdsaToP1363\` in @adcp/client/signing.`
+    );
+  }
+  return base;
 }
 
 function failReport(
@@ -181,7 +222,7 @@ async function buildProviderFromOptions(options: GradeSignerOptions): Promise<Si
   const hasKey = options.keyFilePath !== undefined;
   const hasUrl = options.signerUrl !== undefined;
   if (hasKey === hasUrl) {
-    throw new Error('gradeSigner: pass exactly one of keyFilePath or signerUrl');
+    throw new Error('gradeSigner: pass exactly one of --key-file or --signer-url');
   }
   if (hasKey) {
     return await keyFileProvider(options.keyFilePath as string, options.kid, options.algorithm);
@@ -192,6 +233,7 @@ async function buildProviderFromOptions(options: GradeSignerOptions): Promise<Si
     kid: options.kid,
     algorithm: options.algorithm,
     timeoutMs: options.timeoutMs ?? 10_000,
+    allowPrivateIp: options.allowPrivateIp ?? false,
   });
 }
 
@@ -232,6 +274,7 @@ interface HttpOracleOptions {
   kid: string;
   algorithm: AdcpSignAlg;
   timeoutMs: number;
+  allowPrivateIp: boolean;
 }
 
 /**
@@ -259,32 +302,44 @@ function httpOracleProvider(options: HttpOracleOptions): SigningProvider {
     algorithm: options.algorithm,
     fingerprint: `oracle:${options.url}#${options.kid}`,
     async sign(payload: Uint8Array): Promise<Uint8Array> {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), options.timeoutMs);
-      try {
-        const headers: Record<string, string> = { 'content-type': 'application/json' };
-        if (options.authorization) headers.authorization = options.authorization;
-        const response = await fetch(options.url, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify({
-            payload_b64: Buffer.from(payload).toString('base64'),
-            kid: options.kid,
-            alg: options.algorithm,
-          }),
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`signing oracle ${options.url} responded ${response.status} ${response.statusText}`);
-        }
-        const body = (await response.json()) as { signature_b64?: unknown };
-        if (typeof body.signature_b64 !== 'string') {
-          throw new Error(`signing oracle response missing 'signature_b64' string field`);
-        }
-        return new Uint8Array(Buffer.from(body.signature_b64, 'base64'));
-      } finally {
-        clearTimeout(timer);
+      // Route through `ssrfSafeFetch` so the oracle POST inherits DNS
+      // pinning, IMDS-block, manual-redirect (a hostile or compromised
+      // oracle URL can't 302 the `Authorization: Bearer ...` header to
+      // an attacker-controlled host), and a 64 KiB body cap. Plain
+      // `fetch()` would re-introduce the SSRF / redirect-leak surface
+      // every other counterparty-influenced URL in the SDK already
+      // guards against.
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (options.authorization) headers.authorization = options.authorization;
+      const reqBody = JSON.stringify({
+        payload_b64: Buffer.from(payload).toString('base64'),
+        kid: options.kid,
+        alg: options.algorithm,
+      });
+      const response = await ssrfSafeFetch(options.url, {
+        method: 'POST',
+        headers,
+        body: reqBody,
+        timeoutMs: options.timeoutMs,
+        allowPrivateIp: options.allowPrivateIp,
+      });
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(
+          `signing oracle ${options.url} responded ${response.status} (manual-redirect; not following 3xx)`
+        );
       }
+      let parsed: { signature_b64?: unknown };
+      try {
+        parsed = JSON.parse(Buffer.from(response.body).toString('utf8'));
+      } catch (err) {
+        throw new Error(
+          `signing oracle response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      if (typeof parsed.signature_b64 !== 'string') {
+        throw new Error(`signing oracle response missing 'signature_b64' string field`);
+      }
+      return new Uint8Array(Buffer.from(parsed.signature_b64, 'base64'));
     },
   };
 }

--- a/src/lib/testing/storyboard/signer-grader/index.ts
+++ b/src/lib/testing/storyboard/signer-grader/index.ts
@@ -1,0 +1,2 @@
+export { gradeSigner, type GradeSignerOptions } from './grader';
+export type { SignerGradeReport, SignerGradeStep } from './types';

--- a/src/lib/testing/storyboard/signer-grader/index.ts
+++ b/src/lib/testing/storyboard/signer-grader/index.ts
@@ -1,2 +1,2 @@
 export { gradeSigner, type GradeSignerOptions } from './grader';
-export type { SignerGradeReport, SignerGradeStep } from './types';
+export type { SignerGradeErrorCode, SignerGradeReport, SignerGradeStep, SignerGraderErrorCode } from './types';

--- a/src/lib/testing/storyboard/signer-grader/types.ts
+++ b/src/lib/testing/storyboard/signer-grader/types.ts
@@ -1,4 +1,16 @@
-import type { AdcpSignAlg } from '../../../signing';
+import type { AdcpSignAlg, RequestSignatureErrorCode } from '../../../signing';
+
+/**
+ * Grader-side codes for failures that surface *before* the verifier sees
+ * any bytes — i.e., at signer setup, signer invocation, or the verifier
+ * raising something other than a `RequestSignatureError`. Distinct
+ * namespace from `RequestSignatureErrorCode` so consumers writing
+ * exhaustive `switch` over the union see grader-side and verifier-side
+ * failures as different categories.
+ */
+export type SignerGraderErrorCode = 'signer_setup_failed' | 'signer_invocation_failed' | 'verifier_threw_unexpected';
+
+export type SignerGradeErrorCode = RequestSignatureErrorCode | SignerGraderErrorCode;
 
 /**
  * Per-step result from the verifier pipeline. The signer grader runs a
@@ -9,10 +21,12 @@ import type { AdcpSignAlg } from '../../../signing';
 export interface SignerGradeStep {
   status: 'pass' | 'fail' | 'skipped';
   /**
-   * Verifier-side error code when this step fails (one of
-   * `RequestSignatureErrorCode` — see `errors.ts`). Absent on pass.
+   * Error code when the step fails. Either a verifier-side
+   * `RequestSignatureErrorCode` (signature was produced but rejected)
+   * or a grader-side `SignerGraderErrorCode` (failure before the
+   * verifier saw bytes). Absent on pass.
    */
-  error_code?: string;
+  error_code?: SignerGradeErrorCode;
   /** Human-readable diagnostic; on fail, includes the verifier's message. */
   diagnostic?: string;
 }

--- a/src/lib/testing/storyboard/signer-grader/types.ts
+++ b/src/lib/testing/storyboard/signer-grader/types.ts
@@ -1,0 +1,51 @@
+import type { AdcpSignAlg } from '../../../signing';
+
+/**
+ * Per-step result from the verifier pipeline. The signer grader runs a
+ * sample signed request through the SDK's verifier and reports the outcome
+ * step-by-step (mirroring the verifier-checklist semantics in
+ * `verifier.ts`).
+ */
+export interface SignerGradeStep {
+  status: 'pass' | 'fail' | 'skipped';
+  /**
+   * Verifier-side error code when this step fails (one of
+   * `RequestSignatureErrorCode` — see `errors.ts`). Absent on pass.
+   */
+  error_code?: string;
+  /** Human-readable diagnostic; on fail, includes the verifier's message. */
+  diagnostic?: string;
+}
+
+export interface SignerGradeReport {
+  /** Agent URL identifying which signing identity was graded. */
+  agent_url: string;
+  /** JWKS endpoint the verifier resolved against. */
+  jwks_uri: string;
+  /** `kid` advertised by the signer (matches the wire `Signature-Input`). */
+  kid: string;
+  /** Algorithm advertised by the signer. */
+  algorithm: AdcpSignAlg;
+  /** Total wall-clock duration. */
+  duration_ms: number;
+  /**
+   * Whether the signer produced a valid AdCP RFC 9421 signature that the
+   * SDK verifier accepts. `false` if any step failed.
+   */
+  passed: boolean;
+  /** Granular result for each verifier check. */
+  step: SignerGradeStep;
+  /**
+   * Sample request the grader had the signer produce headers for. Useful
+   * for diagnostics when the verifier rejects — operators can pin down
+   * whether the signer's canonicalization, the JWKS resolution, or the
+   * signature itself is the failure point.
+   */
+  sample: {
+    method: string;
+    url: string;
+    body: string;
+    /** Signer-produced headers (empty object if the signer call itself failed). */
+    headers: Record<string, string>;
+  };
+}

--- a/test/lib/signer-grader.test.js
+++ b/test/lib/signer-grader.test.js
@@ -216,10 +216,7 @@ describe('gradeSigner', () => {
     // ed25519 key that's not in the JWKS. Reuses the gov-signing key from the
     // test vectors.
     const govEd = keysData.keys.find(k => k.adcp_use === 'governance-signing' && k.crv === 'Ed25519');
-    if (!govEd) {
-      // No alternate Ed25519 key in vectors — skip this case.
-      return;
-    }
+    assert.ok(govEd, 'test fixture: governance-signing Ed25519 key required for wrong-key assertion');
     const wrongKey = { ...privateJwkFor(ed), d: govEd._private_d_for_test_only };
     writeFileSync(keyFilePath, JSON.stringify(wrongKey));
 
@@ -261,6 +258,52 @@ describe('gradeSigner', () => {
     });
     assert.strictEqual(report.passed, false);
     assert.strictEqual(report.step.error_code, 'signer_setup_failed');
+  });
+
+  test('default coversContentDigest is required → step 11 (digest recompute) is exercised', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    writeFileSync(keyFilePath, JSON.stringify(privateJwkFor(ed)));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath,
+      jwksUrl,
+      allowPrivateIp: true,
+      // No coversContentDigest passed → defaults to 'required'.
+    });
+    assert.strictEqual(report.passed, true);
+    // With required policy, the signer must emit Content-Digest. Confirm
+    // the header is present in the sample headers we report.
+    const headers = report.sample.headers;
+    const lookup = name => {
+      const k = Object.keys(headers).find(h => h.toLowerCase() === name.toLowerCase());
+      return k ? headers[k] : undefined;
+    };
+    assert.ok(lookup('content-digest'), 'Content-Digest header must be present under coversContentDigest=required');
+    assert.match(lookup('signature-input'), /content-digest/);
+  });
+
+  test('coversContentDigest=forbidden → signer omits Content-Digest', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    writeFileSync(keyFilePath, JSON.stringify(privateJwkFor(ed)));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath,
+      jwksUrl,
+      allowPrivateIp: true,
+      coversContentDigest: 'forbidden',
+    });
+    assert.strictEqual(report.passed, true);
+    const headers = report.sample.headers;
+    const sigInput = Object.entries(headers).find(([k]) => k.toLowerCase() === 'signature-input')?.[1];
+    assert.doesNotMatch(sigInput, /content-digest/);
   });
 
   test('JWKS endpoint unreachable → verifier rejects key_unknown / fetch error', async () => {

--- a/test/lib/signer-grader.test.js
+++ b/test/lib/signer-grader.test.js
@@ -1,0 +1,284 @@
+/**
+ * Signer-grader unit + integration tests.
+ *
+ * The grader produces a sample signed request through the user's signer
+ * (key-file mode or HTTP signing-oracle mode), then verifies the result
+ * against the user's published JWKS via the SDK's RFC 9421 verifier. Tests
+ * cover both signer-source modes and the verifier failure paths a misconfigured
+ * adapter would hit.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { writeFileSync, mkdtempSync } = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { gradeSigner } = require('../../dist/lib/testing/storyboard/signer-grader/index.js');
+
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keysData = JSON.parse(require('node:fs').readFileSync(KEYS_PATH, 'utf8'));
+const ed = keysData.keys.find(k => k.kid === 'test-ed25519-2026');
+const es = keysData.keys.find(k => k.kid === 'test-es256-2026');
+
+function privateJwkFor(entry) {
+  const out = { ...entry, d: entry._private_d_for_test_only };
+  delete out._private_d_for_test_only;
+  return out;
+}
+function publicJwkFor(entry) {
+  const out = { ...entry };
+  delete out._private_d_for_test_only;
+  return out;
+}
+
+function startJwksServer(jwks) {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      if (req.url === '/.well-known/jwks.json') {
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ keys: jwks }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end('not found');
+    });
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function startSigningOracle(privateJwk, algorithm) {
+  // A correct signing oracle: takes payload_b64, signs with the private key,
+  // returns signature_b64 in the wire format the verifier expects.
+  const { createPrivateKey, sign: nodeSign } = require('node:crypto');
+  return new Promise(resolve => {
+    const server = http.createServer(async (req, res) => {
+      let raw = '';
+      req.on('data', chunk => (raw += chunk.toString('utf8')));
+      req.on('end', () => {
+        try {
+          const body = JSON.parse(raw);
+          const payload = Buffer.from(body.payload_b64, 'base64');
+          const pk = createPrivateKey({ key: privateJwk, format: 'jwk' });
+          let signature;
+          if (algorithm === 'ed25519') {
+            signature = nodeSign(null, payload, pk);
+          } else {
+            signature = nodeSign('sha256', payload, { key: pk, dsaEncoding: 'ieee-p1363' });
+          }
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(JSON.stringify({ signature_b64: Buffer.from(signature).toString('base64') }));
+        } catch (err) {
+          res.statusCode = 500;
+          res.end(String(err));
+        }
+      });
+    });
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function port(server) {
+  return server.address().port;
+}
+
+describe('gradeSigner', () => {
+  let jwksServer;
+  let jwksUrl;
+  before(async () => {
+    jwksServer = await startJwksServer([publicJwkFor(ed), publicJwkFor(es)]);
+    jwksUrl = `http://127.0.0.1:${port(jwksServer)}/.well-known/jwks.json`;
+  });
+  after(() => {
+    jwksServer.close();
+  });
+
+  test('key-file mode: Ed25519 signer with matching JWKS → PASS', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    writeFileSync(keyFilePath, JSON.stringify(privateJwkFor(ed)));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent', // arbitrary, only used for sample request URL
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath,
+      jwksUrl,
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, true, JSON.stringify(report.step));
+    assert.strictEqual(report.step.status, 'pass');
+    assert.match(report.sample.headers['Signature-Input'], /keyid="test-ed25519-2026"/);
+  });
+
+  test('key-file mode: ECDSA-P256 signer with matching JWKS → PASS', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    writeFileSync(keyFilePath, JSON.stringify(privateJwkFor(es)));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-es256-2026',
+      algorithm: 'ecdsa-p256-sha256',
+      keyFilePath,
+      jwksUrl,
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, true, JSON.stringify(report.step));
+  });
+
+  test('signer-url mode: matching JWKS → PASS', async () => {
+    const oracle = await startSigningOracle(privateJwkFor(ed), 'ed25519');
+    try {
+      const report = await gradeSigner({
+        agentUrl: 'http://127.0.0.1:9999/agent',
+        kid: 'test-ed25519-2026',
+        algorithm: 'ed25519',
+        signerUrl: `http://127.0.0.1:${port(oracle)}/sign`,
+        jwksUrl,
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(report.passed, true, JSON.stringify(report.step));
+    } finally {
+      oracle.close();
+    }
+  });
+
+  test('signer-url 401 surfaces signer_invocation_failed (not generic verifier failure)', async () => {
+    const server = http.createServer((req, res) => {
+      res.statusCode = 401;
+      res.end('unauthorized');
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    try {
+      const report = await gradeSigner({
+        agentUrl: 'http://127.0.0.1:9999/agent',
+        kid: 'test-ed25519-2026',
+        algorithm: 'ed25519',
+        signerUrl: `http://127.0.0.1:${port(server)}/sign`,
+        jwksUrl,
+        allowPrivateIp: true,
+      });
+      assert.strictEqual(report.passed, false);
+      assert.strictEqual(report.step.error_code, 'signer_invocation_failed');
+      assert.match(report.step.diagnostic, /401/);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('mismatched algorithm advertised vs JWK alg → grader surfaces failure (signer-side or verifier-side)', async () => {
+    // Sign with ed25519 keypair but advertise algorithm: ecdsa-p256-sha256.
+    // This is a common KMS-misconfiguration shape. The in-process signer
+    // refuses (Node throws when ECDSA-shaped sign is asked of an Ed25519
+    // key) → signer_invocation_failed. A KMS-backed signer that happily
+    // signs with whatever it has → verifier rejects post-wire. Both
+    // outcomes are operationally useful — the operator sees the failure
+    // before pushing live traffic.
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    writeFileSync(keyFilePath, JSON.stringify(privateJwkFor(ed)));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ecdsa-p256-sha256', // <-- wrong: this kid is Ed25519
+      keyFilePath,
+      jwksUrl,
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, false);
+    assert.match(
+      report.step.error_code,
+      /signer_invocation_failed|request_signature_(invalid|key_purpose_invalid|alg_not_allowed)/
+    );
+  });
+
+  test('signer signs with wrong key (different `d`) → verifier rejects request_signature_invalid', async () => {
+    // Advertise ed25519 + correct kid, but sign with ES256 private material.
+    // This simulates a KMS adapter pointed at the wrong key version.
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    // Create a frankenstein JWK: kid + alg of ed25519, but `d` from a different
+    // ed25519 key that's not in the JWKS. Reuses the gov-signing key from the
+    // test vectors.
+    const govEd = keysData.keys.find(k => k.adcp_use === 'governance-signing' && k.crv === 'Ed25519');
+    if (!govEd) {
+      // No alternate Ed25519 key in vectors — skip this case.
+      return;
+    }
+    const wrongKey = { ...privateJwkFor(ed), d: govEd._private_d_for_test_only };
+    writeFileSync(keyFilePath, JSON.stringify(wrongKey));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath,
+      jwksUrl,
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, false);
+    assert.match(report.step.error_code, /request_signature_invalid|request_signature_key_unknown/);
+  });
+
+  test('passing both --key-file and --signer-url throws a clear setup error', async () => {
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath: '/nonexistent.jwk',
+      signerUrl: 'http://127.0.0.1:1/sign',
+      jwksUrl,
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, false);
+    assert.strictEqual(report.step.error_code, 'signer_setup_failed');
+    assert.match(report.step.diagnostic, /exactly one/);
+  });
+
+  test('key-file points at a missing path → signer_setup_failed', async () => {
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath: '/definitely/not/a/file.jwk',
+      jwksUrl,
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, false);
+    assert.strictEqual(report.step.error_code, 'signer_setup_failed');
+  });
+
+  test('JWKS endpoint unreachable → verifier rejects key_unknown / fetch error', async () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), 'adcp-grader-'));
+    const keyFilePath = path.join(dir, 'key.jwk');
+    writeFileSync(keyFilePath, JSON.stringify(privateJwkFor(ed)));
+
+    const report = await gradeSigner({
+      agentUrl: 'http://127.0.0.1:9999/agent',
+      kid: 'test-ed25519-2026',
+      algorithm: 'ed25519',
+      keyFilePath,
+      jwksUrl: 'http://127.0.0.1:1/.well-known/jwks.json', // unroutable
+      allowPrivateIp: true,
+    });
+    assert.strictEqual(report.passed, false);
+    // Either the verifier surfaces it as request_signature_key_unknown
+    // (after fetch fail) or as a thrown verifier_threw_unexpected.
+    assert.match(report.step.error_code, /request_signature|verifier_threw|signer/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the third leg of the production-signing release: a way for operators to validate their signer end-to-end **before pushing live signed traffic**. Pairs with #1017's `SigningProvider` (give private keys somewhere safe to live) and #1018's `PostgresReplayStore` (give multi-instance verifiers shared replay state).

The grader produces a sample signed AdCP request through the operator's signer (KMS-backed via HTTP oracle, or in-process via JWK file), then verifies it against the operator's published JWKS via the SDK's RFC 9421 verifier. Pass means a counterparty verifier will accept your signatures. Fail surfaces a specific verifier `error_code` + `step` matching the verifier-checklist semantics — so DER-vs-P1363 / kid-mismatch / wrong-key / algorithm-mismatch each show up as distinct diagnostics, instead of the generic `request_signature_invalid` you'd see in the seller's monitoring after the fact.

Closes #610. Accumulates into Release PR #1014 (still 5.20.0 minor).

## What's worth a second pair of eyes

### 1. Two signer-source modes — covers both audiences

- **`--signer-url <url>`** for KMS-backed signers. Minimal HTTP oracle protocol — `POST {payload_b64, kid, alg}` → `{signature_b64}` (raw wire-format bytes, NOT DER) — so any KMS adapter can put a small handler in front of `provider.sign()` for grading without exposing the KMS to the grader. Optional `--signer-auth` header for shared-secret protection of the oracle endpoint.

- **`--key-file <path>`** for local dev / in-process JWK testing. Loads JWK including private `d`, builds a SigningProvider in process. Documented as dev-only.

The signer-source is the only thing that varies between modes — both produce a `SigningProvider`, both flow through the same `signRequestAsync` → verifier path.

### 2. Diagnostic precedence — where the failure surfaces

Three distinct failure layers, each surfaces with its own `error_code`:

- `signer_setup_failed` — bad CLI input (missing key file, both modes set, JSON parse fail, missing `d`)
- `signer_invocation_failed` — signer raised before producing bytes (KMS auth fail, oracle 401, network timeout, in-process algorithm mismatch where Node refuses to sign)
- One of the verifier-side `request_signature_*` codes — bytes were produced but the verifier rejected (DER vs P1363, kid not in JWKS, wrong-key signature)

Operator reads `step.error_code + step.diagnostic` and immediately knows *which layer* of their setup needs attention.

### 3. Programmatic API alongside the CLI

`gradeSigner(options): Promise<SignerGradeReport>` exported from `@adcp/client/testing/storyboard/signer-grader`. CLI is a thin shim. Useful for CI pipelines that want to assert "our KMS adapter still produces valid signatures" without shelling out.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:examples` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build:lib` — clean
- [x] 9 new tests in `test/lib/signer-grader.test.js`:
  - key-file mode: Ed25519 PASS
  - key-file mode: ECDSA-P256 PASS
  - signer-url mode: matching JWKS PASS
  - signer-url 401: `signer_invocation_failed`
  - mismatched algorithm advertised vs JWK alg: failure surfaced (signer-side or verifier-side)
  - signer signs with wrong key: verifier rejects `request_signature_invalid`
  - both `--key-file` and `--signer-url` set: `signer_setup_failed`
  - missing key file: `signer_setup_failed`
  - JWKS unreachable: failure surfaced
- [x] CLI smoke test (local JWKS server + JWK key file + spawned `bin/adcp.js grade signer ...`):
  ```
  Result: PASS
    diagnostic: Signature verified end-to-end against JWKS.
  ```
- [x] All existing 175 signing tests pass — no regressions

## Deferred follow-ups

- Vector-conformance grader for non-SDK implementers (someone writing a Go or Python AdCP signer who wants to grade against the conformance vectors). Different audience than this v1 (which targets SDK users validating their KMS adapter); ship if asked.
- `--brand-json-url` shortcut so the grader can do brand.json discovery instead of requiring `--jwks-url` directly. Not needed for the v1 audience but small follow-up.
- Negative grading ("does my signer correctly *refuse* to produce certain things") — minor; defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)