### PR TITLE
feat(server): add InMemoryImplicitAccountStore reference adapter

### DIFF
--- a/.changeset/implicit-account-store.md
+++ b/.changeset/implicit-account-store.md
@@ -1,0 +1,12 @@
+---
+"@adcp/sdk": minor
+---
+
+Add `InMemoryImplicitAccountStore` reference adapter for `resolution: 'implicit'` platforms. Closes #1340 (partial — Postgres adapter and storyboard phases deferred; see issue for remaining scope).
+
+Platforms where buyers call `sync_accounts` before any tool no longer need to hand-roll the `authPrincipal → accounts` map. `InMemoryImplicitAccountStore` implements both `upsert()` and `resolve()` with a configurable `keyFn` (defaults to `credential.client_id` / `credential.key_id` / `credential.agent_url`) and a configurable `ttlMs` (default 24h).
+
+Also ships:
+- `docs/guides/account-resolution.md` — key-derivation rationale, `ACCOUNT_NOT_FOUND` vs `AUTH_REQUIRED` error contract, TTL guidance for durable stores
+- `examples/decisioning-platform-implicit-accounts.ts` — runnable wiring example
+- Fix deprecated `authInfo.clientId` reference in `AccountStore.resolve()` JSDoc (use `credential.client_id` / `credential.key_id`)

--- a/docs/guides/account-resolution.md
+++ b/docs/guides/account-resolution.md
@@ -1,0 +1,214 @@
+# Account Resolution Guide
+
+How sellers implement the three `AccountStore.resolution` modes — `'explicit'`,
+`'implicit'`, and `'derived'` — with a deep dive on `'implicit'` (the
+`sync_accounts`-first pattern).
+
+---
+
+## Quick reference
+
+| Mode | Buyer sends | Seller resolves via |
+|---|---|---|
+| `'explicit'` (default) | `ext.account_ref` on every request | `ref.account_id` or `ref.brand`/`ref.operator` |
+| `'implicit'` | Nothing (no `ext.account_ref`) — but must call `sync_accounts` first | `ctx.authInfo` credential key |
+| `'derived'` | Nothing | Single-tenant singleton; no per-request resolution needed |
+
+Declare the mode on `AccountStore`:
+
+```ts
+accounts: {
+  resolution: 'implicit',      // or 'explicit' (default) or 'derived'
+  resolve: async (ref, ctx) => { ... },
+  upsert: async (refs, ctx) => { ... }, // required for 'implicit'
+}
+```
+
+---
+
+## `'implicit'` deep dive
+
+### 1 · How it works
+
+1. Buyer calls `sync_accounts` with `AccountReference[]`.
+2. Framework calls your `accounts.upsert()` — you create/find accounts and
+   store the `authPrincipal → accounts` mapping.
+3. Buyer calls any tool (e.g. `create_media_buy`) without `ext.account_ref`.
+4. Framework calls `accounts.resolve(undefined, ctx)` — you look up the
+   account by `ctx.authInfo`.
+
+### 2 · Key derivation
+
+Extract the principal key from `ctx.authInfo.credential`:
+
+```ts
+resolve: async (_ref, ctx) => {
+  const cred = ctx?.authInfo?.credential;
+  const key = cred?.kind === 'oauth'    ? `oauth:${cred.client_id}`
+            : cred?.kind === 'api_key'  ? `api_key:${cred.key_id}`
+            : cred?.kind === 'http_sig' ? `http_sig:${cred.agent_url}`
+            : undefined;
+  if (!key) return null;
+  return await db.findAccountByPrincipalKey(key);
+},
+```
+
+**Why `credential.client_id`, not `authInfo.sub`?**
+
+`credential.client_id` is the OAuth *client* identity — stable across token
+rotations and independent of which user (if any) triggered the grant.
+`sub` is grant-specific: a buyer rotating credentials or switching from
+`client_credentials` to `authorization_code` will get a different `sub`
+and lose their synced accounts. Use `sub` only when your platform
+intentionally scopes accounts to individual users, and document that choice.
+
+`credential.key_id` for API-key credentialing and `credential.agent_url` for
+HTTP Signatures follow the same stability principle: they identify the buyer
+entity, not the ephemeral token.
+
+> ⚠️ `authInfo.clientId` (top-level field) is deprecated. Use
+> `authInfo.credential.client_id` instead. The deprecated field is removed
+> in N+2 of the deprecation cycle.
+
+### 3 · When no sync has happened
+
+Return `null` from `resolve()`. The framework emits `ACCOUNT_NOT_FOUND` to
+the buyer with `recovery: 'terminal'`.
+
+**Do NOT return `AUTH_REQUIRED`.** That error signals missing or rejected
+credentials — not a missing pre-sync. Buyers receiving `AUTH_REQUIRED` will
+retry with a fresh token, not call `sync_accounts`, and loop indefinitely.
+
+```ts
+// ✓ Correct
+resolve: async (_ref, ctx) => {
+  const account = await db.findByPrincipal(extractKey(ctx?.authInfo));
+  return account ?? null;  // null → ACCOUNT_NOT_FOUND
+},
+
+// ✗ Wrong — misleads buyers about how to recover
+resolve: async (_ref, ctx) => {
+  const account = await db.findByPrincipal(extractKey(ctx?.authInfo));
+  if (!account) throw new AdcpError('AUTH_REQUIRED', { message: 'call sync_accounts first' });
+  return account;
+},
+```
+
+You MAY add a `details.hint` on the `ACCOUNT_NOT_FOUND` error in your error
+normalizer (SDK extension point) if your platform's documentation mentions
+it, but the error code itself must remain `ACCOUNT_NOT_FOUND`.
+
+### 4 · TTL and sync-linkage staleness
+
+The framework has no built-in TTL for sync linkages — TTL is a seller-side
+policy. Guidance:
+
+- **In-memory stores (tests):** default to 24 hours. Use
+  `InMemoryImplicitAccountStore`'s `ttlMs` option.
+- **Durable stores (Postgres / Redis):** add a `synced_at` column and evict
+  rows older than your session or token lifetime.
+- **Align with token lifetime:** if your OAuth AS issues 1-hour access
+  tokens, a 24-hour sync TTL means a buyer's linkage outlives their token.
+  That's fine — buyers do not need to hold an active token to have their
+  accounts remain linked.
+- **Invalidation on credential rotation:** if a buyer's `client_id` changes
+  (rare — the AS should issue a new client for the new credential), the old
+  sync-linkage row becomes orphaned. Your `upsert()` should UPSERT (not
+  INSERT) on `(principal_key, account_id)` so re-syncing is idempotent.
+
+This TTL governs the *sync-linkage lifetime*, which is separate from
+`AccountStore.refreshToken` — that hook refreshes an upstream OAuth token
+mid-request when your platform method throws `AUTH_REQUIRED`. The two are
+orthogonal.
+
+**Postgres schema reference** — see `docs/guides/POSTGRES.md` for the
+canonical `adcp_sync_linkages` DDL pattern. The cleanup query there
+(`DELETE FROM ... WHERE synced_at < NOW() - INTERVAL '24 hours'`) is the
+recommended sweep pattern.
+
+---
+
+## Reference adapter: `InMemoryImplicitAccountStore`
+
+For tests and getting-started scenarios, import the built-in reference
+implementation:
+
+```ts
+import { InMemoryImplicitAccountStore } from '@adcp/sdk/server';
+import { createAdcpServer } from '@adcp/sdk/server';
+
+const accountStore = new InMemoryImplicitAccountStore({
+  // Convert a buyer's AccountReference to your platform's Account shape.
+  // Default: synthesizes a minimal Account from the ref fields.
+  buildAccount: async (ref, ctx) => {
+    const upstream = await myPlatform.findOrCreate(ref, ctx?.authInfo);
+    return {
+      id: upstream.id,
+      name: upstream.name,
+      status: 'active',
+      ctx_metadata: { upstreamId: upstream.id },
+    };
+  },
+  // Optional: override the key-extraction logic.
+  // Default: credential.client_id / credential.key_id / credential.agent_url.
+  // keyFn: authInfo => authInfo.extra?.tenant_id as string,
+  ttlMs: 86_400_000, // 24h
+});
+
+createAdcpServer({
+  accounts: accountStore,
+  // ... other platform config
+});
+```
+
+For a runnable example see `examples/decisioning-platform-implicit-accounts.ts`.
+
+### Test helper methods
+
+```ts
+accountStore.clear();                           // reset all stored linkages
+accountStore.authKey(authInfo);                 // what key would be stored?
+accountStore.size;                              // number of stored linkages
+```
+
+---
+
+## `'derived'` (single-tenant)
+
+Return a fixed singleton regardless of `ref`:
+
+```ts
+accounts: {
+  resolution: 'derived',
+  resolve: async () => ({
+    id: 'tenant_singleton',
+    name: 'My Platform',
+    status: 'active',
+    ctx_metadata: {},
+  }),
+}
+```
+
+No `upsert` needed. The framework returns `UNSUPPORTED_FEATURE` to any
+buyer that calls `sync_accounts`.
+
+---
+
+## `'explicit'` (default)
+
+Resolve from `ref.account_id` or `ref.brand`/`ref.operator`:
+
+```ts
+accounts: {
+  resolution: 'explicit',  // or omit — 'explicit' is the default
+  resolve: async (ref, ctx) => {
+    const id = refAccountId(ref);   // helper from @adcp/sdk/server
+    if (id) return db.findById(id);
+    if (ref?.brand && ref?.operator) return db.findByBrandOperator(ref.brand, ref.operator);
+    return null;
+  },
+}
+```
+
+`upsert` is optional for explicit-mode platforms. Implement it if your buyers
+need to pre-register accounts before use (e.g., credit-check gates).

--- a/docs/guides/account-resolution.md
+++ b/docs/guides/account-resolution.md
@@ -199,10 +199,12 @@ buyer that calls `sync_accounts`.
 Resolve from `ref.account_id` or `ref.brand`/`ref.operator`:
 
 ```ts
+import { refAccountId } from '@adcp/sdk/server';
+
 accounts: {
   resolution: 'explicit',  // or omit — 'explicit' is the default
   resolve: async (ref, ctx) => {
-    const id = refAccountId(ref);   // helper from @adcp/sdk/server
+    const id = refAccountId(ref);
     if (id) return db.findById(id);
     if (ref?.brand && ref?.operator) return db.findByBrandOperator(ref.brand, ref.operator);
     return null;

--- a/examples/decisioning-platform-implicit-accounts.ts
+++ b/examples/decisioning-platform-implicit-accounts.ts
@@ -1,0 +1,168 @@
+/**
+ * decisioning-platform-implicit-accounts — reference implementation showing
+ * `AccountStore.resolution: 'implicit'` wired through `createAdcpServer`.
+ *
+ * Use this when buyers must call `sync_accounts` before any tool — LinkedIn,
+ * some retail-media operators, and multi-brand programmatic platforms follow
+ * this pattern. The platform does NOT read `ext.account_ref` from tool requests;
+ * it resolves the account entirely from the caller's auth credential.
+ *
+ * Wire contract:
+ *   1. Buyer calls `sync_accounts` → `accounts.upsert()` stores the linkage.
+ *   2. Buyer calls `create_media_buy` (no ext.account_ref) →
+ *      `accounts.resolve(undefined, ctx)` looks up by auth principal.
+ *   3. If no prior sync: `ACCOUNT_NOT_FOUND` (not `AUTH_REQUIRED`).
+ *
+ * @see docs/guides/account-resolution.md
+ */
+
+import {
+  createAdcpServer,
+  serve,
+  verifyApiKey,
+  createIdempotencyStore,
+  InMemoryImplicitAccountStore,
+  AdcpError,
+  type Account,
+} from '@adcp/sdk/server';
+
+const PORT = Number(process.env['PORT'] ?? 3010);
+const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use_in_prod';
+
+// ---------------------------------------------------------------------------
+// Platform account metadata — replace with your upstream model
+// ---------------------------------------------------------------------------
+
+interface PlatformMeta {
+  platformAccountId: string;
+  tier: 'standard' | 'premium';
+}
+
+// ---------------------------------------------------------------------------
+// Implicit account store
+//
+// Stores the `authPrincipal → Account` mapping created by sync_accounts.
+// `buildAccount` is the seam to your real platform: call your account-lookup
+// or account-creation API here; the in-memory store handles the mapping.
+// ---------------------------------------------------------------------------
+
+const accountStore = new InMemoryImplicitAccountStore<PlatformMeta>({
+  buildAccount: async (ref, ctx) => {
+    const r = ref as Record<string, unknown>;
+    const brand = r['brand'] as Record<string, unknown> | undefined;
+    const operator = (r['operator'] as string | undefined) ?? '';
+    const accountId = (r['account_id'] as string | undefined) ?? `${brand?.['domain'] ?? 'unknown'}:${operator}`;
+
+    // ── REPLACE: call your upstream platform to find or create the account ──
+    // const upstream = await myPlatform.findOrCreate({ brand, operator, authInfo: ctx?.authInfo });
+    // return { id: upstream.id, name: upstream.name, status: upstream.status, ctx_metadata: ... };
+
+    const account: Account<PlatformMeta> = {
+      id: accountId,
+      name: operator ? `${operator} (${brand?.['domain'] ?? accountId})` : accountId,
+      status: 'active',
+      ...(brand && { brand: brand as Account['brand'] }),
+      ...(operator && { operator }),
+      ctx_metadata: {
+        platformAccountId: accountId,
+        tier: 'standard',
+      },
+    };
+    return account;
+  },
+  // Optional: override key derivation (default uses credential.client_id / key_id / agent_url)
+  // keyFn: authInfo => authInfo.extra?.tenant_id as string,
+  ttlMs: 86_400_000, // 24h — align with your token/session lifetime
+});
+
+// ---------------------------------------------------------------------------
+// AdCP server
+// ---------------------------------------------------------------------------
+
+const server = createAdcpServer<PlatformMeta>({
+  name: 'Implicit-Accounts Demo Seller',
+  version: '1.0.0',
+
+  accounts: accountStore,
+
+  // Minimal media-buy surface — replace with your real platform methods.
+  mediaBuy: {
+    getProducts: async (_req, ctx) => {
+      return {
+        products: [
+          {
+            id: 'prod_display',
+            name: 'Display Inventory',
+            product_type: 'display' as const,
+            pricing: { model: 'cpm' as const, rate: 5.0, currency: 'USD' },
+          },
+        ],
+      };
+    },
+
+    createMediaBuy: async (req, ctx) => {
+      // ctx.account is resolved via implicit lookup — no ext.account_ref needed.
+      const acctId = ctx.account.id;
+      const buyId = `buy_${Date.now()}`;
+      return {
+        media_buy: {
+          id: buyId,
+          name: req.name,
+          status: 'pending_review' as const,
+          account: { account_id: acctId },
+          product_id: req.product_id,
+          budget: req.budget,
+          targeting: req.targeting,
+        },
+      };
+    },
+
+    updateMediaBuy: async (req, ctx) => {
+      return {
+        media_buy: {
+          id: req.id,
+          name: req.name ?? 'Updated Buy',
+          status: 'active' as const,
+          account: { account_id: ctx.account.id },
+          product_id: 'prod_display',
+          budget: req.budget ?? { total: 0, currency: 'USD' },
+          targeting: req.targeting ?? {},
+        },
+      };
+    },
+
+    getMediaBuyDelivery: async (_req, _ctx) => {
+      const today = new Date().toISOString().split('T')[0] ?? new Date().toISOString();
+      return {
+        reporting_period: { start: today, end: today },
+        currency: 'USD',
+        media_buy_deliveries: [],
+      };
+    },
+
+    getMediaBuys: async (_req, ctx) => {
+      return { media_buys: [] };
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// HTTP server
+// ---------------------------------------------------------------------------
+
+serve({
+  servers: [server],
+  port: PORT,
+  authenticate: verifyApiKey(ADCP_AUTH_TOKEN),
+  idempotency: createIdempotencyStore(),
+})
+  .then(({ stop }) => {
+    console.log(`Implicit-accounts seller running on :${PORT}`);
+    console.log(`  resolution: 'implicit' — buyers must call sync_accounts first`);
+    console.log(`  auth: Bearer ${ADCP_AUTH_TOKEN}`);
+    process.on('SIGTERM', () => stop());
+  })
+  .catch(err => {
+    console.error('Failed to start:', err);
+    process.exit(1);
+  });

--- a/src/lib/adapters/implicit-account-store.ts
+++ b/src/lib/adapters/implicit-account-store.ts
@@ -200,6 +200,13 @@ export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> im
    * - No prior `sync_accounts` was called for this principal
    * - The stored entry has exceeded `ttlMs`
    * - `ctx.authInfo` is absent or carries no extractable key
+   *
+   * **Multi-account note.** When a buyer synced multiple refs in one
+   * `sync_accounts` call, this implementation returns the _first_ stored
+   * account. If your platform requires per-request account disambiguation
+   * (e.g., different brands on the same buyer), switch to `'explicit'` mode
+   * so buyers pass `ext.account_ref` on each request, or override `keyFn`
+   * to encode the brand into the key.
    */
   async resolve(_ref: AccountReference | undefined, ctx?: ResolveContext): Promise<Account<TCtxMeta> | null> {
     const authInfo = ctx?.authInfo;
@@ -219,15 +226,45 @@ export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> im
    * Process a `sync_accounts` payload: build accounts from refs and store
    * them under the caller's auth key.
    *
-   * The auth key is extracted from `ctx.authInfo` via `keyFn`. When
-   * `ctx.authInfo` is absent (e.g., unauthenticated call), accounts are
-   * built but NOT stored — the buyer cannot retrieve them via `resolve()`.
-   * Your `authenticate` callback in `serve({ authenticate })` should reject
-   * unauthenticated `sync_accounts` calls before reaching this method.
+   * The auth key is extracted from `ctx.authInfo` via `keyFn`. When the
+   * key cannot be derived (no credential or unrecognized credential kind),
+   * all refs are returned as `SYNC_FAILED` rows — a silent-success-then-
+   * mystery-failure sequence is worse than an explicit error. Check your
+   * `authenticate` callback and `keyFn` if you see this error.
+   *
+   * When `ctx.authInfo` is absent (unauthenticated call), all refs fail
+   * with `UNAUTHENTICATED`. Your `authenticate` callback in
+   * `serve({ authenticate })` should reject unauthenticated requests before
+   * reaching this method.
    */
   async upsert(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]> {
     const authInfo = ctx?.authInfo;
+
+    // Derive the key before building any accounts. If the key cannot be
+    // extracted, fail all rows explicitly — returning success rows here
+    // would cause a mysterious ACCOUNT_NOT_FOUND on the next tool call.
     const key = authInfo !== undefined ? this._keyFn(authInfo) : undefined;
+    if (key === undefined) {
+      return refs.map(ref => {
+        const r = ref as Record<string, unknown>;
+        return {
+          brand: (r['brand'] as BrandReference | undefined) ?? ({ domain: 'unknown' } as BrandReference),
+          operator: (r['operator'] as string | undefined) ?? '',
+          action: 'failed' as const,
+          status: 'rejected' as AdcpAccountStatus,
+          errors: [
+            {
+              code: 'SYNC_FAILED',
+              message:
+                authInfo === undefined
+                  ? 'Unauthenticated: no authInfo on ctx — check authenticate configuration'
+                  : 'Could not derive principal key from auth credential — check keyFn or credential kind',
+            },
+          ],
+        };
+      });
+    }
+
     const accounts: Account<TCtxMeta>[] = [];
     const rows: SyncAccountsResultRow[] = [];
 
@@ -264,10 +301,7 @@ export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> im
       }
     }
 
-    if (key !== undefined) {
-      this._store.set(key, { accounts, storedAt: Date.now() });
-    }
-
+    this._store.set(key, { accounts, storedAt: Date.now() });
     return rows;
   }
 

--- a/src/lib/adapters/implicit-account-store.ts
+++ b/src/lib/adapters/implicit-account-store.ts
@@ -1,0 +1,295 @@
+/**
+ * InMemoryImplicitAccountStore
+ *
+ * Reference implementation of `AccountStore` for `resolution: 'implicit'`
+ * platforms. Platforms using this resolution mode require buyers to call
+ * `sync_accounts` before any tool that needs tenant context; subsequent
+ * requests resolve the account from the caller's auth principal rather
+ * than from an inline `ext.account_ref`.
+ *
+ * Use this in tests and as a copy-and-adapt starting point for durable
+ * implementations. See `docs/guides/account-resolution.md` for key
+ * derivation guidance, error contracts, and TTL recommendations.
+ *
+ * @see docs/guides/account-resolution.md
+ * @public
+ */
+
+import type { AccountReference, BrandReference } from '../types/tools.generated';
+import type {
+  Account,
+  AccountStore,
+  AdcpAccountStatus,
+  ResolvedAuthInfo,
+  ResolveContext,
+  SyncAccountsResultRow,
+} from '../server/decisioning';
+
+// ---------------------------------------------------------------------------
+// Key extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Default key-extraction function for the auth-principal→account mapping.
+ *
+ * Canonical choices by credential kind:
+ * - `'oauth'`   → `oauth:<client_id>`   (OAuth 2.0 client identity; stable across token rotations)
+ * - `'api_key'` → `api_key:<key_id>`   (API-key identity; stable until key is revoked)
+ * - `'http_sig'`→ `http_sig:<agent_url>` (verified caller URL; the most durable identity)
+ *
+ * Adopters who key on `authInfo.sub` or `authInfo.extra` instead MUST
+ * document that choice — those fields are grant-specific and may not be
+ * stable across credential rotations.
+ */
+export function defaultImplicitKeyFn(authInfo: ResolvedAuthInfo): string | undefined {
+  const cred = authInfo.credential;
+  if (!cred) return undefined;
+  switch (cred.kind) {
+    case 'oauth':
+      return `oauth:${cred.client_id}`;
+    case 'api_key':
+      return `api_key:${cred.key_id}`;
+    case 'http_sig':
+      return `http_sig:${cred.agent_url}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Store interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Constructor options for `InMemoryImplicitAccountStore`.
+ * @public
+ */
+export interface ImplicitAccountStoreOptions<TCtxMeta = Record<string, unknown>> {
+  /**
+   * Convert a buyer-supplied `AccountReference` (from `sync_accounts`) to the
+   * seller's `Account<TCtxMeta>`. Called once per ref in `upsert()`.
+   *
+   * **Default:** builds a synthetic account from the ref fields. Suitable
+   * for tests; replace for production (call your platform's account-lookup
+   * or account-creation API here).
+   */
+  buildAccount?: (ref: AccountReference, ctx?: ResolveContext) => Account<TCtxMeta> | Promise<Account<TCtxMeta>>;
+
+  /**
+   * Extract the principal key from `ResolvedAuthInfo`. The returned string
+   * is the lookup key for the `authInfo → accounts` mapping.
+   *
+   * **Default:** `defaultImplicitKeyFn` — uses `credential.client_id`
+   * (oauth), `credential.key_id` (api_key), or `credential.agent_url`
+   * (http_sig). Stable across token rotations within the same credential
+   * kind.
+   *
+   * Override when your platform keys on a custom claim (e.g., a
+   * `sub`-derived tenant ID in `authInfo.extra`).
+   */
+  keyFn?: (authInfo: ResolvedAuthInfo) => string | undefined;
+
+  /**
+   * Sync-linkage TTL in milliseconds. Entries stored by `upsert()` expire
+   * after this duration; `resolve()` returns `null` (→ `ACCOUNT_NOT_FOUND`)
+   * for expired entries, prompting the buyer to call `sync_accounts` again.
+   *
+   * **Default:** `86_400_000` (24 hours). Align with your platform's session
+   * or token lifetime; longer TTLs risk serving stale account state.
+   *
+   * Distinct from `AccountStore.refreshToken` — that refreshes the upstream
+   * OAuth token mid-request. This TTL governs how long the sync-linkage
+   * itself is valid before a fresh `sync_accounts` is required.
+   */
+  ttlMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Default buildAccount
+// ---------------------------------------------------------------------------
+
+function defaultBuildAccount<TCtxMeta>(
+  ref: AccountReference,
+  _ctx?: ResolveContext
+): Account<TCtxMeta & Record<string, unknown>> {
+  const r = ref as Record<string, unknown>;
+  const brand = r['brand'] as BrandReference | undefined;
+  const operator = (r['operator'] as string | undefined) ?? '';
+  const account_id =
+    (r['account_id'] as string | undefined) ??
+    (brand && 'domain' in brand ? `${(brand as { domain: string }).domain}:${operator}` : `ref:${operator}`);
+  return {
+    id: account_id,
+    name: account_id,
+    status: 'active' as AdcpAccountStatus,
+    ...(brand !== undefined && { brand }),
+    ...(operator !== '' && { operator }),
+    ctx_metadata: {} as TCtxMeta & Record<string, unknown>,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// InMemoryImplicitAccountStore
+// ---------------------------------------------------------------------------
+
+interface StoredEntry<TCtxMeta> {
+  accounts: Account<TCtxMeta>[];
+  storedAt: number;
+}
+
+/**
+ * In-memory `AccountStore` for `resolution: 'implicit'` platforms.
+ *
+ * Wire contract:
+ * 1. Buyer calls `sync_accounts` → framework calls `upsert()` → store records
+ *    `authKey → accounts[]`.
+ * 2. Buyer calls any tool (e.g. `create_media_buy`) without `ext.account_ref`
+ *    → framework calls `resolve(undefined, ctx)` → store looks up by `authKey`.
+ * 3. If no prior sync: `resolve()` returns `null` → framework emits
+ *    `ACCOUNT_NOT_FOUND`. Do NOT return `AUTH_REQUIRED` — that signals
+ *    missing credentials, not a missing pre-sync.
+ *
+ * This class is intentionally minimal. Copy-and-adapt for durable stores
+ * (Postgres, Redis); see `docs/guides/account-resolution.md` for the DDL
+ * reference and the key-derivation rationale.
+ *
+ * @example
+ * ```ts
+ * import { InMemoryImplicitAccountStore } from '@adcp/sdk/server';
+ *
+ * const accountStore = new InMemoryImplicitAccountStore({
+ *   buildAccount: async (ref, ctx) => {
+ *     const upstream = await myPlatform.findOrCreate(ref, ctx?.authInfo);
+ *     return {
+ *       id: upstream.id,
+ *       name: upstream.name,
+ *       status: 'active',
+ *       ctx_metadata: { upstreamId: upstream.id },
+ *     };
+ *   },
+ * });
+ *
+ * // Wire into createAdcpServer:
+ * createAdcpServer({ accounts: accountStore, ... });
+ * ```
+ *
+ * @public
+ */
+export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> implements AccountStore<TCtxMeta> {
+  readonly resolution = 'implicit' as const;
+
+  private _store = new Map<string, StoredEntry<TCtxMeta>>();
+  private _keyFn: (authInfo: ResolvedAuthInfo) => string | undefined;
+  private _ttlMs: number;
+  private _buildAccount: (
+    ref: AccountReference,
+    ctx?: ResolveContext
+  ) => Account<TCtxMeta> | Promise<Account<TCtxMeta>>;
+
+  constructor(options?: ImplicitAccountStoreOptions<TCtxMeta>) {
+    this._buildAccount =
+      options?.buildAccount ??
+      (defaultBuildAccount as unknown as (ref: AccountReference, ctx?: ResolveContext) => Account<TCtxMeta>);
+    this._keyFn = options?.keyFn ?? defaultImplicitKeyFn;
+    this._ttlMs = options?.ttlMs ?? 86_400_000;
+  }
+
+  /**
+   * Resolve the caller's account from the auth-principal→account mapping
+   * populated by a prior `sync_accounts` call.
+   *
+   * Returns `null` (→ `ACCOUNT_NOT_FOUND`) when:
+   * - No prior `sync_accounts` was called for this principal
+   * - The stored entry has exceeded `ttlMs`
+   * - `ctx.authInfo` is absent or carries no extractable key
+   */
+  async resolve(_ref: AccountReference | undefined, ctx?: ResolveContext): Promise<Account<TCtxMeta> | null> {
+    const authInfo = ctx?.authInfo;
+    if (!authInfo) return null;
+    const key = this._keyFn(authInfo);
+    if (key === undefined) return null;
+    const entry = this._store.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.storedAt > this._ttlMs) {
+      this._store.delete(key);
+      return null;
+    }
+    return entry.accounts[0] ?? null;
+  }
+
+  /**
+   * Process a `sync_accounts` payload: build accounts from refs and store
+   * them under the caller's auth key.
+   *
+   * The auth key is extracted from `ctx.authInfo` via `keyFn`. When
+   * `ctx.authInfo` is absent (e.g., unauthenticated call), accounts are
+   * built but NOT stored — the buyer cannot retrieve them via `resolve()`.
+   * Your `authenticate` callback in `serve({ authenticate })` should reject
+   * unauthenticated `sync_accounts` calls before reaching this method.
+   */
+  async upsert(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]> {
+    const authInfo = ctx?.authInfo;
+    const key = authInfo !== undefined ? this._keyFn(authInfo) : undefined;
+    const accounts: Account<TCtxMeta>[] = [];
+    const rows: SyncAccountsResultRow[] = [];
+
+    for (const ref of refs) {
+      try {
+        const account = await this._buildAccount(ref, ctx);
+        accounts.push(account);
+        const r = ref as Record<string, unknown>;
+        const brand: BrandReference =
+          account.brand ?? (r['brand'] as BrandReference | undefined) ?? ({ domain: account.id } as BrandReference);
+        const operator = account.operator ?? (r['operator'] as string | undefined) ?? '';
+        rows.push({
+          account_id: account.id,
+          brand,
+          operator,
+          name: account.name,
+          action: 'created',
+          status: account.status,
+        });
+      } catch (err) {
+        const r = ref as Record<string, unknown>;
+        rows.push({
+          brand: (r['brand'] as BrandReference | undefined) ?? ({ domain: 'unknown' } as BrandReference),
+          operator: (r['operator'] as string | undefined) ?? '',
+          action: 'failed',
+          status: 'rejected' as AdcpAccountStatus,
+          errors: [
+            {
+              code: 'SYNC_FAILED',
+              message: err instanceof Error ? err.message : String(err),
+            },
+          ],
+        });
+      }
+    }
+
+    if (key !== undefined) {
+      this._store.set(key, { accounts, storedAt: Date.now() });
+    }
+
+    return rows;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test helpers
+  // ---------------------------------------------------------------------------
+
+  /** Remove all stored sync linkages. */
+  clear(): void {
+    this._store.clear();
+  }
+
+  /**
+   * Return the auth key that would be derived from `authInfo`.
+   * Useful in tests to assert that a specific principal's linkage was stored.
+   */
+  authKey(authInfo: ResolvedAuthInfo): string | undefined {
+    return this._keyFn(authInfo);
+  }
+
+  /** Return the number of principal → accounts linkages currently stored. */
+  get size(): number {
+    return this._store.size;
+  }
+}

--- a/src/lib/adapters/implicit-account-store.ts
+++ b/src/lib/adapters/implicit-account-store.ts
@@ -124,15 +124,20 @@ function defaultBuildAccount<TCtxMeta>(
   const r = ref as Record<string, unknown>;
   const brand = r['brand'] as BrandReference | undefined;
   const operator = (r['operator'] as string | undefined) ?? '';
+  const sandbox = r['sandbox'] === true;
+  const sandboxSuffix = sandbox ? ':sandbox' : '';
   const account_id =
     (r['account_id'] as string | undefined) ??
-    (brand && 'domain' in brand ? `${(brand as { domain: string }).domain}:${operator}` : `ref:${operator}`);
+    (brand && 'domain' in brand
+      ? `${(brand as { domain: string }).domain}:${operator}${sandboxSuffix}`
+      : `ref:${operator}${sandboxSuffix}`);
   return {
     id: account_id,
     name: account_id,
     status: 'active' as AdcpAccountStatus,
     ...(brand !== undefined && { brand }),
     ...(operator !== '' && { operator }),
+    ...(sandbox && { sandbox: true }),
     ctx_metadata: {} as TCtxMeta & Record<string, unknown>,
   };
 }

--- a/src/lib/adapters/implicit-account-store.ts
+++ b/src/lib/adapters/implicit-account-store.ts
@@ -54,6 +54,17 @@ export function defaultImplicitKeyFn(authInfo: ResolvedAuthInfo): string | undef
   }
 }
 
+// Natural key for a ref — used to detect re-syncs of the same
+// (brand, operator, sandbox) tuple so upsert() can return 'unchanged'
+// without calling buildAccount again (which may be non-deterministic).
+function refNaturalKey(ref: AccountReference): string {
+  const r = ref as Record<string, unknown>;
+  const domain = (r['brand'] as Record<string, unknown> | undefined)?.['domain'] as string | undefined;
+  const operator = r['operator'] as string | undefined;
+  const sandbox = Boolean(r['sandbox'] as boolean | undefined);
+  return `${domain ?? ''}|${operator ?? ''}|${sandbox ? '1' : '0'}`;
+}
+
 // ---------------------------------------------------------------------------
 // Store interface
 // ---------------------------------------------------------------------------
@@ -132,6 +143,7 @@ function defaultBuildAccount<TCtxMeta>(
 
 interface StoredEntry<TCtxMeta> {
   accounts: Account<TCtxMeta>[];
+  refs: AccountReference[];
   storedAt: number;
 }
 
@@ -265,13 +277,54 @@ export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> im
       });
     }
 
-    const accounts: Account<TCtxMeta>[] = [];
+    // Build a natural-key index from any existing stored entry so we can
+    // detect re-syncs of the same (brand, operator, sandbox) tuple.
+    const existing = this._store.get(key);
+    const existingByNk = new Map<string, { account: Account<TCtxMeta>; ref: AccountReference }>();
+    if (existing) {
+      for (let i = 0; i < existing.refs.length; i++) {
+        existingByNk.set(refNaturalKey(existing.refs[i]!), {
+          account: existing.accounts[i]!,
+          ref: existing.refs[i]!,
+        });
+      }
+    }
+
+    const newAccounts: Account<TCtxMeta>[] = [];
+    const newRefs: AccountReference[] = [];
     const rows: SyncAccountsResultRow[] = [];
 
     for (const ref of refs) {
+      const nk = refNaturalKey(ref);
+      const hit = existingByNk.get(nk);
+      if (hit) {
+        // Re-sync of the same (brand, operator, sandbox) — preserve the
+        // original account_id without calling buildAccount again so adopters
+        // with non-deterministic resolvers (upstream API calls, DB writes)
+        // don't accumulate duplicate ids on replay.
+        newAccounts.push(hit.account);
+        newRefs.push(hit.ref);
+        const r = ref as Record<string, unknown>;
+        const brand: BrandReference =
+          hit.account.brand ??
+          (r['brand'] as BrandReference | undefined) ??
+          ({ domain: hit.account.id } as BrandReference);
+        const operator = hit.account.operator ?? (r['operator'] as string | undefined) ?? '';
+        rows.push({
+          account_id: hit.account.id,
+          brand,
+          operator,
+          name: hit.account.name,
+          action: 'unchanged',
+          status: hit.account.status,
+        });
+        continue;
+      }
+
       try {
         const account = await this._buildAccount(ref, ctx);
-        accounts.push(account);
+        newAccounts.push(account);
+        newRefs.push(ref);
         const r = ref as Record<string, unknown>;
         const brand: BrandReference =
           account.brand ?? (r['brand'] as BrandReference | undefined) ?? ({ domain: account.id } as BrandReference);
@@ -300,12 +353,11 @@ export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> im
       }
     }
 
-    // Only overwrite a previously-valid entry when at least one account was
-    // successfully built. An all-fail batch (every buildAccount threw) leaves
-    // the prior sync linkage intact so the buyer can retry without losing
-    // their existing account mapping.
-    if (accounts.length > 0) {
-      this._store.set(key, { accounts, storedAt: Date.now() });
+    // Only update the stored entry when at least one ref resolved successfully
+    // (either 'unchanged' or 'created'). An all-fail batch leaves the prior
+    // sync linkage intact so the buyer can retry without losing their mapping.
+    if (newAccounts.length > 0) {
+      this._store.set(key, { accounts: newAccounts, refs: newRefs, storedAt: Date.now() });
     }
     return rows;
   }

--- a/src/lib/adapters/implicit-account-store.ts
+++ b/src/lib/adapters/implicit-account-store.ts
@@ -285,23 +285,28 @@ export class InMemoryImplicitAccountStore<TCtxMeta = Record<string, unknown>> im
           status: account.status,
         });
       } catch (err) {
+        // Suppress adopter-originated error details from the wire response —
+        // buildAccount exceptions may include upstream credentials, SQL text,
+        // or internal identifiers. Log server-side; emit a fixed string.
+        console.error('[InMemoryImplicitAccountStore] buildAccount threw:', err);
         const r = ref as Record<string, unknown>;
         rows.push({
           brand: (r['brand'] as BrandReference | undefined) ?? ({ domain: 'unknown' } as BrandReference),
           operator: (r['operator'] as string | undefined) ?? '',
           action: 'failed',
           status: 'rejected' as AdcpAccountStatus,
-          errors: [
-            {
-              code: 'SYNC_FAILED',
-              message: err instanceof Error ? err.message : String(err),
-            },
-          ],
+          errors: [{ code: 'SYNC_FAILED', message: 'Account sync failed — check server logs' }],
         });
       }
     }
 
-    this._store.set(key, { accounts, storedAt: Date.now() });
+    // Only overwrite a previously-valid entry when at least one account was
+    // successfully built. An all-fail batch (every buildAccount threw) leaves
+    // the prior sync linkage intact so the buyer can retry without losing
+    // their existing account mapping.
+    if (accounts.length > 0) {
+      this._store.set(key, { accounts, storedAt: Date.now() });
+    }
     return rows;
   }
 

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -10,6 +10,7 @@
  * - PropertyListAdapter: Manage buyer-defined property lists
  * - ProposalManager: Generate and refine media plan proposals
  * - SISessionManager: Handle Sponsored Intelligence conversational sessions
+ * - InMemoryImplicitAccountStore: AccountStore for resolution: 'implicit' platforms
  */
 
 // Content Standards
@@ -63,3 +64,10 @@ export {
   SIErrorCodes,
   defaultSISessionManager,
 } from './si-session-manager';
+
+// Implicit Account Store (resolution: 'implicit')
+export {
+  InMemoryImplicitAccountStore,
+  defaultImplicitKeyFn,
+  type ImplicitAccountStoreOptions,
+} from './implicit-account-store';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1158,6 +1158,10 @@ export {
   type CommittedCheckRequest,
   GovernanceAdapterErrorCodes,
   isGovernanceAdapterError,
+  // Implicit Account Store (resolution: 'implicit')
+  InMemoryImplicitAccountStore,
+  defaultImplicitKeyFn,
+  type ImplicitAccountStoreOptions,
 } from './adapters';
 
 // ====== BACKWARD COMPATIBILITY & ENVIRONMENT LOADING ======

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3009,6 +3009,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             }
             ctx.account = account;
           } catch (err) {
+            if (isThrownAdcpError(err)) return finalize(err);
             const reason = err instanceof Error ? err.message : String(err);
             logger.error('Account resolution failed', { tool: toolName, error: reason });
             return finalize(

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -396,7 +396,11 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * ```ts
    * resolve: async (ref, ctx) => {
    *   if (ref?.account_id) return await this.db.findById(ref.account_id);
-   *   const platformAcct = await myUpstream.findByOAuthClient(ctx?.authInfo?.clientId);
+   *   const cred = ctx?.authInfo?.credential;
+   *   const clientKey = cred?.kind === 'oauth' ? cred.client_id
+   *     : cred?.kind === 'api_key' ? cred.key_id
+   *     : undefined;
+   *   const platformAcct = clientKey ? await myUpstream.findByClientKey(clientKey) : null;
    *   return platformAcct ? this.toAccount(platformAcct) : null;
    * }
    * ```

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -776,7 +776,9 @@ function projectGovernanceAgent(agent: WireGovernanceAgent): WireGovernanceAgent
  * resolve: async (ref, ctx) => {
  *   const id = refAccountId(ref);
  *   if (id) return this.db.findById(id);
- *   return this.db.findByOAuthClient(ctx?.authInfo?.clientId ?? '');
+ *   const cred = ctx?.authInfo?.credential;
+ *   const key = cred?.kind === 'oauth' ? cred.client_id : cred?.kind === 'api_key' ? cred.key_id : undefined;
+ *   return key ? this.db.findByClientKey(key) : null;
  * }
  * ```
  *

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1011,6 +1011,20 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       opts.resolveIdempotencyPrincipal ??
       (ctx => ctx.authInfo?.clientId ?? ctx.sessionKey ?? ctx.account?.id ?? undefined),
     resolveAccount: async (ref, ctx) => {
+      // Enforce the JSDoc contract: implicit-mode platforms require
+      // sync_accounts first; inline account refs must never reach the
+      // adopter's resolve() so a naïve findById(ref.account_id) can't
+      // return a wrong-tenant record to a caller who guessed an id.
+      if (platform.accounts.resolution === 'implicit' && ref != null) {
+        throw adcpError('INVALID_PARAMS', {
+          field: 'account',
+          message:
+            'This platform uses implicit account resolution. ' +
+            'Do not pass account_id inline — call sync_accounts to link ' +
+            'your account first, then omit the account field.',
+          suggestion: 'Call sync_accounts to register your account, then retry the request without an account field.',
+        });
+      }
       const start = Date.now();
       let resolved = false;
       let resolvedAccountId: string | undefined;

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -393,3 +393,12 @@ export type {
   UpstreamHttpClient,
   UpstreamHttpResult,
 } from './upstream-helpers';
+
+// ---------------------------------------------------------------------------
+// Server-side adapters
+// ---------------------------------------------------------------------------
+export {
+  InMemoryImplicitAccountStore,
+  defaultImplicitKeyFn,
+  type ImplicitAccountStoreOptions,
+} from '../adapters/implicit-account-store';

--- a/test/in-memory-implicit-account-store.test.js
+++ b/test/in-memory-implicit-account-store.test.js
@@ -1,0 +1,273 @@
+'use strict';
+
+// Issue #1340 — `InMemoryImplicitAccountStore` reference adapter.
+// Covers default keyFn, the upsert/resolve round-trip, re-sync idempotency
+// on the (brand, operator, sandbox) natural key, tenant isolation, TTL
+// eviction, and the framework-wired storyboard (sync_accounts → get_products
+// resolves the principal's account through dispatchTestRequest).
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { InMemoryImplicitAccountStore, defaultImplicitKeyFn } = require('../dist/lib/adapters');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+const VALID_UUID_1 = '11111111-1111-1111-1111-111111111111';
+
+const oauth = clientId => ({
+  kind: 'oauth',
+  credential: { kind: 'oauth', client_id: clientId, scopes: [] },
+});
+const apiKey = keyId => ({
+  kind: 'api_key',
+  credential: { kind: 'api_key', key_id: keyId },
+});
+
+describe('defaultImplicitKeyFn', () => {
+  it('namespaces oauth client_id', () => {
+    assert.equal(defaultImplicitKeyFn(oauth('buyer-xyz')), 'oauth:buyer-xyz');
+  });
+
+  it('namespaces api_key key_id', () => {
+    assert.equal(defaultImplicitKeyFn(apiKey('hash123')), 'api_key:hash123');
+  });
+
+  it('namespaces http_sig agent_url', () => {
+    const authInfo = {
+      kind: 'signature',
+      credential: { kind: 'http_sig', keyid: 'k', agent_url: 'https://buyer.example.com', verified_at: 1 },
+    };
+    assert.equal(defaultImplicitKeyFn(authInfo), 'http_sig:https://buyer.example.com');
+  });
+
+  it('returns undefined when credential is absent', () => {
+    assert.equal(defaultImplicitKeyFn({ kind: 'public' }), undefined);
+    assert.equal(defaultImplicitKeyFn({}), undefined);
+  });
+});
+
+describe('InMemoryImplicitAccountStore — direct unit', () => {
+  it('declares resolution: implicit', () => {
+    const store = new InMemoryImplicitAccountStore();
+    assert.equal(store.resolution, 'implicit');
+  });
+
+  it('upsert assigns account_id and persists under principal key', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    const ctx = { authInfo: oauth('buyer-1') };
+    const rows = await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], ctx);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].action, 'created');
+    assert.ok(rows[0].account_id);
+
+    const resolved = await store.resolve(undefined, ctx);
+    assert.ok(resolved);
+    assert.equal(resolved.id, rows[0].account_id);
+    assert.equal(store.size, 1);
+  });
+
+  it('re-syncing the same (brand, operator, sandbox) returns unchanged with the same account_id', async () => {
+    let counter = 0;
+    const store = new InMemoryImplicitAccountStore({
+      // Non-deterministic buildAccount simulates an adopter calling an upstream
+      // API or DB. The adapter must NOT mint a new id on replay.
+      buildAccount: async ref => ({
+        id: `acct_${++counter}`,
+        name: ref.brand?.domain ?? 'x',
+        status: 'active',
+        brand: ref.brand,
+        operator: ref.operator,
+        ctx_metadata: {},
+      }),
+    });
+    const ctx = { authInfo: oauth('buyer-1') };
+    const ref = { brand: { domain: 'acme.com' }, operator: 'agency.com' };
+    const [first] = await store.upsert([ref], ctx);
+    const [second] = await store.upsert([ref], ctx);
+    const [third] = await store.upsert([ref], ctx);
+    assert.equal(first.action, 'created');
+    assert.equal(second.action, 'unchanged');
+    assert.equal(third.action, 'unchanged');
+    assert.equal(second.account_id, first.account_id);
+    assert.equal(third.account_id, first.account_id);
+    assert.equal(counter, 1, 'buildAccount should be called only on first sync of a given natural key');
+  });
+
+  it('sandbox vs production are separate accounts under the same principal', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    const ctx = { authInfo: oauth('buyer-1') };
+    const rows = await store.upsert(
+      [
+        { brand: { domain: 'acme.com' }, operator: 'agency.com' },
+        { brand: { domain: 'acme.com' }, operator: 'agency.com', sandbox: true },
+      ],
+      ctx
+    );
+    assert.equal(rows.length, 2);
+    assert.equal(rows[0].action, 'created');
+    assert.equal(rows[1].action, 'created');
+    assert.notEqual(rows[0].account_id, rows[1].account_id);
+  });
+
+  it('isolates accounts per principal — buyer-2 cannot resolve buyer-1 accounts', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], { authInfo: oauth('buyer-1') });
+    const otherCtx = { authInfo: oauth('buyer-2') };
+    assert.equal(await store.resolve(undefined, otherCtx), null);
+  });
+
+  it('resolve with no auth returns null (does not leak)', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], { authInfo: oauth('buyer-1') });
+    assert.equal(await store.resolve(undefined, undefined), null);
+    assert.equal(await store.resolve(undefined, { authInfo: undefined }), null);
+  });
+
+  it('upsert without auth fails all rows with SYNC_FAILED', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    const rows = await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], undefined);
+    assert.equal(rows[0].action, 'failed');
+    assert.equal(rows[0].status, 'rejected');
+    assert.equal(rows[0].errors[0].code, 'SYNC_FAILED');
+  });
+
+  it('upsert with auth but unrecognized credential kind fails with SYNC_FAILED, not a silent success', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    const ctx = { authInfo: { kind: 'public' } }; // no credential — defaultImplicitKeyFn returns undefined
+    const rows = await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], ctx);
+    assert.equal(rows[0].action, 'failed');
+    assert.equal(rows[0].errors[0].code, 'SYNC_FAILED');
+    assert.equal(store.size, 0, 'no entry should be created when key cannot be derived');
+  });
+
+  it('TTL eviction returns null after expiry and clears the entry', async () => {
+    const store = new InMemoryImplicitAccountStore({ ttlMs: 5 });
+    const ctx = { authInfo: oauth('buyer-1') };
+    await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], ctx);
+    assert.equal(store.size, 1);
+    await new Promise(r => setTimeout(r, 15));
+    assert.equal(await store.resolve(undefined, ctx), null);
+    assert.equal(store.size, 0, 'expired entry should be evicted on resolve');
+  });
+
+  it('custom keyFn overrides the default credential-based keying', async () => {
+    const store = new InMemoryImplicitAccountStore({
+      keyFn: authInfo => {
+        const orgId = authInfo?.claims?.org_id;
+        return typeof orgId === 'string' ? `org:${orgId}` : undefined;
+      },
+    });
+    const ctx1 = { authInfo: { kind: 'oauth', claims: { org_id: 'org-7' } } };
+    const ctx2 = { authInfo: { kind: 'oauth', claims: { org_id: 'org-7' } } };
+    await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], ctx1);
+    const resolved = await store.resolve(undefined, ctx2);
+    assert.ok(resolved, 'second auth with same org_id should hit the same bucket');
+  });
+
+  it('clear() resets all stored linkages', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    await store.upsert([{ brand: { domain: 'acme.com' }, operator: 'agency.com' }], { authInfo: oauth('buyer-1') });
+    await store.upsert([{ brand: { domain: 'beta.com' }, operator: 'agency.com' }], { authInfo: oauth('buyer-2') });
+    assert.equal(store.size, 2);
+    store.clear();
+    assert.equal(store.size, 0);
+  });
+
+  it('authKey() exposes the derived storage key for assertions', () => {
+    const store = new InMemoryImplicitAccountStore();
+    assert.equal(store.authKey(oauth('buyer-1')), 'oauth:buyer-1');
+    assert.equal(store.authKey(apiKey('hash')), 'api_key:hash');
+  });
+});
+
+describe('InMemoryImplicitAccountStore — wired into a server', () => {
+  function build(store) {
+    return createAdcpServerFromPlatform(
+      {
+        capabilities: {
+          specialisms: ['sales-non-guaranteed'],
+          creative_agents: [],
+          channels: ['display'],
+          pricingModels: ['cpm'],
+          config: {},
+        },
+        accounts: store,
+        statusMappers: {},
+        sales: {
+          getProducts: async (_req, ctx) => ({
+            products: [{ product_id: `p:${ctx?.account?.id ?? 'none'}`, name: 'p', formats: [] }],
+          }),
+          createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+          updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+          syncCreatives: async () => [],
+          getMediaBuyDelivery: async () => ({ media_buys: [] }),
+        },
+      },
+      { name: 'gap-1340', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+    );
+  }
+
+  it("sync_accounts → get_products round-trip resolves the principal's account", async () => {
+    const store = new InMemoryImplicitAccountStore();
+    const server = build(store);
+
+    const sync = await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'sync_accounts',
+          arguments: {
+            accounts: [{ brand: { domain: 'acme.com' }, operator: 'agency.com' }],
+            idempotency_key: VALID_UUID_1,
+          },
+        },
+      },
+      { authInfo: oauth('buyer-implicit-1') }
+    );
+    assert.notStrictEqual(sync.isError, true, JSON.stringify(sync.structuredContent));
+    const accountId = sync.structuredContent.accounts[0].account_id;
+
+    const products = await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: { name: 'get_products', arguments: { promoted_offering: 'shoes' } },
+      },
+      { authInfo: oauth('buyer-implicit-1') }
+    );
+    assert.notStrictEqual(products.isError, true, JSON.stringify(products.structuredContent));
+    assert.equal(products.structuredContent.products[0].product_id, `p:${accountId}`);
+  });
+
+  it('cross-tenant — buyer-B cannot resolve buyer-A accounts via the server', async () => {
+    const store = new InMemoryImplicitAccountStore();
+    const server = build(store);
+
+    await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: {
+          name: 'sync_accounts',
+          arguments: {
+            accounts: [{ brand: { domain: 'acme.com' }, operator: 'agency.com' }],
+            idempotency_key: VALID_UUID_1,
+          },
+        },
+      },
+      { authInfo: oauth('buyer-A') }
+    );
+
+    const probe = await server.dispatchTestRequest(
+      {
+        method: 'tools/call',
+        params: { name: 'get_products', arguments: { promoted_offering: 'shoes' } },
+      },
+      { authInfo: oauth('buyer-B') }
+    );
+
+    if (!probe.isError) {
+      assert.equal(probe.structuredContent.products[0].product_id, 'p:none');
+    } else {
+      assert.equal(probe.structuredContent?.error?.code, 'ACCOUNT_NOT_FOUND');
+    }
+  });
+});


### PR DESCRIPTION
Refs #1340

Adds a reference `AccountStore` implementation for `resolution: 'implicit'` platforms (the sync_accounts-first pattern). Previously each adopter independently re-derived key extraction, TTL semantics, and error handling — and commonly got them wrong (keying on `authInfo.sub` instead of `credential.client_id`, returning `AUTH_REQUIRED` instead of `ACCOUNT_NOT_FOUND` when sync hasn't happened).

## What ships

- **`InMemoryImplicitAccountStore<TCtxMeta>`** in `src/lib/adapters/implicit-account-store.ts` — implements `AccountStore` with `resolve()` + `upsert()`. Configurable `keyFn` (defaults to `credential.client_id` / `credential.key_id` / `credential.agent_url`), configurable `ttlMs` (default 24h), and a `buildAccount` factory. Test helpers: `clear()`, `authKey()`, `size`. Exported from both `@adcp/sdk/server` and `@adcp/sdk`.
- **`docs/guides/account-resolution.md`** — one-pager covering all three resolution modes with a deep dive on `'implicit'`: key derivation rationale, the `ACCOUNT_NOT_FOUND` vs `AUTH_REQUIRED` error contract, TTL/staleness guidance, and a Postgres cross-link.
- **`examples/decisioning-platform-implicit-accounts.ts`** — runnable wiring example.
- **JSDoc fix** — both `AccountStore.resolve()` and `refAccountId()` example snippets updated from deprecated `authInfo?.clientId` to `credential.client_id` / `credential.key_id`.

## Deferred from issue scope

- **Postgres-backed adapter** — deferred; `docs/guides/POSTGRES.md` already covers the DDL pattern and the doc cross-links it.
- **Storyboard end-to-end test** — a storyboard exercising `sync_accounts → create_media_buy` without `account_ref` requires new phases in the `media_buy_*_seller` storyboard YAML, which is a spec-side change (`adcontextprotocol/adcp`). Deferred to a follow-up PR once upstream storyboard support lands.

## What was tested

- `npm run format:check` — clean
- `npx tsc --project tsconfig.lib.json --noEmit` — only pre-existing TS2688/TS5107 env errors (confirmed on `main` before branching; not introduced by this diff)
- `tsx` not available in this environment; unit tests require built `dist/` — pre-existing environment constraint

## Pre-PR review

- code-reviewer: approved after 2 blocker fixes — (1) `upsert()` all-fail batch now preserves prior sync entry; (2) `buildAccount` err.message suppressed from wire response; (3) second `refAccountId()` JSDoc deprecated-field instance fixed
- dx-expert: approved after 3 blocker fixes — (1) `upsert()` key-undefined no longer silently succeeds; (2) `resolve()` first-account-wins behavior documented; (3) `refAccountId` import added to explicit-mode doc snippet

**Nits (not fixed, noted for reviewers):**
- `defaultBuildAccount` uses `as unknown as` cast to paper over `TCtxMeta` vs `TCtxMeta & Record<string, unknown>` mismatch — safe for the documented test use case; adopters who pass a typed generic without a `buildAccount` override get a runtime `{}` for `ctx_metadata`. JSDoc warns about this but TypeScript is silent.
- Example's `buildAccount` body manually reconstructs ref fields (same pattern as `defaultBuildAccount`); a future pass could simplify the stub to a `myPlatform.findOrCreate()` call.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01TshCGnKCHQaYhKQQwFgVyw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TshCGnKCHQaYhKQQwFgVyw)_