### PR TITLE
docs(skills): worked example for decideRetry in call-adcp-agent

### DIFF
--- a/.changeset/decideretry-skill-example.md
+++ b/.changeset/decideretry-skill-example.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+`skills/call-adcp-agent/SKILL.md` — worked example for `decideRetry`.
+
+Closes the documentation gap left over from #1156 (the `BuyerRetryPolicy` helper). The skill now shows adopters end-to-end how to wire `decideRetry` into a buyer agent retry loop — including the same-vs-fresh `idempotency_key` rule, jitter on mutate-and-retry, and per-vertical overrides via `BuyerRetryPolicy`.
+
+Two code blocks added:
+
+1. **Default usage** — `decideRetry(error, { attempt })` with `switch`-style branching on the discriminated `RetryDecision`. Shows TypeScript narrowing each branch (delay only on retry, field/suggestion only on mutate-and-retry, message only on escalate) so adopters can't accidentally hold the same `idempotency_key` after a payload mutation.
+
+2. **Per-vertical override** — `BuyerRetryPolicy` instantiation pattern with a `CREATIVE_REJECTED` override demonstrating how a creative-template platform can convert format-mismatch rejections to in-loop mutate-and-retry while keeping brand-safety rejections as escalate.
+
+Skills are bundled with the npm package, so this is a publishable change.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -247,6 +247,79 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 >
 > Spec recovery on these is `correctable`; operator behavior is human-in-loop. The pattern: read `error.message` + `error.suggestion`, surface to the user, **don't loop**.
 
+### Operationalize the recovery rules — `decideRetry`
+
+`@adcp/sdk` exports `decideRetry(error, ctx?)` which encodes the operator-grade defaults from the table above plus this section. It returns a discriminated `RetryDecision` so the type system enforces the same-vs-fresh `idempotency_key` rule:
+
+```typescript
+import { decideRetry } from '@adcp/sdk';
+import { randomUUID } from 'node:crypto';
+
+async function callWithRetry(toolName: string, params: Record<string, unknown>): Promise<unknown> {
+  let attempt = 1;
+  let idempotencyKey = randomUUID();
+
+  while (true) {
+    try {
+      return await agent.call(toolName, { ...params, idempotency_key: idempotencyKey });
+    } catch (e) {
+      const error = extractAdcpError(e); // your SDK's error extractor
+      if (!error) throw e; // not an AdCP-shaped failure — let it bubble
+
+      const decision = decideRetry(error, { attempt });
+
+      if (decision.action === 'retry') {
+        // Server-side transient (RATE_LIMITED, SERVICE_UNAVAILABLE, CONFLICT).
+        // Replay with the SAME idempotency_key after the suggested delay.
+        await sleep(decision.delayMs);
+        attempt++;
+        continue;
+      }
+
+      if (decision.action === 'mutate-and-retry') {
+        // Buyer-fixable. Apply the seller's correction (decision.field /
+        // decision.suggestion) and mint a FRESH idempotency_key — payload
+        // changed, so the seller's replay-window must NOT dedupe.
+        params = applyCorrection(params, error, decision); // your domain logic
+        idempotencyKey = randomUUID();
+        await sleep(decision.delayMs); // small jitter (~125-250ms by default)
+        attempt++;
+        continue;
+      }
+
+      // 'escalate' — stop the loop and surface to a human. Includes
+      // commercial-relationship signals (POLICY_VIOLATION etc.), auth
+      // failures, IDEMPOTENCY_EXPIRED (do a natural-key check first!),
+      // attempt-cap exhaustion, and unknown vendor codes.
+      throw new EscalationRequired(decision.reason, decision.message);
+    }
+  }
+}
+```
+
+The discriminated union means TypeScript narrows correctly in each branch — `decision.delayMs` is only available on retry/mutate-and-retry, `decision.field` only on mutate-and-retry, `decision.message` only on escalate.
+
+For per-vertical overrides (e.g., a creative-template platform that legitimately auto-fixes `CREATIVE_REJECTED` format mismatches), instantiate `BuyerRetryPolicy` directly:
+
+```typescript
+import { BuyerRetryPolicy } from '@adcp/sdk';
+
+const policy = new BuyerRetryPolicy({
+  overrides: {
+    CREATIVE_REJECTED: (error) => {
+      if (error.field === 'creative.format' && /unsupported_format/.test(error.message)) {
+        return { action: 'mutate-and-retry', delayMs: 0, attemptCap: 2, sameIdempotencyKey: false, reason: 'capability' };
+      }
+      return null; // fall through to default (escalate as commercial)
+    },
+  },
+});
+
+const decision = policy.decide(error, { attempt });
+```
+
+Default policy is intentionally conservative — see the source comments in `src/lib/utils/buyer-retry-policy.ts` for per-code reasoning.
+
 If your symptom isn't here, fall through to the next section.
 
 ## If you get stuck


### PR DESCRIPTION
## Summary

Closes the documentation gap left over from #1156. The \`BuyerRetryPolicy\` + \`decideRetry\` helper shipped, but \`skills/call-adcp-agent/SKILL.md\` only mentioned it in the human-escalate callout. This adds an end-to-end worked example.

## What's added

1. **Default-usage example** — \`decideRetry(error, { attempt })\` in a buyer-agent retry loop. Shows the type-narrowed branching:
   - \`'retry'\` → same \`idempotency_key\`, sleep \`decision.delayMs\`
   - \`'mutate-and-retry'\` → fresh \`idempotency_key\`, apply \`decision.field\`/\`decision.suggestion\`
   - \`'escalate'\` → throw to human

2. **Override example** — \`BuyerRetryPolicy\` with a \`CREATIVE_REJECTED\` override demonstrating how a creative-template platform can convert format-mismatch rejections to in-loop mutate-and-retry while keeping brand-safety rejections as the conservative escalate default.

## Test plan

- [x] \`npm run typecheck:skill-examples\` — passes (the new code blocks compile clean against the actual exported \`decideRetry\` / \`BuyerRetryPolicy\` types)
- [x] \`npm run format:check\` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)