### PR TITLE
feat(types): @deprecated aliases for error-details schemas renamed in AdCP 3.0.x (closes #1065)

### DIFF
--- a/.changeset/error-details-aliases.md
+++ b/.changeset/error-details-aliases.md
@@ -1,0 +1,22 @@
+---
+"@adcp/sdk": patch
+---
+
+feat(types): add `@deprecated` aliases for error-details schemas renamed in AdCP 3.0.x
+
+adcp#3149 (`rate-limited.json`) and adcp#3566 (five other error-details files) canonicalized SCREAMING_SNAKE titles like `RATE_LIMITED Details` and `ACCOUNT_SETUP_REQUIRED Details` into Title Case. The previous SDK release emitted `RATE_LIMITEDDetails`, `ACCOUNT_SETUP_REQUIREDDetails`, etc.; post-3.0.4 the canonical names are `RateLimitedDetails`, `AccountSetupRequiredDetails`, etc.
+
+Hand-authored aliases in `src/lib/types/error-details.aliases.ts` preserve the old names for one minor cycle so consumers' imports keep compiling. Each alias is `@deprecated` so editor tooling surfaces the canonical replacement; slated for removal in the next major.
+
+Aliases shipped (covers both type and Schema export pairs):
+
+- `ACCOUNT_SETUP_REQUIREDDetails` / `…Schema` → `AccountSetupRequiredDetails` / `…Schema`
+- `AUDIENCE_TOO_SMALLDetails` / `…Schema` → `AudienceTooSmallDetails` / `…Schema`
+- `BUDGET_TOO_LOWDetails` / `…Schema` → `BudgetTooLowDetails` / `…Schema`
+- `CONFLICTDetails` / `…Schema` → `ConflictDetails` / `…Schema`
+- `POLICY_VIOLATIONDetails` / `…Schema` → `PolicyViolationDetails` / `…Schema`
+- `RATE_LIMITEDDetails` / `…Schema` → `RateLimitedDetails` / `…Schema` (3.0.1 rename)
+
+`creative-rejected.json` is intentionally absent — codegen never emitted a standalone `CreativeRejectedDetails` (or its prior SCREAMING_SNAKE form) because the brand-domain `CreativeRejected` interface lays claim to the namespace first. Tracked as #1271.
+
+Closes #1065.

--- a/src/lib/types/error-details.aliases.ts
+++ b/src/lib/types/error-details.aliases.ts
@@ -1,0 +1,77 @@
+// Back-compat aliases for the error-details schemas renamed in AdCP 3.0.x.
+//
+// adcp#3149 (`rate-limited.json`) and adcp#3566 (other error-details files)
+// canonicalized SCREAMING_SNAKE titles like `RATE_LIMITED Details` and
+// `ACCOUNT_SETUP_REQUIRED Details` into Title Case. The previous SDK release
+// emitted `RATE_LIMITEDDetails`, `ACCOUNT_SETUP_REQUIREDDetails`, etc., because
+// `json-schema-to-typescript` derives type names from each schema's `title`.
+// Post-3.0.4, the canonical names are `RateLimitedDetails`,
+// `AccountSetupRequiredDetails`, etc.
+//
+// These aliases preserve the previously-shipped names for one minor cycle so
+// consumers' imports keep compiling. Each is `@deprecated` so editor tooling
+// surfaces the rename. Slated for removal in the next major.
+//
+// Companion to `inline-enums.aliases.ts`, which handles the `_ScopeValues`
+// surface for the same family (`RATE_LIMITEDDetails_ScopeValues` →
+// `RateLimitedDetails_ScopeValues`). Same pattern as #942's `AgeVerificationMethod1`
+// rename.
+//
+// `creative-rejected.json` is intentionally absent: the codegen pipeline never
+// emits a standalone `CreativeRejectedDetails` (or its prior SCREAMING_SNAKE
+// counterpart) because the brand-domain `CreativeRejected` interface lays
+// claim to the namespace first. Tracking the gap separately — no alias to
+// emit since no prior name was published.
+
+import type {
+  AccountSetupRequiredDetails,
+  AudienceTooSmallDetails,
+  BudgetTooLowDetails,
+  ConflictDetails,
+  PolicyViolationDetails,
+  RateLimitedDetails,
+} from './core.generated';
+import {
+  AccountSetupRequiredDetailsSchema,
+  AudienceTooSmallDetailsSchema,
+  BudgetTooLowDetailsSchema,
+  ConflictDetailsSchema,
+  PolicyViolationDetailsSchema,
+  RateLimitedDetailsSchema,
+} from './schemas.generated';
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `AccountSetupRequiredDetails` from `@adcp/sdk/types`. */
+export type ACCOUNT_SETUP_REQUIREDDetails = AccountSetupRequiredDetails;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `AudienceTooSmallDetails` from `@adcp/sdk/types`. */
+export type AUDIENCE_TOO_SMALLDetails = AudienceTooSmallDetails;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `BudgetTooLowDetails` from `@adcp/sdk/types`. */
+export type BUDGET_TOO_LOWDetails = BudgetTooLowDetails;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `ConflictDetails` from `@adcp/sdk/types`. */
+export type CONFLICTDetails = ConflictDetails;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `PolicyViolationDetails` from `@adcp/sdk/types`. */
+export type POLICY_VIOLATIONDetails = PolicyViolationDetails;
+
+/** @deprecated Renamed in AdCP 3.0.1 (adcp#3149). Use `RateLimitedDetails` from `@adcp/sdk/types`. */
+export type RATE_LIMITEDDetails = RateLimitedDetails;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `AccountSetupRequiredDetailsSchema` from `@adcp/sdk/types`. */
+export const ACCOUNT_SETUP_REQUIREDDetailsSchema = AccountSetupRequiredDetailsSchema;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `AudienceTooSmallDetailsSchema` from `@adcp/sdk/types`. */
+export const AUDIENCE_TOO_SMALLDetailsSchema = AudienceTooSmallDetailsSchema;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `BudgetTooLowDetailsSchema` from `@adcp/sdk/types`. */
+export const BUDGET_TOO_LOWDetailsSchema = BudgetTooLowDetailsSchema;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `ConflictDetailsSchema` from `@adcp/sdk/types`. */
+export const CONFLICTDetailsSchema = ConflictDetailsSchema;
+
+/** @deprecated Renamed in AdCP 3.0.4 (adcp#3566). Use `PolicyViolationDetailsSchema` from `@adcp/sdk/types`. */
+export const POLICY_VIOLATIONDetailsSchema = PolicyViolationDetailsSchema;
+
+/** @deprecated Renamed in AdCP 3.0.1 (adcp#3149). Use `RateLimitedDetailsSchema` from `@adcp/sdk/types`. */
+export const RATE_LIMITEDDetailsSchema = RateLimitedDetailsSchema;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -153,3 +153,8 @@ export * from './inline-enums.generated';
 // `enums/*.json` files). Each alias is `@deprecated` so editor tooling
 // surfaces the canonical replacement; slated for removal in the next major.
 export * from './inline-enums.aliases';
+
+// Back-compat aliases for the 6 error-details schemas renamed in AdCP 3.0.x
+// (adcp#3149 / adcp#3566 canonicalized SCREAMING_SNAKE titles into Title Case).
+// Each alias is `@deprecated`; slated for removal in the next major.
+export * from './error-details.aliases';


### PR DESCRIPTION
## Summary

After the AdCP 3.0.4 bump (#1266), six error-details schema titles canonicalized from SCREAMING_SNAKE to Title Case (adcp#3149 + adcp#3566). The codegen now emits `AccountSetupRequiredDetails`, `ConflictDetails`, etc., directly. The old SCREAMING_SNAKE-derived names are gone from the generated output, breaking any consumer that imported them.

This PR adds `@deprecated` aliases preserving the old names for one minor cycle. Same pattern as #942's `AgeVerificationMethod1` rename and the existing `inline-enums.aliases.ts`.

## Aliases shipped

Hand-authored in `src/lib/types/error-details.aliases.ts`. Each alias covers both type and Zod Schema export pairs:

- `ACCOUNT_SETUP_REQUIREDDetails` → `AccountSetupRequiredDetails`
- `AUDIENCE_TOO_SMALLDetails` → `AudienceTooSmallDetails`
- `BUDGET_TOO_LOWDetails` → `BudgetTooLowDetails`
- `CONFLICTDetails` → `ConflictDetails`
- `POLICY_VIOLATIONDetails` → `PolicyViolationDetails`
- `RATE_LIMITEDDetails` → `RateLimitedDetails` (3.0.1 rename)

Each `@deprecated` JSDoc points at the canonical name and notes the upstream PR.

## What's NOT in this PR

`creative-rejected.json` — the SDK codegen never emitted a standalone `CreativeRejectedDetails` (or its prior SCREAMING_SNAKE form) because the brand-domain `CreativeRejected` interface lays claim to the namespace first. No prior name was published, so there's nothing to alias. Tracked as a separate codegen-gap issue: #1271.

## Test plan

- [x] `npm run typecheck` passes
- [ ] CI green

## Related

- Closes #1065
- Builds on #1266 (AdCP 3.0.4 bump)
- Filed: #1271 (`CreativeRejectedDetails` codegen gap)
- Pattern precedent: #942 (`AgeVerificationMethod1` rename), `src/lib/types/inline-enums.aliases.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)