### PR TITLE
test(capabilities): drift guard for *_TOOLS arrays vs manifest.json (#1192 stage 2)

### DIFF
--- a/.changeset/manifest-tools-drift.md
+++ b/.changeset/manifest-tools-drift.md
@@ -1,0 +1,4 @@
+---
+---
+
+test(capabilities): drift guard for *_TOOLS arrays vs manifest.json — stage 2 of #1192. No library/runtime change. Test-only addition asserting every tool in the hand-curated `*_TOOLS` arrays in `src/lib/utils/capabilities.ts` is a recognized manifest tool. See PR #1298 for the design call against mechanical migration.

--- a/examples/hello_seller_adapter_signal_marketplace.ts
+++ b/examples/hello_seller_adapter_signal_marketplace.ts
@@ -31,11 +31,7 @@ import {
   type AccountStore,
   type Account,
 } from '@adcp/sdk/server';
-import type {
-  GetSignalsResponse,
-  ActivateSignalRequest,
-  ActivateSignalSuccess,
-} from '@adcp/sdk/types';
+import type { GetSignalsResponse, ActivateSignalRequest, ActivateSignalSuccess } from '@adcp/sdk/types';
 import { randomUUID } from 'node:crypto';
 
 const UPSTREAM_URL = process.env['UPSTREAM_URL'] ?? 'http://127.0.0.1:4150';
@@ -77,14 +73,17 @@ interface UpstreamActivation {
 }
 
 class UpstreamClient {
-  constructor(private readonly baseUrl: string, private readonly apiKey: string) {}
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string
+  ) {}
 
   /** Generic JSON request. SWAP this if your backend uses an SDK or different
    *  auth header conventions; the typed entry points below stay the same. */
   private async httpJson<T>(
     method: string,
     path: string,
-    opts: { operatorId?: string; query?: Record<string, string>; body?: unknown } = {},
+    opts: { operatorId?: string; query?: Record<string, string>; body?: unknown } = {}
   ): Promise<{ status: number; body: T | null }> {
     const url = new URL(this.baseUrl + path);
     for (const [k, v] of Object.entries(opts.query ?? {})) url.searchParams.set(k, v);
@@ -104,11 +103,9 @@ class UpstreamClient {
   // SWAP: tenant lookup. Mock exposes /_lookup; production typically a
   // directory service or config registry.
   async lookupOperator(adcpOperator: string): Promise<string | null> {
-    const r = await this.httpJson<{ operator_id?: string }>(
-      'GET',
-      '/_lookup/operator',
-      { query: { adcp_operator: adcpOperator } },
-    );
+    const r = await this.httpJson<{ operator_id?: string }>('GET', '/_lookup/operator', {
+      query: { adcp_operator: adcpOperator },
+    });
     return r.body?.operator_id ?? null;
   }
 
@@ -120,28 +117,20 @@ class UpstreamClient {
 
   // SWAP: single cohort.
   async getCohort(operatorId: string, cohortId: string): Promise<UpstreamCohort | null> {
-    const r = await this.httpJson<UpstreamCohort>(
-      'GET',
-      `/v2/cohorts/${encodeURIComponent(cohortId)}`,
-      { operatorId },
-    );
+    const r = await this.httpJson<UpstreamCohort>('GET', `/v2/cohorts/${encodeURIComponent(cohortId)}`, { operatorId });
     return r.body;
   }
 
   // SWAP: destinations available to this operator.
   async listDestinations(operatorId: string): Promise<UpstreamDestination[]> {
-    const r = await this.httpJson<{ destinations: UpstreamDestination[] }>(
-      'GET',
-      '/v2/destinations',
-      { operatorId },
-    );
+    const r = await this.httpJson<{ destinations: UpstreamDestination[] }>('GET', '/v2/destinations', { operatorId });
     return r.body?.destinations ?? [];
   }
 
   // SWAP: post an activation.
   async activate(
     operatorId: string,
-    body: { cohort_id: string; destination_id: string; pricing_id: string; client_request_id: string },
+    body: { cohort_id: string; destination_id: string; pricing_id: string; client_request_id: string }
   ): Promise<UpstreamActivation> {
     const r = await this.httpJson<UpstreamActivation>('POST', '/v2/activations', {
       operatorId,
@@ -234,16 +223,13 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
           sid =>
             sid.source === 'catalog' &&
             sid.data_provider_domain === c.data_provider_domain &&
-            sid.id === c.data_provider_id,
+            sid.id === c.data_provider_id
         );
       });
       return { signals: filtered.map(toAdcpSignal) } satisfies GetSignalsResponse;
     },
 
-    activateSignal: async (
-      req: ActivateSignalRequest,
-      ctx,
-    ): Promise<ActivateSignalSuccess> => {
+    activateSignal: async (req: ActivateSignalRequest, ctx): Promise<ActivateSignalSuccess> => {
       const operatorId = ctx.account.ctx_metadata.operator_id;
       const cohortId = req.signal_agent_segment_id;
       const cohort = await upstream.getCohort(operatorId, cohortId);
@@ -308,7 +294,7 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
             },
             estimated_activation_duration_minutes: 30,
           };
-        }),
+        })
       );
       return { deployments } satisfies ActivateSignalSuccess;
     },
@@ -340,9 +326,7 @@ serve(
     authenticate: verifyApiKey({
       keys: { [ADCP_AUTH_TOKEN]: { principal: 'compliance-runner' } },
     }),
-  },
+  }
 );
 
-console.log(
-  `signals adapter on http://127.0.0.1:${PORT}/mcp · upstream: ${UPSTREAM_URL}`,
-);
+console.log(`signals adapter on http://127.0.0.1:${PORT}/mcp · upstream: ${UPSTREAM_URL}`);

--- a/src/lib/utils/capabilities.ts
+++ b/src/lib/utils/capabilities.ts
@@ -215,8 +215,24 @@ export interface ToolInfo {
  * These map to task names in the AdCP schema index (kebab-case -> snake_case).
  *
  * Note: Some tools appear in multiple arrays (e.g., list_creative_formats is in
- * both MEDIA_BUY_TOOLS and CREATIVE_TOOLS). This is intentional - these tools
- * serve multiple domains, and their presence should activate all relevant protocols.
+ * both MEDIA_BUY_TOOLS and CREATIVE_TOOLS). This is intentional — these tools
+ * serve multiple domains, and their presence should activate all relevant
+ * protocols when `detectProtocols()` runs.
+ *
+ * **Why these aren't manifest-derived (#1192).** The AdCP manifest
+ * (`schemas/cache/{version}/manifest.json`) carries a single primary `protocol`
+ * per tool — `list_creative_formats` is `media-buy` there, never `creative`.
+ * That's an authoring convenience (where does the tool's spec page live), not
+ * a capability-declaration semantic. The cross-listing here captures
+ * operator reality: a CMP that exposes only `build_creative` /
+ * `list_creative_formats` / `sync_creatives` IS a creative agent, and a buyer
+ * discovering it via `tools/list` should see the `creative` protocol family.
+ * Migrating to manifest-primary would silently flip `detectProtocols()`
+ * results for cross-listed tools and break CMP↔DSP discovery flows. The
+ * drift guard at `test/lib/capabilities-tools-drift.test.js` keeps the arrays
+ * locked to recognized manifest tools (catches typos and removed-upstream
+ * tools) without forcing the arrays to match the manifest's single-valued
+ * view. See PR #1298 for the design rationale.
  */
 export const MEDIA_BUY_TOOLS = [
   'get_products',

--- a/test/examples/hello-seller-adapter-signal-marketplace.test.js
+++ b/test/examples/hello-seller-adapter-signal-marketplace.test.js
@@ -36,11 +36,7 @@ const UPSTREAM_PORT = 41500;
 const ADCP_AUTH_TOKEN = 'sk_harness_do_not_use_in_prod';
 const UPSTREAM_API_KEY = 'mock_signal_market_key_do_not_use_in_prod';
 
-const EXPECTED_ROUTES = [
-  'GET /_lookup/operator',
-  'GET /v2/cohorts',
-  'POST /v2/activations',
-];
+const EXPECTED_ROUTES = ['GET /_lookup/operator', 'GET /v2/cohorts', 'POST /v2/activations'];
 
 function waitForPort(host, port, timeoutMs) {
   const { connect } = require('node:net');
@@ -71,9 +67,12 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
         'tsc',
         '--noEmit',
         EXAMPLE_FILE,
-        '--target', 'ES2022',
-        '--module', 'commonjs',
-        '--moduleResolution', 'node',
+        '--target',
+        'ES2022',
+        '--module',
+        'commonjs',
+        '--moduleResolution',
+        'node',
         '--esModuleInterop',
         '--skipLibCheck',
         '--strict',
@@ -83,13 +82,9 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
         '--noFallthroughCasesInSwitch',
         '--noPropertyAccessFromIndexSignature',
       ],
-      { cwd: REPO_ROOT, encoding: 'utf8', timeout: 120_000 },
+      { cwd: REPO_ROOT, encoding: 'utf8', timeout: 120_000 }
     );
-    assert.equal(
-      res.status,
-      0,
-      `tsc reported errors:\n${(res.stdout || '') + (res.stderr || '')}`,
-    );
+    assert.equal(res.status, 0, `tsc reported errors:\n${(res.stdout || '') + (res.stderr || '')}`);
   });
 
   // -------------------------------------------------------------------------
@@ -108,22 +103,18 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
     // Boot the example as a child process — it calls `serve()` at module
     // load and runs forever. Async spawn keeps the test's event loop alive
     // (same lesson as #1250's runGrader fix: spawnSync would deadlock).
-    agent = spawn(
-      'npx',
-      ['tsx', EXAMPLE_FILE],
-      {
-        cwd: REPO_ROOT,
-        env: {
-          ...process.env,
-          PORT: String(AGENT_PORT),
-          UPSTREAM_URL: mockHandle.url,
-          UPSTREAM_API_KEY,
-          ADCP_AUTH_TOKEN,
-          NODE_ENV: 'development',
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
+    agent = spawn('npx', ['tsx', EXAMPLE_FILE], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PORT: String(AGENT_PORT),
+        UPSTREAM_URL: mockHandle.url,
+        UPSTREAM_API_KEY,
+        ADCP_AUTH_TOKEN,
+        NODE_ENV: 'development',
       },
-    );
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     // Drain stdio so the kernel pipe buffers don't fill and block the child.
     agent.stdout.on('data', () => {});
     agent.stderr.on('data', () => {});
@@ -144,8 +135,7 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
     assert.equal(
       grader.summary.steps_failed,
       0,
-      `storyboard reported ${grader.summary.steps_failed} failed steps:\n` +
-        formatFailures(grader),
+      `storyboard reported ${grader.summary.steps_failed} failed steps:\n` + formatFailures(grader)
     );
     // Allow `partial` overall_status when no steps failed — that's the
     // runner's "silent track" classification (issue #1209). What we
@@ -161,7 +151,7 @@ describe('examples/hello_seller_adapter_signal_marketplace', () => {
     assert.deepEqual(
       missing,
       [],
-      `These upstream routes had zero hits — the adapter is a façade for them:\n  ${missing.join('\n  ')}\n\nFull traffic:\n${JSON.stringify(traffic, null, 2)}`,
+      `These upstream routes had zero hits — the adapter is a façade for them:\n  ${missing.join('\n  ')}\n\nFull traffic:\n${JSON.stringify(traffic, null, 2)}`
     );
   });
 });
@@ -189,7 +179,7 @@ function runGrader(agentUrl, storyboardId) {
       {
         cwd: REPO_ROOT,
         stdio: ['ignore', 'pipe', 'pipe'],
-      },
+      }
     );
     const out = [];
     const err = [];
@@ -204,8 +194,8 @@ function runGrader(agentUrl, storyboardId) {
       } catch (e) {
         reject(
           new Error(
-            `grader stdout was not parseable JSON (storyboard=${storyboardId}):\n${stdout.slice(0, 500)}\n\nstderr: ${Buffer.concat(err).toString('utf8').slice(0, 500)}`,
-          ),
+            `grader stdout was not parseable JSON (storyboard=${storyboardId}):\n${stdout.slice(0, 500)}\n\nstderr: ${Buffer.concat(err).toString('utf8').slice(0, 500)}`
+          )
         );
       }
     });
@@ -219,7 +209,9 @@ function formatFailures(grader) {
     if (!node || typeof node !== 'object') return;
     if (node.passed === false && !node.skipped) {
       const detail = node.details || node.error || '';
-      failed.push(`  ✗ ${node.task || '?'} — ${node.step || node.step_id || '?'}\n      ${String(detail).slice(0, 200)}`);
+      failed.push(
+        `  ✗ ${node.task || '?'} — ${node.step || node.step_id || '?'}\n      ${String(detail).slice(0, 200)}`
+      );
     }
     for (const k of Object.keys(node)) {
       const v = node[k];

--- a/test/lib/capabilities-tools-drift.test.js
+++ b/test/lib/capabilities-tools-drift.test.js
@@ -96,4 +96,18 @@ describe('capabilities.ts: tool arrays drift against manifest.json', () => {
       .sort();
     assert.deepEqual([...PROTOCOL_TOOLS].sort(), manifestProtocolTools);
   });
+
+  it('TMP exemption is still load-bearing — context_match / identity_match remain outside manifest', () => {
+    // Defensive guard: when TMP folds into the AdCP manifest (or gets its own
+    // manifest artifact), this assertion fires and prompts a re-include of
+    // TRUSTED_MATCH_TOOLS in the main drift check above. Without it the
+    // exemption decays silently into a dead carve-out.
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    const manifestTools = new Set(Object.keys(manifest.tools));
+    assert.ok(
+      !manifestTools.has('context_match') && !manifestTools.has('identity_match'),
+      'TMP tools (context_match / identity_match) appear to have folded into manifest.tools — ' +
+        're-include TRUSTED_MATCH_TOOLS in the drift check at line ~59 and remove this guard.'
+    );
+  });
 });

--- a/test/lib/capabilities-tools-drift.test.js
+++ b/test/lib/capabilities-tools-drift.test.js
@@ -51,9 +51,7 @@ const {
 describe('capabilities.ts: tool arrays drift against manifest.json', () => {
   it('every tool in every *_TOOLS array exists in the manifest', () => {
     if (!existsSync(MANIFEST_PATH)) {
-      throw new Error(
-        `Manifest not found at ${MANIFEST_PATH}. Run \`npm run sync-schemas\` first.`
-      );
+      throw new Error(`Manifest not found at ${MANIFEST_PATH}. Run \`npm run sync-schemas\` first.`);
     }
     const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
     const manifestTools = new Set(Object.keys(manifest.tools));

--- a/test/lib/capabilities-tools-drift.test.js
+++ b/test/lib/capabilities-tools-drift.test.js
@@ -1,0 +1,101 @@
+/**
+ * Drift guard for the hand-curated `*_TOOLS` arrays in
+ * `src/lib/utils/capabilities.ts` against the manifest's recognized tools.
+ *
+ * The arrays capture a user-facing protocol-detection semantic the manifest
+ * doesn't carry directly — `build_creative` sits as primary `media-buy` in
+ * the manifest (sellers expose it in the buy flow) but the hand-curated
+ * lists put it under `CREATIVE_TOOLS` (semantic ownership). Pure mechanical
+ * derivation would cause subtle `detectProtocols()` behavior changes, so we
+ * keep the arrays hand-curated. This drift guard ensures every tool in the
+ * arrays is at least a recognized manifest tool — catching typos, orphan
+ * entries, and tools that have been removed upstream.
+ *
+ * The inverse direction (every manifest tool appears somewhere in the
+ * arrays) is intentionally NOT asserted: protocol-level tools like
+ * `get_adcp_capabilities` are surfaced separately via `PROTOCOL_TOOLS`,
+ * and the asymmetric account/property/collection/etc. families don't fit
+ * the protocol-detection model.
+ *
+ * Tracked: adcp-client#1192 (manifest adoption).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { readFileSync, existsSync } = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '../..');
+const ADCP_VERSION_FILE = path.join(ROOT, 'ADCP_VERSION');
+const adcpVersion = existsSync(ADCP_VERSION_FILE) ? readFileSync(ADCP_VERSION_FILE, 'utf8').trim() : 'latest';
+const MANIFEST_PATH = path.join(ROOT, 'schemas/cache', adcpVersion, 'manifest.json');
+
+const {
+  MEDIA_BUY_TOOLS,
+  SIGNALS_TOOLS,
+  GOVERNANCE_TOOLS,
+  CREATIVE_TOOLS,
+  SPONSORED_INTELLIGENCE_TOOLS,
+  COMPLIANCE_TOOLS,
+  BRAND_RIGHTS_TOOLS,
+  EVENT_TRACKING_TOOLS,
+  ACCOUNT_TOOLS,
+  PROTOCOL_TOOLS,
+} = require('../../dist/lib/utils/capabilities');
+
+// Note: TRUSTED_MATCH_TOOLS is intentionally excluded from the drift check —
+// `context_match` / `identity_match` belong to TMP (the Trusted Match Protocol),
+// a separate spec line that AdCP's manifest.json does not enumerate. Re-include
+// once TMP folds into the AdCP manifest or gets its own manifest artifact.
+
+describe('capabilities.ts: tool arrays drift against manifest.json', () => {
+  it('every tool in every *_TOOLS array exists in the manifest', () => {
+    if (!existsSync(MANIFEST_PATH)) {
+      throw new Error(
+        `Manifest not found at ${MANIFEST_PATH}. Run \`npm run sync-schemas\` first.`
+      );
+    }
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    const manifestTools = new Set(Object.keys(manifest.tools));
+
+    const arrays = {
+      MEDIA_BUY_TOOLS,
+      SIGNALS_TOOLS,
+      GOVERNANCE_TOOLS,
+      CREATIVE_TOOLS,
+      SPONSORED_INTELLIGENCE_TOOLS,
+      COMPLIANCE_TOOLS,
+      BRAND_RIGHTS_TOOLS,
+      EVENT_TRACKING_TOOLS,
+      ACCOUNT_TOOLS,
+      PROTOCOL_TOOLS,
+    };
+
+    const orphans = [];
+    for (const [arrayName, tools] of Object.entries(arrays)) {
+      for (const tool of tools) {
+        if (!manifestTools.has(tool)) {
+          orphans.push({ arrayName, tool });
+        }
+      }
+    }
+
+    assert.deepEqual(
+      orphans,
+      [],
+      `Found ${orphans.length} tool(s) in src/lib/utils/capabilities.ts arrays that are not ` +
+        `in manifest.tools. These are typos, removed-upstream tools, or trusted-match/etc. ` +
+        `entries the manifest doesn't track yet:\n` +
+        orphans.map(o => `  ${o.arrayName} contains "${o.tool}" — not found in manifest.tools`).join('\n')
+    );
+  });
+
+  it('PROTOCOL_TOOLS contains exactly the manifest tools whose protocol === "protocol"', () => {
+    const manifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    const manifestProtocolTools = Object.entries(manifest.tools)
+      .filter(([, t]) => t.protocol === 'protocol')
+      .map(([name]) => name)
+      .sort();
+    assert.deepEqual([...PROTOCOL_TOOLS].sort(), manifestProtocolTools);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2 of #1192. After investigation, **option C (drift test only)** is the right call — not the originally-planned mechanical migration of `*_TOOLS` arrays to manifest-derived equivalents.

## Why drift-test-only, not migration

The hand-curated `*_TOOLS` arrays in `src/lib/utils/capabilities.ts` capture a user-facing protocol-detection semantic that the manifest's primary `protocol` field doesn't carry directly. Concrete example:

- `build_creative` sits as primary **`media-buy`** in the manifest (sellers expose it in the buy flow)
- The hand-curated arrays put it under **`CREATIVE_TOOLS`** (semantic ownership — it's about creatives)

If we migrated mechanically:
- `build_creative` would drop out of `CREATIVE_TOOLS`
- A creative-only agent advertising `build_creative` would no longer activate the `creative` protocol detection
- `detectProtocols()` returns subtly different results

Same shape applies to `list_creative_formats`, `list_creatives`, `sync_creatives` — all hand-cross-listed in MEDIA_BUY and CREATIVE.

## What this PR does

Adds `test/lib/capabilities-tools-drift.test.js` with two assertions:

1. **Every tool in the hand-curated `*_TOOLS` arrays exists in `manifest.tools`** — catches typos, orphan entries, tools removed upstream. The arrays stay hand-curated (semantic ownership), but they can't drift silently.

2. **`PROTOCOL_TOOLS` contains exactly the manifest tools where `protocol === 'protocol'`** — tighter check at the protocol-level surface, where there's no ambiguity.

`TRUSTED_MATCH_TOOLS` is intentionally excluded: `context_match` / `identity_match` belong to TMP (Trusted Match Protocol), a separate spec line the manifest doesn't enumerate. The exclusion is documented inline; re-include once TMP folds into the AdCP manifest.

## What's left (stage 3)

`RequiredPlatformsFor<S>` per-tool method-name compile-time constraint. The existing type maps specialisms to platform interfaces (`SalesPlatform`, `CreativeBuilderPlatform`, etc.); extending to per-tool method-name enforcement requires a different shape (and a runtime symmetric check at server creation). That's a meaningful type-system design call worth a separate PR — manifest data is now available (`SPECIALISM_REQUIRED_TOOLS` from `manifest.generated.ts`).

## Test plan

- [x] `node --test test/lib/capabilities-tools-drift.test.js` — 2/2 passing
- [ ] CI green

## Related

- Stage 2 of #1192 (manifest adoption)
- Stage 1 landed in #1275
- Builds on #1266 (3.0.4 bump that brought `manifest.json` into the cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)