### PR TITLE
fix(conformance): enforce storyboard required_tools pre-flight gate in runner

### DIFF
--- a/.changeset/required-tools-preflight-gate.md
+++ b/.changeset/required-tools-preflight-gate.md
@@ -1,0 +1,20 @@
+---
+"@adcp/sdk": patch
+"@adcp/client": patch
+---
+
+fix(conformance): enforce storyboard required_tools pre-flight gate in runner
+
+The `required_tools` field on `Storyboard` was declared and typed but never
+enforced on the normal execution path — only consulted in the degraded-auth
+bailout in `comply.ts`. This meant storyboards targeting media-buy tools (e.g.
+`past_start_enforcement`) ran against signals-only, creative, or governance
+agents that advertise none of those tools, producing misleading per-step
+failures instead of a clean skip.
+
+`executeStoryboardPass` now checks `storyboard.required_tools` immediately
+after profile discovery. If the storyboard declares required tools and the
+agent advertises none of them, the runner returns a synthetic
+`overall_passed: true` / `skip_reason: 'not_applicable'` result — the same
+shape `buildNotApplicableStoryboardResult` produces in comply.ts. Agents that
+advertise at least one required tool proceed normally.

--- a/.changeset/required-tools-preflight-gate.md
+++ b/.changeset/required-tools-preflight-gate.md
@@ -1,5 +1,4 @@
 ---
-"@adcp/sdk": patch
 "@adcp/client": patch
 ---
 
@@ -15,6 +14,5 @@ failures instead of a clean skip.
 `executeStoryboardPass` now checks `storyboard.required_tools` immediately
 after profile discovery. If the storyboard declares required tools and the
 agent advertises none of them, the runner returns a synthetic
-`overall_passed: true` / `skip_reason: 'not_applicable'` result — the same
-shape `buildNotApplicableStoryboardResult` produces in comply.ts. Agents that
+`overall_passed: true` / `skip_reason: 'missing_tool'` result. Agents that
 advertise at least one required tool proceed normally.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -460,6 +460,64 @@ function buildCapabilityUnsupportedResult(
 }
 
 /**
+ * Build a minimal StoryboardResult for a storyboard skipped because the agent
+ * does not advertise any of the tools listed in `required_tools`. The result
+ * carries `skip_reason: 'not_applicable'` and `overall_passed: true` so CLI
+ * reports and JUnit consumers render it as a skip, not a failure.
+ */
+function buildRequiredToolsMissingResult(
+  agentUrls: string[],
+  storyboard: Storyboard,
+  detail: string
+): StoryboardResult {
+  return {
+    storyboard_id: storyboard.id,
+    storyboard_title: storyboard.title,
+    agent_url: agentUrls[0]!,
+    overall_passed: true,
+    phases: [
+      {
+        phase_id: 'not_applicable',
+        phase_title: 'Not applicable — required tools not advertised',
+        passed: true,
+        duration_ms: 0,
+        steps: [
+          {
+            storyboard_id: storyboard.id,
+            step_id: 'not_applicable',
+            phase_id: 'not_applicable',
+            title: `Not applicable — ${detail}`,
+            task: '',
+            passed: true,
+            skipped: true,
+            skip_reason: 'not_applicable' as const,
+            skip: { reason: 'not_applicable' as const, detail },
+            duration_ms: 0,
+            validations: [],
+            context: {},
+            extraction: { path: 'none' },
+          },
+        ],
+      },
+    ],
+    context: {},
+    total_duration_ms: 0,
+    passed_count: 0,
+    failed_count: 0,
+    skipped_count: 1,
+    tested_at: new Date().toISOString(),
+    strict_validation_summary: {
+      observable: false,
+      checked: 0,
+      passed: 0,
+      failed: 0,
+      strict_only_failures: 0,
+      lenient_also_failed: 0,
+    },
+  };
+}
+
+/**
  * Execute a single pass of the storyboard against the supplied replica URLs
  * using round-robin dispatch starting at `dispatchOffset`. Called directly
  * by `runStoryboard` (offset 0) and repeatedly by `runMultiPass` (offsets
@@ -521,6 +579,22 @@ async function executeStoryboardPass(
         if (!options._client) await closeConnections(options.protocol);
         return buildCapabilityUnsupportedResult(agentUrls, storyboard, detail);
       }
+    }
+  }
+
+  // Enforce required_tools pre-flight gate: if the storyboard declares tools
+  // that make it applicable (at least one must be present) and the agent
+  // advertises none of them, skip the whole storyboard instead of producing
+  // misleading per-step failures.
+  if (storyboard.required_tools?.length && options.agentTools) {
+    const hasAnyRequired = storyboard.required_tools.some(t => options.agentTools!.includes(t));
+    if (!hasAnyRequired) {
+      if (!options._client) await closeConnections(options.protocol);
+      return buildRequiredToolsMissingResult(
+        agentUrls,
+        storyboard,
+        `agent does not advertise any of [${storyboard.required_tools.join(', ')}]`
+      );
     }
   }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -462,8 +462,12 @@ function buildCapabilityUnsupportedResult(
 /**
  * Build a minimal StoryboardResult for a storyboard skipped because the agent
  * does not advertise any of the tools listed in `required_tools`. The result
- * carries `skip_reason: 'not_applicable'` and `overall_passed: true` so CLI
+ * carries `skip_reason: 'missing_tool'` and `overall_passed: true` so CLI
  * reports and JUnit consumers render it as a skip, not a failure.
+ *
+ * `missing_tool` (not `not_applicable`) is the correct canonical reason here:
+ * the agent declared a compatible protocol/specialism but lacks the specific
+ * tools this storyboard exercises — distinct from a protocol/version mismatch.
  */
 function buildRequiredToolsMissingResult(
   agentUrls: string[],
@@ -477,21 +481,21 @@ function buildRequiredToolsMissingResult(
     overall_passed: true,
     phases: [
       {
-        phase_id: 'not_applicable',
-        phase_title: 'Not applicable — required tools not advertised',
+        phase_id: 'missing_tool',
+        phase_title: 'Skipped — required tools not advertised',
         passed: true,
         duration_ms: 0,
         steps: [
           {
             storyboard_id: storyboard.id,
-            step_id: 'not_applicable',
-            phase_id: 'not_applicable',
-            title: `Not applicable — ${detail}`,
+            step_id: 'missing_tool',
+            phase_id: 'missing_tool',
+            title: `Skipped — ${detail}`,
             task: '',
             passed: true,
             skipped: true,
-            skip_reason: 'not_applicable' as const,
-            skip: { reason: 'not_applicable' as const, detail },
+            skip_reason: 'missing_tool' as const,
+            skip: { reason: 'missing_tool' as const, detail },
             duration_ms: 0,
             validations: [],
             context: {},
@@ -586,6 +590,13 @@ async function executeStoryboardPass(
   // that make it applicable (at least one must be present) and the agent
   // advertises none of them, skip the whole storyboard instead of producing
   // misleading per-step failures.
+  //
+  // Gate condition: `options.agentTools` is falsy when the caller set
+  // `options._client` without also supplying `agentTools`. In that case the
+  // gate is a no-op — the caller accepted responsibility for tool compatibility
+  // by reusing an external client. The comply() path always populates
+  // `agentTools` before calling runStoryboard(), so the gate is always active
+  // in the standard runner flow.
   if (storyboard.required_tools?.length && options.agentTools) {
     const hasAnyRequired = storyboard.required_tools.some(t => options.agentTools!.includes(t));
     if (!hasAnyRequired) {
@@ -1035,10 +1046,10 @@ async function executeStoryboardPass(
   // Overall pass requires (a) no required-phase failures AND (b) at least one
   // required phase actually passed with at least one non-skipped step AND
   // (c) no assertion failures. Without (b) a storyboard where every phase is
-  // marked optional and every required phase's steps are skipped (e.g.
-  // required_tools filtered out everything) would pass vacuously. (c) makes
-  // assertions gating — a run with all validations green but a cross-step
-  // invariant broken is not conformant.
+  // marked optional and every required phase's steps are individually skipped
+  // (e.g. all steps have requires_tool and none matched) would pass vacuously.
+  // (c) makes assertions gating — a run with all validations green but a
+  // cross-step invariant broken is not conformant.
   // When no phases had executable steps the storyboard result is a skip, not a
   // failure. The index-aligned guard below would hit storyboard.phases[0] ===
   // undefined for an empty-phases storyboard and force requiredPhasesPassed to


### PR DESCRIPTION
Closes #1062

The `required_tools` field on `Storyboard` was declared and typed but never enforced on the normal execution path — it was only consulted in the degraded-auth bailout in `comply.ts` (line 884). This meant storyboards that target media-buy tools (e.g. `past_start_enforcement`) ran against signals-only, creative, or governance agents that advertise none of those tools, producing misleading per-step failures instead of a clean skip.

`executeStoryboardPass` now checks `storyboard.required_tools` immediately after profile discovery. Semantics: "at least one required tool must be advertised" (`Array.some`). When none match, the runner returns a synthetic `overall_passed: true` / `skip_reason: 'missing_tool'` result — the correct canonical skip reason for a tool-gap (distinct from `not_applicable`, which is reserved for protocol/specialism/version mismatches). Agents that advertise at least one required tool proceed normally. The `_client`-without-`agentTools` bypass is intentional and documented inline: callers that reuse an external client accepted tool-compatibility responsibility; `comply()` always populates `agentTools` so the gate is always active on the standard path.

**Note:** This is the client-side half of the fix. The `past_start_enforcement` storyboard YAML also needs `required_tools: [create_media_buy, update_media_buy]` (or step-level `requires_tool:` guards) in the spec repo (`adcontextprotocol/adcp`, same class as #2916). This PR makes the field meaningful so a correctly-annotated YAML produces the right skip immediately.

## What was tested

- `npx tsc --project tsconfig.lib.json --noEmitOnError false` — zero new errors (2 pre-existing config warnings: deprecated `moduleResolution=node10`, missing `@types/node`)
- `npm run format:check` — passes
- `npm test` baseline: 824 pass / 473 fail (pre-existing dist-rebuild failures). With changes: identical storyboard test failure list; no new failures introduced

## Pre-PR review

- **code-reviewer**: approved — no blockers; `some()` semantics correct; connection cleanup mirrors end-of-function pattern; `patch` bump appropriate; stray `@adcp/sdk` entry in changeset fixed; nit on `as const` redundancy (left as-is, consistent with surrounding code)
- **ad-tech-protocol-expert**: approved after blocker fix — `missing_tool` skip reason is correct per runner-output contract (protocol/specialism mismatch uses `not_applicable`; tool-gap uses `missing_tool`); `_client` bypass comment added; stale `requiredPhasesPassed` comment updated

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01NHyPio3KQxDc4i7QEisqcn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHyPio3KQxDc4i7QEisqcn)_