### PR TITLE
fix(client): keep v3 agents v3 when capabilities validation fails

### DIFF
--- a/.changeset/fix-v2-fallback-tighten.md
+++ b/.changeset/fix-v2-fallback-tighten.md
@@ -1,0 +1,23 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(client): don't downgrade obvious v3 agents to v2 on a single capabilities-validation failure
+
+`SingleAgentClient.getCapabilities()` had a coarse v2-fallback heuristic: if `get_adcp_capabilities` was advertised but the call returned `success: false` for any reason, fall back to v2 synthetic capabilities. That's wrong when the agent is clearly a v3 agent that just has a wire-shape bug (e.g., a single missing required field that fails strict schema validation but otherwise returns a fully v3-shaped response).
+
+When the fallback fired, the SDK marked the agent as v2.5, downstream tooling asked for v2.5 schemas (not shipped — only 3.0.x is bundled), and every subsequent step errored with `"AdCP schema data for version v2.5 not found"`. One missing field cascaded into total storyboard failure with errors that had nothing to do with the original problem.
+
+Fix: tighten the fallback heuristic. When `result.success === false` but `result.data` is **structurally v3-shaped**, parse it anyway, surface the validation failure loudly, and continue with v3 capabilities. The agent has a wire-shape bug to fix; downgrading to v2 hides that.
+
+The new `looksLikeV3Capabilities()` helper (exported from `@adcp/sdk` via `src/lib/utils/capabilities.ts`) checks for affirmative v3 signals:
+
+- Presence of the `adcp` envelope block
+- Presence of `supported_protocols` (v3-only top-level field)
+- Presence of any v3 protocol-level capability block (`account`, `media_buy`, `signals`, `creative`, `brand`, `governance`, `sponsored_intelligence`, `compliance_testing`)
+
+Empty / null / non-object responses still fall back to v2 (the existing heuristic — preserved). v2 agents that genuinely don't have any v3 surface in their response continue to be detected correctly.
+
+Surfaced empirically by the matrix v2 mock-server run on adcontextprotocol/adcp-client#1185, where Claude built a v3 signals agent with a single missing field (`account.supported_billing`) that the runner's old fallback turned into a cascade of confusing v2.5 errors. Closes adcontextprotocol/adcp-client#1189.
+
+Pairs with the related v6 framework default fix (#1198 / #1186 — default `supported_billing: ['agent']`). With both fixes, the most common cause of the cascade is gone (#1198), and the runner stops compounding any remaining cause into a confusing v2.5 failure (#1189). Each change stands alone; together they remove one of the gnarliest brittleness patterns in the matrix harness.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -115,6 +115,7 @@ import type { AdcpCapabilities, ToolInfo, FeatureName } from '../utils/capabilit
 import {
   buildSyntheticCapabilities,
   augmentCapabilitiesFromTools,
+  looksLikeV3Capabilities,
   parseCapabilitiesResponse,
   resolveFeature,
   listDeclaredFeatures,
@@ -2765,6 +2766,25 @@ export class SingleAgentClient {
         const result = await this.executor.executeTask<any>(agent, 'get_adcp_capabilities', {}, undefined);
 
         if (result.success && result.data) {
+          this.cachedCapabilities = augmentCapabilitiesFromTools(parseCapabilitiesResponse(result.data), tools);
+          this.maybeWarnV2Sunset(this.cachedCapabilities);
+          return this.cachedCapabilities;
+        }
+        // Tightened v2 fallback (issue #1189). When `result.success` is false
+        // but `result.data` is structurally v3-shaped, the agent is a v3 agent
+        // with a wire-shape bug — typically a single failed schema validation
+        // on `get_adcp_capabilities`. Falling back to v2 in this case masks
+        // the original bug behind cascading "AdCP schema data for version v2.5
+        // not found" errors that nobody can debug. Parse the data anyway,
+        // surface the validation failure loudly, and continue with the
+        // v3 capabilities the agent actually returned.
+        if (result.data && looksLikeV3Capabilities(result.data)) {
+          console.warn(
+            `[AdCP] Agent "${this.agent.id}" returned a get_adcp_capabilities response that ` +
+              `failed validation, but the response is structurally v3-shaped. Treating as v3 ` +
+              `(the agent has a wire-shape bug — that's the thing to fix). ` +
+              (typeof result.error === 'string' ? `Validation error: ${result.error}` : '')
+          );
           this.cachedCapabilities = augmentCapabilitiesFromTools(parseCapabilitiesResponse(result.data), tools);
           this.maybeWarnV2Sunset(this.cachedCapabilities);
           return this.cachedCapabilities;

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -111,7 +111,7 @@ import {
 import * as crypto from 'crypto';
 
 // v3.0 compatibility utilities
-import type { AdcpCapabilities, ToolInfo, FeatureName } from '../utils/capabilities';
+import type { AdcpCapabilities, AdcpMajorVersion, ToolInfo, FeatureName } from '../utils/capabilities';
 import {
   buildSyntheticCapabilities,
   augmentCapabilitiesFromTools,
@@ -2778,14 +2778,29 @@ export class SingleAgentClient {
         // not found" errors that nobody can debug. Parse the data anyway,
         // surface the validation failure loudly, and continue with the
         // v3 capabilities the agent actually returned.
+        //
+        // Override `version`/`majorVersions` after parse: when the response
+        // doesn't carry an explicit `adcp.major_versions` block (one of the
+        // valid v3-shape signals), `parseCapabilitiesResponse` defaults
+        // majorVersions to [2] which would re-classify a known-v3 response
+        // as v2 downstream. The heuristic established v3-shape; honor that.
+        // CodeQL: deliberately omit `result.error` from the log (matches the
+        // existing fallback log below) — it can carry transport-level agent
+        // identifiers that flow through the clear-text-logging tracker.
         if (result.data && looksLikeV3Capabilities(result.data)) {
           console.warn(
             `[AdCP] Agent "${this.agent.id}" returned a get_adcp_capabilities response that ` +
               `failed validation, but the response is structurally v3-shaped. Treating as v3 ` +
-              `(the agent has a wire-shape bug — that's the thing to fix). ` +
-              (typeof result.error === 'string' ? `Validation error: ${result.error}` : '')
+              `(the agent has a wire-shape bug — that's the thing to fix).`,
+            { hasError: !!result.error, hasData: !!result.data }
           );
-          this.cachedCapabilities = augmentCapabilitiesFromTools(parseCapabilitiesResponse(result.data), tools);
+          const parsed = parseCapabilitiesResponse(result.data);
+          const v3Capabilities: AdcpCapabilities = {
+            ...parsed,
+            version: 'v3',
+            majorVersions: parsed.majorVersions.includes(3) ? parsed.majorVersions : ([3] as AdcpMajorVersion[]),
+          };
+          this.cachedCapabilities = augmentCapabilitiesFromTools(v3Capabilities, tools);
           this.maybeWarnV2Sunset(this.cachedCapabilities);
           return this.cachedCapabilities;
         }

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -402,10 +402,9 @@ export function buildSyntheticCapabilities(tools: ToolInfo[]): AdcpCapabilities 
  * check to avoid mis-promoting genuinely empty / null responses.
  */
 export function looksLikeV3Capabilities(data: unknown): boolean {
-  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
-  const obj = data as Record<string, unknown>;
-  if (obj.adcp && typeof obj.adcp === 'object') return true;
-  if (Array.isArray(obj.supported_protocols)) return true;
+  if (!isPlainObject(data)) return false;
+  if (isPlainObject(data.adcp)) return true;
+  if (Array.isArray(data.supported_protocols)) return true;
   const v3Blocks = [
     'account',
     'media_buy',
@@ -416,7 +415,11 @@ export function looksLikeV3Capabilities(data: unknown): boolean {
     'sponsored_intelligence',
     'compliance_testing',
   ] as const;
-  return v3Blocks.some(block => obj[block] && typeof obj[block] === 'object');
+  return v3Blocks.some(block => isPlainObject(data[block]));
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -381,6 +381,45 @@ export function buildSyntheticCapabilities(tools: ToolInfo[]): AdcpCapabilities 
 }
 
 /**
+ * Heuristic: does this `get_adcp_capabilities` response look v3-shaped?
+ *
+ * Used by callers (e.g. SingleAgentClient.getCapabilities) when the response
+ * fails strict schema validation but is structurally non-empty. The question
+ * the heuristic answers is "is this a v3 agent with a wire-shape bug, or a
+ * v2 agent that happens to advertise the tool?". Falling back to v2 in the
+ * former case masks the original bug behind cascading v2.5-schema-not-found
+ * errors; treating it as v3 surfaces the wire-shape bug at its source.
+ *
+ * Affirmative v3 signals (any one is enough):
+ *   - `adcp` block (only v3 servers carry the `{ major_versions, idempotency, ... }` envelope)
+ *   - `supported_protocols` array (v3-only top-level field)
+ *   - any v3 protocol-level capability block (`media_buy`, `signals`, `creative`, `brand`,
+ *     `governance`, `sponsored_intelligence`, `compliance_testing`, `account`)
+ *
+ * v2 servers don't expose `get_adcp_capabilities` at all (the tool itself is
+ * a v3-only addition), so reaching this function with a non-empty payload
+ * already strongly implies v3 — but we belt-and-suspenders the structural
+ * check to avoid mis-promoting genuinely empty / null responses.
+ */
+export function looksLikeV3Capabilities(data: unknown): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const obj = data as Record<string, unknown>;
+  if (obj.adcp && typeof obj.adcp === 'object') return true;
+  if (Array.isArray(obj.supported_protocols)) return true;
+  const v3Blocks = [
+    'account',
+    'media_buy',
+    'signals',
+    'creative',
+    'brand',
+    'governance',
+    'sponsored_intelligence',
+    'compliance_testing',
+  ] as const;
+  return v3Blocks.some(block => obj[block] && typeof obj[block] === 'object');
+}
+
+/**
  * Parse a get_adcp_capabilities response into normalized form
  */
 export function parseCapabilitiesResponse(response: any): AdcpCapabilities {

--- a/test/lib/looks-like-v3-capabilities.test.js
+++ b/test/lib/looks-like-v3-capabilities.test.js
@@ -4,7 +4,7 @@
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
-const { looksLikeV3Capabilities } = require('../../dist/lib/utils/capabilities');
+const { looksLikeV3Capabilities, parseCapabilitiesResponse } = require('../../dist/lib/utils/capabilities');
 
 describe('looksLikeV3Capabilities', () => {
   describe('returns true for v3-shaped responses', () => {
@@ -105,6 +105,42 @@ describe('looksLikeV3Capabilities', () => {
 
     it('rejects adcp when null (defensive)', () => {
       assert.equal(looksLikeV3Capabilities({ adcp: null }), false);
+    });
+
+    it('rejects adcp when array (typeof object would otherwise pass)', () => {
+      assert.equal(looksLikeV3Capabilities({ adcp: [] }), false);
+    });
+
+    it('rejects v3 block when array (typeof object would otherwise pass)', () => {
+      assert.equal(looksLikeV3Capabilities({ media_buy: [] }), false);
+    });
+  });
+
+  describe('parser handoff — when heuristic returns true, downstream callers must see version: v3', () => {
+    // Regression for the bug code-reviewer caught on PR #1201:
+    // parseCapabilitiesResponse defaults majorVersions: [2] when response.adcp
+    // is missing. SingleAgentClient.getCapabilities forces version: 'v3' after
+    // parse when the heuristic confirmed v3-shape; this test pins the bug at
+    // the parser layer so future contributors don't accidentally remove the
+    // override and re-introduce v2 mis-classification.
+
+    it('parser returns version: v2 when only supported_protocols is present (the bug)', () => {
+      // This is the specific failure mode — the parser alone does NOT know
+      // about the heuristic. Callers that rely on parser-only output for
+      // version detection see v2, not v3. Documents the constraint that
+      // motivated the override in SingleAgentClient.getCapabilities.
+      const parsed = parseCapabilitiesResponse({ supported_protocols: ['signals'] });
+      assert.equal(parsed.version, 'v2');
+      assert.deepStrictEqual(parsed.majorVersions, [2]);
+    });
+
+    it('parser returns version: v3 when adcp.major_versions is explicit', () => {
+      const parsed = parseCapabilitiesResponse({
+        adcp: { major_versions: [3] },
+        supported_protocols: ['signals'],
+      });
+      assert.equal(parsed.version, 'v3');
+      assert.deepStrictEqual(parsed.majorVersions, [3]);
     });
   });
 });

--- a/test/lib/looks-like-v3-capabilities.test.js
+++ b/test/lib/looks-like-v3-capabilities.test.js
@@ -1,0 +1,110 @@
+// Unit tests for the v3-shape detection heuristic used by SingleAgentClient
+// to decide whether a failed get_adcp_capabilities response is a v3 wire-shape
+// bug (continue as v3) or genuinely v2 (fall back). See issue #1189.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { looksLikeV3Capabilities } = require('../../dist/lib/utils/capabilities');
+
+describe('looksLikeV3Capabilities', () => {
+  describe('returns true for v3-shaped responses', () => {
+    it('detects adcp envelope block', () => {
+      assert.equal(looksLikeV3Capabilities({ adcp: { major_versions: [3] } }), true);
+    });
+
+    it('detects supported_protocols array', () => {
+      assert.equal(looksLikeV3Capabilities({ supported_protocols: ['signals'] }), true);
+    });
+
+    it('detects empty supported_protocols array (still a v3 signal — the field exists)', () => {
+      assert.equal(looksLikeV3Capabilities({ supported_protocols: [] }), true);
+    });
+
+    it('detects account block', () => {
+      assert.equal(looksLikeV3Capabilities({ account: { require_operator_auth: true } }), true);
+    });
+
+    it('detects media_buy block', () => {
+      assert.equal(looksLikeV3Capabilities({ media_buy: { features: {} } }), true);
+    });
+
+    it('detects signals block', () => {
+      assert.equal(looksLikeV3Capabilities({ signals: { catalog_signals: true } }), true);
+    });
+
+    it('detects creative block', () => {
+      assert.equal(looksLikeV3Capabilities({ creative: { supports_compliance: true } }), true);
+    });
+
+    it('detects brand block', () => {
+      assert.equal(looksLikeV3Capabilities({ brand: { rights: true } }), true);
+    });
+
+    it('detects governance block', () => {
+      assert.equal(looksLikeV3Capabilities({ governance: { spend_authority: true } }), true);
+    });
+
+    it('detects sponsored_intelligence block', () => {
+      assert.equal(looksLikeV3Capabilities({ sponsored_intelligence: { offerings: [] } }), true);
+    });
+
+    it('detects compliance_testing block', () => {
+      assert.equal(looksLikeV3Capabilities({ compliance_testing: { scenarios: [] } }), true);
+    });
+
+    it('detects partial response with v3-shape — the case matrix v2 surfaced', () => {
+      // Failed-validation response from a v3 agent missing one required field.
+      // Falling back to v2 here is what issue #1189 fixes.
+      assert.equal(
+        looksLikeV3Capabilities({
+          adcp: { major_versions: [3] },
+          supported_protocols: ['signals'],
+          account: { require_operator_auth: true /* supported_billing missing */ },
+        }),
+        true
+      );
+    });
+  });
+
+  describe('returns false for non-v3-shaped or empty inputs', () => {
+    it('rejects null', () => {
+      assert.equal(looksLikeV3Capabilities(null), false);
+    });
+
+    it('rejects undefined', () => {
+      assert.equal(looksLikeV3Capabilities(undefined), false);
+    });
+
+    it('rejects empty object', () => {
+      assert.equal(looksLikeV3Capabilities({}), false);
+    });
+
+    it('rejects array', () => {
+      assert.equal(looksLikeV3Capabilities([]), false);
+    });
+
+    it('rejects string', () => {
+      assert.equal(looksLikeV3Capabilities('v3'), false);
+    });
+
+    it('rejects number', () => {
+      assert.equal(looksLikeV3Capabilities(42), false);
+    });
+
+    it('rejects object with only unknown fields', () => {
+      assert.equal(looksLikeV3Capabilities({ foo: 'bar', baz: 1 }), false);
+    });
+
+    it('rejects supported_protocols when not an array (malformed)', () => {
+      assert.equal(looksLikeV3Capabilities({ supported_protocols: 'signals' }), false);
+    });
+
+    it('rejects v3 block when null (defensive)', () => {
+      assert.equal(looksLikeV3Capabilities({ media_buy: null }), false);
+    });
+
+    it('rejects adcp when null (defensive)', () => {
+      assert.equal(looksLikeV3Capabilities({ adcp: null }), false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1189.

## Summary

\`SingleAgentClient.getCapabilities()\` had a coarse v2-fallback heuristic: if \`get_adcp_capabilities\` was advertised but returned \`success: false\` for *any* reason, fall back to v2 synthetic capabilities. That's wrong when the agent is clearly v3 with a wire-shape bug (e.g., a single missing required field).

Observed cascade in the matrix v2 run (PR #1185):
1. Claude builds a v3 signals agent (advertises v3 tools, returns v3-shaped data)
2. \`get_adcp_capabilities\` response missing one required field (\`account.supported_billing\`)
3. Strict schema validation flips \`success\` to false
4. Old heuristic: \"capabilities call failed → must be v2\"
5. SDK marks agent as v2.5 → asks for v2.5 schemas (not shipped) → cascade of \`AdCP schema data for version \"v2.5\" not found\` errors across every subsequent step
6. 8 of 11 storyboard steps cascade-skip with errors that have nothing to do with the original missing field

## Fix

Tighten the fallback heuristic. When \`result.success === false\` but \`result.data\` is **structurally v3-shaped**, parse it anyway, surface the validation failure loudly, and continue with v3 capabilities.

New \`looksLikeV3Capabilities()\` helper in \`src/lib/utils/capabilities.ts\` checks for affirmative v3 signals:

- \`adcp\` envelope block present
- \`supported_protocols\` array present (v3-only top-level field)
- Any v3 protocol-level block present (\`account\`, \`media_buy\`, \`signals\`, \`creative\`, \`brand\`, \`governance\`, \`sponsored_intelligence\`, \`compliance_testing\`)

Empty / null / non-object responses still fall back to v2 — the existing heuristic for genuinely non-v3 agents is preserved.

## Why this is a tightening, not a loosening

Before: \"if capabilities call failed at all → v2\". After: \"if capabilities call failed AND no v3 evidence in the response → v2; otherwise → v3 with a wire-shape bug we should surface\".

The new path is strictly *more conservative* about declaring v2 — it requires affirmative absence of v3 markers, not just any failure. v2 agents (which don't expose \`get_adcp_capabilities\` at all) reach this code path with \`hasCapabilitiesTool: false\` and bypass the entire v3-or-v2 decision. Real v2 agents are unaffected.

## Pairs with #1198

PR #1198 fixes the most common cause of the cascade (\`supported_billing\` default in v6 framework). This PR (#1189) fixes the *amplifier* — the runner brittleness that turned that single missing field into a full storyboard failure. Each change stands alone; together they remove one of the gnarliest brittleness patterns in the matrix harness.

If only #1198 lands: the original cascade still fires for any *other* future schema-validation regression. If only #1189 lands: the cascade is gone but agents still emit malformed capabilities responses. Both should land.

## Test plan

- [x] \`npm run build\` clean
- [x] 22 new unit tests in \`test/lib/looks-like-v3-capabilities.test.js\` exercising the heuristic on positive (v3-shape) and negative (empty/null/non-object/legacy) cases. All passing.
- [ ] Re-run matrix v2 pair after #1198 + #1189 land — expected: storyboard failures now point at real wire-shape bugs in Claude's adapter rather than cascading v2.5 errors.

## Refs

- Closes #1189
- Pairs with #1198 (default \`supported_billing\` in v6 framework)
- Empirical source: PR #1185 (matrix v2 mock-server run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)