### PR TITLE
feat(client): add BuyerRetryPolicy helper with per-code recovery defaults

### DIFF
--- a/.changeset/buyer-retry-policy.md
+++ b/.changeset/buyer-retry-policy.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": minor
+---
+
+Add `BuyerRetryPolicy` helper with per-code recovery defaults.
+
+Translates `AdcpErrorInfo` into a concrete `RetryDecision` (`retry` / `mutate-and-retry` / `escalate`) using operator-grade per-code defaults that go beyond the spec's three-class `recovery` enum. Codes like `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, `CREATIVE_REJECTED`, `AUTH_REQUIRED`, and `PERMISSION_DENIED` default to `escalate` to prevent automated mutation from looking like policy evasion. Supports constructor-level per-code overrides for vertical-specific behavior.
+
+Also adds SKILL.md callout documenting the four human-escalate codes and a worked recovery loop example, and adds a corresponding note in BUILD-AN-AGENT.md for seller-side authors. Closes #1152.

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -524,6 +524,17 @@ return adcpError('ACCOUNT_SUSPENDED', 'Contact support');
 
 See `docs/llms.txt` for the full error code table with recovery classifications.
 
+**Four `correctable` codes require human escalation on the buyer side.** Buyer agents using `BuyerRetryPolicy` (from `@adcp/sdk`) will not auto-retry these — they require operator action:
+
+| Code | Operator semantic |
+|---|---|
+| `POLICY_VIOLATION` | Content/targeting violates seller policy; auto-mutation looks like evasion |
+| `COMPLIANCE_UNSATISFIED` | Compliance section of brief can't be satisfied automatically |
+| `GOVERNANCE_DENIED` | Registered governance agent denied the spend; escalate to plan operator |
+| `AUTH_REQUIRED` | Credential rotation may be required; not a simple retry |
+
+Return these codes with clear `message` fields so buyers can surface them to operators.
+
 ### Storyboards
 
 The `storyboards/` directory contains YAML files that define exactly what tool call sequences a buyer agent will make against your server. Each storyboard includes phases, steps, sample requests/responses, and validation rules.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -233,15 +233,96 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
 | Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
 | `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
-<<<<<<< Updated upstream
 | `406 Not Acceptable` before any AdCP framing | Hand-rolled HTTP without `Accept: text/event-stream` (MCP transport) | Use `@modelcontextprotocol/sdk` client; it sets the right Accept header. |
-=======
->>>>>>> Stashed changes
 | `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
 | `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
 | HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |
 
 If your symptom isn't here, fall through to the next section.
+
+## Recovery in practice: BuyerRetryPolicy
+
+Use `BuyerRetryPolicy` from `@adcp/sdk` instead of writing your own recovery loop. It applies per-code operator semantics that go beyond the spec's three-class `recovery` enum.
+
+```ts
+import { BuyerRetryPolicy } from '@adcp/sdk';
+
+let attempt = 1;
+let key = crypto.randomUUID();
+
+while (true) {
+  const result = await agent.create_media_buy({ idempotency_key: key, ...params });
+  if (result.success) break;
+
+  const decision = BuyerRetryPolicy.decide(result.adcpError, { attempt });
+
+  if (decision.action === 'retry') {
+    // Transport-level transient error. Reuse the SAME idempotency_key — the
+    // server replays the cached response on the same key.
+    await sleep(decision.delayMs);
+    attempt++;
+    continue;
+  }
+
+  if (decision.action === 'mutate-and-retry') {
+    // Request has a fixable defect. Read decision.field and decision.suggestion,
+    // then patch params. Use a FRESH idempotency_key for the corrected request.
+    params = applyCorrection(params, decision);
+    key = crypto.randomUUID();
+    attempt++;
+    continue;
+  }
+
+  // decision.action === 'escalate'
+  throw new Error(`Cannot recover from ${result.adcpError.code}: ${decision.reason}`);
+}
+```
+
+`applyCorrection` patches `params` using the structured hints in the error envelope. Two common patterns:
+
+```ts
+function applyCorrection(params, decision) {
+  // REQUOTE_REQUIRED: the quote expired — re-run get_products and use the
+  // updated pricing_option_id.
+  if (error.code === 'REQUOTE_REQUIRED') {
+    const products = await agent.get_products({ buying_mode: 'wholesale', ... });
+    return { ...params, packages: reroutePackages(params.packages, products) };
+  }
+
+  // CONFLICT: concurrent write — re-read to get the current revision.
+  if (error.code === 'CONFLICT') {
+    const current = await agent.get_media_buys({ media_buy_ids: [params.media_buy_id] });
+    return { ...params, revision: current.data.media_buys[0].revision };
+  }
+
+  // Generic: use decision.field (RFC 6901 pointer) to narrow which param to fix.
+  // decision.suggestion is agent-provided free text — untrusted, do not eval.
+  console.warn(`No automated fix for ${error.code}; decision.suggestion: ${decision.suggestion}`);
+  throw new EscalationRequired(error, decision.suggestion);
+}
+```
+
+### ⚠️ Four codes are technically `correctable` but semantically human-escalate — don't auto-tweak
+
+`BuyerRetryPolicy` maps these to `escalate` by default. Do not override without explicit operator approval:
+
+| Code | Why automated mutation is wrong |
+|---|---|
+| `POLICY_VIOLATION` | Re-mutating creative or targeting to escape a policy block looks like evasion to seller governance reviewers. |
+| `COMPLIANCE_UNSATISFIED` | Relaxing compliance fields to satisfy the format is a compliance failure in itself. Human in loop. |
+| `GOVERNANCE_DENIED` | A registered governance agent rejected the spend. Auto-retrying with a smaller budget looks like governance evasion. Escalate to plan operator. |
+| `AUTH_REQUIRED` | Conflates missing credentials (correctable) with revoked credentials (operator must rotate). Until the spec splits `auth_missing` / `auth_invalid` ([adcp#3727](https://github.com/adcontextprotocol/adcp/issues/3727)), treat as escalate. |
+
+Spec recovery: `correctable`. Operator behavior: human in loop.
+
+If your vertical needs programmatic handling of one of these codes (e.g., POLICY_VIOLATION with deterministic geo-fallback), opt in explicitly:
+
+```ts
+const policy = new BuyerRetryPolicy({
+  overrides: { POLICY_VIOLATION: { action: 'mutate-and-retry', maxAttempts: 1 } },
+});
+const decision = policy.decide(result.adcpError, { attempt });
+```
 
 ## If you get stuck
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -692,6 +692,13 @@ export type {
 
 // ====== ERROR HANDLING & RETRY ======
 export { isRetryable, getRetryDelay } from './utils/retry';
+export { BuyerRetryPolicy } from './utils/buyer-retry-policy';
+export type {
+  RetryDecision,
+  RetryContext,
+  RetryCodeOverride,
+  BuyerRetryPolicyOptions,
+} from './utils/buyer-retry-policy';
 
 // Public API: use these for programmatic error handling
 export {

--- a/src/lib/utils/buyer-retry-policy.test.ts
+++ b/src/lib/utils/buyer-retry-policy.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { BuyerRetryPolicy } from './buyer-retry-policy';
+import { STANDARD_ERROR_CODES } from '../types/error-codes';
+import type { AdcpErrorInfo } from '../core/ConversationTypes';
+import type { StandardErrorCode } from '../types/error-codes';
+
+function makeError(code: string, overrides: Partial<AdcpErrorInfo> = {}): AdcpErrorInfo {
+  const recovery = (STANDARD_ERROR_CODES as any)[code]?.recovery ?? 'terminal';
+  return { code, message: `test error: ${code}`, recovery, ...overrides };
+}
+
+describe('BuyerRetryPolicy', () => {
+  describe('every StandardErrorCode has a defined default', () => {
+    const allCodes = Object.keys(STANDARD_ERROR_CODES) as StandardErrorCode[];
+
+    it.each(allCodes)('code %s → valid RetryDecision on attempt 1', code => {
+      const decision = BuyerRetryPolicy.decide(makeError(code), { attempt: 1 });
+      expect(['retry', 'mutate-and-retry', 'escalate']).toContain(decision.action);
+      expect(typeof decision.maxAttempts).toBe('number');
+      if (decision.action === 'escalate') {
+        expect(typeof decision.reason).toBe('string');
+        expect(decision.maxAttempts).toBe(0);
+      }
+      if (decision.action === 'retry') {
+        expect(typeof decision.delayMs).toBe('number');
+        expect(decision.delayMs).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+
+  describe('governance-evasion codes always escalate', () => {
+    const escalateCodes: StandardErrorCode[] = [
+      'POLICY_VIOLATION',
+      'COMPLIANCE_UNSATISFIED',
+      'GOVERNANCE_DENIED',
+      'CREATIVE_REJECTED',
+      'AUTH_REQUIRED',
+      'PERMISSION_DENIED',
+    ];
+
+    it.each(escalateCodes)('%s → escalate regardless of attempt', code => {
+      expect(BuyerRetryPolicy.decide(makeError(code), { attempt: 1 }).action).toBe('escalate');
+      expect(BuyerRetryPolicy.decide(makeError(code), { attempt: 5 }).action).toBe('escalate');
+    });
+  });
+
+  describe('per-code override beats recovery-class routing', () => {
+    it('GOVERNANCE_UNAVAILABLE is transient but still escalates', () => {
+      const decision = BuyerRetryPolicy.decide(makeError('GOVERNANCE_UNAVAILABLE', { recovery: 'transient' }), {
+        attempt: 1,
+      });
+      expect(decision.action).toBe('escalate');
+    });
+
+    it('CAMPAIGN_SUSPENDED is transient but still escalates', () => {
+      const decision = BuyerRetryPolicy.decide(makeError('CAMPAIGN_SUSPENDED', { recovery: 'transient' }), {
+        attempt: 1,
+      });
+      expect(decision.action).toBe('escalate');
+    });
+
+    it('SESSION_TERMINATED is correctable but maps to mutate-and-retry (re-initiate)', () => {
+      const decision = BuyerRetryPolicy.decide(makeError('SESSION_TERMINATED', { recovery: 'correctable' }), {
+        attempt: 1,
+      });
+      expect(decision.action).toBe('mutate-and-retry');
+      if (decision.action === 'mutate-and-retry') {
+        expect(decision.suggestion).toContain('si_initiate_session');
+        expect(decision.maxAttempts).toBe(1);
+      }
+    });
+  });
+
+  describe('RATE_LIMITED — retry with backoff', () => {
+    it('attempt 1 → retry', () => {
+      const d = BuyerRetryPolicy.decide(makeError('RATE_LIMITED'), { attempt: 1 });
+      expect(d.action).toBe('retry');
+      if (d.action === 'retry') {
+        expect(d.maxAttempts).toBe(5);
+        expect(d.delayMs).toBeGreaterThan(0);
+      }
+    });
+
+    it('honors retryAfterMs when present', () => {
+      const d = BuyerRetryPolicy.decide(makeError('RATE_LIMITED', { retryAfterMs: 30_000 }), { attempt: 1 });
+      expect(d.action).toBe('retry');
+      if (d.action === 'retry') expect(d.delayMs).toBe(30_000);
+    });
+
+    it('attempt 6 → escalate (exceeded maxAttempts 5)', () => {
+      const d = BuyerRetryPolicy.decide(makeError('RATE_LIMITED'), { attempt: 6 });
+      expect(d.action).toBe('escalate');
+    });
+
+    it('attempt 5 → still retry (at the ceiling, not over)', () => {
+      const d = BuyerRetryPolicy.decide(makeError('RATE_LIMITED'), { attempt: 5 });
+      expect(d.action).toBe('retry');
+    });
+  });
+
+  describe('CONFLICT — mutate-and-retry (re-read required)', () => {
+    it('attempt 1 → mutate-and-retry with suggestion', () => {
+      const d = BuyerRetryPolicy.decide(makeError('CONFLICT'), { attempt: 1 });
+      expect(d.action).toBe('mutate-and-retry');
+      if (d.action === 'mutate-and-retry') {
+        expect(d.suggestion).toContain('revision');
+        expect(d.maxAttempts).toBe(2);
+      }
+    });
+
+    it('attempt 3 → escalate (exceeded maxAttempts 2)', () => {
+      const d = BuyerRetryPolicy.decide(makeError('CONFLICT'), { attempt: 3 });
+      expect(d.action).toBe('escalate');
+    });
+  });
+
+  describe('IDEMPOTENCY_CONFLICT / IDEMPOTENCY_EXPIRED', () => {
+    it('IDEMPOTENCY_CONFLICT → mutate-and-retry with fresh-key guidance', () => {
+      const d = BuyerRetryPolicy.decide(makeError('IDEMPOTENCY_CONFLICT'), { attempt: 1 });
+      expect(d.action).toBe('mutate-and-retry');
+      if (d.action === 'mutate-and-retry') {
+        expect(d.suggestion).toContain('UUID v4');
+        expect(d.maxAttempts).toBe(1);
+      }
+    });
+
+    it('IDEMPOTENCY_EXPIRED → mutate-and-retry with natural-key lookup guidance', () => {
+      const d = BuyerRetryPolicy.decide(makeError('IDEMPOTENCY_EXPIRED'), { attempt: 1 });
+      expect(d.action).toBe('mutate-and-retry');
+      if (d.action === 'mutate-and-retry') {
+        expect(d.suggestion).toContain('natural key');
+        expect(d.maxAttempts).toBe(1);
+      }
+    });
+
+    it('IDEMPOTENCY_CONFLICT attempt 2 → escalate', () => {
+      expect(BuyerRetryPolicy.decide(makeError('IDEMPOTENCY_CONFLICT'), { attempt: 2 }).action).toBe('escalate');
+    });
+  });
+
+  describe('terminal codes always escalate', () => {
+    const terminalCodes: StandardErrorCode[] = [
+      'ACCOUNT_NOT_FOUND',
+      'ACCOUNT_PAYMENT_REQUIRED',
+      'ACCOUNT_SUSPENDED',
+      'BUDGET_EXHAUSTED',
+    ];
+
+    it.each(terminalCodes)('%s → escalate', code => {
+      expect(BuyerRetryPolicy.decide(makeError(code), { attempt: 1 }).action).toBe('escalate');
+    });
+  });
+
+  describe('correctable default — mutate-and-retry once', () => {
+    it('PRODUCT_NOT_FOUND → mutate-and-retry', () => {
+      const d = BuyerRetryPolicy.decide(makeError('PRODUCT_NOT_FOUND'), { attempt: 1 });
+      expect(d.action).toBe('mutate-and-retry');
+      if (d.action === 'mutate-and-retry') expect(d.maxAttempts).toBe(1);
+    });
+
+    it('PRODUCT_NOT_FOUND attempt 2 → escalate', () => {
+      expect(BuyerRetryPolicy.decide(makeError('PRODUCT_NOT_FOUND'), { attempt: 2 }).action).toBe('escalate');
+    });
+
+    it('passes field from error when present', () => {
+      const d = BuyerRetryPolicy.decide(makeError('VALIDATION_ERROR', { field: '/packages/0/budget' }), { attempt: 1 });
+      expect(d.action).toBe('mutate-and-retry');
+      if (d.action === 'mutate-and-retry') expect(d.field).toBe('/packages/0/budget');
+    });
+  });
+
+  describe('instance overrides', () => {
+    it('override POLICY_VIOLATION → mutate-and-retry', () => {
+      const policy = new BuyerRetryPolicy({
+        overrides: { POLICY_VIOLATION: { action: 'mutate-and-retry', maxAttempts: 2 } },
+      });
+      const d = policy.decide(makeError('POLICY_VIOLATION'), { attempt: 1 });
+      expect(d.action).toBe('mutate-and-retry');
+      if (d.action === 'mutate-and-retry') expect(d.maxAttempts).toBe(2);
+    });
+
+    it('override escalate with custom reason', () => {
+      const policy = new BuyerRetryPolicy({
+        overrides: { PRODUCT_NOT_FOUND: { action: 'escalate', reason: 'catalog out of date' } },
+      });
+      const d = policy.decide(makeError('PRODUCT_NOT_FOUND'), { attempt: 1 });
+      expect(d.action).toBe('escalate');
+      if (d.action === 'escalate') expect(d.reason).toBe('catalog out of date');
+    });
+
+    it('override retry with fixed delayMs', () => {
+      const policy = new BuyerRetryPolicy({
+        overrides: { RATE_LIMITED: { action: 'retry', maxAttempts: 10, delayMs: 500 } },
+      });
+      const d = policy.decide(makeError('RATE_LIMITED'), { attempt: 1 });
+      expect(d.action).toBe('retry');
+      if (d.action === 'retry') {
+        expect(d.delayMs).toBe(500);
+        expect(d.maxAttempts).toBe(10);
+      }
+    });
+
+    it('override with custom code (unknown to SDK)', () => {
+      const policy = new BuyerRetryPolicy({
+        overrides: { MY_CUSTOM_ERROR: { action: 'retry', maxAttempts: 2 } },
+      });
+      const d = policy.decide({ code: 'MY_CUSTOM_ERROR', message: 'custom' }, { attempt: 1 });
+      expect(d.action).toBe('retry');
+    });
+  });
+
+  describe('static BuyerRetryPolicy.decide', () => {
+    it('is equivalent to default instance', () => {
+      const error = makeError('RATE_LIMITED');
+      const ctx = { attempt: 1 };
+      const staticResult = BuyerRetryPolicy.decide(error, ctx);
+      const instanceResult = new BuyerRetryPolicy().decide(error, ctx);
+      expect(staticResult).toEqual(instanceResult);
+    });
+  });
+
+  describe('unknown / custom error codes', () => {
+    it('unknown code with no recovery falls back to terminal → escalate', () => {
+      const d = BuyerRetryPolicy.decide({ code: 'SELLER_CUSTOM_ERROR', message: 'platform-specific' }, { attempt: 1 });
+      expect(d.action).toBe('escalate');
+    });
+
+    it('unknown code with explicit transient recovery → retry', () => {
+      const d = BuyerRetryPolicy.decide(
+        { code: 'SELLER_RATE_THROTTLED', message: 'slow down', recovery: 'transient', retryAfterMs: 2_000 },
+        { attempt: 1 }
+      );
+      expect(d.action).toBe('retry');
+      if (d.action === 'retry') expect(d.delayMs).toBe(2_000);
+    });
+  });
+});

--- a/src/lib/utils/buyer-retry-policy.ts
+++ b/src/lib/utils/buyer-retry-policy.ts
@@ -1,0 +1,368 @@
+import type { AdcpErrorInfo } from '../core/ConversationTypes';
+import { STANDARD_ERROR_CODES, isStandardErrorCode, type StandardErrorCode } from '../types/error-codes';
+
+/**
+ * Action classification returned by BuyerRetryPolicy.decide().
+ *
+ * - `retry` — resubmit the unchanged request after `delayMs`. Reuse the same
+ *   `idempotency_key` (the server returns the cached response on replay).
+ * - `mutate-and-retry` — fix the request before resubmitting. Use a fresh
+ *   `idempotency_key` for the corrected request. Consult `suggestion` and
+ *   `field` for patching hints.
+ * - `escalate` — automated recovery is not possible. Surface `reason` to the
+ *   operator; do not retry autonomously.
+ *
+ * `maxAttempts` is always present: 0 for `escalate` (do not attempt),
+ * otherwise the total number of allowed attempts for this operation.
+ * `decide()` returns `escalate` automatically when `attempt > maxAttempts`.
+ */
+export type RetryDecision =
+  | { action: 'retry'; delayMs: number; maxAttempts: number }
+  | { action: 'mutate-and-retry'; suggestion?: string; field?: string; maxAttempts: number }
+  | { action: 'escalate'; reason: string; maxAttempts: 0 };
+
+/**
+ * Context passed to BuyerRetryPolicy.decide().
+ */
+export interface RetryContext {
+  /**
+   * 1-indexed attempt number. First call = 1. Pass the current attempt count
+   * so the policy can escalate automatically when the ceiling is reached.
+   */
+  attempt: number;
+  /** Prior errors on this logical operation, if any. */
+  history?: AdcpErrorInfo[];
+}
+
+/** Per-code override shape accepted by the BuyerRetryPolicy constructor. */
+export interface RetryCodeOverride {
+  action: RetryDecision['action'];
+  maxAttempts?: number;
+  /** Fixed delay in ms (retry action only; ignores exponential backoff). */
+  delayMs?: number;
+  /** Reason string (escalate action only). */
+  reason?: string;
+  /** Suggestion string (mutate-and-retry action only). */
+  suggestion?: string;
+}
+
+export interface BuyerRetryPolicyOptions {
+  /**
+   * Per-code overrides for vertical-specific behavior.
+   *
+   * Example — allow programmatic POLICY_VIOLATION correction for a geo-fenced
+   * vertical that can deterministically drop a blocked region:
+   * ```ts
+   * new BuyerRetryPolicy({ overrides: { POLICY_VIOLATION: { action: 'mutate-and-retry' } } })
+   * ```
+   */
+  overrides?: Partial<Record<string, RetryCodeOverride>>;
+}
+
+// Internal per-code entry shape (pre-computed, no user-facing fields).
+type CodeEntry =
+  | { action: 'retry'; maxAttempts: number; baseDelayMs: number }
+  | { action: 'mutate-and-retry'; maxAttempts: number; suggestion?: string }
+  | { action: 'escalate'; reason: string };
+
+// Default per-code policy table.
+// Codes absent from this table fall through to the recovery-class fallback below.
+const DEFAULT_TABLE: Partial<Record<StandardErrorCode, CodeEntry>> = {
+  // Transient — retry with exponential backoff
+  RATE_LIMITED: { action: 'retry', maxAttempts: 5, baseDelayMs: 1_000 },
+  SERVICE_UNAVAILABLE: { action: 'retry', maxAttempts: 3, baseDelayMs: 2_000 },
+
+  // Transient — re-read then re-submit
+  CONFLICT: {
+    action: 'mutate-and-retry',
+    maxAttempts: 2,
+    suggestion: 'Re-read the resource to get the latest revision before retrying the write',
+  },
+
+  // Transient but operator-only resolution — buyer cannot self-unblock
+  GOVERNANCE_UNAVAILABLE: {
+    action: 'escalate',
+    reason: 'Governance agent is unavailable; operator must restore the governance endpoint out-of-band',
+  },
+  CAMPAIGN_SUSPENDED: {
+    action: 'escalate',
+    reason: 'Campaign governance suspended pending human review; operator action required',
+  },
+
+  // Correctable but governance/evasion risk — always escalate
+  POLICY_VIOLATION: {
+    action: 'escalate',
+    reason:
+      'Content or targeting violates seller policy; automated mutation looks like evasion — human review required',
+  },
+  COMPLIANCE_UNSATISFIED: {
+    action: 'escalate',
+    reason: 'Compliance requirement cannot be satisfied automatically; human review required',
+  },
+  GOVERNANCE_DENIED: {
+    action: 'escalate',
+    reason: 'Governance agent denied the transaction; escalate to plan operator',
+  },
+  CREATIVE_REJECTED: {
+    action: 'escalate',
+    reason: 'Creative failed seller content policy review; automated creative substitution looks like evasion',
+  },
+
+  // Correctable but requires out-of-band operator action
+  AUTH_REQUIRED: {
+    action: 'escalate',
+    // Until adcontextprotocol/adcp#3727 splits auth_missing vs auth_invalid,
+    // treat all cases as escalate: revoked credentials need operator rotation.
+    reason: 'Authentication required; operator credential rotation may be needed (see adcp#3727)',
+  },
+  PERMISSION_DENIED: {
+    action: 'escalate',
+    reason: 'Caller not authorized for this action; operator permission grant required',
+  },
+  UNSUPPORTED_FEATURE: {
+    action: 'escalate',
+    reason: 'Feature not supported by this seller; capability discovery required before retrying',
+  },
+  VERSION_UNSUPPORTED: {
+    action: 'escalate',
+    reason: 'AdCP major version not supported; check supported_versions in error details and re-negotiate',
+  },
+  ACCOUNT_SETUP_REQUIRED: {
+    action: 'escalate',
+    reason: 'Account onboarding incomplete; operator must complete setup before buys are accepted',
+  },
+  ACCOUNT_AMBIGUOUS: {
+    action: 'escalate',
+    reason: 'Natural key matches multiple accounts; operator disambiguation required',
+  },
+  SESSION_TERMINATED: {
+    action: 'mutate-and-retry',
+    maxAttempts: 1,
+    suggestion:
+      'The SI session has been terminated. Re-initiate a new session via si_initiate_session with a fresh idempotency_key.',
+  },
+
+  // Idempotency — correctable but with key-specific mutation guidance
+  IDEMPOTENCY_CONFLICT: {
+    action: 'mutate-and-retry',
+    maxAttempts: 1,
+    suggestion: 'The idempotency_key was reused with a different payload. Mint a fresh UUID v4 for the new request.',
+  },
+  IDEMPOTENCY_EXPIRED: {
+    action: 'mutate-and-retry',
+    maxAttempts: 1,
+    suggestion:
+      'The idempotency_key is past the replay window. Look up the resource by natural key first to check if the original request succeeded; then mint a fresh UUID v4.',
+  },
+
+  // Correctable — mutate-and-retry with terms re-quote
+  TERMS_REJECTED: {
+    action: 'mutate-and-retry',
+    maxAttempts: 1,
+    suggestion: 'Buyer-proposed measurement terms were rejected; re-negotiate terms before resubmitting',
+  },
+  REQUOTE_REQUIRED: {
+    action: 'mutate-and-retry',
+    maxAttempts: 1,
+    suggestion:
+      'Parameter envelope changed since original quote; re-run get_products and use the new pricing_option_id',
+  },
+};
+
+/** Compute exponential backoff in ms, capped at 60s. */
+function exponentialBackoff(attempt: number, baseMs: number): number {
+  return Math.min(baseMs * Math.pow(2, attempt - 1), 60_000);
+}
+
+/**
+ * Buyer-side retry policy helper.
+ *
+ * Translates an `AdcpErrorInfo` into a concrete `RetryDecision` with
+ * per-code defaults that reflect operator semantics — not just the spec's
+ * three-class `recovery` enum. Specifically:
+ *
+ * - `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, and
+ *   `CREATIVE_REJECTED` are spec-`correctable` but always escalate: automated
+ *   mutation looks like policy evasion to seller governance.
+ * - `AUTH_REQUIRED` and `PERMISSION_DENIED` escalate: credential issues need
+ *   operator rotation, not retry.
+ * - `IDEMPOTENCY_CONFLICT` / `IDEMPOTENCY_EXPIRED` carry targeted `suggestion`
+ *   strings to prevent duplicate financial transactions.
+ *
+ * @example Static usage (default policy):
+ * ```ts
+ * import { BuyerRetryPolicy } from '@adcp/sdk';
+ *
+ * const decision = BuyerRetryPolicy.decide(result.adcpError, { attempt });
+ * if (decision.action === 'retry') {
+ *   await sleep(decision.delayMs);
+ *   return retry(idempotencyKey); // same key — idempotent replay
+ * }
+ * if (decision.action === 'mutate-and-retry') {
+ *   // Patch the request using decision.field / decision.suggestion,
+ *   // then resubmit with a FRESH idempotency_key.
+ *   return retryWithCorrection(decision);
+ * }
+ * throw new EscalationRequired(error, decision.reason);
+ * ```
+ *
+ * @example Override for a vertical that can programmatically handle policy violations:
+ * ```ts
+ * const policy = new BuyerRetryPolicy({
+ *   overrides: { POLICY_VIOLATION: { action: 'mutate-and-retry' } },
+ * });
+ * ```
+ */
+export class BuyerRetryPolicy {
+  private static readonly _default = new BuyerRetryPolicy();
+
+  private readonly overrides: Partial<Record<string, RetryCodeOverride>>;
+
+  constructor(options?: BuyerRetryPolicyOptions) {
+    this.overrides = options?.overrides ?? {};
+  }
+
+  /**
+   * Decide the retry action for a failed request.
+   *
+   * @param error - The `AdcpErrorInfo` from a failed `TaskResult`.
+   * @param ctx - `attempt` is 1-indexed (first call = 1).
+   *   When `attempt` exceeds the policy's `maxAttempts` for the code, the
+   *   method returns `{ action: 'escalate' }` automatically.
+   */
+  decide(error: AdcpErrorInfo, ctx: RetryContext): RetryDecision {
+    const { code, retryAfterMs, field, suggestion } = error;
+    const { attempt } = ctx;
+
+    // User overrides take precedence over the default table.
+    const override = this.overrides[code];
+    if (override) {
+      return this._applyOverride(override, error, attempt);
+    }
+
+    // Per-code default table checked before recovery-class fallback — critical
+    // for codes whose operator semantics differ from their spec recovery class
+    // (e.g. GOVERNANCE_UNAVAILABLE is `transient` but buyer cannot self-resolve).
+    const entry = DEFAULT_TABLE[code as StandardErrorCode];
+    if (entry) {
+      return this._applyEntry(entry, error, attempt);
+    }
+
+    // Recovery-class fallback for codes not in the per-code table.
+    const recovery =
+      error.recovery ??
+      (isStandardErrorCode(code) ? STANDARD_ERROR_CODES[code as StandardErrorCode].recovery : 'terminal');
+
+    if (recovery === 'transient') {
+      const maxAttempts = 3;
+      if (attempt > maxAttempts) {
+        return {
+          action: 'escalate',
+          reason: `Max attempts (${maxAttempts}) reached for transient error ${code}`,
+          maxAttempts: 0,
+        };
+      }
+      return {
+        action: 'retry',
+        delayMs: retryAfterMs ?? exponentialBackoff(attempt, 2_000),
+        maxAttempts,
+      };
+    }
+
+    if (recovery === 'correctable') {
+      const maxAttempts = 1;
+      if (attempt > maxAttempts) {
+        return {
+          action: 'escalate',
+          reason: `Max attempts (${maxAttempts}) reached for correctable error ${code}`,
+          maxAttempts: 0,
+        };
+      }
+      return {
+        action: 'mutate-and-retry',
+        suggestion,
+        field,
+        maxAttempts,
+      };
+    }
+
+    // terminal (or unknown recovery)
+    return {
+      action: 'escalate',
+      reason: `Terminal error: ${code}${error.message ? ` — ${error.message}` : ''}`,
+      maxAttempts: 0,
+    };
+  }
+
+  private _applyEntry(entry: CodeEntry, error: AdcpErrorInfo, attempt: number): RetryDecision {
+    if (entry.action === 'escalate') {
+      return { action: 'escalate', reason: entry.reason, maxAttempts: 0 };
+    }
+
+    if (attempt > entry.maxAttempts) {
+      return {
+        action: 'escalate',
+        reason: `Max attempts (${entry.maxAttempts}) reached for ${error.code}`,
+        maxAttempts: 0,
+      };
+    }
+
+    if (entry.action === 'retry') {
+      return {
+        action: 'retry',
+        delayMs: error.retryAfterMs ?? exponentialBackoff(attempt, entry.baseDelayMs),
+        maxAttempts: entry.maxAttempts,
+      };
+    }
+
+    // mutate-and-retry
+    return {
+      action: 'mutate-and-retry',
+      suggestion: entry.suggestion ?? error.suggestion,
+      field: error.field,
+      maxAttempts: entry.maxAttempts,
+    };
+  }
+
+  private _applyOverride(override: RetryCodeOverride, error: AdcpErrorInfo, attempt: number): RetryDecision {
+    if (override.action === 'escalate') {
+      return {
+        action: 'escalate',
+        reason: override.reason ?? `Escalated by policy override for ${error.code}`,
+        maxAttempts: 0,
+      };
+    }
+
+    const maxAttempts = override.maxAttempts ?? 1;
+    if (attempt > maxAttempts) {
+      return {
+        action: 'escalate',
+        reason: `Max attempts (${maxAttempts}) reached for ${error.code}`,
+        maxAttempts: 0,
+      };
+    }
+
+    if (override.action === 'retry') {
+      return {
+        action: 'retry',
+        delayMs: override.delayMs ?? error.retryAfterMs ?? exponentialBackoff(attempt, 1_000),
+        maxAttempts,
+      };
+    }
+
+    return {
+      action: 'mutate-and-retry',
+      suggestion: override.suggestion ?? error.suggestion,
+      field: error.field,
+      maxAttempts,
+    };
+  }
+
+  /**
+   * Decide using the default policy (no overrides).
+   * Equivalent to `new BuyerRetryPolicy().decide(error, ctx)`.
+   */
+  static decide(error: AdcpErrorInfo, ctx: RetryContext): RetryDecision {
+    return BuyerRetryPolicy._default.decide(error, ctx);
+  }
+}


### PR DESCRIPTION
Closes #1153
Closes #1152

## Summary

Adds `BuyerRetryPolicy` — a buyer-side retry helper that translates `AdcpErrorInfo` into a concrete `RetryDecision` (`retry` / `mutate-and-retry` / `escalate`) using per-code operator semantics that go beyond the spec's three-class `recovery` enum. After PR #1147 fixed 12 error classes to correctly return `correctable`, a naive buyer treating all `correctable` codes as "auto-mutate and retry" will loop on `POLICY_VIOLATION` (looks like evasion to seller governance) or `AUTH_REQUIRED` (hammers SSO on revoked creds). This helper hardcodes safe defaults so adopters don't rebuild from scratch.

Key design decisions:
- `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, `CREATIVE_REJECTED`, `AUTH_REQUIRED`, `PERMISSION_DENIED` → always `escalate` by default (overridable via constructor)
- `GOVERNANCE_UNAVAILABLE` / `CAMPAIGN_SUSPENDED` are spec-`transient` but also `escalate` — per-code lookup runs before recovery-class fallback
- `IDEMPOTENCY_CONFLICT` / `IDEMPOTENCY_EXPIRED` have targeted `suggestion` strings to prevent duplicate financial transactions
- `SESSION_TERMINATED` → `mutate-and-retry` with re-initiate guidance (not escalate — it's autonomously recoverable)
- `maxAttempts: 0` on `escalate` variant makes discriminated-union narrowing consistent across all three arms
- Static `BuyerRetryPolicy.decide(error, ctx)` for zero-config usage; instance form for per-code overrides

Also: resolves the pre-existing merge conflict in `skills/call-adcp-agent/SKILL.md`, adds a worked recovery loop example with concrete `REQUOTE_REQUIRED` and `CONFLICT` fix patterns, and adds a seller-side callout in `docs/guides/BUILD-AN-AGENT.md` for the four human-escalate codes.

## What tested

- `prettier --check` ✅ (all changed files)
- `tsc --noEmit` ✅ (pre-existing `@types/node` + `moduleResolution=node10` errors on baseline; no new errors)
- `vitest run src/lib/utils/buyer-retry-policy.test.ts` ✅ — **77 tests pass**
  - every `StandardErrorCode` has a valid `RetryDecision` on attempt 1
  - `GOVERNANCE_UNAVAILABLE` / `CAMPAIGN_SUSPENDED` escalate despite being spec-`transient`
  - `SESSION_TERMINATED` maps to `mutate-and-retry` with re-initiate guidance
  - `RATE_LIMITED` attempt-5 → retry, attempt-6 → escalate (ceiling enforcement)
  - All idempotency codes carry targeted suggestion strings
  - Static and instance forms produce identical results
  - Unknown codes with explicit `recovery: 'transient'` fall through correctly

**Nits surfaced by pre-PR review (not fixed — low priority):**
- `exponentialBackoff(attempt=1, baseMs)` returns `baseMs` on first call (intentional — no zero-delay first retry)
- SKILL.md `attempt` could use a `// 1-indexed: start at 1, not 0` comment
- SKILL.md loop uses static form; a comment noting the instance form is available for overrides would help

**Pre-PR review:**
- code-reviewer: approved — no blockers after SESSION_TERMINATED semantic fix and `?? undefined` no-op cleanup
- dx-expert: approved — `applyCorrection` stub replaced with concrete REQUOTE_REQUIRED + CONFLICT examples; idempotency key discipline (reuse for `retry`, fresh for `mutate-and-retry`) is correctly modeled in the loop

**Labels note:** `library` and `skills` labels do not exist in this repo. Bucket is `library + skills`; flagging in run summary for label creation.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01YBBYLqSTuE5Uj9gS1cQKYg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBBYLqSTuE5Uj9gS1cQKYg)_