### PR TITLE
feat(client): transport.maxResponseBytes — closes #1167

### DIFF
--- a/.changeset/transport-max-response-bytes.md
+++ b/.changeset/transport-max-response-bytes.md
@@ -1,0 +1,36 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `transport.maxResponseBytes` for hostile-vendor protection. Closes adcontextprotocol/adcp-client#1167.
+
+`@adcp/sdk` builds the underlying MCP / A2A transport's `fetch` internally, so callers had no seam to inject a size-bounded fetch. That's a real DoS surface against any code crawling untrusted agents (registries, federated discovery, monitoring tools): a hostile vendor publishing a 200 MB JSON-RPC reply gets fully buffered before any application-layer schema validation runs. The 10s default timeout doesn't mitigate — 200 MB at datacenter speeds arrives well under the limit.
+
+```ts
+const client = new ADCPMultiAgentClient(
+  [{ id: 'vendor', agent_uri, protocol: 'mcp' }],
+  {
+    userAgent: 'AAO-Discovery/1.0',
+    transport: { maxResponseBytes: 1_048_576 }, // 1 MB cap on every call
+  }
+);
+
+// Per-call override beats the constructor default — for agents that
+// legitimately publish large catalogs (`list_creative_formats` on a
+// generative seller, `list_properties` on a publisher with 50K URLs).
+const formats = await client.agent('vendor').listCreativeFormats(
+  { /* ... */ },
+  undefined,
+  { transport: { maxResponseBytes: 16 * 1_048_576 } }
+);
+```
+
+When the cap is exceeded, the SDK throws `ResponseTooLargeError` (code `RESPONSE_TOO_LARGE`, extends `ADCPError`). The error carries `limit`, `bytesRead`, `url`, and — when the cap was tripped on a `Content-Length` pre-check — `declaredContentLength`. Recovery is `terminal` from the SDK's view: replaying against the same agent will hit the same cap. The buyer's options are to widen the cap per-call when the agent's payload is legitimately large, or to flag the agent as misbehaving.
+
+**Why a typed knob, not a `fetchOverride`.** Callers composing their own size cap with the SDK's existing `wrapFetchWithCapture`, RFC 9421 signing fetch, and OAuth fetch wrappers is a footgun — the wrap order matters and isn't obvious from the public API. `maxResponseBytes` is a single-purpose ergonomic with a clear contract; future hardening (DNS-rebind defense, scheme allow-list) can add similar typed knobs without callers rewriting their fetch.
+
+**How it works.** `wrapFetchWithSizeLimit` is installed as the innermost transport wrapper for both MCP and A2A — closer to the network than capture / signing — so the diagnostic capture wrapper reads a size-limited body and can't blow memory through `Response.clone()`. Pre-cancels when `Content-Length` exceeds the cap; otherwise streams through a counting `TransformStream` that errors at the cap boundary. The active cap is read from `responseSizeLimitStorage` (AsyncLocalStorage), so cached MCP / A2A connections don't need to rebuild — the cap lives on the request, not on the transport.
+
+**Default is no cap.** Buyers in trusted relationships keep their existing payload sizes; only the registry-crawl / federated-discovery use cases need to set this. When set, per-call `transport.maxResponseBytes` (in `TaskOptions`) overrides the constructor's `transport.maxResponseBytes` (in `SingleAgentClientConfig`).
+
+**Surface area.** New exports: `TransportOptions`, `ResponseTooLargeError`. New fields: `SingleAgentClientConfig.transport`, `TaskOptions.transport`, `CallToolOptions.transport`. No breaking changes to existing fields.

--- a/.changeset/transport-max-response-bytes.md
+++ b/.changeset/transport-max-response-bytes.md
@@ -33,4 +33,16 @@ When the cap is exceeded, the SDK throws `ResponseTooLargeError` (code `RESPONSE
 
 **Default is no cap.** Buyers in trusted relationships keep their existing payload sizes; only the registry-crawl / federated-discovery use cases need to set this. When set, per-call `transport.maxResponseBytes` (in `TaskOptions`) overrides the constructor's `transport.maxResponseBytes` (in `SingleAgentClientConfig`).
 
-**Surface area.** New exports: `TransportOptions`, `ResponseTooLargeError`. New fields: `SingleAgentClientConfig.transport`, `TaskOptions.transport`, `CallToolOptions.transport`. No breaking changes to existing fields.
+**Surface area.** New exports: `TransportOptions`, `ResponseTooLargeError`. New fields: `SingleAgentClientConfig.transport`, `TaskOptions.transport`, `CallToolOptions.transport`, `transport` argument on `createMCPClient` / `createA2AClient` factories. No breaking changes to existing fields.
+
+**Defense detail (post-review hardening).**
+
+- **Forces `Accept-Encoding: identity` when the cap is active** so a hostile vendor can't ship a 5 KB gzip blob that decompresses to GBs and burn asymmetric CPU before the streaming counter trips. Without this, undici's default `Accept-Encoding: gzip, deflate, br` lets the cap count post-decompression bytes only. Forcing identity moves the bomb to the network where the `Content-Length` pre-check catches it. The header is only set when no caller value is present — signing fetches that need a stable signed-bytes shape can override.
+- **Strips the search component from `ResponseTooLargeError.url`.** Some agents publish manifests with auth tokens in the query string (`?api_key=…`); without redaction those land in `err.message`, `err.details.url`, and any downstream log sinks. The error stores the path-only form for diagnostics.
+- **`createMCPClient` / `createA2AClient` factory exports honor the same cap.** They accept a `transport` argument and wrap with `withResponseSizeLimit`, matching the contract the public `TransportOptions` type implies. Without this, callers reaching the factory exports would silently bypass the cap.
+
+**Known gaps tracked as follow-ups (not blocking this ship).**
+
+- OAuth client-credentials token endpoint (`exchangeClientCredentials`) uses raw fetch and bypasses the cap. Pre-existing surface, not a regression from this change. Tracked separately.
+- The cap applies to MCP's long-lived side-channel `GET` for server-initiated messages; the doc warning ("leave unset for long-lived buyer sessions") is the current mitigation. A finer-grained per-response scope is a follow-up.
+- OAuth metadata discovery (`/.well-known/oauth-authorization-server`) doesn't flow through the wrapped fetch — `discoverOAuthMetadata` uses raw fetch. Same DoS surface, separate fix.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -157,6 +157,13 @@ export interface TaskOptions {
    * @internal Do not set in production buyer code.
    */
   skipIdempotencyAutoInject?: boolean;
+  /**
+   * Transport-level safeguards for this call. Overrides the matching field
+   * on the client constructor's `transport` option. Use to lift or tighten
+   * `maxResponseBytes` per call when an agent legitimately publishes large
+   * catalogs (e.g., `list_creative_formats` on a generative seller).
+   */
+  transport?: import('../protocols').TransportOptions;
 }
 
 /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -319,6 +319,15 @@ export interface SingleAgentClientConfig extends ConversationConfig {
   };
   /** Governance configuration for buyer-side campaign governance */
   governance?: import('./GovernanceTypes').GovernanceConfig;
+  /**
+   * Transport-level safeguards. Applies to every call this client dispatches
+   * unless overridden at call time.
+   *
+   * Set `maxResponseBytes` when crawling untrusted agents (registries,
+   * federated discovery layers) to prevent a hostile vendor from buffering
+   * a large reply before any application-layer schema validation runs.
+   */
+  transport?: import('../protocols').TransportOptions;
 }
 
 /**
@@ -428,6 +437,7 @@ export class SingleAgentClient {
       onActivity: config.onActivity,
       governance: config.governance,
       adcpVersion: this.resolvedAdcpVersion,
+      transport: config.transport,
     });
 
     // Create async handler if handlers are provided

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -301,6 +301,11 @@ export class TaskExecutor {
        * truth for both validation and wire-level major.
        */
       adcpVersion?: string;
+      /**
+       * Transport-level safeguards applied to every call this executor
+       * dispatches. Per-call options can override individual fields.
+       */
+      transport?: import('../protocols').TransportOptions;
     } = {}
   ) {
     this.responseParser = new ProtocolResponseParser();
@@ -562,6 +567,7 @@ export class TaskExecutor {
         serverVersion,
         session: { contextId: options.contextId, taskId: options.taskId },
         adcpVersion: this.config.adcpVersion,
+        transport: options.transport ?? this.config.transport,
       });
 
       // Emit protocol_response activity
@@ -1304,6 +1310,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
+        transport: this.config.transport,
       }
     )) as Record<string, unknown>;
     return (response.tasks as TaskInfo[]) || [];
@@ -1360,6 +1367,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
+        transport: this.config.transport,
       }
     )) as Record<string, unknown>;
     // We don't run `extractResponseData` here: that helper's
@@ -1535,6 +1543,7 @@ export class TaskExecutor {
         debugLogs,
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
+        transport: this.config.transport,
       }
     );
 

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -340,6 +340,40 @@ export class FeatureUnsupportedError extends ADCPError {
 }
 
 /**
+ * Error thrown when a response body exceeds the configured `maxResponseBytes`
+ * cap on the transport. Surfaced when crawling untrusted agents (registries,
+ * federated discovery layers) to prevent a hostile vendor from buffering a
+ * large reply before schema validation runs.
+ *
+ * Recovery: `terminal` from the SDK's view — repeating the call against the
+ * same agent will hit the same cap. The buyer's options are to widen the
+ * cap (per-call `transport.maxResponseBytes`) when the agent's payload is
+ * legitimately large, or to flag the agent as misbehaving.
+ */
+export class ResponseTooLargeError extends ADCPError {
+  readonly code = 'RESPONSE_TOO_LARGE';
+
+  constructor(
+    public readonly limit: number,
+    public readonly bytesRead: number,
+    public readonly url: string,
+    /**
+     * The `Content-Length` header value when the cap was tripped before any
+     * body bytes were read. Undefined when the response was streamed and
+     * exceeded the cap mid-flight, or when the server omitted the header.
+     */
+    public readonly declaredContentLength?: number
+  ) {
+    super(
+      declaredContentLength !== undefined
+        ? `Response body declared ${declaredContentLength} bytes, exceeds maxResponseBytes cap of ${limit} (${url})`
+        : `Response body exceeded maxResponseBytes cap of ${limit} after reading ${bytesRead} bytes (${url})`
+    );
+    this.details = { limit, bytesRead, url, declaredContentLength };
+  }
+}
+
+/**
  * Reason the v3 guard refused a mutating dispatch.
  * - `version`: seller's `major_versions` does not include 3
  * - `idempotency`: seller reports v3 but omits the required

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -241,6 +241,7 @@ export {
   VersionUnsupportedError,
   IdempotencyConflictError,
   IdempotencyExpiredError,
+  ResponseTooLargeError,
   adcpErrorToTypedError,
   isADCPError,
   isErrorOfType,
@@ -836,7 +837,7 @@ export {
   closeMCPConnections,
   bundleSupportsAdcpVersionField,
 } from './protocols';
-export type { CallToolOptions } from './protocols';
+export type { CallToolOptions, TransportOptions } from './protocols';
 
 // ====== RESPONSE UTILITIES ======
 // Public utilities for working with AdCP responses

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -13,6 +13,7 @@ import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
+import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 
 if (!A2AClient) {
   throw new Error('A2A SDK client is required. Please install @a2a-js/sdk');
@@ -125,6 +126,10 @@ function buildFetchImpl(authToken: string | undefined) {
   // with a different context.
   const signingContext = signingContextStorage.getStore();
 
+  // Innermost wrapper: enforce response body size cap from the active
+  // `responseSizeLimitStorage` slot. Pass-through when no slot is set.
+  const networkFetch = wrapFetchWithSizeLimit((input, init) => fetch(input as any, init));
+
   // Inner fetch handles auth/header injection and 401 detection. If the
   // agent has request-signing configured, we wrap it with the AdCP signing
   // fetch so the signature covers the exact bytes we're about to send (auth
@@ -177,7 +182,7 @@ function buildFetchImpl(authToken: string | undefined) {
       ),
     });
 
-    const response = await fetch(url, { ...options, headers });
+    const response = await networkFetch(url as any, { ...options, headers });
 
     if (response.status === 401 && context) {
       context.got401Ref.value = true;

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -238,8 +238,16 @@ export class ProtocolClient {
     args: Record<string, unknown>,
     options: CallToolOptions = {}
   ): Promise<unknown> {
-    const { debugLogs = [], webhookUrl, webhookSecret, webhookToken, serverVersion, session, adcpVersion, transport } =
-      options;
+    const {
+      debugLogs = [],
+      webhookUrl,
+      webhookSecret,
+      webhookToken,
+      serverVersion,
+      session,
+      adcpVersion,
+      transport,
+    } = options;
     // Per-instance version envelope. Throws on unparseable pins via
     // `resolveWireMajor`; construction-time `resolveAdcpVersion` is the
     // primary gate but this is the failsafe for callers reaching
@@ -261,206 +269,206 @@ export class ProtocolClient {
           'http.url': agent.agent_uri,
         },
         async () => {
-        // In-process MCP path: pre-connected client, no HTTP transport.
-        // Idempotency injection, schema validation, and governance middleware all
-        // still apply (they run in SingleAgentClient above this call). We skip
-        // URL validation, OAuth refresh, and signing — none apply in-process.
-        if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
-          const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
-          return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
-        }
+          // In-process MCP path: pre-connected client, no HTTP transport.
+          // Idempotency injection, schema validation, and governance middleware all
+          // still apply (they run in SingleAgentClient above this call). We skip
+          // URL validation, OAuth refresh, and signing — none apply in-process.
+          if (agent.protocol === 'mcp' && agent._inProcessMcpClient) {
+            const inProcArgs = applyVersionEnvelope(args, versionEnvelope);
+            return callMCPToolWithClient(agent._inProcessMcpClient, toolName, inProcArgs, debugLogs);
+          }
 
-        validateAgentUrl(agent.agent_uri);
+          validateAgentUrl(agent.agent_uri);
 
-        // OAuth 2.0 client credentials (RFC 6749 §4.4): re-exchange the
-        // secret for a fresh access token whenever the cached one is within
-        // its expiration skew. Runs before every call so mid-session expiry
-        // can't leave the caller with a stale bearer. No-op if the agent
-        // doesn't declare client credentials. Cheap on warm cache (single
-        // `Date.now()` compare); a single POST to the token endpoint on miss.
-        //
-        // `allowPrivateIp` inherits the trust the caller already placed in
-        // `agent.agent_uri` — if they're making a call to a private-IP agent,
-        // they've authorized this process to talk to private-IP hosts, so
-        // the token endpoint on the same network is reachable too. Public
-        // agent URLs with private-IP token endpoints still require an
-        // explicit opt-in via the library API.
-        if (agent.oauth_client_credentials) {
-          const ccStorage = getAgentStorage(agent);
-          const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
-          await ensureClientCredentialsTokens(agent, { storage: ccStorage, allowPrivateIp });
-        }
+          // OAuth 2.0 client credentials (RFC 6749 §4.4): re-exchange the
+          // secret for a fresh access token whenever the cached one is within
+          // its expiration skew. Runs before every call so mid-session expiry
+          // can't leave the caller with a stale bearer. No-op if the agent
+          // doesn't declare client credentials. Cheap on warm cache (single
+          // `Date.now()` compare); a single POST to the token endpoint on miss.
+          //
+          // `allowPrivateIp` inherits the trust the caller already placed in
+          // `agent.agent_uri` — if they're making a call to a private-IP agent,
+          // they've authorized this process to talk to private-IP hosts, so
+          // the token endpoint on the same network is reachable too. Public
+          // agent URLs with private-IP token endpoints still require an
+          // explicit opt-in via the library API.
+          if (agent.oauth_client_credentials) {
+            const ccStorage = getAgentStorage(agent);
+            const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
+            await ensureClientCredentialsTokens(agent, { storage: ccStorage, allowPrivateIp });
+          }
 
-        const authToken = getAuthToken(agent);
+          const authToken = getAuthToken(agent);
 
-        // RFC 9421 signing context. Built once per call and passed through
-        // to each protocol-layer entry (`callMCPToolWithTasks`, `callA2ATool`,
-        // `callMCPToolWithOAuth`) — those entries seed `signingContextStorage`
-        // (AsyncLocalStorage) so the internal transport helpers read it
-        // without an explicit parameter. Keep the explicit arg here: it's the
-        // ALS seed, not incidental plumbing. `get_adcp_capabilities` is
-        // exempt from signing (it's the discovery call itself) and also
-        // triggers cache priming for any other op on agents with
-        // `request_signing` configured.
-        const signingContext = buildAgentSigningContext(agent);
-        if (signingContext && toolName !== CAPABILITY_OP) {
-          await ensureCapabilityLoaded(agent, signingContext, primeArgs =>
-            ProtocolClient.callTool(agent, CAPABILITY_OP, primeArgs, {
-              debugLogs,
-              serverVersion,
-              adcpVersion,
-            })
-          );
-        }
-
-        // Inject the version envelope on every request so sellers can validate
-        // compatibility. Skip for v2 servers — they don't recognise the
-        // version fields and strict-schema agents reject them. The envelope
-        // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
-        // alone; 3.1+ pins get both that and the release-precision string
-        // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
-        // `adcontextprotocol/adcp#3493`.
-        const argsWithVersion = applyVersionEnvelope(args, versionEnvelope);
-
-        // Build push_notification_config for ASYNC TASK STATUS notifications
-        // (NOT for reporting_webhook - that stays in args)
-        // Schema: https://adcontextprotocol.org/schemas/v1/core/push-notification-config.json
-        const pushNotificationConfig: PushNotificationConfig | undefined = webhookUrl
-          ? {
-              url: webhookUrl,
-              ...(webhookToken && { token: webhookToken }),
-              authentication: {
-                schemes: ['HMAC-SHA256'],
-                credentials: webhookSecret || 'placeholder_secret_min_32_characters_required',
-              },
-            }
-          : undefined;
-
-        if (agent.protocol === 'mcp') {
-          // For MCP, include push_notification_config in tool arguments (MCP spec)
-          const argsWithWebhook = pushNotificationConfig
-            ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
-            : argsWithVersion;
-
-          // If the agent config carries authorization-code OAuth tokens,
-          // route through the OAuth provider path so the MCP SDK can refresh
-          // on 401 instead of hard-failing. Excludes client-credentials
-          // agents: they have a cached access token but no refresh_token,
-          // and their refresh path is a secret re-exchange (handled above),
-          // not the SDK's refresh_token grant.
-          if (agent.oauth_tokens && !agent.oauth_client_credentials) {
-            const storage = getAgentStorage(agent);
-            const authProvider = createNonInteractiveOAuthProvider(agent, {
-              agentHint: agent.id,
-              storage,
-            });
-            try {
-              return await callMCPToolWithOAuth({
-                agentUrl: agent.agent_uri,
-                toolName,
-                args: argsWithWebhook,
-                authProvider,
+          // RFC 9421 signing context. Built once per call and passed through
+          // to each protocol-layer entry (`callMCPToolWithTasks`, `callA2ATool`,
+          // `callMCPToolWithOAuth`) — those entries seed `signingContextStorage`
+          // (AsyncLocalStorage) so the internal transport helpers read it
+          // without an explicit parameter. Keep the explicit arg here: it's the
+          // ALS seed, not incidental plumbing. `get_adcp_capabilities` is
+          // exempt from signing (it's the discovery call itself) and also
+          // triggers cache priming for any other op on agents with
+          // `request_signing` configured.
+          const signingContext = buildAgentSigningContext(agent);
+          if (signingContext && toolName !== CAPABILITY_OP) {
+            await ensureCapabilityLoaded(agent, signingContext, primeArgs =>
+              ProtocolClient.callTool(agent, CAPABILITY_OP, primeArgs, {
                 debugLogs,
-                customHeaders: agent.headers,
-                signingContext,
+                serverVersion,
+                adcpVersion,
+              })
+            );
+          }
+
+          // Inject the version envelope on every request so sellers can validate
+          // compatibility. Skip for v2 servers — they don't recognise the
+          // version fields and strict-schema agents reject them. The envelope
+          // shape is per-pin: 3.0 pins get the integer `adcp_major_version`
+          // alone; 3.1+ pins get both that and the release-precision string
+          // `adcp_version` (`'3.1'` / `'3.1.0-beta.1'`) per spec PR
+          // `adcontextprotocol/adcp#3493`.
+          const argsWithVersion = applyVersionEnvelope(args, versionEnvelope);
+
+          // Build push_notification_config for ASYNC TASK STATUS notifications
+          // (NOT for reporting_webhook - that stays in args)
+          // Schema: https://adcontextprotocol.org/schemas/v1/core/push-notification-config.json
+          const pushNotificationConfig: PushNotificationConfig | undefined = webhookUrl
+            ? {
+                url: webhookUrl,
+                ...(webhookToken && { token: webhookToken }),
+                authentication: {
+                  schemes: ['HMAC-SHA256'],
+                  credentials: webhookSecret || 'placeholder_secret_min_32_characters_required',
+                },
+              }
+            : undefined;
+
+          if (agent.protocol === 'mcp') {
+            // For MCP, include push_notification_config in tool arguments (MCP spec)
+            const argsWithWebhook = pushNotificationConfig
+              ? { ...argsWithVersion, push_notification_config: pushNotificationConfig }
+              : argsWithVersion;
+
+            // If the agent config carries authorization-code OAuth tokens,
+            // route through the OAuth provider path so the MCP SDK can refresh
+            // on 401 instead of hard-failing. Excludes client-credentials
+            // agents: they have a cached access token but no refresh_token,
+            // and their refresh path is a secret re-exchange (handled above),
+            // not the SDK's refresh_token grant.
+            if (agent.oauth_tokens && !agent.oauth_client_credentials) {
+              const storage = getAgentStorage(agent);
+              const authProvider = createNonInteractiveOAuthProvider(agent, {
+                agentHint: agent.id,
+                storage,
               });
+              try {
+                return await callMCPToolWithOAuth({
+                  agentUrl: agent.agent_uri,
+                  toolName,
+                  args: argsWithWebhook,
+                  authProvider,
+                  debugLogs,
+                  customHeaders: agent.headers,
+                  signingContext,
+                });
+              } catch (err) {
+                // Refresh failed or server rejected the refreshed token — walk the
+                // discovery chain so the caller can distinguish "re-auth needed"
+                // from other failure modes.
+                await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+                throw err;
+              }
+            }
+
+            // Use callMCPToolWithTasks which auto-detects server tasks capability
+            // and falls back to standard callTool when tasks are not supported
+            try {
+              return await callMCPToolWithTasks(
+                agent.agent_uri,
+                toolName,
+                argsWithWebhook,
+                authToken,
+                debugLogs,
+                agent.headers,
+                signingContext ? { signingContext } : undefined
+              );
             } catch (err) {
-              // Refresh failed or server rejected the refreshed token — walk the
-              // discovery chain so the caller can distinguish "re-auth needed"
-              // from other failure modes.
+              // Client-credentials agents: on 401, the AS may have rotated
+              // something out-of-band. Force a fresh exchange and retry once
+              // before surfacing the error. Bounded (single retry) so we don't
+              // loop if the credentials are genuinely wrong.
+              if (agent.oauth_client_credentials && is401Error(err)) {
+                const ccStorage = getAgentStorage(agent);
+                const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
+                await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
+                const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
+                try {
+                  return await callMCPToolWithTasks(
+                    agent.agent_uri,
+                    toolName,
+                    argsWithWebhook,
+                    retryAuthToken,
+                    debugLogs,
+                    agent.headers,
+                    signingContext ? { signingContext } : undefined
+                  );
+                } catch (retryErr) {
+                  await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
+                  throw retryErr;
+                }
+              }
               await rethrowAsNeedsAuthorization(err, agent.agent_uri);
               throw err;
             }
-          }
-
-          // Use callMCPToolWithTasks which auto-detects server tasks capability
-          // and falls back to standard callTool when tasks are not supported
-          try {
-            return await callMCPToolWithTasks(
-              agent.agent_uri,
-              toolName,
-              argsWithWebhook,
-              authToken,
-              debugLogs,
-              agent.headers,
-              signingContext ? { signingContext } : undefined
-            );
-          } catch (err) {
-            // Client-credentials agents: on 401, the AS may have rotated
-            // something out-of-band. Force a fresh exchange and retry once
-            // before surfacing the error. Bounded (single retry) so we don't
-            // loop if the credentials are genuinely wrong.
-            if (agent.oauth_client_credentials && is401Error(err)) {
-              const ccStorage = getAgentStorage(agent);
-              const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
-              await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
-              const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
-              try {
-                return await callMCPToolWithTasks(
-                  agent.agent_uri,
-                  toolName,
-                  argsWithWebhook,
-                  retryAuthToken,
-                  debugLogs,
-                  agent.headers,
-                  signingContext ? { signingContext } : undefined
-                );
-              } catch (retryErr) {
-                await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
-                throw retryErr;
+          } else if (agent.protocol === 'a2a') {
+            // For A2A, pass pushNotificationConfig separately (not in skill parameters)
+            try {
+              return await callA2ATool(
+                agent.agent_uri,
+                toolName,
+                argsWithVersion,
+                authToken,
+                debugLogs,
+                pushNotificationConfig,
+                agent.headers,
+                signingContext,
+                session
+              );
+            } catch (err) {
+              // Same single-retry-on-401 for client-credentials agents as the
+              // MCP path above. Kept symmetric so A2A CC agents aren't a
+              // second-class experience — including the NeedsAuthorizationError
+              // rewrap on a retry that still 401s.
+              if (agent.oauth_client_credentials && is401Error(err)) {
+                const ccStorage = getAgentStorage(agent);
+                const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
+                await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
+                const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
+                try {
+                  return await callA2ATool(
+                    agent.agent_uri,
+                    toolName,
+                    argsWithVersion,
+                    retryAuthToken,
+                    debugLogs,
+                    pushNotificationConfig,
+                    agent.headers,
+                    signingContext,
+                    session
+                  );
+                } catch (retryErr) {
+                  await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
+                  throw retryErr;
+                }
               }
+              await rethrowAsNeedsAuthorization(err, agent.agent_uri);
+              throw err;
             }
-            await rethrowAsNeedsAuthorization(err, agent.agent_uri);
-            throw err;
+          } else {
+            throw new Error(`Unsupported protocol: ${agent.protocol}`);
           }
-        } else if (agent.protocol === 'a2a') {
-          // For A2A, pass pushNotificationConfig separately (not in skill parameters)
-          try {
-            return await callA2ATool(
-              agent.agent_uri,
-              toolName,
-              argsWithVersion,
-              authToken,
-              debugLogs,
-              pushNotificationConfig,
-              agent.headers,
-              signingContext,
-              session
-            );
-          } catch (err) {
-            // Same single-retry-on-401 for client-credentials agents as the
-            // MCP path above. Kept symmetric so A2A CC agents aren't a
-            // second-class experience — including the NeedsAuthorizationError
-            // rewrap on a retry that still 401s.
-            if (agent.oauth_client_credentials && is401Error(err)) {
-              const ccStorage = getAgentStorage(agent);
-              const allowPrivateIp = isLikelyPrivateUrl(agent.agent_uri);
-              await ensureClientCredentialsTokens(agent, { storage: ccStorage, force: true, allowPrivateIp });
-              const retryAuthToken = agent.oauth_tokens?.access_token ?? authToken;
-              try {
-                return await callA2ATool(
-                  agent.agent_uri,
-                  toolName,
-                  argsWithVersion,
-                  retryAuthToken,
-                  debugLogs,
-                  pushNotificationConfig,
-                  agent.headers,
-                  signingContext,
-                  session
-                );
-              } catch (retryErr) {
-                await rethrowAsNeedsAuthorization(retryErr, agent.agent_uri);
-                throw retryErr;
-              }
-            }
-            await rethrowAsNeedsAuthorization(err, agent.agent_uri);
-            throw err;
-          }
-        } else {
-          throw new Error(`Unsupported protocol: ${agent.protocol}`);
         }
-      }
       )
     );
   }

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -155,12 +155,29 @@ export interface TransportOptions {
    * with `ResponseTooLargeError`. When unset, the SDK does not impose a cap —
    * matches the underlying MCP / A2A transport defaults.
    *
-   * Set this when crawling untrusted agents (registries, federated discovery
-   * layers, monitoring tools) to prevent a hostile vendor from buffering a
-   * large reply before any application-layer schema validation runs. Counted
-   * across response chunks; pre-cancels when `Content-Length` exceeds the cap.
+   * Set this when crawling **untrusted** agents (registries, federated
+   * discovery layers, monitoring tools) to prevent a hostile vendor from
+   * buffering a large reply before any application-layer schema validation
+   * runs. Counted across response chunks; pre-cancels when `Content-Length`
+   * exceeds the cap. Applies to A2A agent-card discovery
+   * (`/.well-known/agent.json`) on the same call as well.
    *
-   * Per-call override beats the value set on the client constructor.
+   * Per-call override (`TaskOptions.transport.maxResponseBytes`) beats the
+   * value set on the client constructor (`SingleAgentClientConfig.transport`).
+   *
+   * @remarks
+   * **Leave unset for long-lived buyer sessions.** When set, the cap applies
+   * to every fetch in the call's ALS scope — including any side-channel
+   * `GET` the MCP transport opens for server-initiated messages. Long-lived
+   * connections that legitimately stream more cumulative bytes than the cap
+   * will be torn down. The option is intended for one-shot discovery / crawl
+   * paths where the response is bounded by definition.
+   *
+   * @remarks
+   * Future hardening knobs (DNS-rebind defense, scheme allow-list, request
+   * timeout overrides) will land here as additional fields rather than
+   * forcing callers to compose their own `fetch` — wrap order with the SDK's
+   * existing signing / capture wrappers is non-obvious and a footgun.
    */
   maxResponseBytes?: number;
 }

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -48,6 +48,7 @@ import { ADCP_MAJOR_VERSION, ADCP_VERSION, parseAdcpMajorVersion } from '../vers
 import { ConfigurationError } from '../errors';
 import { resolveBundleKey } from '../validation/schema-loader';
 import { buildAgentSigningContext, CAPABILITY_OP, ensureCapabilityLoaded } from '../signing/client';
+import { withResponseSizeLimit } from './responseSizeLimit';
 
 /**
  * Derive the wire-level `adcp_major_version` integer from a caller-supplied
@@ -142,6 +143,29 @@ export function applyVersionEnvelope(
 }
 
 /**
+ * Transport-level safeguards applied to a call.
+ *
+ * Wired into the SDK's internal fetch chain via AsyncLocalStorage, so the
+ * cap takes effect even when the underlying transport's connection cache
+ * reuses a fetch that was created on an earlier call with different limits.
+ */
+export interface TransportOptions {
+  /**
+   * Maximum response body size (in octets) the SDK will read before aborting
+   * with `ResponseTooLargeError`. When unset, the SDK does not impose a cap —
+   * matches the underlying MCP / A2A transport defaults.
+   *
+   * Set this when crawling untrusted agents (registries, federated discovery
+   * layers, monitoring tools) to prevent a hostile vendor from buffering a
+   * large reply before any application-layer schema validation runs. Counted
+   * across response chunks; pre-cancels when `Content-Length` exceeds the cap.
+   *
+   * Per-call override beats the value set on the client constructor.
+   */
+  maxResponseBytes?: number;
+}
+
+/**
  * Options for {@link ProtocolClient.callTool}. All fields are optional.
  *
  * `webhookUrl` / `webhookSecret` / `webhookToken` are for ASYNC TASK STATUS
@@ -172,6 +196,11 @@ export interface CallToolOptions {
    * that path to probe seller version negotiation.
    */
   adcpVersion?: string;
+  /**
+   * Transport-level safeguards (size caps, etc.). Per-call override of any
+   * matching field on the client constructor's `transport` option.
+   */
+  transport?: TransportOptions;
 }
 
 /**
@@ -192,7 +221,8 @@ export class ProtocolClient {
     args: Record<string, unknown>,
     options: CallToolOptions = {}
   ): Promise<unknown> {
-    const { debugLogs = [], webhookUrl, webhookSecret, webhookToken, serverVersion, session, adcpVersion } = options;
+    const { debugLogs = [], webhookUrl, webhookSecret, webhookToken, serverVersion, session, adcpVersion, transport } =
+      options;
     // Per-instance version envelope. Throws on unparseable pins via
     // `resolveWireMajor`; construction-time `resolveAdcpVersion` is the
     // primary gate but this is the failsafe for callers reaching
@@ -200,15 +230,20 @@ export class ProtocolClient {
     // MCP path). Returns `{ adcp_major_version }` for 3.0 pins and
     // `{ adcp_major_version, adcp_version }` for 3.1+ pins.
     const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
-    return withSpan(
-      `adcp.${agent.protocol}.call_tool`,
-      {
-        'adcp.agent_id': agent.id,
-        'adcp.protocol': agent.protocol,
-        'adcp.tool': toolName,
-        'http.url': agent.agent_uri,
-      },
-      async () => {
+    // Enter the response-size-limit ALS slot once for this call. The slot is
+    // read by `wrapFetchWithSizeLimit` in both protocol transports, so the
+    // cap applies regardless of which path (MCP / A2A / OAuth refresh) the
+    // call ends up taking. No-op when the cap is unset or non-positive.
+    return withResponseSizeLimit(transport?.maxResponseBytes, () =>
+      withSpan(
+        `adcp.${agent.protocol}.call_tool`,
+        {
+          'adcp.agent_id': agent.id,
+          'adcp.protocol': agent.protocol,
+          'adcp.tool': toolName,
+          'http.url': agent.agent_uri,
+        },
+        async () => {
         // In-process MCP path: pre-connected client, no HTTP transport.
         // Idempotency injection, schema validation, and governance middleware all
         // still apply (they run in SingleAgentClient above this call). We skip
@@ -409,6 +444,7 @@ export class ProtocolClient {
           throw new Error(`Unsupported protocol: ${agent.protocol}`);
         }
       }
+      )
     );
   }
 }

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -503,14 +503,21 @@ async function rethrowAsNeedsAuthorization(err: unknown, agentUrl: string): Prom
 }
 
 /**
- * Simple factory functions for protocol-specific clients
+ * Simple factory functions for protocol-specific clients.
+ *
+ * Both factories accept a `transport` argument that flows through to the
+ * size-cap surface so callers reaching the factory exports honor the same
+ * `maxResponseBytes` contract as `ProtocolClient.callTool`. Without it,
+ * the factories would silently bypass the cap, which the public API
+ * (`TransportOptions`) implies they honor.
  */
 export const createMCPClient = (
   agentUrl: string,
   authToken?: string,
   headers?: Record<string, string>,
   serverVersion?: 'v2' | 'v3',
-  adcpVersion?: string
+  adcpVersion?: string,
+  transport?: TransportOptions
 ) => {
   // Validate the pin at factory time so a typo surfaces here rather than at
   // first call. `buildVersionEnvelope` throws via `resolveWireMajor` on bad
@@ -518,13 +525,15 @@ export const createMCPClient = (
   const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, args: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
-      callMCPToolWithTasks(
-        agentUrl,
-        toolName,
-        applyVersionEnvelope(args, versionEnvelope),
-        authToken,
-        debugLogs,
-        headers
+      withResponseSizeLimit(transport?.maxResponseBytes, () =>
+        callMCPToolWithTasks(
+          agentUrl,
+          toolName,
+          applyVersionEnvelope(args, versionEnvelope),
+          authToken,
+          debugLogs,
+          headers
+        )
       ),
   };
 };
@@ -534,19 +543,22 @@ export const createA2AClient = (
   authToken?: string,
   headers?: Record<string, string>,
   serverVersion?: 'v2' | 'v3',
-  adcpVersion?: string
+  adcpVersion?: string,
+  transport?: TransportOptions
 ) => {
   const versionEnvelope = buildVersionEnvelope(adcpVersion, serverVersion);
   return {
     callTool: (toolName: string, parameters: Record<string, unknown>, debugLogs?: DebugLogEntry[]) =>
-      callA2ATool(
-        agentUrl,
-        toolName,
-        applyVersionEnvelope(parameters, versionEnvelope),
-        authToken,
-        debugLogs,
-        undefined,
-        headers
+      withResponseSizeLimit(transport?.maxResponseBytes, () =>
+        callA2ATool(
+          agentUrl,
+          toolName,
+          applyVersionEnvelope(parameters, versionEnvelope),
+          authToken,
+          debugLogs,
+          undefined,
+          headers
+        )
       ),
   };
 };

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -16,6 +16,7 @@ import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
+import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 
 // Re-export for convenience
 export { UnauthorizedError };
@@ -311,13 +312,18 @@ async function connectMCPWithFallbackImpl(
   label = 'connection'
 ): Promise<MCPClient> {
   const signingContext = signingContextStorage.getStore();
+  // Wrap order (innermost → outermost): network → size-limit → signing → capture.
+  // Size-limit applies to the raw network response so signing/capture see a
+  // bounded body (capture clones via `response.clone()`, which would otherwise
+  // buffer a hostile reply in memory).
+  const sizeLimited = wrapFetchWithSizeLimit((input, init) => fetch(input as any, init));
   const baseFetch: typeof fetch = signingContext
     ? (buildAgentSigningFetch({
-        upstream: (input, init) => fetch(input as any, init),
+        upstream: sizeLimited,
         signing: signingContext.signing,
         getCapability: signingContext.getCapability,
       }) as typeof fetch)
-    : (input, init) => fetch(input as any, init);
+    : sizeLimited;
   const transportOptions: StreamableHTTPClientTransportOptions = {
     requestInit: { headers: authHeaders },
     fetch: wrapFetchWithCapture(baseFetch),
@@ -649,14 +655,16 @@ export async function connectMCP(options: {
 
   // RFC 9421 signing — wrap the transport's fetch so the signer sees the final
   // headers the SDK assembled (including any OAuth-issued Authorization) and
-  // decides per outbound request whether to sign.
+  // decides per outbound request whether to sign. Size-limit sits innermost so
+  // the response body is bounded before signing/capture observe it.
+  const sizeLimited = wrapFetchWithSizeLimit((input, init) => fetch(input as string | URL, init));
   const signedFetch: typeof fetch = signingContext
     ? (buildAgentSigningFetch({
-        upstream: (input, init) => fetch(input as string | URL, init),
+        upstream: sizeLimited,
         signing: signingContext.signing,
         getCapability: signingContext.getCapability,
       }) as typeof fetch)
-    : (input, init) => fetch(input as string | URL, init);
+    : sizeLimited;
   transportOptions.fetch = wrapFetchWithCapture(signedFetch);
 
   const transport = new StreamableHTTPClientTransport(baseUrl, transportOptions);

--- a/src/lib/protocols/responseSizeLimit.ts
+++ b/src/lib/protocols/responseSizeLimit.ts
@@ -1,0 +1,102 @@
+// Response-body byte cap enforcement for hostile-vendor protection.
+//
+// Wraps a base fetch with a streaming size counter so the SDK aborts large
+// responses before any application-layer parsing buffers them. Active when
+// `responseSizeLimitStorage` carries a slot — installed unconditionally as
+// the innermost transport wrapper so production callers without the slot
+// pay only one ALS lookup per request.
+//
+// The wrapper composes inside `wrapFetchWithCapture`: the diagnostic capture
+// reads the size-limited body via `response.clone()`, so a hostile reply
+// can't blow memory through the capture path either.
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { ResponseTooLargeError } from '../errors';
+
+interface SizeLimitSlot {
+  maxResponseBytes: number;
+}
+
+export const responseSizeLimitStorage = new AsyncLocalStorage<SizeLimitSlot>();
+
+/**
+ * Run `fn` with a response body byte cap active. Every fetch made through
+ * a wrapped transport inside `fn` aborts with `ResponseTooLargeError` when
+ * the response body exceeds `maxResponseBytes`. Non-positive caps disable
+ * enforcement (ALS slot is not entered).
+ */
+export function withResponseSizeLimit<T>(maxResponseBytes: number | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!maxResponseBytes || !Number.isFinite(maxResponseBytes) || maxResponseBytes <= 0) {
+    return fn();
+  }
+  return responseSizeLimitStorage.run({ maxResponseBytes }, fn);
+}
+
+function urlOfInput(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+/**
+ * Wrap a fetch implementation so its responses honor the size cap from the
+ * active `responseSizeLimitStorage` slot. Pass-through when no slot is set.
+ *
+ * Pre-checks `Content-Length` and refuses to read the body when the declared
+ * size already exceeds the cap. Otherwise wraps `Response.body` in a
+ * `TransformStream` that counts bytes and errors with `ResponseTooLargeError`
+ * at the cap boundary, propagating to anyone reading the response (including
+ * `Response.clone()` branches used by the diagnostic capture wrapper).
+ */
+export function wrapFetchWithSizeLimit(upstream: typeof fetch): typeof fetch {
+  const wrapped: typeof fetch = async (input, init) => {
+    const slot = responseSizeLimitStorage.getStore();
+    if (!slot) return upstream(input, init);
+
+    const response = await upstream(input, init);
+    return enforceSizeLimit(response, slot.maxResponseBytes, urlOfInput(input));
+  };
+  return wrapped;
+}
+
+function enforceSizeLimit(response: Response, maxBytes: number, url: string): Response {
+  // Cheap pre-check: if the server declares a Content-Length over the cap,
+  // tear the connection down before reading any of the body. Servers can
+  // omit or lie about Content-Length, which is why the streaming counter
+  // below is the authoritative enforcement.
+  const declared = parseContentLength(response.headers.get('content-length'));
+  if (declared !== undefined && declared > maxBytes) {
+    response.body?.cancel().catch(() => {
+      /* socket already closed by transport */
+    });
+    throw new ResponseTooLargeError(maxBytes, 0, url, declared);
+  }
+
+  if (!response.body) return response;
+
+  let bytesRead = 0;
+  const counter = new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      bytesRead += chunk.byteLength;
+      if (bytesRead > maxBytes) {
+        controller.error(new ResponseTooLargeError(maxBytes, bytesRead, url));
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+  });
+
+  return new Response(response.body.pipeThrough(counter), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+function parseContentLength(value: string | null): number | undefined {
+  if (value === null) return undefined;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/src/lib/protocols/responseSizeLimit.ts
+++ b/src/lib/protocols/responseSizeLimit.ts
@@ -39,6 +39,46 @@ function urlOfInput(input: RequestInfo | URL): string {
 }
 
 /**
+ * Strip the search component from a URL before storing it on
+ * `ResponseTooLargeError`. Some agents publish manifests with auth tokens
+ * in the query string (`?api_key=…`); without redaction those land in
+ * `err.message`, `err.details.url`, and downstream log sinks.
+ *
+ * Returns the input unchanged when it can't be parsed (relative paths,
+ * non-URL inputs from custom test stubs) — the alternative is throwing,
+ * which would mask the original `ResponseTooLargeError`.
+ */
+function redactUrlForError(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.search = '';
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Force `Accept-Encoding: identity` on outgoing requests when the size cap
+ * is active. Without this, undici sets `Accept-Encoding: gzip, deflate, br`
+ * by default and decompresses the body before our counter sees it — a
+ * hostile vendor can ship a 5 KB gzip blob that decompresses to GBs and
+ * costs the attacker nothing for asymmetric CPU burn before the cap fires.
+ * Forcing identity removes the asymmetry: the bomb has to be sent on the
+ * wire at full size, where `Content-Length` pre-check catches it.
+ *
+ * No-op when the caller already set their own `Accept-Encoding` (signing
+ * fetch may need a specific value to keep the signed bytes stable).
+ */
+function withIdentityEncoding(init: RequestInit | undefined): RequestInit {
+  const headers = new Headers(init?.headers);
+  if (!headers.has('accept-encoding')) {
+    headers.set('accept-encoding', 'identity');
+  }
+  return { ...(init ?? {}), headers };
+}
+
+/**
  * Wrap a fetch implementation so its responses honor the size cap from the
  * active `responseSizeLimitStorage` slot. Pass-through when no slot is set.
  *
@@ -53,8 +93,8 @@ export function wrapFetchWithSizeLimit(upstream: typeof fetch): typeof fetch {
     const slot = responseSizeLimitStorage.getStore();
     if (!slot) return upstream(input, init);
 
-    const response = await upstream(input, init);
-    return enforceSizeLimit(response, slot.maxResponseBytes, urlOfInput(input));
+    const response = await upstream(input, withIdentityEncoding(init));
+    return enforceSizeLimit(response, slot.maxResponseBytes, redactUrlForError(urlOfInput(input)));
   };
   return wrapped;
 }

--- a/src/lib/protocols/responseSizeLimit.ts
+++ b/src/lib/protocols/responseSizeLimit.ts
@@ -66,9 +66,12 @@ function enforceSizeLimit(response: Response, maxBytes: number, url: string): Re
   // below is the authoritative enforcement.
   const declared = parseContentLength(response.headers.get('content-length'));
   if (declared !== undefined && declared > maxBytes) {
-    response.body?.cancel().catch(() => {
-      /* socket already closed by transport */
-    });
+    // Best-effort cancel so the runtime can release the socket. We swallow
+    // any rejection because the typed `ResponseTooLargeError` below is the
+    // signal the caller acts on — a `cancel()` rejection here would only
+    // happen if the body stream is already errored / locked, in which case
+    // the socket is already on its way down and there's nothing to recover.
+    response.body?.cancel().catch(() => {});
     throw new ResponseTooLargeError(maxBytes, 0, url, declared);
   }
 

--- a/test/unit/a2a-card-size-limit.test.js
+++ b/test/unit/a2a-card-size-limit.test.js
@@ -1,0 +1,98 @@
+/**
+ * Integration check that A2A agent-card discovery honors `maxResponseBytes`.
+ *
+ * The cap is installed in `buildFetchImpl` and handed to the A2A SDK's
+ * `A2AClient.fromCardUrl(cardUrl, { fetchImpl })`. That path fetches
+ * `/.well-known/agent.json` through our wrapped fetch, so an oversized
+ * agent-card must abort with `ResponseTooLargeError` before the body is
+ * parsed — which is what we want, because the JSON parse buffers the
+ * full body in memory otherwise and is exactly the DoS surface the cap
+ * defends against.
+ *
+ * We exercise this end-to-end against a real loopback HTTP server rather
+ * than stubbing `fromCardUrl`, because the contract under test is "the
+ * wrapped fetch composes correctly with the A2A SDK's discovery flow."
+ * Stubbing `fromCardUrl` would skip the seam.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { wrapFetchWithSizeLimit, withResponseSizeLimit } = require('../../dist/lib/protocols/responseSizeLimit');
+const { ResponseTooLargeError } = require('../../dist/lib/errors');
+
+const { A2AClient } = require('@a2a-js/sdk/client');
+
+let server;
+let baseUrl;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    if (req.url === '/.well-known/agent.json') {
+      // Minimum-viable agent card the A2A SDK will accept (`url` is required
+      // for the service endpoint), padded with a hostile-vendor blob in a
+      // free-form field. 5 MB is well over any reasonable discovery cap and
+      // large enough that buffering it is observable as a DoS.
+      const padding = 'x'.repeat(5 * 1024 * 1024);
+      const body = JSON.stringify({
+        name: 'oversized',
+        url: `${baseUrl}/a2a`,
+        description: padding,
+      });
+      res.writeHead(200, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+      res.end(body);
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  await new Promise(resolve => server.close(resolve));
+});
+
+describe('A2A agent-card discovery — maxResponseBytes', () => {
+  it('aborts the agent-card fetch with ResponseTooLargeError when the card exceeds the cap', async () => {
+    // Compose the same way `buildFetchImpl` does internally: the size-limit
+    // wrapper goes innermost so the body is bounded before the A2A SDK's
+    // `response.json()` reads it. (Capture / signing wrappers are layered
+    // on top in production but neither affects this assertion.)
+    const wrappedFetch = wrapFetchWithSizeLimit((input, init) => fetch(input, init));
+
+    await assert.rejects(
+      withResponseSizeLimit(64 * 1024, async () =>
+        A2AClient.fromCardUrl(`${baseUrl}/.well-known/agent.json`, { fetchImpl: wrappedFetch })
+      ),
+      err => {
+        assert.ok(err instanceof ResponseTooLargeError, `expected ResponseTooLargeError, got ${err?.constructor?.name}`);
+        assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+        assert.strictEqual(err.limit, 64 * 1024);
+        // Server emits Content-Length, so the pre-check trips before any
+        // body bytes are read. `bytesRead` is 0, `declaredContentLength`
+        // is the server's announced size.
+        assert.strictEqual(err.bytesRead, 0);
+        assert.ok(err.declaredContentLength > 64 * 1024);
+        return true;
+      }
+    );
+  });
+
+  it('lets a small agent-card flow through unchanged when the cap is generous', async () => {
+    // Same server, same wrapper, same path — but with a cap that comfortably
+    // exceeds the 5 MB card. Pins the negative case so a future change that
+    // tightens the wrapper doesn't silently start rejecting legitimate cards.
+    const wrappedFetch = wrapFetchWithSizeLimit((input, init) => fetch(input, init));
+    const card = await withResponseSizeLimit(16 * 1024 * 1024, () =>
+      A2AClient.fromCardUrl(`${baseUrl}/.well-known/agent.json`, { fetchImpl: wrappedFetch })
+    );
+    // `fromCardUrl` returns an A2AClient instance built from the parsed card.
+    // We don't care about the client beyond "construction succeeded" — the
+    // assertion is "no ResponseTooLargeError thrown."
+    assert.ok(card, 'A2AClient.fromCardUrl should resolve when the card fits the cap');
+  });
+});

--- a/test/unit/a2a-card-size-limit.test.js
+++ b/test/unit/a2a-card-size-limit.test.js
@@ -69,7 +69,10 @@ describe('A2A agent-card discovery — maxResponseBytes', () => {
         A2AClient.fromCardUrl(`${baseUrl}/.well-known/agent.json`, { fetchImpl: wrappedFetch })
       ),
       err => {
-        assert.ok(err instanceof ResponseTooLargeError, `expected ResponseTooLargeError, got ${err?.constructor?.name}`);
+        assert.ok(
+          err instanceof ResponseTooLargeError,
+          `expected ResponseTooLargeError, got ${err?.constructor?.name}`
+        );
         assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
         assert.strictEqual(err.limit, 64 * 1024);
         // Server emits Content-Length, so the pre-check trips before any

--- a/test/unit/response-size-limit.test.js
+++ b/test/unit/response-size-limit.test.js
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for the response-body byte cap (`maxResponseBytes`).
+ *
+ * Covers `wrapFetchWithSizeLimit` + `withResponseSizeLimit` from
+ * `src/lib/protocols/responseSizeLimit.ts`, exercised through the
+ * built `dist/` so the test pins compiled behavior, not source.
+ *
+ * What we're protecting: a hostile vendor publishing a large reply that
+ * gets fully buffered before any application-layer schema validation runs.
+ * The cap aborts the body read at the limit and surfaces a typed error.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  wrapFetchWithSizeLimit,
+  withResponseSizeLimit,
+  responseSizeLimitStorage,
+} = require('../../dist/lib/protocols/responseSizeLimit');
+const { ResponseTooLargeError, ADCPError, isADCPError } = require('../../dist/lib/errors');
+
+function makeFetch(body, headers = {}) {
+  // Returns a function with the fetch shape that yields a Response built
+  // from the supplied bytes. Headers default to omitting Content-Length so
+  // the streaming path is exercised; tests can opt in by passing it.
+  return async () =>
+    new Response(body, {
+      status: 200,
+      headers,
+    });
+}
+
+describe('responseSizeLimit — wrapFetchWithSizeLimit', () => {
+  it('passes responses through when no slot is active', async () => {
+    const upstream = makeFetch(new Uint8Array(1024));
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    // No `withResponseSizeLimit` around the call — the wrapper must be a
+    // no-op so production callers without the option pay nothing.
+    const response = await wrapped('https://example.invalid/');
+    const buf = new Uint8Array(await response.arrayBuffer());
+
+    assert.strictEqual(buf.byteLength, 1024);
+  });
+
+  it('refuses to read the body when Content-Length exceeds the cap', async () => {
+    // Pre-check: when the server declares a body bigger than the cap, the
+    // wrapper throws before constructing a streamed Response, and cancels
+    // the upstream body so the socket can be released. (Runtimes may start
+    // buffering before our wrapper observes the Response — the cancel is
+    // what bounds memory in that race, not blocking the first read.)
+    const upstream = async () =>
+      new Response(new Uint8Array(1024), {
+        status: 200,
+        headers: { 'content-length': '5000' },
+      });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        const response = await wrapped('https://hostile.invalid/');
+        return response.arrayBuffer();
+      }),
+      err => {
+        assert.ok(err instanceof ResponseTooLargeError, 'expected ResponseTooLargeError');
+        assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+        assert.strictEqual(err.limit, 1000);
+        assert.strictEqual(err.declaredContentLength, 5000);
+        assert.strictEqual(err.bytesRead, 0, 'pre-check reports zero bytes-read on the error');
+        return true;
+      }
+    );
+  });
+
+  it('aborts mid-stream when the body exceeds the cap without Content-Length', async () => {
+    // Server lies about size or chunks the response with no Content-Length.
+    // The streaming counter is the authoritative defense: each chunk lands
+    // in the TransformStream, the running total compares to the cap, and
+    // overflow errors the readable side.
+    const upstream = async () => {
+      const body = new ReadableStream({
+        start(controller) {
+          // Two 600-byte chunks; cap is 1000 → overflow on the second chunk.
+          controller.enqueue(new Uint8Array(600));
+          controller.enqueue(new Uint8Array(600));
+          controller.close();
+        },
+      });
+      return new Response(body, { status: 200 });
+    };
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        const response = await wrapped('https://hostile.invalid/');
+        return response.arrayBuffer();
+      }),
+      err => {
+        assert.ok(err instanceof ResponseTooLargeError, 'expected ResponseTooLargeError');
+        assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+        assert.strictEqual(err.limit, 1000);
+        assert.ok(err.bytesRead > 1000, `bytesRead ${err.bytesRead} should exceed limit`);
+        assert.strictEqual(err.declaredContentLength, undefined);
+        return true;
+      }
+    );
+  });
+
+  it('reads under-cap bodies through to completion unchanged', async () => {
+    const payload = new Uint8Array(512).fill(0x41); // 'A'
+    const upstream = makeFetch(payload, { 'content-length': '512' });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    const out = await withResponseSizeLimit(1000, async () => {
+      const response = await wrapped('https://friendly.invalid/');
+      return new Uint8Array(await response.arrayBuffer());
+    });
+
+    assert.strictEqual(out.byteLength, 512);
+    assert.strictEqual(out[0], 0x41);
+    assert.strictEqual(out[511], 0x41);
+  });
+
+  it('counts bytes exactly at the limit boundary as success', async () => {
+    // Boundary case: bytesRead === limit must NOT trip. Only strict overflow
+    // (> limit) is an error. Off-by-one here would reject every response
+    // that happens to match the cap, which is a real fleet-config foot-gun.
+    const upstream = makeFetch(new Uint8Array(1000));
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    const out = await withResponseSizeLimit(1000, async () => {
+      const response = await wrapped('https://example.invalid/');
+      return new Uint8Array(await response.arrayBuffer());
+    });
+
+    assert.strictEqual(out.byteLength, 1000);
+  });
+
+  it('treats invalid Content-Length headers as "not declared" and falls through to streaming', async () => {
+    // Servers occasionally send malformed headers (whitespace, multi-values
+    // pre-coalesce, "chunked" instead of a digit). We must not abort on a
+    // bad header — let the streaming counter make the call.
+    const upstream = makeFetch(new Uint8Array(500), { 'content-length': 'not-a-number' });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    const out = await withResponseSizeLimit(1000, async () => {
+      const response = await wrapped('https://example.invalid/');
+      return new Uint8Array(await response.arrayBuffer());
+    });
+
+    assert.strictEqual(out.byteLength, 500);
+  });
+
+  it('does not enter the ALS slot when the cap is unset, zero, or non-finite', async () => {
+    // `withResponseSizeLimit` short-circuits for invalid caps so a misuse
+    // (e.g., passing `Number.NaN` from a parsed env var) doesn't silently
+    // disable enforcement by entering an ALS slot with a bad value.
+    for (const cap of [undefined, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      let storeWasSet = false;
+      await withResponseSizeLimit(cap, async () => {
+        storeWasSet = responseSizeLimitStorage.getStore() !== undefined;
+      });
+      assert.strictEqual(storeWasSet, false, `cap=${cap} must not enter the ALS slot`);
+    }
+  });
+
+  it('per-call override beats a surrounding constructor-level cap', async () => {
+    // The SDK threads a constructor cap by entering the ALS slot once at
+    // the top of the call. A per-call override reruns `.run({...}, fn)` so
+    // the inner store wins for the duration of the call — same pattern the
+    // `signingContextStorage` uses. Verify the ALS semantics directly.
+    const payload = new Uint8Array(2000);
+    const upstream = makeFetch(payload);
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    // Outer cap (1000) would reject; inner cap (5000) lets it through.
+    const out = await withResponseSizeLimit(1000, () =>
+      withResponseSizeLimit(5000, async () => {
+        const response = await wrapped('https://example.invalid/');
+        return new Uint8Array(await response.arrayBuffer());
+      })
+    );
+    assert.strictEqual(out.byteLength, 2000);
+
+    // Inverse: outer cap (5000) would allow; inner cap (1000) rejects.
+    await assert.rejects(
+      withResponseSizeLimit(5000, () =>
+        withResponseSizeLimit(1000, async () => {
+          const response = await wrapped('https://example.invalid/');
+          return response.arrayBuffer();
+        })
+      ),
+      err => err instanceof ResponseTooLargeError
+    );
+  });
+
+  it('preserves status, status text, and headers on the size-limited response', async () => {
+    // The wrapper rebuilds the Response so it can swap out the body. Status
+    // line and headers must be carried over verbatim — anything that
+    // depends on them (e.g., MCP SDK auth-challenge parsing on 401) breaks
+    // silently otherwise.
+    const upstream = async () =>
+      new Response(new Uint8Array(64), {
+        status: 418,
+        statusText: "I'm a teapot",
+        headers: { 'x-trace-id': 'abc-123', 'content-type': 'application/json' },
+      });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    const response = await withResponseSizeLimit(1000, () => wrapped('https://example.invalid/'));
+    assert.strictEqual(response.status, 418);
+    assert.strictEqual(response.statusText, "I'm a teapot");
+    assert.strictEqual(response.headers.get('x-trace-id'), 'abc-123');
+    assert.strictEqual(response.headers.get('content-type'), 'application/json');
+  });
+});
+
+describe('responseSizeLimit — ResponseTooLargeError shape', () => {
+  it('extends ADCPError, carries code RESPONSE_TOO_LARGE, and registers with isADCPError', () => {
+    const err = new ResponseTooLargeError(1000, 1500, 'https://example.invalid/');
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof ADCPError, 'must extend ADCPError so callers can branch on the base class');
+    assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+    assert.strictEqual(err.limit, 1000);
+    assert.strictEqual(err.bytesRead, 1500);
+    assert.strictEqual(err.url, 'https://example.invalid/');
+    assert.strictEqual(err.declaredContentLength, undefined);
+    assert.ok(isADCPError(err));
+    // details payload doubles as the wire-error body so logs/tickets
+    // surface the cap and observed size without re-parsing the message.
+    assert.deepStrictEqual(err.details, {
+      limit: 1000,
+      bytesRead: 1500,
+      url: 'https://example.invalid/',
+      declaredContentLength: undefined,
+    });
+  });
+
+  it('uses the declared-length message branch when the pre-check trips', () => {
+    const err = new ResponseTooLargeError(1000, 0, 'https://example.invalid/', 5000);
+    assert.match(err.message, /declared 5000 bytes/);
+    assert.match(err.message, /1000/);
+  });
+});

--- a/test/unit/response-size-limit.test.js
+++ b/test/unit/response-size-limit.test.js
@@ -215,6 +215,202 @@ describe('responseSizeLimit — wrapFetchWithSizeLimit', () => {
   });
 });
 
+describe('responseSizeLimit — gzip-bomb defense', () => {
+  it("forces Accept-Encoding: identity when the cap is active so the byte counter sees what's on the wire", async () => {
+    // Without this, undici's default `Accept-Encoding: gzip, deflate, br`
+    // would let a hostile vendor ship a 5 KB compressed blob that
+    // decompresses to GBs and burn asymmetric CPU before the streaming
+    // counter trips. Forcing identity moves the bomb to the network where
+    // Content-Length pre-check catches it.
+    let observedHeader;
+    const upstream = async (_input, init) => {
+      const headers = new Headers(init?.headers);
+      observedHeader = headers.get('accept-encoding');
+      return new Response(new Uint8Array(64));
+    };
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+    await withResponseSizeLimit(1000, async () => {
+      await wrapped('https://example.invalid/');
+    });
+    assert.strictEqual(observedHeader, 'identity');
+  });
+
+  it('respects a caller-set Accept-Encoding (signing fetches need stable signed bytes)', async () => {
+    // The signing wrapper signs over the exact request bytes it's about to
+    // send. If we overwrote a caller's `Accept-Encoding`, the signature
+    // base would diverge from what the server validates. Only set the
+    // header when no caller value is present.
+    let observedHeader;
+    const upstream = async (_input, init) => {
+      observedHeader = new Headers(init?.headers).get('accept-encoding');
+      return new Response(new Uint8Array(64));
+    };
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+    await withResponseSizeLimit(1000, async () => {
+      await wrapped('https://example.invalid/', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      });
+    });
+    assert.strictEqual(observedHeader, 'gzip');
+  });
+
+  it('does not touch outgoing headers when no slot is active', async () => {
+    let observedHeader;
+    const upstream = async (_input, init) => {
+      observedHeader = new Headers(init?.headers).get('accept-encoding');
+      return new Response(new Uint8Array(64));
+    };
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+    // No `withResponseSizeLimit` — production callers without the option
+    // should pay no header cost.
+    await wrapped('https://example.invalid/');
+    assert.strictEqual(observedHeader, null);
+  });
+});
+
+describe('responseSizeLimit — URL redaction in errors', () => {
+  it('strips the query string from ResponseTooLargeError.url so bearer-in-query tokens do not leak to logs', async () => {
+    // Some agents publish manifests with auth tokens in the query string
+    // (`?api_key=…`). The error object is logged, returned to ticket
+    // sinks, surfaced in `error.message`. Strip the search component at
+    // construction time.
+    const upstream = makeFetch(new Uint8Array(2000), { 'content-length': '2000' });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        const response = await wrapped('https://example.invalid/mcp?api_key=secret&trace=abc');
+        return response.arrayBuffer();
+      }),
+      err => {
+        assert.ok(err instanceof ResponseTooLargeError);
+        assert.strictEqual(err.url, 'https://example.invalid/mcp');
+        assert.ok(!err.message.includes('secret'), 'error message must not contain query-string secret');
+        assert.ok(!err.message.includes('api_key'), 'error message must not contain query-string param names');
+        return true;
+      }
+    );
+  });
+
+  it('preserves the URL unchanged when the input is not a parseable URL (test stubs, relative paths)', async () => {
+    // Defensive: if the input doesn't parse as a URL, surface the original
+    // string rather than swallow the error. The diagnostic value of "what
+    // URL did this come from" is more important than the redaction
+    // guarantee in this fallback case (relative paths shouldn't carry
+    // bearer tokens anyway).
+    const upstream = makeFetch(new Uint8Array(2000), { 'content-length': '2000' });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    // Use a Request object built from a relative path through `new URL()`
+    // base — undici will reject it, so we use a custom stub here.
+    const stubUpstream = async () =>
+      new Response(new Uint8Array(2000), { status: 200, headers: { 'content-length': '2000' } });
+    const stubWrapped = wrapFetchWithSizeLimit(stubUpstream);
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        // Pass a non-URL string (the wrapper just stores it; upstream is stubbed).
+        const response = await stubWrapped('not-a-url-at-all');
+        return response.arrayBuffer();
+      }),
+      err => {
+        assert.ok(err instanceof ResponseTooLargeError);
+        assert.strictEqual(err.url, 'not-a-url-at-all');
+        return true;
+      }
+    );
+  });
+});
+
+describe('responseSizeLimit — wrap-order regression guard', () => {
+  it("composes correctly with wrapFetchWithCapture: clones see the size-limited body, can't blow memory", async () => {
+    // The wrap-order claim is: size-limit innermost so capture clones the
+    // bounded body. If a future refactor flipped the order
+    // (`wrapFetchWithSizeLimit(wrapFetchWithCapture(...))`), capture would
+    // clone the unbounded body and `response.text()` would buffer the
+    // hostile reply in memory before the cap fires.
+    //
+    // Direct test: use both wrappers in the right order, exercise the
+    // capture slot + size slot together, assert the size error
+    // propagates through the cloned read path.
+    const { wrapFetchWithCapture, withRawResponseCapture } = require('../../dist/lib/protocols/rawResponseCapture');
+
+    const oversized = new Uint8Array(50_000); // 50 KB
+    const upstream = makeFetch(oversized);
+
+    // Composition order matches `mcp.ts` / `a2a.ts`: size-limit innermost,
+    // capture outermost.
+    const sized = wrapFetchWithSizeLimit(upstream);
+    const captured = wrapFetchWithCapture(sized);
+
+    await assert.rejects(
+      withRawResponseCapture(
+        () =>
+          withResponseSizeLimit(1024, async () => {
+            const response = await captured('https://example.invalid/');
+            // Read the body — this is what the SDK would do. The cap
+            // should fire during the read because the underlying stream
+            // (shared between capture's clone and SDK's read via tee) is
+            // the size-limited one.
+            return response.arrayBuffer();
+          }),
+        { maxBodyBytes: 1024 }
+      ),
+      err => err instanceof ResponseTooLargeError
+    );
+  });
+});
+
+describe('responseSizeLimit — connection-cache reuse', () => {
+  it('two different caps on the same wrapped fetch each apply to their own call', async () => {
+    // The MCP / A2A connection cache hands the same wrapped fetch to
+    // multiple calls. The wrapper reads the cap from the per-request ALS
+    // slot, not from a closure captured at wrapper-creation time, so two
+    // calls with different caps share the same wrapped fetch safely.
+    // This pins that contract — a refactor that moves the slot lookup
+    // to wrapper construction would break it.
+    const upstream = makeFetch(new Uint8Array(2000));
+    const sharedWrapped = wrapFetchWithSizeLimit(upstream);
+
+    // Call 1: cap 1000 — should reject 2000-byte body.
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        const response = await sharedWrapped('https://example.invalid/');
+        return response.arrayBuffer();
+      }),
+      err => err instanceof ResponseTooLargeError
+    );
+
+    // Call 2: cap 5000 — same wrapper, same upstream. Should succeed.
+    const out = await withResponseSizeLimit(5000, async () => {
+      const response = await sharedWrapped('https://example.invalid/');
+      return new Uint8Array(await response.arrayBuffer());
+    });
+    assert.strictEqual(out.byteLength, 2000);
+  });
+
+  it('reverts to no-cap behavior immediately after the slot scope exits', async () => {
+    // ALS hygiene: once the `withResponseSizeLimit(...)` scope exits, the
+    // next call against the same wrapper must see no cap. Otherwise an
+    // ALS leak across awaits would silently cap subsequent calls.
+    const upstream = makeFetch(new Uint8Array(50_000));
+    const sharedWrapped = wrapFetchWithSizeLimit(upstream);
+
+    // Inside scope: cap fires.
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        const response = await sharedWrapped('https://example.invalid/');
+        return response.arrayBuffer();
+      }),
+      err => err instanceof ResponseTooLargeError
+    );
+
+    // Outside scope: same wrapper, no cap, full read.
+    const response = await sharedWrapped('https://example.invalid/');
+    const buf = new Uint8Array(await response.arrayBuffer());
+    assert.strictEqual(buf.byteLength, 50_000);
+  });
+});
+
 describe('responseSizeLimit — ResponseTooLargeError shape', () => {
   it('extends ADCPError, carries code RESPONSE_TOO_LARGE, and registers with isADCPError', () => {
     const err = new ResponseTooLargeError(1000, 1500, 'https://example.invalid/');


### PR DESCRIPTION
## Summary

Exposes a typed `transport.maxResponseBytes` option so callers crawling untrusted agents (registries, federated discovery, monitoring tools) can bound response body reads. Closes #1167.

The SDK builds the underlying MCP / A2A transport's `fetch` internally, so callers had no seam to inject a size-bounded fetch. A hostile vendor publishing a 200 MB JSON-RPC reply gets fully buffered before any application-layer schema validation runs — the 10s default timeout doesn't mitigate at datacenter speeds. This adds a single-purpose typed knob with a clear contract; future hardening (DNS-rebind defense, scheme allow-list) can add similar typed knobs without callers rewriting their fetch.

## What's new

- `SingleAgentClientConfig.transport.maxResponseBytes` — set on the client; applies to every call.
- `TaskOptions.transport.maxResponseBytes` — per-call override (catalog endpoints that legitimately publish large payloads).
- `CallToolOptions.transport` — same field for direct `ProtocolClient.callTool` users.
- `TransportOptions` — exported public type.
- `ResponseTooLargeError` — extends `ADCPError`, code `RESPONSE_TOO_LARGE`. Carries `limit`, `bytesRead`, `url`, optional `declaredContentLength`.

```ts
const client = new ADCPMultiAgentClient(
  [{ id: 'vendor', agent_uri, protocol: 'mcp' }],
  { transport: { maxResponseBytes: 1_048_576 } }
);

// Per-call override for an agent that legitimately publishes a large catalog
const formats = await client.agent('vendor').listCreativeFormats(
  { /* ... */ },
  undefined,
  { transport: { maxResponseBytes: 16 * 1_048_576 } }
);
```

## Implementation

`wrapFetchWithSizeLimit(upstream)` is the innermost transport wrapper for both MCP and A2A — closer to the network than capture / signing — so the diagnostic capture wrapper reads a size-limited body and can't blow memory through `Response.clone()`. Pre-cancels when `Content-Length` exceeds the cap; otherwise wraps `Response.body` in a counting `TransformStream` that errors at the boundary, propagating to all clones.

The active cap is read from `responseSizeLimitStorage` (`AsyncLocalStorage`) at request time, not at transport creation, so the existing MCP / A2A connection cache doesn't need cache-key changes — different per-call caps share the same cached connection safely.

`ProtocolClient.callTool` enters the ALS slot once per call (only when `maxResponseBytes` is set, finite, and positive), so production callers without the option pay only one ALS lookup per request.

## Surface area

| File | Change |
|---|---|
| `src/lib/protocols/responseSizeLimit.ts` | new module — wrapper + ALS slot + entry helper |
| `src/lib/errors/index.ts` | `ResponseTooLargeError` class |
| `src/lib/protocols/index.ts` | `TransportOptions` type, `CallToolOptions.transport`, ALS entry in `ProtocolClient.callTool` |
| `src/lib/protocols/mcp.ts` | install `wrapFetchWithSizeLimit` in `connectMCPWithFallbackImpl` and `connectMCP` (OAuth path) |
| `src/lib/protocols/a2a.ts` | install in `buildFetchImpl` |
| `src/lib/core/SingleAgentClient.ts` | constructor `transport` option |
| `src/lib/core/TaskExecutor.ts` | thread per-call `transport` (overrides constructor) |
| `src/lib/core/ConversationTypes.ts` | `TaskOptions.transport` |
| `src/lib/index.ts` | export `TransportOptions`, `ResponseTooLargeError` |

## Test plan

- [x] `test/unit/response-size-limit.test.js` — 11 cases covering pass-through (no slot), `Content-Length` pre-check, mid-stream abort, exact-boundary success, malformed `Content-Length`, ALS short-circuit on invalid caps, per-call override of constructor cap, header preservation, and error-shape correctness.
- [x] `npm run typecheck` — clean.
- [x] Targeted regression — `mcp-custom-fetch`, `raw-response-capture`, `error-extraction`, etc. all pass.
- [ ] Full `npm test` (CI will run).

## Notes for reviewers

- **A2A coverage.** The wrapper is installed in `buildFetchImpl`, so A2A discovery (`/.well-known/agent.json`) and skill calls both honor the cap.
- **Long-lived MCP side channels.** When a cap is set, it applies to all fetches in the call's ALS scope, including any side-channel GET the MCP transport makes within the call. Callers running long-lived buyer sessions should leave `maxResponseBytes` unset; the option is for one-shot discovery / crawl paths.
- **Default off.** No behavior change for existing callers. The option is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)