### PR TITLE
fix(harness): convert runGrader to async spawn — resolves #1237 same-process deadlock

### DIFF
--- a/.changeset/grader-async-spawn-fix.md
+++ b/.changeset/grader-async-spawn-fix.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(harness): convert matrix harness `runGrader` from `spawnSync` to async `spawn`
+
+The matrix harness (`scripts/manual-testing/agent-skill-storyboard.ts`) is dev-only and not shipped in the npm package. Tagging this `patch` to satisfy the changeset gate; no published code changes.
+
+Background: the harness boots the mock upstream HTTP server in the same Node process. `spawnSync` blocked the event loop while the grader child waited on agent responses → in-process upstream couldn't tick → agent's upstream calls hung → 120s timeout. Same-process deadlock that #1241 didn't catch (its stdin-close fix was correct but only addressed half the failure path).
+
+Fix: async `spawn` + Promise on whichever of `'error'` or `'close'` fires first. Event loop stays live, upstream serves alongside the grader. Verified: signal_marketplace verify-mode log went from 22 lines (timeout) to 632 lines (full grader JSON) at 1.5s wall.
+
+Resolves the residual hang from #1237.

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -461,26 +461,52 @@ async function runGrader(url: string, storyboardId: string): Promise<{ passed: b
   child.stderr.on('data', c => stderrChunks.push(c));
 
   let timedOut = false;
+  // Wrap in an object so TS doesn't narrow the closure-assigned `let` to
+  // `null` at the read site (control-flow analysis can't see across async
+  // boundaries on `let` reassignment).
+  const spawnFailure: { error: NodeJS.ErrnoException | null } = { error: null };
   const timer = setTimeout(() => {
     timedOut = true;
     child.kill('SIGTERM');
   }, 120_000);
 
-  const exitCode: number | null = await new Promise(resolveFn => {
-    child.on('close', code => resolveFn(code));
+  // Wire `'error'` (spawn-fail: ENOENT, EACCES, …) and `'close'` (normal
+  // exit, after stdio drain) together. Without an `'error'` listener Node
+  // throws on emit; without resolving the awaiter on `'error'`, a failed
+  // spawn could hang the harness. `'close'` always fires after `'error'`
+  // for processes that started, so we settle on whichever comes first.
+  const exitCode: number | null = await new Promise<number | null>(resolveFn => {
+    let settled = false;
+    const settle = (code: number | null): void => {
+      if (settled) return;
+      settled = true;
+      resolveFn(code);
+    };
+    child.on('error', err => {
+      spawnFailure.error = err;
+      settle(null);
+    });
+    child.on('close', code => settle(code));
   });
   clearTimeout(timer);
 
   const stdout = Buffer.concat(stdoutChunks).toString('utf8');
   const stderr = Buffer.concat(stderrChunks).toString('utf8');
-  const raw = stdout + stderr;
+  const raw = stdout + stderr + (spawnFailure.error ? `\n[spawn error] ${spawnFailure.error.message}` : '');
 
-  if (timedOut) {
+  if (spawnFailure.error) {
+    log(`grader: spawn failed — ${spawnFailure.error.code ?? '?'}: ${spawnFailure.error.message}`);
+  } else if (timedOut) {
+    // Reconstruct the direct-invocation command from the actual args array
+    // so this hint can't drift from the spawn call above. The operator's
+    // recovery loop is `--mode build --keep` then `--mode verify` — flagged
+    // here so the hint is actionable without re-reading the file header.
     log(
       `grader: subprocess timed out after 120s (storyboard=${storyboardId}). ` +
         `This is a harness-level kill, not an agent conformance failure. ` +
-        `To debug, run the grader directly: ` +
-        `node bin/adcp.js storyboard run ${url} ${storyboardId} --json --allow-http --auth sk_harness_do_not_use_in_prod --webhook-receiver`
+        `To debug, run the grader directly (workspace must still be up — ` +
+        `re-run with --keep + --mode verify if the agent was torn down):\n  ` +
+        `node ${args.join(' ')}`
     );
   } else if (exitCode !== 0) {
     log(`grader: exited with code ${exitCode} (storyboard=${storyboardId})`);

--- a/scripts/manual-testing/agent-skill-storyboard.ts
+++ b/scripts/manual-testing/agent-skill-storyboard.ts
@@ -415,68 +415,80 @@ async function waitForPort(host: string, port: number, timeoutMs: number): Promi
   throw new Error(`timed out waiting for ${host}:${port}`);
 }
 
-function runGrader(url: string, storyboardId: string): { passed: boolean; raw: string } {
+async function runGrader(url: string, storyboardId: string): Promise<{ passed: boolean; raw: string }> {
   const cliPath = join(REPO_ROOT, 'bin', 'adcp.js');
+  // Async `spawn` (not `spawnSync`) is mandatory: the harness boots the mock
+  // upstream HTTP server in the same Node process. `spawnSync` blocks the
+  // event loop, so while the grader runs, the in-process upstream can't
+  // respond to requests from the agent — agent's upstream calls hang, grader
+  // times out waiting on agent, full deadlock at the 120s mark. Async spawn
+  // keeps the loop alive so the upstream serves alongside the grader.
+  // (Original symptom thread: #1237 / #1241.)
+  //
   // `--allow-http` is mandatory — the grader hard-refuses plain-http URLs
   // otherwise (production agents MUST terminate TLS). Harness-tested agents
-  // bind on loopback, so we opt in explicitly.
-  // Presents the harness key wired by the generated server — symmetric with
-  // the `verifyApiKey` block in buildPrompt(). The scary token name exists so
-  // anyone who encounters it in logs or --keep output workspaces recognizes
-  // it's a harness-only credential, not a production pattern.
-  const res = spawnSync(
-    'node',
-    [
-      cliPath,
-      'storyboard',
-      'run',
-      url,
-      storyboardId,
-      '--json',
-      '--allow-http',
-      '--auth',
-      'sk_harness_do_not_use_in_prod',
-      // Host a loopback webhook receiver so storyboards that assert outbound
-      // webhook conformance (webhook_emission, idempotency) can grade instead
-      // of skipping with "Test-kit contract 'webhook_receiver_runner' is not
-      // configured on this runner". Storyboards that don't need it ignore the
-      // receiver.
-      '--webhook-receiver',
-    ],
-    {
-      encoding: 'utf8',
-      timeout: 120_000,
-      // Close stdin so the child doesn't stall on TTY/stdin probing — without
-      // this, spawnSync's default ('pipe') hands the child an open never-
-      // written stdin pipe, on which some library the CLI loads stalls. Direct
-      // shell invocation works because the child inherits the parent's TTY
-      // (issue #1237).
-      stdio: ['ignore', 'pipe', 'pipe'],
-      // Bump from the 1 MiB default. A passing webhook-bundle JSON report
-      // approaches that on its own; on overflow, spawnSync kills with SIGTERM
-      // and returns *truncated* stdout — which would silently mis-grade as
-      // fail (JSON.parse trips on the truncation).
-      maxBuffer: 16 * 1024 * 1024,
-    }
-  );
-  const raw = (res.stdout ?? '') + (res.stderr ?? '');
-  // Use ETIMEDOUT, not `signal === 'SIGTERM'`, to identify the timeout path.
-  // Node sets `error.code === 'ETIMEDOUT'` only when `options.timeout` fires;
-  // `signal === 'SIGTERM'` would also match Ctrl-C, OOM, external kill, or
-  // maxBuffer overflow — none of which deserve the "timed out" message. This
-  // also distinguishes the diagnostic from maxBuffer overflow, which has its
-  // own error code (`ERR_CHILD_PROCESS_STDIO_MAXBUFFER`).
-  if ((res as { error?: NodeJS.ErrnoException }).error?.code === 'ETIMEDOUT') {
+  // bind on loopback, so we opt in explicitly. The harness key in `--auth`
+  // is symmetric with the `verifyApiKey` block in buildPrompt(); the scary
+  // token name makes accidental copy-paste obvious.
+  const args = [
+    cliPath,
+    'storyboard',
+    'run',
+    url,
+    storyboardId,
+    '--json',
+    '--allow-http',
+    '--auth',
+    'sk_harness_do_not_use_in_prod',
+    // Host a loopback webhook receiver so storyboards that assert outbound
+    // webhook conformance (webhook_emission, idempotency) can grade instead
+    // of skipping with "Test-kit contract 'webhook_receiver_runner' is not
+    // configured on this runner". Storyboards that don't need it ignore the
+    // receiver.
+    '--webhook-receiver',
+  ];
+
+  const child = spawn('node', args, {
+    // Close stdin (legacy of #1237 — some library on the CLI side stalled on
+    // an open never-written stdin pipe). stdout/stderr piped so we can
+    // capture and parse.
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  child.stdout.on('data', c => stdoutChunks.push(c));
+  child.stderr.on('data', c => stderrChunks.push(c));
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    child.kill('SIGTERM');
+  }, 120_000);
+
+  const exitCode: number | null = await new Promise(resolveFn => {
+    child.on('close', code => resolveFn(code));
+  });
+  clearTimeout(timer);
+
+  const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+  const stderr = Buffer.concat(stderrChunks).toString('utf8');
+  const raw = stdout + stderr;
+
+  if (timedOut) {
     log(
       `grader: subprocess timed out after 120s (storyboard=${storyboardId}). ` +
         `This is a harness-level kill, not an agent conformance failure. ` +
         `To debug, run the grader directly: ` +
         `node bin/adcp.js storyboard run ${url} ${storyboardId} --json --allow-http --auth sk_harness_do_not_use_in_prod --webhook-receiver`
     );
+  } else if (exitCode !== 0) {
+    log(`grader: exited with code ${exitCode} (storyboard=${storyboardId})`);
   }
+
   let passed = false;
   try {
-    const parsed = JSON.parse(res.stdout);
+    const parsed = JSON.parse(stdout);
     // Pass criteria, in order:
     //   1. `overall_status === 'passing'` — explicit pass from the grader
     //   2. `overall_status === 'partial'` AND zero step/track failures — all
@@ -690,7 +702,7 @@ async function main(): Promise<void> {
 
     const url = `http://127.0.0.1:${args.port}/mcp`;
     log(`grading storyboard ${args.storyboard}`);
-    const { passed: storyboardPassed, raw } = runGrader(url, args.storyboard);
+    const { passed: storyboardPassed, raw } = await runGrader(url, args.storyboard);
     process.stdout.write(raw);
 
     // Façade-detection check (issue #1225). Even if the storyboard passes,


### PR DESCRIPTION
## Summary

PR #1241 closed the stdin-pipe stall but the grader still hung 120s on storyboards that exercise upstream calls. Root cause: the harness boots the mock upstream HTTP server in the **same Node process**, then called `spawnSync` for the grader. `spawnSync` blocks the event loop — while it runs, the in-process upstream can't respond. Agent calls upstream, upstream's HTTP handler never gets a tick, agent blocks on the response, grader blocks on the agent, full deadlock at the configured timeout.

This is the residual hang flagged in #1237 that #1241 didn't address.

## Diagnosis

A standalone reproducer (upstream in a separate child process) ran identical `spawnSync` invocations to completion in ~1s across three stdio configurations (`pipe/pipe`, `pipe/inherit`, `inherit/inherit`). That ruled out:

- stdio buffering / pipe-buffer exhaustion
- webhook-receiver port collision
- the stdin-pipe stall already addressed by #1241

The hang was specific to the harness's combination of (a) in-process upstream + (b) synchronous child wait. Same-process deadlock.

## Fix

Convert `runGrader` to async: `spawn` + readable-stream chunk collection + `Promise` on `'close'`, with `setTimeout` → `child.kill('SIGTERM')` for the 120s cap. The parent event loop stays live, so the in-process upstream serves alongside the grader.

Call site (`main()`) gets `await`.

## Verification

`signal_marketplace` verify-mode against a kept blind-fixture workspace:

| | log size | wall | traffic |
|---|---|---|---|
| before | 22 lines | 120s | `_lookup/operator: 1` only |
| after | 632 lines (full grader JSON) | 1.5s | `_lookup/operator: 2, /v2/cohorts: 2` |

`overall_status: partial` matches direct-grader invocation. The harness's traffic check still correctly flags `POST /v2/activations: 0` (separate storyboard-cascade issue, adcontextprotocol/adcp#3796).

## Refs

- #1237 (the original hang)
- #1241 (closed the stdin-stall; this addresses the residual same-process deadlock)
- adcontextprotocol/adcp#3796 (storyboard cascade — separate, unaffected)

## Test plan

- [x] Async runGrader compiles (strict tsc)
- [x] prettier format clean
- [x] Verify-mode on signal_marketplace returns full grader JSON in 1.5s (was 120s timeout)
- [x] Traffic counters reflect actual storyboard execution
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)