### PR TITLE
fix(server): per-account SeedFixtureCache scoping for multi-tenant servers

### DIFF
--- a/.changeset/per-account-seed-cache.md
+++ b/.changeset/per-account-seed-cache.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(server): per-account SeedFixtureCache scoping for multi-tenant servers
+
+The comply-controller's `SeedFixtureCache` previously keyed by `seed_<scenario>:${id}` (process-wide). Two sandbox accounts on one server (e.g., a single-tenant server with multiple sandbox accounts, or a multi-tenant host that doesn't shard servers per tenant) couldn't seed the same `id` with divergent fixtures — the second seed returned `INVALID_PARAMS` ("Seed replays must carry an equivalent fixture") even though each account's fixture was internally consistent.
+
+`handleTestControllerRequest` now extracts `account.account_id` from the input envelope and prefixes the cache key with it. Same-account replays still hit the equivalent-fixture path (returns `Fixture re-seeded (equivalent)`); cross-account same-id divergent fixtures now succeed cleanly.
+
+Backward-compatible: requests without `account.account_id` still use unscoped keys, preserving existing behavior for adopters who don't pass account refs into seed calls.
+
+Closes #1215.

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -515,11 +515,28 @@ function fixturesEquivalent(a: Record<string, unknown>, b: Record<string, unknow
 
 /** Dispatch a seed scenario through the correct adapter method, honoring the
  * spec idempotency rules when a {@link SeedFixtureCache} is provided. */
+/**
+ * Build the seed-cache key for a scenario. When `scope` is present (the
+ * request's `account.account_id`), it's prefixed so two sandbox accounts
+ * on one server can each seed the same `product_id` with divergent
+ * fixtures without colliding in the process-wide `SeedFixtureCache`.
+ *
+ * Without scope (legacy callers, or requests with no `account` envelope),
+ * the unscoped key is used — preserving the pre-#1215 behavior. Adopters
+ * who relied on cross-account replay equivalence (rare, since storyboards
+ * usually scope per account anyway) are unaffected when their requests
+ * don't carry an `account` block.
+ */
+function makeSeedCacheKey(unscopedKey: string, scope: string | undefined): string {
+  return scope != null && scope.length > 0 ? `${scope}:${unscopedKey}` : unscopedKey;
+}
+
 async function dispatchSeed(
   store: TestControllerStore,
   scenario: SeedScenario,
   params: Record<string, unknown> | undefined,
-  cache: SeedFixtureCache | undefined
+  cache: SeedFixtureCache | undefined,
+  scope: string | undefined
 ): Promise<ComplyTestControllerResponse> {
   // Validate fixture is a plain object (not null, array, or primitive) before
   // casting — the adapter signature promises Record<string, unknown>.
@@ -560,7 +577,7 @@ async function dispatchSeed(
       if (!store.seedProduct) return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
       const productId = params.product_id as string;
       dispatch = {
-        key: `seed_product:${productId}`,
+        key: makeSeedCacheKey(`seed_product:${productId}`, scope),
         invoke: () => store.seedProduct!(productId, fixture),
       };
       break;
@@ -574,7 +591,7 @@ async function dispatchSeed(
       const productId = params.product_id as string;
       const pricingOptionId = params.pricing_option_id as string;
       dispatch = {
-        key: `seed_pricing_option:${productId}:${pricingOptionId}`,
+        key: makeSeedCacheKey(`seed_pricing_option:${productId}:${pricingOptionId}`, scope),
         invoke: () => store.seedPricingOption!(productId, pricingOptionId, fixture),
       };
       break;
@@ -587,7 +604,7 @@ async function dispatchSeed(
       if (!store.seedCreative) return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
       const creativeId = params.creative_id as string;
       dispatch = {
-        key: `seed_creative:${creativeId}`,
+        key: makeSeedCacheKey(`seed_creative:${creativeId}`, scope),
         invoke: () => store.seedCreative!(creativeId, fixture),
       };
       break;
@@ -600,7 +617,7 @@ async function dispatchSeed(
       if (!store.seedPlan) return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
       const planId = params.plan_id as string;
       dispatch = {
-        key: `seed_plan:${planId}`,
+        key: makeSeedCacheKey(`seed_plan:${planId}`, scope),
         invoke: () => store.seedPlan!(planId, fixture),
       };
       break;
@@ -613,7 +630,7 @@ async function dispatchSeed(
       if (!store.seedMediaBuy) return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
       const mediaBuyId = params.media_buy_id as string;
       dispatch = {
-        key: `seed_media_buy:${mediaBuyId}`,
+        key: makeSeedCacheKey(`seed_media_buy:${mediaBuyId}`, scope),
         invoke: () => store.seedMediaBuy!(mediaBuyId, fixture),
       };
       break;
@@ -626,7 +643,7 @@ async function dispatchSeed(
       if (!store.seedCreativeFormat) return controllerError('UNKNOWN_SCENARIO', `Scenario not supported: ${scenario}`);
       const formatId = params.format_id as string;
       dispatch = {
-        key: `seed_creative_format:${formatId}`,
+        key: makeSeedCacheKey(`seed_creative_format:${formatId}`, scope),
         invoke: () => store.seedCreativeFormat!(formatId, fixture),
       };
       break;
@@ -873,8 +890,26 @@ export async function handleTestControllerRequest(
       case SEED_SCENARIOS.SEED_CREATIVE:
       case SEED_SCENARIOS.SEED_PLAN:
       case SEED_SCENARIOS.SEED_MEDIA_BUY:
-      case SEED_SCENARIOS.SEED_CREATIVE_FORMAT:
-        return await dispatchSeed(store, scenario as SeedScenario, params, options?.seedCache);
+      case SEED_SCENARIOS.SEED_CREATIVE_FORMAT: {
+        // Per-account seed-cache scope (issue #1215). Two sandbox accounts on
+        // one server can each seed the same `product_id` with divergent
+        // fixtures; without a scope prefix the cache treats divergent replays
+        // as INVALID_PARAMS even when each account's fixture is internally
+        // self-consistent. Read the request envelope's `account.account_id`
+        // (no resolver call here — test-controller is a generic helper that
+        // doesn't know about platform.accounts.resolve, and read-time
+        // misalignment is fine because the cache only governs idempotency,
+        // not user-visible state). Empty/missing → unscoped (legacy keys).
+        const account = input.account;
+        const scope =
+          account != null && typeof account === 'object'
+            ? (() => {
+                const id = (account as { account_id?: unknown }).account_id;
+                return typeof id === 'string' && id.length > 0 ? id : undefined;
+              })()
+            : undefined;
+        return await dispatchSeed(store, scenario as SeedScenario, params, options?.seedCache, scope);
+      }
 
       default:
         return controllerError('UNKNOWN_SCENARIO', 'Unrecognized scenario name');

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -8,6 +8,7 @@ const {
   enforceMapCap,
   toMcpResponse,
   TOOL_INPUT_SHAPE,
+  createSeedFixtureCache,
 } = require('../dist/lib/server/test-controller');
 const { expectControllerError, expectControllerSuccess } = require('../dist/lib/testing/controller-assertions');
 const { z } = require('zod');
@@ -353,6 +354,137 @@ describe('handleTestControllerRequest', () => {
       });
       assert.strictEqual(result.error, 'INVALID_PARAMS');
       assert.match(result.error_detail, /requires params\.format_id/);
+    });
+  });
+
+  // ── Per-account SeedFixtureCache scoping (issue #1215) ────────
+  describe('seed cache scoping by input.account.account_id', () => {
+    it('two accounts can seed the same product_id with divergent fixtures (no INVALID_PARAMS replay)', async () => {
+      const writes = [];
+      const store = {
+        async seedProduct(productId, fixture) {
+          writes.push({ productId, fixture });
+        },
+      };
+      const seedCache = createSeedFixtureCache();
+
+      // Tenant A seeds product 'p1' with delivery_type='guaranteed'
+      const a = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'tenant_a' },
+          params: { product_id: 'p1', fixture: { delivery_type: 'guaranteed' } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(a.success, true);
+      assert.strictEqual(a.message, 'Fixture seeded');
+
+      // Tenant B seeds the same product 'p1' with delivery_type='non_guaranteed'.
+      // Without per-account scoping this would fail INVALID_PARAMS (divergent fixture).
+      const b = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'tenant_b' },
+          params: { product_id: 'p1', fixture: { delivery_type: 'non_guaranteed' } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(b.success, true, 'tenant_b should be able to seed p1 with a divergent fixture');
+      assert.strictEqual(b.message, 'Fixture seeded');
+
+      // Both writes flowed to the store.
+      assert.strictEqual(writes.length, 2);
+      assert.deepStrictEqual(
+        writes.map(w => w.fixture.delivery_type),
+        ['guaranteed', 'non_guaranteed']
+      );
+    });
+
+    it('same account replaying same fixture still hits the equivalent-replay path', async () => {
+      const writes = [];
+      const store = {
+        async seedProduct(productId, fixture) {
+          writes.push({ productId, fixture });
+        },
+      };
+      const seedCache = createSeedFixtureCache();
+
+      const first = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'acc_1' },
+          params: { product_id: 'p1', fixture: { x: 1 } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(first.message, 'Fixture seeded');
+
+      const replay = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'acc_1' },
+          params: { product_id: 'p1', fixture: { x: 1 } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(replay.success, true);
+      assert.strictEqual(replay.message, 'Fixture re-seeded (equivalent)', 'replay must dedupe within the same account');
+    });
+
+    it('same account replaying with divergent fixture still returns INVALID_PARAMS', async () => {
+      const store = {
+        async seedProduct() {},
+      };
+      const seedCache = createSeedFixtureCache();
+
+      await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'acc_1' },
+          params: { product_id: 'p1', fixture: { x: 1 } },
+        },
+        { seedCache }
+      );
+
+      const divergent = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: 'acc_1' },
+          params: { product_id: 'p1', fixture: { x: 2 } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(divergent.error, 'INVALID_PARAMS', 'divergent replay within same account must still be rejected');
+    });
+
+    it('legacy behavior preserved: requests without account use unscoped keys', async () => {
+      const store = {
+        async seedProduct() {},
+      };
+      const seedCache = createSeedFixtureCache();
+
+      const first = await handleTestControllerRequest(
+        store,
+        { scenario: 'seed_product', params: { product_id: 'p1', fixture: { x: 1 } } },
+        { seedCache }
+      );
+      assert.strictEqual(first.message, 'Fixture seeded');
+
+      // Same product_id, no account, divergent fixture → INVALID_PARAMS (legacy
+      // path; pins backward compat for adopters who never carried account refs).
+      const divergent = await handleTestControllerRequest(
+        store,
+        { scenario: 'seed_product', params: { product_id: 'p1', fixture: { x: 2 } } },
+        { seedCache }
+      );
+      assert.strictEqual(divergent.error, 'INVALID_PARAMS');
     });
   });
 

--- a/test/server-test-controller.test.js
+++ b/test/server-test-controller.test.js
@@ -433,7 +433,11 @@ describe('handleTestControllerRequest', () => {
         { seedCache }
       );
       assert.strictEqual(replay.success, true);
-      assert.strictEqual(replay.message, 'Fixture re-seeded (equivalent)', 'replay must dedupe within the same account');
+      assert.strictEqual(
+        replay.message,
+        'Fixture re-seeded (equivalent)',
+        'replay must dedupe within the same account'
+      );
     });
 
     it('same account replaying with divergent fixture still returns INVALID_PARAMS', async () => {
@@ -461,7 +465,11 @@ describe('handleTestControllerRequest', () => {
         },
         { seedCache }
       );
-      assert.strictEqual(divergent.error, 'INVALID_PARAMS', 'divergent replay within same account must still be rejected');
+      assert.strictEqual(
+        divergent.error,
+        'INVALID_PARAMS',
+        'divergent replay within same account must still be rejected'
+      );
     });
 
     it('legacy behavior preserved: requests without account use unscoped keys', async () => {
@@ -485,6 +493,38 @@ describe('handleTestControllerRequest', () => {
         { seedCache }
       );
       assert.strictEqual(divergent.error, 'INVALID_PARAMS');
+    });
+
+    it('empty-string account_id falls through to legacy unscoped behavior', async () => {
+      // Adopters who carry the account envelope but leave account_id blank
+      // (e.g., a misconfigured request builder) should land in the same
+      // unscoped namespace as no-account-at-all rather than the literal
+      // "empty-string" tenant. Pins the guard's `id.length > 0` check.
+      const store = { async seedProduct() {} };
+      const seedCache = createSeedFixtureCache();
+      await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: '' },
+          params: { product_id: 'p1', fixture: { x: 1 } },
+        },
+        { seedCache }
+      );
+      const divergent = await handleTestControllerRequest(
+        store,
+        {
+          scenario: 'seed_product',
+          account: { account_id: '' },
+          params: { product_id: 'p1', fixture: { x: 2 } },
+        },
+        { seedCache }
+      );
+      assert.strictEqual(
+        divergent.error,
+        'INVALID_PARAMS',
+        'empty-string account_id must collapse into unscoped namespace'
+      );
     });
   });
 


### PR DESCRIPTION
Closes #1215. Surfaced during PR #1100 (catalog-backed auto-seed) review and tracked as a follow-up.

## Problem

The comply-controller's \`SeedFixtureCache\` keyed by \`seed_<scenario>:\${id}\` — process-wide. Two sandbox accounts on one server (single-tenant server with multiple sandbox accounts, or multi-tenant host that doesn't shard servers per tenant) couldn't seed the same \`id\` with divergent fixtures — the second seed returned \`INVALID_PARAMS\` even though each account's fixture was internally self-consistent.

PR #1100's storage-layer fix (per-account \`Map<accountId, Map<productId, fixture>>\`) prevented \`get_products\` cross-tenant leakage but couldn't paper over the cache layer.

## Fix

\`handleTestControllerRequest\` extracts \`account.account_id\` from the input envelope and prefixes the cache key. The new \`makeSeedCacheKey(unscopedKey, scope)\` helper centralizes the prefix logic across all 6 seed scenarios (\`seed_product\`, \`seed_pricing_option\`, \`seed_creative\`, \`seed_plan\`, \`seed_media_buy\`, \`seed_creative_format\`).

## Backward compat

Requests without \`account.account_id\` (legacy adopters who never carried account refs into seed calls) still use unscoped keys — same behavior as before. Same-account replays still hit the equivalent-fixture path (\`Fixture re-seeded (equivalent)\`).

## Tests

4 new tests in \`test/server-test-controller.test.js\` covering:
- **cross-account divergent fixtures succeed** (was INVALID_PARAMS, now passes)
- **same-account equivalent replay dedupes** (unchanged behavior, regression guard)
- **same-account divergent replay still rejected** (intentional within-account idempotency)
- **legacy no-account requests still scope-by-id** (backward compat)

7170/7197 full suite passing. 1 unrelated flake in \`request-signing-replay-perf.test.js\` (passes in isolation; perf-sensitive).

## Test plan
- [x] 4 new test-controller scoping tests pass
- [x] Existing test-controller suite (70 tests) unchanged
- [x] Auto-seed integration tests still pass (9/9)
- [x] \`npm run typecheck\` clean
- [x] Changeset added (patch — additive scoping, no breaking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)