### PR TITLE
fix(client): flatten v3 manifest assets to v2.5 single-asset payload in adaptSyncCreativesRequestForV2

### DIFF
--- a/.changeset/sync-creatives-manifest-flattener.md
+++ b/.changeset/sync-creatives-manifest-flattener.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix `adaptSyncCreativesRequestForV2` to flatten v3 manifest assets to v2.5 single-asset payload.
+
+`adaptSyncCreativesRequestForV2` previously leaked the v3 `assets` manifest shape (`{ role: { asset_type, url, … } }`) through to v2.5 servers unchanged. v2.5's `creative-asset.json` schema expects a single asset payload discriminated by `asset_type`; every adapted creative therefore failed the `oneOf` check and was rejected by strict v2.5 sellers.
+
+The adapter now detects manifest-shaped `assets` (a role-keyed object whose values carry `asset_type`) and extracts the primary (first) role's payload as the v2 asset. Multi-role manifests emit a `console.warn` naming the dropped roles; single-role manifests are silently flattened. Already-flat assets (top-level `asset_type` present) pass through unchanged.
+
+Covers image, video, audio, VAST, text, and HTML asset variants per the v2.5 test plan.

--- a/src/lib/utils/sync-creatives-adapter.ts
+++ b/src/lib/utils/sync-creatives-adapter.ts
@@ -1,39 +1,90 @@
 /**
  * Sync Creatives Adapter
  *
- * Handles conversion between v2 and v3 sync_creatives requests.
- * The library exposes only the v3 API to clients and internally adapts
- * requests for v2 servers.
+ * Adapts v3 `sync_creatives` request payloads for v2.5 servers. The public
+ * surface (`adaptSyncCreativesRequestForV2`) is unchanged; all conversions
+ * are transparent to callers.
  *
- * Key v3 → v2 differences:
- *   - `account` field is required in v3 but absent in v2 — stripped on send
- *   - `catalogs` array on each creative is v3-only — stripped on send
- *   - `status` enum ('approved' | 'rejected') replaces v2 `approved` boolean
+ * v3 → v2 field mappings applied here:
+ *   - `account` / `adcp_major_version` — stripped (v3-only top-level fields)
+ *   - `catalogs` per creative — stripped (v3-only)
+ *   - `status` enum ('approved' | 'rejected') → `approved` boolean
+ *   - `assets` as a role-keyed manifest ({ video: { asset_type, url, … } })
+ *     → flattened to a single v2 asset payload (`oneOf` discriminated by
+ *     `asset_type`). The primary (first) role is forwarded; remaining roles
+ *     are dropped with a console.warn naming the discarded roles. To preserve
+ *     all roles, connect to a v3 server.
+ *   - `assets` already flat (has `asset_type` at top level) — passed through
+ *     unchanged.
+ *   - No `assets` field — omitted.
+ *
+ * @internal Not part of the public @adcp/sdk API surface.
  */
 
 /**
- * Adapt a single creative asset for a v2 server.
- * Strips v3-only fields and converts `status` enum → `approved` boolean.
+ * Returns true for a v3 role-keyed manifest ({ role: AssetInstance, … }).
+ * Returns false for a flat v2 asset payload (has top-level `asset_type`),
+ * for an empty object, or for any non-plain-object value.
  */
-function adaptCreativeAssetForV2(creative: any): any {
-  const { catalogs, status, ...rest } = creative;
+function isManifestShape(assets: unknown): boolean {
+  if (typeof assets !== 'object' || assets === null || Array.isArray(assets)) return false;
+  if ('asset_type' in assets) return false; // already a flat single-asset payload
+  const values = Object.values(assets as object);
+  // Empty object is not a manifest — treat as pass-through
+  return values.some(v => typeof v === 'object' && v !== null && 'asset_type' in v);
+}
 
-  const adapted: any = { ...rest };
+/**
+ * Adapt a single creative for a v2 server.
+ * Strips v3-only fields, converts `status` enum → `approved` boolean,
+ * and flattens a manifest-shaped `assets` to a single v2 asset payload.
+ */
+function adaptCreativeForV2(creative: any): any {
+  const { catalogs, status, assets, ...rest } = creative;
+
+  const base: any = { ...rest };
 
   // Convert v3 status enum → v2 approved boolean
   if (status === 'approved') {
-    adapted.approved = true;
+    base.approved = true;
   } else if (status === 'rejected') {
-    adapted.approved = false;
+    base.approved = false;
   }
   // Any other status value (or absent) — omit approved entirely
 
-  return adapted;
+  if (assets === undefined) {
+    // v3 schema marks assets as required, but guard defensively for any
+    // typed as any that arrives without the field
+    return base;
+  }
+
+  if (!isManifestShape(assets)) {
+    // Already a flat asset payload (has asset_type at top level), an empty
+    // object, or an unrecognised shape — pass through verbatim and let the
+    // server's response validation surface any mismatch
+    return { ...base, assets };
+  }
+
+  // Manifest: { role: AssetInstance, … }
+  // isManifestShape guarantees at least one entry with asset_type, so entries is non-empty
+  const entries = Object.entries(assets as Record<string, unknown>);
+  const [primaryRole, primaryAsset] = entries[0]!;
+
+  if (entries.length > 1) {
+    const allRoles = entries.map(([r]) => r);
+    console.warn(
+      `[AdCP] sync_creatives: creative "${base.creative_id}" has multiple asset roles ` +
+        `(${allRoles.join(', ')}); only "${primaryRole}" will be sent to v2 server. ` +
+        `Upgrade to a v3 server to preserve all roles.`
+    );
+  }
+
+  return { ...base, assets: primaryAsset };
 }
 
 /**
  * Adapt a sync_creatives request for a v2 server.
- * Strips v3-only top-level fields and adapts each creative asset.
+ * Strips v3-only top-level fields and adapts each creative.
  */
 export function adaptSyncCreativesRequestForV2(request: any): any {
   const { account, adcp_major_version, ...rest } = request;
@@ -41,7 +92,7 @@ export function adaptSyncCreativesRequestForV2(request: any): any {
   return {
     ...rest,
     ...(rest.creatives && {
-      creatives: rest.creatives.map(adaptCreativeAssetForV2),
+      creatives: rest.creatives.map(adaptCreativeForV2),
     }),
   };
 }

--- a/src/lib/utils/sync-creatives-adapter.ts
+++ b/src/lib/utils/sync-creatives-adapter.ts
@@ -70,9 +70,7 @@ function adaptCreativeForV2(creative: any): any {
   // entry may be a non-asset role (e.g. metadata). Pick the first entry whose
   // value actually carries asset_type so the forwarded payload is always valid.
   const entries = Object.entries(assets as Record<string, unknown>);
-  const primary = entries.find(
-    ([, v]) => typeof v === 'object' && v !== null && 'asset_type' in v
-  );
+  const primary = entries.find(([, v]) => typeof v === 'object' && v !== null && 'asset_type' in v);
 
   if (!primary) {
     // All roles are malformed — pass through verbatim, let the server reject

--- a/src/lib/utils/sync-creatives-adapter.ts
+++ b/src/lib/utils/sync-creatives-adapter.ts
@@ -66,15 +66,26 @@ function adaptCreativeForV2(creative: any): any {
   }
 
   // Manifest: { role: AssetInstance, … }
-  // isManifestShape guarantees at least one entry with asset_type, so entries is non-empty
+  // isManifestShape guarantees at least one entry with asset_type, but the first
+  // entry may be a non-asset role (e.g. metadata). Pick the first entry whose
+  // value actually carries asset_type so the forwarded payload is always valid.
   const entries = Object.entries(assets as Record<string, unknown>);
-  const [primaryRole, primaryAsset] = entries[0]!;
+  const primary = entries.find(
+    ([, v]) => typeof v === 'object' && v !== null && 'asset_type' in v
+  );
 
-  if (entries.length > 1) {
-    const allRoles = entries.map(([r]) => r);
+  if (!primary) {
+    // All roles are malformed — pass through verbatim, let the server reject
+    return { ...base, assets };
+  }
+
+  const [primaryRole, primaryAsset] = primary;
+  const assetRoles = entries.map(([r]) => r);
+
+  if (assetRoles.length > 1) {
     console.warn(
       `[AdCP] sync_creatives: creative "${base.creative_id}" has multiple asset roles ` +
-        `(${allRoles.join(', ')}); only "${primaryRole}" will be sent to v2 server. ` +
+        `(${assetRoles.join(', ')}); only "${primaryRole}" will be sent to v2 server. ` +
         `Upgrade to a v3 server to preserve all roles.`
     );
   }

--- a/test/lib/request-validation.test.js
+++ b/test/lib/request-validation.test.js
@@ -1057,6 +1057,12 @@ describe('strict request validation against v2 servers', () => {
     assert.ok(call, 'sync_creatives should have reached the protocol layer');
     assert.strictEqual(call.args.account, undefined, 'account is stripped by the v2 adapter');
     assert.ok(Array.isArray(call.args.creatives) && call.args.creatives.length === 1, 'creatives are preserved');
+    // Manifest must be flattened: v2 expects a single asset payload, not { role: payload }
+    assert.deepStrictEqual(
+      call.args.creatives[0].assets,
+      { asset_type: 'video', url: 'https://example.com/video.mp4', width: 1920, height: 1080, duration_ms: 30000 },
+      'v3 manifest assets are flattened to a single v2 asset payload'
+    );
   });
 
   test('strict mode still rejects malformed v3 input from the migrated SingleAgentClient seam', async () => {

--- a/test/lib/sync-creatives-adapter.test.js
+++ b/test/lib/sync-creatives-adapter.test.js
@@ -1,0 +1,215 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  adaptSyncCreativesRequestForV2,
+} = require('../../dist/lib/utils/sync-creatives-adapter.js');
+
+const BASE_REQUEST = {
+  account: { account_id: 'acct-1' },
+  idempotency_key: '33333333-3333-3333-3333-333333333333',
+  creatives: [],
+};
+
+describe('adaptSyncCreativesRequestForV2 — top-level field stripping', () => {
+  test('strips account', () => {
+    const result = adaptSyncCreativesRequestForV2({ ...BASE_REQUEST });
+    assert.strictEqual(result.account, undefined);
+  });
+
+  test('strips adcp_major_version', () => {
+    const result = adaptSyncCreativesRequestForV2({ ...BASE_REQUEST, adcp_major_version: 3 });
+    assert.strictEqual(result.adcp_major_version, undefined);
+  });
+
+  test('preserves idempotency_key', () => {
+    const result = adaptSyncCreativesRequestForV2({ ...BASE_REQUEST });
+    assert.strictEqual(result.idempotency_key, BASE_REQUEST.idempotency_key);
+  });
+});
+
+describe('adaptSyncCreativesRequestForV2 — idempotency', () => {
+  test('same input produces identical output on repeated calls', () => {
+    const input = {
+      ...BASE_REQUEST,
+      creatives: [
+        {
+          creative_id: 'cre-1',
+          assets: { video: { asset_type: 'video', url: 'https://example.com/v.mp4' } },
+        },
+      ],
+    };
+    const r1 = adaptSyncCreativesRequestForV2(input);
+    const r2 = adaptSyncCreativesRequestForV2(input);
+    assert.deepStrictEqual(r1, r2);
+  });
+});
+
+describe('adaptSyncCreativesRequestForV2 — status → approved mapping', () => {
+  test('status "approved" becomes approved: true', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', status: 'approved' }],
+    });
+    assert.strictEqual(result.creatives[0].approved, true);
+    assert.strictEqual(result.creatives[0].status, undefined);
+  });
+
+  test('status "rejected" becomes approved: false', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', status: 'rejected' }],
+    });
+    assert.strictEqual(result.creatives[0].approved, false);
+  });
+
+  test('absent status omits approved entirely', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1' }],
+    });
+    assert.strictEqual(result.creatives[0].approved, undefined);
+  });
+
+  test('catalogs is stripped', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', catalogs: ['cat-1'] }],
+    });
+    assert.strictEqual(result.creatives[0].catalogs, undefined);
+  });
+});
+
+describe('adaptSyncCreativesRequestForV2 — manifest flattening (single-role)', () => {
+  function singleRoleCase(role, assetPayload) {
+    const input = {
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', assets: { [role]: assetPayload } }],
+    };
+    const result = adaptSyncCreativesRequestForV2(input);
+    assert.deepStrictEqual(result.creatives[0].assets, assetPayload, `${role} asset is flattened correctly`);
+    assert.strictEqual(result.creatives[0].creative_id, 'cre-1', 'creative_id is preserved');
+  }
+
+  test('video asset is flattened', () =>
+    singleRoleCase('video', {
+      asset_type: 'video',
+      url: 'https://example.com/video.mp4',
+      width: 1920,
+      height: 1080,
+      duration_ms: 30000,
+    }));
+
+  test('image asset is flattened', () =>
+    singleRoleCase('image', {
+      asset_type: 'image',
+      url: 'https://example.com/img.png',
+      width: 300,
+      height: 250,
+    }));
+
+  test('audio asset is flattened', () =>
+    singleRoleCase('audio', {
+      asset_type: 'audio',
+      url: 'https://example.com/audio.mp3',
+      duration_ms: 15000,
+    }));
+
+  test('VAST asset is flattened', () =>
+    singleRoleCase('vast', {
+      asset_type: 'vast',
+      url: 'https://example.com/vast.xml',
+    }));
+
+  test('text asset is flattened', () =>
+    singleRoleCase('headline', {
+      asset_type: 'text',
+      text: 'Buy now',
+    }));
+
+  test('html asset is flattened', () =>
+    singleRoleCase('body', {
+      asset_type: 'html',
+      html: '<div>Ad</div>',
+    }));
+});
+
+describe('adaptSyncCreativesRequestForV2 — manifest flattening (multi-role)', () => {
+  test('multi-role manifest: only primary (first) role is forwarded', () => {
+    const videoAsset = { asset_type: 'video', url: 'https://example.com/v.mp4' };
+    const bannerAsset = { asset_type: 'image', url: 'https://example.com/banner.png', width: 300, height: 250 };
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', assets: { video: videoAsset, companion: bannerAsset } }],
+    });
+    assert.strictEqual(result.creatives.length, 1, 'only one creative entry emitted');
+    assert.deepStrictEqual(result.creatives[0].assets, videoAsset, 'primary role asset is used');
+    assert.strictEqual(result.creatives[0].creative_id, 'cre-1', 'original creative_id preserved');
+  });
+
+  test('multi-role with same asset_type: no phantom creative_id collision', () => {
+    // Two roles both have asset_type: 'image' — ensures no creative_id--image collision
+    const hero = { asset_type: 'image', url: 'https://example.com/hero.png', width: 1200, height: 628 };
+    const thumb = { asset_type: 'image', url: 'https://example.com/thumb.png', width: 300, height: 250 };
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', assets: { hero, thumbnail: thumb } }],
+    });
+    assert.strictEqual(result.creatives.length, 1);
+    assert.deepStrictEqual(result.creatives[0].assets, hero);
+    assert.strictEqual(result.creatives[0].creative_id, 'cre-1');
+  });
+
+  test('batch with mixed single-role and multi-role creatives: output array length matches input', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [
+        { creative_id: 'cre-a', assets: { video: { asset_type: 'video', url: 'https://example.com/a.mp4' } } },
+        { creative_id: 'cre-b', assets: { image: { asset_type: 'image', url: 'https://example.com/b.png', width: 300, height: 250 }, companion: { asset_type: 'image', url: 'https://example.com/c.png', width: 728, height: 90 } } },
+      ],
+    });
+    // flatMap must not be accidentally used; output is one-to-one with input
+    assert.strictEqual(result.creatives.length, 2);
+    assert.ok(!Array.isArray(result.creatives[0]), 'elements are not nested arrays');
+    assert.ok(!Array.isArray(result.creatives[1]), 'elements are not nested arrays');
+  });
+});
+
+describe('adaptSyncCreativesRequestForV2 — edge cases', () => {
+  test('no assets field: assets is omitted from output', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1' }],
+    });
+    assert.strictEqual(result.creatives[0].assets, undefined);
+  });
+
+  test('already-flat assets (has asset_type at top level): passed through unchanged', () => {
+    const flat = { asset_type: 'image', url: 'https://example.com/img.png', width: 300, height: 250 };
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', assets: flat }],
+    });
+    assert.deepStrictEqual(result.creatives[0].assets, flat);
+  });
+
+  test('empty manifest object: passed through as empty object (not flattened)', () => {
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [{ creative_id: 'cre-1', assets: {} }],
+    });
+    // isManifestShape({}) returns false; empty object passes through verbatim
+    assert.deepStrictEqual(result.creatives[0].assets, {});
+  });
+
+  test('empty creatives array: returns empty array', () => {
+    const result = adaptSyncCreativesRequestForV2({ ...BASE_REQUEST, creatives: [] });
+    assert.deepStrictEqual(result.creatives, []);
+  });
+
+  test('no creatives key: omits creatives from output', () => {
+    const { creatives: _omit, ...noCreatives } = BASE_REQUEST;
+    const result = adaptSyncCreativesRequestForV2(noCreatives);
+    assert.strictEqual(result.creatives, undefined);
+  });
+});

--- a/test/lib/sync-creatives-adapter.test.js
+++ b/test/lib/sync-creatives-adapter.test.js
@@ -1,9 +1,7 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
-const {
-  adaptSyncCreativesRequestForV2,
-} = require('../../dist/lib/utils/sync-creatives-adapter.js');
+const { adaptSyncCreativesRequestForV2 } = require('../../dist/lib/utils/sync-creatives-adapter.js');
 
 const BASE_REQUEST = {
   account: { account_id: 'acct-1' },
@@ -165,7 +163,13 @@ describe('adaptSyncCreativesRequestForV2 — manifest flattening (multi-role)', 
       ...BASE_REQUEST,
       creatives: [
         { creative_id: 'cre-a', assets: { video: { asset_type: 'video', url: 'https://example.com/a.mp4' } } },
-        { creative_id: 'cre-b', assets: { image: { asset_type: 'image', url: 'https://example.com/b.png', width: 300, height: 250 }, companion: { asset_type: 'image', url: 'https://example.com/c.png', width: 728, height: 90 } } },
+        {
+          creative_id: 'cre-b',
+          assets: {
+            image: { asset_type: 'image', url: 'https://example.com/b.png', width: 300, height: 250 },
+            companion: { asset_type: 'image', url: 'https://example.com/c.png', width: 728, height: 90 },
+          },
+        },
       ],
     });
     // flatMap must not be accidentally used; output is one-to-one with input

--- a/test/lib/sync-creatives-adapter.test.js
+++ b/test/lib/sync-creatives-adapter.test.js
@@ -69,6 +69,18 @@ describe('adaptSyncCreativesRequestForV2 — status → approved mapping', () =>
     assert.strictEqual(result.creatives[0].approved, undefined);
   });
 
+  // Non-binary v3 statuses have no v2 equivalent — both status and approved are omitted
+  for (const s of ['pending_review', 'processing', 'archived']) {
+    test(`status "${s}" omits approved (no v2 equivalent)`, () => {
+      const result = adaptSyncCreativesRequestForV2({
+        ...BASE_REQUEST,
+        creatives: [{ creative_id: 'cre-1', status: s }],
+      });
+      assert.strictEqual(result.creatives[0].approved, undefined);
+      assert.strictEqual(result.creatives[0].status, undefined);
+    });
+  }
+
   test('catalogs is stripped', () => {
     const result = adaptSyncCreativesRequestForV2({
       ...BASE_REQUEST,
@@ -176,6 +188,22 @@ describe('adaptSyncCreativesRequestForV2 — manifest flattening (multi-role)', 
     assert.strictEqual(result.creatives.length, 2);
     assert.ok(!Array.isArray(result.creatives[0]), 'elements are not nested arrays');
     assert.ok(!Array.isArray(result.creatives[1]), 'elements are not nested arrays');
+  });
+
+  test('non-asset-first role: primary selection skips to first entry with asset_type', () => {
+    // { thumbnail: {width, height} } has no asset_type — would forward a broken payload
+    // if the adapter picked entries[0] blindly. The fix finds the first asset-bearing entry.
+    const videoAsset = { asset_type: 'video', url: 'https://example.com/v.mp4' };
+    const result = adaptSyncCreativesRequestForV2({
+      ...BASE_REQUEST,
+      creatives: [
+        {
+          creative_id: 'cre-1',
+          assets: { thumbnail: { width: 100, height: 100 }, video: videoAsset },
+        },
+      ],
+    });
+    assert.deepStrictEqual(result.creatives[0].assets, videoAsset, 'first asset_type-bearing role is used');
   });
 });
 


### PR DESCRIPTION
Closes #1116

## Summary

`adaptSyncCreativesRequestForV2` was a thin v3-prefix-stripper: it stripped `account`, `adcp_major_version`, `catalogs`, and converted `status`→`approved`, but spread `...rest` on each creative, leaking the v3 `assets` manifest shape (`{ role: { asset_type, url, … } }`) through to v2.5 servers unchanged. v2.5's `creative-asset.json` schema expects a single asset payload discriminated by `asset_type`; every adapted creative therefore failed the `oneOf` check and was rejected by strict v2.5 sellers.

This PR rewrites the per-creative adapter to detect and flatten manifest-shaped assets:

- **Single-role manifest** (`{ video: { asset_type: 'video', … } }`) → extract the single value, pass as flat `assets`
- **Multi-role manifest** → pick the first entry whose value carries `asset_type` (skipping any non-asset roles), emit `console.warn` naming the discarded roles, keep original `creative_id` intact (no phantom suffix IDs)
- **Already-flat assets** (has `asset_type` at top level) → pass through unchanged
- **No `assets` field / empty manifest / all-malformed roles** → defensive pass-through; let the server validate

## What was tested

- `npx tsc --project tsconfig.lib.json` — clean (pre-existing TS2688/TS5107 on `main` unchanged)
- `npx prettier --check` — clean
- `node --test test/lib/sync-creatives-adapter.test.js` — 26/26 pass (new dedicated suite)
- `node --test test/lib/request-validation.test.js` — 9 pre-existing failures unchanged; the new `deepStrictEqual` assertion on `creatives[0].assets` passes

Pre-existing failures in `request-validation.test.js` are unrelated infrastructure issues present on `main` (confirmed via `git stash` baseline).

## Pre-PR review

- **code-reviewer**: approved — blocker fixed (non-asset-first-role entry now skipped via `find()`; test guards the fix); changeset present; nits noted in summary.
- **dx-expert**: approved — warn message names dropped roles and points at v3 upgrade path; three non-binary status tests added documenting intentional silent-drop; batch-length invariant test guards against accidental `flatMap`.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012XP8dKgUqa37s61cDcm996

---
_Generated by [Claude Code](https://claude.ai/code/session_012XP8dKgUqa37s61cDcm996)_