### PR TITLE
feat(runner): honor provides_state_for with peer_substituted skip reason (closes #1267)

### DIFF
--- a/.changeset/provides-state-for-runner.md
+++ b/.changeset/provides-state-for-runner.md
@@ -1,0 +1,18 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(runner): honor `provides_state_for` storyboard field with `peer_substituted` skip reason
+
+AdCP 3.0.3 (adcp#3734) introduced an optional `provides_state_for: <step_id> | <step_id>[]` field on storyboard steps, declaring that a stateful step's pass establishes equivalent state for the named peer step(s) in the same phase. When the rescue fires, the spec mandates that the rescued target be graded with `skip_reason: 'peer_substituted'` and the detail string `"<target_step_id> state provided by <phase_id>.<substitute_step_id>"` per `runner-output-contract.yaml`.
+
+The SDK already implemented the rescue mechanism in 6.4.1 (#1144) under the field name `peer_substitutes_for`. This change aligns with the spec:
+
+- **Type alias**: `provides_state_for` is now the canonical field on `StoryboardStep`. `peer_substitutes_for` is retained as a `@deprecated` synonym for one minor cycle so existing storyboards keep parsing. Both fields normalize at parse time; the runner reads `provides_state_for ?? peer_substitutes_for`.
+- **Loader validation**: works on whichever field is declared. If both are declared, the loader rejects mismatching values (the deprecation contract is "synonym for", not "additive with"). All same-phase / both-stateful / acyclic / no-self-reference rules apply identically.
+- **Skip reason**: new `peer_substituted` value on `RunnerSkipReason`, distinct from `peer_branch_taken` (branch-set routing) and `not_applicable` (coverage gap). Detail format matches the spec contract.
+- **Runner re-grading**: when a deferred `missing_tool` / `missing_test_controller` skip is rescued by a passing same-phase substitute, the runner re-grades the target's step result from the original hard-missing-state reason to `peer_substituted` with the spec detail string. Without this, the target kept its original `missing_tool` grade — misleading because state DID materialize via the substitute path.
+
+Closes #1267.
+
+Operational impact: `sales-social` explicit-mode platforms (Snap, Meta, TikTok) that pre-provision advertiser accounts out-of-band — and declare `provides_state_for: sync_accounts` on their `list_accounts` step per the 3.0.3 storyboard — graduate from `1/9/0` to `9/10` once their compliance cache refreshes against AdCP 3.0.3+.

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -185,11 +185,16 @@ function validateContextOutputs(
 }
 
 /**
- * Authoring-time validation for `peer_substitutes_for` (#1144). The runner
- * treats the field as same-phase-only and substitution-only-when-stateful;
- * surface those constraints at parse time so storyboard authors see typos
- * and cross-phase references on build, not as a silent no-rescue at run
- * time.
+ * Authoring-time validation for `provides_state_for` (the AdCP 3.0.3 spec
+ * field — adcp#3734) and the legacy `peer_substitutes_for` synonym. The
+ * runner treats the field as same-phase-only and substitution-only-when-
+ * stateful; surface those constraints at parse time so storyboard authors
+ * see typos and cross-phase references on build, not as a silent no-rescue
+ * at run time.
+ *
+ * Both field names parse to the same canonical normalized form on the step
+ * object (the spec name `provides_state_for` is preferred when both are
+ * declared). The deprecation alias is documented in `types.ts`.
  *
  * Rules:
  *   - Each target must reference a step that exists in the same phase.
@@ -199,40 +204,69 @@ function validateContextOutputs(
  *   - The target step must be `stateful: true` — non-stateful targets
  *     don't participate in cascade gating, so a substitution declaration
  *     would be a no-op.
+ *   - When both fields are declared on the same step, they must match
+ *     element-for-element (the deprecation contract is "synonym for", not
+ *     "additive with").
  */
 function validatePeerSubstitutesFor(
   storyboardId: string,
   phase: Storyboard['phases'][number],
   step: Storyboard['phases'][number]['steps'][number]
 ): void {
-  if (step.peer_substitutes_for === undefined) return;
-  const targets = Array.isArray(step.peer_substitutes_for) ? step.peer_substitutes_for : [step.peer_substitutes_for];
+  const newField = step.provides_state_for;
+  const legacyField = step.peer_substitutes_for;
+  if (newField === undefined && legacyField === undefined) return;
+
+  if (newField !== undefined && legacyField !== undefined) {
+    const a = JSON.stringify(Array.isArray(newField) ? newField : [newField]);
+    const b = JSON.stringify(Array.isArray(legacyField) ? legacyField : [legacyField]);
+    if (a !== b) {
+      throw new Error(
+        `[${storyboardId}] phase '${phase.id}' step '${step.id}': both provides_state_for and ` +
+          `peer_substitutes_for declared with different values — pick one (provides_state_for is the ` +
+          `spec field; peer_substitutes_for is a deprecated synonym)`
+      );
+    }
+  }
+
+  // Normalize onto provides_state_for so the runner can read a single field.
+  // peer_substitutes_for stays for back-compat with any consumer code that
+  // already reads it.
+  if (newField === undefined && legacyField !== undefined) {
+    step.provides_state_for = legacyField;
+  } else if (newField !== undefined && legacyField === undefined) {
+    step.peer_substitutes_for = newField;
+  }
+
+  const sourceFieldName = newField !== undefined ? 'provides_state_for' : 'peer_substitutes_for';
+  const declared = step.provides_state_for!;
+  const targets = Array.isArray(declared) ? declared : [declared];
   if (!step.stateful) {
     throw new Error(
-      `[${storyboardId}] phase '${phase.id}' step '${step.id}': peer_substitutes_for is only legal on stateful steps`
+      `[${storyboardId}] phase '${phase.id}' step '${step.id}': ${sourceFieldName} is only legal on stateful steps`
     );
   }
   const phaseStepIds = new Map(phase.steps.map(s => [s.id, s]));
   for (const target of targets) {
     if (typeof target !== 'string' || target.length === 0) {
       throw new Error(
-        `[${storyboardId}] phase '${phase.id}' step '${step.id}': peer_substitutes_for entries must be non-empty strings`
+        `[${storyboardId}] phase '${phase.id}' step '${step.id}': ${sourceFieldName} entries must be non-empty strings`
       );
     }
     if (target === step.id) {
       throw new Error(
-        `[${storyboardId}] phase '${phase.id}' step '${step.id}': peer_substitutes_for cannot reference itself`
+        `[${storyboardId}] phase '${phase.id}' step '${step.id}': ${sourceFieldName} cannot reference itself`
       );
     }
     const targetStep = phaseStepIds.get(target);
     if (!targetStep) {
       throw new Error(
-        `[${storyboardId}] phase '${phase.id}' step '${step.id}': peer_substitutes_for target '${target}' is not a step in this phase (same-phase only)`
+        `[${storyboardId}] phase '${phase.id}' step '${step.id}': ${sourceFieldName} target '${target}' is not a step in this phase (same-phase only)`
       );
     }
     if (!targetStep.stateful) {
       throw new Error(
-        `[${storyboardId}] phase '${phase.id}' step '${step.id}': peer_substitutes_for target '${target}' must be stateful`
+        `[${storyboardId}] phase '${phase.id}' step '${step.id}': ${sourceFieldName} target '${target}' must be stateful`
       );
     }
   }

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -218,6 +218,10 @@ function validatePeerSubstitutesFor(
   if (newField === undefined && legacyField === undefined) return;
 
   if (newField !== undefined && legacyField !== undefined) {
+    // Order-sensitive equality: `[A, B]` vs `[B, A]` would throw despite being
+    // semantically equivalent. Authors mid-migration should write the same list
+    // in both fields; the deprecation alias is a literal synonym, not a
+    // same-set restatement.
     const a = JSON.stringify(Array.isArray(newField) ? newField : [newField]);
     const b = JSON.stringify(Array.isArray(legacyField) ? legacyField : [legacyField]);
     if (a !== b) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1439,10 +1439,10 @@ async function executeStoryboardPass(
       if (!targetResult || !targetResult.skipped) continue;
       // Only re-grade hard-missing-state skips. Other skip reasons (e.g.
       // `prerequisite_failed`, `peer_branch_taken`) on the target are
-      // outside the substitute-rescue contract.
-      if (targetResult.skip_reason !== 'missing_tool' && targetResult.skip_reason !== 'missing_test_controller') {
-        continue;
-      }
+      // outside the substitute-rescue contract. Uses the same helper as
+      // the deferral path (line ~1269 above) so the two sides stay in
+      // lockstep when a future RunnerSkipReason joins the family.
+      if (!isHardMissingStateSkipReason(targetResult.skip_reason)) continue;
       const detail = `${target} state provided by ${phase.id}.${sourceId}`;
       targetResult.skip_reason = 'peer_substituted';
       targetResult.skip = { reason: 'peer_substituted', detail };

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -104,6 +104,7 @@ const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
     'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
   unsatisfied_contract: 'Skipped: test-kit contract is out of scope for this grading run.',
   peer_branch_taken: 'Skipped: a peer branch in the same any_of branch set already contributed the aggregation flag.',
+  peer_substituted: 'Skipped: a same-phase peer step established equivalent state via `provides_state_for`.',
 };
 
 const CONTROLLER_SEEDING_FAILED_DETAIL =
@@ -957,10 +958,12 @@ async function executeStoryboardPass(
     // Path (2): index of declared substitutions for this phase. Map keys
     // are target step IDs (the steps being substituted FOR); values are the
     // step IDs that declared the substitution. Built once per phase from
-    // each step's `peer_substitutes_for` field.
+    // each step's `provides_state_for` field (or the deprecated
+    // `peer_substitutes_for` synonym; the loader normalizes both onto
+    // `provides_state_for` at parse time, so reading either works).
     const phaseSubstitutes = new Map<string, string[]>();
     for (const declaringStep of phase.steps) {
-      const decl = declaringStep.peer_substitutes_for;
+      const decl = declaringStep.provides_state_for ?? declaringStep.peer_substitutes_for;
       if (decl === undefined) continue;
       const targets = Array.isArray(decl) ? decl : [decl];
       for (const target of targets) {
@@ -980,9 +983,15 @@ async function executeStoryboardPass(
       substitutes: string[];
     } | null = null;
     // Targets actually rescued by a passing declared substitute. Populated
-    // when a step with `peer_substitutes_for: X` passes — every X in its
-    // declaration list lands here.
+    // when a step with `provides_state_for: X` (or the deprecated synonym
+    // `peer_substitutes_for: X`) passes — every X in its declaration list
+    // lands here.
     const phaseRescuedTargets = new Set<string>();
+    // Map from rescued target id → the substitute step id that rescued it.
+    // Populated when the substitute passes; consumed at phase end to format
+    // the spec-mandated `peer_substituted` detail string. First substitute
+    // wins if multiple peers cover the same target.
+    const phaseRescueSource = new Map<string, string>();
     // Stateful step IDs in the phase. Used at phase end to decide whether
     // a deferred not_applicable trigger should cascade: if the sole stateful
     // step in the phase returned not_applicable AND there were no peers that
@@ -1319,14 +1328,20 @@ async function executeStoryboardPass(
         if (step.stateful) {
           phaseEstablishedStatefulState = true;
           // Path (2) rescue tracking: a passing step that declared
-          // `peer_substitutes_for: X` rescues X. Recorded against every
+          // `provides_state_for: X` (or the deprecated synonym
+          // `peer_substitutes_for`) rescues X. Recorded against every
           // declared target so phase-end resolution sees the target as
           // covered even if its skip arrives later in the loop.
-          const decl = step.peer_substitutes_for;
+          const decl = step.provides_state_for ?? step.peer_substitutes_for;
           if (decl !== undefined) {
             const targets = Array.isArray(decl) ? decl : [decl];
             for (const target of targets) {
               phaseRescuedTargets.add(target);
+              // Track the rescuing substitute's id so phase-end can format
+              // the contract-mandated `peer_substituted` detail string.
+              if (!phaseRescueSource.has(target)) {
+                phaseRescueSource.set(target, step.id);
+              }
             }
           }
         }
@@ -1387,12 +1402,13 @@ async function executeStoryboardPass(
 
     // Phase-end cascade resolution for deferred `missing_tool` triggers
     // (#1144). A stateful step that skipped with a hard-missing reason
-    // and had at least one declared substitute (`peer_substitutes_for`)
-    // was deferred above. If none of the declared substitutes passed,
-    // the substitution path failed to establish state — promote to a
-    // hard cascade with a detail message that names the substitute(s)
-    // tried so adopters reading the report see the substitution chain
-    // rather than a bare `missing_tool` cascade origin.
+    // and had at least one declared substitute (`provides_state_for`,
+    // formerly `peer_substitutes_for`) was deferred above. If none of
+    // the declared substitutes passed, the substitution path failed to
+    // establish state — promote to a hard cascade with a detail message
+    // that names the substitute(s) tried so adopters reading the report
+    // see the substitution chain rather than a bare `missing_tool`
+    // cascade origin.
     if (
       phasePendingMissingTool &&
       !phaseRescuedTargets.has(phasePendingMissingTool.stepId) &&
@@ -1405,6 +1421,31 @@ async function executeStoryboardPass(
         reason: phasePendingMissingTool.reason,
         substitution_chain: `declared substitute ${subsList} did not pass`,
       });
+    }
+
+    // Phase-end re-grading for rescued targets (adcp#3734, AdCP 3.0.3+).
+    // When a deferred `missing_tool` / `missing_test_controller` skip was
+    // rescued by a passing same-phase substitute, the spec mandates the
+    // target be re-graded with `skip_reason: 'peer_substituted'` and the
+    // detail string `"<target_step_id> state provided by <phase_id>.<substitute_step_id>"`
+    // — see `runner-output-contract.yaml` > `skip_result.reasons.peer_substituted`.
+    // Without this re-grading the target keeps its original `missing_tool`
+    // grade, which is misleading: state DID materialize, just via a
+    // declared substitute path. Tracked: adcp-client#1267.
+    for (const target of phaseRescuedTargets) {
+      const sourceId = phaseRescueSource.get(target);
+      if (!sourceId) continue;
+      const targetResult = stepResults.find(r => r.step_id === target);
+      if (!targetResult || !targetResult.skipped) continue;
+      // Only re-grade hard-missing-state skips. Other skip reasons (e.g.
+      // `prerequisite_failed`, `peer_branch_taken`) on the target are
+      // outside the substitute-rescue contract.
+      if (targetResult.skip_reason !== 'missing_tool' && targetResult.skip_reason !== 'missing_test_controller') {
+        continue;
+      }
+      const detail = `${target} state provided by ${phase.id}.${sourceId}`;
+      targetResult.skip_reason = 'peer_substituted';
+      targetResult.skip = { reason: 'peer_substituted', detail };
     }
 
     phaseResults.push({

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -338,23 +338,37 @@ export interface StoryboardStep {
   /** Whether this step depends on state from a previous step */
   stateful?: boolean;
   /**
-   * Declares that this step substitutes for one or more peer steps in the
-   * same phase. When a target peer skips with `not_applicable` or
-   * `missing_tool` (no advertised tool), the runner defers the cascade and
-   * waives it iff this substitute step passes. Same-phase only; cross-phase
-   * substitution is not supported.
+   * Declares that this step's pass establishes equivalent state for one or
+   * more peer steps in the same phase. When a target peer skips with
+   * `missing_tool` or `missing_test_controller` (no advertised tool),
+   * the runner defers the cascade and waives it iff this substitute step
+   * passes. Same-phase only; cross-phase substitution is not supported.
    *
-   * Canonical case: `list_accounts` declares `peer_substitutes_for:
+   * Canonical case: `list_accounts` declares `provides_state_for:
    * sync_accounts` on explicit-mode social platforms where the buyer never
    * calls `sync_accounts` because accounts are pre-provisioned out-of-band.
    *
    * Without this declaration, a `missing_tool` skip on a stateful step
    * trips the cascade immediately (state genuinely never materialized).
    * With it, the runner gives a declared substitute a chance to establish
-   * equivalent state before tripping.
+   * equivalent state before tripping. When the rescue fires, the target
+   * peer is graded with `skip_reason: 'peer_substituted'` and detail
+   * `"<target_step_id> state provided by <phase_id>.<substitute_step_id>"`
+   * per `runner-output-contract.yaml`.
    *
-   * Use `string[]` for the rare bulk case (e.g., a `bulk_setup` that
-   * substitutes for both account and event-source provisioning).
+   * Use `string[]` for the bulk case (`provides_state_for: [A, B]` is
+   * ALL-OF — one substitute pass establishes state for both A and B).
+   *
+   * Spec source: `compliance/cache/{version}/universal/storyboard-schema.yaml`
+   * (adcp#3734, AdCP 3.0.3+).
+   */
+  provides_state_for?: string | string[];
+
+  /**
+   * @deprecated Renamed to `provides_state_for` to align with the AdCP 3.0.3
+   * spec field (adcp#3734). The old name is still accepted at parse time for
+   * one minor cycle. New storyboards SHOULD use `provides_state_for`. Slated
+   * for removal in the next major.
    */
   peer_substitutes_for?: string | string[];
   /** When true, the step passes if the task returns an error */
@@ -955,7 +969,18 @@ export type RunnerSkipReason =
    * patterns" and runner-output-contract.yaml). Kept distinct from
    * `not_applicable` (coverage gap) and raw `failed` (agent misbehavior).
    */
-  | 'peer_branch_taken';
+  | 'peer_branch_taken'
+  /**
+   * A same-phase peer step declared `provides_state_for: <this_step_id>`
+   * and passed, establishing equivalent state. This step would have graded
+   * `missing_tool` or `missing_test_controller`; the substitute rescued it
+   * so downstream stateful steps can still run. Detail format per
+   * `runner-output-contract.yaml`:
+   * `"<this_step_id> state provided by <phase_id>.<substitute_step_id>"`.
+   * Kept distinct from `peer_branch_taken` (branch-set routing) and
+   * `not_applicable` (coverage gap). Spec source: adcp#3734 (AdCP 3.0.3+).
+   */
+  | 'peer_substituted';
 
 /**
  * Grader-specific skip reasons. These are narrower than the six canonical

--- a/test/lib/storyboard-cascade-skip-on-skip.test.js
+++ b/test/lib/storyboard-cascade-skip-on-skip.test.js
@@ -779,8 +779,12 @@ describe('runStoryboard: #1144 peer_substitutes_for — declared-substitute resc
     });
     const [syncStep, listStep] = result.phases[0].steps;
     const audienceStep = result.phases[1].steps[0];
-    assert.strictEqual(syncStep.skipped, true, 'sync_accounts skipped missing_tool');
-    assert.strictEqual(syncStep.skip_reason, 'missing_tool');
+    assert.strictEqual(syncStep.skipped, true, 'sync_accounts skipped after rescue');
+    // adcp-client#1267: when a substitute passes and rescues a missing_tool
+    // target, the runner re-grades the target with `peer_substituted` per the
+    // AdCP 3.0.3 spec contract (adcp#3734) — was `missing_tool` pre-#1267.
+    assert.strictEqual(syncStep.skip_reason, 'peer_substituted');
+    assert.match(syncStep.skip.detail ?? '', /sync state provided by account_setup\.list/);
     assert.strictEqual(listStep.passed, true, 'list_accounts substitute passes');
     assert.ok(!audienceStep.skipped, 'no cascade — declared substitute established state');
   });
@@ -954,8 +958,12 @@ describe('runStoryboard: #1144 peer_substitutes_for — declared-substitute resc
     });
     const [syncAcc, syncEvt, bulk] = result.phases[0].steps;
     const downstream = result.phases[1].steps[0];
-    assert.strictEqual(syncAcc.skip_reason, 'missing_tool');
-    assert.strictEqual(syncEvt.skip_reason, 'missing_tool');
+    // adcp-client#1267: bulk substitute rescues both — both targets re-graded
+    // to `peer_substituted` per AdCP 3.0.3 contract (was `missing_tool` pre-#1267).
+    assert.strictEqual(syncAcc.skip_reason, 'peer_substituted');
+    assert.strictEqual(syncEvt.skip_reason, 'peer_substituted');
+    assert.match(syncAcc.skip.detail ?? '', /sync_accounts_step state provided by setup_phase\.bulk/);
+    assert.match(syncEvt.skip.detail ?? '', /sync_event_sources_step state provided by setup_phase\.bulk/);
     assert.strictEqual(bulk.passed, true, 'bulk substitute passes');
     assert.ok(!downstream.skipped, 'no cascade — bulk substitute rescued both targets');
   });
@@ -1844,7 +1852,9 @@ describe('runStoryboard: #1161 phase.depends_on cascade scoping', () => {
     const up = result.phases[0].steps[0];
     const [syncStep, listStep] = result.phases[1].steps;
     assert.strictEqual(up.passed, true, 'upstream passed');
-    assert.strictEqual(syncStep.skip_reason, 'missing_tool', 'sync skipped missing_tool');
+    // adcp-client#1267: sync rescued by list — re-graded to peer_substituted.
+    assert.strictEqual(syncStep.skip_reason, 'peer_substituted', 'sync re-graded after rescue');
+    assert.match(syncStep.skip.detail ?? '', /sync state provided by account_setup\.list/);
     assert.strictEqual(listStep.passed, true, 'list (substitute) passed — phase 2 not cascade-tripped');
   });
 

--- a/test/lib/storyboard-provides-state-for.test.js
+++ b/test/lib/storyboard-provides-state-for.test.js
@@ -1,0 +1,140 @@
+/**
+ * Coverage for the AdCP 3.0.3 `provides_state_for` field (adcp#3734) and its
+ * deprecated `peer_substitutes_for` synonym. Both should parse identically;
+ * the loader normalizes onto both fields so consumer code reading either name
+ * keeps working. Mismatched declarations across both fields are rejected at
+ * parse time. Tracked: adcp-client#1267.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { parseStoryboard } = require('../../dist/lib/testing/storyboard/loader');
+
+function minimalStoryboard(stepLines) {
+  return [
+    'id: test_storyboard',
+    'version: "1.0"',
+    'title: Test',
+    'category: test',
+    'summary: s',
+    'narrative: n',
+    'agent:',
+    '  interaction_model: async',
+    '  capabilities: []',
+    'caller:',
+    '  role: buyer',
+    'phases:',
+    '  - id: account_setup',
+    '    title: Account setup',
+    '    steps:',
+    stepLines,
+  ].join('\n');
+}
+
+const TWO_STEPS_BASE = [
+  '      - id: sync_accounts',
+  '        title: Sync',
+  '        task: sync_accounts',
+  '        sample_request: { account_id: a }',
+  '        stateful: true',
+  '      - id: list_accounts',
+  '        title: List',
+  '        task: list_accounts',
+  '        stateful: true',
+].join('\n');
+
+describe('storyboard loader: provides_state_for / peer_substitutes_for', () => {
+  it('parses `provides_state_for` (the AdCP 3.0.3 canonical name)', () => {
+    const yamlContent = minimalStoryboard(`${TWO_STEPS_BASE}
+        provides_state_for: sync_accounts`);
+    const sb = parseStoryboard(yamlContent);
+    const list = sb.phases[0].steps.find(s => s.id === 'list_accounts');
+    assert.equal(list.provides_state_for, 'sync_accounts');
+    // Loader normalizes onto both fields so legacy reader code keeps working.
+    assert.equal(list.peer_substitutes_for, 'sync_accounts');
+  });
+
+  it('parses `peer_substitutes_for` (the deprecated synonym)', () => {
+    const yamlContent = minimalStoryboard(`${TWO_STEPS_BASE}
+        peer_substitutes_for: sync_accounts`);
+    const sb = parseStoryboard(yamlContent);
+    const list = sb.phases[0].steps.find(s => s.id === 'list_accounts');
+    assert.equal(list.peer_substitutes_for, 'sync_accounts');
+    // Loader normalizes the canonical field too so the runner's read site finds it.
+    assert.equal(list.provides_state_for, 'sync_accounts');
+  });
+
+  it('accepts both fields when they declare the same target', () => {
+    const yamlContent = minimalStoryboard(`${TWO_STEPS_BASE}
+        provides_state_for: sync_accounts
+        peer_substitutes_for: sync_accounts`);
+    const sb = parseStoryboard(yamlContent);
+    const list = sb.phases[0].steps.find(s => s.id === 'list_accounts');
+    assert.equal(list.provides_state_for, 'sync_accounts');
+    assert.equal(list.peer_substitutes_for, 'sync_accounts');
+  });
+
+  it('rejects both fields with mismatching values', () => {
+    // `sync_accounts` exists; we reuse it as the second target so the only
+    // failure mode is the mismatch — not "target step does not exist".
+    const TWO_STEPS_PLUS_THIRD = [
+      '      - id: sync_accounts',
+      '        title: Sync',
+      '        task: sync_accounts',
+      '        sample_request: { account_id: a }',
+      '        stateful: true',
+      '      - id: peer_one',
+      '        title: Peer one',
+      '        task: list_accounts',
+      '        stateful: true',
+      '      - id: list_accounts',
+      '        title: List',
+      '        task: list_accounts',
+      '        stateful: true',
+    ].join('\n');
+    const yamlContent = minimalStoryboard(`${TWO_STEPS_PLUS_THIRD}
+        provides_state_for: sync_accounts
+        peer_substitutes_for: peer_one`);
+    assert.throws(() => parseStoryboard(yamlContent), /declared with different values/);
+  });
+
+  it('rejects `provides_state_for` on a non-stateful step', () => {
+    const yamlContent = minimalStoryboard(`      - id: sync_accounts
+        title: Sync
+        task: sync_accounts
+        sample_request: { account_id: a }
+        stateful: true
+      - id: list_accounts
+        title: List
+        task: list_accounts
+        provides_state_for: sync_accounts`);
+    assert.throws(() => parseStoryboard(yamlContent), /only legal on stateful steps/);
+  });
+
+  it('rejects `provides_state_for` referencing a non-stateful target', () => {
+    const yamlContent = minimalStoryboard(`      - id: sync_accounts
+        title: Sync
+        task: sync_accounts
+        sample_request: { account_id: a }
+      - id: list_accounts
+        title: List
+        task: list_accounts
+        stateful: true
+        provides_state_for: sync_accounts`);
+    assert.throws(() => parseStoryboard(yamlContent), /must be stateful/);
+  });
+
+  it('rejects self-reference', () => {
+    const yamlContent = minimalStoryboard(`      - id: sync_accounts
+        title: Sync
+        task: sync_accounts
+        sample_request: { account_id: a }
+        stateful: true
+      - id: list_accounts
+        title: List
+        task: list_accounts
+        stateful: true
+        provides_state_for: list_accounts`);
+    assert.throws(() => parseStoryboard(yamlContent), /cannot reference itself/);
+  });
+});


### PR DESCRIPTION
## Summary

AdCP 3.0.3 (adcp#3734) introduced `provides_state_for: <step_id> | <step_id>[]` as a canonical field on storyboard steps. The SDK already implemented the rescue mechanism in 6.4.1 (#1144) under the legacy name `peer_substitutes_for`. This PR aligns the SDK with the spec's field name and skip-reason contract.

## Changes

### Field migration

`provides_state_for` is now the canonical field on `StoryboardStep`. `peer_substitutes_for` is retained as a `@deprecated` synonym for one minor cycle so existing storyboards keep parsing. Both names normalize at parse time; the runner reads `provides_state_for ?? peer_substitutes_for`.

```yaml
# 3.0.3+ canonical:
- id: list_accounts
  stateful: true
  provides_state_for: sync_accounts

# Legacy (still accepted, deprecated):
- id: list_accounts
  stateful: true
  peer_substitutes_for: sync_accounts
```

### Loader validation

Works on whichever field is declared. If both are declared with different values, the loader rejects (the deprecation contract is "synonym for", not "additive with"). All same-phase / both-stateful / acyclic / no-self-reference rules apply identically.

### New skip reason

`RunnerSkipReason` adds `peer_substituted`, distinct from:
- `peer_branch_taken` — branch-set routing (one of two `any_of` branches)
- `not_applicable` — coverage gap (path doesn't apply to this agent)

### Runner re-grading

When a deferred `missing_tool` / `missing_test_controller` skip is rescued by a passing same-phase substitute, the runner re-grades the target step result from the original hard-missing-state reason to `peer_substituted` with the spec detail string:

```
"<target_step_id> state provided by <phase_id>.<substitute_step_id>"
```

Previously the target kept its original `missing_tool` grade — misleading because state DID materialize via the substitute path.

## Operational impact

`sales-social` explicit-mode platforms (Snap, Meta, TikTok) that pre-provision advertiser accounts out-of-band — and declare `provides_state_for: sync_accounts` on their `list_accounts` step per the 3.0.3 storyboard — graduate from `1/9/0` to `9/10` once their compliance cache refreshes against AdCP 3.0.3+.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 2724 existing storyboard tests pass (no regressions)
- [x] Field-alias parsing tested via existing `peer_substitutes_for` integration tests
- [ ] CI green

## Related

- Closes #1267
- Builds on #1144 / 6.4.1 (cascade-skip plumbing this extends)
- Builds on #1266 (3.0.4 bump that brought the spec field into the cache)
- adcp#3734 (upstream feature issue)
- adcp#3775 (upstream PR adding the field to the 3.0.x line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)