### PR TITLE
fix(storyboard): emit capture_path_not_resolvable / unresolved_substitution (runner-output-contract v1.2.0)

### DIFF
--- a/.changeset/runner-capture-path-grading.md
+++ b/.changeset/runner-capture-path-grading.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Storyboard runner now emits `capture_path_not_resolvable` when a `context_outputs` path resolves to absent, null, or "" (runner-output-contract v1.2.0). The capturing step grades **failed** and contributes to `run_summary.steps_failed`. Consumer steps that encounter an unresolved `$context.*` or `{{prior_step.*}}` token now include an `unresolved_substitution` ValidationResult (previously `validations: []`). Fixes silent-skip cascade diagnostic blind spot affecting 15 storyboards.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.1.0",
+  "version": "6.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.1.0",
+      "version": "6.6.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6398,7 +6398,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.0.0"
+        "@adcp/sdk": "^6.6.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -14,6 +14,14 @@ import { randomUUID } from 'node:crypto';
 import type { StoryboardContext, ContextOutput, ContextInput, ContextProvenanceEntry } from './types';
 import { resolvePath, setPath } from './path';
 
+/** A context_outputs path that resolved to absent, null, or "" (runner-output-contract v1.2.0). */
+export interface ContextCaptureFailed {
+  key: string;
+  path: string;
+  /** The resolved value: null when absent or null; "" when empty string. */
+  actual: unknown;
+}
+
 // ────────────────────────────────────────────────────────────
 // Context extraction: pull known IDs from task responses
 // ────────────────────────────────────────────────────────────
@@ -472,13 +480,14 @@ function expandMustache(input: string, runnerVars: RunnerVariables): string {
  * Apply explicit context_outputs rules to extract values from response data.
  * Entries with `generate` set are skipped — use `applyContextOutputsWithProvenance`
  * (which accepts a context for alias-cache access) to handle those.
+ * Absent, null, and "" are all treated as non-resolvable (runner-output-contract v1.2.0).
  */
 export function applyContextOutputs(data: unknown, outputs: ContextOutput[]): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const output of outputs) {
     if (!output.path) continue;
     const value = resolvePath(data, output.path);
-    if (value !== undefined && value !== null) {
+    if (value !== undefined && value !== null && value !== '') {
       result[output.key] = value;
     }
   }
@@ -491,11 +500,14 @@ export function applyContextOutputs(data: unknown, outputs: ContextOutput[]): Re
  * seller response rejects a value that traces back to one of these keys.
  * `values` carries the same Record as the non-provenance call so the
  * runner's downstream `Object.assign(updatedContext, values)` path is
- * unchanged.
+ * unchanged. `failures` lists path entries whose resolved value was absent,
+ * null, or "" — the runner emits `capture_path_not_resolvable` for these
+ * (runner-output-contract v1.2.0).
  */
 export interface ContextWriteResult {
   values: Record<string, unknown>;
   provenance: Record<string, ContextProvenanceEntry>;
+  failures: ContextCaptureFailed[];
 }
 
 /**
@@ -513,7 +525,7 @@ export function extractContextWithProvenance(taskName: string, data: unknown, st
       source_task: taskName,
     };
   }
-  return { values, provenance };
+  return { values, provenance, failures: [] };
 }
 
 /**
@@ -531,7 +543,8 @@ export function extractContextWithProvenance(taskName: string, data: unknown, st
  * an independent UUID that cannot be matched by an inline `$generate:…` form.
  *
  * Generator entries fire regardless of whether `data` is present; path
- * entries are silently skipped when the resolved value is null/undefined.
+ * entries that resolve to absent, null, or "" are recorded in `failures`
+ * (runner-output-contract v1.2.0 `capture_path_not_resolvable`).
  */
 export function applyContextOutputsWithProvenance(
   data: unknown,
@@ -542,6 +555,7 @@ export function applyContextOutputsWithProvenance(
 ): ContextWriteResult {
   const values: Record<string, unknown> = {};
   const provenance: Record<string, ContextProvenanceEntry> = {};
+  const failures: ContextCaptureFailed[] = [];
   for (const output of outputs) {
     if (output.generate !== undefined) {
       // Generator entries require a context — without one the alias cache
@@ -571,7 +585,7 @@ export function applyContextOutputsWithProvenance(
       };
     } else if (output.path) {
       const value = resolvePath(data, output.path);
-      if (value !== undefined && value !== null) {
+      if (value !== undefined && value !== null && value !== '') {
         values[output.key] = value;
         provenance[output.key] = {
           source_step_id: stepId,
@@ -579,10 +593,13 @@ export function applyContextOutputsWithProvenance(
           response_path: output.path,
           source_task: taskName,
         };
+      } else {
+        // Path resolved to absent, null, or "" — all equally non-resolvable.
+        failures.push({ key: output.key, path: output.path, actual: value !== undefined ? value : null });
       }
     }
   }
-  return { values, provenance };
+  return { values, provenance, failures };
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -139,7 +139,7 @@ export {
   applyContextOutputsWithProvenance,
   applyContextInputs,
 } from './context';
-export type { ContextWriteResult } from './context';
+export type { ContextWriteResult, ContextCaptureFailed } from './context';
 
 // Rejection-hint detection (issue #870)
 export { detectContextRejectionHints } from './rejection-hints';

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -23,6 +23,7 @@ import { detectContextRejectionHints } from './rejection-hints';
 import { detectShapeDriftHints } from './shape-drift-hints';
 import { detectStrictValidationHints } from './strict-validation-hints';
 import { runValidations, type ValidationContext } from './validations';
+import { toJsonPointer } from './path';
 import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
 import { isMutatingTask, generateIdempotencyKey } from '../../utils/idempotency';
@@ -2037,8 +2038,9 @@ async function executeStep(
   // surfaces can still exercise the server's required-field check.
   request = applyIdempotencyInvariant(request, effectiveStep.task, step);
 
-  // Detect unresolved $context placeholders — a prior step likely failed
-  // and didn't produce the expected output. Skip rather than sending garbage.
+  // Detect unresolved $context and {{prior_step.*}} placeholders — a prior
+  // step likely failed and didn't produce the expected output. Skip rather
+  // than sending garbage. Emit unresolved_substitution per runner-output-contract v1.2.0.
   const unresolvedVars = findUnresolvedContextVars(request);
   if (unresolvedVars.length > 0 && !step.expect_error) {
     const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
@@ -2053,7 +2055,16 @@ async function executeStep(
       skip_reason: 'prerequisite_failed',
       skip: buildSkip('prerequisite_failed', detail),
       duration_ms: 0,
-      validations: [],
+      validations: unresolvedVars.map(token => ({
+        check: 'unresolved_substitution',
+        passed: false,
+        description: `Request token '${token}' could not be resolved; upstream step may have failed to capture the expected value.`,
+        expected: token,
+        actual: null,
+        json_pointer: null,
+        schema_id: null,
+        schema_url: null,
+      })),
       context,
       error: detail,
       next,
@@ -2277,7 +2288,7 @@ async function executeStep(
     validations = runValidations(resolvedValidations, vctx);
   }
 
-  const allValidationsPassed = validations.every(v => v.passed);
+  let allValidationsPassed = validations.every(v => v.passed);
 
   // Persist the captured A2A envelope keyed by step id so cross-step
   // validators (`a2a_context_continuity`) on subsequent steps can
@@ -2312,11 +2323,11 @@ async function executeStep(
   // determined (and may already be inline-substituted via $generate:…#<key>)
   // before the request went out. Propagating it even on failure lets the
   // next step use the same ID for a forced-completion or tasks/get follow-up.
-  // `path:` entries are gated on a non-null response and skip silently when
-  // data is absent. Both paths write into updatedContext and receive
-  // updatedContext for alias-cache coherence — forwardAliasCache above
-  // ensures the minted value from any same-step $generate:…#<key> inline
-  // substitution is visible here.
+  // `path:` entries that resolve to absent/null/"" emit capture_path_not_resolvable
+  // (runner-output-contract v1.2.0) and fail the step. Both paths write into
+  // updatedContext and receive updatedContext for alias-cache coherence —
+  // forwardAliasCache above ensures the minted value from any same-step
+  // $generate:…#<key> inline substitution is visible here.
   if (step.context_outputs?.length) {
     const explicit = applyContextOutputsWithProvenance(
       hasData && taskResult ? taskResult.data : undefined,
@@ -2330,6 +2341,23 @@ async function executeStep(
       for (const [key, entry] of Object.entries(explicit.provenance)) {
         runState.contextProvenance.set(key, entry);
       }
+    }
+    if (explicit.failures.length > 0) {
+      for (const failure of explicit.failures) {
+        validations.push({
+          check: 'capture_path_not_resolvable',
+          passed: false,
+          description: `context_outputs path '${failure.path}' did not resolve`,
+          expected: failure.path,
+          actual: failure.actual,
+          json_pointer: toJsonPointer(failure.path),
+          schema_id: null,
+          schema_url: null,
+          ...(requestRecord && { request: requestRecord }),
+          ...(responseRecord && { response: responseRecord }),
+        });
+      }
+      allValidationsPassed = validations.every(v => v.passed);
     }
   }
 
@@ -2974,12 +3002,27 @@ interface FlatStep {
 /**
  * Find any "$context.xxx" strings that weren't resolved during injection.
  */
+// Matches unresolved {{prior_step.*}} mustache tokens left in-place by
+// expandMustache. Uses [^{}]+ (no alternation, bounded by excluded chars) to
+// stay ReDoS-safe — same pattern as MUSTACHE_TOKEN_RE above.
+const UNRESOLVED_PRIOR_STEP_RE = /\{\{prior_step\.[^{}]+\}\}/g;
+
 function findUnresolvedContextVars(obj: unknown): string[] {
   const vars: string[] = [];
   const walk = (val: unknown) => {
     if (typeof val === 'string') {
-      const match = val.match(/^\$context\.(\w+)$/);
-      if (match?.[1]) vars.push(match[1]);
+      // Unresolved $context.* — injectContext returns the literal string when key absent.
+      const ctxMatch = val.match(/^\$context\.(\w+)$/);
+      if (ctxMatch?.[1]) {
+        vars.push(`$context.${ctxMatch[1]}`);
+        return;
+      }
+      // Unresolved {{prior_step.*}} — expandMustache leaves the token in-place.
+      let m: RegExpExecArray | null;
+      UNRESOLVED_PRIOR_STEP_RE.lastIndex = 0;
+      while ((m = UNRESOLVED_PRIOR_STEP_RE.exec(val)) !== null) {
+        vars.push(m[0]);
+      }
     } else if (Array.isArray(val)) {
       val.forEach(walk);
     } else if (val !== null && typeof val === 'object') {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3003,10 +3003,6 @@ interface FlatStep {
  * Find any "$context.xxx" strings that weren't resolved during injection.
  */
 // Matches unresolved {{prior_step.*}} mustache tokens left in-place by
-// expandMustache. Uses [^{}]+ (no alternation, bounded by excluded chars) to
-// stay ReDoS-safe — same pattern as MUSTACHE_TOKEN_RE above.
-const UNRESOLVED_PRIOR_STEP_RE = /\{\{prior_step\.[^{}]+\}\}/g;
-
 function findUnresolvedContextVars(obj: unknown): string[] {
   const vars: string[] = [];
   const walk = (val: unknown) => {
@@ -3018,9 +3014,11 @@ function findUnresolvedContextVars(obj: unknown): string[] {
         return;
       }
       // Unresolved {{prior_step.*}} — expandMustache leaves the token in-place.
+      // Local regex (not module-scope /g) — safe under concurrent async execution.
+      // Uses [^{}]+ (no alternation, bounded by excluded chars) — ReDoS-safe.
+      const unresolvedPriorStepRe = /\{\{prior_step\.[^{}]+\}\}/g;
       let m: RegExpExecArray | null;
-      UNRESOLVED_PRIOR_STEP_RE.lastIndex = 0;
-      while ((m = UNRESOLVED_PRIOR_STEP_RE.exec(val)) !== null) {
+      while ((m = unresolvedPriorStepRe.exec(val)) !== null) {
         vars.push(m[0]);
       }
     } else if (Array.isArray(val)) {

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -503,7 +503,22 @@ export type StoryboardValidationCheck =
    * `context_key_absent` observation.
    * Added for adcp#2642 cross-step comparison primitives.
    */
-  | 'field_equals_context';
+  | 'field_equals_context'
+  /**
+   * Runner-synthesized: a `context_outputs[].path` resolved to absent, `null`,
+   * or `""`. Emitted by the runner (not YAML-authored); contributes to
+   * `run_summary.steps_failed` on the capturing step.
+   * Defined in runner-output-contract v1.2.0 (adcp-client#1251).
+   */
+  | 'capture_path_not_resolvable'
+  /**
+   * Runner-synthesized: a `$context.<name>` or `{{prior_step.<id>.<field>}}`
+   * token could not be resolved at request-build time. Emitted on a consumer
+   * step that skips with `prerequisite_failed`; contributes to
+   * `run_summary.steps_skipped` (not `steps_failed`).
+   * Defined in runner-output-contract v1.2.0 (adcp-client#1251).
+   */
+  | 'unresolved_substitution';
 
 /**
  * Captured A2A wire shape from a `message/send` JSON-RPC response. The

--- a/test/lib/storyboard-capture-grading.test.js
+++ b/test/lib/storyboard-capture-grading.test.js
@@ -9,7 +9,10 @@
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { applyContextOutputsWithProvenance, extractContextWithProvenance } = require('../../dist/lib/testing/storyboard/context');
+const {
+  applyContextOutputsWithProvenance,
+  extractContextWithProvenance,
+} = require('../../dist/lib/testing/storyboard/context');
 const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
 
 // ─── Stub client factory (mirrors storyboard-step-provenance-threading pattern) ─
@@ -21,7 +24,8 @@ function buildStubClient(taskResponses = {}) {
     // Runner dispatches typed methods by camelCase name when available.
     getSignals: async params => taskResponses.get_signals?.(params) ?? { success: false, error: 'no handler' },
     activateSignal: async params => taskResponses.activate_signal?.(params) ?? { success: false, error: 'no handler' },
-    getAdcpCapabilities: async () => taskResponses.get_adcp_capabilities?.() ?? { success: true, data: { version: '1.0' } },
+    getAdcpCapabilities: async () =>
+      taskResponses.get_adcp_capabilities?.() ?? { success: true, data: { version: '1.0' } },
     executeTask: async (name, params) =>
       taskResponses[name]?.(params) ?? { success: false, error: `no handler for ${name}` },
   };
@@ -101,11 +105,7 @@ describe('applyContextOutputsWithProvenance — failures field', () => {
   });
 
   test('extractContextWithProvenance returns empty failures array', () => {
-    const { failures } = extractContextWithProvenance(
-      'get_products',
-      { products: [{ product_id: 'p1' }] },
-      'step1'
-    );
+    const { failures } = extractContextWithProvenance('get_products', { products: [{ product_id: 'p1' }] }, 'step1');
     assert.ok(Array.isArray(failures));
     assert.equal(failures.length, 0);
   });

--- a/test/lib/storyboard-capture-grading.test.js
+++ b/test/lib/storyboard-capture-grading.test.js
@@ -1,0 +1,357 @@
+/**
+ * Tests for runner-output-contract v1.2.0 grading codes:
+ *   - capture_path_not_resolvable (issue #1251)
+ *   - unresolved_substitution (issue #1251)
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { applyContextOutputsWithProvenance, extractContextWithProvenance } = require('../../dist/lib/testing/storyboard/context');
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner');
+
+// ─── Stub client factory (mirrors storyboard-step-provenance-threading pattern) ─
+
+function buildStubClient(taskResponses = {}) {
+  const tools = Object.keys(taskResponses).map(name => ({ name }));
+  return {
+    getAgentInfo: async () => ({ name: 'stub-agent', tools }),
+    // Runner dispatches typed methods by camelCase name when available.
+    getSignals: async params => taskResponses.get_signals?.(params) ?? { success: false, error: 'no handler' },
+    activateSignal: async params => taskResponses.activate_signal?.(params) ?? { success: false, error: 'no handler' },
+    getAdcpCapabilities: async () => taskResponses.get_adcp_capabilities?.() ?? { success: true, data: { version: '1.0' } },
+    executeTask: async (name, params) =>
+      taskResponses[name]?.(params) ?? { success: false, error: `no handler for ${name}` },
+  };
+}
+
+function makeStoryboard(phases) {
+  return {
+    id: 'capture_grading_sb',
+    version: '1.0.0',
+    title: 'Capture grading test',
+    category: 'testing',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases,
+  };
+}
+
+// Stub profile used for agentTools so the runner skips tool-presence checks
+// against discovery and proceeds directly to executing steps.
+function makeStubProfile(taskNames) {
+  return { name: 'stub-agent', tools: taskNames.map(n => ({ name: n })) };
+}
+
+// ─── Unit: applyContextOutputsWithProvenance failures field ───────────────────
+
+describe('applyContextOutputsWithProvenance — failures field', () => {
+  test('absent path produces a failure entry with actual null', () => {
+    const data = { signals: [] };
+    const outputs = [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }];
+    const { values, failures } = applyContextOutputsWithProvenance(data, outputs, 'step1', 'get_signals');
+    assert.deepEqual(values, {});
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].key, 'seg_id');
+    assert.equal(failures[0].path, 'signals[0].signal_agent_segment_id');
+    assert.equal(failures[0].actual, null);
+  });
+
+  test('null value produces a failure entry with actual null', () => {
+    const data = { result: { id: null } };
+    const outputs = [{ key: 'the_id', path: 'result.id' }];
+    const { values, failures } = applyContextOutputsWithProvenance(data, outputs, 'step1', 'some_task');
+    assert.deepEqual(values, {});
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].actual, null);
+  });
+
+  test('empty string value produces a failure entry with actual ""', () => {
+    const data = { result: { id: '' } };
+    const outputs = [{ key: 'the_id', path: 'result.id' }];
+    const { values, failures } = applyContextOutputsWithProvenance(data, outputs, 'step1', 'some_task');
+    assert.deepEqual(values, {});
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].actual, '');
+  });
+
+  test('resolved non-empty value produces no failure', () => {
+    const data = { signals: [{ signal_agent_segment_id: 'seg_abc' }] };
+    const outputs = [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }];
+    const { values, failures } = applyContextOutputsWithProvenance(data, outputs, 'step1', 'get_signals');
+    assert.equal(values.seg_id, 'seg_abc');
+    assert.equal(failures.length, 0);
+  });
+
+  test('mixed outputs: one resolves, one fails', () => {
+    const data = { signals: [{ signal_agent_segment_id: 'seg_x' }] };
+    const outputs = [
+      { key: 'seg_id', path: 'signals[0].signal_agent_segment_id' },
+      { key: 'missing', path: 'signals[0].nonexistent_field' },
+    ];
+    const { values, failures } = applyContextOutputsWithProvenance(data, outputs, 'step1', 'get_signals');
+    assert.equal(values.seg_id, 'seg_x');
+    assert.equal(Object.keys(values).length, 1);
+    assert.equal(failures.length, 1);
+    assert.equal(failures[0].key, 'missing');
+  });
+
+  test('extractContextWithProvenance returns empty failures array', () => {
+    const { failures } = extractContextWithProvenance(
+      'get_products',
+      { products: [{ product_id: 'p1' }] },
+      'step1'
+    );
+    assert.ok(Array.isArray(failures));
+    assert.equal(failures.length, 0);
+  });
+});
+
+// ─── Integration: capture_path_not_resolvable ─────────────────────────────────
+
+describe('runStoryboard: capture_path_not_resolvable grading', () => {
+  const taskNames = ['get_signals'];
+  const stubOpts = client => ({
+    protocol: 'mcp',
+    _client: client,
+    agentTools: taskNames,
+    _profile: makeStubProfile(taskNames),
+  });
+
+  test('absent path (empty array) grades step failed with capture_path_not_resolvable', async () => {
+    const client = buildStubClient({
+      get_signals: () => ({ success: true, data: { signals: [] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            context_outputs: [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }],
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    const step = result.phases[0].steps[0];
+    assert.equal(step.step_id, 'get_sigs');
+    assert.equal(step.passed, false, 'step with unresolvable capture path should fail');
+    const captureResult = step.validations.find(v => v.check === 'capture_path_not_resolvable');
+    assert.ok(captureResult, 'should emit capture_path_not_resolvable ValidationResult');
+    assert.equal(captureResult.passed, false);
+    assert.equal(captureResult.expected, 'signals[0].signal_agent_segment_id');
+    assert.equal(captureResult.json_pointer, '/signals/0/signal_agent_segment_id');
+    assert.equal(captureResult.schema_id, null);
+    assert.equal(captureResult.schema_url, null);
+  });
+
+  test('null response value grades failed with capture_path_not_resolvable', async () => {
+    const client = buildStubClient({
+      get_signals: () => ({ success: true, data: { signals: [{ signal_agent_segment_id: null }] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            context_outputs: [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }],
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, false);
+    const captureResult = step.validations.find(v => v.check === 'capture_path_not_resolvable');
+    assert.ok(captureResult, 'null value should emit capture_path_not_resolvable');
+    assert.equal(captureResult.actual, null);
+  });
+
+  test('empty-string response value grades failed with capture_path_not_resolvable', async () => {
+    const client = buildStubClient({
+      get_signals: () => ({ success: true, data: { signals: [{ signal_agent_segment_id: '' }] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            context_outputs: [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }],
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, false);
+    const captureResult = step.validations.find(v => v.check === 'capture_path_not_resolvable');
+    assert.ok(captureResult, 'empty string should emit capture_path_not_resolvable');
+    assert.equal(captureResult.actual, '');
+  });
+
+  test('capture failure increments failed_count not skipped_count', async () => {
+    const client = buildStubClient({
+      get_signals: () => ({ success: true, data: { signals: [] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            context_outputs: [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }],
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    assert.equal(result.failed_count, 1, 'capture failure should increment failed_count');
+    assert.equal(result.skipped_count, 0);
+  });
+
+  test('successfully resolved path emits no capture_path_not_resolvable and passes', async () => {
+    const client = buildStubClient({
+      get_signals: () => ({ success: true, data: { signals: [{ signal_agent_segment_id: 'seg_abc' }] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            context_outputs: [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }],
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, true);
+    const captureResult = step.validations.find(v => v.check === 'capture_path_not_resolvable');
+    assert.equal(captureResult, undefined, 'resolved path should not emit capture_path_not_resolvable');
+    assert.equal(result.failed_count, 0);
+  });
+});
+
+// ─── Integration: unresolved_substitution ────────────────────────────────────
+
+describe('runStoryboard: unresolved_substitution grading', () => {
+  const taskNames = ['get_signals', 'activate_signal'];
+  const stubOpts = client => ({
+    protocol: 'mcp',
+    _client: client,
+    agentTools: taskNames,
+    _profile: makeStubProfile(taskNames),
+  });
+
+  test('step with unresolved $context.* emits unresolved_substitution ValidationResult', async () => {
+    const client = buildStubClient({
+      // get_signals succeeds but uses a different key than the consumer step expects
+      get_signals: () => ({ success: true, data: { signals: [{ signal_agent_segment_id: 'seg_x' }] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            // context_outputs writes 'seg_id' key via convention extractor (get_signals)
+            // but the consumer step below references 'nonexistent_key' which is never set.
+          },
+          {
+            id: 'activate_sig',
+            title: 'Activate with missing key',
+            task: 'activate_signal',
+            sample_request: { signal_id: '$context.nonexistent_key' },
+            stateful: true,
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    const skipStep = result.phases[0].steps.find(s => s.step_id === 'activate_sig');
+    assert.ok(skipStep, 'activate_sig step should be present');
+    assert.equal(skipStep.skipped, true, 'step with unresolved token should be skipped');
+    assert.equal(skipStep.skip?.reason, 'prerequisite_failed');
+    const subResult = skipStep.validations.find(v => v.check === 'unresolved_substitution');
+    assert.ok(subResult, 'should emit unresolved_substitution ValidationResult');
+    assert.equal(subResult.passed, false);
+    assert.equal(subResult.expected, '$context.nonexistent_key');
+    assert.equal(subResult.actual, null);
+    assert.equal(subResult.json_pointer, null);
+    assert.equal(subResult.schema_id, null);
+    assert.equal(subResult.schema_url, null);
+  });
+
+  test('unresolved_substitution step contributes to skipped_count not failed_count', async () => {
+    const client = buildStubClient({
+      get_signals: () => ({ success: true, data: { signals: [] } }),
+    });
+    const sb = makeStoryboard([
+      {
+        id: 'phase_capture',
+        title: 'Capture',
+        steps: [
+          {
+            id: 'get_sigs',
+            title: 'Get signals',
+            task: 'get_signals',
+            sample_request: {},
+            // capture_path_not_resolvable: signals[0] absent → seg_id never set
+            context_outputs: [{ key: 'seg_id', path: 'signals[0].signal_agent_segment_id' }],
+          },
+          {
+            id: 'activate_sig',
+            title: 'Activate',
+            task: 'activate_signal',
+            sample_request: { signal_id: '$context.seg_id' },
+            stateful: true,
+          },
+        ],
+      },
+    ]);
+    const result = await runStoryboard('http://stub', sb, stubOpts(client));
+    const captureStep = result.phases[0].steps.find(s => s.step_id === 'get_sigs');
+    const skipStep = result.phases[0].steps.find(s => s.step_id === 'activate_sig');
+    // Capture step grades failed (capture_path_not_resolvable)
+    assert.equal(captureStep.passed, false);
+    assert.ok(captureStep.validations.find(v => v.check === 'capture_path_not_resolvable'));
+    // Consumer step grades skipped (unresolved_substitution)
+    assert.equal(skipStep.skipped, true);
+    assert.ok(skipStep.validations.find(v => v.check === 'unresolved_substitution'));
+    // failed_count = 1 (capture step only), skipped_count = 1 (consumer step)
+    assert.equal(result.failed_count, 1, 'only capture step should count as failed');
+    assert.equal(result.skipped_count, 1, 'consumer step should count as skipped');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1251. Implements runner-output-contract v1.2.0 grading codes to surface silent-skip cascades across the 15 affected storyboards.

- **`capture_path_not_resolvable`** — emitted when a `context_outputs[].path` resolves to absent, `null`, or `""` (the three-state rule). The capturing step grades **failed** and contributes to `run_summary.steps_failed`.
- **`unresolved_substitution`** — emitted on a consumer step whose `$context.<name>` or `{{prior_step.*}}` token could not be resolved at request-build time. The step grades **skipped** with `prerequisite_failed` and contributes to `run_summary.steps_skipped` (not `steps_failed`).
- Added both codes to the `StoryboardValidationCheck` union in `types.ts`.
- Fixed concurrent-async hazard: `UNRESOLVED_PRIOR_STEP_RE` was a module-scope `/g` regex whose shared `lastIndex` is unsafe under concurrent `runStoryboard()` calls. Moved to a local constant inside `findUnresolvedContextVars`.

## Changed files

| File | Change |
|---|---|
| `src/lib/testing/storyboard/context.ts` | New `ContextCaptureFailed` interface; `ContextWriteResult` gains `failures` field; `applyContextOutputsWithProvenance` collects failures; `""` parity fix in `applyContextOutputs` |
| `src/lib/testing/storyboard/runner.ts` | `allValidationsPassed` → `let` (recomputed after capture failures); capture block emits `capture_path_not_resolvable`; skip block emits `unresolved_substitution`; regex concurrency fix |
| `src/lib/testing/storyboard/types.ts` | `capture_path_not_resolvable` + `unresolved_substitution` added to `StoryboardValidationCheck` union |
| `src/lib/testing/storyboard/index.ts` | Re-exports `ContextCaptureFailed` |
| `test/lib/storyboard-capture-grading.test.js` | 13 new tests (6 unit + 5 `capture_path_not_resolvable` integration + 2 `unresolved_substitution` integration); all pass |
| `.changeset/runner-capture-path-grading.md` | Patch changeset |

## Test plan

- [ ] `node --test test/lib/storyboard-capture-grading.test.js` → 13/13 pass
- [ ] `npm run typecheck` → clean
- [ ] `npm run build` → clean
- [ ] Storyboard suite regression: `find test/lib -name "storyboard*.test.js" | xargs node --test` → no new failures vs baseline

https://claude.ai/code/session_015RGYaa9qSUWtvZxG1WQmbW

---
_Generated by [Claude Code](https://claude.ai/code/session_015RGYaa9qSUWtvZxG1WQmbW)_