### PR TITLE
fix: A2A storyboard regression-adapter tests silently skipping validators (issue #1178)

### DIFF
--- a/.changeset/storyboard-a2a-validation-gate.md
+++ b/.changeset/storyboard-a2a-validation-gate.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+`executeStep` now opens the validation gate when an A2A envelope is captured even if `taskResult` is undefined. Previously, storyboard steps with A2A-envelope-only validators (e.g., `a2a_submitted_artifact`) were silently skipped when the seller emitted a response that caused the A2A SDK to throw (e.g., `status.state: 'submitted'` on the transport level, which is forbidden by A2A 0.3.0). The gate condition `(taskResult || httpResult)` is expanded to `(taskResult || httpResult || a2aEnvelope)`, so validators that only need the raw wire-shape envelope run correctly against regressed sellers.

--- a/.changeset/storyboard-a2a-validation-gate.md
+++ b/.changeset/storyboard-a2a-validation-gate.md
@@ -2,4 +2,8 @@
 "@adcp/sdk": patch
 ---
 
-`executeStep` now opens the validation gate when an A2A envelope is captured even if `taskResult` is undefined. Previously, storyboard steps with A2A-envelope-only validators (e.g., `a2a_submitted_artifact`) were silently skipped when the seller emitted a response that caused the A2A SDK to throw (e.g., `status.state: 'submitted'` on the transport level, which is forbidden by A2A 0.3.0). The gate condition `(taskResult || httpResult)` is expanded to `(taskResult || httpResult || a2aEnvelope)`, so validators that only need the raw wire-shape envelope run correctly against regressed sellers.
+Two fixes for A2A storyboard regression-adapter tests that were silently skipping validators:
+
+1. **Validation gate** (`executeStep`): the gate condition `(taskResult || httpResult)` is expanded to `(taskResult || httpResult || a2aEnvelope)`, so validators that only need the raw wire-shape envelope (e.g., `a2a_submitted_artifact`, `a2a_context_continuity`) run correctly even when the A2A SDK throws on a forbidden state (e.g., `status.state: 'submitted'` per A2A 0.3.0).
+
+2. **Synthetic capture** (`callA2AToolImpl`): after `client.sendMessage()` returns, a synthetic POST capture is injected directly into the active `rawResponseCaptureStorage` slot. This guarantees `parseLastA2aMessageSendCapture` always finds a capturable envelope regardless of whether the A2A SDK version routes `sendMessage` through an internal transport that bypasses the provided `fetchImpl`. Without this, `priorA2aEnvelopes` would never be populated and `a2a_context_continuity` would silently skip on step 2 with reason `first_a2a_step`.

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -12,7 +12,7 @@ import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
-import { wrapFetchWithCapture } from './rawResponseCapture';
+import { wrapFetchWithCapture, rawResponseCaptureStorage } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 
 if (!A2AClient) {
@@ -342,7 +342,33 @@ async function callA2AToolImpl(
       skill: toolName,
     });
 
+    const sendStartedAt = Date.now();
     const messageResponse = await client.sendMessage(requestPayload);
+
+    // If a raw-response capture slot is active (storyboard runner's
+    // `withRawResponseCapture` wraps each step), inject a synthetic
+    // POST capture from the SDK response so `parseLastA2aMessageSendCapture`
+    // can extract the envelope for A2A-envelope-only validators
+    // (`a2a_submitted_artifact`, `a2a_context_continuity`). This guards
+    // against A2A SDK versions that route `sendMessage` through an
+    // internal transport that bypasses the provided `fetchImpl`.
+    const captureSlot = rawResponseCaptureStorage.getStore();
+    if (captureSlot != null && messageResponse != null) {
+      const msgAny = messageResponse as Record<string, unknown>;
+      const body = msgAny['jsonrpc'] === '2.0'
+        ? JSON.stringify(messageResponse)
+        : JSON.stringify({ jsonrpc: '2.0', id: null, result: msgAny['result'] ?? messageResponse });
+      captureSlot.captures.push({
+        url: agentUrl,
+        method: 'POST',
+        status: 200,
+        headers: {},
+        body,
+        latencyMs: Date.now() - sendStartedAt,
+        timestamp: new Date(sendStartedAt).toISOString(),
+        bodyTruncated: false,
+      });
+    }
 
     debugLogs.push({
       type: messageResponse?.error ? 'error' : 'success',

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2022,7 +2022,7 @@ async function executeStep(
   // `allowed_values` fields so expected values can reference prior steps
   // (e.g., replay tests assert `media_buy_id === $context.initial_media_buy_id`).
   let validations: ValidationResult[] = [];
-  if (step.validations?.length && (taskResult || httpResult)) {
+  if (step.validations?.length && (taskResult || httpResult || a2aEnvelope)) {
     const resolvedValidations = step.validations.map(v => {
       const resolved = { ...v };
       if (resolved.value !== undefined) {


### PR DESCRIPTION
## Summary

Fixes two root causes that caused A2A storyboard regression-adapter tests to silently skip validators on every PR (issue #1178).

### Root cause 1 — validation gate (`runner.ts`)

`executeStep`'s gate condition was `(taskResult || httpResult)`. When a seller emits a response that causes the A2A SDK to throw (e.g. `status.state: 'submitted'`, which is forbidden by A2A 0.3.0), `taskResult` is `undefined` and `httpResult` is `undefined`, so the entire validations block was silently skipped — even though `a2aEnvelope` was populated via `getCapturesFromError`.

**Fix:** one-line change in `runner.ts:2025`:
```diff
-if (step.validations?.length && (taskResult || httpResult)) {
+if (step.validations?.length && (taskResult || httpResult || a2aEnvelope)) {
```

### Root cause 2 — synthetic capture (`a2a.ts`)

`priorA2aEnvelopes` (used by `a2a_context_continuity` to compare `contextId` across steps) is only populated when `a2aEnvelope` is truthy after a step. `a2aEnvelope` comes from `parseLastA2aMessageSendCapture(a2aCaptures)`, which scans HTTP captures collected by `wrapFetchWithCapture`. However, `@a2a-js/sdk`'s `A2AClient.sendMessage()` may use an internal transport that bypasses the provided `fetchImpl`, so `wrapFetchWithCapture` never fires for that call and `a2aCaptures` is empty.

**Fix:** after `client.sendMessage()` returns in `callA2AToolImpl`, inject a synthetic POST capture directly into the active `rawResponseCaptureStorage` ALS slot. This guarantees `parseLastA2aMessageSendCapture` always finds an envelope regardless of SDK internals. Three `messageResponse` shapes are handled:
1. Full JSON-RPC envelope `{ jsonrpc: '2.0', id: ..., result: Task }` — serialized directly
2. Partial envelope `{ result: Task }` without `jsonrpc` — wrapped with `{ jsonrpc: '2.0', id: null, result: Task }`
3. Raw Task `{ kind: 'task', ... }` — `msgAny['result']` is undefined, so wrapped as `{ jsonrpc: '2.0', id: null, result: Task }`

The slot is only set inside `withRawResponseCapture` (storyboard runner context), so this is a no-op in production call paths where no slot is active.

### Known pre-existing debt (not introduced here)

Steps that mix `a2a_submitted_artifact` (needs only `a2aEnvelope`) with `requireTaskResult` validators (e.g. `response_schema`) will hard-fail rather than skip on throw paths. This is pre-existing behaviour in `requireTaskResult` and is out of scope for this patch.

## Test plan

- [ ] `test/storyboard-a2a-wire-shape-capture.test.js` — test #3 (regressed adapter emitting `submitted` state) should now PASS
- [ ] `test/storyboard-a2a-context-continuity-integration.test.js` — test #2 (regressed adapter stamping fresh `contextId` per send) should now PASS (`a2a_context_continuity` fires with `passed: false`, `json_pointer: '/result/contextId'`)
- [ ] `test/storyboard-a2a-async-submitted-yaml.test.js` — regressed-adapter scenario should now PASS
- [ ] All pre-existing passing tests remain green (gate change is additive; synthetic capture is a no-op outside storyboard `withRawResponseCapture` context)

https://claude.ai/code/session_01Ke9JLY5WnxSsxbpLMw37pu