### PR TITLE
feat(decisioning): forward ctx.agent to all AccountStore methods

### DIFF
--- a/.changeset/account-store-ctx-symmetric.md
+++ b/.changeset/account-store-ctx-symmetric.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": patch
+---
+
+`AccountStore.reportUsage` and `AccountStore.getAccountFinancials` now receive `ctx.agent` (the registry-resolved `BuyerAgent`) in addition to `authInfo` and `toolName` — matching the threading already wired for `resolve`, `upsert`, and `list`. Closes the symmetric gap noted in PR #1315 review.
+
+All four `AccountStore` handlers now route through a single internal `toResolveCtx` helper so future additions to `ResolveContext` land on every method automatically. Adopters implementing principal-keyed gates (e.g. `BILLING_NOT_PERMITTED_FOR_AGENT` from adcontextprotocol/adcp#3851, or per-agent financial-read authorization) get the resolved buyer-agent identity on every account-store surface, not just three of five.
+
+No behavior change for adopters that didn't already read `ctx.agent` — the field was simply missing on `reportUsage` / `getAccountFinancials` before.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -417,9 +417,12 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * platform must dedupe replays under the framework's idempotency key.
    *
    * `ctx.authInfo` carries the caller's OAuth principal (when
-   * `serve({ authenticate })` is wired). Platforms fronting an upstream
-   * billing API (Snap, Meta, retail-media) use it to authorize the usage
-   * post against the principal's tenant — same pattern as `accounts.resolve`.
+   * `serve({ authenticate })` is wired); `ctx.agent` carries the resolved
+   * `BuyerAgent` record (when an `agentRegistry` is configured). Platforms
+   * fronting an upstream billing API (Snap, Meta, retail-media) use them
+   * to authorize the usage post against the principal's tenant — same
+   * pattern as `accounts.resolve`. Prefer `ctx.agent` for principal-keyed
+   * commercial gates; see `upsert?` for the rationale.
    */
   reportUsage?(req: ReportUsageRequest, ctx?: ResolveContext): Promise<ReportUsageResponse>;
 
@@ -439,9 +442,11 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * `ctx.account.ctx_metadata` without re-resolving.
    *
    * `ctx.authInfo` carries the caller's OAuth principal (when
-   * `serve({ authenticate })` is wired). Platforms that guard financials
-   * per-principal use it to authorize the read — same pattern as
-   * `accounts.resolve`.
+   * `serve({ authenticate })` is wired); `ctx.agent` carries the resolved
+   * `BuyerAgent` record (when an `agentRegistry` is configured). Platforms
+   * that guard financials per-principal use them to authorize the read —
+   * same pattern as `accounts.resolve`. Prefer `ctx.agent` for principal-
+   * keyed commercial gates; see `upsert?` for the rationale.
    */
   getAccountFinancials?(
     req: GetAccountFinancialsRequest,

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -64,8 +64,9 @@ import {
 } from '../../create-adcp-server';
 import type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor } from '../platform';
 import type { ComplianceTestingCapabilities } from '../capabilities';
-import type { Account, ResolvedAuthInfo } from '../account';
+import type { Account, ResolvedAuthInfo, ResolveContext } from '../account';
 import { AccountNotFoundError, toWireAccount, toWireSyncAccountRow } from '../account';
+import type { BuyerAgent } from '../buyer-agent';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
 import type { CreativeBuilderPlatform } from '../specialisms/creative';
 import type { CreativeAdServerPlatform } from '../specialisms/creative-ad-server';
@@ -1006,11 +1007,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       let resolved = false;
       let resolvedAccountId: string | undefined;
       try {
-        const account = await platform.accounts.resolve(ref, {
-          ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-          toolName: ctx.toolName,
-          ...(ctx.agent != null && { agent: ctx.agent }),
-        });
+        const account = await platform.accounts.resolve(ref, toResolveCtx(ctx, ctx.toolName));
         resolved = account != null;
         resolvedAccountId = account?.id;
         return account;
@@ -1054,11 +1051,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       let resolved = false;
       let resolvedAccountId: string | undefined;
       try {
-        const account = await platform.accounts.resolve(undefined, {
-          ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-          toolName: ctx.toolName,
-          ...(ctx.agent != null && { agent: ctx.agent }),
-        });
+        const account = await platform.accounts.resolve(undefined, toResolveCtx(ctx, ctx.toolName));
         resolved = account != null;
         resolvedAccountId = account?.id;
         return account;
@@ -2253,6 +2246,32 @@ type CtxForFn = (handlerCtx: HandlerContext<Account>) => RequestContext<Account>
 
 function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
   return handlerCtx => buildRequestContext(handlerCtx, ctxMetadataStore);
+}
+
+/**
+ * Project a framework `HandlerContext` / `RequestContext` to the public
+ * `ResolveContext` shape passed to every `AccountStore` method
+ * (`resolve`, `upsert`, `list`, `reportUsage`, `getAccountFinancials`).
+ *
+ * Single source of truth for the threading shape: when `ResolveContext`
+ * gains a new field, update this function and every account-method call
+ * site picks it up. The alternative (inline literals at each call site)
+ * is what produced the original asymmetric `agent` gap on `reportUsage`
+ * and `getAccountFinancials` — fixed by routing all six framework call
+ * sites through here.
+ *
+ * `toolName` is supplied per call site (handlers hardcode their tool
+ * name; the dispatcher's `resolveAccount` / `resolveAccountFromAuth`
+ * paths read it off `RequestContext.toolName`). Spread guards keep
+ * `authInfo` / `agent` keys absent rather than `undefined` — adopters
+ * can use `'authInfo' in ctx` as a presence check.
+ */
+function toResolveCtx(ctx: { authInfo?: ResolvedAuthInfo; agent?: BuyerAgent }, toolName: string): ResolveContext {
+  return {
+    ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+    toolName,
+    ...(ctx.agent != null && { agent: ctx.agent }),
+  };
 }
 
 /**
@@ -3460,11 +3479,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   if (accounts.upsert) {
     handlers.syncAccounts = async (params, ctx) => {
       const refs = (params.accounts ?? []) as AccountReference[];
-      const resolveCtx = {
-        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-        toolName: 'sync_accounts' as const,
-        ...(ctx.agent != null && { agent: ctx.agent }),
-      };
+      const resolveCtx = toResolveCtx(ctx, 'sync_accounts');
       return projectSync(
         () => accounts.upsert!(refs, resolveCtx),
         rows => ({ accounts: rows.map(toWireSyncAccountRow) })
@@ -3475,11 +3490,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
   if (accounts.list) {
     handlers.listAccounts = async (params, ctx) => {
       const filter = params as Parameters<NonNullable<typeof accounts.list>>[0];
-      const resolveCtx = {
-        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-        toolName: 'list_accounts' as const,
-        ...(ctx.agent != null && { agent: ctx.agent }),
-      };
+      const resolveCtx = toResolveCtx(ctx, 'list_accounts');
       // Wrap in projectSync so adopter `throw new AdcpError('PERMISSION_DENIED', ...)`
       // from the list impl projects to the structured wire envelope rather
       // than falling through to the framework's `SERVICE_UNAVAILABLE` mapping.
@@ -3495,10 +3506,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
 
   if (accounts.reportUsage) {
     handlers.reportUsage = async (params, ctx) => {
-      const resolveCtx = {
-        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-        toolName: 'report_usage' as const,
-      };
+      const resolveCtx = toResolveCtx(ctx, 'report_usage');
       return projectSync(
         () => accounts.reportUsage!(params, resolveCtx),
         r => r
@@ -3512,10 +3520,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // platform method runs. Adopters fronting an upstream platform read
       // tokens / upstream IDs off `ctx.account.ctx_metadata` without
       // having to re-resolve from `params.account`.
-      const resolveCtx = {
-        ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-        toolName: 'get_account_financials' as const,
-      };
+      const resolveCtx = toResolveCtx(ctx, 'get_account_financials');
       const resolved = await accounts.resolve(params.account, resolveCtx);
       if (!resolved) {
         throw new AdcpError('ACCOUNT_NOT_FOUND', {

--- a/test/server-account-store-ctx-forwarding.test.js
+++ b/test/server-account-store-ctx-forwarding.test.js
@@ -49,6 +49,14 @@ function buildPlatform(captures, overrides = {}) {
         captures.listFilter = filter;
         return { items: [], nextCursor: null };
       },
+      reportUsage: async (req, ctx) => {
+        captures.reportUsageCtx = ctx;
+        return { accepted: [], rejected: [] };
+      },
+      getAccountFinancials: async (req, ctx) => {
+        captures.getAccountFinancialsCtx = ctx;
+        return { account_id: ctx?.account?.id ?? 'acc_1', currency: 'USD' };
+      },
     },
     statusMappers: {},
     sales: {
@@ -188,5 +196,102 @@ describe('Issue #1310 — accounts.list receives ResolveContext', () => {
     });
     await dispatchList(server);
     assert.ok(captures.listFilter, 'first arg must be the filter, ctx must come second');
+  });
+});
+
+// Symmetric follow-up: `reportUsage` and `getAccountFinancials` already
+// received `authInfo` and `toolName`, but the framework was not forwarding
+// `agent` (the resolved BuyerAgent record). Fixed by routing all four
+// AccountStore handlers through a single `toResolveCtx` helper, so any
+// future addition to `ResolveContext` lands on every method automatically.
+
+const dispatchReportUsage = (server, authInfo) =>
+  server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'report_usage',
+        arguments: {
+          usage: [
+            {
+              account: { account_id: 'acc_1' },
+              period_start: '2026-05-01T00:00:00Z',
+              period_end: '2026-05-02T00:00:00Z',
+              line_item_id: 'li_1',
+              impressions: 1000,
+            },
+          ],
+          idempotency_key: '22222222-2222-2222-2222-222222222222',
+        },
+      },
+    },
+    authInfo ? { authInfo } : undefined
+  );
+
+const dispatchGetAccountFinancials = (server, authInfo) =>
+  server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'get_account_financials',
+        arguments: { account: { account_id: 'acc_1' } },
+      },
+    },
+    authInfo ? { authInfo } : undefined
+  );
+
+describe('Symmetric follow-up — reportUsage receives ctx.agent', () => {
+  it('forwards resolved BuyerAgent to accounts.reportUsage when agentRegistry is configured', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform(captures, {
+        agentRegistry: {
+          async resolve() {
+            return agent;
+          },
+        },
+      }),
+      {
+        name: 'symmetric',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+    const result = await dispatchReportUsage(server, { kind: 'api_key', clientId: 'buyer-xyz' });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(captures.reportUsageCtx?.agent, 'reportUsage MUST receive ctx.agent when agentRegistry is configured');
+    assert.strictEqual(captures.reportUsageCtx.agent.agent_url, 'https://agent.scope3.com');
+    assert.strictEqual(captures.reportUsageCtx.toolName, 'report_usage');
+  });
+});
+
+describe('Symmetric follow-up — getAccountFinancials receives ctx.agent', () => {
+  it('forwards resolved BuyerAgent to accounts.getAccountFinancials when agentRegistry is configured', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const server = createAdcpServerFromPlatform(
+      buildPlatform(captures, {
+        agentRegistry: {
+          async resolve() {
+            return agent;
+          },
+        },
+      }),
+      {
+        name: 'symmetric',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+    const result = await dispatchGetAccountFinancials(server, { kind: 'api_key', clientId: 'buyer-xyz' });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.ok(
+      captures.getAccountFinancialsCtx?.agent,
+      'getAccountFinancials MUST receive ctx.agent when agentRegistry is configured'
+    );
+    assert.strictEqual(captures.getAccountFinancialsCtx.agent.agent_url, 'https://agent.scope3.com');
+    assert.strictEqual(captures.getAccountFinancialsCtx.toolName, 'get_account_financials');
+    assert.ok(captures.getAccountFinancialsCtx.account, 'AccountToolContext keeps `account` populated');
   });
 });


### PR DESCRIPTION
## Summary
- All four `AccountStore` handler call sites (`syncAccounts`, `listAccounts`, `reportUsage`, `getAccountFinancials`) plus the two dispatcher resolver paths (`resolveAccount`, `resolveAccountFromAuth`) now route through a single internal \`toResolveCtx\` helper.
- Closes the symmetric gap flagged on PR #1315 review: \`reportUsage\` and \`getAccountFinancials\` previously got \`authInfo\` + \`toolName\` but not \`agent\`, even though \`accounts.resolve\` / \`upsert\` / \`list\` forward all three.
- Structural improvement: any future field added to \`ResolveContext\` lands on every account-store method automatically. The original inline literals at six call sites were what produced the asymmetric gap in the first place.

## Why this shape, vs. just patching the two missing sites
\"Just add \`agent\` to two more spread literals\" would have fixed the immediate hole but kept the same fragile pattern that produced it. Six call sites copying the same boilerplate is exactly the structure that makes the next \`ResolveContext\` field drift again. One helper, six call sites, one place to update.

## What's NOT in scope
- The custom \`tasks_get\` MCP tool at \`from-platform.ts:1332\` builds its own \`{ authInfo, toolName }\` literal because it runs outside the normal handler-dispatch flow (different \`extra\` shape — no access to the resolved \`BuyerAgent\`). Threading \`agent\` through tasks_get is a separate concern requiring registry-resolution plumbing in the custom-tool path; not bundled here.

## Compatibility
No behavior change for adopters that didn't already read \`ctx.agent\` — the field was simply missing on \`reportUsage\` / \`getAccountFinancials\` before.

## Test plan
- [x] Two new tests in \`test/server-account-store-ctx-forwarding.test.js\` verify the resolved \`BuyerAgent\` reaches \`reportUsage\` and \`getAccountFinancials\` when an \`agentRegistry\` is configured. \`getAccountFinancials\` test also confirms \`AccountToolContext.account\` continues to be populated.
- [x] All 8 tests in the new file pass; 140 tests across adjacent files (\`server-buyer-agent-resolve-seam\`, \`server-buyer-agent-credential-synthesis\`, \`server-decisioning-from-platform\`, \`server-ctx-metadata-leak-paranoia\`) pass.
- [x] \`npm run build\` clean; \`npm run format\` clean; \`npm run typecheck:skill-examples\` clean (no new diagnostics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)