### PR TITLE
fix(server): apply credential redactor to tenant-registry wire-projected reasons (#1330)

### DIFF
--- a/.changeset/tenant-registry-redactor.md
+++ b/.changeset/tenant-registry-redactor.md
@@ -1,0 +1,19 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(server): apply credential redactor to tenant-registry wire-projected reasons (closes #1330)
+
+Stage 4 of #1269 introduced `redactCredentialPatterns` and applied it to the dispatcher's `err.message → details.reason` projections. Code-reviewer flagged additional sites in `tenant-registry.ts` that bypass the redactor — the `TenantStatus.reason` field flows to the wire via the admin router (`GET /tenants/:id`, `POST /tenants/:id/recheck`), and three sites projected upstream `err.message` into the reason without scrubbing.
+
+Fixes four sites:
+- `src/lib/server/decisioning/tenant-registry.ts:399` — JWKS fetch failure (network errors can echo basic-auth-bearing URLs).
+- `src/lib/server/decisioning/tenant-registry.ts:416` — JSON parse failure on JWKS body.
+- `src/lib/server/decisioning/tenant-registry.ts:834` — adopter validator throw (custom validators may include credential bytes in their error messages).
+- `src/lib/server/decisioning/admin-router.ts:94` — `recheck` route's catch-all 500 handler.
+
+The redactor scrubs Bearer tokens, JSON-quoted credential properties, unquoted credential properties, URL-embedded basic-auth, and long token-shaped strings. Already-redacted strings pass through unchanged (idempotent), so propagation paths that concatenate upstream reasons (`tenant-registry.ts:850, 856`) are safe automatically.
+
+4 new tests at `test/server-decisioning-tenant-registry-redaction.test.js` cover Bearer-token redaction, labeled-credential redaction, URL-embedded credential redaction, and benign-error pass-through.
+
+No behavior change for adopters whose validators don't carry credentials in error messages.

--- a/src/lib/server/decisioning/admin-router.ts
+++ b/src/lib/server/decisioning/admin-router.ts
@@ -30,6 +30,7 @@
 
 import type { Request, Response, NextFunction, IRouter } from 'express';
 import type { TenantRegistry } from './tenant-registry';
+import { redactCredentialPatterns } from '../redact';
 
 /**
  * Minimal Express-router-shaped object so we don't need a hard dependency
@@ -88,10 +89,13 @@ export function createTenantAdminHandlers(registry: TenantRegistry): TenantAdmin
           res.status(404).json({ error: 'tenant_not_found', tenant_id: id });
           return;
         }
+        // Redact credential patterns before exposing on the wire (#1330).
+        // The recheck path can throw with upstream errors that echo
+        // basic-auth URLs or other credential bytes.
         res.status(500).json({
           error: 'recheck_failed',
           tenant_id: id,
-          reason: err instanceof Error ? err.message : String(err),
+          reason: redactCredentialPatterns(err instanceof Error ? err.message : String(err)),
         });
       }
     },

--- a/src/lib/server/decisioning/tenant-registry.ts
+++ b/src/lib/server/decisioning/tenant-registry.ts
@@ -29,6 +29,7 @@ import type { DecisioningAdcpServer, CreateAdcpServerFromPlatformOptions } from 
 import { createAdcpServerFromPlatform } from './runtime/from-platform';
 import type { SignerKey } from '../../signing/signer';
 import type { AdcpJsonWebKey } from '../../signing/types';
+import { redactCredentialPatterns } from '../redact';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -396,7 +397,13 @@ export function createDefaultJwksValidator(opts?: { fetchImpl?: typeof fetch; ti
         return {
           ok: false,
           recovery: 'transient',
-          reason: `JWKS fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+          // Redact credential patterns from the upstream error message
+          // before it surfaces on the admin-router wire (#1330). A fetch
+          // failure can echo basic-auth-bearing URLs or upstream-library
+          // diagnostics that include credential bytes.
+          reason: redactCredentialPatterns(
+            `JWKS fetch failed: ${err instanceof Error ? err.message : String(err)}`
+          ) as string,
         };
       }
       if (!response.ok) {
@@ -413,7 +420,9 @@ export function createDefaultJwksValidator(opts?: { fetchImpl?: typeof fetch; ti
         return {
           ok: false,
           recovery: 'permanent',
-          reason: `JWKS body not JSON: ${err instanceof Error ? err.message : String(err)}`,
+          reason: redactCredentialPatterns(
+            `JWKS body not JSON: ${err instanceof Error ? err.message : String(err)}`
+          ) as string,
         };
       }
       const jwks = (body as { jwks?: { keys?: unknown[] } }).jwks;
@@ -831,7 +840,9 @@ export function createTenantRegistry(opts: TenantRegistryOptions): TenantRegistr
         res = {
           ok: false,
           recovery: 'transient',
-          reason: `validator threw on '${url}': ${err instanceof Error ? err.message : String(err)}`,
+          reason: redactCredentialPatterns(
+            `validator threw on '${url}': ${err instanceof Error ? err.message : String(err)}`
+          ) as string,
         };
       }
       perUrlResults.push({ url, res });

--- a/test/server-decisioning-tenant-registry-redaction.test.js
+++ b/test/server-decisioning-tenant-registry-redaction.test.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// #1330 — tenant-registry redaction hardening. The TenantStatus.reason
+// field flows to the wire via the admin router (`GET /tenants/:id`,
+// `POST /tenants/:id/recheck`). Three sites in tenant-registry.ts and
+// one in admin-router.ts project `err.message` from upstream code into
+// the reason; without redaction, an upstream library that includes
+// credential bytes in its error message leaks them on the admin wire.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createTenantRegistry, createSelfSignedTenantKey } = require('../dist/lib/server/decisioning/tenant-registry');
+
+const DEFAULT_SERVER_OPTIONS = { capabilities: { specialisms: [] } };
+
+function basePlatform() {
+  return {
+    capabilities: { specialisms: [], creative_agents: [], channels: [], pricingModels: [], config: {} },
+    accounts: {
+      resolve: async () => null,
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+  };
+}
+
+function fakeValidator(impl) {
+  return { validate: impl };
+}
+
+let SAMPLE_KEY;
+async function ensureSampleKey() {
+  if (!SAMPLE_KEY) SAMPLE_KEY = await createSelfSignedTenantKey('kid-test');
+  return SAMPLE_KEY;
+}
+
+describe('#1330 — tenant-registry redacts credentials from validator error messages', () => {
+  it('validator throw with bearer token in message → reason has token redacted', async () => {
+    const sampleKey = await ensureSampleKey();
+    const validator = fakeValidator(async () => {
+      throw new Error('upstream auth failure: Bearer sk_live_secret_value_abc123');
+    });
+    const registry = createTenantRegistry({
+      jwksValidator: validator,
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+    registry.register('t1', {
+      agentUrl: 'https://t1.example.com',
+      signingKey: sampleKey,
+      platform: basePlatform(),
+    });
+
+    const status = await registry.recheck('t1');
+    assert.equal(status.health, 'pending');
+    assert.ok(status.reason);
+    assert.equal(
+      status.reason.includes('sk_live_secret_value_abc123'),
+      false,
+      `reason leaked credential: ${status.reason}`
+    );
+    assert.match(status.reason, /Bearer <redacted>/);
+  });
+
+  it('validator throw with token=value in message → reason has labeled credential redacted', async () => {
+    const sampleKey = await ensureSampleKey();
+    const validator = fakeValidator(async () => {
+      throw new Error('upstream rejected: token=abc123def456ghi789jkl');
+    });
+    const registry = createTenantRegistry({
+      jwksValidator: validator,
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+    registry.register('t2', {
+      agentUrl: 'https://t2.example.com',
+      signingKey: sampleKey,
+      platform: basePlatform(),
+    });
+
+    const status = await registry.recheck('t2');
+    assert.equal(status.reason.includes('abc123def456ghi789jkl'), false, `reason leaked credential: ${status.reason}`);
+    assert.match(status.reason, /token=<redacted>/);
+  });
+
+  it('validator throw with URL-embedded credential → password redacted, scheme + user preserved', async () => {
+    const sampleKey = await ensureSampleKey();
+    const validator = fakeValidator(async () => {
+      throw new Error('failed to GET https://service:supersecretpassword@vendor.example/jwks');
+    });
+    const registry = createTenantRegistry({
+      jwksValidator: validator,
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+    registry.register('t3', {
+      agentUrl: 'https://t3.example.com',
+      signingKey: sampleKey,
+      platform: basePlatform(),
+    });
+
+    const status = await registry.recheck('t3');
+    assert.equal(status.reason.includes('supersecretpassword'), false);
+    assert.match(status.reason, /https:\/\/service:<redacted>@vendor\.example/);
+  });
+
+  it('benign error messages pass through unchanged (no false-positive redaction)', async () => {
+    const sampleKey = await ensureSampleKey();
+    const validator = fakeValidator(async () => {
+      throw new Error('connection reset by peer');
+    });
+    const registry = createTenantRegistry({
+      jwksValidator: validator,
+      defaultServerOptions: DEFAULT_SERVER_OPTIONS,
+      autoValidate: false,
+    });
+    registry.register('t4', {
+      agentUrl: 'https://t4.example.com',
+      signingKey: sampleKey,
+      platform: basePlatform(),
+    });
+
+    const status = await registry.recheck('t4');
+    assert.match(status.reason, /connection reset by peer/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1330. Phase 1 Stage 4 of #1269 introduced `redactCredentialPatterns` and applied it to the dispatcher's `err.message → details.reason` projections. Code-reviewer flagged additional sites in `tenant-registry.ts` that bypass the redactor — `TenantStatus.reason` flows to the wire via the admin router (`GET /tenants/:id`, `POST /tenants/:id/recheck`), and three sites projected upstream `err.message` into the reason without scrubbing.

## What's fixed

Four sites:

- `src/lib/server/decisioning/tenant-registry.ts:399` — JWKS fetch failure. Network errors can echo basic-auth-bearing URLs (`https://user:pass@vendor/...`) or upstream-library diagnostics that include credential bytes.
- `src/lib/server/decisioning/tenant-registry.ts:416` — JSON parse failure on JWKS body. Body fragments could include credential strings.
- `src/lib/server/decisioning/tenant-registry.ts:834` — adopter validator throw. Custom validators may include credential bytes in their error messages (e.g., a wrapped HTTP-fetch library that echoes the request URL).
- `src/lib/server/decisioning/admin-router.ts:94` — `recheck` route's catch-all 500 handler. Same posture as the validator throws.

## Idempotent propagation

The redactor returns already-redacted strings unchanged, so propagation paths that concatenate upstream reasons (`tenant-registry.ts:850, 856`) are automatically safe once the upstream sites redact. No additional changes needed at those sites.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `test/server-decisioning-tenant-registry-redaction.test.js` — 4/4 pass:
  - Validator throw with `Bearer <token>` → token redacted.
  - Validator throw with `token=value` → labeled credential redacted.
  - Validator throw with URL-embedded credential → password stripped, scheme + user preserved.
  - Benign error message passes through unchanged.
- [x] `test/server-decisioning-tenant-registry.test.js` (existing) — 75/75 pass with redaction in place.
- [x] `npm run format:check` clean.
- [x] Full suite: 7449 pass, 0 fail.

## Cross-links

- #1330 (the tracking issue this closes)
- #1311 (Stage 4 — where `redactCredentialPatterns` was introduced)
- #1269 (BuyerAgentRegistry Phase 1 parent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)