### PR TITLE
fix(testing): runGrader accepts partial overall_status when no failures

### DIFF
--- a/.changeset/fix-grader-partial-pass.md
+++ b/.changeset/fix-grader-partial-pass.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(testing): matrix harness `runGrader` accepts `overall_status: partial` when zero steps/tracks failed
+
+Closes adcontextprotocol/adcp-client#1209.
+
+Pre-fix, `scripts/manual-testing/agent-skill-storyboard.ts` `runGrader` treated `overall_status === 'partial'` as failure, even when the storyboard runner reported `steps_failed: 0` and `tracks_failed: 0`. This produced false negatives when the runner classified a track as "silent" (no specialism-level criteria definitively scored) — every assertion passed but the harness flagged the pair as failed.
+
+Surfaced empirically by the matrix v2 run on adcontextprotocol/adcp-client#1207. Both creative-template pairs (`build-creative-agent × creative_template`, `build-decisioning-creative-template × creative_template`) ran cleanly: Claude built valid agents, all 6 storyboard steps passed, mocks worked correctly. Harness reported 0/3 because `overall_status` wasn't literally `"passing"`.
+
+Fix: pass when `overall_status === 'passing'` OR when `overall_status === 'partial'` AND `steps_failed === 0` AND `tracks_failed === 0`. Logs a one-line note when the partial-but-clean path triggers so the rationale isn't silent.
+
+This is a dev/test surface fix only — no impact on published runtime code. The matrix harness lives in `scripts/manual-testing/` and is invoked via `npm run compliance:skill-matrix`; adopters' storyboard pipelines use `bin/adcp.js storyboard run` directly and aren't affected.

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -409,11 +409,33 @@ function runGrader(url: string, storyboardId: string): { passed: boolean; raw: s
   let passed = false;
   try {
     const parsed = JSON.parse(res.stdout);
+    // Pass criteria, in order:
+    //   1. `overall_status === 'passing'` — explicit pass from the grader
+    //   2. `overall_status === 'partial'` AND zero step/track failures — all
+    //      observed assertions passed but the runner classified the track as
+    //      'silent' (no specialism-level criteria definitively scored).
+    //      Treating this as fail produces false negatives when the agent is
+    //      actually conformant (issue #1209).
+    //   3. Legacy fallback when overall_status is absent — relies on summary
+    //      counts.
+    const summary = parsed.summary as
+      | { tracks_passed?: number; tracks_failed?: number; steps_passed?: number; steps_failed?: number }
+      | undefined;
+    const stepsFailed = summary?.steps_failed ?? 0;
+    const tracksFailed = summary?.tracks_failed ?? 0;
     if (typeof parsed.overall_status === 'string') {
-      passed = parsed.overall_status === 'passing';
-    } else if (parsed.summary && typeof parsed.summary === 'object') {
-      const s = parsed.summary as { tracks_passed?: number; tracks_failed?: number };
-      passed = (s.tracks_failed ?? 0) === 0 && (s.tracks_passed ?? 0) > 0;
+      if (parsed.overall_status === 'passing') {
+        passed = true;
+      } else if (parsed.overall_status === 'partial' && stepsFailed === 0 && tracksFailed === 0) {
+        passed = true;
+        log(
+          `grader returned overall_status=partial with no failed steps/tracks — treating as pass (issue #1209)`
+        );
+      } else {
+        passed = false;
+      }
+    } else if (summary) {
+      passed = tracksFailed === 0 && (summary.tracks_passed ?? 0) > 0;
     }
   } catch {
     // stdout wasn't clean JSON — the CLI printed an error to stderr and


### PR DESCRIPTION
Closes #1209.

## Problem

`runGrader` in `scripts/manual-testing/agent-skill-storyboard.ts` treated `overall_status === 'partial'` as failure even when the grader reported `steps_failed: 0` and `tracks_failed: 0`. False negatives when the runner classified a track as 'silent' (no specialism-level criteria definitively scored).

Surfaced empirically by the matrix v2 run on PR #1207. Both creative-template pairs built valid agents with 6/6 steps passing; harness reported 0/3 because `overall_status` wasn't literally `"passing"`.

## Fix

Pass when:
- `overall_status === 'passing'` (existing) OR
- `overall_status === 'partial'` AND `steps_failed === 0` AND `tracks_failed === 0` (new)

Logs a one-line note when the partial-but-clean path triggers so the rationale isn't silent.

## Risk

Dev/test surface only — no impact on published runtime code. The matrix harness lives in `scripts/manual-testing/` and is invoked via `npm run compliance:skill-matrix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)