### PR TITLE
feat(cli): adcp storyboard run --no-sandbox stamps ext.adcp.disable_sandbox=true

### DIFF
--- a/.changeset/no-sandbox-disable-routing-hint.md
+++ b/.changeset/no-sandbox-disable-routing-hint.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": patch
+---
+
+feat(cli): `adcp storyboard run --no-sandbox` now signals adopters to bypass internal sandbox routing
+
+Closes #841. The existing `--no-sandbox` flag set `account.sandbox: false` (a value), but agents that branch on env vars, brand-domain heuristics, or fixture substitutes still routed sandbox-shaped responses despite the production flag. Compliance passes against the sandbox path; buyer agents break against prod. (Surfaced empirically by `scope3data/agentic-adapters#100`.)
+
+`--no-sandbox` now ALSO stamps `ext.adcp.disable_sandbox: true` on every outgoing request. Adopters that read this field bypass internal sandbox routing and exercise their real adapter path. Agents that don't recognize the field ignore it (`ext` is accepted-without-error per AdCP 3.0 spec).
+
+Programmatic callers of `runStoryboard` can pass `disable_sandbox: true` in `StoryboardRunOptions` to get the same behavior without the flag. The pair (`sandbox: false` + `disable_sandbox: true`) is the strongest "production path only" signal the SDK can send.
+
+The agent-side disclosure piece (surfacing "sandbox-masked: test did not exercise real handler" in reports when the agent's own heuristic still fires) is intentionally scoped out — a separate design discussion.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1212,10 +1212,13 @@ RUN OPTIONS (full assessment):
   --file PATH         Run an ad-hoc storyboard YAML (spec evolution)
   --timeout SECONDS   Timeout in seconds (default: 120)
   --brief TEXT        Custom brief for product discovery
-  --no-sandbox        Force account.sandbox=false on every request. The
-                      default leaves sandbox unset (spec-equivalent to false),
-                      but agents that branch on field PRESENCE behave
-                      differently from agents that branch on VALUE.
+  --no-sandbox        Force production-path responses (#841). Sets
+                      account.sandbox=false on every request AND stamps
+                      ext.adcp.disable_sandbox=true to signal adopters
+                      to bypass internal sandbox routing (env-var
+                      fallbacks, brand-domain heuristics, fixture
+                      substitutes). Agents that don't recognize the
+                      ext.adcp.disable_sandbox field ignore it.
 
 WEBHOOK OPTIONS:
   --webhook-receiver [MODE]       Host an ephemeral receiver so expect_webhook*
@@ -1680,7 +1683,7 @@ async function handleStoryboardRun(args) {
       resolvedOauthClientCredentials,
     }),
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.noSandbox && { sandbox: false }),
+    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -2360,7 +2363,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
     result = await runAgainstLocalAgent({
       createAgent,
       storyboards: storyboardsSpec,
-      ...(opts.noSandbox && { runStoryboardOptions: { sandbox: false } }),
+      ...(opts.noSandbox && { runStoryboardOptions: { sandbox: false, disable_sandbox: true } }),
       onStoryboardComplete:
         jsonOutput || format === 'junit'
           ? undefined
@@ -2671,7 +2674,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(opts.allowHttp && { allow_http: true }),
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.noSandbox && { sandbox: false }),
+    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -2838,7 +2841,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(authOption && { auth: authOption }),
     ...(opts.allowHttp && { allow_http: true }),
     ...(webhookReceiverOpts ?? {}),
-    ...(opts.noSandbox && { sandbox: false }),
+    ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
   };
 
   if (!opts.jsonOutput) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -2015,6 +2015,20 @@ async function executeStep(
   // when individual builders or sample_request YAML omit brand.
   request = applyBrandInvariant(request, options, effectiveStep.task);
 
+  // Per-run sandbox-bypass hint (#841). When the operator passes
+  // `--no-sandbox` (or sets `disable_sandbox: true` programmatically), the
+  // runner stamps `ext.adcp.disable_sandbox: true` on every outgoing
+  // request. Adopters that read this field bypass their internal sandbox
+  // routing — env-var fallbacks, brand-domain heuristics, fixture
+  // substitutes — and exercise their real adapter path. Agents that
+  // don't recognize the field ignore it (per spec, `ext` is accepted
+  // without error and not echoed). Gated on the schema check that
+  // `applyBrandInvariant` uses for `account` and `brand` so tools whose
+  // `additionalProperties: false` schema would reject `ext` aren't broken.
+  if (options.disable_sandbox === true) {
+    request = applyDisableSandboxHint(request, effectiveStep.task);
+  }
+
   // Mutating AdCP requests require idempotency_key per spec. Storyboard
   // yamls generally omit it so authors don't have to remember it on every
   // mutating step — mint one here on the runner's behalf, matching how a
@@ -2869,6 +2883,49 @@ export function applyBrandInvariant(
     result.account = resolveAccount(options);
   }
   return result;
+}
+
+/**
+ * Inject `ext.adcp.disable_sandbox: true` into the outgoing request when the
+ * operator passed `--no-sandbox` (or `disable_sandbox: true` programmatically).
+ * Issue #841.
+ *
+ * `ext` is the spec-blessed channel for read-by-agent extensions and is
+ * accepted-without-error on every tool, so the schema check is conservative
+ * — only inject when the tool's request schema permits a top-level `ext`
+ * field. Tools with `additionalProperties: false` that don't list `ext`
+ * would fail strict AJV validation otherwise.
+ *
+ * Merging strategy: preserve any existing `ext.adcp` block the storyboard
+ * fixture or builder authored (e.g. vendor extensions a future scenario
+ * might exercise). The injected `disable_sandbox` flag rides alongside
+ * those rather than overwriting them.
+ */
+export function applyDisableSandboxHint(request: Record<string, unknown>, taskName?: string): Record<string, unknown> {
+  if (taskName && !schemaAllowsTopLevelField(taskName, 'ext')) return request;
+
+  const existingExt = request.ext;
+  const existingExtObj =
+    existingExt != null && typeof existingExt === 'object' && !Array.isArray(existingExt)
+      ? (existingExt as Record<string, unknown>)
+      : {};
+
+  const existingAdcpExt = existingExtObj.adcp;
+  const existingAdcpExtObj =
+    existingAdcpExt != null && typeof existingAdcpExt === 'object' && !Array.isArray(existingAdcpExt)
+      ? (existingAdcpExt as Record<string, unknown>)
+      : {};
+
+  return {
+    ...request,
+    ext: {
+      ...existingExtObj,
+      adcp: {
+        ...existingAdcpExtObj,
+        disable_sandbox: true,
+      },
+    },
+  };
 }
 
 /**

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -166,6 +166,20 @@ export interface TestOptions {
   // sandbox: true. For explicit accounts, discovers sandbox accounts via list_accounts.
   sandbox?: boolean;
   /**
+   * When true, the runner injects `ext.adcp.disable_sandbox: true` on every
+   * outgoing request, signaling the agent under test to bypass any internal
+   * sandbox routing (env-var fallbacks, brand-domain heuristics, fixture
+   * substitutes) and exercise its real adapter path. Distinct from `sandbox`
+   * (which sets `account.sandbox: false` — a value, not a routing hint).
+   *
+   * Honored by adopters who explicitly read `ext.adcp.disable_sandbox`.
+   * Agents that don't recognize the field ignore it (per spec, `ext` is
+   * accepted-without-error). The pair (sandbox=false + disable_sandbox=true)
+   * is the strongest "production path only" signal the runner can send;
+   * `--no-sandbox` on `adcp storyboard run` sets both. Issue #841.
+   */
+  disable_sandbox?: boolean;
+  /**
    * Fictional-entity test-kit data loaded from `test-kits/<name>.yaml`.
    * Storyboard phases may skip based on fields here (e.g. `skip_if: "!test_kit.auth.api_key"`).
    */

--- a/test/lib/storyboard-disable-sandbox-hint.test.js
+++ b/test/lib/storyboard-disable-sandbox-hint.test.js
@@ -1,0 +1,97 @@
+/**
+ * Storyboard runner: ext.adcp.disable_sandbox hint (issue #841).
+ *
+ * When the operator passes `--no-sandbox`, the runner stamps
+ * `ext.adcp.disable_sandbox: true` on every outgoing request so adopters
+ * that read this field bypass internal sandbox routing (env-var
+ * fallbacks, brand-domain heuristics, fixture substitutes) and exercise
+ * their real adapter path.
+ *
+ * This is distinct from the existing `--no-sandbox` behavior of setting
+ * `account.sandbox: false` (a value, not a routing hint). The pair
+ * (sandbox=false + disable_sandbox=true) is the strongest "production
+ * path only" signal the runner can send.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { applyDisableSandboxHint } = require('../../dist/lib/testing/storyboard/runner.js');
+
+describe('applyDisableSandboxHint', () => {
+  test('injects ext.adcp.disable_sandbox=true on a request with no existing ext block', () => {
+    const result = applyDisableSandboxHint({ product_id: 'p1' });
+    assert.deepStrictEqual(result, {
+      product_id: 'p1',
+      ext: { adcp: { disable_sandbox: true } },
+    });
+  });
+
+  test('preserves existing ext fields outside the adcp namespace', () => {
+    const result = applyDisableSandboxHint({
+      product_id: 'p1',
+      ext: { vendor_x: { foo: 'bar' } },
+    });
+    assert.deepStrictEqual(result.ext, {
+      vendor_x: { foo: 'bar' },
+      adcp: { disable_sandbox: true },
+    });
+  });
+
+  test('preserves existing ext.adcp.* keys alongside disable_sandbox', () => {
+    const result = applyDisableSandboxHint({
+      product_id: 'p1',
+      ext: { adcp: { other_hint: true } },
+    });
+    assert.deepStrictEqual(result.ext.adcp, {
+      other_hint: true,
+      disable_sandbox: true,
+    });
+  });
+
+  test('does not mutate the input request', () => {
+    const original = { product_id: 'p1', ext: { adcp: { other_hint: true } } };
+    const snapshot = JSON.parse(JSON.stringify(original));
+    applyDisableSandboxHint(original);
+    assert.deepStrictEqual(original, snapshot, 'input must not be mutated');
+  });
+
+  test('treats non-object ext gracefully (replaces with new object)', () => {
+    // Defensive: a malformed fixture might author `ext: null` or `ext: 'string'`.
+    // The hint must still land cleanly without throwing or coalescing into a
+    // shape that fails AJV validation.
+    const result = applyDisableSandboxHint({ product_id: 'p1', ext: null });
+    assert.deepStrictEqual(result.ext, { adcp: { disable_sandbox: true } });
+
+    const result2 = applyDisableSandboxHint({ product_id: 'p1', ext: 'malformed' });
+    assert.deepStrictEqual(result2.ext, { adcp: { disable_sandbox: true } });
+  });
+
+  test('treats non-object ext.adcp gracefully (replaces with new object)', () => {
+    const result = applyDisableSandboxHint({
+      product_id: 'p1',
+      ext: { adcp: 'not-an-object' },
+    });
+    assert.deepStrictEqual(result.ext.adcp, { disable_sandbox: true });
+  });
+
+  test('injects ext on every AdCP 3.0 tool (ext is standardized at the top level)', () => {
+    // AdCP 3.0.1 standardizes `ext` as a top-level field on every tool's
+    // request schema, so the schema-permits-ext check is permissive in
+    // practice. Spot-check a few representative tools to confirm the hint
+    // lands cleanly across protocol surfaces.
+    for (const taskName of ['get_products', 'comply_test_controller', 'tasks_get', 'si_get_offering']) {
+      const result = applyDisableSandboxHint({ scenario: 'list_scenarios' }, taskName);
+      assert.deepStrictEqual(
+        result.ext?.adcp?.disable_sandbox,
+        true,
+        `${taskName} request should carry ext.adcp.disable_sandbox=true`
+      );
+    }
+  });
+
+  test('runs without taskName (defensive — preserves test-call ergonomics)', () => {
+    const result = applyDisableSandboxHint({ product_id: 'p1' });
+    assert.deepStrictEqual(result.ext.adcp.disable_sandbox, true);
+  });
+});


### PR DESCRIPTION
Closes #841.

## Problem

\`--no-sandbox\` set \`account.sandbox: false\` (a value), but agents with internal sandbox routing — env-var fallbacks, brand-domain heuristics, fixture substitutes — still served sandbox-shaped responses. Compliance passes against the sandbox path; buyer agents break against prod.

Real example from the issue: \`scope3data/agentic-adapters#100\` — real \`buildCreative\` returns \`{ tag_url, tag_type, media_type }\`; sandbox \`handleBuildCreative\` returns \`{ creative_manifest: { format_id, assets } }\`. Compliance never exercised the real shape.

## Fix

\`--no-sandbox\` now ALSO stamps \`ext.adcp.disable_sandbox: true\` on every outgoing request via a new \`applyDisableSandboxHint\` helper in the storyboard runner. Adopters that read this field bypass internal sandbox routing and exercise their real adapter path. Agents that don't recognize the field ignore it (per AdCP 3.0 spec, \`ext\` is accepted-without-error and not echoed).

## Convention rationale

Three options were considered in the issue's deferral comment:

| Convention | Pro | Con |
|---|---|---|
| \`context.disable_sandbox\` | Rides existing envelope | Spec says agents should not parse \`context\` |
| \`X-AdCP-Disable-Sandbox\` header | Clean separation | Per-transport plumbing for MCP + A2A; A2A-over-SSE may not expose per-message headers |
| \`ext.adcp.disable_sandbox\` ← chosen | Spec-blessed channel for read-by-agent extensions; transport-neutral | We're claiming the \`ext.adcp.*\` namespace |

\`ext\` is the only field designed for agents to read AND that's transport-neutral. The \`ext.adcp.*\` namespace is reasonable for the SDK to claim; future spec PRs can formalize.

## What's NOT in this PR

The "sandbox-masked: test did not exercise real handler" report-side disclosure — when the agent's own sandbox heuristic still fires despite the hint — is intentionally scoped out per the deferral comment. Needs agent-side cooperation (response carries \`sandbox_active: true\`) and is a separate design discussion.

## Tests

8 unit tests in \`test/lib/storyboard-disable-sandbox-hint.test.js\`:
- Bare injection on a request with no existing \`ext\`
- Preservation of vendor namespaces in \`ext\`
- Preservation of other \`ext.adcp.*\` keys alongside \`disable_sandbox\`
- Input non-mutation
- Defensive handling of malformed \`ext\` / \`ext.adcp\` shapes
- Multi-tool spot-check across \`get_products\`, \`comply_test_controller\`, \`tasks_get\`, \`si_get_offering\`
- No-taskName ergonomics

## Test plan
- [x] 8 new tests pass
- [x] Adjacent storyboard runner tests pass (132 total in batch)
- [x] \`npm run typecheck\` clean
- [x] CLI help text updated
- [x] Changeset added (patch — additive flag behavior, opt-in for adopters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)