### PR TITLE
refactor(server): rename TMeta → TCtxMeta generic param in v6.0 interfaces

### DIFF
--- a/.changeset/rename-tmeta-to-tctxmeta.md
+++ b/.changeset/rename-tmeta-to-tctxmeta.md
@@ -2,4 +2,4 @@
 "@adcp/sdk": patch
 ---
 
-Rename generic type parameter `TMeta → TCtxMeta` across all v6.0 server-platform interfaces (`DecisioningPlatform`, `SalesPlatform`, `AccountStore`, `Account`, and all specialism interfaces). Non-breaking — TypeScript generic parameter names are positional; no adopter code references `TMeta` by name. Aligns the parameter name with the `ctx_metadata` field it parameterizes, resolving IDE-hover ambiguity introduced by the `Account.metadata → Account.ctx_metadata` rename in 5a490534.
+Rename generic type parameter `TMeta → TCtxMeta` across all v6.0 server-platform interfaces (`DecisioningPlatform`, `SalesPlatform`, `AccountStore`, `Account`, and all specialism interfaces). Non-breaking — TypeScript generic parameter names are positional; no adopter code references `TMeta` by name. Aligns the parameter name with the `ctx_metadata` field it parameterizes, resolving IDE-hover ambiguity.

--- a/.changeset/rename-tmeta-to-tctxmeta.md
+++ b/.changeset/rename-tmeta-to-tctxmeta.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Rename generic type parameter `TMeta → TCtxMeta` across all v6.0 server-platform interfaces (`DecisioningPlatform`, `SalesPlatform`, `AccountStore`, `Account`, and all specialism interfaces). Non-breaking — TypeScript generic parameter names are positional; no adopter code references `TMeta` by name. Aligns the parameter name with the `ctx_metadata` field it parameterizes, resolving IDE-hover ambiguity introduced by the `Account.metadata → Account.ctx_metadata` rename in 5a490534.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -1,8 +1,8 @@
 /**
  * Account model. Single-level (matches AdCP wire's AccountReference).
  * Platform-internal hierarchies (GAM Network → Advertiser → Order;
- * Spotify Brand → Campaign) are encoded in `metadata`, not in the typed
- * shape. Generic `TMeta` lets platforms type their metadata at the call site.
+ * Spotify Brand → Campaign) are encoded in `ctx_metadata`, not in the typed
+ * shape. Generic `TCtxMeta` lets platforms type their `ctx_metadata` blob at the call site.
  *
  * Tenant isolation is enforced at `accounts.resolve()` returning null for
  * cross-scope references, not via a multi-level type.
@@ -26,17 +26,17 @@ import type { CursorPage, CursorRequest } from './pagination';
  * Account — framework's rich representation. A strict superset of the wire
  * `Account` shape (from `list_accounts` / response envelopes):
  *
- *   - Adds `metadata: TMeta` (platform-internal fields the framework doesn't
+ *   - Adds `ctx_metadata: TCtxMeta` (platform-internal fields the framework doesn't
  *     read but adopters use to thread platform-specific data)
  *   - Adds `authInfo: AuthPrincipal` (auth context for the request — MUST NOT
  *     leak to the wire)
  *   - All wire-required fields (`id`/`account_id`, `name`, `status`) are
  *     required here too.
  *
- * Framework projects to wire shape via `toWireAccount`: strips `metadata` +
+ * Framework projects to wire shape via `toWireAccount`: strips `ctx_metadata` +
  * `authInfo`, renames `id` → `account_id`. ~10 lines, no `as never` casts.
  */
-export interface Account<TMeta = Record<string, unknown>> {
+export interface Account<TCtxMeta = Record<string, unknown>> {
   /** Your platform's account_id. Maps to wire `Account.account_id`. */
   id: string;
 
@@ -87,7 +87,7 @@ export interface Account<TMeta = Record<string, unknown>> {
    * Put adapter state in `ctx_metadata`; treat it as fresh from your
    * `accounts.resolve()` on every request.
    */
-  ctx_metadata: TMeta;
+  ctx_metadata: TCtxMeta;
 
   /** Caller's authenticated principal. **Stripped before emitting on the wire.** */
   authInfo: AuthPrincipal;
@@ -148,7 +148,7 @@ export interface AuthPrincipal {
   claims?: Record<string, unknown>;
 }
 
-export interface AccountStore<TMeta = Record<string, unknown>> {
+export interface AccountStore<TCtxMeta = Record<string, unknown>> {
   /**
    * How buyers reference accounts on this platform.
    * - `'explicit'` — buyer passes `account_id` inline on every request (Snap,
@@ -201,7 +201,7 @@ export interface AccountStore<TMeta = Record<string, unknown>> {
    *   throw a generic exception. Framework maps to `SERVICE_UNAVAILABLE`
    *   so the buyer can retry.
    */
-  resolve(ref: AccountReference | undefined, ctx?: ResolveContext): Promise<Account<TMeta> | null>;
+  resolve(ref: AccountReference | undefined, ctx?: ResolveContext): Promise<Account<TCtxMeta> | null>;
 
   /**
    * sync_accounts API surface. Framework normalizes the wire request; platform
@@ -219,7 +219,7 @@ export interface AccountStore<TMeta = Record<string, unknown>> {
    *
    * **Optional.** Same rationale as `upsert` — stateless platforms can omit.
    */
-  list?(filter: AccountFilter & CursorRequest): Promise<CursorPage<Account<TMeta>>>;
+  list?(filter: AccountFilter & CursorRequest): Promise<CursorPage<Account<TCtxMeta>>>;
 
   /**
    * report_usage API surface. Operator-billed platforms accept usage rows
@@ -315,18 +315,18 @@ export type AdcpAccountStatus =
 import type { Account as WireAccount } from '../../types/tools.generated';
 
 /**
- * Project a framework `Account<TMeta>` to the wire `Account` shape.
+ * Project a framework `Account<TCtxMeta>` to the wire `Account` shape.
  *
- * Strips `metadata` and `authInfo` (framework-internal); renames `id` →
+ * Strips `ctx_metadata` and `authInfo` (framework-internal); renames `id` →
  * `account_id`; passes through `name`, `status`, `brand`, `operator`,
  * `advertiser`, and `billing.invoicedTo` mappings.
  *
  * Used by the framework when emitting `list_accounts` and other wire
  * responses that include account data. Adopters never call this directly —
- * they return `Account<TMeta>` from `accounts.resolve` / `accounts.list`
+ * they return `Account<TCtxMeta>` from `accounts.resolve` / `accounts.list`
  * and the framework projects.
  */
-export function toWireAccount<TMeta>(account: Account<TMeta>): WireAccount {
+export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount {
   const wire: WireAccount = {
     account_id: account.id,
     name: account.name,

--- a/src/lib/server/decisioning/context.ts
+++ b/src/lib/server/decisioning/context.ts
@@ -35,8 +35,8 @@ import type { CtxMetadataRef, ResourceKind } from '../ctx-metadata';
 // Unconstrained `TAccount` (no `extends Account`) so adopters with metadata
 // types that don't extend `Record<string, unknown>` (interfaces without index
 // signatures, type aliases pointing to unions, etc.) can still parameterize.
-// The framework only ever passes the resolved `Account<TMeta>` here; constraint
-// is implicit through the generic flow from `DecisioningPlatform<_, TMeta>`.
+// The framework only ever passes the resolved `Account<TCtxMeta>` here; constraint
+// is implicit through the generic flow from `DecisioningPlatform<_, TCtxMeta>`.
 export interface RequestContext<TAccount = Account> {
   /** Resolved account for this request. */
   account: TAccount;

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -125,7 +125,7 @@ type _ok_sales_no_required_caps =
   Record<string, never> extends RequiredCapabilitiesFor<'sales-non-guaranteed'> ? true : false;
 const _check_sales_no_required_caps: _ok_sales_no_required_caps = true;
 
-// ── Account is generic over TMeta ─────────────────────────────────────
+// ── Account is generic over TCtxMeta ─────────────────────────────────────
 
 interface GAMAccountMeta {
   networkId: string;

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -58,14 +58,14 @@ import type { AdCPSpecialism } from '../../types/tools.generated';
  *
  * @template TConfig Platform-specific config typed at the call site.
  *                   Example: `class GAM implements DecisioningPlatform<{ networkId: string }>`.
- * @template TMeta   Platform-specific Account.metadata typed at the call site.
+ * @template TCtxMeta   Platform-specific `Account.ctx_metadata` blob typed at the call site.
  */
-export interface DecisioningPlatform<TConfig = unknown, TMeta = Record<string, unknown>> {
+export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string, unknown>> {
   /** Capability declaration; single source of truth for get_adcp_capabilities. */
   capabilities: DecisioningCapabilities<TConfig>;
 
   /** Account model + tenant resolution. */
-  accounts: AccountStore<TMeta>;
+  accounts: AccountStore<TCtxMeta>;
 
   /**
    * Native-status mappers (account, mediaBuy, creative, plan).
@@ -90,22 +90,22 @@ export interface DecisioningPlatform<TConfig = unknown, TMeta = Record<string, u
    * differences are runtime-only.
    */
   getCapabilitiesFor?(
-    account: Account<TMeta>
+    account: Account<TCtxMeta>
   ): DecisioningCapabilities<TConfig> | Promise<DecisioningCapabilities<TConfig>>;
 
   // Per-specialism sub-interfaces — optional at the type level; required at the
   // call site by RequiredPlatformsFor<S>. v1.0 ships these. Each is parameterized
-  // by `TMeta` so adopters get typed `ctx.account.ctx_metadata` access in their
+  // by `TCtxMeta` so adopters get typed `ctx.account.ctx_metadata` access in their
   // method bodies without casting.
-  sales?: SalesPlatform<TMeta>;
-  creative?: CreativeBuilderPlatform<TMeta> | CreativeAdServerPlatform<TMeta>;
-  audiences?: AudiencePlatform<TMeta>;
-  signals?: SignalsPlatform<TMeta>;
-  campaignGovernance?: CampaignGovernancePlatform<TMeta>;
-  contentStandards?: ContentStandardsPlatform<TMeta>;
-  propertyLists?: PropertyListsPlatform<TMeta>;
-  collectionLists?: CollectionListsPlatform<TMeta>;
-  brandRights?: BrandRightsPlatform<TMeta>;
+  sales?: SalesPlatform<TCtxMeta>;
+  creative?: CreativeBuilderPlatform<TCtxMeta> | CreativeAdServerPlatform<TCtxMeta>;
+  audiences?: AudiencePlatform<TCtxMeta>;
+  signals?: SignalsPlatform<TCtxMeta>;
+  campaignGovernance?: CampaignGovernancePlatform<TCtxMeta>;
+  contentStandards?: ContentStandardsPlatform<TCtxMeta>;
+  propertyLists?: PropertyListsPlatform<TCtxMeta>;
+  collectionLists?: CollectionListsPlatform<TCtxMeta>;
+  brandRights?: BrandRightsPlatform<TCtxMeta>;
 
   // v1.1+ specialisms add: creative-review, plus the 2 brand-rights wire
   // tools awaiting AdcpToolMap landing (`update_rights`, `creative_approval`).
@@ -157,36 +157,36 @@ type SignalSpecialism = 'signal-marketplace' | 'signal-owned';
 // value without shape changes.
 type CampaignGovernanceSpecialism = 'governance-spend-authority' | 'governance-delivery-monitor';
 
-// `TMeta` defaults to `any` so callers that don't pass it explicitly (the
+// `TCtxMeta` defaults to `any` so callers that don't pass it explicitly (the
 // common case — `RequiredPlatformsFor<S>` without a second argument) get a
 // constraint that accepts any adopter metadata shape. The `any` is not a
 // soundness escape — adopters declare metadata inside `DecisioningPlatform<_,
-// TMeta>` directly; this constraint exists only to compile-check that
+// TCtxMeta>` directly; this constraint exists only to compile-check that
 // claimed specialisms have a matching sub-interface field on the platform.
 export type RequiredPlatformsFor<
   S extends AdCPSpecialism,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TMeta = any,
+  TCtxMeta = any,
 > = S extends 'creative-template' | 'creative-generative'
-  ? { creative: CreativeBuilderPlatform<TMeta> }
+  ? { creative: CreativeBuilderPlatform<TCtxMeta> }
   : S extends 'creative-ad-server'
-    ? { creative: CreativeAdServerPlatform<TMeta> }
+    ? { creative: CreativeAdServerPlatform<TCtxMeta> }
     : S extends SalesSpecialism
-      ? { sales: SalesPlatform<TMeta> }
+      ? { sales: SalesPlatform<TCtxMeta> }
       : S extends 'audience-sync'
-        ? { audiences: AudiencePlatform<TMeta> }
+        ? { audiences: AudiencePlatform<TCtxMeta> }
         : S extends SignalSpecialism
-          ? { signals: SignalsPlatform<TMeta> }
+          ? { signals: SignalsPlatform<TCtxMeta> }
           : S extends CampaignGovernanceSpecialism
-            ? { campaignGovernance: CampaignGovernancePlatform<TMeta> }
+            ? { campaignGovernance: CampaignGovernancePlatform<TCtxMeta> }
             : S extends 'property-lists'
-              ? { propertyLists: PropertyListsPlatform<TMeta> }
+              ? { propertyLists: PropertyListsPlatform<TCtxMeta> }
               : S extends 'collection-lists'
-                ? { collectionLists: CollectionListsPlatform<TMeta> }
+                ? { collectionLists: CollectionListsPlatform<TCtxMeta> }
                 : S extends 'content-standards'
-                  ? { contentStandards: ContentStandardsPlatform<TMeta> }
+                  ? { contentStandards: ContentStandardsPlatform<TCtxMeta> }
                   : S extends 'brand-rights'
-                    ? { brandRights: BrandRightsPlatform<TMeta> }
+                    ? { brandRights: BrandRightsPlatform<TCtxMeta> }
                     : Record<string, never>;
 
 /**

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -566,7 +566,7 @@ export interface DecisioningAdcpServer extends AdcpServer {
 }
 
 // Use `DecisioningPlatform<any, any>` for the generic constraint. The default
-// `TMeta = Record<string, unknown>` doesn't accept adopter metadata interfaces
+// `TCtxMeta = Record<string, unknown>` doesn't accept adopter metadata interfaces
 // without an index signature (e.g., `interface MyMeta { brand_id: string }`),
 // which is a needless friction point — adopter metadata is opaque to the
 // framework, so we don't need to constrain it here.

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -80,10 +80,10 @@ function buildCtxMetadataAccessor(store: CtxMetadataStore, accountId: string): C
   };
 }
 
-export function buildRequestContext<TMeta = Record<string, unknown>>(
-  handlerCtx: HandlerContext<Account<TMeta>>,
+export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
+  handlerCtx: HandlerContext<Account<TCtxMeta>>,
   ctxMetadataStore?: CtxMetadataStore
-): RequestContext<Account<TMeta>> {
+): RequestContext<Account<TCtxMeta>> {
   // `account` may legitimately be undefined for tools whose wire request
   // doesn't carry an `account` field AND whose `resolveAccountFromAuth`
   // returned null (`'explicit'`-mode adopters who don't model the
@@ -102,7 +102,7 @@ export function buildRequestContext<TMeta = Record<string, unknown>>(
   //      specialisms — the tool is unreachable
   //   3. Read `ctx.account` defensively (`as Account | undefined` cast)
   //      and look up by request body when missing
-  const account = handlerCtx.account as Account<TMeta>;
+  const account = handlerCtx.account as Account<TCtxMeta>;
 
   const stubResolver = (name: string) => async (): Promise<never> => {
     throw new Error(

--- a/src/lib/server/decisioning/specialisms/audiences.ts
+++ b/src/lib/server/decisioning/specialisms/audiences.ts
@@ -15,7 +15,7 @@ import type { Account } from '../account';
 import type { RequestContext } from '../context';
 import type { SyncAudiencesRequest, SyncAudiencesSuccess } from '../../../types/tools.generated';
 
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
 /**
  * The wire schema doesn't export a top-level `Audience` type; the shape lives
@@ -37,7 +37,7 @@ export type SyncAudiencesRow = SyncAudiencesSuccess['audiences'][number];
 
 export type AudienceStatus = NonNullable<SyncAudiencesRow['status']>;
 
-export interface AudiencePlatform<TMeta = Record<string, unknown>> {
+export interface AudiencePlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Push audiences to the platform. Framework handles batching, idempotency,
    * cross-tenant scoping. Platform handles match-rate computation and
@@ -54,7 +54,7 @@ export interface AudiencePlatform<TMeta = Record<string, unknown>> {
    * Throw `new AdcpError(...)` for buyer-fixable rejection
    * (`AUDIENCE_TOO_SMALL`, etc.).
    */
-  syncAudiences(audiences: Audience[], ctx: Ctx<TMeta>): Promise<SyncAudiencesRow[]>;
+  syncAudiences(audiences: Audience[], ctx: Ctx<TCtxMeta>): Promise<SyncAudiencesRow[]>;
 
   /**
    * Batch-poll current status for one or more audiences. Sync — this is a
@@ -73,5 +73,5 @@ export interface AudiencePlatform<TMeta = Record<string, unknown>> {
    * APIs that natively return per-audience-id arrays — adopters do NOT
    * need to wrap a single-id lookup over an N-call loop.
    */
-  pollAudienceStatuses(audienceIds: readonly string[], ctx: Ctx<TMeta>): Promise<Map<string, AudienceStatus>>;
+  pollAudienceStatuses(audienceIds: readonly string[], ctx: Ctx<TCtxMeta>): Promise<Map<string, AudienceStatus>>;
 }

--- a/src/lib/server/decisioning/specialisms/brand-rights.ts
+++ b/src/lib/server/decisioning/specialisms/brand-rights.ts
@@ -42,16 +42,16 @@ import type {
   AcquireRightsRejected,
 } from '../../../types/core.generated';
 
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export interface BrandRightsPlatform<TMeta = Record<string, unknown>> {
+export interface BrandRightsPlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Read brand identity record — `brand_id`, `house`, localized `names`,
    * optional logos / industries / `keller_type`. Sync; no async ceremony.
    * Throw `AdcpError('REFERENCE_NOT_FOUND')` when the brand reference
    * doesn't resolve to an identity the platform tracks.
    */
-  getBrandIdentity(req: GetBrandIdentityRequest, ctx: Ctx<TMeta>): Promise<GetBrandIdentitySuccess>;
+  getBrandIdentity(req: GetBrandIdentityRequest, ctx: Ctx<TCtxMeta>): Promise<GetBrandIdentitySuccess>;
 
   /**
    * List rights matching a brand + use query. Sync read; framework
@@ -63,7 +63,7 @@ export interface BrandRightsPlatform<TMeta = Record<string, unknown>> {
    * Note: the wire field is `rights`, NOT `offerings`. Adopters who
    * named their internal model `offerings` translate at this seam.
    */
-  getRights(req: GetRightsRequest, ctx: Ctx<TMeta>): Promise<GetRightsSuccess>;
+  getRights(req: GetRightsRequest, ctx: Ctx<TCtxMeta>): Promise<GetRightsSuccess>;
 
   /**
    * Acquire rights — buyer commits to an offering. Four wire-spec arms:
@@ -107,6 +107,6 @@ export interface BrandRightsPlatform<TMeta = Record<string, unknown>> {
    */
   acquireRights(
     req: AcquireRightsRequest,
-    ctx: Ctx<TMeta>
+    ctx: Ctx<TCtxMeta>
   ): Promise<AcquireRightsAcquired | AcquireRightsPendingApproval | AcquireRightsRejected>;
 }

--- a/src/lib/server/decisioning/specialisms/campaign-governance.ts
+++ b/src/lib/server/decisioning/specialisms/campaign-governance.ts
@@ -40,9 +40,9 @@ import type {
   GetPlanAuditLogsResponse,
 } from '../../../types/tools.generated';
 
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export interface CampaignGovernancePlatform<TMeta = Record<string, unknown>> {
+export interface CampaignGovernancePlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Runtime governance decision. Buyer (or seller, on the seller's behalf)
    * sends a proposed action; the agent inspects it against the plan and
@@ -57,24 +57,24 @@ export interface CampaignGovernancePlatform<TMeta = Record<string, unknown>> {
    * `status: 'denied'` for governance decisions that ARE the answer
    * (the plan exists and the agent is rejecting the action).
    */
-  checkGovernance(req: CheckGovernanceRequest, ctx: Ctx<TMeta>): Promise<CheckGovernanceResponse>;
+  checkGovernance(req: CheckGovernanceRequest, ctx: Ctx<TCtxMeta>): Promise<CheckGovernanceResponse>;
 
   /**
    * Plan CRUD. Buyers sync their campaign plans into the governance
    * agent so the agent can maintain spend authority + delivery context.
    */
-  syncPlans(req: SyncPlansRequest, ctx: Ctx<TMeta>): Promise<SyncPlansResponse>;
+  syncPlans(req: SyncPlansRequest, ctx: Ctx<TCtxMeta>): Promise<SyncPlansResponse>;
 
   /**
    * Outcome reporting. Sellers report what actually happened (impressions
    * delivered, spend incurred, status transitions) so the agent can
    * calibrate future decisions.
    */
-  reportPlanOutcome(req: ReportPlanOutcomeRequest, ctx: Ctx<TMeta>): Promise<ReportPlanOutcomeResponse>;
+  reportPlanOutcome(req: ReportPlanOutcomeRequest, ctx: Ctx<TCtxMeta>): Promise<ReportPlanOutcomeResponse>;
 
   /**
    * Audit log read. Returns the chronological history of governance
    * decisions + outcome reports for a plan.
    */
-  getPlanAuditLogs(req: GetPlanAuditLogsRequest, ctx: Ctx<TMeta>): Promise<GetPlanAuditLogsResponse>;
+  getPlanAuditLogs(req: GetPlanAuditLogsRequest, ctx: Ctx<TCtxMeta>): Promise<GetPlanAuditLogsResponse>;
 }

--- a/src/lib/server/decisioning/specialisms/content-standards.ts
+++ b/src/lib/server/decisioning/specialisms/content-standards.ts
@@ -52,31 +52,37 @@ import type {
   GetCreativeFeaturesResponse,
 } from '../../../types/tools.generated';
 
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export interface ContentStandardsPlatform<TMeta = Record<string, unknown>> {
+export interface ContentStandardsPlatform<TCtxMeta = Record<string, unknown>> {
   /** Discover content standards published by this agent. */
-  listContentStandards(req: ListContentStandardsRequest, ctx: Ctx<TMeta>): Promise<ListContentStandardsResponse>;
+  listContentStandards(req: ListContentStandardsRequest, ctx: Ctx<TCtxMeta>): Promise<ListContentStandardsResponse>;
 
   /** Read a single content standard by id. */
-  getContentStandards(req: GetContentStandardsRequest, ctx: Ctx<TMeta>): Promise<GetContentStandardsResponse>;
+  getContentStandards(req: GetContentStandardsRequest, ctx: Ctx<TCtxMeta>): Promise<GetContentStandardsResponse>;
 
   /**
    * Create a new content standard. Adopter validates the policy schema
    * and returns the persisted record. Idempotent on the buyer's
    * `idempotency_key`.
    */
-  createContentStandards(req: CreateContentStandardsRequest, ctx: Ctx<TMeta>): Promise<CreateContentStandardsResponse>;
+  createContentStandards(
+    req: CreateContentStandardsRequest,
+    ctx: Ctx<TCtxMeta>
+  ): Promise<CreateContentStandardsResponse>;
 
   /** Update an existing content standard. */
-  updateContentStandards(req: UpdateContentStandardsRequest, ctx: Ctx<TMeta>): Promise<UpdateContentStandardsResponse>;
+  updateContentStandards(
+    req: UpdateContentStandardsRequest,
+    ctx: Ctx<TCtxMeta>
+  ): Promise<UpdateContentStandardsResponse>;
 
   /**
    * Calibrate content against the published standards. Returns the
    * standard's current calibration profile + any flags raised against
    * the submitted content.
    */
-  calibrateContent(req: CalibrateContentRequest, ctx: Ctx<TMeta>): Promise<CalibrateContentResponse>;
+  calibrateContent(req: CalibrateContentRequest, ctx: Ctx<TCtxMeta>): Promise<CalibrateContentResponse>;
 
   /**
    * Validate that a delivered media-buy / creative meets the buyer's
@@ -86,7 +92,7 @@ export interface ContentStandardsPlatform<TMeta = Record<string, unknown>> {
    */
   validateContentDelivery(
     req: ValidateContentDeliveryRequest,
-    ctx: Ctx<TMeta>
+    ctx: Ctx<TCtxMeta>
   ): Promise<ValidateContentDeliveryResponse>;
 
   /**
@@ -95,12 +101,12 @@ export interface ContentStandardsPlatform<TMeta = Record<string, unknown>> {
    * who don't expose artifact archival omit. Required by governance
    * receivers running adjacency validation.
    */
-  getMediaBuyArtifacts?(req: GetMediaBuyArtifactsRequest, ctx: Ctx<TMeta>): Promise<GetMediaBuyArtifactsResponse>;
+  getMediaBuyArtifacts?(req: GetMediaBuyArtifactsRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuyArtifactsResponse>;
 
   /**
    * Read per-creative analyzed features (object detection, scene
    * classification, transcript) the agent extracted during calibration.
    * Optional — adopters without analyzer pipelines omit.
    */
-  getCreativeFeatures?(req: GetCreativeFeaturesRequest, ctx: Ctx<TMeta>): Promise<GetCreativeFeaturesResponse>;
+  getCreativeFeatures?(req: GetCreativeFeaturesRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeFeaturesResponse>;
 }

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -43,9 +43,9 @@ import type {
 import type { SyncCreativesRow } from './sales';
 
 type Creative = CreativeAsset;
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export interface CreativeAdServerPlatform<TMeta = Record<string, unknown>> {
+export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Build / retrieve creative tags. Two invocation modes per the spec:
    *
@@ -68,11 +68,11 @@ export interface CreativeAdServerPlatform<TMeta = Record<string, unknown>> {
    */
   buildCreative(
     req: BuildCreativeRequest,
-    ctx: Ctx<TMeta>
+    ctx: Ctx<TCtxMeta>
   ): Promise<CreativeManifest | CreativeManifest[] | BuildCreativeSuccess | BuildCreativeMultiSuccess>;
 
   /** Preview-only variant — sandbox URL or inline HTML, expires. Always sync. */
-  previewCreative(req: PreviewCreativeRequest, ctx: Ctx<TMeta>): Promise<PreviewCreativeResponse>;
+  previewCreative(req: PreviewCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<PreviewCreativeResponse>;
 
   // sync_creatives: sync OR task — `SyncCreativesResponse` has a Submitted arm.
 
@@ -83,7 +83,10 @@ export interface CreativeAdServerPlatform<TMeta = Record<string, unknown>> {
    * `'updated'` for replacements, `'unchanged'` when matching. Optional
    * `status: 'pending_review'` for sync-arm rows awaiting manual review.
    */
-  syncCreatives?(creatives: Creative[], ctx: Ctx<TMeta>): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
+  syncCreatives?(
+    creatives: Creative[],
+    ctx: Ctx<TCtxMeta>
+  ): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
 
   /**
    * Read creatives from the library. Filters + pagination. When
@@ -91,7 +94,7 @@ export interface CreativeAdServerPlatform<TMeta = Record<string, unknown>> {
    * graph. When `req.include_pricing`, include vendor pricing options
    * on each creative.
    */
-  listCreatives(req: ListCreativesRequest, ctx: Ctx<TMeta>): Promise<ListCreativesResponse>;
+  listCreatives(req: ListCreativesRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativesResponse>;
 
   /**
    * Per-creative delivery actuals (impressions, spend, pacing). Sync —
@@ -99,5 +102,5 @@ export interface CreativeAdServerPlatform<TMeta = Record<string, unknown>> {
    * latest cached actuals and emit `delivery_report` status changes
    * via `publishStatusChange` when fresh reports are available.
    */
-  getCreativeDelivery(filter: GetCreativeDeliveryRequest, ctx: Ctx<TMeta>): Promise<GetCreativeDeliveryResponse>;
+  getCreativeDelivery(filter: GetCreativeDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeDeliveryResponse>;
 }

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -61,7 +61,7 @@ export type BuildCreativeReturn =
   | BuildCreativeMultiSuccess;
 
 type Creative = CreativeAsset;
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
 // Re-export SyncCreativesRow so creative-specialism adopters don't need to
 // reach into the sales module to import the shared row type.
@@ -103,7 +103,7 @@ export type { SyncCreativesRow };
  * (rare in the wild) front each archetype as a separate tenant via
  * `TenantRegistry`.
  */
-export interface CreativeBuilderPlatform<TMeta = Record<string, unknown>> {
+export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Build the creative. Single method covers template-driven transform
    * (`req.template_id` + asset slots), brief-to-creative generation
@@ -116,7 +116,7 @@ export interface CreativeBuilderPlatform<TMeta = Record<string, unknown>> {
    * `BuildCreativeMultiSuccess` envelope when you need to set
    * `sandbox` / `expires_at` / `preview`.
    */
-  buildCreative(req: BuildCreativeRequest, ctx: Ctx<TMeta>): Promise<BuildCreativeReturn>;
+  buildCreative(req: BuildCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<BuildCreativeReturn>;
 
   /**
    * Preview-only variant — sandbox URL or inline HTML, expires. Always
@@ -125,7 +125,7 @@ export interface CreativeBuilderPlatform<TMeta = Record<string, unknown>> {
    * `UNSUPPORTED_FEATURE` to buyers calling `preview_creative` against
    * a platform that didn't wire this.
    */
-  previewCreative?(req: PreviewCreativeRequest, ctx: Ctx<TMeta>): Promise<PreviewCreativeResponse>;
+  previewCreative?(req: PreviewCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<PreviewCreativeResponse>;
 
   /**
    * Refine a prior generation. `taskId` references a prior submission.
@@ -134,7 +134,7 @@ export interface CreativeBuilderPlatform<TMeta = Record<string, unknown>> {
    * re-calling `buildCreative` with different inputs and don't carry
    * generation state across calls.
    */
-  refineCreative?(taskId: string, refinement: RefinementMessage, ctx: Ctx<TMeta>): Promise<CreativeManifest>;
+  refineCreative?(taskId: string, refinement: RefinementMessage, ctx: Ctx<TCtxMeta>): Promise<CreativeManifest>;
 
   /**
    * Sync review surface. Stateless platforms typically auto-approve;
@@ -142,7 +142,10 @@ export interface CreativeBuilderPlatform<TMeta = Record<string, unknown>> {
    * `ctx.handoffToTask(fn)` to defer to a background task. Unified
    * hybrid shape — return rows OR `ctx.handoffToTask(fn)`.
    */
-  syncCreatives?(creatives: Creative[], ctx: Ctx<TMeta>): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
+  syncCreatives?(
+    creatives: Creative[],
+    ctx: Ctx<TCtxMeta>
+  ): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
 }
 
 /**
@@ -154,7 +157,7 @@ export interface CreativeBuilderPlatform<TMeta = Record<string, unknown>> {
  * release while adopters migrate. Will be removed in a future
  * release.
  */
-export type CreativeTemplatePlatform<TMeta = Record<string, unknown>> = CreativeBuilderPlatform<TMeta>;
+export type CreativeTemplatePlatform<TCtxMeta = Record<string, unknown>> = CreativeBuilderPlatform<TCtxMeta>;
 
 /**
  * @deprecated Use `CreativeBuilderPlatform` — the unified interface
@@ -162,7 +165,7 @@ export type CreativeTemplatePlatform<TMeta = Record<string, unknown>> = Creative
  * `CreativeTemplatePlatform` deprecation note. Will be removed in a
  * future release.
  */
-export type CreativeGenerativePlatform<TMeta = Record<string, unknown>> = CreativeBuilderPlatform<TMeta>;
+export type CreativeGenerativePlatform<TCtxMeta = Record<string, unknown>> = CreativeBuilderPlatform<TCtxMeta>;
 
 // ---------------------------------------------------------------------------
 // Shared shapes

--- a/src/lib/server/decisioning/specialisms/lists.ts
+++ b/src/lib/server/decisioning/specialisms/lists.ts
@@ -51,24 +51,24 @@ import type {
   DeleteCollectionListResponse,
 } from '../../../types/tools.generated';
 
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export interface PropertyListsPlatform<TMeta = Record<string, unknown>> {
+export interface PropertyListsPlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Create a property list. Returns a `fetch_token` the buyer stores in
    * their secret manager. Token is scoped to this list_id; MUST NOT be
    * reused across lists.
    */
-  createPropertyList(req: CreatePropertyListRequest, ctx: Ctx<TMeta>): Promise<CreatePropertyListResponse>;
+  createPropertyList(req: CreatePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<CreatePropertyListResponse>;
 
   /** Patch an existing property list. */
-  updatePropertyList(req: UpdatePropertyListRequest, ctx: Ctx<TMeta>): Promise<UpdatePropertyListResponse>;
+  updatePropertyList(req: UpdatePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<UpdatePropertyListResponse>;
 
   /** Read a property list by id. Sellers call this with the fetch_token. */
-  getPropertyList(req: GetPropertyListRequest, ctx: Ctx<TMeta>): Promise<GetPropertyListResponse>;
+  getPropertyList(req: GetPropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<GetPropertyListResponse>;
 
   /** Discover property lists the caller is authorized to read. */
-  listPropertyLists(req: ListPropertyListsRequest, ctx: Ctx<TMeta>): Promise<ListPropertyListsResponse>;
+  listPropertyLists(req: ListPropertyListsRequest, ctx: Ctx<TCtxMeta>): Promise<ListPropertyListsResponse>;
 
   /**
    * Delete a property list. MUST revoke the fetch_token immediately and
@@ -76,13 +76,13 @@ export interface PropertyListsPlatform<TMeta = Record<string, unknown>> {
    * a list-changed webhook). Compromise-driven revocation MUST also
    * trigger this path.
    */
-  deletePropertyList(req: DeletePropertyListRequest, ctx: Ctx<TMeta>): Promise<DeletePropertyListResponse>;
+  deletePropertyList(req: DeletePropertyListRequest, ctx: Ctx<TCtxMeta>): Promise<DeletePropertyListResponse>;
 }
 
-export interface CollectionListsPlatform<TMeta = Record<string, unknown>> {
-  createCollectionList(req: CreateCollectionListRequest, ctx: Ctx<TMeta>): Promise<CreateCollectionListResponse>;
-  updateCollectionList(req: UpdateCollectionListRequest, ctx: Ctx<TMeta>): Promise<UpdateCollectionListResponse>;
-  getCollectionList(req: GetCollectionListRequest, ctx: Ctx<TMeta>): Promise<GetCollectionListResponse>;
-  listCollectionLists(req: ListCollectionListsRequest, ctx: Ctx<TMeta>): Promise<ListCollectionListsResponse>;
-  deleteCollectionList(req: DeleteCollectionListRequest, ctx: Ctx<TMeta>): Promise<DeleteCollectionListResponse>;
+export interface CollectionListsPlatform<TCtxMeta = Record<string, unknown>> {
+  createCollectionList(req: CreateCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<CreateCollectionListResponse>;
+  updateCollectionList(req: UpdateCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<UpdateCollectionListResponse>;
+  getCollectionList(req: GetCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<GetCollectionListResponse>;
+  listCollectionLists(req: ListCollectionListsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCollectionListsResponse>;
+  deleteCollectionList(req: DeleteCollectionListRequest, ctx: Ctx<TCtxMeta>): Promise<DeleteCollectionListResponse>;
 }

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -91,7 +91,7 @@ import type {
 } from '../../../types/tools.generated';
 
 type Creative = CreativeAsset;
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
 /**
  * Wire success-row shape for `sync_creatives`. Returning the array of these
@@ -100,7 +100,7 @@ type Ctx<TMeta> = RequestContext<Account<TMeta>>;
  */
 export type SyncCreativesRow = SyncCreativesSuccess['creatives'][number];
 
-export interface SalesPlatform<TMeta = Record<string, unknown>> {
+export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
   // ── get_products: sync only — by design, not just by spec ─────────
   // get_products is a CATALOG LOOKUP — fast read against the seller's
   // existing inventory. It is NOT the right wire surface for proposal
@@ -124,7 +124,7 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // workflows declare it via `capabilities` so buyers can route
   // appropriately before the first call.
   /** Sync catalog lookup: filters in, products out. NOT for proposal generation. */
-  getProducts(req: GetProductsRequest, ctx: Ctx<TMeta>): Promise<GetProductsResponse>;
+  getProducts(req: GetProductsRequest, ctx: Ctx<TCtxMeta>): Promise<GetProductsResponse>;
 
   // ── create_media_buy: unified hybrid shape ──────────────────────────
 
@@ -176,7 +176,7 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
    */
   createMediaBuy(
     req: CreateMediaBuyRequest,
-    ctx: Ctx<TMeta>
+    ctx: Ctx<TCtxMeta>
   ): Promise<CreateMediaBuySuccess | TaskHandoff<CreateMediaBuySuccess>>;
 
   // ── update_media_buy: sync only (today) ─────────────────────────────
@@ -189,7 +189,7 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // `publishStatusChange` on `resource_type: 'media_buy'` rather than
   // HITL on this tool.
   /** Sync update. Returns the patched buy. */
-  updateMediaBuy(buyId: string, patch: UpdateMediaBuyRequest, ctx: Ctx<TMeta>): Promise<UpdateMediaBuySuccess>;
+  updateMediaBuy(buyId: string, patch: UpdateMediaBuyRequest, ctx: Ctx<TCtxMeta>): Promise<UpdateMediaBuySuccess>;
 
   // ── sync_creatives: unified hybrid shape ────────────────────────────
 
@@ -217,11 +217,14 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
    * }
    * ```
    */
-  syncCreatives?(creatives: Creative[], ctx: Ctx<TMeta>): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
+  syncCreatives?(
+    creatives: Creative[],
+    ctx: Ctx<TCtxMeta>
+  ): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
 
   // ── get_media_buy_delivery: sync only ───────────────────────────────
 
-  getMediaBuyDelivery(filter: GetMediaBuyDeliveryRequest, ctx: Ctx<TMeta>): Promise<GetMediaBuyDeliveryResponse>;
+  getMediaBuyDelivery(filter: GetMediaBuyDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuyDeliveryResponse>;
 
   // ── get_media_buys: sync only — REQUIRED ──────────────────────────────
   // Read tool — buyers fetch a list of their media buys (often filtered by
@@ -237,7 +240,7 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // Proposal-mode adopters (write-only via push channels) return an empty
   // `media_buys: []` array — that's a valid response.
   /** List media buys this account owns. Filter + pagination per the wire shape. */
-  getMediaBuys(req: GetMediaBuysRequest, ctx: Ctx<TMeta>): Promise<GetMediaBuysResponse>;
+  getMediaBuys(req: GetMediaBuysRequest, ctx: Ctx<TCtxMeta>): Promise<GetMediaBuysResponse>;
 
   // ── provide_performance_feedback: sync only ─────────────────────────
   // Write tool — buyers report aggregate creative-level performance
@@ -252,7 +255,7 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   /** Accept buyer-side performance signals on a media buy / creative. */
   providePerformanceFeedback?(
     req: ProvidePerformanceFeedbackRequest,
-    ctx: Ctx<TMeta>
+    ctx: Ctx<TCtxMeta>
   ): Promise<ProvidePerformanceFeedbackSuccess>;
 
   // ── list_creative_formats: sync only ────────────────────────────────
@@ -263,7 +266,7 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // Self-hosted sellers (own creative library) implement this directly.
   //
   // ⚠️  NO-ACCOUNT TOOL. See `providePerformanceFeedback` note above.
-  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TMeta>): Promise<ListCreativeFormatsResponse>;
+  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativeFormatsResponse>;
 
   // ── list_creatives: sync only ───────────────────────────────────────
   // Read tool — buyers query the seller's creative library. Optional
@@ -271,25 +274,25 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // `creative_agents` declared in capabilities; ad-server-style sales
   // platforms implement directly. Note: also lives on `CreativeAdServerPlatform.listCreatives`
   // for the standalone-creative-agent shape.
-  listCreatives?(req: ListCreativesRequest, ctx: Ctx<TMeta>): Promise<ListCreativesResponse>;
+  listCreatives?(req: ListCreativesRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativesResponse>;
 
   // ── sync_catalogs: sync only ────────────────────────────────────────
   // Retail-media catalog sync. Buyers push product catalogs (SKUs, ASINs,
   // store-ids) for `sales-catalog-driven` agents (Amazon, Criteo, Citrusad,
   // Walmart Connect, Shopify ad surfaces). Optional — non-retail sales
   // adopters omit. Idempotent on the buyer's `idempotency_key`.
-  syncCatalogs?(req: SyncCatalogsRequest, ctx: Ctx<TMeta>): Promise<SyncCatalogsSuccess>;
+  syncCatalogs?(req: SyncCatalogsRequest, ctx: Ctx<TCtxMeta>): Promise<SyncCatalogsSuccess>;
 
   // ── log_event: sync only ────────────────────────────────────────────
   // Conversion / engagement event logging. Buyers post events tied to
   // a `media_buy_id` for performance attribution. Used by retail-media
   // (post-purchase events) and conversion-tracked sales (Snap pixel,
   // Meta CAPI, LinkedIn conversions API). Optional.
-  logEvent?(req: LogEventRequest, ctx: Ctx<TMeta>): Promise<LogEventSuccess>;
+  logEvent?(req: LogEventRequest, ctx: Ctx<TCtxMeta>): Promise<LogEventSuccess>;
 
   // ── sync_event_sources: sync only ──────────────────────────────────
   // Register conversion event sources (websites, apps, offline pixel
   // IDs) so subsequent `log_event` calls can be attributed correctly.
   // Optional — adopters who don't expose conversion tracking omit.
-  syncEventSources?(req: SyncEventSourcesRequest, ctx: Ctx<TMeta>): Promise<SyncEventSourcesSuccess>;
+  syncEventSources?(req: SyncEventSourcesRequest, ctx: Ctx<TCtxMeta>): Promise<SyncEventSourcesSuccess>;
 }

--- a/src/lib/server/decisioning/specialisms/signals.ts
+++ b/src/lib/server/decisioning/specialisms/signals.ts
@@ -33,9 +33,9 @@ import type {
   ActivateSignalSuccess,
 } from '../../../types/tools.generated';
 
-type Ctx<TMeta> = RequestContext<Account<TMeta>>;
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
 
-export interface SignalsPlatform<TMeta = Record<string, unknown>> {
+export interface SignalsPlatform<TCtxMeta = Record<string, unknown>> {
   /**
    * Catalog discovery. Sync — query your signal index, return signals
    * matching the buyer's filters (industry, intent type, audience size,
@@ -46,7 +46,7 @@ export interface SignalsPlatform<TMeta = Record<string, unknown>> {
    * `'POLICY_VIOLATION'` if the buyer doesn't have rights to the data
    * category they're requesting).
    */
-  getSignals(req: GetSignalsRequest, ctx: Ctx<TMeta>): Promise<GetSignalsResponse>;
+  getSignals(req: GetSignalsRequest, ctx: Ctx<TCtxMeta>): Promise<GetSignalsResponse>;
 
   /**
    * Provision a signal onto one or more destination platforms (Snap,
@@ -67,5 +67,5 @@ export interface SignalsPlatform<TMeta = Record<string, unknown>> {
    *   - `'POLICY_VIOLATION'` — buyer lacks rights to activate this data
    *   - `'INVALID_REQUEST'` — missing or unrecognized destination
    */
-  activateSignal(req: ActivateSignalRequest, ctx: Ctx<TMeta>): Promise<ActivateSignalSuccess>;
+  activateSignal(req: ActivateSignalRequest, ctx: Ctx<TCtxMeta>): Promise<ActivateSignalSuccess>;
 }


### PR DESCRIPTION
Closes #1083

Renames the generic type parameter `TMeta → TCtxMeta` across all v6.0 server-platform interfaces. After the `Account.metadata → Account.ctx_metadata` field rename landed, the old parameter name `TMeta` read ambiguously in IDE hovers — it could mean account metadata, package metadata, anything. `TCtxMeta` directly echoes the `ctx_metadata` field it parameterizes, removing that ambiguity for adopters and codegen agents alike.

**Files changed (15 source + 1 changeset):**
- `account.ts` — `Account<TCtxMeta>`, `AccountStore<TCtxMeta>`, `toWireAccount<TCtxMeta>`; JSDoc updated (`metadata` → `ctx_metadata` in prose)
- `platform.ts` — `DecisioningPlatform<TConfig, TCtxMeta>`; `@template` tag updated
- `context.ts`, `decisioning.type-checks.ts`, `runtime/from-platform.ts`, `runtime/to-context.ts` — comment/signature updates
- All 9 specialism files — `Ctx<TCtxMeta>` type alias + interface param rename
- `.changeset/rename-tmeta-to-tctxmeta.md` — patch changeset

**Why non-breaking:** TypeScript generic parameter names are positional. Adopter call sites write `DecisioningPlatform<MyConfig, MyMeta>` — the name `TMeta` is never referenced by name in userland code. There is no `export type TMeta = ...` anywhere in the public surface.

## What was tested

- `npm run format:check` — all files pass Prettier
- `npm run typecheck` — same pre-existing infrastructure errors as `main` (deprecated `moduleResolution=node10`; unrelated to this PR)
- `npm run build:lib` — passes
- `npm test` — same pre-existing failure count as `main` (infrastructure issues unrelated to this rename; 78 pass on both)
- `grep -rn "\bTMeta\b" src/` — zero hits after rename

**Pre-PR review:**
- code-reviewer: approved — rename complete, no `TMeta` remaining in source, `toWireAccount<TCtxMeta>` compiles correctly, no conditional-type interactions, changeset correct
- dx-expert: approved — export chain intact (`server/index.ts` → `decisioning/index.ts`), `docs/llms.txt` and `docs/TYPE-SUMMARY.md` clean, all skill files clean, examples unaffected (use positional args), `patch` bump level correct

**Nits noted (not fixed):** `docs/proposals/` contains 51 `TMeta` references across 8 design-RFC files — intentionally out of scope; agents are not directed to those paths.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01XPMPMTRvyWxHTetJ5NRhwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPMPMTRvyWxHTetJ5NRhwU)_