### PR TITLE
fix(conformance): exempt sync_accounts ↔ list_accounts substitution from F6 cascade-skip

### DIFF
--- a/.changeset/fix-sync-accounts-cascade-skip.md
+++ b/.changeset/fix-sync-accounts-cascade-skip.md
@@ -1,0 +1,20 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(conformance): sync_accounts not_applicable no longer cascades to list_accounts
+
+The F6 cascade-skip treated `sync_accounts` returning `not_applicable`
+(explicit-mode: `require_operator_auth: true`) the same as "state never
+materialized", which then cascade-skipped `list_accounts` as
+`prerequisite_failed`. The AdCP spec defines `sync_accounts ↔
+list_accounts` as mutually exclusive substitutes; explicit-mode adopters
+use `list_accounts` to establish account state instead of `sync_accounts`.
+
+The runner now exempts the cascade when `sync_accounts` skips
+`not_applicable` AND `list_accounts` is in the agent's advertised tool
+list. If `list_accounts` is also missing, the normal `missing_tool`
+cascade fires on that step.
+
+Reported by @bokelley from the scope3data/agentic-adapters workspace
+migration (12 adapter storyboards collapsed to 1/10 passing steps).

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -446,6 +446,31 @@ createAdcpServerFromPlatform(platform, {
   or pin the consumer-side `zod` to `<4.3.0` until you've audited
   affected schemas. Not an SDK bug — flagging here so adopters
   migrating off 5.x see the symptom in context.
+- **`Format['assets']` cast tightening.** v6 narrowed `Format['assets']`
+  to `(BaseIndividualAsset | RepeatableGroupAsset)[]` (previously the
+  type was looser). A bare `as Format['assets']` cast from
+  `Record<string, unknown>[]` now fails TypeScript's overlap check
+  (`Conversion of type 'Record<string, unknown>[]' to type '...' may be
+  a mistake because neither type sufficiently overlaps`). Fix: build
+  asset objects as properly-typed values from the start, or use a
+  two-step cast where a broad intermediate is required:
+
+  ```ts
+  // Before (compiled in v5, breaks in v6)
+  return { ..., assets: builtAssets as Format['assets'] };
+
+  // After — option A: type the builder to return the correct union
+  function buildAdcpAsset(slot: AssetSlot): BaseIndividualAsset | RepeatableGroupAsset { ... }
+  return { ..., assets: format.assets.map(buildAdcpAsset) };
+
+  // After — option B: two-step cast (use sparingly; type-unsafe)
+  return { ..., assets: builtAssets as unknown as Format['assets'] };
+  ```
+
+  The `getIndividualAssets` / `getRepeatableGroups` helpers in
+  `@adcp/sdk/server` return the typed union directly; prefer those
+  over manual map+cast in `build_creative` / `preview_creative`
+  handlers.
 
 ## Auto-hydration error contract
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1092,13 +1092,26 @@ async function executeStoryboardPass(
         // — already handled by phase-level cascade, `oauth_not_advertised`
         // — phase-absent path) deliberately don't trip the flag.
         if (step.stateful && isMissingStateSkipReason(result.skip_reason)) {
-          statefulFailed = true;
-          // Record provenance for the cascade detail message. First trip
-          // wins — subsequent triggers don't overwrite, since the cascade
-          // text references the originating diagnostic (the leftmost
-          // missing-state stateful step in the phase).
-          if (statefulSkipTrigger === null) {
-            statefulSkipTrigger = { stepId: step.id, reason: result.skip_reason ?? 'missing_tool' };
+          // Exception: the spec defines sync_accounts ↔ list_accounts as mutually
+          // exclusive substitutes. Explicit-mode adopters (require_operator_auth: true)
+          // use list_accounts instead of sync_accounts to establish account state.
+          // When sync_accounts skips not_applicable AND list_accounts is advertised,
+          // state WILL materialize via list_accounts — don't cascade-skip it as if
+          // state never materialized. If list_accounts is also missing, the normal
+          // missing_tool cascade fires on that step instead.
+          const isSyncAccountsSubstitution =
+            step.task === 'sync_accounts' &&
+            result.skip_reason === 'not_applicable' &&
+            options.agentTools?.includes('list_accounts') === true;
+          if (!isSyncAccountsSubstitution) {
+            statefulFailed = true;
+            // Record provenance for the cascade detail message. First trip
+            // wins — subsequent triggers don't overwrite, since the cascade
+            // text references the originating diagnostic (the leftmost
+            // missing-state stateful step in the phase).
+            if (statefulSkipTrigger === null) {
+              statefulSkipTrigger = { stepId: step.id, reason: result.skip_reason ?? 'missing_tool' };
+            }
           }
         }
       } else if (result.passed) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1092,13 +1092,14 @@ async function executeStoryboardPass(
         // — already handled by phase-level cascade, `oauth_not_advertised`
         // — phase-absent path) deliberately don't trip the flag.
         if (step.stateful && isMissingStateSkipReason(result.skip_reason)) {
-          // Exception: the spec defines sync_accounts ↔ list_accounts as mutually
-          // exclusive substitutes. Explicit-mode adopters (require_operator_auth: true)
-          // use list_accounts instead of sync_accounts to establish account state.
-          // When sync_accounts skips not_applicable AND list_accounts is advertised,
-          // state WILL materialize via list_accounts — don't cascade-skip it as if
-          // state never materialized. If list_accounts is also missing, the normal
-          // missing_tool cascade fires on that step instead.
+          // Exception: for account-state establishment specifically, sync_accounts
+          // and list_accounts are spec-defined mode substitutes. Explicit-mode
+          // adopters (require_operator_auth: true) use list_accounts instead of
+          // sync_accounts to establish account state; sync_accounts is simply not
+          // applicable to them. When sync_accounts skips not_applicable AND
+          // list_accounts is in the agent's tool list, state WILL materialize via
+          // list_accounts — don't cascade-skip it. If list_accounts is also missing,
+          // the normal missing_tool cascade fires on that step instead.
           const isSyncAccountsSubstitution =
             step.task === 'sync_accounts' &&
             result.skip_reason === 'not_applicable' &&


### PR DESCRIPTION
Refs #1005

## Summary

Two post-merge findings from @bokelley's workspace migration to 6.0.0, reported on PR #1005 (Round-9).

**Finding 1 (high — conformance runner):** The F6 cascade-skip introduced in PR #1005 treated `sync_accounts` returning `not_applicable` (explicit-mode: `require_operator_auth: true`) the same as "state never materialized", which then cascade-skipped `list_accounts` as `prerequisite_failed`. The AdCP spec defines `sync_accounts` and `list_accounts` as mode substitutes for account-state establishment — explicit-mode adopters use `list_accounts` instead. This collapsed 12 adapter storyboards from 3–9 passing steps to 1/10.

**Finding 2 (low — migration doc):** v6 narrowed `Format['assets']` to `(BaseIndividualAsset | RepeatableGroupAsset)[]`; bare `as Format['assets']` casts from `Record<string, unknown>[]` now fail TypeScript's overlap check. Added a note with option A (type the builder correctly) and option B (two-step cast), plus a pointer to the SDK helpers.

## Changes

- `src/lib/testing/storyboard/runner.ts` — exempts the cascade trigger when `sync_accounts` skips `not_applicable` AND `list_accounts` is in the agent's advertised tool list. If `list_accounts` is also missing, the normal `missing_tool` cascade fires on that step.
- `docs/migration-5.x-to-6.x.md` — adds `Format['assets']` cast-tightening note to Common gotchas.
- `.changeset/fix-sync-accounts-cascade-skip.md` — patch changeset.

## What tested

- `npx tsc --project tsconfig.lib.json --noEmit` — no new errors (pre-existing env errors: missing `@types/node`, deprecated `moduleResolution=node10`; both exist on main without this diff).
- `npm test` — 670 failures pre-exist on main; identical count without this diff.
- Code correctness verified: cascade logic lives only in `executeStoryboardPass`; `runStoryboardStep` calls `executeStep` directly and never reaches this code path.

## Pre-PR review

- **code-reviewer:** approved — logic of `isSyncAccountsSubstitution` guard is correct; `=== true` idiom safely handles `undefined?.includes` returning `undefined`; one hard blocker (missing changeset) was fixed before push.
- **ad-tech-protocol-expert:** approved — `sync_accounts ↔ list_accounts` substitution for account-state establishment is spec-grounded (enforced in `capabilities.ts:269`; corroborated by the `sync_accounts` gate comment at runner.ts:1669); using `agentTools` is the correct signal (populated from `profile.tools` via `get_adcp_capabilities`). Comment refined per nit: exclusivity is scoped to account-state establishment, not global.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01LKoy2TYnR3nhfpMeh4i3n6

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKoy2TYnR3nhfpMeh4i3n6)_