### PR TITLE
fix(grader): repair undici lookup callback shape for Node 22+ HTTPS targets

### DIFF
--- a/.changeset/fix-probe-lookup-callback.md
+++ b/.changeset/fix-probe-lookup-callback.md
@@ -1,0 +1,7 @@
+---
+"@adcp/client": patch
+---
+
+fix(grader): repair undici lookup callback shape in request-signing probe
+
+`adcp grade request-signing` failed with "Invalid IP address: undefined" against any endpoint behind Cloudflare or an anycast load balancer. On Node 22+ with HTTPS targets, undici calls the `connect.lookup` function with `{ all: true }` and expects the array form of the callback (`cb(null, [{address, family}])`), but the probe was using the single-value form (`cb(null, address, family)`). The fix aligns the callback with the pattern already used in `ssrf-fetch.ts` and preserves DNS-rebinding protection.

--- a/src/lib/testing/storyboard/request-signing/probe.ts
+++ b/src/lib/testing/storyboard/request-signing/probe.ts
@@ -1,3 +1,4 @@
+import { type LookupAddress, type LookupOptions } from 'dns';
 import { lookup as dnsLookup } from 'dns/promises';
 import { Agent, fetch as undiciFetch } from 'undici';
 import { isAlwaysBlocked, isPrivateIp } from '../probes';
@@ -30,10 +31,12 @@ export interface ProbeResult {
  * Send a signed HTTP request to an AdCP agent and capture the response fields
  * needed for conformance grading (status, WWW-Authenticate error code, body).
  *
- * Reuses the SSRF guards established by `fetchProbe` — same classifier, same
- * IP pin against DNS rebinding. Bodies are capped at 64 KiB and parsed as JSON
- * when content-type matches; otherwise returned as text. `redirect: 'manual'`
- * is enforced so an agent that 301s can't smuggle the grader elsewhere.
+ * Reuses the SSRF guards from the address classifiers — scheme check,
+ * `isAlwaysBlocked`, `isPrivateIp` — then pins the outbound connection to the
+ * pre-validated address via an undici dispatcher, defeating DNS rebinding.
+ * Bodies are capped at 64 KiB and parsed as JSON when content-type matches;
+ * otherwise returned as text. `redirect: 'manual'` is enforced so an agent
+ * that 301s can't smuggle the grader elsewhere.
  */
 export async function probeSignedRequest(signed: SignedHttpRequest, options: ProbeOptions = {}): Promise<ProbeResult> {
   const start = Date.now();
@@ -90,8 +93,24 @@ export async function probeSignedRequest(signed: SignedHttpRequest, options: Pro
     }
   }
   const pinned = addresses[0]!;
+  const pinnedFamily = pinned.family === 6 ? 6 : 4;
+  // undici calls lookup with { all: true } for HTTPS targets on Node 22+, which
+  // expects the array form of the callback. Handle both shapes so the pin works
+  // across Node versions.
   const dispatcher = new Agent({
-    connect: { lookup: (_h, _o, cb) => cb(null, pinned.address, pinned.family) },
+    connect: {
+      lookup: (
+        _h: string,
+        opts: LookupOptions | undefined,
+        cb: (err: NodeJS.ErrnoException | null, address: string | LookupAddress[], family?: number) => void
+      ) => {
+        if (opts?.all) {
+          cb(null, [{ address: pinned.address, family: pinnedFamily }]);
+        } else {
+          cb(null, pinned.address, pinnedFamily);
+        }
+      },
+    },
   });
 
   const ac = new AbortController();

--- a/src/lib/testing/storyboard/request-signing/probe.ts
+++ b/src/lib/testing/storyboard/request-signing/probe.ts
@@ -63,22 +63,27 @@ export async function probeSignedRequest(signed: SignedHttpRequest, options: Pro
     return result;
   }
 
+  // Strip URL brackets from IPv6 literals (`[::1]` → `::1`) before DNS lookup
+  // and address classification. `URL.hostname` wraps IPv6 in brackets; both
+  // `dns.lookup` and the address classifiers need the bare form.
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+
   let addresses: { address: string; family: number }[];
   try {
-    addresses = await dnsLookup(parsed.hostname, { all: true });
+    addresses = await dnsLookup(hostname, { all: true });
   } catch (err) {
-    result.error = `DNS lookup failed for ${parsed.hostname}: ${err instanceof Error ? err.message : String(err)}`;
+    result.error = `DNS lookup failed for ${hostname}: ${err instanceof Error ? err.message : String(err)}`;
     result.duration_ms = Date.now() - start;
     return result;
   }
   if (addresses.length === 0) {
-    result.error = `DNS returned no addresses for ${parsed.hostname}`;
+    result.error = `DNS returned no addresses for ${hostname}`;
     result.duration_ms = Date.now() - start;
     return result;
   }
   for (const a of addresses) {
     if (isAlwaysBlocked(a.address)) {
-      result.error = `Refusing to probe always-blocked address ${a.address} for ${parsed.hostname}`;
+      result.error = `Refusing to probe always-blocked address ${a.address} for ${hostname}`;
       result.duration_ms = Date.now() - start;
       return result;
     }
@@ -86,7 +91,7 @@ export async function probeSignedRequest(signed: SignedHttpRequest, options: Pro
   if (!options.allowPrivateIp) {
     for (const a of addresses) {
       if (isPrivateIp(a.address)) {
-        result.error = `Refusing to probe private/loopback address ${a.address} for ${parsed.hostname}`;
+        result.error = `Refusing to probe private/loopback address ${a.address} for ${hostname}`;
         result.duration_ms = Date.now() - start;
         return result;
       }


### PR DESCRIPTION
Closes #1025

On Node 22+ with HTTPS targets, undici calls `connect.lookup` with `{ all: true }` and expects the array form of the callback (`cb(null, [{address, family}])`). The request-signing probe was using the single-value form (`cb(null, address, family)`), producing "Invalid IP address: undefined" on every probe against any endpoint behind Cloudflare or an anycast load balancer — making `adcp grade request-signing` completely non-functional against production deployments. The fix aligns the callback with the already-working pattern in `src/lib/net/ssrf-fetch.ts` and preserves the DNS-rebinding protection. Also fixes a pre-existing gap: IPv6-literal hostnames were not bracket-stripped before `dns.lookup`, mirroring the same one-liner from `ssrf-fetch.ts`.

**What was tested:**
- `npm run format:check` — passed
- `npm run typecheck` — pre-existing `@types/node` / `moduleResolution` deprecation errors only; no new errors introduced (verified by stashing the change and comparing)
- `npm run build:lib` — blocked by missing `tsx` in this environment (pre-existing); TypeScript compilation of the changed file passes with no new errors
- `npm test` — 603 failures vs. 608 baseline (5 fewer failures, no regressions introduced)

**Pre-PR review:**
- code-reviewer: approved — fix is correct and complete; `pinnedFamily` narrowing present; IPv6 bracket stripping added; nit noted (body-truncation early-return pre-exists, out of scope)
- security-reviewer: approved — DNS-rebinding protection is equivalent; callback shape change only; SSRF guards (scheme check, `isAlwaysBlocked`, `isPrivateIp`, `redirect: manual`, body cap) all intact; IP-in-error-message divergence from `ssrf-fetch.ts` noted as low-risk nit for this tool context

**Nit (not fixed, low risk):** `probe.ts` includes the resolved IP address directly in `result.error` strings (lines 81–92). `ssrf-fetch.ts` intentionally omits the IP from human-readable messages to avoid leaking internal topology into compliance reports. For a CLI grader whose output stays on the operator's terminal this is low risk, but worth aligning in a follow-up.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01648bZhu2JMjvS7WC949n2J

---
_Generated by [Claude Code](https://claude.ai/code/session_01648bZhu2JMjvS7WC949n2J)_