### PR TITLE
feat(v2.5): schema cache + warn-only post-adapter validation + conformance suite

### DIFF
--- a/.changeset/v2-5-adapter-conformance-suite.md
+++ b/.changeset/v2-5-adapter-conformance-suite.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+Adds an adapter-conformance test suite that pins the v3→v2 wire adapters against the cached v2.5 schema bundle. CI signal for "the v2 wire adapters produce v2.5-conformant output."
+
+Each canonical v3 fixture runs through `adaptRequestForServerVersion`; the adapted output must validate against `schemas/cache/v2.5/`. Tools with known drift have explicit `expected_failures` entries pointing at the tracking issue and pinning the failure-mode pointers — so a fix that closes the gap surfaces as an unexpected pass and prompts the entry to be removed. A "every v2-adapted tool has a fixture" guard test ensures new adapters can't ship without conformance coverage.
+
+Initial state: `get_products` and `update_media_buy` conform clean. `create_media_buy` has known drift on `/buyer_ref` (top-level + per-package), tracked at adcontextprotocol/adcp-client#1115. `sync_creatives` has known drift on `/creatives/0/assets/video` (v3 manifest shape vs v2.5 single-asset-payload `oneOf`), tracked at adcontextprotocol/adcp-client#1116.
+
+No source changes. Test-only — but a changeset because the suite is the binding contract for v2 wire conformance going forward.

--- a/.changeset/v2-5-post-adapter-validation.md
+++ b/.changeset/v2-5-post-adapter-validation.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': minor
+---
+
+Adds a warn-only post-adapter validation pass against the v2.5 schema bundle. After `adaptRequestForServerVersion` rewrites a v3 request into v2 wire format for a v2-detected agent, `SingleAgentClient` calls `executor.validateAdaptedRequestAgainstV2(taskName, adaptedParams)` which validates the adapted shape against the cached v2.5 schemas in warn mode. Symmetric counterpart to the existing pre-adapter v3 pass: that one catches "user wrote bad v3", this one catches "adapter produced bad v2.5".
+
+Always warn-only — adapter bugs shouldn't break user requests, and the v3 pre-send pass already vouched for the user-facing input shape. The pass surfaces drift via `debugLogs` (when callers pass an array; SDK-internal call sites currently don't, so warnings are silent in production until the upcoming adapter-conformance test suite consumes them as CI signal).
+
+Skips silently for tasks without a v2.5 schema (custom tools, tasks added since 2.5.3) and when the v2.5 bundle isn't cached. Caller in `SingleAgentClient` gates on `serverVersion === 'v2'` so v3-targeted traffic doesn't pay the validation cost.
+
+Initial baseline against the canonical adapter outputs surfaced two real drift items worth tracking separately: `adaptCreateMediaBuyRequestForV2` doesn't emit `buyer_ref` (v2.5 requires it top-level + per-package), and `adaptSyncCreativesRequestForV2`'s `assets.video` shape fails a `oneOf` in v2.5. These will be addressed alongside the adapter-conformance test suite.
+
+`TaskExecutor.validateAdaptedRequestAgainstV2(taskName, adaptedParams, debugLogs?)` is the public seam; mirrors the shape of `validateRequest`.

--- a/.changeset/v2-5-schema-cache.md
+++ b/.changeset/v2-5-schema-cache.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': minor
+---
+
+Adds v2.5 schema bundle support so the SDK can validate against the actually-shipping AdCP 2.5.3 contract, not just v3.
+
+`scripts/sync-v2-5-schemas.ts` (`npm run sync-schemas:v2.5`) pulls the v2.5.3 schema bundle from `adcontextprotocol/adcp@2.5-maintenance` at a pinned commit and drops it at `schemas/cache/v2.5/`. The pinned-SHA approach is necessary because the upstream `v2.5.2` and `v2.5.3` releases were never tagged or published as GitHub releases despite shipping in `package.json` and `CHANGELOG.md` (filed at `adcontextprotocol/adcp#3689`); pulling from the published spec site would silently regress to v2.5.1, missing the `additionalProperties: true` forward-compat relaxation, the `error.json` `details` typing fix, and the `impressions` / `paused` package-request fields.
+
+The existing `resolveBundleKey('v2.5')` legacy alias and `copy-schemas-to-dist.ts` legacy-prerelease path both already routed `v2.5` correctly without resolver changes — the bundle ships at `dist/lib/schemas-data/v2.5/` alongside `dist/lib/schemas-data/3.0/`.
+
+`schema-loader.ts`'s `ensureCoreLoaded` now registers request tool files in addition to fragments. v2.5's source tree ships flat (no pre-bundled `bundled/` subtree) with cross-fragment `$ref`s like `media-buy/create-media-buy-request.json` referencing `/schemas/media-buy/package-request.json`. The filename-suffix heuristic in `buildFileIndex` misclassifies fragments like `package-request.json` as tools (`package::request`), so the previous "skip everything in fileIndex" rule left them unregistered and AJV emitted `MissingRefError` on the cross-fragment lookup. The narrowed rule now skips only response tool files (which need `relaxResponseRoot` lazy-applied via `getValidator`); request tool files and fragments are pre-registered, so cross-fragment `$ref`s resolve at compile time. v3's bundled-schemas path is unaffected (refs were already inlined).
+
+No buyer-facing API surface change. Internal-only — the v2.5 bundle is reachable via `getValidator(toolName, direction, 'v2.5')` for upcoming adapter-conformance work.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm run format:check
 
       - name: Sync schemas from AdCP
-        run: npm run sync-schemas
+        run: npm run sync-schemas:all
 
       - name: Validate generated files are in sync
         run: |

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
     "test:status-report": "node test/utils/final-status-report.js",
     "sync-schemas": "tsx scripts/sync-schemas.ts",
     "sync-schemas:v2.5": "tsx scripts/sync-v2-5-schemas.ts",
+    "sync-schemas:all": "npm run sync-schemas && npm run sync-schemas:v2.5",
     "schema-diff": "tsx scripts/schema-diff.ts",
     "generate-types": "tsx scripts/generate-types.ts && tsx scripts/generate-enum-arrays.ts",
     "generate-registry-types": "tsx scripts/generate-registry-types.ts",

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
     "test:protocol-comparison": "node test/utils/comprehensive-protocol-comparison.js",
     "test:status-report": "node test/utils/final-status-report.js",
     "sync-schemas": "tsx scripts/sync-schemas.ts",
+    "sync-schemas:v2.5": "tsx scripts/sync-v2-5-schemas.ts",
     "schema-diff": "tsx scripts/schema-diff.ts",
     "generate-types": "tsx scripts/generate-types.ts && tsx scripts/generate-enum-arrays.ts",
     "generate-registry-types": "tsx scripts/generate-registry-types.ts",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
   ],
   "scripts": {
     "prepare": "node scripts/install-hooks.js 2>/dev/null || true",
-    "prepublishOnly": "npm run clean && npm run sync-schemas && (test -f src/lib/types/tools.generated.ts || npm run generate-types) && npm run build:lib && node --test-timeout=60000 --test-force-exit --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js",
+    "prepublishOnly": "npm run clean && npm run sync-schemas:all && (test -f src/lib/types/tools.generated.ts || npm run generate-types) && npm run build:lib && node --test-timeout=60000 --test-force-exit --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js",
     "build": "npm run build:lib",
     "build:lib": "npm run sync-version && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",

--- a/scripts/generate-wellknown-schemas.ts
+++ b/scripts/generate-wellknown-schemas.ts
@@ -26,14 +26,39 @@ function getLatestCacheDir(): string {
   if (!existsSync(SCHEMA_CACHE_DIR)) {
     throw new Error('Schema cache directory not found. Run "npm run sync-schemas" first.');
   }
-  const versions = readdirSync(SCHEMA_CACHE_DIR)
+  // Restrict to MAJOR.MINOR.PATCH-shaped directories. Legacy aliases
+  // (`v2.5`, `v2.6`) and the `latest` symlink would otherwise win the
+  // descending alphabetical sort because `v` > `3` lexically — well-known
+  // schemas (`brand.json`, `adagents.json`) live only in the primary AdCP
+  // version cache, so picking the v2.5 bundle would fail with "brand.json
+  // not found." Sort by major/minor/patch numerically; the newest stable
+  // (or prerelease) wins.
+  const semverDirs = readdirSync(SCHEMA_CACHE_DIR)
+    .filter(f => /^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(f))
     .filter(f => statSync(path.join(SCHEMA_CACHE_DIR, f)).isDirectory())
-    .sort()
-    .reverse();
-  if (versions.length === 0) {
-    throw new Error('No cached schema versions found.');
+    .map(name => {
+      const m = name.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/)!;
+      return {
+        name,
+        major: parseInt(m[1]!, 10),
+        minor: parseInt(m[2]!, 10),
+        patch: parseInt(m[3]!, 10),
+        prerelease: m[4] ?? '',
+      };
+    })
+    .sort((a, b) => {
+      if (a.major !== b.major) return b.major - a.major;
+      if (a.minor !== b.minor) return b.minor - a.minor;
+      if (a.patch !== b.patch) return b.patch - a.patch;
+      // Stable beats prerelease at the same numeric version.
+      if (a.prerelease === '' && b.prerelease !== '') return -1;
+      if (a.prerelease !== '' && b.prerelease === '') return 1;
+      return b.prerelease.localeCompare(a.prerelease);
+    });
+  if (semverDirs.length === 0) {
+    throw new Error('No semver-shaped schema versions found in cache.');
   }
-  return path.join(SCHEMA_CACHE_DIR, versions[0]);
+  return path.join(SCHEMA_CACHE_DIR, semverDirs[0]!.name);
 }
 
 function loadCachedSchema(schemaRef: string): any {

--- a/scripts/generate-zod-schemas.ts
+++ b/scripts/generate-zod-schemas.ts
@@ -16,16 +16,37 @@ function getLatestCacheDir(): string {
     throw new Error('Schema cache directory not found');
   }
 
-  const versions = readdirSync(SCHEMA_CACHE_DIR)
-    .filter(f => statSync(path.join(SCHEMA_CACHE_DIR, f)).isDirectory())
-    .sort()
-    .reverse();
+  // Restrict to MAJOR.MINOR.PATCH-shaped directories so legacy aliases
+  // (`v2.5`, `v2.6`) and the `latest` symlink don't shadow the real
+  // primary-version cache. `v` > `3` lexically, so naive sort+reverse
+  // would otherwise pick `v2.5` and break Zod generation.
+  const semverDirs = readdirSync(SCHEMA_CACHE_DIR)
+    .filter((f: string) => /^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(f))
+    .filter((f: string) => statSync(path.join(SCHEMA_CACHE_DIR, f)).isDirectory())
+    .map((name: string) => {
+      const m = name.match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/)!;
+      return {
+        name,
+        major: parseInt(m[1]!, 10),
+        minor: parseInt(m[2]!, 10),
+        patch: parseInt(m[3]!, 10),
+        prerelease: m[4] ?? '',
+      };
+    })
+    .sort((a: { major: number; minor: number; patch: number; prerelease: string }, b: typeof a) => {
+      if (a.major !== b.major) return b.major - a.major;
+      if (a.minor !== b.minor) return b.minor - a.minor;
+      if (a.patch !== b.patch) return b.patch - a.patch;
+      if (a.prerelease === '' && b.prerelease !== '') return -1;
+      if (a.prerelease !== '' && b.prerelease === '') return 1;
+      return b.prerelease.localeCompare(a.prerelease);
+    });
 
-  if (versions.length === 0) {
-    throw new Error('No cached schema versions found');
+  if (semverDirs.length === 0) {
+    throw new Error('No semver-shaped schema versions found in cache');
   }
 
-  return path.join(SCHEMA_CACHE_DIR, versions[0]);
+  return path.join(SCHEMA_CACHE_DIR, semverDirs[0]!.name);
 }
 
 // Core AdCP schemas to generate - includes all nested types

--- a/scripts/sync-v2-5-schemas.ts
+++ b/scripts/sync-v2-5-schemas.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+/**
+ * Fetch the AdCP v2.5.x schema bundle from `adcontextprotocol/adcp` and drop
+ * it at `schemas/cache/v2.5/` so the existing `resolveBundleKey('v2.5')`
+ * legacy alias finds it.
+ *
+ * Why a separate script: upstream's published spec site (`adcontextprotocol.org`)
+ * only serves released spec versions (latest v2.5 release is v2.5.1, Dec 2025).
+ * The actual v2.5.3 cut — including `additionalProperties: true` for forward
+ * compat, the `error.json` typing fix, and the `impressions` / `paused`
+ * package-request fields — was bumped in `package.json` and `CHANGELOG.md`
+ * on the `2.5-maintenance` branch but never tagged or released
+ * (adcontextprotocol/adcp#3689). Until that's resolved we pull from a pinned
+ * branch SHA so we get the actually-shipping shape, not the stale tagged one.
+ *
+ * The v3 sync flow (`sync-schemas.ts`) stays as-is. This is purely additive.
+ */
+
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import path from 'path';
+import * as tar from 'tar';
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SCHEMA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache');
+
+// Pinned source — change this constant to refresh from a newer 2.5-maintenance
+// commit. Keep it explicit so CI builds are reproducible and a downstream
+// `additionalProperties` flip can't silently land via the implicit "HEAD".
+const SOURCE_REPO = 'adcontextprotocol/adcp';
+const SOURCE_BRANCH = '2.5-maintenance';
+const SOURCE_SHA = '4e553ad955f83b49c7d221ab5c3ff78237ad02e3';
+const TARGET_BUNDLE_KEY = 'v2.5';
+
+async function fetchBinary(url: string): Promise<Buffer> {
+  const res = await fetch(url, { redirect: 'follow' });
+  if (!res.ok) throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+async function main(): Promise<void> {
+  console.log(`📥 Fetching ${SOURCE_REPO}@${SOURCE_SHA} (${SOURCE_BRANCH})`);
+  const tarballUrl = `https://codeload.github.com/${SOURCE_REPO}/tar.gz/${SOURCE_SHA}`;
+
+  mkdirSync(REPO_ROOT, { recursive: true });
+  const workDir = mkdtempSync(path.join(REPO_ROOT, '.adcp-v2-5-sync-'));
+  try {
+    const tgz = await fetchBinary(tarballUrl);
+    const tgzPath = path.join(workDir, 'bundle.tgz');
+    writeFileSync(tgzPath, tgz);
+    await tar.x({ file: tgzPath, cwd: workDir });
+
+    // GitHub archives wrap content in `<repo-name>-<sha>/`.
+    const wrapper = `adcp-${SOURCE_SHA}`;
+    const sourceTree = path.join(workDir, wrapper, 'static', 'schemas', 'source');
+    if (!existsSync(sourceTree)) {
+      throw new Error(`Expected ${sourceTree} in tarball — upstream layout may have changed.`);
+    }
+
+    // Read the upstream-declared adcp_version so we can fail loud if the SHA
+    // we pinned no longer points at a 2.5.x build.
+    const indexJson = JSON.parse(readFileSync(path.join(sourceTree, 'index.json'), 'utf8'));
+    const upstreamVersion: string = indexJson.adcp_version ?? '<unknown>';
+    if (!upstreamVersion.startsWith('2.5.')) {
+      throw new Error(
+        `Pinned SHA reports adcp_version ${JSON.stringify(upstreamVersion)} — expected 2.5.x. ` +
+          `Update SOURCE_SHA or pull from a different branch.`
+      );
+    }
+    console.log(`✅ Upstream reports adcp_version=${upstreamVersion}`);
+
+    const dest = path.join(SCHEMA_CACHE_DIR, TARGET_BUNDLE_KEY);
+    if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
+    mkdirSync(path.dirname(dest), { recursive: true });
+    cpSync(sourceTree, dest, { recursive: true });
+
+    console.log(`📁 Schemas:    ${dest}`);
+    console.log(`📌 Source:     ${SOURCE_REPO}@${SOURCE_SHA}`);
+    console.log(`💡 Bundle key resolves via legacy alias 'v2.5' in resolveBundleKey().`);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/sync-v2-5-schemas.ts
+++ b/scripts/sync-v2-5-schemas.ts
@@ -16,25 +16,64 @@
  * The v3 sync flow (`sync-schemas.ts`) stays as-is. This is purely additive.
  */
 
-import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { createHash } from 'crypto';
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import path from 'path';
 import * as tar from 'tar';
 
 const REPO_ROOT = path.join(__dirname, '..');
 const SCHEMA_CACHE_DIR = path.join(REPO_ROOT, 'schemas/cache');
 
-// Pinned source — change this constant to refresh from a newer 2.5-maintenance
-// commit. Keep it explicit so CI builds are reproducible and a downstream
-// `additionalProperties` flip can't silently land via the implicit "HEAD".
+// Pinned source — change all three constants together to refresh from a newer
+// 2.5-maintenance commit. Keep them explicit so CI builds are reproducible
+// and a downstream `additionalProperties` flip can't silently land via the
+// implicit "HEAD".
 const SOURCE_REPO = 'adcontextprotocol/adcp';
 const SOURCE_BRANCH = '2.5-maintenance';
 const SOURCE_SHA = '4e553ad955f83b49c7d221ab5c3ff78237ad02e3';
+// SHA-256 of the codeload tarball at the pinned SHA. Defense-in-depth: the
+// codeload URL is content-addressed by GitHub but TLS substitution / a
+// compromised CI runner could still swap bytes. Mismatch fails the sync
+// before any extraction. Refresh by running:
+//   curl -sL "https://codeload.github.com/<repo>/tar.gz/<sha>" | shasum -a 256
+const SOURCE_TARBALL_SHA256 = '580656d6466ef9f0d1119985e6726c2efea718dc671e2ad30957fcb2fd54af0f';
 const TARGET_BUNDLE_KEY = 'v2.5';
 
 async function fetchBinary(url: string): Promise<Buffer> {
   const res = await fetch(url, { redirect: 'follow' });
   if (!res.ok) throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
   return Buffer.from(await res.arrayBuffer());
+}
+
+/**
+ * Reject any symlinks anywhere under `root`. We only ship JSON-Schema
+ * files; an upstream symlink (legitimate or hostile) would let `cpSync`'s
+ * default symlink-following pivot a copy outside the source tree.
+ */
+function assertNoSymlinks(root: string): void {
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const abs = path.join(dir, entry.name);
+      if (entry.isSymbolicLink() || lstatSync(abs).isSymbolicLink()) {
+        throw new Error(
+          `Refusing to sync v2.5 bundle: symlink detected at ${abs}. The upstream schema tree should be plain files only.`
+        );
+      }
+      if (entry.isDirectory()) stack.push(abs);
+    }
+  }
 }
 
 async function main(): Promise<void> {
@@ -45,9 +84,21 @@ async function main(): Promise<void> {
   const workDir = mkdtempSync(path.join(REPO_ROOT, '.adcp-v2-5-sync-'));
   try {
     const tgz = await fetchBinary(tarballUrl);
+    const actualSha = createHash('sha256').update(tgz).digest('hex');
+    if (actualSha !== SOURCE_TARBALL_SHA256) {
+      throw new Error(
+        `Tarball sha256 mismatch.\n  expected: ${SOURCE_TARBALL_SHA256}\n  actual:   ${actualSha}\n` +
+          `Refresh by running:\n  curl -sL "${tarballUrl}" | shasum -a 256\n` +
+          `and updating SOURCE_TARBALL_SHA256.`
+      );
+    }
+    console.log(`✅ tarball sha256 verified (${actualSha.slice(0, 12)}…)`);
+
     const tgzPath = path.join(workDir, 'bundle.tgz');
     writeFileSync(tgzPath, tgz);
-    await tar.x({ file: tgzPath, cwd: workDir });
+    // node-tar 7+ defaults to defending against `..` and absolute paths.
+    // `strict: true` upgrades suspicious entries from warning to throw.
+    await tar.x({ file: tgzPath, cwd: workDir, strict: true });
 
     // GitHub archives wrap content in `<repo-name>-<sha>/`.
     const wrapper = `adcp-${SOURCE_SHA}`;
@@ -68,10 +119,35 @@ async function main(): Promise<void> {
     }
     console.log(`✅ Upstream reports adcp_version=${upstreamVersion}`);
 
+    // Reject any symlinks the tarball might have shipped — `cpSync`
+    // follows them by default, which would let an upstream link copy
+    // through to anywhere on disk. node-tar's default extraction blocks
+    // symlinks-out-of-cwd, but explicit symlinks staying inside the
+    // source tree would still be honoured by cpSync.
+    assertNoSymlinks(sourceTree);
+
     const dest = path.join(SCHEMA_CACHE_DIR, TARGET_BUNDLE_KEY);
     if (existsSync(dest)) rmSync(dest, { recursive: true, force: true });
     mkdirSync(path.dirname(dest), { recursive: true });
-    cpSync(sourceTree, dest, { recursive: true });
+    cpSync(sourceTree, dest, { recursive: true, verbatimSymlinks: true });
+
+    // Provenance file: lets downstream consumers diff bundles across
+    // refreshes without re-running this script.
+    writeFileSync(
+      path.join(dest, '_provenance.json'),
+      JSON.stringify(
+        {
+          source_repo: SOURCE_REPO,
+          source_branch: SOURCE_BRANCH,
+          source_sha: SOURCE_SHA,
+          source_tarball_sha256: SOURCE_TARBALL_SHA256,
+          upstream_adcp_version: upstreamVersion,
+          synced_at: new Date().toISOString(),
+        },
+        null,
+        2
+      ) + '\n'
+    );
 
     console.log(`📁 Schemas:    ${dest}`);
     console.log(`📌 Source:     ${SOURCE_REPO}@${SOURCE_SHA}`);

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1159,6 +1159,14 @@ export class SingleAgentClient {
     const serverVersion = await this.detectServerVersion();
     const adaptedParams = await this.adaptRequestForServerVersion(taskType, normalizedParams);
 
+    // Symmetric to the pre-adapter v3 pass above: when the adapter
+    // rewrote the request for a v2 server, warn-validate the adapted
+    // shape against the cached v2.5 schema bundle. Surfaces drift
+    // between what the adapter emits and what a v2.5 server expects.
+    if (serverVersion === 'v2') {
+      this.executor.validateAdaptedRequestAgainstV2(taskType, adaptedParams);
+    }
+
     const result = await this.executor.executeTask<T>(
       agent,
       taskType,
@@ -2135,6 +2143,12 @@ export class SingleAgentClient {
     // fields like buying_mode when talking to v2 agents).
     const serverVersion = await this.detectServerVersion();
     const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams);
+
+    // Symmetric warn-only post-adapter pass against the v2.5 schema bundle.
+    // Surfaces drift between adapter output and v2.5 wire shape.
+    if (serverVersion === 'v2') {
+      this.executor.validateAdaptedRequestAgainstV2(taskName, adaptedParams);
+    }
 
     const result = await this.executor.executeTask<T>(
       agent,

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -342,6 +342,23 @@ export class TaskExecutor {
   }
 
   /**
+   * After `adaptRequestForServerVersion` has rewritten a v3 request into v2
+   * wire format, validate the adapted shape against the cached v2.5 schema
+   * bundle. Always warn-only — adapter bugs shouldn't break user requests,
+   * and the v3 pre-send pass already vouched for the user-facing input.
+   * This pass exists to surface drift between what the adapter emits and
+   * what a v2.5 server expects on the wire (primarily as CI signal via the
+   * adapter-conformance test suite).
+   *
+   * Skips silently for tasks without a v2.5 schema or when the v2.5 bundle
+   * isn't cached. Caller is responsible for gating on `serverVersion === 'v2'`
+   * so v3-targeted traffic doesn't pay the validation cost.
+   */
+  validateAdaptedRequestAgainstV2(taskName: string, adaptedParams: unknown, debugLogs?: any[]): void {
+    validateOutgoingRequest(taskName, adaptedParams, 'warn', debugLogs, 'v2.5');
+  }
+
+  /**
    * Generate webhook URL for protocol-level webhook support
    */
   /**

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -335,13 +335,30 @@ function ensureInit(version: string): LoaderState {
  */
 function ensureCoreLoaded(s: LoaderState): void {
   if (s.coreLoaded) return;
-  const toolFiles = new Set(s.fileIndex.values());
+  // Tool RESPONSE files only — those need lazy compile through `getValidator`
+  // so `relaxResponseRoot` can apply. Tool REQUEST files and unclassified
+  // fragments are safe to pre-register: requests don't need root-level
+  // relaxation, and fragments registered here are exactly what cross-tool
+  // `$ref`s expect to find by `$id`.
+  //
+  // Why this matters: bundles whose source tree doesn't include a `bundled/`
+  // pre-resolved subtree (e.g. v2.5, where the spec ships flat schemas with
+  // unresolved `$ref`s) classify fragments like `media-buy/package-request.json`
+  // as tool `package::request` via the filename-suffix heuristic in
+  // `buildFileIndex`. Skipping all tool files would leave that fragment
+  // unregistered, so a later compile of `create_media_buy` fails on
+  // `MissingRefError: can't resolve /schemas/media-buy/package-request.json`.
+  const responseToolFiles = new Set<string>();
+  for (const [key, file] of s.fileIndex) {
+    if (key.endsWith('::request')) continue;
+    responseToolFiles.add(file);
+  }
   for (const entry of readdirSync(s.root, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     if (entry.name === 'bundled') continue;
     const abs = path.join(s.root, entry.name);
     for (const file of walkJsonFiles(abs)) {
-      if (toolFiles.has(file)) continue;
+      if (responseToolFiles.has(file)) continue;
       const schema = loadJson(file);
       if (typeof schema.$id === 'string' && !s.ajv.getSchema(schema.$id)) {
         s.ajv.addSchema(schema);

--- a/test/lib/adapter-v2-5-conformance.test.js
+++ b/test/lib/adapter-v2-5-conformance.test.js
@@ -19,12 +19,17 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
 const { validateRequest } = require('../../dist/lib/validation/schema-validator');
+const { hasSchemaBundle } = require('../../dist/lib/validation/schema-loader.js');
 const { adaptGetProductsRequestForV2 } = require('../../dist/lib/utils/pricing-adapter');
 const {
   adaptCreateMediaBuyRequestForV2,
   adaptUpdateMediaBuyRequestForV2,
 } = require('../../dist/lib/utils/creative-adapter');
 const { adaptSyncCreativesRequestForV2 } = require('../../dist/lib/utils/sync-creatives-adapter');
+
+// Fresh clones that haven't run `npm run sync-schemas:v2.5` won't have the
+// bundle. CI runs `sync-schemas:all` so it's present there.
+const V2_5_AVAILABLE = hasSchemaBundle('v2.5');
 
 // Canonical v3 inputs per tool. Match the shape a v3 buyer would write
 // before any wire adaptation.
@@ -94,52 +99,56 @@ const FIXTURES = {
   },
 };
 
-describe('v2 adapter conformance against v2.5 schema bundle', () => {
-  for (const [taskName, fixture] of Object.entries(FIXTURES)) {
-    if (fixture.expected_failures) {
-      test(`${taskName} — KNOWN drift, tracked at ${fixture.expected_failures.issue}`, () => {
+describe(
+  'v2 adapter conformance against v2.5 schema bundle',
+  { skip: V2_5_AVAILABLE ? false : 'v2.5 bundle not cached — run `npm run sync-schemas:v2.5`' },
+  () => {
+    for (const [taskName, fixture] of Object.entries(FIXTURES)) {
+      if (fixture.expected_failures) {
+        test(`${taskName} — KNOWN drift, tracked at ${fixture.expected_failures.issue}`, () => {
+          const adapted = fixture.adapter(structuredClone(fixture.v3));
+          const outcome = validateRequest(taskName, adapted, 'v2.5');
+          assert.strictEqual(
+            outcome.valid,
+            false,
+            `${taskName} unexpectedly passed v2.5 validation. If ${fixture.expected_failures.issue} was fixed, ` +
+              `remove the expected_failures entry and let this test enforce conformance.`
+          );
+          // Pin the specific failure mode so a fix that changes the shape
+          // surfaces as an assertion break here (signaling the test should
+          // be flipped to a passing fixture).
+          const surfacedPointers = new Set(outcome.issues.map(i => i.pointer));
+          for (const expected of fixture.expected_failures.pointers) {
+            assert.ok(
+              surfacedPointers.has(expected),
+              `${taskName} did not surface expected drift at ${expected}; surfaced: ${[...surfacedPointers].join(', ')}. ` +
+                `If the failure mode changed, update or remove this fixture.`
+            );
+          }
+        });
+        continue;
+      }
+      test(`${taskName} — adapted shape conforms to v2.5`, () => {
         const adapted = fixture.adapter(structuredClone(fixture.v3));
         const outcome = validateRequest(taskName, adapted, 'v2.5');
         assert.strictEqual(
           outcome.valid,
-          false,
-          `${taskName} unexpectedly passed v2.5 validation. If ${fixture.expected_failures.issue} was fixed, ` +
-            `remove the expected_failures entry and let this test enforce conformance.`
+          true,
+          `${taskName} adapter output failed v2.5 validation:\n${outcome.issues
+            .map(i => `  - ${i.pointer} | ${i.keyword} | ${i.message}`)
+            .join('\n')}`
         );
-        // Pin the specific failure mode so a fix that changes the shape
-        // surfaces as an assertion break here (signaling the test should
-        // be flipped to a passing fixture).
-        const surfacedPointers = new Set(outcome.issues.map(i => i.pointer));
-        for (const expected of fixture.expected_failures.pointers) {
-          assert.ok(
-            surfacedPointers.has(expected),
-            `${taskName} did not surface expected drift at ${expected}; surfaced: ${[...surfacedPointers].join(', ')}. ` +
-              `If the failure mode changed, update or remove this fixture.`
-          );
-        }
       });
-      continue;
     }
-    test(`${taskName} — adapted shape conforms to v2.5`, () => {
-      const adapted = fixture.adapter(structuredClone(fixture.v3));
-      const outcome = validateRequest(taskName, adapted, 'v2.5');
-      assert.strictEqual(
-        outcome.valid,
-        true,
-        `${taskName} adapter output failed v2.5 validation:\n${outcome.issues
-          .map(i => `  - ${i.pointer} | ${i.keyword} | ${i.message}`)
-          .join('\n')}`
-      );
+
+    test('every v2-adapted tool has a fixture in this suite', () => {
+      // Authoritative list mirrors `SingleAgentClient.adaptRequestForServerVersion`.
+      // If a new adapter lands without a fixture, this test fails so we don't
+      // ship an unvalidated v2 wire path.
+      const adaptedTools = ['get_products', 'create_media_buy', 'update_media_buy', 'sync_creatives'];
+      for (const tool of adaptedTools) {
+        assert.ok(FIXTURES[tool], `missing conformance fixture for v2-adapted tool: ${tool}`);
+      }
     });
   }
-
-  test('every v2-adapted tool has a fixture in this suite', () => {
-    // Authoritative list mirrors `SingleAgentClient.adaptRequestForServerVersion`.
-    // If a new adapter lands without a fixture, this test fails so we don't
-    // ship an unvalidated v2 wire path.
-    const adaptedTools = ['get_products', 'create_media_buy', 'update_media_buy', 'sync_creatives'];
-    for (const tool of adaptedTools) {
-      assert.ok(FIXTURES[tool], `missing conformance fixture for v2-adapted tool: ${tool}`);
-    }
-  });
-});
+);

--- a/test/lib/adapter-v2-5-conformance.test.js
+++ b/test/lib/adapter-v2-5-conformance.test.js
@@ -1,0 +1,145 @@
+// Adapter conformance against the v2.5 schema bundle.
+//
+// Takes a canonical v3 input for each tool that has a v2 adapter, runs it
+// through `adaptRequestForServerVersion`, and asserts the adapted shape
+// validates against `schemas/cache/v2.5/`. CI signal for "the v2 wire
+// adapters produce v2.5-conformant output."
+//
+// Tools with KNOWN drift get explicit `expected_failures` entries pointing at
+// the tracking issue. The test asserts the failure mode matches what was
+// surfaced (so a fix that closes the gap surfaces as an unexpected pass and
+// prompts the test to be flipped to "must pass"). When the underlying issue
+// is closed, the entry is removed and the case becomes a regular passing
+// fixture.
+//
+// Add new fixtures here when adding a v2 adapter. The conformance suite is
+// the source of truth for what shape a v2.5 server expects to receive.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { validateRequest } = require('../../dist/lib/validation/schema-validator');
+const { adaptGetProductsRequestForV2 } = require('../../dist/lib/utils/pricing-adapter');
+const {
+  adaptCreateMediaBuyRequestForV2,
+  adaptUpdateMediaBuyRequestForV2,
+} = require('../../dist/lib/utils/creative-adapter');
+const { adaptSyncCreativesRequestForV2 } = require('../../dist/lib/utils/sync-creatives-adapter');
+
+// Canonical v3 inputs per tool. Match the shape a v3 buyer would write
+// before any wire adaptation.
+const FIXTURES = {
+  get_products: {
+    adapter: adaptGetProductsRequestForV2,
+    v3: {
+      buying_mode: 'brief',
+      brief: 'Premium ad placements',
+      brand: { domain: 'example.com' },
+    },
+  },
+  create_media_buy: {
+    adapter: adaptCreateMediaBuyRequestForV2,
+    v3: {
+      account: { account_id: 'acct-1' },
+      brand: { domain: 'example.com' },
+      packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+      start_time: 'asap',
+      end_time: '2027-12-31T23:59:59Z',
+      idempotency_key: '11111111-1111-1111-1111-111111111111',
+    },
+    expected_failures: {
+      // adcontextprotocol/adcp-client#1115 — adapter should derive buyer_ref
+      // from idempotency_key (top-level + per-package). Until then the
+      // adapter omits buyer_ref and v2.5 rejects the request.
+      issue: 'adcontextprotocol/adcp-client#1115',
+      pointers: ['/buyer_ref', '/packages/0/buyer_ref'],
+    },
+  },
+  update_media_buy: {
+    adapter: adaptUpdateMediaBuyRequestForV2,
+    v3: {
+      media_buy_id: 'mb-1',
+      idempotency_key: '22222222-2222-2222-2222-222222222222',
+    },
+  },
+  sync_creatives: {
+    adapter: adaptSyncCreativesRequestForV2,
+    v3: {
+      account: { account_id: 'acct-1' },
+      creatives: [
+        {
+          creative_id: 'cre-1',
+          name: 'Test Creative',
+          format_id: { agent_url: 'https://test.example', id: 'format1' },
+          assets: {
+            video: {
+              asset_type: 'video',
+              url: 'https://example.com/video.mp4',
+              width: 1920,
+              height: 1080,
+              duration_ms: 30000,
+            },
+          },
+        },
+      ],
+      idempotency_key: '33333333-3333-3333-3333-333333333333',
+    },
+    expected_failures: {
+      // adcontextprotocol/adcp-client#1116 — adapter is a thin
+      // prefix-stripper, leaks v3 manifest shape to v2.5's
+      // single-asset-payload oneOf.
+      issue: 'adcontextprotocol/adcp-client#1116',
+      pointers: ['/creatives/0/assets/video'],
+    },
+  },
+};
+
+describe('v2 adapter conformance against v2.5 schema bundle', () => {
+  for (const [taskName, fixture] of Object.entries(FIXTURES)) {
+    if (fixture.expected_failures) {
+      test(`${taskName} — KNOWN drift, tracked at ${fixture.expected_failures.issue}`, () => {
+        const adapted = fixture.adapter(structuredClone(fixture.v3));
+        const outcome = validateRequest(taskName, adapted, 'v2.5');
+        assert.strictEqual(
+          outcome.valid,
+          false,
+          `${taskName} unexpectedly passed v2.5 validation. If ${fixture.expected_failures.issue} was fixed, ` +
+            `remove the expected_failures entry and let this test enforce conformance.`
+        );
+        // Pin the specific failure mode so a fix that changes the shape
+        // surfaces as an assertion break here (signaling the test should
+        // be flipped to a passing fixture).
+        const surfacedPointers = new Set(outcome.issues.map(i => i.pointer));
+        for (const expected of fixture.expected_failures.pointers) {
+          assert.ok(
+            surfacedPointers.has(expected),
+            `${taskName} did not surface expected drift at ${expected}; surfaced: ${[...surfacedPointers].join(', ')}. ` +
+              `If the failure mode changed, update or remove this fixture.`
+          );
+        }
+      });
+      continue;
+    }
+    test(`${taskName} — adapted shape conforms to v2.5`, () => {
+      const adapted = fixture.adapter(structuredClone(fixture.v3));
+      const outcome = validateRequest(taskName, adapted, 'v2.5');
+      assert.strictEqual(
+        outcome.valid,
+        true,
+        `${taskName} adapter output failed v2.5 validation:\n${outcome.issues
+          .map(i => `  - ${i.pointer} | ${i.keyword} | ${i.message}`)
+          .join('\n')}`
+      );
+    });
+  }
+
+  test('every v2-adapted tool has a fixture in this suite', () => {
+    // Authoritative list mirrors `SingleAgentClient.adaptRequestForServerVersion`.
+    // If a new adapter lands without a fixture, this test fails so we don't
+    // ship an unvalidated v2 wire path.
+    const adaptedTools = ['get_products', 'create_media_buy', 'update_media_buy', 'sync_creatives'];
+    for (const tool of adaptedTools) {
+      assert.ok(FIXTURES[tool], `missing conformance fixture for v2-adapted tool: ${tool}`);
+    }
+  });
+});

--- a/test/lib/post-adapter-v2-5-validation.test.js
+++ b/test/lib/post-adapter-v2-5-validation.test.js
@@ -8,97 +8,107 @@ const assert = require('node:assert');
 
 const { validateRequest } = require('../../dist/lib/validation');
 const { validateOutgoingRequest } = require('../../dist/lib/validation/client-hooks.js');
+const { hasSchemaBundle } = require('../../dist/lib/validation/schema-loader.js');
 
-describe('post-adapter v2.5 validation', () => {
-  test('v2.5 schema bundle is loadable and a clean adapted get_products payload validates', () => {
-    // The shape adaptGetProductsRequestForV2 emits — minimum: brief.
-    // (account/brand/buying_mode get stripped by the v2 adapter.)
-    const outcome = validateRequest(
-      'get_products',
-      {
-        brief: 'Premium ad placements',
-      },
-      'v2.5'
-    );
-    assert.strictEqual(outcome.valid, true, `expected valid; got: ${JSON.stringify(outcome.issues)}`);
-  });
+// Fresh clones that haven't run `npm run sync-schemas:v2.5` won't have the
+// bundle. CI runs `sync-schemas:all` so it's present there. Locally, skip
+// with a clear message rather than fail with confusing AJV errors.
+const V2_5_AVAILABLE = hasSchemaBundle('v2.5');
 
-  test('warn-only mode never throws and writes drift to debugLogs', () => {
-    // Construct a v2.5-invalid create_media_buy payload (missing required
-    // buyer_ref). Confirm validateOutgoingRequest with mode='warn' returns
-    // an outcome AND appends a warning entry to the debugLogs array.
-    const debugLogs = [];
-    let threw = false;
-    try {
-      validateOutgoingRequest(
-        'create_media_buy',
+describe(
+  'post-adapter v2.5 validation',
+  { skip: V2_5_AVAILABLE ? false : 'v2.5 bundle not cached — run `npm run sync-schemas:v2.5`' },
+  () => {
+    test('v2.5 schema bundle is loadable and a clean adapted get_products payload validates', () => {
+      // The shape adaptGetProductsRequestForV2 emits — minimum: brief.
+      // (account/brand/buying_mode get stripped by the v2 adapter.)
+      const outcome = validateRequest(
+        'get_products',
         {
-          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+          brief: 'Premium ad placements',
+        },
+        'v2.5'
+      );
+      assert.strictEqual(outcome.valid, true, `expected valid; got: ${JSON.stringify(outcome.issues)}`);
+    });
+
+    test('warn-only mode never throws and writes drift to debugLogs', () => {
+      // Construct a v2.5-invalid create_media_buy payload (missing required
+      // buyer_ref). Confirm validateOutgoingRequest with mode='warn' returns
+      // an outcome AND appends a warning entry to the debugLogs array.
+      const debugLogs = [];
+      let threw = false;
+      try {
+        validateOutgoingRequest(
+          'create_media_buy',
+          {
+            packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+            start_time: 'asap',
+            end_time: '2027-12-31T23:59:59Z',
+            idempotency_key: '11111111-1111-1111-1111-111111111111',
+          },
+          'warn',
+          debugLogs,
+          'v2.5'
+        );
+      } catch (err) {
+        threw = true;
+      }
+      assert.strictEqual(threw, false, 'warn-only mode must never throw');
+      assert.ok(debugLogs.length > 0, 'expected at least one debug log entry');
+      const warning = debugLogs.find(e => e.type === 'warning');
+      assert.ok(warning, `expected a warning entry; got: ${JSON.stringify(debugLogs)}`);
+      assert.match(warning.message, /create_media_buy/);
+      assert.ok(Array.isArray(warning.issues) && warning.issues.length > 0);
+    });
+
+    test('warn-only mode is silent when payload validates clean', () => {
+      const debugLogs = [];
+      validateOutgoingRequest('get_products', { brief: 'test' }, 'warn', debugLogs, 'v2.5');
+      assert.strictEqual(debugLogs.length, 0, `clean payload should not log; got: ${JSON.stringify(debugLogs)}`);
+    });
+
+    test('omitted debugLogs does not throw when validation fails', () => {
+      // Defensive: SingleAgentClient call sites pass no debugLogs today.
+      // The warn path must tolerate that without crashing.
+      let threw = false;
+      try {
+        validateOutgoingRequest(
+          'create_media_buy',
+          { packages: [], start_time: 'asap', end_time: '2027-12-31T23:59:59Z' },
+          'warn',
+          undefined,
+          'v2.5'
+        );
+      } catch {
+        threw = true;
+      }
+      assert.strictEqual(threw, false, 'warn mode without debugLogs must not throw');
+    });
+
+    test('TaskExecutor.validateAdaptedRequestAgainstV2 is warn-only and version-pinned to v2.5', () => {
+      // Reach into the built executor module and confirm the public seam
+      // doesn't throw on v2.5-invalid input. The whole point is that adapter
+      // bugs surface as drift signal, not as user-request failures.
+      const { AdCPClient } = require('../../dist/lib/index.js');
+      const mockAgent = { id: 'test-agent', name: 'Test', agent_uri: 'https://test.example', protocol: 'a2a' };
+      const client = new AdCPClient([mockAgent]);
+      const inner = client.agent(mockAgent.id).client;
+      const executor = inner.executor;
+      assert.ok(typeof executor.validateAdaptedRequestAgainstV2 === 'function', 'public seam must exist');
+
+      // Known-invalid v2.5 shape (missing buyer_ref). Must not throw.
+      let threw = false;
+      try {
+        executor.validateAdaptedRequestAgainstV2('create_media_buy', {
+          packages: [],
           start_time: 'asap',
           end_time: '2027-12-31T23:59:59Z',
-          idempotency_key: '11111111-1111-1111-1111-111111111111',
-        },
-        'warn',
-        debugLogs,
-        'v2.5'
-      );
-    } catch (err) {
-      threw = true;
-    }
-    assert.strictEqual(threw, false, 'warn-only mode must never throw');
-    assert.ok(debugLogs.length > 0, 'expected at least one debug log entry');
-    const warning = debugLogs.find(e => e.type === 'warning');
-    assert.ok(warning, `expected a warning entry; got: ${JSON.stringify(debugLogs)}`);
-    assert.match(warning.message, /create_media_buy/);
-    assert.ok(Array.isArray(warning.issues) && warning.issues.length > 0);
-  });
-
-  test('warn-only mode is silent when payload validates clean', () => {
-    const debugLogs = [];
-    validateOutgoingRequest('get_products', { brief: 'test' }, 'warn', debugLogs, 'v2.5');
-    assert.strictEqual(debugLogs.length, 0, `clean payload should not log; got: ${JSON.stringify(debugLogs)}`);
-  });
-
-  test('omitted debugLogs does not throw when validation fails', () => {
-    // Defensive: SingleAgentClient call sites pass no debugLogs today.
-    // The warn path must tolerate that without crashing.
-    let threw = false;
-    try {
-      validateOutgoingRequest(
-        'create_media_buy',
-        { packages: [], start_time: 'asap', end_time: '2027-12-31T23:59:59Z' },
-        'warn',
-        undefined,
-        'v2.5'
-      );
-    } catch {
-      threw = true;
-    }
-    assert.strictEqual(threw, false, 'warn mode without debugLogs must not throw');
-  });
-
-  test('TaskExecutor.validateAdaptedRequestAgainstV2 is warn-only and version-pinned to v2.5', () => {
-    // Reach into the built executor module and confirm the public seam
-    // doesn't throw on v2.5-invalid input. The whole point is that adapter
-    // bugs surface as drift signal, not as user-request failures.
-    const { AdCPClient } = require('../../dist/lib/index.js');
-    const mockAgent = { id: 'test-agent', name: 'Test', agent_uri: 'https://test.example', protocol: 'a2a' };
-    const client = new AdCPClient([mockAgent]);
-    const inner = client.agent(mockAgent.id).client;
-    const executor = inner.executor;
-    assert.ok(typeof executor.validateAdaptedRequestAgainstV2 === 'function', 'public seam must exist');
-
-    // Known-invalid v2.5 shape (missing buyer_ref). Must not throw.
-    let threw = false;
-    try {
-      executor.validateAdaptedRequestAgainstV2('create_media_buy', {
-        packages: [],
-        start_time: 'asap',
-        end_time: '2027-12-31T23:59:59Z',
-      });
-    } catch {
-      threw = true;
-    }
-    assert.strictEqual(threw, false, 'validateAdaptedRequestAgainstV2 must never throw');
-  });
-});
+        });
+      } catch {
+        threw = true;
+      }
+      assert.strictEqual(threw, false, 'validateAdaptedRequestAgainstV2 must never throw');
+    });
+  }
+);

--- a/test/lib/post-adapter-v2-5-validation.test.js
+++ b/test/lib/post-adapter-v2-5-validation.test.js
@@ -1,0 +1,104 @@
+// Tests for the warn-only post-adapter validation pass.
+// After SingleAgentClient calls adaptRequestForServerVersion, when targeting
+// a v2 server, the SDK validates the adapted shape against the cached v2.5
+// schema bundle. Warn-only — never throws, surfaces drift via debugLogs.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { validateRequest } = require('../../dist/lib/validation');
+const { validateOutgoingRequest } = require('../../dist/lib/validation/client-hooks.js');
+
+describe('post-adapter v2.5 validation', () => {
+  test('v2.5 schema bundle is loadable and a clean adapted get_products payload validates', () => {
+    // The shape adaptGetProductsRequestForV2 emits — minimum: brief.
+    // (account/brand/buying_mode get stripped by the v2 adapter.)
+    const outcome = validateRequest(
+      'get_products',
+      {
+        brief: 'Premium ad placements',
+      },
+      'v2.5'
+    );
+    assert.strictEqual(outcome.valid, true, `expected valid; got: ${JSON.stringify(outcome.issues)}`);
+  });
+
+  test('warn-only mode never throws and writes drift to debugLogs', () => {
+    // Construct a v2.5-invalid create_media_buy payload (missing required
+    // buyer_ref). Confirm validateOutgoingRequest with mode='warn' returns
+    // an outcome AND appends a warning entry to the debugLogs array.
+    const debugLogs = [];
+    let threw = false;
+    try {
+      validateOutgoingRequest(
+        'create_media_buy',
+        {
+          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: '11111111-1111-1111-1111-111111111111',
+        },
+        'warn',
+        debugLogs,
+        'v2.5'
+      );
+    } catch (err) {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'warn-only mode must never throw');
+    assert.ok(debugLogs.length > 0, 'expected at least one debug log entry');
+    const warning = debugLogs.find(e => e.type === 'warning');
+    assert.ok(warning, `expected a warning entry; got: ${JSON.stringify(debugLogs)}`);
+    assert.match(warning.message, /create_media_buy/);
+    assert.ok(Array.isArray(warning.issues) && warning.issues.length > 0);
+  });
+
+  test('warn-only mode is silent when payload validates clean', () => {
+    const debugLogs = [];
+    validateOutgoingRequest('get_products', { brief: 'test' }, 'warn', debugLogs, 'v2.5');
+    assert.strictEqual(debugLogs.length, 0, `clean payload should not log; got: ${JSON.stringify(debugLogs)}`);
+  });
+
+  test('omitted debugLogs does not throw when validation fails', () => {
+    // Defensive: SingleAgentClient call sites pass no debugLogs today.
+    // The warn path must tolerate that without crashing.
+    let threw = false;
+    try {
+      validateOutgoingRequest(
+        'create_media_buy',
+        { packages: [], start_time: 'asap', end_time: '2027-12-31T23:59:59Z' },
+        'warn',
+        undefined,
+        'v2.5'
+      );
+    } catch {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'warn mode without debugLogs must not throw');
+  });
+
+  test('TaskExecutor.validateAdaptedRequestAgainstV2 is warn-only and version-pinned to v2.5', () => {
+    // Reach into the built executor module and confirm the public seam
+    // doesn't throw on v2.5-invalid input. The whole point is that adapter
+    // bugs surface as drift signal, not as user-request failures.
+    const { AdCPClient } = require('../../dist/lib/index.js');
+    const mockAgent = { id: 'test-agent', name: 'Test', agent_uri: 'https://test.example', protocol: 'a2a' };
+    const client = new AdCPClient([mockAgent]);
+    const inner = client.agent(mockAgent.id).client;
+    const executor = inner.executor;
+    assert.ok(typeof executor.validateAdaptedRequestAgainstV2 === 'function', 'public seam must exist');
+
+    // Known-invalid v2.5 shape (missing buyer_ref). Must not throw.
+    let threw = false;
+    try {
+      executor.validateAdaptedRequestAgainstV2('create_media_buy', {
+        packages: [],
+        start_time: 'asap',
+        end_time: '2027-12-31T23:59:59Z',
+      });
+    } catch {
+      threw = true;
+    }
+    assert.strictEqual(threw, false, 'validateAdaptedRequestAgainstV2 must never throw');
+  });
+});

--- a/test/lib/schema-loader-per-version.test.js
+++ b/test/lib/schema-loader-per-version.test.js
@@ -197,4 +197,25 @@ describe('schema-loader per-version state', () => {
     assert.strictEqual(resolveBundleKey('v2.5'), 'v2.5');
     assert.strictEqual(resolveBundleKey('v2.6'), 'v2.6');
   });
+
+  test('ensureCoreLoaded narrowing keeps v3 bundled-path validators intact', () => {
+    // Regression guard for the v2.5-schemas branch: when ensureCoreLoaded was
+    // narrowed from "skip all fileIndex entries" to "skip only response tool
+    // files" so v2.5 flat-tree fragments register, v3's bundled-path
+    // validators must still resolve through getValidator unchanged. Bundled
+    // and flat-tree request schemas have distinct $ids (bundled has
+    // `/schemas/3.0.1/bundled/...` vs flat `/schemas/3.0.1/...`), so no
+    // AJV-side collision; this test pins that invariant.
+    _resetValidationLoader('3.0.1');
+    const v = getValidator('create_media_buy', 'request', '3.0.1');
+    assert.ok(v, 'v3 create_media_buy::request must compile after narrowing');
+    // Schema reference should point at the bundled file (the path the loader
+    // selects when the bundled tree exists).
+    const schema = v.schema;
+    assert.match(
+      schema.$id,
+      /\/bundled\//,
+      `expected bundled $id, got: ${schema.$id} — bundled-path priority must survive ensureCoreLoaded narrowing`
+    );
+  });
 });


### PR DESCRIPTION
First of ~5 PRs landing v2.5 wire support. This one's foundation: pulls the v2.5.3 schema bundle in, adds a warn-only post-adapter validation pass, lays down a conformance test suite. Two real adapter drift items surface as known-failures here; tracked at #1115 and #1116, fixed in follow-up PRs.

## Summary

- **`scripts/sync-v2-5-schemas.ts`** (`npm run sync-schemas:v2.5`): pulls v2.5.3 schemas from `adcontextprotocol/adcp@2.5-maintenance` at a pinned SHA. Necessary because `v2.5.2` and `v2.5.3` were never tagged or released upstream despite shipping in `package.json` and `CHANGELOG.md` — filed at `adcontextprotocol/adcp#3689`. Pulling from the published spec site would silently regress to v2.5.1, missing `additionalProperties: true` forward-compat, the `error.json` typing fix, and the `impressions` / `paused` package-request fields. Tarball SHA-256 pinned alongside the commit SHA; symlinks rejected at extraction; provenance file written to `schemas/cache/v2.5/_provenance.json`.
- **`schemas/cache/v2.5/`** populated (158 schemas, gitignored — refresh via the script). Existing `resolveBundleKey('v2.5')` legacy alias and `copy-schemas-to-dist.ts` legacy-prerelease path both already routed `v2.5` correctly without resolver changes — bundle ships at `dist/lib/schemas-data/v2.5/`.
- **`src/lib/validation/schema-loader.ts`** narrowed `ensureCoreLoaded` from "skip all fileIndex entries" to "skip only response tool files." v2.5's source tree ships flat (no pre-bundled `bundled/` subtree) with cross-fragment `\$ref`s; the previous rule left fragments like `media-buy/package-request.json` unregistered and AJV emitted `MissingRefError` on cross-fragment lookups. v3's bundled-schemas path is unaffected (refs were already inlined). Regression test pinned in `test/lib/schema-loader-per-version.test.js`.
- **`TaskExecutor.validateAdaptedRequestAgainstV2(taskName, adaptedParams, debugLogs?)`** — new public seam. Always warn-only, version-pinned to v2.5. `SingleAgentClient.executeAndHandle` and `SingleAgentClient.executeTask` both call it after `adaptRequestForServerVersion` when `serverVersion === 'v2'`. Symmetric to PR #1106's pre-adapter v3 pass: that one catches "user wrote bad v3", this one catches "adapter produced bad v2.5".
- **`test/lib/adapter-v2-5-conformance.test.js`** — pins canonical v3 fixtures through every v2 adapter, asserts each adapted output validates against `schemas/cache/v2.5/`. Tools with known drift have explicit `expected_failures` entries pointing at the tracking issue and pinning failure-mode pointers — so a fix that closes the gap surfaces as an unexpected pass and prompts the entry to be removed. A "every v2-adapted tool has a fixture" guard ensures new adapters can't ship without conformance coverage.

## Conformance state at this PR

| Tool | v2.5 conformance |
|---|---|
| `get_products` | ✓ clean |
| `create_media_buy` | × known drift at `/buyer_ref` + `/packages/0/buyer_ref` (#1115) |
| `update_media_buy` | ✓ clean |
| `sync_creatives` | × known drift at `/creatives/0/assets/video` (#1116) |

## Expert review

Three parallel reviews: code-reviewer, ad-tech-protocol-expert, security-reviewer. Convergent must-fix items addressed in `7b8316fd`:
- Tarball SHA-256 pin (defense against MITM / force-push substitution)
- Symlink defense for `cpSync` post-extract
- Provenance file
- `sync-schemas:all` umbrella so CI can pull both bundles in one command
- v3 `ensureCoreLoaded` regression test

Deferred per expert advice: AJV `strict: true` (broader change), `\$id`-driven file classification (filename-suffix heuristic limitation; tracking issue worth filing later), tempdir to `os.tmpdir` (cosmetic).

## Behavior change

**Today, this PR is foundation — minimal user-visible behavior change.** The warn-only post-adapter pass runs but doesn't surface drift to user-visible logs (`SingleAgentClient` call sites pass no `debugLogs`; warn mode without `debugLogs` writes nowhere). The published npm package may not include the v2.5 bundle until the build pipeline is wired — separate follow-up PR.

The real value lands in the follow-up PRs:
- adapter buyer_ref fix (#1115) — every v2 `create_media_buy` from a v3 buyer is rejected today; this fixes it.
- adapter sync-creatives manifest flatten (#1116) — v3 manifests fail v2.5's single-asset payload `oneOf`.
- Build pipeline wire — ensures published package ships v2.5 schemas.
- Debug surfacing — makes the warn-only pass visible via `result.metadata.debug_logs`.

CI signal for adapter drift IS available now via the conformance test suite — a developer touching any v2 adapter gets immediate feedback whether their change broke or fixed something.

## Test plan

- [x] `npm run sync-schemas:v2.5` populates the bundle, sha256 verifies, provenance written
- [x] `npm run build:lib` ships both bundles in `dist/lib/schemas-data/`
- [x] `node --test test/lib/schema-loader-per-version.test.js` — 18 pass, including the new ensureCoreLoaded regression test
- [x] `node --test test/lib/post-adapter-v2-5-validation.test.js` — 5 pass
- [x] `node --test test/lib/adapter-v2-5-conformance.test.js` — 5 pass (2 expected-failures, 3 clean conformance, 1 fixture-coverage guard)
- [x] `node --test test/lib/*.test.js` — 5541 pass / 7 pre-existing skipped / 0 fail

## Related

- Filed: `adcontextprotocol/adcp#3689` (upstream tag/release pipeline)
- Filed: `adcontextprotocol/adcp-client#1115` (buyer_ref derivation — next PR)
- Filed: `adcontextprotocol/adcp-client#1116` (sync-creatives manifest flatten — follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)