### PR TITLE
fix(server): extend VERSION_UNSUPPORTED check to single-field version claims

### DIFF
--- a/.changeset/single-field-version-unsupported.md
+++ b/.changeset/single-field-version-unsupported.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(server): extend VERSION_UNSUPPORTED check to single-field version claims (#1075)
+
+`createAdcpServer`'s version check previously fired only when both `adcp_version` and `adcp_major_version` were present with disagreeing majors (the dual-field drift guard). A buyer sending only `adcp_major_version: 99` or only `adcp_version: "99.0"` against a 3.0-pinned seller would bypass the check entirely — the unsupported integer reached the handler unvalidated.
+
+This patch adds the missing boundary enforcement: after the dual-field disagreement check, the handler now computes the effective claimed major from whichever version field(s) are present and rejects it with `VERSION_UNSUPPORTED` if it is not in the seller's advertised `major_versions`. The error includes `details.supported_versions` (e.g. `["3.0"]`) so buyers can negotiate a downgrade, and `details.requested_version` when an `adcp_version` string was supplied.
+
+Spec MUST per `tools.generated.ts:253`: sellers MUST validate against their supported `major_versions` and return `VERSION_UNSUPPORTED` if unsupported.
+
+No security impact — the schema bundle is server-pinned and the buyer's version claim does not affect dispatch. This is a spec-conformance improvement that closes a wire-level invariant gap surfaced in the security review of PR #1073.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2405,6 +2405,40 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
         }
 
+        // Single-field (and dual-agreeing) version check against the server's
+        // advertised major_versions. The dual-field disagreement block above
+        // catches mismatched pairs; this catches:
+        //   (a) adcp_major_version only — e.g. a 3.0-era buyer sending 99
+        //   (b) adcp_version only — e.g. a 3.1+ buyer probing with "99.0"
+        //   (c) both fields agreeing on an unsupported major (dual disagreement
+        //       is already caught above, so this block is never reached for
+        //       mismatched pairs)
+        // Spec MUST per `tools.generated.ts:253` — sellers MUST validate
+        // against their supported `major_versions` and return VERSION_UNSUPPORTED.
+        const serverMajorVersions = capConfig?.major_versions ?? [3];
+        let claimedMajor: number | undefined;
+        if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor)) {
+          claimedMajor = reqAdcpMajor;
+        } else if (typeof reqAdcpVersion === 'string') {
+          const m = parseAdcpMajorVersion(reqAdcpVersion);
+          if (Number.isFinite(m)) claimedMajor = m;
+        }
+        if (claimedMajor !== undefined && !serverMajorVersions.includes(claimedMajor)) {
+          return finalize(
+            adcpError('VERSION_UNSUPPORTED', {
+              message:
+                `Seller supports major version(s) ${serverMajorVersions.join(', ')}; ` +
+                `request carries major ${claimedMajor}.`,
+              details: {
+                supported_versions: serverMajorVersions.map(v => `${v}.0`),
+                // Echo the string field when present; omit for integer-only requests
+                // so buyers can distinguish "unsupported version" from "unknown major".
+                ...(typeof reqAdcpVersion === 'string' && { requested_version: reqAdcpVersion }),
+              },
+            })
+          );
+        }
+
         // --- Request schema validation (opt-in) ---
         // Runs before idempotency so drifted payloads never touch the
         // replay cache. `off` short-circuits without calling AJV.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -735,6 +735,8 @@ export interface BrandRightsHandlers<TAccount = unknown> {
 // Capabilities config
 // ---------------------------------------------------------------------------
 
+const DEFAULT_MAJOR_VERSIONS: number[] = [3];
+
 export interface AdcpCapabilitiesConfig {
   major_versions?: number[];
   features?: Partial<MediaBuyFeatures>;
@@ -2413,9 +2415,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         //   (c) both fields agreeing on an unsupported major (dual disagreement
         //       is already caught above, so this block is never reached for
         //       mismatched pairs)
-        // Spec MUST per `tools.generated.ts:253` — sellers MUST validate
+        // Spec MUST per spec PR `adcontextprotocol/adcp#3493` — sellers MUST validate
         // against their supported `major_versions` and return VERSION_UNSUPPORTED.
-        const serverMajorVersions = capConfig?.major_versions ?? [3];
+        const serverMajorVersions = capConfig?.major_versions ?? DEFAULT_MAJOR_VERSIONS;
         let claimedMajor: number | undefined;
         if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor)) {
           claimedMajor = reqAdcpMajor;
@@ -3082,7 +3084,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
   const capabilitiesData: GetAdCPCapabilitiesResponse = {
     adcp: {
-      major_versions: capConfig?.major_versions ?? [3],
+      major_versions: capConfig?.major_versions ?? DEFAULT_MAJOR_VERSIONS,
       idempotency: idempotencyCapability,
     },
     supported_protocols: protocols as GetAdCPCapabilitiesResponse['supported_protocols'],

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.24.0';
+export const LIBRARY_VERSION = '5.25.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.24.0',
+  library: '5.25.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T00:01:28.269Z',
+  generatedAt: '2026-04-30T10:20:03.781Z',
 } as const;
 
 /**

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -1748,4 +1748,111 @@ describe('createAdcpServer', () => {
       );
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Single-field VERSION_UNSUPPORTED check (#1075)
+  // -------------------------------------------------------------------------
+  // Regression guard for the gap where a buyer sending only adcp_major_version
+  // (or only adcp_version) against a 3.0-pinned seller would bypass the
+  // dual-field disagreement check and reach the handler unvalidated.
+  // Spec MUST per tools.generated.ts:253 — sellers must validate against their
+  // supported major_versions regardless of which version field(s) are present.
+  describe('single-field VERSION_UNSUPPORTED check', () => {
+    function makeServer() {
+      return createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: { getProducts: async () => ({ products: [] }) },
+      });
+    }
+
+    it('returns VERSION_UNSUPPORTED for adcp_major_version: 99 only (integer, no string field)', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_major_version: 99 });
+      assert.strictEqual(result.isError, true);
+      const err = result.structuredContent.adcp_error;
+      assert.strictEqual(err.code, 'VERSION_UNSUPPORTED');
+      assert.ok(err.message.includes('request carries major 99'), `unexpected message: ${err.message}`);
+    });
+
+    it('returns VERSION_UNSUPPORTED for adcp_version: "99.0" only (string, no integer field)', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_version: '99.0' });
+      assert.strictEqual(result.isError, true);
+      const err = result.structuredContent.adcp_error;
+      assert.strictEqual(err.code, 'VERSION_UNSUPPORTED');
+      assert.ok(err.message.includes('request carries major 99'), `unexpected message: ${err.message}`);
+    });
+
+    it('populates supported_versions from server major_versions (default [3] → ["3.0"])', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_major_version: 99 });
+      const details = result.structuredContent.adcp_error.details;
+      assert.deepStrictEqual(details.supported_versions, ['3.0']);
+    });
+
+    it('echoes requested_version from adcp_version string field when present', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_version: '99.0' });
+      assert.strictEqual(result.structuredContent.adcp_error.details?.requested_version, '99.0');
+    });
+
+    it('omits requested_version when only adcp_major_version is sent', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_major_version: 99 });
+      assert.strictEqual(result.structuredContent.adcp_error.details?.requested_version, undefined);
+    });
+
+    it('existing dual-field disagreement check fires first (message contains "majors must agree")', async () => {
+      const server = makeServer();
+      // adcp_version major=3 but adcp_major_version=99 — disagree
+      const result = await callToolRaw(server, 'get_products', {
+        adcp_version: '3.0',
+        adcp_major_version: 99,
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'VERSION_UNSUPPORTED');
+      assert.ok(
+        result.structuredContent.adcp_error.message.includes('majors must agree'),
+        `expected "majors must agree" in message; got: ${result.structuredContent.adcp_error.message}`
+      );
+    });
+
+    it('passes through when adcp_major_version matches server major (no error)', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_major_version: 3 });
+      assert.strictEqual(result.isError, undefined);
+      assert.ok(result.structuredContent?.products);
+    });
+
+    it('passes through for stringified adcp_major_version matching server major ("3" coerced to 3)', async () => {
+      const server = makeServer();
+      const result = await callToolRaw(server, 'get_products', { adcp_major_version: '3' });
+      assert.strictEqual(result.isError, undefined);
+    });
+
+    it('passes through safely for non-finite adcp_major_version (NaN stays undefined)', async () => {
+      const server = makeServer();
+      // "not-a-number" coerces to NaN via parseInt → Number.isFinite(NaN) is false → claimedMajor stays undefined
+      const result = await callToolRaw(server, 'get_products', { adcp_major_version: 'not-a-number' });
+      assert.strictEqual(result.isError, undefined);
+    });
+
+    it('custom major_versions: [3, 4] rejects only truly unsupported major', async () => {
+      const server = createAdcpServer({
+        name: 'Test',
+        version: '1.0.0',
+        mediaBuy: { getProducts: async () => ({ products: [] }) },
+        capabilities: { major_versions: [3, 4] },
+      });
+      // 4 is supported — no error
+      const ok = await callToolRaw(server, 'get_products', { adcp_major_version: 4 });
+      assert.strictEqual(ok.isError, undefined);
+      // 5 is not supported
+      const err = await callToolRaw(server, 'get_products', { adcp_major_version: 5 });
+      assert.strictEqual(err.isError, true);
+      assert.strictEqual(err.structuredContent.adcp_error.code, 'VERSION_UNSUPPORTED');
+      assert.deepStrictEqual(err.structuredContent.adcp_error.details?.supported_versions, ['3.0', '4.0']);
+    });
+  });
 });

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -1803,6 +1803,20 @@ describe('createAdcpServer', () => {
       assert.strictEqual(result.structuredContent.adcp_error.details?.requested_version, undefined);
     });
 
+    it('returns VERSION_UNSUPPORTED when both fields agree on an unsupported major', async () => {
+      const server = makeServer();
+      // Both agree on major 99 — dual-field disagreement check passes (no mismatch),
+      // but the supported-versions check catches the unsupported major.
+      const result = await callToolRaw(server, 'get_products', {
+        adcp_version: '99.0',
+        adcp_major_version: 99,
+      });
+      assert.strictEqual(result.isError, true);
+      assert.strictEqual(result.structuredContent.adcp_error.code, 'VERSION_UNSUPPORTED');
+      assert.ok(result.structuredContent.adcp_error.message.includes('request carries major 99'));
+      assert.strictEqual(result.structuredContent.adcp_error.details?.requested_version, '99.0');
+    });
+
     it('existing dual-field disagreement check fires first (message contains "majors must agree")', async () => {
       const server = makeServer();
       // adcp_version major=3 but adcp_major_version=99 — disagree


### PR DESCRIPTION
Closes #1075

`createAdcpServer`'s version-disagreement check (added in 5.25 per spec PR `adcontextprotocol/adcp#3493`) only fires when **both** `adcp_version` and `adcp_major_version` are present with disagreeing majors. A buyer sending only `adcp_major_version: 99` (or only `adcp_version: "99.0"`) against a 3.0-pinned seller bypassed the check entirely — the unsupported major reached the handler unvalidated. This PR inserts a follow-up check (after the existing dual-field guard) that computes the effective claimed major from whichever field(s) are present and rejects it with `VERSION_UNSUPPORTED` if the major is not in the seller's advertised `major_versions`. The error includes `details.supported_versions` so buyers can negotiate a downgrade.

**What was tested:**
- `npm run build:lib` — clean (only pre-existing TS deprecation warnings, present on `main`)
- `node --test test/server-create-adcp-server.test.js` — 98/98 pass (11 new tests added)
- `node --test test/*.test.js` — 57 pre-existing failures unchanged, 0 new failures
- Pre-push hook (format + typecheck + build) — passed on both commits

**Pre-PR review:**
- code-reviewer: approved — no blockers; one issue (missing dual-agreeing-unsupported test) fixed before push; nit on spec cross-reference fixed (uses `adcp#3493` instead of generated-file line number)
- ad-tech-protocol-expert: approved — `VERSION_UNSUPPORTED` is the correct code per spec; `supported_versions: ["3.0"]` format matches `VersionUnsupportedDetails`; 3.0-era buyers tolerate `details` per forward-compat requirement; latent drift risk on `?? [3]` default resolved by extracting `DEFAULT_MAJOR_VERSIONS` constant shared by both sites

**Nits surfaced (not fixed — in PR body per policy):**
- `supported_versions` mapping (`v => \`${v}.0\``) assumes each major integer maps to its `.0` patch; correct for current `major_versions: [3]` but implicit — a comment could note this assumption for future multi-minor sellers
- `requested_version` echoes the raw `adcp_version` string without normalization (e.g., `"  99.0  "` with padding would echo with whitespace); cosmetic, not semantic

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1076` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01T9APRhaSeJ6yWYCu1U2nMh

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9APRhaSeJ6yWYCu1U2nMh)_