### PR TITLE
fix(tests): close HTTP servers correctly and track setTimeout IDs

### DIFF
--- a/.changeset/test-resource-leaks.md
+++ b/.changeset/test-resource-leaks.md
@@ -1,0 +1,4 @@
+---
+---
+
+test: close HTTP servers in tests + track setTimeout IDs (no library change).

--- a/test/lib/task-executor-mocking-strategy.test.js
+++ b/test/lib/task-executor-mocking-strategy.test.js
@@ -19,8 +19,11 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
   let originalCallTool;
   let mockAgent;
   let testEmitter;
+  let pendingTimers;
 
   beforeEach(() => {
+    pendingTimers = [];
+
     // Fresh module imports
     delete require.cache[require.resolve('../../dist/lib/index.js')];
     const lib = require('../../dist/lib/index.js');
@@ -40,6 +43,8 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
   });
 
   afterEach(() => {
+    for (const id of pendingTimers) clearTimeout(id);
+    pendingTimers = [];
     if (originalCallTool) {
       ProtocolClient.callTool = originalCallTool;
     }
@@ -56,9 +61,11 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
         generateUrl: mock.fn(taskId => `https://webhook.test/${taskId}`),
         registerWebhook: mock.fn(async (agent, taskId, webhookUrl) => {
           // Simulate webhook delivery after a delay
-          setTimeout(() => {
-            testEmitter.emit('webhook', taskId, webhookData);
-          }, 100);
+          pendingTimers.push(
+            setTimeout(() => {
+              testEmitter.emit('webhook', taskId, webhookData);
+            }, 100)
+          );
         }),
         processWebhook: mock.fn(async (token, body) => {
           webhookReceived = true;
@@ -561,10 +568,12 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
           if (stepIndex < realWorldSteps.length - 1 && !stepTransitionScheduled) {
             stepTransitionScheduled = true;
             const duration = stepDurations[stepIndex];
-            setTimeout(() => {
-              stepIndex++;
-              stepTransitionScheduled = false;
-            }, duration);
+            pendingTimers.push(
+              setTimeout(() => {
+                stepIndex++;
+                stepTransitionScheduled = false;
+              }, duration)
+            );
           }
 
           return { task: step };
@@ -605,5 +614,3 @@ describe('TaskExecutor Mocking Strategies', { skip: process.env.CI ? 'Slow tests
     });
   });
 });
-
-console.log('TaskExecutor mocking strategy test suite loaded successfully');

--- a/test/server-auth-introspection.test.js
+++ b/test/server-auth-introspection.test.js
@@ -1,4 +1,4 @@
-const { describe, it, before, after, beforeEach } = require('node:test');
+const { describe, it, before, after, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const http = require('http');
 

--- a/test/server-auth-introspection.test.js
+++ b/test/server-auth-introspection.test.js
@@ -105,7 +105,12 @@ describe('verifyIntrospection — authentication flow', () => {
     });
   });
 
-  after(() => upstream && upstream.server.close());
+  afterEach(async () => {
+    if (upstream?.server) {
+      upstream.server.closeAllConnections?.();
+      await new Promise(r => upstream.server.close(r));
+    }
+  });
 
   it('returns null when no bearer header is present', async () => {
     const auth = verifyIntrospection({ introspectionUrl: upstream.url, clientId: 'c', clientSecret: 's' });
@@ -218,7 +223,10 @@ describe('verifyIntrospection — audience binding', () => {
     });
   });
 
-  after(() => upstream.server.close());
+  after(async () => {
+    upstream.server.closeAllConnections?.();
+    await new Promise(r => upstream.server.close(r));
+  });
 
   it('accepts when aud claim matches the configured audience (string)', async () => {
     audienceResponse = { active: true, sub: 'u', aud: 'https://seller.example.com/mcp' };
@@ -296,7 +304,8 @@ describe('verifyIntrospection — error handling', () => {
         }
       );
     } finally {
-      upstream.server.close();
+      upstream.server.closeAllConnections?.();
+      await new Promise(r => upstream.server.close(r));
     }
   });
 
@@ -312,7 +321,8 @@ describe('verifyIntrospection — error handling', () => {
         err => err instanceof AuthError
       );
     } finally {
-      upstream.server.close();
+      upstream.server.closeAllConnections?.();
+      await new Promise(r => upstream.server.close(r));
     }
   });
 
@@ -328,7 +338,8 @@ describe('verifyIntrospection — error handling', () => {
         err => err instanceof AuthError
       );
     } finally {
-      upstream.server.close();
+      upstream.server.closeAllConnections?.();
+      await new Promise(r => upstream.server.close(r));
     }
   });
 
@@ -374,7 +385,10 @@ describe('verifyIntrospection — cache', () => {
     });
   });
 
-  after(() => upstream.server.close());
+  after(async () => {
+    upstream.server.closeAllConnections?.();
+    await new Promise(r => upstream.server.close(r));
+  });
 
   beforeEach(() => {
     callCount = 0;


### PR DESCRIPTION
Refs #1048

Fixes three classes of test resource leaks that produce ~95 orphan `node` processes per run and risk the `Buffer.indexOf` infinite hang described in the issue.

## What changed

**`test/server-auth-introspection.test.js` — 6 locations:**

| Location | Was | Fix |
|---|---|---|
| `authentication flow` describe, line 108 | `after(() => upstream && upstream.server.close())` (ran once, cleaned up only the last server; `beforeEach` creates one server per test) | Replaced with `afterEach` + `closeAllConnections?.()` + `await new Promise(r => server.close(r))` + null guard |
| `audience binding` describe, line 221 | `after(() => upstream.server.close())` (non-async, non-awaited, no `closeAllConnections`) | Made async, added proper teardown |
| `error handling` describe, 3 `finally` blocks (lines ~299, 315, 331) | `upstream.server.close()` bare | Added `closeAllConnections?.()` + awaited close |
| `cache` describe, line 377 | `after(() => upstream.server.close())` (non-async, non-awaited) | Made async, added proper teardown |

Also adds `afterEach` to the `node:test` import (was missing, causing `ReferenceError` at load time for the `authentication flow` describe).

The correct teardown pattern — already documented and applied at line 367 of the same file for the timeout test — is now consistently applied everywhere.

**`test/lib/task-executor-mocking-strategy.test.js` — timer hygiene:**

- Added `let pendingTimers` to the outer `describe` scope, reset to `[]` in `beforeEach`, cleared with `clearTimeout` in `afterEach`.
- Two `setTimeout` calls (lines ~64 and ~574) now push their IDs into `pendingTimers` so they are cancelled if the test ends before they fire — prevents timer callbacks from mutating test-scoped state (`stepIndex`, `testEmitter`) after teardown.
- Removed module-level `console.log` that fired on every `require()`.

## What this does NOT fix

**The primary Buffer.indexOf infinite loop (Problem A):** Static analysis of the named suspect files (`webhook-emitter-server-e2e.test.js`, `storyboard-webhook-receiver.test.js`, `webhook-signature-verification.test.js`, `request-signing-*.test.js`) did not locate a readline-style loop — the hang source is more likely in an MCP SSE client test that holds an open streaming response. The issue's bisection strategy (`--test-concurrency=1 --test-timeout=15000`) is the right path to identify it; that fix will come in a follow-up.

**The `timeout 1200` safety net in `npm test`:** Explicitly suggested in the issue as an optional defensive measure. Skipped here because `timeout` is Linux-only (unavailable on macOS without coreutils) and `package.json` edits warrant a separate, focused PR.

**Other files with the same `server.close()` defect:** `test/request-signing-e2e.test.js:139`, `test/request-signing-runner-integration.test.js:199`, `test/request-signing-grader-e2e.test.js:140` — flagged for a follow-on sweep.

## What was tested

- `npm run format:check` — passes ✅
- `npm run typecheck` — pre-existing TS config errors (`TS2688`, `TS5107`) unrelated to this diff; present on `main` before these changes
- `npm run build:lib` — `tsx` not available in this environment; `dist/` not rebuilt; changes are plain JS test files with no TypeScript compilation step
- `npm test` — full suite requires `dist/`; could not run locally due to toolchain constraint; changes follow patterns already proven correct at line 367 of the same file

**Pre-PR review:**
- code-reviewer: approved — no blockers; one defensive guard applied (`upstream?.server` null check in `afterEach`)
- dx-expert: approved after blocker fix — missing `afterEach` import caught and fixed before push

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01C9e1CgKWJx92NvAKrZzeYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9e1CgKWJx92NvAKrZzeYw)_