### PR TITLE
refactor(client): drop unnecessary debug_logs cast at v2.5 drift merge sites

### DIFF
--- a/.changeset/v2-5-debug-surfacing.md
+++ b/.changeset/v2-5-debug-surfacing.md
@@ -8,4 +8,6 @@ Drift from the warn-only post-adapter v2.5 validation pass now surfaces via `res
 
 No public API change. The `executor.validateAdaptedRequestAgainstV2(taskName, params, debugLogs?)` seam already accepted an optional `debugLogs` parameter — only the call sites changed.
 
+**Drop-on-error semantics.** Drift is merged into `result.debug_logs` only after `executor.executeTask` returns. If the executor throws before producing a result, drift collected pre-call is dropped — the executor owns the result envelope and the merge happens once we have one in hand. This matches the executor's own debug-log behavior, which is also tied to a successful return.
+
 Closes the observability hole the v2.5-foundation PR (`#1121`) deliberately deferred. Lays the groundwork for the broader compatibility-matrix work that needs reliable drift signal across version pairs.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -1181,10 +1181,11 @@ export class SingleAgentClient {
 
     // Merge collected drift into the executor's debug_logs so adopters
     // reading result.debug_logs see post-adapter v2.5 warnings alongside
-    // the executor's own logs.
+    // the executor's own logs. On error paths the executor may not surface
+    // result.debug_logs at all — drift collected before the failure is
+    // dropped, matching the executor's own debug-log behavior.
     if (v25DriftLogs.length > 0) {
-      const existing = (result.debug_logs as any[] | undefined) ?? [];
-      (result as { debug_logs?: any[] }).debug_logs = [...existing, ...v25DriftLogs];
+      result.debug_logs = [...(result.debug_logs ?? []), ...v25DriftLogs];
     }
 
     // Normalize response to v3 format
@@ -2173,8 +2174,7 @@ export class SingleAgentClient {
     );
 
     if (v25DriftLogs.length > 0) {
-      const existing = (result.debug_logs as any[] | undefined) ?? [];
-      (result as { debug_logs?: any[] }).debug_logs = [...existing, ...v25DriftLogs];
+      result.debug_logs = [...(result.debug_logs ?? []), ...v25DriftLogs];
     }
 
     // Normalize response to v3 format for consistent API surface


### PR DESCRIPTION
## Summary

The `surface v2.5 drift via result.debug_logs` feature shipped as part of #1134's squash merge. After rebasing, the only remaining work on this PR is a small cleanup: drop the redundant `(result as { debug_logs?: any[] })` cast at the merge sites.

`debug_logs?: any[]` is already declared on `TaskResultBase`, so `result.debug_logs` is directly typed — the cast was unnecessary. Replaced with direct assignment + nullish coalescing on the existing read.

Also documented drop-on-error semantics in the changeset: drift is merged after `executor.executeTask` returns; if the executor throws, pre-call drift is dropped, matching the executor's own debug-log behavior.

## Test plan

- [x] `npm run typecheck` clean
- [x] `NODE_ENV=test node --test test/lib/v2-5-drift-surfacing.test.js` — 3/3 pass