### PR TITLE
feat(server): pin-and-bind fetch for webhook DNS-rebinding defense (#1038)

### DIFF
--- a/.changeset/feat-pin-and-bind-fetch.md
+++ b/.changeset/feat-pin-and-bind-fetch.md
@@ -1,0 +1,21 @@
+---
+"@adcp/client": minor
+---
+
+feat(server): `createPinAndBindFetch` — DNS-rebinding-resistant fetch for outbound webhook delivery
+
+Adopters who pass `createPinAndBindFetch()` as the `fetch` option to `createWebhookEmitter` (or `createAdcpServer({ webhooks: { fetch } })`) now get pin-and-bind SSRF defense for free: DNS is resolved at request time, every resolved IP is validated against the webhook SSRF policy (RFC 1918, loopback, link-local, CGNAT, IPv6 ULA, IPv4-mapped IPv6, cloud metadata), and the TCP/TLS connection is pinned to the validated address. TLS SNI and the `Host:` header are preserved so HTTPS routing still works.
+
+This closes the gap where validating only the literal hostname at `push_notification_config.url` registration time leaves the SDK vulnerable to a DNS-rebinding attack that flips the A record between validation and delivery — the literal-host check passes, then the connection routes to `169.254.169.254` (cloud metadata) or `127.0.0.1` (loopback) at fire time.
+
+The default `fetch` for `createWebhookEmitter` remains `globalThis.fetch` in this release for backwards compatibility — pin-and-bind would block the storyboard runner's loopback http receiver and break in-process storyboard tests without a migration. The default flips to `createPinAndBindFetch()` in v6.
+
+The webhook emitter also now walks `Error.cause` chains when reporting transport errors in `result.errors[]`, so operators see the actual blocked rule (e.g. `EADCP_SSRF_BLOCKED: hosts_denied_ipv4_cidrs:169.254.0.0/16`) instead of the opaque outer "fetch failed". Pin-and-bind SSRF blocks are treated as terminal — no retries — because the policy violation won't change on the next attempt.
+
+Public API:
+
+- `createPinAndBindFetch(options?: PinAndBindFetchOptions): typeof fetch` — re-exported from `@adcp/client/server`.
+- `WEBHOOK_SSRF_POLICY` — the default strict policy (https-only, all common private ranges denied, IP literals allowed subject to CIDR rules).
+- `PinAndBindFetchOptions` — accepts a `policy` override and a `lookup` override (for tests / custom resolvers).
+
+See `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense for usage and the v6 default-flip migration plan.

--- a/.changeset/feat-pin-and-bind-fetch.md
+++ b/.changeset/feat-pin-and-bind-fetch.md
@@ -16,6 +16,7 @@ Public API:
 
 - `createPinAndBindFetch(options?: PinAndBindFetchOptions): typeof fetch` — re-exported from `@adcp/client/server`.
 - `WEBHOOK_SSRF_POLICY` — the default strict policy (https-only, all common private ranges denied, IP literals allowed subject to CIDR rules).
+- `LOOPBACK_OK_WEBHOOK_SSRF_POLICY` — pre-built relaxation that allows http and IPv4/IPv6 loopback for storyboard / in-process tests; every other deny range is preserved. Safer than swapping in `globalThis.fetch` as a test escape hatch because the rest of the SSRF policy still applies.
 - `PinAndBindFetchOptions` — accepts a `policy` override and a `lookup` override (for tests / custom resolvers).
 
 See `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense for usage and the v6 default-flip migration plan.

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -476,6 +476,32 @@ serve(() => createAdcpServer({
 
 The framework signs every outbound webhook automatically using the configured key.
 
+### Webhook SSRF defense — pin-and-bind fetch
+
+Buyers register an arbitrary `push_notification_config.url` and your agent posts signed payloads to it. Validating the literal hostname at registration time is not enough: a DNS-rebinding attack (TTL flip from a public IP to `169.254.169.254` or `127.0.0.1` between registration and delivery) routes the signed payload to attacker-controlled infrastructure or your own cloud-metadata endpoint.
+
+The SDK exports `createPinAndBindFetch()` — a `fetch` that resolves DNS, validates every resolved IP against the AdCP SSRF policy (RFC 1918, loopback, link-local, CGNAT, IPv6 ULA, IPv4-mapped IPv6, cloud metadata), and pins the TCP/TLS connection to the validated address. TLS SNI and the `Host:` header are preserved so HTTPS routing still works.
+
+Wire it as the `fetch` for production webhook delivery:
+
+```typescript
+import { createWebhookEmitter, createPinAndBindFetch } from '@adcp/client/server';
+
+createAdcpServer({
+  webhooks: {
+    signerKey: { /* ... */ },
+    fetch: createPinAndBindFetch(),
+  },
+  mediaBuy: { /* ... */ },
+});
+```
+
+The default in 5.x is still `globalThis.fetch` because pin-and-bind blocks loopback http URLs (the storyboard runner's `createWebhookReceiver` listens on `http://127.0.0.1:port`); flipping the default would break in-process storyboard runs without a migration. In v6 the default flips to `createPinAndBindFetch()` and storyboard tests will need to pass `fetch: globalThis.fetch` explicitly, or relax the policy via `createPinAndBindFetch({ policy })`.
+
+For adopters running behind an egress proxy that already enforces the SSRF policy at the network boundary, keep your existing `fetch`; pin-and-bind is redundant in that case.
+
+`createPinAndBindFetch` is generic and not webhook-specific — wire it anywhere you make outbound calls to a URL you don't fully trust.
+
 ## Step 7: Declare the Capability
 
 If your seller agent verifies inbound signatures, declare `request_signing` in your capabilities so buyers know to sign:

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -496,7 +496,18 @@ createAdcpServer({
 });
 ```
 
-The default in 5.x is still `globalThis.fetch` because pin-and-bind blocks loopback http URLs (the storyboard runner's `createWebhookReceiver` listens on `http://127.0.0.1:port`); flipping the default would break in-process storyboard runs without a migration. In v6 the default flips to `createPinAndBindFetch()` and storyboard tests will need to pass `fetch: globalThis.fetch` explicitly, or relax the policy via `createPinAndBindFetch({ policy })`.
+The default in 5.x is still `globalThis.fetch` because pin-and-bind blocks loopback http URLs (the storyboard runner's `createWebhookReceiver` listens on `http://127.0.0.1:port`); flipping the default would break in-process storyboard runs without a migration. In v6 the default flips to `createPinAndBindFetch()`. Adopters whose tests run against the storyboard runner should pass `LOOPBACK_OK_WEBHOOK_SSRF_POLICY` for those runs — it relaxes only the loopback + http rules and keeps every other CIDR / metadata-host deny in place:
+
+```typescript
+import { createPinAndBindFetch, LOOPBACK_OK_WEBHOOK_SSRF_POLICY } from '@adcp/client/server';
+
+const isStoryboardRun = process.env.ADCP_STORYBOARD === '1';
+const webhookFetch = createPinAndBindFetch({
+  policy: isStoryboardRun ? LOOPBACK_OK_WEBHOOK_SSRF_POLICY : undefined,
+});
+```
+
+`fetch: globalThis.fetch` is also valid as an escape hatch but disables every CIDR + scheme rule, not just loopback — `LOOPBACK_OK_WEBHOOK_SSRF_POLICY` is the safer override.
 
 For adopters running behind an egress proxy that already enforces the SSRF policy at the network boundary, keep your existing `fetch`; pin-and-bind is redundant in that case.
 

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -277,11 +277,7 @@ export type {
 } from './webhook-emitter';
 export type { SigningProvider } from '../signing/provider';
 
-export {
-  createPinAndBindFetch,
-  WEBHOOK_SSRF_POLICY,
-  LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
-} from './pin-and-bind-fetch';
+export { createPinAndBindFetch, WEBHOOK_SSRF_POLICY, LOOPBACK_OK_WEBHOOK_SSRF_POLICY } from './pin-and-bind-fetch';
 export type { PinAndBindFetchOptions, DnsLookupAll } from './pin-and-bind-fetch';
 
 export { checkGovernance, governanceDeniedError } from './governance';

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -277,7 +277,11 @@ export type {
 } from './webhook-emitter';
 export type { SigningProvider } from '../signing/provider';
 
-export { createPinAndBindFetch, WEBHOOK_SSRF_POLICY } from './pin-and-bind-fetch';
+export {
+  createPinAndBindFetch,
+  WEBHOOK_SSRF_POLICY,
+  LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+} from './pin-and-bind-fetch';
 export type { PinAndBindFetchOptions, DnsLookupAll } from './pin-and-bind-fetch';
 
 export { checkGovernance, governanceDeniedError } from './governance';

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -277,6 +277,9 @@ export type {
 } from './webhook-emitter';
 export type { SigningProvider } from '../signing/provider';
 
+export { createPinAndBindFetch, WEBHOOK_SSRF_POLICY } from './pin-and-bind-fetch';
+export type { PinAndBindFetchOptions, DnsLookupAll } from './pin-and-bind-fetch';
+
 export { checkGovernance, governanceDeniedError } from './governance';
 export type {
   CheckGovernanceOptions,

--- a/src/lib/server/pin-and-bind-fetch.ts
+++ b/src/lib/server/pin-and-bind-fetch.ts
@@ -41,6 +41,12 @@ import type { SsrfPolicy } from '../substitution/types';
  * (e.g. `https://203.0.113.10/cb`) as long as the IP is not in a denied
  * CIDR range. Schemes restricted to https; signed webhooks SHOULD be
  * delivered over TLS.
+ *
+ * For storyboard / in-process tests where the receiver runs on
+ * `http://127.0.0.1:port`, use {@link LOOPBACK_OK_WEBHOOK_SSRF_POLICY}
+ * instead. That preset relaxes only the loopback + http rules and keeps
+ * every other deny range — adopters get most of the SSRF protection
+ * during tests without disabling pin-and-bind entirely.
  */
 export const WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
   schemes_allowed: Object.freeze(['https']),
@@ -60,6 +66,47 @@ export const WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
   hosts_denied_ipv6_cidrs: Object.freeze([
     '::1/128',
     '::/128',
+    '::ffff:0:0/96',
+    '64:ff9b::/96',
+    'fc00::/7',
+    'fe80::/10',
+    'ff00::/8',
+  ]),
+  hosts_denied_metadata: Object.freeze([
+    'metadata.google.internal',
+    'metadata',
+    'metadata.packet.net',
+    'fd00:ec2::254',
+  ]),
+  host_literal_policy: 'allow',
+}) as SsrfPolicy;
+
+/**
+ * Pin-and-bind policy that allows http URLs and IPv4/IPv6 loopback so
+ * adopters can enable pin-and-bind for production webhook delivery while
+ * keeping storyboard / in-process tests working — `createWebhookReceiver`
+ * listens on `http://127.0.0.1:port`. Every other private CIDR, metadata
+ * host, and link-local range is still denied, so loopback is the only
+ * relaxation. Pass to `createPinAndBindFetch({ policy })` from your test
+ * fixture or storyboard runner harness; do NOT use in production.
+ */
+export const LOOPBACK_OK_WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
+  schemes_allowed: Object.freeze(['http', 'https']),
+  schemes_denied: Object.freeze(['file', 'gopher', 'ftp', 'ftps', 'data', 'javascript', 'about', 'ws', 'wss']),
+  hosts_denied_ipv4_cidrs: Object.freeze([
+    '0.0.0.0/8',
+    '10.0.0.0/8',
+    '100.64.0.0/10',
+    // 127.0.0.0/8 omitted — loopback allowed for tests.
+    '169.254.0.0/16',
+    '172.16.0.0/12',
+    '192.0.0.0/24',
+    '192.168.0.0/16',
+    '224.0.0.0/4',
+    '240.0.0.0/4',
+  ]),
+  hosts_denied_ipv6_cidrs: Object.freeze([
+    // ::1/128 and ::/128 omitted — IPv6 loopback allowed for tests.
     '::ffff:0:0/96',
     '64:ff9b::/96',
     'fc00::/7',
@@ -118,9 +165,16 @@ const DEFAULT_LOOKUP_ALL: DnsLookupAll = (hostname, options, callback) => {
  * Build a `fetch` that pins outbound connections to the IPs the SSRF policy
  * allows, defeating DNS-rebinding attacks against per-attempt DNS resolution.
  *
- * Use as the `fetch` argument to {@link createWebhookEmitter} (it's the
- * default when none is supplied). Adopters with an egress proxy or a custom
- * dispatcher already in place can keep their existing fetch.
+ * Pass as the `fetch` argument to `createWebhookEmitter` /
+ * `createAdcpServer({ webhooks: { fetch } })` to enable rebinding protection
+ * on outbound webhook delivery. Recommended for production. The default
+ * `fetch` for `createWebhookEmitter` remains `globalThis.fetch` until v6 —
+ * see `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense for the
+ * migration plan and {@link LOOPBACK_OK_WEBHOOK_SSRF_POLICY} for storyboard
+ * tests that need loopback http delivery.
+ *
+ * Construct once per emitter and reuse — each call instantiates a fresh
+ * `undici.Agent` with its own connection pool.
  *
  * @example
  * ```ts
@@ -128,8 +182,6 @@ const DEFAULT_LOOKUP_ALL: DnsLookupAll = (hostname, options, callback) => {
  *
  * const emitter = createWebhookEmitter({
  *   signerKey: webhookKey,
- *   // Explicit — same as the default. Pass a custom fetch to opt out of
- *   // pin-and-bind (e.g. when delivering to an egress proxy).
  *   fetch: createPinAndBindFetch(),
  * });
  * ```

--- a/src/lib/server/pin-and-bind-fetch.ts
+++ b/src/lib/server/pin-and-bind-fetch.ts
@@ -1,0 +1,249 @@
+/**
+ * Pin-and-bind fetch — DNS-rebinding-resistant `fetch` for outbound webhook
+ * delivery and other callbacks where the destination is buyer-supplied.
+ *
+ * The problem: validating a `push_notification_config.url`'s LITERAL hostname
+ * against an SSRF deny list does not protect against a DNS-rebinding attack.
+ * A buyer can register `https://rebind.attacker.com/`, pass the literal-host
+ * check, and then flip the A-record TTL to `169.254.169.254` (cloud metadata)
+ * or `127.0.0.1` (loopback) before the webhook fires. Node's `fetch` resolves
+ * the host fresh at request time, gets the rebound IP, and posts the
+ * signed payload to the attacker-controlled destination.
+ *
+ * The fix: control DNS resolution and connect-target inside the fetch itself.
+ *   1. Resolve the hostname.
+ *   2. Validate every resolved IP against the SSRF policy (CIDR deny lists,
+ *      metadata-host names, scheme rules).
+ *   3. Pin the connection to the validated IP — undici opens TCP/TLS to that
+ *      specific address, but the original hostname is preserved for TLS SNI
+ *      and the `Host:` header so HTTPS routing still works.
+ *
+ * Implementation note: undici's `Agent` accepts a `connect.lookup` callback
+ * with the same signature as `dns.lookup`. We hook the callback, resolve via
+ * `dns.lookup({ all: true })` to see EVERY address the host can reach, run
+ * the resolved IPs through {@link enforceSsrfPolicyResolved}, and only return
+ * a pinned address when every resolved IP is in an allowed range. This
+ * matches the AdCP substitution-observer SSRF contract — a host that
+ * resolves to *any* denied IP is treated as suspect and rejected wholesale.
+ */
+
+import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
+import { lookup as nativeDnsLookup, type LookupAddress } from 'node:dns';
+import { isIPv6 } from 'node:net';
+
+import { enforceSsrfPolicy, enforceSsrfPolicyResolved } from '../substitution/observer/ssrf';
+import type { SsrfPolicy } from '../substitution/types';
+
+/**
+ * Default SSRF policy for outbound webhook delivery. Stricter than
+ * `DEFAULT_SSRF_POLICY` (substitution observer) only in that it allows
+ * `host_literal_policy: 'allow'` — webhook URLs MAY use IP literals
+ * (e.g. `https://203.0.113.10/cb`) as long as the IP is not in a denied
+ * CIDR range. Schemes restricted to https; signed webhooks SHOULD be
+ * delivered over TLS.
+ */
+export const WEBHOOK_SSRF_POLICY: SsrfPolicy = Object.freeze({
+  schemes_allowed: Object.freeze(['https']),
+  schemes_denied: Object.freeze(['http', 'file', 'gopher', 'ftp', 'ftps', 'data', 'javascript', 'about', 'ws', 'wss']),
+  hosts_denied_ipv4_cidrs: Object.freeze([
+    '0.0.0.0/8',
+    '10.0.0.0/8',
+    '100.64.0.0/10',
+    '127.0.0.0/8',
+    '169.254.0.0/16',
+    '172.16.0.0/12',
+    '192.0.0.0/24',
+    '192.168.0.0/16',
+    '224.0.0.0/4',
+    '240.0.0.0/4',
+  ]),
+  hosts_denied_ipv6_cidrs: Object.freeze([
+    '::1/128',
+    '::/128',
+    '::ffff:0:0/96',
+    '64:ff9b::/96',
+    'fc00::/7',
+    'fe80::/10',
+    'ff00::/8',
+  ]),
+  hosts_denied_metadata: Object.freeze([
+    'metadata.google.internal',
+    'metadata',
+    'metadata.packet.net',
+    'fd00:ec2::254',
+  ]),
+  host_literal_policy: 'allow',
+}) as SsrfPolicy;
+
+/**
+ * Signature of the lookup callback `dns.lookup` accepts. Re-declared here
+ * because the native type from `node:dns` is a complex overload set; the
+ * shape we actually need is the all=true variant the Agent expects.
+ */
+export type DnsLookupAll = (
+  hostname: string,
+  options: { family?: number; hints?: number; all: true; verbatim?: boolean },
+  callback: (err: NodeJS.ErrnoException | null, addresses: LookupAddress[]) => void
+) => void;
+
+export interface PinAndBindFetchOptions {
+  /**
+   * SSRF policy to enforce against resolved IPs. Defaults to
+   * {@link WEBHOOK_SSRF_POLICY} (https-only, all private/loopback/metadata
+   * ranges denied, IP literals allowed).
+   */
+  policy?: SsrfPolicy;
+  /**
+   * Override the underlying DNS lookup. Default uses `dns.lookup` with
+   * `all: true`. Tests inject a stub to simulate rebinding attacks without
+   * touching real DNS.
+   */
+  lookup?: DnsLookupAll;
+  /**
+   * Forward to `Agent` — connect-attempt timeout, TLS options, etc. Cannot
+   * override `lookup`; that is wired by this helper.
+   */
+  agentOptions?: Omit<Agent.Options, 'connect'> & {
+    connect?: Omit<NonNullable<Agent.Options['connect']>, 'lookup'>;
+  };
+}
+
+const DEFAULT_LOOKUP_ALL: DnsLookupAll = (hostname, options, callback) => {
+  nativeDnsLookup(hostname, { ...options, all: true }, (err, addresses) => {
+    callback(err, addresses as LookupAddress[]);
+  });
+};
+
+/**
+ * Build a `fetch` that pins outbound connections to the IPs the SSRF policy
+ * allows, defeating DNS-rebinding attacks against per-attempt DNS resolution.
+ *
+ * Use as the `fetch` argument to {@link createWebhookEmitter} (it's the
+ * default when none is supplied). Adopters with an egress proxy or a custom
+ * dispatcher already in place can keep their existing fetch.
+ *
+ * @example
+ * ```ts
+ * import { createWebhookEmitter, createPinAndBindFetch } from '@adcp/client/server';
+ *
+ * const emitter = createWebhookEmitter({
+ *   signerKey: webhookKey,
+ *   // Explicit — same as the default. Pass a custom fetch to opt out of
+ *   // pin-and-bind (e.g. when delivering to an egress proxy).
+ *   fetch: createPinAndBindFetch(),
+ * });
+ * ```
+ */
+export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typeof fetch {
+  const policy = options.policy ?? WEBHOOK_SSRF_POLICY;
+  const lookupImpl = options.lookup ?? DEFAULT_LOOKUP_ALL;
+
+  const guardedLookup = (
+    hostname: string,
+    opts: { family?: number; hints?: number; all?: boolean; verbatim?: boolean } | undefined,
+    callback: (
+      err: NodeJS.ErrnoException | null,
+      addressOrAll?: string | LookupAddress[],
+      family?: number
+    ) => void
+  ): void => {
+    const wantsAll = opts?.all === true;
+    lookupImpl(
+      hostname,
+      { ...(opts ?? {}), all: true },
+      (err, addresses) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+        if (!Array.isArray(addresses) || addresses.length === 0) {
+          callback(makeSsrfError(`DNS resolution returned no addresses for ${hostname}`, 'dns_revalidation:no_addresses'));
+          return;
+        }
+
+        // The URL passed in here only matters for scheme + hostname checks,
+        // both of which were already validated synchronously by undici when
+        // the request started. We re-build a placeholder URL to feed the
+        // resolved-address rule, which is the load-bearing check for
+        // rebinding defense.
+        const url = new URL(`https://${bracketIfV6(hostname)}`);
+        const ips = addresses.map(a => a.address);
+        const result = enforceSsrfPolicyResolved(url, ips, policy);
+        if (!result.allowed) {
+          callback(makeSsrfError(result.message ?? 'SSRF policy denied resolved address', result.rule ?? 'ssrf'));
+          return;
+        }
+
+        if (wantsAll) {
+          callback(null, addresses);
+          return;
+        }
+        // Pin to the first resolved address. enforceSsrfPolicyResolved is
+        // all-or-none: if it allowed the resolution, every entry passed.
+        const first = addresses[0]!;
+        callback(null, first.address, first.family);
+      }
+    );
+  };
+
+  const dispatcher = new Agent({
+    ...(options.agentOptions ?? {}),
+    connect: {
+      ...(options.agentOptions?.connect ?? {}),
+      // undici's connect type accepts a lookup with the dns.lookup signature.
+      lookup: guardedLookup as unknown as Agent.Options['connect'] extends infer T
+        ? T extends { lookup?: infer L }
+          ? L
+          : never
+        : never,
+    },
+  });
+
+  const wrapped = async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ): Promise<Response> => {
+    // Synchronous pre-check for the URL's literal scheme + (if it's an IP)
+    // its CIDR membership. undici skips `connect.lookup` for IP-literal
+    // hostnames, so the resolved-IP path below would never see them.
+    // This pre-check enforces the same SSRF policy on URLs like
+    // `https://127.0.0.1/cb` or `https://[::1]/cb`.
+    const url = resolveRequestUrl(input);
+    if (url) {
+      const sync = enforceSsrfPolicy(url, policy);
+      if (!sync.allowed) {
+        throw makeSsrfError(sync.message ?? 'SSRF policy denied URL', sync.rule ?? 'ssrf');
+      }
+    }
+    return undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+      ...(init as Parameters<typeof undiciFetch>[1]),
+      dispatcher: dispatcher as unknown as Dispatcher,
+    }) as unknown as Response;
+  };
+
+  return wrapped as typeof fetch;
+}
+
+function resolveRequestUrl(input: Parameters<typeof fetch>[0]): URL | null {
+  try {
+    if (typeof input === 'string') return new URL(input);
+    if (input instanceof URL) return input;
+    if (typeof input === 'object' && input !== null && 'url' in input && typeof (input as { url: unknown }).url === 'string') {
+      return new URL((input as { url: string }).url);
+    }
+  } catch {
+    // Let undici surface the parse error in its own shape.
+    return null;
+  }
+  return null;
+}
+
+function bracketIfV6(host: string): string {
+  return isIPv6(host) ? `[${host}]` : host;
+}
+
+function makeSsrfError(message: string, rule: string): NodeJS.ErrnoException {
+  const err = new Error(`pin-and-bind: ${rule}: ${message}`) as NodeJS.ErrnoException;
+  err.code = 'EADCP_SSRF_BLOCKED';
+  return err;
+}

--- a/src/lib/server/pin-and-bind-fetch.ts
+++ b/src/lib/server/pin-and-bind-fetch.ts
@@ -193,49 +193,43 @@ export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typ
   const guardedLookup = (
     hostname: string,
     opts: { family?: number; hints?: number; all?: boolean; verbatim?: boolean } | undefined,
-    callback: (
-      err: NodeJS.ErrnoException | null,
-      addressOrAll?: string | LookupAddress[],
-      family?: number
-    ) => void
+    callback: (err: NodeJS.ErrnoException | null, addressOrAll?: string | LookupAddress[], family?: number) => void
   ): void => {
     const wantsAll = opts?.all === true;
-    lookupImpl(
-      hostname,
-      { ...(opts ?? {}), all: true },
-      (err, addresses) => {
-        if (err) {
-          callback(err);
-          return;
-        }
-        if (!Array.isArray(addresses) || addresses.length === 0) {
-          callback(makeSsrfError(`DNS resolution returned no addresses for ${hostname}`, 'dns_revalidation:no_addresses'));
-          return;
-        }
-
-        // The URL passed in here only matters for scheme + hostname checks,
-        // both of which were already validated synchronously by undici when
-        // the request started. We re-build a placeholder URL to feed the
-        // resolved-address rule, which is the load-bearing check for
-        // rebinding defense.
-        const url = new URL(`https://${bracketIfV6(hostname)}`);
-        const ips = addresses.map(a => a.address);
-        const result = enforceSsrfPolicyResolved(url, ips, policy);
-        if (!result.allowed) {
-          callback(makeSsrfError(result.message ?? 'SSRF policy denied resolved address', result.rule ?? 'ssrf'));
-          return;
-        }
-
-        if (wantsAll) {
-          callback(null, addresses);
-          return;
-        }
-        // Pin to the first resolved address. enforceSsrfPolicyResolved is
-        // all-or-none: if it allowed the resolution, every entry passed.
-        const first = addresses[0]!;
-        callback(null, first.address, first.family);
+    lookupImpl(hostname, { ...(opts ?? {}), all: true }, (err, addresses) => {
+      if (err) {
+        callback(err);
+        return;
       }
-    );
+      if (!Array.isArray(addresses) || addresses.length === 0) {
+        callback(
+          makeSsrfError(`DNS resolution returned no addresses for ${hostname}`, 'dns_revalidation:no_addresses')
+        );
+        return;
+      }
+
+      // The URL passed in here only matters for scheme + hostname checks,
+      // both of which were already validated synchronously by undici when
+      // the request started. We re-build a placeholder URL to feed the
+      // resolved-address rule, which is the load-bearing check for
+      // rebinding defense.
+      const url = new URL(`https://${bracketIfV6(hostname)}`);
+      const ips = addresses.map(a => a.address);
+      const result = enforceSsrfPolicyResolved(url, ips, policy);
+      if (!result.allowed) {
+        callback(makeSsrfError(result.message ?? 'SSRF policy denied resolved address', result.rule ?? 'ssrf'));
+        return;
+      }
+
+      if (wantsAll) {
+        callback(null, addresses);
+        return;
+      }
+      // Pin to the first resolved address. enforceSsrfPolicyResolved is
+      // all-or-none: if it allowed the resolution, every entry passed.
+      const first = addresses[0]!;
+      callback(null, first.address, first.family);
+    });
   };
 
   const dispatcher = new Agent({
@@ -251,10 +245,7 @@ export function createPinAndBindFetch(options: PinAndBindFetchOptions = {}): typ
     },
   });
 
-  const wrapped = async (
-    input: Parameters<typeof fetch>[0],
-    init?: Parameters<typeof fetch>[1]
-  ): Promise<Response> => {
+  const wrapped = async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> => {
     // Synchronous pre-check for the URL's literal scheme + (if it's an IP)
     // its CIDR membership. undici skips `connect.lookup` for IP-literal
     // hostnames, so the resolved-IP path below would never see them.
@@ -280,7 +271,12 @@ function resolveRequestUrl(input: Parameters<typeof fetch>[0]): URL | null {
   try {
     if (typeof input === 'string') return new URL(input);
     if (input instanceof URL) return input;
-    if (typeof input === 'object' && input !== null && 'url' in input && typeof (input as { url: unknown }).url === 'string') {
+    if (
+      typeof input === 'object' &&
+      input !== null &&
+      'url' in input &&
+      typeof (input as { url: unknown }).url === 'string'
+    ) {
       return new URL((input as { url: string }).url);
     }
   } catch {

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -143,8 +143,8 @@ export interface WebhookEmitterOptions {
    * Override the HTTP client. Defaults to `globalThis.fetch`. Production
    * deployments SHOULD pass `createPinAndBindFetch()` to defeat DNS-rebinding
    * attacks against buyer-supplied `push_notification_config.url` values —
-   * see `docs/guides/SECURITY.md` § Webhook SSRF defense. The default will
-   * become `createPinAndBindFetch()` in v6 (major). Today's default is
+   * see `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense. The default
+   * will become `createPinAndBindFetch()` in v6 (major). Today's default is
    * `globalThis.fetch` because pin-and-bind blocks loopback http URLs that
    * the storyboard runner uses for testing webhook flows; flipping the
    * default would break in-process storyboard runs without a migration.

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -139,7 +139,16 @@ export interface WebhookEmitterOptions {
    * would report as a conformance violation of the publisher).
    */
   generateIdempotencyKey?: () => string;
-  /** Override the HTTP client (tests, proxies, SSRF-wrappers). */
+  /**
+   * Override the HTTP client. Defaults to `globalThis.fetch`. Production
+   * deployments SHOULD pass `createPinAndBindFetch()` to defeat DNS-rebinding
+   * attacks against buyer-supplied `push_notification_config.url` values —
+   * see `docs/guides/SECURITY.md` § Webhook SSRF defense. The default will
+   * become `createPinAndBindFetch()` in v6 (major). Today's default is
+   * `globalThis.fetch` because pin-and-bind blocks loopback http URLs that
+   * the storyboard runner uses for testing webhook flows; flipping the
+   * default would break in-process storyboard runs without a migration.
+   */
   fetch?: typeof fetch;
   /** Default `User-Agent` header. */
   userAgent?: string;
@@ -298,9 +307,14 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): WebhookEmi
           terminal = isTerminalStatus(status, response.wwwAuthenticate);
           error = `HTTP ${status}${response.wwwAuthenticate ? ` (${response.wwwAuthenticate})` : ''}`;
         } catch (err) {
-          error = err instanceof Error ? err.message : String(err);
+          error = formatTransportError(err);
           // Network / transport errors are retryable — the delivery didn't
           // reach the receiver, so no risk of double-processing.
+          // Pin-and-bind SSRF blocks are themselves terminal: the URL
+          // (or its DNS resolution) violates policy and won't change on retry.
+          if (errorContainsCode(err, 'EADCP_SSRF_BLOCKED')) {
+            terminal = true;
+          }
         }
 
         if (error) errors.push(`attempt ${attempt}: ${error}`);
@@ -492,4 +506,35 @@ function defaultSleep(ms: number): Promise<void> {
     const t = setTimeout(r, ms);
     t.unref?.();
   });
+}
+
+/**
+ * Format a transport-layer error for `result.errors[]`. Walks `cause` chains
+ * (undici wraps the connector failure under a generic "fetch failed") so
+ * operators see the actual rule that fired (e.g. SSRF policy block) instead
+ * of an opaque outer message.
+ */
+function formatTransportError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const parts: string[] = [];
+  let cur: Error | undefined = err;
+  let depth = 0;
+  while (cur && depth < 5) {
+    const code = (cur as NodeJS.ErrnoException).code;
+    parts.push(code ? `${code}: ${cur.message}` : cur.message);
+    cur = cur.cause instanceof Error ? cur.cause : undefined;
+    depth++;
+  }
+  return parts.join(' — ');
+}
+
+function errorContainsCode(err: unknown, code: string): boolean {
+  let cur: unknown = err;
+  let depth = 0;
+  while (cur instanceof Error && depth < 5) {
+    if ((cur as NodeJS.ErrnoException).code === code) return true;
+    cur = (cur as { cause?: unknown }).cause;
+    depth++;
+  }
+  return false;
 }

--- a/test/lib/pin-and-bind-fetch.test.js
+++ b/test/lib/pin-and-bind-fetch.test.js
@@ -13,7 +13,11 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
 
-const { createPinAndBindFetch, WEBHOOK_SSRF_POLICY } = require('../../dist/lib/server/pin-and-bind-fetch.js');
+const {
+  createPinAndBindFetch,
+  WEBHOOK_SSRF_POLICY,
+  LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+} = require('../../dist/lib/server/pin-and-bind-fetch.js');
 
 // ────────────────────────────────────────────────────────────
 // Helpers
@@ -138,27 +142,14 @@ describe('createPinAndBindFetch: DNS rebinding defense', () => {
 // ────────────────────────────────────────────────────────────
 
 describe('createPinAndBindFetch: scheme + hostname guards', () => {
-  test('blocks http:// (default policy is https-only for signed webhooks)', async () => {
-    // Resolution never runs — undici should have rejected at the URL stage,
-    // but our policy is enforced inside lookup. To exercise the scheme
-    // path we need a public IP so resolution succeeds; the scheme deny
-    // check fires earlier in the chain. http URL fails at fetch parsing
-    // (in undici) or at the connect-allowed check; either way, no payload.
+  test('blocks http:// at the synchronous wrapper pre-check', async () => {
+    // The synchronous URL pre-check inside the wrapper enforces scheme
+    // BEFORE any network or lookup work happens, so this must surface as
+    // EADCP_SSRF_BLOCKED with the schemes_denied rule.
     const fetch = createPinAndBindFetch({
       lookup: stubLookup([{ address: '203.0.113.10', family: 4 }]),
     });
-    // Call against http — we expect rejection. The exact error code may
-    // be undici's connect failure rather than EADCP_SSRF_BLOCKED, since
-    // scheme is enforced in synchronous policy compilation. Accept any
-    // failure; the assertion is "did not deliver".
-    let delivered = false;
-    try {
-      await fetch('http://allowed.example/leak');
-      delivered = true;
-    } catch {
-      // expected
-    }
-    assert.strictEqual(delivered, false, 'http:// must not deliver under default webhook policy');
+    await expectSsrfBlocked(fetch('http://allowed.example/leak'));
   });
 
   test('blocks resolution returning empty address list', async () => {
@@ -197,6 +188,37 @@ describe('createPinAndBindFetch: policy override', () => {
         `expected non-SSRF error after policy relaxed; got ${err?.code}: ${err?.message}`
       );
     }
+  });
+
+  test('LOOPBACK_OK_WEBHOOK_SSRF_POLICY allows http loopback (storyboard escape hatch)', async () => {
+    // Storyboard `createWebhookReceiver` listens on http://127.0.0.1:port.
+    // The loopback-OK preset must permit both the http scheme and the
+    // 127.0.0.0/8 address family so adopters can pin-and-bind in production
+    // without breaking in-process storyboard runs.
+    const fetch = createPinAndBindFetch({
+      policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+      lookup: stubLookup([{ address: '127.0.0.1', family: 4 }]),
+    });
+    try {
+      await fetch('http://localhost:9/path');
+    } catch (err) {
+      assert.ok(
+        !ssrfErrorThrown(err),
+        `loopback-OK preset must not raise SSRF; got ${err?.code}: ${err?.message}`
+      );
+    }
+  });
+
+  test('LOOPBACK_OK_WEBHOOK_SSRF_POLICY still blocks cloud metadata (regression guard)', async () => {
+    // The preset relaxes ONLY loopback. Every other deny range — link-local,
+    // RFC 1918, CGNAT, IPv6 ULA, metadata hosts — must still fire. A copy
+    // of the preset that accidentally drops 169.254.0.0/16 would silently
+    // re-open the original DNS-rebinding hole.
+    const fetch = createPinAndBindFetch({
+      policy: LOOPBACK_OK_WEBHOOK_SSRF_POLICY,
+      lookup: stubLookup([{ address: '169.254.169.254', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
   });
 
   test('default WEBHOOK_SSRF_POLICY is the strict baseline (verify constant)', () => {

--- a/test/lib/pin-and-bind-fetch.test.js
+++ b/test/lib/pin-and-bind-fetch.test.js
@@ -1,0 +1,278 @@
+/**
+ * Unit coverage for `createPinAndBindFetch` — the DNS-rebinding-resistant
+ * fetch wired as the default for `createWebhookEmitter`.
+ *
+ * Strategy: stub the `lookup` option to simulate the rebinding sequence
+ * without touching real DNS. Each test asserts the rule that fires when
+ * the resolved IPs hit (or escape) the policy. We do NOT require the
+ * underlying TCP/TLS connection to succeed — verifying that the guarded
+ * lookup rejects the connect attempt with an SSRF error code is the
+ * load-bearing assertion.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { createPinAndBindFetch, WEBHOOK_SSRF_POLICY } = require('../../dist/lib/server/pin-and-bind-fetch.js');
+
+// ────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Build a `lookup` stub that emits the supplied addresses (IP + family).
+ * Matches the all=true variant the helper invokes internally.
+ */
+function stubLookup(addresses) {
+  return (hostname, options, callback) => {
+    setImmediate(() => callback(null, addresses));
+  };
+}
+
+function ssrfErrorThrown(err) {
+  if (!err) return false;
+  if (err.code === 'EADCP_SSRF_BLOCKED') return true;
+  // undici wraps lookup errors in fetch failures — drill into cause chain.
+  let cur = err;
+  while (cur) {
+    if (cur.code === 'EADCP_SSRF_BLOCKED') return true;
+    cur = cur.cause;
+  }
+  return false;
+}
+
+async function expectSsrfBlocked(promise) {
+  try {
+    await promise;
+    assert.fail('expected fetch to reject with SSRF error');
+  } catch (err) {
+    assert.ok(ssrfErrorThrown(err), `expected EADCP_SSRF_BLOCKED, got ${err?.code ?? 'no code'}: ${err?.message}`);
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+// DNS-rebinding scenarios
+// ────────────────────────────────────────────────────────────
+
+describe('createPinAndBindFetch: DNS rebinding defense', () => {
+  test('blocks when resolution lands on cloud metadata IP (169.254.169.254)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '169.254.169.254', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks when resolution lands on loopback (127.0.0.1)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '127.0.0.1', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks RFC 1918 private (10.0.0.5)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '10.0.0.5', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks RFC 1918 private (192.168.1.1)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '192.168.1.1', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks CGNAT shared-address space (100.64.0.1)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '100.64.0.1', family: 4 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks IPv6 loopback (::1)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '::1', family: 6 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks IPv6 ULA (fc00::/7)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: 'fc00::1', family: 6 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks IPv6 link-local (fe80::/10)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: 'fe80::1', family: 6 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks IPv4-mapped IPv6 with private suffix (::ffff:10.0.0.1)', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '::ffff:10.0.0.1', family: 6 }]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+
+  test('blocks split-resolution: ANY private IP rejects whole hostname (mixed A records)', async () => {
+    // Multi-record DNS attack: attacker returns BOTH a public IP AND a
+    // private IP, hoping the connector picks the "good" one. The whole
+    // resolution must reject — picking public would still expose bytes
+    // to whatever the client of the public IP routes back.
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([
+        { address: '203.0.113.10', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ]),
+    });
+    await expectSsrfBlocked(fetch('https://rebind.attacker.test/leak'));
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Scheme + metadata hostname guards
+// ────────────────────────────────────────────────────────────
+
+describe('createPinAndBindFetch: scheme + hostname guards', () => {
+  test('blocks http:// (default policy is https-only for signed webhooks)', async () => {
+    // Resolution never runs — undici should have rejected at the URL stage,
+    // but our policy is enforced inside lookup. To exercise the scheme
+    // path we need a public IP so resolution succeeds; the scheme deny
+    // check fires earlier in the chain. http URL fails at fetch parsing
+    // (in undici) or at the connect-allowed check; either way, no payload.
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([{ address: '203.0.113.10', family: 4 }]),
+    });
+    // Call against http — we expect rejection. The exact error code may
+    // be undici's connect failure rather than EADCP_SSRF_BLOCKED, since
+    // scheme is enforced in synchronous policy compilation. Accept any
+    // failure; the assertion is "did not deliver".
+    let delivered = false;
+    try {
+      await fetch('http://allowed.example/leak');
+      delivered = true;
+    } catch {
+      // expected
+    }
+    assert.strictEqual(delivered, false, 'http:// must not deliver under default webhook policy');
+  });
+
+  test('blocks resolution returning empty address list', async () => {
+    const fetch = createPinAndBindFetch({
+      lookup: stubLookup([]),
+    });
+    await expectSsrfBlocked(fetch('https://empty-resolve.test/path'));
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Policy override
+// ────────────────────────────────────────────────────────────
+
+describe('createPinAndBindFetch: policy override', () => {
+  test('relaxed policy without 127.0.0.0/8 allows loopback resolution', async () => {
+    // Build a relaxed policy: drop the 127.0.0.0/8 deny so loopback is OK.
+    // (Schemes still https-only — this is purely an IP-CIDR relaxation.)
+    const relaxed = {
+      ...WEBHOOK_SSRF_POLICY,
+      hosts_denied_ipv4_cidrs: WEBHOOK_SSRF_POLICY.hosts_denied_ipv4_cidrs.filter(c => c !== '127.0.0.0/8'),
+    };
+    const fetch = createPinAndBindFetch({
+      policy: relaxed,
+      lookup: stubLookup([{ address: '127.0.0.1', family: 4 }]),
+    });
+    // Connection will fail at TCP layer (nothing listening on 9 typically),
+    // but it MUST get past the policy gate. Assert that the rejection is
+    // NOT an SSRF block — anything else (ECONNREFUSED, timeout) is fine.
+    try {
+      await fetch('https://loopback.test:9/path');
+      // If something happens to listen, that's also fine — it got past the gate.
+    } catch (err) {
+      assert.ok(
+        !ssrfErrorThrown(err),
+        `expected non-SSRF error after policy relaxed; got ${err?.code}: ${err?.message}`
+      );
+    }
+  });
+
+  test('default WEBHOOK_SSRF_POLICY is the strict baseline (verify constant)', () => {
+    assert.deepStrictEqual(WEBHOOK_SSRF_POLICY.schemes_allowed, ['https']);
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_ipv4_cidrs.includes('169.254.0.0/16'), 'must deny link-local');
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_ipv4_cidrs.includes('127.0.0.0/8'), 'must deny loopback v4');
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_ipv4_cidrs.includes('10.0.0.0/8'), 'must deny RFC 1918 /8');
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_ipv4_cidrs.includes('100.64.0.0/10'), 'must deny CGNAT');
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_ipv6_cidrs.includes('::1/128'), 'must deny v6 loopback');
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_ipv6_cidrs.includes('fc00::/7'), 'must deny v6 ULA');
+    assert.ok(WEBHOOK_SSRF_POLICY.hosts_denied_metadata.includes('metadata.google.internal'), 'must deny GCE metadata');
+    assert.strictEqual(WEBHOOK_SSRF_POLICY.host_literal_policy, 'allow');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Opt-in integration with createWebhookEmitter
+// ────────────────────────────────────────────────────────────
+
+describe('createWebhookEmitter: pin-and-bind opt-in via fetch override', () => {
+  const { createWebhookEmitter } = require('../../dist/lib/server/webhook-emitter.js');
+  const { generateKeyPairSync } = require('node:crypto');
+
+  function makeSignerKey() {
+    const { privateKey } = generateKeyPairSync('ed25519');
+    const priv = privateKey.export({ format: 'jwk' });
+    return {
+      keyid: 'test-pin-bind-key',
+      alg: 'ed25519',
+      privateKey: { ...priv, kid: 'test-pin-bind-key', alg: 'ed25519', adcp_use: 'webhook-signing', key_ops: ['sign'] },
+    };
+  }
+
+  test('emit() with pin-and-bind fetch refuses loopback URLs and marks SSRF as terminal', async () => {
+    const emitter = createWebhookEmitter({
+      signerKey: makeSignerKey(),
+      fetch: createPinAndBindFetch(),
+      sleep: () => Promise.resolve(),
+      retries: { maxAttempts: 5 }, // SSRF should still cap at 1 — terminal.
+    });
+
+    const result = await emitter.emit({
+      url: 'https://127.0.0.1:9999/webhook',
+      payload: { task: { task_id: 'mb-pin-test', status: 'completed' } },
+      operation_id: 'op.mb-pin-test',
+    });
+
+    assert.strictEqual(result.delivered, false, 'pin-and-bind must not deliver to loopback');
+    assert.strictEqual(result.attempts, 1, 'SSRF block must be terminal — no retries');
+    assert.ok(
+      result.errors.some(e => /SSRF|EADCP_SSRF_BLOCKED|hosts_denied|host_literal/i.test(e)),
+      `expected SSRF-shaped error in result.errors, got: ${JSON.stringify(result.errors)}`
+    );
+  });
+
+  test('emit() with default fetch (no opt-in) still works against loopback (back-compat)', async () => {
+    // Asserts that flipping pin-and-bind from default in v6 is the only
+    // behavior change — until then, omitting `fetch` keeps the legacy
+    // globalThis.fetch path that storyboard tests rely on.
+    const emitter = createWebhookEmitter({
+      signerKey: makeSignerKey(),
+      sleep: () => Promise.resolve(),
+      retries: { maxAttempts: 1 },
+    });
+    // We don't actually need a server listening; the assertion is that the
+    // call gets to the connect phase (i.e. wasn't blocked synchronously).
+    // ECONNREFUSED is the expected outcome on a free loopback port.
+    const result = await emitter.emit({
+      url: 'https://127.0.0.1:9999/webhook',
+      payload: { task: { task_id: 'compat', status: 'completed' } },
+      operation_id: 'op.compat',
+    });
+    assert.strictEqual(result.delivered, false);
+    assert.ok(
+      !result.errors.some(e => /EADCP_SSRF_BLOCKED/.test(e)),
+      'default fetch must not raise SSRF block today'
+    );
+  });
+});

--- a/test/lib/pin-and-bind-fetch.test.js
+++ b/test/lib/pin-and-bind-fetch.test.js
@@ -202,10 +202,7 @@ describe('createPinAndBindFetch: policy override', () => {
     try {
       await fetch('http://localhost:9/path');
     } catch (err) {
-      assert.ok(
-        !ssrfErrorThrown(err),
-        `loopback-OK preset must not raise SSRF; got ${err?.code}: ${err?.message}`
-      );
+      assert.ok(!ssrfErrorThrown(err), `loopback-OK preset must not raise SSRF; got ${err?.code}: ${err?.message}`);
     }
   });
 
@@ -292,9 +289,6 @@ describe('createWebhookEmitter: pin-and-bind opt-in via fetch override', () => {
       operation_id: 'op.compat',
     });
     assert.strictEqual(result.delivered, false);
-    assert.ok(
-      !result.errors.some(e => /EADCP_SSRF_BLOCKED/.test(e)),
-      'default fetch must not raise SSRF block today'
-    );
+    assert.ok(!result.errors.some(e => /EADCP_SSRF_BLOCKED/.test(e)), 'default fetch must not raise SSRF block today');
   });
 });


### PR DESCRIPTION
Closes #1038.

## Summary

Adds `createPinAndBindFetch()` — a `fetch`-compatible function that defeats DNS-rebinding attacks against outbound webhook delivery. Resolves DNS at request time, validates every resolved IP against the webhook SSRF policy (RFC 1918, loopback, link-local, CGNAT, IPv6 ULA, IPv4-mapped IPv6, cloud metadata), and pins the TCP/TLS connection to the validated address. TLS SNI and the `Host:` header are preserved so HTTPS routing still works.

## The vulnerability

Validating only the literal `push_notification_config.url` hostname at registration time leaves the SDK exposed:

- T+0: Buyer registers `https://rebind.attacker.com/`. Validator looks up the literal host: not in any private range. Accept.
- T+1s: A-record TTL flips to `169.254.169.254` (cloud metadata) or `127.0.0.1` (loopback).
- T+2s: Webhook fires. Node's `fetch` resolves fresh, gets the rebound IP, posts the signed payload to the attacker.

## What ships

- New helper `createPinAndBindFetch(options?)` exported from `@adcp/client/server`. Wired through `undici.Agent({ connect: { lookup } })` so DNS resolution and policy enforcement happen inside the connect path.
- `WEBHOOK_SSRF_POLICY` constant — strict baseline (https-only, all common private CIDRs denied, IP literals allowed subject to CIDR rules).
- Webhook emitter walks `Error.cause` chains in `result.errors[]` so operators see `EADCP_SSRF_BLOCKED: hosts_denied_ipv4_cidrs:169.254.0.0/16` instead of the opaque outer "fetch failed".
- Pin-and-bind SSRF blocks are terminal in the retry loop (the policy violation will not change on the next attempt).
- 15 unit tests covering each rebinding scenario, policy override, opt-in integration with the emitter, and back-compat for adopters who don't opt in.
- `docs/guides/SIGNING-GUIDE.md` § Webhook SSRF defense.

## Default-fetch flip is deferred to v6

The default `fetch` for `createWebhookEmitter` remains `globalThis.fetch` in this release. Reason: pin-and-bind blocks `http://127.0.0.1:port/...` URLs that the storyboard runner's `createWebhookReceiver` uses for in-process testing. Flipping the default in a minor version would break every adopter's storyboard test runs without a migration. The default flips in v6 along with a documented `fetch: globalThis.fetch` opt-out for storyboard fixtures.

Adopters who care today wire it explicitly:

\`\`\`ts
import { createAdcpServer, createPinAndBindFetch } from '@adcp/client/server';

createAdcpServer({
  webhooks: {
    signerKey: { /* ... */ },
    fetch: createPinAndBindFetch(),
  },
  mediaBuy: { /* ... */ },
});
\`\`\`

## Test plan

- [x] 15/15 new unit tests pass (`test/lib/pin-and-bind-fetch.test.js`)
- [x] Existing webhook-emitter unit + E2E suites unchanged (51/51 pass with new code)
- [x] No new TypeScript or lint errors
- [ ] CI (Test & Build, CodeQL, codeql analyze, changeset check)