### PR TITLE
docs(signing): cross-link spec decision + self-signed dev path recipe

### DIFF
--- a/.changeset/signing-doc-paper-trail.md
+++ b/.changeset/signing-doc-paper-trail.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+Cross-link the merged spec decision (adcp#3742, "synchronous response bodies are not signed — by design") in `TenantConfig.signingKey`'s JSDoc, and add a "Self-signed dev path" recipe to `docs/guides/SIGNING-GUIDE.md`.
+
+The field's prior doc described the signing scope as "RFC 9421 response signing" — that wording predated the spec decision and didn't match what the SDK actually does. Updated to reflect: scope is webhook-signing only; the synchronous tools/call reply is not signed at the body level by deliberate design (TLS for sync, signed webhooks for async); adopters needing attestable artifacts for synchronous flows use the request-the-webhook pattern. Doc points at `docs/building/understanding/security-model.mdx` § "What gets signed — and what doesn't" for the canonical reasoning.
+
+The signing guide now carries the worked recipe for the multi-tenant self-signed dev loop: `createTenantRegistry` + `createSelfSignedTenantKey()` + `createNoopJwksValidator()` (gated to `NODE_ENV` ∈ {test, development} unless `ADCP_NOOP_JWKS_ACK=1`). Production promotion path covered (publish JWK to brand.json, swap in-memory key for KMS-backed `SigningProvider`). Plus the omit-key path for adopters who aren't ready to sign yet.
+
+No behavior change.

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -513,6 +513,86 @@ For adopters running behind an egress proxy that already enforces the SSRF polic
 
 `createPinAndBindFetch` is generic and not webhook-specific — wire it anywhere you make outbound calls to a URL you don't fully trust.
 
+### Multi-tenant: signing key on `TenantConfig` (auto-wired)
+
+When you're hosting many tenants with `createTenantRegistry`, set the webhook signing key once on `TenantConfig.signingKey` — the registry plumbs it into the tenant's webhook emitter automatically so you don't have to wire `serverOptions.webhooks.signerKey` per tenant.
+
+```typescript
+import { createTenantRegistry } from '@adcp/sdk/server';
+
+const registry = createTenantRegistry({
+  defaultServerOptions: { name: 'multi-tenant-host', version: '1.0.0' },
+});
+
+registry.register('acme', {
+  agentUrl: 'https://acme.example.com',
+  signingKey: {
+    keyId: 'acme-2026-05',
+    publicJwk: { ...acmePublicJwk, adcp_use: 'webhook-signing' },
+    privateJwk: { ...acmePrivateJwk, adcp_use: 'webhook-signing' },
+  },
+  platform: acmePlatform,
+});
+```
+
+The registry validates two things for you:
+
+1. **JWKS publication.** `publicJwk` MUST appear in the tenant's brand.json at `{agentUrl}/.well-known/brand.json` — the registry fetches it on register() and refuses traffic to tenants whose key isn't published (default validator).
+2. **Key purpose.** Both halves of the key MUST carry `adcp_use: "webhook-signing"`. Mismatched or missing `adcp_use` throws at register() with a remediation hint, citing adcp#2423 (key-purpose discriminator).
+
+Adopters wiring KMS-backed signing or a distinct webhook key per tenant set `serverOptions.webhooks.signerKey` / `signerProvider` explicitly — the explicit config wins and auto-wiring is skipped.
+
+### Self-signed dev path
+
+Production needs a published brand.json at `{agentUrl}/.well-known/brand.json` with the public key under `jwks.keys[]`. Dev / sandbox / fast-iteration loops don't have that yet, but adopters still want to exercise the signing pipeline locally. Two helpers cover the gap:
+
+```typescript
+import {
+  createTenantRegistry,
+  createSelfSignedTenantKey,
+  createNoopJwksValidator,
+} from '@adcp/sdk/server';
+
+// 1. Generate an Ed25519 keypair tagged adcp_use: 'webhook-signing'.
+//    No KMS, no JWKS publication — keypair lives in-process.
+const key = await createSelfSignedTenantKey({ keyId: 'dev-key-1' });
+
+// 2. Skip the brand.json roundtrip with the no-op validator.
+//    REFUSES to construct outside NODE_ENV ∈ {test, development} unless
+//    you set ADCP_NOOP_JWKS_ACK=1 — keeps prod safe by default.
+const registry = createTenantRegistry({
+  jwksValidator: createNoopJwksValidator(),
+  defaultServerOptions: { name: 'dev', version: '0.0.0' },
+});
+
+// 3. Register and go. The auto-wire still fires; webhooks are
+//    RFC 9421-signed with `key`, validation against brand.json is
+//    skipped, tenant reaches `healthy` immediately.
+registry.register('dev-tenant', {
+  agentUrl: 'https://dev-tenant.localhost',
+  signingKey: key,
+  platform: yourPlatform,
+});
+```
+
+Promotion path to production: replace `createNoopJwksValidator()` with the default (just remove the `jwksValidator` line), publish the public half of `key` at `{agentUrl}/.well-known/brand.json` under `jwks.keys[]` with `adcp_use: "webhook-signing"`, swap the in-memory key for a KMS-backed `SigningProvider` wired on `serverOptions.webhooks.signerProvider` for tenants where the in-process risk profile isn't acceptable.
+
+### Unsigned tenants (3.x optional path)
+
+AdCP 3.x classifies request signing as optional but recommended. Adopters spiking the SDK before standing up KMS or publishing brand.json can omit `signingKey` entirely:
+
+```typescript
+registry.register('not-signing-yet', {
+  agentUrl: 'https://later.example.com',
+  // signingKey omitted — JWKS validation skipped, webhook auto-wire
+  // skipped, tenant goes straight to `healthy` with
+  // reason: 'unsigned (no signingKey)'. Outbound webhooks are unsigned.
+  platform: yourPlatform,
+});
+```
+
+AdCP 4.0 will mandate `signingKey`; until then this is a soft launch path. Buyers MUST NOT break when an agent doesn't sign in 3.x — the "tolerate Signature headers regardless" baseline applies whether or not the agent signs (CLAUDE.md § Protocol-Wide Requirements).
+
 ## Step 7: Declare the Capability
 
 If your seller agent verifies inbound signatures, declare `request_signing` in your capabilities so buyers know to sign:

--- a/src/lib/server/decisioning/tenant-registry.ts
+++ b/src/lib/server/decisioning/tenant-registry.ts
@@ -116,27 +116,55 @@ export interface TenantConfig<P extends DecisioningPlatform = DecisioningPlatfor
    */
   jwksUrl?: string;
   /**
-   * Signing keypair for RFC 9421 response signing. **Optional in 3.x;
+   * Tenant's webhook-signing identity (RFC 9421). **Optional in 3.x;
    * mandated in 4.0.**
    *
-   * When set, the registry validates `publicJwk` appears in the tenant's
-   * published JWKS at `{agentUrl}/.well-known/brand.json` (or `jwksUrl`
-   * if overridden) before transitioning the tenant to `healthy`.
+   * **Scope is webhooks only.** AdCP 3.x defines exactly one
+   * outbound seller-→buyer signing surface: webhook deliveries. The
+   * synchronous tools/call reply is **not** signed at the body level
+   * — TLS provides session-scoped integrity for the immediate response,
+   * and signed webhooks carry durable at-rest integrity for async
+   * artifacts. This is the deliberate two-surface design, not a
+   * coverage gap; see `docs/building/understanding/security-model.mdx`
+   * § "What gets signed — and what doesn't" (adcp#3737, resolved by
+   * adcp#3742). Adopters who need attestable artifacts for
+   * synchronous flows structure the tool to emit a signed webhook
+   * (the "request-the-webhook" pattern in the same doc).
    *
-   * When omitted, JWKS validation is skipped entirely — the tenant
-   * transitions directly from `pending` to `healthy` on register(), with
-   * `reason: 'unsigned (no signingKey)'`. AdCP 3.x treats request signing
-   * as optional, so adopters spiking the SDK before standing up KMS or
-   * publishing brand.json can ship without signing material. Buyers MUST
-   * NOT break when an agent doesn't sign in 3.x — that's covered by the
+   * When set, the registry does two things:
+   *
+   *   1. **JWKS validation.** Confirms `publicJwk` appears in the
+   *      tenant's published JWKS at `{agentUrl}/.well-known/brand.json`
+   *      (or `jwksUrl` if overridden) before transitioning the tenant
+   *      to `healthy`.
+   *   2. **Webhook auto-wire.** Plumbs the privateJwk into
+   *      `serverOptions.webhooks.signerKey` automatically, so outbound
+   *      webhook deliveries are signed without the adopter wiring the
+   *      key twice. Strict on `adcp_use: "webhook-signing"` per AdCP
+   *      key-purpose discriminator (adcp#2423). Adopters wiring a
+   *      KMS-backed signer or a distinct webhook key per tenant set
+   *      `serverOptions.webhooks.signerKey` / `signerProvider`
+   *      explicitly — the explicit config wins and auto-wiring is
+   *      skipped.
+   *
+   * When omitted, both behaviors short-circuit: JWKS validation is
+   * skipped, the tenant transitions directly from `pending` to
+   * `healthy` on register() with `reason: 'unsigned (no signingKey)'`,
+   * and outbound webhooks are emitted unsigned (or, in 4.0, would be
+   * a registration error). AdCP 3.x treats signing as optional, so
+   * adopters spiking the SDK before standing up KMS or publishing
+   * brand.json can ship without signing material. Buyers MUST NOT
+   * break when an agent doesn't sign in 3.x — that's covered by the
    * "tolerate Signature headers" baseline regardless of whether the
    * agent itself signs.
    *
    * For local dev with signing enabled, pair `createSelfSignedTenantKey()`
-   * (generates an Ed25519 keypair) with `createNoopJwksValidator()`
+   * (generates an Ed25519 keypair already tagged
+   * `adcp_use: "webhook-signing"`) with `createNoopJwksValidator()`
    * (skips the brand.json roundtrip in dev/test). Production adopters
    * keep the default validator and publish the public half via
-   * brand.json.
+   * brand.json. See `docs/guides/SIGNING-GUIDE.md` § "Self-signed dev
+   * path" for the worked recipe.
    */
   signingKey?: TenantSigningKey;
   /** The DecisioningPlatform impl for this tenant. */

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.1.0';
+export const LIBRARY_VERSION = '6.3.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.1.0',
+  library: '6.3.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-01T01:17:37.625Z',
+  generatedAt: '2026-05-01T12:53:33.638Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Two doc-only follow-ups now that adcp#3742 ([\"synchronous response bodies are not signed — by design\"](https://github.com/adcontextprotocol/adcp/pull/3742)) is merged and #1166 (optional + auto-wired \`TenantConfig.signingKey\`) shipped in \`@adcp/sdk@6.3.0\`:

**1. Cross-link the spec decision into the SDK.** \`TenantConfig.signingKey\`'s JSDoc previously read *\"RFC 9421 response signing\"* — wording that predated the spec decision and didn't match what the SDK does. Updated to:

- State the scope explicitly: webhook-signing only.
- Carry the spec rationale: TLS for sync, signed webhooks for async, by deliberate two-surface design.
- Reference the canonical doc (\`docs/building/understanding/security-model.mdx\` § \"What gets signed — and what doesn't\").
- Point at the request-the-webhook pattern for adopters who hit the audit / forwarding edge case.

Adopters reading the field doc in their IDE now see the canonical reasoning without grepping. Closes a quiet documentation drift between the SDK's field comments and the spec's normative posture.

**2. Self-signed dev path recipe in SIGNING-GUIDE.md.** Pulls the multi-tenant signing-key story out of the migration doc into the canonical guide. New subsections under Step 6 (Sign Outbound Webhooks):

- **Multi-tenant: signing key on TenantConfig (auto-wired)** — the production pattern. One key per tenant, JWKS-validated against published brand.json, plumbed into webhook emission automatically.
- **Self-signed dev path** — \`createSelfSignedTenantKey()\` + \`createNoopJwksValidator()\`, with the NODE_ENV allowlist callout (\`ADCP_NOOP_JWKS_ACK=1\` for non-standard environments) and a clear promotion-to-production checklist.
- **Unsigned tenants (3.x optional path)** — omit-the-key flow for adopters not yet ready to sign, with the 4.0-mandate framing.

## Why now

The adoption surface for the registry signing path just landed in 6.3.0 but lives in the migration doc. Adopters not migrating from 5.x will skim SIGNING-GUIDE.md and miss the helpers. This closes that gap while the spec decision is fresh.

## No behavior change

JSDoc + Markdown only. No runtime, no API surface, no tests changed. Patch-level changeset added because JSDoc on exported types ships in the published \`.d.ts\`.

\`src/lib/version.ts\` change is the auto-generated sync to 6.3.0 from this morning's release — \`npm run sync-version\` regenerates it on every build, didn't catch up before #1166's commit was authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)