### PR TITLE
fix(client): wrap SingleAgentClient.executeTask in try/catch (fixes #1148)

### DIFF
--- a/.changeset/execute-task-error-envelope.md
+++ b/.changeset/execute-task-error-envelope.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+`executeTask` now returns a structured `TaskResult` instead of throwing for pre-flight errors (fixes #1148).
+
+**Symptom:** `agent.executeTask('list_authorized_properties', {})` against a v2.5 MCP seller threw `TypeError: Cannot read properties of undefined (reading 'status')` instead of returning `{ success: false, status: 'failed', error: '...' }`.
+
+**Root cause:** `SingleAgentClient.executeTask` (the public generic path used for tasks without a named wrapper) had no top-level try/catch. Pre-flight steps — feature validation, endpoint discovery, schema validation, version detection, and request adaptation — could escape as raw exceptions. The internal `TaskExecutor.executeTask` already wraps network-layer errors; `SingleAgentClient` had no matching safety net for the steps it runs before delegating to the executor.
+
+`list_authorized_properties` is the common trigger because it has no named helper method on `AgentClient` (deprecated in favour of `get_adcp_capabilities`) so all callers go through `executeTask`. On a v2.5 MCP seller, the response shape is unexpected and a TypeError escapes during pre-flight processing.
+
+**Fix:** Wrap the full `SingleAgentClient.executeTask` body in a try/catch. Structured protocol errors that carry typed fields callers use for recovery decisions are rethrown: `AuthenticationRequiredError` (and its subclass `NeedsAuthorizationError`), `TaskTimeoutError`, `VersionUnsupportedError`, and `FeatureUnsupportedError`. Unexpected errors (TypeErrors, schema-parser panics, etc.) are converted to `{ success: false, status: 'failed', error: message }` envelopes matching the declared return type `Promise<TaskResult<T>>`. The fluent `.match()` method works correctly on error envelopes via `attachMatch`.
+
+Callers that followed the TypeScript return type and checked `result.success` / `result.status` are unaffected. Callers that relied on `executeTask` throwing for non-protocol pre-flight errors will now receive a structured failure envelope instead — which is the correct behaviour per the declared type.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2172,52 +2172,94 @@ export class SingleAgentClient {
     inputHandler?: InputHandler,
     options?: TaskOptions
   ): Promise<TaskResult<T>> {
-    const normalizedParams = normalizeRequestParams(taskName, params, {
-      skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
-    });
-    await this.validateTaskFeatures(taskName);
-    if (this.config.requireV3ForMutations && isMutatingTask(taskName)) {
-      await this.requireSupportedMajor(taskName);
+    const startTime = Date.now();
+    try {
+      const normalizedParams = normalizeRequestParams(taskName, params, {
+        skipIdempotencyAutoInject: options?.skipIdempotencyAutoInject,
+      });
+      await this.validateTaskFeatures(taskName);
+      if (this.config.requireV3ForMutations && isMutatingTask(taskName)) {
+        await this.requireSupportedMajor(taskName);
+      }
+      const agent = await this.ensureEndpointDiscovered();
+
+      // Schema-driven pre-send validation runs on the unadapted v3 shape so
+      // wire-format adapters (e.g. adaptGetProductsRequestForV2) don't strip
+      // v3-only fields out from under the v3 bundled schema.
+      this.executor.validateRequest(taskName, normalizedParams);
+
+      // Adapt request for the server's protocol version (e.g. strip v3-only
+      // fields like buying_mode when talking to v2 agents).
+      const serverVersion = await this.detectServerVersion();
+      const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams);
+
+      // Symmetric warn-only post-adapter pass against the v2.5 schema bundle.
+      // Drift gets surfaced via result.metadata.debug_logs so adapter
+      // regressions in production aren't silently swallowed.
+      const v25DriftLogs: any[] = [];
+      if (serverVersion === 'v2') {
+        this.executor.validateAdaptedRequestAgainstV2(taskName, adaptedParams, v25DriftLogs);
+      }
+
+      const result = await this.executor.executeTask<T>(
+        agent,
+        taskName,
+        adaptedParams,
+        inputHandler,
+        options,
+        serverVersion
+      );
+
+      if (v25DriftLogs.length > 0) {
+        result.debug_logs = [...(result.debug_logs ?? []), ...v25DriftLogs];
+      }
+
+      // Normalize response to v3 format for consistent API surface
+      if (result.success && result.data) {
+        result.data = this.normalizeResponseToV3(taskName, result.data) as T;
+      }
+
+      return result;
+    } catch (error) {
+      // Structured protocol errors carry typed fields (reason, actualVersion,
+      // unsupportedFeatures, …) that callers use for recovery decisions. Auth
+      // and timeout errors trigger OAuth flows / cancellation. All four are
+      // established throws — rethrow so callers' existing catch sites work.
+      if (
+        error instanceof AuthenticationRequiredError ||
+        error instanceof TaskTimeoutError ||
+        error instanceof VersionUnsupportedError ||
+        error instanceof FeatureUnsupportedError
+      ) {
+        throw error;
+      }
+      // Unexpected pre-flight errors (e.g. a TypeError from response parsing
+      // during version detection) surface as a structured TaskResult rather
+      // than escaping as raw exceptions — matching the declared return type
+      // and the contract the internal executor already upholds for network
+      // errors. attachMatch ensures the fluent .match() API works on this path.
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return attachMatch({
+        success: false as const,
+        status: 'failed' as const,
+        error: errorMessage,
+        metadata: {
+          taskId: crypto.randomUUID(),
+          taskName,
+          agent: {
+            id: this.agent.id,
+            name: this.agent.name,
+            protocol: this.normalizedAgent.protocol,
+          },
+          responseTimeMs: Date.now() - startTime,
+          timestamp: new Date().toISOString(),
+          clarificationRounds: 0,
+          status: 'failed',
+        },
+        conversation: [],
+        debug_logs: [],
+      });
     }
-    const agent = await this.ensureEndpointDiscovered();
-
-    // Schema-driven pre-send validation runs on the unadapted v3 shape so
-    // wire-format adapters (e.g. adaptGetProductsRequestForV2) don't strip
-    // v3-only fields out from under the v3 bundled schema.
-    this.executor.validateRequest(taskName, normalizedParams);
-
-    // Adapt request for the server's protocol version (e.g. strip v3-only
-    // fields like buying_mode when talking to v2 agents).
-    const serverVersion = await this.detectServerVersion();
-    const adaptedParams = await this.adaptRequestForServerVersion(taskName, normalizedParams);
-
-    // Symmetric warn-only post-adapter pass against the v2.5 schema bundle.
-    // Drift gets surfaced via result.metadata.debug_logs so adapter
-    // regressions in production aren't silently swallowed.
-    const v25DriftLogs: any[] = [];
-    if (serverVersion === 'v2') {
-      this.executor.validateAdaptedRequestAgainstV2(taskName, adaptedParams, v25DriftLogs);
-    }
-
-    const result = await this.executor.executeTask<T>(
-      agent,
-      taskName,
-      adaptedParams,
-      inputHandler,
-      options,
-      serverVersion
-    );
-
-    if (v25DriftLogs.length > 0) {
-      result.debug_logs = [...(result.debug_logs ?? []), ...v25DriftLogs];
-    }
-
-    // Normalize response to v3 format for consistent API surface
-    if (result.success && result.data) {
-      result.data = this.normalizeResponseToV3(taskName, result.data) as T;
-    }
-
-    return result;
   }
 
   // ====== DEFERRED TASK MANAGEMENT ======

--- a/test/lib/execute-task-error-envelope.test.js
+++ b/test/lib/execute-task-error-envelope.test.js
@@ -1,0 +1,207 @@
+/**
+ * Regression test for issue #1148:
+ * executeTask('list_authorized_properties', {}) against a v2.5 MCP seller
+ * threw "Cannot read properties of undefined (reading 'status')" instead of
+ * returning a structured TaskResult.
+ *
+ * Root cause: SingleAgentClient.executeTask (public) had no top-level
+ * try/catch, so pre-flight errors escaped as raw exceptions rather than
+ * being wrapped in a TaskResult envelope.
+ *
+ * Fix: wrap the entire method body in try/catch; rethrow
+ * AuthenticationRequiredError, TaskTimeoutError, VersionUnsupportedError,
+ * and FeatureUnsupportedError (structured protocol errors callers handle
+ * explicitly), convert unexpected errors to { success: false, status: 'failed' }.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  AdCPClient,
+  AuthenticationRequiredError,
+  VersionUnsupportedError,
+  FeatureUnsupportedError,
+} = require('../../dist/lib/index.js');
+
+// Minimal v2-style capabilities that satisfy cachedCapabilities type checks.
+const V2_CAPABILITIES = {
+  version: 'v2',
+  majorVersions: [2],
+  protocols: ['media_buy'],
+  features: {
+    inlineCreativeManagement: false,
+    conversionTracking: false,
+    audienceTargeting: false,
+    propertyListFiltering: false,
+    contentStandards: false,
+  },
+  extensions: [],
+  _synthetic: false,
+};
+
+function makeAgentClient(agentId = 'wonderstruck') {
+  const mockAgent = {
+    id: agentId,
+    name: 'Wonderstruck v2.5',
+    agent_uri: 'https://seller.wonderstruck.example/mcp',
+    protocol: 'mcp',
+  };
+  const client = new AdCPClient([mockAgent]);
+  const agent = client.agent(agentId);
+  const inner = agent.client;
+
+  // Skip endpoint discovery — pre-set the state that getCapabilities would normally
+  // populate so the test focuses on the executeTask error-envelope path.
+  inner.discoveredEndpoint = mockAgent.agent_uri;
+  inner.cachedCapabilities = V2_CAPABILITIES;
+
+  return { agent, inner };
+}
+
+describe('executeTask error envelope (issue #1148)', () => {
+  test('returns structured TaskResult instead of throwing when a pre-flight step throws unexpectedly', async () => {
+    const { agent, inner } = makeAgentClient();
+
+    // Simulate the v2.5 seller scenario: detectServerVersion throws a TypeError
+    // (e.g. the MCP response body is empty and something reads .status on undefined).
+    // This is the class of error that escaped before the fix.
+    const originalDetect = inner.detectServerVersion.bind(inner);
+    inner.detectServerVersion = async () => {
+      throw new TypeError("Cannot read properties of undefined (reading 'status')");
+    };
+
+    let result;
+    try {
+      result = await agent.executeTask('list_authorized_properties', {});
+    } finally {
+      inner.detectServerVersion = originalDetect;
+    }
+
+    // Before the fix, the line above would have thrown and 'result' would
+    // be undefined.  After the fix it must return a structured envelope.
+    assert.ok(result, 'executeTask must return a result, not throw');
+    assert.strictEqual(result.success, false, 'success must be false');
+    assert.strictEqual(result.status, 'failed', 'status must be failed');
+    assert.ok(typeof result.error === 'string' && result.error.length > 0, 'error message must be present');
+    assert.ok(
+      result.error.includes('Cannot read properties of undefined'),
+      `error message should propagate the original message; got: ${result.error}`
+    );
+    assert.ok(result.metadata, 'metadata must be present');
+    assert.ok(typeof result.metadata.taskId === 'string', 'metadata.taskId must be a string');
+    assert.strictEqual(result.metadata.taskName, 'list_authorized_properties');
+    assert.ok(Array.isArray(result.conversation), 'conversation must be an array');
+    assert.ok(Array.isArray(result.debug_logs), 'debug_logs must be an array');
+    // fluent .match() must work on the error envelope (attachMatch coverage)
+    assert.ok(typeof result.match === 'function', 'result.match must be a function');
+  });
+
+  test('auth errors still propagate as throws (backward-compat for OAuth flows)', async () => {
+    const { agent, inner } = makeAgentClient('seller-auth');
+
+    const originalDetect = inner.detectServerVersion.bind(inner);
+    inner.detectServerVersion = async () => {
+      throw new AuthenticationRequiredError('https://seller.wonderstruck.example/mcp', undefined);
+    };
+
+    try {
+      await assert.rejects(
+        () => agent.executeTask('list_authorized_properties', {}),
+        err => {
+          assert.ok(
+            err instanceof AuthenticationRequiredError,
+            `expected AuthenticationRequiredError, got ${err?.constructor?.name}: ${err?.message}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      inner.detectServerVersion = originalDetect;
+    }
+  });
+
+  test('VersionUnsupportedError still propagates as throw (structured fields must not be swallowed)', async () => {
+    const { agent, inner } = makeAgentClient('seller-version');
+
+    const originalDetect = inner.detectServerVersion.bind(inner);
+    inner.detectServerVersion = async () => {
+      throw new VersionUnsupportedError('create_media_buy', 'synthetic', 'v2', 'https://seller.example/mcp');
+    };
+
+    try {
+      await assert.rejects(
+        () => agent.executeTask('create_media_buy', { idempotency_key: 'k1' }),
+        err => {
+          assert.ok(
+            err instanceof VersionUnsupportedError,
+            `expected VersionUnsupportedError, got ${err?.constructor?.name}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      inner.detectServerVersion = originalDetect;
+    }
+  });
+
+  test('FeatureUnsupportedError still propagates as throw (structured fields must not be swallowed)', async () => {
+    const { agent, inner } = makeAgentClient('seller-feature');
+
+    const originalDetect = inner.detectServerVersion.bind(inner);
+    inner.detectServerVersion = async () => {
+      throw new FeatureUnsupportedError(['propertyListFiltering'], [], 'seller-feature');
+    };
+
+    try {
+      await assert.rejects(
+        () => agent.executeTask('list_authorized_properties', {}),
+        err => {
+          assert.ok(
+            err instanceof FeatureUnsupportedError,
+            `expected FeatureUnsupportedError, got ${err?.constructor?.name}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      inner.detectServerVersion = originalDetect;
+    }
+  });
+
+  test('list_authorized_properties with a well-behaved mock returns a result without throwing', async () => {
+    const { AdCPClient, ProtocolClient } = require('../../dist/lib/index.js');
+
+    const mockAgent = {
+      id: 'seller-v2-ok',
+      name: 'Well-behaved v2.5 seller',
+      agent_uri: 'https://seller.example.com/mcp',
+      protocol: 'mcp',
+    };
+    const client = new AdCPClient([mockAgent]);
+    const agent = client.agent(mockAgent.id);
+    const inner = agent.client;
+    inner.discoveredEndpoint = mockAgent.agent_uri;
+    inner.cachedCapabilities = V2_CAPABILITIES;
+
+    const original = ProtocolClient.callTool;
+    ProtocolClient.callTool = async (_cfg, name) => {
+      if (name === 'list_authorized_properties') {
+        return { structuredContent: { properties: [] } };
+      }
+      return { structuredContent: {} };
+    };
+
+    let result;
+    try {
+      result = await agent.executeTask('list_authorized_properties', {});
+    } finally {
+      ProtocolClient.callTool = original;
+    }
+
+    assert.ok(result, 'result must be defined');
+    // May succeed or fail depending on response parsing — either way, no throw.
+    assert.ok(typeof result.success === 'boolean', 'result.success must be a boolean');
+    assert.ok(typeof result.status === 'string', 'result.status must be a string');
+  });
+});


### PR DESCRIPTION
Closes #1148

`SingleAgentClient.executeTask` (the public generic path used for tasks without a named helper method — including the deprecated `list_authorized_properties`) had no top-level try/catch. Pre-flight steps — feature validation, endpoint discovery, version detection, and request adaptation — could throw raw exceptions instead of returning the declared `Promise<TaskResult<T>>`. Against a v2.5 MCP seller, a TypeError during version-detection response parsing escaped uncaught, producing "Cannot read properties of undefined (reading 'status')" at the call site. The fix wraps the entire method body in a try/catch and converts unexpected errors to structured `{ success: false, status: 'failed' }` envelopes. Four established protocol errors that callers handle explicitly are rethrown: `AuthenticationRequiredError`, `TaskTimeoutError`, `VersionUnsupportedError`, and `FeatureUnsupportedError`. The fluent `.match()` API works on error envelopes via `attachMatch`.

## What was tested

- `npm run format:check` — PASS (all files use Prettier code style)
- `npx tsc --project tsconfig.lib.json --noEmit` — only pre-existing TS2688/TS5107 errors (deprecated `moduleResolution` + missing `@types/node`; both present on `main` before this branch)
- `npm run build:lib` — environment missing `tsx`; pre-existing issue confirmed across multiple PRs on this repo
- `node --test test/lib/execute-task-error-envelope.test.js` — requires build step; not runnable in this environment (same pre-existing constraint)
- Regression test added: `test/lib/execute-task-error-envelope.test.js` covers TypeError→envelope path, `AuthenticationRequiredError` rethrow, `VersionUnsupportedError` rethrow, `FeatureUnsupportedError` rethrow, and the well-behaved mock (no throw)

## Pre-PR review

- **code-reviewer:** approved after 2 blockers fixed — (1) `VersionUnsupportedError`/`FeatureUnsupportedError` added to rethrow set to preserve structured typed fields; (2) `attachMatch` added so `.match()` works on error envelopes
- **dx-expert:** approved — no blockers; 3 nits all in PR description prose (rethrow set not explicitly listed; `attachMatch` not shown in synopsis; optional migration note). Code is correct as landed.

## Nits noted by reviewers (not fixed — captured here per triage policy)

- PR synopsis initially omitted `VersionUnsupportedError`/`FeatureUnsupportedError` from the rethrow guard; code is correct, description now corrected above.
- Optional migration note: callers whose `executeTask` calls produced `TypeError` (non-protocol errors) will now receive `{ success: false, status: 'failed' }` instead of a throw. `VersionUnsupportedError` and `FeatureUnsupportedError` continue to throw as before.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_016MPqxuMSLeBhDMpzvb9FHg

---
_Generated by [Claude Code](https://claude.ai/code/session_016MPqxuMSLeBhDMpzvb9FHg)_