### PR TITLE
fix(server): Account v3 wire alignment — billing_entity, reporting_bucket, write-only bank strip

### DIFF
--- a/.changeset/account-v3-wire-alignment.md
+++ b/.changeset/account-v3-wire-alignment.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/sdk": patch
+"@adcp/sdk": minor
 ---
 
 fix(server): extend Account<TCtxMeta> with AdCP 3.0.1 wire fields and strip write-only billing_entity.bank in toWireAccount

--- a/.changeset/account-v3-wire-alignment.md
+++ b/.changeset/account-v3-wire-alignment.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(server): extend Account<TCtxMeta> with AdCP 3.0.1 wire fields and strip write-only billing_entity.bank in toWireAccount
+
+Closes #1256

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -463,13 +463,11 @@ export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount
   if (account.account_scope !== undefined) wire.account_scope = account.account_scope;
   if (account.governance_agents !== undefined) wire.governance_agents = account.governance_agents;
 
-  if (process.env.NODE_ENV !== 'production') {
-    // Safety net: catches future refactors that assign billing_entity directly
-    // without stripping bank. Dead code under the current destructure, but
-    // protects against someone switching to a shallower copy.
-    if (wire.billing_entity !== undefined && 'bank' in wire.billing_entity) {
-      throw new Error('toWireAccount: billing_entity.bank present after strip — invariant violated');
-    }
+  // Always check — a bank-data leak in production is worse than a 500.
+  // Dead code under the current destructure, but protects against a future
+  // refactor that copies billing_entity without stripping bank.
+  if (wire.billing_entity !== undefined && 'bank' in wire.billing_entity) {
+    throw new Error('toWireAccount: billing_entity.bank present after strip — invariant violated');
   }
   return wire;
 }

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -13,12 +13,16 @@
  */
 
 import type {
+  Account as WireAccount,
   BrandReference,
   AccountReference,
   ReportUsageRequest,
   ReportUsageResponse,
   GetAccountFinancialsRequest,
   GetAccountFinancialsSuccess,
+  BusinessEntity,
+  PaymentTerms,
+  AccountScope,
 } from '../../types/tools.generated';
 import type { CursorPage, CursorRequest } from './pagination';
 
@@ -70,6 +74,41 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * assert the right party is billed.
    */
   billing?: { invoicedTo: 'agent' | 'operator' | BrandReference };
+
+  /**
+   * Business entity details for the party responsible for payment.
+   *
+   * `billing_entity.bank` is write-only per the AdCP spec — the framework
+   * strips it in `toWireAccount` before emitting on the wire. Adopters may
+   * populate it internally (e.g., after receiving it from a buyer request),
+   * but it will never reach the wire response.
+   */
+  billing_entity?: BusinessEntity;
+
+  /** Offline reporting delivery bucket. Verbatim pass-through to the wire. */
+  reporting_bucket?: WireAccount['reporting_bucket'];
+
+  /** Rate card identifier applied to this account. */
+  rate_card?: string;
+
+  /** Payment terms for this account. */
+  payment_terms?: PaymentTerms;
+
+  /** Maximum outstanding balance allowed. */
+  credit_limit?: { amount: number; currency: string };
+
+  /** Setup instructions shown when status is `'pending_approval'`. */
+  setup?: WireAccount['setup'];
+
+  /** How the seller scoped this billing account relative to operator/brand dimensions. */
+  account_scope?: AccountScope;
+
+  /**
+   * Governance agent endpoints registered on this account. Credential fields
+   * within each entry are write-only per the spec and are not echoed in
+   * responses.
+   */
+  governance_agents?: WireAccount['governance_agents'];
 
   /**
    * Adapter-internal opaque state. Framework doesn't read this; **stripped
@@ -382,8 +421,6 @@ export type AdcpAccountStatus =
 // Wire projection — strip framework-internal fields before emit
 // ---------------------------------------------------------------------------
 
-import type { Account as WireAccount } from '../../types/tools.generated';
-
 /**
  * Project a framework `Account<TCtxMeta>` to the wire `Account` shape.
  *
@@ -412,6 +449,27 @@ export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount
     // (Amazon DSP-shaped flow), which projects to `'advertiser'`.
     const t = account.billing.invoicedTo;
     wire.billing = typeof t === 'string' ? t : 'advertiser';
+  }
+  if (account.billing_entity !== undefined) {
+    // `bank` is write-only per the AdCP spec: MUST NOT be echoed in responses.
+    const { bank: _bank, ...rest } = account.billing_entity;
+    wire.billing_entity = rest as BusinessEntity;
+  }
+  if (account.reporting_bucket !== undefined) wire.reporting_bucket = account.reporting_bucket;
+  if (account.rate_card !== undefined) wire.rate_card = account.rate_card;
+  if (account.payment_terms !== undefined) wire.payment_terms = account.payment_terms;
+  if (account.credit_limit !== undefined) wire.credit_limit = account.credit_limit;
+  if (account.setup !== undefined) wire.setup = account.setup;
+  if (account.account_scope !== undefined) wire.account_scope = account.account_scope;
+  if (account.governance_agents !== undefined) wire.governance_agents = account.governance_agents;
+
+  if (process.env.NODE_ENV !== 'production') {
+    // Safety net: catches future refactors that assign billing_entity directly
+    // without stripping bank. Dead code under the current destructure, but
+    // protects against someone switching to a shallower copy.
+    if (wire.billing_entity !== undefined && 'bank' in wire.billing_entity) {
+      throw new Error('toWireAccount: billing_entity.bank present after strip — invariant violated');
+    }
   }
   return wire;
 }

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3361,7 +3361,16 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       const refs = (params.accounts ?? []) as AccountReference[];
       return projectSync(
         () => accounts.upsert!(refs),
-        rows => ({ accounts: rows })
+        rows => ({
+          accounts: rows.map(row => {
+            // billing_entity.bank is write-only per spec — strip it defensively
+            // so an adopter who echoes the inbound request back can't leak it.
+            const be = (row as { billing_entity?: Record<string, unknown> }).billing_entity;
+            if (!be) return row;
+            const { bank: _bank, ...restBe } = be;
+            return { ...row, billing_entity: restBe } as unknown as typeof row;
+          }),
+        })
       );
     };
   }

--- a/test/lib/account-wire-projection.test.js
+++ b/test/lib/account-wire-projection.test.js
@@ -1,0 +1,116 @@
+// Tests for toWireAccount — confirms v3 field projection and write-only bank strip.
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { toWireAccount } = require('../../dist/lib/server/decisioning/account');
+
+function baseAccount(overrides = {}) {
+  return {
+    id: 'acc_1',
+    name: 'Acme Corp',
+    status: 'active',
+    ctx_metadata: {},
+    authInfo: { kind: 'api_key' },
+    ...overrides,
+  };
+}
+
+describe('toWireAccount — v3 field projection', () => {
+  it('projects existing fields unchanged', () => {
+    const wire = toWireAccount(
+      baseAccount({
+        brand: { domain: 'acme.example' },
+        operator: 'agency.example',
+        advertiser: 'acme.example',
+        billing: { invoicedTo: 'operator' },
+      })
+    );
+    assert.strictEqual(wire.account_id, 'acc_1');
+    assert.strictEqual(wire.name, 'Acme Corp');
+    assert.strictEqual(wire.status, 'active');
+    assert.deepStrictEqual(wire.brand, { domain: 'acme.example' });
+    assert.strictEqual(wire.operator, 'agency.example');
+    assert.strictEqual(wire.advertiser, 'acme.example');
+    assert.strictEqual(wire.billing, 'operator');
+  });
+
+  it('strips billing_entity.bank and emits the rest', () => {
+    const account = baseAccount({
+      billing_entity: {
+        legal_name: 'Acme Legal GmbH',
+        vat_id: 'DE123456789',
+        bank: {
+          account_holder: 'Acme Legal GmbH',
+          iban: 'DE89370400440532013000',
+          bic: 'COBADEFFXXX',
+        },
+      },
+    });
+    const wire = toWireAccount(account);
+    assert.ok(wire.billing_entity, 'billing_entity should be present');
+    assert.strictEqual(wire.billing_entity.legal_name, 'Acme Legal GmbH');
+    assert.strictEqual(wire.billing_entity.vat_id, 'DE123456789');
+    assert.ok(!('bank' in wire.billing_entity), 'bank must be stripped from wire output');
+  });
+
+  it('emits billing_entity without bank when no bank was set', () => {
+    const account = baseAccount({
+      billing_entity: { legal_name: 'No Bank Corp' },
+    });
+    const wire = toWireAccount(account);
+    assert.ok(wire.billing_entity);
+    assert.strictEqual(wire.billing_entity.legal_name, 'No Bank Corp');
+    assert.ok(!('bank' in wire.billing_entity));
+  });
+
+  it('passes reporting_bucket through verbatim', () => {
+    const bucket = {
+      protocol: 's3',
+      bucket: 'acme-reports',
+      prefix: 'daily/',
+      file_retention_days: 30,
+    };
+    const wire = toWireAccount(baseAccount({ reporting_bucket: bucket }));
+    assert.deepStrictEqual(wire.reporting_bucket, bucket);
+  });
+
+  it('passes rate_card, payment_terms, credit_limit, setup, account_scope, governance_agents through', () => {
+    const account = baseAccount({
+      rate_card: 'rc_standard',
+      payment_terms: 'net_30',
+      credit_limit: { amount: 50000, currency: 'USD' },
+      setup: {
+        message: 'Complete your credit application',
+        url: 'https://example.com/apply',
+        expires_at: '2026-06-01T00:00:00Z',
+      },
+      account_scope: 'brand',
+      governance_agents: [{ url: 'https://gov.example.com/mcp', categories: ['budget_authority'] }],
+    });
+    const wire = toWireAccount(account);
+    assert.strictEqual(wire.rate_card, 'rc_standard');
+    assert.strictEqual(wire.payment_terms, 'net_30');
+    assert.deepStrictEqual(wire.credit_limit, { amount: 50000, currency: 'USD' });
+    assert.deepStrictEqual(wire.setup, {
+      message: 'Complete your credit application',
+      url: 'https://example.com/apply',
+      expires_at: '2026-06-01T00:00:00Z',
+    });
+    assert.strictEqual(wire.account_scope, 'brand');
+    assert.deepStrictEqual(wire.governance_agents, [
+      { url: 'https://gov.example.com/mcp', categories: ['budget_authority'] },
+    ]);
+  });
+
+  it('omits new fields from wire when not set — existing adopters unaffected', () => {
+    const wire = toWireAccount(baseAccount());
+    assert.strictEqual(wire.billing_entity, undefined);
+    assert.strictEqual(wire.reporting_bucket, undefined);
+    assert.strictEqual(wire.rate_card, undefined);
+    assert.strictEqual(wire.payment_terms, undefined);
+    assert.strictEqual(wire.credit_limit, undefined);
+    assert.strictEqual(wire.setup, undefined);
+    assert.strictEqual(wire.account_scope, undefined);
+    assert.strictEqual(wire.governance_agents, undefined);
+  });
+});

--- a/test/lib/account-wire-projection.test.js
+++ b/test/lib/account-wire-projection.test.js
@@ -41,8 +41,8 @@ describe('toWireAccount — v3 field projection', () => {
         vat_id: 'DE123456789',
         bank: {
           account_holder: 'Acme Legal GmbH',
-          iban: 'DE89370400440532013000',
-          bic: 'COBADEFFXXX',
+          iban: 'XX00000000000000000000',
+          bic: 'TESTBIC0XXX',
         },
       },
     });


### PR DESCRIPTION
Closes #1256

## Summary

`Account<TCtxMeta>` at `src/lib/server/decisioning/account.ts:39` was missing eight optional fields present in the AdCP 3.0.1 wire schema. `toWireAccount` silently dropped them, causing cross-language parity failures (JS sellers couldn't emit `billing_entity`, `reporting_bucket`, etc. even though Python sellers could).

## Changes

**`src/lib/server/decisioning/account.ts`**
- Extends `Account<TCtxMeta>` with the eight missing optional fields: `billing_entity`, `reporting_bucket`, `rate_card`, `payment_terms`, `credit_limit`, `setup`, `account_scope`, `governance_agents` — all optional, all non-breaking
- Updates `toWireAccount` to project all new fields; strips `billing_entity.bank` (write-only per AdCP spec: "MUST NOT be echoed in responses") via destructuring
- Adds an always-on invariant assertion — a bank-data leak in production is worse than a 500

**`src/lib/server/decisioning/runtime/from-platform.ts`**
- Extends the `sync_accounts` projection to strip `billing_entity.bank` from upsert result rows. `toWireAccount` only covered `list_accounts`; an adopter echoing the inbound request back could have leaked bank details on the `sync_accounts` path.

**`test/lib/account-wire-projection.test.js`**
- 6 new unit tests: bank strip with bank populated, bank strip with no bank set, `reporting_bucket` verbatim pass-through, all six scalar fields, backward-compat (existing adopters unaffected)

**`.changeset/account-v3-wire-alignment.md`**
- `minor` bump (additive public API extension)

## What was tested

- `npm run build:lib` — clean
- `npm run typecheck` — clean
- `node --test test/lib/account-wire-projection.test.js` — 6/6 pass
- `npm test` — 225 pre-existing failures, identical count vs. `main` baseline; no new failures

## Pre-PR review

- **code-reviewer**: approved — fixed 2 blockers (changeset `patch`→`minor`; fictional IBAN/BIC in test fixtures) and 1 security concern (removed `NODE_ENV` guard from bank-strip assertion)
- **security-reviewer**: approved — fixed 2 blockers (always-on assertion; `sync_accounts` bank-strip gap)

Nits surfaced (not blocking, recorded for reviewer):
- `as BusinessEntity` cast on `account.ts:456` is currently safe (`bank` is optional in the type); would only matter if `bank` were made required in a future spec version
- `governance_agents` test fixture doesn't assert `http://` URL rejection — validation is not `toWireAccount`'s job; could be a follow-up

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1258` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01KW6KiW6oSKLnKNs2r5Y2ox