### PR TITLE
fix(server): default supported_billing: [] in createAdcpServerFromPlatform (match v5 behavior)

### DIFF
--- a/.changeset/issue-1186-default-supported-billing.md
+++ b/.changeset/issue-1186-default-supported-billing.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+Fix `createAdcpServerFromPlatform` v6 regression: always emit `supported_billing: []` when the account block is projected (adcp-client#1186).
+
+When `requireOperatorAuth` is `true` (or derived from `accounts.resolution: 'explicit'`) but `supportedBillings` is not set, the v6 path omitted `supported_billing` entirely from the wire `get_adcp_capabilities` response. The AdCP schema requires the field whenever the `account` block is present, so schema validation failed with `missing required property 'supported_billing'` — and the storyboard runner cascade-failed every subsequent step. The v5 `createAdcpServer` path correctly defaulted to `[]`; this fix restores parity. Also corrects the `DecisioningCapabilities.supportedBillings` JSDoc which incorrectly claimed the default was `['agent']`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.1.0",
+  "version": "6.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.1.0",
+      "version": "6.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6398,7 +6398,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.0.0"
+        "@adcp/sdk": "^6.3.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -127,7 +127,8 @@ export interface DecisioningCapabilities<TConfig = unknown> {
    * Billing parties this platform supports. `'operator'` = retail-media model
    * (Criteo, Amazon — operator pays the publisher and bills the brand).
    * `'agent'` = pass-through model (buyer's agent settles directly with the
-   * platform). Defaults to `['agent']` when omitted.
+   * platform). Defaults to `[]` when omitted (buyers treat an empty list as
+   * unspecified; set explicitly for retail-media or agent-billed agents).
    */
   supportedBillings?: ReadonlyArray<'operator' | 'agent'>;
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -764,7 +764,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   const hasAccountProjection = requireOperatorAuth === true || (supportedBillings?.length ?? 0) > 0;
   const accountOverrides: Partial<NonNullable<GetAdCPCapabilitiesResponse['account']>> = {
     ...(requireOperatorAuth === true && { require_operator_auth: true }),
-    ...(supportedBillings?.length && { supported_billing: [...supportedBillings] }),
+    supported_billing: supportedBillings?.length ? [...supportedBillings] : [],
   };
 
   // Compliance-testing scenarios projection. Adopters who claim the

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.1.0';
+export const LIBRARY_VERSION = '6.3.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.1.0',
+  library: '6.3.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-01T01:17:37.625Z',
+  generatedAt: '2026-05-01T13:18:34.872Z',
 } as const;
 
 /**

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -285,6 +285,23 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.deepStrictEqual(account.supported_billing, ['operator']);
   });
 
+  it('requireOperatorAuth:true without supportedBillings emits supported_billing:[] — regression #1186', async () => {
+    // When the account block is projected (because requireOperatorAuth is true)
+    // but supportedBillings is not set, the wire account object must still carry
+    // supported_billing: [] so schema validation passes. Pre-fix, the field was
+    // omitted entirely, causing a cascade of storyboard failures.
+    const server = createAdcpServerFromPlatform(basePlatform({ requireOperatorAuth: true }), {
+      name: 'h',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'strict' },
+    });
+    const result = await dispatchCapabilities(server);
+    assert.ok(!result.isError, `schema validation must pass: ${JSON.stringify(result.content)}`);
+    const account = result.structuredContent?.account;
+    assert.ok(account, 'account block must be present when requireOperatorAuth is set');
+    assert.deepStrictEqual(account.supported_billing, []);
+  });
+
   it('omitting all three leaves get_adcp_capabilities unchanged (no empty media_buy block)', async () => {
     const server = createAdcpServerFromPlatform(basePlatform(), {
       name: 'h',


### PR DESCRIPTION
Closes #1186

## Summary

When `requireOperatorAuth` is `true` (or derived from `accounts.resolution: 'explicit'`) but `supportedBillings` is not set, the v6 `createAdcpServerFromPlatform` path projected the account block to the wire response but omitted `supported_billing`. The AdCP schema requires the field whenever `account` is present, so schema validation failed with `missing required property 'supported_billing'` — and the storyboard runner cascade-failed every subsequent step.

**Root cause:** `src/lib/server/decisioning/runtime/from-platform.ts:767` used a conditional spread `...(supportedBillings?.length && { supported_billing: [...] })` that produced nothing when `supportedBillings` was undefined or empty. The v5 `createAdcpServer` path at `create-adcp-server.ts:3431` correctly defaulted to `supported_billing: capConfig.account.supportedBilling ?? []`.

**Fix:** Replace the conditional spread with `supported_billing: supportedBillings?.length ? [...supportedBillings] : []` — same one-line change the v5 path uses. Also corrects the `DecisioningCapabilities.supportedBillings` JSDoc which claimed the default was `['agent']` (it was always `[]`).

## What was tested

- `npm run format:check` — passed
- `npx tsc --project tsconfig.lib.json` — passed (pre-existing `TS2688`/`TS5107` env errors unrelated to this change)
- `node --test test/server-decisioning-capability-projections.test.js` — **13/13 pass** (new regression test is test #12)
- Full suite: 4542 tests, 4278 pass, 220 fail — baseline has 222 fail; no new failures introduced
- New regression test uses `validation: { responses: 'strict' }` to exercise the actual schema-validation path that the bug broke

**Nits noted (not fixed in this PR):**
- The `accounts.resolution: 'explicit'` path in the pre-existing test (line 210) uses `responses: 'off'` — a follow-up could upgrade it to `responses: 'strict'` + assert `supported_billing: []`. The fix is correct for both paths since the logic is shared; this is a coverage gap, not a correctness gap.
- `docs/llms.txt` and `skills/build-retail-media-agent/SKILL.md` have zero mentions of `supportedBillings` — doc improvement tracked in issue.

## Pre-PR review

- code-reviewer: approved — no blockers; fix is minimal and correct; test correctly exercises schema validation with `responses: 'strict'`
- dx-expert: approved — no blockers; JSDoc correction is accurate; changeset bump (`patch`) is appropriate

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01CbCVxFuiFnDHrBFwNFbWMs

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbCVxFuiFnDHrBFwNFbWMs)_