### PR TITLE
feat(signing): pemToAdcpJwk helper, lazy KMS provider, and tripwire pattern

### DIFF
--- a/.changeset/signing-provider-lifecycle-jwk.md
+++ b/.changeset/signing-provider-lifecycle-jwk.md
@@ -1,10 +1,14 @@
 ---
-"@adcp/client": minor
+"@adcp/client": patch
 ---
 
-Add `pemToAdcpJwk` helper and improve GCP KMS signing example with lifecycle patterns and tripwire support
+Address SigningProvider first-adopter friction (#1022 from #3283 KMS integration)
 
-- `pemToAdcpJwk(pem, { kid, algorithm, adcp_use })` — new export from `@adcp/client/signing` that converts a public-key PEM to an AdCP JWK with correct JOSE `alg`, `adcp_use`, and `key_ops` fields. Protects against common footguns: using the AdCP wire alg name instead of the JOSE alg name, omitting `adcp_use`, or publishing `key_ops: ["sign"]` instead of `["verify"]`.
-- `createGcpKmsSigningProviderLazy` — lazy-init variant of the GCP KMS example adapter. Uses a rejection-clearing in-flight promise to prevent thundering herd on concurrent first calls and avoids permanently caching transient init failures.
-- `GcpKmsSigningProviderOptions.expectedPublicKeyPem` — optional tripwire: commits the expected SPKI bytes alongside the code and asserts at provider init that KMS returns the same public key, catching silent out-of-band rotations before they cause widespread verifier rejections.
-- `SigningProvider.fingerprint` JSDoc: clarifies that the field may embed infra identifiers (e.g., GCP project ID) and recommends using `kid` for observability logs instead.
+Six small additions surfaced by the first KMS-backed SigningProvider deployment. All additive — no breaking changes, no wire-format changes.
+
+- **`pemToAdcpJwk(pem, { kid, algorithm, adcp_use })`** — new export from `@adcp/client/signing` (via `src/lib/signing/jwks-helpers.ts`). Converts a public-key PEM to an AdCP JWK with the fields that matter for publication at `/.well-known/jwks.json`: `alg` uses the JOSE name (`"EdDSA"` / `"ES256"`), not the AdCP wire identifier — confusing the two is the most common footgun and silently produces `request_signature_key_purpose_invalid` at step 8. `adcp_use` is required by AdCP verifiers at step 8 (hard gate). `key_ops: ["verify"]` because the published JWK is the public half. Throws `TypeError` on private-key PEM input (credential leak guard) and on unsupported algorithm values.
+- **`createGcpKmsSigningProviderLazy`** (example) — synchronous variant of the eager factory. Defers `getPublicKey` to the first `sign()` call. Uses rejection-clearing in-flight promise dedup to prevent thundering herd on concurrent first calls and avoid permanently caching transient init failures.
+- **`expectedPublicKeyPem` tripwire** (example) — optional field on `GcpKmsSigningProviderOptions` (both factories). Compares SPKI bytes at init time; throws explicitly when KMS returns null PEM with the tripwire set (no silent bypass). Catches out-of-band key rotations before they cause widespread verifier `request_signature_key_unknown` failures.
+- **`SigningProvider.fingerprint` JSDoc** — clarifies that the field may embed infra identifiers (e.g., GCP project ID via the version resource name) and recommends `kid` for shared observability pipelines.
+- **Multi-purpose key publication guidance** — example JSDoc now points at the JWKS-shape guidance (two JWK entries with different `kid` values and matching key bytes, tagged `adcp_use: 'request-signing'` / `'webhook-signing'`). Cryptographically safe via RFC 9421's `tag` profile isolation.
+- **`jwks_uri` informational override** — new optional field on `AgentRequestSigningOperationOverrides` (visible on both inline and provider config shapes). Mirrors what brand.json publishes for split-domain setups where the JWKS lives off the conventional `${agent_url}/.well-known/jwks.json` path. Carried for self-describing config + audit logs; the SDK doesn't consume it for signing (verifiers walk brand.json from `agent_url`).

--- a/.changeset/signing-provider-lifecycle-jwk.md
+++ b/.changeset/signing-provider-lifecycle-jwk.md
@@ -1,0 +1,10 @@
+---
+"@adcp/client": minor
+---
+
+Add `pemToAdcpJwk` helper and improve GCP KMS signing example with lifecycle patterns and tripwire support
+
+- `pemToAdcpJwk(pem, { kid, algorithm, adcp_use })` — new export from `@adcp/client/signing` that converts a public-key PEM to an AdCP JWK with correct JOSE `alg`, `adcp_use`, and `key_ops` fields. Protects against common footguns: using the AdCP wire alg name instead of the JOSE alg name, omitting `adcp_use`, or publishing `key_ops: ["sign"]` instead of `["verify"]`.
+- `createGcpKmsSigningProviderLazy` — lazy-init variant of the GCP KMS example adapter. Uses a rejection-clearing in-flight promise to prevent thundering herd on concurrent first calls and avoids permanently caching transient init failures.
+- `GcpKmsSigningProviderOptions.expectedPublicKeyPem` — optional tripwire: commits the expected SPKI bytes alongside the code and asserts at provider init that KMS returns the same public key, catching silent out-of-band rotations before they cause widespread verifier rejections.
+- `SigningProvider.fingerprint` JSDoc: clarifies that the field may embed infra identifiers (e.g., GCP project ID) and recommends using `kid` for observability logs instead.

--- a/.changeset/signing-provider-lifecycle-jwk.md
+++ b/.changeset/signing-provider-lifecycle-jwk.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/client": patch
+"@adcp/client": minor
 ---
 
 Address SigningProvider first-adopter friction (#1022 from #3283 KMS integration)

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -53,13 +53,12 @@
  *   caller. Reusing the same key across protocols creates a cross-protocol
  *   oracle.
  *
- * Multi-purpose keys (request + webhook signing on the same KMS material):
- * - Cryptographically safe — RFC 9421's `tag` parameter isolates the two
- *   profiles (`adcp/request-signing/v1` vs `adcp/webhook-signing/v1`).
- * - Publish two JWK entries with different `kid` values and matching `x`/`y`
- *   bytes, each tagged with the relevant `adcp_use` (`request-signing` /
- *   `webhook-signing`). See `docs/guides/SIGNING-GUIDE.md` § "Step 2: Publish
- *   your public keys" for the JWKS shape.
+ * Request-signing vs webhook-signing keys: AdCP **requires distinct key
+ * material** per purpose (see `docs/guides/SIGNING-GUIDE.md` § Key
+ * separation). The verifier's `adcp_use` discriminator and RFC 9421's `tag`
+ * parameter are gating checks that reject wrong-purpose presentation; they
+ * are not a license to share the underlying scalar across profiles. Mint a
+ * second `cryptoKeyVersion` for webhook signing — KMS makes this cheap.
  */
 
 import { createHash, createPublicKey } from 'node:crypto';

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -52,6 +52,14 @@
  * - Treat the KMS key as single-purpose: the AdCP signing path is the only
  *   caller. Reusing the same key across protocols creates a cross-protocol
  *   oracle.
+ *
+ * Multi-purpose keys (request + webhook signing on the same KMS material):
+ * - Cryptographically safe — RFC 9421's `tag` parameter isolates the two
+ *   profiles (`adcp/request-signing/v1` vs `adcp/webhook-signing/v1`).
+ * - Publish two JWK entries with different `kid` values and matching `x`/`y`
+ *   bytes, each tagged with the relevant `adcp_use` (`request-signing` /
+ *   `webhook-signing`). See `docs/guides/SIGNING-GUIDE.md` § "Step 2: Publish
+ *   your public keys" for the JWKS shape.
  */
 
 import { createHash, createPublicKey } from 'node:crypto';

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -42,7 +42,8 @@
  * - GCP KMS Ed25519 (`EC_SIGN_ED25519`) is GA but availability varies by
  *   region/tier. Verify in your target region before pinning.
  * - The `versionName` pins a specific `cryptoKeyVersion`. Rotation is a
- *   redeploy. For lazy primary lookup, see the `lazyPrimary` example below.
+ *   redeploy. See `createGcpKmsSigningProviderLazy` below for a variant that
+ *   defers initialization until the first signed request.
  *
  * IAM (least privilege):
  * - GCP: `roles/cloudkms.signer` scoped to the specific `cryptoKeyVersions/N`
@@ -53,7 +54,7 @@
  *   oracle.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, createPublicKey } from 'node:crypto';
 import type { SigningProvider } from '@adcp/client/signing';
 import { derEcdsaToP1363, SigningProviderAlgorithmMismatchError } from '@adcp/client/signing';
 
@@ -84,6 +85,28 @@ export interface GcpKmsSigningProviderOptions {
    * Stubbable for tests via the {@link GcpKmsClientLike} structural type.
    */
   client: GcpKmsClientLike;
+  /**
+   * Optional tripwire: a PEM-encoded public key committed to your source repo.
+   * When provided, the constructor compares the SPKI bytes returned by KMS
+   * against this value and throws if they differ.
+   *
+   * This catches silent out-of-band key rotations (disabled key version, IAM
+   * swap, hostile substitution) before the first signed request. Without it,
+   * a rotated KMS key starts producing signatures that verifiers reject with
+   * `request_signature_key_unknown` — no clear signal that the JWKS is stale.
+   *
+   * Pattern:
+   * ```
+   * # Export the expected public key once and commit it:
+   * gcloud kms keys versions get-public-key 1 \
+   *   --location=us-east1 --keyring=adcp --key=adcp-signing \
+   *   --output-file=keys/addie-2026-04.pem
+   * git add keys/addie-2026-04.pem && git commit -m "chore: commit signer public key for tripwire"
+   * ```
+   *
+   * Then pass `expectedPublicKeyPem: fs.readFileSync('keys/addie-2026-04.pem', 'utf8')`.
+   */
+  expectedPublicKeyPem?: string;
 }
 
 /**
@@ -91,6 +114,12 @@ export interface GcpKmsSigningProviderOptions {
  * construction to validate the declared algorithm matches the underlying
  * key — fails fast with {@link SigningProviderAlgorithmMismatchError} rather
  * than producing signatures verifiers would reject downstream.
+ *
+ * If `expectedPublicKeyPem` is provided, also asserts the SPKI bytes returned
+ * by KMS match the committed PEM (tripwire against silent key rotation).
+ *
+ * For a variant that defers initialization to the first `sign()` call, see
+ * {@link createGcpKmsSigningProviderLazy}.
  */
 export async function createGcpKmsSigningProvider(options: GcpKmsSigningProviderOptions): Promise<SigningProvider> {
   const [pubResp] = await options.client.getPublicKey({ name: options.versionName });
@@ -100,32 +129,128 @@ export async function createGcpKmsSigningProvider(options: GcpKmsSigningProvider
     throw new SigningProviderAlgorithmMismatchError(options.algorithm, kmsAlgorithm, options.kid);
   }
 
+  if (options.expectedPublicKeyPem != null && pubResp.pem != null) {
+    assertSpkiMatches(options.versionName, pubResp.pem, options.expectedPublicKeyPem);
+  }
+
   return {
     keyid: options.kid,
     algorithm: options.algorithm,
     fingerprint: options.versionName,
     async sign(payload: Uint8Array): Promise<Uint8Array> {
-      if (options.algorithm === 'ecdsa-p256-sha256') {
-        const digest = createHash('sha256').update(payload).digest();
-        const [resp] = await options.client.asymmetricSign({
-          name: options.versionName,
-          digest: { sha256: digest },
-        });
-        const sig = coerceSignature(resp.signature);
-        return derEcdsaToP1363(sig, 32);
-      }
-      const [resp] = await options.client.asymmetricSign({
-        name: options.versionName,
-        data: payload,
-      });
-      return coerceSignature(resp.signature);
+      return kmsSign(options, payload);
     },
   };
 }
 
+/**
+ * Lazy-initialization variant of {@link createGcpKmsSigningProvider}.
+ *
+ * Unlike the eager factory, this constructor returns synchronously without
+ * touching KMS. The first `sign()` call triggers `getPublicKey` (algorithm
+ * validation + optional tripwire check). Subsequent calls skip initialization.
+ *
+ * Choose between eager and lazy based on your operational priorities:
+ *
+ * | | Eager (`createGcpKmsSigningProvider`) | Lazy (this) |
+ * |---|---|---|
+ * | Boot fails if KMS unreachable | yes | no |
+ * | Misconfiguration surface | deploy time | first request |
+ * | Cold-start latency on first sign | none (already done) | one `getPublicKey` RTT |
+ *
+ * **Thundering-herd / concurrent-first-call safety:** the lazy pattern below
+ * uses an in-flight promise that is deduplicated across concurrent callers.
+ * Critically, the promise is **cleared on rejection** so a transient KMS blip
+ * during the first call retries rather than permanently caching the failure:
+ *
+ * ```
+ * inflightInit = init().catch(err => { inflightInit = null; throw err; });
+ * ```
+ *
+ * Without the `catch` clear, a transient network error during init permanently
+ * bricks the provider for the lifetime of the process — every subsequent
+ * `sign()` call receives the same rejected promise.
+ */
+export function createGcpKmsSigningProviderLazy(options: GcpKmsSigningProviderOptions): SigningProvider {
+  let initialized = false;
+  let inflightInit: Promise<void> | null = null;
+
+  async function ensureInitialized(): Promise<void> {
+    if (initialized) return;
+    if (!inflightInit) {
+      inflightInit = initProvider().then(
+        () => {
+          initialized = true;
+          inflightInit = null;
+        },
+        err => {
+          inflightInit = null; // Clear so the next call retries
+          throw err;
+        }
+      );
+    }
+    return inflightInit;
+  }
+
+  async function initProvider(): Promise<void> {
+    const [pubResp] = await options.client.getPublicKey({ name: options.versionName });
+    const kmsAlgorithm = pubResp.algorithm ?? '';
+    const expectedKmsAlgorithm = mapDeclaredAlgorithmToKms(options.algorithm);
+    if (kmsAlgorithm !== expectedKmsAlgorithm) {
+      throw new SigningProviderAlgorithmMismatchError(options.algorithm, kmsAlgorithm, options.kid);
+    }
+    if (options.expectedPublicKeyPem != null && pubResp.pem != null) {
+      assertSpkiMatches(options.versionName, pubResp.pem, options.expectedPublicKeyPem);
+    }
+  }
+
+  return {
+    keyid: options.kid,
+    algorithm: options.algorithm,
+    fingerprint: options.versionName,
+    async sign(payload: Uint8Array): Promise<Uint8Array> {
+      await ensureInitialized();
+      return kmsSign(options, payload);
+    },
+  };
+}
+
+// --- Shared helpers ---
+
 function mapDeclaredAlgorithmToKms(alg: 'ed25519' | 'ecdsa-p256-sha256'): string {
   // GCP KMS algorithm enum names per CryptoKeyVersion.CryptoKeyVersionAlgorithm.
   return alg === 'ed25519' ? 'EC_SIGN_ED25519' : 'EC_SIGN_P256_SHA256';
+}
+
+async function kmsSign(options: GcpKmsSigningProviderOptions, payload: Uint8Array): Promise<Uint8Array> {
+  if (options.algorithm === 'ecdsa-p256-sha256') {
+    const digest = createHash('sha256').update(payload).digest();
+    const [resp] = await options.client.asymmetricSign({
+      name: options.versionName,
+      digest: { sha256: digest },
+    });
+    const sig = coerceSignature(resp.signature);
+    return derEcdsaToP1363(sig, 32);
+  }
+  const [resp] = await options.client.asymmetricSign({
+    name: options.versionName,
+    data: payload,
+  });
+  return coerceSignature(resp.signature);
+}
+
+function assertSpkiMatches(versionName: string, actualPem: string, expectedPem: string): void {
+  const toSpki = (pem: string) =>
+    createPublicKey({ key: pem, format: 'pem' }).export({ type: 'spki', format: 'der' }) as Buffer;
+  const actual = toSpki(actualPem);
+  const expected = toSpki(expectedPem);
+  if (!actual.equals(expected)) {
+    throw new Error(
+      `KMS key ${versionName} public SPKI does not match the committed expectedPublicKeyPem. ` +
+        `An out-of-band key rotation may have occurred. ` +
+        `Commit the new public key PEM and redeploy to clear this guard.`
+    );
+  }
 }
 
 function coerceSignature(value: Buffer | Uint8Array | string | null | undefined): Uint8Array {

--- a/examples/gcp-kms-signing-provider.ts
+++ b/examples/gcp-kms-signing-provider.ts
@@ -129,7 +129,12 @@ export async function createGcpKmsSigningProvider(options: GcpKmsSigningProvider
     throw new SigningProviderAlgorithmMismatchError(options.algorithm, kmsAlgorithm, options.kid);
   }
 
-  if (options.expectedPublicKeyPem != null && pubResp.pem != null) {
+  if (options.expectedPublicKeyPem != null) {
+    if (pubResp.pem == null) {
+      throw new Error(
+        `KMS returned no public key material for ${options.versionName}; cannot verify expectedPublicKeyPem tripwire.`
+      );
+    }
     assertSpkiMatches(options.versionName, pubResp.pem, options.expectedPublicKeyPem);
   }
 
@@ -199,7 +204,12 @@ export function createGcpKmsSigningProviderLazy(options: GcpKmsSigningProviderOp
     if (kmsAlgorithm !== expectedKmsAlgorithm) {
       throw new SigningProviderAlgorithmMismatchError(options.algorithm, kmsAlgorithm, options.kid);
     }
-    if (options.expectedPublicKeyPem != null && pubResp.pem != null) {
+    if (options.expectedPublicKeyPem != null) {
+      if (pubResp.pem == null) {
+        throw new Error(
+          `KMS returned no public key material for ${options.versionName}; cannot verify expectedPublicKeyPem tripwire.`
+        );
+      }
       assertSpkiMatches(options.versionName, pubResp.pem, options.expectedPublicKeyPem);
     }
   }

--- a/src/lib/signing/client.ts
+++ b/src/lib/signing/client.ts
@@ -74,3 +74,4 @@ export {
   type AgentSigningIdentitySnapshot,
 } from './agent-context';
 export { ensureCapabilityLoaded, CAPABILITY_OP } from './capability-priming';
+export { pemToAdcpJwk, type AdcpUse, type PemToAdcpJwkOptions } from './jwks-helpers';

--- a/src/lib/signing/jwks-helpers.ts
+++ b/src/lib/signing/jwks-helpers.ts
@@ -65,7 +65,12 @@ export interface PemToAdcpJwkOptions {
  * ```
  */
 export function pemToAdcpJwk(pem: string, options: PemToAdcpJwkOptions): AdcpJsonWebKey {
-  if (/PRIVATE\s+KEY/.test(pem)) {
+  // Anchored to the BEGIN line so a public-key PEM that mentions "PRIVATE
+  // KEY" in surrounding metadata or comments doesn't false-positive. RFC
+  // 7468 mandates exact uppercase between dashes; matching all standard
+  // private-key headers (`PRIVATE KEY` PKCS#8, `RSA/EC/OPENSSH/ENCRYPTED
+  // PRIVATE KEY`).
+  if (/-----BEGIN [^-]*PRIVATE KEY-----/.test(pem)) {
     throw new TypeError(
       'pemToAdcpJwk received a private-key PEM. ' +
         'Pass only a public-key PEM (SPKI format: "BEGIN PUBLIC KEY"). ' +

--- a/src/lib/signing/jwks-helpers.ts
+++ b/src/lib/signing/jwks-helpers.ts
@@ -1,0 +1,97 @@
+import { createPublicKey } from 'node:crypto';
+import type { AdcpJsonWebKey, AdcpSignAlg } from './types';
+
+/**
+ * Maps AdCP wire-format algorithm identifiers to JOSE `alg` names.
+ *
+ * These are distinct vocabularies used in different contexts:
+ * - AdCP wire identifier (`'ed25519'`, `'ecdsa-p256-sha256'`) appears in
+ *   `Signature-Input` and `SigningProvider.algorithm`.
+ * - JOSE alg name (`'EdDSA'`, `'ES256'`) appears in published JWKs so JOSE
+ *   consumers can locate the right verifier. The AdCP step-8 check asserts this
+ *   mapping; using an AdCP wire identifier in place of the JOSE name produces a
+ *   `request_signature_key_purpose_invalid` rejection before any crypto runs.
+ */
+const WIRE_ALG_TO_JOSE: Record<AdcpSignAlg, string> = {
+  ed25519: 'EdDSA',
+  'ecdsa-p256-sha256': 'ES256',
+};
+
+export type AdcpUse = 'request-signing' | 'webhook-signing';
+
+export interface PemToAdcpJwkOptions {
+  /** `kid` to embed in the JWK — must match the value published in `Signature-Input`. */
+  kid: string;
+  /** AdCP wire-format algorithm. Controls which JOSE `alg` name is emitted. */
+  algorithm: AdcpSignAlg;
+  /**
+   * Purpose binding, enforced by AdCP verifiers at step 8.
+   * - `'request-signing'` — for JWKs published at the buyer's `jwks_uri`.
+   * - `'webhook-signing'` — for JWKs used to sign outbound webhook callbacks.
+   */
+  adcp_use: AdcpUse;
+}
+
+/**
+ * Convert a public-key PEM (SPKI / `BEGIN PUBLIC KEY` format) to an AdCP JWK
+ * with the correct fields for publication at `/.well-known/jwks.json`.
+ *
+ * The returned JWK uses the JOSE `alg` name (`"EdDSA"`, `"ES256"`), not the
+ * AdCP wire identifier (`"ed25519"`, `"ecdsa-p256-sha256"`). Confusing the two
+ * is a common footgun — they appear in different protocol layers and the AdCP
+ * step-8 verifier asserts the JOSE name. Using a wire identifier in the JWK
+ * causes a `request_signature_key_purpose_invalid` rejection before the
+ * signature is verified.
+ *
+ * Fields set by this helper and why:
+ * - `alg`      — JOSE name; required for AdCP step-8 consistency check.
+ * - `use`      — `"sig"`; RFC 7517 §4.2 intent hint for JOSE consumers.
+ * - `adcp_use` — purpose binding; enforced hard gate at AdCP verifier step 8.
+ * - `key_ops`  — `["verify"]`; AdCP verifier checks for `"verify"`, not `"sign"`,
+ *               because the published JWK is the public half of the keypair.
+ *
+ * @throws TypeError when given a private-key PEM or an unparseable PEM.
+ *
+ * @example
+ * ```ts
+ * import { pemToAdcpJwk } from '@adcp/client/signing';
+ *
+ * const jwk = pemToAdcpJwk(fs.readFileSync('keys/addie-2026-04.pem', 'utf8'), {
+ *   kid: 'addie-2026-04',
+ *   algorithm: 'ed25519',
+ *   adcp_use: 'request-signing',
+ * });
+ * // Serve this object in your /.well-known/jwks.json `keys` array.
+ * ```
+ */
+export function pemToAdcpJwk(pem: string, options: PemToAdcpJwkOptions): AdcpJsonWebKey {
+  if (/PRIVATE\s+KEY/.test(pem)) {
+    throw new TypeError(
+      'pemToAdcpJwk received a private-key PEM. ' +
+        'Pass only a public-key PEM (SPKI format: "BEGIN PUBLIC KEY"). ' +
+        'Publishing a private key in JWKS is a credential leak.'
+    );
+  }
+
+  let keyObj;
+  try {
+    keyObj = createPublicKey({ key: pem, format: 'pem' });
+  } catch (err) {
+    throw new TypeError(
+      `pemToAdcpJwk: failed to parse PEM as a public key — ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Expected SPKI format ("BEGIN PUBLIC KEY").`
+    );
+  }
+
+  const exported = keyObj.export({ format: 'jwk' }) as Record<string, unknown>;
+
+  return {
+    ...exported,
+    kid: options.kid,
+    alg: WIRE_ALG_TO_JOSE[options.algorithm],
+    use: 'sig',
+    adcp_use: options.adcp_use,
+    key_ops: ['verify'],
+  } as AdcpJsonWebKey;
+}

--- a/src/lib/signing/jwks-helpers.ts
+++ b/src/lib/signing/jwks-helpers.ts
@@ -84,12 +84,20 @@ export function pemToAdcpJwk(pem: string, options: PemToAdcpJwkOptions): AdcpJso
     );
   }
 
+  const joseAlg = WIRE_ALG_TO_JOSE[options.algorithm];
+  if (!joseAlg) {
+    throw new TypeError(
+      `pemToAdcpJwk: unsupported algorithm '${options.algorithm}'. ` +
+        `Supported: ${Object.keys(WIRE_ALG_TO_JOSE).join(', ')}.`
+    );
+  }
+
   const exported = keyObj.export({ format: 'jwk' }) as Record<string, unknown>;
 
   return {
     ...exported,
     kid: options.kid,
-    alg: WIRE_ALG_TO_JOSE[options.algorithm],
+    alg: joseAlg,
     use: 'sig',
     adcp_use: options.adcp_use,
     key_ops: ['verify'],

--- a/src/lib/signing/provider.ts
+++ b/src/lib/signing/provider.ts
@@ -71,6 +71,14 @@ export interface SigningProvider {
    * collapse multi-tenant cache isolation. The hash is a defense-in-depth
    * measure, not a security boundary — adapter authors should still supply
    * a high-entropy stable identifier.
+   *
+   * **Logging caution:** `fingerprint` may embed infra identifiers. For GCP
+   * KMS the version resource name
+   * (`projects/<id>/locations/<loc>/keyRings/<ring>/cryptoKeyVersions/<N>`)
+   * exposes project ID and key topology. When emitting to shared logs, traces,
+   * or span attributes, log only the trailing `cryptoKeyVersions/<N>` segment,
+   * or use the stable `kid` instead — it is already published on the wire and
+   * carries no infra topology.
    */
   readonly fingerprint: string;
 }

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -348,6 +348,23 @@ export interface AgentRequestSigningOperationOverrides {
    * seller asks for" behavior.
    */
   sign_supported?: boolean;
+  /**
+   * Optional override for the JWKS endpoint where this agent publishes its
+   * verification keys. Verifiers walk brand.json from `agent_url` to find the
+   * `jwks_uri` — this field is informational, mirroring what brand.json
+   * publishes so audit logs and custom verifier wiring have a single source
+   * of truth for the buyer-side identity.
+   *
+   * Use when the JWKS lives off the conventional
+   * `${agent_url}/.well-known/jwks.json` path — split-domain setups (identity
+   * domain separate from the agent endpoint) being the common case.
+   *
+   * The SDK does not consume this field for signing; it's carried here so the
+   * config object is self-describing. Brand.json publication is the
+   * authoritative side — make sure the `jwks_uri` in your brand.json matches
+   * this value.
+   */
+  jwks_uri?: string;
 }
 
 /**

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -349,20 +349,18 @@ export interface AgentRequestSigningOperationOverrides {
    */
   sign_supported?: boolean;
   /**
-   * Optional override for the JWKS endpoint where this agent publishes its
-   * verification keys. Verifiers walk brand.json from `agent_url` to find the
-   * `jwks_uri` — this field is informational, mirroring what brand.json
-   * publishes so audit logs and custom verifier wiring have a single source
-   * of truth for the buyer-side identity.
+   * Informational mirror of the JWKS endpoint where this agent publishes
+   * its verification keys. Verifiers do not read this field — they walk
+   * brand.json from `agent_url` to discover the authoritative `jwks_uri`.
+   * The field is carried on the buyer-side config so audit logs, custom
+   * verifier wiring, and split-domain setups have a single self-describing
+   * source of truth that matches what brand.json publishes.
    *
-   * Use when the JWKS lives off the conventional
-   * `${agent_url}/.well-known/jwks.json` path — split-domain setups (identity
-   * domain separate from the agent endpoint) being the common case.
-   *
-   * The SDK does not consume this field for signing; it's carried here so the
-   * config object is self-describing. Brand.json publication is the
-   * authoritative side — make sure the `jwks_uri` in your brand.json matches
-   * this value.
+   * Common case: split-domain setups where the JWKS lives off the
+   * conventional `${agent_url}/.well-known/jwks.json` path (identity
+   * domain separate from the agent endpoint). Make sure brand.json's
+   * `jwks_uri` agrees with whatever you set here — brand.json is
+   * authoritative; this field documents intent.
    */
   jwks_uri?: string;
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.19.0';
+export const LIBRARY_VERSION = '5.20.0';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.19.0',
+  library: '5.20.0',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-25T23:27:37.876Z',
+  generatedAt: '2026-04-26T18:17:01.562Z',
 } as const;
 
 /**

--- a/test/lib/jwks-helpers.test.js
+++ b/test/lib/jwks-helpers.test.js
@@ -1,0 +1,139 @@
+/**
+ * Tests for `pemToAdcpJwk` — the public-key PEM → AdCP JWK helper.
+ *
+ * The helper exists because the JOSE/AdCP alg-name vocabulary mismatch
+ * (`EdDSA`/`ES256` on the JWK vs `ed25519`/`ecdsa-p256-sha256` on the wire)
+ * is the most common footgun for KMS adopters publishing JWKS. These tests
+ * lock the mapping + the validation guards.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { generateKeyPairSync } = require('node:crypto');
+
+const { pemToAdcpJwk } = require('../../dist/lib/signing/index.js');
+
+function spkiPem(keyPair) {
+  return keyPair.publicKey.export({ type: 'spki', format: 'pem' }).toString();
+}
+function pkcs8Pem(keyPair) {
+  return keyPair.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+}
+
+describe('pemToAdcpJwk', () => {
+  test('Ed25519 SPKI → JWK with alg "EdDSA" + AdCP fields', () => {
+    const kp = generateKeyPairSync('ed25519');
+    const jwk = pemToAdcpJwk(spkiPem(kp), {
+      kid: 'addie-2026-04',
+      algorithm: 'ed25519',
+      adcp_use: 'request-signing',
+    });
+    assert.strictEqual(jwk.kty, 'OKP');
+    assert.strictEqual(jwk.crv, 'Ed25519');
+    assert.strictEqual(jwk.alg, 'EdDSA'); // JOSE name, not the wire name
+    assert.strictEqual(jwk.kid, 'addie-2026-04');
+    assert.strictEqual(jwk.use, 'sig');
+    assert.strictEqual(jwk.adcp_use, 'request-signing');
+    assert.deepStrictEqual(jwk.key_ops, ['verify']);
+    assert.strictEqual(typeof jwk.x, 'string');
+    assert.strictEqual(jwk.d, undefined, 'must NEVER carry private scalar');
+  });
+
+  test('ECDSA-P256 SPKI → JWK with alg "ES256"', () => {
+    const kp = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const jwk = pemToAdcpJwk(spkiPem(kp), {
+      kid: 'addie-es256-2026-04',
+      algorithm: 'ecdsa-p256-sha256',
+      adcp_use: 'request-signing',
+    });
+    assert.strictEqual(jwk.kty, 'EC');
+    assert.strictEqual(jwk.crv, 'P-256');
+    assert.strictEqual(jwk.alg, 'ES256'); // JOSE name, not the wire name
+    assert.strictEqual(jwk.kid, 'addie-es256-2026-04');
+    assert.strictEqual(jwk.adcp_use, 'request-signing');
+    assert.deepStrictEqual(jwk.key_ops, ['verify']);
+    assert.strictEqual(typeof jwk.x, 'string');
+    assert.strictEqual(typeof jwk.y, 'string');
+    assert.strictEqual(jwk.d, undefined, 'must NEVER carry private scalar');
+  });
+
+  test('webhook-signing adcp_use is preserved verbatim', () => {
+    const kp = generateKeyPairSync('ed25519');
+    const jwk = pemToAdcpJwk(spkiPem(kp), {
+      kid: 'addie-webhook-2026-04',
+      algorithm: 'ed25519',
+      adcp_use: 'webhook-signing',
+    });
+    assert.strictEqual(jwk.adcp_use, 'webhook-signing');
+  });
+
+  test('private-key PEM (PKCS#8) → TypeError, no JWK leaked', () => {
+    const kp = generateKeyPairSync('ed25519');
+    assert.throws(
+      () =>
+        pemToAdcpJwk(pkcs8Pem(kp), {
+          kid: 'addie',
+          algorithm: 'ed25519',
+          adcp_use: 'request-signing',
+        }),
+      err => err instanceof TypeError && /private-key PEM|credential leak/i.test(err.message)
+    );
+  });
+
+  test('private-key PEM (PKCS#1 RSA) → TypeError', () => {
+    // RSA private key has its own header. We don't sign with RSA in AdCP, but
+    // the guard should still catch it before the algorithm check.
+    const rsa = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const rsaPem = rsa.privateKey.export({ type: 'pkcs1', format: 'pem' }).toString();
+    assert.throws(
+      () =>
+        pemToAdcpJwk(rsaPem, {
+          kid: 'addie',
+          algorithm: 'ed25519',
+          adcp_use: 'request-signing',
+        }),
+      err => err instanceof TypeError && /private-key PEM|credential leak/i.test(err.message)
+    );
+  });
+
+  test('public-key PEM with "PRIVATE KEY" mentioned in surrounding metadata is NOT false-positive', () => {
+    // A public PEM with comment-like surrounding text mentioning "PRIVATE
+    // KEY" must still be accepted — the guard anchors to the BEGIN line
+    // header itself (RFC 7468 mandates exact uppercase between dashes).
+    const kp = generateKeyPairSync('ed25519');
+    const noisy = `# Note: do not confuse with the PRIVATE KEY at /etc/keys/old.pem\n${spkiPem(kp)}`;
+    const jwk = pemToAdcpJwk(noisy, {
+      kid: 'addie',
+      algorithm: 'ed25519',
+      adcp_use: 'request-signing',
+    });
+    assert.strictEqual(jwk.kty, 'OKP');
+    assert.strictEqual(jwk.alg, 'EdDSA');
+  });
+
+  test('garbage input → TypeError with parse-failure context', () => {
+    assert.throws(
+      () =>
+        pemToAdcpJwk('not a pem at all', {
+          kid: 'addie',
+          algorithm: 'ed25519',
+          adcp_use: 'request-signing',
+        }),
+      err => err instanceof TypeError && /failed to parse|expected SPKI/i.test(err.message)
+    );
+  });
+
+  test('unsupported algorithm → TypeError listing supported set', () => {
+    const kp = generateKeyPairSync('ed25519');
+    assert.throws(
+      () =>
+        pemToAdcpJwk(spkiPem(kp), {
+          kid: 'addie',
+          // @ts-expect-error — runtime guard for invalid alg
+          algorithm: 'rsa-pss-sha256',
+          adcp_use: 'request-signing',
+        }),
+      err => err instanceof TypeError && /unsupported algorithm/i.test(err.message)
+    );
+  });
+});


### PR DESCRIPTION
Refs #1022

Ships three of the six items raised in #1022 by @bokelley after their first-adopter KMS integration. Items #4 and #6 are deferred (see status comment on the issue); `getPublicJwk()` on the interface (#3b) is breaking and excluded.

## What changed

**`pemToAdcpJwk(pem, { kid, algorithm, adcp_use })`** — new export from `@adcp/client/signing` (via `src/lib/signing/jwks-helpers.ts`). Converts a public-key PEM to an AdCP JWK with the fields that matter for publication at `/.well-known/jwks.json`:

- `alg` uses the JOSE name (`"EdDSA"` / `"ES256"`), not the AdCP wire identifier — confusing the two is the most common footgun and silently produces `request_signature_key_purpose_invalid` at step 8.
- `adcp_use` is required by AdCP verifiers at step 8 (hard gate).
- `key_ops: ["verify"]` because the published JWK is the public half.
- Throws `TypeError` on private-key PEM input (credential leak guard) and on unsupported algorithm values.

**`createGcpKmsSigningProviderLazy`** — synchronous variant of the eager factory. Defers `getPublicKey` to the first `sign()` call. Uses rejection-clearing in-flight promise dedup to prevent thundering herd on concurrent first calls and avoid permanently caching transient init failures.

**`expectedPublicKeyPem` tripwire** — optional field on `GcpKmsSigningProviderOptions` (both factories). Compares SPKI bytes at init time; throws explicitly when KMS returns null PEM with the tripwire set (no silent bypass). Catches out-of-band key rotations before they cause widespread verifier `request_signature_key_unknown` failures.

**`fingerprint` JSDoc** — clarifies that GCP KMS version resource names embed project ID / key topology; recommends `kid` instead for shared observability pipelines.

**Dangling reference fix** — the original example referenced "the `lazyPrimary` example below" but no such block existed; replaced with a link to `createGcpKmsSigningProviderLazy` which is now the actual lazy example.

## What tested

- Format check: `prettier --check` — **passed**
- Typecheck: `tsc --project tsconfig.lib.json --noEmit` — **no new errors** (two pre-existing errors: missing `@types/node` + deprecated `moduleResolution=node10` in tsconfig; confirmed present on `main` before this branch)
- `npm test` blocked by missing `dist/` (build toolchain requires `tsx` which is not installed in this environment; pre-existing condition confirmed by running against unmodified `main`)

**Pre-PR review:**
- code-reviewer: approved — identified and fixed silent tripwire bypass on null `pubResp.pem` (blocker); runtime guard for unsupported algorithm in `pemToAdcpJwk` (nit, fixed); lazy-provider rejection-clearing confirmed correct; SPKI DER equality confirmed
- ad-tech-protocol-expert: approved — `WIRE_ALG_TO_JOSE` map matches verifier's `SIG_PARAMS_ALG_TO_JOSE` exactly; `adcp_use` and `key_ops` field values match verifier step-8 gates; `SigningProvider` interface untouched (non-breaking); `AdcpUse` type aligns with both request and webhook verifier accepted values

**Nits noted but not fixed (surfaced in PR body per triage rules):**
- `pemToAdcpJwk` does not cross-check `options.algorithm` against the exported key material (`kty`/`crv`). Passing `algorithm: 'ecdsa-p256-sha256'` with an Ed25519 PEM would emit `alg: 'ES256'` over an `OKP` JWK body — the verifier's `validateJwkParameterConsistency` catches this at step 8, but with a confusing error code. A follow-up could add the `kty`/`crv` check at the source.

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01KgiM36wbg5DgRvU4t1BPvv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgiM36wbg5DgRvU4t1BPvv)_