### PR TITLE
fix(storyboard): grade unrecognized check kinds as not_applicable (forward-compat)

### DIFF
--- a/.changeset/runner-forward-compat-not-applicable.md
+++ b/.changeset/runner-forward-compat-not-applicable.md
@@ -1,0 +1,12 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(storyboard): grade unrecognized check kinds as not_applicable for forward compatibility
+
+Replaces the hard-fail `default` case in the validation dispatcher with a
+`not_applicable` pass so storyboards authored against a newer spec version
+don't hard-fail on older runners. Adds `ValidationResult.not_applicable` flag
+and `StoryboardResult.validations_not_applicable` counter so consumers can
+distinguish "runner is older than the storyboard" from a clean pass.
+Per runner-output-contract.yaml v2.0.0 (adcp#3816). Refs #1253.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1479,6 +1479,10 @@ async function executeStoryboardPass(
   if (seedingPhaseResult) phaseResults.unshift(seedingPhaseResult);
   const schemasUsed = collectSchemasUsed(phaseResults);
   const strictSummary = summarizeStrictValidation(phaseResults);
+  const notApplicableCount = phaseResults
+    .flatMap(pr => pr.steps)
+    .flatMap(sr => sr.validations)
+    .filter(v => v.not_applicable === true).length;
   const result: StoryboardResult = {
     storyboard_id: storyboard.id,
     storyboard_title: storyboard.title,
@@ -1495,6 +1499,7 @@ async function executeStoryboardPass(
     passed_count: passedCount,
     failed_count: failedCount,
     skipped_count: skippedCount,
+    ...(notApplicableCount > 0 ? { validations_not_applicable: notApplicableCount } : {}),
     tested_at: new Date().toISOString(),
     ...(schemasUsed.length > 0 ? { schemas_used: schemasUsed } : {}),
     ...(assertionResults.length > 0 ? { assertions: assertionResults } : {}),
@@ -1567,6 +1572,9 @@ async function runMultiPass(
       passed_count: result.passed_count,
       failed_count: result.failed_count,
       skipped_count: result.skipped_count,
+      ...(result.validations_not_applicable !== undefined
+        ? { validations_not_applicable: result.validations_not_applicable }
+        : {}),
       duration_ms: result.total_duration_ms,
     });
   }
@@ -1576,6 +1584,7 @@ async function runMultiPass(
   const passed = passes.reduce((sum, p) => sum + p.passed_count, 0);
   const failed = passes.reduce((sum, p) => sum + p.failed_count, 0);
   const skipped = passes.reduce((sum, p) => sum + p.skipped_count, 0);
+  const notApplicableAgg = passes.reduce((sum, p) => sum + (p.validations_not_applicable ?? 0), 0);
   const schemasUsed = passResults.flatMap(r => r.schemas_used ?? []);
   const schemasDedup = [...new Map(schemasUsed.map(s => [s.schema_id, s])).values()];
   // Assertions are scoped per-pass — each pass's runner resolved them
@@ -1598,6 +1607,7 @@ async function runMultiPass(
     passed_count: passed,
     failed_count: failed,
     skipped_count: skipped,
+    ...(notApplicableAgg > 0 ? { validations_not_applicable: notApplicableAgg } : {}),
     tested_at: new Date().toISOString(),
     ...(schemasDedup.length > 0 ? { schemas_used: schemasDedup } : {}),
     ...(assertionsAgg.length > 0 ? { assertions: assertionsAgg } : {}),

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1078,6 +1078,16 @@ export interface ValidationResult {
    */
   warning?: string;
   /**
+   * True when the runner does not implement this check kind and graded it
+   * as not_applicable to preserve forward compatibility with storyboards
+   * authored against a newer spec version. Contributes to
+   * `StoryboardResult.validations_not_applicable` on the run summary.
+   * Consumers that read `passed === true` should also inspect this flag
+   * to distinguish a genuine pass from a forward-compat skip.
+   * Per runner-output-contract.yaml v2.0.0 (adcp#3816).
+   */
+  not_applicable?: true;
+  /**
    * Issue #820 follow-up — strict JSON-schema (AJV) verdict for
    * `response_schema` checks. `passed` remains the lenient Zod outcome
    * (runner's historical pass/fail semantics); `strict` carries the
@@ -1540,6 +1550,16 @@ export interface StoryboardResult {
   passed_count: number;
   failed_count: number;
   skipped_count: number;
+  /**
+   * Count of individual validation checks that were graded as not_applicable
+   * because the runner does not implement the check kind declared in the
+   * storyboard. A non-zero value means this runner is older than the storyboard
+   * — some checks were silently skipped. Consumers MUST NOT treat the absence
+   * of this field (or a zero value) as proof that all checks ran; they should
+   * confirm the runner version matches the storyboard's spec version.
+   * Per runner-output-contract.yaml v2.0.0 (adcp#3816).
+   */
+  validations_not_applicable?: number;
   tested_at: string;
   /**
    * Schemas applied during this run. Per the runner-output contract, runners
@@ -1663,5 +1683,13 @@ export interface StoryboardPassResult {
   passed_count: number;
   failed_count: number;
   skipped_count: number;
+  /**
+   * Count of not_applicable-graded validations in this pass.
+   * A non-zero value means some check kinds in the storyboard were not
+   * implemented by this runner — per-pass signal for multi-pass runs.
+   * Consumers MUST NOT treat absence or zero as proof that all checks ran.
+   * See `StoryboardResult.validations_not_applicable` for full semantics.
+   */
+  validations_not_applicable?: number;
   duration_ms: number;
 }

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -156,12 +156,18 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
     case 'field_equals_context':
       return validateFieldEqualsContext(validation, ctx);
     default:
+      // Forward-compat: unrecognized check kinds grade as not_applicable so
+      // storyboards authored against a newer spec version don't hard-fail on
+      // older runners. Contributes to validations_not_applicable on run_summary.
+      // Per runner-output-contract.yaml v2.0.0 (adcp#3816).
       return {
         check: validation.check,
-        passed: false,
+        passed: true,
         description: validation.description,
-        error: `Unknown validation check: ${validation.check}`,
-        json_pointer: null,
+        not_applicable: true,
+        observations: [
+          `runner does not implement check type '${validation.check}' — graded as not_applicable to preserve forward compatibility`,
+        ],
       };
   }
 }


### PR DESCRIPTION
Refs #1253 (item 1 of 3 — items 2 and 3 tracked separately)

## Summary

The storyboard runner's validation dispatcher currently hard-fails with `passed: false, error: "Unknown validation check: X"` when it encounters a check kind it doesn't implement. Per `runner-output-contract.yaml` v2.0.0 (adcp#3816), runners MUST grade unrecognized authored check kinds as `not_applicable` rather than failing — so that storyboards authored against a newer spec version don't hard-fail on older runners.

This PR ships the independent item 1 from #1253 (the forward-compat default). Items 2 (capture/substitution grading) and 3 (upstream_traffic implementation) are tracked separately in PR #1252 and blocked on adcp#3816 respectively.

**Changes:**
- `validations.ts` — `default` case now returns `passed: true, not_applicable: true` with the skip reason in `observations[]`, following the established A2A transport-gating skip pattern
- `types.ts` — `ValidationResult` gains `not_applicable?: true`; `StoryboardResult` and `StoryboardPassResult` gain `validations_not_applicable?: number`
- `runner.ts` — counts `not_applicable` validations across all steps; propagates through multi-pass aggregation; field is omitted when zero (only emitted when the runner is visibly older than the storyboard)

## What was tested

- `npx tsc --project tsconfig.lib.json --noEmit` — pre-existing TS2688/TS5107 env errors only; no new errors
- `npx tsc --noEmit` — same pre-existing errors; no new type errors from these changes
- Unit tests require built `dist/` which is unavailable in this environment (`tsx` not installed); same pre-existing constraint as PRs #1232, #1238, #1242

## Pre-PR review

- **code-reviewer**: approved — no blockers; nit on `as const` redundancy (fixed) and doc-comment expansion on `StoryboardPassResult` (fixed)
- **ad-tech-protocol-expert**: approved — forward-compat semantics sound; `not_applicable: true` correctly distinguishes "runner doesn't implement check kind" from transport-conditional skips (`a2a_submitted_artifact`); `validations_not_applicable` counter is the correct consumer safety valve; `overall_passed` semantics noted as consumer-responsibility (the JSDoc on `StoryboardResult.validations_not_applicable` carries the MUST NOT warning)

## Nits surfaced (not fixed)

- Protocol expert noted `overall_passed: true` combined with `validations_not_applicable > 0` creates a policy gap: a consumer that only checks `overall_passed` will see a clean pass even if some checks were silently skipped. The spec (`runner-output-contract.yaml` v2.0.0 via adcp#3816) should address whether `overall_passed` must be downgraded when `validations_not_applicable > 0`. The JSDoc warning covers SDK consumers; the spec policy is adcp#3816's scope.

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012M6N1hKLxNKxnvzjikAMPw

---
_Generated by [Claude Code](https://claude.ai/code/session_012M6N1hKLxNKxnvzjikAMPw)_