### PR TITLE
feat(server): @adcp/sdk/server/legacy/v5 subpath for createAdcpServer (#1081)

### DIFF
--- a/.changeset/legacy-v5-subpath.md
+++ b/.changeset/legacy-v5-subpath.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): `@adcp/sdk/server/legacy/v5` subpath for the v5 handler-bag constructor. Adopters mid-migration or pinning to v5 long-term (custom `tools[]`, `mergeSeam`, `preTransport` middleware) import `createAdcpServer` from the subpath; new code keeps reaching for `createAdcpServerFromPlatform` from `@adcp/sdk/server`. Top-level re-export keeps working with its existing `@deprecated` JSDoc tag.
+
+Closes #1081.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
       "require": "./dist/lib/server/index.js",
       "types": "./dist/lib/server/index.d.ts"
     },
+    "./server/legacy/v5": {
+      "import": "./dist/lib/server/legacy/v5/index.js",
+      "require": "./dist/lib/server/legacy/v5/index.js",
+      "types": "./dist/lib/server/legacy/v5/index.d.ts"
+    },
     "./signing": {
       "import": "./dist/lib/signing/index.js",
       "require": "./dist/lib/signing/index.js",

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -327,6 +327,12 @@ export type {
 // function shape that matches your agent. The platform path internally
 // builds an `AdcpServerConfig` and calls `createAdcpServer` — they're
 // not adjacent surfaces, they're parent-child layers of the same SDK.
+//
+// **Pin to v5 long-term?** Import from `@adcp/sdk/server/legacy/v5`
+// instead. The subpath is the stable home for the v5 handler-bag
+// constructor; the top-level re-export here may be removed in a
+// future major. New code should not pin against `legacy/v5` either —
+// reach for `createAdcpServerFromPlatform` first.
 export * from './decisioning';
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/legacy/v5/index.ts
+++ b/src/lib/server/legacy/v5/index.ts
@@ -1,0 +1,73 @@
+/**
+ * `@adcp/sdk/server/legacy/v5` — stable home for the v5 handler-bag
+ * server constructor.
+ *
+ * **New code should not import from this subpath.** The canonical v6
+ * entry point is `createAdcpServerFromPlatform` from `@adcp/sdk/server`,
+ * which wraps this constructor with the typed specialism interfaces,
+ * compile-time capability enforcement, ctx_metadata auto-hydration,
+ * idempotency-principal synthesis, status mappers, multi-tenant routing,
+ * and webhook auto-emit. See `docs/migration-5.x-to-6.x.md`.
+ *
+ * Reasons to import from `legacy/v5` rather than `@adcp/sdk/server`:
+ *
+ *   1. **Mid-migration codebases.** v5 adopters who haven't finished
+ *      migrating to v6 keep working by switching the import path —
+ *      same constructor, same config shape, no behavior change.
+ *
+ *   2. **Escape-hatch handlers** that v6 doesn't model directly: custom
+ *      `tools[]` outside the AdCP wire surface, the `mergeSeam` hook,
+ *      `preTransport` / `signedRequests` middleware. These stay on v5
+ *      until the v6 platform interface picks them up explicitly.
+ *
+ *   3. **Pinning against future v6 evolution.** The top-level export
+ *      is `@deprecated` and may be removed in a major; `legacy/v5`
+ *      is the stable subpath for adopters who genuinely need the v5
+ *      shape long-term.
+ *
+ * The top-level `@adcp/sdk/server` keeps a tag-deprecated re-export of
+ * `createAdcpServer` for one cycle so existing imports don't break on
+ * upgrade. New imports SHOULD reach for the subpath.
+ *
+ * @public
+ */
+
+export {
+  createAdcpServer,
+  requireSessionKey,
+  ADCP_PRE_TRANSPORT,
+  ADCP_SIGNED_REQUESTS_STATE,
+} from '../../create-adcp-server';
+
+export type {
+  AdcpServerConfig,
+  WebhooksConfig,
+  AdcpToolMap,
+  AdcpServerToolName,
+  AdcpCapabilitiesConfig,
+  AdcpCapabilitiesOverrides,
+  AdcpCustomToolConfig,
+  AdcpLogger,
+  SignedRequestsConfig,
+  AdcpPreTransport,
+  AdcpSignedRequestsState,
+  HandlerContext,
+  SessionKeyContext,
+  MediaBuyHandlers,
+  SignalsHandlers,
+  CreativeHandlers,
+  GovernanceHandlers,
+  AccountHandlers,
+  EventTrackingHandlers,
+  SponsoredIntelligenceHandlers,
+  ResolveAccountContext,
+} from '../../create-adcp-server';
+
+export type {
+  AdcpServer,
+  AdcpServerComplianceApi,
+  AdcpServerTransport,
+  AdcpTestRequest,
+  AdcpTestToolsCallRequest,
+  AdcpTestResponse,
+} from '../../adcp-server';

--- a/test/server-legacy-v5-subpath.test.js
+++ b/test/server-legacy-v5-subpath.test.js
@@ -1,0 +1,34 @@
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('@adcp/sdk/server/legacy/v5 subpath', () => {
+  it('exports createAdcpServer (the v5 handler-bag constructor)', () => {
+    const legacy = require('../dist/lib/server/legacy/v5');
+    assert.equal(typeof legacy.createAdcpServer, 'function');
+  });
+
+  it('exports the same createAdcpServer reference as @adcp/sdk/server (no fork)', () => {
+    const fromTopLevel = require('../dist/lib/server').createAdcpServer;
+    const fromSubpath = require('../dist/lib/server/legacy/v5').createAdcpServer;
+    assert.equal(fromTopLevel, fromSubpath, 'subpath re-exports the same function — not a fork');
+  });
+
+  it('exports the v5-adjacent helpers adopters typically reach for alongside createAdcpServer', () => {
+    const legacy = require('../dist/lib/server/legacy/v5');
+    assert.equal(typeof legacy.requireSessionKey, 'function');
+    assert.equal(typeof legacy.ADCP_PRE_TRANSPORT, 'symbol');
+    assert.equal(typeof legacy.ADCP_SIGNED_REQUESTS_STATE, 'symbol');
+  });
+
+  it('subpath resolves through the package "exports" map (not deep-relative)', () => {
+    // Loading via the package name + subpath — what an external consumer
+    // writing `import { createAdcpServer } from '@adcp/sdk/server/legacy/v5'`
+    // would hit. Inside this monorepo we resolve via the relative dist
+    // path; the consumer-facing path resolution is exercised by package
+    // resolution against the published dist + exports map. This test
+    // validates the dist artifact exists and is importable.
+    assert.doesNotThrow(() => require('../dist/lib/server/legacy/v5/index.js'));
+  });
+});


### PR DESCRIPTION
## Summary

Adds \`@adcp/sdk/server/legacy/v5\` as the canonical home for the v5 handler-bag constructor. Same function reference exported from both \`@adcp/sdk/server\` (with its existing \`@deprecated\` JSDoc tag) and the new subpath — no fork, no behavior change.

Why a subpath rather than tag-only deprecation: LLMs reading skills + corpus don't see JSDoc deprecation tags. A subpath is structural — it shows up in import autocomplete and gives the deprecated path a separate home that's safe to pin against long-term. Keeping the top-level re-export for one cycle so existing imports don't break on upgrade.

Pairs with #1088 (corpus migration) — once skills migrate to v6, the v5 import path is the legacy subpath, not the top level.

Closes #1081.

## When adopters reach for legacy/v5

1. Mid-migration codebases that haven't finished the v5→v6 path.
2. Escape-hatch handlers that v6 doesn't model (\`mergeSeam\`, custom \`tools[]\`, \`preTransport\` middleware).
3. Long-term pinning if the top-level deprecated re-export gets removed in a future major.

New code still imports \`createAdcpServerFromPlatform\` from \`@adcp/sdk/server\`.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` passes — subpath emits to \`dist/lib/server/legacy/v5/\`
- [x] \`npm test\` — 4 new subpath tests pass:
  - subpath exports \`createAdcpServer\`
  - same reference as the top-level export (no fork)
  - exports the v5-adjacent helpers (\`requireSessionKey\`, the pre-transport / signed-requests symbols)
  - dist artifact is importable
- [x] \`package.json\` \`exports\` map adds \`./server/legacy/v5\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)