### PR TITLE
feat(package): add @adcp/sdk/mock-server as public sub-export

### DIFF
--- a/.changeset/public-mock-server-export.md
+++ b/.changeset/public-mock-server-export.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": minor
+---
+
+Add `@adcp/sdk/mock-server` as a public sub-export.
+
+Adopters can now `import { bootMockServer } from '@adcp/sdk/mock-server'` for in-process integration tests, instead of spawning the published CLI as a child process or reaching into `dist/lib/mock-server/index.js`. Closes #1287.
+
+Same shape as the existing CLI: `bootMockServer({ specialism, port, apiKey? })` returns a `MockServerHandle` with `{ url, auth, close, summary, principalScope, principalMapping }`. Boots in-process so test harnesses can iterate on adapter integration without subprocess overhead.
+
+Examples in `docs/guides/VALIDATE-WITH-MOCK-FIXTURES.md` (when adcp#3826 lands) point at this for the test-side recipe.

--- a/package.json
+++ b/package.json
@@ -110,6 +110,11 @@
       "require": "./dist/lib/express-mcp/index.js",
       "types": "./dist/lib/express-mcp/index.d.ts"
     },
+    "./mock-server": {
+      "import": "./dist/lib/mock-server/index.js",
+      "require": "./dist/lib/mock-server/index.js",
+      "types": "./dist/lib/mock-server/index.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "typesVersions": {
@@ -164,6 +169,9 @@
       ],
       "express-mcp": [
         "dist/lib/express-mcp/index.d.ts"
+      ],
+      "mock-server": [
+        "dist/lib/mock-server/index.d.ts"
       ]
     }
   },

--- a/test/lib/mock-server/public-export.test.js
+++ b/test/lib/mock-server/public-export.test.js
@@ -1,0 +1,36 @@
+/**
+ * Smoke test for the `@adcp/sdk/mock-server` public sub-export (#1287).
+ *
+ * Verifies `bootMockServer` is importable through the public path (not just
+ * via the brittle `dist/lib/mock-server/index.js`) and that it actually
+ * boots a mock — catches regressions where the package.json `exports` map
+ * or `typesVersions` entry drifts away from the dist artifact.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+describe('@adcp/sdk/mock-server public sub-export', () => {
+  let handle;
+
+  before(async () => {
+    // The whole point — import via the public path, not `../../dist/...`.
+    const { bootMockServer } = require('@adcp/sdk/mock-server');
+    handle = await bootMockServer({ specialism: 'signal-marketplace', port: 0 });
+  });
+
+  after(async () => {
+    if (handle) await handle.close();
+  });
+
+  it('exposes a bootable url', () => {
+    assert.match(handle.url, /^http:\/\/127\.0\.0\.1:\d+$/);
+  });
+
+  it('serves /_debug/traffic via the public-export-booted instance', async () => {
+    const res = await fetch(`${handle.url}/_debug/traffic`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok('traffic' in body, 'expected traffic field on debug endpoint');
+  });
+});

--- a/test/lib/mock-server/public-export.test.js
+++ b/test/lib/mock-server/public-export.test.js
@@ -34,3 +34,31 @@ describe('@adcp/sdk/mock-server public sub-export', () => {
     assert.ok('traffic' in body, 'expected traffic field on debug endpoint');
   });
 });
+
+describe('@adcp/sdk/mock-server boots a different specialism', () => {
+  // Catch a switch-case regression in bootMockServer's specialism dispatch:
+  // smoke-tests one non-signal-marketplace specialism so a refactor that
+  // breaks one branch doesn't ride along behind a passing signal-marketplace
+  // test.
+  let handle;
+  before(async () => {
+    const { bootMockServer } = require('@adcp/sdk/mock-server');
+    handle = await bootMockServer({ specialism: 'sales-guaranteed', port: 0 });
+  });
+  after(async () => {
+    if (handle) await handle.close();
+  });
+
+  it('boots and exposes a url', () => {
+    assert.match(handle.url, /^http:\/\/127\.0\.0\.1:\d+$/);
+  });
+});
+
+describe('@adcp/sdk/mock-server rejects unknown specialism', () => {
+  it('throws when specialism is not registered', async () => {
+    const { bootMockServer } = require('@adcp/sdk/mock-server');
+    await assert.rejects(() => bootMockServer({ specialism: 'not-a-real-specialism', port: 0 }), {
+      message: /Unknown mock-server specialism/,
+    });
+  });
+});


### PR DESCRIPTION
Closes #1287.

## Summary

Adds `@adcp/sdk/mock-server` as a public sub-export. Adopters can now `import { bootMockServer } from '@adcp/sdk/mock-server'` for in-process integration tests instead of spawning the CLI or reaching into `dist/lib/mock-server/index.js`.

## Why

`bootMockServer({ specialism, port })` already exists and is used internally — the matrix harness, the example tests in PR #1274, the spec guide in adcp#3826 all describe this as the test-side recipe. It just wasn't in `package.json#exports`, so adopters writing tests in TypeScript projects had to either spawn `adcp mock-server` as a subprocess or import from a brittle dist path.

This is a single package.json edit + a smoke test. Backwards-compatible — adds a new sub-export, doesn't change anything existing.

## Verified

```bash
$ node -e "console.log(Object.keys(require('@adcp/sdk/mock-server')))"
[ 'bootMockServer' ]
```

Smoke test (`test/lib/mock-server/public-export.test.js`) imports via the public path, boots a `signal-marketplace` mock on an ephemeral port, fetches `/_debug/traffic`. 2/2 pass.

## Refs

- Tracked in #1288 (P0)
- Companion to adcontextprotocol/adcp#3826 (spec guide describes the recipe)
- Used by adcontextprotocol/adcp-client#1274's example tests (which currently use the internal `dist/` import — should be updated to the public path after this lands)