### PR TITLE
fix: declare zod as a peerDependency (^4.1.0)

### DIFF
--- a/.changeset/zod-peerdep.md
+++ b/.changeset/zod-peerdep.md
@@ -1,0 +1,16 @@
+---
+'@adcp/sdk': patch
+---
+
+Declare `zod` as a required peer dependency (`^4.1.0`).
+
+Adopter-reported issue against the v6.0 RC: `pnpm link` (and `npm link`) against a locally checked-out SDK produced 48 TypeScript errors and a 4 GB tsc OOM, because the linked SDK's nested `node_modules/zod` (4.3.6) competed with the consumer's `zod@4.1.12`. Zod 4's `version.minor` literal type tag made the two copies nominally incompatible — `ZodSchema` from the SDK didn't unify with the consumer's `ZodSchema`.
+
+Without a peer-dep declaration, npm hoisting was the only thing keeping the npm-tarball install path working. The fix:
+
+- Move `zod` to `peerDependencies` with range `^4.1.0` so the consumer's resolution is authoritative.
+- Keep `zod` in `devDependencies` for the SDK's own build/test.
+- npm 7+ installs peer deps automatically — most consumers see no migration step.
+- `npm link` / `pnpm link` users may need `pnpm dedupe` (or removal of the linked SDK's nested `node_modules/zod`) so the consumer's `zod` resolves at the workspace root.
+
+Migration doc updated with the link-mode workaround and a separate note about the zod 4.3.0 `.partial()` regression on `.refine()` schemas (not an SDK bug; SDK builds against 4.1.x to avoid silently bumping consumers into the hazard).

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -419,6 +419,26 @@ createAdcpServerFromPlatform(platform, {
   stays inside the SDK's own `node_modules`. Once the SDK is consumed
   via published tarball (`npm install @adcp/sdk@x.y.z`), this
   disappears — link mode is the only setup that triggers it.
+- **`zod` is now a required peer dependency** (`^4.1.0`). The SDK's
+  `ZodSchema` types must resolve to the same `zod` instance the
+  consumer uses; otherwise zod 4's `version.minor` literal type tag
+  makes nominally-identical schemas incompatible at the type level.
+  The npm-tarball install path picks this up automatically (npm 7+
+  installs peer deps); `npm link` / `pnpm link` consumers must run
+  `pnpm dedupe` (or remove the linked SDK's nested `node_modules/zod`)
+  so a single `zod` resolves at the consumer's `node_modules` root.
+  Empirically reported by an adopter: 48 type errors and a 4 GB tsc
+  OOM with two zod copies (4.1.12 vs 4.3.6 in the linked SDK).
+- **zod 4.3.0 `.partial()` regression on `.refine()` schemas.** Zod
+  4.3.0 made `.partial()` throw at runtime when the source schema
+  carries a `.refine(...)`. SDK 6.0 builds against `zod@4.1.x` to
+  avoid silently bumping consumers into this hazard, but consumers
+  whose own `zod` resolves to 4.3+ will hit the throw on any local
+  schema that combines `.partial()` + `.refine()`. Workaround: split
+  the refine into a follow-up `.superRefine` after the `.partial()`,
+  or pin the consumer-side `zod` to `<4.3.0` until you've audited
+  affected schemas. Not an SDK bug — flagging here so adopters
+  migrating off 5.x see the symptom in context.
 
 ## What's deferred to v6.1+
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,8 @@
         "@a2a-js/sdk": "^0.3.4",
         "@modelcontextprotocol/sdk": "^1.17.5",
         "@opentelemetry/api": "^1.0.0",
-        "pg": "^8.0.0"
+        "pg": "^8.0.0",
+        "zod": "^4.1.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {

--- a/package.json
+++ b/package.json
@@ -271,7 +271,8 @@
     "@a2a-js/sdk": "^0.3.4",
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@opentelemetry/api": "^1.0.0",
-    "pg": "^8.0.0"
+    "pg": "^8.0.0",
+    "zod": "^4.1.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {


### PR DESCRIPTION
## Summary

Adopter-reported issue against the v6.0 RC: `pnpm link` / `npm link` against the SDK produced **48 TypeScript errors and a 4 GB tsc OOM**. The linked SDK kept its own `node_modules/zod@4.3.6` next to the consumer's `zod@4.1.12`, and zod 4's `version.minor` literal type tag made the two copies nominally incompatible — `ZodSchema` from the SDK didn't unify with the consumer's `ZodSchema`.

`zod` was in `devDependencies` only. npm-hoisting was the only thing keeping the tarball install path from breaking the same way; with `pnpm link`, hoisting can't help.

## Fix

- Move `zod` to `peerDependencies` with range `^4.1.0` so the consumer's resolution is authoritative.
- Keep `zod` in `devDependencies` for the SDK's own build/test.
- npm 7+ installs peer deps automatically — tarball-install consumers see no migration step.
- `npm link` / `pnpm link` users may need `pnpm dedupe` so the consumer's zod resolves at the workspace root.

## Why ship this BEFORE the v6.0 release-PR (#1085) merges to npm

The release-PR is open and unmerged. Landing this fix on `main` causes the changesets bot to rebase #1085 with the new peer-dep declaration baked into 6.0.0 directly. Adopters install clean. No 6.0.1 needed for this finding.

If we shipped 6.0.0 first and patched in 6.0.1, every CI consumer who pinned `=6.0.0` would carry the broken peer deps in their lockfile until they explicitly upgraded.

## Migration doc

Added two notes to `docs/migration-5.x-to-6.x.md`:

1. **`zod` peer-dep** — explains why the SDK requires it now and how to resolve nested-store conflicts under link mode.
2. **zod 4.3.0 `.partial()` regression** — separate adopter hazard. Zod 4.3 made `.partial()` throw on schemas with `.refine()`. SDK builds against 4.1.x to avoid silently bumping consumers, but consumers whose own zod is on 4.3+ hit the throw on any schema combining `.partial()` + `.refine()`. Not an SDK bug; flagged for visibility.

## Test plan

- [x] `npm install` succeeds with zod listed as both peer-dep and dev-dep
- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] Targeted tests pass (`server-state-store-extensions`, `server-decisioning-from-platform`, `server-create-adcp-server`) — 229/229
- [ ] CI green on this PR
- [ ] Verify the auto-rebase of release-PR #1085 picks up the peer-dep declaration

## Related

- v6.0 PR: #1119 (merged)
- v6.0 release-PR: #1085 (open; this PR rebases ahead of it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)