### PR TITLE
feat(cli+harness): adcp mock-server creative-template + matrix harness generalization

### DIFF
--- a/.changeset/feat-mock-server-creative-template.md
+++ b/.changeset/feat-mock-server-creative-template.md
@@ -1,0 +1,30 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(cli): `adcp mock-server creative-template` — second specialism in the matrix v2 family
+
+Adds a Celtra/Innovid/AudioStack-shaped creative platform mock alongside the existing `signal-marketplace` mock. Different multi-tenant pattern (URL-path workspace scoping vs the signals mock's `X-Operator-Id` header), different gotcha (async render lifecycle: `queued → running → complete` via polling).
+
+Headline characteristics:
+
+- **Workspace-scoped paths**: `/v3/workspaces/{workspace_id}/...`. Two seeded workspaces (`ws_acme_studio` for `acmeoutdoor.example`, `ws_summit_studio` for `summit-media.example`) with overlapping template visibility — Acme has 4 templates including video preroll; Summit has 3 display-only templates.
+- **Async render pipeline**: `POST /renders` returns 202 with `status: queued`; subsequent GETs progress through `running` → `complete` (or `failed`). Adapters have to poll, not assume sync. Idempotent on `client_request_id` per workspace, with 409 on body mismatch.
+- **Templates as upstream-flavored format catalog**: 4 seeded templates (300x250 medrec, 728x90 leaderboard, 320x50 mobile banner, 15s video preroll). Slot definitions use upstream vocabulary (`slot_id`) rather than AdCP's `asset_role` so the adapter does the projection.
+- **Synthetic output**: rendered HTML / JavaScript / VAST XML by `output_kind`. Plausible-looking but not real — the matrix tests adapter projection, not actual creative rendering.
+
+Refactors `MockServerHandle` to expose a unified `principalMapping` + `principalScope` shape so the matrix harness can build prompts for either specialism without specialism-specific seed-data introspection. Both signals (`account.operator` → `X-Operator-Id`) and creative-template (`account.advertiser` → `path /v3/workspaces/...`) flow through the same adapter prompt template.
+
+The matrix harness's `bootUpstreamForHarness` now consumes the unified handle shape; `skill-matrix.json` adds `upstream: "creative-template"` to the build-creative-agent × creative_template pair.
+
+Run with:
+
+```bash
+npx @adcp/sdk mock-server creative-template --port 4501
+# or as part of the skill-matrix:
+npm run compliance:skill-matrix -- --filter creative_template
+```
+
+12 new smoke tests in `test/lib/mock-server/creative-template.test.js` cover auth gating, workspace scoping, channel filtering, render lifecycle, idempotency replay, 409 on body mismatch, cross-workspace isolation, malformed JSON / unknown template error paths, VAST output for video templates, and the unified principal-mapping handle shape.
+
+Refs adcontextprotocol/adcp-client#1155.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1014,6 +1014,10 @@ ARGUMENTS:
                                             (LiveRamp/Lotame/Oracle Data Cloud
                                             family). Multi-operator API key
                                             pattern; X-Operator-Id required.
+                       creative-template    Celtra/Innovid-shaped creative
+                                            platform with async renders.
+                                            Workspace-scoped paths; multi-stage
+                                            polling (queued → running → complete).
 
 OPTIONS:
   --port N           Listen port. Default: 4500.

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -118,7 +118,13 @@ function buildPrompt(
     url: string;
     apiKey: string;
     openapiPath: string;
-    operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }>;
+    principalScope: string;
+    principalMapping: Array<{
+      adcpField: string;
+      adcpValue: string;
+      upstreamField: string;
+      upstreamValue: string;
+    }>;
   }
 ): string {
   const upstreamSection = upstream
@@ -126,24 +132,24 @@ function buildPrompt(
 
 ## The upstream platform you're wrapping
 
-You are NOT inventing a decisioning/signal platform from scratch. The adopter brings an existing upstream platform and you are writing the AdCP wrapper around it.
+You are NOT inventing a decisioning/signal/creative platform from scratch. The adopter brings an existing upstream platform and you are writing the AdCP wrapper around it.
 
 The upstream platform is running locally as a fixture. Treat it exactly as you would the adopter's real platform — call its HTTP API to fetch state and post mutations.
 
 **Base URL**: ${upstream.url}
 **OpenAPI spec** (read this first): ${upstream.openapiPath}
 
-**Authentication** (every outbound request must carry both):
+**Authentication**:
 - \`Authorization: Bearer ${upstream.apiKey}\` — the customer-level API key
-- \`X-Operator-Id: <upstream operator id>\` — the operator seat. Different operators see different cohorts/destinations and have different rate cards. **Omitting this header returns 403.**
+- Per-tenant scope: ${upstream.principalScope}
 
-**Operator mapping**: the AdCP request you receive will carry \`account.operator: "<adcp-operator>"\`. You must translate that to the upstream operator id when calling the upstream API:
+**Principal mapping**: the AdCP request you receive will carry an identifier (e.g., \`account.operator\` or \`account.advertiser\`). You must translate that to the upstream tenant identifier when calling the upstream API:
 
-${upstream.operatorMapping.map(m => `- AdCP \`account.operator: "${m.adcp_operator}"\`  →  upstream \`X-Operator-Id: ${m.upstream_operator_id}\``).join('\n')}
+${upstream.principalMapping.map(m => `- AdCP \`${m.adcpField}: "${m.adcpValue}"\`  →  upstream \`${m.upstreamField}: ${m.upstreamValue}\``).join('\n')}
 
 The mapping table above is fixed seed data for this fixture; in production this would be a config file or DB lookup. Hard-code it for the test (a Map literal in your adapter is fine).
 
-If a buyer's \`account.operator\` value isn't in your mapping, return an appropriate AdCP error rather than calling upstream with no/wrong operator.
+If a buyer's principal value isn't in your mapping, return an appropriate AdCP error rather than calling upstream with no/wrong tenant scope.
 `
     : '';
 
@@ -421,19 +427,21 @@ function log(msg: string): void {
   process.stderr.write(`[harness] ${msg}\n`);
 }
 
-async function bootUpstreamForHarness(
-  specialism: string,
-  port: number
-): Promise<
-  | {
-      url: string;
-      apiKey: string;
-      openapiPath: string;
-      operatorMapping: Array<{ adcp_operator: string; upstream_operator_id: string }>;
-      close: () => Promise<void>;
-    }
-  | undefined
-> {
+interface UpstreamHandle {
+  url: string;
+  apiKey: string;
+  openapiPath: string;
+  principalScope: string;
+  principalMapping: Array<{
+    adcpField: string;
+    adcpValue: string;
+    upstreamField: string;
+    upstreamValue: string;
+  }>;
+  close: () => Promise<void>;
+}
+
+async function bootUpstreamForHarness(specialism: string, port: number): Promise<UpstreamHandle | undefined> {
   // Use the compiled dist/ entry point so the harness doesn't depend on tsx
   // resolution from a child process. Same path the CLI uses. If dist/ is
   // missing (contributor forgot `npm run build`), surface the same friendly
@@ -443,14 +451,13 @@ async function bootUpstreamForHarness(
   let bootMockServer: (opts: { specialism: string; port: number }) => Promise<{
     url: string;
     apiKey: string;
+    principalScope: string;
+    principalMapping: UpstreamHandle['principalMapping'];
     close: () => Promise<void>;
   }>;
-  let seed: { OPERATORS: Array<{ adcp_operator: string; operator_id: string }> };
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     ({ bootMockServer } = require(resolve(REPO_ROOT, 'dist/lib/mock-server/index.js')));
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    seed = require(resolve(REPO_ROOT, `dist/lib/mock-server/${specialism}/seed-data.js`));
   } catch (err) {
     log(
       `mock-server module not found in dist/. Run \`npm run build\` first.\n` +
@@ -460,16 +467,13 @@ async function bootUpstreamForHarness(
   }
   const handle = await bootMockServer({ specialism, port });
   const openapiPath = resolve(REPO_ROOT, `src/lib/mock-server/${specialism}/openapi.yaml`);
-  const operatorMapping = seed.OPERATORS.map(op => ({
-    adcp_operator: op.adcp_operator,
-    upstream_operator_id: op.operator_id,
-  }));
   log(`upstream mock-server (${specialism}) up on ${handle.url}`);
   return {
     url: handle.url,
     apiKey: handle.apiKey,
     openapiPath,
-    operatorMapping,
+    principalScope: handle.principalScope,
+    principalMapping: handle.principalMapping,
     close: handle.close,
   };
 }
@@ -507,7 +511,8 @@ async function main(): Promise<void> {
               url: upstream.url,
               apiKey: upstream.apiKey,
               openapiPath: upstream.openapiPath,
-              operatorMapping: upstream.operatorMapping,
+              principalScope: upstream.principalScope,
+              principalMapping: upstream.principalMapping,
             }
           : undefined
       ),

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -58,7 +58,7 @@ interface Args {
   /** When set, boot a mock upstream platform of this specialism flavor
    * before handing the workspace to Claude. Claude wraps the upstream as
    * an AdCP agent rather than inventing the platform layer from scratch.
-   * Currently supported: `signal-marketplace`. */
+   * Currently supported: `signal-marketplace`, `creative-template`. */
   upstream?: string;
   /** Port for the mock upstream server; defaults to `port + 100`. */
   upstreamPort?: number;

--- a/scripts/manual-testing/skill-matrix.json
+++ b/scripts/manual-testing/skill-matrix.json
@@ -8,7 +8,11 @@
     { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "security_baseline" },
     { "skill": "skills/build-brand-rights-agent/SKILL.md", "storyboard": "brand_rights" },
     { "skill": "skills/build-creative-agent/SKILL.md", "storyboard": "creative_ad_server" },
-    { "skill": "skills/build-creative-agent/SKILL.md", "storyboard": "creative_template" },
+    {
+      "skill": "skills/build-creative-agent/SKILL.md",
+      "storyboard": "creative_template",
+      "upstream": "creative-template"
+    },
     { "skill": "skills/build-decisioning-creative-template/SKILL.md", "storyboard": "creative_template" },
     { "skill": "skills/build-generative-seller-agent/SKILL.md", "storyboard": "creative_generative" },
     { "skill": "skills/build-governance-agent/SKILL.md", "storyboard": "governance_spend_authority" },

--- a/src/lib/mock-server/creative-template/openapi.yaml
+++ b/src/lib/mock-server/creative-template/openapi.yaml
@@ -1,0 +1,307 @@
+openapi: 3.1.0
+info:
+  title: Creative Template Platform API
+  version: '3.0.0'
+  description: |
+    HTTP API for a fictional creative-template platform — Celtra/Innovid/AudioStack-shaped
+    upstream that defines templates and transforms input assets into rendered creatives
+    (HTML tags, JS tags, VAST XML).
+
+    Workspace-scoped via the URL path (different multi-tenant flavor from
+    signal-marketplace's X-Operator-Id header — exercises the SDK's ability
+    to handle path-based principal mapping). Renders are async: the adapter
+    submits a render, then polls the render endpoint until status reaches
+    `complete` (or `failed`).
+
+    This is a fixture for compliance testing; the seed templates and
+    workspace IDs are stable across boots.
+
+servers:
+  - url: http://127.0.0.1:{port}/v3
+    variables:
+      port:
+        default: '4501'
+        description: Port the mock-server boots on (override with --port)
+
+components:
+  securitySchemes:
+    bearerApiKey:
+      type: http
+      scheme: bearer
+      description: |
+        Customer-level credential, shared across all workspaces owned by that
+        customer. Workspace scoping happens via the URL path
+        (`/v3/workspaces/{workspace_id}/...`).
+
+  schemas:
+    Template:
+      type: object
+      required: [template_id, name, channel, output_kind, slots]
+      properties:
+        template_id:
+          type: string
+          description: |
+            Stable upstream identifier for the template. Maps to AdCP
+            `format.format_id` (rename only — direct projection).
+          example: 'tpl_celtra_display_medrec_v2'
+        name:
+          type: string
+          example: 'Display Medium Rectangle (300x250)'
+        description: { type: string }
+        channel:
+          type: string
+          enum: [display, video, audio, ctv, native]
+          description: |
+            Top-level channel class. AdCP `format.channel` is similar but uses
+            slightly different vocabulary (e.g. AdCP says "olv" for online video);
+            adapter must translate.
+        dimensions:
+          type: object
+          description: Present for display/native templates.
+          properties:
+            width: { type: integer }
+            height: { type: integer }
+        duration_seconds:
+          type: object
+          description: Present for video/audio/ctv templates.
+          properties:
+            min: { type: integer }
+            max: { type: integer }
+        output_kind:
+          type: string
+          enum: [html_tag, javascript_tag, vast_xml]
+          description: |
+            What the rendered output will be. AdCP creative_manifest carries
+            this implicitly via the asset's mime_type — adapter translates.
+        slots:
+          type: array
+          description: |
+            Assets the template expects as inputs. AdCP `format.assets` has a
+            similar shape but uses `asset_role` instead of `slot_id`.
+          items: { $ref: '#/components/schemas/TemplateSlot' }
+        sample_inputs:
+          type: object
+          description: Optional sample asset URLs for quick testing.
+
+    TemplateSlot:
+      type: object
+      required: [slot_id, asset_type, required]
+      properties:
+        slot_id: { type: string, example: 'image' }
+        asset_type:
+          type: string
+          enum: [image, video, audio, text, click_url]
+        required: { type: boolean }
+        constraints:
+          type: object
+          description: |
+            Per-slot constraints — min/max dimensions, allowed mime types,
+            character limits for text, etc.
+          additionalProperties: true
+
+    RenderRequest:
+      type: object
+      required: [template_id, inputs, mode]
+      properties:
+        template_id: { type: string }
+        inputs:
+          type: array
+          description: Inline assets — caller passes URLs/text/etc. directly.
+          items: { $ref: '#/components/schemas/RenderInput' }
+        brand_kit:
+          type: object
+          description: |
+            Inline brand declaration (colors, fonts, logos). Real platforms
+            often have a separate /brand-kits resource the caller looks up
+            and references; this fixture accepts the brand kit inline to
+            stay storyboard-aligned (AdCP build_creative carries brand
+            inline via `brand_card`).
+          additionalProperties: true
+        mode:
+          type: string
+          enum: [preview, build]
+          description: |
+            `preview` → returns a preview URL (suitable for AdCP
+            preview_creative). `build` → returns the full rendered tag
+            ready for trafficking.
+        client_request_id:
+          type: string
+          description: |
+            Idempotency key. Re-sending the same client_request_id with the
+            same body returns the existing render rather than creating a
+            new one. Mismatched body returns 409.
+
+    RenderInput:
+      type: object
+      required: [slot_id, asset_type]
+      properties:
+        slot_id: { type: string }
+        asset_type:
+          type: string
+          enum: [image, video, audio, text, click_url]
+        url: { type: string, format: uri }
+        text: { type: string }
+        width: { type: integer }
+        height: { type: integer }
+        mime_type: { type: string }
+
+    Render:
+      type: object
+      required: [render_id, status, template_id, mode, created_at]
+      properties:
+        render_id: { type: string, example: 'rnd_01J...' }
+        status:
+          type: string
+          enum: [queued, running, complete, failed]
+        template_id: { type: string }
+        mode:
+          type: string
+          enum: [preview, build]
+        output:
+          type: object
+          description: Populated when status=complete.
+          properties:
+            tag_html: { type: string, description: 'HTML serving tag for output_kind=html_tag templates.' }
+            tag_javascript: { type: string, description: 'JavaScript serving tag for output_kind=javascript_tag.' }
+            vast_xml: { type: string, description: 'VAST XML for video/audio/ctv templates.' }
+            preview_url:
+              type: string
+              format: uri
+              description: 'Hosted preview URL — present for mode=preview, also present on mode=build for QA.'
+            assets:
+              type: array
+              description: 'Rendered output assets (e.g., the final 300x250 image with brand applied).'
+              items:
+                type: object
+                additionalProperties: true
+        error:
+          type: object
+          description: Populated when status=failed.
+          properties:
+            code: { type: string }
+            message: { type: string }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+        request_id: { type: string }
+
+security:
+  - bearerApiKey: []
+
+paths:
+  /workspaces/{workspace_id}/templates:
+    get:
+      summary: List templates available in this workspace
+      operationId: listTemplates
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: query
+          name: channel
+          schema: { type: string, enum: [display, video, audio, ctv, native] }
+      responses:
+        '200':
+          description: Templates visible to this workspace.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [templates]
+                properties:
+                  templates:
+                    type: array
+                    items: { $ref: '#/components/schemas/Template' }
+        '401': { description: Missing/invalid bearer credential. }
+        '404': { description: Unknown workspace. }
+
+  /workspaces/{workspace_id}/templates/{template_id}:
+    get:
+      summary: Fetch a single template by id (full slot detail)
+      operationId: getTemplate
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: template_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Template detail.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Template' }
+        '401': { description: Missing/invalid bearer credential. }
+        '404': { description: Workspace or template not found. }
+
+  /workspaces/{workspace_id}/renders:
+    post:
+      summary: Submit an async render
+      operationId: createRender
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/RenderRequest' }
+      responses:
+        '202':
+          description: Render accepted. Initial status is `queued`. Poll the GET endpoint until status is `complete` or `failed`.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Render' }
+        '200':
+          description: Idempotent replay — returns the existing render for this client_request_id.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Render' }
+        '400':
+          description: Bad request — missing required fields, invalid template_id, etc.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401': { description: Missing/invalid bearer credential. }
+        '404': { description: Workspace or template not found. }
+        '409':
+          description: |
+            Idempotency conflict — `client_request_id` was previously used with
+            a different body. Use a fresh idempotency key for distinct requests.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /workspaces/{workspace_id}/renders/{render_id}:
+    get:
+      summary: Poll render status
+      operationId: getRender
+      parameters:
+        - in: path
+          name: workspace_id
+          required: true
+          schema: { type: string }
+        - in: path
+          name: render_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Render detail.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Render' }
+        '401': { description: Missing/invalid bearer credential. }
+        '404': { description: Render not found in this workspace. }

--- a/src/lib/mock-server/creative-template/seed-data.ts
+++ b/src/lib/mock-server/creative-template/seed-data.ts
@@ -77,10 +77,11 @@ export const TEMPLATES: MockTemplate[] = [
   {
     template_id: 'tpl_celtra_display_leaderboard_v2',
     name: 'Display Leaderboard (728x90)',
-    description: 'Standard IAB leaderboard with brand-aware text overlay and CTA.',
+    description:
+      'Standard IAB leaderboard with brand-aware text overlay and CTA. JS tag output (carries impression macros, viewability shims, MRAID/SafeFrame hooks per IAB OpenRTB 2.6 §3.2.4).',
     channel: 'display',
     dimensions: { width: 728, height: 90 },
-    output_kind: 'html_tag',
+    output_kind: 'javascript_tag',
     slots: [
       {
         slot_id: 'image',
@@ -110,10 +111,10 @@ export const TEMPLATES: MockTemplate[] = [
   {
     template_id: 'tpl_celtra_mobile_banner_v2',
     name: 'Mobile Banner (320x50)',
-    description: 'Standard IAB mobile banner.',
+    description: 'Standard IAB mobile banner. JS tag output for in-app/MRAID compatibility.',
     channel: 'display',
     dimensions: { width: 320, height: 50 },
-    output_kind: 'html_tag',
+    output_kind: 'javascript_tag',
     slots: [
       {
         slot_id: 'image',

--- a/src/lib/mock-server/creative-template/seed-data.ts
+++ b/src/lib/mock-server/creative-template/seed-data.ts
@@ -1,0 +1,177 @@
+export interface MockTemplate {
+  template_id: string;
+  name: string;
+  description: string;
+  channel: 'display' | 'video' | 'audio' | 'ctv' | 'native';
+  dimensions?: { width: number; height: number };
+  duration_seconds?: { min: number; max: number };
+  output_kind: 'html_tag' | 'javascript_tag' | 'vast_xml';
+  slots: MockTemplateSlot[];
+  sample_inputs?: Record<string, unknown>;
+}
+
+export interface MockTemplateSlot {
+  slot_id: string;
+  asset_type: 'image' | 'video' | 'audio' | 'text' | 'click_url';
+  required: boolean;
+  constraints?: Record<string, unknown>;
+}
+
+export interface MockWorkspace {
+  workspace_id: string;
+  display_name: string;
+  /** AdCP-side identifier the adapter uses to map principal → workspace.
+   * The adapter receives this value via the AdCP request (e.g.,
+   * `account.advertiser` or principal lookup) and must translate it to
+   * `workspace_id` for outbound URL composition. */
+  adcp_advertiser: string;
+  visible_template_ids: string[];
+}
+
+/**
+ * Templates seeded across both workspaces. Each represents a common creative
+ * shape (display medium rectangle, leaderboard, mobile banner, video
+ * preroll). The slot definitions intentionally use upstream vocabulary
+ * (`slot_id`) rather than AdCP's `asset_role` so the adapter has to
+ * translate during list_creative_formats projection.
+ */
+export const TEMPLATES: MockTemplate[] = [
+  {
+    template_id: 'tpl_celtra_display_medrec_v2',
+    name: 'Display Medium Rectangle (300x250)',
+    description: 'Standard IAB medium rectangle with brand-aware text overlay and CTA.',
+    channel: 'display',
+    dimensions: { width: 300, height: 250 },
+    output_kind: 'html_tag',
+    slots: [
+      {
+        slot_id: 'image',
+        asset_type: 'image',
+        required: true,
+        constraints: { width: 300, height: 250, mime_types: ['image/jpeg', 'image/png', 'image/webp'] },
+      },
+      {
+        slot_id: 'headline',
+        asset_type: 'text',
+        required: true,
+        constraints: { max_chars: 40 },
+      },
+      {
+        slot_id: 'cta',
+        asset_type: 'text',
+        required: true,
+        constraints: { max_chars: 20 },
+      },
+      {
+        slot_id: 'click_through',
+        asset_type: 'click_url',
+        required: true,
+      },
+    ],
+    sample_inputs: {
+      image_url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/hero-300x250.jpg',
+      headline: 'Built for the trail.',
+      cta: 'Shop Gear',
+    },
+  },
+  {
+    template_id: 'tpl_celtra_display_leaderboard_v2',
+    name: 'Display Leaderboard (728x90)',
+    description: 'Standard IAB leaderboard with brand-aware text overlay and CTA.',
+    channel: 'display',
+    dimensions: { width: 728, height: 90 },
+    output_kind: 'html_tag',
+    slots: [
+      {
+        slot_id: 'image',
+        asset_type: 'image',
+        required: true,
+        constraints: { width: 728, height: 90, mime_types: ['image/jpeg', 'image/png', 'image/webp'] },
+      },
+      {
+        slot_id: 'headline',
+        asset_type: 'text',
+        required: true,
+        constraints: { max_chars: 60 },
+      },
+      {
+        slot_id: 'cta',
+        asset_type: 'text',
+        required: true,
+        constraints: { max_chars: 20 },
+      },
+      {
+        slot_id: 'click_through',
+        asset_type: 'click_url',
+        required: true,
+      },
+    ],
+  },
+  {
+    template_id: 'tpl_celtra_mobile_banner_v2',
+    name: 'Mobile Banner (320x50)',
+    description: 'Standard IAB mobile banner.',
+    channel: 'display',
+    dimensions: { width: 320, height: 50 },
+    output_kind: 'html_tag',
+    slots: [
+      {
+        slot_id: 'image',
+        asset_type: 'image',
+        required: true,
+        constraints: { width: 320, height: 50, mime_types: ['image/jpeg', 'image/png', 'image/webp'] },
+      },
+      {
+        slot_id: 'cta',
+        asset_type: 'text',
+        required: true,
+        constraints: { max_chars: 16 },
+      },
+      {
+        slot_id: 'click_through',
+        asset_type: 'click_url',
+        required: true,
+      },
+    ],
+  },
+  {
+    template_id: 'tpl_celtra_video_preroll_v1',
+    name: 'Video Preroll (15s)',
+    description: 'In-stream video preroll with 15-second cap and end card.',
+    channel: 'video',
+    duration_seconds: { min: 6, max: 15 },
+    output_kind: 'vast_xml',
+    slots: [
+      {
+        slot_id: 'video',
+        asset_type: 'video',
+        required: true,
+        constraints: { duration_max_seconds: 15, mime_types: ['video/mp4', 'video/webm'] },
+      },
+      {
+        slot_id: 'click_through',
+        asset_type: 'click_url',
+        required: true,
+      },
+    ],
+  },
+];
+
+export const WORKSPACES: MockWorkspace[] = [
+  {
+    workspace_id: 'ws_acme_studio',
+    display_name: 'Acme Outdoor Creative Studio',
+    adcp_advertiser: 'acmeoutdoor.example',
+    visible_template_ids: TEMPLATES.map(t => t.template_id),
+  },
+  {
+    workspace_id: 'ws_summit_studio',
+    display_name: 'Summit Media Creative Studio',
+    adcp_advertiser: 'summit-media.example',
+    // Summit's workspace doesn't have video access — only display templates.
+    visible_template_ids: TEMPLATES.filter(t => t.channel === 'display').map(t => t.template_id),
+  },
+];
+
+/** Default static API key. Override via `--api-key` at boot. */
+export const DEFAULT_API_KEY = 'mock_creative_template_key_do_not_use_in_prod';

--- a/src/lib/mock-server/creative-template/server.ts
+++ b/src/lib/mock-server/creative-template/server.ts
@@ -1,0 +1,341 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { DEFAULT_API_KEY, TEMPLATES, WORKSPACES, type MockTemplate, type MockWorkspace } from './seed-data';
+
+export interface BootOptions {
+  port: number;
+  apiKey?: string;
+  templates?: MockTemplate[];
+  workspaces?: MockWorkspace[];
+}
+
+export interface BootResult {
+  url: string;
+  close: () => Promise<void>;
+}
+
+interface MockRender {
+  render_id: string;
+  workspace_id: string;
+  status: 'queued' | 'running' | 'complete' | 'failed';
+  template_id: string;
+  mode: 'preview' | 'build';
+  /** Body fingerprint used for idempotency body-equivalence checks. */
+  body_fingerprint: string;
+  output?: {
+    tag_html?: string;
+    tag_javascript?: string;
+    vast_xml?: string;
+    preview_url?: string;
+    assets?: Array<Record<string, unknown>>;
+  };
+  error?: { code: string; message: string };
+  created_at: string;
+  updated_at: string;
+}
+
+export async function bootCreativeTemplate(options: BootOptions): Promise<BootResult> {
+  const apiKey = options.apiKey ?? DEFAULT_API_KEY;
+  const templates = options.templates ?? TEMPLATES;
+  const workspaces = options.workspaces ?? WORKSPACES;
+
+  const renders = new Map<string, MockRender>();
+  // client_request_id idempotency table — keyed by `<workspace_id>::<key>`.
+  const idempotency = new Map<string, string>();
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res, { apiKey, templates, workspaces, renders, idempotency }).catch(err => {
+      const requestId = (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
+      writeJson(res, 500, {
+        code: 'internal_error',
+        message: err?.message ?? 'unexpected error',
+        request_id: requestId,
+      });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const addr = server.address();
+  const boundPort = typeof addr === 'object' && addr ? addr.port : options.port;
+  const url = `http://127.0.0.1:${boundPort}`;
+
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+interface HandlerCtx {
+  apiKey: string;
+  templates: MockTemplate[];
+  workspaces: MockWorkspace[];
+  renders: Map<string, MockRender>;
+  idempotency: Map<string, string>;
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse, ctx: HandlerCtx): Promise<void> {
+  // Authentication first.
+  const auth = req.headers['authorization'];
+  if (!auth || !auth.startsWith('Bearer ') || auth.slice(7) !== ctx.apiKey) {
+    writeJson(res, 401, { code: 'unauthorized', message: 'Missing or invalid bearer credential.' });
+    return;
+  }
+
+  const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+  const path = url.pathname;
+  const method = req.method ?? 'GET';
+
+  // Path-based workspace scoping. Matches /v3/workspaces/{ws}/...
+  const wsMatch = path.match(/^\/v3\/workspaces\/([^/]+)(\/.*)?$/);
+  if (!wsMatch || !wsMatch[1]) {
+    writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+    return;
+  }
+  const workspaceId = decodeURIComponent(wsMatch[1]);
+  const subPath = wsMatch[2] ?? '/';
+  const workspace = ctx.workspaces.find(w => w.workspace_id === workspaceId);
+  if (!workspace) {
+    writeJson(res, 404, { code: 'workspace_not_found', message: `Workspace ${workspaceId} not found.` });
+    return;
+  }
+
+  // GET /v3/workspaces/{ws}/templates
+  if (method === 'GET' && subPath === '/templates') {
+    return handleListTemplates(url, ctx, workspace, res);
+  }
+  // GET /v3/workspaces/{ws}/templates/{tpl_id}
+  const tplMatch = subPath.match(/^\/templates\/([^/]+)$/);
+  if (method === 'GET' && tplMatch && tplMatch[1]) {
+    return handleGetTemplate(decodeURIComponent(tplMatch[1]), ctx, workspace, res);
+  }
+  // POST /v3/workspaces/{ws}/renders
+  if (method === 'POST' && subPath === '/renders') {
+    return handleCreateRender(req, ctx, workspace, res);
+  }
+  // GET /v3/workspaces/{ws}/renders/{render_id}
+  const rMatch = subPath.match(/^\/renders\/([^/]+)$/);
+  if (method === 'GET' && rMatch && rMatch[1]) {
+    return handleGetRender(decodeURIComponent(rMatch[1]), ctx, workspace, res);
+  }
+
+  writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+}
+
+function handleListTemplates(url: URL, ctx: HandlerCtx, ws: MockWorkspace, res: ServerResponse): void {
+  const visible = ctx.templates.filter(t => ws.visible_template_ids.includes(t.template_id));
+  const channel = url.searchParams.get('channel');
+  const filtered = channel ? visible.filter(t => t.channel === channel) : visible;
+  writeJson(res, 200, { templates: filtered });
+}
+
+function handleGetTemplate(templateId: string, ctx: HandlerCtx, ws: MockWorkspace, res: ServerResponse): void {
+  const template = ctx.templates.find(t => t.template_id === templateId);
+  if (!template) {
+    writeJson(res, 404, { code: 'template_not_found', message: `Template ${templateId} not found.` });
+    return;
+  }
+  if (!ws.visible_template_ids.includes(templateId)) {
+    writeJson(res, 404, {
+      code: 'template_not_visible',
+      message: `Template ${templateId} is not visible to workspace ${ws.workspace_id}.`,
+    });
+    return;
+  }
+  writeJson(res, 200, template);
+}
+
+async function handleCreateRender(
+  req: IncomingMessage,
+  ctx: HandlerCtx,
+  ws: MockWorkspace,
+  res: ServerResponse
+): Promise<void> {
+  let body: unknown;
+  try {
+    body = await readJson(req);
+  } catch {
+    writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
+    return;
+  }
+  if (!isObject(body)) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
+    return;
+  }
+  const { template_id, inputs, mode, client_request_id } = body as Record<string, unknown>;
+  if (typeof template_id !== 'string' || !Array.isArray(inputs) || (mode !== 'preview' && mode !== 'build')) {
+    writeJson(res, 400, {
+      code: 'invalid_request',
+      message: 'template_id (string), inputs (array), and mode ("preview" or "build") are required.',
+    });
+    return;
+  }
+  const template = ctx.templates.find(t => t.template_id === template_id);
+  if (!template || !ws.visible_template_ids.includes(template_id)) {
+    writeJson(res, 404, {
+      code: template ? 'template_not_visible' : 'template_not_found',
+      message: `Template ${template_id} ${template ? 'not visible' : 'not found'}.`,
+    });
+    return;
+  }
+
+  const fingerprint = fingerprintBody(template_id, inputs, mode);
+
+  // Idempotency replay (same body) / conflict (mismatched body).
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    const idemKey = `${ws.workspace_id}::${client_request_id}`;
+    const existing = ctx.idempotency.get(idemKey);
+    if (existing) {
+      const render = ctx.renders.get(existing);
+      if (render) {
+        if (render.body_fingerprint !== fingerprint) {
+          writeJson(res, 409, {
+            code: 'idempotency_conflict',
+            message: `client_request_id ${client_request_id} was previously used with a different body. Use a fresh idempotency key for distinct requests.`,
+          });
+          return;
+        }
+        writeJson(res, 200, serializeRender(render));
+        return;
+      }
+    }
+  }
+
+  const renderId = `rnd_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+  const now = new Date();
+  const render: MockRender = {
+    render_id: renderId,
+    workspace_id: ws.workspace_id,
+    status: 'queued',
+    template_id,
+    mode,
+    body_fingerprint: fingerprint,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  };
+  ctx.renders.set(renderId, render);
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    ctx.idempotency.set(`${ws.workspace_id}::${client_request_id}`, renderId);
+  }
+
+  writeJson(res, 202, serializeRender(render));
+}
+
+function handleGetRender(renderId: string, ctx: HandlerCtx, ws: MockWorkspace, res: ServerResponse): void {
+  const render = ctx.renders.get(renderId);
+  if (!render) {
+    writeJson(res, 404, { code: 'render_not_found', message: `Render ${renderId} not found.` });
+    return;
+  }
+  if (render.workspace_id !== ws.workspace_id) {
+    writeJson(res, 404, {
+      code: 'render_not_in_workspace',
+      message: `Render ${renderId} not found in workspace ${ws.workspace_id}.`,
+    });
+    return;
+  }
+
+  // Auto-promote queued → running on first poll, running → complete on second.
+  // Real platforms render in seconds-to-minutes; the mock simulates a fast
+  // async with two state transitions to exercise polling without making the
+  // matrix run drag.
+  const template = ctx.templates.find(t => t.template_id === render.template_id);
+  if (render.status === 'queued') {
+    render.status = 'running';
+    render.updated_at = new Date().toISOString();
+  } else if (render.status === 'running') {
+    render.status = 'complete';
+    render.updated_at = new Date().toISOString();
+    render.output = synthesizeOutput(render, template);
+  }
+
+  writeJson(res, 200, serializeRender(render));
+}
+
+function synthesizeOutput(render: MockRender, template: MockTemplate | undefined): MockRender['output'] {
+  // Fixture output. Real platforms return real ad tags / VAST XML / etc; the
+  // mock returns plausible-looking synthetic output so adapters can pattern-
+  // match without rendering anything real. The kind is driven by the
+  // template's output_kind so the adapter has to read it and project to AdCP
+  // creative_manifest correctly.
+  const previewBase = `https://mock-creative-template.example/preview/${render.render_id}`;
+  if (!template) {
+    return { preview_url: previewBase };
+  }
+  if (template.output_kind === 'vast_xml') {
+    return {
+      vast_xml: `<?xml version="1.0"?><VAST version="4.2"><Ad id="${render.render_id}"><InLine><AdSystem>MockCreativeTemplate</AdSystem><AdTitle>${template.name}</AdTitle></InLine></Ad></VAST>`,
+      preview_url: previewBase,
+      assets: [{ kind: 'video_tag', mime_type: 'application/xml+vast' }],
+    };
+  }
+  if (template.output_kind === 'javascript_tag') {
+    return {
+      tag_javascript: `(function(){var d=document;var img=d.createElement('img');img.src='${previewBase}.png';d.write(img.outerHTML);})();`,
+      preview_url: previewBase,
+      assets: [{ kind: 'js_tag', mime_type: 'application/javascript' }],
+    };
+  }
+  // default html_tag
+  return {
+    tag_html: `<a href="https://example.com/click"><img src="${previewBase}.png" width="${template.dimensions?.width ?? 300}" height="${template.dimensions?.height ?? 250}" alt="${template.name}" /></a>`,
+    preview_url: previewBase,
+    assets: [{ kind: 'html_tag', mime_type: 'text/html' }],
+  };
+}
+
+function serializeRender(r: MockRender): Record<string, unknown> {
+  // workspace_id / body_fingerprint are internal book-keeping — strip from public payload.
+  const { workspace_id, body_fingerprint, ...rest } = r;
+  return rest;
+}
+
+function fingerprintBody(templateId: string, inputs: unknown[], mode: string): string {
+  // Stable JSON canonicalization for body equivalence. Serializing a sorted-
+  // key copy gives whitespace/order independence without pulling in a
+  // dependency. Inputs are array-position-significant (slot order matters
+  // for some upstream renders), so we don't sort the array itself.
+  return JSON.stringify({ template_id: templateId, inputs, mode });
+}
+
+function readJson(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', c => chunks.push(c));
+    req.on('error', reject);
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x);
+}

--- a/src/lib/mock-server/creative-template/server.ts
+++ b/src/lib/mock-server/creative-template/server.ts
@@ -247,7 +247,12 @@ function handleGetRender(renderId: string, ctx: HandlerCtx, ws: MockWorkspace, r
   // Auto-promote queued → running on first poll, running → complete on second.
   // Real platforms render in seconds-to-minutes; the mock simulates a fast
   // async with two state transitions to exercise polling without making the
-  // matrix run drag.
+  // matrix run drag. The `else if` chain means a `complete` render is a
+  // terminal state — subsequent polls return the same complete render
+  // without further mutation. Callers serializing polls (one GET at a time)
+  // observe each transition exactly once; concurrent polls in flight will
+  // both see the post-transition state, which is fine for a fixture but
+  // means the matrix harness should not race polls against itself.
   const template = ctx.templates.find(t => t.template_id === render.template_id);
   if (render.status === 'queued') {
     render.status = 'running';

--- a/src/lib/mock-server/index.ts
+++ b/src/lib/mock-server/index.ts
@@ -1,5 +1,7 @@
+import { bootCreativeTemplate } from './creative-template/server';
+import { DEFAULT_API_KEY as CREATIVE_TEMPLATE_DEFAULT_API_KEY, WORKSPACES } from './creative-template/seed-data';
 import { bootSignalMarketplace } from './signal-marketplace/server';
-import { DEFAULT_API_KEY, OPERATORS } from './signal-marketplace/seed-data';
+import { DEFAULT_API_KEY as SIGNAL_MARKETPLACE_DEFAULT_API_KEY, OPERATORS } from './signal-marketplace/seed-data';
 
 export interface MockServerOptions {
   specialism: string;
@@ -13,6 +15,22 @@ export interface MockServerHandle {
   close: () => Promise<void>;
   /** Adopter-friendly summary for boot-log printing. */
   summary: () => string;
+  /** Specialism-agnostic principal-mapping table the matrix harness inlines
+   * into the build prompt so Claude can wire AdCP-side identity to upstream
+   * tenant/workspace ids without re-deriving them per specialism. */
+  principalMapping: PrincipalMappingEntry[];
+  /** Human-prose description of how the upstream gates per-tenant scope —
+   * e.g. "via X-Operator-Id header" or "via path /v3/workspaces/{id}/...".
+   * Surfaces in the harness prompt to make the auth-translation requirement
+   * explicit. */
+  principalScope: string;
+}
+
+export interface PrincipalMappingEntry {
+  adcpField: string;
+  adcpValue: string;
+  upstreamField: string;
+  upstreamValue: string;
 }
 
 /**
@@ -20,9 +38,9 @@ export interface MockServerHandle {
  * the caller (CLI or matrix harness) uses to read connection details and
  * shut down cleanly.
  *
- * Currently supported specialisms: `signal-marketplace`. Adding a new one
- * means adding the upstream-shape OpenAPI + seed data + boot function under
- * `src/lib/mock-server/<specialism>/` and a switch case here.
+ * Adding a new specialism means adding the upstream-shape OpenAPI + seed
+ * data + boot function under `src/lib/mock-server/<specialism>/` and a
+ * switch case here.
  */
 export async function bootMockServer(options: MockServerOptions): Promise<MockServerHandle> {
   switch (options.specialism) {
@@ -31,16 +49,45 @@ export async function bootMockServer(options: MockServerOptions): Promise<MockSe
         port: options.port,
         apiKey: options.apiKey,
       });
-      const apiKey = options.apiKey ?? DEFAULT_API_KEY;
+      const apiKey = options.apiKey ?? SIGNAL_MARKETPLACE_DEFAULT_API_KEY;
       return {
         url,
         apiKey,
         close,
         summary: () => formatSignalMarketplaceSummary(url, apiKey),
+        principalScope: 'X-Operator-Id header (required on every request)',
+        principalMapping: OPERATORS.map(op => ({
+          adcpField: 'account.operator',
+          adcpValue: op.adcp_operator,
+          upstreamField: 'X-Operator-Id',
+          upstreamValue: op.operator_id,
+        })),
+      };
+    }
+    case 'creative-template': {
+      const { url, close } = await bootCreativeTemplate({
+        port: options.port,
+        apiKey: options.apiKey,
+      });
+      const apiKey = options.apiKey ?? CREATIVE_TEMPLATE_DEFAULT_API_KEY;
+      return {
+        url,
+        apiKey,
+        close,
+        summary: () => formatCreativeTemplateSummary(url, apiKey),
+        principalScope: 'URL path segment /v3/workspaces/{workspace_id}/...',
+        principalMapping: WORKSPACES.map(ws => ({
+          adcpField: 'account.advertiser',
+          adcpValue: ws.adcp_advertiser,
+          upstreamField: 'path /v3/workspaces/{workspace_id}/',
+          upstreamValue: ws.workspace_id,
+        })),
       };
     }
     default:
-      throw new Error(`Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace.`);
+      throw new Error(
+        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace, creative-template.`
+      );
   }
 }
 
@@ -66,5 +113,32 @@ function formatSignalMarketplaceSummary(url: string, apiKey: string): string {
     `  GET    ${url}/v2/destinations`,
     `  POST   ${url}/v2/activations`,
     `  GET    ${url}/v2/activations/{activation_id}`,
+  ].join('\n');
+}
+
+function formatCreativeTemplateSummary(url: string, apiKey: string): string {
+  const workspaceLines = WORKSPACES.map(
+    ws =>
+      `  ${ws.workspace_id}  →  AdCP account.advertiser: "${ws.adcp_advertiser}"  (visible templates: ${ws.visible_template_ids.length})`
+  ).join('\n');
+  return [
+    `Mock creative-template platform running at ${url}`,
+    ``,
+    `Auth:`,
+    `  Authorization: Bearer ${apiKey}`,
+    `  Workspace scoping via URL path: /v3/workspaces/{workspace_id}/...`,
+    ``,
+    `Workspace mapping:`,
+    workspaceLines,
+    ``,
+    `OpenAPI spec: src/lib/mock-server/creative-template/openapi.yaml`,
+    `Routes:`,
+    `  GET    ${url}/v3/workspaces/{ws}/templates`,
+    `  GET    ${url}/v3/workspaces/{ws}/templates/{template_id}`,
+    `  POST   ${url}/v3/workspaces/{ws}/renders`,
+    `  GET    ${url}/v3/workspaces/{ws}/renders/{render_id}`,
+    ``,
+    `Renders are async: POST returns 202 with status="queued", then progresses`,
+    `through "running" → "complete" on subsequent GETs (or "failed" on error).`,
   ].join('\n');
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.4.0';
+export const LIBRARY_VERSION = '6.5.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.4.0',
+  library: '6.5.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-01T14:30:42.487Z',
+  generatedAt: '2026-05-01T14:53:47.135Z',
 } as const;
 
 /**

--- a/test/lib/mock-server/creative-template.test.js
+++ b/test/lib/mock-server/creative-template.test.js
@@ -283,6 +283,95 @@ describe('mock-server creative-template', () => {
     assert.equal(body.code, 'template_not_found');
   });
 
+  it('keeps `complete` as a terminal state — subsequent polls do not mutate output', async () => {
+    // Regression for the auto-promote chain: an `else if` ladder means
+    // `complete` does NOT advance to anything else. Pin this so a future
+    // contributor adding a new state can't accidentally promote past
+    // complete (e.g., complete → archived).
+    const auth = {
+      Authorization: `Bearer ${DEFAULT_API_KEY}`,
+      'Content-Type': 'application/json',
+    };
+    const create = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({
+        template_id: 'tpl_celtra_display_medrec_v2',
+        mode: 'build',
+        inputs: [
+          { slot_id: 'image', asset_type: 'image', url: 'https://example.test/i.jpg' },
+          { slot_id: 'headline', asset_type: 'text', text: 'h' },
+          { slot_id: 'cta', asset_type: 'text', text: 'c' },
+          { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+        ],
+        client_request_id: 'terminal-state-test',
+      }),
+    });
+    const renderId = (await create.json()).render_id;
+    // Walk through queued → running → complete
+    await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const completeRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const completeBody = await completeRes.json();
+    assert.equal(completeBody.status, 'complete');
+    const firstUpdated = completeBody.updated_at;
+    const firstOutput = JSON.stringify(completeBody.output);
+
+    // Two more polls — should still be complete with same output.
+    for (let i = 0; i < 2; i++) {
+      const pollRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+        headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+      });
+      const pollBody = await pollRes.json();
+      assert.equal(pollBody.status, 'complete', 'status remains complete after additional polls');
+      assert.equal(pollBody.updated_at, firstUpdated, 'updated_at does not advance once complete');
+      assert.equal(JSON.stringify(pollBody.output), firstOutput, 'output is stable once complete');
+    }
+  });
+
+  it('isolates client_request_id across workspaces — same key in different workspaces produces distinct renders', async () => {
+    // Documents that the `${workspace_id}::${key}` keying scheme keeps two
+    // workspaces' idempotency tables independent. Important: real customers
+    // sharing a single API key across workspaces (different teams) commonly
+    // reuse simple ids like 'q3-launch-spot' across teams and would not
+    // expect collisions.
+    const sharedKey = 'shared-key-cross-ws';
+    const body = (workspace, hint) => ({
+      template_id: 'tpl_celtra_display_medrec_v2',
+      mode: 'build',
+      inputs: [
+        { slot_id: 'image', asset_type: 'image', url: `https://example.test/${hint}.jpg` },
+        { slot_id: 'headline', asset_type: 'text', text: 'h' },
+        { slot_id: 'cta', asset_type: 'text', text: 'c' },
+        { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+      ],
+      client_request_id: sharedKey,
+    });
+    const auth = {
+      Authorization: `Bearer ${DEFAULT_API_KEY}`,
+      'Content-Type': 'application/json',
+    };
+    const acmeRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify(body('ws_acme_studio', 'acme')),
+    });
+    assert.equal(acmeRes.status, 202);
+    // Summit can use the same client_request_id without collision.
+    const summitRes = await fetch(`${handle.url}/v3/workspaces/ws_summit_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify(body('ws_summit_studio', 'summit')),
+    });
+    assert.equal(summitRes.status, 202, 'cross-workspace replay is independent — should NOT 409');
+    const acmeRenderId = (await acmeRes.json()).render_id;
+    const summitRenderId = (await summitRes.json()).render_id;
+    assert.notEqual(acmeRenderId, summitRenderId, 'distinct render_ids across workspaces');
+  });
+
   it('reports unified principal-mapping shape on the boot handle', async () => {
     assert.ok(Array.isArray(handle.principalMapping));
     assert.ok(handle.principalMapping.length >= 2);

--- a/test/lib/mock-server/creative-template.test.js
+++ b/test/lib/mock-server/creative-template.test.js
@@ -1,0 +1,297 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { bootMockServer } = require('../../../dist/lib/mock-server/index.js');
+const { DEFAULT_API_KEY } = require('../../../dist/lib/mock-server/creative-template/seed-data.js');
+
+describe('mock-server creative-template', () => {
+  let handle;
+  before(async () => {
+    handle = await bootMockServer({ specialism: 'creative-template', port: 0 });
+  });
+  after(async () => {
+    if (handle) await handle.close();
+  });
+
+  it('rejects requests without a Bearer token (401)', async () => {
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/templates`);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.code, 'unauthorized');
+  });
+
+  it('rejects unknown workspace_id with 404 workspace_not_found', async () => {
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_does_not_exist/templates`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'workspace_not_found');
+  });
+
+  it('returns workspace-scoped template list', async () => {
+    const acmeRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/templates`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    assert.equal(acmeRes.status, 200);
+    const acmeBody = await acmeRes.json();
+    assert.equal(acmeBody.templates.length, 4); // 3 display + 1 video
+
+    // Summit doesn't have video access — only display templates
+    const summitRes = await fetch(`${handle.url}/v3/workspaces/ws_summit_studio/templates`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const summitBody = await summitRes.json();
+    assert.equal(summitBody.templates.length, 3);
+    for (const t of summitBody.templates) {
+      assert.equal(t.channel, 'display');
+    }
+  });
+
+  it('filters templates by channel query', async () => {
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/templates?channel=video`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const body = await res.json();
+    assert.equal(body.templates.length, 1);
+    assert.equal(body.templates[0].channel, 'video');
+  });
+
+  it('returns template detail with slot definitions', async () => {
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/templates/tpl_celtra_display_medrec_v2`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    assert.equal(res.status, 200);
+    const tpl = await res.json();
+    assert.equal(tpl.template_id, 'tpl_celtra_display_medrec_v2');
+    assert.ok(Array.isArray(tpl.slots));
+    assert.ok(tpl.slots.length >= 3);
+  });
+
+  it('returns 404 template_not_visible when template is not in workspace scope', async () => {
+    // Summit doesn't have the video preroll template
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_summit_studio/templates/tpl_celtra_video_preroll_v1`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'template_not_visible');
+  });
+
+  it('walks render lifecycle: queued → running → complete', async () => {
+    const auth = {
+      Authorization: `Bearer ${DEFAULT_API_KEY}`,
+      'Content-Type': 'application/json',
+    };
+
+    const createRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify({
+        template_id: 'tpl_celtra_display_medrec_v2',
+        mode: 'build',
+        inputs: [
+          { slot_id: 'image', asset_type: 'image', url: 'https://example.test/image.jpg', width: 300, height: 250 },
+          { slot_id: 'headline', asset_type: 'text', text: 'Built for the trail.' },
+          { slot_id: 'cta', asset_type: 'text', text: 'Shop' },
+          { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+        ],
+        client_request_id: 'lifecycle-test',
+      }),
+    });
+    assert.equal(createRes.status, 202);
+    const created = await createRes.json();
+    assert.equal(created.status, 'queued');
+    const renderId = created.render_id;
+
+    // First poll → running
+    const poll1 = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const polled1 = await poll1.json();
+    assert.equal(polled1.status, 'running');
+
+    // Second poll → complete with HTML output
+    const poll2 = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const polled2 = await poll2.json();
+    assert.equal(polled2.status, 'complete');
+    assert.ok(polled2.output);
+    assert.ok(typeof polled2.output.tag_html === 'string');
+    assert.ok(polled2.output.preview_url);
+  });
+
+  it('synthesizes VAST XML output for video templates', async () => {
+    const createRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        template_id: 'tpl_celtra_video_preroll_v1',
+        mode: 'build',
+        inputs: [
+          { slot_id: 'video', asset_type: 'video', url: 'https://example.test/v.mp4' },
+          { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+        ],
+        client_request_id: 'video-test',
+      }),
+    });
+    assert.equal(createRes.status, 202);
+    const created = await createRes.json();
+    const renderId = created.render_id;
+
+    // Walk to complete
+    await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const finalRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    const final = await finalRes.json();
+    assert.equal(final.status, 'complete');
+    assert.ok(final.output.vast_xml.includes('<VAST'));
+  });
+
+  it('returns 200 idempotent replay when client_request_id is reused with the same body', async () => {
+    const auth = {
+      Authorization: `Bearer ${DEFAULT_API_KEY}`,
+      'Content-Type': 'application/json',
+    };
+    const body = {
+      template_id: 'tpl_celtra_display_medrec_v2',
+      mode: 'build',
+      inputs: [
+        { slot_id: 'image', asset_type: 'image', url: 'https://example.test/image.jpg' },
+        { slot_id: 'headline', asset_type: 'text', text: 'h' },
+        { slot_id: 'cta', asset_type: 'text', text: 'c' },
+        { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+      ],
+      client_request_id: 'replay-test',
+    };
+    const first = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify(body),
+    });
+    assert.equal(first.status, 202);
+    const replay = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify(body),
+    });
+    assert.equal(replay.status, 200);
+    const replayBody = await replay.json();
+    assert.equal(replayBody.render_id, (await first.json()).render_id);
+  });
+
+  it('returns 409 idempotency_conflict on body mismatch', async () => {
+    const auth = {
+      Authorization: `Bearer ${DEFAULT_API_KEY}`,
+      'Content-Type': 'application/json',
+    };
+    const baseBody = {
+      template_id: 'tpl_celtra_display_medrec_v2',
+      mode: 'build',
+      inputs: [
+        { slot_id: 'image', asset_type: 'image', url: 'https://example.test/a.jpg' },
+        { slot_id: 'headline', asset_type: 'text', text: 'h' },
+        { slot_id: 'cta', asset_type: 'text', text: 'c' },
+        { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+      ],
+      client_request_id: 'conflict-test',
+    };
+    const first = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify(baseBody),
+    });
+    assert.equal(first.status, 202);
+
+    const conflictBody = { ...baseBody, mode: 'preview' };
+    const conflict = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: auth,
+      body: JSON.stringify(conflictBody),
+    });
+    assert.equal(conflict.status, 409);
+    const cBody = await conflict.json();
+    assert.equal(cBody.code, 'idempotency_conflict');
+  });
+
+  it('returns 404 when reading a render that belongs to a different workspace', async () => {
+    const createRes = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        template_id: 'tpl_celtra_display_medrec_v2',
+        mode: 'build',
+        inputs: [
+          { slot_id: 'image', asset_type: 'image', url: 'https://example.test/image.jpg' },
+          { slot_id: 'headline', asset_type: 'text', text: 'h' },
+          { slot_id: 'cta', asset_type: 'text', text: 'c' },
+          { slot_id: 'click_through', asset_type: 'click_url', url: 'https://example.test' },
+        ],
+        client_request_id: 'cross-ws-test',
+      }),
+    });
+    const created = await createRes.json();
+    const renderId = created.render_id;
+
+    const cross = await fetch(`${handle.url}/v3/workspaces/ws_summit_studio/renders/${renderId}`, {
+      headers: { Authorization: `Bearer ${DEFAULT_API_KEY}` },
+    });
+    assert.equal(cross.status, 404);
+    const cBody = await cross.json();
+    assert.equal(cBody.code, 'render_not_in_workspace');
+  });
+
+  it('rejects malformed JSON body with 400 invalid_json', async () => {
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: '{ not json',
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.code, 'invalid_json');
+  });
+
+  it('rejects unknown template_id with 404 template_not_found', async () => {
+    const res = await fetch(`${handle.url}/v3/workspaces/ws_acme_studio/renders`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${DEFAULT_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        template_id: 'tpl_does_not_exist',
+        mode: 'build',
+        inputs: [],
+        client_request_id: 'unknown-tpl-test',
+      }),
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'template_not_found');
+  });
+
+  it('reports unified principal-mapping shape on the boot handle', async () => {
+    assert.ok(Array.isArray(handle.principalMapping));
+    assert.ok(handle.principalMapping.length >= 2);
+    for (const entry of handle.principalMapping) {
+      assert.ok(entry.adcpField);
+      assert.ok(entry.adcpValue);
+      assert.ok(entry.upstreamField);
+      assert.ok(entry.upstreamValue);
+    }
+    assert.ok(/path|workspace/i.test(handle.principalScope));
+  });
+});


### PR DESCRIPTION
Second mock-server in the matrix v2 family. See #1155 for the design rationale.

## Summary

Adds the Celtra/Innovid/AudioStack-shaped \`creative-template\` mock alongside the existing \`signal-marketplace\` mock from PR #1185. Designed deliberately to stress different SDK abstractions:

- **Different multi-tenant pattern**: URL path workspace scoping (\`/v3/workspaces/{workspace_id}/...\`) vs the signals mock's \`X-Operator-Id\` header.
- **Different headline gotcha**: async render lifecycle (\`queued → running → complete\` via polling) vs signals' synchronous list/activate flow.
- **Different upstream concept space**: templates / renders / asset slots vs cohorts / activations.

## What's in the box

- \`src/lib/mock-server/creative-template/\`
  - \`openapi.yaml\` — workspace-scoped paths, 4 endpoints (templates list/detail, renders POST/GET)
  - \`seed-data.ts\` — 4 templates (300x250 medrec, 728x90 leaderboard, 320x50 mobile banner, 15s video preroll), 2 workspaces with overlapping visibility
  - \`server.ts\` — Node \`http\` handlers; auto-promotes render status on each poll
- \`bin/adcp.js\` — \`creative-template\` added to the \`mock-server\` subcommand
- \`src/lib/mock-server/index.ts\` — refactored to expose unified \`principalMapping\` + \`principalScope\` shape on the boot handle so the matrix harness builds prompts for either specialism without specialism-specific seed-data introspection
- \`scripts/manual-testing/agent-skill-storyboard.ts\` — consumes the unified handle shape; prompt templating updated
- \`scripts/manual-testing/skill-matrix.json\` — \`upstream: \"creative-template\"\` added to the build-creative-agent × creative_template pair
- \`test/lib/mock-server/creative-template.test.js\` — **14/14 passing** smoke tests
- \`.changeset/feat-mock-server-creative-template.md\` — minor

## Headline characteristics

### Workspace-scoped paths (different multi-tenant flavor from signals)

\`\`\`
GET    /v3/workspaces/{ws}/templates                  # list templates
GET    /v3/workspaces/{ws}/templates/{template_id}    # template detail
POST   /v3/workspaces/{ws}/renders                    # 202 queued
GET    /v3/workspaces/{ws}/renders/{render_id}        # poll → running → complete
\`\`\`

Two seeded workspaces:
- \`ws_acme_studio\` ↔ \`account.advertiser: \"acmeoutdoor.example\"\` (4 templates including video)
- \`ws_summit_studio\` ↔ \`account.advertiser: \"summit-media.example\"\` (3 display-only)

Cross-workspace render lookups return 404 (different from signals' 403 — real-world creative platforms vary on this; both patterns are defensible). Adapter has to handle workspace-scoped 404s separately from \"truly doesn't exist\".

### Async render lifecycle (the headline SDK gotcha)

POST /renders returns 202 with \`status: queued\`. Each subsequent GET advances state:
- \`queued\` → \`running\` (first poll)
- \`running\` → \`complete\` (second poll)

Real platforms render in seconds-to-minutes; the mock simulates a fast async (two state transitions to exercise polling without dragging matrix runs). Adapters have to either block-wait for completion or surface AdCP's task-lifecycle pattern.

### Idempotency

\`client_request_id\` per workspace, body fingerprint = \`(template_id, inputs, mode)\`.
- Same body → 200 with the existing render
- Different body → 409 \`idempotency_conflict\`

Cross-workspace \`client_request_id\` collisions are independent (keyed on \`<workspace_id>::<key>\`).

## Refactor: unified principal-mapping handle shape

The matrix harness was hardcoded to read \`OPERATORS\` from signal-marketplace's seed module. Generalized: \`MockServerHandle\` now exposes:

\`\`\`ts
interface MockServerHandle {
  url: string;
  apiKey: string;
  close: () => Promise<void>;
  summary: () => string;
  principalScope: string;          // human-prose: \"X-Operator-Id header\" / \"path /v3/workspaces/...\"
  principalMapping: PrincipalMappingEntry[];  // [{ adcpField, adcpValue, upstreamField, upstreamValue }]
}
\`\`\`

The harness builds the same prompt template for both specialisms — Claude sees consistent instructions \"AdCP \`{adcpField}: {adcpValue}\` → upstream \`{upstreamField}: {upstreamValue}\`\" regardless of whether the specialism uses headers, paths, or future patterns.

## What we deliberately don't test (in this mock)

- Brand-kit threading — defer to a v1 expansion
- Multi-format auto-adapt — protocol-level question
- Generative AI flows — the \`creative-generative\` specialism's domain
- Approval workflows / HITL — the \`governance-spend-authority\` mock's domain

## Refs

- Design issue: #1155
- First mock: #1185 (\`signal-marketplace\`)
- Pairs with the SDK fixes that landed via #1198 / #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)