### PR TITLE
feat(client): default response validation to warn everywhere — closes #1150

### DIFF
--- a/.changeset/warn-default-responses.md
+++ b/.changeset/warn-default-responses.md
@@ -1,0 +1,20 @@
+---
+'@adcp/sdk': minor
+---
+
+Client-side response validation now defaults to `warn` everywhere — previously `strict` in dev/test, `warn` only in production. Drift surfaces through `result.debug_logs` and the response payload reaches the caller; the task no longer fails just because a seller's response missed an optional schema constraint.
+
+**Why.** With #1137's version-pinned validator, a v2.5 seller's perfectly valid v2.5-shaped response is now correctly validated against the v2.5 schema — but v2.5 schemas have wider drift tolerance (envelope nulls, optional-but-required-in-schema fields like `pricing_options`, enum mismatches) than the modern v3 spec. Strict-by-default in dev/test meant integration tests against legitimate v2.5 sellers turned every minor schema gap into a hard failure with `result.data` thrown away — leaving callers staring at "0 products" with no useful signal. `warn` keeps the data flowing and surfaces the drift through the existing `debug_logs` channel that #1133 wired up.
+
+**Server-side unchanged.** `createAdcpServer` still defaults its handler-side validation to `strict` in dev/test/CI. That catches our own handler-output bugs, which strict mode is genuinely good at — distinct from the client-side concern of "seller wrote a slightly off-spec response."
+
+**Opt back in.** Buyers who want hard-stop response validation (conformance harnesses, third-party validators, paranoid CI runs) pass `validation: { responses: 'strict' }` explicitly:
+
+```ts
+new AgentClient({
+  agent_uri: '...',
+  validation: { responses: 'strict' },
+});
+```
+
+Closes adcontextprotocol/adcp-client#1150.

--- a/src/lib/validation/client-hooks.ts
+++ b/src/lib/validation/client-hooks.ts
@@ -10,33 +10,32 @@ import { buildValidationError } from './schema-errors';
 export type ValidationMode = 'strict' | 'warn' | 'off';
 
 export interface ValidationHookConfig {
-  /** Validate outgoing requests. Default: strict in dev/test, warn in prod. */
+  /** Validate outgoing requests. Default: `warn` everywhere. */
   requests?: ValidationMode;
-  /** Validate incoming responses. Default: strict in dev/test, warn in prod. */
+  /** Validate incoming responses. Default: `warn` everywhere. */
   responses?: ValidationMode;
-}
-
-function defaultResponseMode(): ValidationMode {
-  // Responses have been validated strictly by default since the SDK shipped
-  // Zod validation; preserve that in dev/test and soften to warn in prod.
-  return process.env.NODE_ENV === 'production' ? 'warn' : 'strict';
 }
 
 /**
  * Resolve the effective request/response modes.
  *
- * Response default: strict in dev/test, warn in prod (preserves the
- * existing `strictSchemaValidation` contract).
+ * Both default to `warn` everywhere — buyers get drift surfaced through
+ * `result.debug_logs` without losing the response payload to a strict
+ * rejection. v2.5 sellers in particular ship enough legacy drift
+ * (envelope nulls, optional-required fields, enum mismatches) that
+ * strict-by-default leaves callers staring at "0 products" with no
+ * useful signal. Buyers and harnesses that want hard-stop behavior
+ * (conformance suites, third-party validators) opt into strict via
+ * `validation: { responses: 'strict' }` — explicit config always wins.
  *
- * Request default: `warn` everywhere. Strict-by-default would break
- * existing callers that intentionally send partial payloads (error-path
- * tests, exploratory probes) — storyboards and third-party clients that
- * want hard-stop enforcement should set `requests: 'strict'` explicitly.
+ * This is the **client-side** default. `createAdcpServer` keeps its
+ * stricter dev/test handler-validation contract — that catches our own
+ * handler bugs, which strict mode is genuinely good at.
  */
 export function resolveValidationModes(config?: ValidationHookConfig): Required<ValidationHookConfig> {
   return {
     requests: config?.requests ?? 'warn',
-    responses: config?.responses ?? defaultResponseMode(),
+    responses: config?.responses ?? 'warn',
   };
 }
 

--- a/test/lib/adapter-v2-5-conformance.test.js
+++ b/test/lib/adapter-v2-5-conformance.test.js
@@ -85,11 +85,17 @@ const FIXTURES = {
       idempotency_key: '33333333-3333-3333-3333-333333333333',
     },
     expected_failures: {
-      // adcontextprotocol/adcp-client#1116 — adapter is a thin
-      // prefix-stripper, leaks v3 manifest shape to v2.5's
-      // single-asset-payload oneOf.
+      // FOLLOW-UP: #1118's "manifest flatten" claim that v2.5 expects a
+      // single-asset payload is contradicted by the v2.5 schema cache —
+      // `creative-asset.json` declares `assets` as an object with
+      // patternProperties keyed by asset role (i.e., the same role-keyed
+      // manifest shape v3 uses). Post-#1118 the adapter emits a flat
+      // shape that fails v2.5 validation on every flat field. Either the
+      // schema needs updating or the flatten needs reverting; tracking in
+      // a follow-up issue. This fixture pins the current failure surface
+      // so further drift is loud.
       issue: 'adcontextprotocol/adcp-client#1116',
-      pointers: ['/creatives/0/assets/video'],
+      pointers: ['/creatives/0/assets/asset_type'],
     },
   },
 };

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -442,23 +442,19 @@ describe('schema-driven validation', () => {
       assert.strictEqual(modes.requests, 'warn');
     });
 
-    test('responses default to strict in non-production', () => {
+    test('responses default to warn regardless of NODE_ENV', () => {
       const prev = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'development';
       try {
-        const modes = resolveValidationModes();
-        assert.strictEqual(modes.responses, 'strict');
-      } finally {
-        process.env.NODE_ENV = prev;
-      }
-    });
-
-    test('responses default to warn in production', () => {
-      const prev = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-      try {
-        const modes = resolveValidationModes();
-        assert.strictEqual(modes.responses, 'warn');
+        for (const env of ['development', 'test', 'production', undefined]) {
+          if (env === undefined) delete process.env.NODE_ENV;
+          else process.env.NODE_ENV = env;
+          const modes = resolveValidationModes();
+          assert.strictEqual(
+            modes.responses,
+            'warn',
+            `expected warn under NODE_ENV=${env ?? 'unset'}, got ${modes.responses}`
+          );
+        }
       } finally {
         process.env.NODE_ENV = prev;
       }


### PR DESCRIPTION
Closes #1150.

## Summary

Client-side response validation now defaults to `warn` everywhere instead of `strict` in dev/test and `warn` in prod. With #1137's version-pinned validator, the dev/test default rejected legitimate v2.5-shaped responses on minor schema drift and threw away the actual data — leaving buyers staring at "0 products" with no useful signal.

## Why

Three things landed today (#1133/#1137/#1143/#1118) that changed the v2.5 client-side picture:

1. **Drift surfacing** (#1133) — `result.debug_logs` now carries every validation drift entry. Adopters can see what went wrong without losing the response payload.
2. **Version pinning** (#1137) — v2.5 sellers are correctly validated against v2.5 schemas. But v2.5 schemas have wider drift tolerance than modern v3 (envelope nulls per #1149, optional-but-required fields like `pricing_options`, enum mismatches), so accurate validation now produces more rejections.
3. **Adapter registry** (#1143) — adapters between v3 and v2.5 are now typed and per-tool. Drift is concentrated and observable.

In that context, hard-failing on dev/test against schema drift the seller can't realistically avoid is the wrong default. Warn-by-default keeps `result.data` flowing and routes drift to `debug_logs`.

## Server-side unchanged

`createAdcpServer` keeps its `responses: 'strict'` default in dev/test/CI — that catches our own handler-output bugs (a different concern from "seller wrote a slightly off-spec response"). The change is client-side only.

## Opt back in

Conformance harnesses, third-party validators, paranoid CI runs:

```ts
new AgentClient({
  agent_uri: '...',
  validation: { responses: 'strict' },
});
```

Explicit config still wins over the new default.

## Side fix

`adapter-v2-5-conformance.test.js` had a stale expected-failure pointer for sync_creatives — #1118 changed the failure surface. Updated the fixture and added a comment that #1118's flatten direction may be inverted (v2.5 `creative-asset.json` declares `assets` as a role-keyed manifest object, same as v3). Worth a follow-up to confirm seller-runtime expectation vs spec.

## Test plan

- [x] `npm run test:lib` — 5635/5642 pass / 7 skipped / 0 fail
- [x] `resolveValidationModes` test updated to verify warn-by-default across all NODE_ENV values
- [x] Existing tests passing strict explicitly (server-idempotency, schema-validation-server, etc.) unaffected — they pass `validation: { responses: 'strict' }` and override the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)