### PR TITLE
feat(testing): add envelope_field_present storyboard check (adcp#3429)

### DIFF
--- a/.changeset/envelope-field-present.md
+++ b/.changeset/envelope-field-present.md
@@ -6,20 +6,20 @@ feat(testing): add envelope-scoped storyboard validation checks
 
 Storyboards that assert v3 envelope-level fields (`status`, `task_id`, `message`, `replayed`, `governance_context`, `timestamp`, `context_id`, `push_notification_config`) need a way to tell static drift detection to walk `protocol-envelope.json` instead of the per-tool response schema. The previous un-prefixed checks pointed at the inner response schema, which doesn't contain envelope fields, so the `v3-envelope-integrity.yaml` storyboard required a `VERIFIER_UNREACHABLE` exemption.
 
-Adds three envelope-scoped `StoryboardValidationCheck` values:
+Adds five new `StoryboardValidationCheck` values:
 
+- `field_absent` — passes when the path is absent; fails when present (companion to `field_present`)
+- `envelope_field_absent` — envelope-scoped companion to `field_absent`; signals drift detection to walk `protocol-envelope.json`; absence checks skip reachability assertions by design
 - `envelope_field_present` — companion to `field_present`
 - `envelope_field_value` — companion to `field_value`
 - `envelope_field_value_or_absent` — companion to `field_value_or_absent`
 
 **Runtime**: identical semantics to the un-prefixed checks — `TaskResult` already exposes envelope fields at its surface (`data.status`, `data.task_id`, etc.), so the dispatcher passes through to the existing handlers. Result objects report the original check name verbatim so reporters can distinguish. The same passthrough lands in `scripts/conformance-replay.ts` so storyboard replay grades the new checks.
 
-**Drift detection**: walks `ProtocolEnvelopeSchema` (from `core/protocol-envelope.json`) instead of `TOOL_RESPONSE_SCHEMAS[task]` for envelope-scoped entries. The existing un-prefixed checks stay pinned to inner-response schemas.
+**Drift detection**: walks `ProtocolEnvelopeSchema` (from `core/protocol-envelope.json`) instead of `TOOL_RESPONSE_SCHEMAS[task]` for envelope-scoped entries. `field_absent` and `envelope_field_absent` are collected by the drift detector but skip reachability assertions — absence checks have no schema target by design.
 
 **Not envelope fields**: `errors` lives inside `payload` (per the per-tool response schema), and `adcp_version` / `adcp_major_version` are request-side only — these stay on the un-prefixed checks.
 
-Forward-compatible with the current 3.0.1 storyboards (no consumers yet). Lights up when the upstream PR migrates `v3-envelope-integrity.yaml` from `field_present: status` to `envelope_field_present: status` (the `VERIFIER_UNREACHABLE` exemption gets dropped after the next `npm run sync-schemas` post-3.0.2).
-
-A future PR will add `field_absent` + `envelope_field_absent` runner support so `v3-envelope-integrity.yaml` can land its currently-TODO `task_status` / `response_status` MUST-NOT assertions.
+Forward-compatible with the current 3.0.1 storyboards. Lights up when the upstream PR migrates `v3-envelope-integrity.yaml` from `field_present: status` to `envelope_field_present: status` (the `VERIFIER_UNREACHABLE` exemption gets dropped after the next `npm run sync-schemas` post-3.0.2). The `task_status` / `response_status` MUST-NOT assertions in `v3-envelope-integrity.yaml` can now land using `field_absent` / `envelope_field_absent` without a further SDK release.
 
 Refs adcp#3429.

--- a/.changeset/envelope-field-present.md
+++ b/.changeset/envelope-field-present.md
@@ -2,15 +2,24 @@
 '@adcp/client': minor
 ---
 
-feat(testing): add `envelope_field_present` storyboard validation check
+feat(testing): add envelope-scoped storyboard validation checks
 
-Storyboards that assert v3 envelope-level fields (`status`, `task_id`, `adcp_version`, `errors`) need a way to tell static drift detection to walk `protocol-envelope.json` instead of the per-tool response schema. The previous `field_present` check pointed at the inner response schema, which doesn't contain envelope fields, so the `v3-envelope-integrity.yaml` storyboard required a `VERIFIER_UNREACHABLE` exemption.
+Storyboards that assert v3 envelope-level fields (`status`, `task_id`, `message`, `replayed`, `governance_context`, `timestamp`, `context_id`, `push_notification_config`) need a way to tell static drift detection to walk `protocol-envelope.json` instead of the per-tool response schema. The previous un-prefixed checks pointed at the inner response schema, which doesn't contain envelope fields, so the `v3-envelope-integrity.yaml` storyboard required a `VERIFIER_UNREACHABLE` exemption.
 
-Adds `envelope_field_present` as a recognized `StoryboardValidationCheck` value:
+Adds three envelope-scoped `StoryboardValidationCheck` values:
 
-- **Runtime**: identical semantics to `field_present` — `TaskResult` already merges envelope fields into its surface, so the dispatcher passes through to `validateFieldPresent`. Result objects report the original check name verbatim so reporters can distinguish.
-- **Drift detection**: walks `ProtocolEnvelopeSchema` (from `core/protocol-envelope.json`) instead of `TOOL_RESPONSE_SCHEMAS[task]` for `envelope_field_present` entries. The existing `field_present` check stays pinned to inner-response schemas.
+- `envelope_field_present` — companion to `field_present`
+- `envelope_field_value` — companion to `field_value`
+- `envelope_field_value_or_absent` — companion to `field_value_or_absent`
+
+**Runtime**: identical semantics to the un-prefixed checks — `TaskResult` already exposes envelope fields at its surface (`data.status`, `data.task_id`, etc.), so the dispatcher passes through to the existing handlers. Result objects report the original check name verbatim so reporters can distinguish. The same passthrough lands in `scripts/conformance-replay.ts` so storyboard replay grades the new checks.
+
+**Drift detection**: walks `ProtocolEnvelopeSchema` (from `core/protocol-envelope.json`) instead of `TOOL_RESPONSE_SCHEMAS[task]` for envelope-scoped entries. The existing un-prefixed checks stay pinned to inner-response schemas.
+
+**Not envelope fields**: `errors` lives inside `payload` (per the per-tool response schema), and `adcp_version` / `adcp_major_version` are request-side only — these stay on the un-prefixed checks.
 
 Forward-compatible with the current 3.0.1 storyboards (no consumers yet). Lights up when the upstream PR migrates `v3-envelope-integrity.yaml` from `field_present: status` to `envelope_field_present: status` (the `VERIFIER_UNREACHABLE` exemption gets dropped after the next `npm run sync-schemas` post-3.0.2).
+
+A future PR will add `field_absent` + `envelope_field_absent` runner support so `v3-envelope-integrity.yaml` can land its currently-TODO `task_status` / `response_status` MUST-NOT assertions.
 
 Refs adcp#3429.

--- a/.changeset/envelope-field-present.md
+++ b/.changeset/envelope-field-present.md
@@ -1,0 +1,16 @@
+---
+'@adcp/client': minor
+---
+
+feat(testing): add `envelope_field_present` storyboard validation check
+
+Storyboards that assert v3 envelope-level fields (`status`, `task_id`, `adcp_version`, `errors`) need a way to tell static drift detection to walk `protocol-envelope.json` instead of the per-tool response schema. The previous `field_present` check pointed at the inner response schema, which doesn't contain envelope fields, so the `v3-envelope-integrity.yaml` storyboard required a `VERIFIER_UNREACHABLE` exemption.
+
+Adds `envelope_field_present` as a recognized `StoryboardValidationCheck` value:
+
+- **Runtime**: identical semantics to `field_present` — `TaskResult` already merges envelope fields into its surface, so the dispatcher passes through to `validateFieldPresent`. Result objects report the original check name verbatim so reporters can distinguish.
+- **Drift detection**: walks `ProtocolEnvelopeSchema` (from `core/protocol-envelope.json`) instead of `TOOL_RESPONSE_SCHEMAS[task]` for `envelope_field_present` entries. The existing `field_present` check stays pinned to inner-response schemas.
+
+Forward-compatible with the current 3.0.1 storyboards (no consumers yet). Lights up when the upstream PR migrates `v3-envelope-integrity.yaml` from `field_present: status` to `envelope_field_present: status` (the `VERIFIER_UNREACHABLE` exemption gets dropped after the next `npm run sync-schemas` post-3.0.2).
+
+Refs adcp#3429.

--- a/scripts/conformance-replay.ts
+++ b/scripts/conformance-replay.ts
@@ -214,7 +214,17 @@ interface StepResult {
 // Check types this v0 implements. Anything outside this set is logged as
 // 'unimplemented' and counted as a skip — silent fall-through would hide
 // gaps from storyboard authors who add a new check expecting it to gate.
-const IMPLEMENTED_CHECKS = new Set(['response_schema', 'field_present', 'field_value']);
+const IMPLEMENTED_CHECKS = new Set([
+  'response_schema',
+  'field_present',
+  'field_value',
+  // Envelope-scoped variants (adcp#3429). Runtime semantics are identical to
+  // the un-prefixed checks because the SDK's response unwrappers expose
+  // envelope fields at the structuredContent surface (`status`, `task_id`,
+  // `replayed`, etc.); the distinction is for static drift detection.
+  'envelope_field_present',
+  'envelope_field_value',
+]);
 
 // Check types that fundamentally need transport-layer state (HTTP status,
 // auth headers, error envelopes) that in-process dispatch doesn't surface.
@@ -308,16 +318,16 @@ async function runStep(
           .join('; ');
         result.failures.push(`response_schema: ${issues}`);
       }
-    } else if (check === 'field_present') {
+    } else if (check === 'field_present' || check === 'envelope_field_present') {
       if (getByPath(structured, v.path as string) === undefined) {
         allPassed = false;
-        result.failures.push(`field_present ${v.path}: missing`);
+        result.failures.push(`${check} ${v.path}: missing`);
       }
-    } else if (check === 'field_value') {
+    } else if (check === 'field_value' || check === 'envelope_field_value') {
       const actual = getByPath(structured, v.path as string);
       if (actual !== v.value) {
         allPassed = false;
-        result.failures.push(`field_value ${v.path}: got ${JSON.stringify(actual)}, want ${JSON.stringify(v.value)}`);
+        result.failures.push(`${check} ${v.path}: got ${JSON.stringify(actual)}, want ${JSON.stringify(v.value)}`);
       }
     } else if (TRANSPORT_ONLY_CHECKS.has(check)) {
       // Transport-only checks require an HTTP-mode harness; permanently

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -401,13 +401,16 @@ export interface StoryboardStep {
 export type StoryboardValidationCheck =
   | 'response_schema'
   | 'field_present'
-  // Envelope-scoped variant of field_present — the asserted path lives on the
-  // v3 protocol envelope (`status`, `task_id`, `adcp_version`, `errors`)
-  // rather than the inner response. Runtime semantics are identical to
-  // field_present (TaskResult merges envelope fields into the surface);
-  // the distinction is for static drift detection, which walks the envelope
-  // schema instead of the per-tool response schema. Added per adcp#3429.
+  // Envelope-scoped variants — the asserted path lives on the v3 protocol
+  // envelope (`status`, `task_id`, `message`, `replayed`, `governance_context`,
+  // `timestamp`, `context_id`, `push_notification_config`) rather than the
+  // inner response. Runtime semantics are identical to the un-prefixed checks
+  // (TaskResult merges envelope fields onto its surface); the distinction is
+  // for static drift detection, which walks `protocol-envelope.json` instead
+  // of the per-tool response schema. Added per adcp#3429.
   | 'envelope_field_present'
+  | 'envelope_field_value'
+  | 'envelope_field_value_or_absent'
   | 'field_value'
   | 'field_value_or_absent'
   | 'status_code'

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -401,6 +401,7 @@ export interface StoryboardStep {
 export type StoryboardValidationCheck =
   | 'response_schema'
   | 'field_present'
+  | 'field_absent'
   // Envelope-scoped variants — the asserted path lives on the v3 protocol
   // envelope (`status`, `task_id`, `message`, `replayed`, `governance_context`,
   // `timestamp`, `context_id`, `push_notification_config`) rather than the
@@ -409,6 +410,7 @@ export type StoryboardValidationCheck =
   // for static drift detection, which walks `protocol-envelope.json` instead
   // of the per-tool response schema. Added per adcp#3429.
   | 'envelope_field_present'
+  | 'envelope_field_absent'
   | 'envelope_field_value'
   | 'envelope_field_value_or_absent'
   | 'field_value'

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -401,6 +401,13 @@ export interface StoryboardStep {
 export type StoryboardValidationCheck =
   | 'response_schema'
   | 'field_present'
+  // Envelope-scoped variant of field_present — the asserted path lives on the
+  // v3 protocol envelope (`status`, `task_id`, `adcp_version`, `errors`)
+  // rather than the inner response. Runtime semantics are identical to
+  // field_present (TaskResult merges envelope fields into the surface);
+  // the distinction is for static drift detection, which walks the envelope
+  // schema instead of the per-tool response schema. Added per adcp#3429.
+  | 'envelope_field_present'
   | 'field_value'
   | 'field_value_or_absent'
   | 'status_code'

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -113,12 +113,16 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       // the storyboard's probe_protected_resource validates fields in the RFC 9728 JSON.
       return validateFieldPresent(validation, resolveTarget(ctx));
     case 'envelope_field_present':
-      // Envelope-scoped variant — runtime semantics identical to field_present
-      // (TaskResult exposes envelope fields like `status`, `task_id` at the
-      // surface level). The check exists primarily so static drift detection
-      // can walk the envelope schema instead of the inner response. See
-      // adcp#3429.
-      return validateFieldPresent(validation, resolveTarget(ctx));
+    case 'envelope_field_value':
+    case 'envelope_field_value_or_absent':
+      // Envelope-scoped variants — runtime semantics identical to the
+      // un-prefixed checks (TaskResult exposes envelope fields like
+      // `status`, `task_id` at the surface level). The distinct check types
+      // exist primarily so static drift detection can walk the envelope
+      // schema instead of the per-tool response. See adcp#3429.
+      if (validation.check === 'envelope_field_present') return validateFieldPresent(validation, resolveTarget(ctx));
+      if (validation.check === 'envelope_field_value') return validateFieldValue(validation, resolveTarget(ctx));
+      return validateFieldValueOrAbsent(validation, resolveTarget(ctx));
     case 'field_value':
       return validateFieldValue(validation, resolveTarget(ctx));
     case 'field_value_or_absent':
@@ -503,10 +507,10 @@ export { LIST_WRAPPER_TOOLS } from './shape-drift-hints';
 // ────────────────────────────────────────────────────────────
 
 function validateFieldPresent(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
-  // `check` may be `field_present` or `envelope_field_present` (adcp#3429);
-  // both share runtime semantics, but the result should reflect the
-  // storyboard's choice so reporters can distinguish.
-  const checkName = validation.check === 'envelope_field_present' ? 'envelope_field_present' : 'field_present';
+  // `check` is either `field_present` or `envelope_field_present` (adcp#3429);
+  // both share runtime semantics, but the result echoes the storyboard's
+  // choice verbatim so reporters can distinguish.
+  const checkName = validation.check;
   if (!validation.path) {
     return {
       check: checkName,
@@ -558,13 +562,16 @@ function valuesMatch(actual: unknown, expected: unknown): boolean {
 }
 
 function validateFieldValue(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
+  // `check` is either `field_value` or `envelope_field_value` (adcp#3429);
+  // result echoes the storyboard's choice so reporters can distinguish.
+  const checkName = validation.check;
   if (!validation.path) {
     return {
-      check: 'field_value',
+      check: checkName,
       passed: false,
       description: validation.description,
       path: validation.path,
-      error: 'No path specified for field_value validation',
+      error: `No path specified for ${checkName} validation`,
       json_pointer: null,
       expected: 'path must be set in storyboard validation entry',
       actual: null,
@@ -579,7 +586,7 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
     const passed = validation.allowed_values.some(v => valuesMatch(actual, v));
     if (passed) {
       return {
-        check: 'field_value',
+        check: checkName,
         passed: true,
         description: validation.description,
         path: validation.path,
@@ -587,7 +594,7 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
       };
     }
     return {
-      check: 'field_value',
+      check: checkName,
       passed: false,
       description: validation.description,
       path: validation.path,
@@ -603,7 +610,7 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
 
   if (passed) {
     return {
-      check: 'field_value',
+      check: checkName,
       passed: true,
       description: validation.description,
       path: validation.path,
@@ -611,7 +618,7 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
     };
   }
   return {
-    check: 'field_value',
+    check: checkName,
     passed: false,
     description: validation.description,
     path: validation.path,
@@ -632,13 +639,16 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
 // ────────────────────────────────────────────────────────────
 
 function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
+  // `check` is either `field_value_or_absent` or `envelope_field_value_or_absent`
+  // (adcp#3429); result echoes the storyboard's choice verbatim.
+  const checkName = validation.check;
   if (!validation.path) {
     return {
-      check: 'field_value_or_absent',
+      check: checkName,
       passed: false,
       description: validation.description,
       path: validation.path,
-      error: 'No path specified for field_value_or_absent validation',
+      error: `No path specified for ${checkName} validation`,
       json_pointer: null,
       expected: 'path must be set in storyboard validation entry',
       actual: null,
@@ -651,7 +661,7 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
   // Absent → pass. The check only fires when the field is present.
   if (actual === undefined) {
     return {
-      check: 'field_value_or_absent',
+      check: checkName,
       passed: true,
       description: validation.description,
       path: validation.path,
@@ -664,7 +674,7 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
     const passed = validation.allowed_values.some(v => valuesMatch(actual, v));
     if (passed) {
       return {
-        check: 'field_value_or_absent',
+        check: checkName,
         passed: true,
         description: validation.description,
         path: validation.path,
@@ -672,7 +682,7 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
       };
     }
     return {
-      check: 'field_value_or_absent',
+      check: checkName,
       passed: false,
       description: validation.description,
       path: validation.path,
@@ -686,7 +696,7 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
   const passed = valuesMatch(actual, validation.value);
   if (passed) {
     return {
-      check: 'field_value_or_absent',
+      check: checkName,
       passed: true,
       description: validation.description,
       path: validation.path,
@@ -694,7 +704,7 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
     };
   }
   return {
-    check: 'field_value_or_absent',
+    check: checkName,
     passed: false,
     description: validation.description,
     path: validation.path,

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -112,6 +112,13 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       // field_present runs against either MCP task result data OR an HTTP probe body —
       // the storyboard's probe_protected_resource validates fields in the RFC 9728 JSON.
       return validateFieldPresent(validation, resolveTarget(ctx));
+    case 'envelope_field_present':
+      // Envelope-scoped variant — runtime semantics identical to field_present
+      // (TaskResult exposes envelope fields like `status`, `task_id` at the
+      // surface level). The check exists primarily so static drift detection
+      // can walk the envelope schema instead of the inner response. See
+      // adcp#3429.
+      return validateFieldPresent(validation, resolveTarget(ctx));
     case 'field_value':
       return validateFieldValue(validation, resolveTarget(ctx));
     case 'field_value_or_absent':
@@ -496,13 +503,17 @@ export { LIST_WRAPPER_TOOLS } from './shape-drift-hints';
 // ────────────────────────────────────────────────────────────
 
 function validateFieldPresent(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
+  // `check` may be `field_present` or `envelope_field_present` (adcp#3429);
+  // both share runtime semantics, but the result should reflect the
+  // storyboard's choice so reporters can distinguish.
+  const checkName = validation.check === 'envelope_field_present' ? 'envelope_field_present' : 'field_present';
   if (!validation.path) {
     return {
-      check: 'field_present',
+      check: checkName,
       passed: false,
       description: validation.description,
       path: validation.path,
-      error: 'No path specified for field_present validation',
+      error: `No path specified for ${checkName} validation`,
       json_pointer: null,
       expected: 'path must be set in storyboard validation entry',
       actual: null,
@@ -515,7 +526,7 @@ function validateFieldPresent(validation: StoryboardValidation, taskResult: Task
 
   if (present) {
     return {
-      check: 'field_present',
+      check: checkName,
       passed: true,
       description: validation.description,
       path: validation.path,
@@ -524,7 +535,7 @@ function validateFieldPresent(validation: StoryboardValidation, taskResult: Task
   }
 
   return {
-    check: 'field_present',
+    check: checkName,
     passed: false,
     description: validation.description,
     path: validation.path,

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -112,7 +112,10 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       // field_present runs against either MCP task result data OR an HTTP probe body —
       // the storyboard's probe_protected_resource validates fields in the RFC 9728 JSON.
       return validateFieldPresent(validation, resolveTarget(ctx));
+    case 'field_absent':
+      return validateFieldAbsent(validation, resolveTarget(ctx));
     case 'envelope_field_present':
+    case 'envelope_field_absent':
     case 'envelope_field_value':
     case 'envelope_field_value_or_absent':
       // Envelope-scoped variants — runtime semantics identical to the
@@ -121,6 +124,7 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       // exist primarily so static drift detection can walk the envelope
       // schema instead of the per-tool response. See adcp#3429.
       if (validation.check === 'envelope_field_present') return validateFieldPresent(validation, resolveTarget(ctx));
+      if (validation.check === 'envelope_field_absent') return validateFieldAbsent(validation, resolveTarget(ctx));
       if (validation.check === 'envelope_field_value') return validateFieldValue(validation, resolveTarget(ctx));
       return validateFieldValueOrAbsent(validation, resolveTarget(ctx));
     case 'field_value':
@@ -547,6 +551,57 @@ function validateFieldPresent(validation: StoryboardValidation, taskResult: Task
     json_pointer: pointer,
     expected: validation.path,
     actual: value ?? null,
+  };
+}
+
+// ────────────────────────────────────────────────────────────
+// field_absent / envelope_field_absent: check a path does NOT exist
+//
+// Pass when the field is absent (undefined or null). Fail when the field
+// is present with any value. The `envelope_field_absent` variant carries
+// the same runtime semantics but signals to the drift detector that the
+// path lives on the v3 envelope schema rather than the per-tool response.
+// Added per adcp#3429 alongside the `envelope_field_present` family.
+// ────────────────────────────────────────────────────────────
+
+function validateFieldAbsent(validation: StoryboardValidation, taskResult: TaskResult): ValidationResult {
+  const checkName = validation.check;
+  if (!validation.path) {
+    return {
+      check: checkName,
+      passed: false,
+      description: validation.description,
+      path: validation.path,
+      error: `No path specified for ${checkName} validation`,
+      json_pointer: null,
+      expected: 'path must be set in storyboard validation entry',
+      actual: null,
+    };
+  }
+
+  const value = resolvePath(taskResult.data, validation.path);
+  const absent = value === undefined || value === null;
+  const pointer = toJsonPointer(validation.path);
+
+  if (absent) {
+    return {
+      check: checkName,
+      passed: true,
+      description: validation.description,
+      path: validation.path,
+      json_pointer: pointer,
+    };
+  }
+
+  return {
+    check: checkName,
+    passed: false,
+    description: validation.description,
+    path: validation.path,
+    error: `Field found at path: ${validation.path} (expected absent)`,
+    json_pointer: pointer,
+    expected: null,
+    actual: value,
   };
 }
 

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -214,7 +214,9 @@ function collectFieldValidations(storyboards) {
         for (const v of step.validations) {
           if (
             (v.check === 'field_present' ||
+              v.check === 'field_absent' ||
               v.check === 'envelope_field_present' ||
+              v.check === 'envelope_field_absent' ||
               v.check === 'field_value' ||
               v.check === 'envelope_field_value' ||
               v.check === 'field_value_or_absent' ||
@@ -325,6 +327,22 @@ describe('storyboard schema drift', () => {
     }
   });
 
+  describe('field_absent / envelope_field_absent are collected but skip reachability', () => {
+    // Absence checks have no schema target by design — a `field_absent` assertion
+    // validates that a path does NOT exist, so there is no schema field to walk.
+    // We still collect them in collectFieldValidations (above) so a future sweep
+    // can cross-reference storyboard intent, but we do not assert reachability.
+    const absentValidations = fieldValidations.filter(
+      v => v.check === 'field_absent' || v.check === 'envelope_field_absent'
+    );
+    it('absence-check validations are collected without reachability assertions', () => {
+      // Structural smoke-test: if any are present, they must have a path.
+      for (const entry of absentValidations) {
+        assert.ok(entry.path, `${entry.storyboard}/${entry.step}: field_absent entry missing path`);
+      }
+    });
+  });
+
   describe('envelope-scoped validations resolve in the v3 envelope schema', () => {
     // adcp#3429: storyboards assert envelope-level fields (`status`,
     // `task_id`, `message`, `replayed`, `governance_context`, `timestamp`,
@@ -332,6 +350,8 @@ describe('storyboard schema drift', () => {
     // checks so the drift detector knows to walk `protocol-envelope.json`
     // rather than the per-tool response schema. `errors` and `adcp_version`
     // are NOT envelope fields — keep them on the un-prefixed checks.
+    // `envelope_field_absent` is excluded here — absence checks have no schema
+    // target (see the `field_absent / envelope_field_absent` block above).
     const envelopeValidations = fieldValidations.filter(
       v =>
         v.check === 'envelope_field_present' ||

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -17,6 +17,10 @@ const { listAllComplianceStoryboards } = require('../../dist/lib/testing/storybo
 const { parsePath } = require('../../dist/lib/testing/storyboard/path.js');
 const { TOOL_RESPONSE_SCHEMAS } = require('../../dist/lib/utils/response-schemas.js');
 const { CONTEXT_EXTRACTORS } = require('../../dist/lib/testing/storyboard/context.js');
+// `envelope_field_present` validations walk the v3 protocol envelope
+// (`status`, `task_id`, `adcp_version`, `errors`) instead of per-tool
+// response schemas. Added per adcp#3429.
+const { ProtocolEnvelopeSchema } = require('../../dist/lib/types/schemas.generated.js');
 
 // Runner-internal tasks with no agent-facing schema.
 const HARNESS_TASKS = new Set([
@@ -205,7 +209,10 @@ function collectFieldValidations(storyboards) {
         if (isErrorStep) continue;
         for (const v of step.validations) {
           if (
-            (v.check === 'field_present' || v.check === 'field_value' || v.check === 'field_value_or_absent') &&
+            (v.check === 'field_present' ||
+              v.check === 'envelope_field_present' ||
+              v.check === 'field_value' ||
+              v.check === 'field_value_or_absent') &&
             v.path
           ) {
             if (ENVELOPE_PATHS.has(v.path)) continue; // protocol-level, not per-schema
@@ -307,6 +314,27 @@ describe('storyboard schema drift', () => {
           reachable,
           `Path "${entry.path}" is not reachable in ${entry.task} response schema. ` +
             `Segments: ${JSON.stringify(segments)}`
+        );
+      });
+    }
+  });
+
+  describe('envelope_field_present paths are reachable in the v3 envelope schema', () => {
+    // adcp#3429: storyboards assert envelope-level fields (`status`,
+    // `task_id`, `adcp_version`, `errors`) using `envelope_field_present`
+    // so the drift detector knows to walk `protocol-envelope.json`
+    // rather than the per-tool response schema.
+    const envelopeValidations = fieldValidations.filter(v => v.check === 'envelope_field_present');
+
+    for (const entry of envelopeValidations) {
+      const key = `${entry.storyboard}/${entry.step}:${entry.path}`;
+      const skip = skipReason(key);
+      it(`${entry.storyboard}/${entry.step}: ${entry.path} exists in v3 protocol envelope`, { skip }, () => {
+        const segments = parsePath(entry.path);
+        const reachable = isPathReachable(ProtocolEnvelopeSchema, segments);
+        assert.ok(
+          reachable,
+          `Path "${entry.path}" is not reachable in protocol-envelope.json. ` + `Segments: ${JSON.stringify(segments)}`
         );
       });
     }

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -17,9 +17,13 @@ const { listAllComplianceStoryboards } = require('../../dist/lib/testing/storybo
 const { parsePath } = require('../../dist/lib/testing/storyboard/path.js');
 const { TOOL_RESPONSE_SCHEMAS } = require('../../dist/lib/utils/response-schemas.js');
 const { CONTEXT_EXTRACTORS } = require('../../dist/lib/testing/storyboard/context.js');
-// `envelope_field_present` validations walk the v3 protocol envelope
-// (`status`, `task_id`, `adcp_version`, `errors`) instead of per-tool
-// response schemas. Added per adcp#3429.
+// `envelope_field_present` (and `envelope_field_value{,_or_absent}`)
+// validations walk the v3 protocol envelope — `status`, `task_id`,
+// `message`, `replayed`, `governance_context`, `timestamp`, `context_id`,
+// `push_notification_config` — instead of per-tool response schemas.
+// `errors` and `adcp_version` are NOT envelope fields (errors lives inside
+// `payload` per the per-tool response schema; adcp_major_version is on the
+// request, not on either response surface). Added per adcp#3429.
 const { ProtocolEnvelopeSchema } = require('../../dist/lib/types/schemas.generated.js');
 
 // Runner-internal tasks with no agent-facing schema.
@@ -212,7 +216,9 @@ function collectFieldValidations(storyboards) {
             (v.check === 'field_present' ||
               v.check === 'envelope_field_present' ||
               v.check === 'field_value' ||
-              v.check === 'field_value_or_absent') &&
+              v.check === 'envelope_field_value' ||
+              v.check === 'field_value_or_absent' ||
+              v.check === 'envelope_field_value_or_absent') &&
             v.path
           ) {
             if (ENVELOPE_PATHS.has(v.path)) continue; // protocol-level, not per-schema
@@ -319,24 +325,36 @@ describe('storyboard schema drift', () => {
     }
   });
 
-  describe('envelope_field_present paths are reachable in the v3 envelope schema', () => {
+  describe('envelope-scoped validations resolve in the v3 envelope schema', () => {
     // adcp#3429: storyboards assert envelope-level fields (`status`,
-    // `task_id`, `adcp_version`, `errors`) using `envelope_field_present`
-    // so the drift detector knows to walk `protocol-envelope.json`
-    // rather than the per-tool response schema.
-    const envelopeValidations = fieldValidations.filter(v => v.check === 'envelope_field_present');
+    // `task_id`, `message`, `replayed`, `governance_context`, `timestamp`,
+    // `context_id`, `push_notification_config`) using the envelope-scoped
+    // checks so the drift detector knows to walk `protocol-envelope.json`
+    // rather than the per-tool response schema. `errors` and `adcp_version`
+    // are NOT envelope fields — keep them on the un-prefixed checks.
+    const envelopeValidations = fieldValidations.filter(
+      v =>
+        v.check === 'envelope_field_present' ||
+        v.check === 'envelope_field_value' ||
+        v.check === 'envelope_field_value_or_absent'
+    );
 
     for (const entry of envelopeValidations) {
       const key = `${entry.storyboard}/${entry.step}:${entry.path}`;
       const skip = skipReason(key);
-      it(`${entry.storyboard}/${entry.step}: ${entry.path} exists in v3 protocol envelope`, { skip }, () => {
-        const segments = parsePath(entry.path);
-        const reachable = isPathReachable(ProtocolEnvelopeSchema, segments);
-        assert.ok(
-          reachable,
-          `Path "${entry.path}" is not reachable in protocol-envelope.json. ` + `Segments: ${JSON.stringify(segments)}`
-        );
-      });
+      it(
+        `${entry.storyboard}/${entry.step}: ${entry.check} ${entry.path} exists in v3 protocol envelope`,
+        { skip },
+        () => {
+          const segments = parsePath(entry.path);
+          const reachable = isPathReachable(ProtocolEnvelopeSchema, segments);
+          assert.ok(
+            reachable,
+            `Path "${entry.path}" is not reachable in protocol-envelope.json. ` +
+              `Segments: ${JSON.stringify(segments)}`
+          );
+        }
+      );
     }
   });
 

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -233,3 +233,73 @@ describe('envelope_field_present (adcp#3429)', () => {
     assert.match(result.error, /No path specified for envelope_field_present/);
   });
 });
+
+describe('field_absent / envelope_field_absent (adcp#3429)', () => {
+  it('passes when the asserted path is absent from the task data', () => {
+    const taskResult = { success: true, data: { status: 'completed' } };
+    const [result] = runOne(
+      [{ check: 'field_absent', path: 'legacy_status', description: 'legacy_status must not appear' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.check, 'field_absent');
+  });
+
+  it('fails when the asserted path is present', () => {
+    const taskResult = { success: true, data: { status: 'completed', legacy_status: 'active' } };
+    const [result] = runOne(
+      [{ check: 'field_absent', path: 'legacy_status', description: 'legacy_status must not appear' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.check, 'field_absent');
+    assert.match(result.error, /Field found at path: legacy_status/);
+  });
+
+  it('fails with no-path error when path is missing', () => {
+    const taskResult = { success: true, data: { status: 'completed' } };
+    const [result] = runOne(
+      [{ check: 'field_absent', description: 'no path given' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /No path specified for field_absent/);
+  });
+
+  it('envelope_field_absent passes when envelope field is absent', () => {
+    const taskResult = { success: true, data: { task_id: 'task-1' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_absent', path: 'legacy_status', description: 'envelope must not carry legacy_status' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.check, 'envelope_field_absent');
+  });
+
+  it('envelope_field_absent fails when envelope field is present', () => {
+    const taskResult = { success: true, data: { task_id: 'task-1', legacy_status: 'active' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_absent', path: 'legacy_status', description: 'envelope must not carry legacy_status' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.check, 'envelope_field_absent');
+    assert.match(result.error, /Field found at path: legacy_status/);
+  });
+
+  it('envelope_field_absent fails with no-path error when path is missing', () => {
+    const taskResult = { success: true, data: { status: 'completed' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_absent', description: 'no path given' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /No path specified for envelope_field_absent/);
+  });
+});

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -140,3 +140,46 @@ describe('validateErrorCode', () => {
     assert.strictEqual(result.passed, true, result.error);
   });
 });
+
+describe('envelope_field_present (adcp#3429)', () => {
+  // Runtime semantics are identical to field_present — TaskResult merges
+  // envelope fields into its surface so `data.status` is the envelope's
+  // status. The check exists to signal scope to static drift detection,
+  // which walks the envelope schema instead of the inner response.
+  it('passes when the asserted path resolves on the task data', () => {
+    const taskResult = {
+      success: true,
+      data: { status: 'completed', task_id: 'task-1', context: { correlation_id: 'c1' } },
+    };
+    const [result] = runOne(
+      [{ check: 'envelope_field_present', path: 'status', description: 'envelope carries status' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.check, 'envelope_field_present');
+  });
+
+  it('fails when the asserted envelope field is missing', () => {
+    const taskResult = { success: true, data: { context: { correlation_id: 'c1' } } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_present', path: 'status', description: 'envelope carries status' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.check, 'envelope_field_present');
+    assert.match(result.error, /Field not found at path: status/);
+  });
+
+  it('rejects validation entries without a path', () => {
+    const taskResult = { success: true, data: { status: 'completed' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_present', description: 'no path' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.match(result.error, /No path specified for envelope_field_present/);
+  });
+});

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -141,6 +141,56 @@ describe('validateErrorCode', () => {
   });
 });
 
+describe('envelope_field_value (adcp#3429)', () => {
+  it('passes when the envelope field equals the expected value', () => {
+    const taskResult = { success: true, data: { status: 'completed', task_id: 'task-1' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_value', path: 'status', value: 'completed', description: 'envelope status' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.check, 'envelope_field_value');
+  });
+
+  it('fails on mismatch and reports the envelope-scoped check name', () => {
+    const taskResult = { success: true, data: { status: 'submitted' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_value', path: 'status', value: 'completed', description: 'envelope status' }],
+      'get_adcp_capabilities',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.check, 'envelope_field_value');
+    assert.match(result.error, /Expected "completed", got "submitted"/);
+  });
+});
+
+describe('envelope_field_value_or_absent (adcp#3429)', () => {
+  it('passes when the envelope field is absent (tolerant arm)', () => {
+    const taskResult = { success: true, data: { task_id: 'task-1' } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_value_or_absent', path: 'replayed', value: true, description: 'replayed marker' }],
+      'create_media_buy',
+      taskResult
+    );
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.check, 'envelope_field_value_or_absent');
+  });
+
+  it('fails when the envelope field is present with a disallowed value', () => {
+    const taskResult = { success: true, data: { replayed: false } };
+    const [result] = runOne(
+      [{ check: 'envelope_field_value_or_absent', path: 'replayed', value: true, description: 'replayed marker' }],
+      'create_media_buy',
+      taskResult
+    );
+    assert.strictEqual(result.passed, false);
+    assert.strictEqual(result.check, 'envelope_field_value_or_absent');
+    assert.match(result.error, /Expected absent or true, got false/);
+  });
+});
+
 describe('envelope_field_present (adcp#3429)', () => {
   // Runtime semantics are identical to field_present — TaskResult merges
   // envelope fields into its surface so `data.status` is the envelope's


### PR DESCRIPTION
## Summary

Refs [adcp#3429](https://github.com/adcontextprotocol/adcp/issues/3429). Adds runtime + drift support for the storyboard validation that targets the v3 protocol envelope (\`status\`, \`task_id\`, \`adcp_version\`, \`errors\`) instead of per-tool response schemas.

## Why

The 3.0.1 spec ships \`universal/v3-envelope-integrity.yaml\` with \`field_present: status\`, but \`status\` is on the v3 envelope (\`protocol-envelope.json\`), not the inner \`get-adcp-capabilities-response.json\`. The drift detector walks the inner response, so the assertion can't be statically verified — adcp-client#1039 had to add a \`VERIFIER_UNREACHABLE\` exemption.

[adcp#3429](https://github.com/adcontextprotocol/adcp/issues/3429) triage proposed two fixes:

- **Option A**: add a \`response_envelope_schema_ref\` field to the storyboard (no SDK changes)
- **Option B**: add a new \`envelope_field_present\` check type — better long-term design, requires SDK runner support to ship first

This PR is the SDK side of Option B. Once the upstream storyboard migrates \`field_present: status\` → \`envelope_field_present: status\`, the SDK's drift detector validates against the envelope schema and the \`VERIFIER_UNREACHABLE\` exemption can be dropped.

## What changed

**\`src/lib/testing/storyboard/types.ts\`** — \`'envelope_field_present'\` joins the \`StoryboardValidationCheck\` union with a JSDoc explaining the scope difference.

**\`src/lib/testing/storyboard/validations.ts\`** — \`runValidation\` dispatches \`envelope_field_present\` to \`validateFieldPresent\`. Runtime semantics are identical: \`TaskResult\` already merges envelope fields into its surface, so \`data.status\` is the envelope's \`status\`. The result object reports the original check name verbatim (\`'envelope_field_present'\`) so reporters can distinguish.

**\`test/lib/storyboard-drift.test.js\`** — \`collectFieldValidations\` picks up \`envelope_field_present\` entries; a new \`describe\` block walks \`ProtocolEnvelopeSchema\` instead of \`TOOL_RESPONSE_SCHEMAS[task]\`. Existing \`field_present\` block continues to pin to per-tool response schemas.

## Forward-compat

No current 3.0.1 storyboard uses \`envelope_field_present\` yet. The SDK accepts it now so when the upstream storyboard PR lands (and \`npm run sync-schemas\` pulls the new compliance bundle), drift detection picks up the new check immediately. The \`VERIFIER_UNREACHABLE\` exemption in adcp-client#1039 gets dropped in a follow-up after the upstream change ships.

## Test plan

- [x] Build clean (\`npm run build\`)
- [x] Format clean (\`npm run format\`)
- [x] Lint clean — 0 errors (\`npm run lint\`)
- [x] 3 new runtime tests in \`test/lib/storyboard-validations.test.js\` (pass / missing field / missing path)
- [x] Drift detector picks up \`envelope_field_present\` entries when storyboards declare them; existing 493-pass \`storyboard-drift.test.js\` suite continues green
- [x] Changeset: \`@adcp/client\` minor — explains the runtime + drift surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)