### PR TITLE
fix(codegen): honor schema title in gap-schemas dedupe (closes #1271)

### DIFF
--- a/.changeset/creative-rejected-details-codegen.md
+++ b/.changeset/creative-rejected-details-codegen.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(codegen): honor schema title in gap-schemas dedupe (emit CreativeRejectedDetails)
+
+`schemas/cache/3.0.4/error-details/creative-rejected.json` has title "Creative Rejected Details" but the gap-schemas pass derived its dedupe key from the filename (`creative-rejected` → `CreativeRejected`). That collided with the brand-domain `CreativeRejected` interface (different schema, from `creative-approval-response.json`) already in the `generatedTypes` set, so the file was silently skipped before `json-schema-to-typescript` could produce its actual title-derived `CreativeRejectedDetails`.
+
+Six other error-details files (`account-setup-required`, `audience-too-small`, `budget-too-low`, `conflict`, `policy-violation`, `rate-limited`) emit fine because their kebab-name doesn't collide. Only `creative-rejected` was affected; the gap predates 3.0.4.
+
+Fix: peek at the schema's `title` (when present) and use the title-derived name for both the dedupe check and the `compile()` argument. `CreativeRejectedDetails` now emits as a standalone interface. Brand-domain `CreativeRejected` is unaffected.
+
+Closes #1271.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -1577,13 +1577,37 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
     // Skip async response variants
     if (asyncVariantPattern.test(relPath)) continue;
 
-    const typeName = schemaPathToTypeName(relPath);
-
-    // Skip if this type was already generated
-    if (generatedTypes.has(typeName)) continue;
+    const pathDerivedTypeName = schemaPathToTypeName(relPath);
 
     // Skip deprecated schemas
     if (DEPRECATED_SCHEMAS.has(path.basename(relPath, '.json'))) continue;
+
+    // Peek at the schema's `title` before deciding whether to skip for dedupe.
+    // `json-schema-to-typescript` honors `title` over the typeName argument we
+    // pass, so the actual emitted name is title-derived. Using path-only for
+    // dedupe causes spurious skips when two distinct schemas share a kebab-name
+    // (e.g. `error-details/creative-rejected.json` was being dropped because
+    // brand-domain `creative-approval-response.json` already registered
+    // `CreativeRejected` — but the error-details file's title is "Creative
+    // Rejected Details", so jsts would emit `CreativeRejectedDetails`, not a
+    // duplicate. Tracked: adcp-client#1271.
+    let schemaForTypeName: Record<string, unknown> | null = null;
+    try {
+      const schemaPath = path.join(LATEST_CACHE_DIR, relPath);
+      schemaForTypeName = JSON.parse(readFileSync(schemaPath, 'utf8'));
+    } catch {
+      // Fall through to the main compile attempt for consistent error logging
+      schemaForTypeName = null;
+    }
+    const titleDerivedTypeName =
+      typeof schemaForTypeName?.title === 'string' ? schemaForTypeName.title.replace(/[^A-Za-z0-9]/g, '') : '';
+    const typeName = titleDerivedTypeName || pathDerivedTypeName;
+
+    // Skip if this type was already generated. The check uses the
+    // title-preferring name so two distinct schemas that share a kebab-name
+    // but have distinct titles can both emit (the previous behavior used
+    // path-only and silently dropped the second).
+    if (generatedTypes.has(typeName)) continue;
 
     try {
       const schemaPath = path.join(LATEST_CACHE_DIR, relPath);

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.0.4
-// Generated at: 2026-05-02T15:11:28.636Z
+// Generated at: 2026-05-02T16:13:43.797Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -17020,6 +17020,26 @@ export interface ConflictDetails {
    * Current version or ETag on the server
    */
   current_version?: number | string;
+}
+
+
+// error-details/creative-rejected.json
+/**
+ * Recommended details shape for CREATIVE_REJECTED errors. Provides policy reference and rejection reasons so agents can revise.
+ */
+export interface CreativeRejectedDetails {
+  /**
+   * Identifier for the violated policy
+   */
+  policy_id?: string;
+  /**
+   * URL where the full policy can be reviewed
+   */
+  policy_url?: string;
+  /**
+   * Specific reasons the creative was rejected
+   */
+  reasons?: string[];
 }
 
 

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-02T15:11:33.149Z
+// Generated at: 2026-05-02T16:13:48.842Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -3713,6 +3713,12 @@ export const ConflictDetailsSchema = z.object({
     resource_id: z.string().optional(),
     expected_version: z.union([z.number(), z.string()]).optional(),
     current_version: z.union([z.number(), z.string()]).optional()
+}).passthrough();
+
+export const CreativeRejectedDetailsSchema = z.object({
+    policy_id: z.string().optional(),
+    policy_url: z.string().optional(),
+    reasons: z.array(z.string()).optional()
 }).passthrough();
 
 export const PolicyViolationDetailsSchema = z.object({


### PR DESCRIPTION
## Summary

`schemas/cache/3.0.4/error-details/creative-rejected.json` has title "Creative Rejected Details" but the gap-schemas pass derived its dedupe key from the filename (`creative-rejected` → `CreativeRejected`). That collided with the brand-domain `CreativeRejected` interface (different schema, from `creative-approval-response.json`) already in the `generatedTypes` set, so the file was silently skipped before `json-schema-to-typescript` could produce its actual title-derived `CreativeRejectedDetails`.

Six other error-details files (`account-setup-required`, `audience-too-small`, `budget-too-low`, `conflict`, `policy-violation`, `rate-limited`) emit fine because their kebab-name doesn't collide. **Only `creative-rejected` was affected; the gap predates 3.0.4.**

## Fix

In `scripts/generate-types.ts:compileGapSchemas`, peek at the schema's `title` (when present) and use the title-derived name for both the dedupe check AND the `compile()` argument.

```ts
const titleDerivedTypeName =
  typeof schema?.title === 'string' ? schema.title.replace(/[^A-Za-z0-9]/g, '') : '';
const typeName = titleDerivedTypeName || pathDerivedTypeName;
if (generatedTypes.has(typeName)) continue;
```

`CreativeRejectedDetails` now emits as a standalone interface at `core.generated.ts:17092`. Brand-domain `CreativeRejected` at line 5885 is unaffected.

## Verification

- `grep -nE "^export interface CreativeRejected(\b|Details\b)" src/lib/types/core.generated.ts` returns BOTH names with the right shapes
- `npm run typecheck` passes
- The 6 pre-existing error-details types continue to emit (their kebab-names don't collide)

## Test plan

- [x] `npm run typecheck` passes
- [x] `CreativeRejectedDetails` interface emitted with correct shape (`policy_id?`, `policy_url?`, `reasons?`)
- [x] Brand-domain `CreativeRejected` unchanged
- [ ] CI green

## Related

- Closes #1271
- Builds on #1266 (3.0.4 bump that surfaced this gap during the audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)