### PR TITLE
fix(v2-adapter): derive buyer_ref from idempotency_key in create_media_buy (#1115)

### DIFF
--- a/.changeset/v2-5-buyer-ref-derivation.md
+++ b/.changeset/v2-5-buyer-ref-derivation.md
@@ -1,0 +1,16 @@
+---
+'@adcp/sdk': patch
+---
+
+`adaptCreateMediaBuyRequestForV2` now derives `buyer_ref` (top-level + per-package) from the v3 `idempotency_key`, fixing v2.5 wire-validation failures for v3 buyers calling v2 sellers (adcontextprotocol/adcp-client#1115).
+
+v2.5's `create_media_buy` schema requires `buyer_ref` top-level and per-package as the buyer's reference for THIS media buy. v3 doesn't model `buyer_ref` directly, but `idempotency_key` carries the same client-controlled-unique-identity contract. Reusing it preserves the seller-side dedupe contract on replays — the same v3 input always produces the same v2.5 `buyer_ref` values.
+
+Derivation precedence:
+
+- **Top-level `buyer_ref`**: caller-supplied wins → else `idempotency_key` → else omitted (v3 pre-send validation should already have rejected the missing required field; on warn-mode passthrough the v2.5 validator surfaces it).
+- **Per-package `buyer_ref`**: caller-supplied wins → else `package.idempotency_key` → else `${parent_buyer_ref}-${index}`. Position-based composition is stable across replays of the same package list.
+
+`adaptPackageRequestForV2` gains an optional second argument `PackageAdapterContext` (`{ parentBuyerRef?, index? }`) so callers threading per-package derivation supply the parent's reference + index. Backward-compatible: the existing single-argument signature continues to work for callers that don't need derivation (e.g., the existing `update_media_buy` adapter, which passes packages by `package_id`).
+
+Conformance state: the v2.5 adapter-conformance test suite (added in #1121) flips `create_media_buy` from a known-drift `expected_failures` fixture to a passing fixture. Future regressions surface as test failures.

--- a/src/lib/utils/creative-adapter.ts
+++ b/src/lib/utils/creative-adapter.ts
@@ -53,31 +53,87 @@ export interface PackageResponseV2 {
 }
 
 /**
+ * Optional context for deriving a per-package `buyer_ref` when the v3 input
+ * doesn't carry one. v2.5 `package-request.json` requires `buyer_ref` (the
+ * `oneOf` accepts `package_id` OR `buyer_ref`; on creation no `package_id`
+ * exists yet, so `buyer_ref` is the actual required identifier). v3 doesn't
+ * model packages with `buyer_ref`, but `idempotency_key` carries equivalent
+ * client-controlled-unique-identity semantics. The `parentBuyerRef` plus
+ * `index` compose a stable per-package reference that re-derives identically
+ * on replay — preserving the idempotency contract sellers depend on for
+ * deduping.
+ */
+export interface PackageAdapterContext {
+  /** Top-level `buyer_ref` derived from the parent v3 request. */
+  parentBuyerRef?: string;
+  /** Position of the package within the parent's `packages[]` array. */
+  index?: number;
+}
+
+/**
  * Adapt a v3-style package request for a v2 server.
  * Converts creative_assignments to creative_ids (dropping weight and placement_ids).
  * Strips v3-only package fields (optimization_goals, catalogs).
+ *
+ * When `ctx` is provided and the input has no `buyer_ref`, derives one as
+ * `package.idempotency_key || ${ctx.parentBuyerRef}-${ctx.index}` so v2.5
+ * package-request validation passes. Caller-supplied `buyer_ref` always wins.
  */
-export function adaptPackageRequestForV2(pkg: PackageRequestV3): PackageRequestV2 {
-  const { optimization_goals, catalogs, ...rest } = pkg as PackageRequestV3 & {
+export function adaptPackageRequestForV2(pkg: PackageRequestV3, ctx?: PackageAdapterContext): PackageRequestV2 {
+  const {
+    optimization_goals,
+    catalogs,
+    idempotency_key: pkgIdempotencyKey,
+    buyer_ref: callerBuyerRef,
+    ...rest
+  } = pkg as PackageRequestV3 & {
     optimization_goals?: unknown;
     catalogs?: unknown;
+    idempotency_key?: unknown;
+    buyer_ref?: unknown;
   };
 
+  // Derive per-package buyer_ref. Caller-supplied wins; then per-package
+  // idempotency_key; then a stable composition of the parent's buyer_ref
+  // and the package's array index. If none of those are available we
+  // pass through without a buyer_ref and let the v2.5 validator surface
+  // the missing field — better than synthesizing an unstable value that
+  // breaks dedupe on replay.
+  const derivedBuyerRef =
+    typeof callerBuyerRef === 'string' && callerBuyerRef.length > 0
+      ? callerBuyerRef
+      : typeof pkgIdempotencyKey === 'string' && pkgIdempotencyKey.length > 0
+        ? pkgIdempotencyKey
+        : ctx?.parentBuyerRef !== undefined && ctx?.index !== undefined
+          ? `${ctx.parentBuyerRef}-${ctx.index}`
+          : undefined;
+
+  const baseOut: PackageRequestV2 = rest as PackageRequestV2;
   if (!rest.creative_assignments) {
-    return rest as PackageRequestV2;
+    return derivedBuyerRef === undefined ? baseOut : { ...baseOut, buyer_ref: derivedBuyerRef };
   }
 
   const { creative_assignments, ...withoutAssignments } = rest;
 
   return {
     ...withoutAssignments,
+    ...(derivedBuyerRef !== undefined && { buyer_ref: derivedBuyerRef }),
     creative_ids: creative_assignments.map((a: CreativeAssignment) => a.creative_id),
   };
 }
 
 /**
  * Adapt a create_media_buy request for a v2 server.
- * Strips v3-only top-level fields, converts brand → brand_manifest, and adapts packages.
+ * Strips v3-only top-level fields, converts brand → brand_manifest, derives
+ * `buyer_ref` (top-level + per-package) from `idempotency_key`, and adapts
+ * packages.
+ *
+ * v2.5 requires `buyer_ref` as the buyer's reference for THIS media buy,
+ * top-level + per-package. v3 doesn't model `buyer_ref` but `idempotency_key`
+ * carries the same client-controlled-unique-identity semantics. Reusing it
+ * preserves the idempotency contract sellers depend on for deduping replays:
+ * the same v3 request always produces the same v2.5 `buyer_ref`. Caller-
+ * supplied `buyer_ref` (if any) always wins.
  */
 export function adaptCreateMediaBuyRequestForV2(request: any): any {
   const {
@@ -89,6 +145,7 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
     brand_manifest: inputManifest,
     adcp_major_version,
     idempotency_key,
+    buyer_ref: callerBuyerRef,
     ...rest
   } = request;
 
@@ -113,11 +170,23 @@ export function adaptCreateMediaBuyRequestForV2(request: any): any {
         : undefined;
   const brand_manifest = callerUrl || (brand?.domain ? `https://${brand.domain}` : undefined);
 
+  const buyer_ref =
+    typeof callerBuyerRef === 'string' && callerBuyerRef.length > 0
+      ? callerBuyerRef
+      : typeof idempotency_key === 'string' && idempotency_key.length > 0
+        ? idempotency_key
+        : undefined;
+
   return {
     ...rest,
+    ...(buyer_ref !== undefined && { buyer_ref }),
     ...(brand && !brand_manifest && { brand }),
     ...(brand_manifest !== undefined && { brand_manifest }),
-    ...(rest.packages && { packages: rest.packages.map(adaptPackageRequestForV2) }),
+    ...(rest.packages && {
+      packages: rest.packages.map((pkg: PackageRequestV3, index: number) =>
+        adaptPackageRequestForV2(pkg, { parentBuyerRef: buyer_ref, index })
+      ),
+    }),
   };
 }
 

--- a/test/lib/adapter-v2-5-conformance.test.js
+++ b/test/lib/adapter-v2-5-conformance.test.js
@@ -52,13 +52,8 @@ const FIXTURES = {
       end_time: '2027-12-31T23:59:59Z',
       idempotency_key: '11111111-1111-1111-1111-111111111111',
     },
-    expected_failures: {
-      // adcontextprotocol/adcp-client#1115 — adapter should derive buyer_ref
-      // from idempotency_key (top-level + per-package). Until then the
-      // adapter omits buyer_ref and v2.5 rejects the request.
-      issue: 'adcontextprotocol/adcp-client#1115',
-      pointers: ['/buyer_ref', '/packages/0/buyer_ref'],
-    },
+    // Was a known-drift fixture against #1115 until that adapter learned to
+    // derive buyer_ref from idempotency_key (top-level + per-package).
   },
   update_media_buy: {
     adapter: adaptUpdateMediaBuyRequestForV2,

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -528,6 +528,122 @@ describe('Creative Assignment Adapter', () => {
       assert.deepStrictEqual(result.brand, { brand_id: 'br_999' });
       assert.strictEqual(result.brand_manifest, undefined);
     });
+
+    // buyer_ref derivation (#1115) — v2.5 requires `buyer_ref` top-level +
+    // per-package as the buyer's reference for THIS media buy. v3 carries
+    // the same client-controlled-unique-identity contract on
+    // `idempotency_key`; reusing it preserves seller-side dedupe on replays.
+    describe('buyer_ref derivation from idempotency_key (v2.5 conformance)', () => {
+      test('derives top-level buyer_ref from idempotency_key when caller did not supply one', () => {
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-aaa',
+        });
+        assert.strictEqual(result.buyer_ref, 'idemp-aaa');
+      });
+
+      test('caller-supplied buyer_ref wins over idempotency_key derivation', () => {
+        const result = adaptCreateMediaBuyRequestForV2({
+          buyer_ref: 'caller-buyer-1',
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' }],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-aaa',
+        });
+        assert.strictEqual(result.buyer_ref, 'caller-buyer-1');
+      });
+
+      test('no buyer_ref emitted when neither caller buyer_ref nor idempotency_key is present', () => {
+        // v3 pre-send validation should already have rejected this; defensive
+        // path for warn-mode where the request still reaches the adapter.
+        // Better to omit and let v2.5 surface the missing required field
+        // than synthesize an unstable value that breaks dedupe on replay.
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+        });
+        assert.strictEqual(result.buyer_ref, undefined);
+      });
+
+      test('per-package buyer_ref defaults to <parent>-<index> when package supplies neither buyer_ref nor idempotency_key', () => {
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [
+            { product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' },
+            { product_id: 'prod-2', budget: 2000, pricing_option_id: 'po-2' },
+          ],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-bbb',
+        });
+        assert.strictEqual(result.packages[0].buyer_ref, 'idemp-bbb-0');
+        assert.strictEqual(result.packages[1].buyer_ref, 'idemp-bbb-1');
+      });
+
+      test('per-package idempotency_key wins over the parent-derived default', () => {
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [{ product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1', idempotency_key: 'pkg-idemp' }],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-ccc',
+        });
+        assert.strictEqual(result.packages[0].buyer_ref, 'pkg-idemp');
+      });
+
+      test('caller-supplied per-package buyer_ref wins over both', () => {
+        const result = adaptCreateMediaBuyRequestForV2({
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [
+            {
+              product_id: 'prod-1',
+              budget: 1000,
+              pricing_option_id: 'po-1',
+              buyer_ref: 'caller-pkg-1',
+              idempotency_key: 'pkg-idemp',
+            },
+          ],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-ddd',
+        });
+        assert.strictEqual(result.packages[0].buyer_ref, 'caller-pkg-1');
+      });
+
+      test('replays of the same v3 request produce identical buyer_refs (dedupe contract)', () => {
+        // The seller-side dedupe contract relies on replays producing the
+        // SAME buyer_ref. This test pins that invariant: same input → same
+        // output, including all derived buyer_refs.
+        const v3 = {
+          account: { account_id: 'acc-1' },
+          brand: { domain: 'example.com' },
+          packages: [
+            { product_id: 'prod-1', budget: 1000, pricing_option_id: 'po-1' },
+            { product_id: 'prod-2', budget: 2000, pricing_option_id: 'po-2' },
+          ],
+          start_time: 'asap',
+          end_time: '2027-12-31T23:59:59Z',
+          idempotency_key: 'idemp-replay',
+        };
+        const a = adaptCreateMediaBuyRequestForV2(JSON.parse(JSON.stringify(v3)));
+        const b = adaptCreateMediaBuyRequestForV2(JSON.parse(JSON.stringify(v3)));
+        assert.strictEqual(a.buyer_ref, b.buyer_ref);
+        assert.strictEqual(a.packages[0].buyer_ref, b.packages[0].buyer_ref);
+        assert.strictEqual(a.packages[1].buyer_ref, b.packages[1].buyer_ref);
+      });
+    });
   });
 
   describe('adaptGetProductsRequestForV2', () => {


### PR DESCRIPTION
Closes #1115. Stacks on top of #1121 — base is `bokelley/v2.5-schemas` so the conformance-suite update lives in the same review. Once #1121 lands, GitHub will retarget this PR to `main` automatically.

## Summary

v2.5's `create_media_buy` schema requires `buyer_ref` top-level + per-package as the buyer's reference for THIS media buy. The v2 adapter previously omitted it, causing every v3-buyer call against a v2 seller to fail v2.5 wire validation. This PR derives `buyer_ref` from `idempotency_key`, which already carries the client-controlled-unique-identity contract sellers need for dedupe.

## Mapping

Per the protocol expert review on PR #1121 (`bokelley/v2.5-schemas`):

- **Top-level `buyer_ref`**: caller-supplied wins → else `idempotency_key` → else omitted (v3 pre-send validation should have rejected the missing required field; on warn-mode passthrough the v2.5 validator surfaces it).
- **Per-package `buyer_ref`**: caller-supplied wins → else `package.idempotency_key` → else `\${parent_buyer_ref}-\${index}`. Position-based composition is stable across replays.

**Why not generate fresh UUIDs**: replays must hit the same `buyer_ref` or sellers can't dedupe, defeating idempotency. Reusing `idempotency_key` (which already has that contract) is correct.

**Why not use `account.account_id`**: that's tenant identity, not buy identity. v2.5's `buyer_ref` is "buyer's reference for THIS media buy."

## API change

`adaptPackageRequestForV2` gains an optional second argument `PackageAdapterContext` (`{ parentBuyerRef?, index? }`). Backward-compatible — single-argument calls keep working unchanged.

## Conformance

The v2.5 adapter-conformance test suite (added in #1121) flips `create_media_buy` from a known-drift `expected_failures` fixture to a passing fixture. Future regressions on this fixture surface as test failures.

7 new unit tests in `test/lib/v3-compatibility.test.js`:
- Top-level `buyer_ref` derives from `idempotency_key` when caller didn't supply one
- Caller-supplied `buyer_ref` wins over derivation
- No `buyer_ref` emitted when neither is present (defensive — better than synthesizing an unstable value)
- Per-package `buyer_ref` defaults to `\${parent}-\${index}`
- Per-package `idempotency_key` wins over the parent-derived default
- Caller-supplied per-package `buyer_ref` wins over both
- **Replay stability**: identical inputs produce identical `buyer_refs` (pins the dedupe contract)

## Test plan

- [x] `node --test test/lib/adapter-v2-5-conformance.test.js` — 5 pass (create_media_buy now clean; sync_creatives still tracked at #1116)
- [x] `node --test test/lib/v3-compatibility.test.js` — 176 pass (169 existing + 7 new)
- [x] `node --test test/lib/*.test.js` — 5485 pass / 7 pre-existing skipped / 0 fail

## Related

- `bokelley/v2.5-schemas` (PR #1121) — base; foundation, conformance suite, warn-only pass
- `adcontextprotocol/adcp-client#1116` — sync-creatives manifest flatten (next PR)
- `adcontextprotocol/adcp#3689` — upstream tag/release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)