### PR TITLE
fix(server): default account.supported_billing to ['agent'] in v6

### DIFF
--- a/.changeset/fix-supported-billing-default.md
+++ b/.changeset/fix-supported-billing-default.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(server): default `account.supported_billing` to `['agent']` in `createAdcpServerFromPlatform`
+
+When the v6 framework emits the `account` block in `get_adcp_capabilities` (because the platform declares `requireOperatorAuth: true` or `accounts.resolution: 'explicit'`), the schema requires `account.supported_billing` to be present with `minItems: 1`. The framework was spreading the field conditionally (`...(supportedBillings?.length && { supported_billing: [...] })`), which dropped the field entirely when adopters didn't declare `supportedBillings`. The capabilities response then failed schema validation.
+
+Worse, downstream tooling (storyboard runner) auto-downgrades agents to "v2 synthetic capabilities" when capabilities probe fails, which cascades into every subsequent step erroring with "AdCP schema data for version v2.5 not found." One missing field collapsed entire storyboard runs.
+
+Fix: when emitting the `account` block, always include `supported_billing`, defaulting to `['agent']` when adopters don't declare. `'agent'` (agent consolidates billing) matches the platform-interface contract documented at `src/lib/server/decisioning/capabilities.ts:130` ("Defaults to `['agent']` when omitted") and is the least-surprising default for non-media-buy specialisms (signals/creative/governance/etc.).
+
+Surfaced empirically by the matrix v2 mock-server run on adcontextprotocol/adcp-client#1185. Closes adcontextprotocol/adcp-client#1186.
+
+Adopters declaring `supportedBillings: ['operator', 'agent']` (or any non-empty subset) are unaffected — the projection still flows their declared values. Only adopters who omitted the field were exposed to the schema-validation regression; those will now pass with the spec-correct `['agent']` default.
+
+Related upstream issue: adcontextprotocol/adcp#3746 (make `supported_billing` conditional on `supported_protocols.includes('media_buy')` at the schema level — the principled fix). This SDK change is the defensive default until the spec change lands.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -762,9 +762,18 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   const requireOperatorAuth = platform.capabilities.requireOperatorAuth ?? platform.accounts.resolution === 'explicit';
   const supportedBillings = platform.capabilities.supportedBillings;
   const hasAccountProjection = requireOperatorAuth === true || (supportedBillings?.length ?? 0) > 0;
+  // Schema requires `supported_billing` (minItems: 1) whenever the account
+  // block is emitted. Default to ['agent'] when adopters don't declare —
+  // matches the documented platform interface default at
+  // `capabilities.ts:130` ("Defaults to ['agent'] when omitted"). v6 was
+  // dropping the field on undefined which failed schema validation; v5's
+  // `?? []` would also fail (minItems: 1). 'agent' (agent consolidates
+  // billing) is the least-surprising default for non-media-buy specialisms.
   const accountOverrides: Partial<NonNullable<GetAdCPCapabilitiesResponse['account']>> = {
     ...(requireOperatorAuth === true && { require_operator_auth: true }),
-    ...(supportedBillings?.length && { supported_billing: [...supportedBillings] }),
+    ...(hasAccountProjection && {
+      supported_billing: supportedBillings?.length ? [...supportedBillings] : ['agent'],
+    }),
   };
 
   // Compliance-testing scenarios projection. Adopters who claim the

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -769,6 +769,9 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   // dropping the field on undefined which failed schema validation; v5's
   // `?? []` would also fail (minItems: 1). 'agent' (agent consolidates
   // billing) is the least-surprising default for non-media-buy specialisms.
+  // An adopter passing supportedBillings: [] also lands in the default
+  // branch — the closed enum has no semantic meaning for empty, and
+  // emitting an empty array would fail schema regardless.
   const accountOverrides: Partial<NonNullable<GetAdCPCapabilitiesResponse['account']>> = {
     ...(requireOperatorAuth === true && { require_operator_auth: true }),
     ...(hasAccountProjection && {

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -285,7 +285,7 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.deepStrictEqual(account.supported_billing, ['operator']);
   });
 
-  it('explicit resolution without supportedBillings emits account.supported_billing: [\'agent\'] default (regression test for #1186)', async () => {
+  it("explicit resolution without supportedBillings emits account.supported_billing: ['agent'] default (regression test for #1186)", async () => {
     // Schema requires supported_billing (minItems: 1) on every emitted
     // account block. Pre-fix, v6 dropped the field when supportedBillings
     // was undefined → capabilities response failed schema validation →
@@ -310,7 +310,7 @@ describe('Capability projections — declarative capability blocks on Decisionin
     );
   });
 
-  it('requireOperatorAuth=true without supportedBillings emits account.supported_billing: [\'agent\'] default (regression test for #1186)', async () => {
+  it("requireOperatorAuth=true without supportedBillings emits account.supported_billing: ['agent'] default (regression test for #1186)", async () => {
     // Same regression as above, triggered via explicit requireOperatorAuth
     // rather than accounts.resolution.
     const platform = basePlatform({ requireOperatorAuth: true });

--- a/test/server-decisioning-capability-projections.test.js
+++ b/test/server-decisioning-capability-projections.test.js
@@ -285,6 +285,47 @@ describe('Capability projections — declarative capability blocks on Decisionin
     assert.deepStrictEqual(account.supported_billing, ['operator']);
   });
 
+  it('explicit resolution without supportedBillings emits account.supported_billing: [\'agent\'] default (regression test for #1186)', async () => {
+    // Schema requires supported_billing (minItems: 1) on every emitted
+    // account block. Pre-fix, v6 dropped the field when supportedBillings
+    // was undefined → capabilities response failed schema validation →
+    // storyboard runner auto-downgraded to v2 fallback, cascading errors
+    // into every downstream step. Default ['agent'] matches the platform
+    // interface contract documented at capabilities.ts:130.
+    const platform = basePlatform(); // no supportedBillings
+    platform.accounts.resolution = 'explicit';
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'h',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchCapabilities(server);
+    const account = result.structuredContent?.account;
+    assert.ok(account, 'account block projected (explicit resolution)');
+    assert.strictEqual(account.require_operator_auth, true);
+    assert.deepStrictEqual(
+      account.supported_billing,
+      ['agent'],
+      'supported_billing must be present and non-empty on every emitted account block'
+    );
+  });
+
+  it('requireOperatorAuth=true without supportedBillings emits account.supported_billing: [\'agent\'] default (regression test for #1186)', async () => {
+    // Same regression as above, triggered via explicit requireOperatorAuth
+    // rather than accounts.resolution.
+    const platform = basePlatform({ requireOperatorAuth: true });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'h',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchCapabilities(server);
+    const account = result.structuredContent?.account;
+    assert.ok(account, 'account block projected');
+    assert.strictEqual(account.require_operator_auth, true);
+    assert.deepStrictEqual(account.supported_billing, ['agent']);
+  });
+
   it('omitting all three leaves get_adcp_capabilities unchanged (no empty media_buy block)', async () => {
     const server = createAdcpServerFromPlatform(basePlatform(), {
       name: 'h',


### PR DESCRIPTION
Closes #1186.

## Summary

Schema requires \`account.supported_billing\` (\`minItems: 1\`) whenever the \`account\` block is emitted in \`get_adcp_capabilities\`. The v6 framework was spreading the field conditionally:

\`\`\`ts
// src/lib/server/decisioning/runtime/from-platform.ts:767 (before)
...(supportedBillings?.length && { supported_billing: [...supportedBillings] }),
\`\`\`

When adopters didn't declare \`supportedBillings\`, the field was dropped entirely and the capabilities response failed schema validation. The storyboard runner's v2-fallback heuristic then compounded that single missing field into \"AdCP schema data for version v2.5 not found\" errors across every subsequent step (filed separately as #1189 — that brittleness should be tightened independently).

## Fix

Always emit \`supported_billing\` when the account block is emitted, defaulting to \`['agent']\`:

\`\`\`ts
// after
...(hasAccountProjection && {
  supported_billing: supportedBillings?.length ? [...supportedBillings] : ['agent'],
}),
\`\`\`

\`'agent'\` (agent consolidates billing) matches the platform-interface contract documented at \`src/lib/server/decisioning/capabilities.ts:130\` (\"Defaults to \`['agent']\` when omitted\") and is the least-surprising default for non-media-buy specialisms.

## Why \`['agent']\` and not \`[]\`

The schema requires \`minItems: 1\`, so \`[]\` would also fail validation. v5 had \`?? []\` which was equally broken on schema-strict callers — this fix is what v5 should have done.

## Backwards compatibility

- Adopters who declared \`supportedBillings\` explicitly are unaffected — projection still flows their declared values.
- Adopters who omitted the field were the only ones exposed to the regression; they now get the spec-correct \`['agent']\` default.
- No new types, no signature changes — pure runtime behavior fix.

## Test plan

- [x] \`npm run build\` clean
- [x] Two regression tests added in \`test/server-decisioning-capability-projections.test.js\`:
  - explicit \`accounts.resolution: 'explicit'\` without \`supportedBillings\` → emits \`['agent']\`
  - explicit \`requireOperatorAuth: true\` without \`supportedBillings\` → emits \`['agent']\`
- [x] All 14 capability-projection tests pass
- [x] Existing supportedBillings projection tests still pass (declared values flow unchanged)

## Refs

- #1186 — issue this fixes
- #1185 — matrix v2 PR that empirically surfaced this
- #1189 — companion runner brittleness (v2-fallback should be tightened so a single validation failure doesn't downgrade a v3 agent)
- adcontextprotocol/adcp#3746 — upstream spec fix (make field conditional on \`media_buy\` protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)