### PR TITLE
fix(client): extend v3 fallback to cover capabilities-call throws and empty-data cases

### DIFF
--- a/.changeset/extend-v3-fallback.md
+++ b/.changeset/extend-v3-fallback.md
@@ -1,0 +1,19 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(client): extend v3 fallback to cover capabilities-call throws and empty-data cases
+
+#1201 tightened the v2-fallback heuristic in `SingleAgentClient.getCapabilities()` so that v3 agents with wire-shape bugs (returning `success: false` with v3-shaped `result.data`) are no longer mis-classified as v2. But the fix only covered one failure mode. Two residual paths still fell back to v2 synthetic capabilities, cascading into "AdCP schema data for version v2.5 not found" errors:
+
+- `executeTask` throws (transport error, parse error, OAuth flow failure)
+- `success: false` AND `result.data` is empty / not v3-shaped (so the `looksLikeV3Capabilities` heuristic doesn't catch it)
+
+In both cases the agent still has the v3-only `get_adcp_capabilities` tool in its `tools/list` — affirmative evidence that it's v3 even though we couldn't read details. Falling back to v2 synthetic causes `parseAdcpVersion` to ask for v2.5 schemas (not bundled, by design — they're optional) and every subsequent step fails.
+
+This patch:
+- Adds `buildSyntheticV3Capabilities(tools)` to `@adcp/sdk/utils/capabilities` (mirrors `buildSyntheticCapabilities` but emits `version: 'v3'`, `majorVersions: [3]`, `_synthetic: true`).
+- `SingleAgentClient.getCapabilities` returns synthetic v3 caps when `get_adcp_capabilities` is in the tool list but the call fails (any reason).
+- `requireSupportedMajor` skips the version + idempotency-TTL detail checks for synthetic v3 (we know the agent is v3 but couldn't confirm specifics until the caps endpoint is fixed).
+
+Closes #1217.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -114,6 +114,7 @@ import * as crypto from 'crypto';
 import type { AdcpCapabilities, AdcpMajorVersion, ToolInfo, FeatureName } from '../utils/capabilities';
 import {
   buildSyntheticCapabilities,
+  buildSyntheticV3Capabilities,
   augmentCapabilitiesFromTools,
   looksLikeV3Capabilities,
   parseCapabilitiesResponse,
@@ -2846,22 +2847,26 @@ export class SingleAgentClient {
           this.maybeWarnV2Sunset(this.cachedCapabilities);
           return this.cachedCapabilities;
         }
-        // Log when executeTask returns but success is false — this causes
-        // the server to be treated as v2 even though it advertises
-        // get_adcp_capabilities, which will trigger v2 field adapters.
-        // We deliberately omit `result.data` from the log: it can carry
-        // OAuth metadata that flowed through `agent.oauth_client_credentials`,
-        // and CodeQL traces clear-text logging when it appears here. The
-        // shape booleans + status are enough to triage the v2 fallback.
+        // The call returned non-success and the response wasn't even
+        // structurally v3-shaped (so the heuristic above didn't catch it),
+        // OR data is missing entirely. The agent still advertises the
+        // v3-only `get_adcp_capabilities` tool, so it's verifiably v3 —
+        // synthesize v3 capabilities from the tool list and continue
+        // (issue #1217). Falling back to v2 here cascades into "AdCP
+        // schema data for version v2.5 not found" errors that obscure
+        // the real bug (the broken capabilities response).
+        //
+        // We deliberately omit `result.data` and `result.error` from the
+        // log: they can carry OAuth metadata or transport-level identifiers
+        // (CodeQL clear-text-logging tracker). Shape booleans + status are
+        // enough to triage.
         console.warn(
           `[AdCP] Agent "${this.agent.id}" advertises get_adcp_capabilities but the call ` +
-            `returned non-success — falling back to v2 synthetic capabilities. ` +
-            `This may cause v2 field adapters to run against a v3 server.`,
+            `returned non-success and the response is not v3-shaped — treating as v3 (synthetic) ` +
+            `since the agent has the v3-only discovery tool. Fix the agent's ` +
+            `get_adcp_capabilities handler to surface the real failure.`,
           {
             success: result.success,
-            // result.error is a string error message; we don't include its full
-            // text because it can carry agent identifiers from transport-level
-            // failures, but presence/absence is useful for triage.
             hasError: !!result.error,
             hasData: !!result.data,
           }
@@ -2875,18 +2880,27 @@ export class SingleAgentClient {
         }
         console.warn(
           `[AdCP] Agent "${this.agent.id}" advertises get_adcp_capabilities but the call ` +
-            `threw — falling back to v2 synthetic capabilities. ` +
-            `This may cause v2 field adapters to run against a v3 server. ` +
+            `threw — treating as v3 (synthetic) since the agent has the v3-only ` +
+            `discovery tool. Fix the agent's get_adcp_capabilities handler to ` +
+            `surface the real failure. ` +
             `Error: ${error instanceof Error ? error.message : String(error)}`
         );
       }
+
+      // Synthesize v3 capabilities from the tool list. Reached only when
+      // the executor returned non-v3-shaped data, OR threw a non-auth
+      // non-timeout error. The agent's v3-only tool list is the affirmative
+      // signal that it's v3 even though we couldn't read details.
+      this.cachedCapabilities = augmentCapabilitiesFromTools(buildSyntheticV3Capabilities(tools), tools);
+      this.maybeWarnV2Sunset(this.cachedCapabilities);
+      return this.cachedCapabilities;
     }
 
-    // Build synthetic capabilities from tool list (v2)
+    // No get_adcp_capabilities tool — the agent is verifiably v2 (the tool
+    // is v3-only). Synthesize v2 capabilities from the tool list.
     console.warn(
-      `[AdCP] Agent "${this.agent.id}" detected as v2` +
-        (hasCapabilitiesTool ? ' (has get_adcp_capabilities tool but call failed)' : '') +
-        `. Tools: [${tools.map(t => t.name).join(', ')}]`
+      `[AdCP] Agent "${this.agent.id}" detected as v2 (no get_adcp_capabilities tool). ` +
+        `Tools: [${tools.map(t => t.name).join(', ')}]`
     );
     this.cachedCapabilities = buildSyntheticCapabilities(tools);
     return this.cachedCapabilities;
@@ -3042,9 +3056,19 @@ export class SingleAgentClient {
     if (this.isV2Allowed()) return;
     const capabilities = await this.getCapabilities();
 
-    if (capabilities._synthetic) {
+    // Synthetic + v2: no `get_adcp_capabilities` tool — we can't confirm the
+    // agent supports our version, throw so the caller fails loud rather than
+    // silently sending v2-adapted requests to an unknown agent.
+    // Synthetic + v3: the tool was present but the call failed — the agent
+    // is verifiably v3 (it advertises the v3-only discovery tool). Skip the
+    // detail-level checks (supportedVersions, majorVersions, idempotency
+    // TTL) since we couldn't read those fields; we know the spec requires
+    // v3 to support idempotency, just can't confirm the TTL until the
+    // capabilities endpoint is fixed (#1217).
+    if (capabilities._synthetic && capabilities.version !== 'v3') {
       throw new VersionUnsupportedError(taskType, 'synthetic', capabilities.version, this.agent.agent_uri);
     }
+    if (capabilities._synthetic) return;
     // Prefer release-precision matching when the seller advertises
     // `supported_versions` (AdCP 3.1+ per spec PR `adcontextprotocol/adcp#3493`).
     // Fall back to the deprecated integer `major_versions` for legacy 3.0

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -399,6 +399,7 @@ export class SingleAgentClient {
   private cachedCapabilities?: AdcpCapabilities; // Cache detected server capabilities
   private cachedToolSchemas?: Map<string, Record<string, unknown>>; // inputSchema.properties per tool name
   private _v2WarningFired = false; // Gate: emit the v2-sunset warning once per client instance
+  private _syntheticV3WarningFired = false; // Gate: emit the synthetic-v3 warning once per client instance
   private readonly resolvedAdcpVersion: string;
 
   constructor(
@@ -2863,8 +2864,10 @@ export class SingleAgentClient {
         console.warn(
           `[AdCP] Agent "${this.agent.id}" advertises get_adcp_capabilities but the call ` +
             `returned non-success and the response is not v3-shaped — treating as v3 (synthetic) ` +
-            `since the agent has the v3-only discovery tool. Fix the agent's ` +
-            `get_adcp_capabilities handler to surface the real failure.`,
+            `since the agent has the v3-only discovery tool. ` +
+            `This client routes to v3 adapters, but calls reading capability details ` +
+            `(idempotency TTL, supported_versions, feature flags) will fail until the agent ` +
+            `operator fixes the capabilities endpoint at ${this.agent.agent_uri}.`,
           {
             success: result.success,
             hasError: !!result.error,
@@ -2880,9 +2883,10 @@ export class SingleAgentClient {
         }
         console.warn(
           `[AdCP] Agent "${this.agent.id}" advertises get_adcp_capabilities but the call ` +
-            `threw — treating as v3 (synthetic) since the agent has the v3-only ` +
-            `discovery tool. Fix the agent's get_adcp_capabilities handler to ` +
-            `surface the real failure. ` +
+            `threw — treating as v3 (synthetic) since the agent has the v3-only discovery tool. ` +
+            `This client routes to v3 adapters, but calls reading capability details ` +
+            `(idempotency TTL, supported_versions, feature flags) will fail until the agent ` +
+            `operator fixes the capabilities endpoint at ${this.agent.agent_uri}. ` +
             `Error: ${error instanceof Error ? error.message : String(error)}`
         );
       }
@@ -2931,6 +2935,29 @@ export class SingleAgentClient {
         `v2 went unsupported on 2026-04-20 (AdCP 3.0 GA). ` +
         `Upgrade the agent to v3 or set ADCP_ALLOW_V2=1 to suppress this warning. ` +
         `See https://github.com/adcontextprotocol/adcp/issues/2220`
+    );
+  }
+
+  /**
+   * Warn once per client when `requireSupportedMajor` accepts synthetic v3
+   * capabilities — the agent advertised the v3-only `get_adcp_capabilities`
+   * tool but the call itself failed, so the version + idempotency-TTL
+   * checks were skipped. Adopters who depend on TTL guarantees (BYOK retry
+   * callers, idempotency replay logic) should know they're in a degraded
+   * mode where the agent is verifiably v3 but specifics are unverifiable
+   * until the agent's capabilities endpoint is fixed.
+   *
+   * One-shot via `_syntheticV3WarningFired` (matches `maybeWarnV2Sunset`
+   * cadence). Issue #1217.
+   */
+  private maybeWarnSyntheticV3(): void {
+    if (this._syntheticV3WarningFired) return;
+    this._syntheticV3WarningFired = true;
+    console.warn(
+      `[adcp] Warning: agent ${this.agent.agent_uri} advertises get_adcp_capabilities (v3-only) ` +
+        `but the call failed. Treating as v3 (synthetic) — version + idempotency-TTL checks skipped. ` +
+        `Calls to getIdempotencyReplayTtlSeconds() will throw until the agent's capabilities ` +
+        `endpoint is fixed. Report the wire-shape bug to the agent operator at ${this.agent.agent_uri}.`
     );
   }
 
@@ -3068,7 +3095,15 @@ export class SingleAgentClient {
     if (capabilities._synthetic && capabilities.version !== 'v3') {
       throw new VersionUnsupportedError(taskType, 'synthetic', capabilities.version, this.agent.agent_uri);
     }
-    if (capabilities._synthetic) return;
+    if (capabilities._synthetic) {
+      // Synthetic v3 — silent passage of the version + idempotency-TTL
+      // checks. Adopters who called `requireSupportedMajor` precisely
+      // because they need TTL guarantees deserve to know the check was
+      // skipped. Emit a one-time warning per client (matches the
+      // `maybeWarnV2Sunset` cadence so we don't spam every call).
+      this.maybeWarnSyntheticV3();
+      return;
+    }
     // Prefer release-precision matching when the seller advertises
     // `supported_versions` (AdCP 3.1+ per spec PR `adcontextprotocol/adcp#3493`).
     // Fall back to the deprecated integer `major_versions` for legacy 3.0

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -971,6 +971,7 @@ export {
 //   - `SingleAgentClient#requireV3()` / `AgentClient#requireV3()` — runtime gate
 export {
   buildSyntheticCapabilities,
+  buildSyntheticV3Capabilities,
   parseCapabilitiesResponse,
   supportsV3,
   supportsProtocol,

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -381,6 +381,52 @@ export function buildSyntheticCapabilities(tools: ToolInfo[]): AdcpCapabilities 
 }
 
 /**
+ * Build synthetic v3 capabilities when the agent advertises
+ * `get_adcp_capabilities` (a v3-only tool) but the call itself failed —
+ * either the executor threw, or the response was non-success with no
+ * structurally v3-shaped data (the case `looksLikeV3Capabilities` would
+ * have caught).
+ *
+ * The agent is verifiably v3 because the v3-only discovery tool is
+ * present in `tools/list`. Falling back to v2 synthetic in this case
+ * triggers v2.5-schema lookups that have nothing to do with the original
+ * failure, cascading "AdCP schema data for version v2.5 not found"
+ * across every subsequent step. Treating as v3 (synthetic) lets the
+ * caller continue against the right adapter set; the underlying
+ * `get_adcp_capabilities` failure still surfaces in logs at the
+ * call site.
+ *
+ * Sets `_synthetic: true` so version-compat checks know detail-level
+ * fields (idempotency TTL, supportedVersions) are unknown — callers
+ * skip those checks rather than throw `VersionUnsupportedError` on a
+ * verifiably-v3 agent.
+ *
+ * Refs: #1217 (carve-out from #1197/closed), #1189 / #1201 (the v3-shape
+ * heuristic this complements).
+ */
+export function buildSyntheticV3Capabilities(tools: ToolInfo[]): AdcpCapabilities {
+  const toolNames = new Set(tools.map(t => t.name));
+  const protocols = detectProtocolsFromTools(toolNames);
+
+  const features: MediaBuyFeatures = {
+    inlineCreativeManagement: toolNames.has('sync_creatives'),
+    propertyListFiltering: false,
+    contentStandards: false,
+    conversionTracking: EVENT_TRACKING_TOOLS.some(t => toolNames.has(t)),
+    audienceTargeting: toolNames.has('sync_audiences'),
+  };
+
+  return {
+    version: 'v3',
+    majorVersions: [3],
+    protocols,
+    features,
+    extensions: [],
+    _synthetic: true,
+  };
+}
+
+/**
  * Heuristic: does this `get_adcp_capabilities` response look v3-shaped?
  *
  * Used by callers (e.g. SingleAgentClient.getCapabilities) when the response

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.5.0';
+export const LIBRARY_VERSION = '6.6.0';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.5.0',
+  library: '6.6.0',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-01T14:53:47.135Z',
+  generatedAt: '2026-05-01T17:10:32.911Z',
 } as const;
 
 /**

--- a/test/lib/synthetic-v3-fallback.test.js
+++ b/test/lib/synthetic-v3-fallback.test.js
@@ -107,3 +107,63 @@ describe('SingleAgentClient.requireSupportedMajor with synthetic capabilities (i
     await assert.rejects(() => client.requireSupportedMajor('test'), VersionUnsupportedError);
   });
 });
+
+describe('SingleAgentClient.maybeWarnSyntheticV3 — one-time warning when checks skipped', () => {
+  function captureWarnings() {
+    const captured = [];
+    const original = console.warn;
+    console.warn = (...args) => {
+      captured.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    };
+    return {
+      get calls() {
+        return captured;
+      },
+      restore() {
+        console.warn = original;
+      },
+    };
+  }
+
+  it('emits exactly one warning when requireSupportedMajor accepts synthetic v3', async () => {
+    const warn = captureWarnings();
+    try {
+      const client = new SingleAgentClient(stubAgent);
+      client.cachedCapabilities = buildSyntheticV3Capabilities([{ name: 'get_adcp_capabilities' }]);
+
+      await client.requireSupportedMajor('test');
+      await client.requireSupportedMajor('test');
+      await client.requireSupportedMajor('test');
+
+      const synthV3Warns = warn.calls.filter(c => c.includes('synthetic') && c.includes('v3-only'));
+      assert.equal(synthV3Warns.length, 1, 'synthetic-v3 warning must fire once per client');
+      assert.match(synthV3Warns[0], /idempotency-TTL/);
+      assert.match(synthV3Warns[0], /report.*operator/i);
+    } finally {
+      warn.restore();
+    }
+  });
+
+  it('does NOT warn for real v3 capabilities passing the check', async () => {
+    const warn = captureWarnings();
+    try {
+      const client = new SingleAgentClient(stubAgent);
+      client.cachedCapabilities = {
+        version: 'v3',
+        majorVersions: [3],
+        protocols: ['media_buy'],
+        features: {},
+        extensions: [],
+        _synthetic: false,
+        idempotency: { replayTtlSeconds: 86400 },
+      };
+
+      await client.requireSupportedMajor('test');
+
+      const synthV3Warns = warn.calls.filter(c => c.includes('synthetic'));
+      assert.equal(synthV3Warns.length, 0, 'real v3 caps must not trigger the synthetic-v3 warning');
+    } finally {
+      warn.restore();
+    }
+  });
+});

--- a/test/lib/synthetic-v3-fallback.test.js
+++ b/test/lib/synthetic-v3-fallback.test.js
@@ -1,0 +1,109 @@
+/**
+ * Synthetic v3 fallback — issue #1217.
+ *
+ * When an agent advertises `get_adcp_capabilities` (a v3-only tool) but the
+ * call fails (throws OR returns non-success with no v3-shaped data), the
+ * client now treats the agent as v3 (synthetic) instead of falling back to
+ * v2. The v3-only tool is verifiable evidence that the agent is v3 — falling
+ * to v2 would trigger v2.5-schema lookups that obscure the original failure.
+ *
+ * Composes with #1201 / #1189: that PR handles the case where a non-success
+ * response IS structurally v3-shaped (parse anyway). This issue covers the
+ * remaining cases — empty data, throws, non-v3-shaped data.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { SingleAgentClient } = require('../../dist/lib/core/SingleAgentClient.js');
+const { buildSyntheticV3Capabilities, buildSyntheticCapabilities } = require('../../dist/lib/utils/capabilities.js');
+const { VersionUnsupportedError } = require('../../dist/lib/errors/index.js');
+
+const stubAgent = {
+  id: 'a1',
+  name: 'stub',
+  protocol: 'mcp',
+  agent_uri: 'https://stub.example/mcp',
+};
+
+describe('buildSyntheticV3Capabilities', () => {
+  it('emits version=v3 + majorVersions=[3] + _synthetic=true', () => {
+    const caps = buildSyntheticV3Capabilities([{ name: 'sync_creatives' }]);
+    assert.equal(caps.version, 'v3');
+    assert.deepEqual(caps.majorVersions, [3]);
+    assert.equal(caps._synthetic, true);
+  });
+
+  it('detects features from tool list (sync_creatives → inlineCreativeManagement)', () => {
+    const caps = buildSyntheticV3Capabilities([{ name: 'sync_creatives' }]);
+    assert.equal(caps.features.inlineCreativeManagement, true);
+  });
+
+  it('detects features from tool list (sync_audiences → audienceTargeting)', () => {
+    const caps = buildSyntheticV3Capabilities([{ name: 'sync_audiences' }]);
+    assert.equal(caps.features.audienceTargeting, true);
+  });
+
+  it('keeps v3-only feature flags conservative when undeclared', () => {
+    const caps = buildSyntheticV3Capabilities([]);
+    // We can't read details from get_adcp_capabilities, so v3-only features
+    // we couldn't observe stay false. This is the same shape as v2 synthetic
+    // — only `version` / `majorVersions` differ.
+    assert.equal(caps.features.propertyListFiltering, false);
+    assert.equal(caps.features.contentStandards, false);
+  });
+});
+
+describe('SingleAgentClient.requireSupportedMajor with synthetic capabilities (issue #1217)', () => {
+  it('does NOT throw VersionUnsupportedError on synthetic v3 capabilities', async () => {
+    // The agent had `get_adcp_capabilities` in its tool list but the call
+    // failed. We synthesized v3 caps from the tool list — version-compat
+    // must accept them since the v3-only discovery tool is affirmative
+    // evidence the agent is v3.
+    const client = new SingleAgentClient(stubAgent);
+    client.cachedCapabilities = buildSyntheticV3Capabilities([{ name: 'get_adcp_capabilities' }]);
+
+    await client.requireSupportedMajor('test');
+    // No throw = pass.
+  });
+
+  it('still throws VersionUnsupportedError on synthetic v2 capabilities (no v3 tool present)', async () => {
+    // No get_adcp_capabilities in tool list → agent is verifiably v2 →
+    // version-compat throws (preserves pre-#1217 safety behavior).
+    const client = new SingleAgentClient(stubAgent);
+    client.cachedCapabilities = buildSyntheticCapabilities([{ name: 'list_signals' }]);
+
+    await assert.rejects(() => client.requireSupportedMajor('test'), VersionUnsupportedError);
+  });
+
+  it('skips idempotency-TTL check on synthetic v3 (TTL is unknowable until caps endpoint is fixed)', async () => {
+    // Synthetic v3 caps have no `idempotency` block — we couldn't read the
+    // TTL from get_adcp_capabilities. The check must skip rather than throw,
+    // since the spec requires v3 to support idempotency (we know it's there,
+    // we just can't confirm the TTL).
+    const client = new SingleAgentClient(stubAgent);
+    const caps = buildSyntheticV3Capabilities([{ name: 'get_adcp_capabilities' }]);
+    assert.equal(caps.idempotency, undefined, 'precondition: synthetic v3 has no idempotency block');
+    client.cachedCapabilities = caps;
+
+    await client.requireSupportedMajor('test');
+    // No throw = pass.
+  });
+
+  it('still throws VersionUnsupportedError on real v3 caps missing replayTtlSeconds (non-synthetic)', async () => {
+    // A real v3 agent that advertises caps but somehow omits idempotency TTL
+    // — that's a wire-shape bug worth surfacing loudly, not silently passing.
+    // The synthetic-v3 escape hatch is gated on _synthetic === true.
+    const client = new SingleAgentClient(stubAgent);
+    client.cachedCapabilities = {
+      version: 'v3',
+      majorVersions: [3],
+      protocols: ['media_buy'],
+      features: {},
+      extensions: [],
+      _synthetic: false,
+    };
+
+    await assert.rejects(() => client.requireSupportedMajor('test'), VersionUnsupportedError);
+  });
+});

--- a/test/lib/v3-guard.test.js
+++ b/test/lib/v3-guard.test.js
@@ -53,11 +53,31 @@ describe('SingleAgentClient.requireV3 — corroborated check', () => {
     );
   });
 
-  test('rejects synthetic capabilities even when v3 is claimed', async () => {
+  test('accepts synthetic v3 capabilities (issue #1217 — v3-only tool is affirmative evidence)', async () => {
+    // The agent had `get_adcp_capabilities` (v3-only) in its tool list but
+    // the call failed. Synthetic v3 caps are produced from the tool list as
+    // the verifiable-v3 fallback. requireV3 accepts these silently (with a
+    // one-time warn fired by maybeWarnSyntheticV3) rather than the prior
+    // hard-reject — the agent IS v3, we just couldn't read details. The
+    // strict accessors (getIdempotencyReplayTtlSeconds, etc.) still throw
+    // when called, surfacing the broken caps endpoint at use-site.
     const client = clientWithCapabilities({
       version: 'v3',
       majorVersions: [3],
       idempotency,
+      _synthetic: true,
+    });
+    await client.requireV3('sync_creatives');
+    // No throw = pass.
+  });
+
+  test('still rejects synthetic v2 capabilities (no v3-only tool in tools/list)', async () => {
+    // The synthetic-v3 escape hatch is gated on version === 'v3'. A synthetic
+    // v2 capabilities object (no get_adcp_capabilities tool present) still
+    // fails loudly — that's the case we genuinely don't know the version for.
+    const client = clientWithCapabilities({
+      version: 'v2',
+      majorVersions: [2],
       _synthetic: true,
     });
     await assert.rejects(


### PR DESCRIPTION
Closes #1217. Composes with shipped #1201.

## Problem

#1201 tightened the v2-fallback heuristic in \`SingleAgentClient.getCapabilities()\` for one failure mode: \`success: false\` with v3-shaped \`result.data\`. Two residual paths still fell back to v2 synthetic capabilities, cascading into \"AdCP schema data for version v2.5 not found\" errors:

- \`executeTask\` throws (transport, parse, OAuth flow failure)
- \`success: false\` AND \`result.data\` is empty / not v3-shaped

In both cases the v3-only \`get_adcp_capabilities\` tool is in the agent's \`tools/list\` — affirmative evidence it's v3.

## Fix

1. Add \`buildSyntheticV3Capabilities(tools)\` to \`@adcp/sdk/utils/capabilities\`. Mirrors \`buildSyntheticCapabilities\` but emits \`version: 'v3'\`, \`majorVersions: [3]\`, \`_synthetic: true\`.
2. \`SingleAgentClient.getCapabilities\` returns synthetic v3 caps in both fall-through paths when \`get_adcp_capabilities\` is in the tool list.
3. \`requireSupportedMajor\` accepts synthetic v3 (skips version + idempotency-TTL checks). Synthetic v2 still throws (preserves safety for genuinely unversioned agents). Real v3 caps missing \`replayTtlSeconds\` still throw — only the synthetic-v3 escape hatch skips.

## Tests

8 new tests in \`test/lib/synthetic-v3-fallback.test.js\`:
- \`buildSyntheticV3Capabilities\` shape (4 cases: version/majorVersions, feature detection, conservative defaults)
- \`requireSupportedMajor\` accepts synthetic v3 (no throw)
- \`requireSupportedMajor\` still throws on synthetic v2 (regression guard)
- \`requireSupportedMajor\` skips idempotency-TTL check for synthetic v3
- \`requireSupportedMajor\` still throws on real v3 missing TTL (regression guard)

## Test plan
- [x] 8 new tests pass
- [x] Adjacent tests unaffected (looks-like-v3, idempotency, v2-deprecation: 80 total, 0 fail)
- [x] \`npm run typecheck\` clean
- [x] Changeset added (patch — additive, composes with #1201)

🤖 Generated with [Claude Code](https://claude.com/claude-code)