### PR TITLE
feat(cli+harness): adcp mock-server sales-social — OAuth + sync_audiences + CAPI

### DIFF
--- a/.changeset/feat-mock-server-sales-social.md
+++ b/.changeset/feat-mock-server-sales-social.md
@@ -1,0 +1,36 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(cli+harness): `adcp mock-server sales-social` — third specialism (TikTok-flavored, OAuth + sync_audiences + CAPI)
+
+Adds the third mock-server in the matrix v2 family. Stresses three SDK surfaces the existing mocks (signal-marketplace, creative-template) don't touch:
+
+1. **OAuth 2.0 client_credentials with refresh-token rotation.** Adapters exchange `client_id` + `client_secret` for an `access_token` at `POST /oauth/token`, attach the bearer on every API call, and refresh via the same endpoint with `grant_type=refresh_token` when the token expires. Refresh tokens rotate on use (single-use). This is the first matrix-v2 test of the SDK's OAuth code path that shipped in 5.9.0.
+
+2. **Hashed-PII audience uploads.** Custom audiences accept members as SHA-256-hashed lowercase identifiers (`hashed_email_sha256`, `hashed_phone_sha256`, etc.). Uploading raw PII or wrong-cased hex is rejected with `400 invalid_hash_format`. Mirrors how Meta Custom Audiences, TikTok DMP, LinkedIn Matched Audiences all work.
+
+3. **CAPI / Conversion API event ingestion.** Server-to-server conversion events arrive at `POST /event/track` with a hashed identifier (`email_sha256`, `phone_sha256`, or `external_id_sha256`) and event metadata. Events without a matchable identifier are dropped (counted in `events_dropped`); a batch of all-unmatchable events returns `400 no_matchable_events`.
+
+Plus the supporting upstream surface required by the `sales_social` storyboard:
+
+- Advertiser profile (`GET /v1.3/advertiser/{id}/info`)
+- Catalog CRUD + bulk upload (sync_catalogs mapping)
+- Creative portfolio CRUD (sync_creatives mapping)
+- Pixel CRUD (sync_event_sources mapping)
+
+**Multi-tenancy via path** (`/v1.3/advertiser/{advertiser_id}/...`). Two seeded advertisers with overlapping access. Single OAuth client authorized for both — matches the standard walled-garden model where one app credential serves multiple seats.
+
+**Refactor**: `MockServerHandle.apiKey: string` is replaced by a polymorphic `MockServerHandle.auth: MockServerAuth` discriminated union (`{ kind: 'static_bearer', apiKey } | { kind: 'oauth_client_credentials', clientId, clientSecret, tokenPath }`). The matrix harness branches on `auth.kind` when building the adapter prompt — different flows produce different adapter wiring.
+
+Run with:
+
+```bash
+npx @adcp/sdk mock-server sales-social --port 4502
+# or as part of the skill-matrix:
+npm run compliance:skill-matrix -- --filter sales_social
+```
+
+**21 new smoke tests** in `test/lib/mock-server/sales-social.test.js` cover OAuth handshake (success, bad client_secret, refresh-token rotation, old-token-invalidation), bearer-required API gating, audience create + hashed-PII upload + raw-PII rejection + idempotency conflict, CAPI event ingest with matchable/unmatchable identifiers + unknown pixel, catalog + creative flows, and the unified principal-mapping handle shape.
+
+Refs adcontextprotocol/adcp-client#1155.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1018,11 +1018,18 @@ ARGUMENTS:
                                             platform with async renders.
                                             Workspace-scoped paths; multi-stage
                                             polling (queued → running → complete).
+                       sales-social         TikTok/Meta-shaped social platform
+                                            with OAuth 2.0 client_credentials,
+                                            sync_audiences (hashed-PII upload),
+                                            and CAPI / Conversion API ingestion.
 
 OPTIONS:
   --port N           Listen port. Default: 4500.
-  --api-key KEY      Override the static bearer credential. Defaults to a
-                     stable test key printed at boot.
+  --api-key KEY      Override the static bearer credential. Only applies to
+                     specialisms with static-bearer auth (signal-marketplace,
+                     creative-template). Ignored for OAuth specialisms
+                     (sales-social) — those issue tokens via the OAuth flow.
+                     Defaults to a stable test key printed at boot.
 
 NOTES:
   These mock servers represent the *upstream* platform an adopter wraps,

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -108,6 +108,10 @@ function printUsage(): void {
   );
 }
 
+type UpstreamAuth =
+  | { kind: 'static_bearer'; apiKey: string }
+  | { kind: 'oauth_client_credentials'; clientId: string; clientSecret: string; tokenPath: string };
+
 function buildPrompt(
   skill: string,
   storyboardId: string,
@@ -116,7 +120,7 @@ function buildPrompt(
   upstream?: {
     specialism: string;
     url: string;
-    apiKey: string;
+    auth: UpstreamAuth;
     openapiPath: string;
     principalScope: string;
     principalMapping: Array<{
@@ -127,6 +131,11 @@ function buildPrompt(
     }>;
   }
 ): string {
+  const authSection = upstream
+    ? upstream.auth.kind === 'static_bearer'
+      ? `\n- \`Authorization: Bearer ${upstream.auth.apiKey}\` — the customer-level API key`
+      : `\n- **OAuth 2.0 client_credentials grant.** Exchange these credentials at the token endpoint, then attach the issued \`access_token\` as Bearer on every API call. Refresh on 401 using \`grant_type=refresh_token\`.\n  - Token endpoint: \`POST ${upstream.url}${upstream.auth.tokenPath}\`\n  - \`client_id: "${upstream.auth.clientId}"\`\n  - \`client_secret: "${upstream.auth.clientSecret}"\``
+    : '';
   const upstreamSection = upstream
     ? `
 
@@ -139,8 +148,7 @@ The upstream platform is running locally as a fixture. Treat it exactly as you w
 **Base URL**: ${upstream.url}
 **OpenAPI spec** (read this first): ${upstream.openapiPath}
 
-**Authentication**:
-- \`Authorization: Bearer ${upstream.apiKey}\` — the customer-level API key
+**Authentication**:${authSection}
 - Per-tenant scope: ${upstream.principalScope}
 
 **Principal mapping**: the AdCP request you receive will carry an identifier (e.g., \`account.operator\` or \`account.advertiser\`). You must translate that to the upstream tenant identifier when calling the upstream API:
@@ -429,7 +437,7 @@ function log(msg: string): void {
 
 interface UpstreamHandle {
   url: string;
-  apiKey: string;
+  auth: UpstreamAuth;
   openapiPath: string;
   principalScope: string;
   principalMapping: Array<{
@@ -450,7 +458,7 @@ async function bootUpstreamForHarness(specialism: string, port: number): Promise
   // broken instead of just unbuilt.
   let bootMockServer: (opts: { specialism: string; port: number }) => Promise<{
     url: string;
-    apiKey: string;
+    auth: UpstreamAuth;
     principalScope: string;
     principalMapping: UpstreamHandle['principalMapping'];
     close: () => Promise<void>;
@@ -470,7 +478,7 @@ async function bootUpstreamForHarness(specialism: string, port: number): Promise
   log(`upstream mock-server (${specialism}) up on ${handle.url}`);
   return {
     url: handle.url,
-    apiKey: handle.apiKey,
+    auth: handle.auth,
     openapiPath,
     principalScope: handle.principalScope,
     principalMapping: handle.principalMapping,
@@ -509,7 +517,7 @@ async function main(): Promise<void> {
           ? {
               specialism: args.upstream!,
               url: upstream.url,
-              apiKey: upstream.apiKey,
+              auth: upstream.auth,
               openapiPath: upstream.openapiPath,
               principalScope: upstream.principalScope,
               principalMapping: upstream.principalMapping,

--- a/scripts/manual-testing/skill-matrix.json
+++ b/scripts/manual-testing/skill-matrix.json
@@ -6,6 +6,11 @@
     { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "idempotency" },
     { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "webhook_emission" },
     { "skill": "skills/build-seller-agent/SKILL.md", "storyboard": "security_baseline" },
+    {
+      "skill": "skills/build-seller-agent/SKILL.md",
+      "storyboard": "sales_social",
+      "upstream": "sales-social"
+    },
     { "skill": "skills/build-brand-rights-agent/SKILL.md", "storyboard": "brand_rights" },
     { "skill": "skills/build-creative-agent/SKILL.md", "storyboard": "creative_ad_server" },
     {

--- a/src/lib/mock-server/index.ts
+++ b/src/lib/mock-server/index.ts
@@ -1,5 +1,7 @@
 import { bootCreativeTemplate } from './creative-template/server';
 import { DEFAULT_API_KEY as CREATIVE_TEMPLATE_DEFAULT_API_KEY, WORKSPACES } from './creative-template/seed-data';
+import { bootSalesSocial } from './sales-social/server';
+import { ADVERTISERS, OAUTH_CLIENTS } from './sales-social/seed-data';
 import { bootSignalMarketplace } from './signal-marketplace/server';
 import { DEFAULT_API_KEY as SIGNAL_MARKETPLACE_DEFAULT_API_KEY, OPERATORS } from './signal-marketplace/seed-data';
 
@@ -9,9 +11,38 @@ export interface MockServerOptions {
   apiKey?: string;
 }
 
+/**
+ * How an adapter authenticates with the upstream mock. Specialism mocks
+ * advertise one of these so the matrix harness can build the right
+ * adapter-prompt section.
+ */
+export type MockServerAuth =
+  | {
+      kind: 'static_bearer';
+      /** Bearer token attached on every API call. */
+      apiKey: string;
+    }
+  | {
+      kind: 'oauth_client_credentials';
+      /** OAuth `client_id` for the `client_credentials` grant. */
+      clientId: string;
+      /** OAuth `client_secret` paired with `clientId`. */
+      clientSecret: string;
+      /** Path to the OAuth token endpoint relative to the mock URL,
+       * e.g. `/oauth/token`. Adapters POST `grant_type=client_credentials`
+       * with the client_id/secret to receive an access_token, then attach
+       * it as Bearer on subsequent API calls. Token expires after
+       * `expires_in` seconds (mock returns this in the token response);
+       * adapters refresh via the same endpoint with `grant_type=refresh_token`. */
+      tokenPath: string;
+    };
+
 export interface MockServerHandle {
   url: string;
-  apiKey: string;
+  /** Auth shape this mock requires. The matrix harness branches on
+   * `auth.kind` when building the adapter prompt — different shapes
+   * produce different adapter-side wiring. */
+  auth: MockServerAuth;
   close: () => Promise<void>;
   /** Adopter-friendly summary for boot-log printing. */
   summary: () => string;
@@ -52,7 +83,7 @@ export async function bootMockServer(options: MockServerOptions): Promise<MockSe
       const apiKey = options.apiKey ?? SIGNAL_MARKETPLACE_DEFAULT_API_KEY;
       return {
         url,
-        apiKey,
+        auth: { kind: 'static_bearer', apiKey },
         close,
         summary: () => formatSignalMarketplaceSummary(url, apiKey),
         principalScope: 'X-Operator-Id header (required on every request)',
@@ -72,7 +103,7 @@ export async function bootMockServer(options: MockServerOptions): Promise<MockSe
       const apiKey = options.apiKey ?? CREATIVE_TEMPLATE_DEFAULT_API_KEY;
       return {
         url,
-        apiKey,
+        auth: { kind: 'static_bearer', apiKey },
         close,
         summary: () => formatCreativeTemplateSummary(url, apiKey),
         principalScope: 'URL path segment /v3/workspaces/{workspace_id}/...',
@@ -84,9 +115,32 @@ export async function bootMockServer(options: MockServerOptions): Promise<MockSe
         })),
       };
     }
+    case 'sales-social': {
+      const { url, close } = await bootSalesSocial({ port: options.port });
+      const client = OAUTH_CLIENTS[0];
+      if (!client) throw new Error('sales-social: no OAuth clients seeded');
+      return {
+        url,
+        auth: {
+          kind: 'oauth_client_credentials',
+          clientId: client.client_id,
+          clientSecret: client.client_secret,
+          tokenPath: '/oauth/token',
+        },
+        close,
+        summary: () => formatSalesSocialSummary(url, client),
+        principalScope: 'URL path segment /v1.3/advertiser/{advertiser_id}/...',
+        principalMapping: ADVERTISERS.map(adv => ({
+          adcpField: 'account.advertiser',
+          adcpValue: adv.adcp_advertiser,
+          upstreamField: 'path /v1.3/advertiser/{advertiser_id}/',
+          upstreamValue: adv.advertiser_id,
+        })),
+      };
+    }
     default:
       throw new Error(
-        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace, creative-template.`
+        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace, creative-template, sales-social.`
       );
   }
 }
@@ -140,5 +194,36 @@ function formatCreativeTemplateSummary(url: string, apiKey: string): string {
     ``,
     `Renders are async: POST returns 202 with status="queued", then progresses`,
     `through "running" → "complete" on subsequent GETs (or "failed" on error).`,
+  ].join('\n');
+}
+
+function formatSalesSocialSummary(url: string, client: { client_id: string; client_secret: string }): string {
+  const advertiserLines = ADVERTISERS.map(
+    adv => `  ${adv.advertiser_id}  →  AdCP account.advertiser: "${adv.adcp_advertiser}"`
+  ).join('\n');
+  return [
+    `Mock social platform (TikTok-flavored) running at ${url}`,
+    ``,
+    `Auth (OAuth 2.0 client_credentials):`,
+    `  Token endpoint:  POST ${url}/oauth/token`,
+    `  client_id:       ${client.client_id}`,
+    `  client_secret:   ${client.client_secret}`,
+    `  Then attach the issued access_token as Authorization: Bearer <token>`,
+    `  Refresh via same endpoint with grant_type=refresh_token (token rotation on use).`,
+    ``,
+    `Advertiser mapping (path-scoped):`,
+    advertiserLines,
+    ``,
+    `OpenAPI spec: src/lib/mock-server/sales-social/openapi.yaml`,
+    `Key routes:`,
+    `  POST   ${url}/oauth/token                                                  (no auth)`,
+    `  GET    ${url}/v1.3/advertiser/{advertiser_id}/info`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/custom_audience/create`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/custom_audience/upload      (hashed PII)`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/catalog/create`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/catalog/upload`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/creative/create`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/pixel/create`,
+    `  POST   ${url}/v1.3/advertiser/{advertiser_id}/event/track                  (CAPI)`,
   ].join('\n');
 }

--- a/src/lib/mock-server/sales-social/openapi.yaml
+++ b/src/lib/mock-server/sales-social/openapi.yaml
@@ -1,0 +1,646 @@
+openapi: 3.1.0
+info:
+  title: Social Platform Marketing API
+  version: '1.3.0'
+  description: |
+    HTTP API for a fictional social-platform advertiser API — TikTok Business API
+    flavor (also resembling Meta Marketing API and similar walled-garden ad
+    platforms). Two patterns this fixture stresses that prior matrix-v2 mocks
+    don't cover:
+
+    1. **OAuth 2.0 client_credentials with refresh tokens.** Adapters must
+       exchange `client_id` + `client_secret` for an `access_token` at the
+       OAuth token endpoint, attach the bearer on every API call, and refresh
+       when the token expires. This is genuinely different from the static
+       Bearer pattern signal-marketplace and creative-template use.
+
+    2. **Hashed-PII audience uploads + Conversion API event ingestion.**
+       Audiences are uploaded as SHA-256-hashed lowercase emails/phones (the
+       industry standard for walled-garden activation). Conversion events
+       flow in via the `/event/track` endpoint with hashed user identifiers
+       and event metadata (the "CAPI" pattern Meta + TikTok both use).
+
+    Multi-tenancy via path: `/v1.3/advertiser/{advertiser_id}/...`. Two
+    seeded advertisers with overlapping access. Same boot-time API key /
+    client secret across all tenants (per the standard walled-garden model
+    where one app credential serves multiple seats).
+
+servers:
+  - url: http://127.0.0.1:{port}
+    variables:
+      port:
+        default: '4502'
+        description: Port the mock-server boots on (override with --port)
+
+components:
+  securitySchemes:
+    bearerAccessToken:
+      type: http
+      scheme: bearer
+      description: |
+        OAuth-issued access token. Obtain via POST /oauth/token with
+        client_credentials grant; refresh via POST /oauth/token with
+        refresh_token grant when the token expires (401 from the API).
+
+  schemas:
+    TokenResponse:
+      type: object
+      required: [access_token, refresh_token, token_type, expires_in]
+      properties:
+        access_token: { type: string }
+        refresh_token: { type: string }
+        token_type: { type: string, enum: [bearer], example: 'bearer' }
+        expires_in:
+          type: integer
+          description: Seconds until access_token expires.
+
+    Advertiser:
+      type: object
+      required: [advertiser_id, display_name, currency, timezone, status]
+      properties:
+        advertiser_id: { type: string, example: 'adv_acme_us' }
+        display_name: { type: string }
+        currency: { type: string, example: 'USD' }
+        timezone: { type: string, example: 'America/Los_Angeles' }
+        status: { type: string, enum: [active, suspended, archived] }
+
+    CustomAudience:
+      type: object
+      required: [audience_id, name, source_type, member_count, status, created_at]
+      properties:
+        audience_id: { type: string, example: 'ca_outdoor_enthusiasts' }
+        name: { type: string }
+        description: { type: string }
+        source_type:
+          type: string
+          enum: [customer_file, website_traffic, app_activity, lookalike, engagement]
+          description: |
+            How the audience was sourced. `customer_file` is the most common
+            sync-from-buyer path (hashed-PII upload).
+        member_count:
+          type: integer
+          description: Approximate matched members on the platform side. May lag
+            audience uploads; populated asynchronously after upload settles.
+        status:
+          type: string
+          enum: [building, active, expired, error]
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    AudienceUpload:
+      type: object
+      required: [audience_id, identifier_type, members]
+      properties:
+        audience_id: { type: string }
+        identifier_type:
+          type: string
+          enum: [hashed_email_sha256, hashed_phone_sha256, hashed_email_or_phone_sha256, mobile_advertising_id]
+          description: |
+            What identifier shape the buyer is uploading. Walled gardens reject
+            unhashed PII — adapters that pass through raw email/phone get a
+            400 here.
+        members:
+          type: array
+          description: Identifier values. For hashed types, MUST be SHA-256 hex
+            of the lowercased trimmed identifier — the platform validates the
+            64-char-hex shape and rejects malformed entries.
+          items:
+            type: string
+            pattern: '^[0-9a-f]{64}$|^[A-Za-z0-9-]{20,40}$'
+
+    Catalog:
+      type: object
+      required: [catalog_id, name, vertical, status, item_count]
+      properties:
+        catalog_id: { type: string }
+        name: { type: string }
+        vertical:
+          type: string
+          enum: [retail, travel, automotive, real_estate, hotel]
+        status: { type: string, enum: [active, processing, error] }
+        item_count: { type: integer }
+
+    CatalogItemBatch:
+      type: object
+      required: [catalog_id, items]
+      properties:
+        catalog_id: { type: string }
+        items:
+          type: array
+          minItems: 1
+          maxItems: 5000
+          items:
+            type: object
+            required: [item_id, title, link, image_url, availability, price]
+            properties:
+              item_id: { type: string }
+              title: { type: string }
+              link: { type: string, format: uri }
+              image_url: { type: string, format: uri }
+              availability: { type: string, enum: [in_stock, out_of_stock, preorder] }
+              price: { type: string, example: '49.99 USD' }
+              brand: { type: string }
+              custom_label_0: { type: string }
+
+    CreativePortfolioItem:
+      type: object
+      required: [creative_id, name, format_id, status, created_at]
+      properties:
+        creative_id: { type: string }
+        name: { type: string }
+        format_id: { type: string, enum: [native_feed, story_video, vertical_video, carousel_image] }
+        primary_text: { type: string }
+        cta_label: { type: string }
+        landing_page_url: { type: string, format: uri }
+        media_url: { type: string, format: uri }
+        status: { type: string, enum: [pending_review, approved, rejected, archived] }
+        rejection_reason: { type: string }
+        created_at: { type: string, format: date-time }
+
+    Pixel:
+      type: object
+      required: [pixel_id, name, status, created_at]
+      properties:
+        pixel_id: { type: string }
+        name: { type: string }
+        domain: { type: string }
+        status: { type: string, enum: [active, paused] }
+        events_received_24h:
+          type: integer
+          description: Counter the platform increments as Events API ingests fire.
+        created_at: { type: string, format: date-time }
+
+    EventBatch:
+      type: object
+      required: [pixel_id, events]
+      properties:
+        pixel_id: { type: string }
+        events:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            type: object
+            required: [event_name, event_time, user_data]
+            properties:
+              event_name:
+                type: string
+                description: Standard event name (`Purchase`, `AddToCart`, `Lead`,
+                  `CompleteRegistration`, etc.) or a custom name.
+              event_id:
+                type: string
+                description: Buyer-supplied dedup key. Re-sending the same
+                  `event_id` within a 7-day window does not double-count.
+              event_time:
+                type: integer
+                description: Unix timestamp in seconds.
+              user_data:
+                type: object
+                description: At least one hashed identifier required. Walled
+                  gardens reject events with no matchable identifier.
+                properties:
+                  email_sha256: { type: string, pattern: '^[0-9a-f]{64}$' }
+                  phone_sha256: { type: string, pattern: '^[0-9a-f]{64}$' }
+                  external_id_sha256: { type: string, pattern: '^[0-9a-f]{64}$' }
+                  client_ip_address: { type: string }
+                  client_user_agent: { type: string }
+              custom_data:
+                type: object
+                description: Event-specific properties (`value`, `currency`,
+                  `content_ids`, etc.).
+                additionalProperties: true
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+        request_id: { type: string }
+
+paths:
+  # ────────────────────────────────────────────────────────────
+  # OAuth (no securityScheme — token endpoint is the auth root)
+  # ────────────────────────────────────────────────────────────
+  /oauth/token:
+    post:
+      summary: OAuth 2.0 token endpoint (client_credentials + refresh_token grants)
+      operationId: oauthToken
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [grant_type]
+              properties:
+                grant_type:
+                  type: string
+                  enum: [client_credentials, refresh_token]
+                client_id: { type: string }
+                client_secret: { type: string }
+                refresh_token: { type: string }
+                scope: { type: string }
+      responses:
+        '200':
+          description: Token issued.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/TokenResponse' }
+        '400':
+          description: Invalid grant or missing/wrong client credentials.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  # ────────────────────────────────────────────────────────────
+  # Advertiser
+  # ────────────────────────────────────────────────────────────
+  /v1.3/advertiser/{advertiser_id}/info:
+    get:
+      summary: Fetch advertiser profile
+      operationId: getAdvertiser
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Advertiser profile.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Advertiser' }
+        '401': { description: Missing/expired access token. }
+        '404': { description: Advertiser not found OR not visible to this OAuth client. }
+
+  # ────────────────────────────────────────────────────────────
+  # Custom audiences (sync_audiences mapping target)
+  # ────────────────────────────────────────────────────────────
+  /v1.3/advertiser/{advertiser_id}/custom_audience/list:
+    get:
+      summary: List custom audiences
+      operationId: listCustomAudiences
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Audiences for this advertiser.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [audiences]
+                properties:
+                  audiences:
+                    type: array
+                    items: { $ref: '#/components/schemas/CustomAudience' }
+
+  /v1.3/advertiser/{advertiser_id}/custom_audience/create:
+    post:
+      summary: Create a custom audience shell
+      operationId: createCustomAudience
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, source_type]
+              properties:
+                name: { type: string }
+                description: { type: string }
+                source_type:
+                  type: string
+                  enum: [customer_file, website_traffic, app_activity, lookalike, engagement]
+                client_request_id:
+                  type: string
+                  description: Adapter-supplied idempotency key. Re-sending with
+                    the same id returns the existing audience instead of creating
+                    a duplicate.
+      responses:
+        '201':
+          description: Audience created. Status starts as `building` and
+            transitions to `active` once any subsequent /upload/ call lands
+            members.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CustomAudience' }
+        '200':
+          description: Idempotent replay of the same client_request_id.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CustomAudience' }
+        '400':
+          description: Bad request (e.g. unknown source_type).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '409':
+          description: Idempotency conflict on body mismatch.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /v1.3/advertiser/{advertiser_id}/custom_audience/upload:
+    post:
+      summary: Upload hashed-PII members to an existing audience
+      operationId: uploadCustomAudienceMembers
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AudienceUpload' }
+      responses:
+        '202':
+          description: Upload accepted. Match-rate calculation is async; poll
+            /custom_audience/list to see when `member_count` settles.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [audience_id, status, batch_size]
+                properties:
+                  audience_id: { type: string }
+                  status: { type: string, enum: [building, active] }
+                  batch_size: { type: integer }
+        '400':
+          description: |
+            Invalid hash format (not 64-char hex), unknown identifier_type,
+            or attempt to upload raw PII (rejected — walled gardens require
+            client-side hashing).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404': { description: Audience not found. }
+
+  # ────────────────────────────────────────────────────────────
+  # Catalogs (sync_catalogs mapping target)
+  # ────────────────────────────────────────────────────────────
+  /v1.3/advertiser/{advertiser_id}/catalog/list:
+    get:
+      summary: List product catalogs
+      operationId: listCatalogs
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Catalogs.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [catalogs]
+                properties:
+                  catalogs:
+                    type: array
+                    items: { $ref: '#/components/schemas/Catalog' }
+
+  /v1.3/advertiser/{advertiser_id}/catalog/create:
+    post:
+      summary: Create a product catalog
+      operationId: createCatalog
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, vertical]
+              properties:
+                name: { type: string }
+                vertical:
+                  type: string
+                  enum: [retail, travel, automotive, real_estate, hotel]
+                client_request_id: { type: string }
+      responses:
+        '201':
+          description: Catalog created.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Catalog' }
+        '200':
+          description: Idempotent replay.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Catalog' }
+
+  /v1.3/advertiser/{advertiser_id}/catalog/upload:
+    post:
+      summary: Upload product catalog items
+      operationId: uploadCatalogItems
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CatalogItemBatch' }
+      responses:
+        '202':
+          description: Upload accepted; processing async.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [catalog_id, batch_size]
+                properties:
+                  catalog_id: { type: string }
+                  batch_size: { type: integer }
+
+  # ────────────────────────────────────────────────────────────
+  # Creatives (sync_creatives mapping target)
+  # ────────────────────────────────────────────────────────────
+  /v1.3/advertiser/{advertiser_id}/creative/list:
+    get:
+      summary: List creatives
+      operationId: listCreatives
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Creatives.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [creatives]
+                properties:
+                  creatives:
+                    type: array
+                    items: { $ref: '#/components/schemas/CreativePortfolioItem' }
+
+  /v1.3/advertiser/{advertiser_id}/creative/create:
+    post:
+      summary: Upload a native creative for review
+      operationId: createCreative
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, format_id, primary_text, landing_page_url, media_url]
+              properties:
+                name: { type: string }
+                format_id:
+                  type: string
+                  enum: [native_feed, story_video, vertical_video, carousel_image]
+                primary_text: { type: string }
+                cta_label: { type: string }
+                landing_page_url: { type: string, format: uri }
+                media_url: { type: string, format: uri }
+                client_request_id: { type: string }
+      responses:
+        '201':
+          description: Creative uploaded; status starts as `pending_review`.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CreativePortfolioItem' }
+        '200':
+          description: Idempotent replay.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/CreativePortfolioItem' }
+
+  # ────────────────────────────────────────────────────────────
+  # Pixels / event sources (sync_event_sources mapping target)
+  # ────────────────────────────────────────────────────────────
+  /v1.3/advertiser/{advertiser_id}/pixel/list:
+    get:
+      summary: List pixels (event sources)
+      operationId: listPixels
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Pixels.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [pixels]
+                properties:
+                  pixels:
+                    type: array
+                    items: { $ref: '#/components/schemas/Pixel' }
+
+  /v1.3/advertiser/{advertiser_id}/pixel/create:
+    post:
+      summary: Create a pixel (event source)
+      operationId: createPixel
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                domain: { type: string }
+                client_request_id: { type: string }
+      responses:
+        '201':
+          description: Pixel created.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Pixel' }
+        '200':
+          description: Idempotent replay.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Pixel' }
+
+  # ────────────────────────────────────────────────────────────
+  # Conversion API / events (log_event mapping target)
+  # ────────────────────────────────────────────────────────────
+  /v1.3/advertiser/{advertiser_id}/event/track:
+    post:
+      summary: Server-to-server conversion event ingestion (CAPI)
+      operationId: trackEvents
+      security: [{ bearerAccessToken: [] }]
+      parameters:
+        - in: path
+          name: advertiser_id
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EventBatch' }
+      responses:
+        '200':
+          description: Events accepted (counts increment async).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [pixel_id, events_received, events_dropped]
+                properties:
+                  pixel_id: { type: string }
+                  events_received: { type: integer }
+                  events_dropped:
+                    type: integer
+                    description: Events rejected due to missing matchable identifier
+                      or malformed shape.
+        '400':
+          description: Invalid pixel_id, malformed events, or all events lacked
+            matchable identifiers.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404': { description: Pixel not found. }

--- a/src/lib/mock-server/sales-social/seed-data.ts
+++ b/src/lib/mock-server/sales-social/seed-data.ts
@@ -1,0 +1,61 @@
+export interface MockAdvertiser {
+  advertiser_id: string;
+  display_name: string;
+  /** AdCP-side identifier the adapter receives in `account.advertiser` (or
+   * `account.brand.domain`) and must translate to `advertiser_id` for path
+   * composition. */
+  adcp_advertiser: string;
+  currency: string;
+  timezone: string;
+  status: 'active' | 'suspended' | 'archived';
+}
+
+export interface MockOAuthClient {
+  client_id: string;
+  client_secret: string;
+  /** Advertisers this OAuth client can access. Token issued to this client
+   * is valid for any of these advertisers' resources. */
+  authorized_advertiser_ids: string[];
+}
+
+/**
+ * The "customer-level" OAuth client. Real walled-garden ad APIs issue one
+ * app credential per developer / system-user, valid across multiple
+ * advertiser seats owned by that customer.
+ */
+export const OAUTH_CLIENTS: MockOAuthClient[] = [
+  {
+    client_id: 'tiktok_test_client_001',
+    client_secret: 'tiktok_test_secret_do_not_use_in_prod',
+    authorized_advertiser_ids: ['adv_acme_us', 'adv_summit_us'],
+  },
+];
+
+export const ADVERTISERS: MockAdvertiser[] = [
+  {
+    advertiser_id: 'adv_acme_us',
+    display_name: 'Acme Outdoor — US',
+    adcp_advertiser: 'acmeoutdoor.example',
+    currency: 'USD',
+    timezone: 'America/Los_Angeles',
+    status: 'active',
+  },
+  {
+    advertiser_id: 'adv_summit_us',
+    display_name: 'Summit Media — US',
+    adcp_advertiser: 'summit-media.example',
+    currency: 'USD',
+    timezone: 'America/New_York',
+    status: 'active',
+  },
+];
+
+/** Access token TTL — long enough not to refresh during a single matrix
+ * run, short enough that the refresh path is exercise-able by adopters
+ * who want to test it explicitly (`sleep 3700 && retry`). 1 hour matches
+ * TikTok's documented default. */
+export const ACCESS_TOKEN_TTL_SECONDS = 3600;
+
+/** Refresh token TTL — much longer than access. 30 days. Real platforms
+ * vary; this is in the realistic range. */
+export const REFRESH_TOKEN_TTL_SECONDS = 30 * 24 * 3600;

--- a/src/lib/mock-server/sales-social/server.ts
+++ b/src/lib/mock-server/sales-social/server.ts
@@ -1,0 +1,785 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  ADVERTISERS,
+  OAUTH_CLIENTS,
+  REFRESH_TOKEN_TTL_SECONDS,
+  type MockAdvertiser,
+  type MockOAuthClient,
+} from './seed-data';
+
+export interface BootOptions {
+  port: number;
+  /** Override seed data. */
+  advertisers?: MockAdvertiser[];
+  oauthClients?: MockOAuthClient[];
+  /** Force-set access-token TTL for testing the refresh path. Defaults to
+   * the seed value (3600s). Set to a small number (e.g. 5) to make every
+   * subsequent request require a refresh. */
+  accessTokenTtlSeconds?: number;
+}
+
+export interface BootResult {
+  url: string;
+  close: () => Promise<void>;
+}
+
+interface IssuedAccessToken {
+  access_token: string;
+  refresh_token: string;
+  client_id: string;
+  expires_at_ms: number;
+  refresh_expires_at_ms: number;
+}
+
+interface AudienceState {
+  audience_id: string;
+  advertiser_id: string;
+  name: string;
+  description?: string;
+  source_type: string;
+  member_count: number;
+  status: 'building' | 'active' | 'expired' | 'error';
+  created_at: string;
+  updated_at: string;
+  body_fingerprint: string;
+}
+
+interface CatalogState {
+  catalog_id: string;
+  advertiser_id: string;
+  name: string;
+  vertical: string;
+  status: 'active' | 'processing' | 'error';
+  item_count: number;
+  body_fingerprint: string;
+}
+
+interface CreativeState {
+  creative_id: string;
+  advertiser_id: string;
+  name: string;
+  format_id: string;
+  primary_text: string;
+  cta_label?: string;
+  landing_page_url: string;
+  media_url: string;
+  status: 'pending_review' | 'approved' | 'rejected' | 'archived';
+  created_at: string;
+  body_fingerprint: string;
+}
+
+interface PixelState {
+  pixel_id: string;
+  advertiser_id: string;
+  name: string;
+  domain?: string;
+  status: 'active' | 'paused';
+  events_received_24h: number;
+  created_at: string;
+  body_fingerprint: string;
+}
+
+export async function bootSalesSocial(options: BootOptions): Promise<BootResult> {
+  const advertisers = options.advertisers ?? ADVERTISERS;
+  const oauthClients = options.oauthClients ?? OAUTH_CLIENTS;
+  const accessTtl = options.accessTokenTtlSeconds ?? ACCESS_TOKEN_TTL_SECONDS;
+
+  const tokensByAccess = new Map<string, IssuedAccessToken>();
+  const tokensByRefresh = new Map<string, IssuedAccessToken>();
+
+  // Per-advertiser resource state.
+  const audiences = new Map<string, AudienceState>();
+  const catalogs = new Map<string, CatalogState>();
+  const creatives = new Map<string, CreativeState>();
+  const pixels = new Map<string, PixelState>();
+
+  // Idempotency tables — keyed `<advertiser_id>::<resource_kind>::<client_request_id>`
+  // so cross-advertiser collisions are isolated.
+  const idempotency = new Map<string, string>();
+
+  function issueTokens(client: MockOAuthClient): IssuedAccessToken {
+    const now = Date.now();
+    const t: IssuedAccessToken = {
+      access_token: `tok_${randomUUID().replace(/-/g, '').slice(0, 24)}`,
+      refresh_token: `rfr_${randomUUID().replace(/-/g, '').slice(0, 24)}`,
+      client_id: client.client_id,
+      expires_at_ms: now + accessTtl * 1000,
+      refresh_expires_at_ms: now + REFRESH_TOKEN_TTL_SECONDS * 1000,
+    };
+    tokensByAccess.set(t.access_token, t);
+    tokensByRefresh.set(t.refresh_token, t);
+    return t;
+  }
+
+  function authenticatedClient(req: IncomingMessage): MockOAuthClient | null {
+    const auth = req.headers['authorization'];
+    if (!auth || !auth.startsWith('Bearer ')) return null;
+    const accessToken = auth.slice(7);
+    const issued = tokensByAccess.get(accessToken);
+    if (!issued) return null;
+    if (issued.expires_at_ms < Date.now()) return null;
+    return oauthClients.find(c => c.client_id === issued.client_id) ?? null;
+  }
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res).catch(err => {
+      const requestId = (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
+      writeJson(res, 500, {
+        code: 'internal_error',
+        message: err?.message ?? 'unexpected error',
+        request_id: requestId,
+      });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const addr = server.address();
+  const boundPort = typeof addr === 'object' && addr ? addr.port : options.port;
+  const url = `http://127.0.0.1:${boundPort}`;
+
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+
+  // ────────────────────────────────────────────────────────────
+  // Top-level request dispatcher
+  // ────────────────────────────────────────────────────────────
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+    const path = url.pathname;
+    const method = req.method ?? 'GET';
+
+    // OAuth token endpoint — no Bearer required.
+    if (method === 'POST' && path === '/oauth/token') {
+      return handleOauthToken(req, res);
+    }
+
+    // Everything else requires a valid access token.
+    const client = authenticatedClient(req);
+    if (!client) {
+      writeJson(res, 401, {
+        code: 'unauthorized',
+        message: 'Missing, invalid, or expired bearer token. Acquire one via POST /oauth/token.',
+      });
+      return;
+    }
+
+    // Path-based advertiser scoping.
+    const advMatch = path.match(/^\/v1\.3\/advertiser\/([^/]+)(\/.*)?$/);
+    if (!advMatch || !advMatch[1]) {
+      writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+      return;
+    }
+    const advertiserId = decodeURIComponent(advMatch[1]);
+    const subPath = advMatch[2] ?? '/';
+    const advertiser = advertisers.find(a => a.advertiser_id === advertiserId);
+    if (!advertiser) {
+      writeJson(res, 404, {
+        code: 'advertiser_not_found',
+        message: `Advertiser ${advertiserId} not found.`,
+      });
+      return;
+    }
+    if (!client.authorized_advertiser_ids.includes(advertiserId)) {
+      writeJson(res, 404, {
+        code: 'advertiser_not_authorized',
+        message: `Advertiser ${advertiserId} not visible to this OAuth client.`,
+      });
+      return;
+    }
+
+    // Sub-path routing.
+    if (method === 'GET' && subPath === '/info') return handleGetAdvertiser(advertiser, res);
+
+    // Audiences
+    if (method === 'GET' && subPath === '/custom_audience/list') return handleListAudiences(advertiser, res);
+    if (method === 'POST' && subPath === '/custom_audience/create') return handleCreateAudience(req, advertiser, res);
+    if (method === 'POST' && subPath === '/custom_audience/upload') return handleUploadAudience(req, advertiser, res);
+
+    // Catalogs
+    if (method === 'GET' && subPath === '/catalog/list') return handleListCatalogs(advertiser, res);
+    if (method === 'POST' && subPath === '/catalog/create') return handleCreateCatalog(req, advertiser, res);
+    if (method === 'POST' && subPath === '/catalog/upload') return handleUploadCatalog(req, advertiser, res);
+
+    // Creatives
+    if (method === 'GET' && subPath === '/creative/list') return handleListCreatives(advertiser, res);
+    if (method === 'POST' && subPath === '/creative/create') return handleCreateCreative(req, advertiser, res);
+
+    // Pixels (event sources)
+    if (method === 'GET' && subPath === '/pixel/list') return handleListPixels(advertiser, res);
+    if (method === 'POST' && subPath === '/pixel/create') return handleCreatePixel(req, advertiser, res);
+
+    // Conversion API
+    if (method === 'POST' && subPath === '/event/track') return handleTrackEvents(req, advertiser, res);
+
+    writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // OAuth handler
+  // ────────────────────────────────────────────────────────────
+  async function handleOauthToken(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    let body: Record<string, string>;
+    try {
+      body = await readForm(req);
+    } catch {
+      writeJson(res, 400, { code: 'invalid_request', message: 'Body must be application/x-www-form-urlencoded.' });
+      return;
+    }
+    const grantType = body.grant_type;
+    if (grantType === 'client_credentials') {
+      const client = oauthClients.find(c => c.client_id === body.client_id);
+      if (!client || client.client_secret !== body.client_secret) {
+        writeJson(res, 400, { code: 'invalid_client', message: 'Unknown client_id or wrong client_secret.' });
+        return;
+      }
+      const t = issueTokens(client);
+      writeJson(res, 200, {
+        access_token: t.access_token,
+        refresh_token: t.refresh_token,
+        token_type: 'bearer',
+        expires_in: Math.max(0, Math.floor((t.expires_at_ms - Date.now()) / 1000)),
+      });
+      return;
+    }
+    if (grantType === 'refresh_token') {
+      const refreshToken = body.refresh_token;
+      const issued = refreshToken ? tokensByRefresh.get(refreshToken) : undefined;
+      if (!issued || issued.refresh_expires_at_ms < Date.now()) {
+        writeJson(res, 400, { code: 'invalid_grant', message: 'Unknown or expired refresh_token.' });
+        return;
+      }
+      const client = oauthClients.find(c => c.client_id === issued.client_id);
+      if (!client) {
+        writeJson(res, 400, { code: 'invalid_grant', message: 'Refresh token references a vanished client.' });
+        return;
+      }
+      // Rotate: invalidate old refresh, issue new pair.
+      tokensByRefresh.delete(refreshToken!);
+      tokensByAccess.delete(issued.access_token);
+      const t = issueTokens(client);
+      writeJson(res, 200, {
+        access_token: t.access_token,
+        refresh_token: t.refresh_token,
+        token_type: 'bearer',
+        expires_in: Math.max(0, Math.floor((t.expires_at_ms - Date.now()) / 1000)),
+      });
+      return;
+    }
+    writeJson(res, 400, {
+      code: 'unsupported_grant_type',
+      message: `grant_type must be one of: client_credentials, refresh_token. Got: ${grantType}`,
+    });
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Advertiser handler
+  // ────────────────────────────────────────────────────────────
+  function handleGetAdvertiser(advertiser: MockAdvertiser, res: ServerResponse): void {
+    writeJson(res, 200, advertiser);
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Audience handlers
+  // ────────────────────────────────────────────────────────────
+  function handleListAudiences(advertiser: MockAdvertiser, res: ServerResponse): void {
+    const list = Array.from(audiences.values()).filter(a => a.advertiser_id === advertiser.advertiser_id);
+    writeJson(res, 200, { audiences: list.map(stripBodyFingerprint) });
+  }
+
+  async function handleCreateAudience(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { name, description, source_type, client_request_id } = body as Record<string, unknown>;
+    if (typeof name !== 'string' || typeof source_type !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'name and source_type are required strings.' });
+      return;
+    }
+    const validSources = ['customer_file', 'website_traffic', 'app_activity', 'lookalike', 'engagement'];
+    if (!validSources.includes(source_type)) {
+      writeJson(res, 400, {
+        code: 'invalid_source_type',
+        message: `source_type must be one of ${validSources.join(', ')}.`,
+      });
+      return;
+    }
+    const fingerprint = JSON.stringify({ name, description, source_type });
+    const replay = checkIdempotentReplay(advertiser.advertiser_id, 'audience', client_request_id, fingerprint);
+    if (replay.kind === 'conflict') {
+      writeJson(res, 409, { code: 'idempotency_conflict', message: replay.message });
+      return;
+    }
+    if (replay.kind === 'replay') {
+      const existing = audiences.get(replay.id);
+      if (existing) {
+        writeJson(res, 200, stripBodyFingerprint(existing));
+        return;
+      }
+    }
+    const id = `ca_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+    const now = new Date().toISOString();
+    const audience: AudienceState = {
+      audience_id: id,
+      advertiser_id: advertiser.advertiser_id,
+      name,
+      description: typeof description === 'string' ? description : undefined,
+      source_type,
+      member_count: 0,
+      status: 'building',
+      created_at: now,
+      updated_at: now,
+      body_fingerprint: fingerprint,
+    };
+    audiences.set(id, audience);
+    if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+      idempotency.set(`${advertiser.advertiser_id}::audience::${client_request_id}`, id);
+    }
+    writeJson(res, 201, stripBodyFingerprint(audience));
+  }
+
+  async function handleUploadAudience(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { audience_id, identifier_type, members } = body as Record<string, unknown>;
+    if (typeof audience_id !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'audience_id is required.' });
+      return;
+    }
+    const aud = audiences.get(audience_id);
+    if (!aud || aud.advertiser_id !== advertiser.advertiser_id) {
+      writeJson(res, 404, { code: 'audience_not_found', message: `Audience ${audience_id} not found.` });
+      return;
+    }
+    const validIds = [
+      'hashed_email_sha256',
+      'hashed_phone_sha256',
+      'hashed_email_or_phone_sha256',
+      'mobile_advertising_id',
+    ];
+    if (typeof identifier_type !== 'string' || !validIds.includes(identifier_type)) {
+      writeJson(res, 400, {
+        code: 'invalid_identifier_type',
+        message: `identifier_type must be one of ${validIds.join(', ')}.`,
+      });
+      return;
+    }
+    if (!Array.isArray(members) || members.length === 0) {
+      writeJson(res, 400, { code: 'empty_members', message: 'members must be a non-empty array.' });
+      return;
+    }
+    if (identifier_type.startsWith('hashed_')) {
+      const hashRe = /^[0-9a-f]{64}$/;
+      const malformed = members.filter(m => typeof m !== 'string' || !hashRe.test(m));
+      if (malformed.length > 0) {
+        // Real walled gardens reject silently per-row in batch but for the
+        // test fixture we hard-fail on any malformed — adapter bugs that
+        // pass raw PII or wrong-cased hex get surfaced loudly.
+        writeJson(res, 400, {
+          code: 'invalid_hash_format',
+          message:
+            `${malformed.length} member(s) are not 64-char lowercase hex. Walled gardens require ` +
+            `client-side SHA-256 hashing of the lowercased trimmed identifier; uploading raw PII is rejected.`,
+        });
+        return;
+      }
+    }
+    aud.member_count += members.length;
+    aud.status = 'active';
+    aud.updated_at = new Date().toISOString();
+    writeJson(res, 202, {
+      audience_id,
+      status: aud.status,
+      batch_size: members.length,
+    });
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Catalog handlers
+  // ────────────────────────────────────────────────────────────
+  function handleListCatalogs(advertiser: MockAdvertiser, res: ServerResponse): void {
+    const list = Array.from(catalogs.values()).filter(c => c.advertiser_id === advertiser.advertiser_id);
+    writeJson(res, 200, { catalogs: list.map(stripBodyFingerprint) });
+  }
+
+  async function handleCreateCatalog(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { name, vertical, client_request_id } = body as Record<string, unknown>;
+    if (typeof name !== 'string' || typeof vertical !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'name and vertical are required.' });
+      return;
+    }
+    const fingerprint = JSON.stringify({ name, vertical });
+    const replay = checkIdempotentReplay(advertiser.advertiser_id, 'catalog', client_request_id, fingerprint);
+    if (replay.kind === 'conflict') {
+      writeJson(res, 409, { code: 'idempotency_conflict', message: replay.message });
+      return;
+    }
+    if (replay.kind === 'replay') {
+      const existing = catalogs.get(replay.id);
+      if (existing) {
+        writeJson(res, 200, stripBodyFingerprint(existing));
+        return;
+      }
+    }
+    const id = `cat_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+    const cat: CatalogState = {
+      catalog_id: id,
+      advertiser_id: advertiser.advertiser_id,
+      name,
+      vertical,
+      status: 'active',
+      item_count: 0,
+      body_fingerprint: fingerprint,
+    };
+    catalogs.set(id, cat);
+    if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+      idempotency.set(`${advertiser.advertiser_id}::catalog::${client_request_id}`, id);
+    }
+    writeJson(res, 201, stripBodyFingerprint(cat));
+  }
+
+  async function handleUploadCatalog(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { catalog_id, items } = body as Record<string, unknown>;
+    if (typeof catalog_id !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'catalog_id is required.' });
+      return;
+    }
+    const cat = catalogs.get(catalog_id);
+    if (!cat || cat.advertiser_id !== advertiser.advertiser_id) {
+      writeJson(res, 404, { code: 'catalog_not_found', message: `Catalog ${catalog_id} not found.` });
+      return;
+    }
+    if (!Array.isArray(items) || items.length === 0) {
+      writeJson(res, 400, { code: 'empty_items', message: 'items must be a non-empty array.' });
+      return;
+    }
+    cat.item_count += items.length;
+    writeJson(res, 202, { catalog_id, batch_size: items.length });
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Creative handlers
+  // ────────────────────────────────────────────────────────────
+  function handleListCreatives(advertiser: MockAdvertiser, res: ServerResponse): void {
+    const list = Array.from(creatives.values()).filter(c => c.advertiser_id === advertiser.advertiser_id);
+    writeJson(res, 200, { creatives: list.map(stripBodyFingerprint) });
+  }
+
+  async function handleCreateCreative(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { name, format_id, primary_text, cta_label, landing_page_url, media_url, client_request_id } = body as Record<
+      string,
+      unknown
+    >;
+    if (
+      typeof name !== 'string' ||
+      typeof format_id !== 'string' ||
+      typeof primary_text !== 'string' ||
+      typeof landing_page_url !== 'string' ||
+      typeof media_url !== 'string'
+    ) {
+      writeJson(res, 400, {
+        code: 'invalid_request',
+        message: 'name, format_id, primary_text, landing_page_url, media_url are all required strings.',
+      });
+      return;
+    }
+    const validFormats = ['native_feed', 'story_video', 'vertical_video', 'carousel_image'];
+    if (!validFormats.includes(format_id)) {
+      writeJson(res, 400, { code: 'invalid_format', message: `format_id must be one of ${validFormats.join(', ')}.` });
+      return;
+    }
+    const fingerprint = JSON.stringify({ name, format_id, primary_text, cta_label, landing_page_url, media_url });
+    const replay = checkIdempotentReplay(advertiser.advertiser_id, 'creative', client_request_id, fingerprint);
+    if (replay.kind === 'conflict') {
+      writeJson(res, 409, { code: 'idempotency_conflict', message: replay.message });
+      return;
+    }
+    if (replay.kind === 'replay') {
+      const existing = creatives.get(replay.id);
+      if (existing) {
+        writeJson(res, 200, stripBodyFingerprint(existing));
+        return;
+      }
+    }
+    const id = `cr_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+    const cr: CreativeState = {
+      creative_id: id,
+      advertiser_id: advertiser.advertiser_id,
+      name,
+      format_id,
+      primary_text,
+      cta_label: typeof cta_label === 'string' ? cta_label : undefined,
+      landing_page_url,
+      media_url,
+      status: 'pending_review',
+      created_at: new Date().toISOString(),
+      body_fingerprint: fingerprint,
+    };
+    creatives.set(id, cr);
+    if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+      idempotency.set(`${advertiser.advertiser_id}::creative::${client_request_id}`, id);
+    }
+    writeJson(res, 201, stripBodyFingerprint(cr));
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Pixel handlers
+  // ────────────────────────────────────────────────────────────
+  function handleListPixels(advertiser: MockAdvertiser, res: ServerResponse): void {
+    const list = Array.from(pixels.values()).filter(p => p.advertiser_id === advertiser.advertiser_id);
+    writeJson(res, 200, { pixels: list.map(stripBodyFingerprint) });
+  }
+
+  async function handleCreatePixel(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { name, domain, client_request_id } = body as Record<string, unknown>;
+    if (typeof name !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'name is required.' });
+      return;
+    }
+    const fingerprint = JSON.stringify({ name, domain });
+    const replay = checkIdempotentReplay(advertiser.advertiser_id, 'pixel', client_request_id, fingerprint);
+    if (replay.kind === 'conflict') {
+      writeJson(res, 409, { code: 'idempotency_conflict', message: replay.message });
+      return;
+    }
+    if (replay.kind === 'replay') {
+      const existing = pixels.get(replay.id);
+      if (existing) {
+        writeJson(res, 200, stripBodyFingerprint(existing));
+        return;
+      }
+    }
+    const id = `px_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+    const px: PixelState = {
+      pixel_id: id,
+      advertiser_id: advertiser.advertiser_id,
+      name,
+      domain: typeof domain === 'string' ? domain : undefined,
+      status: 'active',
+      events_received_24h: 0,
+      created_at: new Date().toISOString(),
+      body_fingerprint: fingerprint,
+    };
+    pixels.set(id, px);
+    if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+      idempotency.set(`${advertiser.advertiser_id}::pixel::${client_request_id}`, id);
+    }
+    writeJson(res, 201, stripBodyFingerprint(px));
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Conversion API (events) handler
+  // ────────────────────────────────────────────────────────────
+  async function handleTrackEvents(
+    req: IncomingMessage,
+    advertiser: MockAdvertiser,
+    res: ServerResponse
+  ): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { pixel_id, events } = body as Record<string, unknown>;
+    if (typeof pixel_id !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'pixel_id is required.' });
+      return;
+    }
+    const px = pixels.get(pixel_id);
+    if (!px || px.advertiser_id !== advertiser.advertiser_id) {
+      writeJson(res, 404, { code: 'pixel_not_found', message: `Pixel ${pixel_id} not found.` });
+      return;
+    }
+    if (!Array.isArray(events) || events.length === 0) {
+      writeJson(res, 400, { code: 'empty_events', message: 'events must be a non-empty array.' });
+      return;
+    }
+    let received = 0;
+    let dropped = 0;
+    const hashRe = /^[0-9a-f]{64}$/;
+    for (const ev of events) {
+      if (!ev || typeof ev !== 'object') {
+        dropped++;
+        continue;
+      }
+      const event = ev as Record<string, unknown>;
+      if (typeof event.event_name !== 'string' || typeof event.event_time !== 'number') {
+        dropped++;
+        continue;
+      }
+      const userData = event.user_data as Record<string, unknown> | undefined;
+      const hasMatchableId = !!(
+        userData &&
+        ((typeof userData.email_sha256 === 'string' && hashRe.test(userData.email_sha256)) ||
+          (typeof userData.phone_sha256 === 'string' && hashRe.test(userData.phone_sha256)) ||
+          (typeof userData.external_id_sha256 === 'string' && hashRe.test(userData.external_id_sha256)))
+      );
+      if (!hasMatchableId) {
+        // Walled gardens reject events without a matchable identifier.
+        dropped++;
+        continue;
+      }
+      received++;
+    }
+    if (received === 0) {
+      writeJson(res, 400, {
+        code: 'no_matchable_events',
+        message:
+          `All ${events.length} events were dropped — none carried a hashed identifier ` +
+          `(email_sha256, phone_sha256, or external_id_sha256). Walled-garden CAPI requires ` +
+          `at least one matchable identifier per event.`,
+      });
+      return;
+    }
+    px.events_received_24h += received;
+    writeJson(res, 200, { pixel_id, events_received: received, events_dropped: dropped });
+  }
+
+  // ────────────────────────────────────────────────────────────
+  // Helpers
+  // ────────────────────────────────────────────────────────────
+  function checkIdempotentReplay(
+    advertiserId: string,
+    resourceKind: string,
+    clientRequestId: unknown,
+    fingerprint: string
+  ): { kind: 'replay'; id: string } | { kind: 'conflict'; message: string } | { kind: 'fresh' } {
+    if (typeof clientRequestId !== 'string' || clientRequestId.length === 0) return { kind: 'fresh' };
+    const key = `${advertiserId}::${resourceKind}::${clientRequestId}`;
+    const existingId = idempotency.get(key);
+    if (!existingId) return { kind: 'fresh' };
+    const stored = lookupResource(resourceKind, existingId);
+    if (!stored) return { kind: 'fresh' };
+    if (stored.body_fingerprint !== fingerprint) {
+      return {
+        kind: 'conflict',
+        message: `client_request_id ${clientRequestId} was previously used with a different body. Use a fresh idempotency key for distinct requests.`,
+      };
+    }
+    return { kind: 'replay', id: existingId };
+  }
+
+  function lookupResource(kind: string, id: string): { body_fingerprint: string } | undefined {
+    switch (kind) {
+      case 'audience':
+        return audiences.get(id);
+      case 'catalog':
+        return catalogs.get(id);
+      case 'creative':
+        return creatives.get(id);
+      case 'pixel':
+        return pixels.get(id);
+      default:
+        return undefined;
+    }
+  }
+}
+
+function stripBodyFingerprint<T extends { body_fingerprint?: string }>(record: T): Omit<T, 'body_fingerprint'> {
+  const { body_fingerprint, ...rest } = record;
+  return rest;
+}
+
+function readForm(req: IncomingMessage): Promise<Record<string, string>> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', c => chunks.push(c));
+    req.on('error', reject);
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const out: Record<string, string> = {};
+      for (const pair of raw.split('&')) {
+        if (!pair) continue;
+        const [k, v = ''] = pair.split('=');
+        if (k === undefined) continue;
+        out[decodeURIComponent(k)] = decodeURIComponent(v.replace(/\+/g, ' '));
+      }
+      resolve(out);
+    });
+  });
+}
+
+async function readJsonObject(req: IncomingMessage, res: ServerResponse): Promise<Record<string, unknown> | null> {
+  let body: unknown;
+  try {
+    body = await readJson(req);
+  } catch {
+    writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
+    return null;
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'Body must be a JSON object.' });
+    return null;
+  }
+  return body as Record<string, unknown>;
+}
+
+function readJson(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', c => chunks.push(c));
+    req.on('error', reject);
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}

--- a/test/lib/mock-server/sales-social.test.js
+++ b/test/lib/mock-server/sales-social.test.js
@@ -1,0 +1,375 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { createHash } = require('node:crypto');
+const { bootMockServer } = require('../../../dist/lib/mock-server/index.js');
+const { OAUTH_CLIENTS, ADVERTISERS } = require('../../../dist/lib/mock-server/sales-social/seed-data.js');
+
+const CLIENT_ID = OAUTH_CLIENTS[0].client_id;
+const CLIENT_SECRET = OAUTH_CLIENTS[0].client_secret;
+const ADV = ADVERTISERS[0].advertiser_id;
+
+function sha256Hex(s) {
+  return createHash('sha256').update(s.toLowerCase().trim()).digest('hex');
+}
+
+async function getAccessToken(handle) {
+  const body = new URLSearchParams({
+    grant_type: 'client_credentials',
+    client_id: CLIENT_ID,
+    client_secret: CLIENT_SECRET,
+  });
+  const res = await fetch(`${handle.url}/oauth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  const json = await res.json();
+  if (res.status !== 200) throw new Error(`token endpoint returned ${res.status}: ${JSON.stringify(json)}`);
+  return json;
+}
+
+describe('mock-server sales-social', () => {
+  let handle;
+  before(async () => {
+    handle = await bootMockServer({ specialism: 'sales-social', port: 0 });
+  });
+  after(async () => {
+    if (handle) await handle.close();
+  });
+
+  describe('OAuth handshake', () => {
+    it('issues access + refresh tokens for valid client_credentials', async () => {
+      const tokens = await getAccessToken(handle);
+      assert.ok(tokens.access_token);
+      assert.ok(tokens.refresh_token);
+      assert.equal(tokens.token_type, 'bearer');
+      assert.ok(tokens.expires_in > 0);
+    });
+
+    it('rejects bad client_secret with 400 invalid_client', async () => {
+      const body = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: CLIENT_ID,
+        client_secret: 'wrong',
+      });
+      const res = await fetch(`${handle.url}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+      assert.equal(res.status, 400);
+      const json = await res.json();
+      assert.equal(json.code, 'invalid_client');
+    });
+
+    it('refresh_token grant rotates the refresh token (old becomes invalid)', async () => {
+      const original = await getAccessToken(handle);
+      const refreshBody = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: original.refresh_token,
+      });
+      const refreshRes = await fetch(`${handle.url}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: refreshBody.toString(),
+      });
+      assert.equal(refreshRes.status, 200);
+      const rotated = await refreshRes.json();
+      assert.notEqual(rotated.access_token, original.access_token);
+      assert.notEqual(rotated.refresh_token, original.refresh_token);
+
+      // Original refresh token no longer valid
+      const replayRes = await fetch(`${handle.url}/oauth/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: refreshBody.toString(),
+      });
+      assert.equal(replayRes.status, 400);
+      const replay = await replayRes.json();
+      assert.equal(replay.code, 'invalid_grant');
+    });
+
+    it('boot handle reports oauth_client_credentials auth shape', () => {
+      assert.equal(handle.auth.kind, 'oauth_client_credentials');
+      assert.equal(handle.auth.clientId, CLIENT_ID);
+      assert.equal(handle.auth.clientSecret, CLIENT_SECRET);
+      assert.equal(handle.auth.tokenPath, '/oauth/token');
+    });
+  });
+
+  describe('Bearer authentication on API routes', () => {
+    it('rejects API call without bearer with 401', async () => {
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/info`);
+      assert.equal(res.status, 401);
+      const body = await res.json();
+      assert.equal(body.code, 'unauthorized');
+    });
+
+    it('rejects API call with garbage bearer with 401', async () => {
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/info`, {
+        headers: { Authorization: 'Bearer not_a_real_token' },
+      });
+      assert.equal(res.status, 401);
+    });
+
+    it('accepts API call with freshly-issued access token', async () => {
+      const { access_token } = await getAccessToken(handle);
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/info`, {
+        headers: { Authorization: `Bearer ${access_token}` },
+      });
+      assert.equal(res.status, 200);
+      const adv = await res.json();
+      assert.equal(adv.advertiser_id, ADV);
+    });
+
+    it('returns 404 for advertiser not in OAuth client scope', async () => {
+      const { access_token } = await getAccessToken(handle);
+      const res = await fetch(`${handle.url}/v1.3/advertiser/adv_does_not_exist/info`, {
+        headers: { Authorization: `Bearer ${access_token}` },
+      });
+      assert.equal(res.status, 404);
+    });
+  });
+
+  describe('Custom audience flow (sync_audiences mapping)', () => {
+    let token;
+    before(async () => {
+      token = (await getAccessToken(handle)).access_token;
+    });
+
+    it('creates an audience and uploads hashed members', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+      const createRes = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/custom_audience/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          name: 'Outdoor Enthusiasts US',
+          source_type: 'customer_file',
+          client_request_id: 'audience-create-test',
+        }),
+      });
+      assert.equal(createRes.status, 201);
+      const audience = await createRes.json();
+      assert.equal(audience.status, 'building');
+      assert.equal(audience.member_count, 0);
+
+      const hashedMembers = ['alice@example.com', 'bob@example.com', 'charlie@example.com'].map(sha256Hex);
+      const uploadRes = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/custom_audience/upload`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          audience_id: audience.audience_id,
+          identifier_type: 'hashed_email_sha256',
+          members: hashedMembers,
+        }),
+      });
+      assert.equal(uploadRes.status, 202);
+      const uploadResult = await uploadRes.json();
+      assert.equal(uploadResult.status, 'active');
+      assert.equal(uploadResult.batch_size, 3);
+    });
+
+    it('rejects raw (unhashed) PII upload with 400 invalid_hash_format', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const createRes = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/custom_audience/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          name: 'raw pii test',
+          source_type: 'customer_file',
+          client_request_id: 'raw-pii-create-test',
+        }),
+      });
+      const audience = await createRes.json();
+      const uploadRes = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/custom_audience/upload`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          audience_id: audience.audience_id,
+          identifier_type: 'hashed_email_sha256',
+          members: ['alice@example.com', 'bob@example.com'], // NOT hashed
+        }),
+      });
+      assert.equal(uploadRes.status, 400);
+      const err = await uploadRes.json();
+      assert.equal(err.code, 'invalid_hash_format');
+    });
+
+    it('returns 409 idempotency_conflict on body-mismatched replay', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const first = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/custom_audience/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          name: 'idem original',
+          source_type: 'customer_file',
+          client_request_id: 'audience-conflict-test',
+        }),
+      });
+      assert.equal(first.status, 201);
+      const conflict = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/custom_audience/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          name: 'idem CHANGED',
+          source_type: 'customer_file',
+          client_request_id: 'audience-conflict-test',
+        }),
+      });
+      assert.equal(conflict.status, 409);
+      const c = await conflict.json();
+      assert.equal(c.code, 'idempotency_conflict');
+    });
+  });
+
+  describe('Conversion API / events (log_event mapping)', () => {
+    let token;
+    let pixelId;
+    before(async () => {
+      token = (await getAccessToken(handle)).access_token;
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const px = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/pixel/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({ name: 'capi-test', client_request_id: 'pixel-create-test' }),
+      });
+      pixelId = (await px.json()).pixel_id;
+    });
+
+    it('ingests events with hashed identifiers', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/event/track`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          pixel_id: pixelId,
+          events: [
+            {
+              event_name: 'Purchase',
+              event_id: 'evt_001',
+              event_time: Math.floor(Date.now() / 1000),
+              user_data: { email_sha256: sha256Hex('alice@example.com') },
+              custom_data: { value: 49.99, currency: 'USD' },
+            },
+          ],
+        }),
+      });
+      assert.equal(res.status, 200);
+      const result = await res.json();
+      assert.equal(result.events_received, 1);
+      assert.equal(result.events_dropped, 0);
+    });
+
+    it('drops events without a matchable identifier', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/event/track`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          pixel_id: pixelId,
+          events: [
+            {
+              event_name: 'Purchase',
+              event_time: Math.floor(Date.now() / 1000),
+              user_data: {
+                /* no hashed identifiers */
+              },
+              custom_data: { value: 1 },
+            },
+          ],
+        }),
+      });
+      assert.equal(res.status, 400);
+      const err = await res.json();
+      assert.equal(err.code, 'no_matchable_events');
+    });
+
+    it('returns 404 for unknown pixel_id', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/event/track`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          pixel_id: 'px_does_not_exist',
+          events: [
+            {
+              event_name: 'Purchase',
+              event_time: Math.floor(Date.now() / 1000),
+              user_data: { email_sha256: sha256Hex('alice@example.com') },
+            },
+          ],
+        }),
+      });
+      assert.equal(res.status, 404);
+    });
+  });
+
+  describe('Catalog and creative flows', () => {
+    let token;
+    before(async () => {
+      token = (await getAccessToken(handle)).access_token;
+    });
+
+    it('creates a catalog and uploads items', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const catRes = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/catalog/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({ name: 'outdoor-gear', vertical: 'retail', client_request_id: 'cat-test' }),
+      });
+      assert.equal(catRes.status, 201);
+      const catalog = await catRes.json();
+      const upload = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/catalog/upload`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          catalog_id: catalog.catalog_id,
+          items: [
+            {
+              item_id: 'sku_001',
+              title: 'Trail Pro Tent',
+              link: 'https://example.test/p/sku_001',
+              image_url: 'https://example.test/img/sku_001.jpg',
+              availability: 'in_stock',
+              price: '299.99 USD',
+            },
+          ],
+        }),
+      });
+      assert.equal(upload.status, 202);
+      const result = await upload.json();
+      assert.equal(result.batch_size, 1);
+    });
+
+    it('uploads a native creative with status pending_review', async () => {
+      const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+      const res = await fetch(`${handle.url}/v1.3/advertiser/${ADV}/creative/create`, {
+        method: 'POST',
+        headers: auth,
+        body: JSON.stringify({
+          name: 'trail-pro-spring',
+          format_id: 'native_feed',
+          primary_text: 'Built for the trail.',
+          cta_label: 'Shop Now',
+          landing_page_url: 'https://example.test/spring',
+          media_url: 'https://example.test/media/trail-pro.jpg',
+          client_request_id: 'creative-test',
+        }),
+      });
+      assert.equal(res.status, 201);
+      const creative = await res.json();
+      assert.equal(creative.status, 'pending_review');
+    });
+  });
+
+  it('reports unified principal-mapping shape on the boot handle', () => {
+    assert.ok(Array.isArray(handle.principalMapping));
+    assert.ok(handle.principalMapping.length >= 2);
+    for (const entry of handle.principalMapping) {
+      assert.ok(entry.adcpField);
+      assert.ok(entry.upstreamField);
+    }
+    assert.ok(/path|advertiser/i.test(handle.principalScope));
+  });
+});


### PR DESCRIPTION
Third mock-server in the matrix v2 family. See #1155 for design rationale.

## Summary

Stresses three SDK surfaces the existing mocks (signal-marketplace, creative-template) don't touch:

1. **OAuth 2.0 client_credentials with refresh-token rotation** — first matrix-v2 test of the SDK's OAuth code path that shipped in 5.9.0
2. **Hashed-PII audience uploads** — SHA-256-hashed lowercase identifiers; raw PII or wrong-cased hex rejected with 400. Matches Meta / TikTok / LinkedIn contracts.
3. **CAPI / Conversion API event ingestion** — server-to-server conversion events with hashed identifiers; events without a matchable identifier are dropped/counted

Plus supporting surface required by the \`sales_social\` storyboard: advertiser info, catalog CRUD + upload (\`sync_catalogs\`), creative portfolio CRUD (\`sync_creatives\`), pixel CRUD (\`sync_event_sources\`).

## Refactor: polymorphic auth on MockServerHandle

\`MockServerHandle.apiKey: string\` → \`MockServerHandle.auth: MockServerAuth\` (discriminated union):

\`\`\`ts
type MockServerAuth =
  | { kind: 'static_bearer'; apiKey: string }
  | { kind: 'oauth_client_credentials'; clientId: string; clientSecret: string; tokenPath: string };
\`\`\`

The matrix harness branches on \`auth.kind\` when building the adapter prompt. Static-bearer specialisms (signals, creative-template) get the inline-API-key block; OAuth specialisms (sales-social) get a token-endpoint + credentials block instructing the adapter to do the OAuth handshake.

## Multi-tenancy

Path-scoped: \`/v1.3/advertiser/{advertiser_id}/...\`. Two seeded advertisers with overlapping access. Single OAuth client authorized for both — matches the standard walled-garden model where one app credential serves multiple seats.

## Why TikTok-flavored, not Meta

Per the prior design discussion: TikTok exercises **OAuth client_credentials + refresh tokens** (genuinely new SDK surface). Meta uses **long-lived access tokens** (closer to static Bearer, already covered). Doing both would mostly re-test the same patterns. If matrix runs against TikTok-flavored surface ever surface "we don't handle long-lived tokens well" or "we assume refresh always works," that's the moment Meta becomes worth building.

## Test plan

- [x] \`npm run build\` clean
- [x] **17 smoke tests pass** covering: OAuth handshake (success, bad client_secret, refresh rotation, old-token-invalidation), bearer-required API gating, audience create + hashed-PII upload + raw-PII rejection + idempotency conflict, CAPI event ingest with matchable/unmatchable identifiers + unknown pixel, catalog + creative flows, principal-mapping handle shape
- [x] All 45 mock-server tests pass (17 sales-social + 16 creative-template + 12 signal-marketplace)
- [x] CLI smoke test: \`adcp mock-server sales-social\` boots, OAuth handshake returns valid token

## Refs

- Design issue: #1155
- First mock: #1185 (signal-marketplace)
- Second mock: #1207 (creative-template)
- Sister harness fixes: #1211 (\`runGrader\` partial pass), #1212 (skill strict-shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)