### PR TITLE
fix(release): stop trying to publish @adcp/client (deprecated shim)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,9 +3,9 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [["@adcp/sdk", "@adcp/client"]],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["@adcp/client"]
 }

--- a/.changeset/kill-adcp-client-shim.md
+++ b/.changeset/kill-adcp-client-shim.md
@@ -1,0 +1,16 @@
+---
+'@adcp/sdk': patch
+---
+
+Stop trying to publish `@adcp/client` (the deprecated compat shim).
+
+Background: `@adcp/client` was the legacy package name; v6.0 renamed it to `@adcp/sdk` and the shim re-exported the new package. The 6.0.0 publish attempt left `@adcp/client@6.0.0`'s npm version slot in a "burned" state (visibility removed but slot reserved), so every subsequent release workflow fails with `Cannot publish over previously published version "6.0.0"` — even though the SDK publish succeeds. The release workflow then exits with code 1 because of the shim failure, even on otherwise-clean releases.
+
+Two surgical changes to stop the bleeding:
+
+1. **`packages/client-shim/package.json` → `private: true`.** Source stays in-tree for historical reference; npm publish flow now ignores the package entirely.
+2. **`.changeset/config.json`**: removed the `@adcp/sdk ↔ @adcp/client` linked-version pair (forced lock-step bumps that the npm registry rejected) and added `@adcp/client` to the `ignore` list so changesets stops generating release entries for it.
+
+Operator action (not part of this PR): run `npm deprecate @adcp/client "Renamed to @adcp/sdk in v6.0. Install @adcp/sdk@^6.1.0 instead."` to land a deprecation banner on the existing `@adcp/client` versions still on npm. Adopters with stale lockfiles get a one-line nudge to migrate.
+
+After this lands, the next release-PR's workflow run will publish `@adcp/sdk` cleanly without trying to touch `@adcp/client`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "5.25.1",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "5.25.1",
+      "version": "6.1.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -58,7 +58,7 @@
         "@modelcontextprotocol/sdk": "^1.17.5",
         "@opentelemetry/api": "^1.0.0",
         "pg": "^8.0.0",
-        "zod": "^4.1.0"
+        "zod": "^4.1.5"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -6395,10 +6395,10 @@
     },
     "packages/client-shim": {
       "name": "@adcp/client",
-      "version": "5.25.1",
+      "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^5.25.1"
+        "@adcp/sdk": "^6.0.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/packages/client-shim/package.json
+++ b/packages/client-shim/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@adcp/client",
   "version": "6.0.0",
-  "description": "Renamed to @adcp/sdk. Compatibility shim that re-exports @adcp/sdk under the legacy package name.",
+  "private": true,
+  "description": "DEPRECATED. Renamed to @adcp/sdk. This shim is no longer published — install @adcp/sdk@^6.1.0 instead. Source kept in-tree for historical reference; `private: true` keeps it out of the npm release flow (paired with `ignore: ['@adcp/client']` in .changeset/config.json).",
   "main": "index.js",
   "types": "index.d.ts",
   "type": "commonjs",

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.0.0';
+export const LIBRARY_VERSION = '6.1.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.0.0',
+  library: '6.1.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T23:31:10.778Z',
+  generatedAt: '2026-05-01T01:17:37.625Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Two surgical changes to keep the npm release workflow green. The 6.0.0 publish attempt burned the `@adcp/client@6.0.0` version slot on npm — every subsequent release workflow has been failing with `Cannot publish over previously published version "6.0.0"` even though `@adcp/sdk` publishes cleanly. The workflow exits code 1 because of the shim failure, which fires false-alarm CI failures.

## Changes

1. **`packages/client-shim/package.json` → `private: true`**. Source stays in-tree for historical reference; npm publish flow ignores it entirely.

2. **`.changeset/config.json`**:
   - Removed the `@adcp/sdk ↔ @adcp/client` linked-version pair (forced lock-step bumps that npm rejected)
   - Added `@adcp/client` to the `ignore` list so changesets stops generating release entries

## Operator follow-up

Run locally (needs npm publisher auth, OIDC doesn't apply to deprecate):

```bash
npm deprecate @adcp/client "Renamed to @adcp/sdk in v6.0. Install @adcp/sdk@^6.1.0 instead."
```

That deprecates every published version of `@adcp/client` with a one-line nudge to migrate. Verify with `npm view @adcp/client deprecated`.

## Test plan

- [x] `npm install` clean
- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [ ] CI green
- [ ] Next release-PR workflow merges + publishes `@adcp/sdk` without trying to touch `@adcp/client`

🤖 Generated with [Claude Code](https://claude.com/claude-code)