### PR TITLE
fix(security): extend maxResponseBytes cap to OAuth perimeter (#1175)

### DIFF
--- a/.changeset/oauth-perimeter-size-cap.md
+++ b/.changeset/oauth-perimeter-size-cap.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(security): extend `transport.maxResponseBytes` cap to OAuth token endpoint and authorization-server metadata discovery. `exchangeClientCredentials` and `discoverOAuthMetadata` now wrap their `fetch` with the same size-limit guard that protects MCP/A2A response paths, closing a buffer-bomb surface where a hostile token endpoint or `.well-known` metadata response could exceed the configured cap. Pass-through when no `withResponseSizeLimit` slot is active. Closes #1175.

--- a/src/lib/auth/oauth/ClientCredentialsFlow.ts
+++ b/src/lib/auth/oauth/ClientCredentialsFlow.ts
@@ -33,6 +33,7 @@ import type { AgentOAuthClientCredentials } from '../../types/adcp';
 import type { OAuthConfigStorage } from './types';
 import { resolveSecret } from './secret-resolver';
 import { isLikelyPrivateUrl } from '../../net';
+import { wrapFetchWithSizeLimit } from '../../protocols/responseSizeLimit';
 
 /** Max length we'll echo from an AS-supplied error description into errors. */
 const MAX_AS_ERROR_LENGTH = 200;
@@ -192,7 +193,10 @@ export async function exchangeClientCredentials(
   credentials: AgentOAuthClientCredentials,
   options: ExchangeClientCredentialsOptions = {}
 ): Promise<AgentOAuthTokens> {
-  const fetchImpl = options.fetch ?? fetch;
+  // Wrap with the response-size-limit guard so a hostile token endpoint
+  // can't buffer-bomb on every refresh. Pass-through when no
+  // `withResponseSizeLimit` slot is active. (#1175)
+  const fetchImpl = wrapFetchWithSizeLimit(options.fetch ?? fetch);
   const timeoutMs = options.timeoutMs ?? 30_000;
 
   validateTokenEndpoint(credentials.token_endpoint, { allowPrivateIp: options.allowPrivateIp });

--- a/src/lib/auth/oauth/discovery.ts
+++ b/src/lib/auth/oauth/discovery.ts
@@ -5,6 +5,8 @@
  * MCP servers expose OAuth metadata at /.well-known/oauth-authorization-server
  */
 
+import { wrapFetchWithSizeLimit } from '../../protocols/responseSizeLimit';
+
 /**
  * OAuth Authorization Server Metadata
  * @see https://datatracker.ietf.org/doc/html/rfc8414
@@ -63,7 +65,11 @@ export async function discoverOAuthMetadata(
   agentUrl: string,
   options: DiscoveryOptions = {}
 ): Promise<OAuthMetadata | null> {
-  const { timeout = 5000, fetch: customFetch = fetch } = options;
+  // Wrap with the response-size-limit guard so a hostile metadata endpoint
+  // can't buffer-bomb during discovery. Pass-through when no
+  // `withResponseSizeLimit` slot is active. (#1175)
+  const { timeout = 5000, fetch: providedFetch = fetch } = options;
+  const customFetch = wrapFetchWithSizeLimit(providedFetch);
 
   try {
     const baseUrl = new URL(agentUrl);

--- a/test/unit/oauth-size-limit.test.js
+++ b/test/unit/oauth-size-limit.test.js
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for response-size cap on OAuth perimeter (#1175).
+ *
+ * `exchangeClientCredentials` (token endpoint) and `discoverOAuthMetadata`
+ * (well-known metadata) used raw `fetch` until #1175. Both now wrap with
+ * `wrapFetchWithSizeLimit`, so a hostile AS that buffer-bombs from either
+ * endpoint hits the same cap that protects the MCP/A2A response paths.
+ *
+ * Tests exercise the compiled `dist/` output to pin shipped behavior.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { exchangeClientCredentials } = require('../../dist/lib/auth/oauth/ClientCredentialsFlow');
+const { discoverOAuthMetadata } = require('../../dist/lib/auth/oauth/discovery');
+const { withResponseSizeLimit } = require('../../dist/lib/protocols/responseSizeLimit');
+const { ResponseTooLargeError } = require('../../dist/lib/errors');
+
+describe('OAuth perimeter response-size cap (#1175)', () => {
+  describe('exchangeClientCredentials', () => {
+    const credentials = {
+      token_endpoint: 'https://as.example.invalid/oauth/token',
+      client_id: 'cid',
+      client_secret: 'csecret',
+    };
+
+    it('refuses oversized token responses when a size-limit slot is active', async () => {
+      const oversized = JSON.stringify({ access_token: 'x'.repeat(10_000), token_type: 'Bearer' });
+      const hostileFetch = async () =>
+        new Response(oversized, {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'content-length': String(Buffer.byteLength(oversized)),
+          },
+        });
+
+      await assert.rejects(
+        withResponseSizeLimit(500, () =>
+          exchangeClientCredentials(credentials, { fetch: hostileFetch, allowPrivateIp: true })
+        ),
+        err => {
+          // The cap throws ResponseTooLargeError before parsing; the OAuth
+          // wrapper rethrows it as a ClientCredentialsExchangeError with the
+          // 'network' kind. Either surfaces correctly — we accept both.
+          if (err instanceof ResponseTooLargeError) {
+            assert.strictEqual(err.code, 'RESPONSE_TOO_LARGE');
+            return true;
+          }
+          assert.ok(err.message.includes('exceeds maxResponseBytes') || err.cause instanceof ResponseTooLargeError);
+          return true;
+        }
+      );
+    });
+
+    it('passes responses through when no size-limit slot is active', async () => {
+      const ok = JSON.stringify({ access_token: 'tok', token_type: 'Bearer', expires_in: 3600 });
+      const benignFetch = async () =>
+        new Response(ok, {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'content-length': String(Buffer.byteLength(ok)) },
+        });
+
+      // No `withResponseSizeLimit` wrapper — the wrapper must be a no-op so
+      // direct callers without the option pay nothing.
+      const tokens = await exchangeClientCredentials(credentials, { fetch: benignFetch, allowPrivateIp: true });
+      assert.strictEqual(tokens.access_token, 'tok');
+    });
+  });
+
+  describe('discoverOAuthMetadata', () => {
+    it('refuses oversized metadata responses when a size-limit slot is active', async () => {
+      const oversized = JSON.stringify({
+        authorization_endpoint: 'https://as.example.invalid/auth',
+        token_endpoint: 'https://as.example.invalid/token',
+        // Pad to exceed the cap — discovery doesn't validate size of any
+        // single field, so a hostile AS can stuff arbitrary data here.
+        scopes_supported: Array.from({ length: 1000 }, (_, i) => `scope_${i}_${'x'.repeat(40)}`),
+      });
+      const hostileFetch = async () =>
+        new Response(oversized, {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+            'content-length': String(Buffer.byteLength(oversized)),
+          },
+        });
+
+      // discoverOAuthMetadata swallows individual URL errors and returns
+      // null after exhausting candidates. Under a tight cap, both URL
+      // attempts fail with ResponseTooLargeError → function returns null.
+      const result = await withResponseSizeLimit(500, () =>
+        discoverOAuthMetadata('https://agent.example.invalid/mcp', { fetch: hostileFetch })
+      );
+      assert.strictEqual(result, null, 'oversized metadata must not surface as a successful discovery');
+    });
+
+    it('passes metadata through when no size-limit slot is active', async () => {
+      const ok = JSON.stringify({
+        authorization_endpoint: 'https://as.example.invalid/auth',
+        token_endpoint: 'https://as.example.invalid/token',
+      });
+      const benignFetch = async () =>
+        new Response(ok, {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'content-length': String(Buffer.byteLength(ok)) },
+        });
+
+      const metadata = await discoverOAuthMetadata('https://agent.example.invalid/mcp', { fetch: benignFetch });
+      assert.ok(metadata, 'discovery must succeed without a size-limit slot');
+      assert.strictEqual(metadata.token_endpoint, 'https://as.example.invalid/token');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1175.

## Summary

Two paths bypassed `transport.maxResponseBytes` after #1170 landed it on the MCP/A2A response paths:

1. `exchangeClientCredentials` (token endpoint exchange + 401-retry refresh) used raw `fetch`.
2. `discoverOAuthMetadata` (authorization-server `.well-known` discovery) used raw `fetch`.

Both now wrap with `wrapFetchWithSizeLimit`, inheriting the active `withResponseSizeLimit` slot installed by `ProtocolClient.callTool`. A hostile AS that buffer-bombs from either endpoint hits the same cap that protects the MCP/A2A reply path.

## Why this shape

The `wrapFetchWithSizeLimit` wrapper is a pass-through when no slot is active, so direct callers (`exchangeClientCredentials` invoked outside a `withResponseSizeLimit` boundary) pay nothing. Surfaces only matter when an SDK consumer has set `transport.maxResponseBytes` — exactly the population that asked for the cap.

Token-endpoint cap surfaces as `ResponseTooLargeError` (the standard surface from `wrapFetchWithSizeLimit`). Metadata discovery already swallows per-URL failures and returns `null` after exhausting candidates, so an oversized metadata response naturally falls through to the standard "OAuth not detected" path — no new error code needed.

## Changes

- **`src/lib/auth/oauth/ClientCredentialsFlow.ts`** — wrap `options.fetch ?? fetch` with `wrapFetchWithSizeLimit`. One-line change at the existing `fetchImpl` site.
- **`src/lib/auth/oauth/discovery.ts`** — wrap `options.fetch ?? fetch` similarly.
- **`test/unit/oauth-size-limit.test.js`** — new file. Two scenarios per endpoint: (a) hostile body exceeds cap under active 500-byte slot → expect rejection / null; (b) benign body succeeds with no slot active.

## Test plan
- [x] `node --test test/unit/oauth-size-limit.test.js` — 4/4 pass
- [x] `node --test test/oauth-client-credentials.test.js test/lib/oauth.test.js` — 83/83 pass (no regressions)
- [x] `npm run typecheck` clean
- [x] `npm run format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)