### PR TITLE
docs(skills): callout for human-escalate codes + fix cross-doc recovery contradictions

### DIFF
--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -522,7 +522,9 @@ return adcpError('SERVICE_UNAVAILABLE', 'Try again in 30 seconds');
 return adcpError('ACCOUNT_SUSPENDED', 'Contact support');
 ```
 
-See `docs/llms.txt` for the full error code table with recovery classifications. Note: `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, and `AUTH_REQUIRED` are spec-`correctable` but buyer agents should escalate to operator rather than auto-retry with a mutated payload — see `skills/call-adcp-agent/SKILL.md` for the full escalation table.
+See `docs/llms.txt` for the full error code table with recovery classifications.
+
+Note: `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, and `AUTH_REQUIRED` are spec-`correctable` but buyer agents should escalate to operator rather than auto-retry — see `skills/call-adcp-agent/SKILL.md`.
 
 ### Storyboards
 

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -522,7 +522,7 @@ return adcpError('SERVICE_UNAVAILABLE', 'Try again in 30 seconds');
 return adcpError('ACCOUNT_SUSPENDED', 'Contact support');
 ```
 
-See `docs/llms.txt` for the full error code table with recovery classifications.
+See `docs/llms.txt` for the full error code table with recovery classifications. Note: `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, and `AUTH_REQUIRED` are spec-`correctable` but buyer agents should escalate to operator rather than auto-retry with a mutated payload — see `skills/call-adcp-agent/SKILL.md` for the full escalation table.
 
 ### Storyboards
 

--- a/docs/migration-5.x-to-6.x.md
+++ b/docs/migration-5.x-to-6.x.md
@@ -201,7 +201,8 @@ sales: {
     await this.queueForReview({ taskId: taskCtx.id, request: req });
     const decision = await this.waitForOperator(req);
     if (decision.denied) {
-      throw new AdcpError('GOVERNANCE_DENIED', { recovery: 'terminal', message: decision.reason });
+      // recovery defaults to 'correctable' per spec — buyer should escalate to plan operator
+      throw new AdcpError('GOVERNANCE_DENIED', { message: decision.reason });
     }
     return { media_buy_id: decision.id, status: 'pending_creatives', confirmed_at: new Date().toISOString(), packages: [] };
   }),

--- a/skills/adcp-governance/SKILL.md
+++ b/skills/adcp-governance/SKILL.md
@@ -563,4 +563,4 @@ Common error codes:
 - `UNAUTHORIZED`: Not authorized to access this resource
 - `VALIDATION_ERROR`: Invalid filter or rule configuration
 - `PLAN_NOT_FOUND`: No plan with this ID, or the principal is not authorized for it. Returned indistinguishably from the unauthorized case to prevent plan-ID enumeration.
-- `GOVERNANCE_DENIED`: `check_governance` rejected the action. Read `governance_context.findings[]` to identify the failed rule, correct the payload, and retry.
+- `GOVERNANCE_DENIED`: `check_governance` rejected the action. Read `governance_context.findings[]` to identify the failed rule. If the denial is from seller-side governance middleware over a correctable plan parameter (e.g. budget ceiling), correct within plan limits and retry. If the denial comes from a registered governance agent with spending authority, escalate to the plan operator — do not auto-correct.

--- a/skills/build-decisioning-platform/advanced/REFERENCE.md
+++ b/skills/build-decisioning-platform/advanced/REFERENCE.md
@@ -339,7 +339,7 @@ The escape hatch — `ctx.runAsync` + `ctx.startTask` — exists for the genuine
 
 Common codes:
 
-- **Buyer-fixable** (`recovery: 'correctable'`): `INVALID_REQUEST`, `BUDGET_TOO_LOW`, `POLICY_VIOLATION`, `CREATIVE_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `INVALID_STATE`, `REQUOTE_REQUIRED`, `PERMISSION_DENIED`, `UNSUPPORTED_FEATURE`, `GOVERNANCE_DENIED` *(spec-correctable but treat as operator-escalate in practice — see `skills/call-adcp-agent/SKILL.md`)*
+- **Buyer-fixable** (`recovery: 'correctable'`): `INVALID_REQUEST`, `BUDGET_TOO_LOW`, `CREATIVE_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `INVALID_STATE`, `REQUOTE_REQUIRED`, `PERMISSION_DENIED`, `UNSUPPORTED_FEATURE`; `POLICY_VIOLATION` / `COMPLIANCE_UNSATISFIED` / `GOVERNANCE_DENIED` / `AUTH_REQUIRED` *(correctable per spec but operator-escalate in practice — see `skills/call-adcp-agent/SKILL.md`)*
 - **Transient** (`recovery: 'transient'`, retry with backoff): `RATE_LIMITED` (always include `retry_after`), `SERVICE_UNAVAILABLE`
 - **Terminal** (`recovery: 'terminal'`, requires human action): `ACCOUNT_SUSPENDED`
 

--- a/skills/build-decisioning-platform/advanced/REFERENCE.md
+++ b/skills/build-decisioning-platform/advanced/REFERENCE.md
@@ -339,9 +339,9 @@ The escape hatch — `ctx.runAsync` + `ctx.startTask` — exists for the genuine
 
 Common codes:
 
-- **Buyer-fixable** (`recovery: 'correctable'`): `INVALID_REQUEST`, `BUDGET_TOO_LOW`, `POLICY_VIOLATION`, `CREATIVE_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `INVALID_STATE`, `REQUOTE_REQUIRED`, `GOVERNANCE_DENIED` *(spec-correctable but treat as operator-escalate in practice — see `skills/call-adcp-agent/SKILL.md`)*
+- **Buyer-fixable** (`recovery: 'correctable'`): `INVALID_REQUEST`, `BUDGET_TOO_LOW`, `POLICY_VIOLATION`, `CREATIVE_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `INVALID_STATE`, `REQUOTE_REQUIRED`, `PERMISSION_DENIED`, `UNSUPPORTED_FEATURE`, `GOVERNANCE_DENIED` *(spec-correctable but treat as operator-escalate in practice — see `skills/call-adcp-agent/SKILL.md`)*
 - **Transient** (`recovery: 'transient'`, retry with backoff): `RATE_LIMITED` (always include `retry_after`), `SERVICE_UNAVAILABLE`
-- **Terminal** (`recovery: 'terminal'`, requires human action): `ACCOUNT_SUSPENDED`, `PERMISSION_DENIED`, `UNSUPPORTED_FEATURE`
+- **Terminal** (`recovery: 'terminal'`, requires human action): `ACCOUNT_SUSPENDED`
 
 Generic thrown errors (`Error`, `TypeError`) become `SERVICE_UNAVAILABLE` at the framework boundary.
 

--- a/skills/build-decisioning-platform/advanced/REFERENCE.md
+++ b/skills/build-decisioning-platform/advanced/REFERENCE.md
@@ -234,10 +234,8 @@ sales: SalesPlatform<MyMeta> = {
       const decision = await this.waitForOperatorApproval(req);
 
       if (decision.denied) {
-        throw new AdcpError('GOVERNANCE_DENIED', {
-          recovery: 'terminal',
-          message: decision.reason,
-        });
+        // recovery defaults to 'correctable' per spec — buyer should escalate to plan operator
+        throw new AdcpError('GOVERNANCE_DENIED', { message: decision.reason });
       }
 
       // Return → task transitions to `completed` with this as `result`
@@ -341,9 +339,9 @@ The escape hatch — `ctx.runAsync` + `ctx.startTask` — exists for the genuine
 
 Common codes:
 
-- **Buyer-fixable** (`recovery: 'correctable'`): `INVALID_REQUEST`, `BUDGET_TOO_LOW`, `POLICY_VIOLATION`, `CREATIVE_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `INVALID_STATE`, `REQUOTE_REQUIRED`
+- **Buyer-fixable** (`recovery: 'correctable'`): `INVALID_REQUEST`, `BUDGET_TOO_LOW`, `POLICY_VIOLATION`, `CREATIVE_REJECTED`, `MEDIA_BUY_NOT_FOUND`, `INVALID_STATE`, `REQUOTE_REQUIRED`, `GOVERNANCE_DENIED` *(spec-correctable but treat as operator-escalate in practice — see `skills/call-adcp-agent/SKILL.md`)*
 - **Transient** (`recovery: 'transient'`, retry with backoff): `RATE_LIMITED` (always include `retry_after`), `SERVICE_UNAVAILABLE`
-- **Terminal** (`recovery: 'terminal'`, requires human action): `GOVERNANCE_DENIED`, `ACCOUNT_SUSPENDED`, `PERMISSION_DENIED`, `UNSUPPORTED_FEATURE`
+- **Terminal** (`recovery: 'terminal'`, requires human action): `ACCOUNT_SUSPENDED`, `PERMISSION_DENIED`, `UNSUPPORTED_FEATURE`
 
 Generic thrown errors (`Error`, `TypeError`) become `SERVICE_UNAVAILABLE` at the framework boundary.
 

--- a/skills/build-decisioning-signal-marketplace/SKILL.md
+++ b/skills/build-decisioning-signal-marketplace/SKILL.md
@@ -166,7 +166,7 @@ Common codes for signals:
 | Code                   | When                                                                                          |
 | ---------------------- | --------------------------------------------------------------------------------------------- |
 | `'SIGNAL_NOT_FOUND'`   | unknown `signal_agent_segment_id`                                                             |
-| `'POLICY_VIOLATION'`   | buyer lacks rights to activate this data                                                      |
+| `'POLICY_VIOLATION'`   | buyer lacks rights to activate this data — escalate to operator, do not auto-retry            |
 | `'INVALID_REQUEST'`    | missing destinations, unrecognized destination shape, missing pricing_option_id when required |
 | `'AUDIENCE_TOO_SMALL'` | activated audience falls below match-rate floor                                               |
 | `'RATE_LIMITED'`       | upstream identity-graph throttled                                                             |

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -233,13 +233,23 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | `keyword: 'enum'` at `/destinations/*/type` | Made-up destination type | Use `'platform'` (with `platform`) or `'agent'` (with `agent_url`). |
 | Response carries `status: 'submitted'` and `task_id` | Async — work is queued, NOT done | Poll via `tasks/get` (A2A) or the MCP async task extension using `task_id`. |
 | `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
-<<<<<<< Updated upstream
 | `406 Not Acceptable` before any AdCP framing | Hand-rolled HTTP without `Accept: text/event-stream` (MCP transport) | Use `@modelcontextprotocol/sdk` client; it sets the right Accept header. |
-=======
->>>>>>> Stashed changes
 | `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
 | `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
 | HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |
+
+> **⚠️ Four `correctable` codes require operator escalation, not automated mutation-and-retry.**
+>
+> | Code | Default action | Why |
+> |---|---|---|
+> | `POLICY_VIOLATION` | Escalate to operator | Auto-mutating creative or targeting to pass the check is indistinguishable from policy evasion to governance audit trails |
+> | `COMPLIANCE_UNSATISFIED` | Escalate to operator | The format cannot satisfy the compliance requirement; retrying with relaxed parameters is itself a compliance violation |
+> | `GOVERNANCE_DENIED` | Escalate to plan operator¹ | Retrying with a reduced budget to stay under an authority ceiling looks like governance evasion |
+> | `AUTH_REQUIRED` | Escalate to operator | Conflates "credentials missing" (correctable by agent) with "credentials revoked" (operator must rotate); until [adcp#3727](https://github.com/adcontextprotocol/adcp/issues/3727) splits these, treat as escalate |
+>
+> ¹ **`GOVERNANCE_DENIED` exception:** if `governance_context.findings[]` shows the denial is from seller-side governance middleware over a correctable plan parameter (e.g. budget ceiling exceeded), programmatic correction within plan limits is spec-valid. Escalate when the denial is from a registered governance agent with spending authority.
+>
+> Spec recovery: `correctable`. Operator behavior: human in loop. A retry-policy helper (`BuyerRetryPolicy`) encoding these defaults is in progress ([#1153](https://github.com/adcontextprotocol/adcp-client/issues/1153)).
 
 If your symptom isn't here, fall through to the next section.
 


### PR DESCRIPTION
Closes #1152

Adds an explicit escalation warning to `skills/call-adcp-agent/SKILL.md` for the four `correctable` error codes that a naive LLM buyer agent should NOT auto-retry with a mutated payload: `POLICY_VIOLATION`, `COMPLIANCE_UNSATISFIED`, `GOVERNANCE_DENIED`, and `AUTH_REQUIRED`. PR #1147 correctly aligned these to spec-`correctable`; this PR layers the operator-semantic guidance on top.

Also fixes pre-existing cross-doc contradictions surfaced by this work:

- **`skills/call-adcp-agent/SKILL.md`**: Resolves committed git merge-conflict markers (four literal conflict lines in the committed file). Adds escalation callout table after the symptom-fix table with a `GOVERNANCE_DENIED` exception footnote (spec-valid programmatic correction path for seller-middleware plan-parameter denials).
- **`skills/build-decisioning-platform/advanced/REFERENCE.md`**: `GOVERNANCE_DENIED`, `PERMISSION_DENIED`, and `UNSUPPORTED_FEATURE` were listed as `terminal` — all three are `correctable` per spec (corrected in #1135 and #1147). Moves them to Buyer-fixable. Groups the four escalation codes together with a shared operator-escalate annotation. Removes hardcoded `recovery: 'terminal'` from the HITL code example.
- **`skills/adcp-governance/SKILL.md`**: `GOVERNANCE_DENIED` entry said "correct the payload, and retry" without distinguishing governance-middleware denials (programmatic correction OK) from governance-authority denials (escalate to plan operator).
- **`skills/build-decisioning-signal-marketplace/SKILL.md`**: `POLICY_VIOLATION` row had no escalation note.
- **`docs/migration-5.x-to-6.x.md`**: Removes stale `recovery: 'terminal'` override from the HITL migration code example.
- **`docs/guides/BUILD-AN-AGENT.md`**: Adds cross-reference note to the escalation table.

## What was tested

- `npm run ci:docs-check` attempted — `tsx` not available in this environment (pre-existing env limitation). The check validates `docs/llms.txt` and `docs/TYPE-SUMMARY.md` sync with source — neither file is modified in this PR.
- No merge-conflict markers remain in any changed file.
- All changed files are `.md` only — no TypeScript or library code modified. No changeset needed per CLAUDE.md.

## Known gap (follow-up)

`docs/llms.txt` (generated) lists `AUTH_REQUIRED`, `POLICY_VIOLATION`, and `COMPLIANCE_UNSATISFIED` as bare `correctable` with no escalation note. Manually editing it would break `ci:docs-check` (validates generated-file sync). A follow-up PR should update the generation script to include escalation notes, or add a static appendix.

## Pre-PR review

- **code-reviewer**: approved — no blockers. Two issues fixed: (1) `POLICY_VIOLATION` annotation restructured in REFERENCE.md to unambiguously cover all four escalation codes; (2) `skills/build-decisioning-signal-marketplace/SKILL.md:169` escalation note added.
- **docs-expert**: approved after two rounds — blockers fixed: (1) `PERMISSION_DENIED`/`UNSUPPORTED_FEATURE` moved from Terminal to Buyer-fixable in REFERENCE.md; (2) BUILD-AN-AGENT.md note separated onto its own line. Callout placement, cross-references, and `GOVERNANCE_DENIED` exception wording confirmed adequate for LLM buyer agents.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01R6yxQMFJgP79irEH7d3gLw

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6yxQMFJgP79irEH7d3gLw)_