### PR TITLE
feat(server): dispatchSeed emits SeedSuccess (#1040)

### DIFF
--- a/.changeset/feat-dispatch-seed-seedsuccess.md
+++ b/.changeset/feat-dispatch-seed-seedsuccess.md
@@ -23,5 +23,5 @@ Affects all six seed scenarios: `seed_product`, `seed_pricing_option`, `seed_cre
 ### Migration
 
 - Callers narrowing seed responses with `expectControllerSuccess(result, 'transition')` switch to `expectControllerSuccess(result, 'seed')`. The narrowing falls through to the new arm via the existing `'seed'` overload.
-- Idempotent-replay detection moves from `previous_state === 'existing'` to a stable `message` token (`'Fixture re-seeded (equivalent)'`).
 - Adopters consuming raw `comply_test_controller` responses for seed scenarios stop reading `previous_state`/`current_state` on those responses (the spec's `not.anyOf` forbids them on `SeedSuccess`).
+- Idempotent-replay detection: the SDK now exports `SEED_MESSAGES.replay` (`'Fixture re-seeded (equivalent)'`) and `SEED_MESSAGES.fresh` (`'Fixture seeded'`) for adopters that want to match the SDK's own emission. **Note**: `message` is not a portable replay protocol — third-party sellers MAY emit any string the spec allows (only `success: true` is required), so cross-implementation buyers should not rely on `message` strings. For SDK-emitted responses the constants give a non-magic-string contract.

--- a/.changeset/feat-dispatch-seed-seedsuccess.md
+++ b/.changeset/feat-dispatch-seed-seedsuccess.md
@@ -1,0 +1,27 @@
+---
+"@adcp/client": minor
+---
+
+feat(server): `dispatchSeed` emits `SeedSuccess` (3.0.1's seed-specific arm)
+
+AdCP 3.0.1 added a dedicated `SeedSuccess` arm to `comply-test-controller-response.json` for `seed_*` scenarios:
+
+```json
+{ "success": true, "message": "Fixture seeded" }
+```
+
+The schema's `oneOf` excludes `previous_state`/`current_state` from this branch via `not.anyOf` — seeds are pre-population, not entity transitions. The SDK previously borrowed `StateTransitionSuccess`'s shape (`{ success: true, previous_state: 'none' | 'existing', current_state: 'seeded' | 'existing' }`) which wire-validated as the transition arm under the open `oneOf` but didn't realize the storyboard ergonomics 3.0.1 designed for.
+
+`createComplyController` / `handleTestControllerRequest` now return `SeedSuccess` from every `seed_*` scenario:
+
+- Fresh seed → `{ success: true, message: 'Fixture seeded' }`
+- Idempotent replay (same id + equivalent fixture) → `{ success: true, message: 'Fixture re-seeded (equivalent)' }`
+- Divergent fixture → unchanged (`INVALID_PARAMS`)
+
+Affects all six seed scenarios: `seed_product`, `seed_pricing_option`, `seed_creative`, `seed_plan`, `seed_media_buy`, `seed_creative_format`. `force_*` scenarios continue to return `StateTransitionSuccess`.
+
+### Migration
+
+- Callers narrowing seed responses with `expectControllerSuccess(result, 'transition')` switch to `expectControllerSuccess(result, 'seed')`. The narrowing falls through to the new arm via the existing `'seed'` overload.
+- Idempotent-replay detection moves from `previous_state === 'existing'` to a stable `message` token (`'Fixture re-seeded (equivalent)'`).
+- Adopters consuming raw `comply_test_controller` responses for seed scenarios stop reading `previous_state`/`current_state` on those responses (the spec's `not.anyOf` forbids them on `SeedSuccess`).

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -84,6 +84,7 @@ export {
   TOOL_INPUT_SHAPE,
   CONTROLLER_SCENARIOS,
   SEED_SCENARIOS,
+  SEED_MESSAGES,
   SESSION_ENTRY_CAP,
   enforceMapCap,
   createSeedFixtureCache,

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -440,8 +440,8 @@ function controllerError(
 /**
  * Per-controller cache for seed-fixture equivalence checks. The handler uses
  * it to enforce the spec-level rule that re-seeding with the same ID and an
- * equivalent fixture yields `previous_state: "existing"`, while a divergent
- * fixture returns `INVALID_PARAMS`.
+ * equivalent fixture yields `SeedSuccess` with `message: "Fixture re-seeded
+ * (equivalent)"`, while a divergent fixture returns `INVALID_PARAMS`.
  *
  * Passed explicitly to {@link handleTestControllerRequest} so custom wrappers
  * can scope the cache to a session, tenant, or test run. Keys are
@@ -634,12 +634,16 @@ async function dispatchSeed(
       );
     }
     await dispatch.invoke();
-    return { success: true, previous_state: 'existing', current_state: 'existing' };
+    // SeedSuccess (3.0.1+): message-only arm. The schema's `oneOf` excludes
+    // `previous_state`/`current_state` from this branch — seeds are
+    // pre-population, not entity transitions. Idempotent-replay token is
+    // the trailing "(equivalent)" qualifier on the message string.
+    return { success: true, message: 'Fixture re-seeded (equivalent)' };
   }
 
   await dispatch.invoke();
   cache?.set(dispatch.key, fixture);
-  return { success: true, previous_state: 'none', current_state: 'seeded' };
+  return { success: true, message: 'Fixture seeded' };
 }
 
 /**
@@ -876,13 +880,14 @@ function summarize(data: ComplyTestControllerResponse): string {
   if (data.success === false) return `Controller error: ${data.error}`;
   if ('scenarios' in data) return `Supported scenarios: ${data.scenarios.join(', ')}`;
   if ('previous_state' in data) {
-    if (data.previous_state === 'none' && data.current_state === 'seeded') return 'Fixture seeded';
-    if (data.previous_state === 'existing' && data.current_state === 'existing')
-      return 'Fixture re-seeded (equivalent)';
     return `Transitioned from ${data.previous_state} to ${data.current_state}`;
   }
   if ('simulated' in data) return `Simulation complete: ${JSON.stringify(data.simulated)}`;
   if ('forced' in data) return `Directive registered: arm=${data.forced.arm}`;
+  // SeedSuccess (3.0.1+): message-only arm. dispatchSeed sets the message
+  // to 'Fixture seeded' / 'Fixture re-seeded (equivalent)'; third-party
+  // sellers may emit other strings (or none — the spec only requires
+  // success).
   return data.message ?? 'Scenario succeeded';
 }
 

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -167,6 +167,21 @@ export const SEED_SCENARIOS = {
 } as const satisfies Record<string, SeedScenario>;
 
 /**
+ * Stable `SeedSuccess.message` strings the SDK's `dispatchSeed` emits.
+ * Adopters who want to detect first-seed vs idempotent-replay can match
+ * on these constants instead of grepping for the literal prose.
+ *
+ * Third-party sellers MAY emit any string the spec allows (the spec only
+ * requires `success: true`); these constants are SDK-specific contracts
+ * and not portable across implementations. For cross-implementation
+ * replay detection, do not rely on `message`.
+ */
+export const SEED_MESSAGES = {
+  fresh: 'Fixture seeded',
+  replay: 'Fixture re-seeded (equivalent)',
+} as const;
+
+/**
  * Build-time check: every scenario in the generated union must appear in
  * {@link CONTROLLER_SCENARIOS}. When the protocol adds a new scenario and
  * this type goes non-`never`, TypeScript will reject the assignment below
@@ -636,14 +651,14 @@ async function dispatchSeed(
     await dispatch.invoke();
     // SeedSuccess (3.0.1+): message-only arm. The schema's `oneOf` excludes
     // `previous_state`/`current_state` from this branch — seeds are
-    // pre-population, not entity transitions. Idempotent-replay token is
-    // the trailing "(equivalent)" qualifier on the message string.
-    return { success: true, message: 'Fixture re-seeded (equivalent)' };
+    // pre-population, not entity transitions. {@link SEED_MESSAGES} carries
+    // the SDK-specific replay-detection token.
+    return { success: true, message: SEED_MESSAGES.replay };
   }
 
   await dispatch.invoke();
   cache?.set(dispatch.key, fixture);
-  return { success: true, message: 'Fixture seeded' };
+  return { success: true, message: SEED_MESSAGES.fresh };
 }
 
 /**

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -10,7 +10,8 @@
  *   - Param validation + typed error envelopes (`UNKNOWN_SCENARIO`,
  *     `INVALID_PARAMS`, `NOT_FOUND`, `INVALID_TRANSITION`, `FORBIDDEN`)
  *   - Seed re-seed idempotency (same id + equivalent fixture =
- *     `previous_state: "existing"`; divergent fixture = `INVALID_PARAMS`)
+ *     `SeedSuccess` with `message: "Fixture re-seeded (equivalent)"`;
+ *     divergent fixture = `INVALID_PARAMS`)
  *   - Optional sandbox gating at both `tools/list` and per-request level
  *
  * The helper does NOT own the state machine. Transition enforcement lives

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -146,9 +146,10 @@ export interface SimulateBudgetSpendParams {
 // ────────────────────────────────────────────────────────────
 
 /** Seed adapters persist the fixture to the seller's data layer. Return
- * value is ignored — the helper builds the `previous_state` / `current_state`
- * envelope from its own idempotency cache. Throw {@link TestControllerError}
- * for typed errors (`INVALID_PARAMS`, `FORBIDDEN`). */
+ * value is ignored — the helper builds the `SeedSuccess` envelope (the
+ * 3.0.1+ message-only seed arm) from its own idempotency cache. Throw
+ * {@link TestControllerError} for typed errors (`INVALID_PARAMS`,
+ * `FORBIDDEN`). */
 export type SeedAdapter<P> = (params: P, ctx: ComplyControllerContext) => Promise<void> | void;
 
 /** Force adapters return a {@link StateTransitionSuccess}. Throw

--- a/src/lib/testing/controller-assertions.ts
+++ b/src/lib/testing/controller-assertions.ts
@@ -94,13 +94,11 @@ export function expectControllerSuccess(result: ComplyTestControllerResponse, ki
 /**
  * Narrow to the `SeedSuccess` arm (3.0.1+ message-only seed acknowledgement).
  *
- * Use this when consuming responses from sellers that emit the new
- * `SeedSuccess` shape (`{ success: true, message? }`). The SDK's own
- * `dispatchSeed` continues to return `StateTransitionSuccess`
- * (`previous_state` / `current_state`) — that path narrows under
- * `kind: 'transition'`. A future minor will migrate the SDK to emit
- * `SeedSuccess` directly; this overload is in place now for inter-op
- * with sellers already on the new arm.
+ * Every `seed_*` scenario returns `SeedSuccess` (`{ success: true, message? }`)
+ * — both responses produced by the SDK's own `dispatchSeed` and responses
+ * from third-party sellers. Force_* scenarios continue to return
+ * `StateTransitionSuccess` (`previous_state` / `current_state`) under
+ * `kind: 'transition'`.
  */
 export function expectControllerSuccess(result: ComplyTestControllerResponse, kind: 'seed'): SeedSuccess;
 export function expectControllerSuccess(result: ComplyTestControllerResponse): AnyControllerSuccess;

--- a/test/comply-controller.test.js
+++ b/test/comply-controller.test.js
@@ -117,7 +117,7 @@ describe('createComplyController — dispatch', () => {
 });
 
 describe('createComplyController — seed idempotency', () => {
-  it('seeds a fresh fixture and returns previous_state: "none"', async () => {
+  it('seeds a fresh fixture and returns SeedSuccess message="Fixture seeded"', async () => {
     const persisted = new Map();
     const controller = createComplyController({
       seed: {
@@ -131,12 +131,15 @@ describe('createComplyController — seed idempotency', () => {
       params: { product_id: 'p1', fixture: { delivery_type: 'non_guaranteed' } },
     });
     assert.strictEqual(result.success, true);
-    assert.strictEqual(result.previous_state, 'none');
-    assert.strictEqual(result.current_state, 'seeded');
+    assert.strictEqual(result.message, 'Fixture seeded');
+    // SeedSuccess MUST NOT carry transition fields — the spec's `not.anyOf`
+    // forbids them on this arm.
+    assert.strictEqual(result.previous_state, undefined);
+    assert.strictEqual(result.current_state, undefined);
     assert.ok(persisted.has('p1'));
   });
 
-  it('re-seeds with equivalent fixture returns previous_state: "existing" and still invokes adapter', async () => {
+  it('re-seeds with equivalent fixture returns SeedSuccess message="Fixture re-seeded (equivalent)" and still invokes adapter', async () => {
     let adapterCalls = 0;
     const controller = createComplyController({
       seed: {
@@ -149,15 +152,15 @@ describe('createComplyController — seed idempotency', () => {
       scenario: 'seed_product',
       params: { product_id: 'p1', fixture: { delivery_type: 'non_guaranteed', channels: ['display'] } },
     });
-    assert.strictEqual(first.previous_state, 'none');
+    assert.strictEqual(first.message, 'Fixture seeded');
     // Reordered keys — canonical JSON should treat this as equivalent.
     const second = await controller.handleRaw({
       scenario: 'seed_product',
       params: { product_id: 'p1', fixture: { channels: ['display'], delivery_type: 'non_guaranteed' } },
     });
     assert.strictEqual(second.success, true);
-    assert.strictEqual(second.previous_state, 'existing');
-    assert.strictEqual(second.current_state, 'existing');
+    assert.strictEqual(second.message, 'Fixture re-seeded (equivalent)');
+    assert.strictEqual(second.previous_state, undefined);
     assert.strictEqual(adapterCalls, 2, 'adapter invoked on each call so its storage stays idempotent');
   });
 
@@ -200,7 +203,7 @@ describe('createComplyController — seed idempotency', () => {
       params: { creative_id: 'same-id', fixture: { status: 'approved' } },
     });
     assert.strictEqual(creativeResult.success, true);
-    assert.strictEqual(creativeResult.previous_state, 'none', 'creative with same id must be fresh');
+    assert.strictEqual(creativeResult.message, 'Fixture seeded', 'creative with same id must be fresh');
   });
 
   it('honors a caller-supplied seedCache for external scoping', async () => {
@@ -222,7 +225,7 @@ describe('createComplyController — seed idempotency', () => {
       scenario: 'seed_product',
       params: { product_id: 'p1', fixture: { v: 1 } },
     });
-    assert.strictEqual(result.previous_state, 'existing');
+    assert.strictEqual(result.message, 'Fixture re-seeded (equivalent)');
   });
 
   it('returns INVALID_PARAMS when a seed is missing its required id', async () => {
@@ -264,12 +267,12 @@ describe('createComplyController — seed idempotency', () => {
       scenario: 'seed_product',
       params: { product_id: 'p1' },
     });
-    assert.strictEqual(first.previous_state, 'none');
+    assert.strictEqual(first.message, 'Fixture seeded');
     const second = await controller.handleRaw({
       scenario: 'seed_product',
       params: { product_id: 'p1', fixture: {} },
     });
-    assert.strictEqual(second.previous_state, 'existing', 'omitted fixture and {} should be equivalent');
+    assert.strictEqual(second.message, 'Fixture re-seeded (equivalent)', 'omitted fixture and {} should be equivalent');
   });
 
   it('treats a cache that evicted between has() and get() as fresh', async () => {
@@ -294,7 +297,7 @@ describe('createComplyController — seed idempotency', () => {
     });
     assert.ok(hasCalled);
     assert.strictEqual(result.success, true);
-    assert.strictEqual(result.previous_state, 'none', 'evicted entry should seed fresh, not crash');
+    assert.strictEqual(result.message, 'Fixture seeded', 'evicted entry should seed fresh, not crash');
   });
 });
 
@@ -353,7 +356,7 @@ describe('createComplyController — seed cache cap', () => {
       params: { product_id: 'p1', fixture: { v: 1 } },
     });
     assert.strictEqual(replay.success, true);
-    assert.strictEqual(replay.previous_state, 'existing');
+    assert.strictEqual(replay.message, 'Fixture re-seeded (equivalent)');
   });
 });
 

--- a/test/lib/storyboard-controller-seeding.test.js
+++ b/test/lib/storyboard-controller-seeding.test.js
@@ -127,9 +127,7 @@ function successResponse() {
   return {
     success: true,
     data: {
-      content: [
-        { type: 'text', text: JSON.stringify({ success: true, previous_state: 'none', current_state: 'seeded' }) },
-      ],
+      content: [{ type: 'text', text: JSON.stringify({ success: true, message: 'Fixture seeded' }) }],
     },
   };
 }

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -340,8 +340,8 @@ describe('handleTestControllerRequest', () => {
         params: { format_id: 'audio_30s', fixture: { duration: 30 } },
       });
       assert.strictEqual(result.success, true);
-      assert.strictEqual(result.previous_state, 'none');
-      assert.strictEqual(result.current_state, 'seeded');
+      assert.strictEqual(result.message, 'Fixture seeded');
+      assert.strictEqual(result.previous_state, undefined);
       assert.deepStrictEqual(calls, [{ formatId: 'audio_30s', fixture: { duration: 30 } }]);
     });
 
@@ -1093,11 +1093,11 @@ describe('expectControllerSuccess', () => {
     assert.strictEqual(ok.forced.task_id, 'task-abc');
   });
 
-  it('narrows to seed arm when kind="seed" (interop with sellers that emit SeedSuccess)', () => {
+  it('narrows to seed arm when kind="seed"', () => {
     // SeedSuccess is the message-only arm 3.0.1 introduced. The SDK's own
-    // dispatchSeed still returns StateTransitionSuccess (previous_state /
-    // current_state), but `expectControllerSuccess(_, 'seed')` covers
-    // responses from third-party sellers that emit the new arm.
+    // dispatchSeed emits this arm (`{ success: true, message: 'Fixture
+    // seeded' | 'Fixture re-seeded (equivalent)' }`). Third-party sellers
+    // can use any message string the spec allows.
     const ok = expectControllerSuccess({ success: true, message: 'Format pre-populated' }, 'seed');
     assert.strictEqual(ok.message, 'Format pre-populated');
   });


### PR DESCRIPTION
Closes #1040.

## Summary

AdCP 3.0.1 added a dedicated `SeedSuccess` arm to `comply-test-controller-response.json` for `seed_*` scenarios. The schema's `oneOf` excludes `previous_state`/`current_state` from this branch via `not.anyOf` — seeds are pre-population, not entity transitions. The SDK previously borrowed `StateTransitionSuccess`'s shape, which wire-validated under the open `oneOf` but didn't realize the storyboard ergonomics 3.0.1 designed for.

`dispatchSeed` now returns:
- Fresh seed: `{ success: true, message: 'Fixture seeded' }`
- Replay (equivalent fixture): `{ success: true, message: 'Fixture re-seeded (equivalent)' }`
- Divergent fixture: unchanged (`INVALID_PARAMS`)

Affects all six seed scenarios. `force_*` scenarios continue to return `StateTransitionSuccess`.

## Migration

- Callers narrowing seed responses with `expectControllerSuccess(result, 'transition')` switch to `expectControllerSuccess(result, 'seed')`. The `'seed'` overload was already in place; narrowing falls through to the new arm cleanly.
- Idempotent-replay detection moves from `previous_state === 'existing'` to a stable `message` token (`'Fixture re-seeded (equivalent)'`).
- Adopters consuming raw `comply_test_controller` responses for seed scenarios stop reading `previous_state`/`current_state` on those responses (the spec's `not.anyOf` forbids them).

## Major vs minor

The issue body suggested major. I shipped as **minor** based on the existing public commitment in `controller-assertions.ts` JSDoc — it explicitly promised "A future minor will migrate the SDK to emit SeedSuccess directly." Wire validation works either way (open `oneOf`); the breakage is limited to TypeScript narrowing on seed responses. If you want this re-classed major, change the changeset bump and I'll regenerate.

## Test plan

- [x] 133/133 controller + storyboard-seeding tests pass after migration
- [x] No new TypeScript or lint errors
- [x] No remaining references to `previous_state`/`current_state` for seed shape in src/ or test/
- [ ] CI (Test & Build, CodeQL, changeset check)