### PR TITLE
docs: pre-ship asks — hydration error contract + 6.0 migration cheatsheet

### DIFF
--- a/.changeset/preship-asks-1-3.md
+++ b/.changeset/preship-asks-1-3.md
@@ -1,0 +1,31 @@
+---
+'@adcp/sdk': patch
+---
+
+Pre-ship round 2: auto-hydration error contract + 6.0 migration cheatsheet.
+
+## Auto-hydration error contract (ask #1)
+
+Pinned the documented contract for stale/missing references in `hydrateSingleResource` JSDoc and the migration guide:
+
+- Hydration miss does NOT cause `MEDIA_BUY_NOT_FOUND` / `PRODUCT_NOT_FOUND` etc. The framework cache is a hint, not a source-of-truth check.
+- On a miss the handler runs anyway with `target[attachField]` undefined.
+- Adopters who want strict existence checks implement them in the handler (with the typed error classes — `MediaBuyNotFoundError`, etc.).
+
+New contract test in `test/server-auto-hydration-extended.test.js` pins the behavior: handler IS called on miss, framework does NOT synthesize an error response.
+
+## 6.0 migration cheatsheet (ask #3)
+
+`docs/migration-5.x-to-6.x.md` gains a top-level "tl;dr — five breaking changes to search-replace" table covering:
+
+1. `Account.metadata` → `Account.ctx_metadata`
+2. `@adcp/sdk/server/decisioning` → `@adcp/sdk/server`
+3. `createAdcpServer` → `createAdcpServerFromPlatform` (or `@adcp/sdk/server/legacy/v5`)
+4. `TMeta` → `TCtxMeta` generic param
+5. `getMediaBuys` required on `SalesPlatform`
+
+Plus a one-shot search-replace recipe block for adopters who skipped rounds 11–14 and face the cumulative diff at GA.
+
+## Note on ask #2 (already shipped)
+
+`resolveIdempotencyPrincipal` already takes `IdempotencyPrincipalParams` — a typed shape with `account?: { account_id?, brand?, sandbox? }` and `brand?: { domain? }` extending `Record<string, unknown>`. Adopters scoping by `params.account?.account_id` or `params.brand?.domain` get autocomplete + narrowing without a cast. See `src/lib/server/create-adcp-server.ts:681-686` and the signature at line 1230.

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -12,6 +12,44 @@
 > migrators move one specialism at a time without rewriting the whole
 > agent.
 
+## tl;dr — five breaking changes to search-replace
+
+If you've been on the field for 2-3 weeks and skipping rounds, these
+are the cumulative breaking changes you face on `npm update @adcp/sdk`.
+Each is mechanical; the full list is what makes the major-version bump
+feel archaeological if you only see them all at once.
+
+| # | What | Search → Replace | Why |
+|---|---|---|---|
+| 1 | `Account.metadata` → `Account.ctx_metadata` | `\.metadata` (in your `accounts.resolve`/`upsert`/`list` returns and any `ctx.account.metadata` reads) → `.ctx_metadata` | Naming consistency with the resource-level `ctx_metadata` substrate. The wire field was renamed pre-GA (5a490534). |
+| 2 | `@adcp/sdk/server/decisioning` → `@adcp/sdk/server` | `from '@adcp/sdk/server/decisioning'` → `from '@adcp/sdk/server'` | Decisioning runtime promoted to the canonical server entry point. The old subpath is no longer published. |
+| 3 | `createAdcpServer` → `createAdcpServerFromPlatform` (or the legacy subpath) | `import { createAdcpServer } from '@adcp/sdk'` → `import { createAdcpServer } from '@adcp/sdk/server/legacy/v5'` for in-flight migrations; new code reaches for `createAdcpServerFromPlatform` from `@adcp/sdk/server` | The v5 handler-bag constructor moved to a stable subpath. The top-level re-export carries a `@deprecated` JSDoc tag for one cycle and may be removed in a future major. See § Step-by-step migration below for the full v5 → v6 rewrite. |
+| 4 | `TMeta` → `TCtxMeta` generic param | `<TConfig, TMeta>` → `<TConfig, TCtxMeta>` (purely internal — only matters if you reference the generic by name in your own type aliases) | Type-level rename to align with the `ctx_metadata` field name. No runtime impact; default inference still binds at the call site. |
+| 5 | `getMediaBuys` is now required on `SalesPlatform` | Add `getMediaBuys: async () => ({ media_buys: [] })` if your seller doesn't model persistent media buys (write-only push-channel adopters return an empty array) | Compile-time enforcement that every seller can be enumerated. Previously optional; missing it now fails the typecheck. |
+
+### One-shot search-replace for greenfield 5.x → 6.0
+
+```sh
+# Rename Account.metadata → Account.ctx_metadata in your handler bodies.
+# Verify each hit by hand — only Account references should change; do NOT
+# blindly rewrite every `.metadata` (e.g., `package.metadata` is unrelated).
+grep -rn '\.metadata' src/ | grep -i 'account\|Account'
+
+# Move imports to the new server entry.
+sed -i '' "s|from '@adcp/sdk/server/decisioning'|from '@adcp/sdk/server'|g" src/**/*.ts
+
+# In-flight v5 stayers: pin to the legacy subpath.
+sed -i '' "s|import { createAdcpServer } from '@adcp/sdk'|import { createAdcpServer } from '@adcp/sdk/server/legacy/v5'|g" src/**/*.ts
+
+# Add the getMediaBuys stub to any sales platforms that don't have it.
+# Manual — grep for SalesPlatform implementations and add the no-op.
+grep -rn 'sales:' src/ --include='*.ts' | grep -v 'getMediaBuys'
+```
+
+Adopters who already split per-call rounds (rounds 11–14 readers) have
+applied each of these in isolation; this section is for adopters who
+skipped to GA and need the cumulative view.
+
 ## Why migrate?
 
 v6.0 collapses the v5 handler-bag (per-domain `mediaBuy` / `creative` /
@@ -234,6 +272,38 @@ createAdcpServerFromPlatform(platform, {
 
 ## Common gotchas
 
+- **Auto-hydration is a hint, not a source-of-truth check.** When
+  `update_media_buy { media_buy_id: 'mb_unknown' }` arrives, the
+  framework looks up `mb_unknown` in the ctx_metadata cache and:
+  1. Hit → attaches `req.media_buy` with the wire shape + `ctx_metadata`.
+  2. Miss → leaves `req.media_buy` undefined and **runs the handler
+     anyway**.
+
+  The framework does NOT throw `MEDIA_BUY_NOT_FOUND` / `PRODUCT_NOT_FOUND`
+  / `SIGNAL_NOT_FOUND` / `RIGHTS_NOT_FOUND` on a miss — that would force
+  every adopter to pre-warm the cache before serving traffic, which is
+  the wrong default for a hint-based cache. Causes of a miss:
+
+  1. Buyer hasn't called the discovery verb in this session (cold start,
+     fresh tenant, post-restart). Hydration is purely additive context.
+  2. Cache evicted (TTL, LRU). Same.
+  3. Buyer truly referenced an unknown id. The publisher's DB is the
+     source of truth and SHOULD reject in the handler.
+
+  Adopters who want strict existence checks implement them in the
+  handler:
+
+  ```ts
+  updateMediaBuy: async (id, patch, ctx) => {
+    if (!patch.media_buy && !(await db.findMediaBuy(id))) {
+      throw new MediaBuyNotFoundError({ message: `media_buy ${id} not found` });
+    }
+    // ...
+  }
+  ```
+
+  Same pattern for `req.signal` (activate_signal), `req.rights`
+  (acquire_rights), `req.creative` (provide_performance_feedback).
 - **`accounts.resolve()` is mandatory.** Even single-tenant agents must
   declare `resolution: 'derived'` and return a synthetic singleton. The
   framework calls `resolve()` on every request.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2040,23 +2040,59 @@ async function hydratePackagesWithProducts(
  * primary resource lives directly on the request body (`update_media_buy`,
  * `provide_performance_feedback`, `activate_signal`, `acquire_rights`).
  * Walks the store for `(kind, id)`, attaches `target[attachField] =
- * { ...resource, ctx_metadata }` when the entry has a wire resource. Misses
- * are silent — publisher falls back to its own DB.
+ * { ...resource, ctx_metadata }` when the entry has a wire resource.
+ *
+ * ## Error contract on missing references
+ *
+ * **Misses are silent. The handler runs anyway with `target[attachField]`
+ * undefined.** This is deliberate — the framework cache is a *hint*, not
+ * the source of truth. A miss can mean any of:
+ *
+ *   1. The buyer never called the discovery verb in this session (cold
+ *      start, fresh tenant). Hydration is purely additive context; the
+ *      publisher's own DB is authoritative for whether the id exists.
+ *   2. The cache evicted (TTL, LRU). Same: publisher's DB stays the
+ *      source of truth.
+ *   3. The buyer truly referenced an unknown id. The publisher SHOULD
+ *      reject this — see the handler-side guard pattern below.
+ *
+ * Adopters who want strict existence checks (option 1: framework throws
+ * `PRODUCT_NOT_FOUND` / `MEDIA_BUY_NOT_FOUND` and the handler never runs)
+ * implement that check inside the handler:
+ *
+ * ```ts
+ * updateMediaBuy: async (id, patch, ctx) => {
+ *   // Hydration miss + DB miss = unknown to this seller.
+ *   if (!patch.media_buy && !(await db.findMediaBuy(id))) {
+ *     throw new MediaBuyNotFoundError({ message: `media_buy ${id} not found` });
+ *   }
+ *   // ...
+ * }
+ * ```
+ *
+ * The framework cannot distinguish (1)/(2) from (3) without consulting the
+ * publisher's DB, which is exactly what the handler does. Erroring at the
+ * framework layer would force every adopter to manage cache warmth or
+ * pre-load every media_buy into the cache before serving traffic — wrong
+ * default for a hint-based cache.
+ *
+ * ## Field semantics on the hydrated value
  *
  * The attached field is **non-enumerable** so accidental serialization
- * (JSON.stringify on the request body, spread copy, Object.entries log line)
+ * (`JSON.stringify(req)`, spread `{...req}`, `Object.entries(req)`)
  * doesn't leak the publisher's `ctx_metadata` blob into request-side audit
- * sinks. Direct property access (`req.media_buy.ctx_metadata`) still works;
- * the hydrated field is invisible only to enumeration-based serializers.
+ * sinks. Direct property access (`req.media_buy.ctx_metadata`) still
+ * works; the field is invisible only to enumeration-based serializers.
  *
  * Hydrated fields carry a `__adcp_hydrated__: true` non-enumerable marker
  * so handler authors and middleware can disambiguate "publisher passed it"
  * from "framework attached it" — the field is **advisory context only**;
- * the wire contract is defined by the spec request fields, not by what the
- * SDK happens to attach.
+ * the wire contract is defined by the spec request fields, not by what
+ * the SDK happens to attach.
  *
- * Failures are logged + swallowed. Hydration must NEVER break a successful
- * dispatch.
+ * Store-fetch failures (Postgres unavailable, etc.) are logged + swallowed.
+ * Hydration must NEVER break a successful dispatch — same posture as a
+ * cache miss.
  */
 async function hydrateSingleResource(
   store: CtxMetadataStore | undefined,

--- a/test/server-auto-hydration-extended.test.js
+++ b/test/server-auto-hydration-extended.test.js
@@ -147,11 +147,7 @@ describe('auto-hydration — update_media_buy', () => {
     assert.equal(observedReq.media_buy, undefined, 'CONTRACT: req.media_buy is undefined on miss');
     // Response should be whatever the handler returned — NOT a framework
     // not-found error. Adopters opt into strict checks in their handler.
-    assert.equal(
-      resp.isError,
-      undefined,
-      'CONTRACT: framework does not synthesize an error on hydration miss'
-    );
+    assert.equal(resp.isError, undefined, 'CONTRACT: framework does not synthesize an error on hydration miss');
   });
 });
 

--- a/test/server-auto-hydration-extended.test.js
+++ b/test/server-auto-hydration-extended.test.js
@@ -108,10 +108,16 @@ describe('auto-hydration — update_media_buy', () => {
     );
   });
 
-  it('updateMediaBuy without prior getMediaBuys — req.media_buy is undefined (falls through)', async () => {
+  it('error contract: hydration miss → handler runs un-hydrated, NOT a framework-thrown NOT_FOUND', async () => {
+    // Pins the documented contract: the framework cache is a hint, not the
+    // source of truth. A miss means "publisher's DB decides whether the id
+    // exists" — NOT "framework rejects with PRODUCT_NOT_FOUND / MEDIA_BUY_NOT_FOUND".
+    // Adopters who want strict existence checks implement them in the handler.
+    let handlerCalled = false;
     let observedReq;
     const platform = makeBasePlatform({
       updateMediaBuy: async (id, params, ctx) => {
+        handlerCalled = true;
         observedReq = params;
         return { media_buy_id: id, status: 'paused', packages: [] };
       },
@@ -125,7 +131,7 @@ describe('auto-hydration — update_media_buy', () => {
       validation: { requests: 'off', responses: 'off' },
     });
 
-    await server.dispatchTestRequest({
+    const resp = await server.dispatchTestRequest({
       method: 'tools/call',
       params: {
         name: 'update_media_buy',
@@ -137,8 +143,15 @@ describe('auto-hydration — update_media_buy', () => {
       },
     });
 
-    assert.ok(observedReq);
-    assert.equal(observedReq.media_buy, undefined, 'no hydration for unseen id');
+    assert.equal(handlerCalled, true, 'CONTRACT: hydration miss does NOT block the handler');
+    assert.equal(observedReq.media_buy, undefined, 'CONTRACT: req.media_buy is undefined on miss');
+    // Response should be whatever the handler returned — NOT a framework
+    // not-found error. Adopters opt into strict checks in their handler.
+    assert.equal(
+      resp.isError,
+      undefined,
+      'CONTRACT: framework does not synthesize an error on hydration miss'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Three pre-ship asks before tagging 6.0.0 GA. Two land in this PR (1 + 3); ask #2 was already shipped — this PR adds visibility.

## Ask #1 — auto-hydration error contract

With auto-hydration on 4 mutating verbs, the contract for stale or missing references multiplies. **Documented + tested:** the framework treats hydration as a hint, not a source-of-truth check.

- **Miss → handler runs un-hydrated** (the chosen option, NOT a framework-thrown `*_NOT_FOUND`).
- Three reasons a miss can happen: cold start (buyer never called the discovery verb in this session), cache eviction, or buyer truly referenced an unknown id.
- Publisher's DB is the source of truth — adopters who want strict existence checks implement them in the handler with the typed error classes (\`MediaBuyNotFoundError\`, etc.).

JSDoc on \`hydrateSingleResource\` lays out the three options and the rationale for picking #2. Migration guide gets a "Common gotchas" entry with the handler-side guard pattern. New contract test pins the behavior:

\`\`\`ts
assert.equal(handlerCalled, true, 'CONTRACT: hydration miss does NOT block the handler');
assert.equal(observedReq.media_buy, undefined, 'CONTRACT: req.media_buy is undefined on miss');
assert.equal(resp.isError, undefined, 'CONTRACT: framework does not synthesize an error on hydration miss');
\`\`\`

## Ask #2 — `resolveIdempotencyPrincipal` typed params (already shipped)

Already done. \`resolveIdempotencyPrincipal\` takes \`IdempotencyPrincipalParams\` (\`src/lib/server/create-adcp-server.ts:681-686\`):

\`\`\`ts
export interface IdempotencyPrincipalParams extends Record<string, unknown> {
  account?: { account_id?: string; brand?: { domain?: string }; sandbox?: boolean; [k: string]: unknown };
  brand?: { domain?: string; [k: string]: unknown };
}
\`\`\`

Adopters scoping by \`params.account?.account_id\` or \`params.brand?.domain\` (the public-token-shared-across-tenants pattern) get autocomplete + narrowing without a cast. The \`Record<string, unknown>\` index signature is still there for tool-specific scoping (e.g., custom session header on \`si_send_message\`). Surfaced in the changeset for visibility.

## Ask #3 — 6.0 migration cheatsheet

\`docs/migration-5.x-to-6.x.md\` gains a top-of-file \"tl;dr — five breaking changes to search-replace\" table covering the cumulative breaks adopters face on \`npm update @adcp/sdk\`:

| # | What | Search → Replace |
|---|---|---|
| 1 | \`Account.metadata\` → \`Account.ctx_metadata\` | (Account refs only) |
| 2 | \`@adcp/sdk/server/decisioning\` → \`@adcp/sdk/server\` | path move |
| 3 | \`createAdcpServer\` → \`createAdcpServerFromPlatform\` (or legacy subpath) | new entry point |
| 4 | \`TMeta\` → \`TCtxMeta\` generic param | type-level only |
| 5 | \`getMediaBuys\` required on \`SalesPlatform\` | add stub |

Plus a one-shot sed/grep recipe block for adopters who skipped rounds 11–14 and need the cumulative diff at once.

## Test plan

- [x] \`npm run typecheck\` passes
- [x] \`npm run build\` passes
- [x] Auto-hydration tests pass (10 total: 6 in this suite + 4 prior)
- [x] Contract test pins miss-handler-runs behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)