### PR TITLE
feat(server): catalog-backed auto-seed for comply_test_controller

### DIFF
--- a/.changeset/comply-catalog-auto-seed.md
+++ b/.changeset/comply-catalog-auto-seed.md
@@ -1,0 +1,20 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): catalog-backed auto-seed for comply_test_controller
+
+When `createAdcpServerFromPlatform` is called with `complyTest` and a sales
+platform that wires `getProducts`, but without explicit `seed.product` or
+`seed_pricing_option` adapters, the framework now auto-derives those adapters
+from an in-memory store and wires a `testController` bridge so seeded products
+appear in `get_products` responses on sandbox requests.
+
+This removes the footgun where LLM-generated platforms fail comply storyboards
+because the slim skill guide doesn't mention that `seed_product` requires an
+explicit adapter. Publishers wiring `getProducts` now get free comply-sandbox
+seeding without writing any seed adapter code.
+
+Explicit `seed.product` / `seed_pricing_option` adapters and explicit
+`testController` bridges always take priority — the auto-seed is only applied
+when neither is present.

--- a/.changeset/comply-catalog-auto-seed.md
+++ b/.changeset/comply-catalog-auto-seed.md
@@ -1,12 +1,12 @@
 ---
-"@adcp/sdk": minor
+"@adcp/sdk": patch
 ---
 
 feat(server): catalog-backed auto-seed for comply_test_controller
 
 When `createAdcpServerFromPlatform` is called with `complyTest` and a sales
 platform that wires `getProducts`, but without explicit `seed.product` or
-`seed_pricing_option` adapters, the framework now auto-derives those adapters
+`seed.pricing_option` adapters, the framework now auto-derives those adapters
 from an in-memory store and wires a `testController` bridge so seeded products
 appear in `get_products` responses on sandbox requests.
 
@@ -15,6 +15,12 @@ because the slim skill guide doesn't mention that `seed_product` requires an
 explicit adapter. Publishers wiring `getProducts` now get free comply-sandbox
 seeding without writing any seed adapter code.
 
-Explicit `seed.product` / `seed_pricing_option` adapters and explicit
+The store is keyed by `account.account_id` so two sandbox accounts on the
+same server (multi-tenant TenantRegistry hosts, or single-tenant servers with
+multiple sandbox accounts) never share a seed namespace. Adopters who need
+tighter scoping (per-session, per-brand) wire `bridgeFromSessionStore`
+explicitly.
+
+Explicit `seed.product` / `seed.pricing_option` adapters and explicit
 `testController` bridges always take priority — the auto-seed is only applied
 when neither is present.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -115,7 +115,9 @@ const DEFAULT_FRAMEWORK_LOGGER: AdcpLogger = {
 };
 import { createInMemoryStatusChangeBus, type StatusChangeBus, type PublishStatusChangeOpts } from '../status-changes';
 import { createComplyController, type ComplyControllerConfig } from '../../../testing/comply-controller';
-import { bridgeFromTestControllerStore } from '../../test-controller-bridge';
+import type { TestControllerBridge } from '../../test-controller-bridge';
+import { mergeSeedProduct } from '../../../testing/seed-merge';
+import type { Product } from '../../../types/tools.generated';
 import { normalizeErrors } from '../../normalize-errors';
 
 /**
@@ -857,22 +859,39 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // without the adopter writing any adapter code. The bridge makes seeded
   // products visible in `get_products` responses on sandbox requests.
   //
+  // **Multi-tenant isolation.** The store is keyed by `account_id` so two
+  // sandbox accounts on the same server (e.g. multiple tenants under one
+  // TenantRegistry-fronted server, or distinct sandbox accounts on a
+  // single-tenant server) never see each other's seeded products in
+  // `get_products`. Adopters who need tighter scoping (per-session,
+  // per-brand, per-storyboard-run) wire `bridgeFromSessionStore` explicitly
+  // — auto-seed is the floor, not the ceiling.
+  //
+  // **Caveat.** The comply-controller's process-wide `SeedFixtureCache`
+  // (`test-controller.ts createSeedFixtureCache`) keys by
+  // `seed_product:${product_id}` and rejects divergent fixtures replayed
+  // under the same id with `INVALID_PARAMS`. So two sandbox accounts can
+  // freely seed *different* product_ids without leakage, but cannot seed
+  // the same product_id with different fixtures on one server. That's a
+  // pre-existing SDK limitation independent of auto-seed; lifting it
+  // requires per-account seedCache scoping — tracked as a follow-up.
+  //
   // The entire auto-seed path is skipped when EITHER `seed.product` OR
-  // `seed_pricing_option` is explicitly wired — mixing explicit and auto-seed
+  // `seed.pricing_option` is explicitly wired — mixing explicit and auto-seed
   // adapters against the same bridge would yield inconsistent `get_products`
   // responses. In that case the adopter owns the full seed + bridge wiring.
-  const autoSeedStore: Map<string, unknown> | undefined =
+  const autoSeedStore: Map<string, Map<string, unknown>> | undefined =
     opts.complyTest != null &&
     platform.sales?.getProducts != null &&
     !opts.testController &&
     !opts.complyTest.seed?.product &&
     !opts.complyTest.seed?.pricing_option
-      ? new Map<string, unknown>()
+      ? new Map<string, Map<string, unknown>>()
       : undefined;
 
   const config: AdcpServerConfig<Account> = {
     ...opts,
-    ...(autoSeedStore != null && { testController: bridgeFromTestControllerStore(autoSeedStore) }),
+    ...(autoSeedStore != null && { testController: makeAutoSeedBridge(autoSeedStore) }),
     ...(projectedCapabilitiesConfig != null && { capabilities: projectedCapabilitiesConfig }),
     // Pool-derived stores override the spread above when adopters supplied
     // `pool` but no explicit per-store opt. Explicit values still win.
@@ -1047,19 +1066,29 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     if (autoSeedStore != null) {
       // Inject auto-seed adapters for `seed_product` and `seed_pricing_option`
       // when the adopter didn't wire explicit ones. Explicit adapters win — the
-      // spread only fills the undefined slots.
+      // spread only fills the undefined slots. Each write is keyed by the
+      // request's `account.account_id` so two sandbox accounts can seed the
+      // same `product_id` without colliding.
       const explicitSeed = opts.complyTest.seed ?? {};
       const autoSeed = { ...explicitSeed };
 
       if (!explicitSeed.product) {
-        autoSeed.product = async params => {
-          autoSeedStore.set(params.product_id, { ...params.fixture, product_id: params.product_id });
+        autoSeed.product = async (params, ctx) => {
+          const accountId = readAutoSeedAccountId(ctx.input);
+          if (accountId == null) return;
+          autoSeedStoreFor(autoSeedStore, accountId).set(params.product_id, {
+            ...params.fixture,
+            product_id: params.product_id,
+          });
         };
       }
 
       if (!explicitSeed.pricing_option) {
-        autoSeed.pricing_option = async params => {
-          const existing = autoSeedStore.get(params.product_id) as Record<string, unknown> | undefined;
+        autoSeed.pricing_option = async (params, ctx) => {
+          const accountId = readAutoSeedAccountId(ctx.input);
+          if (accountId == null) return;
+          const accountStore = autoSeedStoreFor(autoSeedStore, accountId);
+          const existing = accountStore.get(params.product_id) as Record<string, unknown> | undefined;
           const pricingOption = { ...params.fixture, pricing_option_id: params.pricing_option_id };
           const existingOptions = Array.isArray(
             (existing as { pricing_options?: unknown[] } | undefined)?.pricing_options
@@ -1072,7 +1101,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
               typeof p === 'object' &&
               (p as Record<string, unknown>).pricing_option_id !== params.pricing_option_id
           );
-          autoSeedStore.set(params.product_id, {
+          accountStore.set(params.product_id, {
             ...(existing ?? { product_id: params.product_id }),
             pricing_options: [...filtered, pricingOption],
           });
@@ -3362,4 +3391,65 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   }
 
   return handlers;
+}
+
+// ────────────────────────────────────────────────────────────
+// Auto-seed helpers (catalog-backed comply sandbox; issue #1091)
+// ────────────────────────────────────────────────────────────
+
+// Pull the request's account_id from the comply tool input. Sandbox-flagged
+// requests carry it on `input.account.account_id`; non-sandbox traffic is
+// already short-circuited by `complyTest.sandboxGate`, so a missing id here
+// means the adapter fired outside the gated path — drop the write rather
+// than collapse it into a shared namespace.
+function readAutoSeedAccountId(input: Record<string, unknown>): string | undefined {
+  const account = input.account;
+  if (account == null || typeof account !== 'object') return undefined;
+  const id = (account as { account_id?: unknown }).account_id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
+function autoSeedStoreFor(
+  store: Map<string, Map<string, unknown>>,
+  accountId: string
+): Map<string, unknown> {
+  let inner = store.get(accountId);
+  if (inner == null) {
+    inner = new Map<string, unknown>();
+    store.set(accountId, inner);
+  }
+  return inner;
+}
+
+// Build a `TestControllerBridge` over the per-account auto-seed store. The
+// bridge filters seeded products by the resolved account so multi-tenant
+// servers (TenantRegistry-fronted, or single-tenant with multiple sandbox
+// accounts) never leak fixtures across tenants. Reads
+// `ctx.account?.id` first (set by `resolveAccount` at request time) and
+// falls back to `ctx.input.account.account_id` when no resolver is wired.
+function makeAutoSeedBridge(
+  store: Map<string, Map<string, unknown>>
+): TestControllerBridge<unknown> {
+  return {
+    getSeededProducts: ctx => {
+      const resolved = (ctx.account as { id?: unknown } | undefined)?.id;
+      const accountId =
+        typeof resolved === 'string' && resolved.length > 0 ? resolved : readAutoSeedAccountId(ctx.input);
+      if (accountId == null) return [];
+      const inner = store.get(accountId);
+      if (inner == null || inner.size === 0) return [];
+      const products: Product[] = [];
+      for (const [productId, fixture] of inner.entries()) {
+        const merged = mergeSeedProduct(
+          {},
+          {
+            ...(fixture && typeof fixture === 'object' ? (fixture as Partial<Product>) : {}),
+            product_id: productId,
+          }
+        );
+        products.push(merged as Product);
+      }
+      return products;
+    },
+  };
 }

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3409,10 +3409,7 @@ function readAutoSeedAccountId(input: Record<string, unknown>): string | undefin
   return typeof id === 'string' && id.length > 0 ? id : undefined;
 }
 
-function autoSeedStoreFor(
-  store: Map<string, Map<string, unknown>>,
-  accountId: string
-): Map<string, unknown> {
+function autoSeedStoreFor(store: Map<string, Map<string, unknown>>, accountId: string): Map<string, unknown> {
   let inner = store.get(accountId);
   if (inner == null) {
     inner = new Map<string, unknown>();
@@ -3427,9 +3424,7 @@ function autoSeedStoreFor(
 // accounts) never leak fixtures across tenants. Reads
 // `ctx.account?.id` first (set by `resolveAccount` at request time) and
 // falls back to `ctx.input.account.account_id` when no resolver is wired.
-function makeAutoSeedBridge(
-  store: Map<string, Map<string, unknown>>
-): TestControllerBridge<unknown> {
+function makeAutoSeedBridge(store: Map<string, Map<string, unknown>>): TestControllerBridge<unknown> {
   return {
     getSeededProducts: ctx => {
       const resolved = (ctx.account as { id?: unknown } | undefined)?.id;

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -115,6 +115,7 @@ const DEFAULT_FRAMEWORK_LOGGER: AdcpLogger = {
 };
 import { createInMemoryStatusChangeBus, type StatusChangeBus, type PublishStatusChangeOpts } from '../status-changes';
 import { createComplyController, type ComplyControllerConfig } from '../../../testing/comply-controller';
+import { bridgeFromTestControllerStore } from '../../test-controller-bridge';
 import { normalizeErrors } from '../../normalize-errors';
 
 /**
@@ -849,8 +850,29 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     }
   }
 
+  // Auto-seed: when the platform has a `getProducts` catalog and the adopter
+  // wired `complyTest` without ANY explicit seed adapters and without a
+  // `testController` bridge, the framework provides default in-memory seed
+  // adapters so storyboards can call `seed_product` / `seed_pricing_option`
+  // without the adopter writing any adapter code. The bridge makes seeded
+  // products visible in `get_products` responses on sandbox requests.
+  //
+  // The entire auto-seed path is skipped when EITHER `seed.product` OR
+  // `seed_pricing_option` is explicitly wired — mixing explicit and auto-seed
+  // adapters against the same bridge would yield inconsistent `get_products`
+  // responses. In that case the adopter owns the full seed + bridge wiring.
+  const autoSeedStore: Map<string, unknown> | undefined =
+    opts.complyTest != null &&
+    platform.sales?.getProducts != null &&
+    !opts.testController &&
+    !opts.complyTest.seed?.product &&
+    !opts.complyTest.seed?.pricing_option
+      ? new Map<string, unknown>()
+      : undefined;
+
   const config: AdcpServerConfig<Account> = {
     ...opts,
+    ...(autoSeedStore != null && { testController: bridgeFromTestControllerStore(autoSeedStore) }),
     ...(projectedCapabilitiesConfig != null && { capabilities: projectedCapabilitiesConfig }),
     // Pool-derived stores override the spread above when adopters supplied
     // `pool` but no explicit per-store opt. Explicit values still win.
@@ -1020,7 +1042,47 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // or environment-level by guarding the createAdcpServerFromPlatform
   // call site itself).
   if (opts.complyTest != null) {
-    const controller = createComplyController(opts.complyTest);
+    let complyConfig = opts.complyTest;
+
+    if (autoSeedStore != null) {
+      // Inject auto-seed adapters for `seed_product` and `seed_pricing_option`
+      // when the adopter didn't wire explicit ones. Explicit adapters win — the
+      // spread only fills the undefined slots.
+      const explicitSeed = opts.complyTest.seed ?? {};
+      const autoSeed = { ...explicitSeed };
+
+      if (!explicitSeed.product) {
+        autoSeed.product = async params => {
+          autoSeedStore.set(params.product_id, { ...params.fixture, product_id: params.product_id });
+        };
+      }
+
+      if (!explicitSeed.pricing_option) {
+        autoSeed.pricing_option = async params => {
+          const existing = autoSeedStore.get(params.product_id) as Record<string, unknown> | undefined;
+          const pricingOption = { ...params.fixture, pricing_option_id: params.pricing_option_id };
+          const existingOptions = Array.isArray(
+            (existing as { pricing_options?: unknown[] } | undefined)?.pricing_options
+          )
+            ? (existing as { pricing_options: unknown[] }).pricing_options
+            : [];
+          const filtered = existingOptions.filter(
+            (p): p is Record<string, unknown> =>
+              p != null &&
+              typeof p === 'object' &&
+              (p as Record<string, unknown>).pricing_option_id !== params.pricing_option_id
+          );
+          autoSeedStore.set(params.product_id, {
+            ...(existing ?? { product_id: params.product_id }),
+            pricing_options: [...filtered, pricingOption],
+          });
+        };
+      }
+
+      complyConfig = { ...opts.complyTest, seed: autoSeed };
+    }
+
+    const controller = createComplyController(complyConfig);
     controller.register(server);
   }
 

--- a/test/server-decisioning-comply-auto-seed.test.js
+++ b/test/server-decisioning-comply-auto-seed.test.js
@@ -274,4 +274,58 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
 
     assert.strictEqual(result.structuredContent?.error, 'UNKNOWN_SCENARIO');
   });
+
+  it('multi-tenant: two sandbox accounts on one server do NOT share the auto-seed namespace', async () => {
+    // Realistic multi-tenant pattern: each tenant has its own catalog with
+    // distinct product_ids. Tenant A's seeded products must not appear in
+    // tenant B's `get_products`, and vice versa.
+    //
+    // Note on cross-tenant *same-id divergent-fixture* collisions: the SDK's
+    // process-wide `SeedFixtureCache` keys by `seed_product:${product_id}`
+    // (test-controller.ts:~563) and rejects divergent fixtures with
+    // INVALID_PARAMS. That's a pre-existing SDK limitation tracked
+    // separately — auto-seed's per-account store can't paper over it.
+    // True per-account seedCache scoping is a follow-up; for now,
+    // multi-tenant correctness is "different products don't leak."
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      ...BASE_OPTS,
+      complyTest: { sandboxGate: SANDBOX_GATE },
+    });
+
+    await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'tenant_a', sandbox: true },
+      params: {
+        product_id: 'tenant_a_display',
+        fixture: { delivery_type: 'non_guaranteed', channels: ['display'] },
+      },
+    });
+
+    await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'tenant_b', sandbox: true },
+      params: {
+        product_id: 'tenant_b_video',
+        fixture: { delivery_type: 'guaranteed', channels: ['video'] },
+      },
+    });
+
+    const aProducts = (
+      await callGetProducts(server, { account: { account_id: 'tenant_a', sandbox: true } })
+    ).structuredContent.products;
+    const bProducts = (
+      await callGetProducts(server, { account: { account_id: 'tenant_b', sandbox: true } })
+    ).structuredContent.products;
+
+    assert.ok(aProducts.some(p => p.product_id === 'tenant_a_display'), 'tenant_a should see its own product');
+    assert.ok(
+      !aProducts.some(p => p.product_id === 'tenant_b_video'),
+      "tenant_a must NOT see tenant_b's product (cross-tenant leak)"
+    );
+    assert.ok(bProducts.some(p => p.product_id === 'tenant_b_video'), 'tenant_b should see its own product');
+    assert.ok(
+      !bProducts.some(p => p.product_id === 'tenant_a_display'),
+      "tenant_b must NOT see tenant_a's product (cross-tenant leak)"
+    );
+  });
 });

--- a/test/server-decisioning-comply-auto-seed.test.js
+++ b/test/server-decisioning-comply-auto-seed.test.js
@@ -310,19 +310,23 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
       },
     });
 
-    const aProducts = (
-      await callGetProducts(server, { account: { account_id: 'tenant_a', sandbox: true } })
-    ).structuredContent.products;
-    const bProducts = (
-      await callGetProducts(server, { account: { account_id: 'tenant_b', sandbox: true } })
-    ).structuredContent.products;
+    const aProducts = (await callGetProducts(server, { account: { account_id: 'tenant_a', sandbox: true } }))
+      .structuredContent.products;
+    const bProducts = (await callGetProducts(server, { account: { account_id: 'tenant_b', sandbox: true } }))
+      .structuredContent.products;
 
-    assert.ok(aProducts.some(p => p.product_id === 'tenant_a_display'), 'tenant_a should see its own product');
+    assert.ok(
+      aProducts.some(p => p.product_id === 'tenant_a_display'),
+      'tenant_a should see its own product'
+    );
     assert.ok(
       !aProducts.some(p => p.product_id === 'tenant_b_video'),
       "tenant_a must NOT see tenant_b's product (cross-tenant leak)"
     );
-    assert.ok(bProducts.some(p => p.product_id === 'tenant_b_video'), 'tenant_b should see its own product');
+    assert.ok(
+      bProducts.some(p => p.product_id === 'tenant_b_video'),
+      'tenant_b should see its own product'
+    );
     assert.ok(
       !bProducts.some(p => p.product_id === 'tenant_a_display'),
       "tenant_b must NOT see tenant_a's product (cross-tenant leak)"

--- a/test/server-decisioning-comply-auto-seed.test.js
+++ b/test/server-decisioning-comply-auto-seed.test.js
@@ -1,0 +1,277 @@
+// Integration tests for catalog-backed auto-seed: when a platform wires
+// `getProducts` and provides `complyTest` without explicit `seed.product` /
+// `seed_pricing_option` adapters, the framework auto-derives those adapters
+// and wires a `testController` bridge so seeded products appear in
+// `get_products` without any adapter code from the adopter.
+//
+// Acceptance criteria (issue #1091):
+//   - seed_product succeeds for sandbox requests when getProducts is wired
+//   - seed_pricing_option succeeds (merges into the product fixture)
+//   - seeded product is visible in get_products (via bridge) on sandbox requests
+//   - non-sandbox request is rejected by the sandboxGate (FORBIDDEN)
+//   - explicit seed.product adapter takes priority — auto-derive does not override
+//   - auto-seed is NOT applied when opts.testController is already set
+//   - auto-seed is NOT applied when getProducts is not wired
+
+process.env.NODE_ENV = 'test';
+process.env.ADCP_SANDBOX = '1'; // suppress ungated-warning
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+function basePlatform({ getProducts } = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      compliance_testing: {},
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    statusMappers: {},
+    accounts: {
+      // Propagate sandbox flag from AccountReference so the bridge's belt-and-
+      // suspenders check (ctx.account.sandbox === true) passes for sandbox requests.
+      resolve: async ref => ({
+        id: ref?.account_id ?? 'auto_seed_acc',
+        operator: 'test.example.com',
+        ctx_metadata: {},
+        authInfo: { kind: 'api_key' },
+        ...(ref?.sandbox === true && { sandbox: true }),
+      }),
+    },
+    sales: {
+      getProducts: getProducts ?? (async () => ({ products: [] })),
+      createMediaBuy: async () => ({
+        media_buy_id: 'mb_1',
+        status: 'pending_creatives',
+        confirmed_at: '2026-04-28T00:00:00Z',
+        packages: [],
+      }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({
+        currency: 'USD',
+        reporting_period: { start: '2026-04-01', end: '2026-04-30' },
+        media_buy_deliveries: [],
+      }),
+    },
+  };
+}
+
+const SANDBOX_GATE = input => input.account?.sandbox === true;
+const BASE_OPTS = {
+  name: 'auto-seed-host',
+  version: '0.0.1',
+  validation: { requests: 'off', responses: 'off' },
+};
+
+async function callComply(server, args) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: { name: 'comply_test_controller', arguments: args },
+  });
+}
+
+async function callGetProducts(server, args) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: { name: 'get_products', arguments: args },
+  });
+}
+
+describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091)', () => {
+  it('seed_product succeeds for a sandbox account when no explicit adapter is wired', async () => {
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      ...BASE_OPTS,
+      complyTest: { sandboxGate: SANDBOX_GATE },
+    });
+
+    const result = await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_1', sandbox: true },
+      params: {
+        product_id: 'sports_display_auction',
+        fixture: { delivery_type: 'non_guaranteed', channels: ['display'] },
+      },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it('seeded product is visible in get_products after seed_product', async () => {
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      ...BASE_OPTS,
+      complyTest: { sandboxGate: SANDBOX_GATE },
+    });
+
+    await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_1', sandbox: true },
+      params: {
+        product_id: 'sports_display_auction',
+        fixture: {
+          delivery_type: 'non_guaranteed',
+          channels: ['display'],
+          pricing_options: [{ pricing_option_id: 'cpm_1', model: 'cpm', floor: { amount: 5, currency: 'USD' } }],
+        },
+      },
+    });
+
+    const result = await callGetProducts(server, {
+      account: { account_id: 'acc_1', sandbox: true },
+    });
+
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    const products = result.structuredContent.products;
+    assert.ok(Array.isArray(products), 'products should be an array');
+    const seeded = products.find(p => p.product_id === 'sports_display_auction');
+    assert.ok(seeded, 'seeded product should appear in get_products for sandbox request');
+    assert.strictEqual(seeded.delivery_type, 'non_guaranteed');
+  });
+
+  it('seed_pricing_option auto-derive merges pricing option into the seeded product', async () => {
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      ...BASE_OPTS,
+      complyTest: { sandboxGate: SANDBOX_GATE },
+    });
+
+    // Seed the parent product first
+    await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_1', sandbox: true },
+      params: {
+        product_id: 'sports_display_auction',
+        fixture: { delivery_type: 'non_guaranteed', channels: ['display'] },
+      },
+    });
+
+    // Now seed a pricing option on that product
+    const poResult = await callComply(server, {
+      scenario: 'seed_pricing_option',
+      account: { account_id: 'acc_1', sandbox: true },
+      params: {
+        product_id: 'sports_display_auction',
+        pricing_option_id: 'cpm_floor_5',
+        fixture: { model: 'cpm', floor: { amount: 5, currency: 'USD' } },
+      },
+    });
+
+    assert.notStrictEqual(poResult.isError, true, JSON.stringify(poResult.structuredContent));
+    assert.strictEqual(poResult.structuredContent.success, true);
+
+    // Verify the pricing option merged into the product in get_products
+    const gpResult = await callGetProducts(server, {
+      account: { account_id: 'acc_1', sandbox: true },
+    });
+    const products = gpResult.structuredContent.products;
+    const seeded = products.find(p => p.product_id === 'sports_display_auction');
+    assert.ok(seeded, 'seeded product should appear');
+    const po = (seeded.pricing_options ?? []).find(p => p.pricing_option_id === 'cpm_floor_5');
+    assert.ok(po, 'seeded pricing option should be present in the product');
+  });
+
+  it('non-sandbox request is rejected with FORBIDDEN when sandboxGate is wired', async () => {
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      ...BASE_OPTS,
+      complyTest: { sandboxGate: SANDBOX_GATE },
+    });
+
+    const result = await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_prod', sandbox: false },
+      params: {
+        product_id: 'some_product',
+        fixture: {},
+      },
+    });
+
+    assert.strictEqual(result.structuredContent?.success, false);
+    assert.strictEqual(result.structuredContent?.error, 'FORBIDDEN');
+  });
+
+  it('explicit seed.product adapter takes priority over auto-derive', async () => {
+    let explicitCalled = false;
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      ...BASE_OPTS,
+      complyTest: {
+        sandboxGate: SANDBOX_GATE,
+        seed: {
+          product: async params => {
+            explicitCalled = true;
+            // explicit adapter stores nothing — just marks it was called
+          },
+        },
+      },
+    });
+
+    await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_1', sandbox: true },
+      params: {
+        product_id: 'explicit_product',
+        fixture: { delivery_type: 'non_guaranteed' },
+      },
+    });
+
+    assert.ok(explicitCalled, 'explicit seed.product adapter should be called');
+
+    // The auto-bridge is NOT wired when explicit adapter is present (or at least
+    // the product is not in the auto-seed store, so get_products returns empty)
+    const gpResult = await callGetProducts(server, {
+      account: { account_id: 'acc_1', sandbox: true },
+    });
+    const products = gpResult.structuredContent.products ?? [];
+    const found = products.find(p => p.product_id === 'explicit_product');
+    // Explicit adapters own their storage — the framework's auto-bridge is not wired
+    assert.ok(!found, 'auto-bridge should NOT be wired when explicit seed.product is provided');
+  });
+
+  it('auto-seed is not applied when getProducts is not wired (no sales catalog)', async () => {
+    const platformNoSales = {
+      ...basePlatform(),
+      sales: undefined,
+      capabilities: {
+        ...basePlatform().capabilities,
+        specialisms: [], // no sales specialisms
+      },
+    };
+
+    // Supply complyTest with only a force adapter (no sales); platform has no getProducts
+    let callCount = 0;
+    const server = createAdcpServerFromPlatform(
+      { ...platformNoSales, sales: null },
+      {
+        ...BASE_OPTS,
+        complyTest: {
+          sandboxGate: SANDBOX_GATE,
+          force: {
+            creative_status: async () => {
+              callCount++;
+              return {
+                success: true,
+                transition: 'forced',
+                resource_type: 'creative',
+                resource_id: 'x',
+                previous_state: 'pending_review',
+                current_state: 'approved',
+              };
+            },
+          },
+        },
+      }
+    );
+
+    // seed_product should return UNKNOWN_SCENARIO (no auto-seed, no explicit adapter)
+    const result = await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_1', sandbox: true },
+      params: { product_id: 'no_catalog_product', fixture: {} },
+    });
+
+    assert.strictEqual(result.structuredContent?.error, 'UNKNOWN_SCENARIO');
+  });
+});


### PR DESCRIPTION
Closes #1091

## Summary

When `createAdcpServerFromPlatform` is called with `complyTest` and a sales platform that wires `getProducts`, but without explicit `seed.product` or `seed_pricing_option` adapters, the framework now auto-derives those adapters from an in-memory store and wires a `TestControllerBridge` so seeded products appear in `get_products` responses on sandbox requests.

**What this fixes:** LLM-generated platforms following the slim skill guide fail comply storyboards because `seed_product` requires an explicit adapter that the guide doesn't mention. Publishers wiring `getProducts` now get free comply-sandbox seeding without writing any seed adapter code.

**Priority rules (explicit always wins):**
- If `complyTest.seed.product` is set → auto-derive is skipped entirely
- If `complyTest.seed.pricing_option` is set → auto-derive is skipped entirely (both adapters must share the same store; partial auto-derive would cause inconsistent `get_products`)
- If `opts.testController` is already set → no auto-bridge is created
- If `platform.sales?.getProducts` is not wired → no auto-seed (no catalog to bridge to)

## Changes

- **`src/lib/server/decisioning/runtime/from-platform.ts`**: Added `autoSeedStore` guard and auto-seed adapter injection in the `complyTest` wiring block
- **`test/server-decisioning-comply-auto-seed.test.js`**: 6 integration tests covering all acceptance criteria from issue #1091
- **`.changeset/comply-catalog-auto-seed.md`**: minor bump changeset

## What was tested

All 6 integration tests pass (`node --test test/server-decisioning-comply-auto-seed.test.js`):
- `seed_product` succeeds for sandbox account with no explicit adapter
- Seeded product visible in `get_products` after `seed_product` (via bridge)
- `seed_pricing_option` merges pricing option into seeded product
- Non-sandbox request rejected with `FORBIDDEN` via `sandboxGate`
- Explicit `seed.product` adapter takes priority — no override by auto-derive
- No auto-seed when `getProducts` is not wired

Pre-existing tsc errors (`Cannot find type definition file for 'node'`, TS5107 `moduleResolution=node10 deprecated`) are on `main` and not introduced by this PR.

## Pre-PR expert review

**code-reviewer**: Approved after two blockers were fixed:
1. Asymmetry bug — if only `seed.pricing_option` was explicit, auto-`seed.product` would write to `autoSeedStore` while the explicit adapter wrote elsewhere, making `get_products` inconsistent. Fixed by requiring BOTH seed adapters to be absent before enabling auto-seed.
2. Key order — `{ product_id: params.product_id, ...params.fixture }` allowed fixture to override the authoritative ID. Fixed to `{ ...params.fixture, product_id: params.product_id }`.

**ad-tech-protocol-expert**: Approved. Confirmed spec-compliant: auto-seed goes through the same `SeedFixtureCache` idempotency path as explicit adapters (enforced inside `handleTestControllerRequest` before any adapter is called). Store growth is bounded by `SESSION_ENTRY_CAP`.

---
*Triage-managed PR — opened by Claude Code triage agent for issue #1091.*

https://claude.ai/code/session_01ViJ8mcmpcDmarr3heAA8jU

---
_Generated by [Claude Code](https://claude.ai/code/session_01ViJ8mcmpcDmarr3heAA8jU)_