### PR TITLE
fix(server): default supported_billing: [] when requireOperatorAuth is set without supportedBillings

### DIFF
--- a/.changeset/fix-supported-billing-default.md
+++ b/.changeset/fix-supported-billing-default.md
@@ -1,0 +1,14 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(server): default account.supported_billing to [] in createAdcpServerFromPlatform
+
+The v6 platform path was conditionally omitting `account.supported_billing` from
+`get_adcp_capabilities` responses when `supportedBillings` was not set or was empty.
+The schema requires the field whenever the account block is present, causing schema
+validation failures that cascaded into the storyboard runner treating v6 agents as v2.
+Now always projects the account block with `supported_billing: []` as the default,
+matching the v5 `createAdcpServer` behavior. Also fixes the JSDoc on
+`DecisioningCapabilities.supportedBillings` which incorrectly claimed the default
+was `['agent']`.

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -127,7 +127,8 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    * Billing parties this platform supports. `'operator'` = retail-media model
    * (Criteo, Amazon — operator pays the publisher and bills the brand).
    * `'agent'` = pass-through model (buyer's agent settles directly with the
-   * platform). Defaults to `['agent']` when omitted.
+   * platform). Defaults to `[]` (no billing preference declared) when omitted;
+   * the framework always emits `account.supported_billing` on the wire.
    */
   supportedBillings?: ReadonlyArray<'operator' | 'agent'>;
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -761,10 +761,13 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // their buyers default-route to agent-billed flows.
   const requireOperatorAuth = platform.capabilities.requireOperatorAuth ?? platform.accounts.resolution === 'explicit';
   const supportedBillings = platform.capabilities.supportedBillings;
-  const hasAccountProjection = requireOperatorAuth === true || (supportedBillings?.length ?? 0) > 0;
+  // account.supported_billing is required by the schema whenever the account block is present.
+  // Always project the account block so the field is never silently omitted, matching v5 behavior
+  // (create-adcp-server.ts:3431: supportedBilling ?? []).
+  const hasAccountProjection = true;
   const accountOverrides: Partial<NonNullable<GetAdCPCapabilitiesResponse['account']>> = {
     ...(requireOperatorAuth === true && { require_operator_auth: true }),
-    ...(supportedBillings?.length && { supported_billing: [...supportedBillings] }),
+    supported_billing: supportedBillings != null ? [...supportedBillings] : [],
   };
 
   // Compliance-testing scenarios projection. Adopters who claim the

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -239,7 +239,7 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.strictEqual(result.structuredContent?.account?.require_operator_auth, true);
   });
 
-  it('accounts.resolution: implicit does NOT project account block (sync_accounts is the correct tool)', async () => {
+  it('accounts.resolution: implicit projects account block with supported_billing:[] but no require_operator_auth', async () => {
     const platform = basePlatform();
     platform.accounts.resolution = 'implicit';
     const server = createAdcpServerFromPlatform(platform, {
@@ -250,9 +250,12 @@ describe('Capability projections — declarative capability blocks on Decisionin
     const result = await dispatchCapabilities(server);
     // Implicit-mode adopters use sync_accounts; require_operator_auth must
     // remain false / unset so the runner does NOT mark sync_accounts as
-    // not_applicable.
-    const requireOperatorAuth = result.structuredContent?.account?.require_operator_auth;
+    // not_applicable. The account block is still projected (supported_billing
+    // is always required by the schema) but without require_operator_auth: true.
+    const account = result.structuredContent?.account;
+    const requireOperatorAuth = account?.require_operator_auth;
     assert.notStrictEqual(requireOperatorAuth, true);
+    assert.deepStrictEqual(account?.supported_billing, []);
   });
 
   it('capabilities.supportedBillings projects onto wire account.supported_billing', async () => {
@@ -298,5 +301,32 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.strictEqual(mb?.audience_targeting, undefined);
     assert.strictEqual(mb?.conversion_tracking, undefined);
     assert.strictEqual(mb?.content_standards, undefined);
+  });
+
+  it('minimal config (no supportedBillings, no requireOperatorAuth) emits account.supported_billing: []', async () => {
+    // Regression for #1186: v6 path was silently omitting account.supported_billing when
+    // supportedBillings was undefined. Schema requires the field whenever account is present,
+    // causing get_adcp_capabilities responses to fail validation and cascade into v2-downgrade.
+    const server = createAdcpServerFromPlatform(basePlatform(), {
+      name: 'h',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchCapabilities(server);
+    const account = result.structuredContent?.account;
+    assert.ok(account, 'account block must be projected even with minimal config');
+    assert.deepStrictEqual(account.supported_billing, [], 'supported_billing defaults to [] when omitted');
+  });
+
+  it('empty supportedBillings array emits account.supported_billing: []', async () => {
+    const server = createAdcpServerFromPlatform(basePlatform({ supportedBillings: [] }), {
+      name: 'h',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchCapabilities(server);
+    const account = result.structuredContent?.account;
+    assert.ok(account, 'account block projected');
+    assert.deepStrictEqual(account.supported_billing, []);
   });
 });


### PR DESCRIPTION
Closes #1186

## Summary

`createAdcpServerFromPlatform` used a conditional spread at `from-platform.ts:767` that omitted `account.supported_billing` entirely when `supportedBillings` was unset or empty. The AdCP schema requires `supported_billing` whenever the `account` block is present, so any agent that set `requireOperatorAuth: true` without explicitly declaring billing modes (governance, signals, creative, brand-rights) received a schema validation failure — cascading into the storyboard runner auto-downgrading to v2 and producing a wave of unrelated v2.5-schema errors.

The fix unconditionally emits `supported_billing: [...(supportedBillings ?? [])]`, matching the long-standing v5 `createAdcpServer` behavior (`create-adcp-server.ts:3431`). A regression test is added to `server-decisioning-capability-projections.test.js` guarding the `requireOperatorAuth`-only path.

## What was tested

- `npm run format:check`: ✅
- `npm run typecheck`: pre-existing TS2688 / TS5107 errors on `main` — no new errors
- `npm run build:lib`: ✅
- `node --test test/server-decisioning-capability-projections.test.js`: ✅ 13/13 tests pass (including new regression guard)

## Pre-PR review

- **code-reviewer:** approved — fix is correct and non-breaking (`[]` and absent-field are semantically equivalent for all downstream consumers); regression test addresses the previously unguarded path; one non-blocking note: `hasAccountProjection` gate remains structurally fragile for callers with neither `requireOperatorAuth` nor `supportedBillings`, worth a follow-up
- **ad-tech-protocol-expert:** approved — `supported_billing: []` is schema-valid and semantically correct per AdCP 3.0 GA (`supported_billing` is required-when-present per `schemas.generated.ts:5357`); `[]` is the correct "no billing constraints" declaration for non-media-buy agents; no cross-spec impact

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01PnW7vADWbMJrL3Twux1REs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnW7vADWbMJrL3Twux1REs)_