### PR TITLE
fix(testing): signals governance advisory block now fires correctly

### DIFF
--- a/.changeset/fix-signals-governance-advisory.md
+++ b/.changeset/fix-signals-governance-advisory.md
@@ -10,6 +10,9 @@ for `.signals`/`.all_signals` keys that never exist in that format, so
 `withRestrictedAttrs` and `withPolicyCategories` were always empty arrays.
 
 `discoverSignals` now returns the raw `GetSignalsResponse.signals` array alongside
-the digested `AgentProfile.supported_signals` array. The governance block uses the
-raw array directly, allowing `restricted_attributes` and `policy_categories`
-extension fields to be evaluated correctly.
+the digested `AgentProfile.supported_signals` array. The advisory block uses the
+raw array directly and also evaluates signals discovered via the fallback-brief
+loop, so agents whose first `get_signals` call returns empty are still graded.
+The advisory hint now points operators at the spec-correct surface for declaring
+`restricted_attributes`/`policy_categories` (the `signal_catalog` in
+`adagents.json`).

--- a/.changeset/fix-signals-governance-advisory.md
+++ b/.changeset/fix-signals-governance-advisory.md
@@ -1,0 +1,15 @@
+---
+"@adcp/client": patch
+---
+
+fix(testing): signals governance advisory block now fires correctly
+
+The governance advisory check in `testSignalsFlow` was silently a no-op: it
+re-parsed `signalsStep.response_preview` (a pre-formatted summary string) looking
+for `.signals`/`.all_signals` keys that never exist in that format, so
+`withRestrictedAttrs` and `withPolicyCategories` were always empty arrays.
+
+`discoverSignals` now returns the raw `GetSignalsResponse.signals` array alongside
+the digested `AgentProfile.supported_signals` array. The governance block uses the
+raw array directly, allowing `restricted_attributes` and `policy_categories`
+extension fields to be evaluated correctly.

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -466,12 +466,19 @@ export async function discoverSignals(
   client: TestClient,
   profile: AgentProfile,
   options: TestOptions
-): Promise<{ signals: AgentProfile['supported_signals']; step: TestStepResult; schemaStep?: TestStepResult }> {
+): Promise<{
+  signals: AgentProfile['supported_signals'];
+  rawSignals: GetSignalsResponse['signals'];
+  step: TestStepResult;
+  schemaStep?: TestStepResult;
+}> {
   const signals: AgentProfile['supported_signals'] = [];
+  let rawSignals: GetSignalsResponse['signals'] = [];
 
   if (!profile.tools.includes('get_signals')) {
     return {
       signals,
+      rawSignals,
       step: {
         step: 'Discover signals',
         passed: false,
@@ -495,7 +502,7 @@ export async function discoverSignals(
   if (result?.success && result?.data) {
     schemaStep = validateResponseSchema('get_signals', result.data);
     const responseData = result.data as GetSignalsResponse;
-    const rawSignals = responseData.signals ?? [];
+    rawSignals = responseData.signals ?? [];
 
     for (const signal of rawSignals) {
       signals.push({
@@ -524,7 +531,7 @@ export async function discoverSignals(
     step.error = result.error || 'get_signals failed';
   }
 
-  return { signals, step, schemaStep };
+  return { signals, rawSignals, step, schemaStep };
 }
 
 /**

--- a/src/lib/testing/scenarios/signals.ts
+++ b/src/lib/testing/scenarios/signals.ts
@@ -37,7 +37,12 @@ export async function testSignalsFlow(
   }
 
   // Discover available signals
-  const { signals: discoveredSignals, step: signalsStep, schemaStep } = await discoverSignals(client, profile, options);
+  const {
+    signals: discoveredSignals,
+    rawSignals: rawDiscoveredSignals,
+    step: signalsStep,
+    schemaStep,
+  } = await discoverSignals(client, profile, options);
   steps.push(signalsStep);
   if (schemaStep) steps.push(schemaStep);
 
@@ -73,35 +78,31 @@ export async function testSignalsFlow(
   profile.supported_signals = allSignals;
 
   // Check for governance metadata on discovered signals (advisory)
-  if (signalsStep.passed && signalsStep.response_preview) {
-    try {
-      const rawSignals = JSON.parse(signalsStep.response_preview);
-      const signalsArray = rawSignals.signals || rawSignals.all_signals || [];
-      const withRestrictedAttrs = signalsArray.filter((s: any) => s.restricted_attributes?.length > 0);
-      const withPolicyCategories = signalsArray.filter((s: any) => s.policy_categories?.length > 0);
+  if (signalsStep.passed && rawDiscoveredSignals.length > 0) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- restricted_attributes/policy_categories are governance extensions not in the core schema
+    const withRestrictedAttrs = rawDiscoveredSignals.filter((s: any) => s.restricted_attributes?.length > 0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const withPolicyCategories = rawDiscoveredSignals.filter((s: any) => s.policy_categories?.length > 0);
 
-      if (signalsArray.length > 0 && withRestrictedAttrs.length === 0 && withPolicyCategories.length === 0) {
-        steps.push({
-          step: 'Governance metadata on signals (advisory)',
-          task: 'get_signals',
-          passed: true,
-          duration_ms: 0,
-          details: `None of ${signalsArray.length} signal(s) declare restricted_attributes or policy_categories. Governance agents will fall back to semantic inference for these signals.`,
-          warnings: [
-            'Signals without declared governance metadata require LLM-based inference for compliance checking. Consider declaring restricted_attributes and policy_categories on sensitive signals.',
-          ],
-        });
-      } else if (withRestrictedAttrs.length > 0 || withPolicyCategories.length > 0) {
-        steps.push({
-          step: 'Governance metadata on signals (advisory)',
-          task: 'get_signals',
-          passed: true,
-          duration_ms: 0,
-          details: `${withRestrictedAttrs.length}/${signalsArray.length} signal(s) declare restricted_attributes, ${withPolicyCategories.length}/${signalsArray.length} declare policy_categories`,
-        });
-      }
-    } catch {
-      // response_preview may not be parseable JSON — skip advisory
+    if (withRestrictedAttrs.length === 0 && withPolicyCategories.length === 0) {
+      steps.push({
+        step: 'Governance metadata on signals (advisory)',
+        task: 'get_signals',
+        passed: true,
+        duration_ms: 0,
+        details: `None of ${rawDiscoveredSignals.length} signal(s) declare restricted_attributes or policy_categories. Governance agents will fall back to semantic inference for these signals.`,
+        warnings: [
+          'Signals without declared governance metadata require LLM-based inference for compliance checking. Consider declaring restricted_attributes and policy_categories on sensitive signals.',
+        ],
+      });
+    } else {
+      steps.push({
+        step: 'Governance metadata on signals (advisory)',
+        task: 'get_signals',
+        passed: true,
+        duration_ms: 0,
+        details: `${withRestrictedAttrs.length}/${rawDiscoveredSignals.length} signal(s) declare restricted_attributes, ${withPolicyCategories.length}/${rawDiscoveredSignals.length} declare policy_categories`,
+      });
     }
   }
 

--- a/src/lib/testing/scenarios/signals.ts
+++ b/src/lib/testing/scenarios/signals.ts
@@ -13,7 +13,7 @@
 import { randomUUID } from 'crypto';
 
 import type { TestOptions, TestStepResult, AgentProfile, TaskResult } from '../types';
-import type { ActivateSignalSuccess, Destination } from '../../types/tools.generated';
+import type { ActivateSignalSuccess, Destination, GetSignalsResponse } from '../../types/tools.generated';
 import { getOrCreateClient, runStep, getOrDiscoverProfile, discoverSignals, validateResponseSchema } from '../client';
 
 /**
@@ -39,7 +39,7 @@ export async function testSignalsFlow(
   // Discover available signals
   const {
     signals: discoveredSignals,
-    rawSignals: rawDiscoveredSignals,
+    rawSignals: firstRawSignals,
     step: signalsStep,
     schemaStep,
   } = await discoverSignals(client, profile, options);
@@ -48,6 +48,7 @@ export async function testSignalsFlow(
 
   // Use mutable array to collect signals
   const allSignals: NonNullable<AgentProfile['supported_signals']> = discoveredSignals || [];
+  let governanceRawSignals: GetSignalsResponse['signals'] = firstRawSignals;
 
   if (!signalsStep.passed || allSignals.length === 0) {
     // If get_signals failed or returned empty, try with more specific briefs
@@ -59,7 +60,11 @@ export async function testSignalsFlow(
     ];
 
     for (const brief of fallbackBriefs) {
-      const { signals: retrySignals, step: retryStep } = await discoverSignals(client, profile, {
+      const {
+        signals: retrySignals,
+        rawSignals: retryRawSignals,
+        step: retryStep,
+      } = await discoverSignals(client, profile, {
         ...options,
         brief,
       });
@@ -69,6 +74,7 @@ export async function testSignalsFlow(
 
       if (retrySignals && retrySignals.length > 0) {
         allSignals.push(...retrySignals);
+        governanceRawSignals = retryRawSignals;
         break;
       }
     }
@@ -77,12 +83,21 @@ export async function testSignalsFlow(
   // Store discovered signals in profile
   profile.supported_signals = allSignals;
 
-  // Check for governance metadata on discovered signals (advisory)
-  if (signalsStep.passed && rawDiscoveredSignals.length > 0) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- restricted_attributes/policy_categories are governance extensions not in the core schema
-    const withRestrictedAttrs = rawDiscoveredSignals.filter((s: any) => s.restricted_attributes?.length > 0);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const withPolicyCategories = rawDiscoveredSignals.filter((s: any) => s.policy_categories?.length > 0);
+  // Check for governance metadata on discovered signals (advisory).
+  // restricted_attributes/policy_categories are defined on SignalDefinition
+  // (the adagents.json signal_catalog), but may pass through on get_signals
+  // response items via additionalProperties. We accept either surface here.
+  if (governanceRawSignals.length > 0) {
+    type GovSignal = GetSignalsResponse['signals'][number] & {
+      restricted_attributes?: string[];
+      policy_categories?: string[];
+    };
+    const withRestrictedAttrs = governanceRawSignals.filter(
+      (s): s is GovSignal => ((s as GovSignal).restricted_attributes?.length ?? 0) > 0
+    );
+    const withPolicyCategories = governanceRawSignals.filter(
+      (s): s is GovSignal => ((s as GovSignal).policy_categories?.length ?? 0) > 0
+    );
 
     if (withRestrictedAttrs.length === 0 && withPolicyCategories.length === 0) {
       steps.push({
@@ -90,9 +105,9 @@ export async function testSignalsFlow(
         task: 'get_signals',
         passed: true,
         duration_ms: 0,
-        details: `None of ${rawDiscoveredSignals.length} signal(s) declare restricted_attributes or policy_categories. Governance agents will fall back to semantic inference for these signals.`,
+        details: `None of ${governanceRawSignals.length} signal(s) declare restricted_attributes or policy_categories. Governance agents will fall back to semantic inference for these signals.`,
         warnings: [
-          'Signals without declared governance metadata require LLM-based inference for compliance checking. Consider declaring restricted_attributes and policy_categories on sensitive signals.',
+          'Signals without declared governance metadata require LLM-based inference for compliance checking. Per AdCP 3.0, declare restricted_attributes and policy_categories on signal_catalog entries in adagents.json (they may also pass through on get_signals response items).',
         ],
       });
     } else {
@@ -101,7 +116,7 @@ export async function testSignalsFlow(
         task: 'get_signals',
         passed: true,
         duration_ms: 0,
-        details: `${withRestrictedAttrs.length}/${rawDiscoveredSignals.length} signal(s) declare restricted_attributes, ${withPolicyCategories.length}/${rawDiscoveredSignals.length} declare policy_categories`,
+        details: `${withRestrictedAttrs.length}/${governanceRawSignals.length} signal(s) declare restricted_attributes, ${withPolicyCategories.length}/${governanceRawSignals.length} declare policy_categories`,
       });
     }
   }


### PR DESCRIPTION
Refs #1033

The governance advisory check in `testSignalsFlow` was silently a no-op. It re-parsed `signalsStep.response_preview` — a pre-formatted summary object with keys `signal_count`, `signal_types`, `sample_signals` — looking for `.signals`/`.all_signals` keys that never exist in that shape. As a result `withRestrictedAttrs` and `withPolicyCategories` were always empty arrays and the advisory step was never pushed to the output.

`discoverSignals` now returns the raw `GetSignalsResponse['signals']` array alongside the digested `AgentProfile.supported_signals` array. The governance block uses the raw array directly — no JSON.parse round-trip.

**What was tested:**
- `tsc --project tsconfig.lib.json --noEmitOnError false` — zero new errors (2 pre-existing config warnings: deprecated `moduleResolution=node10`, missing `@types/node`)
- `npm run build:lib` — passes
- `npm test` — 3413 pass, 320 pre-existing failures (none in signals/discoverSignals paths), exit 0
- `prettier --check` on changed files — clean

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit: fallback brief loop ignores `rawSignals` without an explanatory comment (intentional — governance advisory is first-call only)
- ad-tech-protocol-expert: approved — non-breaking additive return field; elevated nit: `restricted_attributes`/`policy_categories` are not in the `get_signals` wire schema at AdCP 3.0 GA (they live on `SignalDefinition` in `adagents.json`), so the "none declared" advisory branch will fire for every conformant agent. The advisory is informational-only (`passed: true`) and the mechanism is now correct; the message surface is a separate spec-alignment question (tracked as a follow-up concern by the protocol expert)

~~**Nits surfaced (not fixed — low priority):**~~
~~Both nits noted by the pre-PR review were resolved in the rebase commits: `rawSignals` is now threaded through (no stale "intentionally unused" comment needed), and the advisory message was reworded to point at `signal_catalog` in `adagents.json`, the correct AdCP 3.0 GA location.~~

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01HVTtnJtpj9dqwJQGngjAts

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVTtnJtpj9dqwJQGngjAts)_