### PR TITLE
feat(decisioning): close v6 platform gaps for creative-template adopters (#1324, #1325, #1327)

### DIFF
--- a/.changeset/creative-list-creative-formats.md
+++ b/.changeset/creative-list-creative-formats.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": minor
+---
+
+`CreativeBuilderPlatform.listCreativeFormats?` and `CreativeAdServerPlatform.listCreativeFormats?` are now modeled on the typed v6 platform interfaces and dispatched through `buildCreativeHandlers`. Closes adcp-client#1324 — pre-fix, every `creative-template` / `creative-generative` / `creative-ad-server` adopter that owned a format catalog had to drop down to the v5 escape hatch (`opts.creative.listCreativeFormats`) because the typed-platform path didn't carry the surface.
+
+The dispatch is no-account: the framework calls `accounts.resolve(undefined)` for the request (the wire schema doesn't carry an `account` field), so the typed signature uses `NoAccountCtx<TCtxMeta>` (see the #1327 changeset) — adopters who read `ctx.account.ctx_metadata` get a compile-time error and must narrow.
+
+Adopters who delegate format definitions via `capabilities.creative_agents` continue to omit the method; the framework returns `UNSUPPORTED_FEATURE` to buyers, same as before.

--- a/.changeset/format-renders-codegen-tighten.md
+++ b/.changeset/format-renders-codegen-tighten.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": patch
+---
+
+`Format.renders[]` codegen now extracts each `oneOf` branch as a closed shape — `{ role; dimensions; ... }` and `{ role; parameters_from_format_id: true }` — instead of collapsing the first branch to `{ [k: string]: unknown }`. Closes adcp-client#1325. The SDK's typed render factories (`displayRender`, `parameterizedRender`, `templateRender`) now compose cleanly with `Format['renders']` under `--strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes`.
+
+Implementation: a new `flattenMutualExclusiveOneOf` preprocess in `scripts/generate-types.ts` detects the JSON Schema "X xor Y" idiom (`oneOf` branches with `{ required: [X], not: { required: [Y] } }` and no other keys) and inlines the parent's `properties` into each branch with the excluded fields removed. The mutual-exclusivity constraint stays enforced at runtime by Ajv against the unstripped schema; the codegen pass only widens what TypeScript can express. Same fix applied to `sync_plans` plan budget (`reallocation_threshold` xor `reallocation_unlimited`), which had the identical loose-arm shape.
+
+`RenderDimensions.unit` is now `DimensionUnit` (the schema enum: `'px' | 'dp' | 'inches' | 'cm' | 'mm' | 'pt'`) instead of an open `string` — adopters who passed `unit: 'feet'` or other off-spec strings will now see a TS error. Closes adcp-client#1325.

--- a/.changeset/no-account-ctx-narrow.md
+++ b/.changeset/no-account-ctx-narrow.md
@@ -1,0 +1,33 @@
+---
+"@adcp/sdk": minor
+---
+
+Tools whose wire request doesn't carry an `account` field — `preview_creative`, `list_creative_formats`, `provide_performance_feedback` — now use a new `NoAccountCtx<TCtxMeta>` request-context type whose `account` is `Account<TCtxMeta> | undefined`. Closes adcp-client#1327 — pre-fix, the typed handler signature claimed `ctx.account: Account<TCtxMeta>` (non-optional) while the framework dispatched these tools with `ctx.account === undefined` whenever `accounts.resolve(undefined)` returned null, producing runtime crashes (`Cannot read properties of undefined`) deep in adopter code. The narrow converts the runtime gate into a compile-time invariant — same shape as the `definePlatformWithCompliance` fix in #1262.
+
+Affected interfaces:
+- `CreativeBuilderPlatform.previewCreative?(req, ctx: NoAccountCtx<TCtxMeta>)`
+- `CreativeBuilderPlatform.listCreativeFormats?(req, ctx: NoAccountCtx<TCtxMeta>)` (new in #1324)
+- `CreativeAdServerPlatform.previewCreative(req, ctx: NoAccountCtx<TCtxMeta>)`
+- `CreativeAdServerPlatform.listCreativeFormats?(req, ctx: NoAccountCtx<TCtxMeta>)` (new in #1324)
+- `SalesPlatform.providePerformanceFeedback?(req, ctx: NoAccountCtx<TCtxMeta>)`
+- `SalesPlatform.listCreativeFormats?(req, ctx: NoAccountCtx<TCtxMeta>)`
+
+Migration for adopters: in handlers for these tools, narrow `ctx.account` before reading `ctx_metadata` / `id`. Three patterns:
+
+```ts
+// 1. Singleton fallback — return a non-null Account from accounts.resolve(undefined).
+//    `ctx.account` is always defined; no narrow needed.
+
+// 2. Auth-derived lookup — accounts.resolve(undefined, ctx) reads ctx.authInfo.clientId.
+
+// 3. Defensive narrow inside the handler:
+previewCreative: async (req, ctx) => {
+  if (ctx.account == null) {
+    throw new AdcpError('ACCOUNT_NOT_FOUND', { recovery: 'correctable', message: '...' });
+  }
+  const ws = ctx.account.ctx_metadata.workspace_id;
+  // ...
+}
+```
+
+This is a TypeScript-level breaking change for adopters who were dereferencing `ctx.account` unconditionally — the runtime behavior is unchanged. Adopters of `'derived'`-resolution stores that always return a singleton are unaffected at runtime, but the compiler will now require the narrow.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -287,7 +287,72 @@ export function enforceStrictSchema(schema: any): any {
     );
   }
 
-  return strictSchema;
+  return flattenMutualExclusiveOneOf(strictSchema);
+}
+
+/**
+ * Inline parent `properties` into `oneOf` branches that use the JSON Schema
+ * "X xor Y" mutual-exclusivity pattern (`{ required: [X], not: { required:
+ * [Y] } }`). Without this, json-schema-to-typescript can't extract each branch
+ * as a closed shape — branches with only `required` + `not` (no own type or
+ * properties) collapse to `{ [k: string]: unknown }`. The result is unions
+ * like `Format.renders[]` whose loose arm rejects the SDK's typed factory
+ * builders (`displayRender({...})`) under strict tsc.
+ *
+ * Detection (conservative): all `oneOf` branches must match a `{ required,
+ * not: { required }, properties?, title?, description? }` shape with no other
+ * keys. The transform inlines outer `properties` into each branch (minus the
+ * fields each branch's `not.required` excludes), promotes outer `required`
+ * into each branch, and drops the branch-level `not`. The mutual-exclusivity
+ * constraint stays enforced at runtime by Ajv against the unstripped schema —
+ * the codegen pass only widens what TypeScript can express.
+ *
+ * Schemas this affects today: `Format.renders[]`, `sync_plans` plan budget.
+ * Both share the same authorial idiom upstream (adcontextprotocol/adcp).
+ */
+function flattenMutualExclusiveOneOf(schema: any): any {
+  if (!schema || typeof schema !== 'object') return schema;
+  if (!schema.properties || !schema.oneOf || !Array.isArray(schema.oneOf)) return schema;
+  const branches = schema.oneOf;
+  if (branches.length < 2) return schema;
+
+  const ALLOWED_BRANCH_KEYS = new Set(['required', 'not', 'properties', 'title', 'description']);
+  const allBranchesAreMutex = branches.every((b: any) => {
+    if (!b || typeof b !== 'object') return false;
+    if (!Array.isArray(b.required) || b.required.length === 0) return false;
+    if (!b.not || typeof b.not !== 'object') return false;
+    if (!Array.isArray(b.not.required) || b.not.required.length === 0) return false;
+    if (Object.keys(b).some(k => !ALLOWED_BRANCH_KEYS.has(k))) return false;
+    if (Object.keys(b.not).some(k => k !== 'required')) return false;
+    return true;
+  });
+  if (!allBranchesAreMutex) return schema;
+
+  const outerProps = schema.properties as Record<string, any>;
+  const outerRequired: string[] = Array.isArray(schema.required) ? schema.required : [];
+
+  const newOneOf = branches.map((branch: any) => {
+    const excluded = new Set<string>(branch.not.required);
+    const branchOwnProps: Record<string, any> = branch.properties ?? {};
+    const branchProps: Record<string, any> = {};
+    for (const [name, prop] of Object.entries(outerProps)) {
+      if (excluded.has(name)) continue;
+      branchProps[name] = branchOwnProps[name] ?? prop;
+    }
+    const required = Array.from(new Set([...outerRequired, ...branch.required]));
+    const out: Record<string, unknown> = { type: 'object' };
+    if (branch.title) out.title = branch.title;
+    if (branch.description) out.description = branch.description;
+    out.properties = branchProps;
+    if (required.length > 0) out.required = required;
+    out.additionalProperties = false;
+    return out;
+  });
+
+  const result = { ...schema, oneOf: newOneOf };
+  delete result.properties;
+  delete result.required;
+  return result;
 }
 
 // Load AdCP tool schemas from cache

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -339,12 +339,21 @@ function flattenMutualExclusiveOneOf(schema: any): any {
       if (excluded.has(name)) continue;
       branchProps[name] = branchOwnProps[name] ?? prop;
     }
-    const required = Array.from(new Set([...outerRequired, ...branch.required]));
+    // Drop any outer `required` field this branch excluded — keeping it
+    // would leave a required key with no matching `properties` entry, which
+    // jsts emits as `field: unknown` and Ajv would reject on the unstripped
+    // schema anyway.
+    const filteredOuterRequired = outerRequired.filter(name => !excluded.has(name));
+    const required = Array.from(new Set([...filteredOuterRequired, ...branch.required]));
     const out: Record<string, unknown> = { type: 'object' };
     if (branch.title) out.title = branch.title;
     if (branch.description) out.description = branch.description;
     out.properties = branchProps;
     if (required.length > 0) out.required = required;
+    // Closed shape — branches must enumerate their fields. If a future
+    // upstream schema needs an open branch, file an issue and either widen
+    // detection (require explicit `additionalProperties: true` on the branch)
+    // or skip flattening.
     out.additionalProperties = false;
     return out;
   });

--- a/scripts/skill-examples.baseline.json
+++ b/scripts/skill-examples.baseline.json
@@ -247,7 +247,7 @@
   {
     "source": "skills/build-generative-seller-agent/SKILL.md",
     "errorCode": "TS2322",
-    "messagePrefix": "Type '(req: PreviewCreativeRequest, ctx: Ctx<Record<string, unknown>>) => Promis"
+    "messagePrefix": "Type '(req: PreviewCreativeRequest, ctx: NoAccountCtx<Record<string, unknown>>) "
   },
   {
     "source": "skills/build-generative-seller-agent/SKILL.md",
@@ -442,7 +442,7 @@
   {
     "source": "skills/build-retail-media-agent/SKILL.md",
     "errorCode": "TS2322",
-    "messagePrefix": "Type '(req: ProvidePerformanceFeedbackRequest, ctx: Ctx<Record<string, unknown>>"
+    "messagePrefix": "Type '(req: ProvidePerformanceFeedbackRequest, ctx: NoAccountCtx<Record<string, "
   },
   {
     "source": "skills/build-retail-media-agent/SKILL.md",

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -327,6 +327,10 @@ export interface AccountToolContext<TCtxMeta = Record<string, unknown>> extends 
  *
  * @public
  */
+// Inline type-import on `RequestContext` instead of a top-level
+// `import type { RequestContext } from './context'` — `context.ts` already
+// imports `Account` from this file, so a top-level import would form a
+// circular type dependency.
 export type NoAccountCtx<TCtxMeta = Record<string, unknown>> = Omit<
   import('./context').RequestContext<Account<TCtxMeta>>,
   'account'

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -298,6 +298,47 @@ export interface AccountToolContext<TCtxMeta = Record<string, unknown>> extends 
   account: Account<TCtxMeta>;
 }
 
+/**
+ * Request context for tools whose wire request does not carry an `account`
+ * field — `preview_creative`, `list_creative_formats`, and
+ * `provide_performance_feedback`. The framework calls
+ * `accounts.resolve(undefined, ctx)` for these, accepting a `null` return; if
+ * `null`, `ctx.account` is undefined when the handler runs.
+ *
+ * Adopter handlers MUST handle the `undefined` case explicitly. Choose one of:
+ *
+ *   1. **Singleton fallback** — return a non-null synthetic `Account` from
+ *      `accounts.resolve(undefined, ctx)` for the publisher-wide tenant
+ *      (e.g., format catalog, performance feedback aggregation). Inside the
+ *      handler, narrow with `if (!ctx.account) throw ...` once and treat
+ *      `ctx.account` as defined for the rest.
+ *   2. **Auth-derived lookup** — in `accounts.resolve(undefined, ctx)`, look
+ *      up by `ctx.authInfo.clientId` (or whichever principal field your auth
+ *      wires) and return the matching account.
+ *   3. **Error out** — throw `AdcpError({ code: 'ACCOUNT_NOT_FOUND' })` from
+ *      within the handler when `ctx.account == null` and the operation
+ *      requires tenant scoping.
+ *
+ * The narrowed type catches the mismatch at authorship time — adopters who
+ * forget to handle `ctx.account === undefined` get a TS error, not a runtime
+ * `Cannot read properties of undefined` deep in their upstream call. Same
+ * shape as the `definePlatformWithCompliance` invariant: convert a runtime
+ * gate into a compile-time one.
+ *
+ * @public
+ */
+export type NoAccountCtx<TCtxMeta = Record<string, unknown>> = Omit<
+  import('./context').RequestContext<Account<TCtxMeta>>,
+  'account'
+> & {
+  /**
+   * Resolved account, OR `undefined` when the wire request didn't carry an
+   * account ref AND `accounts.resolve(undefined, ctx)` returned null. Always
+   * narrow before reading `ctx_metadata` / `id`.
+   */
+  account: Account<TCtxMeta> | undefined;
+};
+
 export interface AuthPrincipal {
   /** Stable identifier for the calling agent (e.g., `https://buyer.example.com/mcp`). */
   agent_url?: string;

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -343,6 +343,64 @@ type _ct_opts_requires_complytest =
   CreateAdcpServerFromPlatformOptions extends RequiredOptsFor<_PlatformWithCT> ? 'assignable' : 'not-assignable';
 const _check_ct_opts_requires: _ct_opts_requires_complytest = 'not-assignable';
 
+// ── #1325: Format.renders[] codegen tight enough for typed builders ──
+
+// Positive: typed `displayRender({...})` value is assignable to `Format.renders[]`.
+// Pre-#1325, codegen produced `{ [k: string]: unknown } | { parameters_from_format_id: true }`,
+// which rejected the closed-shape DimensionsRender returned by displayRender.
+import { displayRender, parameterizedRender } from '../../utils/format-render-builders';
+import type { Format, PreviewCreativeResponse } from '../../types/tools.generated';
+function _format_renders_accept_display_render(): void {
+  type FormatRenders = NonNullable<Format['renders']>;
+  const renders: FormatRenders = [
+    displayRender({ role: 'primary', dimensions: { width: 300, height: 250 } }),
+    parameterizedRender({ role: 'companion' }),
+  ];
+  void renders;
+}
+
+// ── #1327: NoAccountCtx narrows ctx.account on no-account tools ──
+
+import { defineCreativeBuilderPlatform } from './platform-helpers';
+
+// Stub return values — not under test here. The interesting assertion is
+// the typed `ctx.account` narrowing inside the handler body.
+const _previewStub: PreviewCreativeResponse = {} as PreviewCreativeResponse;
+
+// Positive: a previewCreative handler reading `ctx.account.ctx_metadata` MUST
+// narrow first — `ctx.account` is `Account | undefined` for no-account tools.
+function _preview_creative_requires_account_narrow(): void {
+  defineCreativeBuilderPlatform<{ workspace_id: string }>({
+    buildCreative: async () => ({}) as never,
+    previewCreative: async (_req, ctx) => {
+      // ctx.account: Account<{ workspace_id: string }> | undefined
+      if (ctx.account == null) {
+        return _previewStub;
+      }
+      // After narrow, ctx_metadata is readable.
+      const _ws: string = ctx.account.ctx_metadata.workspace_id;
+      void _ws;
+      return _previewStub;
+    },
+  });
+}
+
+// Negative: reading `ctx.account.ctx_metadata` WITHOUT narrowing is a TS error.
+// This is the regression alarm — pre-#1327, ctx.account was non-optional and
+// adopters would write this code, then crash at runtime when accounts.resolve(undefined)
+// returned null. The type now forces the narrow at authorship.
+function _preview_creative_rejects_unnarrowed_access(): void {
+  defineCreativeBuilderPlatform<{ workspace_id: string }>({
+    buildCreative: async () => ({}) as never,
+    previewCreative: async (_req, ctx) => {
+      // @ts-expect-error — ctx.account is `Account | undefined`; reading without narrowing fails.
+      const _ws: string = ctx.account.ctx_metadata.workspace_id;
+      void _ws;
+      return _previewStub;
+    },
+  });
+}
+
 // Reference all symbols once so eslint-disable is targeted.
 export const _references = [
   _signals_only_capabilities_compiles,
@@ -381,4 +439,7 @@ export const _references = [
   _check_opts_no_ct,
   _check_opts_with_ct,
   _check_ct_opts_requires,
+  _format_renders_accept_display_render,
+  _preview_creative_requires_account_narrow,
+  _preview_creative_rejects_unnarrowed_access,
 ] as const;

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -343,13 +343,13 @@ type _ct_opts_requires_complytest =
   CreateAdcpServerFromPlatformOptions extends RequiredOptsFor<_PlatformWithCT> ? 'assignable' : 'not-assignable';
 const _check_ct_opts_requires: _ct_opts_requires_complytest = 'not-assignable';
 
-// ── #1325: Format.renders[] codegen tight enough for typed builders ──
+// ── Format.renders[] accepts typed render builders ──
 
-// Positive: typed `displayRender({...})` value is assignable to `Format.renders[]`.
-// Pre-#1325, codegen produced `{ [k: string]: unknown } | { parameters_from_format_id: true }`,
-// which rejected the closed-shape DimensionsRender returned by displayRender.
 import { displayRender, parameterizedRender } from '../../utils/format-render-builders';
 import type { Format, PreviewCreativeResponse } from '../../types/tools.generated';
+
+// `displayRender(...)` and `parameterizedRender(...)` produce closed shapes
+// that must be assignable to `Format['renders'][number]` under strict tsc.
 function _format_renders_accept_display_render(): void {
   type FormatRenders = NonNullable<Format['renders']>;
   const renders: FormatRenders = [
@@ -359,36 +359,29 @@ function _format_renders_accept_display_render(): void {
   void renders;
 }
 
-// ── #1327: NoAccountCtx narrows ctx.account on no-account tools ──
+// ── NoAccountCtx narrows ctx.account on no-account tools ──
 
 import { defineCreativeBuilderPlatform } from './platform-helpers';
 
-// Stub return values — not under test here. The interesting assertion is
-// the typed `ctx.account` narrowing inside the handler body.
-const _previewStub: PreviewCreativeResponse = {} as PreviewCreativeResponse;
-
-// Positive: a previewCreative handler reading `ctx.account.ctx_metadata` MUST
-// narrow first — `ctx.account` is `Account | undefined` for no-account tools.
+// `previewCreative` handlers must narrow `ctx.account` before reading
+// `ctx_metadata` — the wire schema does not carry an `account` field, so
+// `ctx.account` is `Account<TCtxMeta> | undefined`.
 function _preview_creative_requires_account_narrow(): void {
   defineCreativeBuilderPlatform<{ workspace_id: string }>({
     buildCreative: async () => ({}) as never,
     previewCreative: async (_req, ctx) => {
-      // ctx.account: Account<{ workspace_id: string }> | undefined
       if (ctx.account == null) {
-        return _previewStub;
+        return {} as PreviewCreativeResponse;
       }
-      // After narrow, ctx_metadata is readable.
       const _ws: string = ctx.account.ctx_metadata.workspace_id;
       void _ws;
-      return _previewStub;
+      return {} as PreviewCreativeResponse;
     },
   });
 }
 
-// Negative: reading `ctx.account.ctx_metadata` WITHOUT narrowing is a TS error.
-// This is the regression alarm — pre-#1327, ctx.account was non-optional and
-// adopters would write this code, then crash at runtime when accounts.resolve(undefined)
-// returned null. The type now forces the narrow at authorship.
+// Reading `ctx.account.ctx_metadata` without a narrow MUST fail typecheck
+// — this is the regression alarm guarding the no-account contract.
 function _preview_creative_rejects_unnarrowed_access(): void {
   defineCreativeBuilderPlatform<{ workspace_id: string }>({
     buildCreative: async () => ({}) as never,
@@ -396,7 +389,7 @@ function _preview_creative_rejects_unnarrowed_access(): void {
       // @ts-expect-error — ctx.account is `Account | undefined`; reading without narrowing fails.
       const _ws: string = ctx.account.ctx_metadata.workspace_id;
       void _ws;
-      return _previewStub;
+      return {} as PreviewCreativeResponse;
     },
   });
 }

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -37,9 +37,10 @@
  * `tasks/get` wire handler, per-server + module-level `publishStatusChange`.
  *
  * **Still deferred (rc.1+):** MCP Resources subscription projection for
- * `publishStatusChange`; `resolveAccount(undefined, { authInfo, toolName })`
- * refactor for `provide_performance_feedback` / `list_creative_formats`
- * no-account path in `'explicit'`-mode adopters (see `SalesPlatform` JSDoc).
+ * `publishStatusChange`. The no-account tool surface (`preview_creative`,
+ * `list_creative_formats`, `provide_performance_feedback`) is now typed
+ * via `NoAccountCtx<TCtxMeta>` — handlers receive `ctx.account: Account |
+ * undefined` and must narrow before reading `ctx_metadata`.
  *
  * Status: Preview / 6.0. Not yet exported from the public `./server`
  * subpath; reach in via `@adcp/sdk/server/decisioning/runtime` for
@@ -3086,9 +3087,11 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
     },
 
     previewCreative: async (params, ctx) => {
-      if (!('previewCreative' in creative)) {
+      if (!('previewCreative' in creative) || (creative as CreativeBuilderPlatform).previewCreative == null) {
         return adcpError('UNSUPPORTED_FEATURE', {
-          message: 'preview_creative not supported by this platform',
+          message:
+            'preview_creative: this creative platform did not implement previewCreative. ' +
+            'Add `previewCreative(req, ctx)` to your CreativeBuilderPlatform / CreativeAdServerPlatform literal.',
         });
       }
       const reqCtx = ctxFor(ctx);
@@ -3106,7 +3109,10 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
     listCreativeFormats: async (params, ctx) => {
       if (!('listCreativeFormats' in creative) || creative.listCreativeFormats == null) {
         return adcpError('UNSUPPORTED_FEATURE', {
-          message: 'list_creative_formats not supported by this creative platform',
+          message:
+            'list_creative_formats: this creative platform did not implement listCreativeFormats. ' +
+            'Add `listCreativeFormats(req, ctx)` to your CreativeBuilderPlatform / CreativeAdServerPlatform literal, ' +
+            'or delegate via `capabilities.creative_agents`.',
         });
       }
       const reqCtx = ctxFor(ctx);

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1081,9 +1081,9 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     },
     // Merge: platform-derived handlers WIN per-key over adopter-supplied
     // custom handlers. Adopter handlers fill gaps for tools the v6 platform
-    // doesn't yet model (getMediaBuys, listCreativeFormats, content-standards
-    // CRUD, sync_event_sources, etc.). See `CreateAdcpServerFromPlatformOptions`
-    // JSDoc for the migration-seam contract.
+    // doesn't yet model (content-standards CRUD, sync_event_sources, etc.).
+    // See `CreateAdcpServerFromPlatformOptions` JSDoc for the migration-seam
+    // contract.
     mediaBuy: mergeHandlers(
       opts.mediaBuy,
       buildMediaBuyHandlers(
@@ -3095,6 +3095,24 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
       return projectSync(
         () => (creative as CreativeBuilderPlatform).previewCreative!(params, reqCtx),
         preview => preview
+      );
+    },
+
+    // No-account tool — `list_creative_formats` request schema doesn't carry
+    // `account`. The framework's `resolveAccountFromAuth` runs and accepts a
+    // null return; the platform method receives `ctx.account` possibly
+    // undefined per `NoAccountCtx`. Wired identically on both
+    // `CreativeBuilderPlatform` and `CreativeAdServerPlatform`.
+    listCreativeFormats: async (params, ctx) => {
+      if (!('listCreativeFormats' in creative) || creative.listCreativeFormats == null) {
+        return adcpError('UNSUPPORTED_FEATURE', {
+          message: 'list_creative_formats not supported by this creative platform',
+        });
+      }
+      const reqCtx = ctxFor(ctx);
+      return projectSync(
+        () => (creative as CreativeBuilderPlatform).listCreativeFormats!(params, reqCtx),
+        r => r
       );
     },
 

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -24,7 +24,7 @@
  * @public
  */
 
-import type { Account } from '../account';
+import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
 import type {
@@ -34,6 +34,8 @@ import type {
   PreviewCreativeResponse,
   ListCreativesRequest,
   ListCreativesResponse,
+  ListCreativeFormatsRequest,
+  ListCreativeFormatsResponse,
   GetCreativeDeliveryRequest,
   GetCreativeDeliveryResponse,
   CreativeAsset,
@@ -71,8 +73,26 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
     ctx: Ctx<TCtxMeta>
   ): Promise<CreativeManifest | CreativeManifest[] | BuildCreativeSuccess | BuildCreativeMultiSuccess>;
 
-  /** Preview-only variant — sandbox URL or inline HTML, expires. Always sync. */
-  previewCreative(req: PreviewCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<PreviewCreativeResponse>;
+  /**
+   * Preview-only variant — sandbox URL or inline HTML, expires. Always sync.
+   *
+   * ⚠️  NO-ACCOUNT TOOL — `ctx: NoAccountCtx<TCtxMeta>`. The wire request
+   * does not carry an `account` field; narrow `ctx.account` before reading
+   * `ctx_metadata` / `id`. See {@link NoAccountCtx}.
+   */
+  previewCreative(req: PreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativeResponse>;
+
+  /**
+   * Format catalog. Optional because adopters who delegate format definitions
+   * to a separate creative agent (declared via `capabilities.creative_agents`)
+   * don't own them; the framework returns `UNSUPPORTED_FEATURE` when omitted.
+   *
+   * ⚠️  NO-ACCOUNT TOOL. See `previewCreative` note above.
+   */
+  listCreativeFormats?(
+    req: ListCreativeFormatsRequest,
+    ctx: NoAccountCtx<TCtxMeta>
+  ): Promise<ListCreativeFormatsResponse>;
 
   // sync_creatives: sync OR task — `SyncCreativesResponse` has a Submitted arm.
 

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -15,7 +15,7 @@
  * @public
  */
 
-import type { Account } from '../account';
+import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
 import type {
@@ -26,6 +26,8 @@ import type {
   BuildCreativeMultiSuccess,
   PreviewCreativeRequest,
   PreviewCreativeResponse,
+  ListCreativeFormatsRequest,
+  ListCreativeFormatsResponse,
 } from '../../../types/tools.generated';
 import type { SyncCreativesRow } from './sales';
 
@@ -124,8 +126,33 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
    * preview ahead of generation can omit it; the framework returns
    * `UNSUPPORTED_FEATURE` to buyers calling `preview_creative` against
    * a platform that didn't wire this.
+   *
+   * ⚠️  NO-ACCOUNT TOOL — `ctx: NoAccountCtx<TCtxMeta>`. The wire request
+   * does not carry an `account` field, so `ctx.account` may be `undefined`
+   * when `accounts.resolve(undefined)` returned null. Narrow before reading
+   * `ctx.account.ctx_metadata`. See {@link NoAccountCtx}.
    */
-  previewCreative?(req: PreviewCreativeRequest, ctx: Ctx<TCtxMeta>): Promise<PreviewCreativeResponse>;
+  previewCreative?(req: PreviewCreativeRequest, ctx: NoAccountCtx<TCtxMeta>): Promise<PreviewCreativeResponse>;
+
+  /**
+   * Format catalog. Buyers call `list_creative_formats` to discover the
+   * formats this agent supports. Optional because adopters who declare
+   * their formats via `capabilities.creative_agents` (delegating to a
+   * separate creative agent) don't own format definitions; the framework
+   * surfaces `UNSUPPORTED_FEATURE` when omitted.
+   *
+   * ⚠️  NO-ACCOUNT TOOL — `ctx: NoAccountCtx<TCtxMeta>`. The wire request
+   * does not carry an `account` field. The framework dispatches with
+   * `ctx.account === undefined` for `'explicit'`-resolution adopters that
+   * don't return a synthetic singleton from `accounts.resolve(undefined)`.
+   * Format catalogs are typically publisher-wide and account-independent;
+   * read configuration from your platform's static catalog rather than
+   * `ctx.account.ctx_metadata`.
+   */
+  listCreativeFormats?(
+    req: ListCreativeFormatsRequest,
+    ctx: NoAccountCtx<TCtxMeta>
+  ): Promise<ListCreativeFormatsResponse>;
 
   /**
    * Refine a prior generation. `taskId` references a prior submission.

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -145,9 +145,10 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
    * does not carry an `account` field. The framework dispatches with
    * `ctx.account === undefined` for `'explicit'`-resolution adopters that
    * don't return a synthetic singleton from `accounts.resolve(undefined)`.
-   * Format catalogs are typically publisher-wide and account-independent;
-   * read configuration from your platform's static catalog rather than
-   * `ctx.account.ctx_metadata`.
+   * Format catalogs are typically publisher-wide; if yours is per-tenant
+   * (Bannerflow / Celtra-style multi-tenant catalogs), return a synthetic
+   * account from `accounts.resolve(undefined)` keyed on
+   * `ctx.authInfo.clientId` and narrow `ctx.account` inside the handler.
    */
   listCreativeFormats?(
     req: ListCreativeFormatsRequest,

--- a/src/lib/server/decisioning/specialisms/sales.ts
+++ b/src/lib/server/decisioning/specialisms/sales.ts
@@ -60,7 +60,7 @@
  * @public
  */
 
-import type { Account } from '../account';
+import type { Account, NoAccountCtx } from '../account';
 import type { RequestContext } from '../context';
 import type { TaskHandoff } from '../async-outcome';
 import type {
@@ -249,13 +249,15 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
   // buyer expects to be able to call it. Framework returns UNSUPPORTED_FEATURE
   // when omitted.
   //
-  // ⚠️  NO-ACCOUNT TOOL. The wire request does not carry an `account` field.
-  // `ctx.account` is undefined for `'explicit'`-resolution adopters.
-  // See the `SalesPlatform` JSDoc ("No-account tools") for safe patterns.
+  // ⚠️  NO-ACCOUNT TOOL — `ctx: NoAccountCtx<TCtxMeta>`. The wire request
+  // does not carry an `account` field. `ctx.account` may be `undefined` for
+  // `'explicit'`-resolution adopters; narrow before reading
+  // `ctx.account.ctx_metadata`. See {@link NoAccountCtx} and the
+  // `SalesPlatform` JSDoc ("No-account tools") for safe patterns.
   /** Accept buyer-side performance signals on a media buy / creative. */
   providePerformanceFeedback?(
     req: ProvidePerformanceFeedbackRequest,
-    ctx: Ctx<TCtxMeta>
+    ctx: NoAccountCtx<TCtxMeta>
   ): Promise<ProvidePerformanceFeedbackSuccess>;
 
   // ── list_creative_formats: sync only ────────────────────────────────
@@ -265,8 +267,12 @@ export interface SalesPlatform<TCtxMeta = Record<string, unknown>> {
   // own format definitions; framework can resolve from the declared agents.
   // Self-hosted sellers (own creative library) implement this directly.
   //
-  // ⚠️  NO-ACCOUNT TOOL. See `providePerformanceFeedback` note above.
-  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativeFormatsResponse>;
+  // ⚠️  NO-ACCOUNT TOOL — `ctx: NoAccountCtx<TCtxMeta>`. See
+  // `providePerformanceFeedback` note above.
+  listCreativeFormats?(
+    req: ListCreativeFormatsRequest,
+    ctx: NoAccountCtx<TCtxMeta>
+  ): Promise<ListCreativeFormatsResponse>;
 
   // ── list_creatives: sync only ───────────────────────────────────────
   // Read tool — buyers query the seller's creative library. Optional

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.0.4
-// Generated at: 2026-05-02T16:13:43.797Z
+// Generated at: 2026-05-02T20:06:01.742Z
 
 // MEDIA-BUY SCHEMA
 /**
@@ -15053,6 +15053,10 @@ export interface FlightItem {
  */
 export type FormatIDParameter = 'dimensions' | 'duration';
 /**
+ * Unit of measurement for width/height values. Defaults to 'px' when absent. Print formats use 'inches' or 'cm'.
+ */
+export type DimensionUnit = 'px' | 'dp' | 'inches' | 'cm' | 'mm' | 'pt';
+/**
  * Image asset
  */
 export type IndividualImageAsset = BaseIndividualAsset;
@@ -15182,9 +15186,57 @@ export interface Format {
    */
   renders?: (
     | {
-        [k: string]: unknown | undefined;
+        /**
+         * Semantic role of this rendered piece (e.g., 'primary', 'companion', 'mobile_variant')
+         */
+        role: string;
+        /**
+         * Dimensions for this rendered piece. Defaults to pixels when unit is absent.
+         */
+        dimensions: {
+          /**
+           * Fixed width. Interpretation depends on unit (default: pixels).
+           */
+          width?: number;
+          /**
+           * Fixed height. Interpretation depends on unit (default: pixels).
+           */
+          height?: number;
+          /**
+           * Minimum width for responsive renders
+           */
+          min_width?: number;
+          /**
+           * Minimum height for responsive renders
+           */
+          min_height?: number;
+          /**
+           * Maximum width for responsive renders
+           */
+          max_width?: number;
+          /**
+           * Maximum height for responsive renders
+           */
+          max_height?: number;
+          unit?: DimensionUnit;
+          /**
+           * Indicates which dimensions are responsive/fluid
+           */
+          responsive?: {
+            width: boolean;
+            height: boolean;
+          };
+          /**
+           * Fixed aspect ratio constraint (e.g., '16:9', '4:3', '1:1', '1.91:1')
+           */
+          aspect_ratio?: string;
+        };
       }
     | {
+        /**
+         * Semantic role of this rendered piece (e.g., 'primary', 'companion', 'mobile_variant')
+         */
+        role: string;
         parameters_from_format_id: true;
       }
   )[];
@@ -15959,10 +16011,6 @@ export type AssetRequirements =
   | DAASTAssetRequirements
   | URLAssetRequirements
   | WebhookAssetRequirements;
-/**
- * Unit of measurement for width/height values. Defaults to 'px' when absent. Print formats use 'inches' or 'cm'.
- */
-export type DimensionUnit = 'px' | 'dp' | 'inches' | 'cm' | 'mm' | 'pt';
 /**
  * Requirements for image creative assets. These define the technical constraints for image files.
  */

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-05-02T16:13:48.842Z
+// Generated at: 2026-05-02T20:06:19.119Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -3258,6 +3258,8 @@ export const FlightItemSchema = z.object({
 
 export const FormatIDParameterSchema = z.union([z.literal("dimensions"), z.literal("duration")]);
 
+export const DimensionUnitSchema = z.union([z.literal("px"), z.literal("dp"), z.literal("inches"), z.literal("cm"), z.literal("mm"), z.literal("pt")]);
+
 export const OverlaySchema = z.object({
     id: z.string(),
     description: z.string().optional(),
@@ -3437,6 +3439,31 @@ export const RealEstateItemSchema = z.object({
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
+export const ImageAssetRequirementsSchema = z.object({
+    min_width: z.number().optional(),
+    max_width: z.number().optional(),
+    min_height: z.number().optional(),
+    max_height: z.number().optional(),
+    unit: DimensionUnitSchema.optional(),
+    aspect_ratio: z.string().optional(),
+    formats: z.array(z.union([z.literal("jpg"), z.literal("jpeg"), z.literal("png"), z.literal("gif"), z.literal("webp"), z.literal("svg"), z.literal("avif"), z.literal("tiff"), z.literal("pdf"), z.literal("eps")])).optional(),
+    min_dpi: z.number().optional(),
+    bleed: z.union([z.object({
+            uniform: z.number()
+        }).passthrough(), z.object({
+            top: z.number(),
+            right: z.number(),
+            bottom: z.number(),
+            left: z.number()
+        }).passthrough()]).optional(),
+    color_space: z.union([z.literal("rgb"), z.literal("cmyk"), z.literal("grayscale")]).optional(),
+    max_file_size_kb: z.number().optional(),
+    transparency_required: z.boolean().optional(),
+    animation_allowed: z.boolean().optional(),
+    max_animation_duration_ms: z.number().optional(),
+    max_weight_grams: z.number().optional()
+}).passthrough();
+
 export const VideoAssetRequirementsSchema = z.object({
     min_width: z.number().optional(),
     max_width: z.number().optional(),
@@ -3527,33 +3554,6 @@ export const URLAssetRequirementsSchema = z.object({
 
 export const WebhookAssetRequirementsSchema = z.object({
     methods: z.array(z.union([z.literal("GET"), z.literal("POST")])).optional()
-}).passthrough();
-
-export const DimensionUnitSchema = z.union([z.literal("px"), z.literal("dp"), z.literal("inches"), z.literal("cm"), z.literal("mm"), z.literal("pt")]);
-
-export const ImageAssetRequirementsSchema = z.object({
-    min_width: z.number().optional(),
-    max_width: z.number().optional(),
-    min_height: z.number().optional(),
-    max_height: z.number().optional(),
-    unit: DimensionUnitSchema.optional(),
-    aspect_ratio: z.string().optional(),
-    formats: z.array(z.union([z.literal("jpg"), z.literal("jpeg"), z.literal("png"), z.literal("gif"), z.literal("webp"), z.literal("svg"), z.literal("avif"), z.literal("tiff"), z.literal("pdf"), z.literal("eps")])).optional(),
-    min_dpi: z.number().optional(),
-    bleed: z.union([z.object({
-            uniform: z.number()
-        }).passthrough(), z.object({
-            top: z.number(),
-            right: z.number(),
-            bottom: z.number(),
-            left: z.number()
-        }).passthrough()]).optional(),
-    color_space: z.union([z.literal("rgb"), z.literal("cmyk"), z.literal("grayscale")]).optional(),
-    max_file_size_kb: z.number().optional(),
-    transparency_required: z.boolean().optional(),
-    animation_allowed: z.boolean().optional(),
-    max_animation_duration_ms: z.number().optional(),
-    max_weight_grams: z.number().optional()
 }).passthrough();
 
 export const ScalarBindingSchema = z.object({
@@ -4738,8 +4738,24 @@ export const SyncPlansRequestSchema = z.object({
         plan_id: z.string(),
         brand: BrandReferenceSchema,
         objectives: z.string(),
-        budget: z.union([z.record(z.string(), z.unknown()), z.object({
-                reallocation_unlimited: z.literal(true)
+        budget: z.union([z.object({
+                total: z.number(),
+                currency: z.string(),
+                per_seller_max_pct: z.number().optional(),
+                reallocation_threshold: z.number(),
+                allocations: z.record(z.string(), z.object({
+                        amount: z.number().optional(),
+                        max_pct: z.number().optional()
+                    }).passthrough()).optional()
+            }).passthrough(), z.object({
+                total: z.number(),
+                currency: z.string(),
+                per_seller_max_pct: z.number().optional(),
+                reallocation_unlimited: z.literal(true),
+                allocations: z.record(z.string(), z.object({
+                        amount: z.number().optional(),
+                        max_pct: z.number().optional()
+                    }).passthrough()).optional()
             }).passthrough()]),
         channels: z.object({
             required: z.array(MediaChannelSchema).optional(),
@@ -6203,7 +6219,24 @@ export const FormatSchema = z.object({
     description: z.string().optional(),
     example_url: z.string().optional(),
     accepts_parameters: z.array(FormatIDParameterSchema).optional(),
-    renders: z.array(z.union([z.record(z.string(), z.unknown()), z.object({
+    renders: z.array(z.union([z.object({
+            role: z.string(),
+            dimensions: z.object({
+                width: z.number().optional(),
+                height: z.number().optional(),
+                min_width: z.number().optional(),
+                min_height: z.number().optional(),
+                max_width: z.number().optional(),
+                max_height: z.number().optional(),
+                unit: DimensionUnitSchema.optional(),
+                responsive: z.object({
+                    width: z.boolean(),
+                    height: z.boolean()
+                }).passthrough().optional(),
+                aspect_ratio: z.string().optional()
+            }).passthrough()
+        }).passthrough(), z.object({
+            role: z.string(),
             parameters_from_format_id: z.literal(true)
         }).passthrough()])).optional(),
     assets: z.array(z.union([IndividualImageAssetSchema, IndividualVideoAssetSchema, IndividualAudioAssetSchema, IndividualTextAssetSchema, IndividualMarkdownAssetSchema, IndividualHtmlAssetSchema, IndividualCssAssetSchema, IndividualJavaScriptAssetSchema, IndividualVastAssetSchema, IndividualDaastAssetSchema, IndividualUrlAssetSchema, IndividualWebhookAssetSchema, IndividualBriefAssetSchema, IndividualCatalogAssetSchema, RepeatableGroupAssetSchema])).optional(),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -2705,6 +2705,10 @@ export interface ListCreativeFormatsRequest {
  */
 export type FormatIDParameter = 'dimensions' | 'duration';
 /**
+ * Unit of measurement for width/height values. Defaults to 'px' when absent. Print formats use 'inches' or 'cm'.
+ */
+export type DimensionUnit = 'px' | 'dp' | 'inches' | 'cm' | 'mm' | 'pt';
+/**
  * Image asset
  */
 export type IndividualImageAsset = BaseIndividualAsset;
@@ -2962,9 +2966,57 @@ export interface Format {
    */
   renders?: (
     | {
-        [k: string]: unknown | undefined;
+        /**
+         * Semantic role of this rendered piece (e.g., 'primary', 'companion', 'mobile_variant')
+         */
+        role: string;
+        /**
+         * Dimensions for this rendered piece. Defaults to pixels when unit is absent.
+         */
+        dimensions: {
+          /**
+           * Fixed width. Interpretation depends on unit (default: pixels).
+           */
+          width?: number;
+          /**
+           * Fixed height. Interpretation depends on unit (default: pixels).
+           */
+          height?: number;
+          /**
+           * Minimum width for responsive renders
+           */
+          min_width?: number;
+          /**
+           * Minimum height for responsive renders
+           */
+          min_height?: number;
+          /**
+           * Maximum width for responsive renders
+           */
+          max_width?: number;
+          /**
+           * Maximum height for responsive renders
+           */
+          max_height?: number;
+          unit?: DimensionUnit;
+          /**
+           * Indicates which dimensions are responsive/fluid
+           */
+          responsive?: {
+            width: boolean;
+            height: boolean;
+          };
+          /**
+           * Fixed aspect ratio constraint (e.g., '16:9', '4:3', '1:1', '1.91:1')
+           */
+          aspect_ratio?: string;
+        };
       }
     | {
+        /**
+         * Semantic role of this rendered piece (e.g., 'primary', 'companion', 'mobile_variant')
+         */
+        role: string;
         parameters_from_format_id: true;
       }
   )[];
@@ -11492,10 +11544,71 @@ export interface SyncPlansRequest {
      */
     budget:
       | {
-          [k: string]: unknown | undefined;
+          /**
+           * Total authorized budget.
+           */
+          total: number;
+          /**
+           * ISO 4217 currency code.
+           */
+          currency: string;
+          /**
+           * Maximum percentage of budget that can go to a single seller.
+           */
+          per_seller_max_pct?: number;
+          /**
+           * Amount above which budget reallocations require human escalation. The orchestrator can reallocate spend across sellers, channels, or purchase types up to this threshold per change without asking a human. Set equal to `total` for effectively unlimited reallocation; set to 0 to require approval for every reallocation. Separate from `plan.human_review_required`, which governs decisions affecting data subjects (targeting, creative, delivery) under GDPR Art 22 / EU AI Act Annex III. Denominated in `budget.currency`.
+           */
+          reallocation_threshold: number;
+          /**
+           * Optional budget partition across purchase types. Keys are purchase-type enum values (media_buy, rights_license, signal_activation, creative_services). When present, the governance agent validates spend against both the total and the per-type allocation. When absent, all spend counts against the single total regardless of purchase type.
+           */
+          allocations?: {
+            [k: string]:
+              | {
+                  /**
+                   * Maximum budget for this purchase type.
+                   */
+                  amount?: number;
+                  /**
+                   * Maximum percentage of total budget for this purchase type.
+                   */
+                  max_pct?: number;
+                }
+              | undefined;
+          };
         }
       | {
+          /**
+           * Total authorized budget.
+           */
+          total: number;
+          /**
+           * ISO 4217 currency code.
+           */
+          currency: string;
+          /**
+           * Maximum percentage of budget that can go to a single seller.
+           */
+          per_seller_max_pct?: number;
           reallocation_unlimited: true;
+          /**
+           * Optional budget partition across purchase types. Keys are purchase-type enum values (media_buy, rights_license, signal_activation, creative_services). When present, the governance agent validates spend against both the total and the per-type allocation. When absent, all spend counts against the single total regardless of purchase type.
+           */
+          allocations?: {
+            [k: string]:
+              | {
+                  /**
+                   * Maximum budget for this purchase type.
+                   */
+                  amount?: number;
+                  /**
+                   * Maximum percentage of total budget for this purchase type.
+                   */
+                  max_pct?: number;
+                }
+              | undefined;
+          };
         };
     /**
      * Channel constraints. If omitted, all channels are allowed.

--- a/src/lib/types/v2-5/tools.generated.ts
+++ b/src/lib/types/v2-5/tools.generated.ts
@@ -1849,9 +1849,56 @@ export interface Format {
    */
   renders?: (
     | {
-        [k: string]: unknown | undefined;
+        /**
+         * Semantic role of this rendered piece (e.g., 'primary', 'companion', 'mobile_variant')
+         */
+        role: string;
+        /**
+         * Dimensions for this rendered piece (in pixels)
+         */
+        dimensions: {
+          /**
+           * Fixed width in pixels
+           */
+          width?: number;
+          /**
+           * Fixed height in pixels
+           */
+          height?: number;
+          /**
+           * Minimum width in pixels for responsive renders
+           */
+          min_width?: number;
+          /**
+           * Minimum height in pixels for responsive renders
+           */
+          min_height?: number;
+          /**
+           * Maximum width in pixels for responsive renders
+           */
+          max_width?: number;
+          /**
+           * Maximum height in pixels for responsive renders
+           */
+          max_height?: number;
+          /**
+           * Indicates which dimensions are responsive/fluid
+           */
+          responsive?: {
+            width: boolean;
+            height: boolean;
+          };
+          /**
+           * Fixed aspect ratio constraint (e.g., '16:9', '4:3', '1:1')
+           */
+          aspect_ratio?: string;
+        };
       }
     | {
+        /**
+         * Semantic role of this rendered piece (e.g., 'primary', 'companion', 'mobile_variant')
+         */
+        role: string;
         parameters_from_format_id: true;
       }
   )[];

--- a/src/lib/utils/format-render-builders.ts
+++ b/src/lib/utils/format-render-builders.ts
@@ -1,3 +1,5 @@
+import type { DimensionUnit } from '../types/core.generated';
+
 // Typed factory helpers for `Format.renders[]` entries (format declarations
 // returned by `list_creative_formats`).
 //
@@ -27,7 +29,7 @@ export interface RenderDimensions {
   width: number;
   height: number;
   /** Unit defaults to pixels. Set explicitly for non-pixel formats (e.g. DOOH physical dimensions). */
-  unit?: string;
+  unit?: DimensionUnit;
 }
 
 /** Fixed-dimensions render — display banners, video placements, any format with a known W×H. */

--- a/test/lib/format-render-builders.test.js
+++ b/test/lib/format-render-builders.test.js
@@ -24,11 +24,12 @@ test('parameterizedRender auto-injects parameters_from_format_id: true', () => {
 });
 
 test('displayRender supports non-pixel units (e.g. DOOH physical dimensions)', () => {
+  // Schema's `dimension-unit` enum: 'px' | 'dp' | 'inches' | 'cm' | 'mm' | 'pt'
   const render = displayRender({
     role: 'primary',
-    dimensions: { width: 12, height: 8, unit: 'feet' },
+    dimensions: { width: 12, height: 8, unit: 'inches' },
   });
-  assert.strictEqual(render.dimensions.unit, 'feet');
+  assert.strictEqual(render.dimensions.unit, 'inches');
 });
 
 test('templateRender is an alias for parameterizedRender', () => {

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -370,6 +370,101 @@ describe('CreativeBuilderPlatform + AudiencePlatform wiring', () => {
     assert.ok(sawReq, 'generative builder.buildCreative invoked');
   });
 
+  it('list_creative_formats dispatches through platform.creative.listCreativeFormats (#1324)', async () => {
+    // Creative-template / creative-generative agents that own format
+    // catalogs implement listCreativeFormats on CreativeBuilderPlatform.
+    // Pre-#1324, the only way to wire it was via the v5 escape hatch
+    // (`opts.creative.listCreativeFormats`) — the typed-platform path
+    // didn't model it.
+    let sawReq;
+    const platform = {
+      capabilities: {
+        specialisms: ['creative-template'],
+        creative_agents: [],
+        channels: ['display'],
+        pricingModels: ['cpm'],
+        config: {},
+      },
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({
+          id: 'singleton',
+          name: 'Acme',
+          status: 'active',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+        }),
+      },
+      statusMappers: {},
+      creative: {
+        buildCreative: async () => ({ manifest_id: 'mf_1', assets: [] }),
+        listCreativeFormats: async req => {
+          sawReq = req;
+          return {
+            formats: [
+              {
+                format_id: { id: 'standard_300x250', agent_url: 'https://example.com/mcp' },
+                name: 'Standard Display',
+                renders: [{ role: 'primary', dimensions: { width: 300, height: 250 } }],
+              },
+            ],
+          };
+        },
+      },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'creative-template',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'list_creative_formats', arguments: {} },
+    });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(sawReq, 'creative.listCreativeFormats should be invoked');
+    assert.strictEqual(result.structuredContent.formats[0].format_id.id, 'standard_300x250');
+  });
+
+  it('list_creative_formats against creative platform without listCreativeFormats returns UNSUPPORTED_FEATURE (#1324)', async () => {
+    const platform = {
+      capabilities: {
+        specialisms: ['creative-template'],
+        creative_agents: [],
+        channels: ['display'],
+        pricingModels: ['cpm'],
+        config: {},
+      },
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({
+          id: 'singleton',
+          name: 'Acme',
+          status: 'active',
+          metadata: {},
+          authInfo: { kind: 'api_key' },
+        }),
+      },
+      statusMappers: {},
+      creative: {
+        buildCreative: async () => ({ manifest_id: 'mf_1', assets: [] }),
+        // No listCreativeFormats — adopters who delegate via creative_agents
+        // declarations omit it; framework returns UNSUPPORTED_FEATURE.
+      },
+    };
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'creative-template',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'list_creative_formats', arguments: {} },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.match(result.structuredContent.adcp_error?.code ?? '', /UNSUPPORTED_FEATURE/);
+  });
+
   it('F13: preview_creative against builder without previewCreative returns UNSUPPORTED_FEATURE', async () => {
     // Generative-only platforms that omit previewCreative MUST surface
     // an UNSUPPORTED_FEATURE error to buyers calling preview_creative,


### PR DESCRIPTION
## Summary

Three coordinated fixes that surfaced together while building the worked-reference creative-template adapter (#1274 lineage). Each closes a distinct DX gap; they share the no-account / typed-handler / typed-Format surface so they ship as one PR.

- **Closes #1324** — `listCreativeFormats?` on `CreativeBuilderPlatform` and `CreativeAdServerPlatform`
- **Closes #1325** — `Format.renders[]` codegen tightening (no more `{ [k: string]: unknown }`)
- **Closes #1327** — `NoAccountCtx<TCtxMeta>` narrows `ctx.account` for no-account tools at compile time

## Changes

### #1324 — `listCreativeFormats?` on creative platforms

`listCreativeFormats?(req, ctx)` is now modeled on both `CreativeBuilderPlatform` and `CreativeAdServerPlatform`, dispatched through `buildCreativeHandlers` (`from-platform.ts`). Pre-fix, every creative-agent adopter that owned a format catalog had to drop down to the v5 escape hatch (`opts.creative.listCreativeFormats`) — the typed-platform path didn't carry the surface. Adopters who delegate via `capabilities.creative_agents` continue to omit; framework returns `UNSUPPORTED_FEATURE`.

### #1325 — codegen tightening for `Format.renders[]`

New `flattenMutualExclusiveOneOf` preprocess in `scripts/generate-types.ts` detects the JSON Schema "X xor Y" idiom (`oneOf` branches with `{ required: [X], not: { required: [Y] } }` and no other keys) and inlines parent properties per branch with the excluded fields removed. The mutual-exclusivity constraint stays enforced at runtime by Ajv against the unstripped schema; the codegen pass only widens what TypeScript can express.

`Format.renders[]` is now:
```ts
renders?: (
  | { role: string; dimensions: { width?: number; height?: number; ... } }
  | { role: string; parameters_from_format_id: true }
)[];
```

Both branches are closed shapes — `displayRender({...})` and `parameterizedRender({...})` compose cleanly under strict tsc. Same fix benefits `sync_plans` plan budget (`reallocation_threshold` xor `reallocation_unlimited`), which had the identical loose-arm shape.

`RenderDimensions.unit` tightened from `string` to the schema's `DimensionUnit` enum (`'px' | 'dp' | 'inches' | 'cm' | 'mm' | 'pt'`) — adopters who passed `unit: 'feet'` or other off-spec strings will now see a TS error.

### #1327 — `NoAccountCtx<TCtxMeta>` for no-account tools

New `NoAccountCtx<TCtxMeta>` type in `account.ts` whose `account: Account<TCtxMeta> | undefined`. Applied to:

- `CreativeBuilderPlatform.previewCreative?`
- `CreativeBuilderPlatform.listCreativeFormats?` (new)
- `CreativeAdServerPlatform.previewCreative`
- `CreativeAdServerPlatform.listCreativeFormats?` (new)
- `SalesPlatform.providePerformanceFeedback?`
- `SalesPlatform.listCreativeFormats?`

Same shape as the `definePlatformWithCompliance` fix in #1262 — converts a runtime gate (`Cannot read properties of undefined (reading 'ctx_metadata')` deep in upstream calls) into a compile-time invariant. The runtime dispatch was already passing `ctx.account === undefined` for these tools whenever `accounts.resolve(undefined)` returned null; this PR makes the compiler force the narrow at authorship.

## Test plan

- [x] `npm test` — 7,485 pass, 7 skipped, 0 fail
- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] New runtime tests in `test/server-decisioning-from-platform.test.js` cover `listCreativeFormats` dispatch + UNSUPPORTED_FEATURE
- [x] New type-only tests in `decisioning.type-checks.ts` cover (a) `displayRender` assignability to `Format['renders']`, (b) positive `previewCreative` narrow, (c) negative `@ts-expect-error` regression alarm on unnarrowed `ctx.account.ctx_metadata` access
- [x] Reviewed by ad-tech-protocol-expert (sound-with-caveats; nits addressed), code-reviewer (no blockers; must-fix and nits addressed), dx-expert (ship; doc follow-ups noted)

## Migration notes

Three changesets included:
- `creative-list-creative-formats.md` (minor) — new platform method
- `format-renders-codegen-tighten.md` (patch) — codegen + RenderDimensions.unit narrow
- `no-account-ctx-narrow.md` (minor) — `NoAccountCtx` typing change

Adopters of `'derived'` resolution stores that always return a singleton are unaffected at runtime, but the compiler will now require `if (!ctx.account) ...` narrows in `previewCreative` / `listCreativeFormats` / `providePerformanceFeedback` handlers. Migration guidance is in the `no-account-ctx-narrow` changeset and the `NoAccountCtx` JSDoc.

## Follow-ups (not in this PR)

DX expert flagged skill / migration-doc updates. Out of scope for this PR; will follow:
- `skills/build-creative-agent/SKILL.md` — show `if (!ctx.account)` narrow in cookbook examples
- `skills/build-decisioning-creative-template/SKILL.md` — update `previewCreative` example signature
- `docs/migration-4.x-to-5.x.md` — add 5.x → next-minor stanza for the codegen tightening + `NoAccountCtx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)