### PR TITLE
feat(server): BuyerAgentRegistry Phase 1 Stage 4 — status enforcement + credential redaction (#1269)

### DIFF
--- a/.changeset/buyer-agent-registry-stage-4.md
+++ b/.changeset/buyer-agent-registry-stage-4.md
@@ -1,0 +1,37 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): BuyerAgentRegistry — Phase 1 Stage 4 (status enforcement + credential redaction)
+
+Phase 1 Stage 4 of #1269. Wires the durable identity surface from Stages 1-3 into request gating + closes the credential-leak surface in error projections.
+
+**Status enforcement.** Resolved `BuyerAgent.status === 'suspended' | 'blocked'` triggers framework-level rejection on new requests:
+
+- `PERMISSION_DENIED` envelope with `error.details.scope: 'agent'` and `error.details.status: <status>`.
+- Status check runs in the dispatcher seam right after registry resolution, BEFORE `accounts.resolve` — no tenant lookup wasted on rejected requests.
+- `'active'` agents pass through unchanged.
+- `null` registry returns (unrecognized agent) do NOT trigger status enforcement — Phase 2 (#1292) handles per-agent billing rejection separately.
+
+In-flight protection: the seam runs once per synchronous request, not on `tasks_get` polls or background webhook deliveries. A task started under an `'active'` agent and continued after status flips to `'suspended'` is NOT retroactively cancelled. Sellers who need hard cutoff implement that in their platform method via `BuyerAgent.status` checks (the resolved record is on `ctx.agent`).
+
+**Credential pattern redaction.** New `redactCredentialPatterns(message)` helper (`@adcp/sdk/server/redact`, internal) scrubs known credential shapes from any string projected to `error.details.reason` on the wire. Applied to all six dispatcher sites where `err.message → details.reason`:
+
+- Buyer-agent registry resolution failures
+- `resolveAccount` failures
+- `resolveAccountFromAuth` failures
+- `resolveSessionKey` failures
+- Idempotency principal resolution failures
+- Tool handler throws
+
+Patterns scrubbed:
+- `Bearer <token>` headers
+- JSON-quoted credential fields: `"token":"..."`, `"client_secret":"..."`, etc.
+- Unquoted credential fields: `token=...`, `client_id: ...`, `key=...`, etc.
+- Long token-shaped strings (≥ 32 chars of base64/hex/url-safe, word-bounded)
+
+The redactor is conservative — false positives (legitimate IDs that match a pattern) get redacted; false negatives are minimized. Adopters who need the unredacted error log it server-side; production-default `exposeErrorDetails: false` already gates the wire path.
+
+13 new tests across status enforcement (active passes, suspended/blocked rejected with structured details, runs before accounts.resolve, null doesn't trigger), redactor unit tests (Bearer headers, labeled patterns, JSON-quoted shapes, long-token detection, prose preserved, edge cases), and registry-throw / handler-throw end-to-end redaction. Full suite: 7353 pass, 0 fail.
+
+Phase 2 (#1292) — framework-level billing-capability enforcement and the AdCP-3.1 error-code emission — is still gated on the SDK's 3.1 cutover.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -56,6 +56,7 @@ import type { TaskStore, TaskMessageQueue } from './tasks';
 import { adcpError } from './errors';
 import type { BuyerAgent, BuyerAgentRegistry } from './decisioning/buyer-agent';
 import type { ResolvedAuthInfo } from './decisioning/account';
+import { redactCredentialPatterns } from './redact';
 import { ADCP_ERROR_FIELD_ALLOWLIST } from './envelope-allowlist';
 import { InMemoryStateStore } from './state-store';
 import type { AdcpStateStore } from './state-store';
@@ -2788,6 +2789,34 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // OAuth credentials get a registry-resolved `ctx.agent` but
               // NO verified `agent_url` — that's correct: bearer auth
               // doesn't prove the agent_url cryptographically.
+
+              // --- Status enforcement (Stage 4 of #1269) ---
+              // Reject new requests from `suspended` / `blocked` agents
+              // with PERMISSION_DENIED + `details.scope: 'agent'`.
+              // In-flight tasks owned by a now-suspended agent are NOT
+              // retroactively cancelled — this seam runs once per
+              // synchronous request, not on `tasks_get` polls or
+              // background webhook deliveries. Sellers who need hard
+              // cutoff implement that in their platform method via
+              // `BuyerAgent.status` checks (the resolved record is
+              // available on every method that takes ctx.agent).
+              //
+              // Phase 2 (#1292) may swap to upstream `AGENT_SUSPENDED` /
+              // `AGENT_BLOCKED` codes if those land via separate spec PR;
+              // until then, `PERMISSION_DENIED + scope:'agent'` carries
+              // the structured signal a buyer can dispatch on without
+              // parsing prose.
+              if (resolved.status === 'suspended' || resolved.status === 'blocked') {
+                return finalize(
+                  adcpError('PERMISSION_DENIED', {
+                    message:
+                      resolved.status === 'suspended'
+                        ? 'Buyer agent is suspended. Contact the seller to restore access.'
+                        : 'Buyer agent is blocked.',
+                    details: { scope: 'agent', status: resolved.status },
+                  })
+                );
+              }
             }
           } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
@@ -2795,7 +2824,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Buyer-agent registry resolution failed',
-                ...(exposeErrorDetails && { details: { reason } }),
+                ...(exposeErrorDetails && { details: { reason: redactCredentialPatterns(reason) } }),
               })
             );
           }
@@ -2950,7 +2979,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Account resolution failed',
-                ...(exposeErrorDetails && { details: { reason } }),
+                ...(exposeErrorDetails && { details: { reason: redactCredentialPatterns(reason) } }),
               })
             );
           }
@@ -2974,7 +3003,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Account resolution failed',
-                ...(exposeErrorDetails && { details: { reason } }),
+                ...(exposeErrorDetails && { details: { reason: redactCredentialPatterns(reason) } }),
               })
             );
           }
@@ -2996,7 +3025,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Session key resolution failed',
-                ...(exposeErrorDetails && { details: { reason } }),
+                ...(exposeErrorDetails && { details: { reason: redactCredentialPatterns(reason) } }),
               })
             );
           }
@@ -3118,7 +3147,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             return finalize(
               adcpError('SERVICE_UNAVAILABLE', {
                 message: 'Idempotency check failed',
-                ...(exposeErrorDetails && { details: { reason } }),
+                ...(exposeErrorDetails && { details: { reason: redactCredentialPatterns(reason) } }),
               })
             );
           }
@@ -3388,9 +3417,11 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // of diagnostic time on the matrix harness — dev callers want
               // the real reason at the call site, not hidden in server logs.
               message: exposeErrorDetails
-                ? `Tool ${toolName} handler threw: ${reason}`
+                ? `Tool ${toolName} handler threw: ${redactCredentialPatterns(reason)}`
                 : `Tool ${toolName} encountered an internal error`,
-              ...(exposeErrorDetails && { details: { reason, handler: handlerKey } }),
+              ...(exposeErrorDetails && {
+                details: { reason: redactCredentialPatterns(reason), handler: handlerKey },
+              }),
             })
           );
         }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -2807,12 +2807,23 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // the structured signal a buyer can dispatch on without
               // parsing prose.
               if (resolved.status === 'suspended' || resolved.status === 'blocked') {
+                // `PERMISSION_DENIED`'s spec-default `recovery` is
+                // `correctable`, but the agent-status semantics are
+                // different per status:
+                //   - `'suspended'` is transient: re-onboarding /
+                //     contacting the seller may restore access.
+                //   - `'blocked'` is terminal: a buyer agent that's
+                //     been permanently denied SHOULD NOT loop.
+                // Setting recovery explicitly per status lets buyers
+                // dispatch retry-vs-escalate without parsing
+                // `details.status` prose.
                 return finalize(
                   adcpError('PERMISSION_DENIED', {
                     message:
                       resolved.status === 'suspended'
                         ? 'Buyer agent is suspended. Contact the seller to restore access.'
                         : 'Buyer agent is blocked.',
+                    recovery: resolved.status === 'suspended' ? 'transient' : 'terminal',
                     details: { scope: 'agent', status: resolved.status },
                   })
                 );

--- a/src/lib/server/redact.ts
+++ b/src/lib/server/redact.ts
@@ -23,48 +23,64 @@
  * pipelines reach for `pickSafeDetails` instead.
  */
 
+// Credential-label alternation reused across multiple patterns. Captures
+// common credential field names with both `_` and `-` separators.
+// `key` is the bare form (e.g. `key=foo`); the underscored variants
+// (`api_key`, `key_id`, `signing_key`) are explicit alternation
+// branches because regex alternation matches left-to-right and the
+// longer labels would never match if `key` came first.
+const CREDENTIAL_LABEL =
+  '(api[_-]?key|key[_-]?id|signing[_-]?key|client[_-]?secret|client[_-]?id|password|passwd|pwd|secret|token|key|jwt|bearer)';
+
 /**
  * Patterns the redactor scrubs. Applied in order; each pattern replaces
  * the matched substring with a placeholder. Patterns are case-insensitive
  * where the match makes sense.
  *
  * 1. `Authorization: Bearer <token>` and similar HTTP-Auth shapes.
- * 2. `key=`, `token=`, `secret=`, `password=`, `client_id=`,
- *    `client_secret=`, `api_key=`, `key_id=` patterns (with optional
- *    quoting and varied separators).
- * 3. Long alphanumeric strings (length ≥ 32) that look like tokens
+ * 2. URL-embedded basic-auth: `https://user:pass@host/` → strips the
+ *    password component (preserves scheme + user for diagnostic value).
+ * 3. JSON-quoted credential fields: `"token":"value"`,
+ *    `"client_secret":"value"`, etc.
+ * 4. Unquoted / single-quoted credential fields: `token=value`,
+ *    `client_id: value`, `key=value` — varied separators and quoting.
+ * 5. Long alphanumeric strings (length ≥ 32) that look like tokens
  *    (no spaces, hex / base64 / base64url charsets). Catches tokens
  *    appearing without a labeling prefix.
  *
- * The 32-character threshold balances catching real tokens (most
- * production tokens are ≥ 32 chars) against false positives on shorter
- * IDs (UUIDs at 36 chars match, which is fine — a UUID embedded in
- * an error message gets redacted, the server-side log keeps it).
+ * The 32-character threshold for the unlabeled pattern balances
+ * catching real tokens (most production tokens are ≥ 32 chars) against
+ * false positives on shorter IDs (UUIDs at 36 chars match, which is
+ * fine — a UUID embedded in an error message gets redacted, the
+ * server-side log keeps it).
+ *
+ * Signature accepts `unknown` rather than `string` so the dispatcher
+ * can pass `String(err)` results without coercing first; the runtime
+ * guard returns the input unchanged for non-string values.
  */
-// Credential-label alternation reused across multiple patterns. Captures
-// common credential field names with both `_` and `-` separators.
-const CREDENTIAL_LABEL =
-  '(token|api[_-]?key|secret|password|passwd|pwd|client[_-]?secret|client[_-]?id|key[_-]?id|signing[_-]?key|jwt|bearer)';
-
-export function redactCredentialPatterns(message: string): string {
+export function redactCredentialPatterns(message: unknown): unknown {
   if (typeof message !== 'string' || message.length === 0) return message;
   return (
     message
       // 1. Authorization headers — `Bearer <token>`.
       .replace(/\bBearer\s+[A-Za-z0-9_\-.~+/=]{8,}/gi, 'Bearer <redacted>')
-      // 2. JSON-quoted credential properties: "token":"value",
+      // 2. URL-embedded basic-auth: strip the password component.
+      //    Matches `scheme://user:password@host/...` and replaces just
+      //    the password, preserving scheme + user for diagnostic value.
+      .replace(/(https?:\/\/[^:/\s@]+:)[^@\s]+@/gi, '$1<redacted>@')
+      // 3. JSON-quoted credential properties: "token":"value",
       //    "client_secret":"value", etc. Matches any non-empty quoted
       //    value (including short ones — labeled credentials are always
       //    secrets regardless of length).
       .replace(new RegExp(`"${CREDENTIAL_LABEL}"\\s*:\\s*"[^"]+"`, 'gi'), '"$1":"<redacted>"')
-      // 3. Unquoted / single-quoted credential properties:
+      // 4. Unquoted / single-quoted credential properties:
       //    `token=value`, `client_id: value`. Allows optional quote
       //    around both the label and the value.
       .replace(
         new RegExp(`\\b${CREDENTIAL_LABEL}['"]?\\s*[=:]\\s*['"]?[A-Za-z0-9_\\-.~+/=]{4,}['"]?`, 'gi'),
         '$1=<redacted>'
       )
-      // 4. Long token-shaped strings (≥ 32 chars of base64/hex/url-safe)
+      // 5. Long token-shaped strings (≥ 32 chars of base64/hex/url-safe)
       //    without an obvious label. Word-boundary anchored so legitimate
       //    prose / sentence fragments don't match. The lower bound is 32
       //    to avoid eating short hex IDs (8-char UUID prefixes etc.).

--- a/src/lib/server/redact.ts
+++ b/src/lib/server/redact.ts
@@ -1,0 +1,73 @@
+/**
+ * Credential-shape redactor for diagnostic strings projected to the wire
+ * via `error.details.reason`. Stage 4 of #1269 — defense-in-depth against
+ * adopter-thrown errors whose `message` includes credential payloads
+ * (raw bearer tokens, OAuth client secrets, signing keyids).
+ *
+ * **Production-default exposure is already gated** on
+ * `exposeErrorDetails: process.env.NODE_ENV !== 'production'`. This
+ * redactor closes the pre-production gap: adopters running in dev /
+ * staging with `exposeErrorDetails: true` no longer leak credential
+ * bytes when their resolver throws an error like
+ * `Error('lookup failed for token=sk_live_abc')`.
+ *
+ * The redactor is intentionally conservative — it produces false
+ * positives (legitimate IDs that match a credential pattern get
+ * redacted too) rather than false negatives. Adopters who need the
+ * unredacted error log it server-side, where the framework's logger
+ * forwards `err.message` unchanged.
+ *
+ * @internal — used by the dispatcher's `err.message → details.reason`
+ * projections (`create-adcp-server.ts`). Not part of the adopter
+ * surface; adopters who want to sanitize `error.details` for their own
+ * pipelines reach for `pickSafeDetails` instead.
+ */
+
+/**
+ * Patterns the redactor scrubs. Applied in order; each pattern replaces
+ * the matched substring with a placeholder. Patterns are case-insensitive
+ * where the match makes sense.
+ *
+ * 1. `Authorization: Bearer <token>` and similar HTTP-Auth shapes.
+ * 2. `key=`, `token=`, `secret=`, `password=`, `client_id=`,
+ *    `client_secret=`, `api_key=`, `key_id=` patterns (with optional
+ *    quoting and varied separators).
+ * 3. Long alphanumeric strings (length ≥ 32) that look like tokens
+ *    (no spaces, hex / base64 / base64url charsets). Catches tokens
+ *    appearing without a labeling prefix.
+ *
+ * The 32-character threshold balances catching real tokens (most
+ * production tokens are ≥ 32 chars) against false positives on shorter
+ * IDs (UUIDs at 36 chars match, which is fine — a UUID embedded in
+ * an error message gets redacted, the server-side log keeps it).
+ */
+// Credential-label alternation reused across multiple patterns. Captures
+// common credential field names with both `_` and `-` separators.
+const CREDENTIAL_LABEL =
+  '(token|api[_-]?key|secret|password|passwd|pwd|client[_-]?secret|client[_-]?id|key[_-]?id|signing[_-]?key|jwt|bearer)';
+
+export function redactCredentialPatterns(message: string): string {
+  if (typeof message !== 'string' || message.length === 0) return message;
+  return (
+    message
+      // 1. Authorization headers — `Bearer <token>`.
+      .replace(/\bBearer\s+[A-Za-z0-9_\-.~+/=]{8,}/gi, 'Bearer <redacted>')
+      // 2. JSON-quoted credential properties: "token":"value",
+      //    "client_secret":"value", etc. Matches any non-empty quoted
+      //    value (including short ones — labeled credentials are always
+      //    secrets regardless of length).
+      .replace(new RegExp(`"${CREDENTIAL_LABEL}"\\s*:\\s*"[^"]+"`, 'gi'), '"$1":"<redacted>"')
+      // 3. Unquoted / single-quoted credential properties:
+      //    `token=value`, `client_id: value`. Allows optional quote
+      //    around both the label and the value.
+      .replace(
+        new RegExp(`\\b${CREDENTIAL_LABEL}['"]?\\s*[=:]\\s*['"]?[A-Za-z0-9_\\-.~+/=]{4,}['"]?`, 'gi'),
+        '$1=<redacted>'
+      )
+      // 4. Long token-shaped strings (≥ 32 chars of base64/hex/url-safe)
+      //    without an obvious label. Word-boundary anchored so legitimate
+      //    prose / sentence fragments don't match. The lower bound is 32
+      //    to avoid eating short hex IDs (8-char UUID prefixes etc.).
+      .replace(/\b[A-Za-z0-9_\-.~+/=]{32,}\b/g, '<redacted-token>')
+  );
+}

--- a/test/server-buyer-agent-status-and-redaction.test.js
+++ b/test/server-buyer-agent-status-and-redaction.test.js
@@ -133,7 +133,7 @@ describe('Stage 4 — status enforcement', () => {
     assert.equal(handlerInvoked, false, 'handler MUST NOT run for suspended agent');
   });
 
-  it('blocked agent → 403 PERMISSION_DENIED with details.status=blocked', async () => {
+  it('blocked agent → 403 PERMISSION_DENIED with details.status=blocked AND recovery=terminal', async () => {
     const platform = buildPlatform({
       agentRegistry: BuyerAgentRegistry.signingOnly({
         resolveByAgentUrl: async () => sampleAgent({ status: 'blocked' }),
@@ -153,6 +153,29 @@ describe('Stage 4 — status enforcement', () => {
     assert.equal(result.isError, true);
     assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
     assert.equal(result.structuredContent.adcp_error.details.status, 'blocked');
+    // Blocked is terminal — buyers MUST NOT auto-retry; recovery dispatches
+    // correctly without parsing details.status.
+    assert.equal(result.structuredContent.adcp_error.recovery, 'terminal');
+  });
+
+  it('suspended agent → recovery=transient (re-onboarding may resolve)', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ status: 'suspended' }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(result.structuredContent.adcp_error.recovery, 'transient');
   });
 
   it('status enforcement runs BEFORE accounts.resolve (no tenant lookup wasted)', async () => {
@@ -182,6 +205,55 @@ describe('Stage 4 — status enforcement', () => {
       extra: { credential: sigCredential() },
     });
     assert.equal(accountResolveInvoked, false, 'accounts.resolve MUST NOT run when agent is suspended');
+  });
+
+  it('handler that started under an active agent completes even if registry flips to suspended mid-flight', async () => {
+    // The seam runs once per dispatch. A long-running handler that
+    // started while the agent was active completes successfully — the
+    // status enforcement is at request entry, not retroactive.
+    let registryStatus = 'active';
+    let handlerCompleted = false;
+    const platform = buildPlatform({
+      sales: {
+        getProducts: async () => {
+          // Simulate the agent flipping to suspended while the handler
+          // is mid-flight. On a real adopter this would be a separate
+          // request mutating the agent record in the seller's DB.
+          registryStatus = 'suspended';
+          handlerCompleted = true;
+          return { products: [] };
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ status: registryStatus }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.equal(handlerCompleted, true, 'handler MUST complete despite mid-flight status flip');
+    // The NEXT request — fired after the flip — sees suspended and is rejected.
+    const nextResult = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(nextResult.isError, true);
+    assert.equal(nextResult.structuredContent.adcp_error.details.status, 'suspended');
   });
 
   it('null registry result (no recognized agent) does NOT trigger status enforcement', async () => {
@@ -261,6 +333,29 @@ describe('Stage 4 — credential pattern redaction (redactCredentialPatterns)', 
   it('redacts in JSON-shaped error messages (common adopter format)', () => {
     const out = redactCredentialPatterns('upstream API: {"error":"unauthorized","token":"abc123def456ghijkl"}');
     assert.equal(out.includes('abc123def456ghijkl'), false, `secret not redacted: ${out}`);
+  });
+
+  it('redacts the bare `key=...` form (most common credential shape in upstream errors)', () => {
+    // Code-reviewer flagged: previous `CREDENTIAL_LABEL` had `api_key` /
+    // `key_id` / `signing_key` but missed bare `key=value`. Added `key`
+    // to the alternation.
+    const out = redactCredentialPatterns('upstream rejected: key=mySecretValue');
+    assert.match(out, /key=<redacted>/);
+    assert.equal(out.includes('mySecretValue'), false);
+  });
+
+  it('redacts URL-embedded basic-auth credentials', () => {
+    // Security-reviewer flagged: `https://user:pass@host/` shape was
+    // not covered by any of the 4 original patterns. Added URL pattern.
+    const out = redactCredentialPatterns('failed to GET https://service:s3cr3tValue@vendor.example/lookup');
+    assert.match(out, /https:\/\/service:<redacted>@vendor\.example/);
+    assert.equal(out.includes('s3cr3tValue'), false);
+  });
+
+  it('redacts multiple credentials on the same line', () => {
+    const out = redactCredentialPatterns('auth: token=foo123bar secret=baz456qux');
+    assert.equal(out.includes('foo123bar'), false);
+    assert.equal(out.includes('baz456qux'), false);
   });
 });
 

--- a/test/server-buyer-agent-status-and-redaction.test.js
+++ b/test/server-buyer-agent-status-and-redaction.test.js
@@ -1,0 +1,323 @@
+'use strict';
+
+// Stage 4 of #1269 — status enforcement + credential pattern redaction.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+const { BuyerAgentRegistry, markVerifiedHttpSig } = require('../dist/lib/server/decisioning/buyer-agent');
+const { redactCredentialPatterns } = require('../dist/lib/server/redact');
+
+const sampleAgent = (overrides = {}) => ({
+  agent_url: 'https://agent.scope3.com',
+  display_name: 'Scope3',
+  status: 'active',
+  billing_capabilities: new Set(['operator']),
+  ...overrides,
+});
+
+function buildPlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async (ref, ctx) => {
+        if (ref == null) return null;
+        return {
+          id: ref?.account_id ?? 'acc_1',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+          _resolveAgent: ctx?.agent,
+        };
+      },
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    statusMappers: {},
+    sales: {
+      getProducts: async (_req, ctx) => ({ products: [], _ctxAgent: ctx?.agent }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+    },
+    ...overrides,
+  };
+}
+
+const sigCredential = (overrides = {}) =>
+  markVerifiedHttpSig({
+    kind: 'http_sig',
+    keyid: 'kid',
+    agent_url: 'https://agent.scope3.com',
+    verified_at: 1714660000,
+    ...overrides,
+  });
+
+const dispatchWithAuthInfo = (server, authInfo) =>
+  server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'acc_test' },
+        },
+      },
+    },
+    { authInfo }
+  );
+
+describe('Stage 4 — status enforcement', () => {
+  it('active agent → request dispatches normally', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ status: 'active' }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.equal(result.structuredContent._ctxAgent.status, 'active');
+  });
+
+  it('suspended agent → 403 PERMISSION_DENIED with details.scope=agent', async () => {
+    let handlerInvoked = false;
+    const platform = buildPlatform({
+      sales: {
+        getProducts: async () => {
+          handlerInvoked = true;
+          return { products: [] };
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ status: 'suspended' }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+    assert.equal(result.structuredContent.adcp_error.details.scope, 'agent');
+    assert.equal(result.structuredContent.adcp_error.details.status, 'suspended');
+    assert.equal(handlerInvoked, false, 'handler MUST NOT run for suspended agent');
+  });
+
+  it('blocked agent → 403 PERMISSION_DENIED with details.status=blocked', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ status: 'blocked' }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+    assert.equal(result.structuredContent.adcp_error.details.status, 'blocked');
+  });
+
+  it('status enforcement runs BEFORE accounts.resolve (no tenant lookup wasted)', async () => {
+    let accountResolveInvoked = false;
+    const platform = buildPlatform({
+      accounts: {
+        resolve: async () => {
+          accountResolveInvoked = true;
+          return { id: 'acc_1', metadata: {}, authInfo: { kind: 'api_key' } };
+        },
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ status: 'suspended' }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(accountResolveInvoked, false, 'accounts.resolve MUST NOT run when agent is suspended');
+  });
+
+  it('null registry result (no recognized agent) does NOT trigger status enforcement', async () => {
+    // Defense-in-depth: null returns from the registry shouldn't be
+    // confused with status rejection. The framework continues dispatch
+    // (Phase 1's design; Stage 4 / Phase 2 enforcement is per-agent
+    // billing capability, not "no agent at all").
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => null,
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+  });
+});
+
+describe('Stage 4 — credential pattern redaction (redactCredentialPatterns)', () => {
+  it('redacts Bearer tokens', () => {
+    const out = redactCredentialPatterns('Authorization failed: Bearer sk_live_a1b2c3d4e5');
+    assert.match(out, /Bearer <redacted>/);
+    assert.equal(out.includes('sk_live_a1b2c3d4e5'), false);
+  });
+
+  it('redacts labeled credential patterns (token=, key=, secret=, etc.)', () => {
+    const cases = [
+      'lookup failed for token=sk_live_a1b2c3d4e5',
+      'API call rejected: api_key=abc123def456ghi789',
+      'auth error: client_id=oauth_client_xyz client_secret=very-secret-value',
+      'request body: {"password":"mySecret123"}',
+      'header: key_id=signing-2026-01',
+    ];
+    for (const input of cases) {
+      const out = redactCredentialPatterns(input);
+      assert.equal(/<redacted>/.test(out), true, `expected redaction in: ${input} → ${out}`);
+    }
+  });
+
+  it('redacts long token-shaped strings even without a labeling prefix', () => {
+    const longToken = 'a'.repeat(40);
+    const out = redactCredentialPatterns(`upstream rejected ${longToken}`);
+    assert.match(out, /<redacted-token>/);
+    assert.equal(out.includes(longToken), false);
+  });
+
+  it('does NOT redact normal English prose / short identifiers', () => {
+    const inputs = [
+      'Account not found',
+      'Invalid request: missing field "brief"',
+      'Database connection timeout after 30 seconds',
+      'Rate limited; retry after 60s',
+      'Account acc_1 has no permissions',
+    ];
+    for (const input of inputs) {
+      const out = redactCredentialPatterns(input);
+      assert.equal(out, input, `unexpected redaction in: ${input} → ${out}`);
+    }
+  });
+
+  it('handles empty / non-string inputs cleanly', () => {
+    assert.equal(redactCredentialPatterns(''), '');
+    assert.equal(redactCredentialPatterns(undefined), undefined);
+    assert.equal(redactCredentialPatterns(null), null);
+    assert.equal(redactCredentialPatterns(42), 42);
+  });
+
+  it('redacts in JSON-shaped error messages (common adopter format)', () => {
+    const out = redactCredentialPatterns('upstream API: {"error":"unauthorized","token":"abc123def456ghijkl"}');
+    assert.equal(out.includes('abc123def456ghijkl'), false, `secret not redacted: ${out}`);
+  });
+});
+
+describe('Stage 4 — registry-throw redaction end-to-end', () => {
+  it('SERVICE_UNAVAILABLE details.reason is sanitized when adopter throws with credential bytes', async () => {
+    const platform = buildPlatform({
+      agentRegistry: {
+        async resolve() {
+          throw new Error('lookup failed for token=sk_live_secret123def456ghi789');
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      // exposeErrorDetails defaults to non-production (i.e., true) here.
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'SERVICE_UNAVAILABLE');
+    const reason = result.structuredContent.adcp_error.details?.reason;
+    assert.ok(reason, 'details.reason should be present in non-prod');
+    assert.equal(reason.includes('sk_live_secret123def456ghi789'), false, `secret leaked on the wire: ${reason}`);
+    assert.match(reason, /<redacted/);
+  });
+
+  it('handler-throw details.reason is also sanitized', async () => {
+    const platform = buildPlatform({
+      sales: {
+        getProducts: async () => {
+          throw new Error('upstream auth: Bearer sk_live_handler_secret_abc123def456');
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchWithAuthInfo(server, {
+      token: 'sig-tok',
+      clientId: 'signing:kid',
+      scopes: [],
+      extra: { credential: sigCredential() },
+    });
+    assert.equal(result.isError, true);
+    const errorEnvelope = JSON.stringify(result.structuredContent.adcp_error);
+    assert.equal(errorEnvelope.includes('sk_live_handler_secret_abc123def456'), false);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 Stage 4 of #1269. Wires durable identity (Stages 1-3) into request gating + closes the credential-leak surface in error projections.

## What's in

**Status enforcement:**
- Resolved `BuyerAgent.status === 'suspended' | 'blocked'` → `PERMISSION_DENIED` envelope with `error.details.scope: 'agent'` and `error.details.status: <status>`.
- Runs after registry resolution, BEFORE `accounts.resolve` — no tenant lookup wasted on rejected requests.
- `'active'` agents pass through unchanged.
- `null` registry returns do NOT trigger status enforcement (per-agent billing rejection is Phase 2's gate).
- In-flight protection: seam runs once per synchronous request, not on `tasks_get` polls or background webhook deliveries — a task started under an `'active'` agent and continued after suspension is NOT retroactively cancelled.

**Credential pattern redaction:**
- New `redactCredentialPatterns(message)` helper (`src/lib/server/redact.ts`, internal).
- Applied to all 6 dispatcher sites where `err.message → details.reason`: registry resolution, `resolveAccount`, `resolveAccountFromAuth`, `resolveSessionKey`, idempotency principal resolution, tool handler throws.
- Scrubs: Bearer headers, JSON-quoted credential fields (`"token":"..."`), unquoted forms (`token=...`, `key=...`), long token-shaped strings (≥ 32 chars of base64/hex/url-safe).
- Conservative — false positives get redacted; false negatives minimized.

## What's NOT in (Stage 5 / Phase 2)

- `CachingBuyerAgentRegistry` decorator + conformance fixtures → Stage 5.
- Framework-level `billing_capability` enforcement + AdCP-3.1 error-code emission → Phase 2 (#1292), gated on SDK 3.1 cutover.
- `billing_capabilities` Set hardening (`Object.freeze` doesn't lock `[[SetData]]`) → deferred per Stage 2 review; Phase 2's check is `.has()`-only so the leak surface is bounded.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `test/server-buyer-agent-status-and-redaction.test.js` — 13/13 pass:
  - Active agent dispatches normally.
  - Suspended → 403 with `details.scope: 'agent'`, `details.status: 'suspended'`; handler not invoked.
  - Blocked → 403 with `details.status: 'blocked'`.
  - Status enforcement runs BEFORE `accounts.resolve`.
  - `null` registry does NOT trigger status enforcement.
  - Redactor: Bearer tokens, labeled patterns (token/key/secret/password/etc.), long token-shaped strings, prose preserved, edge cases (empty, undefined), JSON-shaped error messages.
  - End-to-end: registry-throw `details.reason` is sanitized; handler-throw `details.reason` is sanitized.
- [x] `npm run format:check` clean.
- [x] Full suite: 7353 pass, 0 fail.

## Cross-links

- #1269 (Phase 1 parent issue)
- #1293 (Stage 1 — types + factories, merged)
- #1297 (Stage 2 — resolve seam, merged)
- #1305 (Stage 3 — credential synthesis + verifier brand, merged)
- #1292 (Phase 2 — gated on SDK 3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)