### PR TITLE
docs(skills): add SHAPE-GOTCHAS.md for common discriminated-union mistakes

### DIFF
--- a/.changeset/skills-shape-gotchas.md
+++ b/.changeset/skills-shape-gotchas.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+docs(skills): add `skills/SHAPE-GOTCHAS.md` covering the five discriminated-union and embedded-shape patterns adopters consistently get wrong on first pass (ActivationKey, SignalID, VASTAsset, PreviewCreativeResponse, BuildCreativeReturn). Linked from `build-seller-agent`, `build-creative-agent`, `build-signals-agent` SKILL.md preambles. No code change; documentation lives under `skills/**/*` which ships in the npm package, hence the patch bump.

--- a/skills/SHAPE-GOTCHAS.md
+++ b/skills/SHAPE-GOTCHAS.md
@@ -1,0 +1,171 @@
+# Common shape gotchas
+
+Discriminated-union and embedded-shape patterns adopters consistently get wrong on the first pass. The strict response validators in the storyboard runner catch these at runtime; type checkers don't, because the types are technically satisfiable in the wrong shape. Each entry below: the wrong shape adopters write first, the right shape, and a one-line "why."
+
+Five patterns surfaced repeatedly while building reference adapters (`examples/hello_seller_adapter_*.ts`) and during blind LLM matrix runs. Catching them costs 1–3 iterations of "why is this field reported missing?" — this page is the shortcut.
+
+---
+
+## 1. `ActivationKey` `oneOf` — `key`/`value` are top-level, not nested
+
+When returning `activate_signal` deployments with `type: 'key_value'` activation keys, `key` and `value` sit at the TOP level of `activation_key`. NOT nested under a `key_value` sub-field.
+
+✗ Wrong (intuitive — the discriminator name *suggests* nesting):
+
+```ts
+activation_key: {
+  type: 'key_value',
+  key_value: { key: 'segment', value: 'abc123' },
+}
+```
+
+✓ Right (matches `/schemas/3.0/core/activation-key.json` `oneOf[1]`):
+
+```ts
+activation_key: {
+  type: 'key_value',
+  key: 'segment',
+  value: 'abc123',
+}
+```
+
+`value` MUST be a string. The schema allows a `segment_id` variant for platform-segment-id activations:
+
+```ts
+activation_key: { type: 'segment_id', segment_id: 'plat_seg_xyz' }
+```
+
+— same flatness, single string ID under the discriminator.
+
+---
+
+## 2. `signal_ids` is `signal_id[]` (provenance objects), not `string[]`
+
+`get_signals` accepts a `signal_ids` filter to look up specific signals by data-provider provenance. The filter is an array of provenance tuples, NOT bare ID strings.
+
+✗ Wrong:
+
+```ts
+{ signal_ids: ['cohort_abc', 'cohort_xyz'] }
+```
+
+✓ Right (matches `/schemas/3.0/core/signal-id.json`):
+
+```ts
+{
+  signal_ids: [
+    { source: 'catalog', data_provider_domain: 'tridentauto.example', id: 'likely_ev_buyers' },
+    { source: 'catalog', data_provider_domain: 'tridentauto.example', id: 'purchase_propensity' },
+  ],
+}
+```
+
+`SignalID` is a discriminated union: `source: 'catalog'` (with `data_provider_domain` + `id`) or `source: 'agent'` (with `agent_url` + `id`). When implementing the filter on the seller side, narrow on `source` before reading `data_provider_domain` — only the catalog variant has it.
+
+---
+
+## 3. `VASTAsset` requires an embedded `delivery_type` discriminator
+
+`asset_type: 'vast'` is itself a discriminator at the asset level. A *second* discriminator (`delivery_type`) picks between inline VAST XML and a redirect URL. Both are required; you can't pass `content` or `vast_url` without `delivery_type`.
+
+✗ Wrong (flat `content` without `delivery_type`):
+
+```ts
+{ asset_type: 'vast', content: '<VAST version="4.2">...</VAST>' }
+```
+
+✓ Right — inline VAST:
+
+```ts
+{ asset_type: 'vast', delivery_type: 'inline', content: '<VAST version="4.2">...</VAST>' }
+```
+
+✓ Right — redirect VAST:
+
+```ts
+{ asset_type: 'vast', delivery_type: 'redirect', vast_url: 'https://ad-server.example/vast/abc.xml' }
+```
+
+Same pattern applies to `DAASTAsset` (audio).
+
+---
+
+## 4. `PreviewCreativeResponse` is a three-way discriminated union
+
+`preview_creative` returns one of `single | batch | variant`, with `response_type` as the discriminator. Even single-preview responses use the `previews[]` ARRAY shape — the validator grades per variant and won't accept a flat single-preview shape.
+
+✗ Wrong (flat object, no discriminator):
+
+```ts
+{ preview: { type: 'url', url: 'https://...', expires_at: '...' } }
+```
+
+✓ Right (single-variant `previews[]` array):
+
+```ts
+{
+  response_type: 'single',
+  previews: [
+    {
+      preview_id: 'prv_abc',
+      renders: [
+        {
+          render_id: 'rnd_1',
+          output_format: 'url',
+          preview_url: 'https://preview.example/abc',
+          role: 'primary',
+        },
+      ],
+      input: { name: 'default' },
+    },
+  ],
+  expires_at: '2026-05-03T00:00:00Z',
+}
+```
+
+Each `PreviewRender` requires `render_id`, `output_format: 'url'` (or `'inline_html'`), `preview_url`, and `role`. Don't omit `role` — the validator requires it.
+
+---
+
+## 5. `BuildCreativeReturn` has 4 valid shapes — framework auto-wraps the bare manifest
+
+`build_creative` handlers can return any of:
+
+```ts
+type BuildCreativeReturn =
+  | CreativeManifest                    // bare single — framework wraps as { creative_manifest: <obj> }
+  | CreativeManifest[]                  // bare multi  — framework wraps as { creative_manifests: <arr> }
+  | BuildCreativeSuccess                // shaped single — passthrough; you set sandbox/expires_at/preview
+  | BuildCreativeMultiSuccess           // shaped multi  — passthrough
+```
+
+Easy mistake: return a bare `CreativeManifest` and confirm the response *seems* fine via tests that read `response.format_id` directly. The wire shape after framework wrapping is `response.creative_manifest.format_id` — a level deeper. Storyboards check the wire path; if you didn't go through the framework wrapper in your test, the storyboard will surface "field missing at `creative_manifest.format_id`" while your local test passes.
+
+If you need to set `sandbox: true` or attach `preview` previews, return the shaped envelope directly:
+
+```ts
+return {
+  creative_manifest: { format_id: { agent_url, id }, assets },
+  sandbox: true,
+  expires_at: '2026-05-03T00:00:00Z',
+};
+```
+
+---
+
+## How to debug a "Field not found at path: …" error fast
+
+The validator's path naming is precise. When you see:
+
+```
+✗ Response matches schema: : Invalid input;
+✗ Field not found at path: deployments[0].activation_key
+```
+
+Three steps:
+
+1. Find the schema file the validator names (typically `/schemas/3.0/<protocol>/<task>-response.json` or `/schemas/3.0/core/<type>.json`).
+2. Inside the schema, find the `oneOf` (or `anyOf`) at that path. The error path tells you which variant the validator was trying to match.
+3. Compare the schema's required fields to your actual response. The wrong shape tells you which discriminator branch you accidentally landed on.
+
+Schemas are the authoritative spec for shape. Prose around the schema (in skills, in field descriptions) is supplementary — when prose and schema disagree, the schema wins, and the validator agrees with the schema.

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -9,6 +9,8 @@ description: Use when building an AdCP creative agent — an ad server, creative
 
 A creative agent manages the creative lifecycle: accepts assets from buyers, stores them in a library, builds serving tags, and renders previews. Unlike a generative seller (which also sells inventory), a creative agent is a standalone creative platform — it manages creatives but doesn't sell media.
 
+> **Common shape gotchas:** `PreviewCreativeResponse` is a three-way discriminated union (`single` | `batch` | `variant`); `BuildCreativeReturn` has 4 valid shapes (framework auto-wraps bare manifests); `VASTAsset` requires `delivery_type` (`'inline'` or `'redirect'`) before `content`/`vast_url`. See [SHAPE-GOTCHAS.md](../SHAPE-GOTCHAS.md) for the patterns adopters consistently get wrong on first pass — schema validators catch these at runtime; type checkers don't.
+
 ## When to Use
 
 - User wants to build an ad server, creative management platform, or creative rendering service

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -9,6 +9,8 @@ description: Use when building an AdCP seller agent — a publisher, SSP, or ret
 
 A seller agent receives briefs from buyers, returns products with pricing, accepts media buys, manages creatives, and reports delivery. The business model — what you sell, how you price it, and whether humans approve deals — shapes every implementation decision. Determine that first.
 
+> **Common shape gotchas:** `BuildCreativeReturn` has 4 valid shapes (framework auto-wraps the bare manifest), `VASTAsset` requires an embedded `delivery_type` discriminator. See [SHAPE-GOTCHAS.md](../SHAPE-GOTCHAS.md) for patterns adopters consistently get wrong on first pass — schema validators catch these at runtime; type checkers don't.
+
 ## When to Use
 
 - User wants to build an agent that sells ad inventory

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -9,6 +9,8 @@ description: Use when building an AdCP signals agent, creating an audience data 
 
 A signals agent serves audience segments to buyers for campaign targeting. Two tools: `get_signals` (discovery) and `activate_signal` (push to DSPs or sales agents). The business model — marketplace vs owned data — shapes every implementation decision. Determine that first.
 
+> **Common shape gotchas:** `signal_ids[]` in `get_signals` is `signal_id[]` (provenance objects with `source`/`data_provider_domain`/`id`), not bare strings. `activate_signal` returns deployments with `ActivationKey` `oneOf` — for `type: 'key_value'` the `key` and `value` fields sit at the TOP level of `activation_key`, NOT nested under a `key_value` sub-field. See [SHAPE-GOTCHAS.md](../SHAPE-GOTCHAS.md) for the patterns adopters consistently get wrong on first pass.
+
 ## When to Use
 
 - User wants to build an agent that serves audience/targeting data


### PR DESCRIPTION
Closes #1284.

## Summary

Adds `skills/SHAPE-GOTCHAS.md` — a reference for the 5 discriminated-union and embedded-shape patterns adopters consistently get wrong on first pass:

1. **`ActivationKey` `oneOf`** — `key`/`value` are top-level for `type: 'key_value'`, NOT nested under `key_value`
2. **`signal_ids` is `signal_id[]`** — array of provenance objects (`{source, data_provider_domain, id}`), NOT array of strings
3. **`VASTAsset` embedded `delivery_type`** — `'inline'` or `'redirect'` discriminator before `content`/`vast_url`
4. **`PreviewCreativeResponse` three-way oneOf** — `single | batch | variant`; even single uses `previews[]` array shape
5. **`BuildCreativeReturn` 4 shapes** — framework auto-wraps bare manifests; storyboard checks the wire path (`creative_manifest.X`) not the bare path

Each entry: ✗ what adopters write first → ✓ what passes the schema validator → why the schema disagrees with intuition. Plus a "how to debug a 'Field not found at path' error fast" section covering the path-naming → oneOf-branch lookup workflow.

Linked from `build-seller-agent`, `build-creative-agent`, and `build-signals-agent` SKILL.md preambles via a single blockquote callout each. Adopters reading any of those find this without needing to know the new file exists.

## Why this exists (evidence)

These five patterns surfaced repeatedly while building reference adapters (`examples/hello_seller_adapter_signal_marketplace.ts`, etc.) and during blind LLM matrix runs. Each cost 1–3 iterations of "why is this field reported missing?" — type checkers don't catch them because the wrong shape is technically satisfiable; only the runtime validator does. This page is the shortcut.

The four inline gotchas in `examples/hello_seller_adapter_signal_marketplace.ts` were the prototype — moving them to a shared reference makes them discoverable without forking that example.

## Refs

- Tracked in #1288 (P1 in the rollup)
- Companion to #1283 (runtime validation errors include schema $id + branch hints) — both close the loop on shape-mismatch debug
- Surfaced in #1274 example cleanup; documented inline there

## Test plan

- [x] All three skill SKILL.md files keep parsing as valid markdown
- [x] Cross-reference link `../SHAPE-GOTCHAS.md` resolves from each `skills/build-*-agent/SKILL.md`
- [x] No external link rot — schema paths use the canonical `/schemas/3.0/...` form
- [ ] CI