### PR TITLE
fix(client): transport hygiene — per-call override + field rename + MCP test

### DIFF
--- a/.changeset/transport-response-size-hygiene.md
+++ b/.changeset/transport-response-size-hygiene.md
@@ -1,0 +1,16 @@
+---
+'@adcp/sdk': patch
+---
+
+transport.maxResponseBytes hygiene: thread per-call override through TaskExecutor secondary call sites, rename ResponseTooLargeError field, add MCP integration test. Closes #1177.
+
+- `TaskExecutor.getTaskStatus`, `listTasksForAgent`, `listTasks`, `getTaskList`, `continueTaskWithInput`, and
+  `pollTaskCompletion` now accept a per-call `transport?` override that beats the constructor-level cap.
+  `SubmittedContinuation.track` exposes the per-call override; `waitForCompletion` inherits the
+  transport cap from task-submission time (intentional — polling loops run an indefinite number of
+  requests and a per-loop override would be a footgun).
+- `ResponseTooLargeError.declaredContentLength` renamed to `contentLengthHeader` (pre-release fix;
+  the field was introduced in the same release cycle and has zero published consumer surface).
+- `test/unit/mcp-tool-size-limit.test.js` — end-to-end integration test proving the cap fires through
+  `ProtocolClient.callTool` → `connectMCPWithFallbackImpl` → `wrapFetchWithSizeLimit` for the
+  non-OAuth MCP path.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -269,9 +269,9 @@ export interface SubmittedContinuation<T> {
   taskId: string;
   /** Webhook URL where server will notify completion */
   webhookUrl?: string;
-  /** Get current task status */
-  track: () => Promise<TaskInfo>;
-  /** Wait for completion with polling */
+  /** Get current task status. Pass `transport` to override the executor-constructor cap for this poll. */
+  track: (transport?: import('../protocols').TransportOptions) => Promise<TaskInfo>;
+  /** Wait for completion with polling. Transport cap is fixed at task-submission time; use `track` for per-poll override. */
   waitForCompletion: (pollInterval?: number) => Promise<TaskResult<T>>;
 }
 

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1118,8 +1118,10 @@ export class TaskExecutor {
     const submitted: SubmittedContinuation<T> = {
       taskId: serverTaskId,
       webhookUrl,
-      track: () => this.getTaskStatus(agent, serverTaskId),
-      waitForCompletion: (pollInterval = 60000) => this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval),
+      track: (transport?: import('../protocols').TransportOptions) =>
+        this.getTaskStatus(agent, serverTaskId, transport ?? options.transport),
+      waitForCompletion: (pollInterval = 60000) =>
+        this.pollTaskCompletion<T>(agent, serverTaskId, pollInterval, options.transport),
     };
 
     return {
@@ -1292,7 +1294,10 @@ export class TaskExecutor {
   /**
    * List tasks for an agent, preferring MCP Tasks protocol when available.
    */
-  private async listTasksForAgent(agent: AgentConfig): Promise<TaskInfo[]> {
+  private async listTasksForAgent(
+    agent: AgentConfig,
+    transport?: import('../protocols').TransportOptions
+  ): Promise<TaskInfo[]> {
     // Try MCP Tasks protocol method first
     if (agent.protocol === 'mcp') {
       const authToken = getAuthToken(agent);
@@ -1310,7 +1315,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
-        transport: this.config.transport,
+        transport: transport ?? this.config.transport,
       }
     )) as Record<string, unknown>;
     return (response.tasks as TaskInfo[]) || [];
@@ -1319,9 +1324,9 @@ export class TaskExecutor {
   /**
    * Task tracking methods (PR #78)
    */
-  async listTasks(agent: AgentConfig): Promise<TaskInfo[]> {
+  async listTasks(agent: AgentConfig, transport?: import('../protocols').TransportOptions): Promise<TaskInfo[]> {
     try {
-      return await this.listTasksForAgent(agent);
+      return await this.listTasksForAgent(agent, transport);
     } catch {
       // Static message only — CodeQL's taint analysis treats `error` and
       // every property of it as sensitive once it originates from an
@@ -1332,7 +1337,11 @@ export class TaskExecutor {
     }
   }
 
-  async getTaskStatus(agent: AgentConfig, taskId: string): Promise<TaskInfo> {
+  async getTaskStatus(
+    agent: AgentConfig,
+    taskId: string,
+    transport?: import('../protocols').TransportOptions
+  ): Promise<TaskInfo> {
     // AdCP `tasks/get` is the cross-protocol work-status interface
     // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
     // Dispatched as a buyer-callable tool over the agent's transport
@@ -1367,7 +1376,7 @@ export class TaskExecutor {
       {
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
-        transport: this.config.transport,
+        transport: transport ?? this.config.transport,
       }
     )) as Record<string, unknown>;
     // We don't run `extractResponseData` here: that helper's
@@ -1382,9 +1391,14 @@ export class TaskExecutor {
     return mapTasksGetResponseToTaskInfo(response);
   }
 
-  async pollTaskCompletion<T>(agent: AgentConfig, taskId: string, pollInterval = 60000): Promise<TaskResult<T>> {
+  async pollTaskCompletion<T>(
+    agent: AgentConfig,
+    taskId: string,
+    pollInterval = 60000,
+    transport?: import('../protocols').TransportOptions
+  ): Promise<TaskResult<T>> {
     while (true) {
-      const status = await this.getTaskStatus(agent, taskId);
+      const status = await this.getTaskStatus(agent, taskId, transport);
 
       if (status.status === ADCP_STATUS.COMPLETED) {
         const pollSuccess = this.isOperationSuccess(status.result);
@@ -1543,7 +1557,7 @@ export class TaskExecutor {
         debugLogs,
         serverVersion: this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
-        transport: this.config.transport,
+        transport: options.transport ?? this.config.transport,
       }
     );
 
@@ -1647,12 +1661,12 @@ export class TaskExecutor {
   /**
    * Get task list for a specific agent
    */
-  async getTaskList(agentId: string): Promise<TaskInfo[]> {
+  async getTaskList(agentId: string, transport?: import('../protocols').TransportOptions): Promise<TaskInfo[]> {
     // First try to get from agent via protocol
     const agent = this.findAgentById(agentId);
     if (agent) {
       try {
-        return await this.listTasksForAgent(agent);
+        return await this.listTasksForAgent(agent, transport);
       } catch {
         // Static message — see comment on listTasks above.
         console.warn('Failed to get remote task list (see DEBUG=adcp:* logs for detail)');

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -358,18 +358,19 @@ export class ResponseTooLargeError extends ADCPError {
     public readonly bytesRead: number,
     public readonly url: string,
     /**
-     * The `Content-Length` header value when the cap was tripped before any
-     * body bytes were read. Undefined when the response was streamed and
-     * exceeded the cap mid-flight, or when the server omitted the header.
+     * The parsed value of the `Content-Length` response header when the cap
+     * was tripped on the pre-check (before any body bytes were read). Undefined
+     * when the response was streamed and exceeded the cap mid-flight, or when
+     * the server omitted the header.
      */
-    public readonly declaredContentLength?: number
+    public readonly contentLengthHeader?: number
   ) {
     super(
-      declaredContentLength !== undefined
-        ? `Response body declared ${declaredContentLength} bytes, exceeds maxResponseBytes cap of ${limit} (${url})`
+      contentLengthHeader !== undefined
+        ? `Response body declared ${contentLengthHeader} bytes, exceeds maxResponseBytes cap of ${limit} (${url})`
         : `Response body exceeded maxResponseBytes cap of ${limit} after reading ${bytesRead} bytes (${url})`
     );
-    this.details = { limit, bytesRead, url, declaredContentLength };
+    this.details = { limit, bytesRead, url, contentLengthHeader };
   }
 }
 

--- a/test/unit/a2a-card-size-limit.test.js
+++ b/test/unit/a2a-card-size-limit.test.js
@@ -76,10 +76,10 @@ describe('A2A agent-card discovery — maxResponseBytes', () => {
         assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
         assert.strictEqual(err.limit, 64 * 1024);
         // Server emits Content-Length, so the pre-check trips before any
-        // body bytes are read. `bytesRead` is 0, `declaredContentLength`
+        // body bytes are read. `bytesRead` is 0, `contentLengthHeader`
         // is the server's announced size.
         assert.strictEqual(err.bytesRead, 0);
-        assert.ok(err.declaredContentLength > 64 * 1024);
+        assert.ok(err.contentLengthHeader > 64 * 1024);
         return true;
       }
     );

--- a/test/unit/mcp-tool-size-limit.test.js
+++ b/test/unit/mcp-tool-size-limit.test.js
@@ -1,0 +1,182 @@
+/**
+ * Integration check that MCP tool calls honor `maxResponseBytes`.
+ *
+ * The cap is installed in `connectMCPWithFallbackImpl` (mcp.ts non-OAuth path,
+ * ~line 319) as the innermost transport wrapper. `ProtocolClient.callTool` enters
+ * the AsyncLocalStorage slot via `withResponseSizeLimit`, so the cap applies to
+ * every fetch made by the transport during that call — including the StreamableHTTP
+ * `initialize` handshake and the `tools/call` response.
+ *
+ * We test the wiring end-to-end against a real loopback HTTP server that speaks
+ * minimal StreamableHTTP JSON-RPC. An oversized `tools/call` reply must abort with
+ * `ResponseTooLargeError` before the body is buffered by the MCP SDK's JSON parser.
+ *
+ * **OAuth path coverage.** The OAuth path installs the same `wrapFetchWithSizeLimit`
+ * wrapper independently (mcp.ts ~line 660). That path is intentionally not exercised
+ * here — it requires an OAuth provider and the ALS / wrapper semantics are identical.
+ *
+ * **Pattern.** Mirrors `test/unit/a2a-card-size-limit.test.js` — real loopback server,
+ * no MCP SDK dependency on the server side, same `before`/`after` lifecycle.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { ProtocolClient, closeMCPConnections } = require('../../dist/lib/protocols');
+const { ResponseTooLargeError } = require('../../dist/lib/errors');
+
+let server;
+let baseUrl;
+
+before(async () => {
+  server = http.createServer((req, res) => {
+    // Route by URL path: /big → oversized tools/call, /small → pass-through.
+    const oversized = req.url === '/big';
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      let msg;
+      try {
+        msg = JSON.parse(body);
+      } catch {
+        res.writeHead(400);
+        res.end();
+        return;
+      }
+
+      if (msg.method === 'initialize') {
+        // Echo the client's protocolVersion so the SDK accepts the response.
+        const protocolVersion = msg.params?.protocolVersion ?? '2025-03-26';
+        const reply = JSON.stringify({
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: {
+            protocolVersion,
+            capabilities: {},
+            serverInfo: { name: 'stub-mcp', version: '0.0.1' },
+          },
+        });
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'mcp-session-id': 'test-session-stub',
+        });
+        res.end(reply);
+        return;
+      }
+
+      if (msg.method === 'notifications/initialized') {
+        res.writeHead(202);
+        res.end();
+        return;
+      }
+
+      if (msg.method === 'tools/call') {
+        if (oversized) {
+          // 5 MB — well above the 64 KB test cap. Setting Content-Length lets
+          // the pre-check fire before any body bytes are read, making the test
+          // deterministic without streaming 5 MB.
+          const padding = 'x'.repeat(5 * 1024 * 1024);
+          const reply = JSON.stringify({
+            jsonrpc: '2.0',
+            id: msg.id,
+            result: { content: [{ type: 'text', text: padding }] },
+          });
+          res.writeHead(200, {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(reply),
+          });
+          res.end(reply);
+        } else {
+          const reply = JSON.stringify({
+            jsonrpc: '2.0',
+            id: msg.id,
+            result: { content: [{ type: 'text', text: 'ok' }] },
+          });
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(reply);
+        }
+        return;
+      }
+
+      // Fallback for capability probes and unknown methods.
+      const reply = JSON.stringify({ jsonrpc: '2.0', id: msg.id ?? null, result: {} });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(reply);
+    });
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  closeMCPConnections();
+  await new Promise(resolve => server.close(resolve));
+});
+
+describe('MCP tools/call — maxResponseBytes', () => {
+  it('aborts a tools/call response with ResponseTooLargeError when it exceeds the cap', async () => {
+    // Full wiring path under test:
+    //   ProtocolClient.callTool
+    //     → withResponseSizeLimit(64 KB)          (enters ALS slot)
+    //     → callMCPToolWithTasks
+    //       → withCachedConnection
+    //         → connectMCPWithFallbackImpl
+    //             wrapFetchWithSizeLimit(fetch)    (reads ALS slot per request)
+    //         → MCPClient.connect()               (initialize — small, passes cap)
+    //       → client.callTool()                   (tools/call — 5 MB declared,
+    //                                              Content-Length pre-check fires)
+    await assert.rejects(
+      () =>
+        ProtocolClient.callTool(
+          { id: 'vendor-big', name: 'Stub MCP Big', protocol: 'mcp', agent_uri: `${baseUrl}/big` },
+          'get_adcp_capabilities',
+          {},
+          { transport: { maxResponseBytes: 64 * 1024 } }
+        ),
+      err => {
+        assert.ok(
+          err instanceof ResponseTooLargeError,
+          `expected ResponseTooLargeError, got ${err?.constructor?.name}: ${err?.message}`
+        );
+        assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+        assert.strictEqual(err.limit, 64 * 1024);
+        // Server sets Content-Length so the pre-check fires before any body
+        // bytes are read. `bytesRead` must be 0; `contentLengthHeader` is the
+        // server's announced size.
+        assert.strictEqual(err.bytesRead, 0);
+        assert.ok(
+          err.contentLengthHeader > 64 * 1024,
+          `expected contentLengthHeader > ${64 * 1024}, got ${err.contentLengthHeader}`
+        );
+        return true;
+      }
+    );
+  });
+
+  it('lets a tools/call response through unchanged when the cap is generous', async () => {
+    // Flush the cached connection from the first test so the small agent gets
+    // a fresh StreamableHTTP session. The two URL paths are different (/big vs
+    // /small) so they use separate connection-cache slots anyway, but clearing
+    // is defensive against future cache-key changes.
+    closeMCPConnections();
+
+    // No ResponseTooLargeError — the stub returns a small 'ok' body at /small.
+    const result = await ProtocolClient.callTool(
+      { id: 'vendor-small', name: 'Stub MCP Small', protocol: 'mcp', agent_uri: `${baseUrl}/small` },
+      'get_adcp_capabilities',
+      {},
+      { transport: { maxResponseBytes: 16 * 1024 * 1024 } }
+    );
+
+    // We don't assert on the result shape — the stub returns minimal JSON-RPC
+    // and the response is unwrapped by the SDK. The assertion is "no
+    // ResponseTooLargeError was thrown" (the rejects check above would have
+    // caught it).
+    assert.ok(result !== undefined, 'callTool should resolve when the cap is generous');
+  });
+});

--- a/test/unit/response-size-limit.test.js
+++ b/test/unit/response-size-limit.test.js
@@ -65,7 +65,7 @@ describe('responseSizeLimit — wrapFetchWithSizeLimit', () => {
         assert.ok(err instanceof ResponseTooLargeError, 'expected ResponseTooLargeError');
         assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
         assert.strictEqual(err.limit, 1000);
-        assert.strictEqual(err.declaredContentLength, 5000);
+        assert.strictEqual(err.contentLengthHeader, 5000);
         assert.strictEqual(err.bytesRead, 0, 'pre-check reports zero bytes-read on the error');
         return true;
       }
@@ -100,7 +100,7 @@ describe('responseSizeLimit — wrapFetchWithSizeLimit', () => {
         assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
         assert.strictEqual(err.limit, 1000);
         assert.ok(err.bytesRead > 1000, `bytesRead ${err.bytesRead} should exceed limit`);
-        assert.strictEqual(err.declaredContentLength, undefined);
+        assert.strictEqual(err.contentLengthHeader, undefined);
         return true;
       }
     );
@@ -420,7 +420,7 @@ describe('responseSizeLimit — ResponseTooLargeError shape', () => {
     assert.strictEqual(err.limit, 1000);
     assert.strictEqual(err.bytesRead, 1500);
     assert.strictEqual(err.url, 'https://example.invalid/');
-    assert.strictEqual(err.declaredContentLength, undefined);
+    assert.strictEqual(err.contentLengthHeader, undefined);
     assert.ok(isADCPError(err));
     // details payload doubles as the wire-error body so logs/tickets
     // surface the cap and observed size without re-parsing the message.
@@ -428,7 +428,7 @@ describe('responseSizeLimit — ResponseTooLargeError shape', () => {
       limit: 1000,
       bytesRead: 1500,
       url: 'https://example.invalid/',
-      declaredContentLength: undefined,
+      contentLengthHeader: undefined,
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #1177. Three hygiene items left over from #1170 (`transport.maxResponseBytes`).

- **Thread `transport` per-call override through all `TaskExecutor` secondary call sites.** `getTaskStatus`, `listTasksForAgent`, `listTasks`, `getTaskList`, `pollTaskCompletion`, and `continueTaskWithInput` previously always used `this.config.transport`. They now accept `transport?: TransportOptions` and apply `transport ?? this.config.transport`. `SubmittedContinuation.track` exposes the per-call override; `waitForCompletion` intentionally inherits the cap from task-submission time (applying a per-loop override to an unbounded polling loop is a footgun).
- **Rename `ResponseTooLargeError.declaredContentLength` → `contentLengthHeader`.** Pre-release rename — the field was introduced in the same cycle as this PR's predecessor and has zero published consumer surface. `contentLengthHeader` names the HTTP artifact precisely (RFC 9110 §8.6) where `declaredContentLength` was ambiguous.
- **`test/unit/mcp-tool-size-limit.test.js`** — end-to-end integration test using a real loopback StreamableHTTP server. Proves the cap fires through `ProtocolClient.callTool` → `connectMCPWithFallbackImpl` → `wrapFetchWithSizeLimit` on the non-OAuth MCP path (Content-Length pre-check, then pass-through with generous cap). Mirrors `test/unit/a2a-card-size-limit.test.js`.

## Test plan

- [ ] `npm run build:lib` — compile before running `test/unit/` tests (they import from `dist/`)
- [ ] `node --test test/unit/mcp-tool-size-limit.test.js` — two cases: oversized aborts with `ResponseTooLargeError`, small passes through
- [ ] `node --test test/unit/a2a-card-size-limit.test.js` — renamed field assertions still pass
- [ ] `node --test test/unit/response-size-limit.test.js` — renamed field assertions still pass
- [ ] `npm test` — full suite green

https://claude.ai/code/session_01HGc4GtVy8zFzykKn9AurZN

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGc4GtVy8zFzykKn9AurZN)_