### PR TITLE
fix(server): forward authInfo/agent/toolName ctx to AccountStore.upsert and list (#1310)

### DIFF
--- a/.changeset/account-store-ctx-forwarding.md
+++ b/.changeset/account-store-ctx-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Forward `authInfo`, `agent`, and `toolName` from request context to `AccountStore.upsert` and `AccountStore.list`. Adds optional `ctx?: ResolveContext` second parameter to both methods (non-breaking — existing implementations compile and run unchanged). Also fixes the same `ctx.agent` omission in the existing `reportUsage` and `getAccountFinancials` dispatchers. Unblocks principal-based billing gates on `sync_accounts` (adcp spec PR #3851).

--- a/.changeset/account-store-ctx-forwarding.md
+++ b/.changeset/account-store-ctx-forwarding.md
@@ -2,4 +2,4 @@
 "@adcp/sdk": patch
 ---
 
-Forward `authInfo`, `agent`, and `toolName` from request context to `AccountStore.upsert` and `AccountStore.list`. Adds optional `ctx?: ResolveContext` second parameter to both methods (non-breaking — existing implementations compile and run unchanged). Also fixes the same `ctx.agent` omission in the existing `reportUsage` and `getAccountFinancials` dispatchers. Unblocks principal-based billing gates on `sync_accounts` (adcp spec PR #3851).
+Forward `authInfo`, `agent`, and `toolName` from request context to `AccountStore.upsert` and `AccountStore.list`. Adds optional `ctx?: ResolveContext` second parameter to both methods (non-breaking — existing implementations compile and run unchanged). Also fixes the same `ctx.agent` omission in the existing `reportUsage` and `getAccountFinancials` dispatchers. Unblocks adopter-side principal-based billing gates on `sync_accounts` (adcp#3831); framework-level enforcement lands in Phase 2 (#1292).

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -380,9 +380,11 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * `ctx.authInfo` carries the caller's OAuth principal (when
    * `serve({ authenticate })` is wired). `ctx.agent` is the resolved buyer
    * agent from `BuyerAgentRegistry` (when configured) — use it for per-agent
-   * billing gates such as `BILLING_NOT_PERMITTED_FOR_AGENT` (adcp spec
-   * PR #3851), which fires when the caller's onboarded commercial state doesn't
-   * permit the requested billing value.
+   * billing gates such as `BILLING_NOT_PERMITTED_FOR_AGENT` (adcp#3831,
+   * Phase 2 enforcement via #1292), which fires when the caller's onboarded
+   * commercial state doesn't permit the requested billing value. Phase 2
+   * (#1292) will add framework-level enforcement; adopters can implement the
+   * gate adoptyer-side today via `ctx.agent?.billing_capabilities`.
    */
   upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
 

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -376,15 +376,28 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * **Optional.** Stateless platforms (creative-template, signal-marketplace
    * proxies) that don't manage account lifecycle can omit this; framework
    * surfaces `UNSUPPORTED_FEATURE` to buyers calling `sync_accounts`.
+   *
+   * `ctx.authInfo` carries the caller's OAuth principal (when
+   * `serve({ authenticate })` is wired). `ctx.agent` is the resolved buyer
+   * agent from `BuyerAgentRegistry` (when configured) — use it for per-agent
+   * billing gates such as `BILLING_NOT_PERMITTED_FOR_AGENT` (adcp spec
+   * PR #3851), which fires when the caller's onboarded commercial state doesn't
+   * permit the requested billing value.
    */
-  upsert?(refs: AccountReference[]): Promise<SyncAccountsResultRow[]>;
+  upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
 
   /**
    * list_accounts API surface. Framework wraps with cursor envelope.
    *
    * **Optional.** Same rationale as `upsert` — stateless platforms can omit.
+   *
+   * `ctx.authInfo` carries the caller's OAuth principal (when
+   * `serve({ authenticate })` is wired). `ctx.agent` carries the resolved
+   * buyer agent from `BuyerAgentRegistry` (when configured) — use it to
+   * scope the returned accounts to the calling principal's commercial
+   * relationship.
    */
-  list?(filter: AccountFilter & CursorRequest): Promise<CursorPage<Account<TCtxMeta>>>;
+  list?(filter: AccountFilter & CursorRequest, ctx?: ResolveContext): Promise<CursorPage<Account<TCtxMeta>>>;
 
   /**
    * report_usage API surface. Operator-billed platforms accept usage rows

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3458,23 +3458,33 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   const handlers: AccountHandlers<Account> = {};
 
   if (accounts.upsert) {
-    handlers.syncAccounts = async (params, _ctx) => {
+    handlers.syncAccounts = async (params, ctx) => {
       const refs = (params.accounts ?? []) as AccountReference[];
+      const resolveCtx = {
+        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+        ...(ctx.agent != null && { agent: ctx.agent }),
+        toolName: 'sync_accounts',
+      };
       return projectSync(
-        () => accounts.upsert!(refs),
+        () => accounts.upsert!(refs, resolveCtx),
         rows => ({ accounts: rows.map(toWireSyncAccountRow) })
       );
     };
   }
 
   if (accounts.list) {
-    handlers.listAccounts = async (params, _ctx) => {
+    handlers.listAccounts = async (params, ctx) => {
       const filter = params as Parameters<NonNullable<typeof accounts.list>>[0];
+      const resolveCtx = {
+        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+        ...(ctx.agent != null && { agent: ctx.agent }),
+        toolName: 'list_accounts',
+      };
       // Wrap in projectSync so adopter `throw new AdcpError('PERMISSION_DENIED', ...)`
       // from the list impl projects to the structured wire envelope rather
       // than falling through to the framework's `SERVICE_UNAVAILABLE` mapping.
       return projectSync(
-        () => accounts.list!(filter),
+        () => accounts.list!(filter, resolveCtx),
         page => ({
           accounts: page.items.map(toWireAccount),
           ...(page.nextCursor != null && { next_cursor: page.nextCursor }),
@@ -3487,7 +3497,8 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
     handlers.reportUsage = async (params, ctx) => {
       const resolveCtx = {
         ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-        toolName: 'report_usage' as const,
+        ...(ctx.agent != null && { agent: ctx.agent }),
+        toolName: 'report_usage',
       };
       return projectSync(
         () => accounts.reportUsage!(params, resolveCtx),
@@ -3504,7 +3515,8 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // having to re-resolve from `params.account`.
       const resolveCtx = {
         ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-        toolName: 'get_account_financials' as const,
+        ...(ctx.agent != null && { agent: ctx.agent }),
+        toolName: 'get_account_financials',
       };
       const resolved = await accounts.resolve(params.account, resolveCtx);
       if (!resolved) {

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -1521,6 +1521,69 @@ describe('Custom-handler merge seam (incremental migration)', () => {
     assert.ok(sawCall, 'opts.accounts.listAccounts MUST run when platform.accounts.list is undefined');
   });
 
+  it('accounts.upsert receives authInfo and toolName via ctx (#1310)', async () => {
+    let receivedCtx;
+    const platform = buildPlatform({
+      accounts: {
+        resolve: async ref => ({ id: ref?.account_id ?? 'acc_1', metadata: {}, authInfo: { kind: 'api_key' } }),
+        upsert: async (refs, ctx) => {
+          receivedCtx = ctx;
+          return [];
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'ctx-fwd',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'sync_accounts',
+          arguments: {
+            account: { account_id: 'acc_1' },
+            accounts: [{ brand: { domain: 'acme.com' }, operator: 'acme.com' }],
+            idempotency_key: '22222222-2222-2222-2222-222222222222',
+          },
+        },
+      },
+      { authInfo: { clientId: 'buyer_abc', token: 'tok_xyz' } }
+    );
+    assert.ok(receivedCtx, 'accounts.upsert must receive ctx');
+    assert.strictEqual(receivedCtx.authInfo?.clientId, 'buyer_abc', 'ctx.authInfo.clientId forwarded');
+    assert.strictEqual(receivedCtx.toolName, 'sync_accounts', 'ctx.toolName is sync_accounts');
+  });
+
+  it('accounts.list receives authInfo and toolName via ctx (#1310)', async () => {
+    let receivedCtx;
+    const platform = buildPlatform({
+      accounts: {
+        resolve: async ref => ({ id: ref?.account_id ?? 'acc_1', metadata: {}, authInfo: { kind: 'api_key' } }),
+        list: async (filter, ctx) => {
+          receivedCtx = ctx;
+          return { items: [], nextCursor: null };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'ctx-fwd',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: { name: 'list_accounts', arguments: { account: { account_id: 'acc_1' } } },
+      },
+      { authInfo: { clientId: 'buyer_abc', token: 'tok_xyz' } }
+    );
+    assert.ok(receivedCtx, 'accounts.list must receive ctx');
+    assert.strictEqual(receivedCtx.authInfo?.clientId, 'buyer_abc', 'ctx.authInfo.clientId forwarded');
+    assert.strictEqual(receivedCtx.toolName, 'list_accounts', 'ctx.toolName is list_accounts');
+  });
+
   it('platform-derived handler wins when both define the same key', async () => {
     const platform = buildPlatform({
       sales: {


### PR DESCRIPTION
Closes #1310

`AccountStore.upsert` and `AccountStore.list` captured `_ctx` in the framework dispatcher but discarded it, silently blocking any adopter who needs the calling principal (e.g. for the per-agent billing gate `BILLING_NOT_PERMITTED_FOR_AGENT` from adcp#3831). This PR adds optional `ctx?: ResolveContext` to both interface methods (non-breaking — existing implementations compile unchanged) and updates `buildAccountHandlers` to forward `authInfo`, `agent`, and `toolName` using the same pattern already established for `accounts.resolve` at lines 1009-1012. Also fixes the identical pre-existing `ctx.agent` omission in the `reportUsage` and `getAccountFinancials` dispatcher blocks in the same function.

## What was tested

- `npm run format:check` — passed
- `npx tsc --project tsconfig.lib.json` — only pre-existing `TS2688`/`TS5107` tsconfig warnings (not code errors); no new errors introduced
- `test/server-decisioning-from-platform.test.js` — 109/109 pass (2 new ctx-forwarding tests added for `upsert` and `list`)
- Full suite (`test/*.test.js test/lib/*.test.js`) — 232 failures before and after; no new failures

## Pre-PR review

- **code-reviewer:** approved — no blockers; noted `#3851→#3831` reference (fixed in follow-up commit) and missing `ctx.agent` test coverage as issues (no blocker); `as const` removal is intentional cleanup
- **ad-tech-protocol-expert:** approved — non-breaking per spec; `ResolveContext` is correct shape for `upsert`/`list`; `sync_accounts`/`list_accounts` toolName strings are correct wire names; Phase 2 caveat added to JSDoc per reviewer recommendation

## Nits (not fixed, surfaced for human reviewer)

- `ctx.agent` forwarding is untested — wiring a full `BuyerAgentRegistry` in a test is medium complexity; the `authInfo`+`toolName` tests cover the new dispatcher path and the `ctx.agent` branch follows identical conditional-spread logic. A follow-up can add registry-backed agent forwarding tests once Phase 2 (#1292) lands.
- The `#3851` reference in the original issue (vs `adcp#3831` used throughout the codebase for `BILLING_NOT_PERMITTED_FOR_AGENT`) may indicate a distinct follow-up spec PR — if so, the JSDoc reference should be revisited when that PR merges.

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01V19x4iEy2Gt3yqt4d9vpj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01V19x4iEy2Gt3yqt4d9vpj4)_