### PR TITLE
fix(validation): skip missing-schema bundle in warn mode instead of throwing

### DIFF
--- a/.changeset/schema-bundle-warn-skip.md
+++ b/.changeset/schema-bundle-warn-skip.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+Fix warn-mode validation crashing when schema bundle is not populated
+
+Commit `df91b27` changed the client-side validation default from `off` to `warn`, but the `warn` path in `validateOutgoingRequest` and `validateIncomingResponse` did not handle the `SchemaBundleNotFoundError` that `resolveSchemaRoot` throws when `npm run sync-schemas` has not been run. The unhandled error propagated through `SingleAgentClient.createMediaBuy` (and every other typed method), causing storyboard A2A tests and context-retention tests to fail on every CI run.
+
+Three fixes:
+
+1. `schema-loader.ts`: Introduce `SchemaBundleNotFoundError` (typed, `code: 'SCHEMA_BUNDLE_NOT_FOUND'`) so callers can distinguish "schemas not populated" (infrastructure gap, safe to skip in `warn` mode) from `ConfigurationError` (bad version string, always re-throw).
+
+2. `client-hooks.ts`: Catch `SchemaBundleNotFoundError` in `validateOutgoingRequest` and `validateIncomingResponse` when mode is `warn` — log a `type: 'warning'` debug entry and skip validation rather than throwing. In `strict` mode, re-throw so hard-stop callers still get the error they opted into.
+
+3. `validations.ts`: Wrap the `validateResponse` call in `computeStrictVerdict` in a try-catch that returns `undefined` on `SchemaBundleNotFoundError` — the function's contract is already "return undefined when no AJV schema is available."
+
+Test fix: the regressed-adapter fixture in `storyboard-a2a-async-submitted-yaml.test.js` used `supported_protocols: ['media-buy']` (hyphen) instead of `['media_buy']` (underscore), causing the capability feature gate to skip the `create_media_buy` step before the wire-shape assertion could run.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -11,6 +11,7 @@
 import { TOOL_RESPONSE_SCHEMAS } from '../../utils/response-schemas';
 import { TRANSPORT_SUFFIX_REGEX } from '../../utils/a2a-discovery';
 import { validateResponse, type ValidationIssue } from '../../validation/schema-validator';
+import { SchemaBundleNotFoundError } from '../../validation/schema-loader';
 import { ADCP_VERSION } from '../../version';
 import type { TaskResult } from '../types';
 import type {
@@ -388,7 +389,13 @@ function validateResponseSchema(
  * outside the `bundled/` tree the loader walks today).
  */
 function computeStrictVerdict(taskName: string, payload: unknown): StrictValidationVerdict | undefined {
-  const outcome = validateResponse(taskName, payload);
+  let outcome: ReturnType<typeof validateResponse>;
+  try {
+    outcome = validateResponse(taskName, payload);
+  } catch (err) {
+    if (err instanceof SchemaBundleNotFoundError) return undefined;
+    throw err;
+  }
   // `variant: 'skipped'` means no AJV validator compiled for this task (no
   // strictness signal to emit); treat the same as "no AJV schema available".
   if (outcome.variant === 'skipped') return undefined;

--- a/src/lib/validation/client-hooks.ts
+++ b/src/lib/validation/client-hooks.ts
@@ -5,6 +5,7 @@
  */
 
 import { validateRequest, validateResponse, formatIssues, type ValidationOutcome } from './schema-validator';
+import { SchemaBundleNotFoundError } from './schema-loader';
 import { buildValidationError } from './schema-errors';
 
 export type ValidationMode = 'strict' | 'warn' | 'off';
@@ -57,11 +58,30 @@ function logWarning(debugLogs: DebugLogEntry[] | undefined, taskName: string, ou
   });
 }
 
+function logSchemaBundleMissing(
+  debugLogs: DebugLogEntry[] | undefined,
+  taskName: string,
+  direction: 'request' | 'response'
+): void {
+  if (!debugLogs) return;
+  debugLogs.push({
+    type: 'warning',
+    message:
+      `Schema bundle unavailable for ${taskName} ${direction} validation — skipping. ` +
+      `Run \`npm run sync-schemas\` and \`npm run build:lib\` to populate schemas.`,
+    timestamp: new Date().toISOString(),
+  });
+}
+
 /**
  * Run request validation per the configured mode.
  * - `off`: no-op (true).
- * - `warn`: log to debug + continue (true).
+ * - `warn`: log to debug + continue (true). When the schema bundle is missing,
+ *   logs a warning and skips rather than throwing — "surface drift if you can"
+ *   is the intent, not "block on missing infrastructure."
  * - `strict`: throw `ValidationError` with JSON Pointer to the first bad field.
+ *   When the schema bundle is missing, re-throws so hard-stop callers get the
+ *   clear error they opted into.
  *
  * `version` selects which AdCP version's schema bundle to validate against;
  * defaults to the SDK-pinned `ADCP_VERSION`. Pass the per-instance value from
@@ -75,7 +95,16 @@ export function validateOutgoingRequest(
   version?: string
 ): ValidationOutcome | undefined {
   if (mode === 'off') return undefined;
-  const outcome = validateRequest(taskName, params, version);
+  let outcome: ValidationOutcome;
+  try {
+    outcome = validateRequest(taskName, params, version);
+  } catch (err) {
+    if (err instanceof SchemaBundleNotFoundError && mode === 'warn') {
+      logSchemaBundleMissing(debugLogs, taskName, 'request');
+      return undefined;
+    }
+    throw err;
+  }
   if (outcome.valid) return outcome;
   if (mode === 'warn') {
     logWarning(debugLogs, taskName, outcome);
@@ -88,10 +117,13 @@ export function validateOutgoingRequest(
  * Run response validation per the configured mode.
  * - `off`: no-op (valid).
  * - `warn`: log + return invalid outcome so the caller can surface details.
+ *   When the schema bundle is missing, logs a warning and returns valid rather
+ *   than throwing.
  * - `strict`: return the invalid outcome so the caller fails the task.
- * Does NOT throw — matches the existing response-side contract where a
- * validation failure turns a task into `status: 'failed'` rather than
- * raising out of the SDK.
+ *   When the schema bundle is missing, re-throws.
+ * Does NOT throw on validation failures — matches the existing response-side
+ * contract where a validation failure turns a task into `status: 'failed'`
+ * rather than raising out of the SDK.
  */
 export function validateIncomingResponse(
   taskName: string,
@@ -101,7 +133,16 @@ export function validateIncomingResponse(
   version?: string
 ): ValidationOutcome {
   if (mode === 'off') return { valid: true, issues: [], variant: 'sync' };
-  const outcome = validateResponse(taskName, data, version);
+  let outcome: ValidationOutcome;
+  try {
+    outcome = validateResponse(taskName, data, version);
+  } catch (err) {
+    if (err instanceof SchemaBundleNotFoundError && mode === 'warn') {
+      logSchemaBundleMissing(debugLogs, taskName, 'response');
+      return { valid: true, issues: [], variant: 'sync' };
+    }
+    throw err;
+  }
   if (!outcome.valid && mode === 'warn') {
     logWarning(debugLogs, taskName, outcome);
   }

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -23,6 +23,21 @@ import { ConfigurationError } from '../errors';
 export type ResponseVariant = 'sync' | 'submitted' | 'working' | 'input-required';
 export type Direction = 'request' | ResponseVariant;
 
+/**
+ * Thrown by `resolveSchemaRoot` when the schema bundle for the requested
+ * AdCP version is not present in either the dist build or the source-tree
+ * cache. Distinct from `ConfigurationError` (bad version format) so callers
+ * can differentiate "schemas not populated" (infrastructure gap, warn-safe)
+ * from "version string is garbage" (programmer error, always re-throw).
+ */
+export class SchemaBundleNotFoundError extends Error {
+  readonly code = 'SCHEMA_BUNDLE_NOT_FOUND';
+  constructor(message: string) {
+    super(message);
+    this.name = 'SchemaBundleNotFoundError';
+  }
+}
+
 interface LoadedSchema {
   $id?: string;
   [k: string]: unknown;
@@ -142,7 +157,7 @@ function resolveSchemaRoot(version: string): string {
     if (cached.length > 0) return path.join(cacheRoot, cached[0]!.name);
   }
 
-  throw new Error(
+  throw new SchemaBundleNotFoundError(
     `AdCP schema data for version "${version}" not found. ` +
       `Looked for bundle key "${key}" in ${distCandidate}, exact path ${exactCandidate}, ` +
       `and the latest-patch fallback in ${cacheRoot}. ` +

--- a/test/storyboard-a2a-async-submitted-yaml.test.js
+++ b/test/storyboard-a2a-async-submitted-yaml.test.js
@@ -292,7 +292,7 @@ describe(
                       kind: 'data',
                       data: {
                         adcp_version: '3.0.0',
-                        supported_protocols: ['media-buy'],
+                        supported_protocols: ['media_buy'],
                         tools: [{ name: 'create_media_buy' }, { name: 'get_products' }],
                       },
                     },


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes #1178 — two test files failed on every CI run because `df91b27` changed the client-side validation default from `'off'` to `'warn'`, but the `warn` path didn't handle `SchemaBundleNotFoundError` (the error `resolveSchemaRoot` throws when `npm run sync-schemas` has not been run). The unhandled throw propagated through `SingleAgentClient.createMediaBuy` (and every other typed method), crashing the A2A storyboard tests and context-retention tests before they could even reach the agent.

Three code changes + one test fix:

- **`schema-loader.ts`**: Introduce `SchemaBundleNotFoundError` (typed, `code: 'SCHEMA_BUNDLE_NOT_FOUND'`) so callers can distinguish "schemas not populated" (infrastructure gap, safe to skip in `warn` mode) from `ConfigurationError` (bad version string, always re-throw). These two error classes are mutually exclusive on any given call — `resolveBundleKey` throws `ConfigurationError` before `resolveSchemaRoot` is reached.

- **`client-hooks.ts`**: Catch `SchemaBundleNotFoundError` in `validateOutgoingRequest` and `validateIncomingResponse` when mode is `'warn'` — log a `type: 'warning'` debug entry and skip rather than throwing. In `strict` mode, re-throw so hard-stop callers still get the error they opted into. Callers who need a pre-flight check before entering strict mode can use the existing `hasSchemaBundle(version)` export from `schema-loader.ts` — no need to catch `SchemaBundleNotFoundError` directly.

- **`validations.ts`**: Wrap the `validateResponse` call in `computeStrictVerdict` in a try-catch that returns `undefined` on `SchemaBundleNotFoundError`. The function's existing contract is already "no AJV schema available → return undefined" (via `variant: 'skipped'`); this extends that contract to cover the missing-bundle case.

- **`test/storyboard-a2a-async-submitted-yaml.test.js`**: The regressed-adapter fixture used `supported_protocols: ['media-buy']` (hyphen) instead of `['media_buy']` (underscore). The underscore form is the correct `AdcpProtocol` wire value — the hyphen form caused the `create_media_buy` capability feature gate to skip the step entirely, so the `a2a_submitted_artifact` wire-shape assertion never ran. This was the second reason test 3 was returning `validations: []`.

## Test plan

- [x] `test/storyboard-a2a-async-submitted-yaml.test.js` — all 3 subtests pass (was: tests 2 and 3 failing)
- [x] `test/lib/a2a-context-retention.test.js` — all 10 subtests pass (was: 7 subtests in second describe block failing)
- [x] `npm run ci:quick` passes format, typecheck, and build; test failure count drops from 219 (baseline) to 186 (remaining failures are pre-existing, unrelated to this PR)
- [x] Changeset created (`patch` bump — bug fix, no API additions)

https://claude.ai/code/session_012oTudtWvJZboMNcBNV1EbE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_012oTudtWvJZboMNcBNV1EbE)_