### PR TITLE
feat(server): BuyerAgentRegistry Phase 1 Stage 5 — caching decorator (#1269)

### DIFF
--- a/.changeset/buyer-agent-registry-stage-5.md
+++ b/.changeset/buyer-agent-registry-stage-5.md
@@ -1,0 +1,32 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): BuyerAgentRegistry — Phase 1 Stage 5 (caching decorator)
+
+Phase 1 Stage 5 of #1269. Adds `BuyerAgentRegistry.cached(inner, options)` — a TTL-based caching decorator with concurrent-resolve coalescing and LRU eviction.
+
+**Usage:**
+
+```ts
+const registry = BuyerAgentRegistry.cached(
+  BuyerAgentRegistry.signingOnly({
+    resolveByAgentUrl: async url => db.findBuyerAgent(url),
+  }),
+  { ttlSeconds: 60 }
+);
+```
+
+**Properties:**
+
+- **TTL-bounded.** Successful resolutions cached for `ttlSeconds` (default 60). Negative cache (null returns) is OPT-IN via `cacheNullsTtlSeconds` (default 0 — freshly onboarded agents are recognized within one request).
+- **LRU-evicted.** Bounded to `maxSize` entries (default 10000). Map-iteration-order gives LRU-on-access for free; touch on hit re-inserts the entry as most-recent.
+- **Concurrent-resolve coalesced.** N parallel `resolve()` calls on the same credential produce ONE upstream invocation; subsequent callers await the in-flight promise.
+- **Per-kind cache keys.** Keys are namespaced (`http_sig:`, `api_key:`, `oauth:`) so a string colliding across credential kinds (e.g., an `agent_url` matching an `api_key.key_id` value) cannot leak an agent from one resolution path to another.
+- **Skips uncacheable inputs.** When `credential === undefined`, `resolve()` falls through to the inner registry on each call — adopters with custom auth that hasn't migrated to credential synthesis (Stage 3) see no behavior change.
+
+Mirrors the `AsyncCachingJwksResolver` over `JwksResolver` pattern already in `src/lib/signing/`.
+
+16 new tests cover: TTL hit/miss, expiration, null caching opt-in, pass-through for undefined credential, per-kind key isolation, concurrent-resolve coalescing (10 parallel resolves → 1 upstream call, all see same result reference), LRU eviction with touch-on-hit, option validation. Full suite: 7412 pass, 0 fail.
+
+This is the final stage of Phase 1's planned implementation. Phase 2 (#1292) — framework-level billing-capability enforcement and AdCP-3.1 error-code emission — remains gated on the SDK's 3.1 cutover.

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -443,6 +443,184 @@ export function mixed(opts: {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Caching decorator — Phase 1 Stage 5 of #1269
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link cached}.
+ *
+ * @public
+ */
+export interface BuyerAgentCacheOptions {
+  /**
+   * TTL (seconds) for successful resolutions. Default: 60.
+   *
+   * Adopters whose registry sits in front of a Postgres / external lookup
+   * benefit from caching for the request lifecycle of a single buyer's
+   * traffic burst. Long TTLs (several minutes) are appropriate for
+   * stable agent records; short TTLs (a few seconds) for rapidly-mutating
+   * relationships (suspension flags, billing-capability changes).
+   *
+   * Status changes propagate within `ttlSeconds` of the seller flipping
+   * the agent's row in their store — adopters needing instant
+   * propagation either set a short TTL or invalidate the cache out-of-
+   * band when they mutate.
+   */
+  ttlSeconds?: number;
+
+  /**
+   * TTL (seconds) for `null` returns (negative cache). Default: 0
+   * (don't cache nulls). A freshly onboarded agent is recognized within
+   * one request when nulls aren't cached; sellers willing to delay
+   * recognition by N seconds in exchange for fewer DB hits set this to
+   * a small positive value.
+   */
+  cacheNullsTtlSeconds?: number;
+
+  /**
+   * Maximum cache entries before LRU eviction. Default: 10000.
+   * The cache is bounded so a malicious or misconfigured caller spamming
+   * unique credentials (e.g., random api keys probing the seller's
+   * onboarding surface) can't exhaust memory.
+   */
+  maxSize?: number;
+
+  /** Override clock for deterministic tests. Returns ms since epoch. */
+  now?: () => number;
+}
+
+interface CacheEntry {
+  value: BuyerAgent | null;
+  expiresAtMs: number;
+}
+
+/**
+ * Compute a cache key from a credential. Returns null when the
+ * credential is undefined — uncacheable, falls through to the inner
+ * registry on each call. Keys are namespaced by kind so an api_key
+ * `key_id` value can never collide with an http_sig `keyid` value or
+ * an oauth `client_id`. Note that `key_id` is already a stable hash
+ * (Stage 3); using it as a cache key is safe.
+ */
+function cacheKeyForCredential(credential: AdcpCredential | undefined): string | null {
+  if (credential === undefined) return null;
+  switch (credential.kind) {
+    case 'http_sig':
+      return `http_sig:${credential.agent_url}`;
+    case 'api_key':
+      return `api_key:${credential.key_id}`;
+    case 'oauth':
+      return `oauth:${credential.client_id}`;
+  }
+}
+
+/**
+ * Wrap a {@link BuyerAgentRegistry} with TTL-based result caching and
+ * concurrent-resolve coalescing. Adopters whose `resolveByAgentUrl` /
+ * `resolveByCredential` hit a database or external service compose
+ * the cache via:
+ *
+ * ```ts
+ * const registry = BuyerAgentRegistry.cached(
+ *   BuyerAgentRegistry.signingOnly({
+ *     resolveByAgentUrl: async url => db.findBuyerAgent(url),
+ *   }),
+ *   { ttlSeconds: 60 }
+ * );
+ * ```
+ *
+ * Cache properties:
+ * - **TTL-bounded.** Entries expire after `ttlSeconds` (default 60).
+ *   Negative cache (null returns) is opt-in via `cacheNullsTtlSeconds`.
+ * - **LRU-evicted.** Bounded to `maxSize` entries (default 10000).
+ *   Oldest-accessed entry evicts on overflow.
+ * - **Concurrent-resolve coalesced.** N parallel `resolve()` calls on
+ *   the same key produce ONE upstream invocation. Subsequent callers
+ *   await the in-flight promise — important when the seller front-ends
+ *   a slow upstream and a buyer burst arrives.
+ * - **Per-kind cache keys.** Keys are namespaced (`http_sig:`,
+ *   `api_key:`, `oauth:`) so cross-kind collisions cannot leak an agent
+ *   resolved through one credential type to a different type.
+ * - **Skips uncacheable inputs.** When the credential is undefined,
+ *   `resolve()` falls through to the inner registry on each call —
+ *   adopters wiring custom auth without `credential` synthesis (Stage 3
+ *   migration cycle) see no behavior change.
+ *
+ * Mirrors the `AsyncCachingJwksResolver` over `JwksResolver` pattern
+ * already in `src/lib/signing/`.
+ *
+ * @public
+ */
+export function cached(inner: BuyerAgentRegistry, options: BuyerAgentCacheOptions = {}): BuyerAgentRegistry {
+  if (typeof inner !== 'object' || inner === null || typeof inner.resolve !== 'function') {
+    throw new TypeError('BuyerAgentRegistry.cached: `inner` must be a BuyerAgentRegistry');
+  }
+  const ttlMs = (options.ttlSeconds ?? 60) * 1000;
+  const nullsTtlMs = (options.cacheNullsTtlSeconds ?? 0) * 1000;
+  const maxSize = options.maxSize ?? 10000;
+  const now = options.now ?? Date.now;
+
+  if (ttlMs <= 0) throw new RangeError('BuyerAgentRegistry.cached: ttlSeconds must be > 0');
+  if (nullsTtlMs < 0) throw new RangeError('BuyerAgentRegistry.cached: cacheNullsTtlSeconds must be >= 0');
+  if (maxSize < 1) throw new RangeError('BuyerAgentRegistry.cached: maxSize must be >= 1');
+
+  // Map iteration order is insertion order, so re-inserting on hit
+  // gives us LRU-on-access semantics for free.
+  const cache = new Map<string, CacheEntry>();
+  const inFlight = new Map<string, Promise<BuyerAgent | null>>();
+
+  return {
+    async resolve(authInfo) {
+      const key = cacheKeyForCredential(authInfo.credential);
+      if (key === null) {
+        // Uncacheable input — pass through. Adopters wiring custom
+        // auth that hasn't migrated to `credential` synthesis see
+        // every call hit the inner resolver.
+        return inner.resolve(authInfo);
+      }
+
+      const entry = cache.get(key);
+      if (entry !== undefined && now() < entry.expiresAtMs) {
+        // LRU touch: re-insert so this entry becomes the most-recent.
+        cache.delete(key);
+        cache.set(key, entry);
+        return entry.value;
+      }
+      if (entry !== undefined) {
+        // Expired — drop before refetch.
+        cache.delete(key);
+      }
+
+      // Coalesce concurrent resolves: subsequent callers on the same
+      // key await the existing in-flight promise rather than firing
+      // their own upstream lookup.
+      const existing = inFlight.get(key);
+      if (existing !== undefined) return existing;
+
+      const promise = (async () => {
+        const value = await inner.resolve(authInfo);
+        const entryTtlMs = value === null ? nullsTtlMs : ttlMs;
+        if (entryTtlMs > 0) {
+          cache.set(key, { value, expiresAtMs: now() + entryTtlMs });
+          while (cache.size > maxSize) {
+            const oldestKey = cache.keys().next().value;
+            if (oldestKey === undefined) break;
+            cache.delete(oldestKey);
+          }
+        }
+        return value;
+      })();
+      inFlight.set(key, promise);
+      try {
+        return await promise;
+      } finally {
+        inFlight.delete(key);
+      }
+    },
+  };
+}
+
 /**
  * Factory namespace mirroring the documented surface from #1269. Adopters
  * import the namespace and call `BuyerAgentRegistry.signingOnly({...})`,
@@ -454,4 +632,5 @@ export const BuyerAgentRegistry = {
   signingOnly,
   bearerOnly,
   mixed,
+  cached,
 };

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -475,6 +475,12 @@ export interface BuyerAgentCacheOptions {
    * one request when nulls aren't cached; sellers willing to delay
    * recognition by N seconds in exchange for fewer DB hits set this to
    * a small positive value.
+   *
+   * **Timing-oracle note.** When null caching is enabled, an
+   * unauthenticated prober comparing hit vs. miss latency on null
+   * returns can infer "this credential was probed recently." Pair with
+   * rate-limiting at the edge if your deployment runs in a hostile
+   * environment. The default (0) avoids the oracle entirely.
    */
   cacheNullsTtlSeconds?: number;
 
@@ -496,6 +502,35 @@ interface CacheEntry {
 }
 
 /**
+ * Cached registry surface. Strict superset of {@link BuyerAgentRegistry}
+ * with explicit invalidation hooks adopters call when they mutate the
+ * backing record (status flip, billing-capability change). Without
+ * `invalidate`, adopters could only purge stale entries by waiting for
+ * `ttlSeconds` to expire — for status changes that's exactly the
+ * window during which a now-suspended agent retains access.
+ *
+ * `BuyerAgentRegistry.cached(...)` returns this richer type so adopters
+ * can hold a reference and call the invalidation methods directly.
+ *
+ * @public
+ */
+export interface CachedBuyerAgentRegistry extends BuyerAgentRegistry {
+  /**
+   * Drop the cache entry for a single credential. No-op when the
+   * credential isn't currently cached. Use this when the agent's
+   * record is mutated in your backing store so the next request
+   * re-resolves rather than serving the stale entry.
+   */
+  invalidate(credential: AdcpCredential): void;
+
+  /**
+   * Drop all cached entries. Use on bulk record mutations (onboarding-
+   * record migration, daily reset) or test-environment cleanup.
+   */
+  clear(): void;
+}
+
+/**
  * Compute a cache key from a credential. Returns null when the
  * credential is undefined — uncacheable, falls through to the inner
  * registry on each call. Keys are namespaced by kind so an api_key
@@ -512,6 +547,14 @@ function cacheKeyForCredential(credential: AdcpCredential | undefined): string |
       return `api_key:${credential.key_id}`;
     case 'oauth':
       return `oauth:${credential.client_id}`;
+    default: {
+      // Exhaustiveness check — adding a new credential kind without
+      // updating this switch produces a compile error here, not a
+      // runtime cache-miss bug.
+      const _exhaustive: never = credential;
+      void _exhaustive;
+      return null;
+    }
   }
 }
 
@@ -546,13 +589,20 @@ function cacheKeyForCredential(credential: AdcpCredential | undefined): string |
  *   `resolve()` falls through to the inner registry on each call —
  *   adopters wiring custom auth without `credential` synthesis (Stage 3
  *   migration cycle) see no behavior change.
+ * - **Explicit invalidation.** Returns a {@link CachedBuyerAgentRegistry}
+ *   with `.invalidate(credential)` and `.clear()` methods. Call
+ *   `invalidate` when you mutate an agent's record (status flip,
+ *   billing-capability change) so the next request re-resolves rather
+ *   than serving the stale entry. Without this, the stale-status window
+ *   is bounded by `ttlSeconds` — a now-suspended agent retains access
+ *   for up to that long.
  *
  * Mirrors the `AsyncCachingJwksResolver` over `JwksResolver` pattern
  * already in `src/lib/signing/`.
  *
  * @public
  */
-export function cached(inner: BuyerAgentRegistry, options: BuyerAgentCacheOptions = {}): BuyerAgentRegistry {
+export function cached(inner: BuyerAgentRegistry, options: BuyerAgentCacheOptions = {}): CachedBuyerAgentRegistry {
   if (typeof inner !== 'object' || inner === null || typeof inner.resolve !== 'function') {
     throw new TypeError('BuyerAgentRegistry.cached: `inner` must be a BuyerAgentRegistry');
   }
@@ -594,7 +644,11 @@ export function cached(inner: BuyerAgentRegistry, options: BuyerAgentCacheOption
 
       // Coalesce concurrent resolves: subsequent callers on the same
       // key await the existing in-flight promise rather than firing
-      // their own upstream lookup.
+      // their own upstream lookup. If the upstream rejects, all
+      // coalesced callers see the same rejection; the `finally` below
+      // releases `inFlight` so the next caller retries upstream
+      // (rejected promises do NOT poison the cache — `cache.set`
+      // inside the IIFE is unreachable on rejection).
       const existing = inFlight.get(key);
       if (existing !== undefined) return existing;
 
@@ -602,6 +656,19 @@ export function cached(inner: BuyerAgentRegistry, options: BuyerAgentCacheOption
         const value = await inner.resolve(authInfo);
         const entryTtlMs = value === null ? nullsTtlMs : ttlMs;
         if (entryTtlMs > 0) {
+          // Defense-in-depth: freeze the resolved record before
+          // sharing across coalesced callers. The dispatcher seam
+          // also freezes per-request (Stage 2), but freezing here
+          // makes the cached-shared-reference invariant load-
+          // bearing rather than coincidental — a future caller
+          // mutating `BuyerAgent.status` would otherwise corrupt
+          // every other cached-hit consumer's view.
+          if (value !== null && !Object.isFrozen(value)) {
+            if (value.billing_capabilities instanceof Set) {
+              Object.freeze(value.billing_capabilities);
+            }
+            Object.freeze(value);
+          }
           cache.set(key, { value, expiresAtMs: now() + entryTtlMs });
           while (cache.size > maxSize) {
             const oldestKey = cache.keys().next().value;
@@ -617,6 +684,15 @@ export function cached(inner: BuyerAgentRegistry, options: BuyerAgentCacheOption
       } finally {
         inFlight.delete(key);
       }
+    },
+
+    invalidate(credential) {
+      const key = cacheKeyForCredential(credential);
+      if (key !== null) cache.delete(key);
+    },
+
+    clear() {
+      cache.clear();
     },
   };
 }

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -107,6 +107,7 @@ export type {
   BuyerAgentRegistry as BuyerAgentRegistryProtocol,
   BuyerAgentResolveInput,
   BuyerAgentCacheOptions,
+  CachedBuyerAgentRegistry,
   AdcpCredential,
   ResolveBuyerAgentByAgentUrl,
   ResolveBuyerAgentByCredential,

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -106,6 +106,7 @@ export type {
   BuyerAgentStatus,
   BuyerAgentRegistry as BuyerAgentRegistryProtocol,
   BuyerAgentResolveInput,
+  BuyerAgentCacheOptions,
   AdcpCredential,
   ResolveBuyerAgentByAgentUrl,
   ResolveBuyerAgentByCredential,

--- a/test/lib/buyer-agent-cache.test.js
+++ b/test/lib/buyer-agent-cache.test.js
@@ -1,0 +1,343 @@
+'use strict';
+
+// Stage 5 of #1269 — `BuyerAgentRegistry.cached` decorator.
+//
+// Tests the caching decorator's contracts:
+//   - TTL-bounded
+//   - LRU-evicted on max-size overflow
+//   - Concurrent-resolve coalesced (one upstream call per N parallel resolves)
+//   - Per-kind cache keys (no cross-kind collisions)
+//   - Skips uncacheable inputs (credential === undefined → pass-through)
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { BuyerAgentRegistry, markVerifiedHttpSig } = require('../../dist/lib/server/decisioning/buyer-agent');
+
+const sampleAgent = (overrides = {}) => ({
+  agent_url: 'https://agent.scope3.com',
+  display_name: 'Scope3',
+  status: 'active',
+  billing_capabilities: new Set(['operator']),
+  ...overrides,
+});
+
+const sigCredential = (overrides = {}) =>
+  markVerifiedHttpSig({
+    kind: 'http_sig',
+    keyid: 'kid',
+    agent_url: 'https://agent.scope3.com',
+    verified_at: 1714660000,
+    ...overrides,
+  });
+
+const apiKeyCredential = (overrides = {}) => ({
+  kind: 'api_key',
+  key_id: 'hashed_key_id',
+  ...overrides,
+});
+
+const oauthCredential = (overrides = {}) => ({
+  kind: 'oauth',
+  client_id: 'oauth_client_xyz',
+  scopes: [],
+  ...overrides,
+});
+
+describe('BuyerAgentRegistry.cached — basic semantics', () => {
+  it('serves a cache hit on a second call with the same credential within TTL', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        upstreamCalls++;
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    const first = await registry.resolve({ credential: sigCredential() });
+    const second = await registry.resolve({ credential: sigCredential() });
+
+    assert.equal(upstreamCalls, 1, 'second call MUST hit cache, not upstream');
+    assert.equal(first.agent_url, 'https://agent.scope3.com');
+    assert.equal(second.agent_url, 'https://agent.scope3.com');
+  });
+
+  it('expires entries after TTL and re-resolves upstream', async () => {
+    let nowMs = 1_000_000;
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        upstreamCalls++;
+        return sampleAgent();
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, {
+      ttlSeconds: 30,
+      now: () => nowMs,
+    });
+
+    await registry.resolve({ credential: sigCredential() });
+    nowMs += 29_000; // 29s later — within TTL
+    await registry.resolve({ credential: sigCredential() });
+    assert.equal(upstreamCalls, 1, 'within TTL → still cached');
+
+    nowMs += 2_000; // 31s total — TTL expired
+    await registry.resolve({ credential: sigCredential() });
+    assert.equal(upstreamCalls, 2, 'past TTL → upstream re-resolves');
+  });
+
+  it('does NOT cache nulls by default (cacheNullsTtlSeconds defaults to 0)', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        upstreamCalls++;
+        return null;
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    await registry.resolve({ credential: sigCredential() });
+    await registry.resolve({ credential: sigCredential() });
+    assert.equal(
+      upstreamCalls,
+      2,
+      'nulls must NOT be cached by default — freshly onboarded agents are recognized within one request'
+    );
+  });
+
+  it('caches nulls when cacheNullsTtlSeconds > 0', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        upstreamCalls++;
+        return null;
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, {
+      ttlSeconds: 60,
+      cacheNullsTtlSeconds: 10,
+    });
+
+    await registry.resolve({ credential: sigCredential() });
+    await registry.resolve({ credential: sigCredential() });
+    assert.equal(upstreamCalls, 1, 'nulls cached for cacheNullsTtlSeconds');
+  });
+
+  it('skips caching when credential is undefined (pass-through)', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        upstreamCalls++;
+        return sampleAgent();
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    await registry.resolve({}); // no credential
+    await registry.resolve({}); // no credential
+    // Inner returns null for undefined credential without invoking the resolver
+    // (signingOnly's first guard); the cache skips both. The point: every call
+    // hits the inner registry rather than caching a null result.
+    assert.equal(upstreamCalls, 0); // inner's signingOnly short-circuits before resolver
+    // But the cache MUST NOT have stored a null here either; verify by
+    // returning a real agent next and checking it's invoked.
+    const inner2 = BuyerAgentRegistry.bearerOnly({
+      resolveByCredential: async () => {
+        upstreamCalls++;
+        return sampleAgent();
+      },
+    });
+    const registry2 = BuyerAgentRegistry.cached(inner2, { ttlSeconds: 60 });
+    await registry2.resolve({}); // no credential → bearerOnly returns null without resolver
+    await registry2.resolve({ credential: apiKeyCredential() }); // now real call
+    assert.equal(upstreamCalls, 1, "pass-through path doesn't poison the cache");
+  });
+});
+
+describe('BuyerAgentRegistry.cached — per-kind cache keys', () => {
+  it('different credential kinds are cached independently (no cross-kind collision)', async () => {
+    const calls = [];
+    const inner = BuyerAgentRegistry.mixed({
+      resolveByAgentUrl: async url => {
+        calls.push({ kind: 'signed', url });
+        return sampleAgent({ agent_url: url, display_name: 'signed-resolved' });
+      },
+      resolveByCredential: async cred => {
+        calls.push({ kind: cred.kind, value: cred.kind === 'api_key' ? cred.key_id : cred.client_id });
+        return sampleAgent({ display_name: `${cred.kind}-resolved` });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    // Same string value across kinds — must NOT collide.
+    const collisionValue = 'collision';
+    await registry.resolve({
+      credential: markVerifiedHttpSig({
+        kind: 'http_sig',
+        keyid: 'k',
+        agent_url: collisionValue,
+        verified_at: 0,
+      }),
+    });
+    await registry.resolve({ credential: { kind: 'api_key', key_id: collisionValue } });
+    await registry.resolve({ credential: { kind: 'oauth', client_id: collisionValue, scopes: [] } });
+
+    assert.equal(calls.length, 3, 'one upstream call per kind despite identical value strings');
+    assert.deepEqual(calls.map(c => c.kind).sort(), ['api_key', 'oauth', 'signed']);
+  });
+
+  it('different agent_url values within the same kind are cached separately', async () => {
+    const urls = [];
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        urls.push(url);
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://agent-a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://agent-b.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://agent-a.com' }) });
+
+    assert.deepEqual(urls, ['https://agent-a.com', 'https://agent-b.com']);
+  });
+});
+
+describe('BuyerAgentRegistry.cached — concurrent resolve coalescing', () => {
+  it('N parallel resolves on the same key produce ONE upstream call', async () => {
+    let upstreamCalls = 0;
+    let release;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        upstreamCalls++;
+        // Block until the test releases — simulates a slow upstream.
+        await new Promise(resolve => {
+          release = resolve;
+        });
+        return sampleAgent();
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    // Fire 10 parallel resolves on the same key.
+    const promises = Array.from({ length: 10 }, () => registry.resolve({ credential: sigCredential() }));
+
+    // Wait one microtask so all 10 enter the inFlight check.
+    await new Promise(resolve => setImmediate(resolve));
+    assert.equal(upstreamCalls, 1, 'parallel resolves MUST coalesce to one upstream call');
+
+    release();
+    const results = await Promise.all(promises);
+    assert.equal(results.length, 10);
+    assert.equal(
+      results.every(r => r?.agent_url === 'https://agent.scope3.com'),
+      true
+    );
+  });
+
+  it('coalesced resolves all see the same result reference (no duplication)', async () => {
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => sampleAgent(),
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    const [a, b, c] = await Promise.all([
+      registry.resolve({ credential: sigCredential() }),
+      registry.resolve({ credential: sigCredential() }),
+      registry.resolve({ credential: sigCredential() }),
+    ]);
+    assert.strictEqual(a, b);
+    assert.strictEqual(b, c);
+  });
+
+  it('inFlight entry is released after the resolve completes (no leak)', async () => {
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => sampleAgent(),
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    await registry.resolve({ credential: sigCredential() });
+    // Force TTL expiration via a fresh registry to test re-resolve path.
+    let nowMs = 1_000_000;
+    const registry2 = BuyerAgentRegistry.cached(inner, { ttlSeconds: 1, now: () => nowMs });
+    await registry2.resolve({ credential: sigCredential() });
+    nowMs += 2_000;
+    await registry2.resolve({ credential: sigCredential() }); // must succeed, not deadlock
+  });
+});
+
+describe('BuyerAgentRegistry.cached — LRU eviction', () => {
+  it('evicts oldest entry when maxSize is reached', async () => {
+    const lookups = [];
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        lookups.push(url);
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60, maxSize: 2 });
+
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+    // Cache holds [a, b]. Adding c evicts a (oldest).
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://c.com' }) });
+    // Re-resolving a should hit upstream again (was evicted).
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+
+    assert.deepEqual(lookups, ['https://a.com', 'https://b.com', 'https://c.com', 'https://a.com']);
+  });
+
+  it('LRU touch on cache hit moves entry to most-recent (delays eviction)', async () => {
+    const lookups = [];
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        lookups.push(url);
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60, maxSize: 2 });
+
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+    // Touch `a` — now b is oldest.
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    // Add c — should evict b (oldest) not a.
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://c.com' }) });
+    // a should still be cached, b should be re-resolved.
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+
+    assert.deepEqual(lookups, [
+      'https://a.com', // initial
+      'https://b.com', // initial
+      'https://c.com', // initial
+      'https://b.com', // re-resolved (was evicted by LRU)
+    ]);
+  });
+});
+
+describe('BuyerAgentRegistry.cached — option validation', () => {
+  it('throws on invalid inner', () => {
+    assert.throws(() => BuyerAgentRegistry.cached(null), /must be a BuyerAgentRegistry/);
+    assert.throws(() => BuyerAgentRegistry.cached({}), /must be a BuyerAgentRegistry/);
+    assert.throws(() => BuyerAgentRegistry.cached('not-a-registry'), /must be a BuyerAgentRegistry/);
+  });
+
+  it('throws on non-positive ttlSeconds', () => {
+    const inner = BuyerAgentRegistry.signingOnly({ resolveByAgentUrl: async () => sampleAgent() });
+    assert.throws(() => BuyerAgentRegistry.cached(inner, { ttlSeconds: 0 }), /ttlSeconds/);
+    assert.throws(() => BuyerAgentRegistry.cached(inner, { ttlSeconds: -1 }), /ttlSeconds/);
+  });
+
+  it('throws on negative cacheNullsTtlSeconds', () => {
+    const inner = BuyerAgentRegistry.signingOnly({ resolveByAgentUrl: async () => sampleAgent() });
+    assert.throws(() => BuyerAgentRegistry.cached(inner, { cacheNullsTtlSeconds: -1 }), /cacheNullsTtlSeconds/);
+  });
+
+  it('throws on maxSize < 1', () => {
+    const inner = BuyerAgentRegistry.signingOnly({ resolveByAgentUrl: async () => sampleAgent() });
+    assert.throws(() => BuyerAgentRegistry.cached(inner, { maxSize: 0 }), /maxSize/);
+  });
+});

--- a/test/lib/buyer-agent-cache.test.js
+++ b/test/lib/buyer-agent-cache.test.js
@@ -124,34 +124,23 @@ describe('BuyerAgentRegistry.cached — basic semantics', () => {
     assert.equal(upstreamCalls, 1, 'nulls cached for cacheNullsTtlSeconds');
   });
 
-  it('skips caching when credential is undefined (pass-through)', async () => {
-    let upstreamCalls = 0;
-    const inner = BuyerAgentRegistry.signingOnly({
-      resolveByAgentUrl: async () => {
-        upstreamCalls++;
-        return sampleAgent();
+  it('skips caching when credential is undefined (pass-through to inner)', async () => {
+    // signingOnly's guard returns null before invoking the resolver,
+    // so we count cache-side calls via inner.resolve invocations.
+    let innerResolveCalls = 0;
+    const inner = {
+      async resolve() {
+        innerResolveCalls++;
+        return null;
       },
-    });
+    };
     const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
 
     await registry.resolve({}); // no credential
     await registry.resolve({}); // no credential
-    // Inner returns null for undefined credential without invoking the resolver
-    // (signingOnly's first guard); the cache skips both. The point: every call
-    // hits the inner registry rather than caching a null result.
-    assert.equal(upstreamCalls, 0); // inner's signingOnly short-circuits before resolver
-    // But the cache MUST NOT have stored a null here either; verify by
-    // returning a real agent next and checking it's invoked.
-    const inner2 = BuyerAgentRegistry.bearerOnly({
-      resolveByCredential: async () => {
-        upstreamCalls++;
-        return sampleAgent();
-      },
-    });
-    const registry2 = BuyerAgentRegistry.cached(inner2, { ttlSeconds: 60 });
-    await registry2.resolve({}); // no credential → bearerOnly returns null without resolver
-    await registry2.resolve({ credential: apiKeyCredential() }); // now real call
-    assert.equal(upstreamCalls, 1, "pass-through path doesn't poison the cache");
+    // Pass-through: every call hits inner.resolve directly; the cache
+    // is never consulted because the credential is uncacheable.
+    assert.equal(innerResolveCalls, 2, 'undefined credential MUST pass through to inner on every call');
   });
 });
 
@@ -252,19 +241,144 @@ describe('BuyerAgentRegistry.cached — concurrent resolve coalescing', () => {
     assert.strictEqual(b, c);
   });
 
-  it('inFlight entry is released after the resolve completes (no leak)', async () => {
+  it('expired entry triggers re-resolve without deadlock (inFlight released after settle)', async () => {
+    let nowMs = 1_000_000;
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => {
+        upstreamCalls++;
+        return sampleAgent();
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 1, now: () => nowMs });
+
+    await registry.resolve({ credential: sigCredential() });
+    nowMs += 2_000; // expire
+    await registry.resolve({ credential: sigCredential() }); // must succeed, not deadlock
+    assert.equal(upstreamCalls, 2, 'expired entry → re-resolve');
+  });
+
+  it('rejected upstream propagates to all coalesced callers AND does not poison the cache', async () => {
+    let upstreamCalls = 0;
+    let mode = 'reject';
+    const inner = {
+      async resolve() {
+        upstreamCalls++;
+        // Yield once so concurrent callers can land in the inFlight map
+        // before this one settles, then dispatch on the current mode.
+        await new Promise(resolve => setImmediate(resolve));
+        if (mode === 'reject') throw new Error('upstream DB outage');
+        return sampleAgent();
+      },
+    };
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    // Phase 1: fire 5 parallel resolves; all should coalesce and reject.
+    const promises = Array.from({ length: 5 }, () => registry.resolve({ credential: sigCredential() }));
+    const settled = await Promise.allSettled(promises);
+    assert.equal(upstreamCalls, 1, 'coalesced to one upstream call');
+    assert.equal(
+      settled.every(r => r.status === 'rejected' && r.reason.message === 'upstream DB outage'),
+      true,
+      'all coalesced callers see the same rejection'
+    );
+
+    // Phase 2: cache MUST NOT carry a poisoned entry; next call retries.
+    mode = 'resolve';
+    const result = await registry.resolve({ credential: sigCredential() });
+    assert.equal(upstreamCalls, 2, 'rejected upstream did not cache; next call hits upstream again');
+    assert.ok(result);
+  });
+
+  it('returned BuyerAgent is the same reference for coalesced callers AND for cache hits', async () => {
+    const agent = sampleAgent();
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async () => agent,
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    const first = await registry.resolve({ credential: sigCredential() });
+    const second = await registry.resolve({ credential: sigCredential() });
+    assert.strictEqual(first, second, 'cache hit must return the same reference');
+    // The cache freezes the value before sharing — defense-in-depth
+    // against future mutation across coalesced callers.
+    assert.equal(Object.isFrozen(first), true);
+  });
+});
+
+describe('BuyerAgentRegistry.cached — invalidate / clear API', () => {
+  it('invalidate(credential) drops the matching cache entry; next resolve hits upstream', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        upstreamCalls++;
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    const cred = sigCredential();
+    await registry.resolve({ credential: cred });
+    await registry.resolve({ credential: cred });
+    assert.equal(upstreamCalls, 1, 'second call cached');
+
+    registry.invalidate(cred);
+    await registry.resolve({ credential: cred });
+    assert.equal(upstreamCalls, 2, 'invalidated key MUST re-resolve upstream');
+  });
+
+  it('invalidate(other) does NOT drop unrelated entries', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        upstreamCalls++;
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+    assert.equal(upstreamCalls, 2);
+
+    registry.invalidate(sigCredential({ agent_url: 'https://a.com' }));
+    // b is still cached.
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+    assert.equal(upstreamCalls, 2, 'invalidate(a) MUST NOT drop b');
+    // a re-resolves.
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    assert.equal(upstreamCalls, 3);
+  });
+
+  it('clear() drops every entry', async () => {
+    let upstreamCalls = 0;
+    const inner = BuyerAgentRegistry.signingOnly({
+      resolveByAgentUrl: async url => {
+        upstreamCalls++;
+        return sampleAgent({ agent_url: url });
+      },
+    });
+    const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
+
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+    assert.equal(upstreamCalls, 2);
+
+    registry.clear();
+
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://a.com' }) });
+    await registry.resolve({ credential: sigCredential({ agent_url: 'https://b.com' }) });
+    assert.equal(upstreamCalls, 4, 'clear() MUST evict all cached entries');
+  });
+
+  it('invalidate() on a never-cached credential is a no-op', async () => {
     const inner = BuyerAgentRegistry.signingOnly({
       resolveByAgentUrl: async () => sampleAgent(),
     });
     const registry = BuyerAgentRegistry.cached(inner, { ttlSeconds: 60 });
-
-    await registry.resolve({ credential: sigCredential() });
-    // Force TTL expiration via a fresh registry to test re-resolve path.
-    let nowMs = 1_000_000;
-    const registry2 = BuyerAgentRegistry.cached(inner, { ttlSeconds: 1, now: () => nowMs });
-    await registry2.resolve({ credential: sigCredential() });
-    nowMs += 2_000;
-    await registry2.resolve({ credential: sigCredential() }); // must succeed, not deadlock
+    // No resolves have happened — invalidate must not throw.
+    registry.invalidate(sigCredential());
+    registry.clear();
   });
 });
 


### PR DESCRIPTION
## Summary

Phase 1 Stage 5 of #1269 — final stage. Adds `BuyerAgentRegistry.cached(inner, options)`, a TTL-based caching decorator with concurrent-resolve coalescing and LRU eviction.

## Usage

\`\`\`ts
const registry = BuyerAgentRegistry.cached(
  BuyerAgentRegistry.signingOnly({
    resolveByAgentUrl: async url => db.findBuyerAgent(url),
  }),
  { ttlSeconds: 60 }
);
\`\`\`

## Properties

- **TTL-bounded.** Successful resolutions cached for `ttlSeconds` (default 60). Negative cache (null returns) is OPT-IN via `cacheNullsTtlSeconds` (default 0).
- **LRU-evicted.** Bounded to `maxSize` (default 10000). Map iteration order gives LRU-on-access for free; touch on hit re-inserts as most-recent.
- **Concurrent-resolve coalesced.** N parallel `resolve()` calls on the same credential produce ONE upstream invocation. Subsequent callers await the in-flight promise.
- **Per-kind cache keys** (`http_sig:`, `api_key:`, `oauth:`) prevent cross-kind string collisions from leaking an agent across resolution paths.
- **Skips uncacheable inputs.** When `credential === undefined`, falls through to the inner registry — adopters with custom auth that hasn't migrated to credential synthesis (Stage 3) see no behavior change.

Mirrors the `AsyncCachingJwksResolver` over `JwksResolver` pattern already in `src/lib/signing/`.

## What's NOT in (Phase 2)

- Framework-level `billing_capability` enforcement + AdCP-3.1 error-code emission → Phase 2 (#1292), gated on SDK 3.1 cutover.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `test/lib/buyer-agent-cache.test.js` — 16/16 pass:
  - Basic semantics: cache hit within TTL, expiration, no-cache-nulls default, opt-in null caching, pass-through on undefined credential.
  - Per-kind cache keys: cross-kind collision prevented; same-kind different-value cached separately.
  - Concurrent-resolve coalescing: 10 parallel resolves → 1 upstream call; coalesced resolves see the same result reference; in-flight entries released after completion.
  - LRU eviction: oldest entry evicts on overflow; touch-on-hit delays eviction.
  - Option validation: invalid inner, ttlSeconds, cacheNullsTtlSeconds, maxSize.
- [x] `npm run format:check` clean.
- [x] Full suite: 7412 pass, 0 fail.

## Phase 1 status after this PR

| Stage | Status |
|---|---|
| Stage 1 — types + factories (#1293) | merged |
| Stage 2 — resolve seam + ctx threading (#1297) | merged |
| Stage 3 — credential synthesis + ResolvedAuthInfo migration (#1305) | merged |
| Stage 4 — status enforcement + credential pattern redaction (#1311) | merged |
| **Stage 5 — caching decorator** | **this PR** |

Phase 1 is complete with this PR.

## Cross-links

- #1269 (Phase 1 parent issue)
- #1292 (Phase 2 — gated on SDK 3.1)
- adcontextprotocol/adcp#3831 (spec PR for Phase 2's error codes)
- adcontextprotocol/adcp#3871 (spec issue I filed today for AGENT_SUSPENDED / AGENT_BLOCKED standardization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)