### PR TITLE
feat(server): auto-hydration on 4 mutating verbs (#1086)

### DIFF
--- a/.changeset/auto-hydration-extensions.md
+++ b/.changeset/auto-hydration-extensions.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): auto-hydration on `update_media_buy`, `provide_performance_feedback`, `activate_signal`, `acquire_rights`. Each mutating verb now auto-hydrates its primary resource(s) from the ctx_metadata store — handlers receive `req.media_buy`, `req.creative`, `req.signal`, `req.rights` populated with the wire shape + `ctx_metadata` blob from the prior discovery call (`get_media_buys`, `get_signals`, `get_rights`). Misses are silent; publishers fall back to their own DB.
+
+Adds auto-store on `get_signals` (kind: `signal`) and `get_rights` (kind: `rights_grant`) returns to feed the hydration path.
+
+Closes #1086.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2511,15 +2511,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
         );
         const creativeId = (params as { creative_id?: string }).creative_id;
         if (creativeId) {
-          await hydrateSingleResource(
-            ctxMetadataStore,
-            accountId,
-            'creative',
-            creativeId,
-            'creative',
-            params,
-            logger
-          );
+          await hydrateSingleResource(ctxMetadataStore, accountId, 'creative', creativeId, 'creative', params, logger);
         }
         return projectSync(
           () => sales.providePerformanceFeedback!(params, reqCtx),

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -83,6 +83,7 @@ import type { AdcpLogger } from '../../create-adcp-server';
 import { buildRequestContext, buildHandoffContext } from './to-context';
 import {
   type CtxMetadataStore,
+  type ResourceKind,
   createCtxMetadataStore,
   pgCtxMetadataStore,
   getCtxMetadataMigration,
@@ -978,10 +979,20 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       'eventTracking',
       mergeOpts
     ),
-    signals: mergeHandlers(opts.signals, buildSignalsHandlers(platform, ctxFor), 'signals', mergeOpts),
+    signals: mergeHandlers(
+      opts.signals,
+      buildSignalsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger),
+      'signals',
+      mergeOpts
+    ),
     governance: mergeHandlers(opts.governance, buildGovernanceHandlers(platform, ctxFor), 'governance', mergeOpts),
     accounts: mergeHandlers(opts.accounts, buildAccountHandlers(platform, ctxFor), 'accounts', mergeOpts),
-    brandRights: mergeHandlers(opts.brandRights, buildBrandRightsHandlers(platform, ctxFor), 'brandRights', mergeOpts),
+    brandRights: mergeHandlers(
+      opts.brandRights,
+      buildBrandRightsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger),
+      'brandRights',
+      mergeOpts
+    ),
     customTools: {
       ...opts.customTools,
       tasks_get: buildTasksGetTool(platform, taskRegistry),
@@ -1930,7 +1941,7 @@ function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
 async function autoStoreResources(
   store: CtxMetadataStore | undefined,
   accountId: string | undefined,
-  kind: 'product' | 'media_buy' | 'package' | 'creative' | 'audience' | 'signal',
+  kind: ResourceKind,
   resources: readonly unknown[] | undefined,
   idField: string,
   logger: AdcpLogger
@@ -2007,6 +2018,45 @@ async function hydratePackagesWithProducts(
     }
     (pkg as Record<string, unknown>)['product'] = hydrated;
   }
+}
+
+/**
+ * Auto-hydrate one resource referenced by id at the top level of a request.
+ *
+ * Generalization of {@link hydratePackagesWithProducts} for verbs whose
+ * primary resource lives directly on the request body (`update_media_buy`,
+ * `provide_performance_feedback`, `activate_signal`, `acquire_rights`).
+ * Walks the store for `(kind, id)`, attaches `target[attachField] =
+ * { ...resource, ctx_metadata }` when the entry has a wire resource. Misses
+ * are silent — publisher falls back to its own DB.
+ *
+ * Failures are logged + swallowed. Hydration must NEVER break a successful
+ * dispatch.
+ */
+async function hydrateSingleResource(
+  store: CtxMetadataStore | undefined,
+  accountId: string | undefined,
+  kind: ResourceKind,
+  id: string | undefined,
+  attachField: string,
+  target: unknown,
+  logger: AdcpLogger
+): Promise<void> {
+  if (!store || !accountId || !id || target == null || typeof target !== 'object') return;
+  let entry: { value: unknown; resource?: unknown } | undefined;
+  try {
+    entry = await store.getEntry(accountId, kind, id);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[adcp/decisioning] auto-hydrate ${kind}:${id} failed: ${msg}`);
+    return;
+  }
+  if (!entry?.resource || typeof entry.resource !== 'object') return;
+  const hydrated: Record<string, unknown> = { ...(entry.resource as Record<string, unknown>) };
+  if (entry.value !== null && entry.value !== undefined) {
+    hydrated['ctx_metadata'] = entry.value;
+  }
+  (target as Record<string, unknown>)[attachField] = hydrated;
 }
 
 /**
@@ -2322,6 +2372,19 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
           recovery: 'correctable',
         });
       }
+      // Auto-hydrate: attach the full MediaBuy (wire shape + ctx_metadata)
+      // at `req.media_buy`. Publisher reads `req.media_buy.ctx_metadata?.gam`
+      // directly — no separate lookup. Misses are silent; publisher falls
+      // back to its own DB.
+      await hydrateSingleResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'media_buy',
+        media_buy_id,
+        'media_buy',
+        params,
+        logger
+      );
       return projectSync(
         async () => {
           const push = extractPushConfig(params, logger, {
@@ -2431,6 +2494,33 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
     ...(sales.providePerformanceFeedback && {
       providePerformanceFeedback: async (params, ctx) => {
         const reqCtx = ctxFor(ctx);
+        // Auto-hydrate `req.media_buy` from the prior createMediaBuy /
+        // getMediaBuys store entry, plus `req.creative` when the buyer
+        // scoped feedback to a specific creative. Both fields are optional
+        // hydration targets — adopters who only care about the feedback
+        // payload itself can ignore them.
+        const accountId = reqCtx.account?.id;
+        await hydrateSingleResource(
+          ctxMetadataStore,
+          accountId,
+          'media_buy',
+          (params as { media_buy_id?: string }).media_buy_id,
+          'media_buy',
+          params,
+          logger
+        );
+        const creativeId = (params as { creative_id?: string }).creative_id;
+        if (creativeId) {
+          await hydrateSingleResource(
+            ctxMetadataStore,
+            accountId,
+            'creative',
+            creativeId,
+            'creative',
+            params,
+            logger
+          );
+        }
         return projectSync(
           () => sales.providePerformanceFeedback!(params, reqCtx),
           r => r
@@ -2649,7 +2739,9 @@ function buildEventTrackingHandlers<P extends DecisioningPlatform<any, any>>(
 
 function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
   platform: P,
-  ctxFor: CtxForFn
+  ctxFor: CtxForFn,
+  ctxMetadataStore: CtxMetadataStore | undefined,
+  logger: AdcpLogger
 ): SignalsHandlers<Account> | undefined {
   const signals = platform.signals;
   if (!signals) return undefined;
@@ -2657,12 +2749,37 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
     getSignals: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
       return projectSync(
-        () => signals.getSignals(params, reqCtx),
+        async () => {
+          const result = await signals.getSignals(params, reqCtx);
+          // Auto-store signals so subsequent activate_signal can hydrate
+          // `req.signal` from the publisher's prior catalog entry.
+          await autoStoreResources(
+            ctxMetadataStore,
+            reqCtx.account?.id,
+            'signal',
+            (result as { signals?: readonly unknown[] })?.signals,
+            'signal_agent_segment_id',
+            logger
+          );
+          return result;
+        },
         r => r
       );
     },
     activateSignal: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
+      // Auto-hydrate `req.signal` from the prior getSignals store entry —
+      // publisher reads pricing options, agent segment id, ctx_metadata
+      // directly without the buyer round-tripping the full signal object.
+      await hydrateSingleResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'signal',
+        (params as { signal_agent_segment_id?: string }).signal_agent_segment_id,
+        'signal',
+        params,
+        logger
+      );
       return projectSync(
         () => signals.activateSignal(params, reqCtx),
         r => r
@@ -2673,7 +2790,9 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
 
 function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
   platform: P,
-  ctxFor: CtxForFn
+  ctxFor: CtxForFn,
+  ctxMetadataStore: CtxMetadataStore | undefined,
+  logger: AdcpLogger
 ): BrandRightsHandlers<Account> | undefined {
   const br = platform.brandRights;
   if (!br) return undefined;
@@ -2688,7 +2807,21 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
     getRights: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
       return projectSync(
-        () => br.getRights(params, reqCtx),
+        async () => {
+          const result = await br.getRights(params, reqCtx);
+          // Auto-store rights offerings so subsequent acquire_rights can
+          // hydrate `req.rights` (pricing_options + ctx_metadata) without
+          // a separate publisher lookup.
+          await autoStoreResources(
+            ctxMetadataStore,
+            reqCtx.account?.id,
+            'rights_grant',
+            (result as { rights?: readonly unknown[] })?.rights,
+            'rights_id',
+            logger
+          );
+          return result;
+        },
         r => r
       );
     },
@@ -2699,6 +2832,17 @@ function buildBrandRightsHandlers<P extends DecisioningPlatform<any, any>>(
     // (the spec doesn't define a polling tool for `acquire_rights`).
     acquireRights: async (params, ctx) => {
       const reqCtx = ctxFor(ctx);
+      // Auto-hydrate `req.rights` from the prior getRights catalog entry.
+      // Publisher reads selected pricing option + ctx_metadata directly.
+      await hydrateSingleResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'rights_grant',
+        (params as { rights_id?: string }).rights_id,
+        'rights',
+        params,
+        logger
+      );
       return projectSync(
         () => br.acquireRights(params, reqCtx),
         r => r

--- a/test/server-auto-hydration-extended.test.js
+++ b/test/server-auto-hydration-extended.test.js
@@ -80,11 +80,7 @@ describe('auto-hydration — update_media_buy', () => {
     assert.ok(observedReq.media_buy, 'req.media_buy hydrated');
     assert.equal(observedReq.media_buy.media_buy_id, 'mb_42');
     assert.equal(observedReq.media_buy.status, 'active');
-    assert.deepEqual(
-      observedReq.media_buy.ctx_metadata,
-      { gam: { order_id: '12345' } },
-      'ctx_metadata round-tripped'
-    );
+    assert.deepEqual(observedReq.media_buy.ctx_metadata, { gam: { order_id: '12345' } }, 'ctx_metadata round-tripped');
   });
 
   it('updateMediaBuy without prior getMediaBuys — req.media_buy is undefined (falls through)', async () => {
@@ -136,10 +132,16 @@ describe('auto-hydration — provide_performance_feedback', () => {
 
     const ctxMetadata = makeStore();
     // Pre-seed creative store via direct setResource (no syncCreatives in this minimal setup)
-    await ctxMetadata.setResource('acct_default', 'creative', 'cr_99', {
-      creative_id: 'cr_99',
-      status: 'approved',
-    }, { dsp_creative_id: 'dsp_555' });
+    await ctxMetadata.setResource(
+      'acct_default',
+      'creative',
+      'cr_99',
+      {
+        creative_id: 'cr_99',
+        status: 'approved',
+      },
+      { dsp_creative_id: 'dsp_555' }
+    );
 
     const server = createAdcpServerFromPlatform(platform, {
       name: 'Test',
@@ -345,9 +347,6 @@ describe('auto-hydration — acquire_rights', () => {
     assert.ok(observedReq, 'acquireRights called');
     assert.ok(observedReq.rights, 'req.rights hydrated');
     assert.equal(observedReq.rights.rights_id, 'rt_001');
-    assert.deepEqual(
-      observedReq.rights.ctx_metadata,
-      { license_type: 'commercial', territory: 'US' }
-    );
+    assert.deepEqual(observedReq.rights.ctx_metadata, { license_type: 'commercial', territory: 'US' });
   });
 });

--- a/test/server-auto-hydration-extended.test.js
+++ b/test/server-auto-hydration-extended.test.js
@@ -1,0 +1,353 @@
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform, createCtxMetadataStore, memoryCtxMetadataStore } = require('../dist/lib/server');
+
+function makeBasePlatform(overrides = {}) {
+  return {
+    capabilities: {
+      adcp_version: '3.0.0',
+      specialisms: ['sales-non-guaranteed'],
+      pricingModels: ['cpm'],
+      channels: ['display'],
+      formats: [{ format_id: 'display_300x250' }],
+      idempotency: { replay_ttl_seconds: 86400 },
+    },
+    accounts: {
+      resolution: 'derived',
+      resolve: async () => ({ id: 'acct_default', operator: 'test', ctx_metadata: {} }),
+      upsert: async () => ({ ok: true, items: [] }),
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+      getMediaBuyDelivery: async () => ({ deliveries: [] }),
+      getMediaBuys: async () => ({ media_buys: [] }),
+      ...overrides,
+    },
+  };
+}
+
+function makeStore() {
+  return createCtxMetadataStore({
+    backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+  });
+}
+
+describe('auto-hydration — update_media_buy', () => {
+  it('updateMediaBuy receives req.media_buy hydrated from prior getMediaBuys', async () => {
+    let observedReq;
+    const platform = makeBasePlatform({
+      getMediaBuys: async () => ({
+        media_buys: [{ media_buy_id: 'mb_42', status: 'active', ctx_metadata: { gam: { order_id: '12345' } } }],
+      }),
+      updateMediaBuy: async (id, params, ctx) => {
+        observedReq = params;
+        return { media_buy_id: id, status: 'paused', packages: [] };
+      },
+    });
+
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_media_buys', arguments: {} },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb_42',
+          paused: true,
+          idempotency_key: 'idem_update_001_aaaaaaaa',
+        },
+      },
+    });
+
+    assert.ok(observedReq, 'updateMediaBuy was called');
+    assert.ok(observedReq.media_buy, 'req.media_buy hydrated');
+    assert.equal(observedReq.media_buy.media_buy_id, 'mb_42');
+    assert.equal(observedReq.media_buy.status, 'active');
+    assert.deepEqual(
+      observedReq.media_buy.ctx_metadata,
+      { gam: { order_id: '12345' } },
+      'ctx_metadata round-tripped'
+    );
+  });
+
+  it('updateMediaBuy without prior getMediaBuys — req.media_buy is undefined (falls through)', async () => {
+    let observedReq;
+    const platform = makeBasePlatform({
+      updateMediaBuy: async (id, params, ctx) => {
+        observedReq = params;
+        return { media_buy_id: id, status: 'paused', packages: [] };
+      },
+    });
+
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb_unseen',
+          paused: true,
+          idempotency_key: 'idem_unseen_001_aaaaaaaa',
+        },
+      },
+    });
+
+    assert.ok(observedReq);
+    assert.equal(observedReq.media_buy, undefined, 'no hydration for unseen id');
+  });
+});
+
+describe('auto-hydration — provide_performance_feedback', () => {
+  it('hydrates req.media_buy and req.creative when both ids referenced', async () => {
+    let observedReq;
+    const platform = makeBasePlatform({
+      getMediaBuys: async () => ({
+        media_buys: [{ media_buy_id: 'mb_perf', status: 'active', ctx_metadata: { campaign: 'c1' } }],
+      }),
+      providePerformanceFeedback: async (params, ctx) => {
+        observedReq = params;
+        return { feedback_id: 'fb_1' };
+      },
+    });
+
+    const ctxMetadata = makeStore();
+    // Pre-seed creative store via direct setResource (no syncCreatives in this minimal setup)
+    await ctxMetadata.setResource('acct_default', 'creative', 'cr_99', {
+      creative_id: 'cr_99',
+      status: 'approved',
+    }, { dsp_creative_id: 'dsp_555' });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_media_buys', arguments: {} },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'provide_performance_feedback',
+        arguments: {
+          media_buy_id: 'mb_perf',
+          creative_id: 'cr_99',
+          measurement_period: { start: '2026-04-01T00:00:00Z', end: '2026-04-30T00:00:00Z' },
+          performance_index: 1.2,
+          idempotency_key: 'idem_perf_001_aaaaaaaaa',
+        },
+      },
+    });
+
+    assert.ok(observedReq, 'feedback handler called');
+    assert.ok(observedReq.media_buy, 'req.media_buy hydrated');
+    assert.equal(observedReq.media_buy.media_buy_id, 'mb_perf');
+    assert.deepEqual(observedReq.media_buy.ctx_metadata, { campaign: 'c1' });
+    assert.ok(observedReq.creative, 'req.creative hydrated');
+    assert.equal(observedReq.creative.creative_id, 'cr_99');
+    assert.deepEqual(observedReq.creative.ctx_metadata, { dsp_creative_id: 'dsp_555' });
+  });
+
+  it('skips creative hydration when creative_id absent', async () => {
+    let observedReq;
+    const platform = makeBasePlatform({
+      providePerformanceFeedback: async (params, ctx) => {
+        observedReq = params;
+        return { feedback_id: 'fb_1' };
+      },
+    });
+
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'provide_performance_feedback',
+        arguments: {
+          media_buy_id: 'mb_unseen',
+          measurement_period: { start: '2026-04-01T00:00:00Z', end: '2026-04-30T00:00:00Z' },
+          performance_index: 1.0,
+          idempotency_key: 'idem_perf_002_aaaaaaaaa',
+        },
+      },
+    });
+
+    assert.ok(observedReq);
+    assert.equal(observedReq.creative, undefined, 'no creative hydration without creative_id');
+  });
+});
+
+describe('auto-hydration — activate_signal', () => {
+  it('activateSignal receives req.signal hydrated from prior getSignals', async () => {
+    let observedReq;
+    const signalsImpl = {
+      getSignals: async () => ({
+        signals: [
+          {
+            signal_agent_segment_id: 'seg_abc',
+            name: 'Sports Fans',
+            ctx_metadata: { ttl_days: 30, taxonomy: 'iab-1' },
+          },
+        ],
+      }),
+      activateSignal: async (params, ctx) => {
+        observedReq = params;
+        return { decisioning_platform_segment_id: 'dsp_seg_abc', estimated_activation_duration_minutes: 5 };
+      },
+    };
+
+    const platform = {
+      ...makeBasePlatform(),
+      capabilities: {
+        adcp_version: '3.0.0',
+        specialisms: ['signal-marketplace'],
+        pricingModels: ['cpm'],
+        channels: ['display'],
+        formats: [{ format_id: 'display_300x250' }],
+        idempotency: { replay_ttl_seconds: 86400 },
+      },
+      signals: signalsImpl,
+    };
+
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_signals', arguments: { signal_spec: 'sports', deliver_to: { platforms: 'all' } } },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'activate_signal',
+        arguments: {
+          signal_agent_segment_id: 'seg_abc',
+          destinations: [{ platform: 'gam' }],
+          idempotency_key: 'idem_activate_001_aaaaaa',
+        },
+      },
+    });
+
+    assert.ok(observedReq, 'activateSignal called');
+    assert.ok(observedReq.signal, 'req.signal hydrated');
+    assert.equal(observedReq.signal.signal_agent_segment_id, 'seg_abc');
+    assert.equal(observedReq.signal.name, 'Sports Fans');
+    assert.deepEqual(observedReq.signal.ctx_metadata, { ttl_days: 30, taxonomy: 'iab-1' });
+  });
+});
+
+describe('auto-hydration — acquire_rights', () => {
+  it('acquireRights receives req.rights hydrated from prior getRights', async () => {
+    let observedReq;
+    const brandRightsImpl = {
+      getBrandIdentity: async () => ({ brand_id: 'b1', display_name: 'Acme' }),
+      getRights: async () => ({
+        rights: [
+          {
+            rights_id: 'rt_001',
+            ctx_metadata: { license_type: 'commercial', territory: 'US' },
+          },
+        ],
+      }),
+      acquireRights: async (params, ctx) => {
+        observedReq = params;
+        return {
+          rights_id: 'rt_001',
+          status: 'acquired',
+          brand_id: 'b1',
+          terms: 'standard',
+          generation_credentials: [],
+          rights_constraint: {},
+        };
+      },
+    };
+
+    const platform = {
+      ...makeBasePlatform(),
+      capabilities: {
+        adcp_version: '3.0.0',
+        specialisms: ['brand-rights'],
+        pricingModels: ['cpm'],
+        channels: ['display'],
+        formats: [{ format_id: 'display_300x250' }],
+        idempotency: { replay_ttl_seconds: 86400 },
+      },
+      brandRights: brandRightsImpl,
+    };
+
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_rights', arguments: { brand: { brand_id: 'b1' } } },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'acquire_rights',
+        arguments: {
+          rights_id: 'rt_001',
+          pricing_option_id: 'po_basic',
+          buyer: { brand_id: 'b1' },
+          campaign: { description: 'Q2 launch', uses: ['display_ads'] },
+          idempotency_key: 'idem_acquire_001_aaaaaaa',
+        },
+      },
+    });
+
+    assert.ok(observedReq, 'acquireRights called');
+    assert.ok(observedReq.rights, 'req.rights hydrated');
+    assert.equal(observedReq.rights.rights_id, 'rt_001');
+    assert.deepEqual(
+      observedReq.rights.ctx_metadata,
+      { license_type: 'commercial', territory: 'US' }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extends the 6.1 auto-hydration substrate (which covered \`createMediaBuy → req.packages[i].product\`) to every other mutating verb that references a publisher resource by id:

| Verb | Hydrated field | Source |
|---|---|---|
| \`update_media_buy\` | \`req.media_buy\` | prior \`get_media_buys\` |
| \`provide_performance_feedback\` | \`req.media_buy\`, \`req.creative\` (when \`creative_id\` set) | prior \`get_media_buys\` + creative store |
| \`activate_signal\` | \`req.signal\` | prior \`get_signals\` |
| \`acquire_rights\` | \`req.rights\` | prior \`get_rights\` |

Adds auto-store on \`get_signals\` (kind: \`signal\`) and \`get_rights\` (kind: \`rights_grant\`) returns to feed the hydration path.

Each handler now receives the full wire resource shape plus the publisher-attached \`ctx_metadata\` blob inline, so adopters don't re-implement adapter-state lookups in mutating handlers. Misses are silent — publishers fall back to their own DB if the buyer references an id the framework hasn't seen.

Closes #1086.

## Implementation notes

- New generic helper \`hydrateSingleResource\` for top-level-id hydration, alongside the existing package-walking \`hydratePackagesWithProducts\`.
- \`autoStoreResources\` widened from a hard-coded kind union to \`ResourceKind\` so future verbs can extend without touching the helper.
- \`buildSignalsHandlers\` and \`buildBrandRightsHandlers\` signatures threaded with \`ctxMetadataStore\` + \`logger\` (matching the pattern \`buildMediaBuyHandlers\` already follows).

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` passes
- [x] \`npm test\` — 6847 pass, 0 fail (full suite)
- [x] 6 new tests in \`test/server-auto-hydration-extended.test.js\`:
  - update_media_buy hit + miss
  - provide_performance_feedback both ids + media_buy only (no creative_id)
  - activate_signal round-trip
  - acquire_rights round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)