### PR TITLE
feat(decisioning): forward ctx.agent to tasks_get accounts.resolve

### DIFF
--- a/.changeset/tasks-get-agent-forwarding.md
+++ b/.changeset/tasks-get-agent-forwarding.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": patch
+---
+
+`tasks_get` now resolves the calling `BuyerAgent` (when an `agentRegistry` is configured) and threads it to `accounts.resolve` as `ctx.agent` — same contract as every other AccountStore call site after #1315 + #1321.
+
+The custom-tool path historically bypassed `BuyerAgentRegistry.resolve` because it sits outside the dispatcher's main handler-dispatch flow, leaving adopters' resolve impls to see `ctx.agent: undefined` on `tasks_get` calls but populated on every other tool. That asymmetry quietly broke the "use `ctx.agent` for principal-keyed gates" guidance the JSDoc on `upsert?` / `reportUsage?` / `getAccountFinancials?` adopted in the prior two releases.
+
+**Status enforcement is deliberately NOT replicated.** A buyer agent suspended *after* kicking off an HITL task must still be able to poll for terminal state — refusing the poll would strand work with no visibility. Sellers who need hard cutoff implement that policy inside their own `accounts.resolve` (read `ctx.agent.status`, throw `AdcpError`). The dispatcher's main path enforces status at request entry; the polling path does not. Tests pin both behaviors.
+
+Registry failures during a poll fall through to `agent: undefined` rather than breaking the poll — same defensive shape as the dispatcher.
+
+No behavior change for adopters who don't read `ctx.agent` from inside their resolver.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1141,7 +1141,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     ),
     customTools: {
       ...opts.customTools,
-      tasks_get: buildTasksGetTool(platform, taskRegistry, platform.agentRegistry),
+      tasks_get: buildTasksGetTool(platform, taskRegistry, platform.agentRegistry, fwLogger),
     },
   };
 
@@ -1286,7 +1286,8 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
   platform: P,
   taskRegistry: TaskRegistry,
-  agentRegistry: BuyerAgentRegistry | undefined
+  agentRegistry: BuyerAgentRegistry | undefined,
+  logger: AdcpLogger
 ) {
   const inputShape = {
     // Cap task_id length: framework-issued task ids are
@@ -1369,8 +1370,16 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
             }
             agent = resolved;
           }
-        } catch {
-          // swallow per the policy above — agent stays undefined
+        } catch (err) {
+          // Swallow to keep the poll alive (see policy comment above), but
+          // log so upstream-IDP outages are visible to operators. Without
+          // this log, buyers seeing REFERENCE_NOT_FOUND for valid tasks
+          // (because adopters' resolvers return null without `ctx.agent`)
+          // would be invisible in adopter logs. Per security-reviewer
+          // defense-in-depth note on PR #1323.
+          logger.warn?.('Buyer-agent registry resolution failed during tasks_get poll', {
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
       }
       const resolveCtx = {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -66,7 +66,7 @@ import type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor
 import type { ComplianceTestingCapabilities } from '../capabilities';
 import type { Account, ResolvedAuthInfo, ResolveContext } from '../account';
 import { AccountNotFoundError, toWireAccount, toWireSyncAccountRow } from '../account';
-import type { BuyerAgent } from '../buyer-agent';
+import type { BuyerAgent, BuyerAgentRegistry } from '../buyer-agent';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
 import type { CreativeBuilderPlatform } from '../specialisms/creative';
 import type { CreativeAdServerPlatform } from '../specialisms/creative-ad-server';
@@ -1141,7 +1141,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     ),
     customTools: {
       ...opts.customTools,
-      tasks_get: buildTasksGetTool(platform, taskRegistry),
+      tasks_get: buildTasksGetTool(platform, taskRegistry, platform.agentRegistry),
     },
   };
 
@@ -1283,7 +1283,11 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
  * (`resolution: 'derived'`) get scoping for free via the auth-derived
  * resolver.
  */
-function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(platform: P, taskRegistry: TaskRegistry) {
+function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
+  platform: P,
+  taskRegistry: TaskRegistry,
+  agentRegistry: BuyerAgentRegistry | undefined
+) {
   const inputShape = {
     // Cap task_id length: framework-issued task ids are
     // `task_<UUIDv4>` = 41 chars. Cap at 128 so a malicious buyer can't
@@ -1328,9 +1332,51 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(platform: P,
       extra: { authInfo?: ResolvedAuthInfo }
     ) => {
       const ref = args.account;
+      // Resolve the buyer agent (when an `agentRegistry` is configured) so
+      // adopters' `accounts.resolve` impl sees `ctx.agent` — same contract as
+      // every other AccountStore method. Bypasses the dispatcher's
+      // resolution-and-status-enforcement seam at
+      // `create-adcp-server.ts:2748-2832` deliberately:
+      //
+      //   - **Status enforcement is intentionally skipped on tasks_get
+      //     polls.** A buyer agent suspended AFTER kicking off an HITL task
+      //     must still be able to learn the task's terminal state — refusing
+      //     the poll would strand work with no visibility. Hard-cutoff
+      //     sellers implement that policy inside their `accounts.resolve`
+      //     or downstream by reading `ctx.agent.status` themselves.
+      //   - **Registry failures don't break the poll.** A transient registry
+      //     error during a read poll falls through to `agent: undefined`;
+      //     adopters who require a resolved agent for tenant scoping can
+      //     return null from their `accounts.resolve` and the existing
+      //     ACCOUNT_NOT_FOUND surface fires.
+      let agent: BuyerAgent | undefined;
+      if (agentRegistry !== undefined) {
+        try {
+          const resolved = await agentRegistry.resolve({
+            ...(extra?.authInfo?.credential !== undefined && { credential: extra.authInfo.credential }),
+            ...(extra?.authInfo?.extra !== undefined && { extra: extra.authInfo.extra }),
+          });
+          if (resolved != null) {
+            // Mirror the dispatcher's freeze contract: lock the resolved
+            // record (and `billing_capabilities` Set if present) so adopter
+            // code cannot mutate shared registry state across requests.
+            // See `create-adcp-server.ts:2762-2779` for the full rationale.
+            if (!Object.isFrozen(resolved)) {
+              if (resolved.billing_capabilities instanceof Set) {
+                Object.freeze(resolved.billing_capabilities);
+              }
+              Object.freeze(resolved);
+            }
+            agent = resolved;
+          }
+        } catch {
+          // swallow per the policy above — agent stays undefined
+        }
+      }
       const resolveCtx = {
         ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
         toolName: 'tasks_get',
+        ...(agent !== undefined && { agent }),
       };
       let resolvedAccountId: string | undefined;
       if (ref) {

--- a/test/server-tasks-get-agent-forwarding.test.js
+++ b/test/server-tasks-get-agent-forwarding.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+// Symmetric follow-up: `tasks_get` calls `platform.accounts.resolve` from
+// the custom-tool path, which historically bypassed `BuyerAgentRegistry`
+// resolution and threaded `ctx.agent: undefined` through to adopters'
+// resolve impls. PR #1315 + #1321 documented the contract that `ctx.agent`
+// reaches every account-store method when an `agentRegistry` is configured;
+// this test file pins the same contract on the tasks_get polling surface.
+//
+// Two policies the tests anchor:
+//   1. Agent IS resolved and threaded through to `accounts.resolve`.
+//   2. Agent-status enforcement (suspended/blocked → 403) is DELIBERATELY
+//      skipped on tasks_get polls so a buyer suspended after kicking off
+//      an HITL task can still learn the terminal state. Hard cutoff is the
+//      adopter's choice via `ctx.agent.status` checks inside their resolver.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+const sampleAgent = (overrides = {}) => ({
+  agent_url: 'https://agent.scope3.com',
+  display_name: 'Scope3',
+  status: 'active',
+  billing_capabilities: new Set(['operator']),
+  ...overrides,
+});
+
+function buildHitlPlatform(captures, overrides = {}) {
+  const taskFn = overrides.taskFn ?? (async () => ({ media_buy_id: 'mb_42', status: 'active' }));
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async (ref, ctx) => {
+        captures.lastResolveCtx = ctx;
+        return {
+          id: ref?.account_id ?? 'acc_1',
+          name: 'Acme',
+          status: 'active',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+        };
+      },
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: (_req, ctx) => ctx.handoffToTask(async () => taskFn()),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_42' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+    },
+    ...(overrides.agentRegistry !== undefined && { agentRegistry: overrides.agentRegistry }),
+  };
+}
+
+async function createCompletedTask(server, accountId) {
+  const result = await server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'create_media_buy',
+      arguments: {
+        buyer_ref: 'b1',
+        idempotency_key: '11111111-1111-1111-1111-111111111111',
+        packages: [],
+        start_time: '2026-05-01T00:00:00Z',
+        end_time: '2026-06-01T00:00:00Z',
+        account: { account_id: accountId },
+      },
+    },
+  });
+  await server.awaitTask(result.structuredContent.task_id);
+  return result.structuredContent.task_id;
+}
+
+const dispatchTasksGet = (server, taskId, accountId) =>
+  server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'tasks_get',
+      arguments: { task_id: taskId, account: { account_id: accountId } },
+    },
+  });
+
+describe('tasks_get — agent forwarding to accounts.resolve', () => {
+  it('forwards resolved BuyerAgent to accounts.resolve when agentRegistry is configured', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const server = createAdcpServerFromPlatform(
+      buildHitlPlatform(captures, {
+        agentRegistry: {
+          async resolve() {
+            return agent;
+          },
+        },
+      }),
+      { name: 'p', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+    const taskId = await createCompletedTask(server, 'acc_owner');
+    // Reset captures so the assertion targets the tasks_get call, not
+    // create_media_buy's earlier resolve.
+    captures.lastResolveCtx = undefined;
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(captures.lastResolveCtx, 'tasks_get must call accounts.resolve');
+    assert.ok(captures.lastResolveCtx.agent, 'accounts.resolve MUST receive ctx.agent from tasks_get');
+    assert.strictEqual(captures.lastResolveCtx.agent.agent_url, 'https://agent.scope3.com');
+    assert.strictEqual(captures.lastResolveCtx.toolName, 'tasks_get');
+  });
+
+  it('omits ctx.agent when no agentRegistry is configured (no regression)', async () => {
+    const captures = {};
+    const server = createAdcpServerFromPlatform(buildHitlPlatform(captures), {
+      name: 'p',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const taskId = await createCompletedTask(server, 'acc_owner');
+    captures.lastResolveCtx = undefined;
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(result.isError, true);
+    assert.ok(captures.lastResolveCtx, 'tasks_get must call accounts.resolve');
+    assert.strictEqual(captures.lastResolveCtx.agent, undefined);
+    assert.strictEqual(captures.lastResolveCtx.toolName, 'tasks_get');
+  });
+
+  it('freezes the resolved BuyerAgent before threading to resolve', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const server = createAdcpServerFromPlatform(
+      buildHitlPlatform(captures, {
+        agentRegistry: {
+          async resolve() {
+            return agent;
+          },
+        },
+      }),
+      { name: 'p', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+    const taskId = await createCompletedTask(server, 'acc_owner');
+    await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.equal(Object.isFrozen(agent), true, 'resolved BuyerAgent must be frozen by tasks_get path');
+    assert.equal(Object.isFrozen(agent.billing_capabilities), true);
+  });
+
+  it('registry resolve throwing on the poll does not break the poll (agent stays undefined)', async () => {
+    const captures = {};
+    const registry = {
+      async resolve() {
+        return sampleAgent();
+      },
+    };
+    const server = createAdcpServerFromPlatform(buildHitlPlatform(captures, { agentRegistry: registry }), {
+      name: 'p',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const taskId = await createCompletedTask(server, 'acc_owner');
+    // Flip the registry to throw AFTER the task is created (registry must
+    // succeed during create_media_buy for the dispatcher's main path).
+    registry.resolve = async () => {
+      throw new Error('upstream-id-provider-down');
+    };
+    captures.lastResolveCtx = undefined;
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(
+      result.isError,
+      true,
+      `registry failure must not break the poll, got ${JSON.stringify(result.structuredContent)}`
+    );
+    assert.strictEqual(captures.lastResolveCtx.agent, undefined);
+  });
+});
+
+describe('tasks_get — agent status policy (suspended/blocked agents can still poll)', () => {
+  // Pinned policy: the dispatcher's status-enforcement seam at
+  // `create-adcp-server.ts:2796-2802` deliberately skips status checks on
+  // tasks_get polls. A buyer agent suspended/blocked AFTER kicking off an
+  // HITL task must still be able to retrieve the terminal state — refusing
+  // the poll would strand work with no visibility. This anchor catches a
+  // future refactor that would tighten status enforcement onto the polling
+  // path and break that contract.
+
+  it('suspended agent can still poll tasks_get', async () => {
+    const captures = {};
+    const agent = sampleAgent();
+    const registry = {
+      async resolve() {
+        return agent;
+      },
+    };
+    const server = createAdcpServerFromPlatform(buildHitlPlatform(captures, { agentRegistry: registry }), {
+      name: 'p',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const taskId = await createCompletedTask(server, 'acc_owner');
+    // Status flip happens AFTER the task is created. Ordering matters: the
+    // create_media_buy flow runs through the dispatcher's status seam (which
+    // would 403 if the agent were suspended at that moment) and freezes the
+    // agent record. We mutate `status` via a fresh object reference returned
+    // from the registry for subsequent calls — Object.freeze locks the
+    // previously-resolved record, but new resolve() calls return a new value.
+    registry.resolve = async () => sampleAgent({ status: 'suspended' });
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(
+      result.isError,
+      true,
+      `suspended agents must still be able to poll tasks_get, got ${JSON.stringify(result.structuredContent)}`
+    );
+    assert.strictEqual(result.structuredContent.task_id, taskId);
+    assert.strictEqual(result.structuredContent.status, 'completed');
+  });
+
+  it('blocked agent can still poll tasks_get', async () => {
+    const captures = {};
+    const registry = {
+      async resolve() {
+        return sampleAgent();
+      },
+    };
+    const server = createAdcpServerFromPlatform(buildHitlPlatform(captures, { agentRegistry: registry }), {
+      name: 'p',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const taskId = await createCompletedTask(server, 'acc_owner');
+    registry.resolve = async () => sampleAgent({ status: 'blocked' });
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(
+      result.isError,
+      true,
+      `blocked agents must still be able to poll tasks_get, got ${JSON.stringify(result.structuredContent)}`
+    );
+    assert.strictEqual(result.structuredContent.task_id, taskId);
+  });
+});


### PR DESCRIPTION
## Summary
- \`tasks_get\` now resolves the calling \`BuyerAgent\` (when an \`agentRegistry\` is configured) and threads it to \`platform.accounts.resolve\` as \`ctx.agent\`.
- Closes the asymmetry left by PR #1315 + #1321 — the custom-tool path historically bypassed registry resolution because it sits outside the dispatcher's main handler-dispatch flow.
- **Status enforcement is deliberately NOT replicated.** A buyer suspended after kicking off an HITL task must still be able to poll for terminal state. Tests pin both contracts so a future refactor can't silently tighten status enforcement onto the polling path.

## Why this needs fixing
The contract docstrings landed on \`upsert?\` / \`reportUsage?\` / \`getAccountFinancials?\` in the prior two PRs say \"prefer \`ctx.agent\` for principal-keyed gates.\" That guidance was a half-truth as long as \`tasks_get\` skipped registry resolution: an adopter who wrote their resolver to key on \`ctx.agent\` would see it undefined on every \`tasks_get\` call and have to special-case the polling path.

## Why status enforcement stays off the polling path
The dispatcher comment at \`create-adcp-server.ts:2796-2802\` makes the policy explicit: status checks (suspended/blocked → 403) deliberately skip on \`tasks_get\` polls and background webhooks because refusing the poll would strand in-flight work with no visibility. This PR pins that policy in tests rather than relying on its current emergent behavior, so future tightening fails loudly.

## What's NOT in scope
- Replicating the dispatcher's full agent-resolution-and-status-enforcement seam in the custom-tool path. The right long-term shape is v6.1's native MCP \`tasks/get\` method dispatch, which puts the polling path on the regular handler-dispatch path naturally. This PR is the bounded contract patch that holds until then.

## Compatibility
No behavior change for adopters that don't read \`ctx.agent\` from inside their resolver.

## Test plan
- [x] 6 new tests in \`test/server-tasks-get-agent-forwarding.test.js\`:
  - resolved BuyerAgent reaches \`accounts.resolve\` from \`tasks_get\`
  - no agentRegistry configured → \`ctx.agent\` undefined (no regression)
  - agent is shallow-frozen before threading (mirrors dispatcher freeze contract)
  - registry throwing on the poll falls through to \`agent: undefined\` (poll still succeeds)
  - suspended agent can still poll \`tasks_get\` (policy)
  - blocked agent can still poll \`tasks_get\` (policy)
- [x] All 154 tests across adjacent files (\`server-account-store-ctx-forwarding\`, \`server-buyer-agent-resolve-seam\`, \`server-buyer-agent-credential-synthesis\`, \`server-decisioning-from-platform\`, \`server-ctx-metadata-leak-paranoia\`) pass.
- [x] \`npm run build\` clean; \`npm run format\` clean; \`npm run typecheck:skill-examples\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)