### PR TITLE
fix(codegen): emit CreativeRejectedDetails from error-details/creative-rejected.json

### DIFF
--- a/.changeset/fix-creative-rejected-details-codegen.md
+++ b/.changeset/fix-creative-rejected-details-codegen.md
@@ -1,0 +1,15 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(codegen): emit `CreativeRejectedDetails` from error-details/creative-rejected.json
+
+`compileGapSchemas` was checking `generatedTypes.has(typeName)` using the file-path-derived
+name (`CreativeRejected`), which was already registered by the brand-domain
+`creative-approval-response.json` pass, so the schema was silently skipped. The fix reads
+the JSON Schema `title` field first and gates on the title-derived name
+(`CreativeRejectedDetails`) instead, which does not collide.
+
+Adds `CreativeRejectedDetails` interface and `CreativeRejectedDetailsSchema` Zod schema,
+matching the six other error-details types already emitted. Fixes a long-standing gap —
+not a regression of the 3.0.4 bump.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1437,17 +1437,39 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
 
     const typeName = schemaPathToTypeName(relPath);
 
-    // Skip if this type was already generated
-    if (generatedTypes.has(typeName)) continue;
-
     // Skip deprecated schemas
     if (DEPRECATED_SCHEMAS.has(path.basename(relPath, '.json'))) continue;
 
+    // Load schema early to determine the title-derived type name.
+    // json-schema-to-typescript uses the schema title (when present) as the
+    // emitted interface name rather than our file-path-derived hint. Checking
+    // generatedTypes against only the path-derived name silently drops schemas
+    // whose path name collides with an existing type but whose title-derived
+    // name does not (e.g. error-details/creative-rejected.json → path gives
+    // "CreativeRejected" which collides with a brand-domain type, while title
+    // "Creative Rejected Details" gives "CreativeRejectedDetails" which is new).
+    let schema: any;
     try {
-      const schemaPath = path.join(LATEST_CACHE_DIR, relPath);
-      let schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
+      schema = JSON.parse(readFileSync(path.join(LATEST_CACHE_DIR, relPath), 'utf8'));
+    } catch (error: any) {
+      console.warn(`⚠️  Failed to compile gap schema ${relPath}: ${error.message}`);
+      continue;
+    }
 
-      // Apply same preprocessing as other schema passes
+    const titleTypeName = schema.title
+      ? schema.title
+          .replace(/[^a-zA-Z0-9\s]/g, ' ')
+          .split(/\s+/)
+          .filter(Boolean)
+          .map((w: string) => w.charAt(0).toUpperCase() + w.slice(1))
+          .join('')
+      : typeName;
+
+    // Skip if this type was already generated
+    if (generatedTypes.has(titleTypeName)) continue;
+
+    try {
+      // Apply same preprocessing as other schema passes (schema already loaded above)
       const fileName = path.basename(relPath, '.json');
       if (DEPRECATED_ENUM_VALUES[fileName]) {
         schema = removeDeprecatedFields(schema, fileName);
@@ -1461,7 +1483,7 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
       }
 
       const strictSchema = enforceStrictSchema(removeArrayLengthConstraints(schema));
-      const types = await compile(strictSchema, typeName, {
+      const types = await compile(strictSchema, titleTypeName, {
         bannerComment: '',
         style: { semi: true, singleQuote: true },
         additionalProperties: false,

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -17085,6 +17085,26 @@ export interface ConflictDetails {
 }
 
 
+// error-details/creative-rejected.json
+/**
+ * Recommended details shape for CREATIVE_REJECTED errors. Provides policy reference and rejection reasons so agents can adjust creative content.
+ */
+export interface CreativeRejectedDetails {
+  /**
+   * Identifier for the policy that rejected the creative
+   */
+  policy_id?: string;
+  /**
+   * URL where the rejecting policy can be reviewed
+   */
+  policy_url?: string;
+  /**
+   * Human-readable rejection reasons
+   */
+  reasons?: string[];
+}
+
+
 // error-details/policy-violation.json
 /**
  * Recommended details shape for POLICY_VIOLATION errors. Provides policy reference and violated rules so agents can adjust requests.

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -3735,6 +3735,12 @@ export const ConflictDetailsSchema = z.object({
     current_version: z.union([z.number(), z.string()]).optional()
 }).passthrough();
 
+export const CreativeRejectedDetailsSchema = z.object({
+    policy_id: z.string().optional(),
+    policy_url: z.string().optional(),
+    reasons: z.array(z.string()).optional()
+}).passthrough();
+
 export const PolicyViolationDetailsSchema = z.object({
     policy_id: z.string().optional(),
     policy_url: z.string().optional(),


### PR DESCRIPTION
Closes #1271

## Summary

`compileGapSchemas` in `scripts/generate-types.ts` was checking `generatedTypes.has(typeName)` using the file-path-derived name (`"CreativeRejected"` from `creative-rejected.json`), which was already registered by the brand-domain `creative-approval-response.json` pass. The schema was silently skipped before compilation — `json-schema-to-typescript` was never invoked — so `CreativeRejectedDetails` was never emitted. The other six `error-details/` schemas worked because their file-path names don't collide with anything already generated.

**Fix:** load the schema before the skip check, derive `titleTypeName` from `schema.title` (the name `json-schema-to-typescript` will actually emit), and gate the skip check on that. Also pass `titleTypeName` to `compile()` to keep the hint and the guard consistent.

The `core.generated.ts` and `schemas.generated.ts` additions are manually applied to represent what the fixed codegen produces. CI runs `npm run sync-schemas && npm run generate-types` on merge and will produce the canonical output; these manual edits let reviewers see and verify the expected shape now.

## What was tested

- `npm run format:check` — ✅ pass
- `npm run typecheck` — ✅ pass
- `npm run build:lib` — ✅ pass
- `npm test` — blocked by `schemas:ensure` network fetch in this environment (CI will run full suite)

## Pre-PR review

- code-reviewer: approved — no blockers; nits are leading-digit guard assumption (non-issue for current schemas) and duplicate `typeName`/`pascalName` computation (pre-existing)
- ad-tech-protocol-expert: approved — non-breaking per spec; `CREATIVE_REJECTED` is defined in `error-codes.ts`; fix closes spec-drift, not a new feature; `.passthrough()` correctly matches the other six error-details Zod peers

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01XehShSY6xvCzDJkSgtH5Kn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XehShSY6xvCzDJkSgtH5Kn)_