### PR TITLE
fix(server): unblock adopter tsc --noEmit by un-stripping public symbols

### DIFF
--- a/.changeset/blue-lemons-nail.md
+++ b/.changeset/blue-lemons-nail.md
@@ -1,0 +1,23 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix four `@internal`-leak bugs that broke adopter `tsc --noEmit` (#1236).
+
+`stripInternal: true` deleted these declarations from the published `.d.ts`
+while consumers (the public `AdcpServer` interface, the main `index.d.ts`
+re-exports) kept referencing them, producing TS2304/TS2305 errors on every
+adopter without `skipLibCheck`:
+
+- `ADCP_SERVER_BRAND` (`server/adcp-server.ts`) — also converted from
+  `declare const` to a real `Symbol(...)` const so the binding survives
+  emit. Brand is `never`-typed and never set on the runtime object.
+- `extractAdcpErrorFromMcp`, `extractAdcpErrorFromTransport`
+  (`utils/error-extraction.ts`) — re-exported from `@adcp/sdk`, not
+  internal.
+- `createSingleAgentClient` (`core/SingleAgentClient.ts`) — re-exported
+  from `@adcp/sdk`, not internal.
+
+Adds `npm run check:adopter-types` (wired into CI) which packs the SDK,
+scaffolds a minimal adopter, and runs `tsc --noEmit` against the
+published types so this class of leak fails CI instead of shipping.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Build library
         run: npm run build:lib
 
+      - name: Adopter type-check (catch d.ts leaks)
+        run: npm run check:adopter-types
+
       - name: Typecheck examples
         run: npm run typecheck:examples
 

--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
     "compliance:skill-matrix": "tsx scripts/manual-testing/run-skill-matrix.ts",
     "typecheck:skill-examples": "tsx scripts/typecheck-skill-examples.ts",
     "check:skill-sync": "tsx scripts/check-skill-sync.ts",
+    "check:adopter-types": "tsx scripts/check-adopter-types.ts",
     "sync-version": "tsx scripts/sync-version.ts",
     "validate-schemas": "tsx scripts/validate-schemas.ts",
     "lint": "eslint 'src/lib/testing/**/*.ts'",

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -1,0 +1,114 @@
+#!/usr/bin/env tsx
+/**
+ * Adopter type-check guard.
+ *
+ * Packs the SDK as it would ship to npm, scaffolds a minimal adopter
+ * project that imports every public subpath, and runs `tsc --noEmit`
+ * against it. Catches the class of bug where an internal symbol or
+ * `declare`-only binding ends up referenced by a public `.d.ts` but
+ * stripped from the emitted bundle — which compiles cleanly inside the
+ * monorepo but fails on every adopter (issue #1236).
+ *
+ * Run via `npm run check:adopter-types`. Exits non-zero on any tsc
+ * diagnostic against the scaffold.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const REPO_ROOT = join(__dirname, '..');
+
+const ADOPTER_TSCONFIG = {
+  compilerOptions: {
+    target: 'ES2022',
+    module: 'commonjs',
+    moduleResolution: 'node',
+    esModuleInterop: true,
+    strict: true,
+    skipLibCheck: false,
+    noEmit: true,
+    types: ['node'],
+    ignoreDeprecations: '6.0',
+  },
+  include: ['adopter.ts'],
+};
+
+const ADOPTER_SOURCE = `
+// Mirrors the repro from issue #1236 — minimal adopter import via the
+// subpaths that produced TS2304 leaks (\`stripInternal\` deleted the
+// declaration but consumers kept referencing it). Narrow on purpose:
+// pulling \`@adcp/sdk/server\`'s full transitive surface drags in
+// peerDependency type errors (express, @opentelemetry/api) that are
+// orthogonal to this guard's scope. Widen when those are addressed.
+import type { AdcpServer } from '@adcp/sdk/server';
+import { createSingleAgentClient, extractAdcpErrorFromMcp, extractAdcpErrorFromTransport } from '@adcp/sdk';
+
+declare const _server: AdcpServer;
+void _server;
+void createSingleAgentClient;
+void extractAdcpErrorFromMcp;
+void extractAdcpErrorFromTransport;
+`;
+
+function run(cmd: string, args: string[], cwd: string): void {
+  execFileSync(cmd, args, { cwd, stdio: 'inherit' });
+}
+
+function main(): void {
+  console.log('[adopter-types] packing SDK...');
+  const tarballDir = mkdtempSync(join(tmpdir(), 'adcp-adopter-pack-'));
+  run('npm', ['pack', '--pack-destination', tarballDir, '--silent'], REPO_ROOT);
+  const tarball = readdirSync(tarballDir).find(f => f.endsWith('.tgz'));
+  if (!tarball) throw new Error('npm pack did not produce a tarball');
+  const tarballPath = join(tarballDir, tarball);
+
+  console.log('[adopter-types] scaffolding adopter project...');
+  const adopterDir = mkdtempSync(join(tmpdir(), 'adcp-adopter-check-'));
+  writeFileSync(
+    join(adopterDir, 'package.json'),
+    JSON.stringify({ name: 'adopter-types-check', version: '0.0.0', private: true })
+  );
+  writeFileSync(join(adopterDir, 'tsconfig.json'), JSON.stringify(ADOPTER_TSCONFIG, null, 2));
+  writeFileSync(join(adopterDir, 'adopter.ts'), ADOPTER_SOURCE);
+
+  // @types/express and @opentelemetry/api cover transitive type references
+  // from the server bundle — adopters who import `@adcp/sdk/server` need
+  // these (express is the HTTP adapter, opentelemetry is the optional
+  // observability peer). Installing them here scopes this guard to
+  // detection of `@internal`-leak class bugs (issue #1236) without flagging
+  // the orthogonal "transitive types not auto-installed" class, which is
+  // tracked separately.
+  console.log('[adopter-types] installing tarball + adopter peers...');
+  run(
+    'npm',
+    [
+      'install',
+      '--no-audit',
+      '--no-fund',
+      '--silent',
+      tarballPath,
+      'typescript',
+      '@types/node',
+      '@types/express',
+      '@opentelemetry/api',
+    ],
+    adopterDir
+  );
+
+  console.log('[adopter-types] running tsc --noEmit against published types...');
+  try {
+    run('npx', ['--no-install', 'tsc', '--noEmit'], adopterDir);
+    console.log('[adopter-types] PASS — published .d.ts files type-check cleanly for an adopter.');
+  } catch {
+    console.error('[adopter-types] FAIL — published .d.ts files do not type-check on a clean adopter project.');
+    console.error(`  Scaffold preserved at: ${adopterDir}`);
+    console.error(`  Reproduce: cd ${adopterDir} && npx tsc --noEmit`);
+    process.exit(1);
+  }
+
+  rmSync(tarballDir, { recursive: true, force: true });
+  rmSync(adopterDir, { recursive: true, force: true });
+}
+
+main();

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -3265,12 +3265,11 @@ export class SingleAgentClient {
 }
 
 /**
- * Factory function to create a single-agent client (internal use)
+ * Factory function to create a single-agent client.
  *
  * @param agent - Agent configuration
  * @param config - Client configuration
  * @returns Configured SingleAgentClient instance
- * @internal
  */
 export function createSingleAgentClient(agent: AgentConfig, config?: SingleAgentClientConfig): SingleAgentClient {
   return new SingleAgentClient(agent, config);

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -176,13 +176,19 @@ export interface AdcpServerComplianceApi {
  * tried to reach for an MCP-SDK method the framework intentionally
  * doesn't expose.
  *
- * The brand is opaque (`never`-valued) and never set at runtime — only
- * the wrapper produced by `createAdcpServer()` carries the type-level
+ * The brand is `never`-typed and never set on the runtime object, so
+ * `Object.getOwnPropertySymbols(server)` won't expose it — only the
+ * wrapper produced by `createAdcpServer()` carries the type-level
  * signature, via the `as AdcpServerInternal` cast in `wrapMcpServer()`.
  *
- * @internal
+ * Must be a real (non-`declare`) const so the d.ts emit retains it. An
+ * `export declare const X: unique symbol` in a `.ts` source file does
+ * not survive emit — the binding gets dropped from the published d.ts
+ * while consumers (the public `AdcpServer` interface) keep referencing
+ * it, which produces `TS2304: Cannot find name 'ADCP_SERVER_BRAND'` on
+ * any adopter `tsc --noEmit` against `@adcp/sdk/server` (issue #1236).
  */
-export declare const ADCP_SERVER_BRAND: unique symbol;
+export const ADCP_SERVER_BRAND: unique symbol = Symbol('ADCP_SERVER_BRAND');
 
 /**
  * Opaque handle returned by `createAdcpServer()`.

--- a/src/lib/utils/error-extraction.ts
+++ b/src/lib/utils/error-extraction.ts
@@ -27,7 +27,6 @@ export interface ExtractedAdcpError {
 }
 
 /**
- * @internal
  * Extract an AdCP error from an MCP tool response.
  *
  * Detection order (per transport error mapping spec):
@@ -97,7 +96,6 @@ export function extractAdcpErrorFromMcp(
 }
 
 /**
- * @internal
  * Extract an AdCP error from a JSON-RPC transport error.
  * Checks error.data.adcp_error for structured transport-level errors
  * (e.g., -32029 rate limit from infrastructure).


### PR DESCRIPTION
Closes #1236.

## Summary

The issue's stated cause (zod-v4 locale CJS, `@types/glob`, minimatch errors) does **not** reproduce in a clean adopter — those errors were artifacts of the matrix-blind-fixture workspace. A **different** adopter blocker does reproduce with the issue's exact repro:

```
node_modules/@adcp/sdk/dist/lib/server/adcp-server.d.ts(176,15):
  error TS2304: Cannot find name 'ADCP_SERVER_BRAND'.
```

Plus three more from `index.d.ts`. Same root cause across all four: `@internal`-tagged exports are stripped from the published `.d.ts` while public consumers keep referencing them, producing TS2304/TS2305 on every adopter without `skipLibCheck`.

## Fix

Four leaks, one root cause:

| Symbol | File | Fix |
|---|---|---|
| `ADCP_SERVER_BRAND` | `server/adcp-server.ts` | Drop `@internal` + convert `declare const` → real `Symbol(...)` (declare const isn't preserved in `.d.ts` emit even without `stripInternal`) |
| `extractAdcpErrorFromMcp` | `utils/error-extraction.ts` | Drop `@internal` (re-exported from `index.ts`) |
| `extractAdcpErrorFromTransport` | `utils/error-extraction.ts` | Drop `@internal` (re-exported from `index.ts`) |
| `createSingleAgentClient` | `core/SingleAgentClient.ts` | Drop `@internal` (re-exported from `index.ts`) |

Brand stays `never`-typed and is never set on the runtime object, so nominal typing is preserved. The `Symbol(...)` value is exported but adopters can't construct or use it meaningfully.

## CI guard

New `npm run check:adopter-types` (wired into the Test & Build job): packs the SDK, scaffolds a minimal adopter project, and runs `tsc --noEmit` against the published `.d.ts`. Catches this leak class before it ships.

Scoped narrowly on purpose — the wider "transitive peer types not auto-installed" class (`@types/express`, `@opentelemetry/api` types not resolved through dependent imports) is a separate adopter blocker that needs its own fix. The scaffold installs those peers so this guard stays focused on `@internal`-leak detection.

## Test plan

- [x] `npm run check:adopter-types` — passes locally on this branch
- [x] `npm run check:adopter-types` reverts cleanly produced FAIL on `ADCP_SERVER_BRAND` (verified during development)
- [x] `npm run typecheck` passes
- [x] `npm run build:lib` passes
- [x] `npm run format:check` passes
- [x] Targeted unit tests pass (`brand-rights.test.js`, `single-agent-client-needs-auth.test.js`)
- [ ] CI Test & Build (in flight)
- [ ] CI commitlint, changeset-check (in flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)