### PR TITLE
feat(server): auto-hydrate patch.mediaBuy in updateMediaBuy

### DIFF
--- a/.changeset/update-media-buy-auto-hydration.md
+++ b/.changeset/update-media-buy-auto-hydration.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): auto-hydrate `patch.mediaBuy` in `updateMediaBuy` from prior `getMediaBuys`/`createMediaBuy`
+
+Extends the auto-hydration mechanism (introduced for `createMediaBuy` in 6.1) to `update_media_buy`. The SDK now attaches the full `MediaBuy` wire object — including `ctx_metadata` — at `patch.mediaBuy` before invoking the publisher's `updateMediaBuy` handler. Keyed by `media_buy_id`; silently no-ops when the store has no record (publisher falls back to its own DB). The `getMediaBuys` store-write already existed; this PR adds the read/hydrate side.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "5.22.0",
+  "version": "5.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "5.22.0",
+      "version": "5.25.1",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6394,10 +6394,10 @@
     },
     "packages/client-shim": {
       "name": "@adcp/client",
-      "version": "5.22.0",
+      "version": "5.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^5.22.0"
+        "@adcp/sdk": "^5.25.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/skills/build-decisioning-platform/SKILL.md
+++ b/skills/build-decisioning-platform/SKILL.md
@@ -168,6 +168,8 @@ class MyPlatform implements DecisioningPlatform {
     //    (6.2 will pre-read state + decompose into atomic verbs; track adcp-client#1071.)
     updateMediaBuy: async (mediaBuyId, patch, _ctx) => {
       const mediaBuy = patch.mediaBuy; // SDK-hydrated full MediaBuy (incl. ctx_metadata)
+      // Pure-SDK path: no own DB, treat cache-miss as not-found.
+      // If you have your own DB, replace the throw with a DB lookup.
       if (!mediaBuy) throw new MediaBuyNotFoundError(mediaBuyId);
 
       for (const pkg of patch.packages ?? []) {

--- a/skills/build-decisioning-platform/SKILL.md
+++ b/skills/build-decisioning-platform/SKILL.md
@@ -18,19 +18,30 @@ For 95% of sales agents, these are the only `@adcp/sdk/server` imports you need:
 ```ts
 import {
   // Server entry + persistence
-  createAdcpServerFromPlatform, getAllAdcpMigrations, serve,
+  createAdcpServerFromPlatform,
+  getAllAdcpMigrations,
+  serve,
   // Wire-shape helpers (eliminate 30+ lines of boilerplate per Product)
-  buildProduct, buildPackage, buildPricingOption,
+  buildProduct,
+  buildPackage,
+  buildPricingOption,
   // Typed errors — pick from this catalog instead of `throw new AdcpError(...)`
-  PackageNotFoundError, MediaBuyNotFoundError, ProductNotFoundError,
-  BudgetTooLowError, BackwardsTimeRangeError, InvalidStateError,
-  RateLimitedError, UnsupportedFeatureError,
+  PackageNotFoundError,
+  MediaBuyNotFoundError,
+  ProductNotFoundError,
+  BudgetTooLowError,
+  BackwardsTimeRangeError,
+  InvalidStateError,
+  RateLimitedError,
+  UnsupportedFeatureError,
   // Types
-  type DecisioningPlatform, type SalesPlatform,
+  type DecisioningPlatform,
+  type SalesPlatform,
 } from '@adcp/sdk/server';
 ```
 
 For other agent shapes:
+
 - **Creative agent (template / generative):** swap `SalesPlatform` for `CreativeBuilderPlatform`
 - **Signals agent:** swap for `SignalsPlatform`
 - **Brand-rights agent:** swap for `BrandRightsPlatform`
@@ -57,10 +68,16 @@ The full export list is in `@adcp/sdk/server`. Many surfaces are marked `@deprec
 ```ts
 import {
   createAdcpServerFromPlatform,
-  createCtxMetadataStore, memoryCtxMetadataStore,
-  PackageNotFoundError, MediaBuyNotFoundError, ProductNotFoundError,
-  BudgetTooLowError, BackwardsTimeRangeError, InvalidStateError,
-  type DecisioningPlatform, type SalesPlatform,
+  createCtxMetadataStore,
+  memoryCtxMetadataStore,
+  PackageNotFoundError,
+  MediaBuyNotFoundError,
+  ProductNotFoundError,
+  BudgetTooLowError,
+  BackwardsTimeRangeError,
+  InvalidStateError,
+  type DecisioningPlatform,
+  type SalesPlatform,
 } from '@adcp/sdk/server';
 
 class MyPlatform implements DecisioningPlatform {
@@ -68,13 +85,13 @@ class MyPlatform implements DecisioningPlatform {
     adcp_version: '3.0.0',
     specialisms: ['sales-non-guaranteed'] as const,
     pricingModels: ['cpm'] as const,
-    channels: ['display', 'video'] as const,                  // strict literal-union — TS catches typos
+    channels: ['display', 'video'] as const, // strict literal-union — TS catches typos
     formats: [{ format_id: 'display_300x250' }],
     idempotency: { replay_ttl_seconds: 86400 },
   };
 
   accounts = {
-    resolution: 'derived' as const,                            // single tenant; framework returns the same Account every call
+    resolution: 'derived' as const, // single tenant; framework returns the same Account every call
     resolve: async () => ({ id: 'pub_main', operator: 'mypub', ctx_metadata: {} }),
     upsert: async () => ({ ok: true, items: [] }),
     list: async () => ({ items: [], nextCursor: null }),
@@ -90,8 +107,10 @@ class MyPlatform implements DecisioningPlatform {
           name: p.name,
           format_ids: p.formatIds.map(id => ({ id })),
           delivery_type: 'non_guaranteed',
-          pricing_options: [{ pricing_option_id: `${p.id}-cpm`, model: 'cpm', floor: { amount: p.floor, currency: 'USD' } }],
-          ctx_metadata: { gam: { ad_unit_ids: p.adUnitIds } },  // stashed; framework round-trips
+          pricing_options: [
+            { pricing_option_id: `${p.id}-cpm`, model: 'cpm', floor: { amount: p.floor, currency: 'USD' } },
+          ],
+          ctx_metadata: { gam: { ad_unit_ids: p.adUnitIds } }, // stashed; framework round-trips
         })),
       };
     },
@@ -124,8 +143,8 @@ class MyPlatform implements DecisioningPlatform {
       // Stash your platform's IDs so subsequent updateMediaBuy can hydrate them too.
       return {
         media_buy_id: order.id,
-        status: 'pending_creatives',                           // creative state machine — see advanced/STATE-MACHINE.md
-        ctx_metadata: { gam_order_id: order.gamOrderId },     // SDK persists; subsequent updateMediaBuy gets req.ctx_metadata.gam_order_id
+        status: 'pending_creatives', // creative state machine — see advanced/STATE-MACHINE.md
+        ctx_metadata: { gam_order_id: order.gamOrderId }, // SDK persists; subsequent updateMediaBuy gets req.ctx_metadata.gam_order_id
         packages: order.lineItems.map(li => ({
           package_id: li.id,
           status: 'pending_creatives',
@@ -135,21 +154,28 @@ class MyPlatform implements DecisioningPlatform {
       };
     },
 
-    // 3. Update a buy. SDK auto-hydrates the resolved MediaBuy (and its packages,
-    //    each with ctx_metadata) at req.mediaBuy when present in the store from a
-    //    prior createMediaBuy / getMediaBuys call. Falls back gracefully if absent
-    //    (publisher uses their own DB).
+    // 3. Update a buy. SDK auto-hydrates the full MediaBuy object (wire fields +
+    //    ctx_metadata for both the buy and each package) at patch.mediaBuy, keyed
+    //    by media_buy_id, from a prior createMediaBuy / getMediaBuys call.
+    //    Falls back gracefully if absent (publisher uses their own DB).
+    //
+    //    CONTRACT — patch.mediaBuy is `undefined` when the SDK has no record of
+    //    that media_buy_id. That's NOT authoritative "doesn't exist" — the SDK
+    //    store is a cache. Decision tree when undefined:
+    //      - Have your own buy DB → look up there.
+    //      - Pure-SDK store (no own DB) → throw MediaBuyNotFoundError immediately.
+    //      - Either way: never let `undefined` flow downstream silently.
     //    (6.2 will pre-read state + decompose into atomic verbs; track adcp-client#1071.)
-    updateMediaBuy: async (mediaBuyId, patch, ctx) => {
-      const orderMeta = await ctx.ctxMetadata?.mediaBuy(mediaBuyId);
-      if (!orderMeta) throw new MediaBuyNotFoundError(mediaBuyId);
+    updateMediaBuy: async (mediaBuyId, patch, _ctx) => {
+      const mediaBuy = patch.mediaBuy; // SDK-hydrated full MediaBuy (incl. ctx_metadata)
+      if (!mediaBuy) throw new MediaBuyNotFoundError(mediaBuyId);
 
       for (const pkg of patch.packages ?? []) {
-        const pkgMeta = await ctx.ctxMetadata?.package(pkg.package_id);
+        const pkgMeta = mediaBuy.packages?.find(p => p.package_id === pkg.package_id);
         if (!pkgMeta) throw new PackageNotFoundError(pkg.package_id);
-        await this.platform.updateLineItem(pkgMeta.gam_line_item_id, pkg);
+        await this.platform.updateLineItem(pkgMeta.ctx_metadata?.gam_line_item_id, pkg);
       }
-      const order = await this.platform.getOrder(orderMeta.gam_order_id);
+      const order = await this.platform.getOrder(mediaBuy.ctx_metadata?.gam_order_id);
       return this.toMediaBuy(order);
     },
 
@@ -180,14 +206,14 @@ class MyPlatform implements DecisioningPlatform {
           media_buy_id: buy.id,
           status: this.statusMappers.mediaBuy(buy.nativeStatus),
           buyer_ref: buy.buyerRef,
-          total_budget: { amount: buy.budgetAmount, currency: buy.currency },  // REQUIRED on the wire shape
+          total_budget: { amount: buy.budgetAmount, currency: buy.currency }, // REQUIRED on the wire shape
           start_time: buy.startTime,
           end_time: buy.endTime,
           packages: buy.lineItems.map(li => ({
             package_id: li.id,
             status: this.statusMappers.mediaBuy(li.nativeStatus),
             buyer_ref: li.buyerRef,
-            ctx_metadata: { gam_line_item_id: li.gamLineItemId },               // round-trip publisher state
+            ctx_metadata: { gam_line_item_id: li.gamLineItemId }, // round-trip publisher state
           })),
           ctx_metadata: { gam_order_id: buy.gamOrderId },
         })),
@@ -208,25 +234,25 @@ That's the agent. Five functions. The framework wires the wire protocol around i
 
 ```ts
 import {
-  PackageNotFoundError,        // wrong package_id on update
-  MediaBuyNotFoundError,       // wrong media_buy_id
-  ProductNotFoundError,        // wrong product_id on create
-  ProductUnavailableError,     // product exists but sold out
-  CreativeNotFoundError,       // wrong creative_id
-  CreativeRejectedError,       // brand-safety failed, etc.
-  BudgetTooLowError,           // under floor (correctable — buyer raises)
-  BudgetExhaustedError,        // pacing burst hit cap
-  IdempotencyConflictError,    // same key, different payload
-  InvalidRequestError,         // generic field-level bad input
-  InvalidStateError,           // illegal transition (paused → archived violations)
-  BackwardsTimeRangeError,     // start_time >= end_time
-  AuthRequiredError,           // need auth, then retry
-  PermissionDeniedError,       // auth present, lacks scope
-  RateLimitedError,            // throttled (clamps retry_after to [1, 3600])
-  UnsupportedFeatureError,     // tool unimplemented
-  ComplianceUnsatisfiedError,  // brand-safety attestation missing
-  GovernanceDeniedError,       // spending authority revoked
-  PolicyViolationError,        // categorical content rejection
+  PackageNotFoundError, // wrong package_id on update
+  MediaBuyNotFoundError, // wrong media_buy_id
+  ProductNotFoundError, // wrong product_id on create
+  ProductUnavailableError, // product exists but sold out
+  CreativeNotFoundError, // wrong creative_id
+  CreativeRejectedError, // brand-safety failed, etc.
+  BudgetTooLowError, // under floor (correctable — buyer raises)
+  BudgetExhaustedError, // pacing burst hit cap
+  IdempotencyConflictError, // same key, different payload
+  InvalidRequestError, // generic field-level bad input
+  InvalidStateError, // illegal transition (paused → archived violations)
+  BackwardsTimeRangeError, // start_time >= end_time
+  AuthRequiredError, // need auth, then retry
+  PermissionDeniedError, // auth present, lacks scope
+  RateLimitedError, // throttled (clamps retry_after to [1, 3600])
+  UnsupportedFeatureError, // tool unimplemented
+  ComplianceUnsatisfiedError, // brand-safety attestation missing
+  GovernanceDeniedError, // spending authority revoked
+  PolicyViolationError, // categorical content rejection
 } from '@adcp/sdk/server';
 ```
 
@@ -258,20 +284,16 @@ const meta = await ctx.ctxMetadata?.product(productId);
 
 ```ts
 import { Pool } from 'pg';
-import {
-  createAdcpServerFromPlatform,
-  getAllAdcpMigrations,
-  serve,
-} from '@adcp/sdk/server';
+import { createAdcpServerFromPlatform, getAllAdcpMigrations, serve } from '@adcp/sdk/server';
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-await pool.query(getAllAdcpMigrations());                                 // one DDL call, all 3 tables
+await pool.query(getAllAdcpMigrations()); // one DDL call, all 3 tables
 
 const platform = new MyPlatform(myAdServer);
 const server = createAdcpServerFromPlatform(platform, {
   name: 'My Sales Agent',
   version: '1.0.0',
-  pool,                                                                    // wires idempotency + ctxMetadata + taskRegistry
+  pool, // wires idempotency + ctxMetadata + taskRegistry
 });
 
 serve(() => server, { port: process.env.PORT });

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -129,7 +129,7 @@ export type { ContentStandardsPlatform } from './specialisms/content-standards';
 
 export type { PropertyListsPlatform, CollectionListsPlatform } from './specialisms/lists';
 
-export type { SalesPlatform } from './specialisms/sales';
+export type { SalesPlatform, UpdateMediaBuyPatch, MediaBuyRecord } from './specialisms/sales';
 
 export type { AudiencePlatform, Audience, SyncAudiencesRow, AudienceStatus } from './specialisms/audiences';
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -67,6 +67,7 @@ import type { Account, ResolvedAuthInfo } from '../account';
 import { AccountNotFoundError, toWireAccount } from '../account';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
 import type { CreativeBuilderPlatform } from '../specialisms/creative';
+import type { UpdateMediaBuyPatch } from '../specialisms/sales';
 import type { CreativeAdServerPlatform } from '../specialisms/creative-ad-server';
 import type { Audience } from '../specialisms/audiences';
 import type { RequestContext } from '../context';
@@ -2014,8 +2015,8 @@ async function hydratePackagesWithProducts(
  * handler, look up one resource by its ID and attach the full wire shape
  * (including `ctx_metadata`) to the request under `targetField`.
  *
- * For `updateMediaBuy`: attaches the full MediaBuy object at `req.mediaBuy`
- * keyed by `req.media_buy_id`.
+ * For `updateMediaBuy`: attaches the full MediaBuy object at `patch.mediaBuy`
+ * keyed by `patch.media_buy_id`.
  *
  * Failures are logged + swallowed; the publisher still receives the
  * un-hydrated request and can fall back to its own DB.
@@ -2023,7 +2024,7 @@ async function hydratePackagesWithProducts(
 async function hydrateSingleResource(
   store: CtxMetadataStore | undefined,
   accountId: string | undefined,
-  kind: 'product' | 'media_buy' | 'package' | 'creative' | 'audience' | 'signal',
+  kind: 'product' | 'media_buy',
   id: string | undefined,
   targetField: string,
   req: unknown,
@@ -2361,7 +2362,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
         });
       }
       // Auto-hydrate: attach the full MediaBuy object (including ctx_metadata)
-      // at params.mediaBuy, keyed by media_buy_id. Publisher reads
+      // at patch.mediaBuy, keyed by media_buy_id. Publisher reads
       // `patch.mediaBuy.ctx_metadata?.gam_order_id` directly — no separate
       // lookup, no boilerplate.
       //
@@ -2385,7 +2386,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
           const push = extractPushConfig(params, logger, {
             allowPrivateWebhookUrls: pushOpts.allowPrivateWebhookUrls,
           });
-          const result = await sales.updateMediaBuy(media_buy_id, params, reqCtx);
+          const result = await sales.updateMediaBuy(media_buy_id, params as UpdateMediaBuyPatch, reqCtx);
           // F12 sync auto-emit. updateMediaBuy is sync-only on the
           // platform interface (no TaskHandoff arm — spec response
           // doesn't include Submitted), so we don't route through

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2010,6 +2010,44 @@ async function hydratePackagesWithProducts(
 }
 
 /**
+ * Single-resource hydration helper. Before invoking a publisher's mutating
+ * handler, look up one resource by its ID and attach the full wire shape
+ * (including `ctx_metadata`) to the request under `targetField`.
+ *
+ * For `updateMediaBuy`: attaches the full MediaBuy object at `req.mediaBuy`
+ * keyed by `req.media_buy_id`.
+ *
+ * Failures are logged + swallowed; the publisher still receives the
+ * un-hydrated request and can fall back to its own DB.
+ */
+async function hydrateSingleResource(
+  store: CtxMetadataStore | undefined,
+  accountId: string | undefined,
+  kind: 'product' | 'media_buy' | 'package' | 'creative' | 'audience' | 'signal',
+  id: string | undefined,
+  targetField: string,
+  req: unknown,
+  logger: AdcpLogger
+): Promise<void> {
+  if (!store || !accountId || !id) return;
+  let entries: ReadonlyMap<string, { value: unknown; resource?: unknown }>;
+  try {
+    entries = await store.bulkGetEntries(accountId, [{ kind, id }]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[adcp/decisioning] auto-hydrate single ${kind} ${id} failed: ${msg}`);
+    return;
+  }
+  const entry = entries.get(`${kind}:${id}`);
+  if (!entry?.resource || typeof entry.resource !== 'object') return;
+  const hydrated: Record<string, unknown> = { ...(entry.resource as Record<string, unknown>) };
+  if (entry.value !== null && entry.value !== undefined) {
+    hydrated['ctx_metadata'] = entry.value;
+  }
+  (req as Record<string, unknown>)[targetField] = hydrated;
+}
+
+/**
  * Extract the buyer's push-notification webhook config from a request body
  * and validate the URL + token against SSRF / replay primitives.
  *
@@ -2322,6 +2360,26 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
           recovery: 'correctable',
         });
       }
+      // Auto-hydrate: attach the full MediaBuy object (including ctx_metadata)
+      // at params.mediaBuy, keyed by media_buy_id. Publisher reads
+      // `patch.mediaBuy.ctx_metadata?.gam_order_id` directly — no separate
+      // lookup, no boilerplate.
+      //
+      // CONTRACT — `patch.mediaBuy` is `undefined` when the SDK has no record
+      // of that media_buy_id. That's NOT authoritative "doesn't exist" — the
+      // SDK store is a cache. Decision tree when undefined:
+      //   - Have your own buy DB → look up there.
+      //   - Pure-SDK store (no own DB) → throw MediaBuyNotFoundError immediately.
+      //   - Either way: never let `undefined` flow downstream silently.
+      await hydrateSingleResource(
+        ctxMetadataStore,
+        reqCtx.account?.id,
+        'media_buy',
+        media_buy_id,
+        'mediaBuy',
+        params,
+        logger
+      );
       return projectSync(
         async () => {
           const push = extractPushConfig(params, logger, {

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -100,6 +100,28 @@ type Ctx<TMeta> = RequestContext<Account<TMeta>>;
  */
 export type SyncCreativesRow = SyncCreativesSuccess['creatives'][number];
 
+/**
+ * A single media buy entry as returned by `getMediaBuys`.
+ * The framework persists this shape (including `ctx_metadata`) in the
+ * ctx_metadata store after every `getMediaBuys` call so it can be
+ * re-attached to `updateMediaBuy` requests without a round-trip.
+ */
+export type MediaBuyRecord = GetMediaBuysResponse['media_buys'][number];
+
+/**
+ * The `patch` argument received by `SalesPlatform.updateMediaBuy`.
+ * Extends `UpdateMediaBuyRequest` with an optional SDK-hydrated `mediaBuy`
+ * field populated from a prior `getMediaBuys` / `createMediaBuy` response.
+ *
+ * `mediaBuy` is `undefined` when the SDK has no cached record for the given
+ * `media_buy_id` — this is a **cache miss**, not an authoritative "doesn't
+ * exist". Decision tree:
+ *   - Have your own buy DB → query it when `mediaBuy` is `undefined`.
+ *   - Pure-SDK store (no own DB) → throw `MediaBuyNotFoundError(buyId)`.
+ *   - Either way: never let `undefined` flow downstream silently.
+ */
+export type UpdateMediaBuyPatch = UpdateMediaBuyRequest & { mediaBuy?: MediaBuyRecord };
+
 export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // ── get_products: sync only — by design, not just by spec ─────────
   // get_products is a CATALOG LOOKUP — fast read against the seller's
@@ -188,8 +210,8 @@ export interface SalesPlatform<TMeta = Record<string, unknown>> {
   // re-approval flows surface eventual transitions via
   // `publishStatusChange` on `resource_type: 'media_buy'` rather than
   // HITL on this tool.
-  /** Sync update. Returns the patched buy. */
-  updateMediaBuy(buyId: string, patch: UpdateMediaBuyRequest, ctx: Ctx<TMeta>): Promise<UpdateMediaBuySuccess>;
+  /** Sync update. Returns the patched buy. `patch.mediaBuy` is SDK-hydrated when the store has a record (see `UpdateMediaBuyPatch`). */
+  updateMediaBuy(buyId: string, patch: UpdateMediaBuyPatch, ctx: Ctx<TMeta>): Promise<UpdateMediaBuySuccess>;
 
   // ── sync_creatives: unified hybrid shape ────────────────────────────
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.25.0';
+export const LIBRARY_VERSION = '5.25.1';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.25.0',
+  library: '5.25.1',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T09:45:14.937Z',
+  generatedAt: '2026-04-30T13:49:41.488Z',
 } as const;
 
 /**

--- a/test/server-auto-hydration.test.js
+++ b/test/server-auto-hydration.test.js
@@ -195,6 +195,151 @@ describe('createAdcpServerFromPlatform — auto-hydration of products', () => {
     );
   });
 
+  it('updateMediaBuy receives patch.mediaBuy hydrated from prior getMediaBuys', async () => {
+    let observedPatch;
+
+    const platform = makePlatform({
+      getProductsImpl: async () => ({ products: [] }),
+      createMediaBuyImpl: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+      getMediaBuysImpl: async () => ({
+        media_buys: [
+          {
+            media_buy_id: 'mb_hydrate',
+            status: 'active',
+            packages: [{ package_id: 'pkg_1', status: 'active', ctx_metadata: { gam_line_item_id: 'li_7' } }],
+            ctx_metadata: { gam_order_id: 'gam_42' },
+          },
+        ],
+      }),
+    });
+    platform.sales.updateMediaBuy = async (mediaBuyId, patch, _ctx) => {
+      observedPatch = patch;
+      return { media_buy_id: mediaBuyId, status: 'active', packages: [] };
+    };
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    // Step 1: getMediaBuys — SDK auto-stores MediaBuy wire shape + ctx_metadata
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_media_buys', arguments: {} },
+    });
+
+    // Step 2: updateMediaBuy referencing mb_hydrate — SDK auto-hydrates patch.mediaBuy
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: {
+          media_buy_id: 'mb_hydrate',
+          idempotency_key: 'idem_update_hydrate_001',
+        },
+      },
+    });
+
+    assert.ok(observedPatch, 'updateMediaBuy should have been invoked');
+    assert.equal(observedPatch.media_buy_id, 'mb_hydrate', 'wire media_buy_id preserved');
+    assert.ok(observedPatch.mediaBuy, 'patch.mediaBuy should be hydrated by SDK');
+    assert.equal(observedPatch.mediaBuy.media_buy_id, 'mb_hydrate', 'hydrated mediaBuy carries media_buy_id');
+    assert.equal(observedPatch.mediaBuy.status, 'active', 'hydrated mediaBuy carries wire status');
+    assert.deepEqual(
+      observedPatch.mediaBuy.ctx_metadata,
+      { gam_order_id: 'gam_42' },
+      'hydrated mediaBuy carries ctx_metadata blob'
+    );
+    assert.ok(Array.isArray(observedPatch.mediaBuy.packages), 'hydrated mediaBuy carries packages array');
+    assert.equal(
+      observedPatch.mediaBuy.packages[0].ctx_metadata?.gam_line_item_id,
+      'li_7',
+      'package ctx_metadata round-trips'
+    );
+  });
+
+  it('updateMediaBuy does not hydrate when ctxMetadata store is not wired', async () => {
+    let observedPatch;
+    const platform = makePlatform({
+      getProductsImpl: async () => ({ products: [] }),
+      createMediaBuyImpl: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+      getMediaBuysImpl: async () => ({
+        media_buys: [{ media_buy_id: 'mb_hydrate', status: 'active', ctx_metadata: { x: 1 } }],
+      }),
+    });
+    platform.sales.updateMediaBuy = async (mediaBuyId, patch, _ctx) => {
+      observedPatch = patch;
+      return { media_buy_id: mediaBuyId, status: 'active', packages: [] };
+    };
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_media_buys', arguments: {} },
+    });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: { media_buy_id: 'mb_hydrate', idempotency_key: 'idem_update_no_store_001' },
+      },
+    });
+
+    assert.ok(observedPatch);
+    assert.equal(observedPatch.media_buy_id, 'mb_hydrate');
+    assert.equal(observedPatch.mediaBuy, undefined, 'no hydration when no store');
+  });
+
+  it('updateMediaBuy falls back gracefully when media_buy was never seen', async () => {
+    let observedPatch;
+    const platform = makePlatform({
+      getProductsImpl: async () => ({ products: [] }),
+      createMediaBuyImpl: async () => ({ media_buy_id: 'mb_1', status: 'active', packages: [] }),
+    });
+    platform.sales.updateMediaBuy = async (mediaBuyId, patch, _ctx) => {
+      observedPatch = patch;
+      return { media_buy_id: mediaBuyId, status: 'active', packages: [] };
+    };
+
+    const ctxMetadata = createCtxMetadataStore({
+      backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'update_media_buy',
+        arguments: { media_buy_id: 'mb_unknown', idempotency_key: 'idem_update_unseen_001' },
+      },
+    });
+
+    assert.ok(observedPatch);
+    assert.equal(observedPatch.media_buy_id, 'mb_unknown');
+    assert.equal(
+      observedPatch.mediaBuy,
+      undefined,
+      'no hydration for unseen media_buy — publisher falls back to its own DB'
+    );
+  });
+
   it('auto-stores media buys returned from getMediaBuys', async () => {
     let storeWasCalledWith;
     const platform = makePlatform({


### PR DESCRIPTION
Refs #1086

Extends the auto-hydration mechanism (introduced for `createMediaBuy` in 6.1) to `update_media_buy`. The SDK now attaches the full `MediaBuy` wire object — including `ctx_metadata` — at `patch.mediaBuy` before the publisher's `updateMediaBuy` handler runs, keyed by `media_buy_id`. The `getMediaBuys` store-write already existed; this PR adds the read/hydrate side only.

Scoped to `update_media_buy`. Three of the four verbs from issue #1086 are deferred — see the status comment on the parent issue.

## What was tested

- `npm run format:check` — passed
- `npm run build:lib` — passed (pre-existing TS deprecation warnings unrelated to this change)
- `node --test test/server-auto-hydration.test.js` — 7/7 pass (3 new: hydrated path, no-store path, unseen-id path)
- Full suite baseline: same pre-existing failures on `main` and on this branch

## Pre-PR review

Two review passes; blockers fixed between them.

**Pass 1:**
- code-reviewer: one blocker — `patch.mediaBuy` untyped (no field on `UpdateMediaBuyRequest`); cast silently no-ops for adopters using `strict: true`
- dx-expert: same blocker; agent buildability score 2/5 without a typed field; CONTRACT comment good; nit on `req.mediaBuy` vs `patch.mediaBuy` in JSDoc

**Fix applied:** added `MediaBuyRecord` + `UpdateMediaBuyPatch` to `sales.ts`, updated `SalesPlatform.updateMediaBuy` signature, re-exported from `index.ts`, cast `params as UpdateMediaBuyPatch` at call site, narrowed `kind` union to `'product' | 'media_buy'`.

**Pass 2:**
- code-reviewer: approved — blocker resolved; cast is safe (widening, not narrowing); `MediaBuyRecord` type is readable; nit (add comment above cast explaining the mutation that validates it)
- dx-expert: approved — `MediaBuyRecord` hover expands correctly in IDEs; `UpdateMediaBuyPatch` name adequate; SKILL.md decision-tree comment correct

**Open nits (not blocking):**
- Cast at `from-platform.ts:2389` could have a one-line comment referencing `hydrateSingleResource` for self-documentation
- `UpdateMediaBuyPatch` JSDoc mentions `MediaBuyNotFoundError(buyId)` as the throw; consistent with rest of file

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Bev75kcL3kzVBzp4eP2QwK

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bev75kcL3kzVBzp4eP2QwK)_