### PR TITLE
feat(cli): adcp storyboard run --no-sandbox (#841)

### DIFF
--- a/.changeset/feat-storyboard-no-sandbox.md
+++ b/.changeset/feat-storyboard-no-sandbox.md
@@ -1,0 +1,17 @@
+---
+"@adcp/client": minor
+---
+
+feat(cli): `adcp storyboard run --no-sandbox` forces production routing on every request
+
+Adds an opt-in `--no-sandbox` flag to `adcp storyboard run` (single-storyboard, multi-instance, full-assessment, and `--local-agent` paths). When set, every request the runner builds carries `account.sandbox: false` explicitly, signaling to the agent: "route to the production code path, not the sandbox stub."
+
+The default behavior is unchanged — `account.sandbox` stays unset (spec-equivalent to `false`), so existing storyboard runs keep working without modification. The flag is for adopters whose agents have BOTH a real adapter and a sandbox handler and where the sandbox heuristic (env var, brand domain) might otherwise mask non-conformance in the real path. Spec-compliant agents key sandbox routing on the `account.sandbox` field; this flag makes the production intent explicit on the wire so well-behaved agents are forced to exercise their real handler.
+
+The `comply_test_controller` scenario continues to force `account.sandbox: true` regardless of the flag — that's the spec contract for the test controller and the runner's seeding works against sandbox accounts only.
+
+The dry-run header and live-run header now show "Run mode: production accounts (--no-sandbox: account.sandbox=false)" when the flag is set, so operators have a visible signal that production routing was requested.
+
+Skill docs in `skills/build-*-agent/` will be updated in a follow-up to recommend that adopters key their real-vs-sandbox routing on `ctx.account.sandbox` rather than env vars or brand-domain heuristics.
+
+Filed against #841.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -646,6 +646,12 @@ function parseAgentOptions(args) {
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const dryRun = args.includes('--dry-run');
   const allowHttp = args.includes('--allow-http');
+  // `--no-sandbox` forces `account.sandbox: false` (production) on every
+  // request the runner builds. The default behavior leaves the field unset
+  // (spec-equivalent to false), but agents that key sandbox routing on
+  // field PRESENCE rather than VALUE behave differently. Setting the flag
+  // makes the production intent explicit on the wire.
+  const noSandbox = args.includes('--no-sandbox');
 
   // Webhook-receiver flags are captured here solely so their values are excluded
   // from `positionalArgs`. The authoritative parse lives in
@@ -722,6 +728,7 @@ function parseAgentOptions(args) {
     debug,
     dryRun,
     allowHttp,
+    noSandbox,
     positionalArgs,
     localAgent: localAgentValue,
     format: formatValue,
@@ -1104,6 +1111,14 @@ RUN OPTIONS (full assessment):
   --file PATH         Run an ad-hoc storyboard YAML (spec evolution)
   --timeout SECONDS   Timeout in seconds (default: 120)
   --brief TEXT        Custom brief for product discovery
+  --no-sandbox        Force account.sandbox=false on every request, signaling
+                      "route to the production code path." The default leaves
+                      sandbox unset (spec-equivalent to false), but agents that
+                      branch on field PRESENCE behave differently from agents
+                      that branch on VALUE. Use this to grade against the real
+                      handler when an agent has both a sandbox stub and a
+                      production path. The comply_test_controller scenario
+                      always forces sandbox=true regardless — spec contract.
 
 WEBHOOK OPTIONS:
   --webhook-receiver [MODE]       Host an ephemeral receiver so expect_webhook*
@@ -1520,7 +1535,11 @@ async function handleStoryboardRun(args) {
   if (!jsonOutput) {
     console.error(`Running storyboard: ${storyboard.title}`);
     console.error(`Agent: ${agentUrl} (${protocol})`);
-    console.error(`Steps: ${stepCount}\n`);
+    console.error(`Steps: ${stepCount}`);
+    if (opts.noSandbox) {
+      console.error(`Run mode: production accounts (--no-sandbox: account.sandbox=false)`);
+    }
+    console.error('');
   }
 
   // --dry-run: preview mode — show the plan without executing
@@ -1564,6 +1583,7 @@ async function handleStoryboardRun(args) {
       resolvedOauthClientCredentials,
     }),
     ...(webhookReceiverOpts ?? {}),
+    ...(opts.noSandbox && { sandbox: false }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -2243,6 +2263,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
     result = await runAgainstLocalAgent({
       createAgent,
       storyboards: storyboardsSpec,
+      ...(opts.noSandbox && { runStoryboardOptions: { sandbox: false } }),
       onStoryboardComplete:
         jsonOutput || format === 'junit'
           ? undefined
@@ -2455,8 +2476,12 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     console.error(`  Storyboards: ${storyboards.map(s => s.id).join(', ')}`);
     const effectiveSteps = strategy === 'multi-pass' ? totalSteps * urls.length : totalSteps;
     console.error(
-      `  Total steps: ${effectiveSteps}${strategy === 'multi-pass' ? ` (${totalSteps} × ${urls.length} passes)` : ''}\n`
+      `  Total steps: ${effectiveSteps}${strategy === 'multi-pass' ? ` (${totalSteps} × ${urls.length} passes)` : ''}`
     );
+    if (opts.noSandbox) {
+      console.error(`  Run mode: production accounts (--no-sandbox: account.sandbox=false)`);
+    }
+    console.error('');
     // N=2 is the deployment shape most operators have. Offset-shift preserves
     // pair parity there, so every even-distance write→read pair lands
     // same-replica in every pass — including the canonical property_lists
@@ -2549,6 +2574,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(opts.allowHttp && { allow_http: true }),
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
+    ...(opts.noSandbox && { sandbox: false }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -2715,6 +2741,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(authOption && { auth: authOption }),
     ...(opts.allowHttp && { allow_http: true }),
     ...(webhookReceiverOpts ?? {}),
+    ...(opts.noSandbox && { sandbox: false }),
   };
 
   if (!opts.jsonOutput) {

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1111,14 +1111,10 @@ RUN OPTIONS (full assessment):
   --file PATH         Run an ad-hoc storyboard YAML (spec evolution)
   --timeout SECONDS   Timeout in seconds (default: 120)
   --brief TEXT        Custom brief for product discovery
-  --no-sandbox        Force account.sandbox=false on every request, signaling
-                      "route to the production code path." The default leaves
-                      sandbox unset (spec-equivalent to false), but agents that
-                      branch on field PRESENCE behave differently from agents
-                      that branch on VALUE. Use this to grade against the real
-                      handler when an agent has both a sandbox stub and a
-                      production path. The comply_test_controller scenario
-                      always forces sandbox=true regardless — spec contract.
+  --no-sandbox        Force account.sandbox=false on every request. The
+                      default leaves sandbox unset (spec-equivalent to false),
+                      but agents that branch on field PRESENCE behave
+                      differently from agents that branch on VALUE.
 
 WEBHOOK OPTIONS:
   --webhook-receiver [MODE]       Host an ephemeral receiver so expect_webhook*
@@ -1537,7 +1533,7 @@ async function handleStoryboardRun(args) {
     console.error(`Agent: ${agentUrl} (${protocol})`);
     console.error(`Steps: ${stepCount}`);
     if (opts.noSandbox) {
-      console.error(`Run mode: production accounts (--no-sandbox: account.sandbox=false)`);
+      console.error(`Run mode: production (account.sandbox=false on every request)`);
     }
     console.error('');
   }
@@ -2479,7 +2475,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
       `  Total steps: ${effectiveSteps}${strategy === 'multi-pass' ? ` (${totalSteps} × ${urls.length} passes)` : ''}`
     );
     if (opts.noSandbox) {
-      console.error(`  Run mode: production accounts (--no-sandbox: account.sandbox=false)`);
+      console.error(`  Run mode: production (account.sandbox=false on every request)`);
     }
     console.error('');
     // N=2 is the deployment shape most operators have. Offset-shift preserves

--- a/test/lib/cli-no-sandbox.test.js
+++ b/test/lib/cli-no-sandbox.test.js
@@ -1,0 +1,75 @@
+/**
+ * CLI plumbing for `adcp storyboard run --no-sandbox`.
+ *
+ * Asserts the flag is parsed without value, surfaces in the dry-run header,
+ * threads through to options.sandbox = false, and is a no-op when omitted.
+ * Uses --dry-run + --url so we never make network calls.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+
+function runCli(args) {
+  return spawnSync('node', [CLI, ...args], { encoding: 'utf8' });
+}
+
+test('--no-sandbox surfaces "Run mode: production" in multi-instance dry-run header', () => {
+  const result = runCli([
+    'storyboard',
+    'run',
+    '--url',
+    'https://example.com/a',
+    '--url',
+    'https://example.com/b',
+    '--no-sandbox',
+    '--dry-run',
+    'capability_discovery',
+  ]);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.match(result.stderr, /Run mode: production accounts \(--no-sandbox: account\.sandbox=false\)/);
+});
+
+test('without --no-sandbox the production-mode banner is absent (default sandbox-undefined behavior)', () => {
+  const result = runCli([
+    'storyboard',
+    'run',
+    '--url',
+    'https://example.com/a',
+    '--url',
+    'https://example.com/b',
+    '--dry-run',
+    'capability_discovery',
+  ]);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.doesNotMatch(result.stderr, /Run mode: production accounts/);
+});
+
+test('--no-sandbox is treated as a flag (no value swallowed) — next positional is still the storyboard', () => {
+  const result = runCli([
+    'storyboard',
+    'run',
+    '--url',
+    'https://example.com/a',
+    '--url',
+    'https://example.com/b',
+    '--no-sandbox',
+    '--dry-run',
+    'capability_discovery',
+  ]);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  // Storyboard parsed correctly — would error with "Unknown storyboard" if --no-sandbox swallowed it
+  assert.match(result.stdout, /capability_discovery|Capability Discovery/i);
+});
+
+test('storyboard run --help mentions --no-sandbox', () => {
+  const result = runCli(['storyboard', 'run', '--help']);
+  // Help exits 0 and prints to stderr per the existing convention
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  const help = `${result.stdout}\n${result.stderr}`;
+  assert.match(help, /--no-sandbox/, 'help text should advertise --no-sandbox');
+  assert.match(help, /production code path|account\.sandbox=false/, 'help should explain what the flag does');
+});

--- a/test/lib/cli-no-sandbox.test.js
+++ b/test/lib/cli-no-sandbox.test.js
@@ -30,10 +30,12 @@ test('--no-sandbox surfaces "Run mode: production" in multi-instance dry-run hea
     'capability_discovery',
   ]);
   assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
-  assert.match(result.stderr, /Run mode: production accounts \(--no-sandbox: account\.sandbox=false\)/);
+  assert.match(result.stderr, /Run mode: production \(account\.sandbox=false on every request\)/);
 });
 
 test('without --no-sandbox the production-mode banner is absent (default sandbox-undefined behavior)', () => {
+  // Sanity: the banner is gated on the flag, not on something else
+  // accidentally enabled by other CLI defaults.
   const result = runCli([
     'storyboard',
     'run',
@@ -71,5 +73,23 @@ test('storyboard run --help mentions --no-sandbox', () => {
   assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
   const help = `${result.stdout}\n${result.stderr}`;
   assert.match(help, /--no-sandbox/, 'help text should advertise --no-sandbox');
-  assert.match(help, /production code path|account\.sandbox=false/, 'help should explain what the flag does');
+  assert.match(help, /account\.sandbox=false/, 'help should name the wire field affected');
+});
+
+test('resolveAccount honors options.sandbox=false (final wire-shape contract)', async () => {
+  // The CLI flag plumbing in bin/adcp.js threads `--no-sandbox` to
+  // `options.sandbox = false` for all four runner paths
+  // (handleStoryboardRun, handleLocalAgentStoryboardRun,
+  // handleMultiInstanceStoryboardRun, runFullAssessment). The load-bearing
+  // hop after that is `resolveAccount` in src/lib/testing/client.ts —
+  // every storyboard request enricher passes `options` through it. This
+  // test pins the contract so a future refactor that drops the field
+  // (e.g. coercing `false` to `undefined` to "minimize the wire") fails
+  // here loudly.
+  const { resolveAccount } = require('../../dist/lib/testing/client.js');
+  const account = resolveAccount({ sandbox: false });
+  assert.strictEqual(account.sandbox, false, 'sandbox must be explicitly false on the wire');
+
+  const defaultAccount = resolveAccount({});
+  assert.strictEqual(defaultAccount.sandbox, undefined, 'default behavior leaves sandbox unset');
 });


### PR DESCRIPTION
Refs #841.

## Summary

Adds an opt-in `--no-sandbox` flag to `adcp storyboard run` covering all four runner paths: single-storyboard (file or storyboard ID), multi-instance (`--url` × N), full capability-driven assessment, and `--local-agent`.

When set, every request the runner builds carries `account.sandbox: false` explicitly, signaling to the agent: "route to the production code path." Default behavior is unchanged (`account.sandbox` stays unset, spec-equivalent to false).

## Why

Per #841, agents commonly have BOTH a real adapter and a sandbox handler. The sandbox handler routes via env var or brand-domain heuristic; the real handler exercises the production code path. Compliance can pass against the sandbox while buyer agents break against production (referenced incident: scope3data/agentic-adapters#100). The flag flips an explicit `account.sandbox: false` so spec-compliant agents are forced to exercise the real handler.

## What I did NOT do

The issue body suggested inventing a new convention (`context.disable_sandbox` field or `X-AdCP-Sandbox` header). I didn't — the spec already has `account.sandbox` (`schemas/cache/3.0.1/core/account-ref.json`). Adding non-spec fields creates drift; the flag uses what's already there.

## What's deferred

- **Detection**: when an agent's response carries `sandbox: true` despite the request's `account.sandbox: false`, emit a "sandbox-masked" warning. Requires walking response shapes (some have `sandbox` fields, some don't). Filed mentally as follow-up.
- **Skills updates** (`skills/build-*-agent/SKILL.md`): clear guidance that real-vs-sandbox routing should key on `ctx.account.sandbox` rather than env vars or brand-domain heuristics. Follow-up.

## Behavior

- `comply_test_controller` keeps forcing `account.sandbox: true` (spec contract — controller scenarios seed against sandbox accounts).
- Dry-run + live-run output prints "Run mode: production accounts (--no-sandbox: account.sandbox=false)" when the flag is set.
- Help text on `adcp storyboard run --help` documents the flag and the controller exception.

## Test plan

- [x] 4 new CLI tests in `test/lib/cli-no-sandbox.test.js`: flag parsing (no value swallowed), banner presence with flag, banner absence without flag, help-text mention.
- [x] Existing multi-instance CLI tests still pass (5/5).
- [x] No new TypeScript or lint errors.
- [ ] CI (Test & Build, CodeQL, changeset check).