### PR TITLE
chore(commitlint): raise header-max-length 100 → 120

### DIFF
--- a/.changeset/commitlint-header-bump.md
+++ b/.changeset/commitlint-header-bump.md
@@ -1,0 +1,4 @@
+---
+---
+
+chore(commitlint): raise header-max-length 100 → 120 (dev tooling only, no library change).

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -22,5 +22,6 @@ module.exports = {
     'scope-empty': [0], // Allow empty scope
     'subject-case': [0], // Don't enforce subject case
     'body-max-line-length': [0], // Disable body line length limit
+    'header-max-length': [2, 'always', 120],
   },
 };


### PR DESCRIPTION
Closes #1057

Review-round commits with the `type(scope): subject — bullet1, bullet2, bullet3` shape routinely overflow the conventional default of 100 (recent example from #1005 hit 104). Bumping to 120 accommodates the verbose review-round style without forcing truncation that loses information.

Dev tooling only — no library behavior change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)