### PR TITLE
fix(client): widen connectMCPWithFallback retry predicate to cover generic transient errors

### DIFF
--- a/.changeset/widen-mcp-retry-predicate.md
+++ b/.changeset/widen-mcp-retry-predicate.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(client): widen connectMCPWithFallback retry predicate to cover generic transient errors
+
+Previously the single-retry gate was gated on `instanceof StreamableHTTPError`, which only matched the canonical "Session not found" 400. Network blips, JSON parse errors on half-buffered responses, and mid-handshake proxy disconnects (Cloudflare, Fastly) all surface as generic `Error` or `McpError` and were silently skipped. The predicate is now `!is401Error(error)` — retry on any first-connect failure except auth, where a second attempt is pointless.

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -367,14 +367,14 @@ async function connectMCPWithFallbackImpl(
       error,
     });
 
-    // Stale/expired session — retry StreamableHTTP with a fresh connection.
-    // 404 = session not found (per MCP spec), 400 = "Session not found" (SDK #1852),
-    // other StreamableHTTPError codes may also indicate session issues.
-    // Always retry StreamableHTTP before falling back to SSE.
-    if (error instanceof StreamableHTTPError) {
+    // Retry StreamableHTTP once on any transient connect failure — network blips,
+    // JSON parse errors on half-buffered responses, and mid-handshake proxy
+    // disconnects all surface as generic Error or McpError, not StreamableHTTPError.
+    // Auth failures are the only class where retry is pointless and wasteful.
+    if (!is401Error(error)) {
       debugLogs.push({
         type: 'info',
-        message: `MCP: Session error (${error.code}) detected, retrying StreamableHTTP for ${label}`,
+        message: `MCP: Transient connect error (${errorClass}) detected, retrying StreamableHTTP for ${label}`,
         timestamp: new Date().toISOString(),
       });
       try {

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -278,11 +278,11 @@ export interface MCPConnectionResult {
  *
  * Strategy:
  *  1. Try StreamableHTTPClientTransport.
- *  2. If a 404 StreamableHTTPError is returned (stale session), retry once with a
- *     fresh StreamableHTTP connection — the server supports the protocol, the
- *     session just expired.
+ *  2. On any transient connect failure (generic Error, McpError, or StreamableHTTPError),
+ *     retry once with a fresh StreamableHTTP connection. Auth failures (401) are excluded —
+ *     a retry is pointless and wastes a round-trip.
  *  3. If a 401 is returned, throw immediately — auth failure is transport-agnostic.
- *  4. For any other error, fall back to SSEClientTransport with the same headers.
+ *  4. For any other error after retry, fall back to SSEClientTransport with the same headers.
  *
  * The returned client is connected and ready for use. Callers are responsible for
  * calling client.close() when done.
@@ -377,17 +377,22 @@ async function connectMCPWithFallbackImpl(
         message: `MCP: Transient connect error (${errorClass}) detected, retrying StreamableHTTP for ${label}`,
         timestamp: new Date().toISOString(),
       });
+      const retryClient = new MCPClient({ name: 'AdCP-Client', version: '1.0.0' });
       try {
-        const client = new MCPClient({ name: 'AdCP-Client', version: '1.0.0' });
-        await client.connect(new StreamableHTTPClientTransport(url, transportOptions));
+        await retryClient.connect(new StreamableHTTPClientTransport(url, transportOptions));
         trackStreamableHTTPUrl(url.toString());
         debugLogs.push({
           type: 'success',
           message: `MCP: Connected via StreamableHTTP (retry) for ${label}`,
           timestamp: new Date().toISOString(),
         });
-        return client;
+        return retryClient;
       } catch (retryError) {
+        try {
+          await retryClient.close();
+        } catch {
+          /* ignore */
+        }
         debugLogs.push({
           type: 'error',
           message: `MCP: StreamableHTTP retry also failed for ${label}: ${retryError instanceof Error ? retryError.message : String(retryError)}`,

--- a/test/unit/mcp-connect-retry-predicate.test.js
+++ b/test/unit/mcp-connect-retry-predicate.test.js
@@ -70,9 +70,9 @@ describe('connectMCPWithFallback: retry predicate (issue #1246)', () => {
     assert.strictEqual(result, 'retry-succeeded');
   });
 
-  test('StreamableHTTPError 400 (session-not-found) still retries', async () => {
-    // Regression guard: StreamableHTTPError was previously the *only* case that
-    // retried. Widening must not remove this behavior.
+  test('Error with code 400 (non-auth HTTP status) still retries', async () => {
+    // Regression guard: code-400 errors (e.g. StreamableHTTPError "Session not found")
+    // were the only previously-retried case. Widening must keep them retried.
     const err = Object.assign(new Error('Session not found'), { code: 400 });
     const result = await runRetryGate(err, async () => {
       /* retry succeeds */

--- a/test/unit/mcp-connect-retry-predicate.test.js
+++ b/test/unit/mcp-connect-retry-predicate.test.js
@@ -1,0 +1,133 @@
+/**
+ * Unit tests for the connectMCPWithFallback retry predicate (issue #1246).
+ *
+ * The predicate was narrowed to `instanceof StreamableHTTPError`, missing
+ * generic Error and McpError thrown during the initialize handshake.
+ * Fix: retry on any first-connect failure except auth (is401Error).
+ *
+ * Replicates the retry-gate decision logic inline (same pattern as
+ * mcp-discovery-sse-fallback.test.js) so the tests run without dist/.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+// Replicates is401Error() from src/lib/errors/index.ts.
+// Keep in sync with the source; divergence is a test bug.
+function is401Error(error) {
+  if (!error) return false;
+  const status = error?.status || error?.response?.status || error?.cause?.status || error?.code;
+  if (status === 401) return true;
+  const message = error?.message || '';
+  return /\b401\b/.test(message) || /\bunauthorized\b/i.test(message);
+}
+
+// Replicates the retry gate from connectMCPWithFallbackImpl (mcp.ts ~line 374).
+function shouldRetry(error) {
+  return !is401Error(error);
+}
+
+/**
+ * Minimal stand-in for connectMCPWithFallbackImpl's retry branch.
+ * Returns 'retry-succeeded', 'retry-failed', or 'no-retry'.
+ */
+async function runRetryGate(firstConnectError, retryConnect) {
+  if (!shouldRetry(firstConnectError)) {
+    return 'no-retry';
+  }
+  try {
+    await retryConnect();
+    return 'retry-succeeded';
+  } catch {
+    return 'retry-failed';
+  }
+}
+
+describe('connectMCPWithFallback: retry predicate (issue #1246)', () => {
+  // --- Cases that SHOULD retry ---
+
+  test('generic Error on first connect → retry fires', async () => {
+    const err = new Error('Failed to read SSE stream');
+    const result = await runRetryGate(err, async () => {
+      /* retry succeeds */
+    });
+    assert.strictEqual(result, 'retry-succeeded');
+  });
+
+  test('ECONNRESET (cause.code) on first connect → retry fires', async () => {
+    const err = Object.assign(new Error('socket hang up'), { cause: { code: 'ECONNRESET' } });
+    const result = await runRetryGate(err, async () => {
+      /* retry succeeds */
+    });
+    assert.strictEqual(result, 'retry-succeeded');
+  });
+
+  test('JSON parse error (generic Error) on first connect → retry fires', async () => {
+    const err = new SyntaxError('Unexpected token < in JSON at position 0');
+    const result = await runRetryGate(err, async () => {
+      /* retry succeeds */
+    });
+    assert.strictEqual(result, 'retry-succeeded');
+  });
+
+  test('StreamableHTTPError 400 (session-not-found) still retries', async () => {
+    // Regression guard: StreamableHTTPError was previously the *only* case that
+    // retried. Widening must not remove this behavior.
+    const err = Object.assign(new Error('Session not found'), { code: 400 });
+    const result = await runRetryGate(err, async () => {
+      /* retry succeeds */
+    });
+    assert.strictEqual(result, 'retry-succeeded');
+  });
+
+  test('generic Error on both first and retry → retry fires but propagates failure', async () => {
+    const err = new Error('network timeout');
+    const result = await runRetryGate(err, async () => {
+      throw new Error('still failing');
+    });
+    assert.strictEqual(result, 'retry-failed');
+  });
+
+  // --- Cases that must NOT retry ---
+
+  test('401 via StreamableHTTPError.code → no retry', async () => {
+    // MCP SDK StreamableHTTPClientTransport sets .code to the HTTP status.
+    const err = Object.assign(new Error('Unauthorized'), { code: 401 });
+    let retryCalled = false;
+    const result = await runRetryGate(err, async () => {
+      retryCalled = true;
+    });
+    assert.strictEqual(result, 'no-retry');
+    assert.strictEqual(retryCalled, false, 'retry must not fire on 401');
+  });
+
+  test('401 via error.status → no retry', async () => {
+    const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+    let retryCalled = false;
+    const result = await runRetryGate(err, async () => {
+      retryCalled = true;
+    });
+    assert.strictEqual(result, 'no-retry');
+    assert.strictEqual(retryCalled, false);
+  });
+
+  test('401 via message text → no retry', async () => {
+    const err = new Error('HTTP 401 Unauthorized');
+    let retryCalled = false;
+    const result = await runRetryGate(err, async () => {
+      retryCalled = true;
+    });
+    assert.strictEqual(result, 'no-retry');
+    assert.strictEqual(retryCalled, false);
+  });
+
+  test('UnauthorizedError message → no retry', async () => {
+    const err = new Error('unauthorized access');
+    let retryCalled = false;
+    const result = await runRetryGate(err, async () => {
+      retryCalled = true;
+    });
+    assert.strictEqual(result, 'no-retry');
+    assert.strictEqual(retryCalled, false);
+  });
+});


### PR DESCRIPTION
Closes #1246

`connectMCPWithFallback` retried StreamableHTTP only on `instanceof StreamableHTTPError`, which catches the canonical "Session not found" 400 (MCP SDK #1852) but misses the broader class of transient errors that surface as generic `Error` or `McpError` during the `initialize` handshake: network blips, JSON parse errors on half-buffered responses, and mid-handshake proxy disconnects (Cloudflare, Fastly). The retry predicate is now `!is401Error(error)` — retry once on any first-connect failure except auth, where a second attempt is guaranteed wasteful. The `retryClient` resource leak on failed retry (missing `close()` on the second attempt's `MCPClient`) is fixed in the same change. All callers inherit the fix: `callMCPTool`, `mcp-tasks`, discovery, and `getAgentInfo`.

## What tested

- `node --test test/unit/mcp-connect-retry-predicate.test.js` — 9/9 pass (new test file covering generic Error, ECONNRESET, SyntaxError, code-400 regression guard, double-failure fallthrough, and four 401-no-retry cases)
- `npm run format:check` — clean
- `npm run typecheck` — pre-existing TS2688/TS5107 errors unrelated to this change (reproducible on `main` before any changes)
- `npm run build:lib` — pre-existing same errors; `dist/` was already present and tests run against it

## Pre-PR review

- **code-reviewer**: approved after fixes — resource leak (retryClient.close on failure) addressed; JSDoc updated; nits surfaced: (1) 403 Forbidden will retry once unnecessarily before propagating (is401Error only exempts 401; extending to cover 403 is a follow-up, not a blocker here); (2) inline is401Error replicate follows established repo pattern (same as mcp-discovery-sse-fallback.test.js, mcp-private-address-sse-gate.test.js) and is functionally equivalent to source for this call site (field order identical; got401Flag unused in production calls)
- **dx-expert**: approved after fixes — stale JSDoc and misleading test title addressed; nit: retry-failure log could include errorClass for the second-attempt error (follow-up)

## Nits (not fixed)

- 403 Forbidden retries once before propagating — harmless (same outcome, one extra round-trip). Follow-up if operators report noise.
- The retry-failure log at line ~393 only logs the error message, not the error class. Minor triage aid; follow-up.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01JgzJ9xeweyrEUpSRJobHdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01JgzJ9xeweyrEUpSRJobHdm)_