### PR TITLE
feat(validation): add schema_id + selected_branch_index to ValidationOutcome/Issue

### DIFF
--- a/.changeset/validation-schema-id-branch-index.md
+++ b/.changeset/validation-schema-id-branch-index.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+`ValidationOutcome` gains `schema_id?: string` (the root schema's `$id`). `ValidationIssue` gains `selected_branch_index?: number` on `oneOf`/`anyOf` issues where the compaction logic narrowed to a best-match branch. Pairs with `variants[]`: `variants[selected_branch_index]` is the branch the payload appeared to be targeting. Both fields are additive and non-breaking.

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -73,6 +73,17 @@ export interface ValidationIssue {
    * branch detail.
    */
   allowedValues?: readonly unknown[];
+  /**
+   * When `keyword === 'oneOf'` or `'anyOf'` and the compaction logic
+   * identified a best-match branch (fewest residual errors after
+   * discriminator collapse), the zero-based index of that branch in
+   * the schema's `oneOf`/`anyOf` array. Absent when no branch selection
+   * occurred or the issue is not a union type.
+   *
+   * Pairs with `variants[]` — the entry at `variants[selected_branch_index]`
+   * is the branch the payload appeared to be targeting.
+   */
+  selected_branch_index?: number;
 }
 
 export interface ValidationOutcome {
@@ -80,6 +91,13 @@ export interface ValidationOutcome {
   issues: ValidationIssue[];
   /** Which schema variant was selected — useful for logging/debugging. */
   variant: Direction | 'skipped';
+  /**
+   * The `$id` of the root schema validated against (e.g.
+   * `/schemas/3.0.4/core/activation-key.json`). Absent when the
+   * schema has no `$id` or no schema was resolved. Useful for
+   * cross-referencing validation failures against the spec.
+   */
+  schema_id?: string;
   /**
    * True when the response's `status` field named an async variant
    * (`submitted` / `working` / `input-required`) but no compiled schema
@@ -192,8 +210,12 @@ function resolveSchemaPath(rootSchema: unknown, schemaPath: string): unknown {
  *     user's discriminator value satisfied wins over a sibling whose
  *     discriminator they violated. Drop the rest.
  */
-function compactUnionErrors(errors: readonly ErrorObject[], rootSchema: unknown): ErrorObject[] {
-  if (errors.length === 0) return [...errors];
+function compactUnionErrors(
+  errors: readonly ErrorObject[],
+  rootSchema: unknown
+): { errors: ErrorObject[]; selectedBranch: Map<ErrorObject, number> } {
+  const selectedBranch = new Map<ErrorObject, number>();
+  if (errors.length === 0) return { errors: [...errors], selectedBranch };
 
   // Pre-bucket once so each error is scanned a constant number of times even
   // when a malicious or pathological payload pushes Ajv to emit thousands of
@@ -358,9 +380,15 @@ function compactUnionErrors(errors: readonly ErrorObject[], rootSchema: unknown)
     for (const [idx, residual] of residualByVariant) {
       if (idx !== bestIdx) for (const e of residual) dropped.add(e);
     }
+    // Record which branch was selected for this union root so callers can
+    // surface it on the emitted ValidationIssue as selected_branch_index.
+    // Only record when the root itself survives (not dropped by anyZeroResidual).
+    if (bestIdx >= 0 && !dropped.has(root)) {
+      selectedBranch.set(root, bestIdx);
+    }
   }
 
-  return [...errors.filter(e => !dropped.has(e)), ...added];
+  return { errors: [...errors.filter(e => !dropped.has(e)), ...added], selectedBranch };
 }
 
 /**
@@ -402,10 +430,22 @@ export function validateRequest(toolName: string, payload: unknown, version?: st
   const valid = validator(payload) as boolean;
   if (valid) return { valid: true, issues: [], variant: 'request' };
   const rootSchema = (validator as { schema?: unknown }).schema;
-  const compacted = compactUnionErrors(validator.errors ?? [], rootSchema);
+  const schemaId =
+    rootSchema != null && typeof rootSchema === 'object'
+      ? ((rootSchema as { $id?: string }).$id ?? undefined)
+      : undefined;
+  const { errors: compacted, selectedBranch } = compactUnionErrors(validator.errors ?? [], rootSchema);
   return {
     valid: false,
-    issues: compacted.map(formatIssue).map(i => enrichWithVariants(i, rootSchema)),
+    schema_id: schemaId,
+    issues: compacted.map(err => {
+      const issue = formatIssue(err);
+      const branchIdx = selectedBranch.get(err);
+      return enrichWithVariants(
+        branchIdx !== undefined ? { ...issue, selected_branch_index: branchIdx } : issue,
+        rootSchema
+      );
+    }),
     variant: 'request',
   };
 }
@@ -496,10 +536,22 @@ export function validateResponse(toolName: string, payload: unknown, version?: s
     ? { variant_fallback_applied: true, requested_variant: variant }
     : {};
   if (valid) return { valid: true, issues: [], variant: usedVariant, ...fallbackFields };
-  const compacted = compactUnionErrors(effective.errors ?? [], rootSchema);
+  const schemaId =
+    rootSchema != null && typeof rootSchema === 'object'
+      ? ((rootSchema as { $id?: string }).$id ?? undefined)
+      : undefined;
+  const { errors: compacted, selectedBranch } = compactUnionErrors(effective.errors ?? [], rootSchema);
   return {
     valid: false,
-    issues: compacted.map(formatIssue).map(i => enrichWithVariants(i, rootSchema)),
+    schema_id: schemaId,
+    issues: compacted.map(err => {
+      const issue = formatIssue(err);
+      const branchIdx = selectedBranch.get(err);
+      return enrichWithVariants(
+        branchIdx !== undefined ? { ...issue, selected_branch_index: branchIdx } : issue,
+        rootSchema
+      );
+    }),
     variant: usedVariant,
     ...fallbackFields,
   };

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -431,9 +431,7 @@ export function validateRequest(toolName: string, payload: unknown, version?: st
   if (valid) return { valid: true, issues: [], variant: 'request' };
   const rootSchema = (validator as { schema?: unknown }).schema;
   const schemaId =
-    rootSchema != null && typeof rootSchema === 'object'
-      ? ((rootSchema as { $id?: string }).$id ?? undefined)
-      : undefined;
+    rootSchema != null && typeof rootSchema === 'object' ? (rootSchema as { $id?: string }).$id : undefined;
   const { errors: compacted, selectedBranch } = compactUnionErrors(validator.errors ?? [], rootSchema);
   return {
     valid: false,
@@ -537,9 +535,7 @@ export function validateResponse(toolName: string, payload: unknown, version?: s
     : {};
   if (valid) return { valid: true, issues: [], variant: usedVariant, ...fallbackFields };
   const schemaId =
-    rootSchema != null && typeof rootSchema === 'object'
-      ? ((rootSchema as { $id?: string }).$id ?? undefined)
-      : undefined;
+    rootSchema != null && typeof rootSchema === 'object' ? (rootSchema as { $id?: string }).$id : undefined;
   const { errors: compacted, selectedBranch } = compactUnionErrors(effective.errors ?? [], rootSchema);
   return {
     valid: false,


### PR DESCRIPTION
Closes #1283

Adds two additive fields to the validation output to help adopters identify which schema and which discriminator branch rejected their payload:

- **`ValidationOutcome.schema_id?: string`** — the `$id` of the root schema validated against (e.g. `/schemas/3.0.4/core/activation-key.json`). Lets adopters cross-reference `schemas/cache/<version>/` to find the originating file.
- **`ValidationIssue.selected_branch_index?: number`** — on `oneOf`/`anyOf` issues only, the zero-based index of the best-match branch selected by the existing `compactUnionErrors` discriminator-collapse logic. Pairs with the existing `variants[]` field: `variants[selected_branch_index]` is the branch the payload appeared to be targeting.

### What changed

- `compactUnionErrors` now returns `{ errors, selectedBranch }` where `selectedBranch: Map<ErrorObject, number>` maps surviving union-root errors to their selected branch index.
- `validateRequest` / `validateResponse` extract `schema_id` from `rootSchema.$id` and thread `selected_branch_index` onto union-root issues via the map.
- No existing field or behavior changed.

## What was tested

- `tsc --project tsconfig.lib.json` — clean
- `npm run format:check` — clean
- Core test suite (error-extraction, comply-controller, handler-return-tightness) — all pass
- Pre-push hook — passed

## Pre-PR review

- **code-reviewer:** approved — no blockers. Nits: `?? undefined` redundancy (fixed), changeset bump could be `minor` (left as `patch` — additive opt-in fields).
- **dx-expert:** approved — `selected_branch_index` + `variants[]` pairing is actionable; `schema_id` at outcome level is correct (one root schema per call). JSDoc ordering nit surfaced below.

**Open nits (not fixed — deferred to follow-up or reviewer discretion):**
- `selected_branch_index` JSDoc: open with the actionable consequence ("look up `variants[selected_branch_index]`") before explaining the selection algorithm.
- `schema_id` JSDoc: add "Match against `schemas/cache/<version>/` to find the originating file."

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01PhC7e1g1f2ifjG2owcBftN

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhC7e1g1f2ifjG2owcBftN)_