### PR TITLE
feat(cli+harness): adcp mock-server signal-marketplace + matrix v2 plumbing

### DIFF
--- a/.changeset/feat-mock-server-signal-marketplace.md
+++ b/.changeset/feat-mock-server-signal-marketplace.md
@@ -1,0 +1,34 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(cli): `adcp mock-server <specialism>` boots a fake upstream platform fixture for skill-matrix testing
+
+Adds `npx @adcp/sdk mock-server signal-marketplace` (currently the only specialism), which boots a CDP/DMP-shaped HTTP server modeled on LiveRamp / Lotame / Oracle Data Cloud. The mock represents the *upstream platform an adopter wraps*, not an AdCP-shaped agent — it has its own native API (cohorts/destinations/activations rather than signals/deployments) so skill-matrix runs test whether Claude can map an unfamiliar upstream to AdCP using the SDK + skill, not whether Claude can invent a decisioning platform from scratch.
+
+Headline characteristics of the `signal-marketplace` mock:
+
+- **Multi-operator API key pattern** — single `Authorization: Bearer <api_key>` shared across operator seats; per-request `X-Operator-Id` header determines cohort visibility, pricing, and activation scope. Real signal marketplaces all work this way; the mock surfaces the question "where does the SDK want me to put the principal-to-operator mapping?" as a real adopter would surface it.
+- **Two seeded operators** with overlapping cohort visibility — `op_pinnacle` (4 cohorts, all data providers) vs `op_summit` (2 Trident cohorts, +$1 CPM premium rate card). Forces the adapter to genuinely thread the operator from the AdCP `account.operator` field through to the upstream API or fail with empty/wrong data.
+- **Activation lifecycle state machine** — DSP/CTV destinations start `pending`, advance through `in_progress` → `active` on poll; agent destinations are synchronously `active` on create. Idempotent on `client_request_id` per operator (different operators using the same key are independent).
+- **Cross-operator isolation** — fetching another operator's activation returns 403 instead of 404 to prevent existence-oracle probing.
+
+The matrix harness (`scripts/manual-testing/agent-skill-storyboard.ts`, `run-skill-matrix.ts`) now accepts an optional `upstream` field per pair in `skill-matrix.json`. When set, it boots the mock-server before handing the workspace to Claude and surfaces the OpenAPI spec path + operator mapping table to Claude in the build prompt.
+
+Run with:
+
+```bash
+npx @adcp/sdk mock-server signal-marketplace --port 4500
+# or as part of the skill-matrix:
+npm run compliance:skill-matrix -- --filter signal-marketplace
+```
+
+Files added:
+- `src/lib/mock-server/index.ts` — specialism dispatcher
+- `src/lib/mock-server/signal-marketplace/openapi.yaml` — upstream API spec
+- `src/lib/mock-server/signal-marketplace/seed-data.ts` — operators, cohorts, destinations
+- `src/lib/mock-server/signal-marketplace/server.ts` — HTTP handlers
+- `test/lib/mock-server/signal-marketplace.test.js` — 8 smoke tests covering auth, operator scoping, pricing overrides, activation lifecycle, cross-operator isolation
+- `bin/adcp.js` — `mock-server` subcommand routing
+
+Background and design rationale: adcontextprotocol/adcp-client#1155.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1043,6 +1043,10 @@ NOTES:
       }
     } else if (args[i] === '--api-key') {
       apiKey = args[++i];
+      if (apiKey === undefined || apiKey === '' || apiKey.startsWith('--')) {
+        console.error(`ERROR: --api-key requires a value\n`);
+        process.exit(2);
+      }
     } else {
       console.error(`ERROR: unknown option: ${args[i]}\n`);
       process.exit(2);

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1000,6 +1000,90 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
   };
 }
 
+async function handleMockServerCommand(args) {
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`
+Mock upstream-platform server (compliance fixture)
+
+USAGE:
+  adcp mock-server <specialism> [--port N] [--api-key KEY]
+
+ARGUMENTS:
+  <specialism>       Which upstream platform shape to boot. Supported:
+                       signal-marketplace   CDP/DMP-shaped audience marketplace
+                                            (LiveRamp/Lotame/Oracle Data Cloud
+                                            family). Multi-operator API key
+                                            pattern; X-Operator-Id required.
+
+OPTIONS:
+  --port N           Listen port. Default: 4500.
+  --api-key KEY      Override the static bearer credential. Defaults to a
+                     stable test key printed at boot.
+
+NOTES:
+  These mock servers represent the *upstream* platform an adopter wraps,
+  not the AdCP agent the adopter exposes. Use them as the input to a
+  skill-matrix run: hand Claude the OpenAPI spec + the AdCP SKILL.md +
+  a target storyboard, let Claude generate the wrapper, then grade.
+
+  See: src/lib/mock-server/<specialism>/openapi.yaml
+`);
+    process.exit(args.length === 0 ? 2 : 0);
+  }
+
+  const specialism = args[0];
+  let port = 4500;
+  let apiKey;
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--port') {
+      port = Number(args[++i]);
+      if (!Number.isFinite(port) || port <= 0) {
+        console.error(`ERROR: --port must be a positive integer\n`);
+        process.exit(2);
+      }
+    } else if (args[i] === '--api-key') {
+      apiKey = args[++i];
+    } else {
+      console.error(`ERROR: unknown option: ${args[i]}\n`);
+      process.exit(2);
+    }
+  }
+
+  let bootMockServer;
+  try {
+    ({ bootMockServer } = require('../dist/lib/mock-server/index.js'));
+  } catch (err) {
+    console.error(
+      `ERROR: mock-server module not found in dist/. Run \`npm run build\` first.\n  underlying: ${err?.message ?? err}\n`
+    );
+    process.exit(1);
+  }
+
+  let handle;
+  try {
+    handle = await bootMockServer({ specialism, port, apiKey });
+  } catch (err) {
+    console.error(`ERROR: ${err?.message ?? err}\n`);
+    process.exit(1);
+  }
+
+  console.log(handle.summary());
+  console.log('');
+  console.log('Press Ctrl+C to shut down.');
+
+  const shutdown = async signal => {
+    console.error(`\nReceived ${signal}, shutting down...`);
+    try {
+      await handle.close();
+    } catch (err) {
+      console.error(`shutdown error: ${err?.message ?? err}`);
+    }
+    process.exit(0);
+  };
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+}
+
 async function handleComplyCommand(args) {
   // 'adcp comply' is an alias for 'adcp storyboard run'
   if (!args.includes('--json') && !args.includes('--help') && !args.includes('-h')) {
@@ -1037,6 +1121,8 @@ COMMANDS:
   comply <agent> [options]    DEPRECATED — use "storyboard run" instead
   test <agent> [scenario]     Run individual test scenarios (legacy)
   registry <command>          Brand/property registry lookups
+  mock-server <specialism>    Boot a fake upstream platform fixture for
+                              skill-matrix testing
 
   Run 'adcp <command> --help' for details on each command.
 
@@ -3302,6 +3388,11 @@ async function main() {
 
   if (args[0] === 'check-network') {
     await handleCheckNetworkCommand(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'mock-server') {
+    await handleMockServerCommand(args.slice(1));
     return;
   }
 

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -55,6 +55,13 @@ interface Args {
    * to `--output-format stream-json --verbose` and tees stdout to the
    * file (also still inherits to terminal so live watchers see it). */
   transcriptPath?: string;
+  /** When set, boot a mock upstream platform of this specialism flavor
+   * before handing the workspace to Claude. Claude wraps the upstream as
+   * an AdCP agent rather than inventing the platform layer from scratch.
+   * Currently supported: `signal-marketplace`. */
+  upstream?: string;
+  /** Port for the mock upstream server; defaults to `port + 100`. */
+  upstreamPort?: number;
 }
 
 const REPO_ROOT = resolve(__dirname, '..', '..');
@@ -71,6 +78,8 @@ function parseArgs(argv: string[]): Args {
     else if (a === '--keep') out.keep = true;
     else if (a === '--shared-node-modules') out.sharedNodeModules = argv[++i];
     else if (a === '--transcript') out.transcriptPath = resolve(argv[++i]);
+    else if (a === '--upstream') out.upstream = argv[++i];
+    else if (a === '--upstream-port') out.upstreamPort = Number(argv[++i]);
     else if (a === '--help' || a === '-h') {
       printUsage();
       process.exit(0);
@@ -93,12 +102,46 @@ function printUsage(): void {
   [--timeout-ms 600000] \\
   [--keep] \\
   [--shared-node-modules <path>] \\
-  [--transcript <path>]`
+  [--transcript <path>] \\
+  [--upstream <specialism>] \\
+  [--upstream-port 4300]`
   );
 }
 
-function buildPrompt(skill: string, storyboardId: string, port: number, skillAbsDir: string): string {
-  return `You are building a minimal AdCP agent that will be graded by the compliance storyboard \`${storyboardId}\`.
+function buildPrompt(
+  skill: string,
+  storyboardId: string,
+  port: number,
+  skillAbsDir: string,
+  upstream?: { specialism: string; url: string; apiKey: string; openapiPath: string; operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }> }
+): string {
+  const upstreamSection = upstream
+    ? `
+
+## The upstream platform you're wrapping
+
+You are NOT inventing a decisioning/signal platform from scratch. The adopter brings an existing upstream platform and you are writing the AdCP wrapper around it.
+
+The upstream platform is running locally as a fixture. Treat it exactly as you would the adopter's real platform — call its HTTP API to fetch state and post mutations.
+
+**Base URL**: ${upstream.url}
+**OpenAPI spec** (read this first): ${upstream.openapiPath}
+
+**Authentication** (every outbound request must carry both):
+- \`Authorization: Bearer ${upstream.apiKey}\` — the customer-level API key
+- \`X-Operator-Id: <upstream operator id>\` — the operator seat. Different operators see different cohorts/destinations and have different rate cards. **Omitting this header returns 403.**
+
+**Operator mapping**: the AdCP request you receive will carry \`account.operator: "<adcp-operator>"\`. You must translate that to the upstream operator id when calling the upstream API:
+
+${upstream.operatorMapping.map(m => `- AdCP \`account.operator: "${m.adcp_operator}"\`  →  upstream \`X-Operator-Id: ${m.upstream_operator_id}\``).join('\n')}
+
+The mapping table above is fixed seed data for this fixture; in production this would be a config file or DB lookup. Hard-code it for the test (a Map literal in your adapter is fine).
+
+If a buyer's \`account.operator\` value isn't in your mapping, return an appropriate AdCP error rather than calling upstream with no/wrong operator.
+`
+    : '';
+
+  return `You are building a minimal AdCP agent that will be graded by the compliance storyboard \`${storyboardId}\`.${upstreamSection}
 
 ## The skill you're following
 
@@ -372,6 +415,46 @@ function log(msg: string): void {
   process.stderr.write(`[harness] ${msg}\n`);
 }
 
+async function bootUpstreamForHarness(
+  specialism: string,
+  port: number
+): Promise<{
+  url: string;
+  apiKey: string;
+  openapiPath: string;
+  operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }>;
+  close: () => Promise<void>;
+} | undefined> {
+  // Use the compiled dist/ entry point so the harness doesn't depend on tsx
+  // resolution from a child process. Same path the CLI uses.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { bootMockServer } = require(resolve(REPO_ROOT, 'dist/lib/mock-server/index.js')) as {
+    bootMockServer: (opts: { specialism: string; port: number }) => Promise<{
+      url: string;
+      apiKey: string;
+      close: () => Promise<void>;
+    }>;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const seed = require(resolve(REPO_ROOT, `dist/lib/mock-server/${specialism}/seed-data.js`)) as {
+    OPERATORS: Array<{ adcp_operator: string; operator_id: string }>;
+  };
+  const handle = await bootMockServer({ specialism, port });
+  const openapiPath = resolve(REPO_ROOT, `src/lib/mock-server/${specialism}/openapi.yaml`);
+  const operatorMapping = seed.OPERATORS.map(op => ({
+    adcp_operator: op.adcp_operator,
+    upstream_operator_id: op.operator_id,
+  }));
+  log(`upstream mock-server (${specialism}) up on ${handle.url}`);
+  return {
+    url: handle.url,
+    apiKey: handle.apiKey,
+    openapiPath,
+    operatorMapping,
+    close: handle.close,
+  };
+}
+
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
   const skillPath = resolve(args.skill);
@@ -383,12 +466,32 @@ async function main(): Promise<void> {
   log(`skill: ${args.skill}`);
   log(`storyboard: ${args.storyboard}`);
   log(`port: ${args.port}`);
+  if (args.upstream) log(`upstream: ${args.upstream}`);
 
   let agent: ChildProcess | undefined;
+  let upstream: Awaited<ReturnType<typeof bootUpstreamForHarness>>;
   try {
+    if (args.upstream) {
+      const upstreamPort = args.upstreamPort ?? args.port + 100;
+      upstream = await bootUpstreamForHarness(args.upstream, upstreamPort);
+    }
     await bootstrapWorkspace(workDir, args.port, args.sharedNodeModules);
     await runClaude(
-      buildPrompt(skillContent, args.storyboard, args.port, skillDir),
+      buildPrompt(
+        skillContent,
+        args.storyboard,
+        args.port,
+        skillDir,
+        upstream
+          ? {
+              specialism: args.upstream!,
+              url: upstream.url,
+              apiKey: upstream.apiKey,
+              openapiPath: upstream.openapiPath,
+              operatorMapping: upstream.operatorMapping,
+            }
+          : undefined
+      ),
       workDir,
       args.timeoutMs,
       args.transcriptPath
@@ -411,6 +514,13 @@ async function main(): Promise<void> {
       // Give it 2s to shut down cleanly.
       await new Promise(r => setTimeout(r, 2000));
       if (agent.exitCode === null) agent.kill('SIGKILL');
+    }
+    if (upstream) {
+      try {
+        await upstream.close();
+      } catch (err) {
+        log(`upstream close error: ${(err as Error)?.message ?? err}`);
+      }
     }
     if (!args.keep && !args.workDir) {
       await rm(workDir, { recursive: true, force: true });

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -113,7 +113,13 @@ function buildPrompt(
   storyboardId: string,
   port: number,
   skillAbsDir: string,
-  upstream?: { specialism: string; url: string; apiKey: string; openapiPath: string; operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }> }
+  upstream?: {
+    specialism: string;
+    url: string;
+    apiKey: string;
+    openapiPath: string;
+    operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }>;
+  }
 ): string {
   const upstreamSection = upstream
     ? `
@@ -418,27 +424,40 @@ function log(msg: string): void {
 async function bootUpstreamForHarness(
   specialism: string,
   port: number
-): Promise<{
-  url: string;
-  apiKey: string;
-  openapiPath: string;
-  operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }>;
-  close: () => Promise<void>;
-} | undefined> {
-  // Use the compiled dist/ entry point so the harness doesn't depend on tsx
-  // resolution from a child process. Same path the CLI uses.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { bootMockServer } = require(resolve(REPO_ROOT, 'dist/lib/mock-server/index.js')) as {
-    bootMockServer: (opts: { specialism: string; port: number }) => Promise<{
+): Promise<
+  | {
       url: string;
       apiKey: string;
+      openapiPath: string;
+      operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }>;
       close: () => Promise<void>;
-    }>;
-  };
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const seed = require(resolve(REPO_ROOT, `dist/lib/mock-server/${specialism}/seed-data.js`)) as {
-    OPERATORS: Array<{ adcp_operator: string; operator_id: string }>;
-  };
+    }
+  | undefined
+> {
+  // Use the compiled dist/ entry point so the harness doesn't depend on tsx
+  // resolution from a child process. Same path the CLI uses. If dist/ is
+  // missing (contributor forgot `npm run build`), surface the same friendly
+  // hint the CLI gives at bin/adcp.js — `MODULE_NOT_FOUND` straight from
+  // require() is unhelpful and makes contributors think the harness is
+  // broken instead of just unbuilt.
+  let bootMockServer: (opts: { specialism: string; port: number }) => Promise<{
+    url: string;
+    apiKey: string;
+    close: () => Promise<void>;
+  }>;
+  let seed: { OPERATORS: Array<{ adcp_operator: string; operator_id: string }> };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    ({ bootMockServer } = require(resolve(REPO_ROOT, 'dist/lib/mock-server/index.js')));
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    seed = require(resolve(REPO_ROOT, `dist/lib/mock-server/${specialism}/seed-data.js`));
+  } catch (err) {
+    log(
+      `[harness] mock-server module not found in dist/. Run \`npm run build\` first.\n` +
+        `  underlying: ${(err as Error)?.message ?? err}`
+    );
+    throw new Error(`mock-server (${specialism}) not built; run \`npm run build\``);
+  }
   const handle = await bootMockServer({ specialism, port });
   const openapiPath = resolve(REPO_ROOT, `src/lib/mock-server/${specialism}/openapi.yaml`);
   const operatorMapping = seed.OPERATORS.map(op => ({

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -453,7 +453,7 @@ async function bootUpstreamForHarness(
     seed = require(resolve(REPO_ROOT, `dist/lib/mock-server/${specialism}/seed-data.js`));
   } catch (err) {
     log(
-      `[harness] mock-server module not found in dist/. Run \`npm run build\` first.\n` +
+      `mock-server module not found in dist/. Run \`npm run build\` first.\n` +
         `  underlying: ${(err as Error)?.message ?? err}`
     );
     throw new Error(`mock-server (${specialism}) not built; run \`npm run build\``);

--- a/scripts/manual-testing/run-skill-matrix.ts
+++ b/scripts/manual-testing/run-skill-matrix.ts
@@ -36,6 +36,11 @@ import { join, resolve } from 'node:path';
 interface Pair {
   skill: string;
   storyboard: string;
+  /** Optional upstream-platform mock specialism. When set, the harness
+   * boots the corresponding mock-server before handing the workspace to
+   * Claude — Claude wraps the upstream rather than inventing the platform
+   * layer from scratch. Currently supported: `signal-marketplace`. */
+  upstream?: string;
 }
 
 interface Matrix {
@@ -192,6 +197,12 @@ function runOne(pair: Pair, port: number, args: Args, sharedNodeModules?: string
     ];
     if (args.keep) harnessArgs.push('--keep');
     if (sharedNodeModules) harnessArgs.push('--shared-node-modules', sharedNodeModules);
+    if (pair.upstream) {
+      // Upstream port lives on the same per-worker port base, offset by 50,
+      // so the agent (port) and the upstream (port + 50) don't collide and
+      // parallel workers stay clear of each other.
+      harnessArgs.push('--upstream', pair.upstream, '--upstream-port', String(port + 50));
+    }
 
     const started = Date.now();
     const stderrChunks: Buffer[] = [];

--- a/scripts/manual-testing/skill-matrix.json
+++ b/scripts/manual-testing/skill-matrix.json
@@ -15,7 +15,11 @@
     { "skill": "skills/build-governance-agent/SKILL.md", "storyboard": "property_lists" },
     { "skill": "skills/build-retail-media-agent/SKILL.md", "storyboard": "sales_catalog_driven" },
     { "skill": "skills/build-si-agent/SKILL.md", "storyboard": "si_baseline" },
-    { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_marketplace", "upstream": "signal-marketplace" },
+    {
+      "skill": "skills/build-signals-agent/SKILL.md",
+      "storyboard": "signal_marketplace",
+      "upstream": "signal-marketplace"
+    },
     { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_owned" }
   ]
 }

--- a/scripts/manual-testing/skill-matrix.json
+++ b/scripts/manual-testing/skill-matrix.json
@@ -15,7 +15,7 @@
     { "skill": "skills/build-governance-agent/SKILL.md", "storyboard": "property_lists" },
     { "skill": "skills/build-retail-media-agent/SKILL.md", "storyboard": "sales_catalog_driven" },
     { "skill": "skills/build-si-agent/SKILL.md", "storyboard": "si_baseline" },
-    { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_marketplace" },
+    { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_marketplace", "upstream": "signal-marketplace" },
     { "skill": "skills/build-signals-agent/SKILL.md", "storyboard": "signal_owned" }
   ]
 }

--- a/src/lib/mock-server/index.ts
+++ b/src/lib/mock-server/index.ts
@@ -40,9 +40,7 @@ export async function bootMockServer(options: MockServerOptions): Promise<MockSe
       };
     }
     default:
-      throw new Error(
-        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace.`
-      );
+      throw new Error(`Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace.`);
   }
 }
 

--- a/src/lib/mock-server/index.ts
+++ b/src/lib/mock-server/index.ts
@@ -1,0 +1,72 @@
+import { bootSignalMarketplace } from './signal-marketplace/server';
+import { DEFAULT_API_KEY, OPERATORS } from './signal-marketplace/seed-data';
+
+export interface MockServerOptions {
+  specialism: string;
+  port: number;
+  apiKey?: string;
+}
+
+export interface MockServerHandle {
+  url: string;
+  apiKey: string;
+  close: () => Promise<void>;
+  /** Adopter-friendly summary for boot-log printing. */
+  summary: () => string;
+}
+
+/**
+ * Boot a mock upstream platform for the given specialism. Returns a handle
+ * the caller (CLI or matrix harness) uses to read connection details and
+ * shut down cleanly.
+ *
+ * Currently supported specialisms: `signal-marketplace`. Adding a new one
+ * means adding the upstream-shape OpenAPI + seed data + boot function under
+ * `src/lib/mock-server/<specialism>/` and a switch case here.
+ */
+export async function bootMockServer(options: MockServerOptions): Promise<MockServerHandle> {
+  switch (options.specialism) {
+    case 'signal-marketplace': {
+      const { url, close } = await bootSignalMarketplace({
+        port: options.port,
+        apiKey: options.apiKey,
+      });
+      const apiKey = options.apiKey ?? DEFAULT_API_KEY;
+      return {
+        url,
+        apiKey,
+        close,
+        summary: () => formatSignalMarketplaceSummary(url, apiKey),
+      };
+    }
+    default:
+      throw new Error(
+        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace.`
+      );
+  }
+}
+
+function formatSignalMarketplaceSummary(url: string, apiKey: string): string {
+  const operatorLines = OPERATORS.map(
+    op =>
+      `  ${op.operator_id}  →  AdCP account.operator: "${op.adcp_operator}"  (visible cohorts: ${op.visible_cohort_ids.length})`
+  ).join('\n');
+  return [
+    `Mock signal marketplace running at ${url}`,
+    ``,
+    `Auth:`,
+    `  Authorization: Bearer ${apiKey}`,
+    `  X-Operator-Id: <operator_id> (required on every call)`,
+    ``,
+    `Operator mapping:`,
+    operatorLines,
+    ``,
+    `OpenAPI spec: src/lib/mock-server/signal-marketplace/openapi.yaml`,
+    `Routes:`,
+    `  GET    ${url}/v2/cohorts`,
+    `  GET    ${url}/v2/cohorts/{cohort_id}`,
+    `  GET    ${url}/v2/destinations`,
+    `  POST   ${url}/v2/activations`,
+    `  GET    ${url}/v2/activations/{activation_id}`,
+  ].join('\n');
+}

--- a/src/lib/mock-server/signal-marketplace/openapi.yaml
+++ b/src/lib/mock-server/signal-marketplace/openapi.yaml
@@ -42,7 +42,7 @@ components:
   schemas:
     Cohort:
       type: object
-      required: [cohort_id, name, category, member_count, total_universe, freshness_days, activation_status, data_provider_domain, data_provider_id, pricing, value_type]
+      required: [cohort_id, name, category, member_count, total_universe, freshness_days, activation_status, data_provider_domain, data_provider_id, data_provider_name, pricing, value_type]
       properties:
         cohort_id:
           type: string
@@ -75,6 +75,14 @@ components:
           type: string
           description: Data-provider-internal ID for this cohort.
           example: "likely_ev_buyers"
+        data_provider_name:
+          type: string
+          description: |
+            Human-readable name of the upstream data provider — flows directly
+            to AdCP `signal_id.data_provider` (required by signals response
+            schema). Without this field, adapters have to fabricate the value
+            from the domain, which trains the wrong reflex.
+          example: "Trident Auto Insights"
         value_type:
           type: string
           enum: [binary, numeric, categorical]

--- a/src/lib/mock-server/signal-marketplace/openapi.yaml
+++ b/src/lib/mock-server/signal-marketplace/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Cohort Marketplace API
-  version: "2.0.0"
+  version: '2.0.0'
   description: |
     HTTP API for a fictional signal/audience marketplace platform. Models a
     LiveRamp / Lotame / Oracle Data Cloud-shaped upstream that aggregates
@@ -17,7 +17,7 @@ servers:
   - url: http://127.0.0.1:{port}/v2
     variables:
       port:
-        default: "4500"
+        default: '4500'
         description: Port the mock-server boots on (override with --port)
 
 components:
@@ -42,12 +42,26 @@ components:
   schemas:
     Cohort:
       type: object
-      required: [cohort_id, name, category, member_count, total_universe, freshness_days, activation_status, data_provider_domain, data_provider_id, data_provider_name, pricing, value_type]
+      required:
+        [
+          cohort_id,
+          name,
+          category,
+          member_count,
+          total_universe,
+          freshness_days,
+          activation_status,
+          data_provider_domain,
+          data_provider_id,
+          data_provider_name,
+          pricing,
+          value_type,
+        ]
       properties:
         cohort_id:
           type: string
           description: Stable upstream identifier. NOT the same as the marketplace agent's signal_agent_segment_id.
-          example: "up_trident_likely_ev_buyers"
+          example: 'up_trident_likely_ev_buyers'
         name: { type: string }
         description: { type: string }
         category:
@@ -70,11 +84,11 @@ components:
         data_provider_domain:
           type: string
           description: Domain of the upstream data provider — flows directly to AdCP signal_id.data_provider_domain.
-          example: "tridentauto.example"
+          example: 'tridentauto.example'
         data_provider_id:
           type: string
           description: Data-provider-internal ID for this cohort.
-          example: "likely_ev_buyers"
+          example: 'likely_ev_buyers'
         data_provider_name:
           type: string
           description: |
@@ -82,7 +96,7 @@ components:
             to AdCP `signal_id.data_provider` (required by signals response
             schema). Without this field, adapters have to fabricate the value
             from the domain, which trains the wrong reflex.
-          example: "Trident Auto Insights"
+          example: 'Trident Auto Insights'
         value_type:
           type: string
           enum: [binary, numeric, categorical]
@@ -99,7 +113,7 @@ components:
         pricing:
           type: array
           description: Operator-specific rate card. Different operators see different prices on the same cohort.
-          items: { $ref: "#/components/schemas/PricingTier" }
+          items: { $ref: '#/components/schemas/PricingTier' }
         metadata:
           type: object
           additionalProperties: true
@@ -110,7 +124,7 @@ components:
       type: object
       required: [pricing_id, model, currency]
       properties:
-        pricing_id: { type: string, example: "tier_trident_evb_cpm_op_pinnacle" }
+        pricing_id: { type: string, example: 'tier_trident_evb_cpm_op_pinnacle' }
         model:
           type: string
           enum: [cpm]
@@ -118,7 +132,7 @@ components:
         cpm_amount:
           type: number
           description: Cost per mille in `currency`. Required when model=cpm.
-        currency: { type: string, example: "USD" }
+        currency: { type: string, example: 'USD' }
         minimum_spend:
           type: number
           description: Optional floor; operator must commit to at least this spend per activation.
@@ -127,7 +141,7 @@ components:
       type: object
       required: [destination_id, name, platform_type, integration]
       properties:
-        destination_id: { type: string, example: "dest_ttd_main" }
+        destination_id: { type: string, example: 'dest_ttd_main' }
         name: { type: string }
         platform_type:
           type: string
@@ -155,10 +169,10 @@ components:
       type: object
       required: [activation_id, cohort_id, destination_id, status, created_at]
       properties:
-        activation_id: { type: string, example: "act_01J9X..." }
+        activation_id: { type: string, example: 'act_01J9X...' }
         cohort_id: { type: string }
         destination_id: { type: string }
-        pricing_id: { type: string, description: "Which PricingTier was committed." }
+        pricing_id: { type: string, description: 'Which PricingTier was committed.' }
         status:
           type: string
           enum: [pending, in_progress, active, failed, expired]
@@ -219,7 +233,7 @@ paths:
       summary: List cohorts visible to {operator}
       operationId: listCohorts
       parameters:
-        - $ref: "#/components/parameters/OperatorId"
+        - $ref: '#/components/parameters/OperatorId'
         - in: query
           name: category
           schema:
@@ -233,7 +247,7 @@ paths:
           schema: { type: string }
           description: Free-text search across name + description.
       responses:
-        "200":
+        '200':
           description: Cohorts visible to this operator. Empty array if none.
           content:
             application/json:
@@ -243,38 +257,38 @@ paths:
                 properties:
                   cohorts:
                     type: array
-                    items: { $ref: "#/components/schemas/Cohort" }
-        "401": { description: Missing/invalid bearer credential. }
-        "403": { description: Unknown operator. }
+                    items: { $ref: '#/components/schemas/Cohort' }
+        '401': { description: Missing/invalid bearer credential. }
+        '403': { description: Unknown operator. }
 
   /cohorts/{cohort_id}:
     get:
       summary: Fetch cohort detail (with operator-scoped pricing)
       operationId: getCohort
       parameters:
-        - $ref: "#/components/parameters/OperatorId"
+        - $ref: '#/components/parameters/OperatorId'
         - in: path
           name: cohort_id
           required: true
           schema: { type: string }
       responses:
-        "200":
+        '200':
           description: Cohort detail.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Cohort" }
-        "401": { description: Missing/invalid bearer credential. }
-        "403": { description: Unknown operator OR cohort visible to other operators only. }
-        "404": { description: Cohort does not exist. }
+              schema: { $ref: '#/components/schemas/Cohort' }
+        '401': { description: Missing/invalid bearer credential. }
+        '403': { description: Unknown operator OR cohort visible to other operators only. }
+        '404': { description: Cohort does not exist. }
 
   /destinations:
     get:
       summary: List activation destinations available to {operator}
       operationId: listDestinations
       parameters:
-        - $ref: "#/components/parameters/OperatorId"
+        - $ref: '#/components/parameters/OperatorId'
       responses:
-        "200":
+        '200':
           description: Destinations.
           content:
             application/json:
@@ -284,57 +298,65 @@ paths:
                 properties:
                   destinations:
                     type: array
-                    items: { $ref: "#/components/schemas/Destination" }
-        "401": { description: Missing/invalid bearer credential. }
-        "403": { description: Unknown operator. }
+                    items: { $ref: '#/components/schemas/Destination' }
+        '401': { description: Missing/invalid bearer credential. }
+        '403': { description: Unknown operator. }
 
   /activations:
     post:
       summary: Create an activation (push cohort to destination)
       operationId: createActivation
       parameters:
-        - $ref: "#/components/parameters/OperatorId"
+        - $ref: '#/components/parameters/OperatorId'
       requestBody:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/ActivationRequest" }
+            schema: { $ref: '#/components/schemas/ActivationRequest' }
       responses:
-        "201":
+        '201':
           description: Activation created. status will be `pending` initially for DSP destinations and `active` immediately for agent destinations.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Activation" }
-        "200":
+              schema: { $ref: '#/components/schemas/Activation' }
+        '200':
           description: Idempotent replay — returns the existing activation for this client_request_id.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Activation" }
-        "400":
+              schema: { $ref: '#/components/schemas/Activation' }
+        '400':
           description: Bad request — missing required fields, invalid pricing_id for cohort, etc.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Error" }
-        "401": { description: Missing/invalid bearer credential. }
-        "403": { description: Unknown operator OR cohort/destination not visible to this operator. }
-        "404": { description: Cohort or destination does not exist. }
+              schema: { $ref: '#/components/schemas/Error' }
+        '401': { description: Missing/invalid bearer credential. }
+        '403': { description: Unknown operator OR cohort/destination not visible to this operator. }
+        '404': { description: Cohort or destination does not exist. }
+        '409':
+          description: |
+            Idempotency conflict — `client_request_id` was previously used with
+            a different `(cohort_id, destination_id, pricing_id)` tuple. Use a
+            fresh idempotency key for distinct requests.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /activations/{activation_id}:
     get:
       summary: Fetch activation status
       operationId: getActivation
       parameters:
-        - $ref: "#/components/parameters/OperatorId"
+        - $ref: '#/components/parameters/OperatorId'
         - in: path
           name: activation_id
           required: true
           schema: { type: string }
       responses:
-        "200":
+        '200':
           description: Activation detail.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Activation" }
-        "401": { description: Missing/invalid bearer credential. }
-        "403": { description: Activation belongs to a different operator. }
-        "404": { description: Activation does not exist. }
+              schema: { $ref: '#/components/schemas/Activation' }
+        '401': { description: Missing/invalid bearer credential. }
+        '403': { description: Activation belongs to a different operator. }
+        '404': { description: Activation does not exist. }

--- a/src/lib/mock-server/signal-marketplace/openapi.yaml
+++ b/src/lib/mock-server/signal-marketplace/openapi.yaml
@@ -1,0 +1,332 @@
+openapi: 3.1.0
+info:
+  title: Cohort Marketplace API
+  version: "2.0.0"
+  description: |
+    HTTP API for a fictional signal/audience marketplace platform. Models a
+    LiveRamp / Lotame / Oracle Data Cloud-shaped upstream that aggregates
+    audience cohorts from multiple data providers and resells them to
+    operator seats.
+
+    This is a fixture for compliance testing — it has no real data and
+    requires the static API key + operator-id pair documented in the boot
+    log. Cohort visibility, pricing, and activation history are all keyed
+    on the X-Operator-Id header.
+
+servers:
+  - url: http://127.0.0.1:{port}/v2
+    variables:
+      port:
+        default: "4500"
+        description: Port the mock-server boots on (override with --port)
+
+components:
+  securitySchemes:
+    bearerApiKey:
+      type: http
+      scheme: bearer
+      description: |
+        Customer-level credential. The same key is shared across all operator
+        seats owned by that customer. Operator scoping happens via the
+        X-Operator-Id header below.
+  parameters:
+    OperatorId:
+      name: X-Operator-Id
+      in: header
+      required: true
+      schema: { type: string }
+      description: |
+        Operator seat identifier. MUST be present on every request. Determines
+        which cohorts are visible, which pricing applies, and which activations
+        the caller can read. Requests with an unknown operator return 403.
+  schemas:
+    Cohort:
+      type: object
+      required: [cohort_id, name, category, member_count, total_universe, freshness_days, activation_status, data_provider_domain, data_provider_id, pricing, value_type]
+      properties:
+        cohort_id:
+          type: string
+          description: Stable upstream identifier. NOT the same as the marketplace agent's signal_agent_segment_id.
+          example: "up_trident_likely_ev_buyers"
+        name: { type: string }
+        description: { type: string }
+        category:
+          type: string
+          enum: [behavioral, demographic, intent, contextual, retargeting]
+        member_count:
+          type: integer
+          description: |
+            Absolute count of users in the cohort for this operator's seat.
+            Convert to AdCP coverage_percentage by dividing by total_universe.
+        total_universe:
+          type: integer
+          description: Operator's addressable universe (the denominator for coverage %).
+        freshness_days:
+          type: integer
+          description: Days since the cohort was last refreshed. AdCP wants a 0-1 freshness_score; adapter normalizes.
+        activation_status:
+          type: string
+          enum: [active, draft, archived]
+        data_provider_domain:
+          type: string
+          description: Domain of the upstream data provider — flows directly to AdCP signal_id.data_provider_domain.
+          example: "tridentauto.example"
+        data_provider_id:
+          type: string
+          description: Data-provider-internal ID for this cohort.
+          example: "likely_ev_buyers"
+        value_type:
+          type: string
+          enum: [binary, numeric, categorical]
+        range:
+          type: object
+          description: Present when value_type is "numeric".
+          properties:
+            min: { type: number }
+            max: { type: number }
+        categories:
+          type: array
+          description: Present when value_type is "categorical".
+          items: { type: string }
+        pricing:
+          type: array
+          description: Operator-specific rate card. Different operators see different prices on the same cohort.
+          items: { $ref: "#/components/schemas/PricingTier" }
+        metadata:
+          type: object
+          additionalProperties: true
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    PricingTier:
+      type: object
+      required: [pricing_id, model, currency]
+      properties:
+        pricing_id: { type: string, example: "tier_trident_evb_cpm_op_pinnacle" }
+        model:
+          type: string
+          enum: [cpm]
+          description: AdCP-compatible pricing model. Marketplace mock keeps this simple — CPM only.
+        cpm_amount:
+          type: number
+          description: Cost per mille in `currency`. Required when model=cpm.
+        currency: { type: string, example: "USD" }
+        minimum_spend:
+          type: number
+          description: Optional floor; operator must commit to at least this spend per activation.
+
+    Destination:
+      type: object
+      required: [destination_id, name, platform_type, integration]
+      properties:
+        destination_id: { type: string, example: "dest_ttd_main" }
+        name: { type: string }
+        platform_type:
+          type: string
+          enum: [dsp, ssp, social, ctv, retail, agent]
+        integration:
+          type: string
+          enum: [api_push, segment_id, key_value, agent_url]
+          description: |
+            How activation completes. `api_push` pushes segments via API and
+            returns a platform-native segment_id; `segment_id` and `key_value`
+            indicate which activation_key shape AdCP should expect; `agent_url`
+            points at a sales-agent destination.
+        platform_code:
+          type: string
+          description: Vendor code for DSP destinations — e.g. "the-trade-desk", "streamhaus".
+        agent_url:
+          type: string
+          format: uri
+          description: Sales-agent URL for type=agent destinations.
+        expected_match_rate:
+          type: number
+          description: Historical match-rate observed for this operator on this destination, 0-1.
+
+    Activation:
+      type: object
+      required: [activation_id, cohort_id, destination_id, status, created_at]
+      properties:
+        activation_id: { type: string, example: "act_01J9X..." }
+        cohort_id: { type: string }
+        destination_id: { type: string }
+        pricing_id: { type: string, description: "Which PricingTier was committed." }
+        status:
+          type: string
+          enum: [pending, in_progress, active, failed, expired]
+        match_rate:
+          type: number
+          description: Populated when status=active.
+        member_count_matched:
+          type: integer
+          description: Populated when status=active.
+        platform_segment_id:
+          type: string
+          description: Platform-native segment ID for DSP destinations (status=active).
+        agent_activation_key:
+          type: object
+          description: Key/value pair for agent destinations (status=active).
+          additionalProperties: true
+        error:
+          type: object
+          description: Populated when status=failed.
+          properties:
+            code: { type: string }
+            message: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        expires_at: { type: string, format: date-time }
+
+    ActivationRequest:
+      type: object
+      required: [cohort_id, destination_id, pricing_id]
+      properties:
+        cohort_id: { type: string }
+        destination_id: { type: string }
+        pricing_id: { type: string }
+        duration_days:
+          type: integer
+          description: Optional — defaults to 90 if omitted.
+        client_request_id:
+          type: string
+          description: |
+            Idempotency key. Re-sending the same client_request_id returns the
+            existing activation rather than creating a new one. Adopters should
+            map AdCP idempotency_key → client_request_id.
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+        request_id: { type: string }
+
+security:
+  - bearerApiKey: []
+
+paths:
+  /cohorts:
+    get:
+      summary: List cohorts visible to {operator}
+      operationId: listCohorts
+      parameters:
+        - $ref: "#/components/parameters/OperatorId"
+        - in: query
+          name: category
+          schema:
+            type: string
+            enum: [behavioral, demographic, intent, contextual, retargeting]
+        - in: query
+          name: data_provider_domain
+          schema: { type: string }
+        - in: query
+          name: q
+          schema: { type: string }
+          description: Free-text search across name + description.
+      responses:
+        "200":
+          description: Cohorts visible to this operator. Empty array if none.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [cohorts]
+                properties:
+                  cohorts:
+                    type: array
+                    items: { $ref: "#/components/schemas/Cohort" }
+        "401": { description: Missing/invalid bearer credential. }
+        "403": { description: Unknown operator. }
+
+  /cohorts/{cohort_id}:
+    get:
+      summary: Fetch cohort detail (with operator-scoped pricing)
+      operationId: getCohort
+      parameters:
+        - $ref: "#/components/parameters/OperatorId"
+        - in: path
+          name: cohort_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Cohort detail.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Cohort" }
+        "401": { description: Missing/invalid bearer credential. }
+        "403": { description: Unknown operator OR cohort visible to other operators only. }
+        "404": { description: Cohort does not exist. }
+
+  /destinations:
+    get:
+      summary: List activation destinations available to {operator}
+      operationId: listDestinations
+      parameters:
+        - $ref: "#/components/parameters/OperatorId"
+      responses:
+        "200":
+          description: Destinations.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [destinations]
+                properties:
+                  destinations:
+                    type: array
+                    items: { $ref: "#/components/schemas/Destination" }
+        "401": { description: Missing/invalid bearer credential. }
+        "403": { description: Unknown operator. }
+
+  /activations:
+    post:
+      summary: Create an activation (push cohort to destination)
+      operationId: createActivation
+      parameters:
+        - $ref: "#/components/parameters/OperatorId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ActivationRequest" }
+      responses:
+        "201":
+          description: Activation created. status will be `pending` initially for DSP destinations and `active` immediately for agent destinations.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Activation" }
+        "200":
+          description: Idempotent replay — returns the existing activation for this client_request_id.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Activation" }
+        "400":
+          description: Bad request — missing required fields, invalid pricing_id for cohort, etc.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401": { description: Missing/invalid bearer credential. }
+        "403": { description: Unknown operator OR cohort/destination not visible to this operator. }
+        "404": { description: Cohort or destination does not exist. }
+
+  /activations/{activation_id}:
+    get:
+      summary: Fetch activation status
+      operationId: getActivation
+      parameters:
+        - $ref: "#/components/parameters/OperatorId"
+        - in: path
+          name: activation_id
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Activation detail.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Activation" }
+        "401": { description: Missing/invalid bearer credential. }
+        "403": { description: Activation belongs to a different operator. }
+        "404": { description: Activation does not exist. }

--- a/src/lib/mock-server/signal-marketplace/seed-data.ts
+++ b/src/lib/mock-server/signal-marketplace/seed-data.ts
@@ -1,0 +1,243 @@
+export interface MockCohort {
+  cohort_id: string;
+  name: string;
+  description: string;
+  category: 'behavioral' | 'demographic' | 'intent' | 'contextual' | 'retargeting';
+  member_count: number;
+  total_universe: number;
+  freshness_days: number;
+  activation_status: 'active' | 'draft' | 'archived';
+  data_provider_domain: string;
+  data_provider_id: string;
+  value_type: 'binary' | 'numeric' | 'categorical';
+  range?: { min: number; max: number };
+  categories?: string[];
+  pricing: MockPricingTier[];
+  metadata?: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MockPricingTier {
+  pricing_id: string;
+  model: 'cpm';
+  cpm_amount: number;
+  currency: string;
+  minimum_spend?: number;
+}
+
+export interface MockDestination {
+  destination_id: string;
+  name: string;
+  platform_type: 'dsp' | 'ssp' | 'social' | 'ctv' | 'retail' | 'agent';
+  integration: 'api_push' | 'segment_id' | 'key_value' | 'agent_url';
+  platform_code?: string;
+  agent_url?: string;
+  expected_match_rate?: number;
+}
+
+export interface MockOperator {
+  operator_id: string;
+  display_name: string;
+  /** AdCP-side operator identifier the adapter receives in `account.operator`. */
+  adcp_operator: string;
+  visible_cohort_ids: string[];
+  visible_destination_ids: string[];
+  /** Map of cohort_id → operator-scoped pricing override. Falls back to default pricing if absent. */
+  pricing_overrides: Record<string, MockPricingTier[]>;
+}
+
+const NOW = '2026-04-15T12:00:00Z';
+const RECENT = '2026-04-30T08:30:00Z';
+
+/**
+ * Default pricing for each cohort. Operator-specific overrides live on the
+ * MockOperator entries below — this is what `op_pinnacle` (the storyboard's
+ * operator) sees. A second operator in this fixture (`op_summit`) sees the
+ * same Trident cohorts at a different rate.
+ */
+export const COHORTS: MockCohort[] = [
+  {
+    cohort_id: 'ckhsh_us_evb_2024q4_001',
+    name: 'Likely EV Buyers (Trident, US)',
+    description:
+      'Auto-intent shoppers showing strong EV-specific signals — model-comparison sessions, charger-locator activity, and EV-incentive content engagement.',
+    category: 'intent',
+    member_count: 8_000_000,
+    total_universe: 100_000_000,
+    freshness_days: 1,
+    activation_status: 'active',
+    data_provider_domain: 'tridentauto.example',
+    data_provider_id: 'likely_ev_buyers',
+    value_type: 'binary',
+    pricing: [
+      {
+        pricing_id: 'tier_default_evb_cpm',
+        model: 'cpm',
+        cpm_amount: 3.5,
+        currency: 'USD',
+      },
+    ],
+    metadata: { trident_taxonomy_version: '2024.4' },
+    created_at: NOW,
+    updated_at: RECENT,
+  },
+  {
+    cohort_id: 'ckhsh_us_pp_2024q4_002',
+    name: 'Purchase Propensity Score (Trident, US)',
+    description:
+      'Per-user 0-1 propensity score for next-90-day vehicle purchase, modeled across browsing, dealership-visit, and credit-shopping signals.',
+    category: 'behavioral',
+    member_count: 55_000_000,
+    total_universe: 100_000_000,
+    freshness_days: 7,
+    activation_status: 'active',
+    data_provider_domain: 'tridentauto.example',
+    data_provider_id: 'purchase_propensity',
+    value_type: 'numeric',
+    range: { min: 0, max: 1 },
+    pricing: [
+      {
+        pricing_id: 'tier_default_pp_cpm',
+        model: 'cpm',
+        cpm_amount: 4.0,
+        currency: 'USD',
+      },
+    ],
+    metadata: { trident_taxonomy_version: '2024.4' },
+    created_at: NOW,
+    updated_at: RECENT,
+  },
+  {
+    cohort_id: 'ckhsh_us_cv_2024q4_003',
+    name: 'Competitor Dealer Visitors (Meridian, US)',
+    description:
+      'Mobile devices observed in geofenced areas around competitor auto-dealer locations within the past 30 days.',
+    category: 'behavioral',
+    member_count: 6_000_000,
+    total_universe: 100_000_000,
+    freshness_days: 3,
+    activation_status: 'active',
+    data_provider_domain: 'meridiangeo.example',
+    data_provider_id: 'competitor_visitors',
+    value_type: 'binary',
+    pricing: [
+      {
+        pricing_id: 'tier_default_cv_cpm',
+        model: 'cpm',
+        cpm_amount: 5.0,
+        currency: 'USD',
+      },
+    ],
+    metadata: { meridian_geo_radius_meters: 250 },
+    created_at: NOW,
+    updated_at: RECENT,
+  },
+  {
+    cohort_id: 'ckhsh_us_ntb_2024q4_004',
+    name: 'New-to-Brand Auto Shoppers (ShopGrid, US)',
+    description:
+      'Shoppers researching auto purchases who have no prior transaction history with target brand. Built from ShopGrid retail-exhaust data.',
+    category: 'intent',
+    member_count: 25_000_000,
+    total_universe: 100_000_000,
+    freshness_days: 2,
+    activation_status: 'active',
+    data_provider_domain: 'shopgrid.example',
+    data_provider_id: 'new_to_brand',
+    value_type: 'binary',
+    pricing: [
+      {
+        pricing_id: 'tier_default_ntb_cpm',
+        model: 'cpm',
+        cpm_amount: 3.5,
+        currency: 'USD',
+      },
+    ],
+    metadata: { shopgrid_lookback_days: 180 },
+    created_at: NOW,
+    updated_at: RECENT,
+  },
+];
+
+export const DESTINATIONS: MockDestination[] = [
+  {
+    destination_id: 'dest_ttd_main',
+    name: 'The Trade Desk — Production',
+    platform_type: 'dsp',
+    integration: 'segment_id',
+    platform_code: 'the-trade-desk',
+    expected_match_rate: 0.78,
+  },
+  {
+    destination_id: 'dest_streamhaus_ctv',
+    name: 'StreamHaus CTV',
+    platform_type: 'ctv',
+    integration: 'segment_id',
+    platform_code: 'streamhaus',
+    expected_match_rate: 0.62,
+  },
+  {
+    destination_id: 'dest_wonderstruck_agent',
+    name: 'Wonderstruck Sales Agent',
+    platform_type: 'agent',
+    integration: 'agent_url',
+    agent_url: 'https://wonderstruck.salesagents.example',
+    expected_match_rate: 0.95,
+  },
+];
+
+/**
+ * Mapping table the adapter has to consume. The AdCP request carries
+ * `account.operator: "pinnacle-agency.example"`; the adapter maps that to
+ * the upstream operator_id and sends `X-Operator-Id` accordingly.
+ *
+ * Two operators are seeded so the adapter MUST respect the mapping — using
+ * the wrong operator id (or omitting the header) yields a different cohort
+ * set and the storyboard fails.
+ */
+export const OPERATORS: MockOperator[] = [
+  {
+    operator_id: 'op_pinnacle',
+    display_name: 'Pinnacle Agency',
+    adcp_operator: 'pinnacle-agency.example',
+    visible_cohort_ids: COHORTS.map(c => c.cohort_id),
+    visible_destination_ids: DESTINATIONS.map(d => d.destination_id),
+    pricing_overrides: {},
+  },
+  {
+    operator_id: 'op_summit',
+    display_name: 'Summit Media',
+    adcp_operator: 'summit-media.example',
+    // Only sees Trident cohorts.
+    visible_cohort_ids: ['ckhsh_us_evb_2024q4_001', 'ckhsh_us_pp_2024q4_002'],
+    visible_destination_ids: ['dest_ttd_main', 'dest_streamhaus_ctv'],
+    // Premium rate card — same cohorts, +$1 CPM.
+    pricing_overrides: {
+      ckhsh_us_evb_2024q4_001: [
+        {
+          pricing_id: 'tier_summit_evb_cpm',
+          model: 'cpm',
+          cpm_amount: 4.5,
+          currency: 'USD',
+          minimum_spend: 10_000,
+        },
+      ],
+      ckhsh_us_pp_2024q4_002: [
+        {
+          pricing_id: 'tier_summit_pp_cpm',
+          model: 'cpm',
+          cpm_amount: 5.0,
+          currency: 'USD',
+          minimum_spend: 10_000,
+        },
+      ],
+    },
+  },
+];
+
+/**
+ * Default static API key shared across all operators owned by the customer.
+ * Override at boot via `--api-key` if a test wants a different value.
+ */
+export const DEFAULT_API_KEY = 'mock_signal_market_key_do_not_use_in_prod';

--- a/src/lib/mock-server/signal-marketplace/seed-data.ts
+++ b/src/lib/mock-server/signal-marketplace/seed-data.ts
@@ -9,6 +9,11 @@ export interface MockCohort {
   activation_status: 'active' | 'draft' | 'archived';
   data_provider_domain: string;
   data_provider_id: string;
+  /** Human-readable name of the upstream data provider — flows directly to
+   * AdCP `signal_id.data_provider` (required by signals response schema).
+   * Without it, adapters have to fabricate the value from the domain, which
+   * trains the wrong reflex. */
+  data_provider_name: string;
   value_type: 'binary' | 'numeric' | 'categorical';
   range?: { min: number; max: number };
   categories?: string[];
@@ -69,6 +74,7 @@ export const COHORTS: MockCohort[] = [
     activation_status: 'active',
     data_provider_domain: 'tridentauto.example',
     data_provider_id: 'likely_ev_buyers',
+    data_provider_name: 'Trident Auto Insights',
     value_type: 'binary',
     pricing: [
       {
@@ -94,6 +100,7 @@ export const COHORTS: MockCohort[] = [
     activation_status: 'active',
     data_provider_domain: 'tridentauto.example',
     data_provider_id: 'purchase_propensity',
+    data_provider_name: 'Trident Auto Insights',
     value_type: 'numeric',
     range: { min: 0, max: 1 },
     pricing: [
@@ -120,6 +127,7 @@ export const COHORTS: MockCohort[] = [
     activation_status: 'active',
     data_provider_domain: 'meridiangeo.example',
     data_provider_id: 'competitor_visitors',
+    data_provider_name: 'Meridian Geo',
     value_type: 'binary',
     pricing: [
       {
@@ -145,6 +153,7 @@ export const COHORTS: MockCohort[] = [
     activation_status: 'active',
     data_provider_domain: 'shopgrid.example',
     data_provider_id: 'new_to_brand',
+    data_provider_name: 'ShopGrid Retail Data',
     value_type: 'binary',
     pricing: [
       {

--- a/src/lib/mock-server/signal-marketplace/server.ts
+++ b/src/lib/mock-server/signal-marketplace/server.ts
@@ -49,7 +49,7 @@ export async function bootSignalMarketplace(options: BootOptions): Promise<BootR
     }).catch(err => {
       // Defense-in-depth — handlers should never throw, but if one does we
       // emit a 500 with a request_id so adopter logs can still trace it.
-      const requestId = req.headers['x-request-id'] as string | undefined ?? randomUUID();
+      const requestId = (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
       writeJson(res, 500, {
         code: 'internal_error',
         message: err?.message ?? 'unexpected error',
@@ -172,9 +172,7 @@ function handleListCohorts(url: URL, ctx: HandlerCtx, op: MockOperator, res: Ser
   if (category) filtered = filtered.filter(c => c.category === category);
   if (dataProviderDomain) filtered = filtered.filter(c => c.data_provider_domain === dataProviderDomain);
   if (q) {
-    filtered = filtered.filter(
-      c => c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
-    );
+    filtered = filtered.filter(c => c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q));
   }
 
   const projected = filtered.map(c => projectCohortPricing(c, op));
@@ -221,10 +219,7 @@ async function handleCreateActivation(
     writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
     return;
   }
-  const { cohort_id, destination_id, pricing_id, duration_days, client_request_id } = body as Record<
-    string,
-    unknown
-  >;
+  const { cohort_id, destination_id, pricing_id, duration_days, client_request_id } = body as Record<string, unknown>;
   if (typeof cohort_id !== 'string' || typeof destination_id !== 'string' || typeof pricing_id !== 'string') {
     writeJson(res, 400, {
       code: 'invalid_request',
@@ -236,12 +231,31 @@ async function handleCreateActivation(
   // Idempotency replay — same client_request_id under same operator returns the
   // existing activation. Different operators using the same client_request_id
   // are independent because the table is keyed on `<operator_id>::<key>`.
+  // Body equivalence: replays with mismatched (cohort_id, destination_id,
+  // pricing_id) return 409 idempotency_conflict instead of silently returning
+  // the original — matches Stripe's idempotency contract and the AdCP spec
+  // semantics. Surfaces adapter bugs that reuse a single client_request_id
+  // across logically-distinct AdCP requests instead of hiding them.
   if (typeof client_request_id === 'string' && client_request_id.length > 0) {
     const idemKey = `${op.operator_id}::${client_request_id}`;
     const existing = ctx.idempotency.get(idemKey);
     if (existing) {
       const activation = ctx.activations.get(existing);
       if (activation) {
+        const sameBody =
+          activation.cohort_id === cohort_id &&
+          activation.destination_id === destination_id &&
+          activation.pricing_id === pricing_id;
+        if (!sameBody) {
+          writeJson(res, 409, {
+            code: 'idempotency_conflict',
+            message:
+              `client_request_id ${client_request_id} was previously used with a different ` +
+              `(cohort_id, destination_id, pricing_id) tuple. ` +
+              `Use a fresh idempotency key for distinct requests.`,
+          });
+          return;
+        }
         writeJson(res, 200, serializeActivation(activation));
         return;
       }

--- a/src/lib/mock-server/signal-marketplace/server.ts
+++ b/src/lib/mock-server/signal-marketplace/server.ts
@@ -1,0 +1,396 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import {
+  COHORTS,
+  DEFAULT_API_KEY,
+  DESTINATIONS,
+  OPERATORS,
+  type MockCohort,
+  type MockDestination,
+  type MockOperator,
+  type MockPricingTier,
+} from './seed-data';
+
+export interface BootOptions {
+  port: number;
+  apiKey?: string;
+  /** Override seed cohorts. Defaults to fixture data. */
+  cohorts?: MockCohort[];
+  destinations?: MockDestination[];
+  operators?: MockOperator[];
+}
+
+export interface BootResult {
+  url: string;
+  close: () => Promise<void>;
+}
+
+export async function bootSignalMarketplace(options: BootOptions): Promise<BootResult> {
+  const apiKey = options.apiKey ?? DEFAULT_API_KEY;
+  const cohorts = options.cohorts ?? COHORTS;
+  const destinations = options.destinations ?? DESTINATIONS;
+  const operators = options.operators ?? OPERATORS;
+
+  // Activations live in memory. Keyed by activation_id; cross-checked against
+  // operator_id on read so cross-tenant leakage shows up as 403.
+  const activations = new Map<string, MockActivation>();
+  // client_request_id idempotency table — keyed by `<operator_id>::<client_request_id>`
+  // so two operators can use the same client_request_id and not collide.
+  const idempotency = new Map<string, string>();
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res, {
+      apiKey,
+      cohorts,
+      destinations,
+      operators,
+      activations,
+      idempotency,
+    }).catch(err => {
+      // Defense-in-depth — handlers should never throw, but if one does we
+      // emit a 500 with a request_id so adopter logs can still trace it.
+      const requestId = req.headers['x-request-id'] as string | undefined ?? randomUUID();
+      writeJson(res, 500, {
+        code: 'internal_error',
+        message: err?.message ?? 'unexpected error',
+        request_id: requestId,
+      });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  // Use the actually-bound port. Caller may pass 0 to request an OS-assigned
+  // free port (test convenience); reading address() gives the truth either way.
+  const addr = server.address();
+  const boundPort = typeof addr === 'object' && addr ? addr.port : options.port;
+  const url = `http://127.0.0.1:${boundPort}`;
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+interface HandlerCtx {
+  apiKey: string;
+  cohorts: MockCohort[];
+  destinations: MockDestination[];
+  operators: MockOperator[];
+  activations: Map<string, MockActivation>;
+  idempotency: Map<string, string>;
+}
+
+interface MockActivation {
+  activation_id: string;
+  operator_id: string;
+  cohort_id: string;
+  destination_id: string;
+  pricing_id: string;
+  status: 'pending' | 'in_progress' | 'active' | 'failed' | 'expired';
+  match_rate?: number;
+  member_count_matched?: number;
+  platform_segment_id?: string;
+  agent_activation_key?: Record<string, string>;
+  created_at: string;
+  updated_at: string;
+  expires_at: string;
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse, ctx: HandlerCtx): Promise<void> {
+  // Authentication first. Order matters — surface bad-credential errors before
+  // operator/cohort lookups so adopters can debug auth in isolation.
+  const auth = req.headers['authorization'];
+  if (!auth || !auth.startsWith('Bearer ') || auth.slice(7) !== ctx.apiKey) {
+    writeJson(res, 401, { code: 'unauthorized', message: 'Missing or invalid bearer credential.' });
+    return;
+  }
+
+  const operatorHeader = req.headers['x-operator-id'];
+  const operatorId = Array.isArray(operatorHeader) ? operatorHeader[0] : operatorHeader;
+  if (!operatorId) {
+    writeJson(res, 403, {
+      code: 'operator_required',
+      message: 'X-Operator-Id header is required on every request.',
+    });
+    return;
+  }
+  const operator = ctx.operators.find(o => o.operator_id === operatorId);
+  if (!operator) {
+    writeJson(res, 403, {
+      code: 'unknown_operator',
+      message: `Unknown operator: ${operatorId}`,
+    });
+    return;
+  }
+
+  const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+  const path = url.pathname;
+  const method = req.method ?? 'GET';
+
+  // GET /v2/cohorts
+  if (method === 'GET' && path === '/v2/cohorts') {
+    return handleListCohorts(url, ctx, operator, res);
+  }
+  // GET /v2/cohorts/{id}
+  const cohortMatch = path.match(/^\/v2\/cohorts\/([^/]+)$/);
+  if (method === 'GET' && cohortMatch && cohortMatch[1]) {
+    return handleGetCohort(decodeURIComponent(cohortMatch[1]), ctx, operator, res);
+  }
+  // GET /v2/destinations
+  if (method === 'GET' && path === '/v2/destinations') {
+    return handleListDestinations(ctx, operator, res);
+  }
+  // POST /v2/activations
+  if (method === 'POST' && path === '/v2/activations') {
+    return handleCreateActivation(req, ctx, operator, res);
+  }
+  // GET /v2/activations/{id}
+  const activationMatch = path.match(/^\/v2\/activations\/([^/]+)$/);
+  if (method === 'GET' && activationMatch && activationMatch[1]) {
+    return handleGetActivation(decodeURIComponent(activationMatch[1]), ctx, operator, res);
+  }
+
+  writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+}
+
+function handleListCohorts(url: URL, ctx: HandlerCtx, op: MockOperator, res: ServerResponse): void {
+  const visible = ctx.cohorts.filter(c => op.visible_cohort_ids.includes(c.cohort_id));
+  const category = url.searchParams.get('category');
+  const dataProviderDomain = url.searchParams.get('data_provider_domain');
+  const q = url.searchParams.get('q')?.toLowerCase();
+
+  let filtered = visible;
+  if (category) filtered = filtered.filter(c => c.category === category);
+  if (dataProviderDomain) filtered = filtered.filter(c => c.data_provider_domain === dataProviderDomain);
+  if (q) {
+    filtered = filtered.filter(
+      c => c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
+    );
+  }
+
+  const projected = filtered.map(c => projectCohortPricing(c, op));
+  writeJson(res, 200, { cohorts: projected });
+}
+
+function handleGetCohort(cohortId: string, ctx: HandlerCtx, op: MockOperator, res: ServerResponse): void {
+  const cohort = ctx.cohorts.find(c => c.cohort_id === cohortId);
+  if (!cohort) {
+    writeJson(res, 404, { code: 'cohort_not_found', message: `Cohort ${cohortId} not found.` });
+    return;
+  }
+  if (!op.visible_cohort_ids.includes(cohortId)) {
+    // Distinguish "not visible to you" from "doesn't exist" — both real upstreams
+    // do this and it forces the adapter to handle 403 separately from 404.
+    writeJson(res, 403, {
+      code: 'cohort_not_visible',
+      message: `Cohort ${cohortId} is not visible to operator ${op.operator_id}.`,
+    });
+    return;
+  }
+  writeJson(res, 200, projectCohortPricing(cohort, op));
+}
+
+function handleListDestinations(ctx: HandlerCtx, op: MockOperator, res: ServerResponse): void {
+  const visible = ctx.destinations.filter(d => op.visible_destination_ids.includes(d.destination_id));
+  writeJson(res, 200, { destinations: visible });
+}
+
+async function handleCreateActivation(
+  req: IncomingMessage,
+  ctx: HandlerCtx,
+  op: MockOperator,
+  res: ServerResponse
+): Promise<void> {
+  let body: unknown;
+  try {
+    body = await readJson(req);
+  } catch {
+    writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
+    return;
+  }
+  if (!isObject(body)) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
+    return;
+  }
+  const { cohort_id, destination_id, pricing_id, duration_days, client_request_id } = body as Record<
+    string,
+    unknown
+  >;
+  if (typeof cohort_id !== 'string' || typeof destination_id !== 'string' || typeof pricing_id !== 'string') {
+    writeJson(res, 400, {
+      code: 'invalid_request',
+      message: 'cohort_id, destination_id, and pricing_id are required strings.',
+    });
+    return;
+  }
+
+  // Idempotency replay — same client_request_id under same operator returns the
+  // existing activation. Different operators using the same client_request_id
+  // are independent because the table is keyed on `<operator_id>::<key>`.
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    const idemKey = `${op.operator_id}::${client_request_id}`;
+    const existing = ctx.idempotency.get(idemKey);
+    if (existing) {
+      const activation = ctx.activations.get(existing);
+      if (activation) {
+        writeJson(res, 200, serializeActivation(activation));
+        return;
+      }
+    }
+  }
+
+  const cohort = ctx.cohorts.find(c => c.cohort_id === cohort_id);
+  if (!cohort || !op.visible_cohort_ids.includes(cohort_id)) {
+    writeJson(res, cohort ? 403 : 404, {
+      code: cohort ? 'cohort_not_visible' : 'cohort_not_found',
+      message: `Cohort ${cohort_id} ${cohort ? 'not visible to operator' : 'not found'}.`,
+    });
+    return;
+  }
+  const destination = ctx.destinations.find(d => d.destination_id === destination_id);
+  if (!destination || !op.visible_destination_ids.includes(destination_id)) {
+    writeJson(res, destination ? 403 : 404, {
+      code: destination ? 'destination_not_visible' : 'destination_not_found',
+      message: `Destination ${destination_id} ${destination ? 'not visible' : 'not found'}.`,
+    });
+    return;
+  }
+  const pricingTiers = pricingForCohort(cohort, op);
+  const tier = pricingTiers.find(t => t.pricing_id === pricing_id);
+  if (!tier) {
+    writeJson(res, 400, {
+      code: 'invalid_pricing',
+      message: `pricing_id ${pricing_id} is not a valid tier for this cohort under operator ${op.operator_id}.`,
+    });
+    return;
+  }
+
+  const activationId = `act_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + (typeof duration_days === 'number' ? duration_days : 90) * 86400_000);
+
+  // Agent destinations activate synchronously (the SA records and confirms);
+  // DSP/CTV destinations are async — initial pending, transitions to active
+  // when the storyboard's later poll fetches.
+  const isAgentDest = destination.platform_type === 'agent';
+  const activation: MockActivation = {
+    activation_id: activationId,
+    operator_id: op.operator_id,
+    cohort_id,
+    destination_id,
+    pricing_id,
+    status: isAgentDest ? 'active' : 'pending',
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+    expires_at: expiresAt.toISOString(),
+    ...(isAgentDest
+      ? {
+          agent_activation_key: { agent_segment: cohort.data_provider_id },
+          match_rate: destination.expected_match_rate ?? 0.9,
+          member_count_matched: cohort.member_count,
+        }
+      : {}),
+  };
+  ctx.activations.set(activationId, activation);
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    ctx.idempotency.set(`${op.operator_id}::${client_request_id}`, activationId);
+  }
+
+  writeJson(res, 201, serializeActivation(activation));
+}
+
+function handleGetActivation(activationId: string, ctx: HandlerCtx, op: MockOperator, res: ServerResponse): void {
+  const activation = ctx.activations.get(activationId);
+  if (!activation) {
+    writeJson(res, 404, { code: 'activation_not_found', message: `Activation ${activationId} not found.` });
+    return;
+  }
+  if (activation.operator_id !== op.operator_id) {
+    // Cross-operator read attempt — surfaces as 403, not 404, so an attacker
+    // can't probe activation ID space across tenants. Real platforms vary on
+    // this (some return 404 to avoid existence oracles); 403 here is the
+    // adopter-friendly choice for a fixture.
+    writeJson(res, 403, {
+      code: 'activation_not_visible',
+      message: `Activation ${activationId} belongs to a different operator.`,
+    });
+    return;
+  }
+  // Auto-promote pending DSP activations to in_progress on first poll, then
+  // active on second poll. Storyboard's polling loop walks this state machine.
+  if (activation.status === 'pending') {
+    activation.status = 'in_progress';
+    activation.updated_at = new Date().toISOString();
+  } else if (activation.status === 'in_progress') {
+    const cohort = ctx.cohorts.find(c => c.cohort_id === activation.cohort_id);
+    const destination = ctx.destinations.find(d => d.destination_id === activation.destination_id);
+    activation.status = 'active';
+    activation.match_rate = destination?.expected_match_rate ?? 0.75;
+    activation.member_count_matched = Math.floor(
+      (cohort?.member_count ?? 0) * (destination?.expected_match_rate ?? 0.75)
+    );
+    activation.platform_segment_id = `seg_${activation.activation_id.replace('act_', '')}`;
+    activation.updated_at = new Date().toISOString();
+  }
+  writeJson(res, 200, serializeActivation(activation));
+}
+
+function projectCohortPricing(cohort: MockCohort, op: MockOperator): MockCohort {
+  return {
+    ...cohort,
+    pricing: pricingForCohort(cohort, op),
+  };
+}
+
+function pricingForCohort(cohort: MockCohort, op: MockOperator): MockPricingTier[] {
+  const override = op.pricing_overrides[cohort.cohort_id];
+  return override && override.length > 0 ? override : cohort.pricing;
+}
+
+function serializeActivation(a: MockActivation): Record<string, unknown> {
+  // operator_id is internal book-keeping — not part of the public contract.
+  const { operator_id, ...rest } = a;
+  return rest;
+}
+
+function readJson(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', chunk => chunks.push(chunk));
+    req.on('error', reject);
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x);
+}

--- a/test/lib/mock-server/signal-marketplace.test.js
+++ b/test/lib/mock-server/signal-marketplace.test.js
@@ -1,0 +1,171 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { bootMockServer } = require('../../../dist/lib/mock-server/index.js');
+const { DEFAULT_API_KEY } = require('../../../dist/lib/mock-server/signal-marketplace/seed-data.js');
+
+describe('mock-server signal-marketplace', () => {
+  let handle;
+  before(async () => {
+    handle = await bootMockServer({ specialism: 'signal-marketplace', port: 0 });
+  });
+  after(async () => {
+    if (handle) await handle.close();
+  });
+
+  it('rejects requests without a Bearer token (401)', async () => {
+    const res = await fetch(`${handle.url}/v2/cohorts`, {
+      headers: { 'X-Operator-Id': 'op_pinnacle' },
+    });
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.code, 'unauthorized');
+  });
+
+  it('rejects requests without X-Operator-Id (403 operator_required)', async () => {
+    const res = await fetch(`${handle.url}/v2/cohorts`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.equal(body.code, 'operator_required');
+  });
+
+  it('rejects unknown operator (403 unknown_operator)', async () => {
+    const res = await fetch(`${handle.url}/v2/cohorts`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_nonexistent' },
+    });
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.equal(body.code, 'unknown_operator');
+  });
+
+  it('returns operator-scoped cohorts', async () => {
+    const pinnacleRes = await fetch(`${handle.url}/v2/cohorts`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_pinnacle' },
+    });
+    assert.equal(pinnacleRes.status, 200);
+    const pinnacleBody = await pinnacleRes.json();
+    assert.equal(pinnacleBody.cohorts.length, 4);
+
+    const summitRes = await fetch(`${handle.url}/v2/cohorts`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_summit' },
+    });
+    assert.equal(summitRes.status, 200);
+    const summitBody = await summitRes.json();
+    assert.equal(summitBody.cohorts.length, 2);
+    for (const c of summitBody.cohorts) {
+      assert.equal(c.data_provider_domain, 'tridentauto.example');
+    }
+  });
+
+  it('applies operator-specific pricing overrides', async () => {
+    const evbCohortId = 'ckhsh_us_evb_2024q4_001';
+    const pinnacleRes = await fetch(`${handle.url}/v2/cohorts/${evbCohortId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_pinnacle' },
+    });
+    const pinnacleCohort = await pinnacleRes.json();
+    assert.equal(pinnacleCohort.pricing[0].cpm_amount, 3.5);
+    assert.equal(pinnacleCohort.pricing[0].pricing_id, 'tier_default_evb_cpm');
+
+    const summitRes = await fetch(`${handle.url}/v2/cohorts/${evbCohortId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_summit' },
+    });
+    const summitCohort = await summitRes.json();
+    assert.equal(summitCohort.pricing[0].cpm_amount, 4.5);
+    assert.equal(summitCohort.pricing[0].pricing_id, 'tier_summit_evb_cpm');
+  });
+
+  it('returns 403 cohort_not_visible when fetching a cohort outside operator scope', async () => {
+    const meridianCohortId = 'ckhsh_us_cv_2024q4_003';
+    const res = await fetch(`${handle.url}/v2/cohorts/${meridianCohortId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_summit' },
+    });
+    assert.equal(res.status, 403);
+    const body = await res.json();
+    assert.equal(body.code, 'cohort_not_visible');
+  });
+
+  it('creates and walks an activation through pending → in_progress → active', async () => {
+    const cohortId = 'ckhsh_us_evb_2024q4_001';
+    const destinationId = 'dest_ttd_main';
+    const pricingId = 'tier_default_evb_cpm';
+
+    const createRes = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'X-Operator-Id': 'op_pinnacle',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        cohort_id: cohortId,
+        destination_id: destinationId,
+        pricing_id: pricingId,
+        client_request_id: 'test-create-1',
+      }),
+    });
+    assert.equal(createRes.status, 201);
+    const created = await createRes.json();
+    assert.equal(created.status, 'pending');
+    const activationId = created.activation_id;
+
+    const replayRes = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'X-Operator-Id': 'op_pinnacle',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        cohort_id: cohortId,
+        destination_id: destinationId,
+        pricing_id: pricingId,
+        client_request_id: 'test-create-1',
+      }),
+    });
+    assert.equal(replayRes.status, 200);
+    const replayed = await replayRes.json();
+    assert.equal(replayed.activation_id, activationId);
+
+    const poll1 = await fetch(`${handle.url}/v2/activations/${activationId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_pinnacle' },
+    });
+    assert.equal(poll1.status, 200);
+    const polled1 = await poll1.json();
+    assert.equal(polled1.status, 'in_progress');
+
+    const poll2 = await fetch(`${handle.url}/v2/activations/${activationId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_pinnacle' },
+    });
+    const polled2 = await poll2.json();
+    assert.equal(polled2.status, 'active');
+    assert.ok(polled2.platform_segment_id);
+    assert.ok(polled2.match_rate > 0);
+
+    const crossRead = await fetch(`${handle.url}/v2/activations/${activationId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_summit' },
+    });
+    assert.equal(crossRead.status, 403);
+  });
+
+  it('returns synchronous active status for agent destinations', async () => {
+    const createRes = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'X-Operator-Id': 'op_pinnacle',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        cohort_id: 'ckhsh_us_evb_2024q4_001',
+        destination_id: 'dest_wonderstruck_agent',
+        pricing_id: 'tier_default_evb_cpm',
+        client_request_id: 'test-agent-1',
+      }),
+    });
+    assert.equal(createRes.status, 201);
+    const created = await createRes.json();
+    assert.equal(created.status, 'active');
+    assert.ok(created.agent_activation_key);
+  });
+});

--- a/test/lib/mock-server/signal-marketplace.test.js
+++ b/test/lib/mock-server/signal-marketplace.test.js
@@ -168,4 +168,90 @@ describe('mock-server signal-marketplace', () => {
     assert.equal(created.status, 'active');
     assert.ok(created.agent_activation_key);
   });
+
+  it('returns 409 idempotency_conflict when client_request_id is reused with a different body', async () => {
+    // Real upstreams (Stripe, AdCP spec) require returning a conflict on
+    // idempotency-key reuse with mismatched body. Silently returning the
+    // original would hide adapter bugs that reuse a single client_request_id
+    // across logically-distinct AdCP requests.
+    const auth = {
+      Authorization: `Bearer ${DEFAULT_API_KEY}`,
+      'X-Operator-Id': 'op_pinnacle',
+      'Content-Type': 'application/json',
+    };
+
+    const first = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({
+        cohort_id: 'ckhsh_us_evb_2024q4_001',
+        destination_id: 'dest_ttd_main',
+        pricing_id: 'tier_default_evb_cpm',
+        client_request_id: 'idem-conflict-test',
+      }),
+    });
+    assert.equal(first.status, 201);
+
+    const conflict = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({
+        cohort_id: 'ckhsh_us_pp_2024q4_002',
+        destination_id: 'dest_ttd_main',
+        pricing_id: 'tier_default_pp_cpm',
+        client_request_id: 'idem-conflict-test',
+      }),
+    });
+    assert.equal(conflict.status, 409);
+    const conflictBody = await conflict.json();
+    assert.equal(conflictBody.code, 'idempotency_conflict');
+  });
+
+  it('rejects an invalid pricing_id with 400 invalid_pricing', async () => {
+    const res = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'X-Operator-Id': 'op_pinnacle',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        cohort_id: 'ckhsh_us_evb_2024q4_001',
+        destination_id: 'dest_ttd_main',
+        pricing_id: 'tier_does_not_exist',
+        client_request_id: 'invalid-pricing-test',
+      }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.code, 'invalid_pricing');
+  });
+
+  it('rejects malformed JSON body with 400 invalid_json', async () => {
+    const res = await fetch(`${handle.url}/v2/activations`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'X-Operator-Id': 'op_pinnacle',
+        'Content-Type': 'application/json',
+      },
+      body: '{ this is not json',
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.code, 'invalid_json');
+  });
+
+  it('exposes data_provider_name on every cohort (required for AdCP signal_id.data_provider)', async () => {
+    const res = await fetch(`${handle.url}/v2/cohorts`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}`, 'X-Operator-Id': 'op_pinnacle' },
+    });
+    const body = await res.json();
+    for (const cohort of body.cohorts) {
+      assert.ok(
+        typeof cohort.data_provider_name === 'string' && cohort.data_provider_name.length > 0,
+        `cohort ${cohort.cohort_id} missing data_provider_name`
+      );
+    }
+  });
 });


### PR DESCRIPTION
First fixture for **matrix v2** — the upstream-mock-server design described in #1155.

Adds \`npx @adcp/sdk mock-server signal-marketplace\` plus the harness wiring to use it, then runs the existing skill-matrix pair against it to validate the design.

## What's in the box

- \`src/lib/mock-server/index.ts\` — specialism dispatcher
- \`src/lib/mock-server/signal-marketplace/\`
  - \`openapi.yaml\` (~250 lines) — CDP/DMP-shaped upstream API (LiveRamp/Lotame/Oracle Data Cloud flavor); cohorts/destinations/activations rather than signals/deployments
  - \`seed-data.ts\` — 4 cohorts, 3 destinations, 2 operators with overlapping visibility + per-operator pricing overrides
  - \`server.ts\` — Node \`http\` handlers (no express runtime dep); operator-gated; activation lifecycle state machine; idempotent on \`client_request_id\` per operator; cross-operator isolation
- \`bin/adcp.js\` — \`mock-server <specialism> [--port N] [--api-key K]\` subcommand
- \`scripts/manual-testing/agent-skill-storyboard.ts\` — \`--upstream\` / \`--upstream-port\` flags; boots mock before invoking Claude; surfaces OpenAPI path + operator-mapping table to Claude in the build prompt
- \`scripts/manual-testing/run-skill-matrix.ts\` — optional \`upstream\` field per pair in \`skill-matrix.json\`
- \`test/lib/mock-server/signal-marketplace.test.js\` — **8/8 passing** smoke tests (auth, operator scoping, pricing overrides, activation lifecycle, cross-operator isolation, idempotent replay)
- \`.changeset/feat-mock-server-signal-marketplace.md\` — minor

## Headline upstream characteristics

- **Multi-operator API key pattern.** Single \`Authorization: Bearer <key>\` shared across operator seats; per-request \`X-Operator-Id\` header gates visibility and pricing. Real signal marketplaces all work this way; the question \"where does the SDK want me to put principal-to-operator mapping?\" surfaces as a real adopter would surface it.
- **Two seeded operators with overlapping cohort visibility** — \`op_pinnacle\` (4 cohorts, all data providers) vs \`op_summit\` (2 Trident cohorts at +\$1 CPM premium). Forces the adapter to genuinely thread the operator from \`account.operator\` through to upstream API or fail with empty/wrong data.
- **Activation lifecycle state machine.** DSP/CTV destinations: \`pending\` → \`in_progress\` → \`active\` on poll. Agent destinations: synchronously \`active\` on create. Idempotent on \`client_request_id\` per operator.
- **Cross-operator isolation.** Fetching another operator's activation returns 403 to prevent existence-oracle probing.

## First experimental run — actionable signal

Ran \`npm run compliance:skill-matrix -- --filter signal_marketplace --keep-workspaces\`. Result: 0/1 passed, 461.7s wall.

**🟢 The mock-server design works.** Claude correctly figured out (per its own summary):

> *getSignals lists /cohorts, transforms each cohort to a marketplace Signal (signal_agent_segment_id = cohort_id, pricing_option_id = upstream pricing_id). accounts.resolve maps account.operator → X-Operator-Id (pinnacle/summit). activateSignal posts /activations with the AdCP idempotency_key as client_request_id, returns platform deployments async (is_live false + activation_key) or agent deployments sync (is_live true).*

The architectural mapping work — multi-operator threading, idempotency translation, activation lifecycle dispatch — Claude did cleanly. **This is what matrix v2 was designed to test, and the design hypothesis holds.**

**🔴 What broke (and why this is exactly the signal we wanted):**

\`get_adcp_capabilities\` failed validation: \`/account/supported_billing: must have required property 'supported_billing'\`. Tracing:

1. \`skills/build-signals-agent/SKILL.md\` never mentions \`supported_billing\` (0 hits) — Claude couldn't know.
2. \`src/lib/server/decisioning/runtime/from-platform.ts:767\` omits the field when undefined (\`...(supportedBillings?.length && { supported_billing: [...] })\`).
3. Schema requires it unconditionally even for non-media-buy specialisms.
4. \`src/lib/server/create-adcp-server.ts:3431\` (the v5 path) defaults to \`[]\` — v6 regressed safer behavior.

That single missing field cascaded: capabilities failed → runner auto-downgraded to \"v2\" → asked for v2.5 schemas (not in cache) → 8 of 11 storyboard steps cascade-skipped.

**Three follow-up issues filed** capturing this signal:

- SDK fix: default \`supported_billing: []\` in \`createAdcpServerFromPlatform\` (match v5 behavior)
- SDK fix: tighten the v2-fallback heuristic — one schema validation failure shouldn't downgrade an obviously-v3 agent
- Spec fix (upstream \`adcontextprotocol/adcp\`): make \`supported_billing\` conditional on \`supported_protocols.includes('media_buy')\`

## Why merge this even though the experiment 'failed'

The point of matrix v2 isn't that pairs pass — it's that failures are *interpretable* and *actionable*. Pre-this-PR, the same pair failing would surface as \"Claude got confused\" with no actionable fix. Post-this-PR, the same failure surfaced 3 specific code locations to improve. **That's the value proposition.**

Subsequent runs (after the SDK fixes land) will validate whether the wire-shape gaps were the only blockers or whether other patterns surface. We'll know quickly because the experiment is now repeatable.

## Test plan

- [x] \`npm run build\` clean
- [x] \`node --test test/lib/mock-server/signal-marketplace.test.js\` — 8/8 pass
- [x] \`node bin/adcp.js mock-server signal-marketplace\` boots; manual curl validates auth/operator gating
- [x] \`npm run compliance:skill-matrix -- --filter signal_marketplace --keep-workspaces\` runs end-to-end (Claude builds adapter, harness boots agent, grader runs storyboards)

## Refs

- Design issue: #1155
- Memory note in \`.claude/projects/.../memory/project_matrix_v2_mock_server.md\` (not committed; lives in user's auto-memory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)