### PR TITLE
feat(signing): add mintEphemeralSigningKey to @adcp/sdk/signing/testing

### DIFF
--- a/.changeset/mint-ephemeral-signing-key.md
+++ b/.changeset/mint-ephemeral-signing-key.md
@@ -2,9 +2,9 @@
 "@adcp/sdk": minor
 ---
 
-Add `mintEphemeralSigningKey()` to `@adcp/sdk/signing/testing`.
+Add `mintEphemeralEd25519Key()` to `@adcp/sdk/signing/testing`.
 
-Exports `mintEphemeralSigningKey(opts?)` and `EphemeralSigningKey` from
+Exports `mintEphemeralEd25519Key(opts?)` and `EphemeralEd25519Key` from
 `@adcp/sdk/signing/testing`. The helper generates an ephemeral Ed25519
 keypair and returns both halves as fully-shaped `AdcpJsonWebKey` values
 (with `kid`, `alg: 'EdDSA'`, `use: 'sig'`, `adcp_use`, and `key_ops` set

--- a/.changeset/mint-ephemeral-signing-key.md
+++ b/.changeset/mint-ephemeral-signing-key.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": minor
+---
+
+Add `mintEphemeralSigningKey()` to `@adcp/sdk/signing/testing`.
+
+Exports `mintEphemeralSigningKey(opts?)` and `EphemeralSigningKey` from
+`@adcp/sdk/signing/testing`. The helper generates an ephemeral Ed25519
+keypair and returns both halves as fully-shaped `AdcpJsonWebKey` values
+(with `kid`, `alg: 'EdDSA'`, `use: 'sig'`, `adcp_use`, and `key_ops` set
+correctly) — eliminating the manual Node `JsonWebKey.kty?: string` →
+`AdcpJsonWebKey.kty: string` reshape that every dev/test agent had to write
+by hand. Defaults to `adcp_use: 'webhook-signing'`; pass
+`{ adcp_use: 'request-signing' }` for buyer-to-seller test keys.
+
+Also fixes a dangling `testJwk` reference in `SIGNING-GUIDE.md` §Testing
+that left callers without a concrete key-generation example.

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -301,22 +301,28 @@ For non-GCP runtimes that lack OIDC and where the org policy blocks SA keys, the
 
 ### Testing — `InMemorySigningProvider`
 
-The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first. Use `mintEphemeralSigningKey` to generate a typed keypair ready for use with the provider — it handles the Node `JsonWebKey.kty?: string` → `AdcpJsonWebKey.kty: string` reshape so you don't have to:
+The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first. Use `mintEphemeralSigningKey` to generate a typed keypair ready for use with the provider — it handles the Node `JsonWebKey.kty?: string` → `AdcpJsonWebKey.kty: string` reshape so you don't have to.
+
+**Buyer (request-signing):**
 
 ```typescript
+import { createAgentSignedFetch } from '@adcp/sdk/signing';
 import { mintEphemeralSigningKey, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
 
-const { kid, privateKey, publicKey } = await mintEphemeralSigningKey();
+// Pass adcp_use: 'request-signing' — this section is about buyer outbound requests.
+const { kid, algorithm, privateKey, publicKey } = await mintEphemeralSigningKey({
+  adcp_use: 'request-signing',
+});
 // Publish `publicKey` in your /.well-known/jwks.json `keys` array.
 
-const provider = new InMemorySigningProvider({
-  keyid: kid,
-  algorithm: 'ed25519',
-  privateKey,
+const provider = new InMemorySigningProvider({ keyid: kid, algorithm, privateKey });
+const signedFetch = createAgentSignedFetch({
+  signing: { kind: 'provider', provider, agent_url: 'https://your-agent.example.com' },
+  sellerAgentUri: 'https://seller.example.com',
 });
 ```
 
-Pass `{ adcp_use: 'request-signing' }` to `mintEphemeralSigningKey` when generating buyer-to-seller request-signing keys for tests. The default `adcp_use` is `'webhook-signing'`.
+**Seller (webhook-signing):** `mintEphemeralSigningKey()` defaults to `adcp_use: 'webhook-signing'` — omit the option when generating test keys for outbound webhook callbacks.
 
 The `InMemorySigningProvider` constructor refuses to instantiate when `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set explicitly — defense-in-depth so a copy-paste from a test file doesn't accidentally ship to prod. The gate is a self-discipline aid for the bundled implementation; the SDK can't enforce hygiene on third-party providers.
 

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -301,19 +301,24 @@ For non-GCP runtimes that lack OIDC and where the org policy blocks SA keys, the
 
 ### Testing — `InMemorySigningProvider`
 
-The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first:
+The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first. Use `mintEphemeralSigningKey` to generate a typed keypair ready for use with the provider — it handles the Node `JsonWebKey.kty?: string` → `AdcpJsonWebKey.kty: string` reshape so you don't have to:
 
 ```typescript
-import { InMemorySigningProvider } from '@adcp/sdk/signing/testing';
+import { mintEphemeralSigningKey, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
+
+const { kid, privateKey, publicKey } = await mintEphemeralSigningKey();
+// Publish `publicKey` in your /.well-known/jwks.json `keys` array.
 
 const provider = new InMemorySigningProvider({
-  keyid: 'test-2026',
+  keyid: kid,
   algorithm: 'ed25519',
-  privateKey: testJwk,
+  privateKey,
 });
 ```
 
-The constructor refuses to instantiate when `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set explicitly — defense-in-depth so a copy-paste from a test file doesn't accidentally ship to prod. The gate is a self-discipline aid for the bundled implementation; the SDK can't enforce hygiene on third-party providers.
+Pass `{ adcp_use: 'request-signing' }` to `mintEphemeralSigningKey` when generating buyer-to-seller request-signing keys for tests. The default `adcp_use` is `'webhook-signing'`.
+
+The `InMemorySigningProvider` constructor refuses to instantiate when `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set explicitly — defense-in-depth so a copy-paste from a test file doesn't accidentally ship to prod. The gate is a self-discipline aid for the bundled implementation; the SDK can't enforce hygiene on third-party providers.
 
 ### Validating a signer before going live — `adcp grade signer`
 

--- a/docs/guides/SIGNING-GUIDE.md
+++ b/docs/guides/SIGNING-GUIDE.md
@@ -301,16 +301,16 @@ For non-GCP runtimes that lack OIDC and where the org policy blocks SA keys, the
 
 ### Testing — `InMemorySigningProvider`
 
-The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first. Use `mintEphemeralSigningKey` to generate a typed keypair ready for use with the provider — it handles the Node `JsonWebKey.kty?: string` → `AdcpJsonWebKey.kty: string` reshape so you don't have to.
+The SDK ships `InMemorySigningProvider` under a separate import path so production imports surface the KMS path first. Use `mintEphemeralEd25519Key` to generate a typed keypair ready for use with the provider — it handles the Node `JsonWebKey.kty?: string` → `AdcpJsonWebKey.kty: string` reshape so you don't have to.
 
 **Buyer (request-signing):**
 
 ```typescript
 import { createAgentSignedFetch } from '@adcp/sdk/signing';
-import { mintEphemeralSigningKey, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
+import { mintEphemeralEd25519Key, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
 
 // Pass adcp_use: 'request-signing' — this section is about buyer outbound requests.
-const { kid, algorithm, privateKey, publicKey } = await mintEphemeralSigningKey({
+const { kid, algorithm, privateKey, publicKey } = await mintEphemeralEd25519Key({
   adcp_use: 'request-signing',
 });
 // Publish `publicKey` in your /.well-known/jwks.json `keys` array.
@@ -322,7 +322,7 @@ const signedFetch = createAgentSignedFetch({
 });
 ```
 
-**Seller (webhook-signing):** `mintEphemeralSigningKey()` defaults to `adcp_use: 'webhook-signing'` — omit the option when generating test keys for outbound webhook callbacks.
+**Seller (webhook-signing):** `mintEphemeralEd25519Key()` defaults to `adcp_use: 'webhook-signing'` — omit the option when generating test keys for outbound webhook callbacks.
 
 The `InMemorySigningProvider` constructor refuses to instantiate when `NODE_ENV=production` unless `ADCP_ALLOW_IN_MEMORY_SIGNER=1` is set explicitly — defense-in-depth so a copy-paste from a test file doesn't accidentally ship to prod. The gate is a self-discipline aid for the bundled implementation; the SDK can't enforce hygiene on third-party providers.
 

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -97,6 +97,12 @@ export function signerKeyToProvider(key: SignerKey): SigningProvider {
 export interface EphemeralSigningKey {
   /** The `kid` embedded in both JWKs. */
   kid: string;
+  /**
+   * AdCP wire-format algorithm identifier — pass directly to
+   * `InMemorySigningProvider({ algorithm })`. Always `'ed25519'` today;
+   * typed as `AdcpSignAlg` so callers don't hardcode a string literal.
+   */
+  algorithm: AdcpSignAlg;
   /** Public JWK — publish at `/.well-known/jwks.json` or pass to JWKS discovery. */
   publicKey: AdcpJsonWebKey;
   /**
@@ -147,8 +153,8 @@ export interface MintEphemeralSigningKeyOptions {
  * ```ts
  * import { mintEphemeralSigningKey, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
  *
- * const { kid, privateKey, publicKey } = await mintEphemeralSigningKey();
- * const provider = new InMemorySigningProvider({ keyid: kid, algorithm: 'ed25519', privateKey });
+ * const { kid, algorithm, privateKey, publicKey } = await mintEphemeralSigningKey();
+ * const provider = new InMemorySigningProvider({ keyid: kid, algorithm, privateKey });
  * // Publish publicKey in your /.well-known/jwks.json `keys` array.
  * ```
  */
@@ -187,5 +193,5 @@ export async function mintEphemeralSigningKey(opts?: MintEphemeralSigningKeyOpti
     key_ops: ['sign'],
   };
 
-  return { kid: resolvedKid, publicKey, privateKey };
+  return { kid: resolvedKid, algorithm: 'ed25519', publicKey, privateKey };
 }

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -1,4 +1,4 @@
-import { createHash, createPrivateKey, randomUUID, sign as nodeSign, type JsonWebKey } from 'crypto';
+import { createHash, createPrivateKey, randomUUID, sign as nodeSign, type JsonWebKey } from 'node:crypto';
 import type { SigningProvider } from './provider';
 import type { SignerKey } from './signer';
 import type { AdcpUse } from './jwks-helpers';
@@ -94,7 +94,7 @@ export function signerKeyToProvider(key: SignerKey): SigningProvider {
   });
 }
 
-export interface EphemeralSigningKey {
+export interface EphemeralEd25519Key {
   /** The `kid` embedded in both JWKs. */
   kid: string;
   /**
@@ -113,7 +113,7 @@ export interface EphemeralSigningKey {
   privateKey: AdcpJsonWebKey;
 }
 
-export interface MintEphemeralSigningKeyOptions {
+export interface MintEphemeralEd25519KeyOptions {
   /**
    * Stable key ID embedded in both JWKs. Defaults to a random UUID so each
    * call produces a unique kid. Pass a stable value for deterministic IDs
@@ -151,14 +151,14 @@ export interface MintEphemeralSigningKeyOptions {
  *
  * Usage with {@link InMemorySigningProvider}:
  * ```ts
- * import { mintEphemeralSigningKey, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
+ * import { mintEphemeralEd25519Key, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
  *
- * const { kid, algorithm, privateKey, publicKey } = await mintEphemeralSigningKey();
+ * const { kid, algorithm, privateKey, publicKey } = await mintEphemeralEd25519Key();
  * const provider = new InMemorySigningProvider({ keyid: kid, algorithm, privateKey });
  * // Publish publicKey in your /.well-known/jwks.json `keys` array.
  * ```
  */
-export async function mintEphemeralSigningKey(opts?: MintEphemeralSigningKeyOptions): Promise<EphemeralSigningKey> {
+export async function mintEphemeralEd25519Key(opts?: MintEphemeralEd25519KeyOptions): Promise<EphemeralEd25519Key> {
   const { generateKeyPair, exportJWK } = await import('jose');
   const resolvedKid = opts?.kid ?? randomUUID();
   const adcpUse: AdcpUse = opts?.adcp_use ?? 'webhook-signing';
@@ -168,8 +168,8 @@ export async function mintEphemeralSigningKey(opts?: MintEphemeralSigningKeyOpti
   });
   const [pubJwk, privJwk] = await Promise.all([exportJWK(pubKeyObj), exportJWK(privKeyObj)]);
 
-  if (!pubJwk.kty) throw new Error('mintEphemeralSigningKey: jose exportJWK returned publicKey without kty');
-  if (!privJwk.kty) throw new Error('mintEphemeralSigningKey: jose exportJWK returned privateKey without kty');
+  if (!pubJwk.kty) throw new Error('mintEphemeralEd25519Key: jose exportJWK returned publicKey without kty');
+  if (!privJwk.kty) throw new Error('mintEphemeralEd25519Key: jose exportJWK returned privateKey without kty');
 
   const publicKey: AdcpJsonWebKey = {
     ...(pubJwk as Record<string, unknown>),

--- a/src/lib/signing/testing.ts
+++ b/src/lib/signing/testing.ts
@@ -1,6 +1,7 @@
-import { createHash, createPrivateKey, sign as nodeSign, type JsonWebKey } from 'crypto';
+import { createHash, createPrivateKey, randomUUID, sign as nodeSign, type JsonWebKey } from 'crypto';
 import type { SigningProvider } from './provider';
 import type { SignerKey } from './signer';
+import type { AdcpUse } from './jwks-helpers';
 import type { AdcpJsonWebKey, AdcpSignAlg } from './types';
 
 /**
@@ -91,4 +92,100 @@ export function signerKeyToProvider(key: SignerKey): SigningProvider {
     algorithm: key.alg,
     privateKey: key.privateKey,
   });
+}
+
+export interface EphemeralSigningKey {
+  /** The `kid` embedded in both JWKs. */
+  kid: string;
+  /** Public JWK — publish at `/.well-known/jwks.json` or pass to JWKS discovery. */
+  publicKey: AdcpJsonWebKey;
+  /**
+   * Private JWK with `d` scalar. Pass to
+   * `new InMemorySigningProvider({ keyid, algorithm, privateKey })`.
+   * Never publish this value.
+   */
+  privateKey: AdcpJsonWebKey;
+}
+
+export interface MintEphemeralSigningKeyOptions {
+  /**
+   * Stable key ID embedded in both JWKs. Defaults to a random UUID so each
+   * call produces a unique kid. Pass a stable value for deterministic IDs
+   * across test restarts — the `keyid` passed to `InMemorySigningProvider`
+   * must match the `kid` in the published public JWK.
+   */
+  kid?: string;
+  /**
+   * AdCP purpose binding tagged on both JWKs.
+   * - `'webhook-signing'` (default) — outbound webhook callbacks.
+   * - `'request-signing'` — buyer-to-seller signed requests (AdCP step 8).
+   *
+   * For production request-signing keys use `pemToAdcpJwk()` or a KMS-backed
+   * `SigningProvider` instead.
+   */
+  adcp_use?: AdcpUse;
+}
+
+/**
+ * Mint an ephemeral Ed25519 keypair as `AdcpJsonWebKey` pairs, ready for
+ * dev/test signing.
+ *
+ * Handles the Node `KeyObject.export({ format: 'jwk' })` → `AdcpJsonWebKey`
+ * reshape: Node's `JsonWebKey` has `kty?: string` (optional), while
+ * `AdcpJsonWebKey` requires `kty: string`. Without this helper, callers must
+ * write a manual spread + non-null assertion on every key-generation site —
+ * easy to typo on the most critical JWK field.
+ *
+ * Both JWKs are tagged with the correct AdCP fields:
+ * - `alg: 'EdDSA'` — JOSE algorithm name required by AdCP verifiers (step 8).
+ * - `use: 'sig'` — RFC 7517 §4.2 intent hint.
+ * - `adcp_use` — AdCP purpose binding; enforced at step 8. Defaults to
+ *   `'webhook-signing'`; pass `'request-signing'` for buyer-to-seller keys.
+ * - `key_ops`: `['verify']` on `publicKey`, `['sign']` on `privateKey`.
+ *
+ * Usage with {@link InMemorySigningProvider}:
+ * ```ts
+ * import { mintEphemeralSigningKey, InMemorySigningProvider } from '@adcp/sdk/signing/testing';
+ *
+ * const { kid, privateKey, publicKey } = await mintEphemeralSigningKey();
+ * const provider = new InMemorySigningProvider({ keyid: kid, algorithm: 'ed25519', privateKey });
+ * // Publish publicKey in your /.well-known/jwks.json `keys` array.
+ * ```
+ */
+export async function mintEphemeralSigningKey(opts?: MintEphemeralSigningKeyOptions): Promise<EphemeralSigningKey> {
+  const { generateKeyPair, exportJWK } = await import('jose');
+  const resolvedKid = opts?.kid ?? randomUUID();
+  const adcpUse: AdcpUse = opts?.adcp_use ?? 'webhook-signing';
+  const { publicKey: pubKeyObj, privateKey: privKeyObj } = await generateKeyPair('EdDSA', {
+    crv: 'Ed25519',
+    extractable: true,
+  });
+  const [pubJwk, privJwk] = await Promise.all([exportJWK(pubKeyObj), exportJWK(privKeyObj)]);
+
+  if (!pubJwk.kty) throw new Error('mintEphemeralSigningKey: jose exportJWK returned publicKey without kty');
+  if (!privJwk.kty) throw new Error('mintEphemeralSigningKey: jose exportJWK returned privateKey without kty');
+
+  const publicKey: AdcpJsonWebKey = {
+    ...(pubJwk as Record<string, unknown>),
+    kid: resolvedKid,
+    kty: pubJwk.kty,
+    alg: 'EdDSA',
+    use: 'sig',
+    adcp_use: adcpUse,
+    key_ops: ['verify'],
+  };
+
+  const privateKey: AdcpJsonWebKey = {
+    ...(privJwk as Record<string, unknown>),
+    kid: resolvedKid,
+    kty: privJwk.kty,
+    alg: 'EdDSA',
+    use: 'sig',
+    adcp_use: adcpUse,
+    // RFC 7517 §4.3: private JWK states signing intent. Node's createPrivateKey
+    // ignores key_ops at runtime; the field is present for JWK consumers that honour it.
+    key_ops: ['sign'],
+  };
+
+  return { kid: resolvedKid, publicKey, privateKey };
 }

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -21,7 +21,11 @@ const {
   RequestSignatureError,
 } = require('../dist/lib/signing/index.js');
 
-const { InMemorySigningProvider, signerKeyToProvider } = require('../dist/lib/signing/testing.js');
+const {
+  InMemorySigningProvider,
+  signerKeyToProvider,
+  mintEphemeralSigningKey,
+} = require('../dist/lib/signing/testing.js');
 
 const KEYS_PATH = path.join(
   __dirname,
@@ -726,5 +730,63 @@ describe('derEcdsaToP1363', () => {
       () => derEcdsaToP1363(new Uint8Array([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), 32),
       /SEQUENCE tag/
     );
+  });
+});
+
+describe('mintEphemeralSigningKey', () => {
+  test('returns kid, algorithm, publicKey, privateKey', async () => {
+    const result = await mintEphemeralSigningKey();
+    assert.ok(typeof result.kid === 'string' && result.kid.length > 0, 'kid should be a non-empty string');
+    assert.strictEqual(result.algorithm, 'ed25519');
+    assert.ok(result.publicKey, 'publicKey should be present');
+    assert.ok(result.privateKey, 'privateKey should be present');
+  });
+
+  test('publicKey has required AdcpJsonWebKey fields', async () => {
+    const { publicKey } = await mintEphemeralSigningKey();
+    assert.strictEqual(typeof publicKey.kty, 'string', 'kty must be a string');
+    assert.strictEqual(publicKey.alg, 'EdDSA');
+    assert.strictEqual(publicKey.use, 'sig');
+    assert.strictEqual(publicKey.adcp_use, 'webhook-signing');
+    assert.deepStrictEqual(publicKey.key_ops, ['verify']);
+    assert.ok(!publicKey.d, 'publicKey must not contain private scalar d');
+  });
+
+  test('privateKey has required AdcpJsonWebKey fields with d scalar', async () => {
+    const { privateKey } = await mintEphemeralSigningKey();
+    assert.strictEqual(typeof privateKey.kty, 'string', 'kty must be a string');
+    assert.strictEqual(privateKey.alg, 'EdDSA');
+    assert.strictEqual(privateKey.adcp_use, 'webhook-signing');
+    assert.deepStrictEqual(privateKey.key_ops, ['sign']);
+    assert.ok(typeof privateKey.d === 'string' && privateKey.d.length > 0, 'privateKey must have d scalar');
+  });
+
+  test('both keys share the same kid', async () => {
+    const { kid, publicKey, privateKey } = await mintEphemeralSigningKey();
+    assert.strictEqual(publicKey.kid, kid);
+    assert.strictEqual(privateKey.kid, kid);
+  });
+
+  test('passed kid option is reflected in both JWKs', async () => {
+    const { kid, publicKey, privateKey } = await mintEphemeralSigningKey({ kid: 'test-kid-001' });
+    assert.strictEqual(kid, 'test-kid-001');
+    assert.strictEqual(publicKey.kid, 'test-kid-001');
+    assert.strictEqual(privateKey.kid, 'test-kid-001');
+  });
+
+  test('adcp_use: request-signing is reflected in both JWKs', async () => {
+    const { publicKey, privateKey } = await mintEphemeralSigningKey({ adcp_use: 'request-signing' });
+    assert.strictEqual(publicKey.adcp_use, 'request-signing');
+    assert.strictEqual(privateKey.adcp_use, 'request-signing');
+  });
+
+  test('privateKey is usable directly by InMemorySigningProvider without throwing', async () => {
+    const { kid, algorithm, privateKey } = await mintEphemeralSigningKey();
+    assert.doesNotThrow(() => new InMemorySigningProvider({ keyid: kid, algorithm, privateKey }));
+  });
+
+  test('each call produces a unique kid when no kid option is passed', async () => {
+    const [a, b] = await Promise.all([mintEphemeralSigningKey(), mintEphemeralSigningKey()]);
+    assert.notStrictEqual(a.kid, b.kid, 'default kids should be unique across calls');
   });
 });

--- a/test/request-signing-provider.test.js
+++ b/test/request-signing-provider.test.js
@@ -24,7 +24,7 @@ const {
 const {
   InMemorySigningProvider,
   signerKeyToProvider,
-  mintEphemeralSigningKey,
+  mintEphemeralEd25519Key,
 } = require('../dist/lib/signing/testing.js');
 
 const KEYS_PATH = path.join(
@@ -733,9 +733,9 @@ describe('derEcdsaToP1363', () => {
   });
 });
 
-describe('mintEphemeralSigningKey', () => {
+describe('mintEphemeralEd25519Key', () => {
   test('returns kid, algorithm, publicKey, privateKey', async () => {
-    const result = await mintEphemeralSigningKey();
+    const result = await mintEphemeralEd25519Key();
     assert.ok(typeof result.kid === 'string' && result.kid.length > 0, 'kid should be a non-empty string');
     assert.strictEqual(result.algorithm, 'ed25519');
     assert.ok(result.publicKey, 'publicKey should be present');
@@ -743,7 +743,7 @@ describe('mintEphemeralSigningKey', () => {
   });
 
   test('publicKey has required AdcpJsonWebKey fields', async () => {
-    const { publicKey } = await mintEphemeralSigningKey();
+    const { publicKey } = await mintEphemeralEd25519Key();
     assert.strictEqual(typeof publicKey.kty, 'string', 'kty must be a string');
     assert.strictEqual(publicKey.alg, 'EdDSA');
     assert.strictEqual(publicKey.use, 'sig');
@@ -753,7 +753,7 @@ describe('mintEphemeralSigningKey', () => {
   });
 
   test('privateKey has required AdcpJsonWebKey fields with d scalar', async () => {
-    const { privateKey } = await mintEphemeralSigningKey();
+    const { privateKey } = await mintEphemeralEd25519Key();
     assert.strictEqual(typeof privateKey.kty, 'string', 'kty must be a string');
     assert.strictEqual(privateKey.alg, 'EdDSA');
     assert.strictEqual(privateKey.adcp_use, 'webhook-signing');
@@ -762,31 +762,50 @@ describe('mintEphemeralSigningKey', () => {
   });
 
   test('both keys share the same kid', async () => {
-    const { kid, publicKey, privateKey } = await mintEphemeralSigningKey();
+    const { kid, publicKey, privateKey } = await mintEphemeralEd25519Key();
     assert.strictEqual(publicKey.kid, kid);
     assert.strictEqual(privateKey.kid, kid);
   });
 
   test('passed kid option is reflected in both JWKs', async () => {
-    const { kid, publicKey, privateKey } = await mintEphemeralSigningKey({ kid: 'test-kid-001' });
+    const { kid, publicKey, privateKey } = await mintEphemeralEd25519Key({ kid: 'test-kid-001' });
     assert.strictEqual(kid, 'test-kid-001');
     assert.strictEqual(publicKey.kid, 'test-kid-001');
     assert.strictEqual(privateKey.kid, 'test-kid-001');
   });
 
   test('adcp_use: request-signing is reflected in both JWKs', async () => {
-    const { publicKey, privateKey } = await mintEphemeralSigningKey({ adcp_use: 'request-signing' });
+    const { publicKey, privateKey } = await mintEphemeralEd25519Key({ adcp_use: 'request-signing' });
     assert.strictEqual(publicKey.adcp_use, 'request-signing');
     assert.strictEqual(privateKey.adcp_use, 'request-signing');
   });
 
   test('privateKey is usable directly by InMemorySigningProvider without throwing', async () => {
-    const { kid, algorithm, privateKey } = await mintEphemeralSigningKey();
+    const { kid, algorithm, privateKey } = await mintEphemeralEd25519Key();
     assert.doesNotThrow(() => new InMemorySigningProvider({ keyid: kid, algorithm, privateKey }));
   });
 
   test('each call produces a unique kid when no kid option is passed', async () => {
-    const [a, b] = await Promise.all([mintEphemeralSigningKey(), mintEphemeralSigningKey()]);
+    const [a, b] = await Promise.all([mintEphemeralEd25519Key(), mintEphemeralEd25519Key()]);
     assert.notStrictEqual(a.kid, b.kid, 'default kids should be unique across calls');
+  });
+
+  test('minted key signs + verifies end-to-end (catches JWK encoding regressions)', async () => {
+    // Round-trip catches regressions in JWK encoding (base64 vs base64url),
+    // `d` scalar shape, or kid/alg plumbing that construction-only assertions
+    // miss. Uses jose directly for verification so it's independent of the
+    // SigningProvider internals.
+    const { kid, algorithm, publicKey, privateKey } = await mintEphemeralEd25519Key();
+    const provider = new InMemorySigningProvider({ keyid: kid, algorithm, privateKey });
+    const payload = Buffer.from('hello signing test', 'utf8');
+    const signature = await provider.sign(payload);
+    assert.ok(signature && signature.byteLength > 0, 'sign() must return non-empty bytes');
+
+    const { importJWK, FlattenedSign, flattenedVerify } = await import('jose');
+    const privKey = await importJWK(privateKey, 'EdDSA');
+    const pubKey = await importJWK(publicKey, 'EdDSA');
+    const jws = await new FlattenedSign(payload).setProtectedHeader({ alg: 'EdDSA' }).sign(privKey);
+    const verified = await flattenedVerify(jws, pubKey);
+    assert.deepStrictEqual(Buffer.from(verified.payload), payload, 'signed payload round-trips through verify');
   });
 });


### PR DESCRIPTION
Closes #1255

## Summary

`AdcpJsonWebKey` requires `kty: string` but Node's `KeyObject.export({ format: 'jwk' })` returns `JsonWebKey` with `kty?: string`. Every dev/test agent minting an ephemeral Ed25519 keypair for signing had to write a manual reshape — a silent footgun on the most critical JWK field.

This PR adds `mintEphemeralSigningKey(opts?)` to `@adcp/sdk/signing/testing`. It generates an ephemeral Ed25519 keypair via `jose` and returns both halves as fully-typed `AdcpJsonWebKey` values with `kid`, `alg: 'EdDSA'`, `use: 'sig'`, `adcp_use`, `key_ops`, and the new `algorithm: AdcpSignAlg` convenience field pre-populated. Also fixes a dangling `testJwk` reference in `SIGNING-GUIDE.md` that left callers without a concrete key-generation example.

**What ships:**
- `mintEphemeralSigningKey(opts?)` — `async`, returns `EphemeralSigningKey`
- `EphemeralSigningKey` interface — `{ kid, algorithm, publicKey, privateKey }`
- `MintEphemeralSigningKeyOptions` interface — `{ kid?, adcp_use? }`
- Defaults to `adcp_use: 'webhook-signing'`; pass `{ adcp_use: 'request-signing' }` for buyer keys
- `SIGNING-GUIDE.md` §Testing updated with buyer/seller split examples and end-to-end wiring
- 7 tests added to `test/request-signing-provider.test.js`
- Minor changeset (`@adcp/sdk` minor bump)

**What doesn't ship (per expert review):**
- Option 2 (widening `AdcpJsonWebKey.kty` to optional) — breaking type change; deferred/not pursued
- `InMemorySigningProvider` bundled in return value — conflates key generation with the in-memory guard; callers compose manually per existing SDK pattern

## What-tested

- `tsc --project tsconfig.lib.json --noEmit` — clean (pre-existing env errors for `@types/node` and deprecated `moduleResolution` only; unrelated to this diff)
- Tests import from `dist/lib/signing/testing.js` — 7 new test cases covering shape, field values, option passthrough, and `InMemorySigningProvider` compatibility; run against CI build

**Nits surfaced, not fixed:**
- `testing.ts` uses bare `'crypto'` import (pre-existing inconsistency with `'node:crypto'` in newer files)
- `migration-4.x-to-5.x.md` lists `@adcp/sdk/signing/testing` exports but omits the new symbols — low-blast migration doc; easy follow-up

**Pre-PR review:**
- code-reviewer: approved — added `algorithm: AdcpSignAlg` to return type (footgun gap), added 7 tests (missing coverage), defensive `kty` throw assertions correct, lazy `import('jose')` matches tenant-registry precedent
- dx-expert: approved — fixed guide snippet `adcp_use` context mismatch (buyer section needs `request-signing`), added `createAgentSignedFetch` wiring to guide snippet; implementation JSDoc is clean

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_015tmYKvcY5ftaCBfcd7Y3xn

---
_Generated by [Claude Code](https://claude.ai/code/session_015tmYKvcY5ftaCBfcd7Y3xn)_