### PR TITLE
fix: round-1 expert feedback — hydration safety, tenant security, skill banners

### DIFF
--- a/.changeset/expert-feedback-round1.md
+++ b/.changeset/expert-feedback-round1.md
@@ -1,0 +1,24 @@
+---
+'@adcp/sdk': minor
+---
+
+Round-1 expert feedback on 6.0 close-out: hydration safety + tenant security + skill phase-2 partial.
+
+## Hydration safety (security + protocol experts)
+
+- `hydrateSingleResource` and `hydratePackagesWithProducts` now attach the hydrated field as **non-enumerable** so accidental serialization (`JSON.stringify(req)`, spread `{...req}`, `Object.entries(req)`) does NOT carry the publisher's `ctx_metadata` blob into request-side audit / log sinks. Direct property access (`req.media_buy.ctx_metadata`) still works.
+- Hydrated objects carry a non-enumerable `__adcp_hydrated__: true` marker so middleware and handler authors can disambiguate "publisher passed it" from "framework attached it".
+- New leak-prevention test asserts `JSON.stringify` and `Object.keys` do not surface hydrated fields.
+
+## TenantRegistry security (security expert mediums)
+
+- **Per-alias JWKS validation**: `runValidation` now hits every URL in `agentUrls[]` independently. Aliases share the signing key but had no separate brand.json check before — DNS hijack on an alias could serve responses no buyer can verify. First permanent failure short-circuits and disables the tenant.
+- **Register-time collision check**: `register()` rejects when a tenant's `(host, pathPrefix)` route overlaps with an already-registered tenant. Without this two tenants could silently claim the same alias; the first-inserted would win, dependent on Map iteration order.
+- **`TenantStatus.agentUrls`**: status now exposes the full URL list (not just canonical) so ops dashboards can detect aliases and distinguish multi-URL tenants from single-URL ones.
+
+## Seller skill phase-2 partial (DX + product + prompt-engineer)
+
+- Five v5 code blocks in `skills/build-seller-agent/SKILL.md` now carry `> **LEGACY (v5)**` blockquote prefixes flagging the inconsistency between the v6 canonical opening example and the deeper v5 examples that #1088 phase 2 will migrate. The Implementation worked example (line 866 — the highest-LLM-target deep block per prompt-engineer review) gets a stronger callout pointing scaffolders at the v6 skeleton.
+- `createAdcpServer`'s top-level JSDoc adds `@see` breadcrumbs pointing at `createAdcpServerFromPlatform` and the `@adcp/sdk/server/legacy/v5` subpath.
+
+Closes round-1 expert feedback. Refs #1086 #1087 #1088.

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -226,6 +226,8 @@ serve(createAgent, {
 
 **Principal threading.** `resolveSessionKey(ctx)` receives only `{toolName, params, account}` — no auth info. To compose the OAuth subject into the idempotency key you need `resolveIdempotencyPrincipal`, which receives the full `HandlerContext` including `ctx.authInfo` (populated by `verifyBearer` through MCP's `extra.authInfo`):
 
+> **LEGACY (v5)** — example shown with `createAdcpServer`. Both `resolveSessionKey` and `resolveIdempotencyPrincipal` are top-level options on `createAdcpServerFromPlatform(platform, opts)` too; pass them in the same shape. Phase 2 of #1088 will migrate this block. New code passes these to `createAdcpServerFromPlatform`.
+
 ```typescript
 createAdcpServer({
   // ...
@@ -291,6 +293,8 @@ This means: the `task_id` you return on a `sales-guaranteed` `create_media_buy` 
 ## Webhooks (async completion, signed outbound)
 
 Most seller flows need outbound webhooks — `sales-guaranteed` fires on IO completion, `sales-broadcast-tv` fires `window_update` deliveries as C3/C7 data matures, `update_media_buy` fires on bid/budget application. **Don't hand-roll `fetch` with HMAC**. Pass `webhooks: { signerKey }` to `createAdcpServerFromPlatform` and call `ctx.emitWebhook(...)` from any handler — the framework handles RFC 9421 signing, nonce minting, stable `idempotency_key` across retries, 5xx/429 backoff, byte-identical JSON serialization, and the "don't retry on signature failures" terminal behavior.
+
+> **LEGACY (v5)** — example below uses `createAdcpServer`. The `webhooks` option has the same shape on `createAdcpServerFromPlatform(platform, { webhooks: { signerKey, ... } })`; only the constructor name and the platform-vs-handlers shape change. Phase 2 of #1088 will migrate this block. For new code, wrap your handlers in a `DecisioningPlatform` class and pass `webhooks` to `createAdcpServerFromPlatform`.
 
 ```typescript
 import { createAdcpServer, serve } from '@adcp/sdk';
@@ -709,6 +713,8 @@ productRepo.upsert(merged.product_id, merged);
 
 **2. `bridgeFromTestControllerStore`** — wires your seeded `Map` into `get_products` responses automatically. Sandbox requests see seeded + handler products merged (with seeded winning collisions); production traffic (no sandbox marker, or resolved non-sandbox account) skips the bridge entirely.
 
+> **LEGACY (v5)** — example below uses `createAdcpServer`. `testController` is also a top-level option on `createAdcpServerFromPlatform`. Phase 2 of #1088 will migrate this block.
+
 ```ts
 import { createAdcpServer } from '@adcp/sdk';
 import { bridgeFromTestControllerStore } from '@adcp/sdk/server';
@@ -850,6 +856,8 @@ Minimal `tsconfig.json`:
 Use `createAdcpServerFromPlatform` — it auto-wires schemas, response builders, and `get_adcp_capabilities` from the typed `DecisioningPlatform` you provide. Handlers receive `(params, ctx)` where `ctx.store` persists state, `ctx.account` is the resolved account, and `ctx.ctxMetadata` is the resource-keyed cache (when wired).
 
 **Imports**: most things live at `@adcp/sdk`. The idempotency store helpers (`createIdempotencyStore`, `memoryBackend`, `pgBackend`) live at the narrower `@adcp/sdk/server` subpath. Both are re-exported from the root — either works — but splitting them makes intent obvious.
+
+> **LEGACY (v5)** — the worked example below is the v5 handler-bag shape (`createAdcpServer({ accounts, mediaBuy, ... })`). It still compiles via `@adcp/sdk/server/legacy/v5`. **Phase 2 of #1088 will replace this with the v6 `class MySeller implements DecisioningPlatform` shape — refer to the canonical opening example at the top of this skill (lines 44–83) when scaffolding a new agent.** Until phase 2 ships, treat the structure below as illustrative of the handler bodies (governance check, idempotency, `randomUUID`-minted ids, `ctx.store` use) but lift those into a v6 `class MySeller` skeleton rather than copying the constructor call verbatim.
 
 ```typescript
 import { randomUUID } from 'node:crypto';
@@ -1043,6 +1051,8 @@ The buyer signals this by setting `plan.human_review_required: true` on the gove
 4. If `false` — proceed with the normal `checkGovernance()` flow and commit.
 
 ### Worked example
+
+> **LEGACY (v5)** — example uses `createAdcpServer`. The HITL flow (`status: 'submitted'`, `task_id` polling, `buildHumanOverride`) works identically when the agent is built with `createAdcpServerFromPlatform` — only the constructor and the platform-vs-handlers shape differ. Phase 2 of #1088 will migrate this block.
 
 ```typescript
 import {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2249,6 +2249,11 @@ function buildSupportedVersionsList(capConfig: AdcpCapabilitiesConfig | undefine
  * Reach for `createAdcpServer` directly only when you need fine control
  * over individual handlers, are mid-migration from a v5 codebase, or
  * have custom-shaped tools the platform interface doesn't yet model.
+ *
+ * @see {@link createAdcpServerFromPlatform} — the canonical v6 entry.
+ * @see `@adcp/sdk/server/legacy/v5` — the stable subpath for long-term
+ *   v5 pinning. The top-level re-export here may be removed in a
+ *   future major; the subpath is the supported home.
  * See `docs/migration-5.x-to-6.x.md`.
  *
  * Before each handler runs, the framework:

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2016,7 +2016,20 @@ async function hydratePackagesWithProducts(
     if (entry.value !== null && entry.value !== undefined) {
       hydrated['ctx_metadata'] = entry.value;
     }
-    (pkg as Record<string, unknown>)['product'] = hydrated;
+    Object.defineProperty(hydrated, '__adcp_hydrated__', {
+      value: true,
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
+    // Non-enumerable: see hydrateSingleResource for rationale (no leak via
+    // JSON.stringify / spread / Object.entries; direct access works).
+    Object.defineProperty(pkg, 'product', {
+      value: hydrated,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    });
   }
 }
 
@@ -2029,6 +2042,18 @@ async function hydratePackagesWithProducts(
  * Walks the store for `(kind, id)`, attaches `target[attachField] =
  * { ...resource, ctx_metadata }` when the entry has a wire resource. Misses
  * are silent — publisher falls back to its own DB.
+ *
+ * The attached field is **non-enumerable** so accidental serialization
+ * (JSON.stringify on the request body, spread copy, Object.entries log line)
+ * doesn't leak the publisher's `ctx_metadata` blob into request-side audit
+ * sinks. Direct property access (`req.media_buy.ctx_metadata`) still works;
+ * the hydrated field is invisible only to enumeration-based serializers.
+ *
+ * Hydrated fields carry a `__adcp_hydrated__: true` non-enumerable marker
+ * so handler authors and middleware can disambiguate "publisher passed it"
+ * from "framework attached it" — the field is **advisory context only**;
+ * the wire contract is defined by the spec request fields, not by what the
+ * SDK happens to attach.
  *
  * Failures are logged + swallowed. Hydration must NEVER break a successful
  * dispatch.
@@ -2056,7 +2081,22 @@ async function hydrateSingleResource(
   if (entry.value !== null && entry.value !== undefined) {
     hydrated['ctx_metadata'] = entry.value;
   }
-  (target as Record<string, unknown>)[attachField] = hydrated;
+  Object.defineProperty(hydrated, '__adcp_hydrated__', {
+    value: true,
+    enumerable: false,
+    writable: false,
+    configurable: false,
+  });
+  // Attach as non-enumerable so JSON.stringify(req), spread {...req}, and
+  // Object.entries(req) do NOT carry the publisher's ctx_metadata blob into
+  // log lines, audit sinks, or replay payloads. Direct access (req.foo)
+  // still works.
+  Object.defineProperty(target, attachField, {
+    value: hydrated,
+    enumerable: false,
+    writable: true,
+    configurable: true,
+  });
 }
 
 /**

--- a/src/lib/server/decisioning/tenant-registry.ts
+++ b/src/lib/server/decisioning/tenant-registry.ts
@@ -127,7 +127,21 @@ export type TenantHealth = 'pending' | 'healthy' | 'unverified' | 'disabled';
 
 export interface TenantStatus {
   tenantId: string;
+  /**
+   * Canonical URL — the first entry in the tenant's `agentUrls` (or the
+   * single `agentUrl` value). JWKS validates against this URL; ops
+   * dashboards page on this field for the primary identity.
+   */
   agentUrl: string;
+  /**
+   * Full URL list when the tenant was registered with `agentUrls[]`.
+   * Single-URL tenants get a one-element array. Ops dashboards iterate
+   * this field to show every URL serving the tenant; required so admins
+   * can detect stale aliases or accidental host overlap with another
+   * tenant (#1097 follow-up — collision check below errors at register
+   * time, but the operator still wants visibility into what's live).
+   */
+  agentUrls: readonly string[];
   health: TenantHealth;
   /** Reason for unverified/disabled state. */
   reason?: string;
@@ -516,52 +530,75 @@ export function createTenantRegistry(opts: TenantRegistryOptions): TenantRegistr
     if (!entry) {
       throw new Error(`runValidation: tenant '${tenantId}' not registered`);
     }
+    const [canonicalUrl, allUrls] = resolveTenantUrls(entry.config);
+    // Multi-URL tenants validate every URL independently. Aliases share the
+    // signing key; if an alias publishes a brand.json that doesn't include
+    // the key (DNS hijack, operator misconfig, stale mirror), traffic to
+    // that alias would receive responses no buyer can verify. Aggregate
+    // failures: tenant is healthy iff ALL URLs validate; first permanent
+    // failure → disabled; transient-only → pending/unverified per existing
+    // policy. The explicit `jwksUrl` override applies to all URLs (the
+    // documented contract for sub-routed deployments).
+    const perUrlResults: Array<{ url: string; res: JwksValidationResult }> = [];
+    for (const url of allUrls) {
+      let res: JwksValidationResult;
+      try {
+        res = await validator.validate({
+          agentUrl: url,
+          ...(entry.config.jwksUrl !== undefined && { jwksUrl: entry.config.jwksUrl }),
+          signingKey: entry.config.signingKey,
+        });
+      } catch (err) {
+        res = {
+          ok: false,
+          recovery: 'transient',
+          reason: `validator threw on '${url}': ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+      perUrlResults.push({ url, res });
+      // First permanent failure short-circuits — no point hitting the rest;
+      // the tenant is going to disabled regardless.
+      if (!res.ok && res.recovery === 'permanent') break;
+    }
+    // Aggregate: pick the worst outcome across the urls we validated.
     let result: JwksValidationResult;
-    const [canonicalUrl] = resolveTenantUrls(entry.config);
-    try {
-      result = await validator.validate({
-        agentUrl: canonicalUrl,
-        ...(entry.config.jwksUrl !== undefined && { jwksUrl: entry.config.jwksUrl }),
-        signingKey: entry.config.signingKey,
-      });
-    } catch (err) {
-      // Validator threw — treat as transient (network glitch, etc.).
-      // Without this catch the tenant would be stuck in `pending`
-      // forever — `runValidation` rejects, `entry.status` never
-      // transitions. Closes Emma's round-1 #16.
+    const firstPermanent = perUrlResults.find(r => !r.res.ok && r.res.recovery === 'permanent');
+    const firstTransient = perUrlResults.find(r => !r.res.ok && r.res.recovery === 'transient');
+    if (firstPermanent) {
+      result = {
+        ok: false,
+        recovery: 'permanent',
+        reason: `${firstPermanent.url}: ${firstPermanent.res.reason}`,
+      };
+    } else if (firstTransient) {
       result = {
         ok: false,
         recovery: 'transient',
-        reason: `validator threw: ${err instanceof Error ? err.message : String(err)}`,
+        reason: `${firstTransient.url}: ${firstTransient.res.reason}`,
       };
+    } else {
+      result = { ok: true };
     }
     const now = new Date().toISOString();
     const wasFirstValidation = entry.status.health === 'pending';
+    const baseStatus = { tenantId, agentUrl: canonicalUrl, agentUrls: allUrls, lastCheckedAt: now };
     let status: TenantStatus;
     if (result.ok) {
-      status = { tenantId, agentUrl: canonicalUrl, health: 'healthy', lastCheckedAt: now };
+      status = { ...baseStatus, health: 'healthy' };
     } else if (result.recovery === 'transient') {
       // Transient failure on FIRST validation → stay `pending` (refuse
       // traffic). Transient failure AFTER first success → `unverified`
       // (graceful degradation — the tenant's known good).
       status = {
-        tenantId,
-        agentUrl: canonicalUrl,
+        ...baseStatus,
         health: wasFirstValidation ? 'pending' : 'unverified',
         reason: result.reason,
-        lastCheckedAt: now,
       };
     } else {
       // Permanent failure → `disabled` regardless of prior state. The
       // signing-key material doesn't match what's published; refusing
       // traffic is the safe default.
-      status = {
-        tenantId,
-        agentUrl: canonicalUrl,
-        health: 'disabled',
-        reason: result.reason,
-        lastCheckedAt: now,
-      };
+      status = { ...baseStatus, health: 'disabled', reason: result.reason };
     }
     entry.status = status;
     return status;
@@ -577,10 +614,30 @@ export function createTenantRegistry(opts: TenantRegistryOptions): TenantRegistr
         throw new Error(`tenant '${tenantId}' already registered; unregister first`);
       }
       const [canonicalUrl, allUrls] = resolveTenantUrls(config as unknown as TenantConfig);
+      const routes = allUrls.map(url => parseHostAndPrefix(url));
+      // Reject overlapping (host, pathPrefix) routes against already-registered
+      // tenants. Without this, two tenants can claim the same alias host
+      // silently — `resolveByRequest` picks the first-inserted (deterministic
+      // per-process via Map insertion order, but cross-process flaky on
+      // restart-order changes). Surface the collision now rather than
+      // discover it in production. Round-1 expert review (security-medium).
+      for (const route of routes) {
+        for (const [otherId, otherEntry] of tenants) {
+          for (const otherRoute of otherEntry.routes) {
+            if (otherRoute.host === route.host && otherRoute.pathPrefix === route.pathPrefix) {
+              throw new Error(
+                `tenant '${tenantId}' route ${route.host}${route.pathPrefix} collides with tenant '${otherId}'; ` +
+                  `register them under distinct hosts or path prefixes`
+              );
+            }
+          }
+        }
+      }
       const server = buildServer(config as unknown as TenantConfig);
       const initialStatus: TenantStatus = {
         tenantId,
         agentUrl: canonicalUrl,
+        agentUrls: allUrls,
         // `pending` (NOT `unverified`) — first validation hasn't run.
         // resolveByHost refuses traffic until validation succeeds at
         // least once. Closes the register-then-serve race window.
@@ -588,7 +645,6 @@ export function createTenantRegistry(opts: TenantRegistryOptions): TenantRegistr
         reason: 'awaiting initial JWKS validation',
         lastCheckedAt: new Date().toISOString(),
       };
-      const routes = allUrls.map(url => parseHostAndPrefix(url));
       const entry: TenantEntry = {
         config: config as unknown as TenantConfig,
         server,

--- a/test/server-auto-hydration-extended.test.js
+++ b/test/server-auto-hydration-extended.test.js
@@ -81,6 +81,31 @@ describe('auto-hydration — update_media_buy', () => {
     assert.equal(observedReq.media_buy.media_buy_id, 'mb_42');
     assert.equal(observedReq.media_buy.status, 'active');
     assert.deepEqual(observedReq.media_buy.ctx_metadata, { gam: { order_id: '12345' } }, 'ctx_metadata round-tripped');
+
+    // Leak prevention: hydrated field is non-enumerable so accidental
+    // serialization (JSON.stringify, spread, Object.entries) does NOT
+    // carry the publisher's ctx_metadata blob into request-side log
+    // sinks. Direct property access (used above) still works.
+    assert.equal(
+      Object.keys(observedReq).includes('media_buy'),
+      false,
+      'hydrated field is non-enumerable — invisible to Object.keys'
+    );
+    assert.equal(
+      JSON.stringify(observedReq).includes('"media_buy"'),
+      false,
+      'hydrated field does not appear in JSON.stringify output'
+    );
+    assert.equal(
+      JSON.stringify(observedReq).includes('order_id'),
+      false,
+      'publisher ctx_metadata does not leak via accidental serialization'
+    );
+    assert.equal(
+      observedReq.media_buy.__adcp_hydrated__,
+      true,
+      'hydrated objects carry __adcp_hydrated__ marker so middleware can disambiguate'
+    );
   });
 
   it('updateMediaBuy without prior getMediaBuys — req.media_buy is undefined (falls through)', async () => {

--- a/test/server-decisioning-tenant-registry.test.js
+++ b/test/server-decisioning-tenant-registry.test.js
@@ -1045,10 +1045,7 @@ describe('TenantRegistry — multi-URL (agentUrls) cutover support', () => {
     await registry.recheck('multi-status');
 
     const status = registry.getStatus('multi-status');
-    assert.deepStrictEqual(status.agentUrls, [
-      'https://primary.example.com',
-      'https://secondary.example.com',
-    ]);
+    assert.deepStrictEqual(status.agentUrls, ['https://primary.example.com', 'https://secondary.example.com']);
     assert.strictEqual(status.agentUrl, 'https://primary.example.com', 'canonical still surfaced');
   });
 

--- a/test/server-decisioning-tenant-registry.test.js
+++ b/test/server-decisioning-tenant-registry.test.js
@@ -949,7 +949,7 @@ describe('TenantRegistry — multi-URL (agentUrls) cutover support', () => {
     assert.strictEqual(fromNew.server, fromOld.server, 'same server instance for both URLs');
   });
 
-  it('JWKS validation uses agentUrls[0] (canonical) — alias hosts are not separately validated', async () => {
+  it('JWKS validation hits every URL in agentUrls — aliases are validated independently', async () => {
     const seenHosts = [];
     const validator = fakeValidator(async ({ agentUrl }) => {
       seenHosts.push(agentUrl);
@@ -968,7 +968,107 @@ describe('TenantRegistry — multi-URL (agentUrls) cutover support', () => {
     });
     await registry.recheck('cutover');
 
-    assert.deepStrictEqual(seenHosts, ['https://canonical.example.com'], 'only canonical URL drives JWKS');
+    assert.deepStrictEqual(
+      seenHosts,
+      ['https://canonical.example.com', 'https://alias-a.example.com', 'https://alias-b.example.com'],
+      'every alias is independently validated — round-1 expert security finding'
+    );
+  });
+
+  it('aliases with stale brand.json mark the whole tenant disabled', async () => {
+    const validator = fakeValidator(async ({ agentUrl }) => {
+      if (agentUrl === 'https://stale-alias.example.com') {
+        return { ok: false, recovery: 'permanent', reason: 'signingKey not in published JWKS' };
+      }
+      return { ok: true };
+    });
+    const registry = createTenantRegistry({
+      jwksValidator: validator,
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+
+    registry.register('partial', {
+      agentUrls: ['https://canonical.example.com', 'https://stale-alias.example.com'],
+      signingKey: SAMPLE_KEY,
+      platform: basePlatform(),
+    });
+    const status = await registry.recheck('partial');
+    assert.strictEqual(status.health, 'disabled', 'any permanent alias failure disables the tenant');
+    assert.match(status.reason, /stale-alias/);
+  });
+
+  it('rejects register-time route collision against an existing tenant', () => {
+    const registry = createTenantRegistry({
+      jwksValidator: fakeValidator(async () => ({ ok: true })),
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+
+    registry.register('first', {
+      agentUrls: ['https://shared.example.com/api'],
+      signingKey: SAMPLE_KEY,
+      platform: basePlatform(),
+    });
+
+    // Same host + same path prefix → collision.
+    assert.throws(
+      () =>
+        registry.register('second', {
+          agentUrls: ['https://shared.example.com/api'],
+          signingKey: SAMPLE_KEY,
+          platform: basePlatform(),
+        }),
+      /route .* collides with tenant 'first'/
+    );
+
+    // Different path prefix on same host → allowed.
+    registry.register('third', {
+      agentUrls: ['https://shared.example.com/other'],
+      signingKey: SAMPLE_KEY,
+      platform: basePlatform(),
+    });
+  });
+
+  it('TenantStatus.agentUrls surfaces the full URL list for multi-URL tenants', async () => {
+    const registry = createTenantRegistry({
+      jwksValidator: fakeValidator(async () => ({ ok: true })),
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+
+    registry.register('multi-status', {
+      agentUrls: ['https://primary.example.com', 'https://secondary.example.com'],
+      signingKey: SAMPLE_KEY,
+      platform: basePlatform(),
+    });
+    await registry.recheck('multi-status');
+
+    const status = registry.getStatus('multi-status');
+    assert.deepStrictEqual(status.agentUrls, [
+      'https://primary.example.com',
+      'https://secondary.example.com',
+    ]);
+    assert.strictEqual(status.agentUrl, 'https://primary.example.com', 'canonical still surfaced');
+  });
+
+  it('TenantStatus.agentUrls is a one-element array for single-URL tenants (compat)', async () => {
+    const registry = createTenantRegistry({
+      jwksValidator: fakeValidator(async () => ({ ok: true })),
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+
+    registry.register('single', {
+      agentUrl: 'https://only.example.com',
+      signingKey: SAMPLE_KEY,
+      platform: basePlatform(),
+    });
+    await registry.recheck('single');
+
+    const status = registry.getStatus('single');
+    assert.deepStrictEqual(status.agentUrls, ['https://only.example.com']);
+    assert.strictEqual(status.agentUrl, 'https://only.example.com');
   });
 
   it('TenantStatus.agentUrl reports the canonical URL for multi-URL tenants', async () => {


### PR DESCRIPTION
## Summary

Synthesized round-1 expert review (5 parallel agents: protocol, security, code-review, product, DX, prompt-eng) on the just-shipped 6.0 close-out. Lands the 3 ship-blocker fixes + the 3 security-medium follow-ups in one bundle so the Release PR #1085 can ship 6.0.0 GA cleanly.

## Hydration safety *(security + protocol)*

- `hydrateSingleResource` + `hydratePackagesWithProducts` attach the hydrated field as **non-enumerable** so accidental serialization doesn't leak the publisher's \`ctx_metadata\` blob into request-side audit / log sinks. Direct property access (\`req.media_buy.ctx_metadata\`) still works.
- Hydrated objects carry a non-enumerable \`__adcp_hydrated__: true\` marker so middleware can disambiguate framework-attached vs publisher-passed fields.
- New leak-prevention test asserts `JSON.stringify(req)` and `Object.keys(req)` do not surface hydrated fields.

## TenantRegistry security *(security mediums)*

- **Per-alias JWKS validation**: every URL in `agentUrls[]` is validated independently. Without this, an alias whose `brand.json` doesn't include the canonical signing key (DNS hijack, stale mirror, operator misconfig) would still serve signed responses no buyer can verify. First permanent failure short-circuits the loop and disables the tenant.
- **Register-time route collision check**: `register()` rejects when a tenant's `(host, pathPrefix)` overlaps with another. Without this two tenants could silently claim the same alias; first-inserted would win, dependent on Map iteration order.
- **`TenantStatus.agentUrls`**: surfaces the full URL list (not just canonical) so ops dashboards can detect aliases and distinguish multi-URL tenants.

## Seller skill phase-2 partial *(DX + product + prompt-engineer)*

- Five v5 code blocks in `skills/build-seller-agent/SKILL.md` now carry `> **LEGACY (v5)**` blockquote prefixes flagging the inconsistency between the v6 canonical opening example and deeper v5 examples.
- The Implementation worked example (line 866 — highest-LLM-target deep block per prompt-engineer review) gets a stronger callout pointing scaffolders at the v6 skeleton.
- `createAdcpServer`'s top-level JSDoc adds `@see` breadcrumbs to `createAdcpServerFromPlatform` and the `@adcp/sdk/server/legacy/v5` subpath.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` passes
- [x] 48 tenant-registry tests pass (4 new: per-alias validation, collision check, full agentUrls surface, single-URL compat)
- [x] 10 auto-hydration tests pass (1 new: leak-prevention via JSON.stringify + Object.keys + marker)
- [x] \`npx tsx scripts/typecheck-skill-examples.ts\` passes (no new errors)
- [x] Full test suite: 6928/6940 pass (5 cancelled, 7 skipped — same as pre-PR baseline)

## Expert verdict before fixes

| Expert | Verdict |
|---|---|
| Protocol | Ship as-is + doc adjustments |
| Code review | Ship as-is + low-priority cleanup |
| Security | **Ship with must-fixes** ← this PR |
| Product | Ship 6.0, plan 6.0.1 |
| DX | Subpath strong; skill + agentUrls need follow-up ← this PR |
| Prompt-eng | **Phase 2 urgent** ← partial here, full migration tracked on #1088 |

After merge, the Release PR #1085 ships 6.0.0 with all expert ship-blockers addressed. Phase-2 corpus migration (full v5→v6 rewrites across 8 skills + BUILD-AN-AGENT.md) stays tracked on #1088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)