### PR TITLE
feat(server): accounts.resolve security presets (#1339)

### DIFF
--- a/.changeset/resolve-presets.md
+++ b/.changeset/resolve-presets.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): `accounts.resolve` security presets — `requireAccountMatch`, `requireAdvertiserMatch`, `requireOrgScope`. Standardize the post-resolve authorization pattern multi-tenant adopters reach for ("the inner resolver found the account, but is the calling principal authorized for it?") so each adopter doesn't roll their own. Compose with `composeMethod` over `accounts.resolve`; default deny is `null` (avoids principal enumeration) with opt-in `onDeny: 'throw'` for `PermissionDeniedError`. Closes #1339.

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -137,6 +137,12 @@ export type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor
 export { composeMethod } from './compose';
 export type { ComposeHooks, ComposeShortCircuit } from './compose';
 
+// `accounts.resolve` security presets (closes #1339) — canonical post-resolve
+// guards that standardize the multi-tenant authorization pattern instead of
+// every adopter rolling their own.
+export { requireAccountMatch, requireAdvertiserMatch, requireOrgScope } from './resolve-presets';
+export type { ResolveAccountHooks, ResolveGuardOptions } from './resolve-presets';
+
 // Specialism interfaces (v1.0)
 export type {
   CreativeBuilderPlatform,

--- a/src/lib/server/decisioning/resolve-presets.ts
+++ b/src/lib/server/decisioning/resolve-presets.ts
@@ -1,0 +1,182 @@
+/**
+ * `composeMethod` presets for `accounts.resolve`. Standardize the security
+ * pattern multi-tenant adopters reach for: "the inner resolver found the
+ * account, but is the calling principal authorized for it?"
+ *
+ * Hooks here run as `after` on a `composeMethod`-wrapped `accounts.resolve`.
+ * When `inner` returns `null` they propagate `null` (no predicate runs);
+ * otherwise they call the predicate, and on deny return `null` (default —
+ * indistinguishable from "not found", guards against principal enumeration)
+ * or throw {@link PermissionDeniedError} (typed wire error; use only when
+ * the principal already knows the account exists).
+ *
+ * Closes adcp-client#1339.
+ *
+ * @public
+ */
+
+import type { AccountReference } from '../../types/tools.generated';
+import type { Account, ResolveContext } from './account';
+import type { ComposeHooks } from './compose';
+import { PermissionDeniedError } from './errors-typed';
+
+/**
+ * Hook shape for `composeMethod` over `accounts.resolve`. Exported for
+ * adopters writing their own helpers atop these presets.
+ *
+ * @public
+ */
+export type ResolveAccountHooks<TCtxMeta = Record<string, unknown>> = ComposeHooks<
+  AccountReference | undefined,
+  ResolveContext | undefined,
+  Account<TCtxMeta> | null
+>;
+
+/**
+ * Common options for resolve-time guards.
+ *
+ * @public
+ */
+export interface ResolveGuardOptions {
+  /**
+   * Behavior when the predicate denies.
+   *  - `'null'` (default) — return `null`. Buyer sees `ACCOUNT_NOT_FOUND`,
+   *    same as a genuinely-unknown account. Avoids principal enumeration.
+   *  - `'throw'` — throw {@link PermissionDeniedError}. Surfaces a typed
+   *    error to the buyer; use only when the principal is already known
+   *    to be allowed to know the account exists.
+   */
+  onDeny?: 'null' | 'throw';
+
+  /**
+   * Action label attached to {@link PermissionDeniedError} when
+   * `onDeny: 'throw'`. Defaults to `'accounts.resolve'`.
+   */
+  action?: string;
+}
+
+/**
+ * General-purpose post-resolve guard. After the wrapped `accounts.resolve`
+ * runs, calls `predicate(account, ctx)`; on `false` denies per `onDeny`.
+ *
+ * Building block for the specialized presets below; reach for it directly
+ * when your authorization rule needs custom logic.
+ *
+ * @example
+ * ```ts
+ * import { composeMethod, requireAccountMatch } from '@adcp/sdk/server';
+ *
+ * accounts: {
+ *   resolve: composeMethod(
+ *     baseResolve,
+ *     requireAccountMatch((account, ctx) =>
+ *       account.account_scope === 'brand' && ctx?.agent?.id === account.brand?.id
+ *     )
+ *   ),
+ * }
+ * ```
+ *
+ * @public
+ */
+export function requireAccountMatch<TCtxMeta = Record<string, unknown>>(
+  predicate: (account: Account<TCtxMeta>, ctx: ResolveContext | undefined) => boolean | Promise<boolean>,
+  options: ResolveGuardOptions = {}
+): ResolveAccountHooks<TCtxMeta> {
+  const onDeny = options.onDeny ?? 'null';
+  const action = options.action ?? 'accounts.resolve';
+  return {
+    after: async (result, _params, ctx) => {
+      if (result === null) return null;
+      const ok = await predicate(result, ctx);
+      if (ok) return result;
+      if (onDeny === 'throw') {
+        throw new PermissionDeniedError(action);
+      }
+      return null;
+    },
+  };
+}
+
+/**
+ * Gate resolved accounts on `account.advertiser` ∈ roster. Canonical
+ * multi-tenant pattern: each calling principal is configured with a list
+ * of advertisers it may transact for; the inner resolver finds the
+ * account by reference, this preset rejects when the resolved
+ * advertiser isn't in the roster.
+ *
+ * `getRoster` receives the `ResolveContext` and returns the principal's
+ * allowed advertisers (any iterable of strings — array, Set, async lookup).
+ * Accounts whose `advertiser` is undefined are denied.
+ *
+ * Equivalent to {@link requireAccountMatch} with an advertiser-extraction
+ * predicate; sugar for the canonical shape.
+ *
+ * @example
+ * ```ts
+ * import { composeMethod, requireAdvertiserMatch } from '@adcp/sdk/server';
+ *
+ * accounts: {
+ *   resolve: composeMethod(
+ *     baseResolve,
+ *     requireAdvertiserMatch(async (ctx) => tenantRoster.for(ctx?.agent))
+ *   ),
+ * }
+ * ```
+ *
+ * @public
+ */
+export function requireAdvertiserMatch<TCtxMeta = Record<string, unknown>>(
+  getRoster: (ctx: ResolveContext | undefined) => Iterable<string> | Promise<Iterable<string>>,
+  options: ResolveGuardOptions = {}
+): ResolveAccountHooks<TCtxMeta> {
+  return requireAccountMatch<TCtxMeta>(async (account, ctx) => {
+    const advertiser = account.advertiser;
+    if (advertiser === undefined) return false;
+    const roster = await getRoster(ctx);
+    for (const allowed of roster) {
+      if (allowed === advertiser) return true;
+    }
+    return false;
+  }, options);
+}
+
+/**
+ * Gate resolved accounts on org scope: account-side org extractor + ctx-side
+ * org extractor + equality. Use when "is this principal in the same org as
+ * this account?" is the authorization rule.
+ *
+ * Both extractors must return a defined string for the check to pass; either
+ * returning `undefined` denies. Caller is responsible for whatever
+ * normalization (case-folding, trim, alias resolution) is appropriate for
+ * the org identifier shape — the preset compares with strict equality.
+ *
+ * @example
+ * ```ts
+ * import { composeMethod, requireOrgScope } from '@adcp/sdk/server';
+ *
+ * accounts: {
+ *   resolve: composeMethod(
+ *     baseResolve,
+ *     requireOrgScope(
+ *       (account) => account.ctx_metadata.orgId,
+ *       (ctx) => ctx?.authInfo?.extra?.orgId as string | undefined
+ *     )
+ *   ),
+ * }
+ * ```
+ *
+ * @public
+ */
+export function requireOrgScope<TCtxMeta = Record<string, unknown>>(
+  getAccountOrg: (account: Account<TCtxMeta>) => string | undefined,
+  getCtxOrg: (ctx: ResolveContext | undefined) => string | undefined,
+  options: ResolveGuardOptions = {}
+): ResolveAccountHooks<TCtxMeta> {
+  return requireAccountMatch<TCtxMeta>((account, ctx) => {
+    const accountOrg = getAccountOrg(account);
+    if (accountOrg === undefined) return false;
+    const ctxOrg = getCtxOrg(ctx);
+    if (ctxOrg === undefined) return false;
+    return accountOrg === ctxOrg;
+  }, options);
+}

--- a/test/server-decisioning-resolve-presets.test.js
+++ b/test/server-decisioning-resolve-presets.test.js
@@ -1,0 +1,282 @@
+// Tests for #1339 — accounts.resolve security presets layered with
+// composeMethod (requireAccountMatch / requireAdvertiserMatch /
+// requireOrgScope).
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { composeMethod } = require('../dist/lib/server/decisioning/compose');
+const {
+  requireAccountMatch,
+  requireAdvertiserMatch,
+  requireOrgScope,
+} = require('../dist/lib/server/decisioning/resolve-presets');
+const { AdcpError } = require('../dist/lib/server/decisioning/async-outcome');
+
+const buildAccount = (overrides = {}) => ({
+  id: 'acc_1',
+  name: 'Acme',
+  status: 'active',
+  ctx_metadata: {},
+  ...overrides,
+});
+
+describe('requireAccountMatch (#1339)', () => {
+  it('passes through the account when predicate returns true', async () => {
+    const inner = async () => buildAccount({ advertiser: 'acme.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAccountMatch(() => true)
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result.id, 'acc_1');
+  });
+
+  it('returns null when predicate denies (default onDeny)', async () => {
+    const inner = async () => buildAccount({ advertiser: 'acme.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAccountMatch(() => false)
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result, null);
+  });
+
+  it('throws PermissionDeniedError when predicate denies and onDeny=throw', async () => {
+    const inner = async () => buildAccount();
+    const wrapped = composeMethod(
+      inner,
+      requireAccountMatch(() => false, { onDeny: 'throw', action: 'accounts.resolve.test' })
+    );
+    await assert.rejects(
+      () => wrapped({ account_id: 'acc_1' }, {}),
+      err => {
+        assert.ok(err instanceof AdcpError, 'expected AdcpError');
+        assert.strictEqual(err.code, 'PERMISSION_DENIED');
+        assert.strictEqual(err.details?.action, 'accounts.resolve.test');
+        return true;
+      }
+    );
+  });
+
+  it('propagates null from inner without invoking the predicate', async () => {
+    const inner = async () => null;
+    let predicateCalled = false;
+    const wrapped = composeMethod(
+      inner,
+      requireAccountMatch(() => {
+        predicateCalled = true;
+        return false;
+      })
+    );
+    const result = await wrapped({ account_id: 'unknown' }, {});
+    assert.strictEqual(result, null);
+    assert.strictEqual(predicateCalled, false, 'predicate must not run on null');
+  });
+
+  it('passes the resolved account and ctx into the predicate', async () => {
+    const inner = async () => buildAccount({ advertiser: 'acme.com' });
+    let sawAccount;
+    let sawCtx;
+    const wrapped = composeMethod(
+      inner,
+      requireAccountMatch((account, ctx) => {
+        sawAccount = account;
+        sawCtx = ctx;
+        return true;
+      })
+    );
+    await wrapped({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', principal: 'p1' } });
+    assert.strictEqual(sawAccount.advertiser, 'acme.com');
+    assert.deepStrictEqual(sawCtx, { authInfo: { kind: 'oauth', principal: 'p1' } });
+  });
+
+  it('awaits async predicates', async () => {
+    const inner = async () => buildAccount();
+    const wrapped = composeMethod(
+      inner,
+      requireAccountMatch(async () => {
+        await new Promise(resolve => setImmediate(resolve));
+        return false;
+      })
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result, null);
+  });
+});
+
+describe('requireAdvertiserMatch (#1339)', () => {
+  it('allows accounts whose advertiser is in the roster', async () => {
+    const inner = async () => buildAccount({ advertiser: 'acme.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(() => ['nike.com', 'acme.com'])
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result.advertiser, 'acme.com');
+  });
+
+  it('denies accounts whose advertiser is not in the roster', async () => {
+    const inner = async () => buildAccount({ advertiser: 'evil.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(() => ['acme.com'])
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result, null);
+  });
+
+  it('denies accounts with no advertiser set', async () => {
+    const inner = async () => buildAccount();
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(() => ['acme.com'])
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result, null);
+  });
+
+  it('threads ctx into the roster getter for per-principal rosters', async () => {
+    const rosterByAgent = {
+      agent_a: ['acme.com'],
+      agent_b: ['nike.com'],
+    };
+    const inner = async () => buildAccount({ advertiser: 'acme.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(ctx => rosterByAgent[ctx?.agent?.id ?? ''] ?? [])
+    );
+
+    const okResult = await wrapped({ account_id: 'acc_1' }, { agent: { id: 'agent_a' } });
+    assert.strictEqual(okResult?.advertiser, 'acme.com');
+
+    const denyResult = await wrapped({ account_id: 'acc_1' }, { agent: { id: 'agent_b' } });
+    assert.strictEqual(denyResult, null);
+
+    const noAgentResult = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(noAgentResult, null);
+  });
+
+  it('accepts an async roster getter', async () => {
+    const inner = async () => buildAccount({ advertiser: 'acme.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(async () => new Set(['acme.com']))
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(result?.advertiser, 'acme.com');
+  });
+
+  it('throws PermissionDeniedError on deny when configured', async () => {
+    const inner = async () => buildAccount({ advertiser: 'evil.com' });
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(() => ['acme.com'], { onDeny: 'throw', action: 'advertiser.gate' })
+    );
+    await assert.rejects(
+      () => wrapped({ account_id: 'acc_1' }, {}),
+      err => {
+        assert.strictEqual(err.code, 'PERMISSION_DENIED');
+        assert.strictEqual(err.details?.action, 'advertiser.gate');
+        return true;
+      }
+    );
+  });
+
+  it('still propagates null from inner without invoking the roster getter', async () => {
+    const inner = async () => null;
+    let rosterCalled = false;
+    const wrapped = composeMethod(
+      inner,
+      requireAdvertiserMatch(() => {
+        rosterCalled = true;
+        return ['acme.com'];
+      })
+    );
+    const result = await wrapped({ account_id: 'unknown' }, {});
+    assert.strictEqual(result, null);
+    assert.strictEqual(rosterCalled, false);
+  });
+});
+
+describe('requireOrgScope (#1339)', () => {
+  it('allows when account-org and ctx-org match', async () => {
+    const inner = async () => buildAccount({ ctx_metadata: { orgId: 'org_42' } });
+    const wrapped = composeMethod(
+      inner,
+      requireOrgScope(
+        account => account.ctx_metadata.orgId,
+        ctx => ctx?.authInfo?.extra?.orgId
+      )
+    );
+    const result = await wrapped({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', extra: { orgId: 'org_42' } } });
+    assert.strictEqual(result?.id, 'acc_1');
+  });
+
+  it('denies when ctx-org and account-org disagree', async () => {
+    const inner = async () => buildAccount({ ctx_metadata: { orgId: 'org_42' } });
+    const wrapped = composeMethod(
+      inner,
+      requireOrgScope(
+        account => account.ctx_metadata.orgId,
+        ctx => ctx?.authInfo?.extra?.orgId
+      )
+    );
+    const result = await wrapped(
+      { account_id: 'acc_1' },
+      { authInfo: { kind: 'oauth', extra: { orgId: 'org_other' } } }
+    );
+    assert.strictEqual(result, null);
+  });
+
+  it('denies when either side is undefined', async () => {
+    const inner = async () => buildAccount({ ctx_metadata: { orgId: 'org_42' } });
+    const wrapped = composeMethod(
+      inner,
+      requireOrgScope(
+        account => account.ctx_metadata.orgId,
+        ctx => ctx?.authInfo?.extra?.orgId
+      )
+    );
+
+    const noCtxOrg = await wrapped({ account_id: 'acc_1' }, {});
+    assert.strictEqual(noCtxOrg, null);
+
+    const innerNoOrg = async () => buildAccount({ ctx_metadata: {} });
+    const wrappedNoAcct = composeMethod(
+      innerNoOrg,
+      requireOrgScope(
+        account => account.ctx_metadata.orgId,
+        ctx => ctx?.authInfo?.extra?.orgId
+      )
+    );
+    const noAcctOrg = await wrappedNoAcct(
+      { account_id: 'acc_1' },
+      { authInfo: { kind: 'oauth', extra: { orgId: 'org_42' } } }
+    );
+    assert.strictEqual(noAcctOrg, null);
+  });
+});
+
+describe('resolve-presets composition (#1339)', () => {
+  it('layers naturally inside a real DecisioningPlatform.accounts.resolve shape', async () => {
+    // Realistic shape: base resolves by ref into a per-tenant DB,
+    // requireAdvertiserMatch enforces the configured advertiser roster.
+    const db = {
+      acc_1: buildAccount({ id: 'acc_1', advertiser: 'acme.com' }),
+      acc_2: buildAccount({ id: 'acc_2', advertiser: 'evil.com' }),
+    };
+    const baseResolve = async ref => (ref?.account_id ? (db[ref.account_id] ?? null) : null);
+    const tenantRoster = ['acme.com'];
+
+    const resolve = composeMethod(
+      baseResolve,
+      requireAdvertiserMatch(() => tenantRoster)
+    );
+
+    assert.strictEqual((await resolve({ account_id: 'acc_1' }, {}))?.advertiser, 'acme.com');
+    assert.strictEqual(await resolve({ account_id: 'acc_2' }, {}), null);
+    assert.strictEqual(await resolve({ account_id: 'unknown' }, {}), null);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1339. Standardizes the post-resolve authorization pattern multi-tenant adopters reach for — *"the inner resolver found the account, but is the calling principal authorized for it?"* — instead of every adopter rolling their own.

Three exports composing with `composeMethod` over `accounts.resolve`:

- **`requireAccountMatch(predicate, options?)`** — general post-resolve guard
- **`requireAdvertiserMatch(getRoster, options?)`** — gate on `account.advertiser ∈ roster`
- **`requireOrgScope(getAccountOrg, getCtxOrg, options?)`** — gate on `(account org === ctx org)`

```ts
import { composeMethod, requireAdvertiserMatch } from '@adcp/sdk/server';

accounts: {
  resolve: composeMethod(
    baseResolve,
    requireAdvertiserMatch(async (ctx) => tenantRoster.for(ctx?.agent))
  ),
}
```

## Deny semantics

Default `onDeny: 'null'` returns `null` from the wrapped resolver — buyer sees `ACCOUNT_NOT_FOUND`, indistinguishable from a genuinely unknown account. Avoids principal enumeration; matches the canonical `accounts.resolve` failure shape documented on `AccountStore.resolve`.

Opt-in `onDeny: 'throw'` surfaces `PermissionDeniedError` to the buyer. Use only when the principal is already known to be allowed to know the account exists.

The `null`-from-inner case short-circuits — predicates / roster getters do not run when the inner resolver couldn't find the account.

## Test plan

- [x] 17 new unit tests in `test/server-decisioning-resolve-presets.test.js` covering: pass/deny semantics, null short-circuit, async predicates/rosters, ctx threading, throw mode with `action` label propagation, and a realistic composition fixture
- [x] Existing `composeMethod` tests still pass (`test/server-decisioning-compose.test.js`, 10 tests)
- [x] `npm run build:lib` clean
- [x] `npm run format:check` clean
- [x] Changeset added (minor — additive surface)

## Source

Item 1 in the [doha-v20 SDK asks](https://github.com/adcontextprotocol/adcp-client/issues/1339) drafted while migrating an adapter against current SDK HEAD. The companion docs/test-patterns issue (#1345) will reference these once they ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)