### PR TITLE
feat(server): Account v3 wire alignment (#1256)

### DIFF
--- a/.changeset/account-v3-wire-alignment.md
+++ b/.changeset/account-v3-wire-alignment.md
@@ -19,4 +19,10 @@ The framework's `Account<TCtxMeta>` interface and `toWireAccount` projection lag
 
 `toWireAccount` projects each field unchanged, with one exception: `billing_entity.bank` is stripped on emit. The wire schema marks bank coordinates as MUST NOT be echoed in responses (`BusinessEntity.bank` is write-only — included in `sync_accounts` requests, omitted from any response payload). Adopters who load and return a full entity from their store no longer leak bank details to buyers.
 
+`SyncAccountsResultRow` (returned by adopter `accounts.upsert` implementations) is extended in parallel with the same wire-aligned fields and projected through `toWireSyncAccountRow` before emit. The same `billing_entity.bank` strip applies on this path — adopters returning a row literal that spreads a DB record carrying bank coordinates (e.g., `{ ...db.findByBrand(r.brand), action: 'updated' }`) no longer leak bank details to buyers.
+
+`Account.governance_agents` elements are projected to `{ url, categories }` only on emit. The schema notes governance auth credentials are write-only and the codegen'd type already excludes them, but TS is erased at runtime — explicit projection prevents adopters using JS or `as any` from smuggling a `credentials` field straight to the wire.
+
+When `billing_entity` carries only `bank` (no other fields), the projection omits the entire entity rather than emitting an empty object — `BusinessEntity` requires `legal_name` per the wire schema, so the empty case would fail downstream validation.
+
 All additions are optional — adopters who don't set the new fields see no behavior change. Closes #1256.

--- a/.changeset/account-v3-wire-alignment.md
+++ b/.changeset/account-v3-wire-alignment.md
@@ -1,0 +1,22 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): Account v3 wire alignment — billing_entity, lifecycle and reporting fields
+
+The framework's `Account<TCtxMeta>` interface and `toWireAccount` projection lagged the AdCP 3.0 wire schema. Adopters returning `Account<TCtxMeta>` from `accounts.resolve` / `accounts.list` could not populate spec-required commercial fields, and the framework silently dropped them on emit — most visibly, the `setup` payload that drives the `pending_approval` → `active` lifecycle was lost between adopter and buyer.
+
+`Account<TCtxMeta>` now carries the wire-aligned optional fields:
+
+- `billing_entity` — business entity for B2B invoicing (`legal_name`, `vat_id`, `tax_id`, `registration_number`, `address`, `contacts`, write-only `bank`)
+- `rate_card` — applied rate-card identifier
+- `payment_terms` — `net_15` / `net_30` / `net_45` / `net_60` / `net_90` / `prepay`
+- `credit_limit` — `{ amount, currency }`
+- `setup` — `{ url?, message, expires_at? }` for `pending_approval` accounts
+- `account_scope` — `operator` / `brand` / `operator_brand` / `agent`
+- `governance_agents` — registered governance agent endpoints
+- `reporting_bucket` — offline reporting delivery configuration
+
+`toWireAccount` projects each field unchanged, with one exception: `billing_entity.bank` is stripped on emit. The wire schema marks bank coordinates as MUST NOT be echoed in responses (`BusinessEntity.bank` is write-only — included in `sync_accounts` requests, omitted from any response payload). Adopters who load and return a full entity from their store no longer leak bank details to buyers.
+
+All additions are optional — adopters who don't set the new fields see no behavior change. Closes #1256.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -13,8 +13,12 @@
  */
 
 import type {
+  Account as WireAccount,
+  AccountScope,
   BrandReference,
   AccountReference,
+  BusinessEntity,
+  PaymentTerms,
   ReportUsageRequest,
   ReportUsageResponse,
   GetAccountFinancialsRequest,
@@ -70,6 +74,64 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * assert the right party is billed.
    */
   billing?: { invoicedTo: 'agent' | 'operator' | BrandReference };
+
+  /**
+   * Business entity invoiced on this account. Carries legal name, tax IDs,
+   * address, contacts, and (write-only) bank details for B2B invoicing.
+   *
+   * **`bank` is write-only.** The wire schema marks `BusinessEntity.bank` as
+   * MUST NOT be echoed in responses (sellers store and confirm receipt
+   * without returning the details). `toWireAccount` strips it on emit, so
+   * adopters who store the full entity here will not leak bank details to
+   * buyers — but DO NOT rely on the strip for anything beyond response
+   * projection. Adopters loading the entity from their own DB SHOULD apply
+   * the same rule at retrieval time, especially for non-list endpoints.
+   */
+  billing_entity?: BusinessEntity;
+
+  /**
+   * Identifier for the rate card applied to this account. Opaque seller-side
+   * string; emitted unchanged on the wire.
+   */
+  rate_card?: string;
+
+  /** Payment terms applied to this account. */
+  payment_terms?: PaymentTerms;
+
+  /** Maximum outstanding balance allowed on this account. */
+  credit_limit?: WireAccount['credit_limit'];
+
+  /**
+   * Setup payload for accounts in `pending_approval`. Carries the URL/message
+   * the buyer surfaces to a human to complete activation (credit-app, legal
+   * agreement, fund-add). Required-shape: `message` is mandatory; `url` and
+   * `expires_at` are optional.
+   *
+   * The framework does NOT validate that `setup` is populated when status is
+   * `pending_approval` — that's an adopter contract with the spec. It also
+   * does NOT clear `setup` when status leaves `pending_approval`; adopters
+   * who echo the same `Account` across status transitions should drop the
+   * field themselves.
+   */
+  setup?: WireAccount['setup'];
+
+  /** Account scope (operator / brand / operator_brand / agent). */
+  account_scope?: AccountScope;
+
+  /**
+   * Governance agent endpoints registered on this account. Auth credentials
+   * are write-only on the wire and not modeled here — adopters set/update
+   * via `sync_governance`, not by re-emitting the Account.
+   */
+  governance_agents?: WireAccount['governance_agents'];
+
+  /**
+   * Cloud storage bucket for offline reporting delivery. Only present when
+   * the seller's capabilities advertise `reporting_delivery_methods`
+   * including `'offline'`. Per-account access MUST be IAM-scoped — see the
+   * schema description for security constraints.
+   */
+  reporting_bucket?: WireAccount['reporting_bucket'];
 
   /**
    * Adapter-internal opaque state. Framework doesn't read this; **stripped
@@ -382,14 +444,14 @@ export type AdcpAccountStatus =
 // Wire projection — strip framework-internal fields before emit
 // ---------------------------------------------------------------------------
 
-import type { Account as WireAccount } from '../../types/tools.generated';
-
 /**
  * Project a framework `Account<TCtxMeta>` to the wire `Account` shape.
  *
- * Strips `metadata` and `authInfo` (framework-internal); renames `id` →
- * `account_id`; passes through `name`, `status`, `brand`, `operator`,
- * `advertiser`, and `billing.invoicedTo` mappings.
+ * Strips `ctx_metadata` and `authInfo` (framework-internal); renames `id` →
+ * `account_id`; passes through wire-shaped fields. Strips
+ * `billing_entity.bank` per the schema's write-only constraint — bank
+ * coordinates flow buyer→seller in `sync_accounts` requests but MUST NOT
+ * appear in any response payload.
  *
  * Used by the framework when emitting `list_accounts` and other wire
  * responses that include account data. Adopters never call this directly —
@@ -413,6 +475,19 @@ export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount
     const t = account.billing.invoicedTo;
     wire.billing = typeof t === 'string' ? t : 'advertiser';
   }
+  if (account.billing_entity !== undefined) {
+    // Destructuring guarantees `bank` is removed from the projected object
+    // even if the source carries it; the rename to `_bank` documents intent.
+    const { bank: _bank, ...rest } = account.billing_entity;
+    wire.billing_entity = rest;
+  }
+  if (account.rate_card !== undefined) wire.rate_card = account.rate_card;
+  if (account.payment_terms !== undefined) wire.payment_terms = account.payment_terms;
+  if (account.credit_limit !== undefined) wire.credit_limit = account.credit_limit;
+  if (account.setup !== undefined) wire.setup = account.setup;
+  if (account.account_scope !== undefined) wire.account_scope = account.account_scope;
+  if (account.governance_agents !== undefined) wire.governance_agents = account.governance_agents;
+  if (account.reporting_bucket !== undefined) wire.reporting_bucket = account.reporting_bucket;
   return wire;
 }
 

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -15,12 +15,15 @@
 import type {
   Account as WireAccount,
   AccountScope,
+  BillingParty,
   BrandReference,
   AccountReference,
   BusinessEntity,
+  ExtensionObject,
   PaymentTerms,
   ReportUsageRequest,
   ReportUsageResponse,
+  SyncAccountsSuccess,
   GetAccountFinancialsRequest,
   GetAccountFinancialsSuccess,
 } from '../../types/tools.generated';
@@ -62,6 +65,14 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * behalf of an advertiser whose rates differ from the operator's.
    */
   advertiser?: string;
+
+  /**
+   * Optional intermediary who receives invoices on behalf of the advertiser
+   * (e.g., agency holdco). Distinct from `advertiser` (whose rates apply)
+   * and from `billing.invoicedTo` (the legal billing party). Use when the
+   * invoice recipient differs from both — common in agency-handled flows.
+   */
+  billing_proxy?: string;
 
   /**
    * Settlement boundary for operator-billed retail-media platforms.
@@ -132,6 +143,22 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * schema description for security constraints.
    */
   reporting_bucket?: WireAccount['reporting_bucket'];
+
+  /**
+   * Sandbox account marker. For implicit accounts the wire schema treats
+   * this as part of the natural key — the same brand/operator pair can have
+   * separate production and sandbox accounts. For explicit accounts, sandbox
+   * accounts are pre-existing test accounts the seller surfaces via
+   * `list_accounts`.
+   */
+  sandbox?: boolean;
+
+  /**
+   * Wire `ext` extension hatch. Carries forward-compatible additions the
+   * codegen'd type doesn't model yet. Adopters who don't need extensions
+   * leave this undefined.
+   */
+  ext?: ExtensionObject;
 
   /**
    * Adapter-internal opaque state. Framework doesn't read this; **stripped
@@ -423,13 +450,38 @@ export interface AccountFilter {
   status?: AdcpAccountStatus[];
 }
 
+/**
+ * Per-account result row returned by an adopter's `accounts.upsert`
+ * implementation. Maps to one element of the wire `sync_accounts` response's
+ * `accounts[]` array.
+ *
+ * Carries the same optional commercial / lifecycle fields as the wire shape
+ * so adopters can echo `setup` (for `pending_approval` accounts), `billing`,
+ * `billing_entity`, `payment_terms`, etc. on creation. The framework
+ * projects these through `toWireSyncAccountRow` before emit, applying the
+ * same `billing_entity.bank` strip as `toWireAccount` (write-only contract).
+ */
 export interface SyncAccountsResultRow {
   account_id?: string;
   brand: BrandReference;
   operator: string;
+  /** Human-readable account name assigned by the seller. */
+  name?: string;
   action: 'created' | 'updated' | 'unchanged' | 'failed';
   status: AdcpAccountStatus;
+  /** Invoiced-to party. Echoes the request's `billing` after seller acceptance. */
+  billing?: BillingParty;
+  /** Business entity invoiced. `bank` is stripped on emit (write-only). */
+  billing_entity?: BusinessEntity;
+  account_scope?: AccountScope;
+  /** Setup payload for `pending_approval` accounts (URL/message/expiry). */
+  setup?: WireAccount['setup'];
+  rate_card?: string;
+  payment_terms?: PaymentTerms;
+  credit_limit?: WireAccount['credit_limit'];
   errors?: { code: string; message: string }[];
+  warnings?: string[];
+  sandbox?: boolean;
 }
 
 export type AdcpAccountStatus =
@@ -467,6 +519,7 @@ export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount
   if (account.brand !== undefined) wire.brand = account.brand;
   if (account.operator !== undefined) wire.operator = account.operator;
   if (account.advertiser !== undefined) wire.advertiser = account.advertiser;
+  if (account.billing_proxy !== undefined) wire.billing_proxy = account.billing_proxy;
   if (account.billing !== undefined) {
     // Wire `Account.billing: 'operator' | 'agent' | 'advertiser'` is the
     // invoiced-to party. Internal `billing.invoicedTo` collapses string +
@@ -475,20 +528,92 @@ export function toWireAccount<TCtxMeta>(account: Account<TCtxMeta>): WireAccount
     const t = account.billing.invoicedTo;
     wire.billing = typeof t === 'string' ? t : 'advertiser';
   }
-  if (account.billing_entity !== undefined) {
-    // Destructuring guarantees `bank` is removed from the projected object
-    // even if the source carries it; the rename to `_bank` documents intent.
-    const { bank: _bank, ...rest } = account.billing_entity;
-    wire.billing_entity = rest;
-  }
+  const projectedEntity = projectBillingEntity(account.billing_entity);
+  if (projectedEntity !== undefined) wire.billing_entity = projectedEntity;
   if (account.rate_card !== undefined) wire.rate_card = account.rate_card;
   if (account.payment_terms !== undefined) wire.payment_terms = account.payment_terms;
   if (account.credit_limit !== undefined) wire.credit_limit = account.credit_limit;
   if (account.setup !== undefined) wire.setup = account.setup;
   if (account.account_scope !== undefined) wire.account_scope = account.account_scope;
-  if (account.governance_agents !== undefined) wire.governance_agents = account.governance_agents;
+  if (account.governance_agents !== undefined) {
+    wire.governance_agents = account.governance_agents.map(projectGovernanceAgent);
+  }
   if (account.reporting_bucket !== undefined) wire.reporting_bucket = account.reporting_bucket;
+  if (account.sandbox !== undefined) wire.sandbox = account.sandbox;
+  if (account.ext !== undefined) wire.ext = account.ext;
   return wire;
+}
+
+type WireSyncAccountRow = SyncAccountsSuccess['accounts'][number];
+
+/**
+ * Project an adopter `SyncAccountsResultRow` to the wire shape returned by
+ * `sync_accounts`. Applies the same `billing_entity.bank` strip as
+ * `toWireAccount` — the wire schema marks bank coordinates write-only on
+ * EVERY response, not just `list_accounts`. Adopters returning a row that
+ * spreads a DB record carrying `bank` (e.g.,
+ * `{ ...db.findByBrand(r.brand), action: 'updated' }`) have it stripped
+ * before emit.
+ *
+ * Used by the framework when emitting `sync_accounts` responses. Adopters
+ * never call this directly — they return `SyncAccountsResultRow[]` from
+ * `accounts.upsert` and the framework projects.
+ */
+export function toWireSyncAccountRow(row: SyncAccountsResultRow): WireSyncAccountRow {
+  const wire: WireSyncAccountRow = {
+    brand: row.brand,
+    operator: row.operator,
+    action: row.action,
+    status: row.status,
+  };
+  if (row.account_id !== undefined) wire.account_id = row.account_id;
+  if (row.name !== undefined) wire.name = row.name;
+  if (row.billing !== undefined) wire.billing = row.billing;
+  const projectedEntity = projectBillingEntity(row.billing_entity);
+  if (projectedEntity !== undefined) wire.billing_entity = projectedEntity;
+  if (row.account_scope !== undefined) wire.account_scope = row.account_scope;
+  if (row.setup !== undefined) wire.setup = row.setup;
+  if (row.rate_card !== undefined) wire.rate_card = row.rate_card;
+  if (row.payment_terms !== undefined) wire.payment_terms = row.payment_terms;
+  if (row.credit_limit !== undefined) wire.credit_limit = row.credit_limit;
+  if (row.errors !== undefined) wire.errors = row.errors;
+  if (row.warnings !== undefined) wire.warnings = row.warnings;
+  if (row.sandbox !== undefined) wire.sandbox = row.sandbox;
+  return wire;
+}
+
+/**
+ * Strip `BusinessEntity.bank` per the schema's write-only constraint, and
+ * skip emission entirely when nothing else is populated. Bank-only inputs
+ * project to `undefined`, signaling the caller to omit `billing_entity`
+ * rather than emit an empty object that would fail `legal_name` validation.
+ *
+ * Destructure-and-rest excludes `bank` regardless of source shape: own
+ * non-enumerable, getter, prototype-chain, and Proxy-backed bank fields
+ * are all excluded by the ES rest-spread evaluation order
+ * (`CopyDataProperties` walks own-enumerable keys and skips the
+ * destructured names).
+ */
+function projectBillingEntity(entity: BusinessEntity | undefined): BusinessEntity | undefined {
+  if (entity === undefined) return undefined;
+  const { bank: _bank, ...rest } = entity;
+  return Object.keys(rest).length > 0 ? rest : undefined;
+}
+
+type WireGovernanceAgent = NonNullable<WireAccount['governance_agents']>[number];
+
+/**
+ * Project a governance-agent element to the wire shape, dropping any keys
+ * the wire schema doesn't model. The schema notes that authentication
+ * credentials are write-only and not included in responses; the wire type
+ * already carries only `url` and `categories`, but TS is erased at runtime
+ * so adopters using JS or `as any` could otherwise smuggle a `credentials`
+ * field straight to the wire. Explicit projection closes that gap.
+ */
+function projectGovernanceAgent(agent: WireGovernanceAgent): WireGovernanceAgent {
+  const projected: WireGovernanceAgent = { url: agent.url };
+  if (agent.categories !== undefined) projected.categories = agent.categories;
+  return projected;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -64,7 +64,7 @@ import {
 } from '../../create-adcp-server';
 import type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor } from '../platform';
 import type { Account, ResolvedAuthInfo } from '../account';
-import { AccountNotFoundError, toWireAccount } from '../account';
+import { AccountNotFoundError, toWireAccount, toWireSyncAccountRow } from '../account';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
 import type { CreativeBuilderPlatform } from '../specialisms/creative';
 import type { CreativeAdServerPlatform } from '../specialisms/creative-ad-server';
@@ -3361,7 +3361,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       const refs = (params.accounts ?? []) as AccountReference[];
       return projectSync(
         () => accounts.upsert!(refs),
-        rows => ({ accounts: rows })
+        rows => ({ accounts: rows.map(toWireSyncAccountRow) })
       );
     };
   }

--- a/test/server-decisioning-to-wire-account.test.js
+++ b/test/server-decisioning-to-wire-account.test.js
@@ -3,7 +3,7 @@
 const { describe, it } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { toWireAccount } = require('../dist/lib/server/decisioning/account');
+const { toWireAccount, toWireSyncAccountRow } = require('../dist/lib/server/decisioning/account');
 
 const baseAccount = () => ({
   id: 'acc_42',
@@ -99,6 +99,78 @@ describe('toWireAccount', () => {
       const wire = toWireAccount(baseAccount());
       assert.equal('billing_entity' in wire, false);
     });
+
+    it('omits billing_entity when only bank is set (no empty {} on the wire)', () => {
+      // schema requires legal_name on BusinessEntity; emitting `{}` after
+      // strip would fail validation. Project to undefined instead.
+      const wire = toWireAccount({
+        ...baseAccount(),
+        billing_entity: { bank: { account_holder: 'X', iban: 'DE89...' } },
+      });
+      assert.equal('billing_entity' in wire, false);
+    });
+
+    it('handles bank: undefined cleanly (no empty {} either)', () => {
+      const wire = toWireAccount({
+        ...baseAccount(),
+        billing_entity: { bank: undefined },
+      });
+      assert.equal('billing_entity' in wire, false);
+    });
+
+    it('strips bank against a class-instance billing_entity', () => {
+      class BE {
+        constructor() {
+          this.legal_name = 'Acme Corp.';
+          this.vat_id = 'DE123456789';
+          this.bank = { account_holder: 'Acme', iban: 'DE89...' };
+        }
+      }
+      const wire = toWireAccount({ ...baseAccount(), billing_entity: new BE() });
+      assert.equal('bank' in wire.billing_entity, false);
+      assert.equal(wire.billing_entity.legal_name, 'Acme Corp.');
+      assert.equal(wire.billing_entity.vat_id, 'DE123456789');
+    });
+
+    it('strips bank against a no-prototype billing_entity (Object.create(null))', () => {
+      const entity = Object.create(null);
+      entity.legal_name = 'Acme';
+      entity.bank = { iban: 'DE89...' };
+      const wire = toWireAccount({ ...baseAccount(), billing_entity: entity });
+      assert.equal('bank' in wire.billing_entity, false);
+      assert.equal(wire.billing_entity.legal_name, 'Acme');
+    });
+
+    it('strips bank when defined as enumerable getter', () => {
+      const entity = { legal_name: 'Acme' };
+      Object.defineProperty(entity, 'bank', {
+        enumerable: true,
+        configurable: true,
+        get() {
+          return { iban: 'DE89...' };
+        },
+      });
+      const wire = toWireAccount({ ...baseAccount(), billing_entity: entity });
+      assert.equal('bank' in wire.billing_entity, false);
+      assert.equal(wire.billing_entity.legal_name, 'Acme');
+    });
+
+    it('preserves all other optional fields when stripping bank from a fully-populated entity', () => {
+      const billing_entity = {
+        legal_name: 'Acme Corp.',
+        vat_id: 'DE123456789',
+        tax_id: 'US-87-6543210',
+        registration_number: 'HRB 12345',
+        address: { street: '1 Acme Way', city: 'Berlin', postal_code: '10117', country: 'DE' },
+        contacts: [{ role: 'billing', name: 'Alice', email: 'alice@acme.com' }],
+        bank: { account_holder: 'Acme', iban: 'DE89370400440532013000', bic: 'COBADEFFXXX' },
+      };
+      const wire = toWireAccount({ ...baseAccount(), billing_entity });
+      assert.equal('bank' in wire.billing_entity, false);
+      for (const k of ['legal_name', 'vat_id', 'tax_id', 'registration_number', 'address', 'contacts']) {
+        assert.deepEqual(wire.billing_entity[k], billing_entity[k]);
+      }
+    });
   });
 
   describe('lifecycle and commercial fields', () => {
@@ -142,6 +214,28 @@ describe('toWireAccount', () => {
       ]);
     });
 
+    it('drops unknown keys on governance_agents elements (credential smuggling guard)', () => {
+      // Schema notes governance auth credentials are write-only; the wire type
+      // already excludes them, but adopters using JS / `as any` could otherwise
+      // smuggle a credentials field straight to the wire. Element-level
+      // projection closes that gap.
+      const wire = toWireAccount({
+        ...baseAccount(),
+        governance_agents: [
+          {
+            url: 'https://gov.acme.com/mcp',
+            categories: ['budget_authority'],
+            credentials: { token: 'secret_should_never_appear' },
+            api_key: 'secret_should_never_appear',
+          },
+        ],
+      });
+      assert.equal('credentials' in wire.governance_agents[0], false);
+      assert.equal('api_key' in wire.governance_agents[0], false);
+      assert.equal(wire.governance_agents[0].url, 'https://gov.acme.com/mcp');
+      assert.deepEqual(wire.governance_agents[0].categories, ['budget_authority']);
+    });
+
     it('projects reporting_bucket', () => {
       const reporting_bucket = {
         protocol: 's3',
@@ -156,12 +250,25 @@ describe('toWireAccount', () => {
     });
   });
 
+  it('projects billing_proxy, sandbox, ext when set', () => {
+    const wire = toWireAccount({
+      ...baseAccount(),
+      billing_proxy: 'pinnacle.com',
+      sandbox: true,
+      ext: { custom_field: 'value' },
+    });
+    assert.equal(wire.billing_proxy, 'pinnacle.com');
+    assert.equal(wire.sandbox, true);
+    assert.deepEqual(wire.ext, { custom_field: 'value' });
+  });
+
   it('omits all optional fields when not set on the source', () => {
     const wire = toWireAccount(baseAccount());
     for (const k of [
       'brand',
       'operator',
       'advertiser',
+      'billing_proxy',
       'billing',
       'billing_entity',
       'rate_card',
@@ -171,6 +278,117 @@ describe('toWireAccount', () => {
       'account_scope',
       'governance_agents',
       'reporting_bucket',
+      'sandbox',
+      'ext',
+    ]) {
+      assert.equal(k in wire, false, `${k} must be omitted when source has no value`);
+    }
+  });
+});
+
+describe('toWireSyncAccountRow', () => {
+  const baseRow = () => ({
+    brand: { domain: 'acme.com' },
+    operator: 'acme.com',
+    action: 'created',
+    status: 'active',
+  });
+
+  it('passes through the required wire fields', () => {
+    const wire = toWireSyncAccountRow(baseRow());
+    assert.deepEqual(wire, {
+      brand: { domain: 'acme.com' },
+      operator: 'acme.com',
+      action: 'created',
+      status: 'active',
+    });
+  });
+
+  it('strips billing_entity.bank on adopter rows (no leak when adopter spreads a DB record)', () => {
+    // The realistic leak: adopter does `{ ...db.findByBrand(r.brand), action: 'updated' }`
+    // and the DB row carries bank coordinates collected during onboarding.
+    const wire = toWireSyncAccountRow({
+      ...baseRow(),
+      action: 'updated',
+      billing_entity: {
+        legal_name: 'Acme Corp.',
+        vat_id: 'DE123456789',
+        bank: {
+          account_holder: 'Acme Corp.',
+          iban: 'DE89370400440532013000',
+        },
+      },
+    });
+    assert.equal('bank' in wire.billing_entity, false, 'bank MUST NOT appear on sync_accounts response');
+    assert.equal(wire.billing_entity.legal_name, 'Acme Corp.');
+    assert.equal(wire.billing_entity.vat_id, 'DE123456789');
+  });
+
+  it('omits billing_entity when only bank is set (parity with toWireAccount)', () => {
+    const wire = toWireSyncAccountRow({
+      ...baseRow(),
+      billing_entity: { bank: { iban: 'DE89...' } },
+    });
+    assert.equal('billing_entity' in wire, false);
+  });
+
+  it('projects setup, billing, account_scope, rate_card, payment_terms, credit_limit', () => {
+    const setup = {
+      url: 'https://acme.com/onboarding/credit-app',
+      message: 'Complete the credit application to activate this account.',
+      expires_at: '2026-06-01T00:00:00Z',
+    };
+    const wire = toWireSyncAccountRow({
+      ...baseRow(),
+      action: 'created',
+      status: 'pending_approval',
+      billing: 'agent',
+      account_scope: 'operator_brand',
+      setup,
+      rate_card: 'rc_premium_2026',
+      payment_terms: 'net_30',
+      credit_limit: { amount: 250000, currency: 'USD' },
+    });
+    assert.equal(wire.billing, 'agent');
+    assert.equal(wire.account_scope, 'operator_brand');
+    assert.deepEqual(wire.setup, setup);
+    assert.equal(wire.rate_card, 'rc_premium_2026');
+    assert.equal(wire.payment_terms, 'net_30');
+    assert.deepEqual(wire.credit_limit, { amount: 250000, currency: 'USD' });
+  });
+
+  it('projects account_id, name, errors, warnings, sandbox', () => {
+    const wire = toWireSyncAccountRow({
+      ...baseRow(),
+      account_id: 'acc_42',
+      name: 'Acme c/o Pinnacle',
+      action: 'failed',
+      errors: [{ code: 'CREDIT_DECLINED', message: 'Credit application denied.' }],
+      warnings: ['Operator domain not yet verified.'],
+      sandbox: false,
+    });
+    assert.equal(wire.account_id, 'acc_42');
+    assert.equal(wire.name, 'Acme c/o Pinnacle');
+    assert.deepEqual(wire.errors, [{ code: 'CREDIT_DECLINED', message: 'Credit application denied.' }]);
+    assert.deepEqual(wire.warnings, ['Operator domain not yet verified.']);
+    assert.equal(wire.sandbox, false);
+  });
+
+  it('omits all optional fields when source carries only the required four', () => {
+    const wire = toWireSyncAccountRow(baseRow());
+    for (const k of [
+      'account_id',
+      'name',
+      'billing',
+      'billing_entity',
+      'account_scope',
+      'setup',
+      'rate_card',
+      'payment_terms',
+      'credit_limit',
+      'errors',
+      'warnings',
+      'sandbox',
     ]) {
       assert.equal(k in wire, false, `${k} must be omitted when source has no value`);
     }

--- a/test/server-decisioning-to-wire-account.test.js
+++ b/test/server-decisioning-to-wire-account.test.js
@@ -204,14 +204,10 @@ describe('toWireAccount', () => {
       const wire = toWireAccount({
         ...baseAccount(),
         account_scope: 'operator_brand',
-        governance_agents: [
-          { url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] },
-        ],
+        governance_agents: [{ url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] }],
       });
       assert.equal(wire.account_scope, 'operator_brand');
-      assert.deepEqual(wire.governance_agents, [
-        { url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] },
-      ]);
+      assert.deepEqual(wire.governance_agents, [{ url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] }]);
     });
 
     it('drops unknown keys on governance_agents elements (credential smuggling guard)', () => {

--- a/test/server-decisioning-to-wire-account.test.js
+++ b/test/server-decisioning-to-wire-account.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { toWireAccount } = require('../dist/lib/server/decisioning/account');
+
+const baseAccount = () => ({
+  id: 'acc_42',
+  name: 'Acme',
+  status: 'active',
+  ctx_metadata: {},
+  authInfo: { kind: 'api_key' },
+});
+
+describe('toWireAccount', () => {
+  it('renames id → account_id and strips framework-internal fields', () => {
+    const wire = toWireAccount(baseAccount());
+    assert.equal(wire.account_id, 'acc_42');
+    assert.equal(wire.name, 'Acme');
+    assert.equal(wire.status, 'active');
+    assert.equal('id' in wire, false);
+    assert.equal('ctx_metadata' in wire, false);
+    assert.equal('authInfo' in wire, false);
+  });
+
+  it('projects brand, operator, advertiser when set', () => {
+    const wire = toWireAccount({
+      ...baseAccount(),
+      brand: { domain: 'acme.com' },
+      operator: 'pinnacle.com',
+      advertiser: 'acme.com',
+    });
+    assert.deepEqual(wire.brand, { domain: 'acme.com' });
+    assert.equal(wire.operator, 'pinnacle.com');
+    assert.equal(wire.advertiser, 'acme.com');
+  });
+
+  it('collapses billing.invoicedTo string passthrough and BrandReference → "advertiser"', () => {
+    assert.equal(toWireAccount({ ...baseAccount(), billing: { invoicedTo: 'agent' } }).billing, 'agent');
+    assert.equal(toWireAccount({ ...baseAccount(), billing: { invoicedTo: 'operator' } }).billing, 'operator');
+    assert.equal(
+      toWireAccount({ ...baseAccount(), billing: { invoicedTo: { domain: 'amazon.com' } } }).billing,
+      'advertiser'
+    );
+  });
+
+  describe('billing_entity', () => {
+    it('passes through legal_name, vat_id, tax_id, registration_number, address, contacts', () => {
+      const billing_entity = {
+        legal_name: 'Acme Corp.',
+        vat_id: 'DE123456789',
+        tax_id: 'US-87-6543210',
+        registration_number: 'HRB 12345',
+        address: {
+          street: '1 Acme Way',
+          city: 'Berlin',
+          postal_code: '10117',
+          country: 'DE',
+        },
+        contacts: [
+          { role: 'billing', name: 'Alice', email: 'alice@acme.com' },
+          { role: 'legal', name: 'Bob', email: 'legal@acme.com' },
+        ],
+      };
+      const wire = toWireAccount({ ...baseAccount(), billing_entity });
+      assert.deepEqual(wire.billing_entity, billing_entity);
+    });
+
+    it('strips bank from billing_entity (write-only on response)', () => {
+      const wire = toWireAccount({
+        ...baseAccount(),
+        billing_entity: {
+          legal_name: 'Acme Corp.',
+          vat_id: 'DE123456789',
+          bank: {
+            account_holder: 'Acme Corp.',
+            iban: 'DE89370400440532013000',
+            bic: 'COBADEFFXXX',
+          },
+        },
+      });
+      assert.equal('bank' in wire.billing_entity, false, 'bank must NOT appear in projected billing_entity');
+      assert.equal(wire.billing_entity.legal_name, 'Acme Corp.');
+      assert.equal(wire.billing_entity.vat_id, 'DE123456789');
+    });
+
+    it('does not mutate the source billing_entity when stripping bank', () => {
+      const billing_entity = {
+        legal_name: 'Acme Corp.',
+        bank: { account_holder: 'Acme Corp.', iban: 'DE89370400440532013000' },
+      };
+      toWireAccount({ ...baseAccount(), billing_entity });
+      assert.ok(billing_entity.bank, 'source billing_entity.bank must remain intact');
+      assert.equal(billing_entity.bank.iban, 'DE89370400440532013000');
+    });
+
+    it('omits billing_entity entirely when source is undefined', () => {
+      const wire = toWireAccount(baseAccount());
+      assert.equal('billing_entity' in wire, false);
+    });
+  });
+
+  describe('lifecycle and commercial fields', () => {
+    it('projects rate_card, payment_terms, credit_limit unchanged', () => {
+      const wire = toWireAccount({
+        ...baseAccount(),
+        rate_card: 'rc_premium_2026',
+        payment_terms: 'net_30',
+        credit_limit: { amount: 250000, currency: 'USD' },
+      });
+      assert.equal(wire.rate_card, 'rc_premium_2026');
+      assert.equal(wire.payment_terms, 'net_30');
+      assert.deepEqual(wire.credit_limit, { amount: 250000, currency: 'USD' });
+    });
+
+    it('projects setup payload (pending_approval lifecycle)', () => {
+      const setup = {
+        url: 'https://acme.com/onboarding/credit-app',
+        message: 'Complete the credit application to activate this account.',
+        expires_at: '2026-06-01T00:00:00Z',
+      };
+      const wire = toWireAccount({
+        ...baseAccount(),
+        status: 'pending_approval',
+        setup,
+      });
+      assert.deepEqual(wire.setup, setup);
+    });
+
+    it('projects account_scope and governance_agents', () => {
+      const wire = toWireAccount({
+        ...baseAccount(),
+        account_scope: 'operator_brand',
+        governance_agents: [
+          { url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] },
+        ],
+      });
+      assert.equal(wire.account_scope, 'operator_brand');
+      assert.deepEqual(wire.governance_agents, [
+        { url: 'https://gov.acme.com/mcp', categories: ['budget_authority'] },
+      ]);
+    });
+
+    it('projects reporting_bucket', () => {
+      const reporting_bucket = {
+        protocol: 's3',
+        bucket: 'acme-reporting',
+        prefix: 'accounts/acc_42/',
+        region: 'us-east-1',
+        format: 'parquet',
+        file_retention_days: 30,
+      };
+      const wire = toWireAccount({ ...baseAccount(), reporting_bucket });
+      assert.deepEqual(wire.reporting_bucket, reporting_bucket);
+    });
+  });
+
+  it('omits all optional fields when not set on the source', () => {
+    const wire = toWireAccount(baseAccount());
+    for (const k of [
+      'brand',
+      'operator',
+      'advertiser',
+      'billing',
+      'billing_entity',
+      'rate_card',
+      'payment_terms',
+      'credit_limit',
+      'setup',
+      'account_scope',
+      'governance_agents',
+      'reporting_bucket',
+    ]) {
+      assert.equal(k in wire, false, `${k} must be omitted when source has no value`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Extends the framework's adopter-facing `Account<TCtxMeta>` with the AdCP 3.0 wire-aligned optional fields the SDK was silently dropping in `toWireAccount`. Closes #1256.

Spawned out of #1249 (closed) — the only item from that Python-team-parity bundle that is concrete, scoped, and unblocked. The other items are deferred / rejected / RFC-blocked per the evaluation comment on #1249.

## What changed

`Account<TCtxMeta>` now carries:

- `billing_entity` (`BusinessEntity`) — legal name, tax IDs, address, contacts, write-only `bank`
- `rate_card`
- `payment_terms`
- `credit_limit` (`{ amount, currency }`)
- `setup` (`{ url?, message, expires_at? }`) — drives `pending_approval` → `active` lifecycle
- `account_scope`
- `governance_agents`
- `reporting_bucket`

`toWireAccount` projects each field unchanged with one exception: `billing_entity.bank` is stripped on emit per the schema's write-only rule (bank coordinates flow buyer→seller in `sync_accounts` requests but MUST NOT appear in any response payload).

## Most adopter-visible bug it fixes

`pending_approval` accounts could not carry their `setup` payload through the framework — adopters who returned `Account<TCtxMeta>` from `accounts.list` had the `setup` field silently dropped, so buyers had no way to surface the credit-application / legal-agreement URL to a human. The SDK therefore couldn't drive the full `pending_approval` → `active` lifecycle end-to-end. With this PR, the field is preserved.

## Non-breaking

All additions are optional. Adopters who don't set the new fields see no behavior change.

## Test plan

- [x] `npm run typecheck` — clean
- [x] New unit tests at `test/server-decisioning-to-wire-account.test.js` — 12/12 pass:
  - id → account_id rename + framework-internal field strip
  - brand / operator / advertiser / billing.invoicedTo passthrough (existing)
  - billing_entity passes through legal_name / vat_id / tax_id / registration_number / address / contacts
  - **billing_entity.bank stripped on emit** (write-only enforcement)
  - billing_entity strip does not mutate the source object
  - rate_card / payment_terms / credit_limit / setup / account_scope / governance_agents / reporting_bucket projection
  - "all optional fields omitted when source has no value" regression
- [x] Full suite `npm test` — 7220 passing, 7 skipped, 0 failing.

## Changeset

`minor` — additive Protocol change, non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)