### PR TITLE
fix: v6.0.1 — production gate default stateStore + zod floor bump

### DIFF
--- a/.changeset/v6-0-1-production-gate.md
+++ b/.changeset/v6-0-1-production-gate.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+v6.0.1: production gate the default `stateStore` + zod floor bump + missing-peer-dep doc.
+
+**Production gate.** The 6.0 default `InMemoryStateStore` was a process-shared module singleton — correct for dev and single-tenant agents (closes the Pattern 3 SI session-loss bug at the documented `serve(() => createAdcpServer({...}))` factory pattern), but a multi-tenant production deployment that mints one `createAdcpServer` per resolved tenant would silently share state across tenants. 6.0 shipped this as a one-time `logger.warn`; 6.0.1 promotes it to a hard refusal mirroring `buildDefaultTaskRegistry`'s task-registry policy. Outside `{NODE_ENV=test, NODE_ENV=development}` the default in-memory store throws with a three-line explicit recovery path: pass `PostgresStateStore` (recommended), pass `new InMemoryStateStore()` explicitly (acknowledged), or set `ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1` (ops escape hatch). Single-tenant adopters and dev/test deployments are unaffected.
+
+**Gate ordering.** The new state-store gate fires AFTER the existing `idempotency: 'disabled'` gate so adopters who hit both surface the higher-severity error first (idempotency-disabled silently double-executes mutations on retry; state-store sharing leaks tenant data — both bad, idempotency goes first because the recovery is "wire a store" while state-store recovery is "pass your own").
+
+**zod floor bump.** Peer-dep range tightened from `^4.1.0` to `^4.1.5` to match `json-schema-to-zod` (peers `^4.1.3`) and `ts-to-zod` (peers `^4.1.5`) — the SDK's own codegen-tool floors. Removes a build-vs-runtime range mismatch where adopters on `zod@4.1.0`–`4.1.4` would technically fall below the codegen tools' floors.
+
+**Missing-peer-dep troubleshooting doc.** Added a sub-bullet to the migration doc explaining the `Cannot find module 'zod'` symptom (package manager didn't auto-install the peer) and the explicit-install fix. The SDK can't catch this at runtime — `import { z } from 'zod'` resolves at module load, before any SDK code runs — so a documentation pointer is the right shape.
+
+**Test command env.** `npm test` and `npm run test:lib` now set `NODE_ENV=test` so the production gate doesn't refuse on test runs that don't already set the env. Existing tests that flip NODE_ENV mid-run to exercise production paths now also set `ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1` alongside the existing task-registry ack.
+
+897/897 server-side tests pass. The new state-store gate has 6 dedicated tests in `test/server-state-store-extensions.test.js` covering: production-throw, production+ack→allow, production+explicit-store→allow, development→allow, test→allow, undef-NODE_ENV→throw.

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -419,8 +419,9 @@ createAdcpServerFromPlatform(platform, {
   stays inside the SDK's own `node_modules`. Once the SDK is consumed
   via published tarball (`npm install @adcp/sdk@x.y.z`), this
   disappears — link mode is the only setup that triggers it.
-- **`zod` is now a required peer dependency** (`^4.1.0`). The SDK's
-  `ZodSchema` types must resolve to the same `zod` instance the
+- **`zod` is now a required peer dependency** (`^4.1.5` in 6.0.1; was
+  `^4.1.0` in 6.0.0 — bumped to match the codegen tools' floors). The
+  SDK's `ZodSchema` types must resolve to the same `zod` instance the
   consumer uses; otherwise zod 4's `version.minor` literal type tag
   makes nominally-identical schemas incompatible at the type level.
   The npm-tarball install path picks this up automatically (npm 7+
@@ -429,6 +430,12 @@ createAdcpServerFromPlatform(platform, {
   so a single `zod` resolves at the consumer's `node_modules` root.
   Empirically reported by an adopter: 48 type errors and a 4 GB tsc
   OOM with two zod copies (4.1.12 vs 4.3.6 in the linked SDK).
+  - **If you see `Cannot find module 'zod'` at server boot**, your
+    package manager didn't install the peer dep automatically (npm 6,
+    `--legacy-peer-deps`, or pnpm without the auto-install setting).
+    Install explicitly: `npm install zod@^4.1.5` (or `pnpm add zod@^4.1.5`).
+    The SDK can't catch this at runtime — `import { z } from 'zod'`
+    resolves at module load, before any SDK code runs.
 - **zod 4.3.0 `.partial()` regression on `.refine()` schemas.** Zod
   4.3.0 made `.partial()` throw at runtime when the source schema
   carries a `.refine(...)`. SDK 6.0 builds against `zod@4.1.x` to

--- a/package.json
+++ b/package.json
@@ -182,8 +182,8 @@
     "build": "npm run build:lib",
     "build:lib": "npm run sync-version && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
-    "test": "node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js",
-    "test:lib": "node --test-timeout=60000 --test-force-exit --test test/lib/*.test.js",
+    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js",
+    "test:lib": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/*.test.js",
     "test:e2e": "node test/e2e/adcp-e2e.test.js",
     "test:protocols": "node test/run-protocol-tests.js",
     "changeset": "changeset",
@@ -272,7 +272,7 @@
     "@modelcontextprotocol/sdk": "^1.17.5",
     "@opentelemetry/api": "^1.0.0",
     "pg": "^8.0.0",
-    "zod": "^4.1.0"
+    "zod": "^4.1.5"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -307,13 +307,6 @@ export interface AdcpLogger {
  */
 const DEFAULT_STATE_STORE = new InMemoryStateStore();
 
-/**
- * One-time guard so the default-store warning fires at most once per
- * process — adopters using the factory pattern would otherwise see the
- * line on every request.
- */
-let defaultStateStoreWarned = false;
-
 const noopLogger: AdcpLogger = {
   debug() {},
   info() {},
@@ -2337,28 +2330,6 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     testController: testControllerBridge,
   } = config;
 
-  // Multi-tenant footgun warning: the default `stateStore` is a single
-  // module-level `InMemoryStateStore` shared across every `createAdcpServer`
-  // invocation in this process. Single-tenant agents — including everything
-  // the skills demonstrate — get the documented "ctx.store persists across
-  // requests" behavior. Multi-tenant deployments that mint one
-  // `createAdcpServer` per resolved tenant in the factory closure would
-  // silently share state across tenants. v6.0.1 plans to harden this into
-  // a NODE_ENV=production refusal mirroring the task-registry policy
-  // (`buildDefaultTaskRegistry`). Until then: warn once per process so the
-  // awareness is in adopter logs without spamming every request.
-  if (stateStore === DEFAULT_STATE_STORE && !defaultStateStoreWarned) {
-    defaultStateStoreWarned = true;
-    logger.warn(
-      '[adcp/server] createAdcpServer is using the default in-memory state ' +
-        'store (shared module-singleton across all createAdcpServer calls in ' +
-        'this process). Fine for dev + single-tenant agents. Multi-tenant ' +
-        'deployments MUST pass an explicit `stateStore` (PostgresStateStore, ' +
-        'Redis-backed AdcpStateStore, etc.) — the default does NOT partition ' +
-        'state across resolved tenants. v6.0.1 will refuse this in production.'
-    );
-  }
-
   // Resolve `adcpVersion` early — the validator-call closures below capture
   // it by reference and would hit a TDZ ReferenceError if any of them ran
   // synchronously during setup. They don't today (`createAdcpServer`
@@ -2437,6 +2408,49 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       "createAdcpServer: idempotency: 'disabled' is set. Mutating requests will not be replay-checked and " +
         '`get_adcp_capabilities` will declare `idempotency.supported: false`. Use only in non-production test fleets.'
     );
+  }
+
+  // Production gate on the default in-memory `stateStore`. Mirrors
+  // `buildDefaultTaskRegistry` policy in `from-platform.ts` and the
+  // `idempotency: 'disabled'` allowlist above: the module-singleton
+  // default is correct for dev and single-tenant agents, but
+  // multi-tenant production deployments that mint one
+  // `createAdcpServer` per resolved tenant would silently share state
+  // across tenants. Refuse outside `{NODE_ENV=test, NODE_ENV=development}`
+  // unless the adopter sets `ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1` as
+  // an explicit ops escape hatch. v6.0 shipped this as a one-time warn;
+  // 6.0.1 promotes it to a hard refusal so the production footgun closes
+  // before any adopter trips on it.
+  //
+  // Ordered AFTER the idempotency-disabled gate so adopters who hit
+  // both surface the higher-severity error (idempotency-disabled
+  // double-executes mutations on retry; state-store sharing leaks
+  // tenant data — both bad, idempotency goes first because the
+  // recovery is "wire a store" while state-store recovery is "pass
+  // your own").
+  if (stateStore === DEFAULT_STATE_STORE) {
+    const env = process.env.NODE_ENV;
+    const safe = env === 'test' || env === 'development';
+    const ack = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE === '1';
+    if (!safe && !ack) {
+      throw new Error(
+        'createAdcpServer: in-memory state store refused outside ' +
+          '{NODE_ENV=test, NODE_ENV=development}. The default ' +
+          '`InMemoryStateStore` is a process-shared module singleton — ' +
+          'single-tenant agents get the documented `ctx.store` cross-request ' +
+          'persistence, but multi-tenant deployments would silently share ' +
+          'state across resolved tenants. Pick one of:\n' +
+          '  1. (Recommended) Pass `stateStore: new PostgresStateStore({ pool })` ' +
+          'to keep state across restarts AND partition across tenants. See ' +
+          '`@adcp/sdk/server` for the migration helper.\n' +
+          '  2. Pass `stateStore: new InMemoryStateStore()` explicitly if you ' +
+          'accept that state is per-process and shared across all resolved ' +
+          'tenants. Single-tenant agents only.\n' +
+          '  3. ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1 env flag is the ops ' +
+          'escape hatch (same effect as #2 but config-only); prefer #2 in ' +
+          'adopter code so the choice is visible at the call site.'
+      );
+    }
   }
 
   // Enforce lock-step between the `signed-requests` specialism claim and the

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.25.1';
+export const LIBRARY_VERSION = '6.0.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.25.1',
+  library: '6.0.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T17:37:54.387Z',
+  generatedAt: '2026-04-30T23:31:10.778Z',
 } as const;
 
 /**

--- a/test/server-decisioning-allow-private-webhook-urls.test.js
+++ b/test/server-decisioning-allow-private-webhook-urls.test.js
@@ -134,13 +134,16 @@ describe('F11: allowPrivateWebhookUrls opt — relaxes loopback/private-IP guard
     const warnings = [];
     const originalWarn = console.warn;
     const originalEnv = process.env.NODE_ENV;
-    const originalAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+    const originalAckTasks = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+    const originalAckState = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
     console.warn = (...args) => warnings.push(args.join(' '));
     process.env.NODE_ENV = 'production';
-    // The in-memory task registry refuses to construct outside test/dev
-    // unless this ack is set. Production is fine for THIS test because we
-    // only care that the allowPrivateWebhookUrls warn fires.
+    // The in-memory task registry AND the in-memory state store both
+    // refuse to construct outside test/dev unless these acks are set.
+    // Production is fine for THIS test because we only care that the
+    // allowPrivateWebhookUrls warn fires.
     process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = '1';
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = '1';
     try {
       createAdcpServerFromPlatform(basePlatform(), {
         ...BASE_OPTS,
@@ -149,8 +152,10 @@ describe('F11: allowPrivateWebhookUrls opt — relaxes loopback/private-IP guard
     } finally {
       console.warn = originalWarn;
       process.env.NODE_ENV = originalEnv;
-      if (originalAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
-      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = originalAck;
+      if (originalAckTasks === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = originalAckTasks;
+      if (originalAckState === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = originalAckState;
     }
     const hit = warnings.find(w => w.includes('allowPrivateWebhookUrls'));
     assert.ok(hit, `expected footgun warning, got: ${JSON.stringify(warnings)}`);

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -714,20 +714,19 @@ describe('NODE_ENV gate on default in-memory task registry', () => {
   }
 
   function withEnv(env, fn) {
-    const prev = process.env.NODE_ENV;
-    const prevAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
-    if (env.NODE_ENV === undefined) delete process.env.NODE_ENV;
-    else process.env.NODE_ENV = env.NODE_ENV;
-    if (env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS === undefined)
-      delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
-    else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+    const prev = {};
+    for (const k of Object.keys(env)) {
+      prev[k] = process.env[k];
+      if (env[k] === undefined) delete process.env[k];
+      else process.env[k] = env[k];
+    }
     try {
       fn();
     } finally {
-      if (prev === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = prev;
-      if (prevAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
-      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = prevAck;
+      for (const k of Object.keys(env)) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+      }
     }
   }
 
@@ -782,25 +781,42 @@ describe('NODE_ENV gate on default in-memory task registry', () => {
   });
 
   it('NODE_ENV=production WITH ADCP_DECISIONING_ALLOW_INMEMORY_TASKS=1 → allows (with documented data-loss tradeoff)', () => {
-    withEnv({ NODE_ENV: 'production', ADCP_DECISIONING_ALLOW_INMEMORY_TASKS: '1' }, () => {
-      assert.doesNotThrow(() =>
-        createAdcpServerFromPlatform(emptyPlatform(), {
-          name: 't',
-          version: '0',
-          validation: { requests: 'off', responses: 'off' },
-        })
-      );
-    });
+    // The 6.0.1 stateStore gate is parallel to the task-registry gate.
+    // Both have their own ADCP_DECISIONING_ALLOW_INMEMORY_* ack flag. A
+    // production deployment that opts into in-memory tasks AND in-memory
+    // state must set both — they're separate footguns with separate
+    // recoveries.
+    withEnv(
+      {
+        NODE_ENV: 'production',
+        ADCP_DECISIONING_ALLOW_INMEMORY_TASKS: '1',
+        ADCP_DECISIONING_ALLOW_INMEMORY_STATE: '1',
+      },
+      () => {
+        assert.doesNotThrow(() =>
+          createAdcpServerFromPlatform(emptyPlatform(), {
+            name: 't',
+            version: '0',
+            validation: { requests: 'off', responses: 'off' },
+          })
+        );
+      }
+    );
   });
 
   it('explicit taskRegistry provided → no NODE_ENV check', () => {
     const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
+    const { InMemoryStateStore } = require('../dist/lib/server/state-store');
     withEnv({ NODE_ENV: 'production' }, () => {
       assert.doesNotThrow(() =>
         createAdcpServerFromPlatform(emptyPlatform(), {
           name: 't',
           version: '0',
           taskRegistry: createInMemoryTaskRegistry(),
+          // Explicit stateStore opt-in mirrors the explicit-taskRegistry
+          // pattern this test exercises — both opt-outs have to be
+          // exercised together for the production smoke check.
+          stateStore: new InMemoryStateStore(),
           validation: { requests: 'off', responses: 'off' },
         })
       );

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -727,9 +727,21 @@ describe('createAdcpServer config warnings', () => {
   it("idempotency: 'disabled' allows ADCP_IDEMPOTENCY_DISABLED_ACK=1 escape hatch under any NODE_ENV", () => {
     const warns = [];
     const logger = { debug: () => {}, info: () => {}, warn: msg => warns.push(msg), error: () => {} };
-    withEnv({ NODE_ENV: 'staging', ADCP_IDEMPOTENCY_DISABLED_ACK: '1' }, () => {
-      assert.doesNotThrow(() => buildDisabled({ logger }));
-    });
+    // 6.0.1 added a parallel state-store ack — the in-memory state store
+    // refuses to construct outside test/dev unless ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1.
+    // This test exercises the idempotency-disabled escape hatch under
+    // staging, which means we also need the state-store escape hatch
+    // for the agent to start at all. Both gates are independent footguns.
+    withEnv(
+      {
+        NODE_ENV: 'staging',
+        ADCP_IDEMPOTENCY_DISABLED_ACK: '1',
+        ADCP_DECISIONING_ALLOW_INMEMORY_STATE: '1',
+      },
+      () => {
+        assert.doesNotThrow(() => buildDisabled({ logger }));
+      }
+    );
     assert.ok(warns.some(m => /idempotency: 'disabled' is set/.test(m)));
   });
 

--- a/test/server-state-store-extensions.test.js
+++ b/test/server-state-store-extensions.test.js
@@ -664,3 +664,106 @@ describe('default stateStore — multi-tenant footgun warning', () => {
     assert.equal(multiTenantWarnings.length, 0, 'explicit stateStore must not trigger the default-store warning');
   });
 });
+
+describe('default stateStore — production gate (v6.0.1)', () => {
+  // Mirrors `buildDefaultTaskRegistry` policy: outside
+  // {NODE_ENV=test, NODE_ENV=development}, the in-memory default
+  // refuses to mint unless the adopter sets
+  // `ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1` as the ops escape hatch.
+  function withEnv(overrides, fn) {
+    const prev = {};
+    for (const k of Object.keys(overrides)) {
+      prev[k] = process.env[k];
+      if (overrides[k] === undefined) delete process.env[k];
+      else process.env[k] = overrides[k];
+    }
+    try {
+      fn();
+    } finally {
+      for (const k of Object.keys(overrides)) {
+        if (prev[k] === undefined) delete process.env[k];
+        else process.env[k] = prev[k];
+      }
+    }
+  }
+
+  it('NODE_ENV=production + default stateStore → throws with migration message', () => {
+    withEnv({ NODE_ENV: 'production', ADCP_DECISIONING_ALLOW_INMEMORY_STATE: undefined }, () => {
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'p',
+            version: '1.0.0',
+            capabilities: { major_versions: [3] },
+          }),
+        err =>
+          /in-memory state store refused outside.*NODE_ENV=test, NODE_ENV=development/.test(err.message) &&
+          /PostgresStateStore/.test(err.message) &&
+          /ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1/.test(err.message)
+      );
+    });
+  });
+
+  it('NODE_ENV=production + ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1 → allows', () => {
+    withEnv({ NODE_ENV: 'production', ADCP_DECISIONING_ALLOW_INMEMORY_STATE: '1' }, () => {
+      assert.doesNotThrow(() =>
+        createAdcpServer({
+          name: 'p',
+          version: '1.0.0',
+          capabilities: { major_versions: [3] },
+        })
+      );
+    });
+  });
+
+  it('NODE_ENV=production + explicit stateStore → no env check', () => {
+    withEnv({ NODE_ENV: 'production' }, () => {
+      assert.doesNotThrow(() =>
+        createAdcpServer({
+          name: 'p',
+          version: '1.0.0',
+          capabilities: { major_versions: [3] },
+          stateStore: new InMemoryStateStore(),
+        })
+      );
+    });
+  });
+
+  it('NODE_ENV=development + default stateStore → no throw (dev is the safe set)', () => {
+    withEnv({ NODE_ENV: 'development', ADCP_DECISIONING_ALLOW_INMEMORY_STATE: undefined }, () => {
+      assert.doesNotThrow(() =>
+        createAdcpServer({
+          name: 'd',
+          version: '1.0.0',
+          capabilities: { major_versions: [3] },
+        })
+      );
+    });
+  });
+
+  it('NODE_ENV=test + default stateStore → no throw', () => {
+    withEnv({ NODE_ENV: 'test', ADCP_DECISIONING_ALLOW_INMEMORY_STATE: undefined }, () => {
+      assert.doesNotThrow(() =>
+        createAdcpServer({
+          name: 't',
+          version: '1.0.0',
+          capabilities: { major_versions: [3] },
+        })
+      );
+    });
+  });
+
+  it('undefined NODE_ENV + default stateStore → throws (matches task-registry policy strictness)', () => {
+    withEnv({ NODE_ENV: undefined, ADCP_DECISIONING_ALLOW_INMEMORY_STATE: undefined }, () => {
+      assert.throws(
+        () =>
+          createAdcpServer({
+            name: 'u',
+            version: '1.0.0',
+            capabilities: { major_versions: [3] },
+          }),
+        /in-memory state store refused outside/
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

v6.0.1 patch. Closes [#1124](https://github.com/adcontextprotocol/adcp-client/issues/1124) plus two folded bonus items from the v6.0 expert reviews.

## Changes

### Production gate on the default `stateStore` (closes #1124)

The 6.0 default `InMemoryStateStore` is a process-shared module singleton. Correct for dev + single-tenant agents (closed Pattern 3 SI session loss), but multi-tenant production deployments that mint one `createAdcpServer` per resolved tenant would silently share state across tenants. 6.0 shipped this as a one-time `logger.warn`; 6.0.1 promotes it to a hard refusal mirroring `buildDefaultTaskRegistry`'s task-registry policy.

Outside `{NODE_ENV=test, NODE_ENV=development}`, the default in-memory store throws with three explicit recoveries:

```
1. (Recommended) Pass `stateStore: new PostgresStateStore({ pool })`
2. Pass `stateStore: new InMemoryStateStore()` explicitly (single-tenant only)
3. Set ADCP_DECISIONING_ALLOW_INMEMORY_STATE=1 (ops escape hatch)
```

**Gate ordering**: fires AFTER the existing `idempotency: 'disabled'` gate so adopters who hit both surface the higher-severity error first.

### zod peer-dep floor bump `^4.1.0 → ^4.1.5`

Matches `json-schema-to-zod` (peers `^4.1.3`) and `ts-to-zod` (peers `^4.1.5`) — the SDK's own codegen-tool floors. Removes a build-vs-runtime range mismatch where adopters on `zod@4.1.0–4.1.4` would technically fall below the codegen tools' floors. From the v6.0 protocol-expert review.

### Missing-peer-dep doc (`Cannot find module 'zod'`)

Added a troubleshooting bullet to the migration doc explaining the symptom and the explicit-install fix. The SDK can't catch this at runtime — `import { z } from 'zod'` resolves at module load, before any SDK code runs — so documentation is the right shape (corrects the dx-expert's suggestion of a try/require which doesn't work for top-level imports).

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] **897/897 server-side tests pass**
- [x] 6 new production-gate tests in `test/server-state-store-extensions.test.js` covering: production-throw, ack-allows, explicit-store-allows, development-allows, test-allows, undef-NODE_ENV-throws
- [ ] CI green

## Adopter migration impact

Production deployments running `createAdcpServer()` WITHOUT an explicit stateStore will see a hard error at boot (was a one-time warn in 6.0). The error message tells them exactly what to do; same migration shape as the v5 → v6 task-registry change. For dev/test (matrix harness, local iteration, CI test suites), nothing changes — `npm test` now sets `NODE_ENV=test` automatically, so existing tests don't trip the gate.

## Related

- v6.0 PRs: #1119 (deep fixes), #1125 (zod peerDep), #1126 (final asks)
- Tracked v6.1 follow-up: #1120 (seller-skill behavioral coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)