### PR TITLE
fix(server): auto-seed adapters use resolved account id (symmetric with bridge)

### DIFF
--- a/.changeset/auto-seed-symmetric-resolution.md
+++ b/.changeset/auto-seed-symmetric-resolution.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(server): auto-seed adapters use resolved account id (symmetric with bridge)
+
+The catalog-backed auto-seed adapters introduced in #1100 wrote fixtures keyed by raw `input.account.account_id`, while the bridge read from `ctx.account?.id` (the resolved id set by the framework's `resolveAccount`). On a platform whose resolver maps `account_id` to a distinct internal id (e.g., a tenant-prefixed shape), the asymmetry caused silent fixture loss — `seed_product` succeeded but `get_products` couldn't find the seeded product because the namespace key on read didn't match the one on write.
+
+Auto-seed adapters now run `platform.accounts.resolve` on the request's `account` reference and use the resolved `id` as the namespace key, matching what the bridge reads. Adopters with identity resolvers (the common case) see no behavior change.
+
+Also: when the auto-seed adapter fires without a resolvable account (typically a misconfigured `sandboxGate` that lets account-less requests through), it now logs a warn-level diagnostic and drops the write, instead of silently returning. Misconfigurations that previously caused "seeds vanish without explanation" now surface as a single actionable log line.
+
+Closes #1216.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1067,15 +1067,46 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       // Inject auto-seed adapters for `seed_product` and `seed_pricing_option`
       // when the adopter didn't wire explicit ones. Explicit adapters win — the
       // spread only fills the undefined slots. Each write is keyed by the
-      // request's `account.account_id` so two sandbox accounts can seed the
-      // same `product_id` without colliding.
+      // resolved account `id` so the adapter and bridge read the same
+      // namespace: the bridge uses `ctx.account?.id` (set by the framework's
+      // `resolveAccount` on the `get_products` path), and the adapter must
+      // run `platform.accounts.resolve` itself because the comply-controller
+      // doesn't pre-resolve. If we read raw `account_id` on write but resolved
+      // `id` on read, an adopter whose resolver maps `account_id` → distinct
+      // internal id (e.g., `acc_1` → `tenant_a:acc_1`) gets silent fixture
+      // leakage across namespaces — the bug surfaces as "seed succeeded but
+      // get_products doesn't see it" with no log signal.
       const explicitSeed = opts.complyTest.seed ?? {};
       const autoSeed = { ...explicitSeed };
 
+      const resolveAutoSeedAccountId = async (input: Record<string, unknown>): Promise<string | undefined> => {
+        const ref = input.account;
+        if (ref == null || typeof ref !== 'object') return undefined;
+        try {
+          const resolved = await platform.accounts.resolve(ref as AccountReference, {
+            toolName: 'comply_test_controller',
+          });
+          const id = (resolved as { id?: unknown } | null | undefined)?.id;
+          if (typeof id === 'string' && id.length > 0) return id;
+        } catch (err) {
+          fwLogger.warn('[adcp/auto-seed] platform.accounts.resolve threw during seed write; dropping fixture', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        return undefined;
+      };
+
       if (!explicitSeed.product) {
         autoSeed.product = async (params, ctx) => {
-          const accountId = readAutoSeedAccountId(ctx.input);
-          if (accountId == null) return;
+          const accountId = await resolveAutoSeedAccountId(ctx.input);
+          if (accountId == null) {
+            fwLogger.warn(
+              '[adcp/auto-seed] seed_product fired without a resolvable account; dropping write. ' +
+                'Verify the request carries `account.account_id` and that platform.accounts.resolve handles it.',
+              { product_id: params.product_id }
+            );
+            return;
+          }
           autoSeedStoreFor(autoSeedStore, accountId).set(params.product_id, {
             ...params.fixture,
             product_id: params.product_id,
@@ -1085,8 +1116,15 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
       if (!explicitSeed.pricing_option) {
         autoSeed.pricing_option = async (params, ctx) => {
-          const accountId = readAutoSeedAccountId(ctx.input);
-          if (accountId == null) return;
+          const accountId = await resolveAutoSeedAccountId(ctx.input);
+          if (accountId == null) {
+            fwLogger.warn(
+              '[adcp/auto-seed] seed_pricing_option fired without a resolvable account; dropping write. ' +
+                'Verify the request carries `account.account_id` and that platform.accounts.resolve handles it.',
+              { product_id: params.product_id, pricing_option_id: params.pricing_option_id }
+            );
+            return;
+          }
           const accountStore = autoSeedStoreFor(autoSeedStore, accountId);
           const existing = accountStore.get(params.product_id) as Record<string, unknown> | undefined;
           const pricingOption = { ...params.fixture, pricing_option_id: params.pricing_option_id };

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1089,8 +1089,12 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           const id = (resolved as { id?: unknown } | null | undefined)?.id;
           if (typeof id === 'string' && id.length > 0) return id;
         } catch (err) {
+          // Don't surface `err.message` — adopter resolvers (especially
+          // OAuth-backed ones) sometimes embed token fragments or account
+          // refs in thrown errors. The error class name is enough triage
+          // signal; the resolver itself owns its own error logging upstream.
           fwLogger.warn('[adcp/auto-seed] platform.accounts.resolve threw during seed write; dropping fixture', {
-            error: err instanceof Error ? err.message : String(err),
+            errorType: err instanceof Error ? err.name : typeof err,
           });
         }
         return undefined;
@@ -3435,11 +3439,13 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
 // Auto-seed helpers (catalog-backed comply sandbox; issue #1091)
 // ────────────────────────────────────────────────────────────
 
-// Pull the request's account_id from the comply tool input. Sandbox-flagged
-// requests carry it on `input.account.account_id`; non-sandbox traffic is
-// already short-circuited by `complyTest.sandboxGate`, so a missing id here
-// means the adapter fired outside the gated path — drop the write rather
-// than collapse it into a shared namespace.
+// Bridge-side fallback: pull the raw `account.account_id` from a tool input
+// when the framework didn't pre-resolve `ctx.account` (e.g., a custom
+// dispatcher that bypasses `resolveAccount`). The auto-seed bridge prefers
+// `ctx.account?.id` (resolved by the framework on `get_products`); this
+// helper only runs when that's absent. Auto-seed *writes* go through
+// `resolveAutoSeedAccountId` (defined inline in the auto-seed wiring) so
+// the namespace key on write always matches the bridge's resolved-id read.
 function readAutoSeedAccountId(input: Record<string, unknown>): string | undefined {
   const account = input.account;
   if (account == null || typeof account !== 'object') return undefined;

--- a/test/server-decisioning-comply-auto-seed.test.js
+++ b/test/server-decisioning-comply-auto-seed.test.js
@@ -332,4 +332,95 @@ describe('createAdcpServerFromPlatform — catalog-backed auto-seed (issue #1091
       "tenant_b must NOT see tenant_a's product (cross-tenant leak)"
     );
   });
+
+  it('resolver mapping: adapter writes under resolved id, not raw account_id (issue #1216)', async () => {
+    // Adopters can wire a resolver that maps `account_id` (request envelope)
+    // to a distinct internal `id` (e.g., for prefixed multi-tenant ids).
+    // The bridge reads `ctx.account?.id` (the resolved id). Without the
+    // symmetric write-side resolution, the adapter would write under the
+    // raw `account_id` and the bridge would fail to find it on read.
+    const platform = basePlatform();
+    platform.accounts.resolve = async ref => ({
+      id: ref?.account_id ? `mapped:${ref.account_id}` : 'mapped:unknown',
+      operator: 'test.example.com',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+      ...(ref?.sandbox === true && { sandbox: true }),
+    });
+
+    const server = createAdcpServerFromPlatform(platform, {
+      ...BASE_OPTS,
+      complyTest: { sandboxGate: SANDBOX_GATE },
+    });
+
+    await callComply(server, {
+      scenario: 'seed_product',
+      account: { account_id: 'acc_42', sandbox: true },
+      params: {
+        product_id: 'mapped_product',
+        fixture: { delivery_type: 'non_guaranteed', channels: ['display'] },
+      },
+    });
+
+    const result = await callGetProducts(server, {
+      account: { account_id: 'acc_42', sandbox: true },
+    });
+
+    const products = result.structuredContent.products;
+    const seeded = products.find(p => p.product_id === 'mapped_product');
+    assert.ok(seeded, 'seeded product must appear under the resolved namespace key, not raw account_id');
+    assert.strictEqual(seeded.delivery_type, 'non_guaranteed');
+  });
+
+  it('warn-on-drop: seed_product with no account.account_id logs and drops, no fixture leaks (issue #1216)', async () => {
+    // sandboxGate normally rejects account-less requests; this test pretends
+    // the gate misconfigured (returns true unconditionally) so we hit the
+    // adapter directly with no account ref. The auto-seed must NOT collapse
+    // the missing-account case into a shared namespace — it must drop AND
+    // emit a warn-level log so the misconfiguration is diagnosable.
+    const warnings = [];
+    const platform = basePlatform();
+    const server = createAdcpServerFromPlatform(platform, {
+      ...BASE_OPTS,
+      logger: {
+        debug: () => {},
+        info: () => {},
+        warn: (message, meta) => warnings.push({ message, meta }),
+        error: () => {},
+      },
+      complyTest: {
+        sandboxGate: () => true, // permissive gate (misconfiguration scenario)
+      },
+    });
+
+    const result = await callComply(server, {
+      scenario: 'seed_product',
+      // account omitted — bypasses the normal sandboxGate check via the permissive gate above
+      params: {
+        product_id: 'orphan_product',
+        fixture: { delivery_type: 'non_guaranteed' },
+      },
+    });
+
+    // The seed call itself succeeds (returns SeedSuccess via SeedFixtureCache)
+    // but the auto-seed adapter dropped the write and warned.
+    assert.notStrictEqual(result.isError, true);
+    const droppedWarning = warnings.find(w => w.message.includes('seed_product fired without a resolvable account'));
+    assert.ok(
+      droppedWarning,
+      'expected a warn-level log when seed fires with no account; got: ' + JSON.stringify(warnings)
+    );
+    assert.strictEqual(droppedWarning.meta.product_id, 'orphan_product');
+
+    // Confirm no fixture leaked into a shared namespace: a sandbox account's
+    // get_products must NOT see the orphan.
+    const gpResult = await callGetProducts(server, {
+      account: { account_id: 'any_acc', sandbox: true },
+    });
+    const products = gpResult.structuredContent.products ?? [];
+    assert.ok(
+      !products.some(p => p.product_id === 'orphan_product'),
+      'orphan product must NOT leak into any account namespace'
+    );
+  });
 });


### PR DESCRIPTION
Closes #1216. Two reviewer-flagged nits from PR #1100:

## 1. Symmetric account-id resolution

The auto-seed adapters wrote fixtures keyed by raw \`input.account.account_id\`, while the bridge reads from \`ctx.account?.id\` (the resolved id set by the framework's \`resolveAccount\`). On a platform whose resolver maps \`account_id\` → distinct internal id (e.g., \`acc_1\` → \`tenant_a:acc_1\`), the asymmetry caused silent fixture loss — \`seed_product\` succeeded but \`get_products\` couldn't find the seeded product because the namespace key on read didn't match the one on write.

**Fix:** auto-seed adapters now run \`platform.accounts.resolve\` on the request's \`account\` reference and use the resolved \`id\` as the namespace key, matching what the bridge reads. Adopters with identity resolvers (the common case) see no behavior change.

## 2. Warn instead of silent drop

When the adapter fires without a resolvable account (typically a misconfigured \`sandboxGate\` that lets account-less requests through), it now emits a warn-level log via the framework logger and drops the write. Previously the drop was silent, so misconfigured gates produced \"seeds vanish without explanation\" with no diagnosable signal.

## Tests

- **\`resolver mapping: adapter writes under resolved id\`** — verifies a custom resolver that maps account_id → \`mapped:acc_42\` lets seed/get_products round-trip through the resolved namespace.
- **\`warn-on-drop: seed_product with no account.account_id logs and drops, no fixture leaks\`** — exercises the misconfigured-gate scenario, asserts a warn fires AND no fixture leaks into any account namespace.
- 7 existing tests unchanged. Full suite: 7161/7168 passing (7 intentional skips, 0 fails).

## Test plan
- [x] Existing auto-seed tests pass (7/7)
- [x] New tests cover both code paths (2/2)
- [x] \`npm run typecheck\` clean
- [x] \`npm test\` full suite: 0 failures
- [x] Changeset added (patch — additive behavior, no public API surface change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)