### PR TITLE
feat(decisioning): forward ctx to AccountStore.upsert/list (#1310)

### DIFF
--- a/.changeset/account-store-upsert-list-ctx.md
+++ b/.changeset/account-store-upsert-list-ctx.md
@@ -21,4 +21,14 @@ accounts: {
 }
 ```
 
-Backwards-compatible: `ctx` is optional on the platform side, so existing implementations that don't accept the second arg keep working.
+Backwards-compatible at the type level: `ctx` is optional on the platform side, so existing implementations that don't accept the second arg keep compiling.
+
+**Security-relevant migration note for multi-tenant adopters.** Pre-this-release, adopters had no way to scope `accounts.list` per-principal — implementations either returned all accounts (over-disclosure) or rejected the operation. Post-this-release, scoping becomes possible. **This is opt-in, not automatic.** Multi-tenant adopters should add principal scoping in the upgrade:
+
+```ts
+list: async (filter, ctx) => {
+  // Scope to the calling agent's accounts. Without this, every authenticated
+  // caller sees every account.
+  return db.listAccounts(filter, { agentUrl: ctx?.agent?.agent_url });
+},
+```

--- a/.changeset/account-store-upsert-list-ctx.md
+++ b/.changeset/account-store-upsert-list-ctx.md
@@ -1,0 +1,24 @@
+---
+"@adcp/sdk": minor
+---
+
+`AccountStore.upsert` and `AccountStore.list` now receive an optional `ResolveContext` second argument. Closes #1310.
+
+The framework forwards `authInfo`, `toolName`, and `agent` (when an `agentRegistry` is configured) — the same shape already threaded to `accounts.resolve`, `reportUsage`, and `getAccountFinancials`. Adopters can implement principal-keyed gates on `sync_accounts` / `list_accounts` (e.g. the spec's `BILLING_NOT_PERMITTED_FOR_AGENT` per-buyer-agent gate from adcontextprotocol/adcp#3851) without re-deriving identity from the request.
+
+```ts
+accounts: {
+  upsert: async (refs, ctx) => {
+    if (!agentMayBillVia(ctx?.agent, refs[0].billing)) {
+      throw new AdcpError('BILLING_NOT_PERMITTED_FOR_AGENT', { recovery: 'terminal' });
+    }
+    // ...
+  },
+  list: async (filter, ctx) => {
+    // Scope the listing to the calling agent's accounts.
+    return db.accounts(filter, { agentUrl: ctx?.agent?.agent_url });
+  },
+}
+```
+
+Backwards-compatible: `ctx` is optional on the platform side, so existing implementations that don't accept the second arg keep working.

--- a/scripts/skill-examples.baseline.json
+++ b/scripts/skill-examples.baseline.json
@@ -752,12 +752,12 @@
   {
     "source": "skills/build-seller-agent/SKILL.md",
     "errorCode": "TS2322",
-    "messagePrefix": "Type '(params: any, ctx: any) => Promise<{ items: never[]; nextCursor: null; }>'"
+    "messagePrefix": "Type '(params: AccountFilter & CursorRequest, ctx: ResolveContext | undefined) ="
   },
   {
     "source": "skills/build-seller-agent/SKILL.md",
     "errorCode": "TS2322",
-    "messagePrefix": "Type '(params: any, ctx: any) => Promise<{ ok: boolean; items: never[]; }>' is n"
+    "messagePrefix": "Type '(params: AccountReference[], ctx: ResolveContext | undefined) => Promise<{"
   },
   {
     "source": "skills/build-seller-agent/SKILL.md",
@@ -862,27 +862,7 @@
   {
     "source": "skills/build-seller-agent/SKILL.md",
     "errorCode": "TS7006",
-    "messagePrefix": "Parameter 'ctx' implicitly has an 'any' type."
-  },
-  {
-    "source": "skills/build-seller-agent/SKILL.md",
-    "errorCode": "TS7006",
-    "messagePrefix": "Parameter 'ctx' implicitly has an 'any' type."
-  },
-  {
-    "source": "skills/build-seller-agent/SKILL.md",
-    "errorCode": "TS7006",
     "messagePrefix": "Parameter 'outcome' implicitly has an 'any' type."
-  },
-  {
-    "source": "skills/build-seller-agent/SKILL.md",
-    "errorCode": "TS7006",
-    "messagePrefix": "Parameter 'params' implicitly has an 'any' type."
-  },
-  {
-    "source": "skills/build-seller-agent/SKILL.md",
-    "errorCode": "TS7006",
-    "messagePrefix": "Parameter 'params' implicitly has an 'any' type."
   },
   {
     "source": "skills/build-si-agent/SKILL.md",

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -383,6 +383,15 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * implementing principal-keyed gates (e.g., per-buyer-agent
    * `BILLING_NOT_PERMITTED_FOR_AGENT` on the spec's billing surfaces) read
    * the principal here — same threading as `accounts.resolve`.
+   *
+   * **Prefer `ctx.agent` over `ctx.authInfo.credential` for commercial-
+   * relationship decisions.** `ctx.agent` is the registry-resolved durable
+   * identity (status, billing capabilities, default account terms);
+   * `ctx.authInfo.credential` is the raw transport-level credential. For
+   * billing gates the registry-resolved identity is canonical. Use
+   * `credential` only for transport-level branching (e.g., reading the
+   * verified `agent_url` from `credential.kind === 'http_sig'` when
+   * `agentRegistry` is not configured).
    */
   upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
 
@@ -536,6 +545,12 @@ export interface AccountFilter {
  * `billing_entity`, `payment_terms`, etc. on creation. The framework
  * projects these through `toWireSyncAccountRow` before emit, applying the
  * same `billing_entity.bank` strip as `toWireAccount` (write-only contract).
+ *
+ * **MUST NOT carry `authInfo` or other auth-derived fields.** This shape is
+ * emitted on the `sync_accounts` response wire. The framework's projector
+ * does not read `authInfo`, but adopters MUST NOT add an `authInfo` key on
+ * returned rows — same MUST-NOT-LEAK rule the framework enforces on
+ * `Account.authInfo`.
  */
 export interface SyncAccountsResultRow {
   account_id?: string;

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -376,15 +376,26 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * **Optional.** Stateless platforms (creative-template, signal-marketplace
    * proxies) that don't manage account lifecycle can omit this; framework
    * surfaces `UNSUPPORTED_FEATURE` to buyers calling `sync_accounts`.
+   *
+   * `ctx.authInfo` carries the caller's authenticated principal (when
+   * `serve({ authenticate })` is wired); `ctx.agent` carries the resolved
+   * `BuyerAgent` record (when an `agentRegistry` is configured). Adopters
+   * implementing principal-keyed gates (e.g., per-buyer-agent
+   * `BILLING_NOT_PERMITTED_FOR_AGENT` on the spec's billing surfaces) read
+   * the principal here — same threading as `accounts.resolve`.
    */
-  upsert?(refs: AccountReference[]): Promise<SyncAccountsResultRow[]>;
+  upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
 
   /**
    * list_accounts API surface. Framework wraps with cursor envelope.
    *
    * **Optional.** Same rationale as `upsert` — stateless platforms can omit.
+   *
+   * `ctx.authInfo` and `ctx.agent` carry the caller's principal — adopters
+   * scope the listing per-principal (e.g., return only accounts visible to
+   * the calling buyer agent) without re-deriving identity from the request.
    */
-  list?(filter: AccountFilter & CursorRequest): Promise<CursorPage<Account<TCtxMeta>>>;
+  list?(filter: AccountFilter & CursorRequest, ctx?: ResolveContext): Promise<CursorPage<Account<TCtxMeta>>>;
 
   /**
    * report_usage API surface. Operator-billed platforms accept usage rows

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3458,23 +3458,33 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   const handlers: AccountHandlers<Account> = {};
 
   if (accounts.upsert) {
-    handlers.syncAccounts = async (params, _ctx) => {
+    handlers.syncAccounts = async (params, ctx) => {
       const refs = (params.accounts ?? []) as AccountReference[];
+      const resolveCtx = {
+        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+        toolName: 'sync_accounts' as const,
+        ...(ctx.agent != null && { agent: ctx.agent }),
+      };
       return projectSync(
-        () => accounts.upsert!(refs),
+        () => accounts.upsert!(refs, resolveCtx),
         rows => ({ accounts: rows.map(toWireSyncAccountRow) })
       );
     };
   }
 
   if (accounts.list) {
-    handlers.listAccounts = async (params, _ctx) => {
+    handlers.listAccounts = async (params, ctx) => {
       const filter = params as Parameters<NonNullable<typeof accounts.list>>[0];
+      const resolveCtx = {
+        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+        toolName: 'list_accounts' as const,
+        ...(ctx.agent != null && { agent: ctx.agent }),
+      };
       // Wrap in projectSync so adopter `throw new AdcpError('PERMISSION_DENIED', ...)`
       // from the list impl projects to the structured wire envelope rather
       // than falling through to the framework's `SERVICE_UNAVAILABLE` mapping.
       return projectSync(
-        () => accounts.list!(filter),
+        () => accounts.list!(filter, resolveCtx),
         page => ({
           accounts: page.items.map(toWireAccount),
           ...(page.nextCursor != null && { next_cursor: page.nextCursor }),

--- a/test/server-account-store-ctx-forwarding.test.js
+++ b/test/server-account-store-ctx-forwarding.test.js
@@ -1,0 +1,192 @@
+'use strict';
+
+// Issue #1310 — `AccountStore.upsert` and `AccountStore.list` accept
+// (and the framework forwards) the same `ResolveContext` shape that
+// `accounts.resolve` already gets. Adopters implementing principal-based
+// gates on `sync_accounts` / `list_accounts` (e.g. the spec's
+// `BILLING_NOT_PERMITTED_FOR_AGENT` per-buyer-agent gate from
+// adcontextprotocol/adcp#3851) need the calling principal — same plumbing
+// already wired for `resolve`, `reportUsage`, `getAccountFinancials`.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+const sampleAgent = () => ({
+  agent_url: 'https://agent.scope3.com',
+  display_name: 'Scope3',
+  status: 'active',
+  billing_capabilities: new Set(['operator']),
+});
+
+function buildPlatform(captures, overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async ref => ({
+        id: ref?.account_id ?? 'acc_1',
+        metadata: {},
+        authInfo: { kind: 'api_key' },
+      }),
+      upsert: async (refs, ctx) => {
+        captures.upsertCtx = ctx;
+        return refs.map(r => ({
+          brand: r.brand ?? { domain: 'acme.com' },
+          operator: r.operator ?? 'acme.com',
+          action: 'created',
+          status: 'active',
+        }));
+      },
+      list: async (filter, ctx) => {
+        captures.listCtx = ctx;
+        captures.listFilter = filter;
+        return { items: [], nextCursor: null };
+      },
+    },
+    statusMappers: {},
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+    },
+    ...overrides,
+  };
+}
+
+const dispatchSync = (server, authInfo) =>
+  server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'sync_accounts',
+        arguments: {
+          accounts: [{ brand: { domain: 'acme.com' }, operator: 'acme.com' }],
+          idempotency_key: '11111111-1111-1111-1111-111111111111',
+        },
+      },
+    },
+    authInfo ? { authInfo } : undefined
+  );
+
+const dispatchList = (server, authInfo) =>
+  server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: { name: 'list_accounts', arguments: {} },
+    },
+    authInfo ? { authInfo } : undefined
+  );
+
+describe('Issue #1310 — accounts.upsert receives ResolveContext', () => {
+  it('forwards authInfo from request ctx to accounts.upsert', async () => {
+    const captures = {};
+    const server = createAdcpServerFromPlatform(buildPlatform(captures), {
+      name: 'gap-1310',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const authInfo = { kind: 'api_key', clientId: 'buyer-xyz' };
+    const result = await dispatchSync(server, authInfo);
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(captures.upsertCtx, 'upsert MUST receive a non-null ctx');
+    assert.deepStrictEqual(captures.upsertCtx.authInfo, authInfo, 'upsert ctx.authInfo must match request authInfo');
+    assert.strictEqual(captures.upsertCtx.toolName, 'sync_accounts', 'toolName must be set');
+  });
+
+  it('forwards resolved BuyerAgent to accounts.upsert when agentRegistry is configured', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform(captures, {
+        agentRegistry: {
+          async resolve() {
+            return agent;
+          },
+        },
+      }),
+      {
+        name: 'gap-1310',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+    const result = await dispatchSync(server, { kind: 'api_key', clientId: 'buyer-xyz' });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(captures.upsertCtx?.agent, 'upsert MUST receive ctx.agent when agentRegistry is configured');
+    assert.strictEqual(captures.upsertCtx.agent.agent_url, 'https://agent.scope3.com');
+  });
+
+  it('upsert ctx.authInfo is undefined when no authentication is wired', async () => {
+    const captures = {};
+    const server = createAdcpServerFromPlatform(buildPlatform(captures), {
+      name: 'gap-1310',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatchSync(server);
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(captures.upsertCtx, 'upsert MUST receive a ctx object even when authInfo is absent');
+    assert.strictEqual(captures.upsertCtx.authInfo, undefined);
+    assert.strictEqual(captures.upsertCtx.toolName, 'sync_accounts');
+  });
+});
+
+describe('Issue #1310 — accounts.list receives ResolveContext', () => {
+  it('forwards authInfo from request ctx to accounts.list', async () => {
+    const captures = {};
+    const server = createAdcpServerFromPlatform(buildPlatform(captures), {
+      name: 'gap-1310',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const authInfo = { kind: 'oauth', clientId: 'buyer-xyz' };
+    const result = await dispatchList(server, authInfo);
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(captures.listCtx, 'list MUST receive a non-null ctx');
+    assert.deepStrictEqual(captures.listCtx.authInfo, authInfo);
+    assert.strictEqual(captures.listCtx.toolName, 'list_accounts');
+  });
+
+  it('forwards resolved BuyerAgent to accounts.list when agentRegistry is configured', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform(captures, {
+        agentRegistry: {
+          async resolve() {
+            return agent;
+          },
+        },
+      }),
+      {
+        name: 'gap-1310',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+    const result = await dispatchList(server, { kind: 'api_key', clientId: 'buyer-xyz' });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(captures.listCtx?.agent, 'list MUST receive ctx.agent when agentRegistry is configured');
+    assert.strictEqual(captures.listCtx.agent.agent_url, 'https://agent.scope3.com');
+  });
+
+  it('list filter is still passed as the first arg', async () => {
+    const captures = {};
+    const server = createAdcpServerFromPlatform(buildPlatform(captures), {
+      name: 'gap-1310',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await dispatchList(server);
+    assert.ok(captures.listFilter, 'first arg must be the filter, ctx must come second');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds optional `ResolveContext` second arg to `AccountStore.upsert` and `AccountStore.list`.
- Framework forwards `authInfo`, `toolName`, and `agent` (when `agentRegistry` is configured) — same shape already threaded to `accounts.resolve`, `reportUsage`, `getAccountFinancials`.
- Unblocks principal-keyed gates on `sync_accounts` / `list_accounts` (e.g. the `BILLING_NOT_PERMITTED_FOR_AGENT` per-buyer-agent gate from [adcp#3851](https://github.com/adcontextprotocol/adcp/pull/3851)) without re-deriving identity from the request.

Closes #1272.
Closes #1310. (Same gap, refiled with the billing-gate motivation; #1272 has the multi-tenant `org_id` framing.)

## Why
Two motivations converged on the same gap:

- **#1272 (multi-tenant tenancy)**: adopters whose auth principal determines tenant need `authInfo` inside `upsert()` to write a tenant key onto new accounts, and inside `list()` to scope the roster. Without forwarded ctx, every workaround fails (instance fields race; ALS doesn't propagate across the SDK's await chains; per-request stores violate the SDK's long-lived-store contract).
- **#1310 (billing gates)**: per [adcp#3851](https://github.com/adcontextprotocol/adcp/pull/3851), the spec defines `BILLING_NOT_PERMITTED_FOR_AGENT` as a per-buyer-agent gate keyed on the calling principal. The training-agent reference impl wires it on the legacy `/mcp` route (where principal flows naturally); v6 per-tenant routes can't expose `sync_accounts` with the gate because there's no way to read the principal inside `accounts.upsert`. Wiring `accounts.upsert` would silently NO-OP the gate.

`reportUsage` and `getAccountFinancials` already get ctx; this closes the symmetric gap on the only two `AccountStore` methods that didn't.

## Compatibility
`ctx` is optional on the platform side. Existing `upsert(refs)` / `list(filter)` implementations keep working — adopters needing principal-based gates / tenant scoping opt in by accepting the second arg.

## Test plan
- [x] Six new tests in `test/server-account-store-ctx-forwarding.test.js` cover:
  - upsert receives `authInfo` from request ctx
  - upsert receives resolved `BuyerAgent` when `agentRegistry` is configured
  - upsert ctx survives without authentication wired (authInfo undefined; toolName still set)
  - same three for list (filter still passed as first arg)
- [x] All 146 tests in adjacent files (`server-buyer-agent-resolve-seam`, `server-buyer-agent-credential-synthesis`, `server-decisioning-from-platform`, `server-ctx-metadata-leak-paranoia`) pass.
- [x] `npm run build` clean; `npm run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)