### PR TITLE
feat(validation): add schemaId + discriminator hints to VALIDATION_ERROR (#1283)

### DIFF
--- a/.changeset/validation-error-schema-and-branch-hints.md
+++ b/.changeset/validation-error-schema-and-branch-hints.md
@@ -1,0 +1,26 @@
+---
+"@adcp/sdk": minor
+---
+
+Validation errors now name the rejecting schema and the discriminator the payload was inferred to be targeting. Closes #1283.
+
+`ValidationIssue` carries two new optional fields:
+
+- **`schemaId`** — `$id` of the rejecting schema, resolved by finding the longest registered AJV `$id` that prefixes the issue's `schemaPath`. For tools served from the flat schema tree (e.g. `governance/`, `brand/`) where `$ref`s are followed at runtime, this lands on the deeper sub-schema. For tools served from the pre-resolved `bundled/` tree (most of the catalog — signals, media-buy, creative), inner `$id`s are stripped at bundle time so `schemaId` resolves to the response root. Either way, the field names exactly the schema the validator looked at.
+- **`discriminator`** — array of `{field, value}` pairs identifying the variant the payload was inferred to be targeting. Populated when `compactUnionErrors`' const-discriminator collapse picks a "best surviving variant" (the user matched the discriminator but missed required fields or other constraints inside it). Compound discriminators like `audience-selector`'s `(type, value_type)` produce multi-entry arrays. Names align with OpenAPI 3.x `discriminator.propertyName`.
+
+Both fields ride on every `VALIDATION_ERROR` envelope by default — same precedent as `variants[]` and `allowedValues`, which already ship always-on with the rationale "PUBLIC spec data, not internal handler shape." The `exposeSchemaPath` gate stays in place for `schemaPath` itself.
+
+The prose `adcp_error.message` mirrors the new fields so adopters debugging from a wire envelope alone don't need to walk `issues[]`. The `(schema: …)` half is suppressed when the issue's `schemaId` equals the validator's root (bundled-tree default — restating the tool name doesn't help). New `ValidationOutcome.schemaId` exposes the root for callers building their own envelopes:
+
+```
+activate_signal response failed schema validation at /deployments/0/activation_key/key:
+  must have required property 'key' (discriminator: type='key_value')
+```
+
+Empirically every example built during the matrix-blind-fixtures lineage took 1–3 iterations to resolve a discriminated-union error that's now one-shot once the adopter reads the `discriminator` tag.
+
+**Known limitations** (follow-ups filed separately):
+- Bundled tools strip inner `$id`s — `schemaId` lands on the response root, not the deeper sub-schema referenced by `$ref`. A spec companion issue covers `$id` retention during bundling.
+- Synthetic union-root errors in nested unions can carry the outer discriminator (e.g. `type='platform'`) while leaf errors carry the inner (`type='key_value'`). The leaf is the actionable one; the root is contextual. Spec companion covers de-duplication.
+- The optional `hint` field from issue #1283's "Proposed change" #3 (curated prose like "type='key_value' requires top-level `key` and `value`") is deferred — requires per-tool curation and ships separately.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -118,8 +118,11 @@ Every validation failure produces:
 - `issues[].pointer` — RFC 6901 JSON Pointer to the field.
 - `issues[].keyword` — AJV keyword (`required`, `type`, `oneOf`, `anyOf`, `additionalProperties`, `format`, `enum`).
 - `issues[].variants` — when the keyword is `oneOf` or `anyOf`, each entry lists one variant's `required` + declared `properties`. **Pick ONE variant**, send only its `required` fields. This is the fastest recovery path when you didn't know the field was a union.
+- `issues[].discriminator` — when an SDK ≥6.7 picks a "best surviving variant" of a const-discriminated union, this is the `[{field, value}, …]` pairs that variant requires. Reads as the validator's verdict on which branch you were inferred to be targeting. Example: `discriminator: [{field: 'type', value: 'key_value'}]` plus `pointer: '/deployments/0/activation_key/key'` and `keyword: 'required'` means "you picked the `key_value` activation_key variant and it requires top-level `key` and `value`." Compound discriminators like `audience-selector`'s `(type, value_type)` produce two-entry arrays.
+- `issues[].schemaId` — `$id` of the rejecting schema. For tools served from the bundled tree this is usually the response root; for flat-tree tools it can land on the deeper sub-schema. Diagnostic only; the actionable lever is `discriminator` + `variants` + `pointer`.
+- `issues[].allowedValues` — closed enum lists for `keyword: 'enum'` issues. Picking from this list closes the case in one round.
 
-Patch the pointers, don't re-guess what the skill or the `variants` already told you, resend. Three attempts should cover every field.
+**Recovery order**: read `discriminator` first (names which branch to fix), then `variants` (lists every option if you're not in a branch), then `pointer` + `keyword` + `message` for the leaf fix. Patch and resend. Three attempts should cover every field.
 
 ## Minimal working examples
 
@@ -225,6 +228,7 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | Symptom | What it means | Fix |
 |---|---|---|
 | `keyword: 'oneOf'` with `variants[]` | Discriminated union — you sent fields from multiple variants, or none | Pick ONE variant from `variants[]`. Send only its `required` fields. |
+| `discriminator: [{field, value}]` on a `required` issue | Validator inferred which branch you targeted; you missed required fields IN that branch | Read the `discriminator` pair, fill the missing required fields at the same level (don't nest under the discriminator field name). |
 | 2-3 `additionalProperties` errors at the same pointer | You merged `oneOf` variants ({account_id, brand, operator, …}) | Drop to one variant. Don't keep "extra" fields "for completeness". |
 | `keyword: 'required'`, `pointer: '/idempotency_key'` | Mutating tool, no UUID | Generate fresh UUID per logical operation. Reuse it on retries. |
 | `keyword: 'type'` or `additionalProperties` at `/budget` | Sent `{amount, currency}` | `budget` is a number. Currency is implied by `pricing_option_id`. |

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2877,13 +2877,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 // stripped schemaPath even in dev — asymmetric with response-side.
                 const payload = buildAdcpValidationErrorPayload(toolName, 'request', issues, {
                   exposeSchemaPath: exposeErrorDetails,
+                  rootSchemaId: outcome.schemaId,
                 });
                 return finalize(adcpError('VALIDATION_ERROR', payload));
               }
-              logger.warn(`Schema validation warning (request) for ${toolName}: ${formatIssues(issues)}`, {
-                tool: toolName,
-                issues,
-              });
+              logger.warn(
+                `Schema validation warning (request) for ${toolName}: ${formatIssues(issues, 3, { rootSchemaId: outcome.schemaId })}`,
+                {
+                  tool: toolName,
+                  issues,
+                }
+              );
             }
           }
         }
@@ -3185,14 +3189,18 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             const payload = formatted.structuredContent;
             const outcome = validateResponse(toolName, payload, adcpVersion);
             if (!outcome.valid) {
-              logger.warn(`Schema validation warning (response) for ${toolName}: ${formatIssues(outcome.issues)}`, {
-                tool: toolName,
-                issues: outcome.issues,
-                variant: outcome.variant,
-              });
+              logger.warn(
+                `Schema validation warning (response) for ${toolName}: ${formatIssues(outcome.issues, 3, { rootSchemaId: outcome.schemaId })}`,
+                {
+                  tool: toolName,
+                  issues: outcome.issues,
+                  variant: outcome.variant,
+                }
+              );
               if (responseValidationMode === 'strict') {
                 const errPayload = buildAdcpValidationErrorPayload(toolName, 'response', outcome.issues, {
                   exposeSchemaPath: exposeErrorDetails,
+                  rootSchemaId: outcome.schemaId,
                 });
                 const errEnvelope = adcpError('VALIDATION_ERROR', errPayload);
                 if (idempotencyCheck && idempotency) {

--- a/src/lib/validation/schema-errors.ts
+++ b/src/lib/validation/schema-errors.ts
@@ -4,7 +4,23 @@
  */
 
 import { ValidationError } from '../errors';
-import type { ValidationIssue } from './schema-validator';
+import { formatDiscriminator, type ValidationIssue } from './schema-validator';
+
+/**
+ * Build the `(schema: …; discriminator: …)` suffix for a single issue's
+ * prose message. Suppresses `schema:` when the issue's `schemaId` matches
+ * `rootSchemaId` (it would just restate the tool the adopter already
+ * knows), and `discriminator:` when no const-discriminator was resolved.
+ * Returns an empty string when both halves drop out so callers can compose
+ * conditionally.
+ */
+function buildIssueProseSuffix(issue: ValidationIssue, rootSchemaId: string | undefined): string {
+  const parts: string[] = [];
+  if (issue.schemaId && issue.schemaId !== rootSchemaId) parts.push(`schema: ${issue.schemaId}`);
+  const discriminator = formatDiscriminator(issue.discriminator);
+  if (discriminator) parts.push(`discriminator: ${discriminator}`);
+  return parts.length > 0 ? ` (${parts.join('; ')})` : '';
+}
 
 export interface ValidationErrorDetails {
   /** Tool that was being validated. */
@@ -28,7 +44,9 @@ export function buildValidationError(
 ): ValidationError {
   const first = issues[0];
   const field = first?.pointer ?? '/';
-  const constraint = first ? `${first.keyword}: ${first.message}` : 'schema validation failed';
+  const constraint = first
+    ? `${first.keyword}: ${first.message}${buildIssueProseSuffix(first, undefined)}`
+    : 'schema validation failed';
   const err = new ValidationError(field, undefined, `${tool} ${side}: ${constraint}`);
   err.details = { tool, side, issues } satisfies ValidationErrorDetails;
   return err;
@@ -72,7 +90,7 @@ export function buildAdcpValidationErrorPayload(
   tool: string,
   side: 'request' | 'response',
   issues: ValidationIssue[],
-  options: { exposeSchemaPath?: boolean } = {}
+  options: { exposeSchemaPath?: boolean; rootSchemaId?: string } = {}
 ): {
   message: string;
   field?: string;
@@ -80,10 +98,21 @@ export function buildAdcpValidationErrorPayload(
   details: Record<string, unknown>;
 } {
   const first = issues[0];
-  const message =
-    first != null
-      ? `${tool} ${side} failed schema validation at ${first.pointer}: ${first.message}`
-      : `${tool} ${side} failed schema validation`;
+  let message: string;
+  if (first != null) {
+    // Prose suffix mirrors `formatIssueLine` so adopters reading
+    // `adcp_error.message` directly see the rejecting schema $id and
+    // (when known) the union discriminator the payload was inferred to be
+    // targeting (issue #1283). `rootSchemaId` (passed by callers that
+    // know the validator's root, e.g. the server middleware threading
+    // through from `validateRequest`/`validateResponse`) suppresses the
+    // `schema:` half when the issue landed on the response root — typical
+    // for AdCP's bundled tree, where most issues do, and where the schema
+    // suffix would just restate the tool name.
+    message = `${tool} ${side} failed schema validation at ${first.pointer}: ${first.message}${buildIssueProseSuffix(first, options.rootSchemaId)}`;
+  } else {
+    message = `${tool} ${side} failed schema validation`;
+  }
   // `exposeSchemaPath` gates `schemaPath` only. Not `variants`.
   // Different sensitivity classes justify different defaults:
   //   - `schemaPath` (e.g. `#/properties/account/oneOf/2`) encodes which

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -412,6 +412,26 @@ export function listValidatorKeys(version: string = ADCP_VERSION): string[] {
   return [...s.fileIndex.keys()].sort();
 }
 
+/**
+ * `$id`s of every schema currently registered with the AdCP validator's AJV
+ * instance for `version`. Used by the schema-validator to extract the
+ * rejecting sub-schema's `$id` from an Ajv error's `schemaPath`: when a
+ * `$ref` is followed, Ajv prefixes the schemaPath with the target schema's
+ * `$id`, so the longest registered `$id` that prefixes a schemaPath is the
+ * sub-schema responsible for the failure.
+ *
+ * The set grows as `getValidator` calls trigger `ensureCoreLoaded` and
+ * compile new tool roots — callers should read it AFTER the validate call
+ * they're projecting errors from.
+ */
+export function getRegisteredSchemaIds(version: string = ADCP_VERSION): readonly string[] {
+  const s = ensureInit(version);
+  // Ajv 8 keeps registered schemas at `ajv.schemas` (URI → SchemaEnv). Returning
+  // the keys is enough for prefix matching; we don't expose the SchemaEnv values.
+  const registry = (s.ajv as unknown as { schemas?: Record<string, unknown> }).schemas;
+  return registry ? Object.keys(registry) : [];
+}
+
 /** Suffix used in the suffix table — exported for testing. */
 export { SCHEMA_FILENAME_SUFFIX };
 

--- a/src/lib/validation/schema-validator.ts
+++ b/src/lib/validation/schema-validator.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ErrorObject } from 'ajv';
-import { getValidator, type Direction, type ResponseVariant } from './schema-loader';
+import { getValidator, getRegisteredSchemaIds, type Direction, type ResponseVariant } from './schema-loader';
 import { parseAdcpMajorVersion } from '../version';
 
 /**
@@ -43,6 +43,43 @@ export interface ValidationIssue {
   keyword: string;
   /** Path inside the schema that rejected the payload. */
   schemaPath: string;
+  /**
+   * `$id` of the rejecting schema. Resolved by finding the longest
+   * registered AJV `$id` that prefixes {@link schemaPath}.
+   *
+   * Bundling caveat: AdCP ships most tools through `schemas/cache/<v>/bundled/`
+   * with `$ref`s pre-resolved and inner `$id`s stripped at bundle time. For
+   * those tools, `schemaId` resolves to the response root (e.g.
+   * `/schemas/3.0.4/bundled/signals/activate-signal-response.json`), not
+   * the deeper sub-schema. Tools served from the flat tree (`governance/`,
+   * `brand/`, etc.) preserve sub-schema `$id`s, so `schemaId` can land on
+   * something deeper like `/schemas/3.0.4/core/activation-key.json`. Either
+   * way, the field names exactly the schema the validator looked at.
+   *
+   * Always projected — the `$id` is the published spec URI, not internal
+   * handler shape. (Same precedent as {@link ValidationIssue.variants} and
+   * {@link ValidationIssue.allowedValues}, both of which already ship
+   * always-on with the same rationale.)
+   *
+   * Absent only when the rejecting schema didn't declare an `$id`.
+   */
+  schemaId?: string;
+  /**
+   * Discriminator field/value pair(s) of a `oneOf`/`anyOf` that the payload
+   * was inferred to be targeting. Populated by {@link compactUnionErrors}
+   * when a const-discriminator collapse picks a "best surviving variant" —
+   * the variant the user matched the discriminator of but missed required
+   * fields or other constraints in. Compound discriminators like
+   * `audience-selector`'s `(type, value_type)` produce multi-entry arrays.
+   *
+   * Names align with OpenAPI 3.x `discriminator.propertyName`.
+   *
+   * Absent when no discriminator could be resolved — either the keyword
+   * isn't a union, the union has no `const`-asserting properties, or the
+   * payload didn't match any branch's discriminator (in which case the
+   * synthetic `enum`-keyword issue carries `allowedValues` instead).
+   */
+  discriminator?: ReadonlyArray<{ field: string; value: unknown }>;
   /**
    * Variants a caller can pick from when `keyword === 'oneOf'` or
    * `'anyOf'`. Each entry carries the variant's required fields + known
@@ -81,6 +118,15 @@ export interface ValidationOutcome {
   /** Which schema variant was selected — useful for logging/debugging. */
   variant: Direction | 'skipped';
   /**
+   * `$id` of the root validator that produced this outcome (e.g.
+   * `/schemas/3.0.4/bundled/signals/activate-signal-response.json`). Lets
+   * downstream callers suppress redundant `(schema: ...)` prose suffixes
+   * on issues that landed on the response root — typical for the bundled
+   * tree, where most issues do. Absent when no schema was applied
+   * (`variant: 'skipped'`) or the root schema didn't declare an `$id`.
+   */
+  schemaId?: string;
+  /**
    * True when the response's `status` field named an async variant
    * (`submitted` / `working` / `input-required`) but no compiled schema
    * existed for that variant, so validation fell back to the sync
@@ -96,7 +142,61 @@ export interface ValidationOutcome {
 
 const OK: ValidationOutcome = Object.freeze({ valid: true, issues: [], variant: 'skipped' });
 
-function formatIssue(err: ErrorObject): ValidationIssue {
+/**
+ * Marker attached by {@link compactUnionErrors} to the residual errors of
+ * the variant it picked as the best surviving branch. Carries the
+ * discriminator field+value pair(s) that variant requires, so
+ * {@link formatIssue} can surface the branch identifier on every issue
+ * inherited from that variant. Marker key is namespaced with `__adcp_` to
+ * avoid colliding with anything Ajv may add.
+ */
+type AdcpDiscriminatedError = ErrorObject & {
+  __adcp_discriminator?: ReadonlyArray<{ field: string; value: unknown }>;
+};
+
+/**
+ * Find the longest registered AJV `$id` that prefixes `schemaPath` — that
+ * `$id` belongs to the schema (or `$ref`'d sub-schema) responsible for the
+ * failure. Returns `undefined` for inline (`#/...`) paths when the root
+ * schema doesn't declare an `$id`.
+ *
+ * AJV 8 prefixes a `$ref`'d schema's errors with the target schema's `$id`
+ * (e.g. `/schemas/3.0.4/core/activation-key.json/oneOf/1/required`), so
+ * the prefix search resolves cleanly without re-traversing the schema
+ * graph. The match must end at a path boundary — `'/'` or `'#'` — so an
+ * `$id` ending in `.json` can't false-match a sibling whose `$id` is a
+ * proper extension of it.
+ */
+function extractSchemaId(
+  schemaPath: string,
+  rootSchema: unknown,
+  registeredIds: readonly string[]
+): string | undefined {
+  if (schemaPath.startsWith('#') || schemaPath === '') {
+    const id = (rootSchema as { $id?: unknown } | null | undefined)?.$id;
+    return typeof id === 'string' ? id : undefined;
+  }
+  // The Ajv registry includes the JSON Schema meta-schema
+  // (`http://json-schema.org/draft-07/schema`) alongside AdCP `$id`s. Ajv
+  // never emits schemaPaths prefixed with the meta-schema URL — those
+  // paths use the relative `#/...` form and take the branch above — so
+  // the meta-schema entry never false-matches here.
+  let best: string | undefined;
+  for (const id of registeredIds) {
+    if (!id) continue;
+    if (schemaPath === id || schemaPath.startsWith(`${id}/`) || schemaPath.startsWith(`${id}#`)) {
+      if (best === undefined || id.length > best.length) best = id;
+    }
+  }
+  return best;
+}
+
+interface FormatContext {
+  rootSchema: unknown;
+  registeredIds: readonly string[];
+}
+
+function formatIssue(err: ErrorObject, ctx: FormatContext): ValidationIssue {
   const instancePath = err.instancePath || '';
   const missingProperty =
     err.keyword === 'required' &&
@@ -120,11 +220,16 @@ function formatIssue(err: ErrorObject): ValidationIssue {
     ? `must be one of: ${allowedValues!.map(v => JSON.stringify(v)).join(', ')}`
     : (err.message ?? 'validation failed');
 
+  const schemaId = extractSchemaId(err.schemaPath, ctx.rootSchema, ctx.registeredIds);
+  const discriminator = (err as AdcpDiscriminatedError).__adcp_discriminator;
+
   return {
     pointer: `${instancePath}${missingProperty}` || '/',
     message,
     keyword: err.keyword,
     schemaPath: err.schemaPath,
+    ...(schemaId !== undefined && { schemaId }),
+    ...(discriminator !== undefined && discriminator.length > 0 && { discriminator }),
     ...(allowedValues !== undefined && { allowedValues }),
   };
 }
@@ -358,6 +463,40 @@ function compactUnionErrors(errors: readonly ErrorObject[], rootSchema: unknown)
     for (const [idx, residual] of residualByVariant) {
       if (idx !== bestIdx) for (const e of residual) dropped.add(e);
     }
+
+    // Tag the surviving variant's residuals with the discriminator
+    // field+value pair(s) it requires. Adopters reading the projected
+    // issue see "branch: type='key_value'" alongside the missing-required
+    // error, so they know which branch the seller's payload was inferred
+    // to be targeting (issue #1283). Compound discriminators (e.g.,
+    // `audience-selector`'s (type, value_type)) become multi-entry
+    // arrays — order follows iteration of `constAsserters`, which mirrors
+    // the variant's `properties` declaration order.
+    if (bestIdx >= 0) {
+      const pairs: Array<{ field: string; value: unknown }> = [];
+      for (const [relPath, asserters] of constAsserters) {
+        const constValue = asserters.get(bestIdx);
+        if (constValue === undefined) continue;
+        const field = relPath.startsWith('/') ? relPath.slice(1) : relPath;
+        pairs.push({ field, value: constValue });
+      }
+      if (pairs.length > 0) {
+        const surviving = residualByVariant.get(bestIdx) ?? [];
+        for (const e of surviving) {
+          // Deepest-first ordering means inner unions tag first; if a
+          // residual is already tagged it carries the more specific
+          // (deeper) discriminator, which is what the adopter needs to
+          // fix. Don't clobber it with the outer union's tag — the outer
+          // discriminator is context, not the actionable lever.
+          // Bucketing-by-deepest-prefix in `errorsByOneOfPath` already
+          // protects most leaf errors from entering this loop, but the
+          // explicit guard makes the invariant resilient to future
+          // changes in that bucket scheme.
+          if ((e as AdcpDiscriminatedError).__adcp_discriminator !== undefined) continue;
+          (e as AdcpDiscriminatedError).__adcp_discriminator = pairs;
+        }
+      }
+    }
   }
 
   return [...errors.filter(e => !dropped.has(e)), ...added];
@@ -400,13 +539,20 @@ export function validateRequest(toolName: string, payload: unknown, version?: st
   const validator = getValidator(toolName, 'request', version);
   if (!validator) return OK;
   const valid = validator(payload) as boolean;
-  if (valid) return { valid: true, issues: [], variant: 'request' };
   const rootSchema = (validator as { schema?: unknown }).schema;
+  const rootSchemaId =
+    rootSchema && typeof rootSchema === 'object' && typeof (rootSchema as { $id?: unknown }).$id === 'string'
+      ? ((rootSchema as { $id: string }).$id as string)
+      : undefined;
+  if (valid) return { valid: true, issues: [], variant: 'request', ...(rootSchemaId && { schemaId: rootSchemaId }) };
+  const registeredIds = getRegisteredSchemaIds(version);
+  const ctx: FormatContext = { rootSchema, registeredIds };
   const compacted = compactUnionErrors(validator.errors ?? [], rootSchema);
   return {
     valid: false,
-    issues: compacted.map(formatIssue).map(i => enrichWithVariants(i, rootSchema)),
+    issues: compacted.map(e => formatIssue(e, ctx)).map(i => enrichWithVariants(i, rootSchema)),
     variant: 'request',
+    ...(rootSchemaId && { schemaId: rootSchemaId }),
   };
 }
 
@@ -495,21 +641,90 @@ export function validateResponse(toolName: string, payload: unknown, version?: s
   const fallbackFields: Pick<ValidationOutcome, 'variant_fallback_applied' | 'requested_variant'> = variantFallback
     ? { variant_fallback_applied: true, requested_variant: variant }
     : {};
-  if (valid) return { valid: true, issues: [], variant: usedVariant, ...fallbackFields };
+  const rootSchemaId =
+    rootSchema && typeof rootSchema === 'object' && typeof (rootSchema as { $id?: unknown }).$id === 'string'
+      ? ((rootSchema as { $id: string }).$id as string)
+      : undefined;
+  if (valid) {
+    return {
+      valid: true,
+      issues: [],
+      variant: usedVariant,
+      ...(rootSchemaId && { schemaId: rootSchemaId }),
+      ...fallbackFields,
+    };
+  }
+  const registeredIds = getRegisteredSchemaIds(version);
+  const ctx: FormatContext = { rootSchema, registeredIds };
   const compacted = compactUnionErrors(effective.errors ?? [], rootSchema);
   return {
     valid: false,
-    issues: compacted.map(formatIssue).map(i => enrichWithVariants(i, rootSchema)),
+    issues: compacted.map(e => formatIssue(e, ctx)).map(i => enrichWithVariants(i, rootSchema)),
     variant: usedVariant,
+    ...(rootSchemaId && { schemaId: rootSchemaId }),
     ...fallbackFields,
   };
 }
 
-/** Render a compact one-line summary of the failures — useful for logs. */
-export function formatIssues(issues: ValidationIssue[], limit = 3): string {
+/**
+ * Render `discriminator[]` as `field='value', other='x'`. Strings are
+ * single-quoted (matches the issue #1283 example shape) with embedded
+ * apostrophes backslash-escaped so a future spec const containing `'`
+ * can't produce ambiguous output. Other JSON-safe values use
+ * `JSON.stringify` so booleans and numbers stay unambiguous. Returns an
+ * empty string when the array is empty so callers can compose
+ * conditionally.
+ */
+export function formatDiscriminator(
+  discriminator: ReadonlyArray<{ field: string; value: unknown }> | undefined
+): string {
+  if (!discriminator || discriminator.length === 0) return '';
+  return discriminator
+    .map(({ field, value }) => {
+      if (typeof value !== 'string') return `${field}=${JSON.stringify(value)}`;
+      const escaped = value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      return `${field}='${escaped}'`;
+    })
+    .join(', ');
+}
+
+/**
+ * One-line render of a validation issue with `(schema: <$id>)` and
+ * `(discriminator: <field>='<value>')` suffixes when the issue carries
+ * them. Used by both {@link formatIssues} and the prose `message` field on
+ * `VALIDATION_ERROR` envelopes (issue #1283), so adopters debugging from
+ * the wire envelope alone see the rejecting schema and union discriminator
+ * without having to walk `issues[]`.
+ *
+ * The `(schema: ...)` suffix is suppressed for inline failures whose
+ * `schemaId` is the response root — the tool name already conveys that,
+ * and AdCP's bundled tree strips inner `$id`s so most issues land on the
+ * root. Suppressing keeps the prose tight on the cases where the schema
+ * field would just restate the tool the adopter already knows. Adopters
+ * who want the field unconditionally read it from the structured
+ * `issues[].schemaId`.
+ */
+export function formatIssueLine(issue: ValidationIssue, options: { rootSchemaId?: string } = {}): string {
+  const parts: string[] = [`${issue.pointer} ${issue.message}`];
+  if (issue.schemaId && issue.schemaId !== options.rootSchemaId) {
+    parts.push(`(schema: ${issue.schemaId})`);
+  }
+  const discriminator = formatDiscriminator(issue.discriminator);
+  if (discriminator) parts.push(`(discriminator: ${discriminator})`);
+  return parts.join(' ');
+}
+
+/**
+ * Render a compact one-line summary of the failures — useful for logs.
+ *
+ * `rootSchemaId`, when supplied, suppresses the `(schema: ...)` suffix on
+ * issues whose `schemaId` matches it (typical for issues that landed on
+ * the response root). Pass `undefined` to always emit the suffix.
+ */
+export function formatIssues(issues: ValidationIssue[], limit = 3, options: { rootSchemaId?: string } = {}): string {
   const head = issues
     .slice(0, limit)
-    .map(i => `${i.pointer} ${i.message}`)
+    .map(i => formatIssueLine(i, options))
     .join('; ');
   const rest = issues.length - limit;
   return rest > 0 ? `${head} (+${rest} more)` : head;

--- a/test/lib/schema-validation.test.js
+++ b/test/lib/schema-validation.test.js
@@ -297,6 +297,294 @@ describe('schema-driven validation', () => {
     });
   });
 
+  describe('schemaId + discriminator enrichment (issue #1283)', () => {
+    test('schemaId resolves to the validating schema $id', () => {
+      // Adopters debugging an activate_signal validation error need to know
+      // which schema rejected their payload. AdCP ships activate_signal in
+      // the pre-resolved `bundled/` tree — the activation_key sub-schema is
+      // inlined at bundle time without an inner $id — so the rejecting
+      // schemaId is the response root. That's still the right answer for
+      // the wire envelope: it names the schema the validator actually used,
+      // matching exactly what `npm view @adcp/sdk` ships.
+      const outcome = validateResponse('activate_signal', {
+        deployments: [
+          {
+            type: 'platform',
+            platform: 'dsp1',
+            is_live: true,
+            activation_key: { type: 'key_value' },
+          },
+        ],
+      });
+      assert.strictEqual(outcome.valid, false);
+      const issue = outcome.issues.find(i => i.pointer.startsWith('/deployments/0/activation_key'));
+      assert.ok(issue, `expected an activation_key issue, got: ${JSON.stringify(outcome.issues)}`);
+      assert.ok(
+        typeof issue.schemaId === 'string' && issue.schemaId.endsWith('.json'),
+        `expected a registered schema $id, got: ${JSON.stringify(issue.schemaId)}`
+      );
+      assert.ok(
+        issue.schemaId.includes('activate-signal-response') || issue.schemaId.includes('activation-key'),
+        `schemaId should name the activate_signal response or its activation-key fragment, got: ${issue.schemaId}`
+      );
+    });
+
+    test('schemaId falls back to the root validator $id for inline failures', () => {
+      // get_products-request rejects an empty payload at the request root —
+      // schemaPath is `#/required`, so schemaId comes from the root schema's $id.
+      const outcome = validateRequest('get_products', {});
+      assert.strictEqual(outcome.valid, false);
+      const issue = outcome.issues[0];
+      assert.ok(issue);
+      assert.ok(typeof issue.schemaId === 'string', `expected schemaId on root issue, got: ${JSON.stringify(issue)}`);
+      assert.ok(
+        issue.schemaId.endsWith('-request.json'),
+        `schemaId should be the request schema $id, got: ${issue.schemaId}`
+      );
+    });
+
+    test('discriminator is attached to the surviving variant on a const collapse', () => {
+      // activation_key is a oneOf split by `type` const ('segment_id' vs 'key_value').
+      // Outer deployment matches the platform variant cleanly so only the inner
+      // activation_key oneOf cascades. Picking type='key_value' but omitting
+      // `key`/`value` leaves variant[1] as the best surviving variant — every
+      // residual error inherited from that variant should carry
+      // `discriminator: [{field: 'type', value: 'key_value'}]`.
+      const outcome = validateResponse('activate_signal', {
+        deployments: [
+          {
+            type: 'platform',
+            platform: 'dsp1',
+            is_live: true,
+            activation_key: { type: 'key_value' },
+          },
+        ],
+      });
+      assert.strictEqual(outcome.valid, false);
+      const tagged = outcome.issues.filter(i => Array.isArray(i.discriminator));
+      assert.ok(
+        tagged.length > 0,
+        `expected at least one issue with a discriminator tag, got: ${JSON.stringify(outcome.issues)}`
+      );
+      const sample = tagged[0];
+      assert.deepStrictEqual(
+        sample.discriminator,
+        [{ field: 'type', value: 'key_value' }],
+        `discriminator should reflect the picked variant, got: ${JSON.stringify(sample.discriminator)}`
+      );
+    });
+
+    test('formatIssues suffixes prose with schema and discriminator when present', () => {
+      const issues = [
+        {
+          pointer: '/deployments/0/activation_key',
+          message: "must have required property 'key'",
+          keyword: 'required',
+          schemaPath: '/schemas/3.0.4/core/activation-key.json/oneOf/1/required',
+          schemaId: '/schemas/3.0.4/core/activation-key.json',
+          discriminator: [{ field: 'type', value: 'key_value' }],
+        },
+      ];
+      const summary = formatIssues(issues);
+      assert.ok(
+        summary.includes('(schema: /schemas/3.0.4/core/activation-key.json)'),
+        `summary should embed schema $id, got: ${summary}`
+      );
+      assert.ok(
+        summary.includes("(discriminator: type='key_value')"),
+        `summary should embed discriminator, got: ${summary}`
+      );
+    });
+
+    test('formatIssues suppresses (schema: …) when schemaId equals the rootSchemaId', () => {
+      // Most issues land on the response root in the bundled tree; the
+      // schema suffix would just restate the tool name. Adopters who want
+      // the field unconditionally read it from the structured issues[].
+      const rootSchemaId = '/schemas/3.0.4/bundled/signals/activate-signal-response.json';
+      const issues = [
+        {
+          pointer: '/deployments/0/activation_key/key',
+          message: "must have required property 'key'",
+          keyword: 'required',
+          schemaPath: '/schemas/3.0.4/bundled/signals/activate-signal-response.json/oneOf/0/...',
+          schemaId: rootSchemaId,
+          discriminator: [{ field: 'type', value: 'key_value' }],
+        },
+      ];
+      const summary = formatIssues(issues, 3, { rootSchemaId });
+      assert.ok(!summary.includes('(schema:'), `schema suffix should be suppressed at root, got: ${summary}`);
+      assert.ok(
+        summary.includes("(discriminator: type='key_value')"),
+        `discriminator suffix must still ship, got: ${summary}`
+      );
+    });
+
+    test('discriminator is absent when no const collapse picks a variant', () => {
+      // create_content_standards uses an anyOf split by `required`-only
+      // (policies vs registry_policy_ids), no `const` asserters.
+      // discriminator is reserved for const-asserting unions where we
+      // can name a specific field/value pair.
+      const res = validateRequest('create_content_standards', {
+        idempotency_key: '00000000-0000-0000-0000-000000000000',
+        account: { account_id: 'acme' },
+        scope: { kind: 'buyer' },
+      });
+      assert.strictEqual(res.valid, false);
+      const anyOfIssue = res.issues.find(i => i.keyword === 'anyOf');
+      assert.ok(anyOfIssue, 'anyOf issue must be present');
+      assert.strictEqual(
+        anyOfIssue.discriminator,
+        undefined,
+        `non-const unions must not carry discriminator, got: ${JSON.stringify(anyOfIssue.discriminator)}`
+      );
+      // ...but variants[] still ships (the public-spec recovery info).
+      assert.ok(Array.isArray(anyOfIssue.variants));
+    });
+
+    test('nested unions: inner discriminator tag is preserved on leaf errors', () => {
+      // activate_signal-response has nested oneOfs:
+      //   response root oneOf (success/error) →
+      //     deployments[].items oneOf (platform/agent) →
+      //       activation_key oneOf (segment_id/key_value)
+      // User picks platform deployment + key_value activation_key but
+      // omits `key`/`value`. The leaf `required` errors live inside the
+      // INNER activation_key oneOf — their tag must reflect the most-
+      // specific discriminator (`type='key_value'`), not the outer
+      // deployment discriminator (`type='platform'`). Adopters fix the
+      // payload by reading the leaf, so the leaf tag is the actionable one.
+      const outcome = validateResponse('activate_signal', {
+        deployments: [
+          {
+            type: 'platform',
+            platform: 'dsp1',
+            is_live: true,
+            activation_key: { type: 'key_value' },
+          },
+        ],
+      });
+      assert.strictEqual(outcome.valid, false);
+      const leaf = outcome.issues.find(i => i.pointer === '/deployments/0/activation_key/key');
+      assert.ok(leaf, `expected a leaf 'required' issue, got: ${JSON.stringify(outcome.issues)}`);
+      assert.deepStrictEqual(
+        leaf.discriminator,
+        [{ field: 'type', value: 'key_value' }],
+        `leaf tag must be the inner discriminator, got: ${JSON.stringify(leaf.discriminator)}`
+      );
+    });
+
+    test('formatDiscriminator escapes apostrophes in const string values', () => {
+      // No live AdCP const carries an apostrophe today, but a future
+      // spec addition could. The wire suffix must stay unambiguous.
+      const issues = [
+        {
+          pointer: '/x',
+          message: 'must match',
+          keyword: 'enum',
+          schemaPath: '#/properties/x/enum',
+          discriminator: [{ field: 'flavor', value: "it's spicy" }],
+        },
+      ];
+      const summary = formatIssues(issues);
+      assert.ok(
+        summary.includes("flavor='it\\'s spicy'"),
+        `apostrophe must be escaped in discriminator suffix, got: ${summary}`
+      );
+    });
+
+    test('compound discriminators produce a multi-entry array', () => {
+      // Synthetic ValidationIssue with two discriminator pairs (mirrors
+      // audience-selector's `(type, value_type)` shape). formatDiscriminator
+      // joins multiple entries with `, ` so adopters reading the wire
+      // envelope see every discriminator field.
+      const issues = [
+        {
+          pointer: '/audience_selector',
+          message: 'must have required property X',
+          keyword: 'required',
+          schemaPath: '#/properties/audience_selector/oneOf/2/required',
+          discriminator: [
+            { field: 'type', value: 'demographic' },
+            { field: 'value_type', value: 'range' },
+          ],
+        },
+      ];
+      const summary = formatIssues(issues);
+      assert.ok(
+        summary.includes("(discriminator: type='demographic', value_type='range')"),
+        `compound discriminator must render as comma-joined pairs, got: ${summary}`
+      );
+    });
+
+    test('buildAdcpValidationErrorPayload prose embeds schema and discriminator hints', () => {
+      const issues = [
+        {
+          pointer: '/deployments/0/activation_key',
+          message: "must have required property 'key'",
+          keyword: 'required',
+          schemaPath: '/schemas/3.0.4/core/activation-key.json/oneOf/1/required',
+          schemaId: '/schemas/3.0.4/core/activation-key.json',
+          discriminator: [{ field: 'type', value: 'key_value' }],
+        },
+      ];
+      const payload = buildAdcpValidationErrorPayload('activate_signal', 'response', issues);
+      assert.ok(
+        payload.message.includes('schema: /schemas/3.0.4/core/activation-key.json'),
+        `wire message should name the schema, got: ${payload.message}`
+      );
+      assert.ok(
+        payload.message.includes("discriminator: type='key_value'"),
+        `wire message should name the discriminator, got: ${payload.message}`
+      );
+      // schemaId and discriminator must survive the default (exposeSchemaPath: false) projection.
+      assert.strictEqual(payload.issues[0].schemaId, '/schemas/3.0.4/core/activation-key.json');
+      assert.deepStrictEqual(payload.issues[0].discriminator, [{ field: 'type', value: 'key_value' }]);
+      assert.strictEqual(payload.issues[0].schemaPath, undefined, 'schemaPath stripped by default — schemaId is not');
+    });
+
+    test('buildAdcpValidationErrorPayload suppresses redundant schema suffix when rootSchemaId matches', () => {
+      const rootSchemaId = '/schemas/3.0.4/bundled/signals/activate-signal-response.json';
+      const issues = [
+        {
+          pointer: '/deployments/0/activation_key/key',
+          message: "must have required property 'key'",
+          keyword: 'required',
+          schemaPath: '/schemas/3.0.4/bundled/signals/activate-signal-response.json/oneOf/0/.../required',
+          schemaId: rootSchemaId,
+          discriminator: [{ field: 'type', value: 'key_value' }],
+        },
+      ];
+      const payload = buildAdcpValidationErrorPayload('activate_signal', 'response', issues, { rootSchemaId });
+      assert.ok(
+        !payload.message.includes('schema:'),
+        `schema suffix should be suppressed when schemaId matches rootSchemaId, got: ${payload.message}`
+      );
+      assert.ok(
+        payload.message.includes("discriminator: type='key_value'"),
+        `discriminator suffix must still ship, got: ${payload.message}`
+      );
+      // The structured issue still carries schemaId for adopters who want it.
+      assert.strictEqual(payload.issues[0].schemaId, rootSchemaId);
+    });
+
+    test('ValidationOutcome surfaces the root validator schemaId', () => {
+      const outcome = validateResponse('activate_signal', {
+        deployments: [
+          {
+            type: 'platform',
+            platform: 'dsp1',
+            is_live: true,
+            activation_key: { type: 'key_value' },
+          },
+        ],
+      });
+      assert.strictEqual(
+        outcome.schemaId,
+        '/schemas/3.0.4/bundled/signals/activate-signal-response.json',
+        `outcome.schemaId should name the root validator, got: ${outcome.schemaId}`
+      );
+    });
+  });
+
   describe('listValidatorKeys', () => {
     test('exposes every (tool, direction) pair with a shipped schema', () => {
       const keys = listValidatorKeys();


### PR DESCRIPTION
## Summary

Closes #1283. Validation envelopes now name the rejecting schema (`$id`) and the discriminator field/value pair the payload was inferred to be targeting. Resolves the matrix-blind-fixtures pain where every discriminated-union mismatch took 1–3 iterations to fix.

`ValidationIssue` gains two optional fields:
- **`schemaId`** — `$id` of the rejecting schema; longest-prefix match against AJV's registered URIs. Lands on the deeper sub-schema for flat-tree tools (`governance/`, `brand/`); lands on the response root for bundled tools (signals, media-buy, creative — most of the catalog) because bundling strips inner `$id`s.
- **`discriminator`** — `[{field, value}, …]` of the variant the payload matched the discriminator of but missed required fields in. Compound discriminators like `audience-selector`'s `(type, value_type)` produce multi-entry arrays. Names align with OpenAPI 3.x.

Both fields ride the wire by default — same precedent as `variants[]` and `allowedValues`. Only `schemaPath` stays `exposeSchemaPath`-gated. The prose `adcp_error.message` mirrors the new fields and suppresses the `(schema: …)` half when the issue lands on the response root (would just restate the tool name). New `ValidationOutcome.schemaId` exposes the root for callers building their own envelopes.

Empirical example post-PR:
```
activate_signal response failed schema validation at /deployments/0/activation_key/key:
  must have required property 'key' (discriminator: type='key_value')
```

`skills/call-adcp-agent/SKILL.md` updated with a recovery recipe so adopter LLMs read `discriminator` first.

## Reviews

Ran code-reviewer, ad-tech-protocol-expert, security-reviewer, dx-expert in parallel:
- **Code review**: caught two real issues — `formatBranch` apostrophe escaping and a nested-union overwrite path. Both fixed (escape + already-tagged guard).
- **Protocol**: flagged consistency with the spec's `schemaPath` warning. Resolved by treating new fields as same-class as `variants[]`/`allowedValues` (already always-on); spec companion follow-ups will canonicalize the field names and propose `$id` retention during bundling.
- **Security**: clean — schemas are publicly published, branch values come from trusted const literals, no tenant data crosses, no prompt-injection surface.
- **DX**: flagged changeset/JSDoc honesty about bundled-tree behavior + missing skill docs. Both addressed. Hint feature deferred per issue #1283's "Proposed change" #3.

## Known limitations (filed as follow-ups)

- Bundled tools strip inner `$id`s — `schemaId` lands on the response root, not the deeper sub-schema. Spec companion will propose `$id` retention during bundling.
- Synthetic union-root errors in nested unions can carry the outer discriminator while leaf errors carry the inner — leaf is the actionable one.
- Optional `hint` field deferred (per-tool curation).

## Test plan

- [x] `npm run build:lib` clean
- [x] `tsc --noEmit` clean
- [x] `NODE_ENV=test npm run test:lib` — 5752 pass / 0 fail / 7 skipped (1593 suites)
- [x] Empirical run against the issue's exact case (`activate_signal` + `activation_key` mismatch) — branch tag resolves the ambiguity one-shot
- [x] 8 new test cases in `schema-validation.test.js`: schemaId resolution, discriminator on const collapse, formatIssues prose suffix, root suppression, compound discriminator, nested-union leaf preservation, apostrophe escaping, ValidationOutcome.schemaId

🤖 Generated with [Claude Code](https://claude.com/claude-code)