### PR TITLE
fix(v2-adapter): emit buyer_ref in adaptCreateMediaBuyRequestForV2 (top-level + per-package)

### DIFF
--- a/.changeset/buyer-ref-v2-adapter.md
+++ b/.changeset/buyer-ref-v2-adapter.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(v2-adapter): emit buyer_ref in adaptCreateMediaBuyRequestForV2 (top-level + per-package)
+
+v2.5 schema requires buyer_ref on both the top-level create_media_buy request and each package.
+The adapter now derives top-level buyer_ref from idempotency_key, and per-package buyer_ref from
+the package's own idempotency_key (falling back to `${idempotency_key}-${index}`). Both are stable
+across replays, preserving idempotency semantics. Real v2.5.3+ sellers enforcing required-field
+validation will no longer reject adapted requests.

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -127,10 +127,13 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
         if (adapted.buyer_ref) {
           return adapted;
         }
-        // v2.5 requires per-package buyer_ref; derive from the package's own
-        // idempotency_key when present (from pre-adapted pkg), falling back to
-        // a stable index suffix. Use spread to avoid mutating adapted's object.
-        return { ...adapted, buyer_ref: pkg.idempotency_key || `${idempotency_key}-${i}` };
+        // v2.5 requires per-package buyer_ref. Anchor on product_id +
+        // pricing_option_id — intrinsic, order-independent package identifiers
+        // that remain stable if the caller reconstructs the same packages in a
+        // different array order on replay. Index i is a last-resort fallback.
+        const pkgKey =
+          [pkg.product_id, pkg.pricing_option_id].filter(Boolean).join('-') || String(i);
+        return { ...adapted, buyer_ref: `${idempotency_key}-${pkgKey}` };
       }),
     }),
   };

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -115,9 +115,22 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
 
   return {
     ...rest,
+    // v2.5 requires buyer_ref at the top level; idempotency_key carries the
+    // same semantics (client-controlled unique reference, stable on replay).
+    buyer_ref: idempotency_key,
     ...(brand && !brand_manifest && { brand }),
     ...(brand_manifest !== undefined && { brand_manifest }),
-    ...(rest.packages && { packages: rest.packages.map(adaptPackageRequestForV2) }),
+    ...(rest.packages && {
+      packages: rest.packages.map((pkg: any, i: number) => {
+        const adapted = adaptPackageRequestForV2(pkg);
+        // v2.5 requires per-package buyer_ref; derive from the package's own
+        // idempotency_key when present, falling back to a stable index suffix.
+        if (!adapted.buyer_ref) {
+          adapted.buyer_ref = pkg.idempotency_key || `${idempotency_key}-${i}`;
+        }
+        return adapted;
+      }),
+    }),
   };
 }
 

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -117,18 +117,20 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
     ...rest,
     // v2.5 requires buyer_ref at the top level; idempotency_key carries the
     // same semantics (client-controlled unique reference, stable on replay).
-    buyer_ref: idempotency_key,
+    // Preserve a caller-supplied buyer_ref when present.
+    buyer_ref: rest.buyer_ref ?? idempotency_key,
     ...(brand && !brand_manifest && { brand }),
     ...(brand_manifest !== undefined && { brand_manifest }),
     ...(rest.packages && {
       packages: rest.packages.map((pkg: any, i: number) => {
         const adapted = adaptPackageRequestForV2(pkg);
-        // v2.5 requires per-package buyer_ref; derive from the package's own
-        // idempotency_key when present, falling back to a stable index suffix.
-        if (!adapted.buyer_ref) {
-          adapted.buyer_ref = pkg.idempotency_key || `${idempotency_key}-${i}`;
+        if (adapted.buyer_ref) {
+          return adapted;
         }
-        return adapted;
+        // v2.5 requires per-package buyer_ref; derive from the package's own
+        // idempotency_key when present (from pre-adapted pkg), falling back to
+        // a stable index suffix. Use spread to avoid mutating adapted's object.
+        return { ...adapted, buyer_ref: pkg.idempotency_key || `${idempotency_key}-${i}` };
       }),
     }),
   };

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -129,11 +129,13 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
         }
         // v2.5 requires per-package buyer_ref. Anchor on product_id +
         // pricing_option_id — intrinsic, order-independent package identifiers
-        // that remain stable if the caller reconstructs the same packages in a
-        // different array order on replay. Index i is a last-resort fallback.
+        // stable across replays regardless of array position. Use '~' as field
+        // delimiter because AdCP IDs are alphanumeric+hyphen only; '~' cannot
+        // appear in either ID, so the boundary is unambiguous (no collisions).
+        // Index i is the last-resort fallback for packages missing both fields.
         const pkgKey =
-          [pkg.product_id, pkg.pricing_option_id].filter(Boolean).join('-') || String(i);
-        return { ...adapted, buyer_ref: `${idempotency_key}-${pkgKey}` };
+          [pkg.product_id, pkg.pricing_option_id].filter(Boolean).join('~') || String(i);
+        return { ...adapted, buyer_ref: `${idempotency_key}~${pkgKey}` };
       }),
     }),
   };

--- a/test/lib/creative-adapter.test.js
+++ b/test/lib/creative-adapter.test.js
@@ -48,6 +48,12 @@ describe('adaptCreateMediaBuyRequestForV2 — buyer_ref (issue #1115)', () => {
     assert.equal(adapted.packages[0].buyer_ref, 'explicit-buyer-ref');
   });
 
+  test('does not overwrite a top-level buyer_ref supplied by the caller', () => {
+    const req = { ...baseRequest(), buyer_ref: 'caller-supplied-ref' };
+    const adapted = adaptCreateMediaBuyRequestForV2(req);
+    assert.equal(adapted.buyer_ref, 'caller-supplied-ref');
+  });
+
   test('buyer_ref is stable across replays (same idempotency_key → same buyer_ref)', () => {
     const a = adaptCreateMediaBuyRequestForV2(baseRequest());
     const b = adaptCreateMediaBuyRequestForV2(baseRequest());

--- a/test/lib/creative-adapter.test.js
+++ b/test/lib/creative-adapter.test.js
@@ -29,8 +29,23 @@ describe('adaptCreateMediaBuyRequestForV2 — buyer_ref (issue #1115)', () => {
 
   test('emits per-package buyer_ref anchored on product_id + pricing_option_id (order-independent)', () => {
     const adapted = adaptCreateMediaBuyRequestForV2(baseRequest());
-    assert.equal(adapted.packages[0].buyer_ref, `${IK}-prod-1-po-1`);
-    assert.equal(adapted.packages[1].buyer_ref, `${IK}-prod-2-po-2`);
+    assert.equal(adapted.packages[0].buyer_ref, `${IK}~prod-1~po-1`);
+    assert.equal(adapted.packages[1].buyer_ref, `${IK}~prod-2~po-2`);
+  });
+
+  test('separator ~ prevents collision when IDs contain hyphens', () => {
+    // 'a-b' + 'c' and 'a' + 'b-c' must produce different buyer_refs
+    const req = {
+      ...baseRequest(),
+      packages: [
+        { product_id: 'a-b', pricing_option_id: 'c', budget: 100 },
+        { product_id: 'a', pricing_option_id: 'b-c', budget: 100 },
+      ],
+    };
+    const adapted = adaptCreateMediaBuyRequestForV2(req);
+    assert.notEqual(adapted.packages[0].buyer_ref, adapted.packages[1].buyer_ref);
+    assert.equal(adapted.packages[0].buyer_ref, `${IK}~a-b~c`);
+    assert.equal(adapted.packages[1].buyer_ref, `${IK}~a~b-c`);
   });
 
   test('per-package buyer_ref is stable when package order is reversed on replay', () => {

--- a/test/lib/creative-adapter.test.js
+++ b/test/lib/creative-adapter.test.js
@@ -1,0 +1,69 @@
+// Tests for buyer_ref emission in adaptCreateMediaBuyRequestForV2 (issue #1115)
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  adaptCreateMediaBuyRequestForV2,
+  adaptPackageRequestForV2,
+} = require('../../dist/lib/utils/creative-adapter.js');
+
+const IK = '11111111-1111-1111-1111-111111111111';
+
+const baseRequest = () => ({
+  account: { account_id: 'acct-1' },
+  brand: { domain: 'example.com' },
+  packages: [
+    { product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' },
+    { product_id: 'prod-2', budget: 500, pricing_option_id: 'po-2' },
+  ],
+  start_time: 'asap',
+  end_time: '2027-12-31T23:59:59Z',
+  idempotency_key: IK,
+});
+
+describe('adaptCreateMediaBuyRequestForV2 — buyer_ref (issue #1115)', () => {
+  test('emits top-level buyer_ref derived from idempotency_key', () => {
+    const adapted = adaptCreateMediaBuyRequestForV2(baseRequest());
+    assert.equal(adapted.buyer_ref, IK, 'top-level buyer_ref must equal idempotency_key');
+  });
+
+  test('emits per-package buyer_ref with stable index suffix when package has no idempotency_key', () => {
+    const adapted = adaptCreateMediaBuyRequestForV2(baseRequest());
+    assert.equal(adapted.packages[0].buyer_ref, `${IK}-0`);
+    assert.equal(adapted.packages[1].buyer_ref, `${IK}-1`);
+  });
+
+  test('per-package buyer_ref uses package idempotency_key when present', () => {
+    const req = baseRequest();
+    req.packages[0].idempotency_key = 'pkg-key-aaa';
+    const adapted = adaptCreateMediaBuyRequestForV2(req);
+    assert.equal(adapted.packages[0].buyer_ref, 'pkg-key-aaa');
+    assert.equal(adapted.packages[1].buyer_ref, `${IK}-1`);
+  });
+
+  test('does not overwrite an explicit per-package buyer_ref', () => {
+    const req = baseRequest();
+    req.packages[0].buyer_ref = 'explicit-buyer-ref';
+    const adapted = adaptCreateMediaBuyRequestForV2(req);
+    assert.equal(adapted.packages[0].buyer_ref, 'explicit-buyer-ref');
+  });
+
+  test('buyer_ref is stable across replays (same idempotency_key → same buyer_ref)', () => {
+    const a = adaptCreateMediaBuyRequestForV2(baseRequest());
+    const b = adaptCreateMediaBuyRequestForV2(baseRequest());
+    assert.equal(a.buyer_ref, b.buyer_ref);
+    assert.equal(a.packages[0].buyer_ref, b.packages[0].buyer_ref);
+    assert.equal(a.packages[1].buyer_ref, b.packages[1].buyer_ref);
+  });
+
+  test('idempotency_key is stripped from v2 output (not passed to v2 server)', () => {
+    const adapted = adaptCreateMediaBuyRequestForV2(baseRequest());
+    assert.equal(adapted.idempotency_key, undefined, 'idempotency_key must not appear in v2 output');
+  });
+
+  test('adaptPackageRequestForV2 preserves pre-existing buyer_ref', () => {
+    const pkg = { product_id: 'p1', buyer_ref: 'keep-me' };
+    const adapted = adaptPackageRequestForV2(pkg);
+    assert.equal(adapted.buyer_ref, 'keep-me');
+  });
+});

--- a/test/lib/creative-adapter.test.js
+++ b/test/lib/creative-adapter.test.js
@@ -27,18 +27,22 @@ describe('adaptCreateMediaBuyRequestForV2 — buyer_ref (issue #1115)', () => {
     assert.equal(adapted.buyer_ref, IK, 'top-level buyer_ref must equal idempotency_key');
   });
 
-  test('emits per-package buyer_ref with stable index suffix when package has no idempotency_key', () => {
+  test('emits per-package buyer_ref anchored on product_id + pricing_option_id (order-independent)', () => {
     const adapted = adaptCreateMediaBuyRequestForV2(baseRequest());
-    assert.equal(adapted.packages[0].buyer_ref, `${IK}-0`);
-    assert.equal(adapted.packages[1].buyer_ref, `${IK}-1`);
+    assert.equal(adapted.packages[0].buyer_ref, `${IK}-prod-1-po-1`);
+    assert.equal(adapted.packages[1].buyer_ref, `${IK}-prod-2-po-2`);
   });
 
-  test('per-package buyer_ref uses package idempotency_key when present', () => {
-    const req = baseRequest();
-    req.packages[0].idempotency_key = 'pkg-key-aaa';
-    const adapted = adaptCreateMediaBuyRequestForV2(req);
-    assert.equal(adapted.packages[0].buyer_ref, 'pkg-key-aaa');
-    assert.equal(adapted.packages[1].buyer_ref, `${IK}-1`);
+  test('per-package buyer_ref is stable when package order is reversed on replay', () => {
+    const req1 = baseRequest();
+    const req2 = { ...baseRequest(), packages: [...baseRequest().packages].reverse() };
+    const a = adaptCreateMediaBuyRequestForV2(req1);
+    const b = adaptCreateMediaBuyRequestForV2(req2);
+    // Each package must get the same buyer_ref regardless of position
+    const refsByProduct = (pkgs) => Object.fromEntries(
+      pkgs.map(p => [p.product_id, p.buyer_ref])
+    );
+    assert.deepEqual(refsByProduct(a.packages), refsByProduct(b.packages));
   });
 
   test('does not overwrite an explicit per-package buyer_ref', () => {


### PR DESCRIPTION
Closes #1115

`adaptCreateMediaBuyRequestForV2` was not emitting `buyer_ref`, causing v2.5 sellers enforcing required-field validation to reject adapted `create_media_buy` requests. This PR derives top-level `buyer_ref` from the v3 `idempotency_key` (same semantics: client-controlled unique reference, stable on replay), preserved via `rest.buyer_ref ?? idempotency_key` so a caller-supplied value is never overwritten. Per-package `buyer_ref` is anchored on `product_id~pricing_option_id` — intrinsic, order-independent identifiers — using `~` as a delimiter (not valid in AdCP alphanumeric+hyphen IDs, so no collision possible). Per-package injection uses a non-mutating spread.

## What was tested

- `npm run format:check` — passed
- `npx tsc --project tsconfig.lib.json --noEmitOnError false` — compiled (pre-existing `TS2688`/`TS5107` on `main`, not introduced here)
- `node --test test/lib/creative-adapter.test.js` — 9/9 pass (new suite: top-level emission, per-package product-anchored key, separator-collision case, order-reversal replay stability, caller buyer_ref preservation at top and per-package, replay idempotency, idempotency_key strip, adaptPackageRequestForV2 passthrough)
- `node --test test/lib/pricing-adapter.test.js` — 45/45 pass (regression)

## Pre-PR review — two iterations

**Iteration 1 — pass 1:**
- **code-reviewer**: 2 blockers — (a) `buyer_ref: idempotency_key` unconditionally overwrites caller-supplied top-level `buyer_ref`; (b) mutating `adapted.buyer_ref = ...` in place. Fixed in `d1133b2` via `rest.buyer_ref ?? idempotency_key` + non-mutating spread.
- **ad-tech-protocol-expert** (background): blocker — index-based per-package suffix `${ik}-${i}` is order-dependent on replay. Fixed in `09404f1` by anchoring on `product_id+pricing_option_id`.

**Iteration 2 — pass 2:**
- **code-reviewer**: blocker — hyphen join-delimiter causes collisions when IDs contain hyphens (`a-b` + `c` === `a` + `b-c`). Fixed in `bfb0b7b` by switching delimiter to `~`. Separator-collision test added.
- **ad-tech-protocol-expert** (background, on iteration-1 diff): approved order-independence approach; nit — absent-ID index fallback reintroduces order-dependence for packages missing both `product_id` and `pricing_option_id`; documented as known limitation in code comment, index fallback retained as last resort per spec guidance.

**Open nits (non-blocking):**
- Absent-ID fallback (`String(i)`) is still order-dependent for packages missing both identifiers — this is an edge case the v3 spec does not define per-package keys for; documented in code comment.
- `adaptUpdateMediaBuyRequestForV2` does not inject `buyer_ref` — intentional, `update_media_buy` uses `media_buy_id` as its stable reference in v2.5.
- Full `context.buyer_ref → normalize → adapt → v2 wire` pipeline integration test is out of scope for this fix.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01NaFsfiBGzSXVLXM2UAveCm