### PR TITLE
docs(skills): callout for human-escalate codes — closes #1153

### DIFF
--- a/.changeset/skill-callout-human-escalate-codes.md
+++ b/.changeset/skill-callout-human-escalate-codes.md
@@ -1,0 +1,16 @@
+---
+'@adcp/sdk': patch
+---
+
+`skills/call-adcp-agent/SKILL.md` and `docs/guides/BUILD-AN-AGENT.md` — callout block for the four spec-`correctable`-but-operator-human-escalate codes.
+
+Surfaced during the recovery-classification audit closing #1136 and shipping in 6.3.0. Spec recovery is `correctable` for `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, and `AUTH_REQUIRED`, but the operator semantic is human-in-loop:
+
+- `POLICY_VIOLATION` / `COMPLIANCE_UNSATISFIED` / `GOVERNANCE_DENIED` are commercial-relationship signals. Auto-mutating creative, targeting, or budget and resubmitting looks like evasion to a seller's governance reviewer. Naive LLM agent loops that read `error.recovery === 'correctable'` and retry-with-tweaks will produce bad outcomes (and potentially get the buyer flagged).
+- `AUTH_REQUIRED` conflates missing creds (genuinely correctable — re-handshake) with revoked / expired creds (operator must rotate). Until [adcontextprotocol/adcp#3730](https://github.com/adcontextprotocol/adcp/issues/3730) splits this into `auth_missing` + `auth_invalid`, treat as escalate-after-one-attempt to avoid retry storms on revoked keys.
+
+The skill now teaches: spec recovery is `correctable`, operator behavior is human-in-loop. Read `error.message` + `error.suggestion`, surface to the user, don't loop.
+
+Closes #1153. Companion to #1152 (the future `BuyerRetryPolicy` helper which will operationalize these defaults in code rather than docs).
+
+Skills are bundled with the npm package (`files: ["skills/**/*"]`), so this is a publishable change.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -522,6 +522,8 @@ return adcpError('SERVICE_UNAVAILABLE', 'Try again in 30 seconds');
 return adcpError('ACCOUNT_SUSPENDED', 'Contact support');
 ```
 
+> **Heads-up for buyer-agent authors**: four codes are spec-`correctable` but operator-semantically human-escalate — don't auto-mutate-and-retry on `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, or `AUTH_REQUIRED`. Surface to the user. (`AUTH_REQUIRED` conflates missing-creds with revoked-creds; until [adcontextprotocol/adcp#3730](https://github.com/adcontextprotocol/adcp/issues/3730) splits these, treat as escalate.) See `skills/call-adcp-agent/SKILL.md` for the full callout.
+
 See `docs/llms.txt` for the full error code table with recovery classifications.
 
 ### Storyboards

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -233,13 +233,19 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
 | Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
 | `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
-<<<<<<< Updated upstream
 | `406 Not Acceptable` before any AdCP framing | Hand-rolled HTTP without `Accept: text/event-stream` (MCP transport) | Use `@modelcontextprotocol/sdk` client; it sets the right Accept header. |
-=======
->>>>>>> Stashed changes
-| `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
+| `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. (See exceptions below — four codes are technically `correctable` but operator-semantically human-escalate.) |
 | `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
 | HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |
+
+> **⚠️ Four codes are technically `correctable` but operator-semantically human-escalate. Don't auto-tweak.**
+>
+> - **`POLICY_VIOLATION`** — buyer's content/targeting violates seller policy. Auto-mutating creative or targeting and resubmitting **looks like evasion** to the seller's governance reviewer. Surface to a human.
+> - **`COMPLIANCE_UNSATISFIED`** — required disclosure can't be satisfied by the chosen format. Auto-relaxing the compliance section IS the compliance failure. Surface to a human.
+> - **`GOVERNANCE_DENIED`** — registered governance agent rejected the spend. Auto-shrinking budget and retrying looks like governance evasion. Surface to the plan operator.
+> - **`AUTH_REQUIRED`** — conflates missing creds (genuinely correctable) with revoked / expired creds (operator must rotate). Until [adcontextprotocol/adcp#3730](https://github.com/adcontextprotocol/adcp/issues/3730) splits this into `auth_missing` + `auth_invalid`, treat as escalate-after-one-attempt.
+>
+> Spec recovery on these is `correctable`; operator behavior is human-in-loop. The pattern: read `error.message` + `error.suggestion`, surface to the user, **don't loop**.
 
 If your symptom isn't here, fall through to the next section.
 


### PR DESCRIPTION
## Summary

Closes #1153. Companion to #1152 (BuyerRetryPolicy helper).

Adds a callout block in \`skills/call-adcp-agent/SKILL.md\` (and a heads-up in \`docs/guides/BUILD-AN-AGENT.md\`) for four codes where the spec's \`correctable\` classification diverges from the operator-grade behavior:

- \`POLICY_VIOLATION\` / \`COMPLIANCE_UNSATISFIED\` / \`GOVERNANCE_DENIED\` — commercial-relationship signals. Auto-mutate-and-retry looks like evasion to seller-side governance.
- \`AUTH_REQUIRED\` — conflates missing creds (correctable) with revoked creds (operator must rotate). Tracked upstream at adcontextprotocol/adcp#3730 for a spec-level split.

The skill now teaches: read \`error.message\` + \`error.suggestion\`, surface to the user, don't loop.

Surfaced by the product-expert review on #1147 — flagged that flipping these 12 codes from \`terminal\` to spec-\`correctable\` (which the SDK had been buggily hardcoding the other way) would cause naive buyer agents to retry-with-tweaks where they should escalate.

## Drive-by

Resolved a stale merge conflict (\`<<<<<<< Updated upstream\` / \`>>>>>>> Stashed changes\`) sitting on the recovery-symptom table in SKILL.md.

## Test plan

- [x] \`npm run typecheck:skill-examples\` — passes (no code-block changes)
- [x] \`npm run format:check\` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)