### PR TITLE
revert: storyboardContext on AssertionContext (#1142)

### DIFF
--- a/.changeset/revert-storyboardcontext-on-assertions.md
+++ b/.changeset/revert-storyboardcontext-on-assertions.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': minor
+---
+
+Reverts #1142, removing `storyboardContext?: StoryboardContext` from `AssertionContext` and the per-step / final-step shallow-copy threading in the runner.
+
+The field was preemptive surface with no consumer. None of the bundled invariants (`status.monotonic`, `idempotency.conflict_no_payload_leak`, `context.no_secret_echo`, `governance.denial_blocks_mutation`) read it; programmatic assertions already accumulate cross-step state through `ctx.state` (which is exactly how `status.monotonic`'s `history` works). Issue #1140 was about YAML validators (the `check:` clause), not assertion handlers — that scope is fully covered by #1141 (`field_less_than` / `field_equals_context` reading from `ValidationContext.storyboardContext`). The asymmetry is correct: declarative validators need context exposure, imperative assertions don't.
+
+Custom invariants that need cross-step state should continue using `ctx.state` (set in `onStart`, mutated in `onStep`, read in `onEnd`).
+
+Breaking-shape change to a public optional field, shipped as minor while 6.x is still in its breaking phase. Window-of-removal is hours old — the field landed in 6.4.0, no docs advertised it, no third-party consumer has had time to depend on it.

--- a/src/lib/testing/storyboard/assertions.ts
+++ b/src/lib/testing/storyboard/assertions.ts
@@ -24,7 +24,6 @@
 import type {
   AssertionResult,
   Storyboard,
-  StoryboardContext,
   StoryboardInvariants,
   StoryboardRunOptions,
   StoryboardStepResult,
@@ -46,24 +45,6 @@ export interface AssertionContext {
   agentUrl: string;
   options: StoryboardRunOptions;
   state: Record<string, unknown>;
-  /**
-   * Accumulated cross-step context as of the end of the prior step.
-   *
-   * Populated by the runner before each `onStep` call so assertion handlers
-   * can read values extracted or declared via `context_outputs` in earlier
-   * steps. For the first step this reflects the initial context only (from
-   * `StoryboardRunOptions.context`). Not set on `onStart` (no steps have
-   * run yet); on `onEnd` reflects the context after the final step.
-   *
-   * Key names match those used in `context_outputs` entries and
-   * `$context.*` placeholder substitutions throughout the storyboard
-   * definition (Option 2 / context-outputs style — see adcp-client#1140
-   * and adcontextprotocol/adcp#2642).
-   *
-   * Missing keys return `undefined`; assertion implementations decide
-   * how to handle absent context (skip the check, emit a fail, etc.).
-   */
-  storyboardContext?: StoryboardContext;
 }
 
 /**

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1117,18 +1117,6 @@ async function executeStoryboardPass(
       stepResults.push(result);
       priorStepResults.set(step.id, result);
 
-      // Thread accumulated cross-step context into each assertion context
-      // before onStep fires. `context` here is the accumulated state from
-      // all prior steps (updated at the bottom of this loop); assertions
-      // read it via ctx.storyboardContext to implement cross-step comparison
-      // validators (adcp-client#1140, Option 2 / context-outputs style).
-      // Each assertion gets its own shallow copy so a mutating handler
-      // doesn't corrupt the view seen by subsequent assertions in the same
-      // step, or the live accumulator seen by subsequent steps.
-      for (const spec of assertions) {
-        assertionContexts.get(spec.id)!.storyboardContext = { ...context };
-      }
-
       // Fire per-step assertions. Each result is appended to the step's
       // `validations[]` under `check: "assertion"` so existing UI renders
       // them alongside inline checks, and mirrored into `assertionResults`
@@ -1383,12 +1371,6 @@ async function executeStoryboardPass(
     countedAsFailed
   );
   skippedCount += branchSetDelta.skippedDelta;
-
-  // Update assertion contexts with the final accumulated context so onEnd
-  // handlers see the full run's context (not just through the penultimate step).
-  for (const spec of assertions) {
-    assertionContexts.get(spec.id)!.storyboardContext = { ...context };
-  }
 
   // Fire storyboard-scoped assertions. These observe the full run and can
   // emit `scope: "storyboard"` findings that flip `overall_passed` without

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.3.0';
+export const LIBRARY_VERSION = '6.4.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.3.0',
+  library: '6.4.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-01T12:53:33.638Z',
+  generatedAt: '2026-05-01T14:30:42.487Z',
 } as const;
 
 /**


### PR DESCRIPTION
Reverts #1142.

## Why

#1142 added `storyboardContext?: StoryboardContext` to `AssertionContext` plus per-step / final-step shallow-copy threading in the runner. After it merged, a closer look showed it's preemptive surface with no consumer:

- None of the four bundled invariants (`status.monotonic`, `idempotency.conflict_no_payload_leak`, `context.no_secret_echo`, `governance.denial_blocks_mutation`) read `ctx.storyboardContext`. Confirmed by grep across `src/lib/testing/storyboard/default-invariants.ts`.
- Programmatic assertions already accumulate cross-step state through `ctx.state` — that's exactly how `status.monotonic`'s `history` Map works. Reading from `storyboardContext` provides a parallel channel that's never needed.
- Issue #1140 was about **YAML validators** (the `check:` clause), not assertion handlers. That scope is fully covered by #1141, which reads from `ValidationContext.storyboardContext` — a separate interface that already existed before #1142.

The asymmetry is correct, not a gap to fill: declarative validators are stateless and need context exposure; imperative assertions have `ctx.state` and don't. Custom invariants that need cross-step state should continue using `ctx.state`.

## Why now

The window for cheap removal is hours old. #1142 landed in 6.4.0 today; no docs advertised the field, no third-party consumer has had time to depend on it. Removing later means a deprecation cycle; removing now is just a clean revert.

The CLAUDE.md principle this reinforces: "Don't add features, refactor, or introduce abstractions beyond what the task requires."

## Compatibility

Breaking-shape change to a public optional field on an exported interface. Shipped as **minor** while 6.x is still in its breaking phase (per project policy — same as the original #1142 changeset).

## What was tested

- `npm run build` — clean
- `npm run format:check` — clean
- `npm run sync-version` — clean
- `NODE_ENV=test node --test test/lib/storyboard-default-invariants.test.js test/lib/storyboard-runner-contract.test.js test/lib/storyboard-track-silent-rollup.test.js test/lib/storyboard-assertion-registry.test.js test/lib/compliance.test.js` — **217/217 pass**

## Test plan

- [ ] Confirm CI green
- [ ] Sanity check: changeset rolls forward as 6.5.0 (minor) on the next Release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)