### PR TITLE
feat(creative): add listCreativeFormats? to CreativeBuilderPlatform and CreativeAdServerPlatform

### DIFF
--- a/.changeset/creative-platform-list-formats.md
+++ b/.changeset/creative-platform-list-formats.md
@@ -1,0 +1,27 @@
+---
+"@adcp/sdk": minor
+---
+
+`listCreativeFormats?` added to `CreativeBuilderPlatform` and `CreativeAdServerPlatform`. Closes #1324.
+
+Creative-agent adopters building against the v6 typed platform path can now wire `list_creative_formats` directly on the platform class, eliminating the need for the v5 escape hatch:
+
+```ts
+// Before — had to mix v6 typed + v5 untyped
+creative: defineCreativeBuilderPlatform({
+  buildCreative: async (req, ctx) => { ... },
+}),
+createAdcpServerFromPlatform(platform, {
+  creative: { listCreativeFormats: async () => { ... } }, // untyped
+});
+
+// After — stays on the typed platform
+creative: defineCreativeBuilderPlatform({
+  buildCreative: async (req, ctx) => { ... },
+  listCreativeFormats: async (req, ctx) => { ... }, // typed
+}),
+```
+
+`listCreativeFormats` is optional — adopters who declare `creative_agents` in capabilities can omit it; the framework can discover formats from those references. The method carries a `⚠️ NO-ACCOUNT TOOL` JSDoc matching `SalesPlatform.listCreativeFormats`: the wire request carries no `account` field, so `ctx.account` may be `undefined` for `'explicit'`-resolution adopters.
+
+Backwards-compatible: the method is optional (`?`) on both interfaces; existing adopters using the v5 escape hatch continue to work while they migrate.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -519,7 +519,7 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
   //
   // **Merge semantics**: platform-derived handlers WIN per-key. Adopter-
   // supplied handlers fill gaps for un-wired tools (`getMediaBuys`,
-  // `listCreativeFormats`, `providePerformanceFeedback`, `reportUsage`,
+  // `providePerformanceFeedback`, `reportUsage`,
   // `syncEventSources`, `logEvent`, `getAccountFinancials`, content-
   // standards CRUD, etc.).
   //
@@ -1081,8 +1081,8 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     },
     // Merge: platform-derived handlers WIN per-key over adopter-supplied
     // custom handlers. Adopter handlers fill gaps for tools the v6 platform
-    // doesn't yet model (getMediaBuys, listCreativeFormats, content-standards
-    // CRUD, sync_event_sources, etc.). See `CreateAdcpServerFromPlatformOptions`
+    // doesn't yet model (getMediaBuys, content-standards CRUD,
+    // sync_event_sources, etc.). See `CreateAdcpServerFromPlatformOptions`
     // JSDoc for the migration-seam contract.
     mediaBuy: mergeHandlers(
       opts.mediaBuy,
@@ -1495,7 +1495,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
  * Used to bridge the gap between v6 specialism interfaces (which model the
  * stable v1.0 surface) and adopter codebases that need to dispatch
  * tools the platform shape doesn't cover yet (getMediaBuys,
- * listCreativeFormats, providePerformanceFeedback, reportUsage,
+ * providePerformanceFeedback, reportUsage,
  * sync_event_sources, log_event, content-standards CRUD, etc.).
  *
  * **Collision detection.** When a custom-supplied handler would be
@@ -3129,6 +3129,17 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
         r => r
       );
     },
+
+    ...('listCreativeFormats' in creative &&
+      creative.listCreativeFormats && {
+        listCreativeFormats: async (params, ctx) => {
+          const reqCtx = ctxFor(ctx);
+          return projectSync(
+            () => creative.listCreativeFormats!(params, reqCtx),
+            r => r
+          );
+        },
+      }),
 
     // Ad-server-specialism methods. Only the CreativeAdServerPlatform variant
     // implements these; framework returns UNSUPPORTED_FEATURE for the other

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -32,6 +32,8 @@ import type {
   CreativeManifest,
   PreviewCreativeRequest,
   PreviewCreativeResponse,
+  ListCreativeFormatsRequest,
+  ListCreativeFormatsResponse,
   ListCreativesRequest,
   ListCreativesResponse,
   GetCreativeDeliveryRequest,
@@ -87,6 +89,27 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
     creatives: Creative[],
     ctx: Ctx<TCtxMeta>
   ): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
+
+  // ── list_creative_formats: sync only ────────────────────────────────
+  // Discovery tool — buyers query what creative formats this ad server
+  // accepts. Optional because ad-server adopters that declare
+  // `creative_agents` in capabilities can delegate format discovery
+  // to those agents. Self-hosted ad servers implement directly.
+  //
+  // ⚠️  NO-ACCOUNT TOOL. The wire request does not carry an `account`
+  // field. `ctx.account` is undefined for `'explicit'`-resolution
+  // adopters. Three safe patterns:
+  //
+  // 1. **`'derived'` resolution** — `accounts.resolve(undefined)` returns
+  //    a singleton; `ctx.account` is always set.
+  // 2. **Don't implement the method** — the framework returns
+  //    `UNSUPPORTED_FEATURE`; buyers using declared `creative_agents`
+  //    still receive a response.
+  // 3. **Explicit-mode with defensive read** — cast `ctx.account as
+  //    Account | undefined` and derive the account from the request
+  //    body, or throw `AdcpError('ACCOUNT_NOT_FOUND')`.
+  /** Format catalog. What creative formats this ad server accepts. */
+  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativeFormatsResponse>;
 
   /**
    * Read creatives from the library. Filters + pagination. When

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -26,6 +26,8 @@ import type {
   BuildCreativeMultiSuccess,
   PreviewCreativeRequest,
   PreviewCreativeResponse,
+  ListCreativeFormatsRequest,
+  ListCreativeFormatsResponse,
 } from '../../../types/tools.generated';
 import type { SyncCreativesRow } from './sales';
 
@@ -146,6 +148,28 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
     creatives: Creative[],
     ctx: Ctx<TCtxMeta>
   ): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
+
+  // ── list_creative_formats: sync only ────────────────────────────────
+  // Discovery tool — buyers query what creative formats this builder
+  // produces. Optional for adopters who declare `creative_agents` in
+  // capabilities — the framework can discover formats from those
+  // references. Self-hosted builders (own format catalog) implement
+  // this directly.
+  //
+  // ⚠️  NO-ACCOUNT TOOL. The wire request does not carry an `account`
+  // field. `ctx.account` is undefined for `'explicit'`-resolution
+  // adopters. Three safe patterns:
+  //
+  // 1. **`'derived'` resolution** — `accounts.resolve(undefined)` returns
+  //    a singleton; `ctx.account` is always set.
+  // 2. **Don't implement the method** — the framework returns
+  //    `UNSUPPORTED_FEATURE`; buyers using declared `creative_agents`
+  //    still receive a response.
+  // 3. **Explicit-mode with defensive read** — cast `ctx.account as
+  //    Account | undefined` and derive the account from the request
+  //    body, or throw `AdcpError('ACCOUNT_NOT_FOUND')`.
+  /** Format catalog. What creative formats this builder produces. */
+  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativeFormatsResponse>;
 }
 
 /**


### PR DESCRIPTION
Closes #1324

`list_creative_formats` is wire-required for creative agents claiming `creative-template` or `creative-generative`, but it was missing from both `CreativeBuilderPlatform` and `CreativeAdServerPlatform`. Adopters had to mix the v6 typed platform path with a v5 untyped escape hatch (`opts.creative.listCreativeFormats`). This PR adds `listCreativeFormats?` as an optional method to both interfaces and wires it through `buildCreativeHandlers` in `from-platform.ts`, matching the dispatch pattern already used for `SalesPlatform.listCreativeFormats`. The method carries a `⚠️ NO-ACCOUNT TOOL` JSDoc block on both interfaces documenting all three safe patterns for explicit-resolution adopters. Three comment-only gap references to `listCreativeFormats` in `from-platform.ts` are also updated.

**What tested:**
- `prettier --check` on all changed files: ✅ clean
- `tsc --noEmit` on repo: pre-existing env errors (`@types/node` missing, `moduleResolution=node10` deprecation) — not caused by this diff (verified by stashing and confirming identical errors on HEAD~1)
- `node --test test/lib/mock-server/creative-template.test.js`: ✅ 1 suite pass; two other test suites fail with `Cannot find module 'zod'` — pre-existing missing dep in this environment, not caused by this diff

**Nits (not fixed, noted for follow-up):**
- `creative-ad-server.ts` `previewCreative` is required (no `?`) while `creative.ts` has it optional — pre-existing asymmetry, out of scope
- `buildCreativeReturn` alias used in `creative.ts` but inlined in `creative-ad-server.ts` — pre-existing inconsistency
- Skill doc (`skills/build-creative-agent/SKILL.md`) could be updated to show `listCreativeFormats?` on the typed platform — follow-up

**Pre-PR review:**
- code-reviewer: approved — no blockers; guard style fixed to use `'in'` pattern matching local `buildCreativeHandlers` convention; `⚠️ NO-ACCOUNT TOOL` constraint documented
- dx-expert: approved — no blockers; no-account patterns now inlined on both interfaces for full discoverability; v5 escape-hatch gap closed for the 80%+ case

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_012NCikSoa5UhHUfA5Qh8njk

---
_Generated by [Claude Code](https://claude.ai/code/session_012NCikSoa5UhHUfA5Qh8njk)_