### PR TITLE
docs(upstream-recorder): multi-tenant factory pattern + llms.txt mention

### DIFF
--- a/.changeset/upstream-recorder-multi-tenant-doc.md
+++ b/.changeset/upstream-recorder-multi-tenant-doc.md
@@ -1,0 +1,4 @@
+---
+---
+
+Documentation-only: build-seller-agent SKILL gains a "Multi-tenant adopters" section showing the `registerTestController` factory-shape pattern with per-request principal resolution (OAuth client_credentials / session-token / explicit-anonymous-rejection branches), and `docs/llms.txt` gains a paragraph surfacing `@adcp/sdk/upstream-recorder` to coding agents. No code changes; no published-package change.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1165,6 +1165,12 @@ Group A storyboards seed fixtures via `comply_test_controller.seed_product` (and
 
 Wire on `createAdcpServer({ testController: bridgeFromTestControllerStore(store, baseline) })`. See `skills/build-seller-agent/SKILL.md` for the full pattern alongside `createComplyController`.
 
+### Anti-façade upstream-traffic recording (`@adcp/sdk/upstream-recorder`)
+
+Storyboards declaring `check: upstream_traffic` (runner-output-contract v2.0.0, spec PR adcontextprotocol/adcp#3816) verify that an adapter actually called its upstream platform with the storyboard-supplied identifiers — distinguishing a real adapter from one returning shape-valid AdCP responses without touching upstream. Adopters opt in by advertising `query_upstream_traffic` on their `comply_test_controller`.
+
+`@adcp/sdk/upstream-recorder` is the producer-side reference middleware: a sandbox-only-by-default helper that wraps the adapter's HTTP layer with per-principal isolation, record-time secret redaction, ring-buffer + TTL eviction, and a `query()` method that maps onto the controller wire shape via `toQueryUpstreamTrafficResponse()`. Wire-up is four steps — boot recorder, wrap fetch, scope handlers in `runWithPrincipal`, return `toQueryUpstreamTrafficResponse(recorder.query(...))` from your `comply_test_controller`'s `query_upstream_traffic` scenario. Worked example at `examples/hello_seller_adapter_signal_marketplace.ts`. See `skills/build-seller-agent/SKILL.md` § "Opting into `upstream_traffic`" for the full pattern, including multi-tenant principal resolution.
+
 ## Key Types
 
 See docs/TYPE-SUMMARY.md for field-level detail. Key types at a glance:

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -908,6 +908,18 @@ function generateLlmsTxt(
   );
   ln();
 
+  // --- Anti-façade upstream-traffic recorder ---
+  ln(`### Anti-façade upstream-traffic recording (\`@adcp/sdk/upstream-recorder\`)`);
+  ln();
+  ln(
+    `Storyboards declaring \`check: upstream_traffic\` (runner-output-contract v2.0.0, spec PR adcontextprotocol/adcp#3816) verify that an adapter actually called its upstream platform with the storyboard-supplied identifiers — distinguishing a real adapter from one returning shape-valid AdCP responses without touching upstream. Adopters opt in by advertising \`query_upstream_traffic\` on their \`comply_test_controller\`.`
+  );
+  ln();
+  ln(
+    `\`@adcp/sdk/upstream-recorder\` is the producer-side reference middleware: a sandbox-only-by-default helper that wraps the adapter's HTTP layer with per-principal isolation, record-time secret redaction, ring-buffer + TTL eviction, and a \`query()\` method that maps onto the controller wire shape via \`toQueryUpstreamTrafficResponse()\`. Wire-up is four steps — boot recorder, wrap fetch, scope handlers in \`runWithPrincipal\`, return \`toQueryUpstreamTrafficResponse(recorder.query(...))\` from your \`comply_test_controller\`'s \`query_upstream_traffic\` scenario. Worked example at \`examples/hello_seller_adapter_signal_marketplace.ts\`. See \`skills/build-seller-agent/SKILL.md\` § "Opting into \`upstream_traffic\`" for the full pattern, including multi-tenant principal resolution.`
+  );
+  ln();
+
   // --- Key types ---
   ln(`## Key Types`);
   ln();

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -950,7 +950,82 @@ registerTestController(adcpServer, {
 });
 ```
 
-For multi-tenant adopters where principal varies per request, use the factory shape — `createStore: async input => ({ queryUpstreamTraffic: ... })` — so the resolver runs once per request with access to the controller request's `account` block.
+#### Multi-tenant adopters: factory shape with per-request principal resolution
+
+The wire-up above hardcodes `RECORDER_PRINCIPAL` because the example uses static-API-key auth (one principal for the whole process). Multi-tenant adopters — OAuth `client_credentials` sellers, session-token sellers, anyone whose `comply_test_controller` request can come from different tenants — MUST resolve the principal **per request** so cross-tenant isolation actually holds. Use `registerTestController`'s factory shape, which runs a fresh `createStore` per request with access to the controller's input:
+
+```ts
+import { CONTROLLER_SCENARIOS } from '@adcp/sdk/server';
+
+registerTestController(adcpServer, {
+  // Static capability list — answered without invoking createStore so
+  // list_scenarios pings don't pay a session-rehydration cost.
+  scenarios: [
+    CONTROLLER_SCENARIOS.FORCE_CREATIVE_STATUS,
+    // ... your existing canonical scenarios ...
+    'query_upstream_traffic', // extension scenario, advertised verbatim
+  ],
+  createStore: async input => {
+    // input is the parsed comply_test_controller request — { scenario,
+    // params, context, ext, account } as the buyer sent it. Resolve the
+    // calling principal from your auth layer here.
+    const principal = await resolvePrincipal(input);
+
+    return {
+      // ... your existing force/seed/simulate methods ...
+
+      queryUpstreamTraffic: async params =>
+        toQueryUpstreamTrafficResponse(
+          recorder.query({
+            principal,
+            sinceTimestamp: params.since_timestamp,
+            endpointPattern: params.endpoint_pattern,
+            limit: params.limit,
+          })
+        ),
+    };
+  },
+});
+```
+
+The `resolvePrincipal(input)` resolver is where adopter auth-layer choice lives:
+
+```ts
+async function resolvePrincipal(input: Record<string, unknown>): Promise<string> {
+  // OAuth client_credentials: derive from your token-introspection cache,
+  // keyed off the bearer the request arrived with. The same principal
+  // string MUST be returned by your handler-side `runWithPrincipal(p, fn)`
+  // wrapper — keep both call sites pointing at one resolver.
+  const oauth = await loadOAuthSession(input);
+  if (oauth) return oauth.client_id;
+
+  // Session-token sellers: resolve account from the session id and use
+  // its stable account.id.
+  const session = (input.context as { session_id?: string })?.session_id;
+  if (session) {
+    const acct = await accountFromSession(session);
+    return acct.id;
+  }
+
+  // Public-sandbox adopters serving anonymous traffic: a stable
+  // per-session identifier you mint at session start. The literal
+  // string "anonymous" collides across tenants — don't use it.
+  throw new Error('No auth context available; cannot scope upstream-traffic query');
+}
+```
+
+On the AdCP-handler side, call the **same** `resolvePrincipal` from `runWithPrincipal`. The `ctx` an AdCP handler receives carries the same auth shape your controller-side `input` does (often `ctx.account`, sometimes `ctx.authInfo` for the raw transport layer). Wrap a thin shim:
+
+```ts
+async function syncAudiences(req, ctx) {
+  const principal = await resolvePrincipal(adcpCtxToControllerInput(ctx));
+  await recorder.runWithPrincipal(principal, async () => {
+    await fetch('https://platform.example/v1/audience/upload', { /* ... */ });
+  });
+}
+```
+
+If the two call sites pick the principal differently — for example, controller-side resolves from `input.account.operator` but handler-side uses `ctx.account.id` directly — your storyboard runs grade `failed` with `matched_count: 0` and the diagnostic looks identical to a façade. Use one resolver, call it from both ends.
 
 #### Adopters not on `fetch`
 


### PR DESCRIPTION
Documentation reinforcement for the upstream-recorder shipped in #1304. No code changes — fills two gaps the multi-expert review on #1304 flagged.

## Summary

- **build-seller-agent SKILL § Multi-tenant adopters**: new section between the wire-up snippet and the axios/got escape hatch. Worked code for \`registerTestController\`'s factory shape (\`scenarios + createStore\`), a \`resolvePrincipal(input)\` resolver with OAuth client_credentials / session-token / explicit-anonymous-rejection branches, and the symmetry constraint pinned: the SAME resolver MUST run on the AdCP handler side inside \`runWithPrincipal\`. Divergent resolvers between record-time and query-time look identical to a façade in storyboard output (\`matched_count: 0\`).
- **\`docs/llms.txt\`**: paragraph on \`@adcp/sdk/upstream-recorder\` under the seller-side compliance section so coding agents discovering the SDK find it. Two-line description + worked-example link.

The hardcoded \`RECORDER_PRINCIPAL\` pattern in \`examples/hello_seller_adapter_signal_marketplace.ts\` only suits single-tenant API-key auth. OAuth client_credentials sellers, session-token sellers — anyone whose \`comply_test_controller\` request can come from different tenants — MUST resolve principal per request so cross-tenant isolation actually holds. This PR adds the worked code so adopters reading the SKILL cold have an unambiguous path for whichever auth shape their seller actually runs.

## Test plan

- [x] \`npm run format:check\` clean.
- [x] No code changes — test suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)