### PR TITLE
feat(server): definePlatform/defineSalesPlatform helpers — fix req: unknown in typed-platform handlers

### DIFF
--- a/.changeset/platform-define-helpers.md
+++ b/.changeset/platform-define-helpers.md
@@ -1,0 +1,45 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): add `definePlatform` / `defineSalesPlatform` / `defineAudiencePlatform` (and one per remaining specialism) identity helpers
+
+Fixes the TypeScript contextual-typing gap that caused handler method parameters to
+resolve as `req: unknown` when a `DecisioningPlatform` (or sub-interface) was built as
+an object literal and passed directly to `createAdcpServerFromPlatform`.
+
+Root cause: `createAdcpServerFromPlatform<P extends DecisioningPlatform<any,any>>(platform: P & ...)`
+infers `P` from the argument rather than using the constraint for contextual typing, so
+nested method parameters (`req`, `ctx`) can't be contextually typed from the interface.
+
+The helpers are pure identity functions that force a concrete `DecisioningPlatform<TConfig, TCtxMeta>`
+(or per-specialism sub-interface) as the declared parameter type, giving TypeScript the
+annotation it needs:
+
+```ts
+// Before — req: unknown, 16 manual casts
+createAdcpServerFromPlatform({
+  sales: {
+    syncEventSources: async (req, ctx) => {
+      const sources = ((req as { event_sources?: unknown[] }).event_sources ?? [])...
+    }
+  }
+}, opts);
+
+// After — req: SyncEventSourcesRequest ✓, ctx.account.ctx_metadata: SocialMeta ✓
+createAdcpServerFromPlatform({
+  sales: defineSalesPlatform<SocialMeta>({
+    syncEventSources: async (req, ctx) => {
+      const sources = req.event_sources ?? [];  // no cast
+    }
+  })
+}, opts);
+```
+
+The class pattern with explicit property-type annotations (`sales: SalesPlatform<Meta> = {...}`)
+continues to work without any helper. The helpers are the object-literal escape hatch.
+
+Also fixes a misleading note in `skills/build-seller-agent/specialisms/sales-social.md` that
+described handler-bag grouping for the legacy `createAdcpServer` path, which steered LLM
+adopters toward `req: unknown` handlers instead of the typed platform interface. Replaced
+with the `createAdcpServerFromPlatform` method-mapping table.

--- a/skills/build-seller-agent/specialisms/sales-social.md
+++ b/skills/build-seller-agent/specialisms/sales-social.md
@@ -18,7 +18,6 @@ Storyboard: `social_platform` (category `sales_social`, track `audiences`).
 - `sync_accounts` with `account_scope`, `payment_terms`, `setup` fields — advertiser onboarding with identity verification setup_url when pending
 - `list_accounts` with brand filter — buyers listing their accounts on your platform
 - `sync_audiences` → returns `{ audiences: [{ audience_id, name, status: 'active', action: 'created' }] }` — buyer pushes audience segment definitions for platform match
-- `sync_catalogs` → product catalog push for dynamic product ads (Meta DPA, Snap Dynamic Ads, TikTok Dynamic Showcase). The storyboard's catalog-item macros (`{SKU}`, `{GTIN}`) resolve per-impression at render time.
 - `sync_creatives` for platform-native assemblies with `{ creative_id, action, status: 'pending_review' }` — image + headline + description slots assembled into the native unit
 - `log_event` → returns `{ events: [{ event_id, status: 'accepted' }] }` — server-side conversion events for attribution / optimization
 - `get_account_financials` → returns `{ account, financials: { currency, current_spend, remaining_balance, payment_status } }` — prepaid-balance monitoring typical of walled gardens

--- a/skills/build-seller-agent/specialisms/sales-social.md
+++ b/skills/build-seller-agent/specialisms/sales-social.md
@@ -28,12 +28,32 @@ Storyboard: `social_platform` (category `sales_social`, track `audiences`).
 | Wire tool | Platform field | Method |
 |---|---|---|
 | `sync_audiences` | `audiences` (`AudiencePlatform<TCtxMeta>`) | `audiences.syncAudiences` |
-| `sync_catalogs` | `sales` (`SalesPlatform<TCtxMeta>`) | `sales.syncCatalogs` |
-| `log_event` | `sales` | `sales.logEvent` |
+| `log_event` | `sales` (`SalesPlatform<TCtxMeta>`) | `sales.logEvent` |
 | `sync_event_sources` | `sales` | `sales.syncEventSources` |
 | `get_account_financials` | `accounts` (`AccountStore<TCtxMeta>`) | `accounts.getAccountFinancials` |
 | `sync_accounts` | `accounts` | `accounts.upsert` |
 
-Declare `TCtxMeta` once as your advertiser-metadata shape (e.g., `interface SocialMeta { advertiserId: string; pixelId: string }`) on `DecisioningPlatform<Config, SocialMeta>` and every handler's `ctx.account.ctx_metadata` is fully typed — no casts needed. Use `defineSalesPlatform<SocialMeta>({...})` or `defineAudiencePlatform<SocialMeta>({...})` when building inline (object literal) rather than as a class to preserve typed `req` parameters in handler bodies.
+(`sync_catalogs` → `sales.syncCatalogs` is only needed if you also claim `sales-catalog-driven` / `sales-retail-media` for DPA support.)
+
+Declare `TCtxMeta` once as your advertiser-metadata shape (e.g., `interface SocialMeta { advertiserId: string; pixelId: string }`) on `DecisioningPlatform<Config, SocialMeta>` and every handler's `ctx.account.ctx_metadata` is fully typed — no casts needed.
+
+When building inline with object literals, wrap both sub-objects with typed helpers to preserve typed `req` parameters in handler bodies:
+
+```ts
+createAdcpServerFromPlatform({
+  capabilities: { specialisms: ['sales-social', 'sales-non-guaranteed', 'audience-sync'] as const, ... },
+  accounts: { resolve: async (ref) => ..., upsert: async (refs) => ..., getAccountFinancials: async (req, ctx) => ... },
+  sales: defineSalesPlatform<SocialMeta>({
+    getProducts: async (req, ctx) => ...,  // req: GetProductsRequest ✓
+    syncEventSources: async (req, ctx) => { const sources = req.event_sources ?? []; ... },
+    logEvent: async (req, ctx) => ...,
+    // ... other sales methods
+  }),
+  audiences: defineAudiencePlatform<SocialMeta>({
+    syncAudiences: async (audiences, ctx) => { /* audiences: Audience[] ✓ */ },
+    pollAudienceStatuses: async (ids, ctx) => ...,
+  }),
+}, opts);
+```
 
 **Don't** rip out `get_products` or `create_media_buy` when adding `sales-social` — you need them. The failure mode from doing so: buyers who discover your agent via `get_adcp_capabilities` expecting a media-buy seller hit immediate compliance failures when every baseline storyboard fails with "tool not registered," and your entire `sales-non-guaranteed` bundle regresses to 0/N passing.

--- a/skills/build-seller-agent/specialisms/sales-social.md
+++ b/skills/build-seller-agent/specialisms/sales-social.md
@@ -23,6 +23,17 @@ Storyboard: `social_platform` (category `sales_social`, track `audiences`).
 - `log_event` → returns `{ events: [{ event_id, status: 'accepted' }] }` — server-side conversion events for attribution / optimization
 - `get_account_financials` → returns `{ account, financials: { currency, current_spend, remaining_balance, payment_status } }` — prepaid-balance monitoring typical of walled gardens
 
-**Handler grouping in `createAdcpServer`:** `sync_audiences`, `sync_catalogs`, and `log_event` live under `eventTracking`, NOT `mediaBuy`. `get_account_financials` and `sync_accounts` live under `accounts`. Baseline `get_products`/`create_media_buy`/etc. stay under `mediaBuy`.
+**Method mapping in `createAdcpServerFromPlatform`:** every `sales-social` tool maps to a typed method on the platform object — no manual handler-bag grouping required:
+
+| Wire tool | Platform field | Method |
+|---|---|---|
+| `sync_audiences` | `audiences` (`AudiencePlatform<TCtxMeta>`) | `audiences.syncAudiences` |
+| `sync_catalogs` | `sales` (`SalesPlatform<TCtxMeta>`) | `sales.syncCatalogs` |
+| `log_event` | `sales` | `sales.logEvent` |
+| `sync_event_sources` | `sales` | `sales.syncEventSources` |
+| `get_account_financials` | `accounts` (`AccountStore<TCtxMeta>`) | `accounts.getAccountFinancials` |
+| `sync_accounts` | `accounts` | `accounts.upsert` |
+
+Declare `TCtxMeta` once as your advertiser-metadata shape (e.g., `interface SocialMeta { advertiserId: string; pixelId: string }`) on `DecisioningPlatform<Config, SocialMeta>` and every handler's `ctx.account.ctx_metadata` is fully typed — no casts needed. Use `defineSalesPlatform<SocialMeta>({...})` or `defineAudiencePlatform<SocialMeta>({...})` when building inline (object literal) rather than as a class to preserve typed `req` parameters in handler bodies.
 
 **Don't** rip out `get_products` or `create_media_buy` when adding `sales-social` — you need them. The failure mode from doing so: buyers who discover your agent via `get_adcp_capabilities` expecting a media-buy seller hit immediate compliance failures when every baseline storyboard fails with "tool not registered," and your entire `sales-non-guaranteed` bundle regresses to 0/N passing.

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -22,7 +22,7 @@ import type {
   SalesPlatform,
   AudiencePlatform,
 } from './index';
-import { AdcpError, AccountNotFoundError } from './index';
+import { AdcpError, AccountNotFoundError, defineSalesPlatform, defineAudiencePlatform } from './index';
 
 // ── AdcpError construction ────────────────────────────────────────────
 
@@ -251,6 +251,29 @@ type _missing_sales_required =
   RequiredPlatformsFor<'sales-non-guaranteed'> extends infer R ? (R extends { sales: unknown } ? true : false) : false;
 const _check_sales_required: _missing_sales_required = true;
 
+// ── Platform identity helpers — defineSalesPlatform / defineAudiencePlatform ─
+
+interface _SocialMeta {
+  advertiserId: string;
+  pixelId: string;
+}
+
+// Positive: defineSalesPlatform<TCtxMeta> is pure identity — input type equals output type.
+function _define_sales_platform_identity(p: SalesPlatform<_SocialMeta>): SalesPlatform<_SocialMeta> {
+  return defineSalesPlatform<_SocialMeta>(p);
+}
+
+// Positive: defineAudiencePlatform<TCtxMeta> is pure identity.
+function _define_audience_platform_identity(p: AudiencePlatform<_SocialMeta>): AudiencePlatform<_SocialMeta> {
+  return defineAudiencePlatform<_SocialMeta>(p);
+}
+
+// Negative: defineAudiencePlatform rejects a method typed as a non-function.
+function _define_audience_platform_rejects_wrong_shape() {
+  // @ts-expect-error — syncAudiences must be a function, not a string.
+  return defineAudiencePlatform<_SocialMeta>({ syncAudiences: 'not-a-function' });
+}
+
 // Reference all symbols once so eslint-disable is targeted.
 export const _references = [
   _adcp_error_minimum,
@@ -278,4 +301,7 @@ export const _references = [
   _check_sales_required,
   _check_brand_rights_requires_brand,
   _check_sales_no_required_caps,
+  _define_sales_platform_identity,
+  _define_audience_platform_identity,
+  _define_audience_platform_rejects_wrong_shape,
 ] as const;

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -230,6 +230,28 @@ export {
 export { batchPoll, validationError, upstreamError } from './helpers';
 export type { RequestShape } from './helpers';
 
+// Platform identity helpers — fix TypeScript's contextual-typing gap when
+// building a DecisioningPlatform (or sub-interface) as an object literal.
+// Without these, `createAdcpServerFromPlatform({ sales: { syncEventSources:
+// async (req, ctx) => {...} } })` gives `req: unknown` because the generic
+// `P extends DecisioningPlatform<any,any>` is inferred, not declared.
+// Wrapping the sub-object with e.g. `defineSalesPlatform<MyMeta>({...})`
+// forces the concrete type annotation TypeScript needs. The helpers are
+// pure identity functions — zero runtime cost.
+export {
+  definePlatform,
+  defineSalesPlatform,
+  defineAudiencePlatform,
+  defineSignalsPlatform,
+  defineCreativeBuilderPlatform,
+  defineCreativeAdServerPlatform,
+  defineCampaignGovernancePlatform,
+  defineContentStandardsPlatform,
+  definePropertyListsPlatform,
+  defineCollectionListsPlatform,
+  defineBrandRightsPlatform,
+} from './platform-helpers';
+
 // Wire-shape assembly helpers — emit correct Product / PricingOption /
 // package shapes from intent-shaped input. Reduces 30+ lines of wire
 // boilerplate per resource. Used in slim skill examples so LLMs scaffold

--- a/src/lib/server/decisioning/platform-helpers.ts
+++ b/src/lib/server/decisioning/platform-helpers.ts
@@ -1,0 +1,230 @@
+/**
+ * Identity helpers for `createAdcpServerFromPlatform` adopters who build their
+ * platform as an object literal rather than a class.
+ *
+ * **The problem they solve:**
+ *
+ * `createAdcpServerFromPlatform<P extends DecisioningPlatform<any, any>>(platform: P)`
+ * infers `P` from the argument, which defeats TypeScript's contextual typing for
+ * method parameters inside nested object literals. Without an explicit type annotation,
+ * a handler like `syncEventSources: async (req, ctx) => {...}` gets `req: unknown`.
+ *
+ * These helpers force a concrete `DecisioningPlatform<TConfig, TCtxMeta>` (or
+ * per-specialism sub-interface) as the argument type, giving TypeScript the
+ * annotation it needs to flow types into nested method bodies:
+ *
+ * ```ts
+ * // Without helper — req: unknown
+ * createAdcpServerFromPlatform({
+ *   sales: { syncEventSources: async (req, ctx) => { req.event_sources } }
+ * }, opts);
+ *
+ * // With defineSalesPlatform — req: SyncEventSourcesRequest ✓
+ * createAdcpServerFromPlatform({
+ *   sales: defineSalesPlatform<MyMeta>({
+ *     syncEventSources: async (req, ctx) => { req.event_sources }
+ *   })
+ * }, opts);
+ * ```
+ *
+ * Alternatively, the class pattern with explicit property-type annotations achieves
+ * the same result without helpers:
+ *
+ * ```ts
+ * class MySeller implements DecisioningPlatform<Config, MyMeta> {
+ *   sales: SalesPlatform<MyMeta> = {
+ *     syncEventSources: async (req, ctx) => { req.event_sources } // req typed ✓
+ *   };
+ * }
+ * ```
+ *
+ * Use whichever pattern fits your codebase.
+ *
+ * @public
+ */
+
+import type { DecisioningPlatform } from './platform';
+import type { SalesPlatform } from './specialisms/sales';
+import type { AudiencePlatform } from './specialisms/audiences';
+import type { SignalsPlatform } from './specialisms/signals';
+import type { CreativeBuilderPlatform } from './specialisms/creative';
+import type { CreativeAdServerPlatform } from './specialisms/creative-ad-server';
+import type { CampaignGovernancePlatform } from './specialisms/campaign-governance';
+import type { ContentStandardsPlatform } from './specialisms/content-standards';
+import type { BrandRightsPlatform } from './specialisms/brand-rights';
+import type { PropertyListsPlatform, CollectionListsPlatform } from './specialisms/lists';
+
+/**
+ * Type-level identity for a full `DecisioningPlatform` object literal.
+ *
+ * Fixes TypeScript's contextual-typing gap when passing an object literal
+ * directly to `createAdcpServerFromPlatform`. Wrap your platform object with
+ * this helper to get typed `req` and `ctx` parameters in every handler body.
+ *
+ * @example
+ * ```ts
+ * import { createAdcpServerFromPlatform, definePlatform } from '@adcp/sdk/server';
+ *
+ * interface MyMeta { advertiserId: string }
+ *
+ * const server = createAdcpServerFromPlatform(
+ *   definePlatform<{ networkId: string }, MyMeta>({
+ *     capabilities: { specialisms: ['sales-non-guaranteed'], ... },
+ *     accounts: { resolve: async (ref) => ... },
+ *     sales: {
+ *       getProducts: async (req, ctx) => {
+ *         // req: GetProductsRequest ✓  ctx.account.ctx_metadata: MyMeta ✓
+ *       },
+ *     },
+ *   }),
+ *   { name: 'my-seller', version: '1.0.0' }
+ * );
+ * ```
+ */
+export function definePlatform<TConfig = unknown, TCtxMeta = Record<string, unknown>>(
+  platform: DecisioningPlatform<TConfig, TCtxMeta>
+): DecisioningPlatform<TConfig, TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `SalesPlatform` sub-object.
+ *
+ * Use this to type-annotate the `sales` property when building inline rather
+ * than with a class. Every handler method (`getProducts`, `createMediaBuy`,
+ * `syncEventSources`, etc.) gets its proper typed `req` parameter.
+ *
+ * @example
+ * ```ts
+ * import { createAdcpServerFromPlatform, defineSalesPlatform } from '@adcp/sdk/server';
+ *
+ * interface SocialMeta { advertiserId: string; pixelId: string }
+ *
+ * const server = createAdcpServerFromPlatform({
+ *   capabilities: { specialisms: ['sales-social', 'sales-non-guaranteed'], ... },
+ *   accounts: { resolve: async (ref) => ... },
+ *   sales: defineSalesPlatform<SocialMeta>({
+ *     getProducts: async (req, ctx) => { ... },
+ *     createMediaBuy: async (req, ctx) => { ... },
+ *     // req is fully typed throughout ✓
+ *     syncEventSources: async (req, ctx) => {
+ *       const sources = req.event_sources ?? [];  // no cast needed
+ *     },
+ *   }),
+ * }, { name: 'social-seller', version: '1.0.0' });
+ * ```
+ */
+export function defineSalesPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: SalesPlatform<TCtxMeta>
+): SalesPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for an `AudiencePlatform` sub-object.
+ *
+ * Use when the `audiences` field is built inline. Ensures `audiences` and
+ * `audienceIds` parameters are typed rather than inferred as `unknown`.
+ *
+ * @example
+ * ```ts
+ * audiences: defineAudiencePlatform<SocialMeta>({
+ *   syncAudiences: async (audiences, ctx) => {
+ *     // audiences: Audience[] ✓  ctx.account.ctx_metadata: SocialMeta ✓
+ *   },
+ *   pollAudienceStatuses: async (audienceIds, ctx) => { ... },
+ * }),
+ * ```
+ */
+export function defineAudiencePlatform<TCtxMeta = Record<string, unknown>>(
+  platform: AudiencePlatform<TCtxMeta>
+): AudiencePlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `SignalsPlatform` sub-object.
+ *
+ * @example
+ * ```ts
+ * signals: defineSignalsPlatform<SignalsMeta>({
+ *   getSignals: async (req, ctx) => { ... },
+ *   activateSignal: async (req, ctx) => { ... },
+ * }),
+ * ```
+ */
+export function defineSignalsPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: SignalsPlatform<TCtxMeta>
+): SignalsPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `CreativeBuilderPlatform` sub-object.
+ *
+ * @example
+ * ```ts
+ * creative: defineCreativeBuilderPlatform<CreativeMeta>({
+ *   buildCreative: async (req, ctx) => { ... },
+ * }),
+ * ```
+ */
+export function defineCreativeBuilderPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: CreativeBuilderPlatform<TCtxMeta>
+): CreativeBuilderPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `CreativeAdServerPlatform` sub-object.
+ */
+export function defineCreativeAdServerPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: CreativeAdServerPlatform<TCtxMeta>
+): CreativeAdServerPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `CampaignGovernancePlatform` sub-object.
+ */
+export function defineCampaignGovernancePlatform<TCtxMeta = Record<string, unknown>>(
+  platform: CampaignGovernancePlatform<TCtxMeta>
+): CampaignGovernancePlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `ContentStandardsPlatform` sub-object.
+ */
+export function defineContentStandardsPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: ContentStandardsPlatform<TCtxMeta>
+): ContentStandardsPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `PropertyListsPlatform` sub-object.
+ */
+export function definePropertyListsPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: PropertyListsPlatform<TCtxMeta>
+): PropertyListsPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `CollectionListsPlatform` sub-object.
+ */
+export function defineCollectionListsPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: CollectionListsPlatform<TCtxMeta>
+): CollectionListsPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `BrandRightsPlatform` sub-object.
+ */
+export function defineBrandRightsPlatform<TCtxMeta = Record<string, unknown>>(
+  platform: BrandRightsPlatform<TCtxMeta>
+): BrandRightsPlatform<TCtxMeta> {
+  return platform;
+}


### PR DESCRIPTION
Refs #1235

## Summary

Fixes the TypeScript contextual-typing gap that caused handler method parameters to resolve as `req: unknown` when a `DecisioningPlatform` (or sub-interface) was built as an object literal and passed directly to `createAdcpServerFromPlatform`. A `sales_social` matrix validation run produced 16 manual `as { ... }` coercions in a 743-line `server.ts`; this PR eliminates the need for all of them.

**Root cause:** `createAdcpServerFromPlatform<P>(platform: P & ...)` infers `P` from the argument instead of using the constraint for contextual typing. TypeScript can't backpropagate parameter types into nested method bodies from a generic constraint.

**Fix (non-breaking):** Ten pure identity functions — one per platform sub-interface — that force a concrete parameter type at the call site:

```ts
// Before — req: unknown, 16 manual as-casts
createAdcpServerFromPlatform({
  sales: {
    syncEventSources: async (req, ctx) => {
      const sources = ((req as { event_sources?: unknown[] }).event_sources ?? []) as Array<{ ... }>;
    }
  }
}, opts);

// After — req: SyncEventSourcesRequest ✓, ctx.account.ctx_metadata: SocialMeta ✓
createAdcpServerFromPlatform({
  sales: defineSalesPlatform({
    syncEventSources: async (req, ctx) => {
      const sources = req.event_sources ?? [];  // no cast
    }
  }),
  audiences: defineAudiencePlatform({
    syncAudiences: async (audiences, ctx) => { ... },  // audiences: Audience[] ✓
  }),
}, opts);
```

The class pattern with explicit property-type annotations (`sales: SalesPlatform = { ... }`) continues to work unchanged. These helpers are the object-literal escape hatch.

**Also:** The `skills/build-seller-agent/specialisms/sales-social.md` had a note describing handler-bag grouping for the legacy `createAdcpServer` path. This actively steered LLM adopters toward the v5 lower-level path (where all `req` parameters are `unknown`) rather than the typed platform surface. Replaced with the `createAdcpServerFromPlatform` method-mapping table, a `TCtxMeta` note, and a concrete two-sub-object code example.

## Note on the signature-change suggestion from #1235

The issue suggested changing `AudiencePlatform.syncAudiences(audiences: Audience[], ctx)` to `(req: SyncAudiencesRequest, ctx)`. This would be a **breaking change** (existing implementations and the canonical example at `examples/decisioning-platform-identity-graph.ts:127` would need updating). The identity-helper approach in this PR solves the core DX problem without breaking existing adopters. The signature change is flagged in the triage comment on #1235 for @bokelley to decide whether to pursue as a separate major-bump PR.

## What was tested

- `npx tsc --project tsconfig.lib.json --noEmit` — no new type errors (pre-existing TS2688/TS5107 env errors unrelated to these changes)
- `npx tsc --noEmit` — clean (same)
- `npm run format:check` — passed
- `node_modules` not present in this environment; `npm test` and `build:lib` could not run. TypeScript compilation serves as the primary gate for a type-level-only change.

## Pre-PR review

- **dx-expert**: approved after two blockers fixed — (1) removed `sync_catalogs` from sales-social method table (it's a retail-media extension, not a social requirement), (2) changed "or" to "and" for `defineSalesPlatform` + `defineAudiencePlatform` and added concrete two-sub-object example
- **code-reviewer**: approved after two fixups — (1) removed `sync_catalogs` from sales-social prose "Additional tools" list (method table was already correct; prose was contradicting it), (2) added type-check coverage in `decisioning.type-checks.ts` — two positive identity assertions and one negative verifying that a wrong method shape is rejected

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout ` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01BfQUoDUmf4gh9Ff1ETnW6v

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfQUoDUmf4gh9Ff1ETnW6v)_