### PR TITLE
docs: surface auto-hydration error contract + tighten idempotency principal types

### DIFF
--- a/.changeset/preship-final-asks.md
+++ b/.changeset/preship-final-asks.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+Pre-ship cleanup driven by adopter feedback on the v6.0 RC. Two surface tightenings + one doc consolidation.
+
+**Auto-hydration error contract surfaced in the migration doc.** With auto-hydration on for four mutating verbs (`createMediaBuy`, `updateMediaBuy`, `activateSignal`, `acquireRights`), the contract for stale or missing references multiplies. The framework's behavior on a hydration miss has been documented in source JSDoc since the auto-hydration extension landed, but adopters reading the skill see only the happy path. New "Auto-hydration error contract" block in `docs/migration-5.x-to-6.x.md` walks the three possible meanings of a miss (cold start, eviction, unknown id), explains why the framework does NOT throw `PRODUCT_NOT_FOUND` / `MEDIA_BUY_NOT_FOUND` (cache is a hint, not source-of-truth), shows the handler-side existence-check pattern with a `MediaBuyNotFoundError` example, and describes the `__adcp_hydrated__` non-enumerable marker for handler authors who want to disambiguate "publisher passed it" from "framework attached it." Adopters can drop their pre-flight existence-check round-trip on hits; misses still flow through the publisher's DB the same way they did in 5.x.
+
+**`IdempotencyPrincipalParams.account` / `.brand` now use canonical wire types.** Previously inline-typed as a flat shape with everything optional. Adopters scoping by `params.account?.account_id` (the public-token-shared-across-tenants pattern) had to live with the loose shape; replaced with `AccountReference` / `BrandReference` from the generated wire types so the discriminated union is exposed end-to-end. Adopters get autocomplete + narrowing on both variants. JSDoc updated with the recommended `if ('account_id' in params.account)` discriminating pattern.
+
+**Migration doc consolidation verified.** The cumulative breaking-changes table in `docs/migration-5.x-to-6.x.md` covers all five round-by-round breaking changes (`Account.metadata` rename, server-subpath consolidation, `createAdcpServer` removal, `TMeta` → `TCtxMeta`, `getMediaBuys` required) with one-liner search-replace recipes — already lands cleanly for the round-skipping adopter view; no edits needed.

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -440,6 +440,70 @@ createAdcpServerFromPlatform(platform, {
   affected schemas. Not an SDK bug — flagging here so adopters
   migrating off 5.x see the symptom in context.
 
+## Auto-hydration error contract
+
+Auto-hydration is on for four mutating verbs in 6.0:
+`createMediaBuy` (per-package `pkg.product`), `updateMediaBuy`
+(`req.media_buy`), `activateSignal` (`req.signal`), and
+`acquireRights` (`req.rights`). The framework looks up each
+referenced id in the `CtxMetadataStore` and attaches the cached
+wire shape (plus `ctx_metadata`) onto the request as a
+non-enumerable field. If you ship `5.x` adapters that did the
+same lookup by hand, you can drop the publisher-side
+existence-check round-trip — but only if you understand the
+contract on a miss.
+
+**Behavior on a miss.** The cache is a *hint*, not source-of-
+truth. When `getEntry(account, kind, id)` returns nothing, the
+framework leaves the attached field undefined and **the handler
+runs anyway**. The publisher's own DB stays authoritative for
+"does this id exist?"
+
+The framework deliberately does NOT throw `PRODUCT_NOT_FOUND` /
+`MEDIA_BUY_NOT_FOUND` on a hydration miss because a miss can mean
+any of:
+
+1. The buyer never called the discovery verb in this session
+   (cold start, fresh tenant). Hydration is purely additive
+   context.
+2. The cache evicted (TTL, LRU). Same: publisher's DB is the
+   source of truth.
+3. The buyer truly referenced an unknown id. The publisher SHOULD
+   reject — this is the existence check that belongs in the
+   handler.
+
+The framework cannot distinguish (1)/(2) from (3) without
+consulting the publisher's DB, which is exactly what the handler
+does. Erroring at the framework layer would force every adopter
+to manage cache warmth or pre-load every resource into the cache
+before serving traffic — wrong default for a hint cache.
+
+**Handler-side existence check pattern:**
+
+```ts
+updateMediaBuy: async (id, patch, ctx) => {
+  // patch.media_buy is set by hydration on hit, undefined on miss.
+  // Fall through to the publisher's DB on miss.
+  const buy = patch.media_buy ?? (await db.findMediaBuy(id));
+  if (!buy) {
+    throw new MediaBuyNotFoundError({ message: `media_buy ${id} not found` });
+  }
+  // ... apply patch ...
+}
+```
+
+**The `__adcp_hydrated__` marker.** Hydrated fields carry a
+non-enumerable `__adcp_hydrated__: true` so handler authors and
+middleware can disambiguate "publisher passed it" from "framework
+attached it." The hydrated field is **advisory context only**;
+the wire contract is defined by the spec's request fields, not by
+what the SDK happens to attach.
+
+**Store-fetch failures** (Postgres unavailable, transient network)
+are logged and swallowed. Hydration must NEVER break a successful
+dispatch — same posture as a cache miss. The handler still runs;
+your DB-side existence check still gates the operation.
+
 ## What's deferred to v6.1+
 
 - Native MCP `tasks/get` method dispatch (we ship `tasks_get` snake-case

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -481,6 +481,12 @@ before serving traffic — wrong default for a hint cache.
 **Handler-side existence check pattern:**
 
 ```ts
+import { MediaBuyNotFoundError } from '@adcp/sdk/server';
+// — or PackageNotFoundError, ProductNotFoundError, CreativeNotFoundError, etc.
+// from `@adcp/sdk/server/decisioning/errors-typed`. Typed classes auto-map
+// to their wire error code with `recovery: 'terminal'` baked in; throw
+// these instead of `new AdcpError(...)` for spec-defined not-found cases.
+
 updateMediaBuy: async (id, patch, ctx) => {
   // patch.media_buy is set by hydration on hit, undefined on miss.
   // Fall through to the publisher's DB on miss.

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -80,6 +80,8 @@ const server = createAdcpServerFromPlatform(new MySeller(), {
 
 The `createAdcpServerFromPlatform` path wraps a typed `DecisioningPlatform` with compile-time specialism enforcement (claim `sales-non-guaranteed`, miss a required `sales.*` method, fail compile), ctx_metadata round-trip + auto-hydration, idempotency-principal synthesis, status mappers, and webhook auto-emit. **Reach for the lower-level `createAdcpServer` from `@adcp/sdk/server/legacy/v5` only when you need fine control over individual handlers, are mid-migration from a v5 codebase, or have custom tools the platform interface doesn't yet model.**
 
+> **On a hydration miss, the framework leaves the hydrated field undefined and runs the handler anyway** — the cache is a hint, not source-of-truth. Your handler keeps its existence check (`patch.media_buy ?? (await db.findMediaBuy(id))`) and throws a typed `MediaBuyNotFoundError` / `PackageNotFoundError` / `ProductNotFoundError` from `@adcp/sdk/server` when both the hydrate and the DB-fallback come up empty. Full rationale in [Auto-hydration error contract](../../docs/migration-5.x-to-6.x.md#auto-hydration-error-contract).
+
 If a specialism's storyboard doesn't exercise one of these tools, the tool is **not optional** — the storyboard is just focused elsewhere (e.g. `sales-social` covers audience sync + DPA + events; the media buy flow itself is covered by `sales-non-guaranteed` or `sales-guaranteed` which you also claim). See § [Tools and Required Response Shapes](#tools-and-required-response-shapes) below for the exact response shape each tool must return.
 
 ## Specialisms This Skill Covers

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -233,7 +233,10 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
 | Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
 | `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
+<<<<<<< Updated upstream
 | `406 Not Acceptable` before any AdCP framing | Hand-rolled HTTP without `Accept: text/event-stream` (MCP transport) | Use `@modelcontextprotocol/sdk` client; it sets the right Accept header. |
+=======
+>>>>>>> Stashed changes
 | `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
 | `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
 | HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -248,6 +248,7 @@ import type {
   ReportUsageResponse,
   PreviewCreativeResponse,
   AccountReference,
+  BrandReference,
   ListContentStandardsResponse,
   GetContentStandardsResponse,
   CreateContentStandardsResponse,
@@ -703,20 +704,34 @@ export type AdcpServerToolName = keyof AdcpToolMap;
  * Parameter shape passed to `resolveIdempotencyPrincipal`. Wide enough to
  * carry any wire request (the framework calls every mutating tool through
  * the same resolver), narrow enough to surface the most-common scoping
- * fields (`account`, `brand`) without a cast.
+ * fields (`account`, `brand`) using the canonical wire types.
  *
- * Adopters scoping by `params.account?.account_id` or
- * `params.brand?.domain` (the public-token-shared-across-tenants pattern)
- * get autocomplete + type narrowing without `as { account?: ... }`. Tool-
- * specific scoping (e.g., custom session header on `si_send_message`)
+ * `account` and `brand` resolve to the same `AccountReference` /
+ * `BrandReference` types the rest of the SDK uses. The
+ * `account: AccountReference` discriminated union forces adopters scoping
+ * by tenant to narrow before reading variant-specific fields:
+ *
+ * ```ts
+ * resolveIdempotencyPrincipal: (ctx, params) => {
+ *   if (params.account && 'account_id' in params.account) {
+ *     return params.account.account_id; // narrowed to {account_id: string}
+ *   }
+ *   if (params.account?.brand?.domain) {
+ *     return `${params.account.brand.domain}:${params.account.operator}`;
+ *   }
+ *   return ctx.account?.id ?? 'anon';
+ * }
+ * ```
+ *
+ * Tool-specific scoping (e.g., custom session header on `si_send_message`)
  * still has the open `Record<string, unknown>` index signature for
  * everything else.
  */
 export interface IdempotencyPrincipalParams extends Record<string, unknown> {
   /** Buyer-supplied account reference. Most mutating tools carry this. */
-  account?: { account_id?: string; brand?: { domain?: string }; sandbox?: boolean; [k: string]: unknown };
+  account?: AccountReference;
   /** Buyer-supplied brand reference (used by some tools without account). */
-  brand?: { domain?: string; [k: string]: unknown };
+  brand?: BrandReference;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Pre-ship cleanup driven by an adopter ranking three asks against the v6.0 RC. **#1 was the only blocker** — the auto-hydration contract on missing references multiplies across four mutating verbs but only the happy path was in adopter-facing docs. **#2 was a polish carry-over from round 12.** **#3 was a docs question already addressed.**

## What changed

### #1 (BLOCKER) — Auto-hydration error contract surfaced in the migration doc

Framework behavior on a hydration miss has been documented in source JSDoc since the auto-hydration extension landed (`from-platform.ts:2076-2135`), but adopters reading the skill see only the happy path. The user listed three options the changeset should spell out:

1. Framework throws typed AdcpError, handler never runs.
2. Framework leaves field undefined, handler chooses what to do.
3. Framework calls handler anyway with whatever stale shape it has.

Actual behavior is **#2** (silent miss, handler authoritative), with thoughtful rationale: a miss can mean cold start, cache eviction, OR a truly unknown id; the framework can't distinguish without consulting the publisher's DB, which is what the handler already does. Erroring at the framework would force every adopter to manage cache warmth before serving traffic — wrong default for a hint cache.

New "Auto-hydration error contract" block in `docs/migration-5.x-to-6.x.md` covers:
- The three possible meanings of a miss
- Why the framework picks #2
- The handler-side existence-check pattern with a typed-error example
- The `__adcp_hydrated__` non-enumerable marker for disambiguation
- Store-fetch failure semantics (logged + swallowed; handler runs)

### #2 (polish) — `IdempotencyPrincipalParams.account` / `.brand` now use canonical wire types

Was inline-typed as a flat shape with everything optional. Adopters overriding the default `resolveIdempotencyPrincipal` to scope by `params.account?.account_id` (public-token-shared-across-tenants pattern) had to live with the loose shape. Replaced with `AccountReference` / `BrandReference` from the generated wire types so the discriminated union is exposed end-to-end. JSDoc updated with the recommended `if ('account_id' in params.account)` pattern.

### #3 (docs) — Migration doc consolidation verified

The cumulative breaking-changes table at `docs/migration-5.x-to-6.x.md:22-28` already covers all five round-by-round breaking changes with one-liner search-replace recipes (`Account.metadata` rename, server-subpath consolidation, `createAdcpServer` removal, `TMeta` → `TCtxMeta`, `getMediaBuys` required). No edits needed.

## Why land before the v6.0.0 release-PR (#1085)

#1085 is open and unmerged. Landing this on `main` causes the changesets bot to rebase #1085 with the new docs + tighter type baked into 6.0.0 directly. Adopters install clean. No 6.0.1 needed for these asks.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] 267/267 server-side tests pass (state-store, decisioning, create-adcp-server, idempotency)
- [x] `IdempotencyPrincipalParams` typecheck against AccountReference/BrandReference passes
- [ ] CI green on this PR
- [ ] Verify release-PR #1085 auto-rebases with these docs + types

## Related

- v6.0 PR: #1119 (merged)
- v6.0 zod peer-dep: #1125 (merged)
- v6.0 release-PR: #1085 (open; this PR rebases ahead of it)
- v6.1 follow-ups: #1120 (seller skill), #1124 (production-gate stateStore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)