### PR TITLE
fix(client): forward per-call transport cap through secondary task paths

### DIFF
--- a/.changeset/task-executor-secondary-transport.md
+++ b/.changeset/task-executor-secondary-transport.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+`getTaskStatus`, `pollTaskCompletion`, and `continueTaskWithInput` now forward the per-call `transport.maxResponseBytes` cap instead of silently falling back to the constructor-level cap. Callers using `transport.maxResponseBytes` on a `TaskOptions`-shaped argument can now tighten the cap on the polling and resume paths. Also adds a loopback-HTTP integration test that exercises `wrapFetchWithSizeLimit` through `ProtocolClient.callTool` on the MCP non-OAuth path.

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
     "build": "npm run build:lib",
     "build:lib": "npm run sync-version && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
-    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js",
+    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js test/unit/*.test.js",
     "test:lib": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/*.test.js",
     "test:e2e": "node test/e2e/adcp-e2e.test.js",
     "test:protocols": "node test/run-protocol-tests.js",

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -3,7 +3,7 @@
 
 import { randomUUID } from 'crypto';
 import type { AgentConfig } from '../types';
-import { ProtocolClient } from '../protocols';
+import { ProtocolClient, type TransportOptions } from '../protocols';
 import { listMCPTasks } from '../protocols/mcp-tasks';
 import { getAuthToken } from '../auth';
 import { is401Error, adcpErrorToTypedError } from '../errors';
@@ -1118,8 +1118,8 @@ export class TaskExecutor {
     const submitted: SubmittedContinuation<T> = {
       taskId: serverTaskId,
       webhookUrl,
-      track: () => this.getTaskStatus(agent, serverTaskId),
-      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval),
+      track: () => this.getTaskStatus(agent, serverTaskId, options.transport),
+      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval, options.transport),
     };
 
     return {
@@ -1332,7 +1332,7 @@ export class TaskExecutor {
     }
   }
 
-  async getTaskStatus(agent: AgentConfig, taskId: string): Promise<TaskInfo> {
+  async getTaskStatus(agent: AgentConfig, taskId: string, transport?: TransportOptions): Promise<TaskInfo> {
     // AdCP `tasks/get` is the cross-protocol work-status interface
     // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
     // Dispatched as a buyer-callable tool over the agent's transport
@@ -1367,7 +1367,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
-        transport: this.config.transport,
+        transport: transport ?? this.config.transport,
       }
     )) as Record<string, unknown>;
     // We don't run `extractResponseData` here: that helper's
@@ -1382,9 +1382,9 @@ export class TaskExecutor {
     return mapTasksGetResponseToTaskInfo(response);
   }
 
-  async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000): Promise<TaskResult<T>> {
+  async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000, transport?: TransportOptions): Promise<TaskResult<T>> {
     while (true) {
-      const status = await this.getTaskStatus(agent, taskId);
+      const status = await this.getTaskStatus(agent, taskId, transport);
 
       if (status.status === ADCP_STATUS.COMPLETED) {
         const pollSuccess = this.isOperationSuccess(status.result);
@@ -1543,7 +1543,7 @@ export class TaskExecutor {
         debugLogs,
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
-        transport: this.config.transport,
+        transport: options.transport ?? this.config.transport,
       }
     );
 

--- a/test/unit/mcp-tool-size-limit.test.js
+++ b/test/unit/mcp-tool-size-limit.test.js
@@ -1,0 +1,157 @@
+/**
+ * Integration check that MCP tool calls honor `maxResponseBytes`.
+ *
+ * The cap is installed via `wrapFetchWithSizeLimit` in two call sites in
+ * `src/lib/protocols/mcp.ts`: line 319 (non-OAuth `connectMCPWithFallbackImpl`)
+ * and line 660 (OAuth `connectMCP`). Without a live-HTTP test, dropping
+ * `wrapFetchWithSizeLimit` from either site wouldn't fail any existing unit
+ * test because the unit tests mock the fetch chain below the transport layer.
+ *
+ * This test exercises the non-OAuth path (the common path for direct-token
+ * agents and unauthenticated dev setups) end-to-end against a real loopback
+ * HTTP server that speaks MCP StreamableHTTP. The assertion is:
+ * "calling `ProtocolClient.callTool` with `transport.maxResponseBytes` set
+ * aborts with `ResponseTooLargeError` when the server's `tools/call` response
+ * body exceeds the cap."
+ *
+ * We use a real server rather than a fetch stub so the test pins the wiring
+ * seam — the exact order `wrapFetchWithSizeLimit` is composed into the MCP
+ * transport chain — rather than the unit behavior of the wrapper itself
+ * (already covered by response-size-limit.test.js).
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { ProtocolClient, closeMCPConnections } = require('../../dist/lib/protocols');
+const { ResponseTooLargeError } = require('../../dist/lib/errors');
+
+// Minimal MCP StreamableHTTP server.
+// Handles: initialize → valid InitializeResult (small, under cap)
+//          notifications (no id) → 202
+//          tools/call → oversized JSON-RPC result with Content-Length set
+// All other methods return a null JSON-RPC result so the SDK doesn't stall.
+function createMCPServer() {
+  return http.createServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405);
+      res.end();
+      return;
+    }
+
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      let msg;
+      try {
+        msg = JSON.parse(body);
+      } catch {
+        res.writeHead(400);
+        res.end();
+        return;
+      }
+
+      // Support batched and single JSON-RPC messages.
+      const messages = Array.isArray(msg) ? msg : [msg];
+      // Notifications have no `id` (or id === null) — no response body needed.
+      const requests = messages.filter(m => m.id != null);
+
+      if (requests.length === 0) {
+        res.writeHead(202);
+        res.end();
+        return;
+      }
+
+      const responses = requests.map(rpc => {
+        if (rpc.method === 'initialize') {
+          return {
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: {
+              protocolVersion: '2025-03-26',
+              capabilities: {},
+              serverInfo: { name: 'test-mcp', version: '1.0.0' },
+            },
+          };
+        }
+
+        if (rpc.method === 'tools/call') {
+          // 2 MB payload — well over any reasonable discovery cap.
+          const padding = 'x'.repeat(2 * 1024 * 1024);
+          return {
+            jsonrpc: '2.0',
+            id: rpc.id,
+            result: {
+              content: [{ type: 'text', text: padding }],
+            },
+          };
+        }
+
+        // Unknown method — return null result so the SDK doesn't stall.
+        return { jsonrpc: '2.0', id: rpc.id, result: null };
+      });
+
+      const responseBody =
+        responses.length === 1 ? JSON.stringify(responses[0]) : JSON.stringify(responses);
+
+      res.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(responseBody),
+      });
+      res.end(responseBody);
+    });
+  });
+}
+
+let server;
+let agentUri;
+
+before(async () => {
+  server = createMCPServer();
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  agentUri = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  // Clear the MCP connection cache so the cached client pointing at our
+  // now-closed loopback server doesn't leak into subsequent test runs.
+  await closeMCPConnections();
+  await new Promise(resolve => server.close(resolve));
+});
+
+describe('MCP tool call — maxResponseBytes', () => {
+  it('aborts tools/call with ResponseTooLargeError when the response body exceeds the cap', async () => {
+    // `initialize` returns ~200 bytes (well under the 64 KB cap).
+    // `tools/call` returns 2 MB with Content-Length set — the pre-check in
+    // `wrapFetchWithSizeLimit` cancels the body before any bytes are read.
+    const agent = {
+      id: 'test-mcp',
+      name: 'Test MCP Agent',
+      protocol: 'mcp',
+      agent_uri: agentUri,
+    };
+
+    await assert.rejects(
+      ProtocolClient.callTool(agent, 'check_size', {}, {
+        transport: { maxResponseBytes: 64 * 1024 },
+      }),
+      err => {
+        assert.ok(
+          err instanceof ResponseTooLargeError,
+          `expected ResponseTooLargeError, got ${err?.constructor?.name}: ${err?.message}`
+        );
+        assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+        assert.strictEqual(err.limit, 64 * 1024);
+        // Server sets Content-Length → pre-check fires, bytesRead is 0.
+        assert.strictEqual(err.bytesRead, 0);
+        assert.ok(
+          err.declaredContentLength > 64 * 1024,
+          `declaredContentLength ${err.declaredContentLength} should exceed limit`
+        );
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
Refs #1177

## Summary

Three gaps in how `transport.maxResponseBytes` propagates after a task is submitted:

- **`getTaskStatus`** — now accepts an optional `transport?: TransportOptions` and passes it to `ProtocolClient.callTool` instead of silently falling back to the constructor-level cap.
- **`pollTaskCompletion`** — same: accepts `transport?`, threads it to the `getTaskStatus` call on every poll tick.
- **`continueTaskWithInput`** — now resolves `options.transport ?? this.config.transport` instead of always using the constructor cap.
- **`setupSubmittedTask` lambdas** — `track` and `waitForCompletion` on the `SubmittedContinuation` now close over `options.transport` so callers that set a per-call cap when they submit a task see the same cap on every subsequent poll/resume without having to thread the option through again.

Also adds a loopback-HTTP integration test (`test/unit/mcp-tool-size-limit.test.js`) that exercises `wrapFetchWithSizeLimit` end-to-end through `ProtocolClient.callTool` on the MCP non-OAuth path against a real `http.Server`. And fixes a pre-existing CI gap: `test/unit/` was never included in the `npm test` glob, so all six existing tests there were silently skipped by CI.

## What's NOT in this PR (item 2 from #1177)

Issue #1177 also requests renaming `ResponseTooLargeError.declaredContentLength` → `contentLengthHeader`. That field is exported on a public error class; renaming it is a **breaking change** and cannot land as a patch. Flagging for @bokelley — either a `minor` bump with a deprecation alias, or a `major` bump with a hard rename. Not included here.

## Known remaining gaps (pre-existing, out of scope)

- **`listTasksForAgent` / `listTasks`** — has no `TaskOptions` parameter at all; hardcodes `this.config.transport`. Structurally consistent (callers of `listTasks` pass no per-call options), but this path is exempt from the fix. Pre-existing.
- **`resumeDeferredTask`** — calls `continueTaskWithInput` with no `options`, so `options.transport` is `undefined` and the constructor cap is used. `DeferredTaskState` (line 234) does not store transport. Fixing this would require a `DeferredTaskState` schema change. Pre-existing.

## What was tested

- `npm run build:lib` — emits to dist (pre-existing TS errors unrelated to this diff; `tsc` still emits because `noEmitOnError` is not set)
- `npm test` — `test/lib/` tests pass; `test/unit/` tests exercise real `@modelcontextprotocol/sdk` and `@a2a-js/sdk` imports not installed in the local dev environment (pre-existing local limitation, not a CI regression — CI runs `npm ci` which installs all deps)
- Manual diff inspection of `TaskExecutor.ts` lines 1121–1122, 1335, 1370, 1385–1387, 1546

## Pre-PR expert review

| Reviewer | Finding | Status |
|---|---|---|
| `ad-tech-protocol-expert` | No blockers — ALS pattern and per-call override semantics are correct | ✅ No blockers |
| `code-reviewer` | **Blocker**: `test/unit/*.test.js` not in CI test glob (pre-existing gap from #1170) | ✅ Fixed (package.json `"test"` script updated) |
| `code-reviewer` | Note: `listTasksForAgent` and `resumeDeferredTask` gaps are out of scope per issue | Documented above |

---

> **Triage-managed PR** — opened by the automated triage agent for issue #1177.
> Items covered: #1177 items 1 and 3.
> Item 2 (breaking rename) flagged for human decision.
> Reviewer: @bokelley

https://claude.ai/code/session_01Ke9JLY5WnxSsxbpLMw37pu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke9JLY5WnxSsxbpLMw37pu)_