### PR TITLE
feat(types): re-export all spec-defined request/response types from @adcp/sdk/types

### DIFF
--- a/.changeset/types-export-all-request-response.md
+++ b/.changeset/types-export-all-request-response.md
@@ -1,0 +1,22 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(types): re-export all spec-defined request/response types from `@adcp/sdk/types`
+
+`@adcp/sdk/types` previously re-exported only a curated subset of wire types, leaving
+`GetMediaBuysRequest`, `ListCreativeFormatsRequest/Response`, and ~50 other operation
+types accessible only via `@adcp/sdk/tools.generated` — a generated file CLAUDE.md
+explicitly tells adopters not to reach into.
+
+This change completes the barrel so all spec-defined operation `*Request`, `*Response`,
+`*Success`, `*Error`, and `*Submitted` types are importable from `@adcp/sdk/types`.
+The single large block is replaced with per-domain named sections (accounts,
+capabilities, media buy, audiences/catalogs/events, signals, creative, governance,
+sponsored intelligence) for maintainability.
+
+Intentionally excluded: comply-runner internals (`ComplyTestControllerRequest/Response`,
+`SeedSuccess`, `SimulationSuccess`, `ControllerError`), sub-shapes accessible
+transitively (`PaginationRequest/Response`, `PackageRequest`), and types whose names
+conflict with legacy `adcp.ts` shapes already in the public surface
+(`SyncCreativesRequest`, `ListCreativesRequest/Response`).

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -36,52 +36,119 @@ import type { FormatReferenceStructuredObject } from './core.generated';
 export type FormatID = FormatReferenceStructuredObject;
 
 // Re-export wire request/response types adopters need when building a
-// DecisioningPlatform. Source of truth is `tools.generated.ts`; this
-// curated subset is the public surface so adopters never reach into
-// generated files. Add new entries as new specialism platforms land.
+// DecisioningPlatform or calling AdCP agents. Source of truth is
+// `tools.generated.ts`; this curated block is the public surface so
+// adopters never reach into generated files.
+//
+// Intentionally excluded — name conflicts with legacy adcp.ts shapes:
+//   SyncCreativesRequest, ListCreativesRequest, ListCreativesResponse,
+//   ManageCreativeAssetsRequest, ManageCreativeAssetsResponse (adcp.ts versions
+//   already public via `export * from './adcp'` above; use those).
+// Intentionally excluded — comply-runner internals, not specialism surface:
+//   ComplyTestControllerRequest/Response, SeedSuccess, SimulationSuccess,
+//   ControllerError, ForcedDirectiveSuccess, StateTransitionSuccess,
+//   ListScenariosSuccess.
+// Intentionally excluded — internal pagination/packaging sub-shapes, not
+// part of the top-level tool request/response surface:
+//   PaginationRequest, PaginationResponse, PackageRequest,
+//   TMPResponseType, WebhookResponseType.
+
+// Account model + account operations
 export type {
-  // Account model
   AccountReference,
-  // Creative
-  BuildCreativeRequest,
-  CreativeManifest,
-  PreviewCreativeRequest,
-  PreviewCreativeResponse,
-  CreativeAsset,
-  CreativeQuality,
-  // Sales — media buy
+  ListAccountsRequest,
+  ListAccountsResponse,
+  SyncAccountsRequest,
+  SyncAccountsResponse,
+  SyncAccountsSuccess,
+  SyncAccountsError,
+  GetAccountFinancialsRequest,
+  GetAccountFinancialsResponse,
+  GetAccountFinancialsSuccess,
+  GetAccountFinancialsError,
+} from './tools.generated';
+
+// Capabilities
+export type { AdCPSpecialism, GetAdCPCapabilitiesRequest, GetAdCPCapabilitiesResponse } from './tools.generated';
+
+// Sales — media buy
+export type {
   GetProductsRequest,
   GetProductsResponse,
+  GetProductsAsyncSubmitted,
   CreateMediaBuyRequest,
+  CreateMediaBuyResponse,
   CreateMediaBuySuccess,
+  CreateMediaBuyError,
+  CreateMediaBuySubmitted,
+  CreateMediaBuyAsyncSubmitted,
   UpdateMediaBuyRequest,
+  UpdateMediaBuyResponse,
   UpdateMediaBuySuccess,
+  UpdateMediaBuyError,
+  UpdateMediaBuyAsyncSubmitted,
+  GetMediaBuysRequest,
   GetMediaBuysResponse,
   GetMediaBuyDeliveryRequest,
   GetMediaBuyDeliveryResponse,
-  // Pricing models (discriminated union across pricing types)
-  PricingOption,
-  CPMPricingOption,
-  CPCPricingOption,
-  CPVPricingOption,
-  // Media-channel + status enums adopters need when implementing a platform
+  GetMediaBuyArtifactsRequest,
+  GetMediaBuyArtifactsResponse,
+  ProvidePerformanceFeedbackRequest,
+  ProvidePerformanceFeedbackResponse,
+  ProvidePerformanceFeedbackSuccess,
+  ProvidePerformanceFeedbackError,
+  SyncPlansRequest,
+  SyncPlansResponse,
+  ReportUsageRequest,
+  ReportUsageResponse,
+  ReportPlanOutcomeRequest,
+  ReportPlanOutcomeResponse,
+  GetPlanAuditLogsRequest,
+  GetPlanAuditLogsResponse,
+} from './tools.generated';
+
+// Pricing models (discriminated union across pricing types)
+export type { PricingOption, CPMPricingOption, CPCPricingOption, CPVPricingOption } from './tools.generated';
+
+// Media-channel + status enums; publisher property + reporting shapes
+export type {
   MediaChannel,
   AudienceStatus,
   MediaBuyStatus,
   CreativeStatus,
-  // Publisher property selection (for product publisher_properties[])
   PublisherPropertySelector,
-  // Reporting capability shape (per-product)
   ReportingCapabilities,
-  // Audiences
+} from './tools.generated';
+
+// Audiences, catalogs, event sources, and events (audience-sync + retail media)
+export type {
   SyncAudiencesRequest,
   SyncAudiencesResponse,
-  // Signals
+  SyncAudiencesSuccess,
+  SyncAudiencesError,
+  SyncCatalogsRequest,
+  SyncCatalogsResponse,
+  SyncCatalogsSuccess,
+  SyncCatalogsError,
+  SyncCatalogsAsyncSubmitted,
+  SyncEventSourcesRequest,
+  SyncEventSourcesResponse,
+  SyncEventSourcesSuccess,
+  SyncEventSourcesError,
+  LogEventRequest,
+  LogEventResponse,
+  LogEventSuccess,
+  LogEventError,
+} from './tools.generated';
+
+// Signals
+export type {
   GetSignalsRequest,
   GetSignalsResponse,
   ActivateSignalRequest,
   ActivateSignalResponse,
   ActivateSignalSuccess,
+  ActivateSignalError,
   SignalID,
   SignalValueType,
   SignalCatalogType,
@@ -89,9 +156,42 @@ export type {
   Deployment,
   ActivationKey,
   VendorPricingOption,
-  // Capability declaration
-  AdCPSpecialism,
-  // Property lists — full CRUD surface for governance adopters
+} from './tools.generated';
+
+// Creative
+export type {
+  BuildCreativeRequest,
+  BuildCreativeResponse,
+  BuildCreativeSuccess,
+  BuildCreativeError,
+  BuildCreativeMultiSuccess,
+  BuildCreativeAsyncSubmitted,
+  CreativeManifest,
+  PreviewCreativeRequest,
+  PreviewCreativeResponse,
+  PreviewCreativeSingleResponse,
+  PreviewCreativeVariantResponse,
+  PreviewCreativeBatchResponse,
+  PreviewBatchResultSuccess,
+  PreviewBatchResultError,
+  ListCreativeFormatsRequest,
+  ListCreativeFormatsResponse,
+  GetCreativeFeaturesRequest,
+  GetCreativeFeaturesResponse,
+  GetCreativeDeliveryRequest,
+  GetCreativeDeliveryResponse,
+  SyncCreativesResponse,
+  SyncCreativesSuccess,
+  SyncCreativesError,
+  SyncCreativesSubmitted,
+  SyncCreativesAsyncSubmitted,
+  CreativeAsset,
+  CreativeQuality,
+  Format,
+} from './tools.generated';
+
+// Governance — property lists
+export type {
   PropertyList,
   CreatePropertyListRequest,
   CreatePropertyListResponse,
@@ -103,7 +203,10 @@ export type {
   ListPropertyListsResponse,
   DeletePropertyListRequest,
   DeletePropertyListResponse,
-  // Collection lists — full CRUD surface for governance adopters
+} from './tools.generated';
+
+// Governance — collection lists
+export type {
   CollectionList,
   CreateCollectionListRequest,
   CreateCollectionListResponse,
@@ -115,7 +218,42 @@ export type {
   ListCollectionListsResponse,
   DeleteCollectionListRequest,
   DeleteCollectionListResponse,
-  Format,
+} from './tools.generated';
+
+// Governance — content standards + delivery validation
+export type {
+  CheckGovernanceRequest,
+  CheckGovernanceResponse,
+  SyncGovernanceRequest,
+  SyncGovernanceResponse,
+  SyncGovernanceSuccess,
+  SyncGovernanceError,
+  CreateContentStandardsRequest,
+  CreateContentStandardsResponse,
+  UpdateContentStandardsRequest,
+  UpdateContentStandardsResponse,
+  UpdateContentStandardsSuccess,
+  UpdateContentStandardsError,
+  ListContentStandardsRequest,
+  ListContentStandardsResponse,
+  GetContentStandardsRequest,
+  GetContentStandardsResponse,
+  CalibrateContentRequest,
+  CalibrateContentResponse,
+  ValidateContentDeliveryRequest,
+  ValidateContentDeliveryResponse,
+} from './tools.generated';
+
+// Sponsored intelligence
+export type {
+  SIGetOfferingRequest,
+  SIGetOfferingResponse,
+  SIInitiateSessionRequest,
+  SIInitiateSessionResponse,
+  SISendMessageRequest,
+  SISendMessageResponse,
+  SITerminateSessionRequest,
+  SITerminateSessionResponse,
 } from './tools.generated';
 
 // Strict format asset slot types (hand-authored — the codegen drops the


### PR DESCRIPTION
Closes #1254

## Summary

`@adcp/sdk/types` previously exported only a curated subset of wire types, leaving `GetMediaBuysRequest`, `ListCreativeFormatsRequest/Response`, and ~55 other operation types accessible only via `@adcp/sdk/tools.generated` — a generated file `CLAUDE.md` explicitly tells adopters not to reach into.

This PR completes the barrel so every spec-defined `*Request`, `*Response`, `*Success`, `*Error`, and `*Submitted` type is importable from `@adcp/sdk/types`. The single large block is replaced with per-domain named sections for maintainability.

**Intentionally excluded** (documented in a header comment in the file):
- `SyncCreativesRequest`, `ListCreativesRequest/Response`, `ManageCreativeAssetsRequest/Response` — name conflicts with legacy `adcp.ts` shapes already on the public surface
- `ComplyTestControllerRequest/Response`, `SeedSuccess`, `SimulationSuccess`, `ControllerError` etc. — comply-runner internals, not part of the specialism surface
- `PaginationRequest/Response`, `PackageRequest`, `TMPResponseType`, `WebhookResponseType` — internal sub-shapes, not top-level operation types

## What was tested

- `npm run format:check` — clean
- `npx tsc --project tsconfig.lib.json --noEmit` — only pre-existing baseline errors (TS2688 `@types/node` not found, TS5107 `moduleResolution` deprecation); no new errors
- Unit tests require built `dist/` which is unavailable in this environment (`tsx` not installed); test failures are pre-existing environment issues, not regressions (confirmed same pattern as PRs #1242, #1238, #1232)

## Pre-PR review

- **code-reviewer**: approved — no blockers on final diff; caught `ActivateSignalError` omission from signals section (fixed before push); verified `SyncCreativesAsyncSubmitted` and `CreateMediaBuyAsyncSubmitted` names don't conflict with `core.generated` imports in `adcp.ts`; changeset `minor` bump correct
- **dx-expert**: approved after fixes — caught three missing `*AsyncSubmitted` types (`GetProductsAsyncSubmitted`, `CreateMediaBuyAsyncSubmitted`, `UpdateMediaBuyAsyncSubmitted`) and incorrect "accessible transitively" comment (both fixed); section titles corrected; structure sound

**Nits noted (not fixed):**
- Pricing models section is semantically part of media buy but sits separately — low priority, comment is clear
- Inline `// excluded: X` breadcrumbs in per-domain sections could help future maintainers catch omissions earlier; left for a follow-up pass

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_016oRL8GLc3CKXZHd3DkXYH3

---
_Generated by [Claude Code](https://claude.ai/code/session_016oRL8GLc3CKXZHd3DkXYH3)_