### PR TITLE
fix(server): VERSION_UNSUPPORTED for single-field version claims (#1075)

### DIFF
--- a/.changeset/single-field-version-unsupported.md
+++ b/.changeset/single-field-version-unsupported.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": minor
+---
+
+fix(server): extend VERSION_UNSUPPORTED to single-field version claims
+
+`createAdcpServer` now rejects requests where `adcp_major_version` (integer) or `adcp_version` (string) is set to an unsupported major, not only when both fields are present and disagree.
+
+**Behavior change for existing callers:** sellers running with the default `major_versions: [3]` will now return `VERSION_UNSUPPORTED` for requests carrying `adcp_major_version: 99` (or any unsupported integer), where before those requests dispatched silently. This closes the spec drift — the AdCP spec requires sellers to validate `major_versions` and return `VERSION_UNSUPPORTED` for unsupported claims. No legitimate production traffic sends unsupported major versions; conformance harnesses testing `VERSION_UNSUPPORTED` behavior are the primary callers of this path.
+
+The `VERSION_UNSUPPORTED` error response now includes `details.supported_versions` (array of version strings derived from the server's `major_versions` config) and `details.requested_version` for both new checks. This unblocks the `error_compliance/unsupported_major_version` storyboard step once PR #1073 (caller-wins fix) and this fix are both merged.
+
+Refs: #1075

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "5.22.0",
+  "version": "5.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "5.22.0",
+      "version": "5.25.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6394,10 +6394,10 @@
     },
     "packages/client-shim": {
       "name": "@adcp/client",
-      "version": "5.22.0",
+      "version": "5.25.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^5.22.0"
+        "@adcp/sdk": "^5.25.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2404,13 +2404,16 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             );
           }
         }
+        // Shared server major-versions list for both single-field checks below.
+        const serverMajorVersions = capConfig?.major_versions ?? [3];
         // Single-field major-version check per spec: "sellers validate against their
         // supported major_versions and return VERSION_UNSUPPORTED if unsupported."
         // The dual-field check above only fires on disagreement between the two fields.
         // A buyer sending only adcp_major_version (integer) bypasses it — handle that here.
         // Also catches dual-field requests where both fields agree on an unsupported major.
+        // `requested_version` echoes the raw integer-as-string (e.g. "99") because the
+        // buyer sent no adcp_version string; the major integer IS their version claim.
         if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor)) {
-          const serverMajorVersions = capConfig?.major_versions ?? [3];
           if (!serverMajorVersions.includes(reqAdcpMajor)) {
             return finalize(
               adcpError('VERSION_UNSUPPORTED', {
@@ -2425,13 +2428,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             );
           }
         }
-        // String-only single-field check: adcp_version present but no adcp_major_version.
-        // The integer check above handles any request where the integer field is present.
+        // String-only single-field check: adcp_version present but no parseable integer field.
+        // Guard is `!Number.isFinite(reqAdcpMajor)` (covers both undefined and NaN from a
+        // non-numeric adcp_major_version string) so non-numeric coercion results don't leak.
         // This branch covers 3.1+ buyers that omit the deprecated integer entirely.
-        if (typeof reqAdcpVersion === 'string' && reqAdcpMajor === undefined) {
+        if (typeof reqAdcpVersion === 'string' && !Number.isFinite(reqAdcpMajor)) {
           const versionMajor = parseAdcpMajorVersion(reqAdcpVersion);
           if (Number.isFinite(versionMajor)) {
-            const serverMajorVersions = capConfig?.major_versions ?? [3];
             if (!serverMajorVersions.includes(versionMajor)) {
               return finalize(
                 adcpError('VERSION_UNSUPPORTED', {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2404,6 +2404,49 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             );
           }
         }
+        // Single-field major-version check per spec: "sellers validate against their
+        // supported major_versions and return VERSION_UNSUPPORTED if unsupported."
+        // The dual-field check above only fires on disagreement between the two fields.
+        // A buyer sending only adcp_major_version (integer) bypasses it — handle that here.
+        // Also catches dual-field requests where both fields agree on an unsupported major.
+        if (reqAdcpMajor !== undefined && Number.isFinite(reqAdcpMajor)) {
+          const serverMajorVersions = capConfig?.major_versions ?? [3];
+          if (!serverMajorVersions.includes(reqAdcpMajor)) {
+            return finalize(
+              adcpError('VERSION_UNSUPPORTED', {
+                message:
+                  `adcp_major_version=${JSON.stringify(reqAdcpMajorRaw)} is not supported; ` +
+                  `seller supports major versions: [${serverMajorVersions.join(', ')}].`,
+                details: {
+                  supported_versions: serverMajorVersions.map(String),
+                  requested_version: String(reqAdcpMajorRaw),
+                },
+              })
+            );
+          }
+        }
+        // String-only single-field check: adcp_version present but no adcp_major_version.
+        // The integer check above handles any request where the integer field is present.
+        // This branch covers 3.1+ buyers that omit the deprecated integer entirely.
+        if (typeof reqAdcpVersion === 'string' && reqAdcpMajor === undefined) {
+          const versionMajor = parseAdcpMajorVersion(reqAdcpVersion);
+          if (Number.isFinite(versionMajor)) {
+            const serverMajorVersions = capConfig?.major_versions ?? [3];
+            if (!serverMajorVersions.includes(versionMajor)) {
+              return finalize(
+                adcpError('VERSION_UNSUPPORTED', {
+                  message:
+                    `adcp_version="${reqAdcpVersion}" (major ${versionMajor}) is not supported; ` +
+                    `seller supports major versions: [${serverMajorVersions.join(', ')}].`,
+                  details: {
+                    supported_versions: serverMajorVersions.map(String),
+                    requested_version: reqAdcpVersion,
+                  },
+                })
+              );
+            }
+          }
+        }
 
         // --- Request schema validation (opt-in) ---
         // Runs before idempotency so drifted payloads never touch the

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.24.0';
+export const LIBRARY_VERSION = '5.25.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.24.0',
+  library: '5.25.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T00:01:28.269Z',
+  generatedAt: '2026-04-30T10:25:42.810Z',
 } as const;
 
 /**

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -1749,3 +1749,89 @@ describe('createAdcpServer', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1075 — single-field VERSION_UNSUPPORTED check
+// ---------------------------------------------------------------------------
+
+describe('#1075 single-field version-unsupported check', () => {
+  // Helper: create a minimal 3.0-pinned server with get_products registered,
+  // validation off so sparse response fixtures don't trigger VALIDATION_ERROR.
+  function make3xServer(capOverrides = {}) {
+    return _createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'off' },
+      capabilities: { major_versions: [3], ...capOverrides },
+      mediaBuy: {
+        getProducts: async () => ({ products: [] }),
+      },
+    });
+  }
+
+  async function dispatch(server, args) {
+    const raw = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_products', arguments: args },
+    });
+    return raw.structuredContent;
+  }
+
+  it('rejects single-field adcp_major_version: 99 with VERSION_UNSUPPORTED', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { adcp_major_version: 99 });
+    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+    assert.deepStrictEqual(result.adcp_error?.details?.supported_versions, ['3']);
+  });
+
+  it('rejects single-field adcp_version: "99.0" (no integer) with VERSION_UNSUPPORTED', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { adcp_version: '99.0' });
+    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+    assert.deepStrictEqual(result.adcp_error?.details?.supported_versions, ['3']);
+  });
+
+  it('passes single-field adcp_major_version: 3 (supported)', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { adcp_major_version: 3 });
+    assert.ok(!result.adcp_error, `expected no error, got: ${JSON.stringify(result.adcp_error)}`);
+  });
+
+  it('passes single-field adcp_version: "3.0" (supported, no integer)', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { adcp_version: '3.0' });
+    assert.ok(!result.adcp_error, `expected no error, got: ${JSON.stringify(result.adcp_error)}`);
+  });
+
+  it('passes requests with no version fields (legacy path)', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { brief: 'coffee' });
+    assert.ok(!result.adcp_error, `expected no error, got: ${JSON.stringify(result.adcp_error)}`);
+  });
+
+  it('rejects stringified adcp_major_version: "99" (coerced)', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { adcp_major_version: '99' });
+    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+  });
+
+  it('existing dual-field disagreement still rejects (adcp_major_version: 99, adcp_version: "3.0")', async () => {
+    const server = make3xServer();
+    const result = await dispatch(server, { adcp_major_version: 99, adcp_version: '3.0' });
+    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+  });
+
+  it('server with major_versions: [2, 3] accepts adcp_major_version: 2', async () => {
+    const server = make3xServer({ major_versions: [2, 3] });
+    const result = await dispatch(server, { adcp_major_version: 2 });
+    assert.ok(!result.adcp_error, `expected no error, got: ${JSON.stringify(result.adcp_error)}`);
+  });
+
+  it('supported_versions detail is populated from server pin', async () => {
+    const server = make3xServer({ major_versions: [3] });
+    const result = await dispatch(server, { adcp_major_version: 99 });
+    assert.ok(Array.isArray(result.adcp_error?.details?.supported_versions));
+    assert.deepStrictEqual(result.adcp_error.details.supported_versions, ['3']);
+    assert.strictEqual(result.adcp_error.details.requested_version, '99');
+  });
+});

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -1780,14 +1780,22 @@ describe('#1075 single-field version-unsupported check', () => {
   it('rejects single-field adcp_major_version: 99 with VERSION_UNSUPPORTED', async () => {
     const server = make3xServer();
     const result = await dispatch(server, { adcp_major_version: 99 });
-    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+    assert.strictEqual(
+      result.adcp_error?.code,
+      'VERSION_UNSUPPORTED',
+      `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`
+    );
     assert.deepStrictEqual(result.adcp_error?.details?.supported_versions, ['3']);
   });
 
   it('rejects single-field adcp_version: "99.0" (no integer) with VERSION_UNSUPPORTED', async () => {
     const server = make3xServer();
     const result = await dispatch(server, { adcp_version: '99.0' });
-    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+    assert.strictEqual(
+      result.adcp_error?.code,
+      'VERSION_UNSUPPORTED',
+      `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`
+    );
     assert.deepStrictEqual(result.adcp_error?.details?.supported_versions, ['3']);
   });
 
@@ -1812,13 +1820,21 @@ describe('#1075 single-field version-unsupported check', () => {
   it('rejects stringified adcp_major_version: "99" (coerced)', async () => {
     const server = make3xServer();
     const result = await dispatch(server, { adcp_major_version: '99' });
-    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+    assert.strictEqual(
+      result.adcp_error?.code,
+      'VERSION_UNSUPPORTED',
+      `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`
+    );
   });
 
   it('existing dual-field disagreement still rejects (adcp_major_version: 99, adcp_version: "3.0")', async () => {
     const server = make3xServer();
     const result = await dispatch(server, { adcp_major_version: 99, adcp_version: '3.0' });
-    assert.strictEqual(result.adcp_error?.code, 'VERSION_UNSUPPORTED', `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`);
+    assert.strictEqual(
+      result.adcp_error?.code,
+      'VERSION_UNSUPPORTED',
+      `expected VERSION_UNSUPPORTED, got: ${JSON.stringify(result)}`
+    );
   });
 
   it('server with major_versions: [2, 3] accepts adcp_major_version: 2', async () => {


### PR DESCRIPTION
Closes #1075

## Summary

`createAdcpServer` was only checking for `VERSION_UNSUPPORTED` when both `adcp_version` (string) and `adcp_major_version` (integer) were present and their majors disagreed. A buyer sending only `adcp_major_version: 99` (single integer field, no string) bypassed the check entirely and the request dispatched normally — in direct violation of the spec's requirement that sellers validate `major_versions` and return `VERSION_UNSUPPORTED` for unsupported claims.

This PR adds two checks immediately after the existing dual-field disagreement check at `src/lib/server/create-adcp-server.ts:2404`:

1. **Integer-only path** — if `adcp_major_version` is present and finite, validate it against `capConfig.major_versions ?? [3]`. Also catches dual-field requests where both fields agree on an unsupported major (previously undetected).
2. **String-only path** — if `adcp_version` is a string and no parseable integer field is present (guard: `!Number.isFinite(reqAdcpMajor)`, covers both `undefined` and `NaN` from non-numeric coercion), validate the parsed major against `major_versions`.

Both checks populate `details.supported_versions` (string array from the server's `major_versions` config) and `details.requested_version` in the error response, enabling buyers to use `extractVersionUnsupportedDetails` for retry negotiation.

## Note on `requested_version` in the integer-only path

For the integer-only path, `requested_version` echoes the raw integer-as-string (e.g. `"99"`) because no `adcp_version` string was provided. The major integer is the buyer's version claim. This differs from the string path (`"99.0"`) and the spec's example format. The difference is documented in a comment; downstream consumers that do version comparisons should handle both forms.

## What was tested

- `npm run build` clean (pre-existing TS deprecation warnings only, present on `main`)
- `node --test` on all 4 version + server-create test files: 133 pass, 0 fail
- 9 new regression tests added to `test/server-create-adcp-server.test.js`: integer-only reject, string-only reject, supported integer pass-through, supported string pass-through, legacy no-fields pass-through, stringified integer coercion, existing dual-field disagreement still rejects, multi-major server accepts older major, `supported_versions` detail populated from server pin
- NaN edge case verified manually: `{ adcp_major_version: "abc", adcp_version: "99.0" }` → `VERSION_UNSUPPORTED`; `{ adcp_major_version: "abc" }` alone → no error

## Pre-PR review

- code-reviewer: approved — NaN guard is correct, duplication removed, no blockers (1 nit: pre-release string coercion to integer is benign pre-existing behavior)
- ad-tech-protocol-expert: approved — `requested_version` semantic is defensible with the comment, `!Number.isFinite` guard is correct per protocol; no blockers

**Nit surfaced (not fixed — for reviewer):** `requested_version` in the integer-only error path emits the raw major integer as a string (`"99"`) rather than a semver-like string (`"99.0"`). The protocol expert notes this may confuse downstream consumers that expect a full version string. Low-risk given no legitimate production traffic sends `adcp_major_version: 99`; fix would be to use `"<N>.x"` format if desired.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01GZ6mL2VqXpuJTK4xbce9Bf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZ6mL2VqXpuJTK4xbce9Bf)_