### PR TITLE
fix(codegen): alias 6 *Asset1 jsts under-resolution artifacts (closes #1264)

### DIFF
--- a/.changeset/codegen-asset-aliases.md
+++ b/.changeset/codegen-asset-aliases.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(codegen): alias 6 jsts under-resolution artifacts after AdCP 3.0.4 asset-union landing
+
+AdCP 3.0.2 introduced `core/assets/asset-union.json` (adcp#3462) as the canonical home for the asset-variant `oneOf`. The bundler still inlines the union at both `creative-asset.json` and `creative-manifest.json` call sites, and `json-schema-to-typescript` under-resolves the second compile pass — dropping the `asset_type` discriminator that the first pass preserved. Six survivors of `removeNumberedTypeDuplicates`'s byte-identity check:
+
+| Type          | First pass (correct)                                  | Second pass (under-resolved)         |
+|---------------|-------------------------------------------------------|--------------------------------------|
+| `VASTAsset`   | `{ asset_type: 'vast'; …metadata… } & (delivery_union)` | `(delivery_union)` — lost wrapper    |
+| `BriefAsset`  | `CreativeBrief & { asset_type: 'brief' }`             | `CreativeBrief` — lost discriminator |
+| `DAASTAsset`, `CatalogAsset`, `AssetVariant`, `CreativeAsset` | … | … |
+
+`applyKnownJstsAliases` runs after the byte-identity dedupe pass and rewrites each known artifact as `type Foo1 = Foo` with a `@deprecated` JSDoc. Type-level safe: the bundled response carries `asset_type` correctly at runtime, so the under-resolved type was strictly weaker than the wire format. The alias gives consumers the correctly-discriminated shape that matches what they receive on the wire. Zod codegen consumes the aliased types and emits matching schema aliases automatically.
+
+Closes #1264.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1158,6 +1158,141 @@ export function filterDuplicateTypeDefinitions(typeDefinitions: string, generate
 }
 
 /**
+ * Some `Foo1` artifacts survive `removeNumberedTypeDuplicates` because their bodies
+ * are not byte-identical to `Foo` — `json-schema-to-typescript` under-resolves the
+ * second compile pass on certain shapes, dropping properties or wrappers the first
+ * pass preserved. Examples (AdCP 3.0.4):
+ *
+ *   VASTAsset      = { asset_type: 'vast'; …metadata… } & ({delivery_type:'url',url} | {delivery_type:'inline',content})
+ *   VASTAsset1     = ({delivery_type:'url',url} | {delivery_type:'inline',content})           ← lost asset_type wrapper
+ *
+ *   BriefAsset     = CreativeBrief & { asset_type: 'brief' }
+ *   BriefAsset1    = CreativeBrief                                                            ← lost asset_type discriminator
+ *
+ *   AssetVariant   = ImageAsset | … | VASTAsset | … | BriefAsset | CatalogAsset
+ *   AssetVariant1  = ImageAsset | … | VASTAsset1 | … | BriefAsset1 | CatalogAsset1            ← references the under-resolved variants
+ *
+ * The spec converged these via `core/assets/asset-union.json` (adcp#3462) — both
+ * `creative-asset.json` and `creative-manifest.json` `$ref` the same union. The
+ * bundler inlines both occurrences though, so jsts sees two anonymous-but-identically-
+ * titled shapes and emits Foo / Foo1.
+ *
+ * Rewriting each `Foo1` as `type Foo1 = Foo` is type-level safe: the bundled
+ * response carries `asset_type` correctly at runtime; the under-resolved TS type
+ * was strictly weaker than the wire format. The alias gives consumers the
+ * correctly-discriminated shape; `@deprecated` JSDoc surfaces the canonical name.
+ *
+ * Tracked: adcp-client#1264.
+ */
+const JSTS_UNDER_RESOLUTION_ALIASES: Array<{ numbered: string; base: string }> = [
+  { numbered: 'VASTAsset1', base: 'VASTAsset' },
+  { numbered: 'DAASTAsset1', base: 'DAASTAsset' },
+  { numbered: 'BriefAsset1', base: 'BriefAsset' },
+  { numbered: 'CatalogAsset1', base: 'CatalogAsset' },
+  { numbered: 'AssetVariant1', base: 'AssetVariant' },
+  { numbered: 'CreativeAsset1', base: 'CreativeAsset' },
+];
+
+export function applyKnownJstsAliases(typeDefinitions: string): string {
+  const lines = typeDefinitions.split('\n');
+  const targetNames = new Set(JSTS_UNDER_RESOLUTION_ALIASES.map(a => a.numbered));
+  const baseByNumbered = new Map(JSTS_UNDER_RESOLUTION_ALIASES.map(a => [a.numbered, a.base]));
+  const aliasedNames = new Set<string>();
+
+  const outputLines: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const typeMatch = line.match(/^export (?:type|interface) (\w+)\b/);
+
+    if (!typeMatch || !targetNames.has(typeMatch[1])) {
+      outputLines.push(line);
+      i++;
+      continue;
+    }
+
+    // Found a target — walk back to swallow any preceding JSDoc, then forward
+    // to the end of the block (brace-balanced for interfaces; first `;` at
+    // brace depth 0 for unions/intersections/aliases).
+    while (
+      outputLines.length > 0 &&
+      (outputLines[outputLines.length - 1].trimStart().startsWith('*') ||
+        outputLines[outputLines.length - 1].trimStart().startsWith('/**') ||
+        outputLines[outputLines.length - 1].trim() === '')
+    ) {
+      outputLines.pop();
+    }
+
+    const numbered = typeMatch[1];
+    const base = baseByNumbered.get(numbered)!;
+
+    let braceDepth = 0;
+    let parenDepth = 0;
+    let endIdx = i;
+    let foundTerminator = false;
+    for (let j = i; j < lines.length; j++) {
+      const cur = lines[j];
+      for (const ch of cur) {
+        if (ch === '{') braceDepth++;
+        else if (ch === '}') braceDepth--;
+        else if (ch === '(') parenDepth++;
+        else if (ch === ')') parenDepth--;
+      }
+      // Interface block: ends at the line that closes braceDepth back to 0.
+      // Type alias block: first `;` at brace+paren depth 0 ends it.
+      if (line.startsWith('export interface')) {
+        if (braceDepth === 0 && j > i) {
+          endIdx = j;
+          foundTerminator = true;
+          break;
+        }
+      } else {
+        if (cur.includes(';') && braceDepth === 0 && parenDepth === 0) {
+          endIdx = j;
+          foundTerminator = true;
+          break;
+        }
+      }
+    }
+
+    if (!foundTerminator) {
+      // Defensive: if we can't find the end, leave the block intact
+      outputLines.push(line);
+      i++;
+      continue;
+    }
+
+    outputLines.push(
+      '/**',
+      ` * Re-export of \`${base}\` under the legacy codegen artifact name.`,
+      ' *',
+      ` * \`${numbered}\` is a json-schema-to-typescript under-resolution artifact —`,
+      ` * the bundler inlined the same schema at two call sites and jsts emitted a numbered`,
+      ` * sibling. The body it produced was strictly weaker than \`${base}\` (missing the`,
+      ` * \`asset_type\` discriminator or its containing wrapper); aliasing to \`${base}\``,
+      ' * gives consumers the correctly-discriminated shape that matches the wire format.',
+      ' *',
+      ` * @deprecated Use \`${base}\` from \`@adcp/sdk/types\`. Slated for removal in the next major.`,
+      ' */',
+      `export type ${numbered} = ${base};`
+    );
+    aliasedNames.add(numbered);
+    i = endIdx + 1;
+  }
+
+  if (aliasedNames.size > 0) {
+    console.log(
+      `🔀 Aliased ${aliasedNames.size} jsts under-resolution artifact(s): ${[...aliasedNames]
+        .map(n => `${n}→${baseByNumbered.get(n)}`)
+        .join(', ')}`
+    );
+  }
+
+  return outputLines.join('\n');
+}
+
+/**
  * Convert method name to proper type name, preserving acronyms.
  * Examples:
  *   siGetOffering -> SIGetOffering
@@ -1645,9 +1780,11 @@ async function generateTypes() {
   const coreTypesPath = path.join(libOutputDir, 'core.generated.ts');
   // Strip inline index-signature arms first so numbered-duplicate detection compares
   // clean bodies (without the { [k: string]: unknown } intersection arms that only appear
-  // on some compile passes of the same schema).
+  // on some compile passes of the same schema). After byte-identity dedupe, alias the
+  // residual jsts under-resolution artifacts (*Asset1, AssetVariant1, CreativeAsset1) —
+  // see applyKnownJstsAliases for the rationale.
   const processedCoreTypes = fixTypedIndexSignatures(
-    removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes))
+    applyKnownJstsAliases(removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes)))
   );
   const coreChanged = writeFileIfChanged(coreTypesPath, processedCoreTypes);
 

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1212,18 +1212,10 @@ export function applyKnownJstsAliases(typeDefinitions: string): string {
       continue;
     }
 
-    // Found a target — walk back to swallow any preceding JSDoc, then forward
-    // to the end of the block (brace-balanced for interfaces; first `;` at
-    // brace depth 0 for unions/intersections/aliases).
-    while (
-      outputLines.length > 0 &&
-      (outputLines[outputLines.length - 1].trimStart().startsWith('*') ||
-        outputLines[outputLines.length - 1].trimStart().startsWith('/**') ||
-        outputLines[outputLines.length - 1].trim() === '')
-    ) {
-      outputLines.pop();
-    }
-
+    // Found a target — locate the end of the block (brace-balanced for
+    // interfaces; first `;` at brace+paren depth 0 for unions/intersections/
+    // aliases) BEFORE swallowing the leading JSDoc, so a defensive bail
+    // (terminator not found) leaves the original prose intact.
     const numbered = typeMatch[1];
     const base = baseByNumbered.get(numbered)!;
 
@@ -1240,7 +1232,11 @@ export function applyKnownJstsAliases(typeDefinitions: string): string {
         else if (ch === ')') parenDepth--;
       }
       // Interface block: ends at the line that closes braceDepth back to 0.
-      // Type alias block: first `;` at brace+paren depth 0 ends it.
+      // Type alias block: first `;` at brace+paren depth 0 ends it. Skip lines
+      // that are JSDoc continuations (`*`-prefixed) so a `;` inside a comment
+      // doesn't terminate the block early.
+      const trimmed = cur.trimStart();
+      const isJsdocLine = trimmed.startsWith('*') || trimmed.startsWith('/*');
       if (line.startsWith('export interface')) {
         if (braceDepth === 0 && j > i) {
           endIdx = j;
@@ -1248,7 +1244,7 @@ export function applyKnownJstsAliases(typeDefinitions: string): string {
           break;
         }
       } else {
-        if (cur.includes(';') && braceDepth === 0 && parenDepth === 0) {
+        if (!isJsdocLine && cur.includes(';') && braceDepth === 0 && parenDepth === 0) {
           endIdx = j;
           foundTerminator = true;
           break;
@@ -1261,6 +1257,17 @@ export function applyKnownJstsAliases(typeDefinitions: string): string {
       outputLines.push(line);
       i++;
       continue;
+    }
+
+    // Now that we've confirmed we'll rewrite this block, swallow any preceding
+    // JSDoc lines from outputLines so the new alias's JSDoc replaces them.
+    while (
+      outputLines.length > 0 &&
+      (outputLines[outputLines.length - 1].trimStart().startsWith('*') ||
+        outputLines[outputLines.length - 1].trimStart().startsWith('/**') ||
+        outputLines[outputLines.length - 1].trim() === '')
+    ) {
+      outputLines.pop();
     }
 
     outputLines.push(

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.0.4
-// Generated at: 2026-05-02T14:30:46.845Z
+// Generated at: 2026-05-02T15:11:28.636Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -9018,82 +9018,65 @@ export type CreativeQuality = 'draft' | 'production';
  */
 export type PreviewOutputFormat = 'url' | 'html';
 /**
- * Canonical union of all asset variant schemas. Referenced from creative-asset.json and creative-manifest.json to ensure a single named type is emitted by schema-to-TypeScript tooling. Add new asset types here and to the creative/asset-types registry.
+ * Re-export of `AssetVariant` under the legacy codegen artifact name.
  *
- * This interface was referenced by `undefined`'s JSON-Schema definition
- * via the `patternProperty` "^[a-z0-9_]+$".
+ * `AssetVariant1` is a json-schema-to-typescript under-resolution artifact —
+ * the bundler inlined the same schema at two call sites and jsts emitted a numbered
+ * sibling. The body it produced was strictly weaker than `AssetVariant` (missing the
+ * `asset_type` discriminator or its containing wrapper); aliasing to `AssetVariant`
+ * gives consumers the correctly-discriminated shape that matches the wire format.
+ *
+ * @deprecated Use `AssetVariant` from `@adcp/sdk/types`. Slated for removal in the next major.
  */
-export type AssetVariant1 =
-  | ImageAsset
-  | VideoAsset
-  | AudioAsset
-  | VASTAsset1
-  | TextAsset
-  | URLAsset
-  | HTMLAsset
-  | JavaScriptAsset
-  | WebhookAsset
-  | CSSAsset
-  | DAASTAsset1
-  | MarkdownAsset
-  | BriefAsset1
-  | CatalogAsset1;
+export type AssetVariant1 = AssetVariant;
 /**
- * VAST (Video Ad Serving Template) tag for third-party video ad serving
+ * Re-export of `VASTAsset` under the legacy codegen artifact name.
+ *
+ * `VASTAsset1` is a json-schema-to-typescript under-resolution artifact —
+ * the bundler inlined the same schema at two call sites and jsts emitted a numbered
+ * sibling. The body it produced was strictly weaker than `VASTAsset` (missing the
+ * `asset_type` discriminator or its containing wrapper); aliasing to `VASTAsset`
+ * gives consumers the correctly-discriminated shape that matches the wire format.
+ *
+ * @deprecated Use `VASTAsset` from `@adcp/sdk/types`. Slated for removal in the next major.
  */
-export type VASTAsset1 =
-  | {
-      /**
-       * Discriminator indicating VAST is delivered via URL endpoint
-       */
-      delivery_type: 'url';
-      /**
-       * URL endpoint that returns VAST XML
-       */
-      url: string;
-    }
-  | {
-      /**
-       * Discriminator indicating VAST is delivered as inline XML content
-       */
-      delivery_type: 'inline';
-      /**
-       * Inline VAST XML content
-       */
-      content: string;
-    };
+export type VASTAsset1 = VASTAsset;
 /**
- * DAAST (Digital Audio Ad Serving Template) tag for third-party audio ad serving
+ * Re-export of `DAASTAsset` under the legacy codegen artifact name.
+ *
+ * `DAASTAsset1` is a json-schema-to-typescript under-resolution artifact —
+ * the bundler inlined the same schema at two call sites and jsts emitted a numbered
+ * sibling. The body it produced was strictly weaker than `DAASTAsset` (missing the
+ * `asset_type` discriminator or its containing wrapper); aliasing to `DAASTAsset`
+ * gives consumers the correctly-discriminated shape that matches the wire format.
+ *
+ * @deprecated Use `DAASTAsset` from `@adcp/sdk/types`. Slated for removal in the next major.
  */
-export type DAASTAsset1 =
-  | {
-      /**
-       * Discriminator indicating DAAST is delivered via URL endpoint
-       */
-      delivery_type: 'url';
-      /**
-       * URL endpoint that returns DAAST XML
-       */
-      url: string;
-    }
-  | {
-      /**
-       * Discriminator indicating DAAST is delivered as inline XML content
-       */
-      delivery_type: 'inline';
-      /**
-       * Inline DAAST XML content
-       */
-      content: string;
-    };
+export type DAASTAsset1 = DAASTAsset;
 /**
- * Campaign-level creative context as an asset. Carries the creative brief through the manifest so it travels with the creative through regeneration, resizing, and auditing.
+ * Re-export of `BriefAsset` under the legacy codegen artifact name.
+ *
+ * `BriefAsset1` is a json-schema-to-typescript under-resolution artifact —
+ * the bundler inlined the same schema at two call sites and jsts emitted a numbered
+ * sibling. The body it produced was strictly weaker than `BriefAsset` (missing the
+ * `asset_type` discriminator or its containing wrapper); aliasing to `BriefAsset`
+ * gives consumers the correctly-discriminated shape that matches the wire format.
+ *
+ * @deprecated Use `BriefAsset` from `@adcp/sdk/types`. Slated for removal in the next major.
  */
-export type BriefAsset1 = CreativeBrief;
+export type BriefAsset1 = BriefAsset;
 /**
- * A typed data feed as a creative asset. Carries catalog context (products, stores, jobs, etc.) within the manifest's assets map.
+ * Re-export of `CatalogAsset` under the legacy codegen artifact name.
+ *
+ * `CatalogAsset1` is a json-schema-to-typescript under-resolution artifact —
+ * the bundler inlined the same schema at two call sites and jsts emitted a numbered
+ * sibling. The body it produced was strictly weaker than `CatalogAsset` (missing the
+ * `asset_type` discriminator or its containing wrapper); aliasing to `CatalogAsset`
+ * gives consumers the correctly-discriminated shape that matches the wire format.
+ *
+ * @deprecated Use `CatalogAsset` from `@adcp/sdk/types`. Slated for removal in the next major.
  */
-export type CatalogAsset1 = Catalog;
+export type CatalogAsset1 = CatalogAsset;
 
 /**
  * Request to generate previews of creative manifests. Uses request_type to select single, batch, or variant mode.
@@ -11796,62 +11779,17 @@ export interface PackageUpdate {
   ext?: ExtensionObject;
 }
 /**
- * Creative asset for upload to library - supports static assets, generative formats, and third-party snippets
+ * Re-export of `CreativeAsset` under the legacy codegen artifact name.
+ *
+ * `CreativeAsset1` is a json-schema-to-typescript under-resolution artifact —
+ * the bundler inlined the same schema at two call sites and jsts emitted a numbered
+ * sibling. The body it produced was strictly weaker than `CreativeAsset` (missing the
+ * `asset_type` discriminator or its containing wrapper); aliasing to `CreativeAsset`
+ * gives consumers the correctly-discriminated shape that matches the wire format.
+ *
+ * @deprecated Use `CreativeAsset` from `@adcp/sdk/types`. Slated for removal in the next major.
  */
-export interface CreativeAsset1 {
-  /**
-   * Unique identifier for the creative
-   */
-  creative_id: string;
-  /**
-   * Human-readable creative name
-   */
-  name: string;
-  format_id: FormatReferenceStructuredObject;
-  /**
-   * Assets required by the format, keyed by asset_id. Each asset value carries an `asset_type` discriminator that selects the matching asset schema.
-   */
-  assets: {
-    [k: string]: AssetVariant1 | undefined;
-  };
-  /**
-   * Preview contexts for generative formats - defines what scenarios to generate previews for
-   */
-  inputs?: {
-    /**
-     * Human-readable name for this preview variant
-     */
-    name: string;
-    /**
-     * Macro values to apply for this preview
-     */
-    macros?: {
-      [k: string]: string | undefined;
-    };
-    /**
-     * Natural language description of the context for AI-generated content
-     */
-    context_description?: string;
-  }[];
-  /**
-   * User-defined tags for organization and searchability
-   */
-  tags?: string[];
-  status?: CreativeStatus;
-  /**
-   * Optional delivery weight for creative rotation when uploading via create_media_buy or update_media_buy (0-100). If omitted, platform determines rotation. Only used during upload to media buy - not stored in creative library.
-   */
-  weight?: number;
-  /**
-   * Optional array of placement IDs where this creative should run when uploading via create_media_buy or update_media_buy. References placement_id values from the product's placements array. If omitted, creative runs on all placements. Only used during upload to media buy - not stored in creative library.
-   */
-  placement_ids?: string[];
-  /**
-   * Industry-standard identifiers for this creative (e.g., Ad-ID, ISCI, Clearcast clock number). In broadcast buying, these identifiers tie the creative to rotation instructions and traffic systems. A creative may have multiple identifiers when different systems reference the same asset.
-   */
-  industry_identifiers?: IndustryIdentifier[];
-  provenance?: Provenance;
-}
+export type CreativeAsset1 = CreativeAsset;
 
 // bundled/property/create-property-list-request.json
 /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-02T14:30:51.841Z
+// Generated at: 2026-05-02T15:11:33.149Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -2184,50 +2184,42 @@ export const CreativeQualitySchema = z.union([z.literal("draft"), z.literal("pro
 
 export const PreviewOutputFormatSchema = z.union([z.literal("url"), z.literal("html")]);
 
-export const VASTAsset1Schema = z.union([z.object({
+export const VASTAssetSchema = z.object({
+    asset_type: z.literal("vast"),
+    vast_version: VASTVersionSchema.optional(),
+    vpaid_enabled: z.boolean().optional(),
+    duration_ms: z.number().optional(),
+    tracking_events: z.array(VASTTrackingEventSchema).optional(),
+    captions_url: z.string().optional(),
+    audio_description_url: z.string().optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([z.object({
         delivery_type: z.literal("url"),
         url: z.string()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
         content: z.string()
-    }).passthrough()]);
+    }).passthrough()]));
 
-export const DAASTAsset1Schema = z.union([z.object({
+export const DAASTAssetSchema = z.object({
+    asset_type: z.literal("daast"),
+    daast_version: DAASTVersionSchema.optional(),
+    duration_ms: z.number().optional(),
+    tracking_events: z.array(DAASTTrackingEventSchema).optional(),
+    companion_ads: z.boolean().optional(),
+    transcript_url: z.string().optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough().and(z.union([z.object({
         delivery_type: z.literal("url"),
         url: z.string()
     }).passthrough(), z.object({
         delivery_type: z.literal("inline"),
         content: z.string()
-    }).passthrough()]);
+    }).passthrough()]));
 
-export const CatalogAsset1Schema = CatalogSchema;
-
-export const CreativeBriefSchema = z.object({
-    name: z.string(),
-    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
-    tone: z.string().optional(),
-    audience: z.string().optional(),
-    territory: z.string().optional(),
-    messaging: z.object({
-        headline: z.string().optional(),
-        tagline: z.string().optional(),
-        cta: z.string().optional(),
-        key_messages: z.array(z.string()).optional()
-    }).passthrough().optional(),
-    reference_assets: z.array(ReferenceAssetSchema).optional(),
-    compliance: z.object({
-        required_disclosures: z.array(z.object({
-            text: z.string(),
-            position: DisclosurePositionSchema.optional(),
-            jurisdictions: z.array(z.string()).optional(),
-            regulation: z.string().optional(),
-            min_duration_ms: z.number().optional(),
-            language: z.string().optional(),
-            persistence: DisclosurePersistenceSchema.optional()
-        }).passthrough()).optional(),
-        prohibited_claims: z.array(z.string()).optional()
-    }).passthrough().optional()
-}).passthrough();
+export const CatalogAssetSchema = CatalogSchema.and(z.object({
+    asset_type: z.literal("catalog")
+}).passthrough());
 
 export const PreviewCreativeSingleResponseSchema = z.object({
     response_type: z.literal("single"),
@@ -3153,38 +3145,12 @@ export const PriceSchema = z.object({
     period: z.union([z.literal("night"), z.literal("month"), z.literal("year"), z.literal("one_time")]).optional()
 }).passthrough();
 
-export const VASTAssetSchema = z.object({
-    asset_type: z.literal("vast"),
-    vast_version: VASTVersionSchema.optional(),
-    vpaid_enabled: z.boolean().optional(),
-    duration_ms: z.number().optional(),
-    tracking_events: z.array(VASTTrackingEventSchema).optional(),
-    captions_url: z.string().optional(),
-    audio_description_url: z.string().optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough().and(z.union([z.object({
-        delivery_type: z.literal("url"),
-        url: z.string()
-    }).passthrough(), z.object({
-        delivery_type: z.literal("inline"),
-        content: z.string()
-    }).passthrough()]));
-
-export const DAASTAssetSchema = z.object({
-    asset_type: z.literal("daast"),
-    daast_version: DAASTVersionSchema.optional(),
-    duration_ms: z.number().optional(),
-    tracking_events: z.array(DAASTTrackingEventSchema).optional(),
-    companion_ads: z.boolean().optional(),
-    transcript_url: z.string().optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough().and(z.union([z.object({
-        delivery_type: z.literal("url"),
-        url: z.string()
-    }).passthrough(), z.object({
-        delivery_type: z.literal("inline"),
-        content: z.string()
-    }).passthrough()]));
+export const OfferingAssetGroupSchema = z.object({
+    asset_group_id: z.string(),
+    asset_type: AssetContentTypeSchema,
+    items: z.array(z.union([TextAssetSchema, ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, URLAssetSchema, HTMLAssetSchema, MarkdownAssetSchema, VASTAssetSchema, DAASTAssetSchema, CSSAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema])),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
 
 export const TravelTimeUnitSchema = z.union([z.literal("min"), z.literal("hr")]);
 
@@ -3226,10 +3192,24 @@ export const DateRangeSchema = z.object({
     end: z.string()
 }).passthrough();
 
-export const OfferingAssetGroupSchema = z.object({
-    asset_group_id: z.string(),
-    asset_type: AssetContentTypeSchema,
-    items: z.array(z.union([TextAssetSchema, ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, URLAssetSchema, HTMLAssetSchema, MarkdownAssetSchema, VASTAssetSchema, DAASTAssetSchema, CSSAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema])),
+export const DestinationItemSchema = z.object({
+    destination_id: z.string(),
+    name: z.string(),
+    description: z.string().optional(),
+    city: z.string().optional(),
+    region: z.string().optional(),
+    country: z.string().optional(),
+    location: z.object({
+        lat: z.number(),
+        lng: z.number()
+    }).passthrough().optional(),
+    destination_type: z.union([z.literal("beach"), z.literal("mountain"), z.literal("urban"), z.literal("cultural"), z.literal("adventure"), z.literal("wellness"), z.literal("cruise")]).optional(),
+    price: PriceSchema.optional(),
+    image_url: z.string().optional(),
+    url: z.string().optional(),
+    rating: z.number().optional(),
+    tags: z.array(z.string()).optional(),
+    assets: z.array(OfferingAssetGroupSchema).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -4104,15 +4084,32 @@ export const RepeatableGroupAssetSchema = z.object({
     assets: z.array(z.union([GroupImageAssetSchema, GroupVideoAssetSchema, GroupAudioAssetSchema, GroupTextAssetSchema, GroupMarkdownAssetSchema, GroupHtmlAssetSchema, GroupCssAssetSchema, GroupJavaScriptAssetSchema, GroupVastAssetSchema, GroupDaastAssetSchema, GroupUrlAssetSchema, GroupWebhookAssetSchema]))
 }).passthrough();
 
-export const BriefAssetSchema = CreativeBriefSchema.and(z.object({
-    asset_type: z.literal("brief")
-}).passthrough());
-
-export const CatalogAssetSchema = CatalogSchema.and(z.object({
-    asset_type: z.literal("catalog")
-}).passthrough());
-
-export const AssetVariantSchema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema]);
+export const CreativeBriefSchema = z.object({
+    name: z.string(),
+    objective: z.union([z.literal("awareness"), z.literal("consideration"), z.literal("conversion"), z.literal("retention"), z.literal("engagement")]).optional(),
+    tone: z.string().optional(),
+    audience: z.string().optional(),
+    territory: z.string().optional(),
+    messaging: z.object({
+        headline: z.string().optional(),
+        tagline: z.string().optional(),
+        cta: z.string().optional(),
+        key_messages: z.array(z.string()).optional()
+    }).passthrough().optional(),
+    reference_assets: z.array(ReferenceAssetSchema).optional(),
+    compliance: z.object({
+        required_disclosures: z.array(z.object({
+            text: z.string(),
+            position: DisclosurePositionSchema.optional(),
+            jurisdictions: z.array(z.string()).optional(),
+            regulation: z.string().optional(),
+            min_duration_ms: z.number().optional(),
+            language: z.string().optional(),
+            persistence: DisclosurePersistenceSchema.optional()
+        }).passthrough()).optional(),
+        prohibited_claims: z.array(z.string()).optional()
+    }).passthrough().optional()
+}).passthrough();
 
 export const PackageSchema = z.object({
     package_id: z.string(),
@@ -4162,24 +4159,6 @@ export const PlannedDeliverySchema = z.object({
     currency: z.string().optional(),
     enforced_policies: z.array(z.string()).optional(),
     ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const CreativeAssetSchema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatReferenceStructuredObjectSchema,
-    assets: z.record(z.string(), AssetVariantSchema),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
 }).passthrough();
 
 export const UpdateMediaBuySuccessSchema = z.object({
@@ -4404,159 +4383,9 @@ export const SyncAudiencesResponseSchema = z.union([SyncAudiencesSuccessSchema, 
 
 export const SyncCatalogsResponseSchema = z.union([SyncCatalogsSuccessSchema, SyncCatalogsErrorSchema]);
 
-export const CreativeManifestSchema = z.object({
-    format_id: FormatReferenceStructuredObjectSchema,
-    assets: z.record(z.string(), AssetVariantSchema),
-    rights: z.array(RightsConstraintSchema).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const BuildCreativeSuccessSchema = z.object({
-    creative_manifest: CreativeManifestSchema,
-    sandbox: z.boolean().optional(),
-    expires_at: z.string().optional(),
-    preview: z.object({
-        previews: z.array(z.object({
-            preview_id: z.string(),
-            renders: z.array(PreviewRenderSchema),
-            input: z.object({
-                name: z.string(),
-                macros: z.record(z.string(), z.string()).optional(),
-                context_description: z.string().optional()
-            }).passthrough()
-        }).passthrough()),
-        interactive_url: z.string().optional(),
-        expires_at: z.string()
-    }).passthrough().optional(),
-    preview_error: ErrorSchema.optional(),
-    pricing_option_id: z.string().optional(),
-    vendor_cost: z.number().optional(),
-    currency: z.string().optional(),
-    consumption: CreativeConsumptionSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const BuildCreativeMultiSuccessSchema = z.object({
-    creative_manifests: z.array(CreativeManifestSchema),
-    sandbox: z.boolean().optional(),
-    expires_at: z.string().optional(),
-    preview: z.object({
-        previews: z.array(z.object({
-            preview_id: z.string(),
-            format_id: FormatReferenceStructuredObjectSchema,
-            renders: z.array(PreviewRenderSchema),
-            input: z.object({
-                name: z.string(),
-                macros: z.record(z.string(), z.string()).optional(),
-                context_description: z.string().optional()
-            }).passthrough()
-        }).passthrough()),
-        interactive_url: z.string().optional(),
-        expires_at: z.string()
-    }).passthrough().optional(),
-    preview_error: ErrorSchema.optional(),
-    pricing_option_id: z.string().optional(),
-    vendor_cost: z.number().optional(),
-    currency: z.string().optional(),
-    consumption: CreativeConsumptionSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const PreviewCreativeRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    request_type: z.union([z.literal("single"), z.literal("batch"), z.literal("variant")]),
-    creative_manifest: CreativeManifestSchema.optional(),
-    format_id: FormatReferenceStructuredObjectSchema.optional(),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    template_id: z.string().optional(),
-    quality: CreativeQualitySchema.optional(),
-    output_format: PreviewOutputFormatSchema.optional(),
-    item_limit: z.number().optional(),
-    requests: z.array(z.object({
-        format_id: FormatReferenceStructuredObjectSchema.optional(),
-        creative_manifest: CreativeManifestSchema,
-        inputs: z.array(z.object({
-            name: z.string(),
-            macros: z.record(z.string(), z.string()).optional(),
-            context_description: z.string().optional()
-        }).passthrough()).optional(),
-        template_id: z.string().optional(),
-        quality: CreativeQualitySchema.optional(),
-        output_format: PreviewOutputFormatSchema.optional(),
-        item_limit: z.number().optional()
-    }).passthrough()).optional(),
-    variant_id: z.string().optional(),
-    creative_id: z.string().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
 export const PreviewCreativeBatchResponseSchema = z.object({
     response_type: z.literal("batch"),
     results: z.array(z.union([PreviewBatchResultSuccessSchema, PreviewBatchResultErrorSchema])),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const PreviewCreativeVariantResponseSchema = z.object({
-    response_type: z.literal("variant"),
-    variant_id: z.string(),
-    creative_id: z.string().optional(),
-    previews: z.array(z.object({
-        preview_id: z.string(),
-        renders: z.array(PreviewRenderSchema)
-    }).passthrough()),
-    manifest: CreativeManifestSchema.optional(),
-    expires_at: z.string().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const CreativeVariantSchema = DeliveryMetricsSchema.and(z.object({
-    variant_id: z.string(),
-    manifest: CreativeManifestSchema.optional(),
-    generation_context: z.object({
-        context_type: z.string().optional(),
-        artifact: z.object({
-            property_id: IdentifierSchema,
-            artifact_id: z.string()
-        }).passthrough().optional(),
-        ext: ExtensionObjectSchema.optional()
-    }).passthrough().optional()
-}).passthrough());
-
-export const GetCreativeDeliveryResponseSchema = z.object({
-    account_id: z.string().optional(),
-    media_buy_id: z.string().optional(),
-    currency: z.string(),
-    reporting_period: z.object({
-        start: z.string(),
-        end: z.string(),
-        timezone: z.string().optional()
-    }).passthrough(),
-    creatives: z.array(z.object({
-        creative_id: z.string(),
-        media_buy_id: z.string().optional(),
-        format_id: FormatReferenceStructuredObjectSchema.optional(),
-        totals: DeliveryMetricsSchema.optional(),
-        variant_count: z.number().optional(),
-        variants: z.array(CreativeVariantSchema)
-    }).passthrough()),
-    pagination: z.object({
-        limit: z.number(),
-        offset: z.number(),
-        has_more: z.boolean(),
-        total: z.number().optional()
-    }).passthrough().optional(),
-    errors: z.array(ErrorSchema).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4576,81 +4405,6 @@ export const ListCreativesRequestSchema = z.object({
     include_pricing: z.boolean().optional(),
     account: AccountReferenceSchema.optional(),
     fields: z.array(z.union([z.literal("creative_id"), z.literal("name"), z.literal("format_id"), z.literal("status"), z.literal("created_date"), z.literal("updated_date"), z.literal("tags"), z.literal("assignments"), z.literal("snapshot"), z.literal("items"), z.literal("variables"), z.literal("concept"), z.literal("pricing_options")])).optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const ListCreativesResponseSchema = z.object({
-    query_summary: z.object({
-        total_matching: z.number(),
-        returned: z.number(),
-        filters_applied: z.array(z.string()).optional(),
-        sort_applied: z.object({
-            field: z.string().optional(),
-            direction: SortDirectionSchema.optional()
-        }).passthrough().optional()
-    }).passthrough(),
-    pagination: PaginationResponseSchema,
-    creatives: z.array(z.object({
-        creative_id: z.string(),
-        account: AccountSchema.optional(),
-        name: z.string(),
-        format_id: FormatReferenceStructuredObjectSchema,
-        status: CreativeStatusSchema,
-        created_date: z.string(),
-        updated_date: z.string(),
-        assets: z.record(z.string(), AssetVariantSchema).optional(),
-        tags: z.array(z.string()).optional(),
-        concept_id: z.string().optional(),
-        concept_name: z.string().optional(),
-        variables: z.array(CreativeVariableSchema).optional(),
-        assignments: z.object({
-            assignment_count: z.number(),
-            assigned_packages: z.array(z.object({
-                package_id: z.string(),
-                assigned_date: z.string()
-            }).passthrough()).optional()
-        }).passthrough().optional(),
-        snapshot: z.object({
-            as_of: z.string(),
-            staleness_seconds: z.number(),
-            impressions: z.number(),
-            last_served: z.string().optional()
-        }).passthrough().optional(),
-        snapshot_unavailable_reason: SnapshotUnavailableReasonSchema.optional(),
-        items: z.array(CreativeItemSchema).optional(),
-        pricing_options: z.array(VendorPricingOptionSchema).optional()
-    }).passthrough()),
-    format_summary: z.record(z.string(), z.number()).optional(),
-    status_summary: z.object({
-        processing: z.number().optional(),
-        approved: z.number().optional(),
-        pending_review: z.number().optional(),
-        rejected: z.number().optional(),
-        archived: z.number().optional()
-    }).passthrough().optional(),
-    errors: z.array(ErrorSchema).optional(),
-    sandbox: z.boolean().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const SyncCreativesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    account: AccountReferenceSchema,
-    creatives: z.array(CreativeAssetSchema),
-    creative_ids: z.array(z.string()).optional(),
-    assignments: z.array(z.object({
-        creative_id: z.string(),
-        package_id: z.string(),
-        weight: z.number().optional(),
-        placement_ids: z.array(z.string()).optional()
-    }).passthrough()).optional(),
-    idempotency_key: z.string(),
-    delete_missing: z.boolean().optional(),
-    dry_run: z.boolean().optional(),
-    validation_mode: ValidationModeSchema.optional(),
-    push_notification_config: PushNotificationConfigSchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -4955,15 +4709,6 @@ export const CalibrateContentResponseSchema = z.union([z.object({
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional()
     }).passthrough()]);
-
-export const GetCreativeFeaturesRequestSchema = z.object({
-    adcp_major_version: z.number().optional(),
-    creative_manifest: CreativeManifestSchema,
-    feature_ids: z.array(z.string()).optional(),
-    account: AccountReferenceSchema.optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
 
 export const GetCreativeFeaturesResponseSchema = z.union([z.object({
         results: z.array(CreativeFeatureResultSchema),
@@ -5694,8 +5439,6 @@ export const GetAccountFinancialsErrorSchema = z.object({
 
 export const UpdateMediaBuyResponseSchema = z.union([UpdateMediaBuySuccessSchema, UpdateMediaBuyErrorSchema]);
 
-export const BuildCreativeResponseSchema = z.union([BuildCreativeSuccessSchema, BuildCreativeMultiSuccessSchema, BuildCreativeErrorSchema]);
-
 export const ListScenariosSuccessSchema = z.object({
     success: z.literal(true),
     scenarios: z.array(z.union([z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_create_media_buy_arm"), z.literal("force_task_completion"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy"), z.literal("seed_creative_format")])),
@@ -5768,6 +5511,12 @@ export const MediaBuySchema = z.object({
     updated_at: z.string().optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
+
+export const BriefAssetSchema = CreativeBriefSchema.and(z.object({
+    asset_type: z.literal("brief")
+}).passthrough());
+
+export const AssetVariantSchema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAssetSchema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAssetSchema, MarkdownAssetSchema, BriefAssetSchema, CatalogAssetSchema]);
 
 export const InstallmentSchema = z.object({
     installment_id: z.string(),
@@ -5899,6 +5648,42 @@ export const GetProductsAsyncInputRequiredSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const CreativeManifestSchema = z.object({
+    format_id: FormatReferenceStructuredObjectSchema,
+    assets: z.record(z.string(), AssetVariantSchema),
+    rights: z.array(RightsConstraintSchema).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const BuildCreativeMultiSuccessSchema = z.object({
+    creative_manifests: z.array(CreativeManifestSchema),
+    sandbox: z.boolean().optional(),
+    expires_at: z.string().optional(),
+    preview: z.object({
+        previews: z.array(z.object({
+            preview_id: z.string(),
+            format_id: FormatReferenceStructuredObjectSchema,
+            renders: z.array(PreviewRenderSchema),
+            input: z.object({
+                name: z.string(),
+                macros: z.record(z.string(), z.string()).optional(),
+                context_description: z.string().optional()
+            }).passthrough()
+        }).passthrough()),
+        interactive_url: z.string().optional(),
+        expires_at: z.string()
+    }).passthrough().optional(),
+    preview_error: ErrorSchema.optional(),
+    pricing_option_id: z.string().optional(),
+    vendor_cost: z.number().optional(),
+    currency: z.string().optional(),
+    consumption: CreativeConsumptionSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
 export const AcquireRightsRequestSchema = z.object({
     adcp_major_version: z.number().optional(),
     rights_id: z.string(),
@@ -6002,9 +5787,185 @@ export const ListContentStandardsResponseSchema = z.union([z.object({
         ext: ExtensionObjectSchema.optional()
     }).passthrough()]);
 
-export const BriefAsset1Schema = CreativeBriefSchema;
+export const CreativeVariantSchema = DeliveryMetricsSchema.and(z.object({
+    variant_id: z.string(),
+    manifest: CreativeManifestSchema.optional(),
+    generation_context: z.object({
+        context_type: z.string().optional(),
+        artifact: z.object({
+            property_id: IdentifierSchema,
+            artifact_id: z.string()
+        }).passthrough().optional(),
+        ext: ExtensionObjectSchema.optional()
+    }).passthrough().optional()
+}).passthrough());
 
-export const PreviewCreativeResponseSchema = z.union([PreviewCreativeSingleResponseSchema, PreviewCreativeBatchResponseSchema, PreviewCreativeVariantResponseSchema]);
+export const GetCreativeDeliveryResponseSchema = z.object({
+    account_id: z.string().optional(),
+    media_buy_id: z.string().optional(),
+    currency: z.string(),
+    reporting_period: z.object({
+        start: z.string(),
+        end: z.string(),
+        timezone: z.string().optional()
+    }).passthrough(),
+    creatives: z.array(z.object({
+        creative_id: z.string(),
+        media_buy_id: z.string().optional(),
+        format_id: FormatReferenceStructuredObjectSchema.optional(),
+        totals: DeliveryMetricsSchema.optional(),
+        variant_count: z.number().optional(),
+        variants: z.array(CreativeVariantSchema)
+    }).passthrough()),
+    pagination: z.object({
+        limit: z.number(),
+        offset: z.number(),
+        has_more: z.boolean(),
+        total: z.number().optional()
+    }).passthrough().optional(),
+    errors: z.array(ErrorSchema).optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const GetCreativeFeaturesRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    creative_manifest: CreativeManifestSchema,
+    feature_ids: z.array(z.string()).optional(),
+    account: AccountReferenceSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const ListCreativesResponseSchema = z.object({
+    query_summary: z.object({
+        total_matching: z.number(),
+        returned: z.number(),
+        filters_applied: z.array(z.string()).optional(),
+        sort_applied: z.object({
+            field: z.string().optional(),
+            direction: SortDirectionSchema.optional()
+        }).passthrough().optional()
+    }).passthrough(),
+    pagination: PaginationResponseSchema,
+    creatives: z.array(z.object({
+        creative_id: z.string(),
+        account: AccountSchema.optional(),
+        name: z.string(),
+        format_id: FormatReferenceStructuredObjectSchema,
+        status: CreativeStatusSchema,
+        created_date: z.string(),
+        updated_date: z.string(),
+        assets: z.record(z.string(), AssetVariantSchema).optional(),
+        tags: z.array(z.string()).optional(),
+        concept_id: z.string().optional(),
+        concept_name: z.string().optional(),
+        variables: z.array(CreativeVariableSchema).optional(),
+        assignments: z.object({
+            assignment_count: z.number(),
+            assigned_packages: z.array(z.object({
+                package_id: z.string(),
+                assigned_date: z.string()
+            }).passthrough()).optional()
+        }).passthrough().optional(),
+        snapshot: z.object({
+            as_of: z.string(),
+            staleness_seconds: z.number(),
+            impressions: z.number(),
+            last_served: z.string().optional()
+        }).passthrough().optional(),
+        snapshot_unavailable_reason: SnapshotUnavailableReasonSchema.optional(),
+        items: z.array(CreativeItemSchema).optional(),
+        pricing_options: z.array(VendorPricingOptionSchema).optional()
+    }).passthrough()),
+    format_summary: z.record(z.string(), z.number()).optional(),
+    status_summary: z.object({
+        processing: z.number().optional(),
+        approved: z.number().optional(),
+        pending_review: z.number().optional(),
+        rejected: z.number().optional(),
+        archived: z.number().optional()
+    }).passthrough().optional(),
+    errors: z.array(ErrorSchema).optional(),
+    sandbox: z.boolean().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const AssetVariant1Schema = AssetVariantSchema;
+
+export const VASTAsset1Schema = VASTAssetSchema;
+
+export const DAASTAsset1Schema = DAASTAssetSchema;
+
+export const BriefAsset1Schema = BriefAssetSchema;
+
+export const CatalogAsset1Schema = CatalogAssetSchema;
+
+export const PreviewCreativeRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    request_type: z.union([z.literal("single"), z.literal("batch"), z.literal("variant")]),
+    creative_manifest: CreativeManifestSchema.optional(),
+    format_id: FormatReferenceStructuredObjectSchema.optional(),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    template_id: z.string().optional(),
+    quality: CreativeQualitySchema.optional(),
+    output_format: PreviewOutputFormatSchema.optional(),
+    item_limit: z.number().optional(),
+    requests: z.array(z.object({
+        format_id: FormatReferenceStructuredObjectSchema.optional(),
+        creative_manifest: CreativeManifestSchema,
+        inputs: z.array(z.object({
+            name: z.string(),
+            macros: z.record(z.string(), z.string()).optional(),
+            context_description: z.string().optional()
+        }).passthrough()).optional(),
+        template_id: z.string().optional(),
+        quality: CreativeQualitySchema.optional(),
+        output_format: PreviewOutputFormatSchema.optional(),
+        item_limit: z.number().optional()
+    }).passthrough()).optional(),
+    variant_id: z.string().optional(),
+    creative_id: z.string().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PreviewCreativeVariantResponseSchema = z.object({
+    response_type: z.literal("variant"),
+    variant_id: z.string(),
+    creative_id: z.string().optional(),
+    previews: z.array(z.object({
+        preview_id: z.string(),
+        renders: z.array(PreviewRenderSchema)
+    }).passthrough()),
+    manifest: CreativeManifestSchema.optional(),
+    expires_at: z.string().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const CreativeAssetSchema = z.object({
+    creative_id: z.string(),
+    name: z.string(),
+    format_id: FormatReferenceStructuredObjectSchema,
+    assets: z.record(z.string(), AssetVariantSchema),
+    inputs: z.array(z.object({
+        name: z.string(),
+        macros: z.record(z.string(), z.string()).optional(),
+        context_description: z.string().optional()
+    }).passthrough()).optional(),
+    tags: z.array(z.string()).optional(),
+    status: CreativeStatusSchema.optional(),
+    weight: z.number().optional(),
+    placement_ids: z.array(z.string()).optional(),
+    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
+    provenance: ProvenanceSchema.optional()
+}).passthrough();
 
 export const BuildCreativeRequestSchema = z.object({
     adcp_major_version: z.number().optional(),
@@ -6139,7 +6100,7 @@ export const PackageUpdateSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
-export const AssetVariant1Schema = z.union([ImageAssetSchema, VideoAssetSchema, AudioAssetSchema, VASTAsset1Schema, TextAssetSchema, URLAssetSchema, HTMLAssetSchema, JavaScriptAssetSchema, WebhookAssetSchema, CSSAssetSchema, DAASTAsset1Schema, MarkdownAssetSchema, BriefAsset1Schema, CatalogAsset1Schema]);
+export const CreativeAsset1Schema = CreativeAssetSchema;
 
 export const CreatePropertyListResponseSchema = z.object({
     list: PropertyListSchema,
@@ -6227,27 +6188,6 @@ export const CollectionSchema = z.object({
         collection_id: z.string(),
         relationship: CollectionRelationshipSchema
     }).passthrough()).optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
-
-export const DestinationItemSchema = z.object({
-    destination_id: z.string(),
-    name: z.string(),
-    description: z.string().optional(),
-    city: z.string().optional(),
-    region: z.string().optional(),
-    country: z.string().optional(),
-    location: z.object({
-        lat: z.number(),
-        lng: z.number()
-    }).passthrough().optional(),
-    destination_type: z.union([z.literal("beach"), z.literal("mountain"), z.literal("urban"), z.literal("cultural"), z.literal("adventure"), z.literal("wellness"), z.literal("cruise")]).optional(),
-    price: PriceSchema.optional(),
-    image_url: z.string().optional(),
-    url: z.string().optional(),
-    rating: z.number().optional(),
-    tags: z.array(z.string()).optional(),
-    assets: z.array(OfferingAssetGroupSchema).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -6439,6 +6379,54 @@ export const UpdateMediaBuyRequestSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const BuildCreativeSuccessSchema = z.object({
+    creative_manifest: CreativeManifestSchema,
+    sandbox: z.boolean().optional(),
+    expires_at: z.string().optional(),
+    preview: z.object({
+        previews: z.array(z.object({
+            preview_id: z.string(),
+            renders: z.array(PreviewRenderSchema),
+            input: z.object({
+                name: z.string(),
+                macros: z.record(z.string(), z.string()).optional(),
+                context_description: z.string().optional()
+            }).passthrough()
+        }).passthrough()),
+        interactive_url: z.string().optional(),
+        expires_at: z.string()
+    }).passthrough().optional(),
+    preview_error: ErrorSchema.optional(),
+    pricing_option_id: z.string().optional(),
+    vendor_cost: z.number().optional(),
+    currency: z.string().optional(),
+    consumption: CreativeConsumptionSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
+export const PreviewCreativeResponseSchema = z.union([PreviewCreativeSingleResponseSchema, PreviewCreativeBatchResponseSchema, PreviewCreativeVariantResponseSchema]);
+
+export const SyncCreativesRequestSchema = z.object({
+    adcp_major_version: z.number().optional(),
+    account: AccountReferenceSchema,
+    creatives: z.array(CreativeAssetSchema),
+    creative_ids: z.array(z.string()).optional(),
+    assignments: z.array(z.object({
+        creative_id: z.string(),
+        package_id: z.string(),
+        weight: z.number().optional(),
+        placement_ids: z.array(z.string()).optional()
+    }).passthrough()).optional(),
+    idempotency_key: z.string(),
+    delete_missing: z.boolean().optional(),
+    dry_run: z.boolean().optional(),
+    validation_mode: ValidationModeSchema.optional(),
+    push_notification_config: PushNotificationConfigSchema.optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
+}).passthrough();
+
 export const CreateCollectionListResponseSchema = z.object({
     list: CollectionListSchema,
     auth_token: z.string(),
@@ -6453,39 +6441,9 @@ export const SyncGovernanceResponseSchema = z.union([SyncGovernanceSuccessSchema
 
 export const GetAccountFinancialsResponseSchema = z.union([GetAccountFinancialsSuccessSchema, GetAccountFinancialsErrorSchema]);
 
-export const AdCPAsyncResponseDataSchema: z.ZodType = z.union([GetProductsResponseSchema, GetProductsAsyncWorkingSchema, GetProductsAsyncInputRequiredSchema, GetProductsAsyncSubmittedSchema, CreateMediaBuyResponseSchema, CreateMediaBuyAsyncWorkingSchema, CreateMediaBuyAsyncInputRequiredSchema, CreateMediaBuyAsyncSubmittedSchema, UpdateMediaBuyResponseSchema, UpdateMediaBuyAsyncWorkingSchema, UpdateMediaBuyAsyncInputRequiredSchema, UpdateMediaBuyAsyncSubmittedSchema, BuildCreativeResponseSchema, BuildCreativeAsyncWorkingSchema, BuildCreativeAsyncInputRequiredSchema, BuildCreativeAsyncSubmittedSchema, SyncCreativesResponseSchema, SyncCreativesAsyncWorkingSchema, SyncCreativesAsyncInputRequiredSchema, SyncCreativesAsyncSubmittedSchema, SyncCatalogsResponseSchema, SyncCatalogsAsyncWorkingSchema, SyncCatalogsAsyncInputRequiredSchema, SyncCatalogsAsyncSubmittedSchema]);
+export const BuildCreativeResponseSchema = z.union([BuildCreativeSuccessSchema, BuildCreativeMultiSuccessSchema, BuildCreativeErrorSchema]);
 
-export const ComplyTestControllerRequestSchema = z.object({
-    scenario: z.union([z.literal("list_scenarios"), z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_create_media_buy_arm"), z.literal("force_task_completion"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy"), z.literal("seed_creative_format")]),
-    params: z.object({
-        creative_id: z.string().optional(),
-        account_id: z.string().optional(),
-        media_buy_id: z.string().optional(),
-        session_id: z.string().optional(),
-        product_id: z.string().optional(),
-        pricing_option_id: z.string().optional(),
-        plan_id: z.string().optional(),
-        fixture: z.object({}).passthrough().optional(),
-        status: z.string().optional(),
-        rejection_reason: z.string().optional(),
-        termination_reason: z.string().optional(),
-        impressions: z.number().optional(),
-        clicks: z.number().optional(),
-        conversions: z.number().optional(),
-        reported_spend: z.object({
-            amount: z.number(),
-            currency: z.string()
-        }).passthrough().optional(),
-        spend_percentage: z.number().optional(),
-        arm: z.union([z.literal("submitted"), z.literal("input-required")]).optional(),
-        task_id: z.string().optional(),
-        message: z.string().optional(),
-        format_id: z.string().optional(),
-        result: AdCPAsyncResponseDataSchema.optional()
-    }).passthrough().optional(),
-    context: ContextObjectSchema.optional(),
-    ext: ExtensionObjectSchema.optional()
-}).passthrough();
+export const AdCPAsyncResponseDataSchema: z.ZodType = z.union([GetProductsResponseSchema, GetProductsAsyncWorkingSchema, GetProductsAsyncInputRequiredSchema, GetProductsAsyncSubmittedSchema, CreateMediaBuyResponseSchema, CreateMediaBuyAsyncWorkingSchema, CreateMediaBuyAsyncInputRequiredSchema, CreateMediaBuyAsyncSubmittedSchema, UpdateMediaBuyResponseSchema, UpdateMediaBuyAsyncWorkingSchema, UpdateMediaBuyAsyncInputRequiredSchema, UpdateMediaBuyAsyncSubmittedSchema, BuildCreativeResponseSchema, BuildCreativeAsyncWorkingSchema, BuildCreativeAsyncInputRequiredSchema, BuildCreativeAsyncSubmittedSchema, SyncCreativesResponseSchema, SyncCreativesAsyncWorkingSchema, SyncCreativesAsyncInputRequiredSchema, SyncCreativesAsyncSubmittedSchema, SyncCatalogsResponseSchema, SyncCatalogsAsyncWorkingSchema, SyncCatalogsAsyncInputRequiredSchema, SyncCatalogsAsyncSubmittedSchema]);
 
 export const ComplyTestControllerResponseSchema = z.union([ListScenariosSuccessSchema, StateTransitionSuccessSchema, SimulationSuccessSchema, ForcedDirectiveSuccessSchema, SeedSuccessSchema, ControllerErrorSchema]);
 
@@ -6505,24 +6463,6 @@ export const MCPWebhookPayloadSchema: z.ZodType = z.object({
 export const AcquireRightsResponseSchema = z.union([AcquireRightsAcquiredSchema, AcquireRightsPendingApprovalSchema, AcquireRightsRejectedSchema, AcquireRightsErrorSchema]);
 
 export const GetRightsResponseSchema = z.union([GetRightsSuccessSchema, GetRightsErrorSchema]);
-
-export const CreativeAsset1Schema = z.object({
-    creative_id: z.string(),
-    name: z.string(),
-    format_id: FormatReferenceStructuredObjectSchema,
-    assets: z.record(z.string(), AssetVariant1Schema),
-    inputs: z.array(z.object({
-        name: z.string(),
-        macros: z.record(z.string(), z.string()).optional(),
-        context_description: z.string().optional()
-    }).passthrough()).optional(),
-    tags: z.array(z.string()).optional(),
-    status: CreativeStatusSchema.optional(),
-    weight: z.number().optional(),
-    placement_ids: z.array(z.string()).optional(),
-    industry_identifiers: z.array(IndustryIdentifierSchema).optional(),
-    provenance: ProvenanceSchema.optional()
-}).passthrough();
 
 export const ValidatePropertyDeliveryResponseSchema = z.object({
     compliant: z.boolean().optional(),
@@ -6571,4 +6511,36 @@ export const CatalogRequirementsSchema = z.object({
     feed_formats: z.array(FeedFormatSchema).optional(),
     offering_asset_constraints: z.array(OfferingAssetConstraintSchema).optional(),
     field_bindings: z.array(CatalogFieldBindingSchema).optional()
+}).passthrough();
+
+export const ComplyTestControllerRequestSchema = z.object({
+    scenario: z.union([z.literal("list_scenarios"), z.literal("force_creative_status"), z.literal("force_account_status"), z.literal("force_media_buy_status"), z.literal("force_create_media_buy_arm"), z.literal("force_task_completion"), z.literal("force_session_status"), z.literal("simulate_delivery"), z.literal("simulate_budget_spend"), z.literal("seed_product"), z.literal("seed_pricing_option"), z.literal("seed_creative"), z.literal("seed_plan"), z.literal("seed_media_buy"), z.literal("seed_creative_format")]),
+    params: z.object({
+        creative_id: z.string().optional(),
+        account_id: z.string().optional(),
+        media_buy_id: z.string().optional(),
+        session_id: z.string().optional(),
+        product_id: z.string().optional(),
+        pricing_option_id: z.string().optional(),
+        plan_id: z.string().optional(),
+        fixture: z.object({}).passthrough().optional(),
+        status: z.string().optional(),
+        rejection_reason: z.string().optional(),
+        termination_reason: z.string().optional(),
+        impressions: z.number().optional(),
+        clicks: z.number().optional(),
+        conversions: z.number().optional(),
+        reported_spend: z.object({
+            amount: z.number(),
+            currency: z.string()
+        }).passthrough().optional(),
+        spend_percentage: z.number().optional(),
+        arm: z.union([z.literal("submitted"), z.literal("input-required")]).optional(),
+        task_id: z.string().optional(),
+        message: z.string().optional(),
+        format_id: z.string().optional(),
+        result: AdCPAsyncResponseDataSchema.optional()
+    }).passthrough().optional(),
+    context: ContextObjectSchema.optional(),
+    ext: ExtensionObjectSchema.optional()
 }).passthrough();

--- a/test/lib/codegen-aliases-drift.test.js
+++ b/test/lib/codegen-aliases-drift.test.js
@@ -1,0 +1,60 @@
+/**
+ * Drift guard: every numbered-suffix `Foo1` export in `core.generated.ts`
+ * must either come from `applyKnownJstsAliases`'s alias rewrite (a one-liner
+ * `export type Foo1 = Foo;`) or be a known false-positive of the
+ * `^[A-Z][A-Za-z]+1\b` pattern.
+ *
+ * Why this exists: AdCP 3.0.4 brought `core/assets/asset-union.json` (adcp#3462)
+ * but the spec bundler still inlines the union at both `creative-asset.json`
+ * and `creative-manifest.json` call sites. `json-schema-to-typescript` sees
+ * two identically-titled shapes and emits Foo/Foo1 — and on the second pass
+ * it under-resolves the body, dropping the `asset_type` discriminator that
+ * the first pass preserved. The post-process pass `applyKnownJstsAliases`
+ * (scripts/generate-types.ts) rewrites each known `*Asset1` artifact as a
+ * `@deprecated` alias to its base. The list is hardcoded — without this
+ * drift guard, a future spec change introducing a 7th `*Asset1` artifact
+ * would slip through silently and ship a strictly-weaker public type.
+ *
+ * Tracked: adcp-client#1264.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const CORE_GENERATED_PATH = path.join(__dirname, '../../src/lib/types/core.generated.ts');
+
+describe('Codegen drift guard: numbered Foo1 exports must be aliased', () => {
+  it('every Foo1 export in core.generated.ts is a one-liner alias to Foo', () => {
+    const src = readFileSync(CORE_GENERATED_PATH, 'utf8');
+    const lines = src.split('\n');
+
+    // Match every `export type Foo1 = ...` or `export interface Foo1 { ... }`
+    // where Foo1 ends in a digit. Capture the line number for diagnostics.
+    const offenders = [];
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const m = line.match(/^export (type|interface) ([A-Z][A-Za-z]+\d+)\b(.*)$/);
+      if (!m) continue;
+      const [, kind, name, rest] = m;
+      // The acceptable shape is exactly: `export type FOO1 = BAR;` (single line, no body).
+      // Anything else (multi-line union/intersection, interface block) means the alias
+      // pass missed it.
+      const isOneLineAlias = kind === 'type' && /^\s*=\s*[A-Z][A-Za-z0-9_]*\s*;\s*$/.test(rest);
+      if (!isOneLineAlias) {
+        offenders.push({ line: i + 1, name, snippet: line });
+      }
+    }
+
+    assert.deepEqual(
+      offenders,
+      [],
+      `Found ${offenders.length} numbered-suffix export(s) in core.generated.ts that are not ` +
+        `one-liner aliases. These are jsts under-resolution artifacts that need entries in ` +
+        `JSTS_UNDER_RESOLUTION_ALIASES (scripts/generate-types.ts) so consumers get the ` +
+        `correctly-discriminated shape:\n` +
+        offenders.map(o => `  ${CORE_GENERATED_PATH}:${o.line}  ${o.snippet}`).join('\n')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

After the AdCP 3.0.4 bump (#1266) brought `core/assets/asset-union.json` into the cache, six numbered duplicate types still appeared in `core.generated.ts`:

| Type          | First pass (correct)                                  | Second pass (under-resolved)         |
|---------------|-------------------------------------------------------|--------------------------------------|
| `VASTAsset`   | `{ asset_type: 'vast'; …metadata… } & (delivery_union)` | `VASTAsset1` = `(delivery_union)` — lost wrapper |
| `BriefAsset`  | `CreativeBrief & { asset_type: 'brief' }`             | `BriefAsset1` = `CreativeBrief` — lost discriminator |
| `DAASTAsset`, `CatalogAsset`, `AssetVariant`, `CreativeAsset` | (correct) | numbered sibling under-resolved |

These survived `removeNumberedTypeDuplicates` because their bodies aren't byte-identical to the canonical version — but that's a `json-schema-to-typescript` compile-pass quirk, not a semantic distinction. The bundled response schema is identical at both `creative-asset.json` and `creative-manifest.json` call sites; jsts just emits different output the second time.

## Fix

Add `applyKnownJstsAliases` to the post-process pipeline in `scripts/generate-types.ts`. After the byte-identity dedupe pass, rewrite each of the six known artifacts as `type Foo1 = Foo` with a `@deprecated` JSDoc.

```ts
const JSTS_UNDER_RESOLUTION_ALIASES = [
  { numbered: 'VASTAsset1', base: 'VASTAsset' },
  { numbered: 'DAASTAsset1', base: 'DAASTAsset' },
  { numbered: 'BriefAsset1', base: 'BriefAsset' },
  { numbered: 'CatalogAsset1', base: 'CatalogAsset' },
  { numbered: 'AssetVariant1', base: 'AssetVariant' },
  { numbered: 'CreativeAsset1', base: 'CreativeAsset' },
];
```

## Why this is safe

The bundled response schema carries `asset_type` correctly at every call site (verified by inspecting `bundled/media-buy/build-creative-response.json` — both Brief Asset occurrences have identical `properties.asset_type` definitions). The under-resolved TS type was *strictly weaker* than the wire format. Aliasing to the canonical name gives consumers the correctly-discriminated shape that matches what they receive on the wire — a type-level correctness improvement, not a regression.

Zod schema codegen consumes the aliased types and emits matching schema aliases automatically (`VASTAsset1Schema = VASTAssetSchema`, etc.) — no separate handling needed.

## Verification

- `grep -E "^export (type|interface) [A-Z][A-Za-z]+1\b" src/lib/types/core.generated.ts` returns only the 6 alias lines; before, it returned 6 distinct under-resolved bodies
- `npm run typecheck` passes
- `npm test`: 7174 tests, all passing
- New post-processor logs:  
  `🔀 Aliased 6 jsts under-resolution artifact(s): AssetVariant1→AssetVariant, VASTAsset1→VASTAsset, …`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] Generated `core.generated.ts` shows 6 alias lines, no more under-resolved bodies
- [ ] CI green

## Related

- Closes #1264
- Builds on #1266 (AdCP 3.0.4 bump that landed `asset-union.json` in our cache)
- adcp#3462 (upstream PR that introduced the canonical asset-union schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)