### PR TITLE
docs(server): add @example and @remarks to WebhooksConfig for IDE discoverability (TA4)

### DIFF
--- a/.changeset/webhooks-config-jsdoc.md
+++ b/.changeset/webhooks-config-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+docs(server): add @example and @remarks to WebhooksConfig for IDE discoverability (TA4)

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1062,6 +1062,22 @@ export interface AdcpCustomToolConfig<
  * hooks. Other emitter-internal knobs (rate limits, transport pool
  * sizing) stay on `WebhookEmitterOptions` for direct emitter callers.
  *
+ * @example In-process JWK signing
+ * ```ts
+ * webhooks: { signerKey: myJwk }
+ * ```
+ *
+ * @example KMS-backed signing via `signerProvider`
+ * ```ts
+ * webhooks: { signerProvider: myKmsProvider, retries: { maxAttempts: 3 } }
+ * ```
+ *
+ * @remarks
+ * Exactly one of `signerKey` or `signerProvider` must be set — providing
+ * both or neither throws `TypeError` at construction time. The key MUST
+ * carry `adcp_use: "webhook-signing"` (a request-signing key is a
+ * conformance violation per adcp#2423 — key purpose discriminator).
+ *
  * @public
  */
 export type WebhooksConfig = Pick<


### PR DESCRIPTION
Closes #1084

Adds two `@example` blocks and a `@remarks` note to `WebhooksConfig` in `src/lib/server/create-adcp-server.ts` so the `signerKey` XOR `signerProvider` constraint is visible at IDE hover time. Previously the constraint was documented only on `AdcpServerConfig.webhooks`, which is one hover-target removed when adopters hold a standalone `WebhooksConfig` reference. Note: the issue named `src/lib/server/decisioning/types.ts` as the target file, but `WebhooksConfig` lives in `create-adcp-server.ts`; the fix is applied to the correct location.

**What was tested:**
- `npm run format:check` — passed
- `npm run build:lib` — passed (schemas/cache missing as expected in CI-less env; pre-push hook confirmed green)
- Pre-existing typecheck failures (`Cannot find type definition file for 'node'`, deprecated `moduleResolution`) confirmed present on `main` before this branch

**Pre-PR review:**
- code-reviewer: approved — no blockers; one nit (add `(key purpose discriminator)` parenthetical for parity with sibling JSDoc) applied
- docs-expert: approved — `TypeError` accuracy confirmed, `adcp_use` requirement present, audience fit correct

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_013txeq45Safz2L65rXeR8Rb

---
_Generated by [Claude Code](https://claude.ai/code/session_013txeq45Safz2L65rXeR8Rb)_