### PR TITLE
fix(grader): skip neg/007 and neg/018 when verifier advertises covers_content_digest='either'

### DIFF
--- a/.changeset/grader-cd-policy-skip.md
+++ b/.changeset/grader-cd-policy-skip.md
@@ -1,0 +1,5 @@
+---
+"@adcp/client": patch
+---
+
+fix(grader): add agentContentDigestPolicy option + --covers-content-digest CLI flag to auto-skip neg/007 and neg/018 when verifier advertises covers_content_digest='either'

--- a/bin/adcp-grade.js
+++ b/bin/adcp-grade.js
@@ -23,6 +23,14 @@ Options:
   --skip-rate-abuse          Skip vector 020 (fastest grading run)
   --rate-abuse-cap <N>       Override per-keyid cap the grader targets
   --skip <id[,id...]>        Skip specific vector ids (e.g. 007-…,018-…)
+  --covers-content-digest    Agent's covers_content_digest policy from
+    <required|forbidden|either>                           get_adcp_capabilities.request_signing. Auto-skips
+                             vectors whose capability assertions can't grade
+                             against this policy (skip_reason:
+                             capability_profile_mismatch). If not set, all
+                             vectors run; policy-mismatched vectors (e.g.
+                             neg/007 and neg/018 against an 'either' agent)
+                             will FAIL instead of SKIP.
   --only <id[,id...]>        Run only the named vector ids
   --allow-live-side-effects  Opt in to vectors 016/020 against non-sandbox
                              endpoints (USE WITH CARE — creates real orders)
@@ -44,6 +52,8 @@ Examples:
   adcp grade request-signing https://agent.example.com/adcp
   adcp grade request-signing http://127.0.0.1:3000 --allow-http --skip-rate-abuse
   adcp grade request-signing https://sandbox.seller.com/adcp --json | jq
+  adcp grade request-signing https://sandbox.seller.com/adcp \\
+    --covers-content-digest either --skip-rate-abuse
 `;
 
 const USAGE_SIGNER = `Usage: adcp grade signer <agent-url> [options]
@@ -186,6 +196,17 @@ async function runRequestSigningGrader(args) {
           process.exit(2);
         }
         break;
+      case '--covers-content-digest': {
+        const policy = args[++i];
+        if (policy !== 'required' && policy !== 'forbidden' && policy !== 'either') {
+          console.error(
+            `ERROR: --covers-content-digest must be "required", "forbidden", or "either", got "${policy}"\n`
+          );
+          process.exit(2);
+        }
+        options.agentContentDigestPolicy = policy;
+        break;
+      }
       case '--json':
         emitJson = true;
         break;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/client",
-  "version": "5.19.0",
+  "version": "5.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/client",
-      "version": "5.19.0",
+      "version": "5.21.1",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.18.0",

--- a/src/lib/testing/storyboard/request-signing/grader.ts
+++ b/src/lib/testing/storyboard/request-signing/grader.ts
@@ -66,6 +66,23 @@ export interface GradeOptions extends LoadVectorsOptions {
    */
   allowLiveSideEffects?: boolean;
   /**
+   * Agent's declared `covers_content_digest` policy from
+   * `get_adcp_capabilities.request_signing.covers_content_digest`. When set
+   * without `agentCapability`, the grader auto-skips **negative** vectors whose
+   * `verifier_capability.covers_content_digest` asserts a policy the agent
+   * didn't advertise (positive vectors are always gradable regardless of policy):
+   *   - `'either'` → skips neg/007 (`'required'`) and neg/018 (`'forbidden'`)
+   *   - `'required'` → skips neg/018; neg/007 still runs
+   *   - `'forbidden'` → skips neg/007; neg/018 still runs
+   *
+   * Skipped vectors use `skip_reason: 'capability_profile_mismatch'`.
+   *
+   * Has no effect when `agentCapability` is provided — the full capability
+   * fixture's `covers_content_digest` field governs via `capabilityMismatch()`.
+   * Use `agentCapability` when you also need `required_for` skip behavior.
+   */
+  agentContentDigestPolicy?: 'required' | 'forbidden' | 'either';
+  /**
    * Transport shape the agent speaks. `'raw'` (default) POSTs per-operation
    * AdCP endpoints matching the vectors' URL shape. `'mcp'` wraps each
    * vector body in a JSON-RPC `tools/call` envelope and POSTs to the MCP
@@ -259,6 +276,19 @@ function preflightSkip(
         skipped: true,
         skip_reason: 'capability_profile_mismatch',
         diagnostic: mismatch,
+      };
+    }
+  }
+  if (kind === 'negative' && !options.agentCapability && options.agentContentDigestPolicy) {
+    const vectorCd = vector.verifier_capability.covers_content_digest;
+    if (vectorCd !== 'either' && vectorCd !== options.agentContentDigestPolicy) {
+      return {
+        ...base,
+        skipped: true,
+        skip_reason: 'capability_profile_mismatch',
+        diagnostic:
+          `Vector asserts covers_content_digest='${vectorCd}' but agent declares '${options.agentContentDigestPolicy}'. ` +
+          `The agent's policy is incompatible with the vector's expected verifier behavior.`,
       };
     }
   }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP client library version
  */
-export const LIBRARY_VERSION = '5.20.0';
+export const LIBRARY_VERSION = '5.21.1';
 
 /**
  * AdCP specification version this library is built for
@@ -27,10 +27,10 @@ export const COMPATIBLE_ADCP_VERSIONS = ['v2.5', 'v2.6', 'v3', '3.0.0-beta.1', '
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.20.0',
+  library: '5.21.1',
   adcp: '3.0.0',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-26T18:17:01.562Z',
+  generatedAt: '2026-04-27T11:41:35.955Z',
 } as const;
 
 /**

--- a/test/request-signing-grader-e2e.test.js
+++ b/test/request-signing-grader-e2e.test.js
@@ -129,12 +129,6 @@ function startGraderServer({ replayCap, coversContentDigest = 'either' }) {
   });
 }
 
-// Vectors 007 and 018 depend on the verifier advertising a specific
-// `covers_content_digest` policy. The main-test server advertises `either`;
-// 007 expects `required` and 018 expects `forbidden`. Each has its own test
-// that stands up a matching server.
-const CAPABILITY_PROFILE_VECTORS = ['007-missing-content-digest', '018-digest-covered-when-forbidden'];
-
 describe('request-signing grader — end-to-end vs. reference verifier', () => {
   let instance;
 
@@ -150,7 +144,7 @@ describe('request-signing grader — end-to-end vs. reference verifier', () => {
     const report = await gradeRequestSigning(instance.url, {
       allowPrivateIp: true,
       skipRateAbuse: true, // 020 has its own test below with matched caps.
-      skipVectors: CAPABILITY_PROFILE_VECTORS,
+      agentContentDigestPolicy: 'either',
     });
 
     assert.ok(report.contract_loaded, 'test-kit contract loaded');
@@ -229,7 +223,7 @@ describe('request-signing grader — end-to-end vs. reference verifier', () => {
       const report = await gradeRequestSigning(fresh.url, {
         allowPrivateIp: true,
         skipRateAbuse: true,
-        skipVectors: CAPABILITY_PROFILE_VECTORS,
+        agentContentDigestPolicy: 'either',
       });
       const rateAbuse = report.negative.find(v => v.vector_id === '020-rate-abuse');
       assert.ok(rateAbuse, '020-rate-abuse present');
@@ -246,7 +240,7 @@ describe('request-signing grader — end-to-end vs. reference verifier', () => {
       const report = await gradeRequestSigning(fresh.url, {
         allowPrivateIp: true,
         skipRateAbuse: true,
-        skipVectors: CAPABILITY_PROFILE_VECTORS,
+        agentContentDigestPolicy: 'either',
       });
       for (const p of report.positive) {
         assert.ok(p.passed, `positive/${p.vector_id} should pass: ${p.diagnostic}`);
@@ -255,5 +249,29 @@ describe('request-signing grader — end-to-end vs. reference verifier', () => {
     } finally {
       fresh.server.close();
     }
+  });
+
+  test('agentContentDigestPolicy "either" auto-skips vectors 007 and 018 with capability_profile_mismatch', async () => {
+    const report = await gradeRequestSigning(instance.url, {
+      allowPrivateIp: true,
+      skipRateAbuse: true,
+      agentContentDigestPolicy: 'either',
+    });
+
+    const v007 = report.negative.find(v => v.vector_id === '007-missing-content-digest');
+    const v018 = report.negative.find(v => v.vector_id === '018-digest-covered-when-forbidden');
+    assert.ok(v007, '007 in report');
+    assert.ok(v018, '018 in report');
+    assert.strictEqual(v007.skipped, true, '007 should be skipped under either policy');
+    assert.strictEqual(v018.skipped, true, '018 should be skipped under either policy');
+    assert.strictEqual(v007.skip_reason, 'capability_profile_mismatch', '007 skip_reason');
+    assert.strictEqual(v018.skip_reason, 'capability_profile_mismatch', '018 skip_reason');
+
+    const failures = [...report.positive, ...report.negative].filter(v => !v.passed && !v.skipped);
+    assert.deepStrictEqual(
+      failures.map(v => v.vector_id),
+      [],
+      'no un-skipped failures when content-digest policy is declared'
+    );
   });
 });

--- a/test/request-signing-grader-mcp.test.js
+++ b/test/request-signing-grader-mcp.test.js
@@ -142,11 +142,6 @@ function stopMcpAgent(child) {
   });
 }
 
-// Vectors 007/018 depend on the verifier advertising a specific
-// covers_content_digest policy; the MCP agent advertises 'either', so skip
-// them the same way the raw-HTTP e2e test does.
-const CAPABILITY_PROFILE_VECTORS = ['007-missing-content-digest', '018-digest-covered-when-forbidden'];
-
 describe('request-signing grader — MCP transport vs. reference MCP agent', () => {
   // Ephemeral ports (PORT=0) eliminate the parallel-worker collision and
   // zombie-port races that used to flake the rate-abuse subtest (#884).
@@ -169,7 +164,7 @@ describe('request-signing grader — MCP transport vs. reference MCP agent', () 
       allowPrivateIp: true,
       transport: 'mcp',
       skipRateAbuse: true,
-      skipVectors: CAPABILITY_PROFILE_VECTORS,
+      agentContentDigestPolicy: 'either',
     });
 
     // Collect failures so a regression prints all at once.


### PR DESCRIPTION
Closes #1031

## Summary

`adcp grade request-signing` was producing false FAIL results for neg/007 (`missing-content-digest`) and neg/018 (`digest-covered-when-forbidden`) when grading against verifiers that advertise `covers_content_digest: 'either'`. The expected 401 rejections can never fire against an `'either'` verifier — the agent spec-compliantly accepts both covered and uncovered requests — so both vectors fail every run, misleading adopters into thinking their verifier is broken.

The grader already had `capabilityMismatch()` logic in `preflightSkip()` that correctly handles this, but it only fires when the full `agentCapability: VerifierCapabilityFixture` is provided. Adopters would need to discover and manually populate that struct, or manually add `--skip 007-...,018-...` to every invocation.

This PR adds a narrow escape hatch:

- **`GradeOptions.agentContentDigestPolicy?: 'required' | 'forbidden' | 'either'`** — when set without `agentCapability`, auto-skips negative vectors whose `verifier_capability.covers_content_digest` can't match. Only affects negative vectors (positive vectors are always gradable regardless of content-digest policy). Skipped with `skip_reason: 'capability_profile_mismatch'`.
- **`--covers-content-digest <required|forbidden|either>`** CLI flag on `adcp grade request-signing` — analogous to the existing flag on `adcp grade signer`.

The rationale for a narrow option rather than synthesizing `agentCapability` from the CLI: passing `agentCapability = { ..., required_for: [] }` would also skip vectors that test `required_for` enforcement, causing under-coverage on a different dimension.

## What was tested

- `tsc --project tsconfig.lib.json --noEmitOnError false` — zero new errors (2 pre-existing config warnings: deprecated `moduleResolution=node10`, missing `@types/node`)
- `npm run format:check` — clean
- `npm test` — 320 failures identical to pre-change baseline (all compliance-cache-dependent; `npm run sync-schemas` requires network access not available in this environment). New tests in `request-signing-grader-e2e.test.js` and `request-signing-grader-mcp.test.js` will pass once CI has the compliance cache.

**Nits surfaced from pre-PR review (not fixed — low priority):**
- `agentContentDigestPolicy: 'required'` skips neg/018 but still runs neg/007; no test covers that specific path (the `'either'` path is the motivating case and is covered)

**Pre-PR review:**
- code-reviewer: approved after two blocker fixes (added `kind === 'negative'` guard; updated MCP test to retire `CAPABILITY_PROFILE_VECTORS` workaround)
- ad-tech-protocol-expert: approved — skip logic is spec-correct; `kind === 'negative'` guard required and added; `skip_reason: 'capability_profile_mismatch'` is the right reuse

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_015KgshPTGDexdFpJpxEdDR9

---
_Generated by [Claude Code](https://claude.ai/code/session_015KgshPTGDexdFpJpxEdDR9)_