### PR TITLE
fix(accounts): forward ResolveContext to AccountStore.upsert() and .list()

### DIFF
--- a/.changeset/accountstore-upsert-list-ctx.md
+++ b/.changeset/accountstore-upsert-list-ctx.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+Forward `ResolveContext` to `AccountStore.upsert()` and `AccountStore.list()` (#1272).
+
+Both methods now accept an optional `ctx?: ResolveContext` second argument, giving
+multi-tenant adopters access to `ctx.authInfo` (the buyer's OAuth principal) at write
+and read time — the same context already available in `resolve()` and `reportUsage()`.
+The framework builds and forwards the context automatically; no call-site change is
+needed for existing adopters who ignore the argument.
+
+Without this, the only workaround was leaving `accounts.upsert` undefined (forcing
+`UNSUPPORTED_FEATURE` on `sync_accounts`). Instance-field stashing and AsyncLocalStorage
+both fail under the SDK's long-lived store contract.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -222,15 +222,28 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * **Optional.** Stateless platforms (creative-template, signal-marketplace
    * proxies) that don't manage account lifecycle can omit this; framework
    * surfaces `UNSUPPORTED_FEATURE` to buyers calling `sync_accounts`.
+   *
+   * `ctx.authInfo` carries the caller's OAuth principal (when
+   * `serve({ authenticate })` is wired). Multi-tenant platforms extract
+   * the buyer's `org_id` / `clientId` from `ctx.authInfo` to tenant-scope
+   * writes — same pattern as `accounts.resolve`. Implementors that don't
+   * need tenant scoping can ignore the second argument.
    */
-  upsert?(refs: AccountReference[]): Promise<SyncAccountsResultRow[]>;
+  upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
 
   /**
    * list_accounts API surface. Framework wraps with cursor envelope.
    *
    * **Optional.** Same rationale as `upsert` — stateless platforms can omit.
+   *
+   * `ctx.authInfo` carries the caller's OAuth principal (when
+   * `serve({ authenticate })` is wired). Multi-tenant platforms filter the
+   * account roster to those belonging to the calling buyer's organization
+   * using `ctx.authInfo.clientId` / `ctx.authInfo.extra` — same pattern as
+   * `accounts.resolve`. Implementors that don't need tenant scoping can
+   * ignore the second argument.
    */
-  list?(filter: AccountFilter & CursorRequest): Promise<CursorPage<Account<TCtxMeta>>>;
+  list?(filter: AccountFilter & CursorRequest, ctx?: ResolveContext): Promise<CursorPage<Account<TCtxMeta>>>;
 
   /**
    * report_usage API surface. Operator-billed platforms accept usage rows

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -226,7 +226,8 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * `ctx.authInfo` carries the caller's OAuth principal (when
    * `serve({ authenticate })` is wired). Multi-tenant platforms extract
    * the buyer's `org_id` / `clientId` from `ctx.authInfo` to tenant-scope
-   * writes — same pattern as `accounts.resolve`. Implementors that don't
+   * writes — same pattern as `accounts.resolve`. `ctx.toolName` is
+   * `'sync_accounts'` for dispatch or logging. Implementors that don't
    * need tenant scoping can ignore the second argument.
    */
   upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
@@ -240,8 +241,9 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * `serve({ authenticate })` is wired). Multi-tenant platforms filter the
    * account roster to those belonging to the calling buyer's organization
    * using `ctx.authInfo.clientId` / `ctx.authInfo.extra` — same pattern as
-   * `accounts.resolve`. Implementors that don't need tenant scoping can
-   * ignore the second argument.
+   * `accounts.resolve`. `ctx.toolName` is `'list_accounts'` for dispatch
+   * or logging. Implementors that don't need tenant scoping can ignore the
+   * second argument.
    */
   list?(filter: AccountFilter & CursorRequest, ctx?: ResolveContext): Promise<CursorPage<Account<TCtxMeta>>>;
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3357,23 +3357,31 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   const handlers: AccountHandlers<Account> = {};
 
   if (accounts.upsert) {
-    handlers.syncAccounts = async (params, _ctx) => {
+    handlers.syncAccounts = async (params, ctx) => {
       const refs = (params.accounts ?? []) as AccountReference[];
+      const resolveCtx = {
+        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+        toolName: 'sync_accounts' as const,
+      };
       return projectSync(
-        () => accounts.upsert!(refs),
+        () => accounts.upsert!(refs, resolveCtx),
         rows => ({ accounts: rows })
       );
     };
   }
 
   if (accounts.list) {
-    handlers.listAccounts = async (params, _ctx) => {
+    handlers.listAccounts = async (params, ctx) => {
       const filter = params as Parameters<NonNullable<typeof accounts.list>>[0];
+      const resolveCtx = {
+        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+        toolName: 'list_accounts' as const,
+      };
       // Wrap in projectSync so adopter `throw new AdcpError('PERMISSION_DENIED', ...)`
       // from the list impl projects to the structured wire envelope rather
       // than falling through to the framework's `SERVICE_UNAVAILABLE` mapping.
       return projectSync(
-        () => accounts.list!(filter),
+        () => accounts.list!(filter, resolveCtx),
         page => ({
           accounts: page.items.map(toWireAccount),
           ...(page.nextCursor != null && { next_cursor: page.nextCursor }),


### PR DESCRIPTION
Closes #1272

`AccountStore.upsert()` and `AccountStore.list()` were the only two methods in the store that received no auth context, despite the framework having `ctx` available at both call sites. This meant multi-tenant adopters could not enforce tenant scoping at write time (`upsert`) or filter by caller organization at read time (`list`) — the only workaround was leaving `accounts.upsert` undefined, forcing `UNSUPPORTED_FEATURE` on `sync_accounts`. The fix adds `ctx?: ResolveContext` to both method signatures and forwards it using the identical `resolveCtx` construction pattern already used by `reportUsage` and `getAccountFinancials`.

**What was tested:**
- `npm run format:check` — passed
- `npm run typecheck` — passed (clean, no new errors)
- `npm run build:lib` — passed
- `npm test` — blocked in this environment by schema-bundle 403 (network constraint); unit tests have no direct coverage of `buildAccountHandlers` (pre-existing gap noted in both experts' reviews)
- Pre-push hook (`format:check` + `typecheck` + `build:lib`) — passed on both commits

**Pre-PR review:**
- code-reviewer: approved — exact structural match to the `reportUsage` pattern; non-breaking; changeset present and correctly classified as `patch`
- dx-expert: approved — JSDoc accurate and sufficient; `toolName` values added per review nit; no migration guidance needed (optional arg, existing callers unaffected)

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_011zafNEJP3sEk2dcYNfESSr

---
_Generated by [Claude Code](https://claude.ai/code/session_011zafNEJP3sEk2dcYNfESSr)_