### PR TITLE
fix(client): getAgentInfo() retries on StreamableHTTP session errors (FastMCP compatibility)

### DIFF
--- a/.changeset/fix-fastmcp-streamablehttp-session.md
+++ b/.changeset/fix-fastmcp-streamablehttp-session.md
@@ -18,3 +18,6 @@ Also:
 - New `mcp_transport?: 'streamable_http' | 'sse'` field on `AgentConfig` for
   future caller-side transport hints (matches the `mcp_transport` registry field
   from adcp#3066 Option B); active wiring in the `callMCPTool` path is a follow-up
+- `discoverMCPEndpoint` now appends an actionable hint when all candidates 404
+  with no 401: points operators to register the exact MCP path as `agent_uri`
+  instead of the host root (closes #1234)

--- a/.changeset/fix-fastmcp-streamablehttp-session.md
+++ b/.changeset/fix-fastmcp-streamablehttp-session.md
@@ -1,0 +1,20 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(client): `getAgentInfo()` retries on StreamableHTTP 400 session errors (FastMCP compatibility)
+
+`AdCPClient.getAgentInfo()` now recovers from 400 "Missing session ID" responses
+returned by FastMCP and other stateful StreamableHTTP servers. When `listTools()`
+fails with `StreamableHTTPError`, the client re-initializes with a fresh connection
+and retries once — matching the session-retry logic already present in the
+standard `callMCPTool` path via `withCachedConnection`.
+
+Also:
+- `getAgentInfo()` now propagates `customHeaders` and `debugLogs` into the
+  underlying `connectMCP()` call (previously silently dropped)
+- `connectMCP()` now calls `trackStreamableHTTPUrl()` on a successful connection
+  so subsequent `callMCPTool` calls for the same URL skip the SSE fallback probe
+- New `mcp_transport?: 'streamable_http' | 'sse'` field on `AgentConfig` for
+  future caller-side transport hints (matches the `mcp_transport` registry field
+  from adcp#3066 Option B); active wiring in the `callMCPTool` path is a follow-up

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2682,7 +2682,9 @@ export class SingleAgentClient {
           // complete cleanly. Re-initialize with a fresh connection and retry once.
           if (!(sessionErr instanceof StreamableHTTPError)) throw sessionErr;
           // Auth/authz failures won't be fixed by reconnecting — fast-fail, matching
-          // the guard in withCachedConnection (mcp.ts).
+          // the guard in withCachedConnection (mcp.ts). StreamableHTTPError.code is
+          // always a numeric HTTP status (no string-message fallback needed here, unlike
+          // is401Error which handles generic Error shapes).
           if (sessionErr.code === 401 || sessionErr.code === 403) throw sessionErr;
           debugLogs.push({
             type: 'info',

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -736,7 +736,11 @@ export class SingleAgentClient {
       `Failed to discover MCP endpoint. Tried:\n` +
         uniqueUrls.map((url, i) => `  ${i + 1}. ${url}`).join('\n') +
         '\n' +
-        `None responded to MCP protocol.`
+        `None responded to MCP protocol.\n` +
+        `Hint: this usually means \`agent_uri\` does not include the MCP endpoint path. ` +
+        `The SDK only probes \`/\`, \`/mcp\`, and \`/mcp/\` automatically. ` +
+        `If your server exposes MCP at a different path (e.g. \`/api/mcp\`, \`/adcp/mcp\`), ` +
+        `register that exact path as \`agent_uri\`.`
     );
   }
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2681,6 +2681,9 @@ export class SingleAgentClient {
           // "Missing session ID" if the initial session negotiation didn't
           // complete cleanly. Re-initialize with a fresh connection and retry once.
           if (!(sessionErr instanceof StreamableHTTPError)) throw sessionErr;
+          // Auth/authz failures won't be fixed by reconnecting — fast-fail, matching
+          // the guard in withCachedConnection (mcp.ts).
+          if (sessionErr.code === 401 || sessionErr.code === 403) throw sessionErr;
           debugLogs.push({
             type: 'info',
             message: `MCP: getAgentInfo StreamableHTTP session error (${sessionErr.code}), reconnecting`,
@@ -2689,6 +2692,11 @@ export class SingleAgentClient {
           const { client: retryClient } = await connectMCP(connectOptions);
           try {
             toolsList = await retryClient.listTools();
+          } catch (retryErr) {
+            if (retryErr instanceof Error && sessionErr instanceof Error) {
+              (retryErr as Error & { cause?: unknown }).cause = sessionErr;
+            }
+            throw retryErr;
           } finally {
             retryClient.close().catch(() => {});
           }

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2655,8 +2655,13 @@ export class SingleAgentClient {
 
       // Use the shared connectMCP path so both static bearer AND saved OAuth
       // tokens work. OAuth takes the refresh-capable authProvider branch.
-      const { connectMCP } = await import('../protocols/mcp');
-      const connectOptions: Parameters<typeof connectMCP>[0] = { agentUrl: agent.agent_uri };
+      const { connectMCP, StreamableHTTPError } = await import('../protocols/mcp');
+      const debugLogs: import('../types/adcp').DebugLogEntry[] = [];
+      const connectOptions: Parameters<typeof connectMCP>[0] = {
+        agentUrl: agent.agent_uri,
+        debugLogs,
+        ...(this.normalizedAgent.headers && { customHeaders: this.normalizedAgent.headers }),
+      };
       if (this.normalizedAgent.oauth_tokens) {
         const { createNonInteractiveOAuthProvider } = await import('../auth/oauth');
         connectOptions.authProvider = createNonInteractiveOAuthProvider(this.normalizedAgent, {
@@ -2668,7 +2673,26 @@ export class SingleAgentClient {
 
       const { client: mcpClient } = await connectMCP(connectOptions);
       try {
-        const toolsList = await mcpClient.listTools();
+        let toolsList: Awaited<ReturnType<typeof mcpClient.listTools>>;
+        try {
+          toolsList = await mcpClient.listTools();
+        } catch (sessionErr) {
+          // FastMCP and other stateful StreamableHTTP servers can return 400
+          // "Missing session ID" if the initial session negotiation didn't
+          // complete cleanly. Re-initialize with a fresh connection and retry once.
+          if (!(sessionErr instanceof StreamableHTTPError)) throw sessionErr;
+          debugLogs.push({
+            type: 'info',
+            message: `MCP: getAgentInfo StreamableHTTP session error (${sessionErr.code}), reconnecting`,
+            timestamp: new Date().toISOString(),
+          });
+          const { client: retryClient } = await connectMCP(connectOptions);
+          try {
+            toolsList = await retryClient.listTools();
+          } finally {
+            retryClient.close().catch(() => {});
+          }
+        }
 
         const tools = toolsList.tools.map(tool => ({
           name: tool.name,
@@ -2685,11 +2709,7 @@ export class SingleAgentClient {
           tools,
         };
       } finally {
-        try {
-          await mcpClient.close();
-        } catch {
-          /* ignore */
-        }
+        mcpClient.close().catch(() => {});
       }
     } else if (this.normalizedAgent.protocol === 'a2a') {
       // Use A2A SDK to get agent card

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -19,7 +19,7 @@ import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 
 // Re-export for convenience
-export { UnauthorizedError };
+export { UnauthorizedError, StreamableHTTPError };
 
 /** Response shape returned by MCPClient.callTool(). */
 type CallToolResponse = {
@@ -671,6 +671,7 @@ export async function connectMCP(options: {
 
   try {
     await mcpClient.connect(transport);
+    trackStreamableHTTPUrl(baseUrl.toString());
     debugLogs.push({
       type: 'success',
       message: 'MCP: Connected successfully',

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -503,9 +503,9 @@ export interface AgentConfig {
    * Matches the `mcp_transport` registry field in adcp#3066 (Option B) so
    * AAO-provided hints can be forwarded here directly.
    *
-   * @remarks Field is defined on the type; active wiring for the standard
-   * `callMCPTool` path is a follow-up. Currently only affects the session-
-   * retry guard in `getAgentInfo()`. See adcp-client#1231.
+   * @remarks Field is declared for forward compatibility; no active wiring yet.
+   * Both the `callMCPTool` and `getAgentInfo()` paths will respect this hint
+   * in a follow-up. See adcp-client#1231.
    */
   mcp_transport?: 'streamable_http' | 'sse';
 

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -502,6 +502,10 @@ export interface AgentConfig {
    *
    * Matches the `mcp_transport` registry field in adcp#3066 (Option B) so
    * AAO-provided hints can be forwarded here directly.
+   *
+   * @remarks Field is defined on the type; active wiring for the standard
+   * `callMCPTool` path is a follow-up. Currently only affects the session-
+   * retry guard in `getAgentInfo()`. See adcp-client#1231.
    */
   mcp_transport?: 'streamable_http' | 'sse';
 

--- a/src/lib/types/adcp.ts
+++ b/src/lib/types/adcp.ts
@@ -489,6 +489,23 @@ export interface AgentConfig {
   request_signing?: AgentRequestSigningConfig;
 
   /**
+   * MCP transport hint. When set, skips auto-detection and uses the specified
+   * transport for MCP protocol agents. Omit to use the default auto-detection
+   * (tries StreamableHTTP, falls back to SSE for public addresses).
+   *
+   * Use `'streamable_http'` for FastMCP and other Python MCP servers that
+   * require the StreamableHTTP session-init handshake (`initialize` →
+   * `Mcp-Session-Id` → tool call). Setting this avoids unnecessary SSE
+   * fallback probes when the server is known to require StreamableHTTP.
+   *
+   * Use `'sse'` for legacy servers that only support the SSE transport.
+   *
+   * Matches the `mcp_transport` registry field in adcp#3066 (Option B) so
+   * AAO-provided hints can be forwarded here directly.
+   */
+  mcp_transport?: 'streamable_http' | 'sse';
+
+  /**
    * Pre-connected MCP `Client` for in-process testing without an HTTP loopback server.
    * When present, tool calls are dispatched directly to this client, bypassing URL
    * validation, OAuth refresh, and the connection cache. All client-side pipeline

--- a/test/unit/mcp-get-agent-info-session.test.js
+++ b/test/unit/mcp-get-agent-info-session.test.js
@@ -54,7 +54,9 @@ async function listToolsWithSessionRetry(mcpClient, connectMCP, connectOptions, 
 }
 
 describe('getAgentInfo: StreamableHTTP session retry', () => {
-  const noopConnect = async () => { throw new Error('should not reconnect'); };
+  const noopConnect = async () => {
+    throw new Error('should not reconnect');
+  };
 
   test('returns tools on first try when listTools succeeds', async () => {
     const mockTools = { tools: [{ name: 'get_adcp_capabilities' }] };
@@ -188,30 +190,34 @@ describe('getAgentInfo: StreamableHTTP session retry', () => {
   test('does not retry on 401 StreamableHTTPError (auth failure)', async () => {
     let connectCalled = false;
     const mcpClient = {
-      listTools: async () => { throw new StreamableHTTPError(401, 'Unauthorized'); },
+      listTools: async () => {
+        throw new StreamableHTTPError(401, 'Unauthorized');
+      },
       close: async () => {},
     };
-    const connectMCP = async () => { connectCalled = true; return { client: null }; };
+    const connectMCP = async () => {
+      connectCalled = true;
+      return { client: null };
+    };
 
-    await assert.rejects(
-      () => listToolsWithSessionRetry(mcpClient, connectMCP, {}),
-      { message: 'Unauthorized' }
-    );
+    await assert.rejects(() => listToolsWithSessionRetry(mcpClient, connectMCP, {}), { message: 'Unauthorized' });
     assert.strictEqual(connectCalled, false, '401 should not trigger reconnect');
   });
 
   test('does not retry on 403 StreamableHTTPError (authorization failure)', async () => {
     let connectCalled = false;
     const mcpClient = {
-      listTools: async () => { throw new StreamableHTTPError(403, 'Forbidden'); },
+      listTools: async () => {
+        throw new StreamableHTTPError(403, 'Forbidden');
+      },
       close: async () => {},
     };
-    const connectMCP = async () => { connectCalled = true; return { client: null }; };
+    const connectMCP = async () => {
+      connectCalled = true;
+      return { client: null };
+    };
 
-    await assert.rejects(
-      () => listToolsWithSessionRetry(mcpClient, connectMCP, {}),
-      { message: 'Forbidden' }
-    );
+    await assert.rejects(() => listToolsWithSessionRetry(mcpClient, connectMCP, {}), { message: 'Forbidden' });
     assert.strictEqual(connectCalled, false, '403 should not trigger reconnect');
   });
 
@@ -220,11 +226,15 @@ describe('getAgentInfo: StreamableHTTP session retry', () => {
     const secondErr = new StreamableHTTPError(400, 'Missing session ID again');
 
     const mcpClient = {
-      listTools: async () => { throw firstErr; },
+      listTools: async () => {
+        throw firstErr;
+      },
       close: async () => {},
     };
     const retryClient = {
-      listTools: async () => { throw secondErr; },
+      listTools: async () => {
+        throw secondErr;
+      },
       close: async () => {},
     };
     const connectMCP = async () => ({ client: retryClient });

--- a/test/unit/mcp-get-agent-info-session.test.js
+++ b/test/unit/mcp-get-agent-info-session.test.js
@@ -31,6 +31,8 @@ async function listToolsWithSessionRetry(mcpClient, connectMCP, connectOptions, 
     toolsList = await mcpClient.listTools();
   } catch (sessionErr) {
     if (!(sessionErr instanceof StreamableHTTPError)) throw sessionErr;
+    // Auth/authz failures won't be fixed by reconnecting — fast-fail
+    if (sessionErr.code === 401 || sessionErr.code === 403) throw sessionErr;
     logs.push({
       type: 'info',
       message: `MCP: getAgentInfo StreamableHTTP session error (${sessionErr.code}), reconnecting`,
@@ -39,6 +41,11 @@ async function listToolsWithSessionRetry(mcpClient, connectMCP, connectOptions, 
     const { client: retryClient } = await connectMCP(connectOptions);
     try {
       toolsList = await retryClient.listTools();
+    } catch (retryErr) {
+      if (retryErr instanceof Error && sessionErr instanceof Error) {
+        retryErr.cause = sessionErr;
+      }
+      throw retryErr;
     } finally {
       retryClient.close().catch(() => {});
     }
@@ -47,6 +54,8 @@ async function listToolsWithSessionRetry(mcpClient, connectMCP, connectOptions, 
 }
 
 describe('getAgentInfo: StreamableHTTP session retry', () => {
+  const noopConnect = async () => { throw new Error('should not reconnect'); };
+
   test('returns tools on first try when listTools succeeds', async () => {
     const mockTools = { tools: [{ name: 'get_adcp_capabilities' }] };
     const mcpClient = {
@@ -54,7 +63,7 @@ describe('getAgentInfo: StreamableHTTP session retry', () => {
       close: async () => {},
     };
 
-    const result = await listToolsWithSessionRetry(mcpClient, null, {});
+    const result = await listToolsWithSessionRetry(mcpClient, noopConnect, {});
     assert.deepStrictEqual(result, mockTools);
   });
 
@@ -174,6 +183,60 @@ describe('getAgentInfo: StreamableHTTP session retry', () => {
     assert.strictEqual(logs.length, 1);
     assert.ok(logs[0].message.includes('reconnecting'), 'log should mention reconnecting');
     assert.ok(logs[0].message.includes('400'), 'log should include the status code');
+  });
+
+  test('does not retry on 401 StreamableHTTPError (auth failure)', async () => {
+    let connectCalled = false;
+    const mcpClient = {
+      listTools: async () => { throw new StreamableHTTPError(401, 'Unauthorized'); },
+      close: async () => {},
+    };
+    const connectMCP = async () => { connectCalled = true; return { client: null }; };
+
+    await assert.rejects(
+      () => listToolsWithSessionRetry(mcpClient, connectMCP, {}),
+      { message: 'Unauthorized' }
+    );
+    assert.strictEqual(connectCalled, false, '401 should not trigger reconnect');
+  });
+
+  test('does not retry on 403 StreamableHTTPError (authorization failure)', async () => {
+    let connectCalled = false;
+    const mcpClient = {
+      listTools: async () => { throw new StreamableHTTPError(403, 'Forbidden'); },
+      close: async () => {},
+    };
+    const connectMCP = async () => { connectCalled = true; return { client: null }; };
+
+    await assert.rejects(
+      () => listToolsWithSessionRetry(mcpClient, connectMCP, {}),
+      { message: 'Forbidden' }
+    );
+    assert.strictEqual(connectCalled, false, '403 should not trigger reconnect');
+  });
+
+  test('chains original sessionErr as .cause when retry also fails', async () => {
+    const firstErr = new StreamableHTTPError(400, 'Missing session ID');
+    const secondErr = new StreamableHTTPError(400, 'Missing session ID again');
+
+    const mcpClient = {
+      listTools: async () => { throw firstErr; },
+      close: async () => {},
+    };
+    const retryClient = {
+      listTools: async () => { throw secondErr; },
+      close: async () => {},
+    };
+    const connectMCP = async () => ({ client: retryClient });
+
+    let thrown;
+    try {
+      await listToolsWithSessionRetry(mcpClient, connectMCP, {});
+    } catch (e) {
+      thrown = e;
+    }
+    assert.strictEqual(thrown, secondErr);
+    assert.strictEqual(thrown.cause, firstErr, 'retry error should have original as .cause');
   });
 
   test('connectOptions are forwarded to the retry connectMCP call', async () => {

--- a/test/unit/mcp-get-agent-info-session.test.js
+++ b/test/unit/mcp-get-agent-info-session.test.js
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for getAgentInfo() StreamableHTTP session retry logic (issue #1231).
+ *
+ * FastMCP and other stateful StreamableHTTP servers return 400 "Missing session
+ * ID" when a tool call arrives before the session is established. The fix adds a
+ * single retry with a fresh connectMCP() call inside getAgentInfo(). These tests
+ * replicate the retry loop in isolation (same technique as mcp-discovery-sse-fallback.test.js).
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+// Mirror StreamableHTTPError shape — tests do NOT import from the SDK directly
+// so this file stays a pure unit test with no real HTTP.
+class StreamableHTTPError extends Error {
+  constructor(code, message) {
+    super(message ?? `StreamableHTTP error: HTTP ${code}`);
+    this.name = 'StreamableHTTPError';
+    this.code = code;
+  }
+}
+
+/**
+ * Replicates the listTools-with-session-retry block from getAgentInfo().
+ * Injectable so we can exercise the decision logic without a real MCPClient.
+ */
+async function listToolsWithSessionRetry(mcpClient, connectMCP, connectOptions, debugLogs) {
+  const logs = debugLogs ?? [];
+  let toolsList;
+  try {
+    toolsList = await mcpClient.listTools();
+  } catch (sessionErr) {
+    if (!(sessionErr instanceof StreamableHTTPError)) throw sessionErr;
+    logs.push({
+      type: 'info',
+      message: `MCP: getAgentInfo StreamableHTTP session error (${sessionErr.code}), reconnecting`,
+      timestamp: new Date().toISOString(),
+    });
+    const { client: retryClient } = await connectMCP(connectOptions);
+    try {
+      toolsList = await retryClient.listTools();
+    } finally {
+      retryClient.close().catch(() => {});
+    }
+  }
+  return toolsList;
+}
+
+describe('getAgentInfo: StreamableHTTP session retry', () => {
+  test('returns tools on first try when listTools succeeds', async () => {
+    const mockTools = { tools: [{ name: 'get_adcp_capabilities' }] };
+    const mcpClient = {
+      listTools: async () => mockTools,
+      close: async () => {},
+    };
+
+    const result = await listToolsWithSessionRetry(mcpClient, null, {});
+    assert.deepStrictEqual(result, mockTools);
+  });
+
+  test('retries with fresh connection on StreamableHTTPError(400) "Missing session ID"', async () => {
+    const mockTools = { tools: [{ name: 'get_products', description: 'List products' }] };
+    let reconnectCount = 0;
+
+    const mcpClient = {
+      listTools: async () => {
+        throw new StreamableHTTPError(400, 'Missing session ID');
+      },
+      close: async () => {},
+    };
+
+    const retryClient = {
+      listTools: async () => mockTools,
+      close: async () => {},
+    };
+
+    const connectMCP = async () => {
+      reconnectCount++;
+      return { client: retryClient };
+    };
+
+    const result = await listToolsWithSessionRetry(mcpClient, connectMCP, {});
+    assert.deepStrictEqual(result, mockTools);
+    assert.strictEqual(reconnectCount, 1, 'should reconnect exactly once');
+  });
+
+  test('retries on any StreamableHTTPError code, not only 400', async () => {
+    const mockTools = { tools: [] };
+    let reconnected = false;
+
+    const mcpClient = {
+      listTools: async () => {
+        throw new StreamableHTTPError(404, 'Session not found');
+      },
+      close: async () => {},
+    };
+
+    const retryClient = {
+      listTools: async () => mockTools,
+      close: async () => {},
+    };
+
+    const connectMCP = async () => {
+      reconnected = true;
+      return { client: retryClient };
+    };
+
+    await listToolsWithSessionRetry(mcpClient, connectMCP, {});
+    assert.strictEqual(reconnected, true, 'should reconnect on 404 as well');
+  });
+
+  test('propagates non-StreamableHTTPError without retrying', async () => {
+    const networkErr = new Error('ECONNREFUSED');
+    let connectCalled = false;
+
+    const mcpClient = {
+      listTools: async () => {
+        throw networkErr;
+      },
+      close: async () => {},
+    };
+
+    const connectMCP = async () => {
+      connectCalled = true;
+      return { client: { listTools: async () => ({ tools: [] }), close: async () => {} } };
+    };
+
+    await assert.rejects(() => listToolsWithSessionRetry(mcpClient, connectMCP, {}), networkErr);
+    assert.strictEqual(connectCalled, false, 'should not reconnect for non-StreamableHTTPError');
+  });
+
+  test('propagates error when retry also fails', async () => {
+    const retryErr = new StreamableHTTPError(400, 'Missing session ID');
+
+    const mcpClient = {
+      listTools: async () => {
+        throw new StreamableHTTPError(400, 'Missing session ID');
+      },
+      close: async () => {},
+    };
+
+    const retryClient = {
+      listTools: async () => {
+        throw retryErr;
+      },
+      close: async () => {},
+    };
+
+    const connectMCP = async () => ({ client: retryClient });
+
+    await assert.rejects(() => listToolsWithSessionRetry(mcpClient, connectMCP, {}), {
+      message: 'Missing session ID',
+    });
+  });
+
+  test('debug log is emitted on session retry', async () => {
+    const logs = [];
+
+    const mcpClient = {
+      listTools: async () => {
+        throw new StreamableHTTPError(400, 'Missing session ID');
+      },
+      close: async () => {},
+    };
+
+    const retryClient = {
+      listTools: async () => ({ tools: [] }),
+      close: async () => {},
+    };
+
+    const connectMCP = async () => ({ client: retryClient });
+
+    await listToolsWithSessionRetry(mcpClient, connectMCP, {}, logs);
+    assert.strictEqual(logs.length, 1);
+    assert.ok(logs[0].message.includes('reconnecting'), 'log should mention reconnecting');
+    assert.ok(logs[0].message.includes('400'), 'log should include the status code');
+  });
+
+  test('connectOptions are forwarded to the retry connectMCP call', async () => {
+    let receivedOptions;
+    const opts = { agentUrl: 'https://example.com', authToken: 'tok', customHeaders: { 'x-org': '1' } };
+
+    const mcpClient = {
+      listTools: async () => {
+        throw new StreamableHTTPError(400, 'Missing session ID');
+      },
+      close: async () => {},
+    };
+
+    const retryClient = {
+      listTools: async () => ({ tools: [] }),
+      close: async () => {},
+    };
+
+    const connectMCP = async options => {
+      receivedOptions = options;
+      return { client: retryClient };
+    };
+
+    await listToolsWithSessionRetry(mcpClient, connectMCP, opts);
+    assert.deepStrictEqual(receivedOptions, opts, 'retry should use the same connectOptions');
+  });
+});


### PR DESCRIPTION
Closes #1231

## Summary

`AdCPClient.getAgentInfo()` used `connectMCP()` with no post-connect retry logic. FastMCP and other stateful StreamableHTTP servers can return HTTP 400 "Missing session ID" on `listTools()` after a successful `initialize` handshake (e.g., when a load balancer routes the two requests to different process instances that don't share session state). The error propagated bare with no recovery path.

The standard `callMCPTool` path already handles this case via `withCachedConnection`'s evict-and-retry loop. This PR brings `getAgentInfo()` to parity.

**Changes:**
- `SingleAgentClient.ts` — `getAgentInfo()` MCP path: catch `StreamableHTTPError` from `listTools()`, re-`connectMCP()` with a fresh session, retry once. 401/403 fast-fail before reconnect (auth failures are not recoverable by reconnecting — matches `withCachedConnection` guard at `mcp.ts:209`). `sessionErr` is chained as `retryErr.cause` on double-failure, matching `withCachedConnection` diagnostic parity.
- `SingleAgentClient.ts` — propagates `customHeaders` and `debugLogs` into `connectOptions` (previously silently dropped).
- `mcp.ts` — `connectMCP()` now calls `trackStreamableHTTPUrl()` on success so subsequent `callMCPTool` calls to the same URL skip the SSE fallback probe.
- `mcp.ts` — re-exports `StreamableHTTPError` for use by consumers.
- `adcp.ts` — adds `mcp_transport?: 'streamable_http' | 'sse'` to `AgentConfig`. Field is defined for forward compatibility and aligns with the `mcp_transport` registry field from adcp#3066 (Option B). Active wiring for the `callMCPTool` path is a follow-up.

## What was tested

- `node --test test/unit/mcp-get-agent-info-session.test.js` — **10/10 pass** (new tests cover: success no-retry, 400 retry, any-code retry, 401 fast-fail, 403 fast-fail, non-`StreamableHTTPError` no-retry, double-failure with cause chain, debug log, connectOptions forwarding)
- `npx tsc --project tsconfig.lib.json --noEmit` — pre-existing TS2688/TS5107 env errors only; no new type errors from these changes
- Existing MCP unit tests: all previously-passing tests still pass

## Nits noted (not fixed)

- `test/unit/mcp-get-agent-info-session.test.js` uses a local `StreamableHTTPError` stub rather than importing from the real SDK. Tests validate the retry logic correctly; a structural mismatch with the SDK class would require an integration test to catch and is out of scope here.
- `mcp_transport` wiring in `callMCPTool` path deferred (noted in JSDoc `@remarks`).

## Pre-PR review

- **code-reviewer**: approved — no resource leaks, `Awaited<ReturnType>` pattern correct, 401/403 guard resolves previous blocker, cause-chaining added, nits noted above
- **ad-tech-protocol-expert**: approved — 401/403 guard spec-compliant (retrying session errors is correct per MCP §6.1; auth errors should fast-fail); cause-chaining correctly positioned; 429/503 handling belongs at a higher call site

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017GhLX3ZU8z7dFWarSxp1Nw

---
_Generated by [Claude Code](https://claude.ai/code/session_017GhLX3ZU8z7dFWarSxp1Nw)_