### PR TITLE
fix(client): default response validation to warn-only everywhere

### DIFF
--- a/.changeset/response-validation-warn-default.md
+++ b/.changeset/response-validation-warn-default.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+Response validation now defaults to `'warn'` everywhere instead of `'strict'` in non-production environments, matching the already-established request-side semantics.
+
+Previously, schema drift in a seller's response would hard-fail the task (`result.success === false`, `result.data` missing) whenever `NODE_ENV !== 'production'`. This broke every buyer calling a v2.5 seller from a local dev or CI environment, because v2.5 sellers routinely emit responses that don't satisfy 100% of the current schema constraints (e.g. `pricing_options` empty, envelope fields sent as `null`). The asymmetry meant request drift was tolerated but response drift was not — the worse failure mode, since the buyer can't control what a seller sends back.
+
+**After this change:** schema drift in a response goes to `result.debug_logs` as a warning; `result.data` contains the wire response unchanged. The task succeeds and the caller can decide what to do with the data.
+
+**To opt into strict mode** (hard-fail on any schema drift), pass `validation: { responses: 'strict' }` when constructing the client. The conformance storyboard runner retains strict mode explicitly so spec deviations surface as test failures.
+
+**Independent axes:** request and response validation are still independently configurable via `validation.requests` / `validation.responses`.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -18,6 +18,11 @@ interface AgentConfig {
   headers?: Record<string, string>;
 }
 
+interface ValidationHookConfig {
+  requests?: 'strict' | 'warn' | 'off';  // default: 'warn'
+  responses?: 'strict' | 'warn' | 'off'; // default: 'warn' — use 'strict' in conformance CI
+}
+
 interface TaskResult<T = any> {
   success: boolean;
   status: 'completed' | 'deferred' | 'submitted' | 'input-required'

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -115,21 +115,25 @@ TypeScript enforces exhaustiveness at compile time when the `_` catchall is omit
 
 Both request and response validation default to **warn-only** (`'warn'`). Schema drift from a seller goes to `result.debug_logs` as a warning; `result.data` still contains the wire response. This matches real-world v2.x deployment reality where sellers may not satisfy 100% of the current schema constraints.
 
-Configure per-client via `validation` in the `ADCPMultiAgentClient` options:
+Configure per-client via `validation` in the `ADCPMultiAgentClient` constructor options (`ADCPMultiAgentClient.simple()` does not expose this option):
 
 ```typescript
-const client = ADCPMultiAgentClient.simple(url, {
-  // validation defaults (both 'warn') — no need to set these unless overriding:
-  validation: {
-    requests: 'warn',    // 'warn' | 'strict' | 'off'
-    responses: 'warn',   // 'warn' | 'strict' | 'off'
-  },
-});
+const client = new ADCPMultiAgentClient(
+  [{ id: 'my-agent', agent_uri: url, protocol: 'mcp' }],
+  {
+    // validation defaults (both 'warn') — no need to set these unless overriding:
+    validation: {
+      requests: 'warn',    // 'warn' | 'strict' | 'off'
+      responses: 'warn',   // 'warn' | 'strict' | 'off'
+    },
+  }
+);
 
 // Strict mode: fail the task when schema drift detected (conformance CI, smoke tests):
-const strictClient = ADCPMultiAgentClient.simple(url, {
-  validation: { responses: 'strict' },
-});
+const strictClient = new ADCPMultiAgentClient(
+  [{ id: 'my-agent', agent_uri: url, protocol: 'mcp' }],
+  { validation: { responses: 'strict' } }
+);
 ```
 
 The storyboard runner and conformance harness always use `responses: 'strict'` so spec deviations surface as test failures.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -111,6 +111,29 @@ const label = result.match!({
 
 TypeScript enforces exhaustiveness at compile time when the `_` catchall is omitted — missing an arm is a type error, not a runtime surprise. The `!` is because `TaskResultBase.match` is declared optional so hand-constructed result literals (tests, middleware) stay valid; every result returned from the SDK has `.match` attached. For hand-constructed literals, use the free function `match(result, handlers)` or call `attachMatch(result)` first.
 
+## Schema Validation
+
+Both request and response validation default to **warn-only** (`'warn'`). Schema drift from a seller goes to `result.debug_logs` as a warning; `result.data` still contains the wire response. This matches real-world v2.x deployment reality where sellers may not satisfy 100% of the current schema constraints.
+
+Configure per-client via `validation` in the `ADCPMultiAgentClient` options:
+
+```typescript
+const client = ADCPMultiAgentClient.simple(url, {
+  // validation defaults (both 'warn') — no need to set these unless overriding:
+  validation: {
+    requests: 'warn',    // 'warn' | 'strict' | 'off'
+    responses: 'warn',   // 'warn' | 'strict' | 'off'
+  },
+});
+
+// Strict mode: fail the task when schema drift detected (conformance CI, smoke tests):
+const strictClient = ADCPMultiAgentClient.simple(url, {
+  validation: { responses: 'strict' },
+});
+```
+
+The storyboard runner and conformance harness always use `responses: 'strict'` so spec deviations surface as test failures.
+
 ## Idempotency (mutating requests)
 
 AdCP v3 requires `idempotency_key` on every mutating request (`create_media_buy`, `update_media_buy`, `activate_signal`, all `sync_*`, `si_send_message`, etc.). The SDK auto-generates a UUID v4 when callers don't supply one, reuses it across internal retries, and surfaces it on the result:

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -274,19 +274,19 @@ export interface SingleAgentClientConfig extends ConversationConfig {
      * - `warn`: log to debug logs and continue
      * - `off`: skip the validator entirely (no overhead)
      *
-     * @default `strict` in dev/test, `warn` in production
+     * @default `'warn'`
      */
     requests?: import('../validation/client-hooks').ValidationMode;
     /**
      * Validate incoming responses against the bundled AdCP JSON schema.
      *
-     * - `strict`: fail the task with `VALIDATION_ERROR`
-     * - `warn`: log to debug logs and surface the task as successful
+     * - `strict`: fail the task with `VALIDATION_ERROR` (use in conformance CI)
+     * - `warn`: log to debug logs and surface the task as successful (default)
      * - `off`: skip the validator entirely
      *
      * Overrides `strictSchemaValidation` when set.
      *
-     * @default `strict` in dev/test, `warn` in production
+     * @default `'warn'`
      */
     responses?: import('../validation/client-hooks').ValidationMode;
     /**

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -145,7 +145,7 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
 
   const multiClient = new ADCPMultiAgentClient([agentConfig], {
     headers,
-    validation: { logSchemaViolations: false },
+    validation: { logSchemaViolations: false, responses: 'strict' },
     ...(options.userAgent && { userAgent: options.userAgent }),
   });
 

--- a/src/lib/validation/client-hooks.ts
+++ b/src/lib/validation/client-hooks.ts
@@ -12,31 +12,24 @@ export type ValidationMode = 'strict' | 'warn' | 'off';
 export interface ValidationHookConfig {
   /** Validate outgoing requests. Default: strict in dev/test, warn in prod. */
   requests?: ValidationMode;
-  /** Validate incoming responses. Default: strict in dev/test, warn in prod. */
+  /** Validate incoming responses. Default: warn everywhere. Use `'strict'` to hard-fail on drift (e.g. conformance runner, CI). */
   responses?: ValidationMode;
-}
-
-function defaultResponseMode(): ValidationMode {
-  // Responses have been validated strictly by default since the SDK shipped
-  // Zod validation; preserve that in dev/test and soften to warn in prod.
-  return process.env.NODE_ENV === 'production' ? 'warn' : 'strict';
 }
 
 /**
  * Resolve the effective request/response modes.
  *
- * Response default: strict in dev/test, warn in prod (preserves the
- * existing `strictSchemaValidation` contract).
- *
- * Request default: `warn` everywhere. Strict-by-default would break
- * existing callers that intentionally send partial payloads (error-path
- * tests, exploratory probes) — storyboards and third-party clients that
- * want hard-stop enforcement should set `requests: 'strict'` explicitly.
+ * Both default to `warn` everywhere. Strict-by-default would break callers
+ * that legitimately send partial payloads or receive v2.x responses that
+ * don't satisfy 100% of the current schema — the client can't control what
+ * a third-party seller sends back. Set `responses: 'strict'` (or
+ * `requests: 'strict'`) explicitly when you want hard-stop enforcement,
+ * e.g. the storyboard runner or a CI smoke test.
  */
 export function resolveValidationModes(config?: ValidationHookConfig): Required<ValidationHookConfig> {
   return {
     requests: config?.requests ?? 'warn',
-    responses: config?.responses ?? defaultResponseMode(),
+    responses: config?.responses ?? 'warn',
   };
 }
 

--- a/src/lib/validation/client-hooks.ts
+++ b/src/lib/validation/client-hooks.ts
@@ -10,7 +10,7 @@ import { buildValidationError } from './schema-errors';
 export type ValidationMode = 'strict' | 'warn' | 'off';
 
 export interface ValidationHookConfig {
-  /** Validate outgoing requests. Default: strict in dev/test, warn in prod. */
+  /** Validate outgoing requests. Default: warn everywhere. */
   requests?: ValidationMode;
   /** Validate incoming responses. Default: warn everywhere. Use `'strict'` to hard-fail on drift (e.g. conformance runner, CI). */
   responses?: ValidationMode;

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -442,25 +442,20 @@ describe('schema-driven validation', () => {
       assert.strictEqual(modes.requests, 'warn');
     });
 
-    test('responses default to strict in non-production', () => {
-      const prev = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'development';
-      try {
-        const modes = resolveValidationModes();
-        assert.strictEqual(modes.responses, 'strict');
-      } finally {
-        process.env.NODE_ENV = prev;
-      }
-    });
-
-    test('responses default to warn in production', () => {
-      const prev = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-      try {
-        const modes = resolveValidationModes();
-        assert.strictEqual(modes.responses, 'warn');
-      } finally {
-        process.env.NODE_ENV = prev;
+    test('responses default to warn everywhere', () => {
+      for (const env of ['development', 'test', 'production', undefined]) {
+        const prev = process.env.NODE_ENV;
+        if (env === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = env;
+        }
+        try {
+          const modes = resolveValidationModes();
+          assert.strictEqual(modes.responses, 'warn', `expected warn for NODE_ENV=${env}`);
+        } finally {
+          process.env.NODE_ENV = prev;
+        }
       }
     });
 


### PR DESCRIPTION
Closes #1150

Response validation previously hard-failed (`result.success === false`, `result.data` missing) whenever `NODE_ENV !== 'production'` and a seller's response had schema drift. This made every buyer's dev/CI environment fail against v2.5 sellers — `pricing_options` empty, envelope nulls, and other v2.5 shape realities caused task failures the buyer couldn't control. The asymmetry with request-side validation (always warn-only) was the root bug.

## Changes

- **`src/lib/validation/client-hooks.ts`** — Remove `defaultResponseMode()` (returned `'strict'` in dev/test). `resolveValidationModes()` now returns `responses: 'warn'` unconditionally. Updated JSDoc on both `requests` and `responses` fields.
- **`src/lib/core/SingleAgentClient.ts`** — Update `@default` annotations on `validation.requests` / `validation.responses` to match the new universal-warn behavior.
- **`src/lib/testing/client.ts`** — `createTestClient()` now sets `validation: { responses: 'strict' }` explicitly so the storyboard runner retains strict mode (surfacing schema drift as test failures).
- **`test/lib/schema-validation.test.js`** — Replace the two environment-specific default tests with a single "responses default to warn everywhere" test covering all `NODE_ENV` variants.
- **`docs/llms.txt`** — Add Schema Validation section (after Error Handling) explaining modes, defaults, and the opt-in strict pattern.
- **`docs/TYPE-SUMMARY.md`** — Add `ValidationHookConfig` to Client Types.
- **`.changeset/response-validation-warn-default.md`** — Patch changeset.

## What was tested

- `node --test test/lib/schema-validation.test.js` — all `resolveValidationModes defaults` subtests pass (10/10 in that group); the `responses default to warn everywhere` assertion passes for `development`, `test`, `production`, and `undefined` NODE_ENV
- Pre-existing test failures (38 → 37): the one reduction is the old `responses: strict in non-production` test that now correctly asserts `warn`
- Build: `tsc --project tsconfig.lib.json` produces output (pre-existing TS config warnings on `node` type definitions are unrelated to this change and exist on `main`)

## Nits (not fixed, low priority)

- `src/lib/validation/client-hooks.ts`: `validateIncomingResponse` returns `{ valid: false }` in warn mode — the mode re-check in `TaskExecutor.validateResponseSchema:1854` corrects this. The dual-layer works correctly; cleaning it up is a separate refactor.
- `src/lib/testing/test-helpers.ts` (5 `ADCPMultiAgentClient` instances): these now default to `warn` mode post-change — correct per the issue intent, but callers relying on the old strict dev/test default for assertions in their own tests will silently stop seeing failures.

## Pre-PR review

- **code-reviewer**: approved — storyboard runner strict mode correctly preserved via `createTestClient`; no blockers; nits noted above
- **dx-expert**: approved (post-blocker-fix) — `ADCPMultiAgentClient.simple()` example corrected to use constructor form; `SingleAgentClient.ts` `@default` annotations updated

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_0192zro2DUduB3VLBWMAqape

---
_Generated by [Claude Code](https://claude.ai/code/session_0192zro2DUduB3VLBWMAqape)_