### PR TITLE
feat(server): compile-time invariant for complyTest / compliance_testing pairing

### DIFF
--- a/.changeset/comply-test-compile-time-invariant.md
+++ b/.changeset/comply-test-compile-time-invariant.md
@@ -1,0 +1,24 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): compile-time invariant for complyTest / compliance_testing pairing
+
+Adds two mechanisms that catch the cap/adapter mismatch earlier than runtime:
+
+- `RequiredOptsFor<P>` — conditional type on `createAdcpServerFromPlatform`'s
+  `opts` parameter. When `P` carries a non-optional `compliance_testing` block
+  (e.g. from `definePlatformWithCompliance`), `complyTest` becomes required in
+  opts at compile time. Previously both directions were runtime-only
+  `PlatformConfigError` throws that were invisible to the harness.
+
+- `definePlatformWithCompliance<TConfig, TCtxMeta>()` — identity helper (same
+  pattern as `defineSalesPlatform` etc.) that enforces `capabilities.compliance_testing`
+  non-optional at the platform definition site. Pairing it with
+  `createAdcpServerFromPlatform` gives full bidirectional enforcement without
+  any API changes to existing call sites.
+
+The runtime check (`PlatformConfigError`) is preserved as defense-in-depth for
+untyped callers.
+
+Closes #1261

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -12,6 +12,7 @@ import type {
   DecisioningPlatform,
   RequiredPlatformsFor,
   RequiredCapabilitiesFor,
+  RequiredOptsFor,
   Account,
   AccountStore,
   DecisioningCapabilities,
@@ -21,8 +22,15 @@ import type {
   CreativeTemplatePlatform,
   SalesPlatform,
   AudiencePlatform,
+  CreateAdcpServerFromPlatformOptions,
 } from './index';
-import { AdcpError, AccountNotFoundError, defineSalesPlatform, defineAudiencePlatform } from './index';
+import {
+  AdcpError,
+  AccountNotFoundError,
+  defineSalesPlatform,
+  defineAudiencePlatform,
+  definePlatformWithCompliance,
+} from './index';
 
 // ── AdcpError construction ────────────────────────────────────────────
 
@@ -274,6 +282,32 @@ function _define_audience_platform_rejects_wrong_shape() {
   return defineAudiencePlatform<_SocialMeta>({ syncAudiences: 'not-a-function' });
 }
 
+// ── definePlatformWithCompliance / RequiredOptsFor invariants ─────────────
+
+// Positive: definePlatformWithCompliance accepts a platform with compliance_testing.
+type _PlatformBase = DecisioningPlatform<unknown, Record<string, unknown>>;
+type _PlatformWithCT = _PlatformBase & {
+  capabilities: { compliance_testing: { scenarios?: [] } };
+};
+function _define_platform_with_compliance_accepts_ct(p: _PlatformWithCT): _PlatformWithCT {
+  return definePlatformWithCompliance(p);
+}
+
+// Negative: definePlatformWithCompliance rejects a platform missing compliance_testing.
+function _define_platform_with_compliance_rejects_missing_ct() {
+  const p: _PlatformBase = {} as unknown as _PlatformBase;
+  // @ts-expect-error — compliance_testing is required; plain DecisioningPlatform has it optional.
+  return definePlatformWithCompliance(p);
+}
+
+// Positive: RequiredOptsFor resolves to base options when P has no compliance_testing.
+type _opts_no_ct = RequiredOptsFor<_PlatformBase>;
+const _check_opts_no_ct: _opts_no_ct extends CreateAdcpServerFromPlatformOptions ? true : false = true;
+
+// Positive: RequiredOptsFor resolves to require complyTest when P has compliance_testing.
+type _opts_with_ct = RequiredOptsFor<_PlatformWithCT>;
+const _check_opts_with_ct: _opts_with_ct extends { complyTest: object } ? true : false = true;
+
 // Reference all symbols once so eslint-disable is targeted.
 export const _references = [
   _adcp_error_minimum,
@@ -304,4 +338,8 @@ export const _references = [
   _define_sales_platform_identity,
   _define_audience_platform_identity,
   _define_audience_platform_rejects_wrong_shape,
+  _define_platform_with_compliance_accepts_ct,
+  _define_platform_with_compliance_rejects_missing_ct,
+  _check_opts_no_ct,
+  _check_opts_with_ct,
 ] as const;

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -23,6 +23,7 @@ import type {
   SalesPlatform,
   AudiencePlatform,
   CreateAdcpServerFromPlatformOptions,
+  ComplianceTestingCapabilities,
 } from './index';
 import {
   AdcpError,
@@ -31,6 +32,7 @@ import {
   defineAudiencePlatform,
   definePlatformWithCompliance,
 } from './index';
+import type { ComplyControllerConfig } from '../../testing/comply-controller';
 
 // ── AdcpError construction ────────────────────────────────────────────
 
@@ -287,16 +289,17 @@ function _define_audience_platform_rejects_wrong_shape() {
 // Positive: definePlatformWithCompliance accepts a platform with compliance_testing.
 type _PlatformBase = DecisioningPlatform<unknown, Record<string, unknown>>;
 type _PlatformWithCT = _PlatformBase & {
-  capabilities: { compliance_testing: { scenarios?: [] } };
+  capabilities: { compliance_testing: ComplianceTestingCapabilities };
 };
 function _define_platform_with_compliance_accepts_ct(p: _PlatformWithCT): _PlatformWithCT {
   return definePlatformWithCompliance(p);
 }
 
-// Negative: definePlatformWithCompliance rejects a platform missing compliance_testing.
+// Negative: definePlatformWithCompliance rejects a platform missing compliance_testing
+// (compliance_testing is optional on DecisioningPlatformCapabilities, required by the helper).
 function _define_platform_with_compliance_rejects_missing_ct() {
   const p: _PlatformBase = {} as unknown as _PlatformBase;
-  // @ts-expect-error — compliance_testing is required; plain DecisioningPlatform has it optional.
+  // @ts-expect-error — compliance_testing is required by the helper but optional on the base type.
   return definePlatformWithCompliance(p);
 }
 
@@ -305,8 +308,16 @@ type _opts_no_ct = RequiredOptsFor<_PlatformBase>;
 const _check_opts_no_ct: _opts_no_ct extends CreateAdcpServerFromPlatformOptions ? true : false = true;
 
 // Positive: RequiredOptsFor resolves to require complyTest when P has compliance_testing.
+// Uses ComplyControllerConfig (not object) to assert the exact required type.
 type _opts_with_ct = RequiredOptsFor<_PlatformWithCT>;
-const _check_opts_with_ct: _opts_with_ct extends { complyTest: object } ? true : false = true;
+const _check_opts_with_ct: _opts_with_ct extends { complyTest: ComplyControllerConfig } ? true : false = true;
+
+// Negative: base opts (complyTest optional) is NOT assignable to CT opts (complyTest required).
+// This is the call-site regression alarm: if RequiredOptsFor stops requiring complyTest,
+// this would flip to 'assignable' and fail to match the 'not-assignable' literal type.
+type _ct_opts_requires_complytest =
+  CreateAdcpServerFromPlatformOptions extends RequiredOptsFor<_PlatformWithCT> ? 'assignable' : 'not-assignable';
+const _check_ct_opts_requires: _ct_opts_requires_complytest = 'not-assignable';
 
 // Reference all symbols once so eslint-disable is targeted.
 export const _references = [
@@ -342,4 +353,5 @@ export const _references = [
   _define_platform_with_compliance_rejects_missing_ct,
   _check_opts_no_ct,
   _check_opts_with_ct,
+  _check_ct_opts_requires,
 ] as const;

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -72,6 +72,7 @@ export {
 // Capabilities (single source of truth for get_adcp_capabilities)
 export type {
   DecisioningCapabilities,
+  ComplianceTestingCapabilities,
   CreativeAgentRef,
   TargetingCapabilities,
   ReportingCapabilities,

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -167,6 +167,7 @@ export {
   createAdcpServerFromPlatform,
   getAllAdcpMigrations,
   type CreateAdcpServerFromPlatformOptions,
+  type RequiredOptsFor,
   type DecisioningAdcpServer,
   type DecisioningObservabilityHooks,
 } from './runtime/from-platform';
@@ -250,6 +251,7 @@ export {
   definePropertyListsPlatform,
   defineCollectionListsPlatform,
   defineBrandRightsPlatform,
+  definePlatformWithCompliance,
 } from './platform-helpers';
 
 // Wire-shape assembly helpers — emit correct Product / PricingOption /

--- a/src/lib/server/decisioning/platform-helpers.ts
+++ b/src/lib/server/decisioning/platform-helpers.ts
@@ -44,6 +44,7 @@
  */
 
 import type { DecisioningPlatform } from './platform';
+import type { ComplianceTestingCapabilities } from './capabilities';
 import type { SalesPlatform } from './specialisms/sales';
 import type { AudiencePlatform } from './specialisms/audiences';
 import type { SignalsPlatform } from './specialisms/signals';
@@ -226,5 +227,49 @@ export function defineCollectionListsPlatform<TCtxMeta = Record<string, unknown>
 export function defineBrandRightsPlatform<TCtxMeta = Record<string, unknown>>(
   platform: BrandRightsPlatform<TCtxMeta>
 ): BrandRightsPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a full `DecisioningPlatform` that wires
+ * `comply_test_controller`. Requires `capabilities.compliance_testing`
+ * to be present in the platform object, enforcing the cap/adapter
+ * pairing at compile time.
+ *
+ * When the returned platform is passed to `createAdcpServerFromPlatform`,
+ * `RequiredOptsFor<P>` resolves to require `complyTest` in opts — so
+ * both halves of the invariant are enforced without runtime-only feedback.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   createAdcpServerFromPlatform,
+ *   definePlatformWithCompliance,
+ * } from '@adcp/sdk/server';
+ *
+ * const server = createAdcpServerFromPlatform(
+ *   definePlatformWithCompliance<Config, Meta>({
+ *     capabilities: {
+ *       specialisms: ['sales-guaranteed'],
+ *       compliance_testing: {}, // required by this helper ✓
+ *     },
+ *     accounts: { resolve: async (ref) => ... },
+ *     sales: { ... },
+ *   }),
+ *   {
+ *     name: 'my-seller',
+ *     version: '1.0.0',
+ *     complyTest: { seed: { product: ... } }, // required by RequiredOptsFor<P> ✓
+ *   }
+ * );
+ * ```
+ */
+export function definePlatformWithCompliance<TConfig = unknown, TCtxMeta = Record<string, unknown>>(
+  platform: DecisioningPlatform<TConfig, TCtxMeta> & {
+    capabilities: { compliance_testing: ComplianceTestingCapabilities };
+  }
+): DecisioningPlatform<TConfig, TCtxMeta> & {
+  capabilities: { compliance_testing: ComplianceTestingCapabilities };
+} {
   return platform;
 }

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -63,6 +63,7 @@ import {
   type HandlerContext,
 } from '../../create-adcp-server';
 import type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor } from '../platform';
+import type { ComplianceTestingCapabilities } from '../capabilities';
 import type { Account, ResolvedAuthInfo } from '../account';
 import { AccountNotFoundError, toWireAccount } from '../account';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
@@ -346,10 +347,19 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * without a gate AND without an env-flag escape (matches the standalone
    * `createComplyController` warning behavior).
    *
-   * **Capability-vs-adapter consistency.** If
-   * `capabilities.compliance_testing` is declared but `complyTest` is
-   * omitted, construction throws `PlatformConfigError` — the framework
-   * refuses to project a discovery block the runtime can't honor.
+   * **Capability-vs-adapter consistency.** Both directions are enforced:
+   *
+   * - `capabilities.compliance_testing` declared without `complyTest` →
+   *   `PlatformConfigError` at construction (and a **compile-time error**
+   *   when `P` is typed with `compliance_testing` non-optional, via
+   *   `RequiredOptsFor<P>`).
+   * - `complyTest` supplied without `capabilities.compliance_testing` →
+   *   `PlatformConfigError` at construction (runtime defense-in-depth).
+   *
+   * To enforce the invariant at compile time when building the platform
+   * as an object literal, wrap it with `definePlatformWithCompliance`:
+   * TypeScript will then require `compliance_testing` on the platform
+   * and `complyTest` on opts together.
    *
    * @public
    */
@@ -519,6 +529,28 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
 }
 
 /**
+ * Derives the opts type for `createAdcpServerFromPlatform` based on whether
+ * the platform declares `capabilities.compliance_testing`.
+ *
+ * When `P` carries a non-optional `compliance_testing` block (e.g. because
+ * the caller used `definePlatformWithCompliance`), this resolves to
+ * `CreateAdcpServerFromPlatformOptions & { complyTest: ComplyControllerConfig }`,
+ * making `complyTest` required. For all other platform shapes the resolved
+ * type is the plain `CreateAdcpServerFromPlatformOptions` — no change.
+ *
+ * Both directions of the mismatch are still caught at runtime by the
+ * `PlatformConfigError` check in `createAdcpServerFromPlatform` as
+ * defense-in-depth for untyped callers.
+ *
+ * @public
+ */
+export type RequiredOptsFor<P extends DecisioningPlatform<any, any>> = P extends {
+  capabilities: { compliance_testing: ComplianceTestingCapabilities };
+}
+  ? CreateAdcpServerFromPlatformOptions & { complyTest: ComplyControllerConfig }
+  : CreateAdcpServerFromPlatformOptions;
+
+/**
  * Adcp server returned by `createAdcpServerFromPlatform`. Adds task-state
  * accessors on top of the standard `AdcpServer` so test harnesses (and the
  * forthcoming `tasks/get` wire handler) can inspect lifecycle.
@@ -578,7 +610,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   platform: P &
     RequiredPlatformsFor<P['capabilities']['specialisms'][number]> &
     RequiredCapabilitiesFor<P['capabilities']['specialisms'][number]>,
-  opts: CreateAdcpServerFromPlatformOptions
+  opts: RequiredOptsFor<P>
 ): DecisioningAdcpServer {
   validatePlatform(platform);
 


### PR DESCRIPTION
Closes #1261

## Summary

`createAdcpServerFromPlatform` had a runtime-only guard for the `complyTest`/`capabilities.compliance_testing` pairing. In CI harnesses that can't see the agent's stderr, a missing `compliance_testing` capability silently made all requests return 500 — the `PlatformConfigError` was invisible.

This PR adds two compile-time mechanisms (both additive/non-breaking):

1. **`RequiredOptsFor<P>`** — conditional type on the `opts` parameter. When `P` extends `{ capabilities: { compliance_testing: ComplianceTestingCapabilities } }`, the resolved opts type is `CreateAdcpServerFromPlatformOptions & { complyTest: ComplyControllerConfig }`, making `complyTest` required. Catches the cap-without-adapter direction at compile time.

2. **`definePlatformWithCompliance<TConfig, TCtxMeta>()`** — identity helper (same pattern as `defineSalesPlatform` etc.) that enforces `capabilities.compliance_testing` non-optional at the platform definition site. Combined with `RequiredOptsFor<P>`, provides bidirectional enforcement: use the helper → TypeScript requires both `compliance_testing` in platform AND `complyTest` in opts.

The runtime `PlatformConfigError` check is preserved as defense-in-depth for untyped/JS callers.

**Coverage**: The cap-with-missing-adapter direction is caught at compile time by `RequiredOptsFor<P>`. The adapter-with-missing-cap direction remains runtime-only — it cannot be expressed as a cross-parameter TypeScript constraint without breaking callers who pass opts as a typed variable.

## What was tested

- `npx tsc --project tsconfig.lib.json --noEmit` — no new errors (pre-existing TS2688/TS5107 env errors unchanged, same as #1240)
- `npm run format:check` — passed
- Type-check tests in `decisioning.type-checks.ts` cover:
  - `definePlatformWithCompliance` accepts a CT platform (positive)
  - `definePlatformWithCompliance` rejects a plain `DecisioningPlatform` with optional `compliance_testing` (`@ts-expect-error`)
  - `RequiredOptsFor<_PlatformBase>` resolves to base opts (positive)
  - `RequiredOptsFor<_PlatformWithCT>` resolves to require `ComplyControllerConfig` (positive, typed to exact type)
  - `CreateAdcpServerFromPlatformOptions` is NOT assignable to `RequiredOptsFor<_PlatformWithCT>` — call-site regression alarm that fires if `RequiredOptsFor` stops requiring `complyTest`

## Nits (not fixed — surfaced for reviewer)

- `definePlatformWithCompliance` breaks the `define<Sub>Platform` naming convention (all other helpers name the sub-interface, not a capability modifier). Reviewer may prefer `defineCompliancePlatform` for naming consistency.

## Pre-PR review

- **code-reviewer**: approved — no blockers. Noted `RequiredOptsFor` inference is safe (`any` in base constraint doesn't escape into the conditional check). Import of `ComplyControllerConfig` is type-only at emit. Pre-blocker issues (fragile `{ scenarios?: [] }` type and `complyTest: object` over-broad check) were fixed before this commit.
- **dx-expert**: approved after blocker fixed — added call-site regression alarm test (`_check_ct_opts_requires`) asserting `CreateAdcpServerFromPlatformOptions` is not assignable to `RequiredOptsFor<_PlatformWithCT>`. Nit: helper naming inconsistency surfaced above.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Eec8o47CTq6jpoDoLGqNoT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eec8o47CTq6jpoDoLGqNoT)_