### PR TITLE
fix(testing): treat runGrader partial+all-silent as pass

### DIFF
--- a/.changeset/fix-grader-partial-silent-pass.md
+++ b/.changeset/fix-grader-partial-silent-pass.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(testing): export `evaluateGraderOutput` — pass/fail predicate for `adcp storyboard run --json` output that correctly handles `overall_status:'partial'` with all-silent tracks (steps_failed=0, tracks_failed=0, tracks_partial=0, tracks_silent>0)

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -35,6 +35,7 @@ import { mkdtemp, readFile, writeFile, rm, stat, chmod, symlink } from 'node:fs/
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { connect } from 'node:net';
+import { evaluateGraderOutput } from '../../src/lib/testing/compliance/grader-output.js';
 
 interface Args {
   skill: string;
@@ -409,11 +410,10 @@ function runGrader(url: string, storyboardId: string): { passed: boolean; raw: s
   let passed = false;
   try {
     const parsed = JSON.parse(res.stdout);
-    if (typeof parsed.overall_status === 'string') {
-      passed = parsed.overall_status === 'passing';
-    } else if (parsed.summary && typeof parsed.summary === 'object') {
-      const s = parsed.summary as { tracks_passed?: number; tracks_failed?: number };
-      passed = (s.tracks_failed ?? 0) === 0 && (s.tracks_passed ?? 0) > 0;
+    const result = evaluateGraderOutput(parsed);
+    passed = result.passed;
+    if (result.passed && result.silentTracks) {
+      log('warning: track classified as silent — grading as pass (no failed or partial tracks)');
     }
   } catch {
     // stdout wasn't clean JSON — the CLI printed an error to stderr and

--- a/src/lib/testing/compliance/grader-output.ts
+++ b/src/lib/testing/compliance/grader-output.ts
@@ -1,3 +1,10 @@
+/**
+ * Pass/fail predicate for `adcp storyboard run --json` output.
+ *
+ * Not re-exported from the compliance barrel — internal to the
+ * `scripts/manual-testing` harness and exposed here only for testability.
+ */
+
 /** Parsed shape of `adcp storyboard run --json` output. */
 interface GraderJSON {
   overall_status?: string;
@@ -22,14 +29,20 @@ export interface GraderEvaluation {
  *
  * Three shapes handled:
  * - `overall_status: 'passing'` → pass.
- * - `overall_status: 'partial'` with zero failed/partial tracks → pass (all-silent
- *   track case; see adcontextprotocol/adcp#2834).
+ * - `overall_status: 'partial'` with `tracks_silent > 0` and zero failed/partial
+ *   tracks → pass (all-silent track case; see adcontextprotocol/adcp#2834).
+ *   `tracks_silent > 0` is required to distinguish "wired but unobserved" from
+ *   "attempted === 0" (wrong storyboard ID or discovery filtered everything), which
+ *   also emits `partial` but must NOT be treated as a pass.
  * - No `overall_status` (pre-6.2 grader output) → pass when no track or step failures.
  *
  * A `partial` output with `tracks_partial > 0` or `tracks_failed > 0` is a real
  * mixed failure and is NOT treated as a pass.
  */
 export function evaluateGraderOutput(parsed: GraderJSON): GraderEvaluation {
+  if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { passed: false, silentTracks: false };
+  }
   if (typeof parsed.overall_status === 'string') {
     if (parsed.overall_status === 'passing') {
       return { passed: true, silentTracks: false };
@@ -37,7 +50,8 @@ export function evaluateGraderOutput(parsed: GraderJSON): GraderEvaluation {
     if (parsed.overall_status === 'partial' && parsed.summary != null && typeof parsed.summary === 'object') {
       const s = parsed.summary;
       const silentTracks = (s.tracks_silent ?? 0) > 0;
-      const passed = (s.steps_failed ?? 0) === 0 && (s.tracks_failed ?? 0) === 0 && (s.tracks_partial ?? 0) === 0;
+      const passed =
+        silentTracks && (s.steps_failed ?? 0) === 0 && (s.tracks_failed ?? 0) === 0 && (s.tracks_partial ?? 0) === 0;
       return { passed, silentTracks };
     }
     // 'partial' without a summary block, or any other non-'passing' status → fail.

--- a/src/lib/testing/compliance/grader-output.ts
+++ b/src/lib/testing/compliance/grader-output.ts
@@ -1,0 +1,55 @@
+/** Parsed shape of `adcp storyboard run --json` output. */
+interface GraderJSON {
+  overall_status?: string;
+  summary?: {
+    steps_failed?: number;
+    tracks_failed?: number;
+    tracks_partial?: number;
+    tracks_silent?: number;
+  };
+}
+
+/** Return value of {@link evaluateGraderOutput}. */
+export interface GraderEvaluation {
+  passed: boolean;
+  /** True when at least one track was classified as silent (wired but unobserved). */
+  silentTracks: boolean;
+}
+
+/**
+ * Determines whether a parsed `adcp storyboard run --json` response represents
+ * a passing conformance run.
+ *
+ * Three shapes handled:
+ * - `overall_status: 'passing'` → pass.
+ * - `overall_status: 'partial'` with zero failed/partial tracks → pass (all-silent
+ *   track case; see adcontextprotocol/adcp#2834).
+ * - No `overall_status` (pre-6.2 grader output) → pass when no track or step failures.
+ *
+ * A `partial` output with `tracks_partial > 0` or `tracks_failed > 0` is a real
+ * mixed failure and is NOT treated as a pass.
+ */
+export function evaluateGraderOutput(parsed: GraderJSON): GraderEvaluation {
+  if (typeof parsed.overall_status === 'string') {
+    if (parsed.overall_status === 'passing') {
+      return { passed: true, silentTracks: false };
+    }
+    if (parsed.overall_status === 'partial' && parsed.summary != null && typeof parsed.summary === 'object') {
+      const s = parsed.summary;
+      const silentTracks = (s.tracks_silent ?? 0) > 0;
+      const passed = (s.steps_failed ?? 0) === 0 && (s.tracks_failed ?? 0) === 0 && (s.tracks_partial ?? 0) === 0;
+      return { passed, silentTracks };
+    }
+    // 'partial' without a summary block, or any other non-'passing' status → fail.
+    return { passed: false, silentTracks: false };
+  }
+  // Fallback: no overall_status field (pre-6.2) — pass if nothing failed.
+  if (parsed.summary != null && typeof parsed.summary === 'object') {
+    const s = parsed.summary;
+    return {
+      passed: (s.steps_failed ?? 0) === 0 && (s.tracks_failed ?? 0) === 0,
+      silentTracks: (s.tracks_silent ?? 0) > 0,
+    };
+  }
+  return { passed: false, silentTracks: false };
+}

--- a/test/lib/harness-grader-output.test.js
+++ b/test/lib/harness-grader-output.test.js
@@ -1,0 +1,150 @@
+'use strict';
+/**
+ * Unit tests for evaluateGraderOutput — the pass/fail predicate used by
+ * runGrader in scripts/manual-testing/agent-skill-storyboard.ts.
+ *
+ * Covers the fix for issue #1209: overall_status:'partial' with all-silent
+ * tracks (steps_failed=0, tracks_failed=0, tracks_partial=0) must be treated
+ * as a pass, not a failure.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { evaluateGraderOutput } = require('../../dist/lib/testing/compliance/grader-output.js');
+
+describe('evaluateGraderOutput', () => {
+  describe('overall_status: passing', () => {
+    it('returns passed=true, silentTracks=false', () => {
+      const result = evaluateGraderOutput({
+        overall_status: 'passing',
+        summary: {
+          tracks_passed: 2,
+          tracks_failed: 0,
+          tracks_partial: 0,
+          tracks_silent: 0,
+          steps_passed: 6,
+          steps_failed: 0,
+        },
+      });
+      assert.equal(result.passed, true);
+      assert.equal(result.silentTracks, false);
+    });
+
+    it('passes even without a summary block', () => {
+      const result = evaluateGraderOutput({ overall_status: 'passing' });
+      assert.equal(result.passed, true);
+      assert.equal(result.silentTracks, false);
+    });
+  });
+
+  describe('overall_status: partial — all-silent tracks (issue #1209)', () => {
+    it('returns passed=true when steps_failed=0, tracks_failed=0, tracks_partial=0', () => {
+      // Exact fixture from the issue — creative-template run on PR #1207
+      const result = evaluateGraderOutput({
+        overall_status: 'partial',
+        tracks: [{ track: 'creative', status: 'silent' }],
+        summary: {
+          tracks_passed: 0,
+          tracks_failed: 0,
+          tracks_silent: 1,
+          tracks_partial: 0,
+          total_steps: 6,
+          steps_passed: 6,
+          steps_failed: 0,
+          steps_skipped: 0,
+        },
+      });
+      assert.equal(result.passed, true);
+      assert.equal(result.silentTracks, true);
+    });
+
+    it('returns passed=true with multiple silent tracks', () => {
+      const result = evaluateGraderOutput({
+        overall_status: 'partial',
+        summary: { tracks_passed: 0, tracks_failed: 0, tracks_partial: 0, tracks_silent: 3, steps_failed: 0 },
+      });
+      assert.equal(result.passed, true);
+      assert.equal(result.silentTracks, true);
+    });
+
+    it('returns passed=false when tracks_failed > 0', () => {
+      const result = evaluateGraderOutput({
+        overall_status: 'partial',
+        summary: { tracks_passed: 1, tracks_failed: 1, tracks_partial: 0, tracks_silent: 0, steps_failed: 2 },
+      });
+      assert.equal(result.passed, false);
+    });
+
+    it('returns passed=false when tracks_partial > 0', () => {
+      const result = evaluateGraderOutput({
+        overall_status: 'partial',
+        summary: { tracks_passed: 1, tracks_failed: 0, tracks_partial: 1, tracks_silent: 0, steps_failed: 0 },
+      });
+      assert.equal(result.passed, false);
+    });
+
+    it('returns passed=false when steps_failed > 0', () => {
+      const result = evaluateGraderOutput({
+        overall_status: 'partial',
+        summary: { tracks_passed: 0, tracks_failed: 0, tracks_partial: 0, tracks_silent: 1, steps_failed: 1 },
+      });
+      assert.equal(result.passed, false);
+    });
+
+    it('returns passed=false when summary is absent', () => {
+      // Guard: partial without summary must not pass (unknown state)
+      const result = evaluateGraderOutput({ overall_status: 'partial' });
+      assert.equal(result.passed, false);
+    });
+  });
+
+  describe('overall_status: failing', () => {
+    it('returns passed=false', () => {
+      const result = evaluateGraderOutput({
+        overall_status: 'failing',
+        summary: { tracks_passed: 0, tracks_failed: 2, tracks_partial: 0, tracks_silent: 0, steps_failed: 4 },
+      });
+      assert.equal(result.passed, false);
+    });
+  });
+
+  describe('no overall_status (pre-6.2 fallback)', () => {
+    it('passes when tracks_failed=0 and steps_failed=0', () => {
+      const result = evaluateGraderOutput({
+        summary: { tracks_passed: 2, tracks_failed: 0, steps_failed: 0 },
+      });
+      assert.equal(result.passed, true);
+    });
+
+    it('fails when tracks_failed > 0', () => {
+      const result = evaluateGraderOutput({
+        summary: { tracks_passed: 1, tracks_failed: 1, steps_failed: 0 },
+      });
+      assert.equal(result.passed, false);
+    });
+
+    it('fails when steps_failed > 0', () => {
+      const result = evaluateGraderOutput({
+        summary: { tracks_passed: 0, tracks_failed: 0, steps_failed: 1 },
+      });
+      assert.equal(result.passed, false);
+    });
+
+    it('passes even when tracks_passed=0 if nothing failed (all-silent pre-6.2)', () => {
+      // Regression guard: the old fallback branch required tracks_passed > 0,
+      // which would fail all-silent runs. The new logic only checks for failures.
+      const result = evaluateGraderOutput({
+        summary: { tracks_passed: 0, tracks_failed: 0, steps_failed: 0 },
+      });
+      assert.equal(result.passed, true);
+    });
+  });
+
+  describe('unparseable / empty input', () => {
+    it('returns passed=false for empty object', () => {
+      const result = evaluateGraderOutput({});
+      assert.equal(result.passed, false);
+    });
+  });
+});

--- a/test/lib/harness-grader-output.test.js
+++ b/test/lib/harness-grader-output.test.js
@@ -141,9 +141,38 @@ describe('evaluateGraderOutput', () => {
     });
   });
 
-  describe('unparseable / empty input', () => {
+  describe('overall_status: partial — no tracks ran (attempted=0)', () => {
+    it('returns passed=false when all track counts are zero (wrong storyboard / discovery filtered)', () => {
+      // computeOverallStatus emits 'partial' when attempted===0. This must NOT pass —
+      // it means no tracks wired at all, not that tracks ran silently.
+      const result = evaluateGraderOutput({
+        overall_status: 'partial',
+        summary: {
+          tracks_passed: 0,
+          tracks_failed: 0,
+          tracks_partial: 0,
+          tracks_silent: 0,
+          steps_failed: 0,
+        },
+      });
+      assert.equal(result.passed, false);
+      assert.equal(result.silentTracks, false);
+    });
+  });
+
+  describe('null / non-object input', () => {
+    it('returns passed=false for null', () => {
+      const result = evaluateGraderOutput(null);
+      assert.equal(result.passed, false);
+    });
+
     it('returns passed=false for empty object', () => {
       const result = evaluateGraderOutput({});
+      assert.equal(result.passed, false);
+    });
+
+    it('returns passed=false for array', () => {
+      const result = evaluateGraderOutput([]);
       assert.equal(result.passed, false);
     });
   });


### PR DESCRIPTION
Closes #1209

## Summary

`runGrader` in `scripts/manual-testing/agent-skill-storyboard.ts` was treating `overall_status:'partial'` as a failure regardless of whether anything actually failed. When all storyboard steps pass but a track is classified as "silent" (wired but unobserved — no specialism-level criteria definitively scored), the grader emits `partial` with zero failed steps and tracks. The old heuristic returned `passed=false` because it only accepted `'passing'`, causing the compliance matrix to report 0/N when N agents actually conform.

The fix extracts the pass/fail predicate into `src/lib/testing/compliance/grader-output.ts` (exported for testability) and adds 17 unit tests covering all input shapes.

**New pass condition for `partial`:** `tracks_silent > 0 AND steps_failed === 0 AND tracks_failed === 0 AND tracks_partial === 0`. The `tracks_silent > 0` floor is required to distinguish the all-silent-tracks case from `attempted === 0` (wrong storyboard ID / discovery filtered everything), which also emits `partial` but must not be treated as a pass.

**Also fixed:** the pre-6.2 fallback branch (no `overall_status`) previously required `tracks_passed > 0`, which also false-failed all-silent runs. Now checks `steps_failed === 0 AND tracks_failed === 0` only.

## What was tested

- `npm run format:check` — clean
- `npm run typecheck` — clean
- `npm run build:lib` — clean
- `node --test test/lib/harness-grader-output.test.js` — **17/17 pass**
- `npm test` — 222 failures (all pre-existing; baseline before this PR is 225; 3 net new passing tests)

## Pre-PR review

- code-reviewer: approved — null guard added, `tracks_silent>0` floor added, changeset included, 17 tests
- ad-tech-protocol-expert: approved — predicate matches `computeOverallStatus` invariant in `comply.ts`; `attempted===0` false-pass blocked by `tracks_silent>0` requirement

## Notes (nits not fixed)

- `grader-output.ts` ships in `dist/lib/**/*` but is not re-exported from the compliance barrel — the file header marks it as internal-to-harness. Consumers can deep-import but it's not a first-class API surface.
- The pre-6.2 fallback branch does not gate on `tracks_partial`; pre-protocol-expert noted this predates the PR and is out of scope.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01XpFY22xTtkedeCnkek6TYS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpFY22xTtkedeCnkek6TYS)_