### PR TITLE
feat(server): BuyerAgentRegistry Phase 1 Stage 2 — resolve seam + ctx threading (#1269)

### DIFF
--- a/.changeset/buyer-agent-registry-stage-2.md
+++ b/.changeset/buyer-agent-registry-stage-2.md
@@ -1,0 +1,24 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): BuyerAgentRegistry — Phase 1 Stage 2 (resolve seam + ctx threading)
+
+Phase 1 Stage 2 of #1269 — wires the `BuyerAgentRegistry` into the dispatcher between authentication and account resolution. The resolved `BuyerAgent` is threaded through `ctx.agent` to `resolveAccount`, `resolveAccountFromAuth`, `resolveSessionKey`, the v6 `RequestContext`, and the v6 `AccountStore.resolve` ctx.
+
+Strict opt-in: when `agentRegistry` is unset on `AdcpServerConfig` (or `DecisioningPlatform.agentRegistry` for v6 adopters), `ctx.agent` stays `undefined` and the framework's request flow is unchanged.
+
+Behavior:
+
+- Registry returns a `BuyerAgent` → framework freezes the record (and its `billing_capabilities` Set's own properties) and sets `ctx.agent`. Note: `Object.freeze` on a `Set` does NOT protect the internal `[[SetData]]` slot — `.add()` / `.delete()` / `.clear()` still mutate. `ReadonlySet` is a TypeScript-only contract; adopters MUST NOT rely on freeze preventing membership changes at runtime.
+- Registry returns `null` → `ctx.agent` stays undefined; dispatch continues. Status enforcement (`suspended` / `blocked`) and per-agent billing rejection are Stage 4 / Phase 2 (#1292) work.
+- Registry throws → framework returns `SERVICE_UNAVAILABLE`. Inner error logged server-side.
+
+The resolve seam runs **before** account resolution and the idempotency-key shape gate, so:
+
+- `resolveAccount(ref, { agent })` and `resolveAccountFromAuth({ agent })` see the resolved buyer agent.
+- `accounts.resolve(ref, { agent })` on the v6 `AccountStore` receives it through `ResolveContext.agent`.
+- `resolveSessionKey({ agent })` sees it.
+- The v6 `RequestContext.agent` is populated for specialism handlers via `buildRequestContext`.
+
+Stage 3 will populate `ResolvedAuthInfo.credential` (kind-discriminated variant) so the factory functions (`signingOnly` / `bearerOnly` / `mixed` from Stage 1) actually route. Until then, the seam is structurally present but factories return `null` for `credential === undefined`, so Stage 2 alone is functionally inert for adopters who haven't synthesized credentials themselves.

--- a/examples/hello_seller_adapter_signal_marketplace.ts
+++ b/examples/hello_seller_adapter_signal_marketplace.ts
@@ -31,11 +31,7 @@ import {
   type AccountStore,
   type Account,
 } from '@adcp/sdk/server';
-import type {
-  GetSignalsResponse,
-  ActivateSignalRequest,
-  ActivateSignalSuccess,
-} from '@adcp/sdk/types';
+import type { GetSignalsResponse, ActivateSignalRequest, ActivateSignalSuccess } from '@adcp/sdk/types';
 import { randomUUID } from 'node:crypto';
 
 const UPSTREAM_URL = process.env['UPSTREAM_URL'] ?? 'http://127.0.0.1:4150';
@@ -77,14 +73,17 @@ interface UpstreamActivation {
 }
 
 class UpstreamClient {
-  constructor(private readonly baseUrl: string, private readonly apiKey: string) {}
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string
+  ) {}
 
   /** Generic JSON request. SWAP this if your backend uses an SDK or different
    *  auth header conventions; the typed entry points below stay the same. */
   private async httpJson<T>(
     method: string,
     path: string,
-    opts: { operatorId?: string; query?: Record<string, string>; body?: unknown } = {},
+    opts: { operatorId?: string; query?: Record<string, string>; body?: unknown } = {}
   ): Promise<{ status: number; body: T | null }> {
     const url = new URL(this.baseUrl + path);
     for (const [k, v] of Object.entries(opts.query ?? {})) url.searchParams.set(k, v);
@@ -104,11 +103,9 @@ class UpstreamClient {
   // SWAP: tenant lookup. Mock exposes /_lookup; production typically a
   // directory service or config registry.
   async lookupOperator(adcpOperator: string): Promise<string | null> {
-    const r = await this.httpJson<{ operator_id?: string }>(
-      'GET',
-      '/_lookup/operator',
-      { query: { adcp_operator: adcpOperator } },
-    );
+    const r = await this.httpJson<{ operator_id?: string }>('GET', '/_lookup/operator', {
+      query: { adcp_operator: adcpOperator },
+    });
     return r.body?.operator_id ?? null;
   }
 
@@ -120,28 +117,20 @@ class UpstreamClient {
 
   // SWAP: single cohort.
   async getCohort(operatorId: string, cohortId: string): Promise<UpstreamCohort | null> {
-    const r = await this.httpJson<UpstreamCohort>(
-      'GET',
-      `/v2/cohorts/${encodeURIComponent(cohortId)}`,
-      { operatorId },
-    );
+    const r = await this.httpJson<UpstreamCohort>('GET', `/v2/cohorts/${encodeURIComponent(cohortId)}`, { operatorId });
     return r.body;
   }
 
   // SWAP: destinations available to this operator.
   async listDestinations(operatorId: string): Promise<UpstreamDestination[]> {
-    const r = await this.httpJson<{ destinations: UpstreamDestination[] }>(
-      'GET',
-      '/v2/destinations',
-      { operatorId },
-    );
+    const r = await this.httpJson<{ destinations: UpstreamDestination[] }>('GET', '/v2/destinations', { operatorId });
     return r.body?.destinations ?? [];
   }
 
   // SWAP: post an activation.
   async activate(
     operatorId: string,
-    body: { cohort_id: string; destination_id: string; pricing_id: string; client_request_id: string },
+    body: { cohort_id: string; destination_id: string; pricing_id: string; client_request_id: string }
   ): Promise<UpstreamActivation> {
     const r = await this.httpJson<UpstreamActivation>('POST', '/v2/activations', {
       operatorId,
@@ -234,16 +223,13 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
           sid =>
             sid.source === 'catalog' &&
             sid.data_provider_domain === c.data_provider_domain &&
-            sid.id === c.data_provider_id,
+            sid.id === c.data_provider_id
         );
       });
       return { signals: filtered.map(toAdcpSignal) } satisfies GetSignalsResponse;
     },
 
-    activateSignal: async (
-      req: ActivateSignalRequest,
-      ctx,
-    ): Promise<ActivateSignalSuccess> => {
+    activateSignal: async (req: ActivateSignalRequest, ctx): Promise<ActivateSignalSuccess> => {
       const operatorId = ctx.account.ctx_metadata.operator_id;
       const cohortId = req.signal_agent_segment_id;
       const cohort = await upstream.getCohort(operatorId, cohortId);
@@ -308,7 +294,7 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
             },
             estimated_activation_duration_minutes: 30,
           };
-        }),
+        })
       );
       return { deployments } satisfies ActivateSignalSuccess;
     },
@@ -340,9 +326,7 @@ serve(
     authenticate: verifyApiKey({
       keys: { [ADCP_AUTH_TOKEN]: { principal: 'compliance-runner' } },
     }),
-  },
+  }
 );
 
-console.log(
-  `signals adapter on http://127.0.0.1:${PORT}/mcp · upstream: ${UPSTREAM_URL}`,
-);
+console.log(`signals adapter on http://127.0.0.1:${PORT}/mcp · upstream: ${UPSTREAM_URL}`);

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -54,6 +54,7 @@ import {
 import { createTaskCapableServer } from './tasks';
 import type { TaskStore, TaskMessageQueue } from './tasks';
 import { adcpError } from './errors';
+import type { BuyerAgent, BuyerAgentRegistry } from './decisioning/buyer-agent';
 import { ADCP_ERROR_FIELD_ALLOWLIST } from './envelope-allowlist';
 import { InMemoryStateStore } from './state-store';
 import type { AdcpStateStore } from './state-store';
@@ -332,6 +333,15 @@ const noopLogger: AdcpLogger = {
  */
 export interface HandlerContext<TAccount = unknown> {
   account?: TAccount;
+  /**
+   * Resolved buyer agent for this request, populated by `BuyerAgentRegistry`
+   * when an `agentRegistry` is configured on the server (Phase 1 of #1269).
+   * Carries the durable commercial relationship — status, billing
+   * capabilities, default account terms — distinct from the per-request
+   * credential. Undefined when no registry is configured OR when the
+   * registry returned `null` for the request's credential.
+   */
+  agent?: BuyerAgent;
   /** Session scoping key derived from the request. Populated when `resolveSessionKey` is configured. */
   sessionKey?: string;
   /** State store for persisting domain objects (media buys, accounts, creatives). */
@@ -370,6 +380,8 @@ export interface SessionKeyContext<TAccount = unknown> {
   toolName: AdcpServerToolName;
   params: Record<string, unknown>;
   account?: TAccount;
+  /** Resolved buyer agent (Phase 1 of #1269), when `agentRegistry` is configured. */
+  agent?: BuyerAgent;
 }
 
 /**
@@ -389,6 +401,15 @@ export interface ResolveAccountContext {
    * MCP request. Undefined when no `authenticate` is configured on `serve()`.
    */
   authInfo?: HandlerContext['authInfo'];
+  /**
+   * Resolved buyer agent (Phase 1 of #1269), when an `agentRegistry` is
+   * configured on the server. Adopters whose `accounts.resolve` shape varies
+   * with the buyer agent's commercial relationship (e.g., agency-mediated
+   * vs. direct billing) read it here without re-resolving from `authInfo`.
+   * Undefined when no registry is configured OR when the registry returned
+   * null for the request's credential.
+   */
+  agent?: BuyerAgent;
 }
 
 /**
@@ -1183,6 +1204,34 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * don't need tenant scoping (publisher-wide format catalogs).
    */
   resolveAccountFromAuth?: (ctx: ResolveAccountContext) => Promise<TAccount | null>;
+
+  /**
+   * Buyer-agent identity registry — Phase 1 of #1269. Optional. When
+   * configured, framework calls `agentRegistry.resolve(authInfo)` once per
+   * request after `authInfo` is populated and before `resolveAccount`. The
+   * resolved {@link BuyerAgent} is threaded through `ctx.agent` to
+   * `resolveAccount`, `resolveAccountFromAuth`, `resolveSessionKey`, and
+   * the specialism handlers.
+   *
+   * Adopters construct via {@link BuyerAgentRegistry.signingOnly},
+   * {@link BuyerAgentRegistry.bearerOnly}, or {@link BuyerAgentRegistry.mixed}.
+   * When omitted, `ctx.agent` stays `undefined` and the framework's request
+   * flow is unchanged — strict opt-in.
+   *
+   * Behavior:
+   * - Registry returns a `BuyerAgent` → framework freezes the record (and
+   *   its `billing_capabilities` Set) and sets `ctx.agent`.
+   * - Registry returns `null` → `ctx.agent` stays undefined; dispatch
+   *   continues. Status enforcement (`suspended`/`blocked`) and per-agent
+   *   billing rejection are Stage 4 / Phase 2 work.
+   * - Registry throws → framework returns `SERVICE_UNAVAILABLE`. Inner
+   *   error logged server-side.
+   *
+   * Phase 1 ships the seam; the framework consumes the resolved record but
+   * does not yet enforce billing capabilities or status. Phase 2 (#1292)
+   * wires those once the SDK pin moves to AdCP 3.1.
+   */
+  agentRegistry?: BuyerAgentRegistry;
 
   /**
    * Derive a session-scoping key from the request. Populates `ctx.sessionKey`
@@ -2315,6 +2364,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     resolveAccount,
     resolveAccountFromAuth,
     resolveSessionKey,
+    agentRegistry,
     exposeErrorDetails = process.env.NODE_ENV !== 'production',
     stateStore = DEFAULT_STATE_STORE,
     logger = noopLogger,
@@ -2657,6 +2707,55 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           return response;
         };
 
+        // --- Buyer-agent registry resolution (Phase 1 of #1269) ---
+        // Runs after `authInfo` is populated and before account resolution
+        // so adopters' `resolveAccount` callbacks see `ctx.agent`. The
+        // registry receives the legacy `ResolvedAuthInfo` shape; Stage 3
+        // wires the kind-discriminated `credential` field that the
+        // factory functions route on. Until then, all factories return
+        // null for `credential === undefined`, so the seam is structurally
+        // present but functionally inert until adopters wire credential
+        // synthesis themselves (or wait for Stage 3).
+        //
+        // Phase 1 does NOT enforce status (suspended/blocked → 403) or
+        // billing capability — those land in Stage 4 and Phase 2 (#1292).
+        if (agentRegistry !== undefined) {
+          try {
+            const resolved = await agentRegistry.resolve({
+              ...(ctx.authInfo?.extra !== undefined && { extra: ctx.authInfo.extra }),
+            });
+            if (resolved !== null) {
+              // Shallow-freeze the resolved record so downstream code cannot
+              // accidentally mutate `status`, `agent_url`, or other own
+              // properties. NOTE: `Object.freeze` on the `billing_capabilities`
+              // Set locks the Set object's own properties but does NOT
+              // protect the internal `[[SetData]]` slot — `.add()` /
+              // `.delete()` / `.clear()` still mutate. `ReadonlySet` is a
+              // TypeScript-only contract; adopters constructing a Set MUST
+              // NOT rely on freeze preventing membership changes at runtime.
+              // Phase 2's billing-capability check only reads via `.has()`,
+              // so adopter mis-mutation would only affect the same request's
+              // own logic — no cross-request leak.
+              if (!Object.isFrozen(resolved)) {
+                if (resolved.billing_capabilities instanceof Set) {
+                  Object.freeze(resolved.billing_capabilities);
+                }
+                Object.freeze(resolved);
+              }
+              ctx.agent = resolved;
+            }
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            logger.error('Buyer-agent registry resolution failed', { tool: toolName, error: reason });
+            return finalize(
+              adcpError('SERVICE_UNAVAILABLE', {
+                message: 'Buyer-agent registry resolution failed',
+                ...(exposeErrorDetails && { details: { reason } }),
+              })
+            );
+          }
+        }
+
         const toolIsMutating = isMutatingTask(toolName);
 
         // Field-disagreement detection per spec PR `adcontextprotocol/adcp#3493`:
@@ -2787,6 +2886,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             const account = await resolveAccount(params.account, {
               toolName: toolName as AdcpServerToolName,
               authInfo: ctx.authInfo,
+              ...(ctx.agent !== undefined && { agent: ctx.agent }),
             });
             if (account == null) {
               logger.warn('Account not found', { tool: toolName, account: params.account });
@@ -2820,6 +2920,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             const account = await resolveAccountFromAuth({
               toolName: toolName as AdcpServerToolName,
               authInfo: ctx.authInfo,
+              ...(ctx.agent !== undefined && { agent: ctx.agent }),
             });
             if (account != null) ctx.account = account;
           } catch (err) {
@@ -2841,6 +2942,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               toolName: toolName as AdcpServerToolName,
               params,
               account: ctx.account,
+              ...(ctx.agent !== undefined && { agent: ctx.agent }),
             });
             if (sessionKey !== undefined) ctx.sessionKey = sessionKey;
           } catch (err) {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2721,10 +2721,16 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // billing capability — those land in Stage 4 and Phase 2 (#1292).
         if (agentRegistry !== undefined) {
           try {
+            // `credential` is intentionally omitted at this stage. Stage 3
+            // (#1269) wires `ResolvedAuthInfo.credential` synthesis from the
+            // auth principal so the factory functions can route by kind.
+            // Until then, the registry's `resolve` will return `null` for
+            // every request without a credential — the seam runs but stays
+            // functionally inert.
             const resolved = await agentRegistry.resolve({
               ...(ctx.authInfo?.extra !== undefined && { extra: ctx.authInfo.extra }),
             });
-            if (resolved !== null) {
+            if (resolved != null) {
               // Shallow-freeze the resolved record so downstream code cannot
               // accidentally mutate `status`, `agent_url`, or other own
               // properties. NOTE: `Object.freeze` on the `billing_capabilities`
@@ -2737,6 +2743,8 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // so adopter mis-mutation would only affect the same request's
               // own logic — no cross-request leak.
               if (!Object.isFrozen(resolved)) {
+                // Map-backed wrappers and other Set-shaped types skip the
+                // Set-freeze branch; the outer record's freeze still applies.
                 if (resolved.billing_capabilities instanceof Set) {
                   Object.freeze(resolved.billing_capabilities);
                 }
@@ -2886,7 +2894,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             const account = await resolveAccount(params.account, {
               toolName: toolName as AdcpServerToolName,
               authInfo: ctx.authInfo,
-              ...(ctx.agent !== undefined && { agent: ctx.agent }),
+              ...(ctx.agent != null && { agent: ctx.agent }),
             });
             if (account == null) {
               logger.warn('Account not found', { tool: toolName, account: params.account });
@@ -2920,7 +2928,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             const account = await resolveAccountFromAuth({
               toolName: toolName as AdcpServerToolName,
               authInfo: ctx.authInfo,
-              ...(ctx.agent !== undefined && { agent: ctx.agent }),
+              ...(ctx.agent != null && { agent: ctx.agent }),
             });
             if (account != null) ctx.account = account;
           } catch (err) {
@@ -2942,7 +2950,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               toolName: toolName as AdcpServerToolName,
               params,
               account: ctx.account,
-              ...(ctx.agent !== undefined && { agent: ctx.agent }),
+              ...(ctx.agent != null && { agent: ctx.agent }),
             });
             if (sessionKey !== undefined) ctx.sessionKey = sessionKey;
           } catch (err) {

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -28,6 +28,7 @@ import type {
   GetAccountFinancialsSuccess,
 } from '../../types/tools.generated';
 import type { CursorPage, CursorRequest } from './pagination';
+import type { BuyerAgent } from './buyer-agent';
 
 /**
  * Account — framework's rich representation. A strict superset of the wire
@@ -218,6 +219,16 @@ export interface ResolveContext {
   authInfo?: ResolvedAuthInfo;
   /** Tool the buyer is calling — useful for tool-aware tenant routing. */
   toolName?: string;
+  /**
+   * Resolved buyer agent from `BuyerAgentRegistry.resolve()`, when an
+   * `agentRegistry` is configured (Phase 1 of #1269). The framework calls
+   * the registry once per request before `accounts.resolve` and threads the
+   * resolved record here so adopters can route tenant resolution against
+   * the durable buyer-agent identity rather than re-deriving it from
+   * `authInfo`. Undefined when no registry is configured OR when the
+   * registry returns null for the request's credential.
+   */
+  agent?: BuyerAgent;
 }
 
 /**

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -258,10 +258,14 @@ export type ResolveBuyerAgentByAgentUrl = (agent_url: string) => Promise<BuyerAg
  *
  * **Credential exposure.** This callback receives unredacted credential
  * payloads (token, key_id, client_id). Adopters MUST NOT log raw credential
- * values. The framework redacts credential payloads in any log line emitted
- * from registry-resolution code (Stage 4); adopter implementations are
- * expected to do the same (or to use prepared-statement parameters that
- * don't log).
+ * values AND MUST NOT include them in thrown `Error` messages — the
+ * framework projects `err.message` into `error.details.reason` on the wire
+ * when `exposeErrorDetails` is on (default: non-production). Throw with
+ * a generic message and log the credential separately if you need it for
+ * server-side debugging. The framework redacts credential payloads in any
+ * log line emitted from registry-resolution code (Stage 4); adopter
+ * implementations are expected to do the same (or to use prepared-statement
+ * parameters that don't log).
  *
  * @public
  */

--- a/src/lib/server/decisioning/context.ts
+++ b/src/lib/server/decisioning/context.ts
@@ -31,6 +31,7 @@ import type {
 } from '../../types/tools.generated';
 import type { TaskHandoff, TaskHandoffContext } from './async-outcome';
 import type { CtxMetadataRef, ResourceKind } from '../ctx-metadata';
+import type { BuyerAgent } from './buyer-agent';
 
 // Unconstrained `TAccount` (no `extends Account`) so adopters with metadata
 // types that don't extend `Record<string, unknown>` (interfaces without index
@@ -40,6 +41,17 @@ import type { CtxMetadataRef, ResourceKind } from '../ctx-metadata';
 export interface RequestContext<TAccount = Account> {
   /** Resolved account for this request. */
   account: TAccount;
+
+  /**
+   * Resolved buyer agent for this request, when an `agentRegistry` is
+   * configured on the platform (Phase 1 of #1269). Carries the durable
+   * commercial relationship — status, billing capabilities, default
+   * account terms — distinct from the per-request credential. Undefined
+   * when no registry is configured OR when the registry returned null
+   * for the request's credential. Phase 2 (#1292) wires framework-level
+   * billing-capability enforcement to the AdCP-3.1 error codes.
+   */
+  agent?: BuyerAgent;
 
   /** Sync reads of in-flight state. */
   state: WorkflowStateReader;

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -12,6 +12,7 @@
 
 import type { DecisioningCapabilities, BrandCapabilities } from './capabilities';
 import type { Account, AccountStore } from './account';
+import type { BuyerAgentRegistry } from './buyer-agent';
 import type { StatusMappers } from './status-mappers';
 import type { SalesPlatform } from './specialisms/sales';
 import type { CreativeBuilderPlatform } from './specialisms/creative';
@@ -68,6 +69,23 @@ export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string
 
   /** Account model + tenant resolution. */
   accounts: AccountStore<TCtxMeta>;
+
+  /**
+   * Buyer-agent identity registry — Phase 1 of #1269. Optional. When
+   * configured, framework calls `agentRegistry.resolve(authInfo)` once per
+   * request before `accounts.resolve` and threads the resolved record
+   * through `ctx.agent` to specialism handlers.
+   *
+   * Adopters construct via {@link BuyerAgentRegistry.signingOnly},
+   * {@link BuyerAgentRegistry.bearerOnly}, or {@link BuyerAgentRegistry.mixed}
+   * depending on their authentication posture. When omitted, `ctx.agent`
+   * is always undefined and the framework's request flow is unchanged.
+   *
+   * Phase 2 (#1292) wires framework-level billing-capability enforcement
+   * against `BuyerAgent.billing_capabilities` and emits the AdCP-3.1
+   * billing error codes. Phase 1 ships the surface and resolution only.
+   */
+  agentRegistry?: BuyerAgentRegistry;
 
   /**
    * Native-status mappers (account, mediaBuy, creative, plan).

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -929,6 +929,11 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     // platform so the v5 dispatcher can call `agentRegistry.resolve()` on
     // every request and populate `ctx.agent`. When the platform omits the
     // field, the v5 surface stays unchanged.
+    //
+    // Precedence: this spread runs AFTER `...opts`, so `platform.agentRegistry`
+    // wins over any `opts.agentRegistry` an adopter passes via the v5 escape
+    // hatch. Same convention as the `idempotency` spread below — the platform
+    // is the authoritative v6 surface; opts is a low-level escape hatch.
     ...(platform.agentRegistry !== undefined && { agentRegistry: platform.agentRegistry }),
     // Pool-derived stores override the spread above when adopters supplied
     // `pool` but no explicit per-store opt. Explicit values still win.
@@ -954,7 +959,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         const account = await platform.accounts.resolve(ref, {
           ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
           toolName: ctx.toolName,
-          ...(ctx.agent !== undefined && { agent: ctx.agent }),
+          ...(ctx.agent != null && { agent: ctx.agent }),
         });
         resolved = account != null;
         resolvedAccountId = account?.id;
@@ -1002,7 +1007,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         const account = await platform.accounts.resolve(undefined, {
           ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
           toolName: ctx.toolName,
-          ...(ctx.agent !== undefined && { agent: ctx.agent }),
+          ...(ctx.agent != null && { agent: ctx.agent }),
         });
         resolved = account != null;
         resolvedAccountId = account?.id;

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -925,6 +925,11 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     ...opts,
     ...(autoSeedStore != null && { testController: makeAutoSeedBridge(autoSeedStore) }),
     ...(projectedCapabilitiesConfig != null && { capabilities: projectedCapabilitiesConfig }),
+    // Buyer-agent registry (Phase 1 of #1269). Threaded through from the
+    // platform so the v5 dispatcher can call `agentRegistry.resolve()` on
+    // every request and populate `ctx.agent`. When the platform omits the
+    // field, the v5 surface stays unchanged.
+    ...(platform.agentRegistry !== undefined && { agentRegistry: platform.agentRegistry }),
     // Pool-derived stores override the spread above when adopters supplied
     // `pool` but no explicit per-store opt. Explicit values still win.
     ...(effectiveIdempotency !== undefined && { idempotency: effectiveIdempotency }),
@@ -949,6 +954,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         const account = await platform.accounts.resolve(ref, {
           ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
           toolName: ctx.toolName,
+          ...(ctx.agent !== undefined && { agent: ctx.agent }),
         });
         resolved = account != null;
         resolvedAccountId = account?.id;
@@ -996,6 +1002,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         const account = await platform.accounts.resolve(undefined, {
           ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
           toolName: ctx.toolName,
+          ...(ctx.agent !== undefined && { agent: ctx.agent }),
         });
         resolved = account != null;
         resolvedAccountId = account?.id;

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -123,6 +123,7 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
 
   return {
     account,
+    ...(handlerCtx.agent !== undefined && { agent: handlerCtx.agent }),
     state: {
       findByObject: () => [],
       findProposalById: () => null,

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -123,7 +123,7 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
 
   return {
     account,
-    ...(handlerCtx.agent !== undefined && { agent: handlerCtx.agent }),
+    ...(handlerCtx.agent != null && { agent: handlerCtx.agent }),
     state: {
       findByObject: () => [],
       findProposalById: () => null,

--- a/test/examples/hello-seller-adapter-signal-marketplace.test.js
+++ b/test/examples/hello-seller-adapter-signal-marketplace.test.js
@@ -36,11 +36,7 @@ const UPSTREAM_PORT = 41500;
 const ADCP_AUTH_TOKEN = 'sk_harness_do_not_use_in_prod';
 const UPSTREAM_API_KEY = 'mock_signal_market_key_do_not_use_in_prod';
 
-const EXPECTED_ROUTES = [
-  'GET /_lookup/operator',
-  'GET /v2/cohorts',
-  'POST /v2/activations',
-];
+const EXPECTED_ROUTES = ['GET /_lookup/operator', 'GET /v2/cohorts', 'POST /v2/activations'];
 
 function waitForPort(host, port, timeoutMs) {
   const { connect } = require('node:net');
@@ -71,9 +67,12 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
         'tsc',
         '--noEmit',
         EXAMPLE_FILE,
-        '--target', 'ES2022',
-        '--module', 'commonjs',
-        '--moduleResolution', 'node',
+        '--target',
+        'ES2022',
+        '--module',
+        'commonjs',
+        '--moduleResolution',
+        'node',
         '--esModuleInterop',
         '--skipLibCheck',
         '--strict',
@@ -83,13 +82,9 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
         '--noFallthroughCasesInSwitch',
         '--noPropertyAccessFromIndexSignature',
       ],
-      { cwd: REPO_ROOT, encoding: 'utf8', timeout: 120_000 },
+      { cwd: REPO_ROOT, encoding: 'utf8', timeout: 120_000 }
     );
-    assert.equal(
-      res.status,
-      0,
-      `tsc reported errors:\n${(res.stdout || '') + (res.stderr || '')}`,
-    );
+    assert.equal(res.status, 0, `tsc reported errors:\n${(res.stdout || '') + (res.stderr || '')}`);
   });
 
   // -------------------------------------------------------------------------
@@ -108,22 +103,18 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
     // Boot the example as a child process — it calls `serve()` at module
     // load and runs forever. Async spawn keeps the test's event loop alive
     // (same lesson as #1250's runGrader fix: spawnSync would deadlock).
-    agent = spawn(
-      'npx',
-      ['tsx', EXAMPLE_FILE],
-      {
-        cwd: REPO_ROOT,
-        env: {
-          ...process.env,
-          PORT: String(AGENT_PORT),
-          UPSTREAM_URL: mockHandle.url,
-          UPSTREAM_API_KEY,
-          ADCP_AUTH_TOKEN,
-          NODE_ENV: 'development',
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
+    agent = spawn('npx', ['tsx', EXAMPLE_FILE], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PORT: String(AGENT_PORT),
+        UPSTREAM_URL: mockHandle.url,
+        UPSTREAM_API_KEY,
+        ADCP_AUTH_TOKEN,
+        NODE_ENV: 'development',
       },
-    );
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     // Drain stdio so the kernel pipe buffers don't fill and block the child.
     agent.stdout.on('data', () => {});
     agent.stderr.on('data', () => {});
@@ -144,8 +135,7 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
     assert.equal(
       grader.summary.steps_failed,
       0,
-      `storyboard reported ${grader.summary.steps_failed} failed steps:\n` +
-        formatFailures(grader),
+      `storyboard reported ${grader.summary.steps_failed} failed steps:\n` + formatFailures(grader)
     );
     // Allow `partial` overall_status when no steps failed — that's the
     // runner's "silent track" classification (issue #1209). What we
@@ -161,7 +151,7 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
     assert.deepEqual(
       missing,
       [],
-      `These upstream routes had zero hits — the adapter is a façade for them:\n  ${missing.join('\n  ')}\n\nFull traffic:\n${JSON.stringify(traffic, null, 2)}`,
+      `These upstream routes had zero hits — the adapter is a façade for them:\n  ${missing.join('\n  ')}\n\nFull traffic:\n${JSON.stringify(traffic, null, 2)}`
     );
   });
 });
@@ -189,7 +179,7 @@ function runGrader(agentUrl, storyboardId) {
       {
         cwd: REPO_ROOT,
         stdio: ['ignore', 'pipe', 'pipe'],
-      },
+      }
     );
     const out = [];
     const err = [];
@@ -204,8 +194,8 @@ function runGrader(agentUrl, storyboardId) {
       } catch (e) {
         reject(
           new Error(
-            `grader stdout was not parseable JSON (storyboard=${storyboardId}):\n${stdout.slice(0, 500)}\n\nstderr: ${Buffer.concat(err).toString('utf8').slice(0, 500)}`,
-          ),
+            `grader stdout was not parseable JSON (storyboard=${storyboardId}):\n${stdout.slice(0, 500)}\n\nstderr: ${Buffer.concat(err).toString('utf8').slice(0, 500)}`
+          )
         );
       }
     });
@@ -219,7 +209,9 @@ function formatFailures(grader) {
     if (!node || typeof node !== 'object') return;
     if (node.passed === false && !node.skipped) {
       const detail = node.details || node.error || '';
-      failed.push(`  ✗ ${node.task || '?'} — ${node.step || node.step_id || '?'}\n      ${String(detail).slice(0, 200)}`);
+      failed.push(
+        `  ✗ ${node.task || '?'} — ${node.step || node.step_id || '?'}\n      ${String(detail).slice(0, 200)}`
+      );
     }
     for (const k of Object.keys(node)) {
       const v = node[k];

--- a/test/server-buyer-agent-resolve-seam.test.js
+++ b/test/server-buyer-agent-resolve-seam.test.js
@@ -225,4 +225,137 @@ describe('buyer-agent registry resolve seam — Stage 2 of #1269', () => {
     assert.ok(sessionKeyAgent, 'resolveSessionKey must see ctx.agent');
     assert.equal(sessionKeyAgent.agent_url, 'https://agent.scope3.com');
   });
+
+  it('registry resolves BEFORE accounts.resolve (call order)', async () => {
+    const callOrder = [];
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          callOrder.push('registry');
+          return sampleAgent();
+        },
+      },
+      accounts: {
+        resolve: async ref => {
+          callOrder.push('accounts.resolve');
+          return { id: ref?.account_id ?? 'acc_1', metadata: {}, authInfo: { kind: 'api_key' } };
+        },
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await dispatch(server);
+    assert.deepEqual(callOrder, ['registry', 'accounts.resolve']);
+  });
+
+  it('threaded ctx.agent is reference-identical across accounts.resolve and the handler (single record per request)', async () => {
+    const agent = sampleAgent();
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          return agent;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server);
+    assert.strictEqual(
+      result.structuredContent._ctxAgent,
+      result.structuredContent._accountResolveAgent,
+      'handler and accounts.resolve must see the same BuyerAgent reference'
+    );
+    assert.strictEqual(
+      result.structuredContent._ctxAgent,
+      agent,
+      'reference must be the same object the registry returned'
+    );
+  });
+
+  it('resolveAccountFromAuth sees ctx.agent (account-less tools)', async () => {
+    let fromAuthAgent;
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          return sampleAgent();
+        },
+      },
+      // Use accounts.resolve(undefined) → capture path so we can verify
+      // the v6 shim's synthesized resolveAccountFromAuth threads ctx.agent
+      // through into platform.accounts.resolve(undefined, ctx).
+      accounts: {
+        resolve: async (ref, ctx) => {
+          if (ref == null) {
+            fromAuthAgent = ctx?.agent;
+            return { id: 'singleton', metadata: {}, authInfo: { kind: 'api_key' } };
+          }
+          return { id: ref.account_id, metadata: {}, authInfo: { kind: 'api_key' } };
+        },
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+      sales: {
+        getProducts: async () => ({ products: [] }),
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+        providePerformanceFeedback: async () => ({}),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'provide_performance_feedback',
+        arguments: {
+          media_buy_id: 'mb_1',
+          performance_index: 0.85,
+          measurement_period: { start: '2026-04-01T00:00:00Z', end: '2026-04-08T00:00:00Z' },
+          idempotency_key: '11111111-1111-1111-1111-111111111111',
+        },
+      },
+    });
+    assert.ok(fromAuthAgent, 'resolveAccountFromAuth (synthesized) must see ctx.agent');
+    assert.equal(fromAuthAgent.agent_url, 'https://agent.scope3.com');
+  });
+
+  it('exposeErrorDetails: false suppresses details.reason on registry-throw SERVICE_UNAVAILABLE', async () => {
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          throw new Error('upstream identity-provider 5xx');
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      exposeErrorDetails: false,
+    });
+    const result = await dispatch(server);
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+    // With exposeErrorDetails: false, error.details must not echo the
+    // adopter's exception text. Stage 4 will add credential redaction in
+    // the always-on path; this test locks the production-default behavior.
+    const details = result.structuredContent.adcp_error.details;
+    assert.ok(
+      details === undefined || details?.reason === undefined,
+      'details.reason must be absent in production-default mode'
+    );
+  });
 });

--- a/test/server-buyer-agent-resolve-seam.test.js
+++ b/test/server-buyer-agent-resolve-seam.test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+// Stage 2 of #1269 — buyer-agent registry resolve seam.
+//
+// These tests exercise the dispatcher's seam end-to-end via
+// `createAdcpServerFromPlatform`. The factory routing tests live in
+// `test/lib/buyer-agent-registry.test.js` (Stage 1); this file asserts the
+// seam wires correctly into the v6 platform shim.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+function buildPlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async (ref, ctx) => ({
+        id: ref?.account_id ?? 'acc_1',
+        metadata: {},
+        authInfo: { kind: 'api_key' },
+        // Stash the resolve-time `agent` so tests can assert threading.
+        _resolveAgent: ctx?.agent,
+      }),
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    statusMappers: {},
+    sales: {
+      getProducts: async (_req, ctx) => ({
+        products: [
+          {
+            product_id: 'p1',
+            name: 'sample',
+            description: '',
+            format_ids: [{ id: 'standard', agent_url: 'https://example.com/mcp' }],
+            delivery_type: 'non_guaranteed',
+            publisher_properties: { reportable: true },
+            reporting_capabilities: { available_dimensions: ['geo'] },
+            pricing_options: [{ pricing_model: 'cpm', rate: 1, currency: 'USD' }],
+          },
+        ],
+        // Echo the agent on the response (under products[0]) so assertions can
+        // inspect what the handler saw via RequestContext.
+        _ctxAgent: ctx?.agent,
+        _accountResolveAgent: ctx?.account?._resolveAgent,
+      }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+    },
+    ...overrides,
+  };
+}
+
+const sampleAgent = () => ({
+  agent_url: 'https://agent.scope3.com',
+  display_name: 'Scope3',
+  status: 'active',
+  billing_capabilities: new Set(['operator', 'agent']),
+  default_account_terms: { rate_card: 'rc_premium' },
+});
+
+const dispatch = server =>
+  server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'get_products',
+      arguments: {
+        brief: 'premium',
+        promoted_offering: 'cars',
+        account: { account_id: 'acc_test' },
+      },
+    },
+  });
+
+describe('buyer-agent registry resolve seam — Stage 2 of #1269', () => {
+  it('no agentRegistry configured → ctx.agent undefined; existing behavior unchanged', async () => {
+    const platform = buildPlatform();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server);
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.strictEqual(result.structuredContent._ctxAgent, undefined, 'handler must see ctx.agent === undefined');
+    assert.strictEqual(
+      result.structuredContent._accountResolveAgent,
+      undefined,
+      'accounts.resolve must see ctx.agent === undefined'
+    );
+  });
+
+  it('agentRegistry returning a BuyerAgent populates ctx.agent and threads it to accounts.resolve and the handler', async () => {
+    const agent = sampleAgent();
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          return agent;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server);
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(result.structuredContent._ctxAgent, 'handler must see ctx.agent populated');
+    assert.strictEqual(result.structuredContent._ctxAgent.agent_url, 'https://agent.scope3.com');
+    assert.ok(result.structuredContent._accountResolveAgent, 'accounts.resolve must see ctx.agent');
+    assert.strictEqual(result.structuredContent._accountResolveAgent.agent_url, 'https://agent.scope3.com');
+  });
+
+  it('framework freezes resolved BuyerAgent and its billing_capabilities Set', async () => {
+    const agent = sampleAgent();
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          return agent;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await dispatch(server);
+    assert.equal(Object.isFrozen(agent), true, 'resolved BuyerAgent must be frozen');
+    // Object.freeze locks the Set's own enumerable properties but does NOT
+    // protect the internal [[SetData]] slot — `.add()` / `.delete()` /
+    // `.clear()` still mutate. `ReadonlySet` is a TypeScript-only contract.
+    // We freeze the Set for completeness (Object.isFrozen → true) but
+    // adopters must not rely on `.add()` throwing at runtime.
+    assert.equal(Object.isFrozen(agent.billing_capabilities), true);
+    // Property assignment on the frozen agent is a no-op; the value stays.
+    try {
+      agent.status = 'blocked';
+    } catch {
+      /* expected in strict mode */
+    }
+    assert.equal(agent.status, 'active', 'frozen agent property must not change');
+  });
+
+  it('agentRegistry returning null → ctx.agent stays undefined; dispatch continues', async () => {
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          return null;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server);
+    // Phase 1: framework does NOT reject on null. Stage 4 / Phase 2 add
+    // the gate; Stage 2 just keeps dispatch flowing.
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent._ctxAgent, undefined);
+  });
+
+  it('agentRegistry throwing → SERVICE_UNAVAILABLE; handler not invoked', async () => {
+    let handlerInvoked = false;
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          throw new Error('upstream identity-provider 5xx');
+        },
+      },
+      sales: {
+        getProducts: async () => {
+          handlerInvoked = true;
+          return { products: [] };
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server);
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+    assert.equal(handlerInvoked, false, 'handler must NOT run when registry throws');
+  });
+
+  it('resolveSessionKey sees ctx.agent', async () => {
+    let sessionKeyAgent;
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          return sampleAgent();
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      resolveSessionKey: async ctx => {
+        sessionKeyAgent = ctx.agent;
+        return 'session-key';
+      },
+    });
+    await dispatch(server);
+    assert.ok(sessionKeyAgent, 'resolveSessionKey must see ctx.agent');
+    assert.equal(sessionKeyAgent.agent_url, 'https://agent.scope3.com');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 Stage 2 of #1269 — wires the `BuyerAgentRegistry` from Stage 1 (#1293) into the dispatcher. The resolved `BuyerAgent` is threaded through `ctx.agent` to `resolveAccount`, `resolveAccountFromAuth`, `resolveSessionKey`, the v6 `RequestContext`, and the v6 `AccountStore.resolve` ctx.

## What's in

- `agentRegistry?: BuyerAgentRegistry` added to `AdcpServerConfig<TAccount>` (v5 surface) and `DecisioningPlatform` (v6 surface). v6 platforms thread through to the v5 config automatically via `createAdcpServerFromPlatform`.
- `agent?: BuyerAgent` field added to: `HandlerContext`, `ResolveAccountContext`, `SessionKeyContext`, `ResolveContext` (v6 `accounts.resolve`), `AccountToolContext`, and `RequestContext`.
- Dispatcher seam in `create-adcp-server.ts` runs after `ctx.authInfo` is populated and before account resolution. Calls `agentRegistry.resolve({ extra })`; on non-null result, freezes the record and sets `ctx.agent`. On throw → `SERVICE_UNAVAILABLE`. On `null` → continues (Stage 4 / Phase 2 add the rejection gate).
- `to-context.ts` `buildRequestContext` propagates `handlerCtx.agent` into the v6 `RequestContext.agent`.

## Strict opt-in

When `agentRegistry` is unset on either surface, `ctx.agent` stays `undefined` and the framework's request flow is unchanged. First test case in the new file asserts this: with no registry configured, the handler sees `ctx.agent === undefined` and `accounts.resolve` sees no `agent` in its ctx.

## Note on `Object.freeze` and `Set`

`Object.freeze` on a `Set` locks the Set's own enumerable properties but does NOT protect the internal `[[SetData]]` slot — `.add()` / `.delete()` / `.clear()` still mutate. `ReadonlySet` is a TypeScript-only contract. Adopters MUST NOT rely on freeze preventing membership changes at runtime. Phase 2's billing-capability check reads via `.has()` only, so adopter mis-mutation would only affect the same request's own logic — no cross-request leak. Documented inline at the freeze site.

## What's NOT in (later Stages)

- `ResolvedAuthInfo.credential` synthesis from auth principal → Stage 3. Until then, the seam is structurally present but factories return null for `credential === undefined`, so Stage 2 alone is functionally inert for adopters who haven't wired credential synthesis themselves.
- Status enforcement (`suspended`/`blocked` → 403), multi-credential conflict resolution, credential redaction → Stage 4.
- `CachingBuyerAgentRegistry` decorator + conformance fixtures → Stage 5.
- Framework-level `billing_capability` enforcement + AdCP-3.1 error-code emission → Phase 2 (#1292), gated on SDK 3.1 cutover.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `test/server-buyer-agent-resolve-seam.test.js` — 6/6 pass:
  - No registry → `ctx.agent` undefined; existing behavior unchanged.
  - Registry returns BuyerAgent → `ctx.agent` populated and threaded to `accounts.resolve` + handler.
  - Framework freezes resolved record (and Set's own properties).
  - Registry returns null → dispatch continues.
  - Registry throws → SERVICE_UNAVAILABLE; handler not invoked.
  - `resolveSessionKey` sees `ctx.agent`.
- [x] `npm run format:check` clean.
- [x] Full suite: 7273 pass, 0 fail.

## Cross-links

- #1269 (parent issue, Phase 1 body)
- #1293 (Stage 1 — types + factories, merged)
- #1292 (Phase 2 — gated on SDK 3.1)
- adcontextprotocol/adcp#3831 (spec PR for the new error codes Phase 2 emits, merged on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)