### PR TITLE
fix(protocols): caller args win over SDK version envelope (#1072)

### DIFF
--- a/.changeset/caller-version-override.md
+++ b/.changeset/caller-version-override.md
@@ -1,0 +1,14 @@
+---
+'@adcp/sdk': patch
+'@adcp/client': patch
+---
+
+fix(protocols): caller-supplied `adcp_major_version` / `adcp_version` no longer overridden by SDK pin (#1072)
+
+`ProtocolClient.callTool` previously spread the wire version envelope after caller `args`, silently rewriting any `adcp_major_version` (or `adcp_version`) the caller put in `args` with the SDK's own pin. This made it impossible for a conformance harness using the SDK as the buyer-side transport to probe seller-side version validation — the bundled `error-compliance.yaml` `version_negotiation/unsupported_major_version` step (which sends `adcp_major_version: 99` to elicit `VERSION_UNSUPPORTED`) could not pass.
+
+Spread order is now reversed at all four wire-injection sites (in-process MCP, HTTP MCP, A2A, both factory functions): caller args win, SDK envelope fills only when absent. Stale dual-field drift (e.g. buyer pinned to 3.1 but with stale integer in args) is still detected at the server boundary by `createAdcpServer`'s field-disagreement check, which returns `VERSION_UNSUPPORTED` per spec PR `adcontextprotocol/adcp#3493`.
+
+`adcp_version` is now also part of `ADCP_ENVELOPE_FIELDS`, so a caller-supplied 3.1+ release-precision string survives the per-tool schema-strip path in `SingleAgentClient` (the same protection `adcp_major_version` already had).
+
+This restores the pre-5.24 caller-wins behavior. No schema or wire changes — purely a buyer-side fix.

--- a/.changeset/caller-version-override.md
+++ b/.changeset/caller-version-override.md
@@ -5,10 +5,13 @@
 
 fix(protocols): caller-supplied `adcp_major_version` / `adcp_version` no longer overridden by SDK pin (#1072)
 
-`ProtocolClient.callTool` previously spread the wire version envelope after caller `args`, silently rewriting any `adcp_major_version` (or `adcp_version`) the caller put in `args` with the SDK's own pin. This made it impossible for a conformance harness using the SDK as the buyer-side transport to probe seller-side version validation — the bundled `error-compliance.yaml` `version_negotiation/unsupported_major_version` step (which sends `adcp_major_version: 99` to elicit `VERSION_UNSUPPORTED`) could not pass.
+**Behavior change for 5.24/5.25 users.** Restores the pre-5.24 caller-wins contract for the wire version envelope. If you pinned `@adcp/sdk` to 5.24 or 5.25 and were relying on the SDK to override stale `adcp_major_version` / `adcp_version` values in your `args` payload, those values now reach the seller verbatim. The 5.25 server-side field-disagreement check in `createAdcpServer` (per spec PR `adcontextprotocol/adcp#3493`) is the correct enforcement boundary for stale-config drift — a 3.1+ buyer carrying both fields with mismatched majors still gets `VERSION_UNSUPPORTED` from a compliant seller.
 
-Spread order is now reversed at all four wire-injection sites (in-process MCP, HTTP MCP, A2A, both factory functions): caller args win, SDK envelope fills only when absent. Stale dual-field drift (e.g. buyer pinned to 3.1 but with stale integer in args) is still detected at the server boundary by `createAdcpServer`'s field-disagreement check, which returns `VERSION_UNSUPPORTED` per spec PR `adcontextprotocol/adcp#3493`.
+**Why.** The 5.24 SDK-overrides-caller behavior made it impossible for conformance harnesses using `ProtocolClient` as buyer transport to probe seller version negotiation. The bundled `compliance/cache/3.0.1/universal/error-compliance.yaml` `unsupported_major_version` step (which sends `adcp_major_version: 99` to elicit `VERSION_UNSUPPORTED`) could not pass — the 99 was rewritten to the SDK pin before leaving the buyer.
 
-`adcp_version` is now also part of `ADCP_ENVELOPE_FIELDS`, so a caller-supplied 3.1+ release-precision string survives the per-tool schema-strip path in `SingleAgentClient` (the same protection `adcp_major_version` already had).
+**Changes:**
 
-This restores the pre-5.24 caller-wins behavior. No schema or wire changes — purely a buyer-side fix.
+- All four wire-injection sites (in-process MCP, HTTP MCP, A2A, `createMCPClient`, `createA2AClient`) now route through a new `applyVersionEnvelope(args, envelope)` helper. Single chokepoint, single test surface, no future-refactor drift between branches. Helper is exported.
+- `adcp_version` added to `ADCP_ENVELOPE_FIELDS` so a caller-supplied 3.1+ release-precision string survives `SingleAgentClient`'s per-tool schema-strip path. Mirrors the existing `adcp_major_version` carve-out — and 3.1 sellers MUST accept `adcp_version` at the envelope layer per spec PR #3493, so strict-schema rejections were a seller bug regardless.
+
+No schema or wire changes — purely a buyer-side fix.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -834,7 +834,6 @@ export {
   createA2AClient,
   closeMCPConnections,
   bundleSupportsAdcpVersionField,
-  applyVersionEnvelope,
 } from './protocols';
 export type { CallToolOptions } from './protocols';
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -834,6 +834,7 @@ export {
   createA2AClient,
   closeMCPConnections,
   bundleSupportsAdcpVersionField,
+  applyVersionEnvelope,
 } from './protocols';
 export type { CallToolOptions } from './protocols';
 

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -146,7 +146,9 @@ export interface CallToolOptions {
    * wire-level `adcp_major_version` field per-call instead of from the
    * SDK-pinned `ADCP_MAJOR_VERSION` constant. Default falls back to the
    * constant so call sites that don't plumb a per-instance version keep
-   * their existing behavior.
+   * their existing behavior. An explicit `adcp_major_version` /
+   * `adcp_version` in `args` overrides this — conformance harnesses use
+   * that path to probe seller version negotiation.
    */
   adcpVersion?: string;
 }
@@ -191,15 +193,18 @@ export class ProtocolClient {
         // still apply (they run in SingleAgentClient above this call). We skip
         // URL validation, OAuth refresh, and signing — none apply in-process.
         if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
-          // Spread `args` first, envelope second — the SDK's per-instance
-          // pin is authoritative for the wire envelope. A caller that
-          // accidentally passed `adcp_major_version` or `adcp_version` in
-          // `args` (stale config, hand-rolled call site) gets their value
-          // overridden by the version envelope. Without this, a stale
-          // integer in caller args would silently contradict the pin and
-          // the server's field-disagreement check (single-field override)
-          // wouldn't catch it.
-          const inProcArgs = { ...args, ...versionEnvelope };
+          // Envelope first, caller args second — caller wins. Conformance
+          // harnesses and version-negotiation probes need to send explicit
+          // `adcp_major_version` / `adcp_version` values to exercise the
+          // seller's `VERSION_UNSUPPORTED` path; an SDK-side override
+          // makes that probe impossible. Stale-config drift surfaces at
+          // the server boundary: when 3.1+ buyers carry both fields and
+          // the majors disagree, `createAdcpServer` returns
+          // VERSION_UNSUPPORTED. Single-field stale drift on the wire
+          // is the price of conformance probing — it's still detectable
+          // (seller responds with VERSION_UNSUPPORTED) and matches the
+          // pre-5.24 caller-wins contract.
+          const inProcArgs = { ...versionEnvelope, ...args };
           return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
         }
 
@@ -252,9 +257,14 @@ export class ProtocolClient {
         // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
         // alone; 3.1+ pins get both that and the release-precision string
         // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
-        // `adcontextprotocol/adcp#3493`. Envelope spread last so the SDK pin
-        // overrides any stale caller-supplied version key in `args`.
-        const argsWithVersion = { ...args, ...versionEnvelope };
+        // `adcontextprotocol/adcp#3493`. Envelope spread first so an
+        // explicit caller-supplied `adcp_major_version` / `adcp_version`
+        // wins — conformance harnesses depend on this to probe seller
+        // version negotiation (storyboard `unsupported_major_version`
+        // sends `adcp_major_version: 99` to elicit `VERSION_UNSUPPORTED`).
+        // Stale dual-field drift is still caught at the server boundary
+        // by `createAdcpServer`'s field-disagreement check.
+        const argsWithVersion = { ...versionEnvelope, ...args };
 
         // Build push_notification_config for ASYNC TASK STATUS notifications
         // (NOT for reporting_webhook - that stays in args)
@@ -443,7 +453,7 @@ export const createMCPClient = (
   const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
-      callMCPToolWithTasks(agentUrl, toolName, { ...args, ...versionEnvelope }, authToken, debugLogs, headers),
+      callMCPToolWithTasks(agentUrl, toolName, { ...versionEnvelope, ...args }, authToken, debugLogs, headers),
   };
 };
 
@@ -457,6 +467,6 @@ export const createA2AClient = (
   const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
-      callA2ATool(agentUrl, toolName, { ...parameters, ...versionEnvelope }, authToken, debugLogs, undefined, headers),
+      callA2ATool(agentUrl, toolName, { ...versionEnvelope, ...parameters }, authToken, debugLogs, undefined, headers),
   };
 };

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -131,6 +131,8 @@ function buildVersionEnvelope(
  * intact. Stale dual-field drift is caught at the server boundary by
  * `createAdcpServer`'s field-disagreement check (spec PR
  * `adcontextprotocol/adcp#3493`).
+ *
+ * @internal
  */
 export function applyVersionEnvelope(
   args: Record<string, unknown>,

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -121,6 +121,25 @@ function buildVersionEnvelope(
 }
 
 /**
+ * Merge the wire-level version envelope into a caller-supplied args object.
+ * Caller args win: an explicit `adcp_major_version` / `adcp_version` in
+ * `args` (e.g. a conformance harness probing `VERSION_UNSUPPORTED`) passes
+ * through unchanged. The envelope only fills fields the caller didn't set.
+ *
+ * Single chokepoint for all four wire-injection sites so a future refactor
+ * can't silently flip the spread order on one branch and leave the others
+ * intact. Stale dual-field drift is caught at the server boundary by
+ * `createAdcpServer`'s field-disagreement check (spec PR
+ * `adcontextprotocol/adcp#3493`).
+ */
+export function applyVersionEnvelope(
+  args: Record<string, unknown>,
+  envelope: Record<string, unknown>
+): Record<string, unknown> {
+  return { ...envelope, ...args };
+}
+
+/**
  * Options for {@link ProtocolClient.callTool}. All fields are optional.
  *
  * `webhookUrl` / `webhookSecret` / `webhookToken` are for ASYNC TASK STATUS
@@ -193,18 +212,7 @@ export class ProtocolClient {
         // still apply (they run in SingleAgentClient above this call). We skip
         // URL validation, OAuth refresh, and signing — none apply in-process.
         if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
-          // Envelope first, caller args second — caller wins. Conformance
-          // harnesses and version-negotiation probes need to send explicit
-          // `adcp_major_version` / `adcp_version` values to exercise the
-          // seller's `VERSION_UNSUPPORTED` path; an SDK-side override
-          // makes that probe impossible. Stale-config drift surfaces at
-          // the server boundary: when 3.1+ buyers carry both fields and
-          // the majors disagree, `createAdcpServer` returns
-          // VERSION_UNSUPPORTED. Single-field stale drift on the wire
-          // is the price of conformance probing — it's still detectable
-          // (seller responds with VERSION_UNSUPPORTED) and matches the
-          // pre-5.24 caller-wins contract.
-          const inProcArgs = { ...versionEnvelope, ...args };
+          const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
           return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
         }
 
@@ -257,14 +265,8 @@ export class ProtocolClient {
         // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
         // alone; 3.1+ pins get both that and the release-precision string
         // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
-        // `adcontextprotocol/adcp#3493`. Envelope spread first so an
-        // explicit caller-supplied `adcp_major_version` / `adcp_version`
-        // wins — conformance harnesses depend on this to probe seller
-        // version negotiation (storyboard `unsupported_major_version`
-        // sends `adcp_major_version: 99` to elicit `VERSION_UNSUPPORTED`).
-        // Stale dual-field drift is still caught at the server boundary
-        // by `createAdcpServer`'s field-disagreement check.
-        const argsWithVersion = { ...versionEnvelope, ...args };
+        // `adcontextprotocol/adcp#3493`.
+        const argsWithVersion = applyVersionEnvelope(args, versionEnvelope);
 
         // Build push_notification_config for ASYNC TASK STATUS notifications
         // (NOT for reporting_webhook - that stays in args)
@@ -453,7 +455,14 @@ export const createMCPClient = (
   const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
-      callMCPToolWithTasks(agentUrl, toolName, { ...versionEnvelope, ...args }, authToken, debugLogs, headers),
+      callMCPToolWithTasks(
+        agentUrl,
+        toolName,
+        applyVersionEnvelope(args, versionEnvelope),
+        authToken,
+        debugLogs,
+        headers
+      ),
   };
 };
 
@@ -467,6 +476,14 @@ export const createA2AClient = (
   const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
-      callA2ATool(agentUrl, toolName, { ...versionEnvelope, ...parameters }, authToken, debugLogs, undefined, headers),
+      callA2ATool(
+        agentUrl,
+        toolName,
+        applyVersionEnvelope(parameters, versionEnvelope),
+        authToken,
+        debugLogs,
+        undefined,
+        headers
+      ),
   };
 };

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -8,6 +8,7 @@
  */
 export const ADCP_ENVELOPE_FIELDS = new Set([
   'adcp_major_version', // Protocol version negotiation — preserved so version probes reach the seller
+  'adcp_version', // AdCP 3.1+ release-precision version string (spec PR #3493) — preserved alongside the integer
   'context', // Opaque pass-through for correlation and workflow state
   'ext', // Vendor-namespaced extensions
   'governance_context', // Governance approval token

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.24.0';
+export const LIBRARY_VERSION = '5.25.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.24.0',
+  library: '5.25.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T00:01:28.269Z',
+  generatedAt: '2026-04-30T09:45:14.937Z',
 } as const;
 
 /**

--- a/test/lib/adcp-major-version.test.js
+++ b/test/lib/adcp-major-version.test.js
@@ -111,14 +111,14 @@ describe('adcp_major_version on requests', () => {
 
 describe('applyVersionEnvelope — single chokepoint for all 4 wire-injection sites', () => {
   test('caller args win over envelope (regression: #1072)', () => {
-    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const { applyVersionEnvelope } = require('../../dist/lib/protocols/index.js');
     const merged = applyVersionEnvelope({ brief: 'probe', adcp_major_version: 99 }, { adcp_major_version: 3 });
     assert.strictEqual(merged.adcp_major_version, 99);
     assert.strictEqual(merged.brief, 'probe');
   });
 
   test('envelope fills fields the caller did not set', () => {
-    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const { applyVersionEnvelope } = require('../../dist/lib/protocols/index.js');
     const merged = applyVersionEnvelope({ brief: 'normal' }, { adcp_major_version: 3, adcp_version: '3.1' });
     assert.strictEqual(merged.adcp_major_version, 3);
     assert.strictEqual(merged.adcp_version, '3.1');
@@ -130,7 +130,7 @@ describe('applyVersionEnvelope — single chokepoint for all 4 wire-injection si
     // integer (caller-overrides the integer, SDK still adds the string)
     // produces a dual-field disagreement on the wire — exactly what the
     // server-side check in createAdcpServer is designed to catch.
-    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const { applyVersionEnvelope } = require('../../dist/lib/protocols/index.js');
     const merged = applyVersionEnvelope(
       { brief: 'probe', adcp_major_version: 99 },
       { adcp_major_version: 3, adcp_version: '3.1' }
@@ -140,14 +140,14 @@ describe('applyVersionEnvelope — single chokepoint for all 4 wire-injection si
   });
 
   test('caller adcp_version string also wins', () => {
-    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const { applyVersionEnvelope } = require('../../dist/lib/protocols/index.js');
     const merged = applyVersionEnvelope({ adcp_version: '99.0' }, { adcp_major_version: 3, adcp_version: '3.1' });
     assert.strictEqual(merged.adcp_version, '99.0');
     assert.strictEqual(merged.adcp_major_version, 3, 'envelope still fills the integer the caller did not set');
   });
 
   test('empty envelope (v2 servers) leaves args untouched', () => {
-    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const { applyVersionEnvelope } = require('../../dist/lib/protocols/index.js');
     const merged = applyVersionEnvelope({ brief: 'v2-call' }, {});
     assert.deepStrictEqual(merged, { brief: 'v2-call' });
   });

--- a/test/lib/adcp-major-version.test.js
+++ b/test/lib/adcp-major-version.test.js
@@ -20,27 +20,84 @@ describe('adcp_major_version on requests', () => {
     assert.strictEqual(ADCP_MAJOR_VERSION, 3);
   });
 
-  test('ProtocolClient injects adcp_major_version into MCP args', async () => {
-    const { ADCP_MAJOR_VERSION } = require('../../dist/lib/version.js');
+  test('ProtocolClient injects adcp_major_version when caller does not set it', async () => {
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+    const { ProtocolClient, ADCP_MAJOR_VERSION } = require('../../dist/lib/index.js');
+    const z = require('zod');
 
-    // Verify the injection logic: adcp_major_version is prepended so caller
-    // args take precedence if they explicitly set it.
-    const callerArgs = { advertiser_id: 'adv-123' };
-    const argsWithVersion = { adcp_major_version: ADCP_MAJOR_VERSION, ...callerArgs };
+    let captured;
+    const server = new McpServer({ name: 'inject-test', version: '1.0.0' });
+    server.registerTool(
+      'get_products',
+      { inputSchema: { brief: z.string().optional(), adcp_major_version: z.number().optional() } },
+      async args => {
+        captured = args;
+        return {
+          content: [{ type: 'text', text: '{}' }],
+          structuredContent: { success: true, products: [] },
+        };
+      }
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
+    await mcpClient.connect(clientTransport);
 
-    assert.strictEqual(argsWithVersion.adcp_major_version, 3);
-    assert.strictEqual(argsWithVersion.advertiser_id, 'adv-123');
+    await ProtocolClient.callTool(
+      { id: 'inject-test', protocol: 'mcp', agent_uri: 'in-process://x', _inProcessMcpClient: mcpClient },
+      'get_products',
+      { brief: 'test' }
+    );
+
+    assert.strictEqual(captured.adcp_major_version, ADCP_MAJOR_VERSION);
+
+    await mcpClient.close();
+    await server.close();
   });
 
-  test('caller-provided adcp_major_version overrides the default', () => {
-    const { ADCP_MAJOR_VERSION } = require('../../dist/lib/version.js');
+  test('caller-provided adcp_major_version overrides the SDK pin (regression: #1072)', async () => {
+    // Conformance harnesses send adcp_major_version: 99 to probe seller
+    // VERSION_UNSUPPORTED. The SDK must not rewrite that value.
+    const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+    const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+    const { ProtocolClient } = require('../../dist/lib/index.js');
+    const z = require('zod');
 
-    // If a caller explicitly passes adcp_major_version, their value wins
-    // because we spread ADCP_MAJOR_VERSION first, then ...args
-    const callerArgs = { adcp_major_version: 2, advertiser_id: 'adv-123' };
-    const argsWithVersion = { adcp_major_version: ADCP_MAJOR_VERSION, ...callerArgs };
+    let captured;
+    const server = new McpServer({ name: 'override-test', version: '1.0.0' });
+    server.registerTool(
+      'get_products',
+      { inputSchema: { brief: z.string().optional(), adcp_major_version: z.number().optional() } },
+      async args => {
+        captured = args;
+        return {
+          content: [{ type: 'text', text: '{}' }],
+          structuredContent: { success: true, products: [] },
+        };
+      }
+    );
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const mcpClient = new Client({ name: 'test-client', version: '1.0.0' });
+    await mcpClient.connect(clientTransport);
 
-    assert.strictEqual(argsWithVersion.adcp_major_version, 2);
+    await ProtocolClient.callTool(
+      { id: 'override-test', protocol: 'mcp', agent_uri: 'in-process://x', _inProcessMcpClient: mcpClient },
+      'get_products',
+      { brief: 'probe', adcp_major_version: 99 }
+    );
+
+    assert.strictEqual(
+      captured.adcp_major_version,
+      99,
+      'caller-supplied adcp_major_version must reach the seller for version-negotiation probes'
+    );
+
+    await mcpClient.close();
+    await server.close();
   });
 
   test('adcp_major_version is an integer between 1 and 99 per schema', () => {

--- a/test/lib/adcp-major-version.test.js
+++ b/test/lib/adcp-major-version.test.js
@@ -108,3 +108,58 @@ describe('adcp_major_version on requests', () => {
     assert.ok(ADCP_MAJOR_VERSION <= 99, 'maximum is 99');
   });
 });
+
+describe('applyVersionEnvelope — single chokepoint for all 4 wire-injection sites', () => {
+  test('caller args win over envelope (regression: #1072)', () => {
+    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const merged = applyVersionEnvelope({ brief: 'probe', adcp_major_version: 99 }, { adcp_major_version: 3 });
+    assert.strictEqual(merged.adcp_major_version, 99);
+    assert.strictEqual(merged.brief, 'probe');
+  });
+
+  test('envelope fills fields the caller did not set', () => {
+    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const merged = applyVersionEnvelope({ brief: 'normal' }, { adcp_major_version: 3, adcp_version: '3.1' });
+    assert.strictEqual(merged.adcp_major_version, 3);
+    assert.strictEqual(merged.adcp_version, '3.1');
+    assert.strictEqual(merged.brief, 'normal');
+  });
+
+  test('asymmetric override: caller integer + SDK 3.1 string both reach wire', () => {
+    // Protocol-expert ask: a 3.1-pinned buyer that supplies only the
+    // integer (caller-overrides the integer, SDK still adds the string)
+    // produces a dual-field disagreement on the wire — exactly what the
+    // server-side check in createAdcpServer is designed to catch.
+    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const merged = applyVersionEnvelope(
+      { brief: 'probe', adcp_major_version: 99 },
+      { adcp_major_version: 3, adcp_version: '3.1' }
+    );
+    assert.strictEqual(merged.adcp_major_version, 99, 'caller integer wins');
+    assert.strictEqual(merged.adcp_version, '3.1', 'SDK fills string when caller did not');
+  });
+
+  test('caller adcp_version string also wins', () => {
+    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const merged = applyVersionEnvelope({ adcp_version: '99.0' }, { adcp_major_version: 3, adcp_version: '3.1' });
+    assert.strictEqual(merged.adcp_version, '99.0');
+    assert.strictEqual(merged.adcp_major_version, 3, 'envelope still fills the integer the caller did not set');
+  });
+
+  test('empty envelope (v2 servers) leaves args untouched', () => {
+    const { applyVersionEnvelope } = require('../../dist/lib/index.js');
+    const merged = applyVersionEnvelope({ brief: 'v2-call' }, {});
+    assert.deepStrictEqual(merged, { brief: 'v2-call' });
+  });
+});
+
+describe('ADCP_ENVELOPE_FIELDS — strip-path carve-outs', () => {
+  test('adcp_version is preserved by SingleAgentClient strip path', () => {
+    // Defends the same caller-override path against schema stripping by
+    // strict MCP agents that publish per-tool input schemas. Mirrors the
+    // existing adcp_major_version carve-out.
+    const { ADCP_ENVELOPE_FIELDS } = require('../../dist/lib/types/adcp.js');
+    assert.ok(ADCP_ENVELOPE_FIELDS.has('adcp_version'), 'adcp_version must be in ADCP_ENVELOPE_FIELDS');
+    assert.ok(ADCP_ENVELOPE_FIELDS.has('adcp_major_version'), 'adcp_major_version must remain in ADCP_ENVELOPE_FIELDS');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1072.

`ProtocolClient.callTool` was spreading the wire version envelope **after** caller `args`, silently rewriting any `adcp_major_version` / `adcp_version` the caller put in `args` with the SDK's own pin. This made it impossible for conformance harnesses using the SDK as buyer transport to probe seller version negotiation.

## Changes

- **Reverse spread order at all four wire-injection sites** (in-process MCP, HTTP MCP, A2A, and both factory functions in `src/lib/protocols/index.ts`) via a new `applyVersionEnvelope(args, envelope)` chokepoint helper. Caller args now win, SDK envelope fills only when absent. Restores the pre-5.24 caller-wins contract. Helper is `@internal` and not part of the public TypeScript surface.
- **Add `adcp_version` to `ADCP_ENVELOPE_FIELDS`** so a caller-supplied 3.1+ release-precision string survives `SingleAgentClient`'s per-tool schema-strip path. Mirrors the existing `adcp_major_version` preservation.
- **Sync `LIBRARY_VERSION`** to 5.25.0 (the previous release PR #1068 missed running `sync-version.ts`, so the published 5.25.0 SDK was reporting `LIBRARY_VERSION = '5.24.0'`).
- **New regression tests**: caller-wins via the helper directly, asymmetric override (caller integer + SDK 3.1 string), caller-supplied `adcp_version` string override, empty-envelope (v2) passthrough, `ADCP_ENVELOPE_FIELDS` carve-out for both fields, plus two end-to-end in-process MCP transport tests.

## Why this is safe

The 5.24 PR that flipped the spread order argued the SDK pin had to override stale caller args because field-disagreement drift would otherwise be silent. 5.25 already added a server-side field-disagreement check in `createAdcpServer` (per spec PR `adcontextprotocol/adcp#3493`) that catches the **dual-field** drift case at the receiving end. Net: caller-wins on the wire, server still rejects mismatched majors with `VERSION_UNSUPPORTED`.

## ⚠️ Doesn't fully unblock the storyboard yet

The bundled `error_compliance/unsupported_major_version` step sends a **single-field** `adcp_major_version: 99` (no `adcp_version`). After this PR the buyer-side rewrite is gone, so the 99 reaches the seller — but `createAdcpServer`'s disagreement check only fires when **both** fields are present, so the framework's own seller silently dispatches against its server-pinned bundle and the storyboard validation `error_code === VERSION_UNSUPPORTED` still doesn't trigger.

Closing the gap requires the server-side single-field check tracked in **#1075**. The local skip in https://github.com/adcontextprotocol/adcp/pull/3626 has to stay until both this PR and #1075 ship.

## Test plan

- [x] `npm run build` clean
- [x] Full lib tests pass (6510 pass, 7 skipped, 0 fail)
- [x] New regression tests confirm `adcp_major_version: 99` reaches the in-process seller unmodified
- [x] Existing in-process injection test confirms SDK pin still applies when caller is silent
- [x] `applyVersionEnvelope` verified absent from `dist/lib/index.d.ts` AND `dist/lib/protocols/index.d.ts` (runtime export retained for tests via `@internal` + stripInternal)
- [x] Prettier clean
- [ ] **After this PR + #1075 both merge**: re-enable `error_compliance/unsupported_major_version` in https://github.com/adcontextprotocol/adcp/pull/3626

🤖 Generated with [Claude Code](https://claude.com/claude-code)