### PR TITLE
fix(validation): swallow schema-bundle-not-found in warn mode (#1178 context-continuity leg)

### DIFF
--- a/.changeset/fix-schema-bundle-warn-mode.md
+++ b/.changeset/fix-schema-bundle-warn-mode.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": patch
+---
+
+fix: `validateOutgoingRequest` in warn mode no longer throws when `schemas/cache/` is unpopulated
+
+Previously, calling any AdCP tool with `validation.requests: 'warn'` (the default) would throw an unhandled `SchemaBundleNotFoundError` if the schema bundle had not been populated via `npm run sync-schemas`. The throw escaped before the warn-mode guard, causing `taskResult` to be `undefined` in the storyboard runner and silently skipping all step validations — including `a2a_context_continuity`.
+
+The fix wraps the `validateRequest` call in a try/catch: in warn mode the error is swallowed and validation is skipped (same behaviour as `off` for missing bundles); in strict mode it re-throws so CI catches misconfigured environments. Closes #1178 (context-continuity integration test leg).

--- a/src/lib/validation/client-hooks.ts
+++ b/src/lib/validation/client-hooks.ts
@@ -75,7 +75,17 @@ export function validateOutgoingRequest(
   version?: string
 ): ValidationOutcome | undefined {
   if (mode === 'off') return undefined;
-  const outcome = validateRequest(taskName, params, version);
+  let outcome: ValidationOutcome;
+  try {
+    outcome = validateRequest(taskName, params, version);
+  } catch (err) {
+    // Schema bundle not found (schemas/cache/ unpopulated). In warn mode,
+    // skip validation rather than crashing the call — schema absence is a
+    // dev-environment gap, not a protocol error. Strict mode re-throws so
+    // CI catches misconfigured test environments.
+    if (mode === 'warn') return undefined;
+    throw err;
+  }
   if (outcome.valid) return outcome;
   if (mode === 'warn') {
     logWarning(debugLogs, taskName, outcome);

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.1.0';
+export const LIBRARY_VERSION = '6.3.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.1.0',
+  library: '6.3.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-01T01:17:37.625Z',
+  generatedAt: '2026-05-01T12:57:23.020Z',
 } as const;
 
 /**

--- a/test/storyboard-a2a-context-continuity-integration.test.js
+++ b/test/storyboard-a2a-context-continuity-integration.test.js
@@ -99,7 +99,7 @@ async function startRegressedA2aFixture() {
           artifacts: [
             {
               artifactId: 'a',
-              parts: [{ kind: 'data', data: { adcp_version: '3.0.0', supported_protocols: ['media-buy'], tools: [] } }],
+              parts: [{ kind: 'data', data: { adcp_version: '3.0.0', supported_protocols: ['media_buy'], tools: [] } }],
             },
           ],
         },


### PR DESCRIPTION
## Problem

`test/storyboard-a2a-context-continuity-integration.test.js` (both tests) was silently swallowing the `a2a_context_continuity` validator because the storyboard runner never saw a `taskResult` — the step always resolved as `{ success: false }` with an unhandled error thrown from `validateOutgoingRequest`.

Root cause chain:

1. `validateOutgoingRequest` (warn mode, the default) calls `validateRequest(taskName, params, version)`.
2. `validateRequest` → `resolveSchemaRoot` throws when `schemas/cache/` is unpopulated (CI doesn't run `sync-schemas`).
3. The throw escapes _before_ the `if (mode === 'warn')` guard — warn mode never catches it.
4. The exception propagates up through `SingleAgentClient.performTask` → `dispatch()` → `runStep`, which sets `taskResult = undefined`.
5. The validation gate in `runner.ts` (`if (step.validations?.length && (taskResult || httpResult))`) never opens, so `validations = []` for every step.
6. `continuityCheck` is `undefined` → `assert.ok(continuityCheck, 'continuity validator ran')` fails.

## Fixes

### 1. `src/lib/validation/client-hooks.ts`

Wrap `validateRequest` in a try/catch inside `validateOutgoingRequest`:

- **warn mode** — swallow the error and return `undefined` (skip validation). Schema absence is a dev-env gap, not a protocol error. Same behaviour as `off` for missing bundles, but without crashing the call.
- **strict mode** — re-throw, so misconfigured CI environments surface the problem explicitly.

### 2. `test/storyboard-a2a-context-continuity-integration.test.js`

Fix `supported_protocols: ['media-buy']` → `['media_buy']` in the regressed fixture's `get_adcp_capabilities` response. The hyphenated form (`'media-buy'`) doesn't match the underscore-separated `FeatureName` constant (`'media_buy'`), so `resolveFeature` returns false → `FeatureUnsupportedError` → `skip_reason: 'not_applicable'` → `second_send` cascade-skipped → `validations = []`. This secondary bug would have re-broken the test even after fix #1.

## Verification

```
node --test test/storyboard-a2a-context-continuity-integration.test.js

# tests 2
# pass  2
# fail  0
```

## Relationship to sibling PRs

| PR | Test file fixed |
|----|----------------|
| #1181 | `storyboard-a2a-async-submitted-yaml.test.js` |
| #1183 | `storyboard-a2a-regression-adapter.test.js` |
| **this PR** | `storyboard-a2a-context-continuity-integration.test.js` |

All three failures share the same root cause (schema-bundle throw in warn mode); this PR is the third leg of the fix for #1178.

https://claude.ai/code/session_019BHrpGSqf9tgrhmi75MaWH

---
_Generated by [Claude Code](https://claude.ai/code/session_019BHrpGSqf9tgrhmi75MaWH)_