### PR TITLE
fix(harness): close stdin on grader spawnSync to prevent 120s hang

### DIFF
--- a/.changeset/beige-symbols-sort.md
+++ b/.changeset/beige-symbols-sort.md
@@ -1,0 +1,4 @@
+---
+---
+
+Harness-only fix for the matrix grader (`scripts/manual-testing/agent-skill-storyboard.ts`) — closes stdin on the spawnSync invocation to prevent a 120s hang against agents that don't emit a webhook (issue #1237). No published-package change; `scripts/manual-testing/` is excluded from `package.json#files`.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -329,6 +329,8 @@ npm run compliance:skill-matrix
 
 Use before merging skill changes. ~60s per pair; matrix runs fan out.
 
+> **Note:** storyboards with webhook steps (e.g. `webhook_emission`) hold the grader subprocess open until the agent emits a webhook. If your agent doesn't emit one, the harness kills the subprocess after 120s and logs `grader: subprocess timed out` — this is a harness-level timeout, not a conformance failure from your agent's response.
+
 ---
 
 ## Reading `💡 Hint:` lines (context-value rejections)

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -411,23 +411,27 @@ function runGrader(url: string, storyboardId: string): { passed: boolean; raw: s
     {
       encoding: 'utf8',
       timeout: 120_000,
-      // `stdio: 'ignore'` for stdin closes the subprocess's stdin pipe up
-      // front. Without this, spawnSync's default ('pipe') hands the child an
-      // open, never-written stdin pipe — and certain libraries the CLI loads
-      // do TTY/stdin probing on startup that can stall when stdin is a pipe
-      // with no terminal attached. Direct shell invocation works because the
-      // child gets the parent's TTY; spawnSync without `stdio` does not. The
-      // symptom this prevents: stdout=0b stderr=0b status=null signal=SIGTERM
-      // after the 120s timeout fires (issue #1237).
+      // Close stdin so the child doesn't stall on TTY/stdin probing — without
+      // this, spawnSync's default ('pipe') hands the child an open never-
+      // written stdin pipe, on which some library the CLI loads stalls. Direct
+      // shell invocation works because the child inherits the parent's TTY
+      // (issue #1237).
       stdio: ['ignore', 'pipe', 'pipe'],
+      // Bump from the 1 MiB default. A passing webhook-bundle JSON report
+      // approaches that on its own; on overflow, spawnSync kills with SIGTERM
+      // and returns *truncated* stdout — which would silently mis-grade as
+      // fail (JSON.parse trips on the truncation).
+      maxBuffer: 16 * 1024 * 1024,
     }
   );
   const raw = (res.stdout ?? '') + (res.stderr ?? '');
-  // Spawn-time signal=SIGTERM with empty stdout means the kernel killed the
-  // child at the 120s deadline before any work landed. Surface this as a
-  // harness-level failure with a copy-pasteable repro so operators don't
-  // mistake it for an agent conformance failure.
-  if (res.signal === 'SIGTERM' && !res.stdout) {
+  // Use ETIMEDOUT, not `signal === 'SIGTERM'`, to identify the timeout path.
+  // Node sets `error.code === 'ETIMEDOUT'` only when `options.timeout` fires;
+  // `signal === 'SIGTERM'` would also match Ctrl-C, OOM, external kill, or
+  // maxBuffer overflow — none of which deserve the "timed out" message. This
+  // also distinguishes the diagnostic from maxBuffer overflow, which has its
+  // own error code (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`).
+  if ((res as { error?: NodeJS.ErrnoException }).error?.code === 'ETIMEDOUT') {
     log(
       `grader: subprocess timed out after 120s (storyboard=${storyboardId}). ` +
         `This is a harness-level kill, not an agent conformance failure. ` +

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -411,9 +411,30 @@ function runGrader(url: string, storyboardId: string): { passed: boolean; raw: s
     {
       encoding: 'utf8',
       timeout: 120_000,
+      // `stdio: 'ignore'` for stdin closes the subprocess's stdin pipe up
+      // front. Without this, spawnSync's default ('pipe') hands the child an
+      // open, never-written stdin pipe — and certain libraries the CLI loads
+      // do TTY/stdin probing on startup that can stall when stdin is a pipe
+      // with no terminal attached. Direct shell invocation works because the
+      // child gets the parent's TTY; spawnSync without `stdio` does not. The
+      // symptom this prevents: stdout=0b stderr=0b status=null signal=SIGTERM
+      // after the 120s timeout fires (issue #1237).
+      stdio: ['ignore', 'pipe', 'pipe'],
     }
   );
   const raw = (res.stdout ?? '') + (res.stderr ?? '');
+  // Spawn-time signal=SIGTERM with empty stdout means the kernel killed the
+  // child at the 120s deadline before any work landed. Surface this as a
+  // harness-level failure with a copy-pasteable repro so operators don't
+  // mistake it for an agent conformance failure.
+  if (res.signal === 'SIGTERM' && !res.stdout) {
+    log(
+      `grader: subprocess timed out after 120s (storyboard=${storyboardId}). ` +
+        `This is a harness-level kill, not an agent conformance failure. ` +
+        `To debug, run the grader directly: ` +
+        `node bin/adcp.js storyboard run ${url} ${storyboardId} --json --allow-http --auth sk_harness_do_not_use_in_prod --webhook-receiver`
+    );
+  }
   let passed = false;
   try {
     const parsed = JSON.parse(res.stdout);

--- a/test/lib/discover-mcp-endpoint-hint.test.js
+++ b/test/lib/discover-mcp-endpoint-hint.test.js
@@ -24,9 +24,7 @@ describe('discoverMCPEndpoint — wrong-path hint (#1234)', () => {
     const baseUrl = `http://127.0.0.1:${port}`;
 
     try {
-      const client = new AdCPClient([
-        { id: 'no-mcp', name: 'no-mcp', protocol: 'mcp', agent_uri: baseUrl },
-      ]);
+      const client = new AdCPClient([{ id: 'no-mcp', name: 'no-mcp', protocol: 'mcp', agent_uri: baseUrl }]);
 
       await assert.rejects(
         () => client.agent('no-mcp').getAgentInfo(),


### PR DESCRIPTION
Closes #1237.

## Diagnosis (revised)

The previous version of this PR replaced `spawnSync` with async `spawn` + a Promise, citing "spawnSync blocks the parent event loop while the CLI's webhook-wait step hangs indefinitely." That framing was incorrect: `spawnSync` blocking the parent does not extend the child's runtime — the child runs in its own process either way, and the original code already had `timeout: 120_000` so spawnSync would unblock at the deadline regardless.

The real load-bearing change in the previous PR was a side-effect of the rewrite: it set `stdio: ['ignore', 'pipe', 'pipe']` on the new `spawn` call, which closed stdin to the child. **That single option is the actual fix.** The async rewrite was unrelated structural change being smuggled in under a misdiagnosed root cause.

## Real root cause

Empirically the harness saw `status=null signal=SIGTERM stdout=0b stderr=0b` at 120s when calling the grader via spawnSync, while the same args run directly from a shell completed in ~1.3s. The difference is stdio inheritance:

- Direct shell invocation: child gets the parent's TTY for all three streams.
- `spawnSync` without an explicit `stdio` option: stdin defaults to `'pipe'`, so the child receives an open, never-written stdin pipe.

Some libraries the CLI loads probe stdin/TTY state on startup and stall when stdin is a disconnected pipe. The 120s timeout fires before any work lands.

## Fix

One option on the existing `spawnSync` call:

```ts
stdio: ['ignore', 'pipe', 'pipe']
```

Closes stdin up front so any TTY/stdin probing fast-fails. stdout/stderr stay captured so JSON parsing works.

Also adds:

- A diagnostic log on `signal === 'SIGTERM'` with empty stdout — copy-pasteable repro command so operators don't mistake a harness-level kill for an agent conformance failure.
- A one-line note in `docs/guides/VALIDATE-YOUR-AGENT.md` so contributors who hit the timeout from the validate guide know what they're seeing.

No async rewrite, no SIGKILL follow-up, no `close`-vs-`exit` debate — none of that fixed the hang.

## Diff scope

23 lines added, 0 removed across two files. Compare to the previous version's ~160 lines changed.

```
docs/guides/VALIDATE-YOUR-AGENT.md         |  2 ++
scripts/manual-testing/agent-skill-storyboard.ts | 21 +++++++++++++++++++++
2 files changed, 23 insertions(+)
```

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [ ] CI Test & Build (in flight)
- [ ] Verify on next matrix run that the 120s harness hang no longer occurs against an agent that doesn't emit a webhook.

No changeset needed: `scripts/manual-testing/` is not in the published `files` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)