### PR TITLE
fix(server): extend version-disagreement check to single-field claims

### DIFF
--- a/.changeset/server-version-unsupported-single-field.md
+++ b/.changeset/server-version-unsupported-single-field.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(server): reject single-field unsupported major versions in createAdcpServer
+
+`createAdcpServer` now returns `VERSION_UNSUPPORTED` (with `supported_versions` in the error details) when a request carries only `adcp_major_version` or only `adcp_version` and the major is outside the server's advertised `major_versions`. Previously only dual-field disagreements were caught; a request with `adcp_major_version: 99` against a 3.0-pinned server would silently reach the handler. This makes the `error-compliance.yaml` `unsupported_major_version` storyboard step deterministic.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2407,11 +2407,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
         }
 
-        // Single-field major version validation per spec PR `adcontextprotocol/adcp#3493`:
+        // Major version range check per spec PR `adcontextprotocol/adcp#3493`:
         // a server advertising `major_versions` MUST reject requests whose claimed
-        // major is outside that set, not just dual-field disagreements.
+        // major is outside that set — whether via adcp_major_version alone, adcp_version
+        // alone, or both fields agreeing on an unsupported major. The dual-field
+        // disagreement check above already handles the case where the two fields
+        // disagree; this block handles the rest.
         // Runs before the `requestValidationMode` gate for the same reason as above.
-        if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor) && typeof reqAdcpVersion !== 'string') {
+        // Note: a malformed adcp_major_version string (e.g. "not-a-number") produces
+        // reqAdcpMajor=NaN, which Number.isFinite rejects, so malformed integers
+        // fall through to schema validation (a pre-existing behavior).
+        if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor)) {
           if (!serverMajorVersions.includes(reqAdcpMajor)) {
             return finalize(
               adcpError('VERSION_UNSUPPORTED', {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2392,6 +2392,8 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             : typeof reqAdcpMajorRaw === 'string'
               ? Number.parseInt(reqAdcpMajorRaw, 10)
               : undefined;
+        const serverMajorVersions: number[] = capConfig?.major_versions ?? [3];
+
         if (typeof reqAdcpVersion === 'string' && reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor)) {
           const stringMajor = parseAdcpMajorVersion(reqAdcpVersion);
           if (Number.isFinite(stringMajor) && stringMajor !== reqAdcpMajor) {
@@ -2400,6 +2402,41 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 message:
                   `Request carries adcp_version="${reqAdcpVersion}" (major ${stringMajor}) and ` +
                   `adcp_major_version=${JSON.stringify(reqAdcpMajorRaw)}; majors must agree.`,
+              })
+            );
+          }
+        }
+
+        // Single-field major version validation per spec PR `adcontextprotocol/adcp#3493`:
+        // a server advertising `major_versions` MUST reject requests whose claimed
+        // major is outside that set, not just dual-field disagreements.
+        // Runs before the `requestValidationMode` gate for the same reason as above.
+        if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor) && typeof reqAdcpVersion !== 'string') {
+          if (!serverMajorVersions.includes(reqAdcpMajor)) {
+            return finalize(
+              adcpError('VERSION_UNSUPPORTED', {
+                message:
+                  `adcp_major_version=${reqAdcpMajor} is not supported; ` +
+                  `server supports major version(s): [${serverMajorVersions.join(', ')}].`,
+                details: {
+                  supported_versions: serverMajorVersions.map(v => `${v}.0`),
+                },
+              })
+            );
+          }
+        }
+        if (typeof reqAdcpVersion === 'string' && reqAdcpMajor === undefined) {
+          const stringMajor = parseAdcpMajorVersion(reqAdcpVersion);
+          if (Number.isFinite(stringMajor) && !serverMajorVersions.includes(stringMajor)) {
+            return finalize(
+              adcpError('VERSION_UNSUPPORTED', {
+                message:
+                  `adcp_version="${reqAdcpVersion}" (major ${stringMajor}) is not supported; ` +
+                  `server supports major version(s): [${serverMajorVersions.join(', ')}].`,
+                details: {
+                  supported_versions: serverMajorVersions.map(v => `${v}.0`),
+                  requested_version: reqAdcpVersion,
+                },
               })
             );
           }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.24.0';
+export const LIBRARY_VERSION = '5.25.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.24.0',
+  library: '5.25.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T00:01:28.269Z',
+  generatedAt: '2026-04-30T10:27:59.273Z',
 } as const;
 
 /**

--- a/test/lib/server-version-unsupported-single-field.test.js
+++ b/test/lib/server-version-unsupported-single-field.test.js
@@ -1,0 +1,75 @@
+/**
+ * Regression tests for single-field VERSION_UNSUPPORTED enforcement in
+ * createAdcpServer per spec PR adcontextprotocol/adcp#3493.
+ *
+ * The server's major_versions advertised in get_adcp_capabilities is a
+ * binding declaration. A request carrying only adcp_major_version or only
+ * adcp_version whose major is outside that set MUST be rejected even when
+ * requestValidationMode is 'off' (the production default).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServer } = require('../../dist/lib/server/create-adcp-server');
+const { extractVersionUnsupportedDetails } = require('../../dist/lib/index.js');
+
+function makeServer(capabilitiesOverrides = {}) {
+  return createAdcpServer({
+    name: 'TestVersionServer',
+    version: '1.0.0',
+    validation: { requests: 'off', responses: 'off' },
+    capabilities: capabilitiesOverrides,
+    mediaBuy: {
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1', packages: [] }),
+    },
+  });
+}
+
+async function dispatch(server, args) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: { name: 'create_media_buy', arguments: args },
+  });
+}
+
+describe('createAdcpServer single-field VERSION_UNSUPPORTED', () => {
+  it('rejects adcp_major_version: 99 alone on default 3.0-pinned server', async () => {
+    const server = makeServer();
+    const result = await dispatch(server, { adcp_major_version: 99 });
+    assert.ok(result.isError, 'response should be an error');
+    const err = result.structuredContent?.adcp_error;
+    assert.equal(err?.code, 'VERSION_UNSUPPORTED');
+    const details = extractVersionUnsupportedDetails(err);
+    assert.ok(Array.isArray(details?.supported_versions), 'should populate supported_versions');
+    assert.deepEqual(details.supported_versions, ['3.0']);
+  });
+
+  it('rejects adcp_version: "99.0" alone on default 3.0-pinned server', async () => {
+    const server = makeServer();
+    const result = await dispatch(server, { adcp_version: '99.0' });
+    assert.ok(result.isError, 'response should be an error');
+    const err = result.structuredContent?.adcp_error;
+    assert.equal(err?.code, 'VERSION_UNSUPPORTED');
+    const details = extractVersionUnsupportedDetails(err);
+    assert.ok(Array.isArray(details?.supported_versions), 'should populate supported_versions');
+    assert.deepEqual(details.supported_versions, ['3.0']);
+    assert.equal(details.requested_version, '99.0');
+  });
+
+  it('allows adcp_major_version: 3 on default 3.0-pinned server', async () => {
+    const server = makeServer();
+    const result = await dispatch(server, { adcp_major_version: 3 });
+    const err = result.structuredContent?.adcp_error;
+    assert.notEqual(err?.code, 'VERSION_UNSUPPORTED', 'supported major should not trigger VERSION_UNSUPPORTED');
+  });
+
+  it('existing dual-field disagreement still returns VERSION_UNSUPPORTED', async () => {
+    const server = makeServer();
+    // adcp_version major (3) disagrees with adcp_major_version (99)
+    const result = await dispatch(server, { adcp_version: '3.1', adcp_major_version: 99 });
+    assert.ok(result.isError, 'dual-field disagreement should be an error');
+    const err = result.structuredContent?.adcp_error;
+    assert.equal(err?.code, 'VERSION_UNSUPPORTED');
+  });
+});

--- a/test/lib/server-version-unsupported-single-field.test.js
+++ b/test/lib/server-version-unsupported-single-field.test.js
@@ -64,6 +64,17 @@ describe('createAdcpServer single-field VERSION_UNSUPPORTED', () => {
     assert.notEqual(err?.code, 'VERSION_UNSUPPORTED', 'supported major should not trigger VERSION_UNSUPPORTED');
   });
 
+  it('rejects dual-field request when both agree on an unsupported major', async () => {
+    const server = makeServer();
+    const result = await dispatch(server, { adcp_version: '99.0', adcp_major_version: 99 });
+    assert.ok(result.isError, 'agreeing dual-field unsupported major should be an error');
+    const err = result.structuredContent?.adcp_error;
+    assert.ok(err, 'structured adcp_error must be present');
+    assert.equal(err.code, 'VERSION_UNSUPPORTED');
+    const details = extractVersionUnsupportedDetails(err);
+    assert.ok(Array.isArray(details?.supported_versions), 'should populate supported_versions');
+  });
+
   it('existing dual-field disagreement still returns VERSION_UNSUPPORTED', async () => {
     const server = makeServer();
     // adcp_version major (3) disagrees with adcp_major_version (99)


### PR DESCRIPTION
Closes #1075.

`createAdcpServer`'s version check only fired when both `adcp_version` and `adcp_major_version` were present and their majors *disagreed*. Three cases were silently passing through to the handler: (a) only `adcp_major_version` present with an unsupported major, (b) both fields present and *agreeing* on an unsupported major, and (c) only `adcp_version` string present with an unsupported major. This meant the `error-compliance.yaml` `unsupported_major_version` storyboard step (which sends `adcp_major_version: 99` alone) could never elicit `VERSION_UNSUPPORTED` from the framework's own seller fixture.

The fix adds two branches immediately after the existing dual-field disagreement check, before the `requestValidationMode` gate (same placement rationale — spec MUST, not opt-in AJV validation):

1. **Integer-major range check** — fires when `reqAdcpMajor` is a finite number and not in `serverMajorVersions`. Covers cases (a) and (b).
2. **String-only range check** — fires when `adcp_version` is a string and `adcp_major_version` is absent. Covers case (c). Echoes `requested_version` in the error details.

Both branches populate `details.supported_versions` as release-precision strings (e.g. `['3.0']`) so `extractVersionUnsupportedDetails` on the buyer side can drive version-negotiation retry.

## What was tested

- `npm run build` — clean
- `npm run typecheck` — clean
- `npm run format:check` — clean
- 5 new regression tests, all pass:
  - `adcp_major_version: 99` alone → `VERSION_UNSUPPORTED` with `supported_versions: ['3.0']`
  - `adcp_version: "99.0"` alone → `VERSION_UNSUPPORTED` with `supported_versions` + `requested_version`
  - `adcp_major_version: 3` (supported) → no error
  - `adcp_major_version: 99` + `adcp_version: "99.0"` (agree, unsupported) → `VERSION_UNSUPPORTED`
  - `adcp_major_version: 99` + `adcp_version: "3.1"` (disagree, pre-existing) → `VERSION_UNSUPPORTED`

## Pre-PR review

- **code-reviewer:** approved — no blockers. Nits: (1) dual-field-agree error message only names `adcp_major_version` even when `adcp_version` is also present (diagnostic, not protocol); (2) dual-field agree test uses `Array.isArray` rather than pinning `['3.0']` exactly (inconsistent assertion depth).
- **ad-tech-protocol-expert:** approved — non-breaking per spec `adcontextprotocol/adcp#3493`; placement and `details` routing confirmed correct.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1076` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018KRopvRBrTxRbgno64PxTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018KRopvRBrTxRbgno64PxTZ)_