### PR TITLE
fix(client): hint at wrong-path agent_uri in discovery failure error (#1234)

### DIFF
--- a/.changeset/discover-mcp-endpoint-hint.md
+++ b/.changeset/discover-mcp-endpoint-hint.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(client): discovery error message hints at wrong-path registration
+
+`SingleAgentClient.discoverMCPEndpoint`'s generic "Failed to discover MCP endpoint" error now includes a hint that the most common cause is `agent_uri` pointing at the host root when the MCP endpoint lives at a non-standard path. The SDK only auto-probes `/`, `/mcp`, and `/mcp/`; servers exposing MCP at `/api/mcp`, `/v1/mcp`, or similar custom paths need that exact path registered as `agent_uri`.
+
+No behavior change — operators get a more actionable error. Helps downstream tools (dashboard probes, registration flows) surface the actual issue instead of "agent offline".
+
+Closes #1234.

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -731,12 +731,20 @@ export class SingleAgentClient {
       throw new AuthenticationRequiredError(providedUri, oauthMetadata || undefined);
     }
 
-    // None worked and no 401 - generic discovery failure
+    // None worked and no 401 - generic discovery failure.
+    // The most common cause is `agent_uri` pointing at the host root when the
+    // MCP endpoint lives at a non-standard path; the SDK only auto-probes `/`,
+    // `/mcp`, and `/mcp/`. Surface that hint so operators can fix the
+    // registration instead of debugging transport.
     throw new Error(
       `Failed to discover MCP endpoint. Tried:\n` +
         uniqueUrls.map((url, i) => `  ${i + 1}. ${url}`).join('\n') +
         '\n' +
-        `None responded to MCP protocol.`
+        `None responded to MCP protocol.\n\n` +
+        `Hint: this usually means agent_uri does not include the MCP endpoint path. ` +
+        `The SDK only probes /, /mcp, and /mcp/ automatically. ` +
+        `If your server exposes MCP at a different path (e.g. /api/mcp, /v1/mcp), ` +
+        `register that exact path as agent_uri.`
     );
   }
 

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -742,9 +742,10 @@ export class SingleAgentClient {
         '\n' +
         `None responded to MCP protocol.\n\n` +
         `Hint: this usually means agent_uri does not include the MCP endpoint path. ` +
-        `The SDK only probes /, /mcp, and /mcp/ automatically. ` +
-        `If your server exposes MCP at a different path (e.g. /api/mcp, /v1/mcp), ` +
-        `register that exact path as agent_uri.`
+        `The SDK auto-appends /mcp and /mcp/ (plus a trailing-slash variant) ` +
+        `to the provided path. If your server exposes MCP at a different path ` +
+        `(e.g. /api/mcp, /v1/mcp) or uses legacy SSE at /sse, register that ` +
+        `exact path as agent_uri.`
     );
   }
 

--- a/test/lib/discover-mcp-endpoint-hint.test.js
+++ b/test/lib/discover-mcp-endpoint-hint.test.js
@@ -1,0 +1,48 @@
+/**
+ * Regression test for issue #1234: discoverMCPEndpoint's "Failed to discover
+ * MCP endpoint" error includes a hint pointing operators at the most common
+ * cause (agent_uri registered at the host root when the MCP endpoint lives
+ * at a non-standard path like /api/mcp or /v1/mcp).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { AdCPClient } = require('../../dist/lib/index.js');
+
+describe('discoverMCPEndpoint — wrong-path hint (#1234)', () => {
+  it('appends a wrong-path hint when no candidate responds with 200 or 401', async () => {
+    // Stub: every POST returns 404. Discovery probes /, /mcp, /mcp/ — none
+    // exists, no 401 anywhere, so we hit the generic-failure branch.
+    const server = http.createServer((_, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address();
+    const baseUrl = `http://127.0.0.1:${port}`;
+
+    try {
+      const client = new AdCPClient([
+        { id: 'no-mcp', name: 'no-mcp', protocol: 'mcp', agent_uri: baseUrl },
+      ]);
+
+      await assert.rejects(
+        () => client.agent('no-mcp').getAgentInfo(),
+        err => {
+          assert.match(err.message, /Failed to discover MCP endpoint/);
+          assert.match(
+            err.message,
+            /Hint:.*agent_uri.*does not include the MCP endpoint path/i,
+            `expected wrong-path hint in: ${err.message}`
+          );
+          assert.match(err.message, /\/api\/mcp|\/v1\/mcp/, 'expected example paths in hint');
+          return true;
+        }
+      );
+    } finally {
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1234. Appends a hint to the `discoverMCPEndpoint` "Failed to discover MCP endpoint" error pointing operators at the most common cause: `agent_uri` registered at the host root when the actual MCP endpoint lives at a non-standard path. Five lines, no behavior change.

Discovered while investigating #1231 (closed as not-a-bug — root cause was registration mismatch). The original symptom: a dashboard probe showed "agent offline" when the agent was healthy and just registered with the wrong path. Better discovery diagnostics shorten the time-to-fix for the most common operator mistake.

This replaces the closed PR #1244, which bundled a more invasive symmetry-fix that wasn't justified by a reproducible failure. The retry-predicate concern surfaced during that review is filed separately as #1246.

## Test plan

- [x] `npm run typecheck` — clean
- [x] New regression test `test/lib/discover-mcp-endpoint-hint.test.js` asserts both the existing failure-list output and the new hint text + example paths