### PR TITLE
feat(server): BuyerAgent.sandbox_only — defense-in-depth for test-only agents

### DIFF
--- a/.changeset/buyer-agent-sandbox-only.md
+++ b/.changeset/buyer-agent-sandbox-only.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): BuyerAgent.sandbox_only — defense-in-depth for test-only agents
+
+Phase 1.5 of #1269 (proposed during review on PR #1320). Adds a `sandbox_only?: boolean` field to `BuyerAgent` plus a framework-level gate.
+
+When `sandbox_only === true`, the framework rejects any request whose resolved `Account.sandbox !== true` with `PERMISSION_DENIED`, `error.details.scope: 'agent'`, `error.details.reason: 'sandbox-only'`, `recovery: 'terminal'`. Composes naturally with `Account.sandbox` from #1256 — same axis at the agent level.
+
+**When to use it.** CI runners, internal QA agents, partner pre-prod environments. If the test agent's credential leaks, blast radius is bounded to sandbox accounts. Production agents leave the field unset (or `false`).
+
+**Gate placement.** Runs after `accounts.resolve` so the framework can compare `agent.sandbox_only` against `account.sandbox`. Runs after Stage 4's status enforcement, so a suspended sandbox-only agent fails with status (not sandbox). Account-less tools (`provide_performance_feedback`, `list_creative_formats`, etc.) pass the gate — the sandbox/production axis doesn't apply when there's no account in scope.
+
+7 new tests cover: sandbox→sandbox succeeds, sandbox→prod rejected with structured envelope, undefined-or-false sandbox_only is permissive on both account types, account-less tools pass, status enforcement fires before sandbox-only enforcement, null registry result skips the gate. Full suite: 7459 pass, 0 fail.
+
+Phase 2 (#1292) — framework-level billing-capability enforcement and AdCP-3.1 error-code emission — is still gated on the SDK's 3.1 cutover.

--- a/.changeset/buyer-agent-sandbox-only.md
+++ b/.changeset/buyer-agent-sandbox-only.md
@@ -12,6 +12,6 @@ When `sandbox_only === true`, the framework rejects any request whose resolved `
 
 **Gate placement.** Runs after `accounts.resolve` so the framework can compare `agent.sandbox_only` against `account.sandbox`. Runs after Stage 4's status enforcement, so a suspended sandbox-only agent fails with status (not sandbox). Account-less tools (`provide_performance_feedback`, `list_creative_formats`, etc.) pass the gate — the sandbox/production axis doesn't apply when there's no account in scope.
 
-7 new tests cover: sandbox→sandbox succeeds, sandbox→prod rejected with structured envelope, undefined-or-false sandbox_only is permissive on both account types, account-less tools pass, status enforcement fires before sandbox-only enforcement, null registry result skips the gate. Full suite: 7459 pass, 0 fail.
+New tests cover: sandbox→sandbox succeeds, sandbox→prod rejected with structured envelope (and the explicit `sandbox: false` variant rejecting the same way as unset), undefined/false `sandbox_only` permissive on both account types (production-agent-on-prod-account explicit), account-less tools pass, status enforcement fires before sandbox-only enforcement, null registry result skips the gate. Full suite green.
 
 Phase 2 (#1292) — framework-level billing-capability enforcement and AdCP-3.1 error-code emission — is still gated on the SDK's 3.1 cutover.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3036,6 +3036,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // agents, partner pre-prod environments): if a sandbox-only
         // agent's credential leaks, blast radius is bounded to sandbox
         // accounts. Production agents leave `sandbox_only` unset.
+        // Strict-by-default: any non-Account shape (legacy v5 adopters,
+        // bespoke account types) lacking the `sandbox` field reads as
+        // `undefined !== true → reject`. That's correct: a sandbox-only
+        // agent operating against an unknown-shape account is the
+        // case where rejection is the safe default — adopters who want
+        // to opt in either flip the agent's `sandbox_only` off or
+        // populate `sandbox: true` on their resolved account.
         if (
           ctx.agent?.sandbox_only === true &&
           ctx.account !== undefined &&

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3024,6 +3024,32 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
         }
 
+        // --- Sandbox-only enforcement (Phase 1.5 of #1269) ---
+        // Runs after account resolution so we can compare the resolved
+        // account's `sandbox` flag against the agent's `sandbox_only`
+        // capability. Account-less tools (provide_performance_feedback,
+        // list_creative_formats, etc.) pass the gate — they don't
+        // operate on a specific account, so the sandbox/production axis
+        // doesn't apply.
+        //
+        // Defense-in-depth for test agents (CI runners, internal QA
+        // agents, partner pre-prod environments): if a sandbox-only
+        // agent's credential leaks, blast radius is bounded to sandbox
+        // accounts. Production agents leave `sandbox_only` unset.
+        if (
+          ctx.agent?.sandbox_only === true &&
+          ctx.account !== undefined &&
+          (ctx.account as { sandbox?: boolean }).sandbox !== true
+        ) {
+          return finalize(
+            adcpError('PERMISSION_DENIED', {
+              message: 'Buyer agent is sandbox-only; this request targets a non-sandbox account.',
+              recovery: 'terminal',
+              details: { scope: 'agent', reason: 'sandbox-only' },
+            })
+          );
+        }
+
         // --- Session key resolution ---
         if (resolveSessionKey) {
           try {

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -162,6 +162,28 @@ export interface BuyerAgent {
    * Most adopters never populate this.
    */
   readonly aliases?: readonly string[];
+
+  /**
+   * When `true`, this buyer agent may ONLY operate against sandbox
+   * accounts. The framework rejects any request whose resolved
+   * `Account.sandbox !== true` with `PERMISSION_DENIED`,
+   * `error.details.scope: 'agent'`, `error.details.reason: 'sandbox-only'`.
+   *
+   * Defense-in-depth for test agents (CI runners, internal QA agents,
+   * partner pre-prod environments): if the test credential leaks, blast
+   * radius is bounded to sandbox accounts. Production agents leave this
+   * unset (or `false`).
+   *
+   * Composes with `Account.sandbox` (the wire-level sandbox marker on
+   * the resolved Account record): the gate fires when `agent.sandbox_only
+   * === true AND ctx.account?.sandbox !== true`. Account-less tools
+   * (`provide_performance_feedback`, `list_creative_formats`, etc.) pass
+   * the gate — they don't operate on a specific account, so the
+   * sandbox/production axis doesn't apply.
+   *
+   * Default `false` (or undefined) — production-allowed.
+   */
+  readonly sandbox_only?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/decisioning/buyer-agent.ts
+++ b/src/lib/server/decisioning/buyer-agent.ts
@@ -181,6 +181,16 @@ export interface BuyerAgent {
    * the gate — they don't operate on a specific account, so the
    * sandbox/production axis doesn't apply.
    *
+   * **Load-bearing pair.** For the gate to admit ANY traffic from a
+   * `sandbox_only` agent, the seller's `accounts.resolve` MUST return
+   * `sandbox: true` on the accounts that agent should reach. Adopters
+   * cloning the worked example with `sandbox_only: true` on their seed
+   * agent and a hardcoded `sandbox: true` resolver are demoware-correct;
+   * production adopters either flip the agent to `sandbox_only: false`
+   * OR have their resolver return `sandbox: true` only for actually-
+   * sandbox accounts. Mismatches between these two sides 403 every
+   * request — failure is loud, not silent.
+   *
    * Default `false` (or undefined) — production-allowed.
    */
   readonly sandbox_only?: boolean;

--- a/test/server-buyer-agent-sandbox-only.test.js
+++ b/test/server-buyer-agent-sandbox-only.test.js
@@ -1,0 +1,276 @@
+'use strict';
+
+// Phase 1.5 of #1269 — sandbox-only agent enforcement.
+//
+// Defense-in-depth for test agents: if `BuyerAgent.sandbox_only === true`,
+// the framework rejects any request whose resolved Account isn't
+// `sandbox: true`. Composes with `Account.sandbox` from #1256.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+const { BuyerAgentRegistry, markVerifiedHttpSig } = require('../dist/lib/server/decisioning/buyer-agent');
+
+const sampleAgent = (overrides = {}) => ({
+  agent_url: 'https://addie.example.com',
+  display_name: 'Addie',
+  status: 'active',
+  billing_capabilities: new Set(['operator']),
+  ...overrides,
+});
+
+const sigCredential = (overrides = {}) =>
+  markVerifiedHttpSig({
+    kind: 'http_sig',
+    keyid: 'kid',
+    agent_url: 'https://addie.example.com',
+    verified_at: 1714660000,
+    ...overrides,
+  });
+
+function buildPlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async (ref, ctx) => {
+        if (ref == null) return null;
+        const isSandboxRef = (ref?.account_id ?? '').startsWith('sandbox_');
+        return {
+          id: ref.account_id,
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+          sandbox: isSandboxRef,
+          _resolveAgent: ctx?.agent,
+        };
+      },
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    statusMappers: {},
+    sales: {
+      getProducts: async (_req, ctx) => ({
+        products: [],
+        _ctxAgent: ctx?.agent,
+        _accountSandbox: ctx?.account?.sandbox,
+      }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      providePerformanceFeedback: async () => ({}),
+    },
+    ...overrides,
+  };
+}
+
+const dispatch = (server, accountId) =>
+  server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: accountId },
+        },
+      },
+    },
+    {
+      authInfo: {
+        token: 'sig-tok',
+        clientId: 'signing:kid',
+        scopes: [],
+        extra: { credential: sigCredential() },
+      },
+    }
+  );
+
+describe('Phase 1.5 — sandbox-only buyer agent enforcement', () => {
+  it('sandbox-only agent → request to sandbox account succeeds', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ sandbox_only: true }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server, 'sandbox_acc_1');
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.equal(result.structuredContent._accountSandbox, true);
+    assert.equal(result.structuredContent._ctxAgent.sandbox_only, true);
+  });
+
+  it('sandbox-only agent → request to non-sandbox account → PERMISSION_DENIED', async () => {
+    let handlerInvoked = false;
+    const platform = buildPlatform({
+      sales: {
+        getProducts: async () => {
+          handlerInvoked = true;
+          return { products: [] };
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+        providePerformanceFeedback: async () => ({}),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ sandbox_only: true }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server, 'prod_acc_1');
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+    assert.equal(result.structuredContent.adcp_error.recovery, 'terminal');
+    assert.equal(result.structuredContent.adcp_error.details.scope, 'agent');
+    assert.equal(result.structuredContent.adcp_error.details.reason, 'sandbox-only');
+    assert.equal(handlerInvoked, false, 'handler MUST NOT run when sandbox-only agent hits production account');
+  });
+
+  it('production agent (sandbox_only undefined) → no gate fires; both account types succeed', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent(), // sandbox_only undefined
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const sandboxResult = await dispatch(server, 'sandbox_acc_1');
+    assert.notStrictEqual(sandboxResult.isError, true);
+
+    const prodResult = await dispatch(server, 'prod_acc_1');
+    assert.notStrictEqual(prodResult.isError, true);
+  });
+
+  it('production agent (sandbox_only: false) → no gate fires (explicit false matches default)', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ sandbox_only: false }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server, 'prod_acc_1');
+    assert.notStrictEqual(result.isError, true);
+  });
+
+  it('sandbox-only agent → account-less tool (no resolved account) passes through', async () => {
+    // Account-less tools (provide_performance_feedback,
+    // list_creative_formats, etc.) don't have an account in scope. The
+    // sandbox/production axis doesn't apply — gate skips.
+    const platform = buildPlatform({
+      accounts: {
+        resolve: async (ref, ctx) => {
+          if (ref == null) {
+            // Auth-derived path: return null → ctx.account stays undefined.
+            return null;
+          }
+          return {
+            id: ref.account_id,
+            metadata: {},
+            authInfo: { kind: 'api_key' },
+            sandbox: false,
+            _resolveAgent: ctx?.agent,
+          };
+        },
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ sandbox_only: true }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'provide_performance_feedback',
+          arguments: {
+            media_buy_id: 'mb_1',
+            performance_index: 0.85,
+            measurement_period: { start: '2026-04-01T00:00:00Z', end: '2026-04-08T00:00:00Z' },
+            idempotency_key: '11111111-1111-1111-1111-111111111111',
+          },
+        },
+      },
+      {
+        authInfo: {
+          token: 'sig-tok',
+          clientId: 'signing:kid',
+          scopes: [],
+          extra: { credential: sigCredential() },
+        },
+      }
+    );
+    // Either succeeds (handler runs) OR fails for an unrelated reason —
+    // critically, NOT with `sandbox-only` rejection.
+    if (result.isError === true) {
+      assert.notEqual(result.structuredContent.adcp_error?.details?.reason, 'sandbox-only');
+    }
+  });
+
+  it('sandbox-only check runs AFTER status enforcement (no double-rejection ambiguity)', async () => {
+    // Suspended sandbox-only agent should fail with status, not sandbox.
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ sandbox_only: true, status: 'suspended' }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server, 'prod_acc_1');
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+    // Status enforcement fires first — `details.reason` should be absent
+    // (status enforcement doesn't set `reason`), and `details.status`
+    // should be 'suspended'.
+    assert.equal(result.structuredContent.adcp_error.details.status, 'suspended');
+  });
+
+  it('null registry result (no agent) → no sandbox-only check; default request flow', async () => {
+    const platform = buildPlatform({
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => null,
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    // No agent resolved → no sandbox_only field to check.
+    const result = await dispatch(server, 'prod_acc_1');
+    assert.notStrictEqual(result.isError, true);
+  });
+});

--- a/test/server-buyer-agent-sandbox-only.test.js
+++ b/test/server-buyer-agent-sandbox-only.test.js
@@ -177,6 +177,71 @@ describe('Phase 1.5 — sandbox-only buyer agent enforcement', () => {
     assert.notStrictEqual(result.isError, true);
   });
 
+  it('production agent + production account → handler runs (gate explicitly does not fire)', async () => {
+    // Per code-reviewer: the existing "no gate fires" test asserts via
+    // overall non-error. This test explicitly confirms the handler
+    // executes — no false-positive where a gate fires but produces a
+    // non-error envelope somehow.
+    let handlerInvoked = false;
+    const platform = buildPlatform({
+      sales: {
+        getProducts: async () => {
+          handlerInvoked = true;
+          return { products: [] };
+        },
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+        providePerformanceFeedback: async () => ({}),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent(), // sandbox_only undefined
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server, 'prod_acc_1');
+    assert.notStrictEqual(result.isError, true);
+    assert.equal(handlerInvoked, true, 'production agent on production account MUST reach the handler');
+  });
+
+  it('sandbox-only agent + account with explicit sandbox: false → reject (vs unset)', async () => {
+    // Code reads `sandbox !== true` so explicit `false` rejects same
+    // as unset. This locks the contract.
+    const platform = buildPlatform({
+      accounts: {
+        resolve: async (ref, ctx) => {
+          if (ref == null) return null;
+          return {
+            id: ref.account_id,
+            metadata: {},
+            authInfo: { kind: 'api_key' },
+            sandbox: false, // explicit false (not unset)
+            _resolveAgent: ctx?.agent,
+          };
+        },
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+      agentRegistry: BuyerAgentRegistry.signingOnly({
+        resolveByAgentUrl: async () => sampleAgent({ sandbox_only: true }),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await dispatch(server, 'any_acc_1');
+    assert.equal(result.isError, true);
+    assert.equal(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+    assert.equal(result.structuredContent.adcp_error.details.reason, 'sandbox-only');
+  });
+
   it('sandbox-only agent → account-less tool (no resolved account) passes through', async () => {
     // Account-less tools (provide_performance_feedback,
     // list_creative_formats, etc.) don't have an account in scope. The


### PR DESCRIPTION
## Summary

Phase 1.5 of #1269 — adds `BuyerAgent.sandbox_only?: boolean` and a framework-level gate. Proposed during review on PR #1320 (Hello Seller adapter integration): every seller has test agents (CI runners, internal QA agents, partner pre-prod environments) that should ONLY operate against sandbox accounts. Without this field, sellers either accept that test agents have production reach or hand-roll the gate per platform.

## What's added

**`BuyerAgent.sandbox_only?: boolean`** — when `true`, the framework rejects any request whose resolved `Account.sandbox !== true` with:

\`\`\`json
{
  "code": "PERMISSION_DENIED",
  "message": "Buyer agent is sandbox-only; this request targets a non-sandbox account.",
  "recovery": "terminal",
  "details": { "scope": "agent", "reason": "sandbox-only" }
}
\`\`\`

Default `false` / undefined — production-allowed.

## Gate placement

Runs **after** `accounts.resolve` so the framework can compare `agent.sandbox_only` against `account.sandbox`. Runs **after** Stage 4's status enforcement, so a suspended sandbox-only agent fails with status (not sandbox) — predictable error ordering.

**Account-less tools pass the gate.** `provide_performance_feedback`, `list_creative_formats`, etc. don't operate on a specific account; the sandbox/production axis doesn't apply.

## Composes with `Account.sandbox` (#1256)

Same axis at the agent level. Adopters who set `Account.sandbox: true` on their resolver get the gate for free; those who don't see no behavior change.

## What's NOT in (deferred)

- Per-row sandbox enforcement on `sync_accounts` request body (where each account in `accounts[]` has its own sandbox flag) — adopter-side gating in `accounts.upsert` for now; Phase 2 candidate.
- Spec issue for `AGENT_SANDBOX_ONLY_VIOLATION` standardized error code — using `PERMISSION_DENIED + scope:'agent' + reason:'sandbox-only'` as the structured signal until then. File upstream alongside adcp#3871 if the pattern broadens.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `test/server-buyer-agent-sandbox-only.test.js` — 7/7 pass:
  - Sandbox-only agent → sandbox account: succeeds.
  - Sandbox-only agent → non-sandbox account: PERMISSION_DENIED with structured envelope (`scope: 'agent'`, `reason: 'sandbox-only'`, `recovery: 'terminal'`); handler not invoked.
  - Production agent (sandbox_only undefined): both account types succeed.
  - Production agent (sandbox_only: false): explicit false matches default.
  - Account-less tool: gate skipped.
  - Status enforcement fires BEFORE sandbox-only check (suspended sandbox-only agent → status error, not sandbox error).
  - Null registry result: gate skipped (no agent to check).
- [x] `npm run format:check` clean.
- [x] Full suite: 7459 pass, 0 fail.

## Cross-links

- #1269 (Phase 1 parent — completed; Phase 1.5 is this PR)
- #1320 (review on this PR's parent example proposed the field)
- #1256 (Account v3 wire alignment — `Account.sandbox` field this composes with)
- #1292 (Phase 2 — gated on SDK 3.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)