### PR TITLE
fix(client): filter oneOf branch sub-errors from Ajv allErrors output

### DIFF
--- a/.changeset/oneof-suberror-filter.md
+++ b/.changeset/oneof-suberror-filter.md
@@ -1,0 +1,21 @@
+---
+"@adcp/sdk": patch
+"@adcp/client": patch
+---
+
+fix(validation): filter oneOf branch sub-errors from Ajv output
+
+Ajv with `allErrors:true` emits per-branch `required`/`type` errors from
+every non-matching `oneOf` variant alongside the top-level `oneOf` node
+error. These sub-branch errors appeared as spurious validation failures
+(e.g. "/products/2/name: must have required property 'name'") even when
+data was schema-valid, causing storyboard CI to report false-negative
+failures for downstream SDKs (adcp-client#1111).
+
+The fix post-filters `validator.errors` in `validateResponse` and
+`validateRequest` to drop any error whose `schemaPath` is a strict
+descendant of a failing `oneOf` node's path. The `oneOf` node error
+itself is preserved and enriched with `variants[]` by the existing
+`enrichWithVariants` helper. `anyOf` sub-errors are intentionally not
+filtered — `anyOf` allows partial matches and its sub-errors carry useful
+disambiguation signal.

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -95,6 +95,34 @@ export interface ValidationOutcome {
 
 const OK: ValidationOutcome = Object.freeze({ valid: true, issues: [], variant: 'skipped' });
 
+/**
+ * Drop sub-branch errors emitted by Ajv's `allErrors:true` mode when a
+ * `oneOf` keyword fails. Ajv validates ALL branches and collects every
+ * sub-error; when no branch matches the `oneOf` node error itself is the
+ * actionable signal — per-branch `required`/`type` errors from non-matching
+ * variants are noise that masks the real failure message.
+ *
+ * Filter rule: an error is a sub-branch error when its `schemaPath` is a
+ * strict descendant of a failing `oneOf` node's `schemaPath` (i.e., the
+ * `oneOf` node error exists in the same error list at a shorter path). The
+ * `oneOf` node errors themselves are always kept; `anyOf` sub-errors are
+ * intentionally NOT filtered because `anyOf` allows partial matches and
+ * its sub-errors carry useful disambiguation signal.
+ */
+function filterOneOfSubErrors(errors: ErrorObject[]): ErrorObject[] {
+  const oneOfPaths = new Set<string>();
+  for (const err of errors) {
+    if (err.keyword === 'oneOf') oneOfPaths.add(err.schemaPath);
+  }
+  if (oneOfPaths.size === 0) return errors;
+  return errors.filter(err => {
+    for (const p of oneOfPaths) {
+      if (err.schemaPath.startsWith(p + '/')) return false;
+    }
+    return true;
+  });
+}
+
 function formatIssue(err: ErrorObject): ValidationIssue {
   const instancePath = err.instancePath || '';
   const missingProperty =
@@ -188,7 +216,9 @@ export function validateRequest(toolName: string, payload: unknown, version?: st
   const rootSchema = (validator as { schema?: unknown }).schema;
   return {
     valid: false,
-    issues: (validator.errors ?? []).map(formatIssue).map(i => enrichWithVariants(i, rootSchema)),
+    issues: filterOneOfSubErrors(validator.errors ?? [])
+      .map(formatIssue)
+      .map(i => enrichWithVariants(i, rootSchema)),
     variant: 'request',
   };
 }
@@ -234,7 +264,9 @@ export function validateResponse(toolName: string, payload: unknown, version?: s
   const rootSchema = (effective as { schema?: unknown }).schema;
   return {
     valid: false,
-    issues: (effective.errors ?? []).map(formatIssue).map(i => enrichWithVariants(i, rootSchema)),
+    issues: filterOneOfSubErrors(effective.errors ?? [])
+      .map(formatIssue)
+      .map(i => enrichWithVariants(i, rootSchema)),
     variant: usedVariant,
     ...fallbackFields,
   };

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -116,6 +116,7 @@ function filterOneOfSubErrors(errors: ErrorObject[]): ErrorObject[] {
   }
   if (oneOfPaths.size === 0) return errors;
   return errors.filter(err => {
+    if (err.keyword === 'oneOf') return true; // always keep oneOf node errors, including nested ones
     for (const p of oneOfPaths) {
       if (err.schemaPath.startsWith(p + '/')) return false;
     }

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -264,21 +264,25 @@ describe('schema-driven validation', () => {
         packages: [{ buyer_ref: 'p1', product_id: 'p1', budget: 10, pricing_option_id: 'po1' }],
       });
       if (!res.valid) {
-        // The oneOf node error at /account should be present
+        // The oneOf node error at /account must be present — it is the actionable signal.
         const oneOfIssue = res.issues.find(i => i.keyword === 'oneOf' && i.pointer === '/account');
-        if (oneOfIssue) {
-          // No issue should have a schemaPath that is a strict child of the oneOf's schemaPath.
-          // Such errors are sub-branch errors from non-matching variants and should be filtered.
-          const oneOfPath = oneOfIssue.schemaPath;
-          const subBranchErrors = res.issues.filter(i => i !== oneOfIssue && i.schemaPath.startsWith(oneOfPath + '/'));
-          assert.deepStrictEqual(
-            subBranchErrors,
-            [],
-            `oneOf branch sub-errors must be filtered; found: ${JSON.stringify(subBranchErrors.map(e => ({ pointer: e.pointer, keyword: e.keyword, schemaPath: e.schemaPath })))}`
-          );
-        }
+        assert.ok(
+          oneOfIssue,
+          `oneOf node error at /account must survive filtering; issues: ${JSON.stringify(res.issues.map(i => i.pointer))}`
+        );
+        // No issue should have a schemaPath that is a strict child of the oneOf's schemaPath.
+        // Such errors are sub-branch errors from non-matching variants and should be filtered.
+        const oneOfPath = oneOfIssue.schemaPath;
+        const subBranchErrors = res.issues.filter(
+          i => i.keyword !== 'oneOf' && i.schemaPath.startsWith(oneOfPath + '/')
+        );
+        assert.deepStrictEqual(
+          subBranchErrors,
+          [],
+          `oneOf branch sub-errors must be filtered; found: ${JSON.stringify(subBranchErrors.map(e => ({ pointer: e.pointer, keyword: e.keyword, schemaPath: e.schemaPath })))}`
+        );
       }
-      // If valid=true or no schema available, the test is vacuous but not misleading.
+      // If valid=true or no schema available (schemas not synced), the test is vacuous but not misleading.
     });
 
     test('variants ship by default; schemaPath stripped unless exposed', () => {

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -245,6 +245,42 @@ describe('schema-driven validation', () => {
       }
     });
 
+    test('oneOf branch sub-errors are filtered; only the node error surfaces', () => {
+      // Regression guard for issue #1111. Ajv with allErrors:true emits per-branch
+      // required/type errors from every non-matching oneOf variant alongside the
+      // node-level oneOf error. Without filtering these are reported as real
+      // failures (e.g. "/products/2/name: must have required property 'name'")
+      // even when data is schema-valid — the same payload that validates clean
+      // under Python jsonschema fails under the unfiltered Ajv output.
+      //
+      // After the fix: only the oneOf node error at /account survives;
+      // branch sub-errors whose schemaPath starts with the oneOf path + '/' are dropped.
+      const res = validateRequest('create_media_buy', {
+        idempotency_key: '00000000-0000-0000-0000-000000000000',
+        account: { account_id: 'acme', brand: { domain: 'acme.com' } },
+        brand: { domain: 'acme.com' },
+        start_time: '2026-05-01T00:00:00Z',
+        end_time: '2026-05-31T23:59:59Z',
+        packages: [{ buyer_ref: 'p1', product_id: 'p1', budget: 10, pricing_option_id: 'po1' }],
+      });
+      if (!res.valid) {
+        // The oneOf node error at /account should be present
+        const oneOfIssue = res.issues.find(i => i.keyword === 'oneOf' && i.pointer === '/account');
+        if (oneOfIssue) {
+          // No issue should have a schemaPath that is a strict child of the oneOf's schemaPath.
+          // Such errors are sub-branch errors from non-matching variants and should be filtered.
+          const oneOfPath = oneOfIssue.schemaPath;
+          const subBranchErrors = res.issues.filter(i => i !== oneOfIssue && i.schemaPath.startsWith(oneOfPath + '/'));
+          assert.deepStrictEqual(
+            subBranchErrors,
+            [],
+            `oneOf branch sub-errors must be filtered; found: ${JSON.stringify(subBranchErrors.map(e => ({ pointer: e.pointer, keyword: e.keyword, schemaPath: e.schemaPath })))}`
+          );
+        }
+      }
+      // If valid=true or no schema available, the test is vacuous but not misleading.
+    });
+
     test('variants ship by default; schemaPath stripped unless exposed', () => {
       // Different sensitivity classes:
       //   - schemaPath encodes seller handler branch ordering (impl detail) → gated


### PR DESCRIPTION
Closes #1111

## Summary

- Adds `filterOneOfSubErrors()` in `src/lib/validation/schema-validator.ts`, applied in both `validateRequest` and `validateResponse` before error formatting.
- Filter rule: drop any AJV error whose `schemaPath` is a strict descendant of a failing `oneOf` node's path. `oneOf` node errors are always kept (including nested ones via an explicit `keyword === 'oneOf'` guard). `anyOf` sub-errors are intentionally NOT filtered — `anyOf` allows partial matches and its per-branch errors carry useful disambiguation signal.
- Adds a regression test in `test/lib/schema-validation.test.js` that asserts `oneOf` sub-branch errors are absent from `validateRequest` output and the node error is preserved.
- Adds `.changeset/oneof-suberror-filter.md` (patch bump for `@adcp/sdk` and `@adcp/client`).

## Root cause

`schema-loader.ts` initialises Ajv with `allErrors: true`. When Ajv evaluates a `oneOf` and no branch matches it:
1. Emits the top-level `oneOf` node error (actionable).
2. Emits one `required`/`type` error per property mismatch *in every branch it evaluated* (noise).

These sub-branch errors surfaced as spurious "must have required property" failures in storyboard CI, causing false-negative reports for downstream SDKs.

## What was tested

- Pre-existing `test/lib/schema-validation.test.js` suite (build/unit — schema-dependent assertions are vacuous without synced schemas but not misleading).
- `test/validation-enum-enrichment.test.js` — unaffected by this change.
- `npx prettier --write` and `npx tsc --noEmit` pass clean on the branch.

## Pre-PR reviews

Two expert reviews were completed before this PR was opened:

- **code-reviewer** — approved after blocker fix (nested `oneOf` guard added; test assertion hardened from silent-vacuous to `assert.ok`).
- **ad-tech-protocol-expert** — approved; filter is mechanically correct, `anyOf` exclusion justified, no impact on `context_value_rejected` hint diagnostics.

## Out of scope / follow-ons

- `NODE_ENV`-sensitive `defaultResponseMode()` in `client-hooks.ts` (separate CI vs local discrepancy vector — distinct issue).
- `anyOf` flooding in `get_adcp_capabilities` responses (separate scope, different keyword).

---

> **Triage-managed PR** — opened by the automated triage agent per `.agents/routines/triage-prompt.md`. Assign a human reviewer before merging.

https://claude.ai/code/session_01Sv61kPXqT5b8bLYZ62muHV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sv61kPXqT5b8bLYZ62muHV)_