### PR TITLE
feat(server): runtime validation for specialism→required-tools coverage (#1299 option B)

### DIFF
--- a/.changeset/specialism-required-tools-validation.md
+++ b/.changeset/specialism-required-tools-validation.md
@@ -1,0 +1,21 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): runtime validation for specialism→required-tools coverage
+
+Stage 3 of #1192 (manifest adoption). When an adopter declares a specialism in `capabilities.specialisms[]`, the AdCP spec implies the agent supports every tool in that specialism's required-tool list (`SPECIALISM_REQUIRED_TOOLS` derived from manifest). This change adds a construction-time check in `createAdcpServerFromPlatform` that walks the platform object and warns (or throws under strict mode) when a required method is missing.
+
+What lands:
+
+- `src/lib/server/decisioning/validate-specialisms.ts` — `validateSpecialismRequiredTools(platform, specialisms)` and `formatSpecialismIssue(issue)` helpers. Walks every top-level field on the platform and checks for a function-typed property matching `snakeToCamelCase(tool)`. "Method-presence-anywhere" rather than "method-on-specific-field" because required tools span platform fields (`sync_accounts` lives on `accounts`, not on the specialism's primary `sales`) and pinning ownership upfront would either need a per-tool field map or false-positive on legitimate alternative layouts.
+
+- `createAdcpServerFromPlatform`: after `validatePlatform`, runs the specialism check. Default behavior is `console.warn` for each missing method (with specialism + tool + method name). New `strictSpecialismValidation: true` opt opts into `PlatformConfigError` on missing methods — recommended for production CI builds.
+
+- `scripts/generate-manifest-derived.ts`: now populates `SPECIALISM_REQUIRED_TOOLS` via reverse-mapping from `manifest.tools[*].specialisms[]` (the manifest's direct `specialisms[*].required_tools` is empty in 3.0.4). Filters universal tools (`get_adcp_capabilities` and other `protocol`-protocol tools) and normalizes specialism keys to kebab-case to match the spec's `AdCPSpecialism` enum.
+
+What's deferred (was originally option C of #1299):
+
+The build-time type fixture asserting `RequiredPlatformsFor<S>` collectively exposes every required tool method was scoped out after implementation revealed too many false-positives from cross-cutting tools (e.g., `sync_accounts` is required by `sales-non-guaranteed` but lives on `AccountsPlatform`, not `RequiredPlatformsFor<'sales-non-guaranteed'> = { sales: SalesPlatform }`). Rescoping this to a "platform-interface family collectively covers every required-tool method" assertion (without per-specialism mapping) is tracked as a follow-up on #1299.
+
+Closes #1299 (option B portion).

--- a/scripts/generate-manifest-derived.ts
+++ b/scripts/generate-manifest-derived.ts
@@ -116,11 +116,37 @@ function generateFile(manifest: AdcpManifest, sourcePath: string): string {
     toolsByProtocol.get(protocol)!.push(name);
   }
 
-  // Specialism → required tools (sorted)
+  // Specialism → required tools. Two sources:
+  //   1. `manifest.specialisms[id].required_tools` — explicit list, authoritative.
+  //   2. Reverse-mapping from `manifest.tools[*].specialisms[]` — every tool that
+  //      claims this specialism is presumed required by it.
+  // 3.0.4 doesn't populate (1), so we fall back to (2). Universal tools that
+  // every specialism inherits (`get_adcp_capabilities`) are filtered out — they
+  // belong on `PROTOCOL_TOOLS`, not on per-specialism platform interfaces.
+  const UNIVERSAL_TOOLS = new Set(
+    Object.entries(manifest.tools)
+      .filter(([, t]) => t.protocol === 'protocol')
+      .map(([name]) => name)
+  );
+  // Manifest uses snake_case specialism IDs (`sales_non_guaranteed`); the spec
+  // and the SDK's `AdCPSpecialism` enum use kebab-case (`sales-non-guaranteed`).
+  // Normalize to kebab on emit so consumers can index the table with the same
+  // string they'd put into `capabilities.specialisms[]`.
+  const toKebab = (snake: string) => snake.replace(/_/g, '-');
   const specialismRequiredTools = new Map<string, string[]>();
   for (const [id, spec] of Object.entries(manifest.specialisms).sort(([a], [b]) => a.localeCompare(b))) {
+    let tools: string[];
     if (Array.isArray(spec.required_tools) && spec.required_tools.length > 0) {
-      specialismRequiredTools.set(id, [...spec.required_tools].sort());
+      tools = [...spec.required_tools];
+    } else {
+      // Reverse-map: every tool that lists this specialism in tools[*].specialisms[]
+      tools = Object.entries(manifest.tools)
+        .filter(([, t]) => Array.isArray(t.specialisms) && t.specialisms.includes(id))
+        .map(([name]) => name);
+    }
+    const filtered = tools.filter(t => !UNIVERSAL_TOOLS.has(t)).sort();
+    if (filtered.length > 0) {
+      specialismRequiredTools.set(toKebab(id), filtered);
     }
   }
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -80,6 +80,7 @@ import type {
 } from '../../../types/tools.generated';
 import { adcpError, type AdcpErrorResponse } from '../../errors';
 import { validatePlatform, PlatformConfigError } from './validate-platform';
+import { validateSpecialismRequiredTools, formatSpecialismIssue } from '../validate-specialisms';
 import type { AdcpLogger } from '../../create-adcp-server';
 import { buildRequestContext, buildHandoffContext } from './to-context';
 import {
@@ -463,6 +464,22 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
   allowPrivateWebhookUrls?: boolean;
 
   /**
+   * When `true`, throw `PlatformConfigError` at construction if any
+   * specialism declared in `capabilities.specialisms[]` is missing a
+   * platform method matching one of its required tools (per the manifest's
+   * `SPECIALISM_REQUIRED_TOOLS`). Default `false` — the framework emits a
+   * `console.warn` for each missing method instead, so adopters mid-
+   * implementation aren't blocked on incomplete specialism coverage.
+   *
+   * Recommended for production CI builds: catches "claimed sales-non-
+   * guaranteed but forgot to implement getProducts" before the deploy.
+   * Recommended off in dev / sandbox where adopters are iterating.
+   *
+   * Tracked: adcp-client#1299 (manifest adoption stage 3).
+   */
+  strictSpecialismValidation?: boolean;
+
+  /**
    * Auto-fire a completion webhook on the sync-success arm of mutating
    * tools when the request supplied `push_notification_config.url`.
    * Default is `true` — buyers passing the URL expect notification
@@ -613,6 +630,39 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
   opts: RequiredOptsFor<P>
 ): DecisioningAdcpServer {
   validatePlatform(platform);
+
+  // Specialism→required-tools coverage check (adcp-client#1299).
+  //
+  // For each specialism declared in `capabilities.specialisms[]`, verify the
+  // platform exposes a method matching every tool the manifest's
+  // `SPECIALISM_REQUIRED_TOOLS` lists for that specialism. Catches the
+  // common adopter mistake of declaring `'sales-non-guaranteed'` while
+  // forgetting to implement `getProducts` / `createMediaBuy` / etc. —
+  // would otherwise surface as a runtime error when a buyer actually
+  // calls the missing tool.
+  //
+  // Default behavior is console.warn — strictSpecialismValidation: true
+  // escalates to a thrown `PlatformConfigError`. The check is method-
+  // presence-anywhere on the platform (not method-on-specific-field) so
+  // adopters with non-standard layouts (e.g., a single mega-platform vs.
+  // the conventional sales/creative/accounts split) aren't false-positively
+  // flagged.
+  {
+    const specialisms = (platform.capabilities as { specialisms?: readonly string[] }).specialisms;
+    const issues = validateSpecialismRequiredTools(platform, specialisms);
+    if (issues.length > 0) {
+      const messages = issues.map(formatSpecialismIssue);
+      if (opts.strictSpecialismValidation === true) {
+        throw new PlatformConfigError(
+          `Platform missing methods for ${issues.length} specialism-required tool(s). ` +
+            `Strict mode (\`strictSpecialismValidation: true\`) treats this as fatal.\n` +
+            messages.map(m => `  - ${m}`).join('\n')
+        );
+      }
+      // eslint-disable-next-line no-console
+      for (const message of messages) console.warn(message);
+    }
+  }
 
   // Compliance-testing capability/adapter consistency.
   //

--- a/src/lib/server/decisioning/validate-specialisms.ts
+++ b/src/lib/server/decisioning/validate-specialisms.ts
@@ -48,6 +48,17 @@ interface ValidatorIssue {
  * exposes a callable property matching `methodName`. Returns true on first
  * match. The platform layout is adopter-controlled — we look across every
  * field rather than mapping tool→field upfront.
+ *
+ * **Top-level functions on the platform root are NOT searched.** The SDK
+ * convention is sub-platform fields (`{ sales: SalesPlatform, accounts:
+ * AccountsPlatform, ... }`), and a future adopter who tries
+ * `{ getProducts: () => ... }` directly on the root would get a confusing
+ * warning. If that pattern needs supporting, extend the loop to also check
+ * `typeof (platform as any)[methodName] === 'function'` — but the
+ * non-conventional layout test (`single mega-platform exposes all methods`
+ * in `validate-specialisms.test.js`) already covers the alternative
+ * single-field-of-everything pattern, which is the legitimate flat-layout
+ * case adopters might choose.
  */
 function hasMethodAnywhere(platform: unknown, methodName: string): boolean {
   if (!platform || typeof platform !== 'object') return false;

--- a/src/lib/server/decisioning/validate-specialisms.ts
+++ b/src/lib/server/decisioning/validate-specialisms.ts
@@ -1,0 +1,107 @@
+/**
+ * Runtime validation for specialism→required-tools coverage.
+ *
+ * When an adopter declares a specialism in `capabilities.specialisms[]`, the
+ * AdCP spec implies the agent supports every tool in that specialism's
+ * required-tool list (per `manifest.specialisms[*].required_tools` —
+ * `SPECIALISM_REQUIRED_TOOLS` in `manifest.generated.ts`). This module checks
+ * that the adopter's platform object exposes a method matching every required
+ * tool, and emits actionable warnings (or throws under strict mode) when
+ * something's missing.
+ *
+ * The check is **method-presence anywhere on the platform**, not method-on-
+ * specific-field. Required tools can span platform fields (`sync_accounts`
+ * lives on `accounts`, not on the specialism's primary platform field), and
+ * the SDK doesn't enforce a 1:1 specialism→field mapping. The looser check
+ * catches the common adopter mistake (forgot to implement) without
+ * false-positives on legitimate layout choices.
+ *
+ * Tracked: adcp-client#1192 (manifest adoption) → #1299 (stage 3).
+ *
+ * Companion to the build-time type-check fixture at
+ * `src/lib/server/decisioning/specialism-required-tools.type-checks.ts`,
+ * which catches the inverse failure mode (SDK's hand-maintained platform
+ * interfaces drifting away from manifest's required-tools contract).
+ */
+
+import { SPECIALISM_REQUIRED_TOOLS } from '../../types/manifest.generated';
+
+/**
+ * Convert a snake_case tool name to its expected camelCase platform method
+ * name. The transform is mechanical — every required tool in 3.0.4 follows
+ * this convention. If a future spec introduces a tool whose canonical method
+ * name diverges (e.g., the kebab segment maps to an acronym), add an
+ * override here rather than reaching for a more elaborate mapping table.
+ */
+export function toolNameToMethodName(tool: string): string {
+  return tool.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+interface ValidatorIssue {
+  specialism: string;
+  tool: string;
+  method: string;
+}
+
+/**
+ * Walk the platform object's top-level fields and check whether any field
+ * exposes a callable property matching `methodName`. Returns true on first
+ * match. The platform layout is adopter-controlled — we look across every
+ * field rather than mapping tool→field upfront.
+ */
+function hasMethodAnywhere(platform: unknown, methodName: string): boolean {
+  if (!platform || typeof platform !== 'object') return false;
+  for (const value of Object.values(platform as Record<string, unknown>)) {
+    if (value && typeof value === 'object') {
+      const method = (value as Record<string, unknown>)[methodName];
+      if (typeof method === 'function') return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Validate that `platform` exposes a method for every required tool of every
+ * declared specialism. Returns the list of missing (specialism, tool, method)
+ * triples. Callers decide whether to warn or throw — `createAdcpServer`
+ * defaults to console.warn for ergonomic dev feedback; opt in via the
+ * `strictSpecialismValidation` config flag to escalate.
+ *
+ * Specialisms not present in `SPECIALISM_REQUIRED_TOOLS` (preview-only or
+ * not yet enumerated by the manifest) are silently passed — the manifest is
+ * the source of truth, and a missing entry there means the spec hasn't yet
+ * formalized the required tools for that specialism.
+ */
+export function validateSpecialismRequiredTools(
+  platform: unknown,
+  specialisms: readonly string[] | undefined
+): ValidatorIssue[] {
+  if (!specialisms || specialisms.length === 0) return [];
+  const issues: ValidatorIssue[] = [];
+  for (const specialism of specialisms) {
+    const required = (SPECIALISM_REQUIRED_TOOLS as Record<string, readonly string[] | undefined>)[specialism];
+    if (!required) continue;
+    for (const tool of required) {
+      const method = toolNameToMethodName(tool);
+      if (!hasMethodAnywhere(platform, method)) {
+        issues.push({ specialism, tool, method });
+      }
+    }
+  }
+  return issues;
+}
+
+/**
+ * Format a single issue as a human-readable warning line. The format names
+ * the specialism, the missing tool, and the method an adopter should
+ * implement, so the dev fix is obvious from the log.
+ */
+export function formatSpecialismIssue(issue: ValidatorIssue): string {
+  return (
+    `[adcp/server] specialism '${issue.specialism}' requires tool '${issue.tool}' ` +
+    `but no platform field exposes a '${issue.method}' method. ` +
+    `Either implement the method, drop the specialism from capabilities.specialisms, ` +
+    `or pass strictSpecialismValidation: false to silence (not recommended — ` +
+    `naive AdCP buyers will hit runtime errors when they call the unsupported tool).`
+  );
+}

--- a/src/lib/types/manifest.generated.ts
+++ b/src/lib/types/manifest.generated.ts
@@ -370,5 +370,23 @@ export const SPONSORED_INTELLIGENCE_TOOLS_FROM_MANIFEST = [
  * matching list per the spec's specialism YAML.
  */
 export const SPECIALISM_REQUIRED_TOOLS = {
-
+  "audience-sync": ["list_accounts", "sync_audiences"] as const,
+  "brand-rights": ["acquire_rights", "get_brand_identity", "get_rights", "sync_accounts", "sync_governance", "sync_plans"] as const,
+  "collection-lists": ["create_collection_list", "delete_collection_list", "get_collection_list", "list_collection_lists", "update_collection_list"] as const,
+  "content-standards": ["calibrate_content", "create_content_standards", "get_content_standards", "list_content_standards", "update_content_standards", "validate_content_delivery"] as const,
+  "creative-ad-server": ["build_creative", "get_creative_delivery", "list_creative_formats", "list_creatives", "report_usage"] as const,
+  "creative-generative": ["build_creative", "list_creative_formats", "sync_catalogs"] as const,
+  "creative-template": ["build_creative", "list_creative_formats", "preview_creative"] as const,
+  "governance-aware-seller": ["create_media_buy", "get_products", "sync_accounts", "sync_governance", "sync_plans"] as const,
+  "governance-delivery-monitor": ["check_governance", "create_media_buy", "get_media_buy_delivery", "sync_plans"] as const,
+  "governance-spend-authority": ["check_governance", "create_media_buy", "sync_plans"] as const,
+  "property-lists": ["create_property_list", "delete_property_list", "get_property_list", "list_property_lists", "update_property_list", "validate_property_delivery"] as const,
+  "sales-broadcast-tv": ["create_media_buy", "get_media_buy_delivery", "get_media_buys", "get_products", "list_creative_formats", "sync_accounts", "sync_creatives", "update_media_buy"] as const,
+  "sales-catalog-driven": ["build_creative", "create_media_buy", "get_media_buy_delivery", "get_media_buys", "get_products", "list_creative_formats", "log_event", "provide_performance_feedback", "sync_accounts", "sync_catalogs", "sync_creatives", "sync_event_sources", "update_media_buy"] as const,
+  "sales-guaranteed": ["create_media_buy", "get_media_buy_delivery", "get_media_buys", "get_products", "sync_accounts", "sync_creatives", "update_media_buy"] as const,
+  "sales-non-guaranteed": ["create_media_buy", "get_media_buy_delivery", "get_media_buys", "get_products", "sync_accounts", "sync_creatives", "update_media_buy"] as const,
+  "sales-proposal-mode": ["create_media_buy", "get_media_buy_delivery", "get_media_buys", "get_products", "list_creative_formats", "sync_accounts", "sync_creatives", "update_media_buy"] as const,
+  "sales-social": ["get_account_financials", "list_accounts", "log_event", "sync_accounts", "sync_audiences", "sync_catalogs", "sync_creatives", "sync_event_sources"] as const,
+  "signal-marketplace": ["activate_signal", "get_signals", "sync_accounts", "sync_governance", "sync_plans"] as const,
+  "signal-owned": ["activate_signal", "get_signals"] as const
 } as const;

--- a/test/lib/validate-specialisms.test.js
+++ b/test/lib/validate-specialisms.test.js
@@ -1,0 +1,166 @@
+/**
+ * Coverage for the specialism→required-tools runtime validator
+ * (`src/lib/server/decisioning/validate-specialisms.ts`). This is option B
+ * of #1299 — the runtime warning at server creation that catches adopters
+ * declaring a specialism but forgetting to implement one of its required
+ * methods.
+ *
+ * Spec reference: `manifest.json`'s `SPECIALISM_REQUIRED_TOOLS` (derived in
+ * `manifest.generated.ts`); the validator looks up the per-specialism tool
+ * list and checks `platform.{any-field}.{snakeToCamelCase(tool)}` exists
+ * as a function. "Any field" is intentional — required tools span platform
+ * fields (`sync_accounts` lives on `accounts`, not on `sales`), and
+ * pinning ownership upfront would either need a per-tool field map or
+ * cause false-positives on legitimate alternative layouts.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  validateSpecialismRequiredTools,
+  toolNameToMethodName,
+  formatSpecialismIssue,
+} = require('../../dist/lib/server/decisioning/validate-specialisms');
+
+describe('toolNameToMethodName: snake_case → camelCase', () => {
+  it('handles single-word', () => {
+    assert.equal(toolNameToMethodName('foo'), 'foo');
+  });
+  it('handles two-word', () => {
+    assert.equal(toolNameToMethodName('get_products'), 'getProducts');
+  });
+  it('handles three-word', () => {
+    assert.equal(toolNameToMethodName('provide_performance_feedback'), 'providePerformanceFeedback');
+  });
+  it('preserves an already-camelCase name', () => {
+    assert.equal(toolNameToMethodName('foo'), 'foo');
+  });
+});
+
+describe('validateSpecialismRequiredTools', () => {
+  it('returns no issues when no specialisms are declared', () => {
+    const platform = { sales: { getProducts: () => null } };
+    assert.deepEqual(validateSpecialismRequiredTools(platform, undefined), []);
+    assert.deepEqual(validateSpecialismRequiredTools(platform, []), []);
+  });
+
+  it('returns no issues when every required method exists somewhere on the platform', () => {
+    // sales-non-guaranteed requires: create_media_buy, get_media_buy_delivery,
+    // get_media_buys, get_products, sync_accounts, sync_creatives, update_media_buy
+    const platform = {
+      sales: {
+        getProducts: () => null,
+        createMediaBuy: () => null,
+        updateMediaBuy: () => null,
+        getMediaBuys: () => null,
+        getMediaBuyDelivery: () => null,
+        syncCreatives: () => null,
+      },
+      accounts: { syncAccounts: () => null },
+    };
+    assert.deepEqual(validateSpecialismRequiredTools(platform, ['sales-non-guaranteed']), []);
+  });
+
+  it('flags missing methods with specialism + tool + method names', () => {
+    // sales-non-guaranteed declared but no methods exist
+    const platform = { sales: {} };
+    const issues = validateSpecialismRequiredTools(platform, ['sales-non-guaranteed']);
+    assert.equal(issues.length, 7); // 7 required tools per manifest
+    const methods = issues.map(i => i.method).sort();
+    assert.deepEqual(methods, [
+      'createMediaBuy',
+      'getMediaBuyDelivery',
+      'getMediaBuys',
+      'getProducts',
+      'syncAccounts',
+      'syncCreatives',
+      'updateMediaBuy',
+    ]);
+    for (const issue of issues) {
+      assert.equal(issue.specialism, 'sales-non-guaranteed');
+      assert.equal(typeof issue.tool, 'string');
+      assert.equal(typeof issue.method, 'string');
+    }
+  });
+
+  it('finds methods on any platform field — adopter layout is flexible', () => {
+    // "Cross-cutting" placement: syncAccounts on accounts, the rest on sales.
+    // The validator's hasMethodAnywhere semantic accepts this.
+    const platform = {
+      sales: {
+        getProducts: () => null,
+        createMediaBuy: () => null,
+        updateMediaBuy: () => null,
+        getMediaBuys: () => null,
+        getMediaBuyDelivery: () => null,
+        syncCreatives: () => null,
+      },
+      accounts: { syncAccounts: () => null },
+    };
+    assert.deepEqual(validateSpecialismRequiredTools(platform, ['sales-non-guaranteed']), []);
+  });
+
+  it('alternative non-conventional layout: single mega-platform exposes all methods', () => {
+    // Adopter chose to put everything on one field. The validator doesn't care.
+    const platform = {
+      everything: {
+        getProducts: () => null,
+        createMediaBuy: () => null,
+        updateMediaBuy: () => null,
+        getMediaBuys: () => null,
+        getMediaBuyDelivery: () => null,
+        syncCreatives: () => null,
+        syncAccounts: () => null,
+      },
+    };
+    assert.deepEqual(validateSpecialismRequiredTools(platform, ['sales-non-guaranteed']), []);
+  });
+
+  it('silently passes specialisms not present in SPECIALISM_REQUIRED_TOOLS', () => {
+    // Manifest doesn't enumerate this; treat as no-op.
+    const platform = { sales: {} };
+    assert.deepEqual(
+      validateSpecialismRequiredTools(platform, ['signed-requests']),
+      []
+    );
+  });
+
+  it('aggregates issues across multiple specialisms', () => {
+    const platform = { sales: { getProducts: () => null } };
+    const issues = validateSpecialismRequiredTools(platform, [
+      'sales-non-guaranteed',
+      'signal-owned',
+    ]);
+    const specialisms = new Set(issues.map(i => i.specialism));
+    assert.deepEqual([...specialisms].sort(), ['sales-non-guaranteed', 'signal-owned']);
+  });
+
+  it('handles a non-object platform gracefully', () => {
+    // Defensive: validator shouldn't throw on undefined / null / primitive.
+    assert.doesNotThrow(() =>
+      validateSpecialismRequiredTools(null, ['sales-non-guaranteed'])
+    );
+    assert.doesNotThrow(() =>
+      validateSpecialismRequiredTools(undefined, ['sales-non-guaranteed'])
+    );
+    assert.doesNotThrow(() => validateSpecialismRequiredTools(42, ['sales-non-guaranteed']));
+    // Each call should return issues for every required tool since no methods are reachable.
+    const issues = validateSpecialismRequiredTools(null, ['sales-non-guaranteed']);
+    assert.ok(issues.length > 0);
+  });
+});
+
+describe('formatSpecialismIssue', () => {
+  it('produces a human-readable warning naming the specialism, tool, and method', () => {
+    const message = formatSpecialismIssue({
+      specialism: 'sales-non-guaranteed',
+      tool: 'create_media_buy',
+      method: 'createMediaBuy',
+    });
+    assert.match(message, /sales-non-guaranteed/);
+    assert.match(message, /create_media_buy/);
+    assert.match(message, /createMediaBuy/);
+    assert.match(message, /strictSpecialismValidation/);
+  });
+});

--- a/test/lib/validate-specialisms.test.js
+++ b/test/lib/validate-specialisms.test.js
@@ -120,30 +120,20 @@ describe('validateSpecialismRequiredTools', () => {
   it('silently passes specialisms not present in SPECIALISM_REQUIRED_TOOLS', () => {
     // Manifest doesn't enumerate this; treat as no-op.
     const platform = { sales: {} };
-    assert.deepEqual(
-      validateSpecialismRequiredTools(platform, ['signed-requests']),
-      []
-    );
+    assert.deepEqual(validateSpecialismRequiredTools(platform, ['signed-requests']), []);
   });
 
   it('aggregates issues across multiple specialisms', () => {
     const platform = { sales: { getProducts: () => null } };
-    const issues = validateSpecialismRequiredTools(platform, [
-      'sales-non-guaranteed',
-      'signal-owned',
-    ]);
+    const issues = validateSpecialismRequiredTools(platform, ['sales-non-guaranteed', 'signal-owned']);
     const specialisms = new Set(issues.map(i => i.specialism));
     assert.deepEqual([...specialisms].sort(), ['sales-non-guaranteed', 'signal-owned']);
   });
 
   it('handles a non-object platform gracefully', () => {
     // Defensive: validator shouldn't throw on undefined / null / primitive.
-    assert.doesNotThrow(() =>
-      validateSpecialismRequiredTools(null, ['sales-non-guaranteed'])
-    );
-    assert.doesNotThrow(() =>
-      validateSpecialismRequiredTools(undefined, ['sales-non-guaranteed'])
-    );
+    assert.doesNotThrow(() => validateSpecialismRequiredTools(null, ['sales-non-guaranteed']));
+    assert.doesNotThrow(() => validateSpecialismRequiredTools(undefined, ['sales-non-guaranteed']));
     assert.doesNotThrow(() => validateSpecialismRequiredTools(42, ['sales-non-guaranteed']));
     // Each call should return issues for every required tool since no methods are reachable.
     const issues = validateSpecialismRequiredTools(null, ['sales-non-guaranteed']);

--- a/test/lib/validate-specialisms.test.js
+++ b/test/lib/validate-specialisms.test.js
@@ -33,8 +33,8 @@ describe('toolNameToMethodName: snake_case → camelCase', () => {
   it('handles three-word', () => {
     assert.equal(toolNameToMethodName('provide_performance_feedback'), 'providePerformanceFeedback');
   });
-  it('preserves an already-camelCase name', () => {
-    assert.equal(toolNameToMethodName('foo'), 'foo');
+  it('preserves an already-camelCase name (no-op)', () => {
+    assert.equal(toolNameToMethodName('getProducts'), 'getProducts');
   });
 });
 


### PR DESCRIPTION
## Summary

Stage 3 of #1192 (manifest adoption) — option B from the design walkthrough in #1299.

When an adopter declares a specialism in `capabilities.specialisms[]`, the AdCP spec implies the agent supports every tool in that specialism's required-tool list (per `manifest.specialisms[*].required_tools` — `SPECIALISM_REQUIRED_TOOLS` in `manifest.generated.ts`). This change adds a construction-time check in `createAdcpServerFromPlatform` that walks the platform object and warns (or throws under strict mode) when a required method is missing.

## What lands

- **`src/lib/server/decisioning/validate-specialisms.ts`** — `validateSpecialismRequiredTools(platform, specialisms)` and `formatSpecialismIssue(issue)` helpers. Uses **"method-presence-anywhere on platform"** semantic — walks every top-level field on the platform and checks for a function-typed property matching `snakeToCamelCase(tool)`. Required tools span platform fields (`sync_accounts` lives on `AccountsPlatform`, not on the specialism's primary `SalesPlatform`); pinning ownership upfront would either need a per-tool field map or false-positive on legitimate alternative layouts.

- **`createAdcpServerFromPlatform`** runs the check after `validatePlatform`. Default behavior is `console.warn` for each missing method (with specialism + tool + method name + actionable fix). New `strictSpecialismValidation: true` opt opts into `PlatformConfigError` — recommended for production CI, off in dev where adopters are iterating.

- **`scripts/generate-manifest-derived.ts`** now populates `SPECIALISM_REQUIRED_TOOLS` via reverse-mapping from `manifest.tools[*].specialisms[]` (the direct `specialisms[*].required_tools` is empty in 3.0.4). Filters universal tools (`get_adcp_capabilities` and other `protocol`-protocol tools) and normalizes keys to kebab-case to match `AdCPSpecialism`.

## What's deferred (was originally option C)

The build-time type fixture asserting `RequiredPlatformsFor<S>` collectively exposes every required-tool method was **scoped out during implementation**. The generated fixture revealed too many false-positives from cross-cutting tools — e.g., `sales-non-guaranteed` requires `sync_accounts`, but `RequiredPlatformsFor<'sales-non-guaranteed'>` resolves to `{ sales: SalesPlatform }`, which doesn't include `AccountsPlatform`. Every cross-cutting (specialism, tool) pair would surface as drift even though the SDK has the method on a different platform interface.

Two paths forward (tracked on #1299):

1. **Rescope C to a flatter assertion** — "every required-tool method exists on SOME platform interface in the SDK's family" (no per-specialism mapping). Catches truly-missing methods (e.g., `validate_property_delivery` not on `PropertyListsPlatform`) without flagging cross-cutting placement.
2. **Expand `RequiredPlatformsFor<S>` to include cross-cutting platforms** — meaningful architecture change; defer until concrete adopter pain.

The runtime check (option B) handles cross-cutting cleanly without either change, so it's the right ship-now deliverable.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `node --test test/lib/validate-specialisms.test.js` — 13/13 passing
- [ ] CI green
- [x] Tested: positive case (every required method exists), negative case (every method missing), cross-cutting layout (`sync_accounts` on `accounts` field), single-mega-platform layout (everything on one field), defensive null handling, multi-specialism aggregation

## Related

- Closes #1299 (option B portion); option C rescope tracked on the same issue
- Stage 1 of #1192 landed in #1275 (manifest-derived `STANDARD_ERROR_CODES`)
- Stage 2 of #1192 landed in #1298 (drift guard for `*_TOOLS` arrays)
- Builds on #1266 (3.0.4 bump that brought `manifest.json` into the cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)