### PR TITLE
fix(types): collapse KNOWN_ERROR_CODES — second hand-rolled error source

### DIFF
--- a/.changeset/known-error-codes-collapse.md
+++ b/.changeset/known-error-codes-collapse.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+Collapse the second hand-rolled error-code source.
+
+`KNOWN_ERROR_CODES` in `src/lib/server/decisioning/async-outcome.ts` was a parallel hand-maintained array of error codes — same shape of bug as the `StandardErrorCode` drift fixed in 6.2.0, just one file over. The author had even left a `TODO(6.0): generate this from schemas/cache/<version>/enums/error-code.json` flag for future-self.
+
+Now derived from the generated `ErrorCodeValues` (and `ErrorCode` aliases `StandardErrorCode`), so:
+
+- New codes added to the spec light up everywhere downstream — typo warn, autocomplete, the `ErrorCode` union — without a hand-edit.
+- The two error-code "sources of truth" are now one source.
+- Warn message reports the count from the array rather than a stale hardcoded "45".
+
+No behavior change at the type or runtime layer; the array contains the same 45 codes it did before, just sourced from codegen now.

--- a/src/lib/server/decisioning/async-outcome.ts
+++ b/src/lib/server/decisioning/async-outcome.ts
@@ -15,66 +15,22 @@
  * @public
  */
 
+import { ErrorCodeValues } from '../../types/enums.generated';
+import type { StandardErrorCode } from '../../types/error-codes';
+
 /**
- * Error code vocabulary mirroring `schemas/cache/3.0.0/enums/error-code.json`
- * (45 standard codes). Adopters can return platform-specific codes too —
- * agents fall back to the `recovery` classification on unknowns via the
- * `(string & {})` escape hatch on `AdcpStructuredError.code`.
- *
- * TODO(6.0): generate this from `schemas/cache/<version>/enums/error-code.json`
- * via the same codegen pipeline as the rest of `tools.generated.ts`.
+ * Error code vocabulary mirroring `schemas/cache/<version>/enums/error-code.json`.
+ * Derived from the generated `ErrorCodeValues` array so adding a code to the
+ * spec lights up everywhere downstream (typo warn, `ErrorCode` union,
+ * autocomplete) without a hand-edit. Adopters can return platform-specific
+ * codes too — agents fall back to the `recovery` classification on unknowns
+ * via the `(string & {})` escape hatch on `AdcpStructuredError.code`.
  */
-export const KNOWN_ERROR_CODES = [
-  'INVALID_REQUEST',
-  'AUTH_REQUIRED',
-  'RATE_LIMITED',
-  'SERVICE_UNAVAILABLE',
-  'POLICY_VIOLATION',
-  'PRODUCT_NOT_FOUND',
-  'PRODUCT_UNAVAILABLE',
-  'PRODUCT_EXPIRED',
-  'PROPOSAL_EXPIRED',
-  'PROPOSAL_NOT_COMMITTED',
-  'BUDGET_TOO_LOW',
-  'BUDGET_EXHAUSTED',
-  'BUDGET_EXCEEDED',
-  'CREATIVE_REJECTED',
-  'CREATIVE_DEADLINE_EXCEEDED',
-  'CREATIVE_NOT_FOUND',
-  'UNSUPPORTED_FEATURE',
-  'AUDIENCE_TOO_SMALL',
-  'ACCOUNT_NOT_FOUND',
-  'ACCOUNT_SETUP_REQUIRED',
-  'ACCOUNT_AMBIGUOUS',
-  'ACCOUNT_PAYMENT_REQUIRED',
-  'ACCOUNT_SUSPENDED',
-  'COMPLIANCE_UNSATISFIED',
-  'GOVERNANCE_DENIED',
-  'GOVERNANCE_UNAVAILABLE',
-  'CAMPAIGN_SUSPENDED',
-  'CONFLICT',
-  'IDEMPOTENCY_CONFLICT',
-  'IDEMPOTENCY_EXPIRED',
-  'INVALID_STATE',
-  'IO_REQUIRED',
-  'MEDIA_BUY_NOT_FOUND',
-  'NOT_CANCELLABLE',
-  'PACKAGE_NOT_FOUND',
-  'PERMISSION_DENIED',
-  'PLAN_NOT_FOUND',
-  'REFERENCE_NOT_FOUND',
-  'REQUOTE_REQUIRED',
-  'SESSION_NOT_FOUND',
-  'SESSION_TERMINATED',
-  'SIGNAL_NOT_FOUND',
-  'TERMS_REJECTED',
-  'VALIDATION_ERROR',
-  'VERSION_UNSUPPORTED',
-] as const;
+export const KNOWN_ERROR_CODES = ErrorCodeValues;
 
-export type ErrorCode = (typeof KNOWN_ERROR_CODES)[number];
+export type ErrorCode = StandardErrorCode;
 
-const KNOWN_ERROR_CODE_SET: ReadonlySet<string> = new Set(KNOWN_ERROR_CODES);
+const KNOWN_ERROR_CODE_SET: ReadonlySet<string> = new Set<string>(KNOWN_ERROR_CODES);
 
 /**
  * Detect typoed error codes in `AdcpError` constructor calls. The
@@ -97,7 +53,7 @@ function maybeWarnUnknownErrorCode(code: string): void {
   // eslint-disable-next-line no-console
   console.warn(
     `[adcp/decisioning] AdcpError code "${code}" is not in the known ErrorCode set ` +
-      `(45 standard codes per schemas/cache/3.0.0/enums/error-code.json). ` +
+      `(${KNOWN_ERROR_CODES.length} standard codes per schemas/cache/<version>/enums/error-code.json). ` +
       `If this is intentional (vendor-specific code), set ADCP_DECISIONING_ALLOW_CUSTOM_CODES=1. ` +
       `Otherwise check spelling against the ErrorCode union.`
   );


### PR DESCRIPTION
## Summary

Follow-up to PR #1135. Same bug, different file.

`KNOWN_ERROR_CODES` in \`src/lib/server/decisioning/async-outcome.ts\` was a parallel hand-maintained array of 45 error codes mirroring the spec enum — exactly the same drift mechanism as \`StandardErrorCode\`. The author had even left a \`TODO(6.0): generate this from schemas/cache/<version>/enums/error-code.json\` flag.

Now:
- \`KNOWN_ERROR_CODES = ErrorCodeValues\` (derived from generated enum)
- \`type ErrorCode = StandardErrorCode\` (already derived in 6.2.0)
- Warn message reports count via \`.length\` rather than a hardcoded \`45\`

Two error-code sources of truth → one. Net diff: -57/+28.

## No behavior change

Same 45 codes, same runtime semantics, same exported names. The \`ErrorCode\` type was previously \`(typeof KNOWN_ERROR_CODES)[number]\` — that union expanded to the same 45 string literals as \`StandardErrorCode\` does now.

## Test plan

- [x] \`npm run typecheck\` — passes
- [x] \`npm run format:check\` — passes
- [x] \`node --test test/server-typed-errors.test.js test/lib/standard-error-codes-drift.test.js test/lib/v3-compatibility.test.js\` — 202/202 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)