### PR TITLE
feat(server): auto-hydration for update_media_buy, activate_signal, and acquire_rights

### DIFF
--- a/.changeset/auto-hydration-update-signal-brand.md
+++ b/.changeset/auto-hydration-update-signal-brand.md
@@ -1,0 +1,21 @@
+---
+'@adcp/sdk': minor
+---
+
+Extend auto-hydration to `update_media_buy`, `activate_signal`, and `acquire_rights`.
+
+**New hydration sites (requires `ctxMetadata` store to be wired):**
+- `update_media_buy`: `patch.media_buy` populated from the store after a prior `createMediaBuy` (sync arm) or `getMediaBuys` call. Publisher reads `patch.media_buy.ctx_metadata?.gam_order_id` directly.
+- `activate_signal`: `req.signal` populated from the store after a prior `getSignals` call, keyed by `signal_agent_segment_id`.
+- `acquire_rights`: `req.brand` populated from the store after a prior `getBrandIdentity` call, keyed by `buyer.brand_id`.
+
+**Store additions:**
+- `getSignals` now auto-stores each returned signal (kind `signal`, id `signal_agent_segment_id`).
+- `getBrandIdentity` now auto-stores the returned brand identity (kind `brand`, id `brand_id`).
+- `createMediaBuy` (sync arm) now auto-stores the created media_buy so `updateMediaBuy` can hydrate it without a prior `getMediaBuys` call.
+
+**`ResourceKind` updated:** added `'brand'` to the closed enum.
+
+**`provide_performance_feedback` intentionally excluded:** this tool carries no `account` field; the ctx-metadata store (scoped per account) cannot be used. See `skills/build-decisioning-platform/SKILL.md` § SDK auto-hydration contract for the documented rationale.
+
+**All hydration is graceful-fallback:** when the SDK has no stored record, the field is `undefined` — the publisher falls back to its own DB. No exception thrown.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "5.22.0",
+  "version": "5.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "5.22.0",
+      "version": "5.25.1",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6394,10 +6394,10 @@
     },
     "packages/client-shim": {
       "name": "@adcp/client",
-      "version": "5.22.0",
+      "version": "5.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^5.22.0"
+        "@adcp/sdk": "^5.25.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/skills/build-decisioning-platform/SKILL.md
+++ b/skills/build-decisioning-platform/SKILL.md
@@ -135,13 +135,23 @@ class MyPlatform implements DecisioningPlatform {
       };
     },
 
-    // 3. Update a buy. SDK auto-hydrates the resolved MediaBuy (and its packages,
-    //    each with ctx_metadata) at req.mediaBuy when present in the store from a
-    //    prior createMediaBuy / getMediaBuys call. Falls back gracefully if absent
-    //    (publisher uses their own DB).
+    // 3. Update a buy. SDK auto-hydrates the resolved MediaBuy (including
+    //    ctx_metadata) at patch.media_buy when present in the store from a
+    //    prior createMediaBuy (sync) or getMediaBuys call. Falls back gracefully
+    //    if absent (publisher uses their own DB).
+    //
+    //    CONTRACT — `patch.media_buy` is `undefined` when the SDK has no stored
+    //    record for that media_buy_id (no prior createMediaBuy/getMediaBuys on
+    //    this instance, or HITL path where the final shape isn't known until the
+    //    background task completes). That is NOT authoritative "doesn't exist".
+    //    Fall back to your own DB when undefined:
+    //
+    //      const existing = patch.media_buy ?? await this.platform.getOrder(mediaBuyId);
+    //      if (!existing) throw new MediaBuyNotFoundError(mediaBuyId);
+    //
     //    (6.2 will pre-read state + decompose into atomic verbs; track adcp-client#1071.)
     updateMediaBuy: async (mediaBuyId, patch, ctx) => {
-      const orderMeta = await ctx.ctxMetadata?.mediaBuy(mediaBuyId);
+      const orderMeta = patch.media_buy?.ctx_metadata ?? await ctx.ctxMetadata?.mediaBuy(mediaBuyId);
       if (!orderMeta) throw new MediaBuyNotFoundError(mediaBuyId);
 
       for (const pkg of patch.packages ?? []) {
@@ -253,6 +263,35 @@ const meta = await ctx.ctxMetadata?.product(productId);
 **Memory backend:** fine for dev; use Postgres in cluster — silent loss after rolling restart produces "package not found" errors that look like publisher bugs and run for weeks.
 
 **Account scoping is automatic.** `ctx.ctxMetadata` binds to `ctx.account.id` per request. No-account tools (`provide_performance_feedback`, `list_creative_formats`) get `ctx.ctxMetadata = undefined` — branch defensively.
+
+## SDK auto-hydration contract
+
+When `ctxMetadata` is wired, the framework automatically attaches full resource objects (with `ctx_metadata`) to mutating requests before your handler fires. You read the object directly — no extra lookup.
+
+| Read call | Stored resource | Hydrated field on mutating call |
+|---|---|---|
+| `getProducts` | `product` (by `product_id`) | `pkg.product` on each `createMediaBuy` package |
+| `createMediaBuy` (sync) or `getMediaBuys` | `media_buy` (by `media_buy_id`) | `patch.media_buy` on `updateMediaBuy` |
+| `getSignals` | `signal` (by `signal_agent_segment_id`) | `req.signal` on `activateSignal` |
+| `getBrandIdentity` | `brand` (by `brand_id`) | `req.brand` on `acquireRights` (via `buyer.brand_id`) |
+
+**The `undefined` contract applies to all four.** When the SDK has no stored record (no prior read call on this instance, HITL path, or different instance in a cluster without Postgres), the hydrated field is `undefined`. That is **not** authoritative evidence the resource doesn't exist — fall back to your own DB:
+
+```ts
+// updateMediaBuy — patch.media_buy may be undefined in HITL / multi-instance deployments
+const existing = patch.media_buy ?? await this.platform.getOrder(mediaBuyId);
+if (!existing) throw new MediaBuyNotFoundError(mediaBuyId);
+const gamOrderId = existing.ctx_metadata?.gam_order_id;
+
+// activateSignal — req.signal may be undefined if getSignals wasn't called first
+const signal = req.signal ?? await this.catalog.findBySegmentId(req.signal_agent_segment_id);
+if (!signal) throw new AdcpError('SIGNAL_NOT_FOUND', { message: `Unknown segment: ${req.signal_agent_segment_id}` });
+
+// acquireRights — req.brand may be undefined if getBrandIdentity wasn't called first
+const brand = req.brand ?? await this.catalog.findBrand(req.buyer?.brand_id);
+```
+
+**`provide_performance_feedback` is not hydrated.** The wire spec does not include an `account` field on this tool, so the ctx-metadata store (which is scoped per account) cannot be used. Read `ctx.ctxMetadata` from a prior call result or your own DB.
 
 ## Run it
 

--- a/src/lib/server/ctx-metadata/store.ts
+++ b/src/lib/server/ctx-metadata/store.ts
@@ -43,6 +43,7 @@ export type ResourceKind =
   | 'creative'
   | 'audience'
   | 'signal'
+  | 'brand'
   | 'rights_grant'
   | 'property_list'
   | 'collection_list';
@@ -55,6 +56,7 @@ const ALL_RESOURCE_KINDS: readonly ResourceKind[] = [
   'creative',
   'audience',
   'signal',
+  'brand',
   'rights_grant',
   'property_list',
   'collection_list',

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2817,7 +2817,16 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
       // Auto-hydrate: attach the full BrandIdentity (including ctx_metadata)
       // at req.brand from the store populated by getBrandIdentity. Publisher
       // reads req.brand.ctx_metadata directly. Falls back gracefully when absent.
+      //
+      // BrandReference.brand_id is optional on the wire spec — a buyer may send
+      // only `buyer.domain`. When absent, hydration is skipped (req.brand stays
+      // undefined) and the publisher must look up from its own catalog.
       const buyerBrandId = (params as { buyer?: { brand_id?: string } }).buyer?.brand_id;
+      if (!buyerBrandId) {
+        logger.debug?.(
+          '[adcp/decisioning] acquireRights: buyer.brand_id absent — brand hydration skipped; publisher must look up from own catalog'
+        );
+      }
       await hydrateRequestResource(
         ctxMetadataStore,
         reqCtx.account?.id,

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -979,10 +979,20 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       'eventTracking',
       mergeOpts
     ),
-    signals: mergeHandlers(opts.signals, buildSignalsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger), 'signals', mergeOpts),
+    signals: mergeHandlers(
+      opts.signals,
+      buildSignalsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger),
+      'signals',
+      mergeOpts
+    ),
     governance: mergeHandlers(opts.governance, buildGovernanceHandlers(platform, ctxFor), 'governance', mergeOpts),
     accounts: mergeHandlers(opts.accounts, buildAccountHandlers(platform, ctxFor), 'accounts', mergeOpts),
-    brandRights: mergeHandlers(opts.brandRights, buildBrandRightsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger), 'brandRights', mergeOpts),
+    brandRights: mergeHandlers(
+      opts.brandRights,
+      buildBrandRightsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger),
+      'brandRights',
+      mergeOpts
+    ),
     customTools: {
       ...opts.customTools,
       tasks_get: buildTasksGetTool(platform, taskRegistry),

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -83,6 +83,7 @@ import type { AdcpLogger } from '../../create-adcp-server';
 import { buildRequestContext, buildHandoffContext } from './to-context';
 import {
   type CtxMetadataStore,
+  type ResourceKind,
   createCtxMetadataStore,
   pgCtxMetadataStore,
   getCtxMetadataMigration,
@@ -978,10 +979,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       'eventTracking',
       mergeOpts
     ),
-    signals: mergeHandlers(opts.signals, buildSignalsHandlers(platform, ctxFor), 'signals', mergeOpts),
+    signals: mergeHandlers(opts.signals, buildSignalsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger), 'signals', mergeOpts),
     governance: mergeHandlers(opts.governance, buildGovernanceHandlers(platform, ctxFor), 'governance', mergeOpts),
     accounts: mergeHandlers(opts.accounts, buildAccountHandlers(platform, ctxFor), 'accounts', mergeOpts),
-    brandRights: mergeHandlers(opts.brandRights, buildBrandRightsHandlers(platform, ctxFor), 'brandRights', mergeOpts),
+    brandRights: mergeHandlers(opts.brandRights, buildBrandRightsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger), 'brandRights', mergeOpts),
     customTools: {
       ...opts.customTools,
       tasks_get: buildTasksGetTool(platform, taskRegistry),
@@ -1930,7 +1931,7 @@ function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
 async function autoStoreResources(
   store: CtxMetadataStore | undefined,
   accountId: string | undefined,
-  kind: 'product' | 'media_buy' | 'package' | 'creative' | 'audience' | 'signal',
+  kind: ResourceKind,
   resources: readonly unknown[] | undefined,
   idField: string,
   logger: AdcpLogger
@@ -2007,6 +2008,42 @@ async function hydratePackagesWithProducts(
     }
     (pkg as Record<string, unknown>)['product'] = hydrated;
   }
+}
+
+/**
+ * Auto-hydrate a single resource on a request object. Before invoking a
+ * publisher's mutating handler, look up the resource by id in the ctx-metadata
+ * store and attach the full wire shape (including `ctx_metadata`) at
+ * `req[targetField]`. Mutates the request in place.
+ *
+ * Failures are logged + swallowed; the publisher still receives the
+ * un-hydrated request and can fall back to its own DB.
+ */
+async function hydrateRequestResource(
+  store: CtxMetadataStore | undefined,
+  accountId: string | undefined,
+  kind: ResourceKind,
+  id: string | undefined,
+  req: unknown,
+  targetField: string,
+  logger: AdcpLogger
+): Promise<void> {
+  if (!store || !accountId || !id) return;
+  let entries: ReadonlyMap<string, { value: unknown; resource?: unknown }>;
+  try {
+    entries = await store.bulkGetEntries(accountId, [{ kind, id }]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[adcp/decisioning] auto-hydrate bulkGet failed: ${msg}`);
+    return;
+  }
+  const entry = entries.get(`${kind}:${id}`);
+  if (!entry?.resource || typeof entry.resource !== 'object') return;
+  const hydrated: Record<string, unknown> = { ...(entry.resource as Record<string, unknown>) };
+  if (entry.value !== null && entry.value !== undefined) {
+    hydrated['ctx_metadata'] = entry.value;
+  }
+  (req as Record<string, unknown>)[targetField] = hydrated;
 }
 
 /**
@@ -2288,6 +2325,21 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
         async () => {
           const push = extractPushConfig(params, logger, { allowPrivateWebhookUrls: pushOpts.allowPrivateWebhookUrls });
           const result = await sales.createMediaBuy(params, reqCtx);
+          // Auto-store the created media_buy on the sync arm so a subsequent
+          // updateMediaBuy can hydrate it without needing a getMediaBuys call
+          // first. HITL path skipped intentionally: the final media_buy shape
+          // isn't known until the background task completes (getMediaBuys will
+          // capture it after the buyer polls / receives the webhook).
+          if (!isTaskHandoff(result)) {
+            await autoStoreResources(
+              ctxMetadataStore,
+              reqCtx.account?.id,
+              'media_buy',
+              [result],
+              'media_buy_id',
+              logger
+            );
+          }
           return routeIfHandoff(
             taskRegistry,
             {
@@ -2322,6 +2374,19 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
           recovery: 'correctable',
         });
       }
+      // Auto-hydrate: attach the full MediaBuy (including ctx_metadata) at
+      // req.media_buy from the store populated by createMediaBuy / getMediaBuys.
+      // Publisher reads req.media_buy.ctx_metadata?.gam_order_id directly.
+      // Falls back gracefully when the SDK has no record — publisher uses its own DB.
+      await hydrateRequestResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'media_buy',
+        media_buy_id,
+        params,
+        'media_buy',
+        logger
+      );
       return projectSync(
         async () => {
           const push = extractPushConfig(params, logger, {
@@ -2649,7 +2714,9 @@ function buildEventTrackingHandlers<P extends DecisioningPlatform<any, any>>(
 
 function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
   platform: P,
-  ctxFor: CtxForFn
+  ctxFor: CtxForFn,
+  ctxMetadataStore: CtxMetadataStore | undefined,
+  logger: AdcpLogger
 ): SignalsHandlers<Account> | undefined {
   const signals = platform.signals;
   if (!signals) return undefined;
@@ -2657,12 +2724,36 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
     getSignals: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
       return projectSync(
-        () => signals.getSignals(params, reqCtx),
+        async () => {
+          const result = await signals.getSignals(params, reqCtx);
+          // Auto-store signals so activateSignal can hydrate req.signal.
+          await autoStoreResources(
+            ctxMetadataStore,
+            reqCtx.account?.id,
+            'signal',
+            (result as { signals?: readonly unknown[] })?.signals,
+            'signal_agent_segment_id',
+            logger
+          );
+          return result;
+        },
         r => r
       );
     },
     activateSignal: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
+      // Auto-hydrate: attach the full Signal (including ctx_metadata) at
+      // req.signal from the store populated by getSignals. Publisher reads
+      // req.signal.ctx_metadata directly. Falls back gracefully when absent.
+      await hydrateRequestResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'signal',
+        (params as { signal_agent_segment_id?: string }).signal_agent_segment_id,
+        params,
+        'signal',
+        logger
+      );
       return projectSync(
         () => signals.activateSignal(params, reqCtx),
         r => r
@@ -2673,7 +2764,9 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
 
 function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
   platform: P,
-  ctxFor: CtxForFn
+  ctxFor: CtxForFn,
+  ctxMetadataStore: CtxMetadataStore | undefined,
+  logger: AdcpLogger
 ): BrandRightsHandlers<Account> | undefined {
   const br = platform.brandRights;
   if (!br) return undefined;
@@ -2681,7 +2774,19 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
     getBrandIdentity: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
       return projectSync(
-        () => br.getBrandIdentity(params, reqCtx),
+        async () => {
+          const result = await br.getBrandIdentity(params, reqCtx);
+          // Auto-store brand identity so acquireRights can hydrate req.brand.
+          await autoStoreResources(
+            ctxMetadataStore,
+            reqCtx.account?.id,
+            'brand',
+            [result].filter(Boolean),
+            'brand_id',
+            logger
+          );
+          return result;
+        },
         r => r
       );
     },
@@ -2699,6 +2804,19 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
     // (the spec doesn't define a polling tool for `acquire_rights`).
     acquireRights: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
+      // Auto-hydrate: attach the full BrandIdentity (including ctx_metadata)
+      // at req.brand from the store populated by getBrandIdentity. Publisher
+      // reads req.brand.ctx_metadata directly. Falls back gracefully when absent.
+      const buyerBrandId = (params as { buyer?: { brand_id?: string } }).buyer?.brand_id;
+      await hydrateRequestResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'brand',
+        buyerBrandId,
+        params,
+        'brand',
+        logger
+      );
       return projectSync(
         () => br.acquireRights(params, reqCtx),
         r => r

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.25.0';
+export const LIBRARY_VERSION = '5.25.1';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.25.0',
+  library: '5.25.1',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T09:45:14.937Z',
+  generatedAt: '2026-04-30T13:29:23.290Z',
 } as const;
 
 /**

--- a/test/server-auto-hydration.test.js
+++ b/test/server-auto-hydration.test.js
@@ -239,3 +239,401 @@ describe('createAdcpServerFromPlatform — auto-hydration of products', () => {
     assert.deepEqual(storeWasCalledWith[4], { gam_order_id: 'gam_42' }, 'publisher ctx_metadata passed as 5th arg');
   });
 });
+
+// ---------------------------------------------------------------------------
+// updateMediaBuy auto-hydration
+// ---------------------------------------------------------------------------
+
+function makeSalesPlatformWithUpdate({ createMediaBuyImpl, updateMediaBuyImpl }) {
+  return {
+    capabilities: {
+      adcp_version: '3.0.0',
+      specialisms: ['sales-non-guaranteed'],
+      pricingModels: ['cpm'],
+      channels: ['display'],
+      formats: [{ format_id: 'display_300x250' }],
+      idempotency: { replay_ttl_seconds: 86400 },
+    },
+    accounts: {
+      resolution: 'derived',
+      resolve: async () => ({ id: 'acct_default', operator: 'test', ctx_metadata: {} }),
+      upsert: async () => ({ ok: true, items: [] }),
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: createMediaBuyImpl,
+      updateMediaBuy: updateMediaBuyImpl,
+      getMediaBuyDelivery: async () => ({ deliveries: [] }),
+      getMediaBuys: async () => ({ media_buys: [] }),
+    },
+  };
+}
+
+describe('createAdcpServerFromPlatform — auto-hydration of media_buy for updateMediaBuy', () => {
+  it('updateMediaBuy receives req.media_buy hydrated from prior createMediaBuy', async () => {
+    let observedMediaBuy;
+
+    const platform = makeSalesPlatformWithUpdate({
+      createMediaBuyImpl: async () => ({
+        media_buy_id: 'mb_upd_1',
+        status: 'pending_creatives',
+        packages: [],
+        ctx_metadata: { gam_order_id: 'gam_99' },
+      }),
+      updateMediaBuyImpl: async (mediaBuyId, patch) => {
+        observedMediaBuy = patch.media_buy;
+        return { media_buy_id: mediaBuyId, status: 'active', packages: [] };
+      },
+    });
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    // Step 1: createMediaBuy — SDK auto-stores the created media_buy
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'create_media_buy',
+        arguments: {
+          buyer_ref: 'br_upd_test',
+          packages: [],
+          start_time: '2026-01-01T00:00:00Z',
+          end_time: '2026-01-08T00:00:00Z',
+          budget: { total: 5000, currency: 'USD' },
+          idempotency_key: 'idem_create_upd_001',
+        },
+      },
+    });
+
+    // Step 2: updateMediaBuy — SDK auto-hydrates req.media_buy
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb_upd_1',
+          idempotency_key: 'idem_update_upd_001',
+        },
+      },
+    });
+
+    assert.ok(observedMediaBuy, 'updateMediaBuy should receive hydrated req.media_buy');
+    assert.equal(observedMediaBuy.media_buy_id, 'mb_upd_1', 'hydrated media_buy carries media_buy_id');
+    assert.equal(observedMediaBuy.status, 'pending_creatives', 'hydrated media_buy carries status');
+    assert.deepEqual(observedMediaBuy.ctx_metadata, { gam_order_id: 'gam_99' }, 'hydrated media_buy carries ctx_metadata');
+  });
+
+  it('updateMediaBuy falls back gracefully when media_buy was never stored', async () => {
+    let observedMediaBuy;
+
+    const platform = makeSalesPlatformWithUpdate({
+      createMediaBuyImpl: async () => ({ media_buy_id: 'mb_other', status: 'active', packages: [] }),
+      updateMediaBuyImpl: async (mediaBuyId, patch) => {
+        observedMediaBuy = patch.media_buy;
+        return { media_buy_id: mediaBuyId, status: 'active', packages: [] };
+      },
+    });
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb_unseen',
+          idempotency_key: 'idem_update_unseen_001',
+        },
+      },
+    });
+
+    assert.equal(observedMediaBuy, undefined, 'no hydration for unseen media_buy — publisher falls back to its own DB');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// activateSignal auto-hydration
+// ---------------------------------------------------------------------------
+
+function makeSignalsPlatform({ getSignalsImpl, activateSignalImpl }) {
+  return {
+    capabilities: {
+      adcp_version: '3.0.0',
+      specialisms: ['signal-marketplace'],
+      pricingModels: ['cpm'],
+      channels: ['display'],
+      formats: [],
+      idempotency: { replay_ttl_seconds: 86400 },
+    },
+    accounts: {
+      resolution: 'derived',
+      resolve: async () => ({ id: 'acct_signals', operator: 'test', ctx_metadata: {} }),
+      upsert: async () => ({ ok: true, items: [] }),
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    signals: {
+      getSignals: getSignalsImpl,
+      activateSignal: activateSignalImpl,
+    },
+  };
+}
+
+describe('createAdcpServerFromPlatform — auto-hydration of signal for activateSignal', () => {
+  it('activateSignal receives req.signal hydrated from prior getSignals', async () => {
+    let observedSignal;
+
+    const platform = makeSignalsPlatform({
+      getSignalsImpl: async () => ({
+        signals: [
+          {
+            signal_agent_segment_id: 'seg_sports_fans',
+            name: 'Sports Fans 18-34',
+            match_rate: 0.72,
+            ctx_metadata: { dmp_segment_id: 'dmp_42' },
+          },
+        ],
+      }),
+      activateSignalImpl: async (req) => {
+        observedSignal = req.signal;
+        return { deployments: [{ platform: 'meta', status: 'pending' }] };
+      },
+    });
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    // Step 1: getSignals — SDK auto-stores each signal by signal_agent_segment_id
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_signals',
+        arguments: { signal_spec: 'sports fans' },
+      },
+    });
+
+    // Step 2: activateSignal — SDK auto-hydrates req.signal
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'activate_signal',
+        arguments: {
+          signal_agent_segment_id: 'seg_sports_fans',
+          destinations: [{ platform: 'meta' }],
+          idempotency_key: 'idem_activate_001',
+        },
+      },
+    });
+
+    assert.ok(observedSignal, 'activateSignal should receive hydrated req.signal');
+    assert.equal(observedSignal.signal_agent_segment_id, 'seg_sports_fans', 'hydrated signal carries segment id');
+    assert.equal(observedSignal.name, 'Sports Fans 18-34', 'hydrated signal carries name');
+    assert.deepEqual(observedSignal.ctx_metadata, { dmp_segment_id: 'dmp_42' }, 'hydrated signal carries ctx_metadata');
+  });
+
+  it('activateSignal falls back gracefully when signal was never seen by getSignals', async () => {
+    let observedSignal;
+
+    const platform = makeSignalsPlatform({
+      getSignalsImpl: async () => ({ signals: [] }),
+      activateSignalImpl: async (req) => {
+        observedSignal = req.signal;
+        return { deployments: [] };
+      },
+    });
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'activate_signal',
+        arguments: {
+          signal_agent_segment_id: 'seg_unknown',
+          destinations: [{ platform: 'meta' }],
+          idempotency_key: 'idem_activate_unseen_001',
+        },
+      },
+    });
+
+    assert.equal(observedSignal, undefined, 'no hydration for unseen signal — publisher falls back to its own catalog');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acquireRights auto-hydration
+// ---------------------------------------------------------------------------
+
+function makeBrandRightsPlatform({ getBrandIdentityImpl, acquireRightsImpl }) {
+  return {
+    capabilities: {
+      adcp_version: '3.0.0',
+      specialisms: ['brand-rights'],
+      pricingModels: [],
+      channels: [],
+      formats: [],
+      idempotency: { replay_ttl_seconds: 86400 },
+    },
+    accounts: {
+      resolution: 'derived',
+      resolve: async () => ({ id: 'acct_brand', operator: 'test', ctx_metadata: {} }),
+      upsert: async () => ({ ok: true, items: [] }),
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    brandRights: {
+      getBrandIdentity: getBrandIdentityImpl,
+      getRights: async () => ({ rights: [] }),
+      acquireRights: acquireRightsImpl,
+    },
+  };
+}
+
+describe('createAdcpServerFromPlatform — auto-hydration of brand for acquireRights', () => {
+  it('acquireRights receives req.brand hydrated from prior getBrandIdentity', async () => {
+    let observedBrand;
+
+    const platform = makeBrandRightsPlatform({
+      getBrandIdentityImpl: async () => ({
+        brand_id: 'acme_outdoor',
+        house: { domain: 'acme.example', name: 'Acme Corporation' },
+        names: [{ en_US: 'Acme Outdoor' }],
+        ctx_metadata: { internal_brand_code: 'ACM-001' },
+      }),
+      acquireRightsImpl: async (req) => {
+        observedBrand = req.brand;
+        return {
+          rights_id: 'likeness_commercial_standard',
+          status: 'acquired',
+          brand_id: 'acme_outdoor',
+          terms: { pricing_option_id: 'po1', amount: 2500, currency: 'USD', uses: ['likeness'] },
+          rights_constraint: { rights_id: 'likeness_commercial_standard', rights_agent: { domain: 'acme.example' }, uses: ['likeness'] },
+        };
+      },
+    });
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    // Step 1: getBrandIdentity — SDK auto-stores the brand by brand_id
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_brand_identity',
+        arguments: { brand: { domain: 'acme.example', brand_id: 'acme_outdoor' } },
+      },
+    });
+
+    // Step 2: acquireRights — SDK auto-hydrates req.brand via buyer.brand_id
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'acquire_rights',
+        arguments: {
+          rights_id: 'likeness_commercial_standard',
+          pricing_option_id: 'po1',
+          buyer: { domain: 'buyer.example', brand_id: 'acme_outdoor' },
+          campaign: { description: 'Summer campaign', uses: ['likeness'] },
+          revocation_webhook: { url: 'https://buyer.example/webhooks/revoke', authentication: { schemes: ['Bearer'], credentials: 'test-creds-32chars-padded-here-xx' } },
+          idempotency_key: 'idem_acquire_001',
+        },
+      },
+    });
+
+    assert.ok(observedBrand, 'acquireRights should receive hydrated req.brand');
+    assert.equal(observedBrand.brand_id, 'acme_outdoor', 'hydrated brand carries brand_id');
+    assert.ok(observedBrand.house, 'hydrated brand carries house');
+    assert.deepEqual(observedBrand.ctx_metadata, { internal_brand_code: 'ACM-001' }, 'hydrated brand carries ctx_metadata');
+  });
+
+  it('acquireRights falls back gracefully when brand was never seen by getBrandIdentity', async () => {
+    let observedBrand;
+
+    const platform = makeBrandRightsPlatform({
+      getBrandIdentityImpl: async () => ({
+        brand_id: 'other_brand',
+        house: { domain: 'other.example', name: 'Other Corp' },
+        names: [{ en_US: 'Other' }],
+      }),
+      acquireRightsImpl: async (req) => {
+        observedBrand = req.brand;
+        return {
+          rights_id: 'r1',
+          status: 'acquired',
+          brand_id: 'acme_outdoor',
+          terms: { pricing_option_id: 'po1', amount: 100, currency: 'USD', uses: ['likeness'] },
+          rights_constraint: { rights_id: 'r1', rights_agent: { domain: 'other.example' }, uses: ['likeness'] },
+        };
+      },
+    });
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'acquire_rights',
+        arguments: {
+          rights_id: 'likeness_commercial_standard',
+          pricing_option_id: 'po1',
+          buyer: { domain: 'buyer.example', brand_id: 'acme_outdoor' },
+          campaign: { description: 'Summer campaign', uses: ['likeness'] },
+          revocation_webhook: { url: 'https://buyer.example/webhooks/revoke', authentication: { schemes: ['Bearer'], credentials: 'test-creds-32chars-padded-here-xx' } },
+          idempotency_key: 'idem_acquire_unseen_001',
+        },
+      },
+    });
+
+    assert.equal(observedBrand, undefined, 'no hydration for unseen brand — publisher falls back to its own catalog');
+  });
+});

--- a/test/server-auto-hydration.test.js
+++ b/test/server-auto-hydration.test.js
@@ -329,7 +329,11 @@ describe('createAdcpServerFromPlatform — auto-hydration of media_buy for updat
     assert.ok(observedMediaBuy, 'updateMediaBuy should receive hydrated req.media_buy');
     assert.equal(observedMediaBuy.media_buy_id, 'mb_upd_1', 'hydrated media_buy carries media_buy_id');
     assert.equal(observedMediaBuy.status, 'pending_creatives', 'hydrated media_buy carries status');
-    assert.deepEqual(observedMediaBuy.ctx_metadata, { gam_order_id: 'gam_99' }, 'hydrated media_buy carries ctx_metadata');
+    assert.deepEqual(
+      observedMediaBuy.ctx_metadata,
+      { gam_order_id: 'gam_99' },
+      'hydrated media_buy carries ctx_metadata'
+    );
   });
 
   it('updateMediaBuy falls back gracefully when media_buy was never stored', async () => {
@@ -411,7 +415,7 @@ describe('createAdcpServerFromPlatform — auto-hydration of signal for activate
           },
         ],
       }),
-      activateSignalImpl: async (req) => {
+      activateSignalImpl: async req => {
         observedSignal = req.signal;
         return { deployments: [{ platform: 'meta', status: 'pending' }] };
       },
@@ -461,7 +465,7 @@ describe('createAdcpServerFromPlatform — auto-hydration of signal for activate
 
     const platform = makeSignalsPlatform({
       getSignalsImpl: async () => ({ signals: [] }),
-      activateSignalImpl: async (req) => {
+      activateSignalImpl: async req => {
         observedSignal = req.signal;
         return { deployments: [] };
       },
@@ -533,14 +537,18 @@ describe('createAdcpServerFromPlatform — auto-hydration of brand for acquireRi
         names: [{ en_US: 'Acme Outdoor' }],
         ctx_metadata: { internal_brand_code: 'ACM-001' },
       }),
-      acquireRightsImpl: async (req) => {
+      acquireRightsImpl: async req => {
         observedBrand = req.brand;
         return {
           rights_id: 'likeness_commercial_standard',
           status: 'acquired',
           brand_id: 'acme_outdoor',
           terms: { pricing_option_id: 'po1', amount: 2500, currency: 'USD', uses: ['likeness'] },
-          rights_constraint: { rights_id: 'likeness_commercial_standard', rights_agent: { domain: 'acme.example' }, uses: ['likeness'] },
+          rights_constraint: {
+            rights_id: 'likeness_commercial_standard',
+            rights_agent: { domain: 'acme.example' },
+            uses: ['likeness'],
+          },
         };
       },
     });
@@ -575,7 +583,10 @@ describe('createAdcpServerFromPlatform — auto-hydration of brand for acquireRi
           pricing_option_id: 'po1',
           buyer: { domain: 'buyer.example', brand_id: 'acme_outdoor' },
           campaign: { description: 'Summer campaign', uses: ['likeness'] },
-          revocation_webhook: { url: 'https://buyer.example/webhooks/revoke', authentication: { schemes: ['Bearer'], credentials: 'test-creds-32chars-padded-here-xx' } },
+          revocation_webhook: {
+            url: 'https://buyer.example/webhooks/revoke',
+            authentication: { schemes: ['Bearer'], credentials: 'test-creds-32chars-padded-here-xx' },
+          },
           idempotency_key: 'idem_acquire_001',
         },
       },
@@ -584,7 +595,11 @@ describe('createAdcpServerFromPlatform — auto-hydration of brand for acquireRi
     assert.ok(observedBrand, 'acquireRights should receive hydrated req.brand');
     assert.equal(observedBrand.brand_id, 'acme_outdoor', 'hydrated brand carries brand_id');
     assert.ok(observedBrand.house, 'hydrated brand carries house');
-    assert.deepEqual(observedBrand.ctx_metadata, { internal_brand_code: 'ACM-001' }, 'hydrated brand carries ctx_metadata');
+    assert.deepEqual(
+      observedBrand.ctx_metadata,
+      { internal_brand_code: 'ACM-001' },
+      'hydrated brand carries ctx_metadata'
+    );
   });
 
   it('acquireRights falls back gracefully when brand was never seen by getBrandIdentity', async () => {
@@ -596,7 +611,7 @@ describe('createAdcpServerFromPlatform — auto-hydration of brand for acquireRi
         house: { domain: 'other.example', name: 'Other Corp' },
         names: [{ en_US: 'Other' }],
       }),
-      acquireRightsImpl: async (req) => {
+      acquireRightsImpl: async req => {
         observedBrand = req.brand;
         return {
           rights_id: 'r1',
@@ -628,7 +643,10 @@ describe('createAdcpServerFromPlatform — auto-hydration of brand for acquireRi
           pricing_option_id: 'po1',
           buyer: { domain: 'buyer.example', brand_id: 'acme_outdoor' },
           campaign: { description: 'Summer campaign', uses: ['likeness'] },
-          revocation_webhook: { url: 'https://buyer.example/webhooks/revoke', authentication: { schemes: ['Bearer'], credentials: 'test-creds-32chars-padded-here-xx' } },
+          revocation_webhook: {
+            url: 'https://buyer.example/webhooks/revoke',
+            authentication: { schemes: ['Bearer'], credentials: 'test-creds-32chars-padded-here-xx' },
+          },
           idempotency_key: 'idem_acquire_unseen_001',
         },
       },

--- a/test/server-auto-hydration.test.js
+++ b/test/server-auto-hydration.test.js
@@ -417,7 +417,7 @@ describe('createAdcpServerFromPlatform — auto-hydration of signal for activate
       }),
       activateSignalImpl: async req => {
         observedSignal = req.signal;
-        return { deployments: [{ platform: 'meta', status: 'pending' }] };
+        return { deployments: [{ type: 'platform', platform: 'dsp-example', is_live: false }] };
       },
     });
 
@@ -448,7 +448,7 @@ describe('createAdcpServerFromPlatform — auto-hydration of signal for activate
         name: 'activate_signal',
         arguments: {
           signal_agent_segment_id: 'seg_sports_fans',
-          destinations: [{ platform: 'meta' }],
+          destinations: [{ type: 'platform', platform: 'dsp-example' }],
           idempotency_key: 'idem_activate_001',
         },
       },
@@ -488,7 +488,7 @@ describe('createAdcpServerFromPlatform — auto-hydration of signal for activate
         name: 'activate_signal',
         arguments: {
           signal_agent_segment_id: 'seg_unknown',
-          destinations: [{ platform: 'meta' }],
+          destinations: [{ type: 'platform', platform: 'dsp-example' }],
           idempotency_key: 'idem_activate_unseen_001',
         },
       },


### PR DESCRIPTION
## Summary

Extends the ctx-metadata auto-hydration pattern — already shipping for `createMediaBuy` → `pkg.product` — to three additional mutating verbs: **`updateMediaBuy`**, **`activateSignal`**, and **`acquireRights`**.

Before this PR, the framework pre-populated `pkg.product` (from the ctx store) on `createMediaBuy` only. Publishers writing the other mutating handlers had to re-fetch context they'd already seen, or else operate on incomplete wire payloads. These three verbs follow the same read-before-write pattern and have clear, unambiguous store keys:

| Verb | Store kind | Lookup key | Injected field |
|---|---|---|---|
| `updateMediaBuy` | `media_buy` | `params.media_buy_id` | `params.media_buy` |
| `activateSignal` | `signal` | `params.signal_agent_segment_id` | `params.signal` |
| `acquireRights` | `brand` | `params.buyer.brand_id` | `params.brand` |

**`provide_performance_feedback` is intentionally excluded.** The ctx-metadata store is account-scoped and that tool carries no `account` field on the wire, so hydration would be a permanent silent no-op. See SKILL.md for the explanation publishers will see.

### What changed

- **`store.ts`** — Added `'brand'` to the `ResourceKind` closed union and `ALL_RESOURCE_KINDS` array. Without this the `bulkGetEntries` call for brand hydration would throw at runtime.
- **`from-platform.ts`** — New `hydrateRequestResource` helper (single-resource counterpart to `hydratePackagesWithProducts`). Wired into `updateMediaBuy`, `activateSignal`, and `acquireRights`. `buildSignalsHandlers` and `buildBrandRightsHandlers` now accept `ctxMetadataStore` + `logger` parameters. `createMediaBuy` sync arm now stores the result before `routeIfHandoff` (HITL path covered later via `getMediaBuys`).
- **`test/server-auto-hydration.test.js`** — 6 new tests (round-trip hydration + graceful fallback for each verb).
- **`skills/build-decisioning-platform/SKILL.md`** — "SDK auto-hydration contract" section with per-verb table and `provide_performance_feedback` exclusion rationale.
- **`.changeset/auto-hydration-update-signal-brand.md`** — Minor bump changeset.

### What was tested

- `node --test test/server-auto-hydration.test.js` — 10/10 pass (4 pre-existing + 6 new)
- `tsc --noEmit` — clean
- `npx prettier --check` — clean (pre-push hook passes)
- `acquireRights` fallback: store miss or absent `buyer.brand_id` leaves params untouched; debug log emitted when `brand_id` absent for observability

### Pre-PR expert reviews

**Code reviewer** (sign-off):
- `[result].filter(Boolean)` guard on `getBrandIdentity` result is correct
- `signal_agent_segment_id` confirmed as the canonical shared key
- All 10 tests pass
- Blockers addressed: destinations discriminant (`type: 'platform'`) + no real brand names in fixtures

**Ad-tech protocol expert** (sign-off):
- `signal_agent_segment_id` as hydration key is correct per the wire spec
- `provide_performance_feedback` exclusion is architecturally sound
- Blocker addressed: `buyer.brand_id` absent case now emits `logger.debug` for observability

---

<!-- triage-managed-pr -->
**Triage**: auto-drafted from issue #1086 · branch `claude/issue-1086-auto-hydration-extensions`

Closes #1086

https://claude.ai/code/session_01Dx3PAwJ5gWgBcPumGL1jCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dx3PAwJ5gWgBcPumGL1jCY)_