### PR TITLE
feat(testing): version-staleness suffix on shape-drift hints (#850)

### DIFF
--- a/.changeset/version-staleness-hint.md
+++ b/.changeset/version-staleness-hint.md
@@ -1,0 +1,15 @@
+---
+"@adcp/client": minor
+---
+
+feat(testing): version-staleness suffix on shape-drift hints when agent reports old SDK version
+
+When a storyboard drift hint recommends a server-side helper (e.g. `buildCreativeResponse()`)
+and the agent's `get_adcp_capabilities` response reports a `library_version` below the
+minimum release that shipped that helper, the hint message is now suffixed with an upgrade
+note: "Note: your agent reports @adcp/client@X.Y.Z — helperFn() ships in @adcp/client ≥N.N.N.
+Upgrade your SDK dep."
+
+The `createAdcpServer` capabilities handler now stamps `library_version: "@adcp/client@X.Y.Z"` in
+the `get_adcp_capabilities` response so agents built on this SDK surface the version automatically.
+Agents that don't emit `library_version` are unaffected — the suffix is silently omitted.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -120,6 +120,7 @@ import type { JwksResolver } from '../signing/jwks';
 import type { ReplayStore } from '../signing/replay';
 import type { RevocationStore } from '../signing/revocation';
 import type { ContentDigestPolicy } from '../signing/types';
+import { LIBRARY_VERSION } from '../version';
 
 // Type-only imports for AdcpToolMap handler signatures (z.input<typeof ...>)
 import type {
@@ -2986,6 +2987,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   if (capConfig?.overrides) {
     applyCapabilityOverrides(capabilitiesData, capConfig.overrides);
   }
+
+  // Stamp the SDK version so conformance tooling can surface version-staleness
+  // hints when the agent's reported version predates recommended helpers.
+  // Cast needed because GetAdCPCapabilitiesResponse is generated and lacks
+  // this field; it remains a forward-compatible extension until the spec
+  // formally defines library_version in a future AdCP minor.
+  (capabilitiesData as Record<string, unknown>).library_version = `@adcp/client@${LIBRARY_VERSION}`;
 
   // Passthrough inputSchema — framework validation is authoritative on
   // both transports (#909). Same rationale as the domain-tool loop above.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2993,7 +2993,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   // Cast needed because GetAdCPCapabilitiesResponse is generated and lacks
   // this field; it remains a forward-compatible extension until the spec
   // formally defines library_version in a future AdCP minor.
-  (capabilitiesData as Record<string, unknown>).library_version = `@adcp/client@${LIBRARY_VERSION}`;
+  (capabilitiesData as unknown as Record<string, unknown>).library_version = `@adcp/client@${LIBRARY_VERSION}`;
 
   // Passthrough inputSchema — framework validation is authoritative on
   // both transports (#909). Same rationale as the domain-tool loop above.

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -260,6 +260,8 @@ export async function discoverAgentProfile(
         if (Array.isArray(specialisms)) {
           profile.specialisms = specialisms.filter((s): s is string => typeof s === 'string');
         }
+        const libVersion = (caps.data as Record<string, unknown>).library_version;
+        if (typeof libVersion === 'string') profile.library_version = libVersion;
       } else {
         profile.capabilities_probe_error = caps?.error || 'get_adcp_capabilities returned no data';
       }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -816,6 +816,7 @@ async function executeStoryboardPass(
         runnerVars,
         contextProvenance,
         priorA2aEnvelopes,
+        agentLibraryVersion: profile?.library_version,
       });
       const result: StoryboardStepResult = { ...rawResult, storyboard_id: storyboard.id };
       if (isMultiInstance) {
@@ -1241,9 +1242,15 @@ export async function runStoryboardStep(
   validateTestKit(options.test_kit);
   const client = getOrCreateClient(agentUrl, options);
 
-  // Discover agent profile for standalone step execution
+  // Discover agent profile for standalone step execution. Captured so the
+  // executeStep call below can thread `library_version` through to
+  // shape-drift hint detection (issue #850).
+  let profile: AgentProfile | undefined;
   if (!options._client) {
-    await getOrDiscoverProfile(client, options);
+    const discovered = await getOrDiscoverProfile(client, options);
+    profile = discovered.profile;
+  } else {
+    profile = options._profile;
   }
 
   const context: StoryboardContext = { ...options.context };
@@ -1286,6 +1293,7 @@ export async function runStoryboardStep(
     runnerVars,
     contextProvenance,
     priorA2aEnvelopes: new Map(),
+    agentLibraryVersion: profile?.library_version,
   });
 
   if (!options._client) {
@@ -1330,6 +1338,14 @@ interface ExecutionState {
    * up from the per-step `ExecutionState` literal.
    */
   priorA2aEnvelopes?: Map<string, A2ATaskEnvelope>;
+  /**
+   * Agent's reported `@adcp/client@X.Y.Z` library version, captured from
+   * the `get_adcp_capabilities` discovery probe. Threaded into shape-drift
+   * hints so the runner can suffix recommendations with a version-staleness
+   * note when a recommended helper postdates the agent's pinned SDK. Issue
+   * #850. Undefined when the agent did not advertise `library_version`.
+   */
+  agentLibraryVersion?: string;
 }
 
 async function executeStep(
@@ -1810,7 +1826,10 @@ async function executeStep(
     }
     return raw;
   })();
-  const shapeDriftHints = driftPayload === undefined ? [] : detectShapeDriftHints(effectiveStep.task, driftPayload, profile?.library_version);
+  const shapeDriftHints =
+    driftPayload === undefined
+      ? []
+      : detectShapeDriftHints(effectiveStep.task, driftPayload, runState.agentLibraryVersion);
   const strictHints = detectStrictValidationHints(effectiveStep.task, validations);
   // Same root cause MAY produce both a `shape_drift` hint and a
   // `format_mismatch` (keyword: 'type') hint — e.g. `list_creatives`

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1810,7 +1810,7 @@ async function executeStep(
     }
     return raw;
   })();
-  const shapeDriftHints = driftPayload === undefined ? [] : detectShapeDriftHints(effectiveStep.task, driftPayload);
+  const shapeDriftHints = driftPayload === undefined ? [] : detectShapeDriftHints(effectiveStep.task, driftPayload, profile?.library_version);
   const strictHints = detectStrictValidationHints(effectiveStep.task, validations);
   // Same root cause MAY produce both a `shape_drift` hint and a
   // `format_mismatch` (keyword: 'type') hint — e.g. `list_creatives`

--- a/src/lib/testing/storyboard/shape-drift-hints.ts
+++ b/src/lib/testing/storyboard/shape-drift-hints.ts
@@ -27,9 +27,6 @@ import type { ShapeDriftHint } from './types';
  */
 const HELPER_MIN_VERSION: Record<string, string> = {
   buildCreativeResponse: '5.14.0',
-  audioAsset: '5.14.0',
-  displayRender: '5.14.0',
-  parameterizedRender: '5.14.0',
   listCreativesResponse: '5.10.0',
   listCreativeFormatsResponse: '5.10.0',
   listAccountsResponse: '5.10.0',
@@ -50,8 +47,12 @@ const HELPER_MIN_VERSION: Record<string, string> = {
  * Handles `@adcp/client@X.Y.Z` format by stripping the package prefix.
  */
 function semverLessThan(a: string, b: string): boolean {
-  const strip = (v: string) => v.replace(/^.*@/, '');
-  const segs = (v: string) => strip(v).split('.').map(s => parseInt(s, 10) || 0);
+  // Strip package prefix (e.g. "@adcp/client@") and pre-release suffix (e.g. "-beta.1")
+  const normalize = (v: string) => v.replace(/^.*@/, '').replace(/-.*$/, '');
+  const segs = (v: string) =>
+    normalize(v)
+      .split('.')
+      .map(s => parseInt(s, 10) || 0);
   const [aMaj, aMin, aPatch] = segs(a);
   const [bMaj, bMin, bPatch] = segs(b);
   if (aMaj !== bMaj) return aMaj < bMaj;
@@ -113,6 +114,9 @@ export function detectShapeDriftHints(taskName: string, payload: unknown, librar
  * no match.
  */
 function appendVersionSuffix(message: string, libraryVersion: string): string {
+  // Skip non-numeric version strings (e.g. "local-dev") to avoid spurious suffixes
+  const stripped = libraryVersion.replace(/^.*@/, '').replace(/-.*$/, '');
+  if (!/^\d+\.\d+/.test(stripped)) return message;
   for (const [helper, minVersion] of Object.entries(HELPER_MIN_VERSION)) {
     if (message.includes(helper) && semverLessThan(libraryVersion, minVersion)) {
       return (

--- a/src/lib/testing/storyboard/shape-drift-hints.ts
+++ b/src/lib/testing/storyboard/shape-drift-hints.ts
@@ -53,8 +53,8 @@ function semverLessThan(a: string, b: string): boolean {
     normalize(v)
       .split('.')
       .map(s => parseInt(s, 10) || 0);
-  const [aMaj, aMin, aPatch] = segs(a);
-  const [bMaj, bMin, bPatch] = segs(b);
+  const [aMaj = 0, aMin = 0, aPatch = 0] = segs(a);
+  const [bMaj = 0, bMin = 0, bPatch = 0] = segs(b);
   if (aMaj !== bMaj) return aMaj < bMaj;
   if (aMin !== bMin) return aMin < bMin;
   return aPatch < bPatch;

--- a/src/lib/testing/storyboard/shape-drift-hints.ts
+++ b/src/lib/testing/storyboard/shape-drift-hints.ts
@@ -21,6 +21,45 @@
 import type { ShapeDriftHint } from './types';
 
 /**
+ * Minimum @adcp/client version in which each server-side helper first shipped.
+ * Used to suffix shape-drift hints when the agent reports an older SDK version.
+ * Keys match the helper name referenced in the hint `message`.
+ */
+const HELPER_MIN_VERSION: Record<string, string> = {
+  buildCreativeResponse: '5.14.0',
+  audioAsset: '5.14.0',
+  displayRender: '5.14.0',
+  parameterizedRender: '5.14.0',
+  listCreativesResponse: '5.10.0',
+  listCreativeFormatsResponse: '5.10.0',
+  listAccountsResponse: '5.10.0',
+  productsResponse: '5.10.0',
+  getMediaBuysResponse: '5.10.0',
+  getSignalsResponse: '5.10.0',
+  listPropertyListsResponse: '5.10.0',
+  listCollectionListsResponse: '5.10.0',
+  listContentStandardsResponse: '5.10.0',
+  getPlanAuditLogsResponse: '5.10.0',
+  syncCreativesResponse: '5.10.0',
+  previewCreativeResponse: '5.10.0',
+};
+
+/**
+ * Compare two semver strings using numeric segment ordering.
+ * Returns true when `a` is strictly less than `b`.
+ * Handles `@adcp/client@X.Y.Z` format by stripping the package prefix.
+ */
+function semverLessThan(a: string, b: string): boolean {
+  const strip = (v: string) => v.replace(/^.*@/, '');
+  const segs = (v: string) => strip(v).split('.').map(s => parseInt(s, 10) || 0);
+  const [aMaj, aMin, aPatch] = segs(a);
+  const [bMaj, bMin, bPatch] = segs(b);
+  if (aMaj !== bMaj) return aMaj < bMaj;
+  if (aMin !== bMin) return aMin < bMin;
+  return aPatch < bPatch;
+}
+
+/**
  * List-shaped tools where handlers commonly return the bare inner array
  * (`[{...}]`) at the top level instead of wrapping it in the required
  * object envelope. Each entry names the wrapper key and the response
@@ -55,10 +94,34 @@ export const LIST_WRAPPER_TOOLS: Record<string, { wrapperKey: string; helper: st
  *   pre-strip. `unknown` rather than `Record<string, unknown>` so bare-
  *   array payloads are recognizable at the top level; object branches
  *   guard internally.
+ * @param libraryVersion — optional SDK version string the agent self-reported
+ *   in `get_adcp_capabilities` (e.g. `"@adcp/client@4.16.2"`). When present
+ *   and below the helper's minimum version, the hint message is suffixed with
+ *   an upgrade note so developers know to update their SDK dep.
  */
-export function detectShapeDriftHints(taskName: string, payload: unknown): ShapeDriftHint[] {
+export function detectShapeDriftHints(taskName: string, payload: unknown, libraryVersion?: string): ShapeDriftHint[] {
   const hint = detect(taskName, payload);
-  return hint ? [hint] : [];
+  if (!hint) return [];
+  if (libraryVersion) hint.message = appendVersionSuffix(hint.message, libraryVersion);
+  return [hint];
+}
+
+/**
+ * If the hint message references a helper that requires a minimum SDK
+ * version and the agent's reported version is below it, append an upgrade
+ * note to the message. Returns the message unchanged if no version data or
+ * no match.
+ */
+function appendVersionSuffix(message: string, libraryVersion: string): string {
+  for (const [helper, minVersion] of Object.entries(HELPER_MIN_VERSION)) {
+    if (message.includes(helper) && semverLessThan(libraryVersion, minVersion)) {
+      return (
+        message +
+        ` (Note: your agent reports ${libraryVersion} — ${helper}() ships in @adcp/client ≥${minVersion}. Upgrade your SDK dep.)`
+      );
+    }
+  }
+  return message;
 }
 
 function detect(taskName: string, payload: unknown): ShapeDriftHint | undefined {

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -257,6 +257,13 @@ export interface AgentProfile {
    * that reference fields not extracted into the normalised profile shape above.
    */
   raw_capabilities?: unknown;
+  /**
+   * SDK version string the agent self-reported in `get_adcp_capabilities`, e.g.
+   * `"@adcp/client@5.14.0"`. Populated opportunistically — absent for hand-rolled
+   * agents that don't emit the field. Used by the storyboard runner to suffix
+   * shape-drift hints when the reported version predates the recommended helper.
+   */
+  library_version?: string;
 }
 
 export interface TestResult {

--- a/test/lib/storyboard-shape-drift-hints.test.js
+++ b/test/lib/storyboard-shape-drift-hints.test.js
@@ -210,7 +210,7 @@ describe('detectShapeDriftHints: version-staleness suffix (issue #850)', () => {
     const [hint] = detectShapeDriftHints('list_creatives', [{ creative_id: 'c1' }], '@adcp/client@4.16.2');
     assert.ok(hint, 'expected a hint');
     assert.match(hint.message, /Note: your agent reports @adcp\/client@4\.16\.2/);
-    assert.match(hint.message, /listCreativesResponse/);
+    assert.match(hint.message, /listCreativesResponse\(\) ships in @adcp\/client ≥5\.10\.0/);
   });
 
   test('no drift detected → no hints regardless of library_version', () => {

--- a/test/lib/storyboard-shape-drift-hints.test.js
+++ b/test/lib/storyboard-shape-drift-hints.test.js
@@ -161,3 +161,64 @@ describe('detectShapeDriftHint (string shim): delegates to structured detector',
     assert.equal(detectShapeDriftHint('build_creative', { creative_manifest: {} }), undefined);
   });
 });
+
+describe('detectShapeDriftHints: version-staleness suffix (issue #850)', () => {
+  test('library_version absent → message unchanged', () => {
+    const [hint] = detectShapeDriftHints('build_creative', {
+      tag_url: 'https://cdn.example.com/ad.mp3',
+      creative_id: 'c1',
+      media_type: 'audio/mpeg',
+    });
+    assert.ok(hint, 'expected a hint');
+    assert.doesNotMatch(hint.message, /Note: your agent reports/);
+  });
+
+  test('library_version present, above minimum → message unchanged', () => {
+    const [hint] = detectShapeDriftHints(
+      'build_creative',
+      { tag_url: 'https://cdn.example.com/ad.mp3', creative_id: 'c1', media_type: 'audio/mpeg' },
+      '@adcp/client@5.20.0'
+    );
+    assert.ok(hint, 'expected a hint');
+    assert.doesNotMatch(hint.message, /Note: your agent reports/);
+  });
+
+  test('library_version present, below minimum (e.g. 5.9.0 < 5.14.0) → suffix appended', () => {
+    const [hint] = detectShapeDriftHints(
+      'build_creative',
+      { tag_url: 'https://cdn.example.com/ad.mp3', creative_id: 'c1', media_type: 'audio/mpeg' },
+      '@adcp/client@5.9.0'
+    );
+    assert.ok(hint, 'expected a hint');
+    assert.match(hint.message, /Note: your agent reports @adcp\/client@5\.9\.0/);
+    assert.match(hint.message, /buildCreativeResponse\(\) ships in @adcp\/client ≥5\.14\.0/);
+    assert.match(hint.message, /Upgrade your SDK dep/);
+  });
+
+  test('semver comparison is numeric, not lexicographic (5.9.0 < 5.14.0, not 5.9.0 > 5.14.0)', () => {
+    // Guard against naive string comparison where "9" > "14" alphabetically
+    const [hint] = detectShapeDriftHints(
+      'build_creative',
+      { tag_url: 'https://cdn.example.com/ad.mp3', creative_id: 'c1' },
+      '@adcp/client@5.9.0'
+    );
+    assert.ok(hint, 'expected a hint');
+    assert.match(hint.message, /Note: your agent reports/, 'suffix must fire for 5.9.0 < 5.14.0');
+  });
+
+  test('bare-array drift with old library_version → suffix appended to list-tool hint', () => {
+    const [hint] = detectShapeDriftHints('list_creatives', [{ creative_id: 'c1' }], '@adcp/client@4.16.2');
+    assert.ok(hint, 'expected a hint');
+    assert.match(hint.message, /Note: your agent reports @adcp\/client@4\.16\.2/);
+    assert.match(hint.message, /listCreativesResponse/);
+  });
+
+  test('no drift detected → no hints regardless of library_version', () => {
+    const hints = detectShapeDriftHints(
+      'build_creative',
+      { creative_manifest: { format_id: 'f1', assets: {} } },
+      '@adcp/client@4.0.0'
+    );
+    assert.equal(hints.length, 0);
+  });
+});


### PR DESCRIPTION
Closes #850

When a storyboard drift hint recommends a server-side helper (e.g. `buildCreativeResponse()`) and the agent self-reported a `library_version` in `get_adcp_capabilities` that predates the helper's minimum SDK release, the hint message is now suffixed: `"Note: your agent reports @adcp/client@4.16.2 — buildCreativeResponse() ships in @adcp/client ≥5.14.0. Upgrade your SDK dep."` Agents that don't emit `library_version` are unaffected. `createAdcpServer` now stamps `library_version` in the capabilities response automatically, so agents built on this SDK surface the version without any adopter changes.

**Changes:**
- `AgentProfile.library_version?: string` — populated from `get_adcp_capabilities` response in `discoverAgentProfile()`
- `createAdcpServer` — stamps `library_version: "@adcp/client@X.Y.Z"` as a forward-compat extension field (schema uses `.passthrough()` so no AJV rejection risk; comment notes this should migrate to `ext.library_version` when the spec formally defines it)
- `detectShapeDriftHints()` — optional third param `libraryVersion`; `HELPER_MIN_VERSION` map; numeric semver comparison with pre-release strip and non-numeric guard
- 6 new tests including the critical `5.9.0 < 5.14.0` case that guards against lexicographic sort bugs

**Nits surfaced from pre-PR review (not fixed — low priority):**
- `hint.message = appendVersionSuffix(...)` mutates the fresh hint object in place; `{ ...hint, message }` would be more consistent with the file's immutable style
- `library_version` wire format is npm-scoped (`@adcp/client@5.20.0`); if a future AdCP minor formalizes the field, bare semver + separate `library_name` will be easier to schema-define
- `HELPER_MIN_VERSION` needs updating alongside new server helpers; a test asserting every `LIST_WRAPPER_TOOLS` key has a corresponding entry would prevent silent drift

**What was tested:**
- `tsc --project tsconfig.lib.json --noEmitOnError false` — zero new errors (2 pre-existing config warnings: deprecated `moduleResolution=node10`, missing `@types/node`)
- `node --test test/lib/storyboard-shape-drift-hints.test.js` — 19/19 pass
- Full suite baseline: 534 pre-existing failures before changes, 534 pre-existing failures after (my 6 new tests all pass; the +6 delta in total count is from the new describe block, not new failures)

**Pre-PR review:**
- code-reviewer: approved after two blocker fixes (dead `HELPER_MIN_VERSION` entries removed, pre-release semver strip added) — nits noted above
- ad-tech-protocol-expert: approved — schema uses `.passthrough()` so extension field is safe; nit on wire format convention noted above

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01GePNjMP1gsdCwndoBMKhHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GePNjMP1gsdCwndoBMKhHJ)_