### PR TITLE
feat(server): BuyerAgentRegistry Phase 1 Stage 1 — types + factories (#1269)

### DIFF
--- a/.changeset/buyer-agent-registry-stage-1.md
+++ b/.changeset/buyer-agent-registry-stage-1.md
@@ -1,0 +1,19 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): BuyerAgentRegistry — Phase 1 Stage 1 (types + factories)
+
+Phase 1 Stage 1 of #1269: durable buyer-agent identity surface, ships in 3.0.x with no wire-emission.
+
+Adds `BuyerAgent`, `BuyerAgentRegistry`, `AdcpCredential`, `BuyerAgentStatus`, and `BuyerAgentBillingMode` exported from `@adcp/sdk/server`. Three factory functions encode the implementer posture at construction:
+
+- `BuyerAgentRegistry.signingOnly({ resolveByAgentUrl })` — production target. Bearer/API-key/OAuth credentials resolve to `null`; only `kind: 'http_sig'` credentials route through `resolveByAgentUrl`.
+- `BuyerAgentRegistry.bearerOnly({ resolveByCredential })` — pre-trust beta. All credentials route through the adopter's mapping; signed credentials are not pre-filtered.
+- `BuyerAgentRegistry.mixed({ resolveByAgentUrl, resolveByCredential })` — transition posture. `kind: 'http_sig'` routes to `resolveByAgentUrl`; bearer/OAuth/api-key routes to `resolveByCredential`. Signed path is preferred when both are present.
+
+`BuyerAgent` carries `readonly` fields for `agent_url`, `display_name`, `status`, set-valued `billing_capabilities`, optional `default_account_terms`, optional `allowed_brands`, and optional `aliases` (rotation grace-period reservation, no special framework behavior in v1).
+
+This stage adds the types and factory functions only. Framework integration (resolve seam, `ctx.agent` threading), the `ResolvedAuthInfo` migration shim, status enforcement, multi-credential conflict resolution, credential redaction, and the caching decorator land in subsequent stages of #1269.
+
+Phase 2 (#1292) — framework-level `billing_capability` enforcement and emission of the `BILLING_NOT_PERMITTED_FOR_AGENT` / `BILLING_NOT_SUPPORTED` codes registered in adcontextprotocol/adcp#3831 — is gated on the SDK's 3.1 cutover.

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -1,0 +1,354 @@
+/**
+ * Buyer-agent identity surface — Phase 1 of #1269.
+ *
+ * Models a buyer agent (the buying entity calling a seller) as a durable
+ * commercial relationship in the seller's records, distinct from the
+ * per-request credential that proves identity. The seller's `BuyerAgent`
+ * record carries onboarding state (status, billing capabilities, default
+ * account terms, allowed brands) that drives commercial behavior.
+ *
+ * The credential answers "who signed?" / "who holds this token?" The
+ * `BuyerAgent` answers "who is this counterparty in our books?" — analogous
+ * to how an SSP has a `buyer_id` row keyed to a DSP regardless of whether
+ * the DSP authenticates via OAuth, signed requests, or a pre-shared API
+ * key. Token proves identity; row drives commercial behavior.
+ *
+ * **Phase 1 scope.** This module ships in 3.0.x with the durable identity
+ * shape. Framework-level billing-capability enforcement and the new error
+ * codes from adcontextprotocol/adcp#3831 land in Phase 2 (#1292), gated on
+ * the SDK's 3.1 cutover.
+ *
+ * @public
+ */
+
+import type { BillingParty, BusinessEntity, PaymentTerms } from '../../types/tools.generated';
+
+/**
+ * Wire billing-party enum re-exported here for the registry surface.
+ * Aliased to `BillingMode` in design discussion (#1269); `BillingParty` is
+ * the canonical wire-schema name.
+ *
+ * @public
+ */
+export type BuyerAgentBillingMode = BillingParty;
+
+/**
+ * Kind-discriminated credential variant on `ResolvedAuthInfo.credential`.
+ *
+ * `kind: 'http_sig'` is cryptographically verified — `agent_url` derives
+ * from the `agents[]` entry whose `jwks_uri` resolved the keyid (per
+ * adcontextprotocol/adcp#3831), NOT from JWK / JWS / envelope claims.
+ * Security-relevant decisions (mutating-tool authorization, brand-side
+ * authorization checks once `BrandAuthorizationResolver` lands) MUST read
+ * `agent_url` from this variant, not from any informational field elsewhere
+ * on `ResolvedAuthInfo`.
+ *
+ * `kind: 'api_key'` and `kind: 'oauth'` carry no `agent_url` on the
+ * credential — the agent identity comes from the registry's
+ * `resolveByCredential` lookup against the seller's onboarding record.
+ *
+ * @public
+ */
+export type AdcpCredential =
+  | { readonly kind: 'api_key'; readonly key_id: string }
+  | {
+      readonly kind: 'oauth';
+      readonly client_id: string;
+      readonly scopes: readonly string[];
+      readonly expires_at?: number;
+    }
+  | { readonly kind: 'http_sig'; readonly keyid: string; readonly agent_url: string; readonly verified_at: number };
+
+/**
+ * Status of a buyer-agent record. Drives framework-level request gating:
+ *
+ * - `'active'` — normal operation; requests dispatch.
+ * - `'suspended'` — temporarily paused; new requests rejected with
+ *   `PERMISSION_DENIED` and `error.details.scope: 'agent'`. In-flight tasks
+ *   are NOT retroactively cancelled — webhooks fire, status updates flow.
+ *   Sellers who need hard cutoff implement that in their platform method
+ *   via `BuyerAgent.status` check.
+ * - `'blocked'` — permanently denied; new requests rejected the same way as
+ *   `'suspended'`. Recovery requires re-onboarding.
+ *
+ * Phase 1 emits `PERMISSION_DENIED + scope:'agent'` for both rejection
+ * states. Phase 2 (#1292) may swap to upstream `AGENT_SUSPENDED` /
+ * `AGENT_BLOCKED` codes if those land via separate spec PR.
+ *
+ * @public
+ */
+export type BuyerAgentStatus = 'active' | 'suspended' | 'blocked';
+
+/**
+ * Buyer-agent record — durable commercial relationship in the seller's
+ * onboarding ledger. Returned by `BuyerAgentRegistry.resolve` and threaded
+ * to handlers via `ctx.agent`.
+ *
+ * Fields are `readonly` to prevent post-resolution mutation that would
+ * silently affect downstream `accounts.resolve` decisions. Mirrors the
+ * Python frozen-dataclass shape for cross-language parity.
+ *
+ * @public
+ */
+export interface BuyerAgent {
+  /**
+   * Canonical agent URL. Treat like a public key: stable enough that
+   * rotation requires explicit re-onboarding. The framework's signed-path
+   * resolution checks both this canonical URL and any `aliases[]` against
+   * the verified `credential.agent_url`. No separate seller-internal id —
+   * adopters who want one mint it in their own DB and key off `agent_url`.
+   */
+  readonly agent_url: string;
+
+  /** Human-readable name for ops / reporting / UI. */
+  readonly display_name: string;
+
+  /** See {@link BuyerAgentStatus}. */
+  readonly status: BuyerAgentStatus;
+
+  /**
+   * Billing models this agent is permitted to request on `sync_accounts`.
+   * Set-valued so real-world models (mixed-billing holdco with both direct
+   * and agency-mediated brands) can be expressed without picking one mode.
+   *
+   * Migration from earlier single-enum sketches:
+   * - `passthrough_only` ↔ `new Set(['operator'])`
+   * - `agent_billable` ↔ `new Set(['agent', 'operator', 'advertiser'])`
+   *
+   * Phase 1 does not enforce — adopters who want enforcement implement it
+   * adopter-side. Phase 2 (#1292) wires framework-level enforcement to the
+   * `BILLING_NOT_PERMITTED_FOR_AGENT` code from adcp#3831 once the SDK
+   * pin moves to AdCP 3.1.
+   */
+  readonly billing_capabilities: ReadonlySet<BuyerAgentBillingMode>;
+
+  /**
+   * Commercial defaults applied when accounts are provisioned under this
+   * agent. Framework merges with per-request overrides on a SPARSE-MERGE
+   * basis: per-request values win for any present field including explicit
+   * `null`. The request is the authoritative current intent; defaults are
+   * seeds for fields the buyer didn't speak to. Adopters who want
+   * non-null-override semantics pre-filter nulls themselves.
+   */
+  readonly default_account_terms?: {
+    readonly rate_card?: string;
+    readonly payment_terms?: PaymentTerms;
+    readonly credit_limit?: { readonly amount: number; readonly currency: string };
+    readonly billing_entity?: BusinessEntity;
+  };
+
+  /**
+   * Static allowlist of brand domains this agent may act for. Pre-RFC
+   * stand-in for the per-request authorization check that
+   * `BrandAuthorizationResolver` will perform once it lands (gated on
+   * Python's RFC + adcp brand-side authz spec finalizing).
+   *
+   * When both this list and `BrandAuthorizationResolver` are configured,
+   * the framework AND-composes them: registry says "we accept this agent
+   * at all"; resolver says "and they're authorized for THIS brand." One-
+   * minor deprecation cycle starts the release after
+   * `BrandAuthorizationResolver` ships; sellers who want the static gate
+   * gone stop populating the field.
+   */
+  readonly allowed_brands?: readonly string[];
+
+  /**
+   * Optional grace-period overlap during `agent_url` rotation. Framework's
+   * signed-path resolution checks both canonical `agent_url` AND `aliases`
+   * against the `agents[]` entry that resolved the verified keyid.
+   *
+   * v1 ships with the field present but no special framework behavior
+   * beyond resolution; v1.5 adds the documented sunset window pattern.
+   * Most adopters never populate this.
+   */
+  readonly aliases?: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Registry Protocol + factory functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal `ResolvedAuthInfo`-shaped argument to `BuyerAgentRegistry.resolve`.
+ * Defined here to break a circular dependency with `account.ts` and to keep
+ * the registry surface decoupled from the legacy `ResolvedAuthInfo` shape
+ * during the two-minor migration cycle.
+ *
+ * Stage 3 of the implementation will widen `ResolvedAuthInfo` itself with
+ * the `credential` field; this interface is the registry-side contract.
+ *
+ * @public
+ */
+export interface BuyerAgentResolveInput {
+  /**
+   * The kind-discriminated credential proven on the request. When absent
+   * (legacy adopters whose `authenticate()` returns the pre-migration
+   * shape), the registry falls back to a synthesized `oauth`-shaped
+   * credential built from the legacy `clientId` / `scopes` / `token` / etc.
+   */
+  readonly credential?: AdcpCredential;
+
+  /** Adopter-provided extension data threaded from `authenticate()`. */
+  readonly extra?: Record<string, unknown>;
+}
+
+/**
+ * Buyer-agent registry — durable identity surface called once per request
+ * before `accounts.resolve`. Adopters construct via one of the factory
+ * functions; the resulting object exposes a single `resolve` method the
+ * framework dispatcher invokes.
+ *
+ * Three implementer postures, encoded at construction:
+ *
+ * - {@link signingOnly} — production target. Bearer/API-key/OAuth requests
+ *   refused at the registry layer; signed requests resolve via
+ *   `resolveByAgentUrl` against the verified `credential.agent_url`.
+ * - {@link bearerOnly} — pre-trust beta. No signature support; bearer-shaped
+ *   credentials resolve via `resolveByCredential` against the seller's
+ *   onboarding ledger.
+ * - {@link mixed} — transition. Both paths active. Signed traffic resolves
+ *   cryptographically; bearer falls through to the legacy key table.
+ *
+ * The factories produce a `BuyerAgentRegistry` whose `resolve` method
+ * routes by `credential.kind` and returns `null` when the credential is
+ * not honored by the configured posture (e.g., bearer credential against
+ * a `signingOnly` registry → `null`, framework rejects the request).
+ *
+ * @public
+ */
+export interface BuyerAgentRegistry {
+  /**
+   * Resolve a request's credential to a buyer-agent record.
+   *
+   * Returns `null` when the credential is not recognized OR when the
+   * configured posture rejects the credential's kind (e.g., `bearerOnly`
+   * registry receiving an `http_sig` credential).
+   *
+   * Throws when the underlying lookup fails (DB outage, identity-provider
+   * 5xx). Framework projects the throw to `SERVICE_UNAVAILABLE` so the
+   * buyer can retry; the inner error is logged server-side.
+   */
+  resolve(authInfo: BuyerAgentResolveInput): Promise<BuyerAgent | null>;
+}
+
+/**
+ * Resolver function type for the signed path. Receives the
+ * cryptographically-verified `agent_url` from the request signature and
+ * returns the seller's record (or `null` for unrecognized agents).
+ *
+ * @public
+ */
+export type ResolveBuyerAgentByAgentUrl = (agent_url: string) => Promise<BuyerAgent | null>;
+
+/**
+ * Resolver function type for the bearer/API-key/OAuth path. Receives the
+ * raw credential and returns the seller's record (or `null` for
+ * unrecognized credentials).
+ *
+ * **Credential exposure.** This callback receives unredacted credential
+ * payloads (token, key_id, client_id). Adopters MUST NOT log raw credential
+ * values. The framework redacts credential payloads in any log line emitted
+ * from registry-resolution code; adopter implementations are expected to
+ * do the same (or to use prepared-statement parameters that don't log).
+ *
+ * @public
+ */
+export type ResolveBuyerAgentByCredential = (credential: AdcpCredential) => Promise<BuyerAgent | null>;
+
+/**
+ * Construct a signing-only `BuyerAgentRegistry`. Bearer/API-key/OAuth
+ * requests resolve to `null` (framework rejects); only signed requests
+ * are honored.
+ *
+ * The path-of-least-resistance factory for production sellers — implement
+ * one resolver, traffic that doesn't sign is automatically refused.
+ *
+ * @public
+ */
+export function signingOnly(opts: { resolveByAgentUrl: ResolveBuyerAgentByAgentUrl }): BuyerAgentRegistry {
+  if (typeof opts.resolveByAgentUrl !== 'function') {
+    throw new TypeError('BuyerAgentRegistry.signingOnly: resolveByAgentUrl must be a function');
+  }
+  const resolveByAgentUrl = opts.resolveByAgentUrl;
+  return {
+    async resolve(authInfo) {
+      const credential = authInfo.credential;
+      if (credential === undefined || credential.kind !== 'http_sig') return null;
+      return resolveByAgentUrl(credential.agent_url);
+    },
+  };
+}
+
+/**
+ * Construct a bearer-only `BuyerAgentRegistry`. Signed requests still
+ * authenticate via the existing signature-verifier surface, but the
+ * registry resolves all credential kinds via `resolveByCredential` against
+ * the seller's onboarding ledger — useful in pre-trust-beta deployments
+ * where the seller maintains a credential→agent table out-of-band.
+ *
+ * @public
+ */
+export function bearerOnly(opts: { resolveByCredential: ResolveBuyerAgentByCredential }): BuyerAgentRegistry {
+  if (typeof opts.resolveByCredential !== 'function') {
+    throw new TypeError('BuyerAgentRegistry.bearerOnly: resolveByCredential must be a function');
+  }
+  const resolveByCredential = opts.resolveByCredential;
+  return {
+    async resolve(authInfo) {
+      const credential = authInfo.credential;
+      if (credential === undefined) return null;
+      return resolveByCredential(credential);
+    },
+  };
+}
+
+/**
+ * Construct a mixed-mode `BuyerAgentRegistry` that supports both signed and
+ * bearer/OAuth/API-key credentials. Signed traffic resolves through
+ * `resolveByAgentUrl` against the verified `credential.agent_url`; non-
+ * signed credentials fall through to `resolveByCredential`.
+ *
+ * Framework prefers the signed path: when both an `Authorization: Bearer`
+ * and a valid `Signature: ...` are present on the same request, the
+ * `http_sig` credential variant is what reaches `resolve`, and only
+ * `resolveByAgentUrl` is invoked. The bearer path is never consulted on
+ * signed traffic.
+ *
+ * @public
+ */
+export function mixed(opts: {
+  resolveByAgentUrl: ResolveBuyerAgentByAgentUrl;
+  resolveByCredential: ResolveBuyerAgentByCredential;
+}): BuyerAgentRegistry {
+  if (typeof opts.resolveByAgentUrl !== 'function') {
+    throw new TypeError('BuyerAgentRegistry.mixed: resolveByAgentUrl must be a function');
+  }
+  if (typeof opts.resolveByCredential !== 'function') {
+    throw new TypeError('BuyerAgentRegistry.mixed: resolveByCredential must be a function');
+  }
+  const resolveByAgentUrl = opts.resolveByAgentUrl;
+  const resolveByCredential = opts.resolveByCredential;
+  return {
+    async resolve(authInfo) {
+      const credential = authInfo.credential;
+      if (credential === undefined) return null;
+      if (credential.kind === 'http_sig') {
+        return resolveByAgentUrl(credential.agent_url);
+      }
+      return resolveByCredential(credential);
+    },
+  };
+}
+
+/**
+ * Factory namespace mirroring the documented surface from #1269. Adopters
+ * import the namespace and call `BuyerAgentRegistry.signingOnly({...})`,
+ * etc. Individual functions are also exported above for direct use.
+ *
+ * @public
+ */
+export const BuyerAgentRegistry = {
+  signingOnly,
+  bearerOnly,
+  mixed,
+};

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -181,10 +181,14 @@ export interface BuyerAgent {
  */
 export interface BuyerAgentResolveInput {
   /**
-   * The kind-discriminated credential proven on the request. When absent
-   * (legacy adopters whose `authenticate()` returns the pre-migration
-   * shape), the registry falls back to a synthesized `oauth`-shaped
-   * credential built from the legacy `clientId` / `scopes` / `token` / etc.
+   * The kind-discriminated credential proven on the request. Stage 3 of
+   * the Phase 1 implementation will populate this from the verifier
+   * (`http_sig`) or from the legacy `ResolvedAuthInfo` shape (`api_key` /
+   * `oauth`); until then, callers pass it through directly when available.
+   *
+   * When absent, the registry's `resolve` returns `null` — the legacy-
+   * shape synthesis lands in Stage 3 alongside the `ResolvedAuthInfo`
+   * migration shim, not Stage 1.
    */
   readonly credential?: AdcpCredential;
 
@@ -245,15 +249,35 @@ export type ResolveBuyerAgentByAgentUrl = (agent_url: string) => Promise<BuyerAg
  * raw credential and returns the seller's record (or `null` for
  * unrecognized credentials).
  *
+ * **Implementations MUST switch on `credential.kind`** and reject (return
+ * `null`) on any kind they don't explicitly recognize. A naive
+ * `WHERE token = $1` lookup against an api-key table would otherwise mis-
+ * resolve when handed an `http_sig` credential whose `keyid` happens to
+ * collide with an existing api-key value — the credential variants share
+ * no key namespace, and the registry MUST NOT bridge them.
+ *
  * **Credential exposure.** This callback receives unredacted credential
  * payloads (token, key_id, client_id). Adopters MUST NOT log raw credential
  * values. The framework redacts credential payloads in any log line emitted
- * from registry-resolution code; adopter implementations are expected to
- * do the same (or to use prepared-statement parameters that don't log).
+ * from registry-resolution code (Stage 4); adopter implementations are
+ * expected to do the same (or to use prepared-statement parameters that
+ * don't log).
  *
  * @public
  */
 export type ResolveBuyerAgentByCredential = (credential: AdcpCredential) => Promise<BuyerAgent | null>;
+
+/**
+ * Belt-and-suspenders check that an `http_sig` credential carries a non-
+ * empty `agent_url`. A misbehaving authenticator could produce `kind:
+ * 'http_sig'` without populating the verified URL — without this guard, the
+ * registry would pass `undefined` (or `''`) to the adopter's resolver and
+ * silently get back `null`. Caller is responsible for the kind dispatch;
+ * this function only validates the http_sig payload shape.
+ */
+function isVerifiedHttpSigPayload(credential: { agent_url?: string }): credential is { agent_url: string } {
+  return typeof credential.agent_url === 'string' && credential.agent_url.length > 0;
+}
 
 /**
  * Construct a signing-only `BuyerAgentRegistry`. Bearer/API-key/OAuth
@@ -274,6 +298,7 @@ export function signingOnly(opts: { resolveByAgentUrl: ResolveBuyerAgentByAgentU
     async resolve(authInfo) {
       const credential = authInfo.credential;
       if (credential === undefined || credential.kind !== 'http_sig') return null;
+      if (!isVerifiedHttpSigPayload(credential)) return null;
       return resolveByAgentUrl(credential.agent_url);
     },
   };
@@ -333,6 +358,12 @@ export function mixed(opts: {
       const credential = authInfo.credential;
       if (credential === undefined) return null;
       if (credential.kind === 'http_sig') {
+        // Reject a malformed `http_sig` credential here rather than falling
+        // through to resolveByCredential. Otherwise `mixed` would be strictly
+        // weaker than signingOnly: an authenticator that produces an
+        // http_sig-shaped credential without a verified agent_url could
+        // bypass signed-path enforcement by routing through the bearer table.
+        if (!isVerifiedHttpSigPayload(credential)) return null;
         return resolveByAgentUrl(credential.agent_url);
       }
       return resolveByCredential(credential);

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -92,6 +92,25 @@ export type {
 
 export { AccountNotFoundError, refAccountId } from './account';
 
+// Buyer-agent identity surface — Phase 1 of #1269. Durable commercial
+// relationship records keyed off the request credential. Factory-pattern
+// registry (signing-only / bearer-only / mixed) encodes the implementer
+// posture at construction; framework calls `BuyerAgentRegistry.resolve`
+// once per request before `accounts.resolve`. Phase 1 ships the shape and
+// resolution; framework-level billing-capability enforcement and the
+// AdCP-3.1 error-code emission land in Phase 2 (#1292).
+export type {
+  BuyerAgent,
+  BuyerAgentBillingMode,
+  BuyerAgentStatus,
+  BuyerAgentRegistry as BuyerAgentRegistryProtocol,
+  BuyerAgentResolveInput,
+  AdcpCredential,
+  ResolveBuyerAgentByAgentUrl,
+  ResolveBuyerAgentByCredential,
+} from './buyer-agent';
+export { BuyerAgentRegistry } from './buyer-agent';
+
 // Native status mapping
 export type { StatusMappers, AdcpMediaBuyStatus, AdcpCreativeStatus, AdcpPlanStatus } from './status-mappers';
 export { identityStatusMappers } from './status-mappers';

--- a/test/lib/buyer-agent-registry.test.js
+++ b/test/lib/buyer-agent-registry.test.js
@@ -96,6 +96,38 @@ describe('BuyerAgentRegistry.signingOnly', () => {
     });
     await assert.rejects(registry.resolve({ credential: sigCredential() }), /upstream DB outage/);
   });
+
+  it('rejects malformed http_sig credentials (missing agent_url)', async () => {
+    let invoked = false;
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        invoked = true;
+        return sampleAgent();
+      },
+    });
+    // A misbehaving authenticator could produce kind: 'http_sig' without
+    // populating agent_url. Without the runtime guard, the registry would
+    // silently pass `undefined` to the resolver and the underlying DB
+    // query would return null — a quiet shape failure.
+    const result = await registry.resolve({
+      credential: { kind: 'http_sig', keyid: 'kid-1', verified_at: 1 },
+    });
+    assert.equal(result, null);
+    assert.equal(invoked, false);
+  });
+
+  it('rejects http_sig credentials with empty agent_url', async () => {
+    let invoked = false;
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        invoked = true;
+        return sampleAgent();
+      },
+    });
+    const result = await registry.resolve({ credential: sigCredential({ agent_url: '' }) });
+    assert.equal(result, null);
+    assert.equal(invoked, false);
+  });
 });
 
 describe('BuyerAgentRegistry.bearerOnly', () => {
@@ -224,6 +256,31 @@ describe('BuyerAgentRegistry.mixed', () => {
       () => BuyerAgentRegistry.mixed({ resolveByCredential: async () => null }),
       /resolveByAgentUrl must be a function/
     );
+  });
+
+  it('rejects malformed http_sig credentials without falling through to resolveByCredential', async () => {
+    // Defense against authenticator bugs: a malformed http_sig credential
+    // must not bypass signed-path enforcement by routing through the bearer
+    // table. mixed registry's malformed-http_sig handling matches
+    // signingOnly's (return null), not bearerOnly's (would let it through).
+    let signedInvoked = false;
+    let bearerInvoked = false;
+    const registry = BuyerAgentRegistry.mixed({
+      resolveByAgentUrl: async () => {
+        signedInvoked = true;
+        return sampleAgent();
+      },
+      resolveByCredential: async () => {
+        bearerInvoked = true;
+        return sampleAgent();
+      },
+    });
+    const result = await registry.resolve({
+      credential: { kind: 'http_sig', keyid: 'kid-1', verified_at: 1 },
+    });
+    assert.equal(result, null);
+    assert.equal(signedInvoked, false);
+    assert.equal(bearerInvoked, false, 'malformed http_sig must NOT fall through to the bearer path');
   });
 });
 

--- a/test/lib/buyer-agent-registry.test.js
+++ b/test/lib/buyer-agent-registry.test.js
@@ -1,0 +1,260 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { BuyerAgentRegistry } = require('../../dist/lib/server/decisioning/buyer-agent');
+
+const sampleAgent = (overrides = {}) => ({
+  agent_url: 'https://agent.scope3.com',
+  display_name: 'Scope3',
+  status: 'active',
+  billing_capabilities: new Set(['operator']),
+  ...overrides,
+});
+
+const sigCredential = (overrides = {}) => ({
+  kind: 'http_sig',
+  keyid: 'scope3-2026-01',
+  agent_url: 'https://agent.scope3.com',
+  verified_at: 1714660000,
+  ...overrides,
+});
+
+const apiKeyCredential = (overrides = {}) => ({
+  kind: 'api_key',
+  key_id: 'sk_live_abc',
+  ...overrides,
+});
+
+const oauthCredential = (overrides = {}) => ({
+  kind: 'oauth',
+  client_id: 'oauth_client_xyz',
+  scopes: ['adcp:read', 'adcp:write'],
+  ...overrides,
+});
+
+describe('BuyerAgentRegistry.signingOnly', () => {
+  it('routes http_sig credentials to resolveByAgentUrl', async () => {
+    let sawArg;
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        sawArg = url;
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const result = await registry.resolve({ credential: sigCredential() });
+    assert.equal(sawArg, 'https://agent.scope3.com');
+    assert.equal(result.agent_url, 'https://agent.scope3.com');
+  });
+
+  it('returns null for api_key credentials (does not invoke resolver)', async () => {
+    let invoked = false;
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        invoked = true;
+        return sampleAgent();
+      },
+    });
+    const result = await registry.resolve({ credential: apiKeyCredential() });
+    assert.equal(result, null);
+    assert.equal(invoked, false, 'resolveByAgentUrl must not be invoked for non-http_sig credentials');
+  });
+
+  it('returns null for oauth credentials', async () => {
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => sampleAgent(),
+    });
+    const result = await registry.resolve({ credential: oauthCredential() });
+    assert.equal(result, null);
+  });
+
+  it('returns null when credential is absent', async () => {
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => sampleAgent(),
+    });
+    const result = await registry.resolve({});
+    assert.equal(result, null);
+  });
+
+  it('throws at construction when resolveByAgentUrl is not a function', () => {
+    assert.throws(
+      () => BuyerAgentRegistry.signingOnly({ resolveByAgentUrl: undefined }),
+      /resolveByAgentUrl must be a function/
+    );
+    assert.throws(
+      () => BuyerAgentRegistry.signingOnly({ resolveByAgentUrl: 'not-a-function' }),
+      /resolveByAgentUrl must be a function/
+    );
+  });
+
+  it('propagates resolver throws (framework projects to SERVICE_UNAVAILABLE upstream)', async () => {
+    const registry = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        throw new Error('upstream DB outage');
+      },
+    });
+    await assert.rejects(registry.resolve({ credential: sigCredential() }), /upstream DB outage/);
+  });
+});
+
+describe('BuyerAgentRegistry.bearerOnly', () => {
+  it('routes api_key credentials to resolveByCredential', async () => {
+    let sawArg;
+    const registry = BuyerAgentRegistry.bearerOnly({
+      resolveByCredential: async cred => {
+        sawArg = cred;
+        return sampleAgent();
+      },
+    });
+    await registry.resolve({ credential: apiKeyCredential() });
+    assert.equal(sawArg.kind, 'api_key');
+    assert.equal(sawArg.key_id, 'sk_live_abc');
+  });
+
+  it('routes oauth credentials to resolveByCredential', async () => {
+    let sawArg;
+    const registry = BuyerAgentRegistry.bearerOnly({
+      resolveByCredential: async cred => {
+        sawArg = cred;
+        return sampleAgent();
+      },
+    });
+    await registry.resolve({ credential: oauthCredential() });
+    assert.equal(sawArg.kind, 'oauth');
+    assert.equal(sawArg.client_id, 'oauth_client_xyz');
+  });
+
+  it('also routes http_sig credentials to resolveByCredential (bearer-only does not refuse signed)', async () => {
+    // bearerOnly is the "I trust adopter mapping for any credential kind"
+    // posture — it doesn't pre-filter http_sig away. The adopter's
+    // resolveByCredential decides what to do with each kind.
+    let sawKind;
+    const registry = BuyerAgentRegistry.bearerOnly({
+      resolveByCredential: async cred => {
+        sawKind = cred.kind;
+        return sampleAgent();
+      },
+    });
+    await registry.resolve({ credential: sigCredential() });
+    assert.equal(sawKind, 'http_sig');
+  });
+
+  it('returns null when credential is absent', async () => {
+    const registry = BuyerAgentRegistry.bearerOnly({
+      resolveByCredential: async () => sampleAgent(),
+    });
+    const result = await registry.resolve({});
+    assert.equal(result, null);
+  });
+
+  it('throws at construction when resolveByCredential is not a function', () => {
+    assert.throws(
+      () => BuyerAgentRegistry.bearerOnly({ resolveByCredential: undefined }),
+      /resolveByCredential must be a function/
+    );
+  });
+});
+
+describe('BuyerAgentRegistry.mixed', () => {
+  it('routes http_sig credentials to resolveByAgentUrl (signed path)', async () => {
+    let sawSignedArg;
+    let bearerInvoked = false;
+    const registry = BuyerAgentRegistry.mixed({
+      resolveByAgentUrl: async url => {
+        sawSignedArg = url;
+        return sampleAgent();
+      },
+      resolveByCredential: async () => {
+        bearerInvoked = true;
+        return sampleAgent();
+      },
+    });
+    await registry.resolve({ credential: sigCredential() });
+    assert.equal(sawSignedArg, 'https://agent.scope3.com');
+    assert.equal(bearerInvoked, false, 'mixed registry must NOT invoke resolveByCredential when http_sig is present');
+  });
+
+  it('routes api_key credentials to resolveByCredential', async () => {
+    let signedInvoked = false;
+    let sawCred;
+    const registry = BuyerAgentRegistry.mixed({
+      resolveByAgentUrl: async () => {
+        signedInvoked = true;
+        return sampleAgent();
+      },
+      resolveByCredential: async cred => {
+        sawCred = cred;
+        return sampleAgent();
+      },
+    });
+    await registry.resolve({ credential: apiKeyCredential() });
+    assert.equal(signedInvoked, false);
+    assert.equal(sawCred.kind, 'api_key');
+  });
+
+  it('routes oauth credentials to resolveByCredential', async () => {
+    let sawCred;
+    const registry = BuyerAgentRegistry.mixed({
+      resolveByAgentUrl: async () => null,
+      resolveByCredential: async cred => {
+        sawCred = cred;
+        return sampleAgent();
+      },
+    });
+    await registry.resolve({ credential: oauthCredential() });
+    assert.equal(sawCred.kind, 'oauth');
+  });
+
+  it('returns null when credential is absent', async () => {
+    const registry = BuyerAgentRegistry.mixed({
+      resolveByAgentUrl: async () => sampleAgent(),
+      resolveByCredential: async () => sampleAgent(),
+    });
+    const result = await registry.resolve({});
+    assert.equal(result, null);
+  });
+
+  it('throws at construction when either resolver is missing', () => {
+    assert.throws(
+      () => BuyerAgentRegistry.mixed({ resolveByAgentUrl: async () => null }),
+      /resolveByCredential must be a function/
+    );
+    assert.throws(
+      () => BuyerAgentRegistry.mixed({ resolveByCredential: async () => null }),
+      /resolveByAgentUrl must be a function/
+    );
+  });
+});
+
+describe('BuyerAgent shape', () => {
+  it('readonly contract preserved through Object.freeze (deep-frozen agent survives serialization)', () => {
+    const agent = Object.freeze({
+      agent_url: 'https://agent.scope3.com',
+      display_name: 'Scope3',
+      status: 'active',
+      billing_capabilities: new Set(['operator', 'agent']),
+    });
+    // Object.freeze doesn't deep-freeze; the test asserts the registry
+    // doesn't *require* mutation of the returned record (the readonly
+    // contract is enforced at the type level, not at runtime).
+    const round = JSON.parse(JSON.stringify({ ...agent, billing_capabilities: [...agent.billing_capabilities] }));
+    assert.equal(round.agent_url, 'https://agent.scope3.com');
+    assert.deepEqual(round.billing_capabilities, ['operator', 'agent']);
+  });
+
+  it('billing_capabilities Set membership semantics work (Phase 2 will check this)', () => {
+    const caps = new Set(['operator']);
+    assert.equal(caps.has('operator'), true);
+    assert.equal(caps.has('agent'), false);
+    assert.equal(caps.has('advertiser'), false);
+  });
+});
+
+describe('BuyerAgentRegistry namespace', () => {
+  it('exposes signingOnly, bearerOnly, mixed', () => {
+    assert.equal(typeof BuyerAgentRegistry.signingOnly, 'function');
+    assert.equal(typeof BuyerAgentRegistry.bearerOnly, 'function');
+    assert.equal(typeof BuyerAgentRegistry.mixed, 'function');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 Stage 1 of #1269 — durable buyer-agent identity surface, types and factory functions only. Pure additive, no runtime wiring; later stages thread the registry through the dispatcher.

## What's in

- `BuyerAgent` interface with `readonly` fields, set-valued `billing_capabilities`, optional `default_account_terms`, `allowed_brands`, `aliases` (rotation reservation).
- `AdcpCredential` discriminated union — `kind: 'api_key' | 'oauth' | 'http_sig'`. The `http_sig` variant carries the cryptographically-verified `agent_url` (per adcontextprotocol/adcp#3831's derivation rule); the bearer variants don't.
- `BuyerAgentStatus` (`'active' | 'suspended' | 'blocked'`) and `BuyerAgentBillingMode` (re-export of wire `BillingParty`).
- `BuyerAgentRegistry` Protocol + three factory functions:
  - `signingOnly({ resolveByAgentUrl })` — bearer kinds resolve to `null`; only `http_sig` routes to the resolver.
  - `bearerOnly({ resolveByCredential })` — all credential kinds route through the adopter's mapping.
  - `mixed({ resolveByAgentUrl, resolveByCredential })` — `http_sig` routes to the signed path, bearer kinds to the credential path; signed preferred when both present.
- `BuyerAgentResolveInput` — minimal input shape for `resolve()`, decoupled from `ResolvedAuthInfo` to keep the registry surface stable across the migration cycle.

## What's NOT in (later Stage)

- Resolve seam wiring in the dispatcher → Stage 2.
- `ResolvedAuthInfo.credential` field with two-minor deprecation → Stage 3.
- Status enforcement (`suspended`/`blocked` → 403), multi-credential conflict resolution, credential redaction → Stage 4.
- `CachingBuyerAgentRegistry` decorator + conformance fixtures → Stage 5.
- Framework-level `billing_capability` enforcement + AdCP-3.1 error-code emission → Phase 2 (#1292), gated on SDK 3.1 cutover.

## Why types-first

Three reasons to land Stage 1 alone:
1. The shape is up for review — adopters and the Python team see the API before any wiring locks it in.
2. Stage 2 (the dispatcher seam) is a more sensitive change; landing the types separately keeps the diffs reviewable.
3. The Python `v3-identity-bundle-design.md` round-2 RFC has `BuyerAgent` / `BuyerAgentRegistry` as its spine — cross-language shape parity benefits from the JS types being concrete and merged.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `test/lib/buyer-agent-registry.test.js` — 19/19 pass:
  - `signingOnly`: routes `http_sig`, returns `null` for `api_key`/`oauth`, returns `null` for absent credential, throws on missing resolver, propagates resolver throws.
  - `bearerOnly`: routes all kinds (including `http_sig`), returns `null` for absent credential, throws on missing resolver.
  - `mixed`: signed path takes precedence; bearer falls through; null on absent.
  - `BuyerAgent` shape: `readonly` semantics survive serialization; Set-membership works.
- [x] `npm run format:check` clean.
- [x] Regression — adjacent test files (`server-decisioning-from-platform`, `server-decisioning-to-wire-account`, new file): 150/150 pass.

## Cross-links

- #1269 (parent issue, body just rewritten with the Phase 1/Phase 2 split)
- #1292 (Phase 2 follow-up — gated on SDK 3.1)
- adcontextprotocol/adcp#3831 (spec PR landing the new error codes in 3.1)
- Python `docs/proposals/v3-identity-bundle-design.md` (cross-language shape parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)