### PR TITLE
feat(types): re-export SI and signals helper types from @adcp/sdk/types

### DIFF
--- a/.changeset/types-si-signal-helper-reexports.md
+++ b/.changeset/types-si-signal-helper-reexports.md
@@ -2,4 +2,4 @@
 "@adcp/sdk": patch
 ---
 
-Re-export SI and signals helper types from `@adcp/sdk/types`: `SICapabilities`, `SIIdentity`, `SISessionStatus`, `SIUIElement`, `SignalFilters`, `SignalTargeting`. Adopters typing handler internals no longer need to reach into `tools.generated`. `AssetVariant` is intentionally excluded — it is the same union as `AssetInstance` (already exported); use `AssetInstance`.
+Re-export SI and signals helper types from `@adcp/sdk/types`: `SICapabilities`, `SIIdentity`, `SISessionStatus`, `SIUIElement`, `SignalFilters`, `SignalTargeting`. Adopters typing handler internals no longer need to reach into `tools.generated`. `AssetVariant` is intentionally excluded — it is a narrower generated union (omits `AudioAsset`); prefer the curated `AssetInstance` union already exported from `@adcp/sdk/types`.

--- a/.changeset/types-si-signal-helper-reexports.md
+++ b/.changeset/types-si-signal-helper-reexports.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Re-export SI and signals helper types from `@adcp/sdk/types`: `SICapabilities`, `SIIdentity`, `SISessionStatus`, `SIUIElement`, `SignalFilters`, `SignalTargeting`. Adopters typing handler internals no longer need to reach into `tools.generated`. `AssetVariant` is intentionally excluded — it is the same union as `AssetInstance` (already exported); use `AssetInstance`.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -156,6 +156,8 @@ export type {
   Deployment,
   ActivationKey,
   VendorPricingOption,
+  SignalFilters,
+  SignalTargeting,
 } from './tools.generated';
 
 // Creative
@@ -245,6 +247,10 @@ export type {
 } from './tools.generated';
 
 // Sponsored intelligence
+// Note: AssetVariant (tools.generated.ts) is intentionally NOT re-exported here.
+// It is the codegen name for the same discriminated union that asset-instances.ts
+// exports as `AssetInstance`. Re-exporting both names for the same type would
+// give adopters two identities for the same concept. Use `AssetInstance`.
 export type {
   SIGetOfferingRequest,
   SIGetOfferingResponse,
@@ -254,6 +260,10 @@ export type {
   SISendMessageResponse,
   SITerminateSessionRequest,
   SITerminateSessionResponse,
+  SICapabilities,
+  SIIdentity,
+  SISessionStatus,
+  SIUIElement,
 } from './tools.generated';
 
 // Strict format asset slot types (hand-authored — the codegen drops the

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -156,7 +156,7 @@ export type {
   Deployment,
   ActivationKey,
   VendorPricingOption,
-  SignalFilters,   // embedded in GetSignalsRequest.filters
+  SignalFilters, // embedded in GetSignalsRequest.filters
   SignalTargeting, // embedded in ActivateSignalRequest.signal_targeting
 } from './tools.generated';
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -156,8 +156,8 @@ export type {
   Deployment,
   ActivationKey,
   VendorPricingOption,
-  SignalFilters,
-  SignalTargeting,
+  SignalFilters,   // embedded in GetSignalsRequest.filters
+  SignalTargeting, // embedded in ActivateSignalRequest.signal_targeting
 } from './tools.generated';
 
 // Creative
@@ -247,10 +247,6 @@ export type {
 } from './tools.generated';
 
 // Sponsored intelligence
-// Note: AssetVariant (tools.generated.ts) is intentionally NOT re-exported here.
-// It is the codegen name for the same discriminated union that asset-instances.ts
-// exports as `AssetInstance`. Re-exporting both names for the same type would
-// give adopters two identities for the same concept. Use `AssetInstance`.
 export type {
   SIGetOfferingRequest,
   SIGetOfferingResponse,
@@ -275,6 +271,9 @@ export * from './format-asset-slots';
 // (which describes what a publisher SELLS in `Format.assets[]`). The
 // individual ImageAsset / VideoAsset / etc. interfaces are generated; this
 // file is the missing canonical union over them.
+// Note: tools.generated.ts also has `AssetVariant`, a narrower generated union
+// that omits AudioAsset. `AssetInstance` (this file) is the curated, complete
+// union — prefer it. `AssetVariant` is intentionally not re-exported.
 export * from './asset-instances';
 
 // Strict per-row types for sync_* response success arms. The codegen


### PR DESCRIPTION
Closes #1291

Adds six named `export type` entries to `src/lib/types/index.ts` so adopters can import handler-internal types from `@adcp/sdk/types` without reaching into the generated file:

- **Signals:** `SignalFilters` (embedded in `GetSignalsRequest.filters`), `SignalTargeting` (embedded in `ActivateSignalRequest.signal_targeting`)
- **Sponsored intelligence:** `SICapabilities`, `SIIdentity`, `SISessionStatus`, `SIUIElement`

`AssetVariant` from `tools.generated.ts` is intentionally excluded — it is a narrower generated union that omits `AudioAsset`. The curated `AssetInstance` union (already exported via `asset-instances.ts`) is the correct choice; a note is added near the `export * from './asset-instances'` line to document this decision.

## What was tested

- `npm run format:check` — clean
- `tsc --project tsconfig.lib.json` — clean (pre-existing `@types/node` deprecation warnings on base branch unaffected)
- `dist/lib/types/index.d.ts` — all six new type names confirmed present in compiled declarations
- Pre-push hook — passed

## Pre-PR review

- **code-reviewer:** approved — no blockers. Flagged that the original `AssetVariant` comment claimed the types were identical (incorrect) and was in the wrong block. Both fixed in follow-up commit.
- **dx-expert:** approved — nits addressed (comment placement, signal type usage hints added inline).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01PhC7e1g1f2ifjG2owcBftN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhC7e1g1f2ifjG2owcBftN)_