### PR TITLE
feat(adapters): createOAuthPassthroughResolver (#1363)

### DIFF
--- a/.changeset/oauth-passthrough-resolver.md
+++ b/.changeset/oauth-passthrough-resolver.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(adapters): `createOAuthPassthroughResolver` — factory for the canonical "Shape B" `accounts.resolve` pattern. Standardizes the `extract bearer → GET /me/adaccounts → match by id → return tenant with ctx_metadata` flow that every adapter wrapping a vendor OAuth + ad-account API (Snap, Meta, TikTok, LinkedIn, Reddit, Pinterest, etc.) re-derives by hand. Composes with `createUpstreamHttpClient`'s `dynamic_bearer.getToken` for per-buyer credential injection. Configurable `idField`, `rowsPath`, `getAuthContext`, and opt-in TTL cache (auth-context keyed so different buyers don't share entries). Closes #1363.

--- a/src/lib/adapters/index.ts
+++ b/src/lib/adapters/index.ts
@@ -63,3 +63,9 @@ export {
   SIErrorCodes,
   defaultSISessionManager,
 } from './si-session-manager';
+
+// OAuth pass-through resolver — closes adcp-client#1363. Standardizes the
+// canonical "Shape B" account-resolution pattern so adapters wrapping a
+// vendor OAuth + ad-account API don't each re-derive the same ~30 LOC of
+// bearer-extract + listing-fetch + match-by-id boilerplate.
+export { createOAuthPassthroughResolver, type OAuthPassthroughResolverOptions } from './oauth-passthrough-resolver';

--- a/src/lib/adapters/oauth-passthrough-resolver.ts
+++ b/src/lib/adapters/oauth-passthrough-resolver.ts
@@ -1,0 +1,222 @@
+/**
+ * OAuth pass-through `accounts.resolve` factory. Standardizes the canonical
+ * "Shape B" account-resolution pattern: an adapter wraps a vendor OAuth +
+ * ad-account API (Snap, Meta, TikTok, LinkedIn, Reddit, Pinterest, etc.) and
+ * resolves the buyer's `AccountReference` by hitting the upstream's
+ * "list-my-accounts" endpoint with the buyer's bearer.
+ *
+ * Without this factory, every Shape B adapter rolls the same ~30 LOC:
+ * extract bearer from `ctx.authInfo`, GET `/me/adaccounts`, match by id,
+ * return tenant with `ctx_metadata` populated. This factory handles the
+ * boilerplate; the adapter supplies the upstream specifics
+ * (`listEndpoint`, `toAccount` mapper) and the auth shape via
+ * {@link createUpstreamHttpClient}'s `dynamic_bearer.getToken`.
+ *
+ * Closes adcp-client#1363.
+ *
+ * @public
+ */
+
+import type { Account, ResolveContext } from '../server/decisioning/account';
+import { refAccountId } from '../server/decisioning/account';
+import type { AccountReference } from '../types/tools.generated';
+import type { AuthContext, UpstreamHttpClient } from '../server/upstream-helpers';
+
+/**
+ * Options for {@link createOAuthPassthroughResolver}.
+ *
+ * @public
+ */
+export interface OAuthPassthroughResolverOptions<TUpstreamRow, TCtxMeta = Record<string, unknown>> {
+  /**
+   * Pre-configured upstream HTTP client (typically from
+   * {@link createUpstreamHttpClient}). Should be configured with
+   * `auth: { kind: 'dynamic_bearer', getToken: (ctx) => ... }` so the
+   * factory's `getAuthContext` output flows through to bearer selection.
+   */
+  httpClient: UpstreamHttpClient;
+
+  /**
+   * Path on the upstream API that returns the buyer's accounts. Common
+   * shapes: `/v1/adaccounts`, `/me/adaccounts`, `/customers`.
+   */
+  listEndpoint: string;
+
+  /**
+   * Property on each upstream row matching the wire `AccountReference.account_id`.
+   * Defaults to `'id'`.
+   */
+  idField?: keyof TUpstreamRow & string;
+
+  /**
+   * Property on the upstream response body that contains the array of rows.
+   * Defaults to `'data'` (Snap, Meta envelope shape). Set to `null` when the
+   * response body itself is the array (some flat-list APIs).
+   */
+  rowsPath?: string | null;
+
+  /**
+   * Extract the auth context to forward to the upstream's
+   * `dynamic_bearer.getToken(ctx)` resolver. The return value flows through
+   * as the `authContext` per-call option on `httpClient.get`.
+   *
+   * Defaults to forwarding `ctx?.authInfo` verbatim — works when the http
+   * client's `getToken` resolver reads `ctx.authInfo.token` /
+   * `ctx.authInfo.credential.token`.
+   */
+  getAuthContext?: (ctx: ResolveContext | undefined) => AuthContext | undefined;
+
+  /**
+   * Map an upstream row to a framework `Account<TCtxMeta>`. Adapters
+   * typically embed the raw row (or distilled fields) in `ctx_metadata` so
+   * downstream specialism methods can read upstream IDs, tokens, etc.
+   * without re-resolving.
+   */
+  toAccount: (row: TUpstreamRow, ctx: ResolveContext | undefined) => Account<TCtxMeta>;
+
+  /**
+   * Optional in-memory result cache. Keyed on
+   * `(getCacheKey(authContext), account_id)`; invalidated by TTL only.
+   *
+   * Set `ttlMs` to enable. Most adopters want 30s–5min — long enough to
+   * absorb a burst of tool calls from one buyer, short enough that a
+   * revoked upstream token surfaces quickly.
+   *
+   * `getCacheKey` defaults to JSON-serializing the auth context. Provide
+   * a narrower key when the auth context contains noise (timestamps,
+   * request ids) that would defeat caching.
+   */
+  cache?: {
+    ttlMs: number;
+    getCacheKey?: (authContext: AuthContext | undefined) => string;
+  };
+}
+
+interface CacheEntry<TCtxMeta> {
+  account: Account<TCtxMeta>;
+  expiresAt: number;
+}
+
+/**
+ * Create an `accounts.resolve` implementation that resolves buyer-supplied
+ * `AccountReference` against an upstream OAuth-protected listing endpoint.
+ * Returns just the resolve function — adapters compose it into their own
+ * `AccountStore` (typically alongside a no-op `upsert` since Shape B
+ * adapters don't manage account lifecycle).
+ *
+ * @example
+ * ```ts
+ * import {
+ *   createUpstreamHttpClient,
+ *   createOAuthPassthroughResolver,
+ *   defineSalesPlatform,
+ * } from '@adcp/sdk/server';
+ *
+ * const snap = createUpstreamHttpClient({
+ *   baseUrl: 'https://adsapi.snapchat.com',
+ *   auth: {
+ *     kind: 'dynamic_bearer',
+ *     getToken: async (ctx) => (ctx as any)?.authInfo?.credential?.token,
+ *   },
+ * });
+ *
+ * const resolve = createOAuthPassthroughResolver({
+ *   httpClient: snap,
+ *   listEndpoint: '/v1/me/adaccounts',
+ *   idField: 'id',
+ *   rowsPath: 'adaccounts',
+ *   toAccount: (row, ctx) => ({
+ *     id: row.id,
+ *     name: row.name,
+ *     status: 'active',
+ *     advertiser: row.advertiser_url,
+ *     ctx_metadata: {
+ *       upstreamId: row.id,
+ *       accessToken: (ctx as any)?.authInfo?.credential?.token,
+ *     },
+ *   }),
+ *   cache: { ttlMs: 60_000 },
+ * });
+ *
+ * defineSalesPlatform({
+ *   accounts: { resolve },
+ *   ...
+ * });
+ * ```
+ *
+ * Behavior:
+ * - The factory only handles the `{ account_id }` discriminated-union arm.
+ *   Other arms (`{ brand, operator }`) and `undefined` ref return `null`
+ *   without calling upstream.
+ * - Upstream throws (4xx/5xx other than 404) propagate verbatim — adopters
+ *   compose `composeMethod` over the result if they want to catch and map
+ *   to a typed envelope (e.g. throw `AdcpError('AUTH_REQUIRED')` on 401).
+ * - Cache is opt-in. When enabled, hits skip the upstream call entirely.
+ *
+ * @public
+ */
+export function createOAuthPassthroughResolver<
+  TUpstreamRow extends Record<string, unknown>,
+  TCtxMeta = Record<string, unknown>,
+>(
+  options: OAuthPassthroughResolverOptions<TUpstreamRow, TCtxMeta>
+): (ref: AccountReference | undefined, ctx?: ResolveContext) => Promise<Account<TCtxMeta> | null> {
+  const idField = (options.idField ?? 'id') as keyof TUpstreamRow & string;
+  const rowsPath = options.rowsPath === undefined ? 'data' : options.rowsPath;
+  const getAuthContext =
+    options.getAuthContext ??
+    ((ctx: ResolveContext | undefined) => ctx?.authInfo as unknown as AuthContext | undefined);
+
+  const cacheTtlMs = options.cache?.ttlMs;
+  const getCacheKey =
+    options.cache?.getCacheKey ??
+    ((authContext: AuthContext | undefined) => (authContext === undefined ? '<none>' : JSON.stringify(authContext)));
+  const cache = cacheTtlMs !== undefined ? new Map<string, CacheEntry<TCtxMeta>>() : undefined;
+
+  return async (ref, ctx) => {
+    const accountId = refAccountId(ref);
+    if (accountId === undefined) return null;
+
+    const authContext = getAuthContext(ctx);
+    let cacheKey: string | undefined;
+    if (cache !== undefined) {
+      cacheKey = `${getCacheKey(authContext)}::${accountId}`;
+      const hit = cache.get(cacheKey);
+      if (hit !== undefined && hit.expiresAt > Date.now()) {
+        return hit.account;
+      }
+      if (hit !== undefined) cache.delete(cacheKey);
+    }
+
+    const result = await options.httpClient.get<unknown>(
+      options.listEndpoint,
+      undefined,
+      undefined,
+      authContext !== undefined ? { authContext } : undefined
+    );
+    if (result.body == null) return null;
+
+    const rows = extractRows<TUpstreamRow>(result.body, rowsPath);
+    if (rows === null) return null;
+
+    const match = rows.find(row => row[idField] === accountId);
+    if (match === undefined) return null;
+
+    const account = options.toAccount(match, ctx);
+
+    if (cache !== undefined && cacheKey !== undefined) {
+      cache.set(cacheKey, { account, expiresAt: Date.now() + cacheTtlMs! });
+    }
+
+    return account;
+  };
+}
+
+function extractRows<TUpstreamRow>(body: unknown, rowsPath: string | null): TUpstreamRow[] | null {
+  if (rowsPath === null) {
+    return Array.isArray(body) ? (body as TUpstreamRow[]) : null;
+  }
+  if (body === null || typeof body !== 'object') return null;
+  const rows = (body as Record<string, unknown>)[rowsPath];
+  return Array.isArray(rows) ? (rows as TUpstreamRow[]) : null;
+}

--- a/src/lib/adapters/oauth-passthrough-resolver.ts
+++ b/src/lib/adapters/oauth-passthrough-resolver.ts
@@ -17,6 +17,7 @@
  * @public
  */
 
+import { createHash } from 'node:crypto';
 import type { Account, ResolveContext } from '../server/decisioning/account';
 import { refAccountId } from '../server/decisioning/account';
 import type { AccountReference } from '../types/tools.generated';
@@ -45,6 +46,12 @@ export interface OAuthPassthroughResolverOptions<TUpstreamRow, TCtxMeta = Record
   /**
    * Property on each upstream row matching the wire `AccountReference.account_id`.
    * Defaults to `'id'`.
+   *
+   * **Footgun:** when the generic `TUpstreamRow` is inferred (no explicit
+   * type argument), `keyof TUpstreamRow & string` collapses to `string` and
+   * a typo in `idField` compiles fine but silently always returns `null`.
+   * Pass an explicit `TUpstreamRow` (or a dummy interface with the upstream's
+   * field names) to get compile-time field validation.
    */
   idField?: keyof TUpstreamRow & string;
 
@@ -52,6 +59,13 @@ export interface OAuthPassthroughResolverOptions<TUpstreamRow, TCtxMeta = Record
    * Property on the upstream response body that contains the array of rows.
    * Defaults to `'data'` (Snap, Meta envelope shape). Set to `null` when the
    * response body itself is the array (some flat-list APIs).
+   *
+   * Single-segment only. APIs with deeper nesting (TikTok's `data.list`,
+   * for example) need a custom response transform — wrap the upstream client
+   * with a fetch override that flattens, or use this factory only for the
+   * 70%-fit upstream shape and write a hand-rolled resolver for the rest.
+   * Google Ads' `customers:listAccessibleCustomers` returns string resource
+   * names (not row objects) and is not a fit for this factory.
    */
   rowsPath?: string | null;
 
@@ -71,29 +85,52 @@ export interface OAuthPassthroughResolverOptions<TUpstreamRow, TCtxMeta = Record
    * typically embed the raw row (or distilled fields) in `ctx_metadata` so
    * downstream specialism methods can read upstream IDs, tokens, etc.
    * without re-resolving.
+   *
+   * **Treat `ctx_metadata.accessToken` (or any embedded credential) as a
+   * secret.** The framework strips `ctx_metadata` from the wire response,
+   * but adopter code that throws an error containing `JSON.stringify(account)`
+   * or logs `ctx.account` at info level WILL leak the token. Either don't
+   * embed the bearer (re-derive from `ctx.authInfo` on each downstream
+   * method), or audit your error projections.
    */
   toAccount: (row: TUpstreamRow, ctx: ResolveContext | undefined) => Account<TCtxMeta>;
 
   /**
-   * Optional in-memory result cache. Keyed on
-   * `(getCacheKey(authContext), account_id)`; invalidated by TTL only.
+   * Optional in-memory listing cache. Caches the full row array per buyer
+   * (keyed on the auth context); resolves `account_id` matches in-memory
+   * within the TTL window. One upstream hit per buyer per TTL period
+   * regardless of how many account_ids that buyer queries.
    *
-   * Set `ttlMs` to enable. Most adopters want 30s–5min — long enough to
-   * absorb a burst of tool calls from one buyer, short enough that a
-   * revoked upstream token surfaces quickly.
+   * Set `ttlMs` to enable (default: no cache, every resolve hits upstream).
    *
-   * `getCacheKey` defaults to JSON-serializing the auth context. Provide
-   * a narrower key when the auth context contains noise (timestamps,
-   * request ids) that would defeat caching.
+   * **TTL guidance:**
+   * - **Read tools** (`get_products`, `list_creative_formats`): 60–300s.
+   *   Buyer-side latency dominates; longer TTL absorbs bursts.
+   * - **Mutating tools** (`create_media_buy`, `update_media_buy`,
+   *   `sync_creatives`): 0–30s, or compose `composeMethod` to skip cache
+   *   on these paths. A revoked-but-not-yet-expired bearer would otherwise
+   *   continue authorizing mutations for the full TTL window.
+   *
+   * `getCacheKey` defaults to a SHA-256 hash of the JSON-serialized auth
+   * context. Hashing (vs raw stringification) keeps the bearer token out
+   * of Map keys — heap dumps and `util.inspect(cache)` no longer surface
+   * plaintext credentials. Provide a custom key when the auth context
+   * contains noise (timestamps, request ids) that would defeat caching.
+   *
+   * Cache size is naturally bounded by the number of distinct buyers
+   * times one entry each. Adopters with token-rotation churn can cap with
+   * `maxEntries` (LRU eviction).
    */
   cache?: {
     ttlMs: number;
     getCacheKey?: (authContext: AuthContext | undefined) => string;
+    /** LRU eviction cap. Defaults to 1024 — enough for most multi-tenant deployments. */
+    maxEntries?: number;
   };
 }
 
-interface CacheEntry<TCtxMeta> {
-  account: Account<TCtxMeta>;
+interface ListingCacheEntry<TUpstreamRow> {
+  rows: TUpstreamRow[];
   expiresAt: number;
 }
 
@@ -132,6 +169,7 @@ interface CacheEntry<TCtxMeta> {
  *     advertiser: row.advertiser_url,
  *     ctx_metadata: {
  *       upstreamId: row.id,
+ *       // Treat as secret — see `toAccount` JSDoc above.
  *       accessToken: (ctx as any)?.authInfo?.credential?.token,
  *     },
  *   }),
@@ -151,7 +189,8 @@ interface CacheEntry<TCtxMeta> {
  * - Upstream throws (4xx/5xx other than 404) propagate verbatim — adopters
  *   compose `composeMethod` over the result if they want to catch and map
  *   to a typed envelope (e.g. throw `AdcpError('AUTH_REQUIRED')` on 401).
- * - Cache is opt-in. When enabled, hits skip the upstream call entirely.
+ * - Cache is opt-in and listing-keyed: one upstream hit per buyer per TTL
+ *   window regardless of how many `account_id`s that buyer queries.
  *
  * @public
  */
@@ -168,10 +207,9 @@ export function createOAuthPassthroughResolver<
     ((ctx: ResolveContext | undefined) => ctx?.authInfo as unknown as AuthContext | undefined);
 
   const cacheTtlMs = options.cache?.ttlMs;
-  const getCacheKey =
-    options.cache?.getCacheKey ??
-    ((authContext: AuthContext | undefined) => (authContext === undefined ? '<none>' : JSON.stringify(authContext)));
-  const cache = cacheTtlMs !== undefined ? new Map<string, CacheEntry<TCtxMeta>>() : undefined;
+  const getCacheKey = options.cache?.getCacheKey ?? defaultGetCacheKey;
+  const maxEntries = options.cache?.maxEntries ?? 1024;
+  const cache = cacheTtlMs !== undefined ? new Map<string, ListingCacheEntry<TUpstreamRow>>() : undefined;
 
   return async (ref, ctx) => {
     const accountId = refAccountId(ref);
@@ -179,37 +217,68 @@ export function createOAuthPassthroughResolver<
 
     const authContext = getAuthContext(ctx);
     let cacheKey: string | undefined;
+    let rows: TUpstreamRow[] | null = null;
+
     if (cache !== undefined) {
-      cacheKey = `${getCacheKey(authContext)}::${accountId}`;
+      cacheKey = getCacheKey(authContext);
       const hit = cache.get(cacheKey);
       if (hit !== undefined && hit.expiresAt > Date.now()) {
-        return hit.account;
+        // Refresh LRU position on hit.
+        cache.delete(cacheKey);
+        cache.set(cacheKey, hit);
+        rows = hit.rows;
+      } else if (hit !== undefined) {
+        cache.delete(cacheKey);
       }
-      if (hit !== undefined) cache.delete(cacheKey);
     }
 
-    const result = await options.httpClient.get<unknown>(
-      options.listEndpoint,
-      undefined,
-      undefined,
-      authContext !== undefined ? { authContext } : undefined
-    );
-    if (result.body == null) return null;
-
-    const rows = extractRows<TUpstreamRow>(result.body, rowsPath);
-    if (rows === null) return null;
+    if (rows === null) {
+      const result = await options.httpClient.get<unknown>(
+        options.listEndpoint,
+        undefined,
+        undefined,
+        authContext !== undefined ? { authContext } : undefined
+      );
+      if (result.body == null) return null;
+      rows = extractRows<TUpstreamRow>(result.body, rowsPath);
+      if (rows === null) return null;
+      if (cache !== undefined && cacheKey !== undefined) {
+        // Evict oldest entry first when at capacity. Map iteration order is
+        // insertion order, so the first key is the LRU-coldest after the
+        // hit-side refresh above.
+        if (cache.size >= maxEntries) {
+          const oldest = cache.keys().next().value;
+          if (oldest !== undefined) cache.delete(oldest);
+        }
+        cache.set(cacheKey, { rows, expiresAt: Date.now() + cacheTtlMs! });
+      }
+    }
 
     const match = rows.find(row => row[idField] === accountId);
     if (match === undefined) return null;
-
-    const account = options.toAccount(match, ctx);
-
-    if (cache !== undefined && cacheKey !== undefined) {
-      cache.set(cacheKey, { account, expiresAt: Date.now() + cacheTtlMs! });
-    }
-
-    return account;
+    return options.toAccount(match, ctx);
   };
+}
+
+/**
+ * Default cache-key derivation: SHA-256 of the JSON-serialized auth context.
+ * Hashing keeps the bearer token out of Map keys (no plaintext credential
+ * surfaces in heap dumps or `util.inspect(cache)` output).
+ *
+ * Falls back to a literal `<none>` key when the auth context is undefined,
+ * and to the truncated stringified value when JSON serialization throws
+ * (circular refs, BigInt, etc.) — adopters with non-serializable auth
+ * contexts should provide their own `getCacheKey`.
+ */
+function defaultGetCacheKey(authContext: AuthContext | undefined): string {
+  if (authContext === undefined) return '<none>';
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(authContext);
+  } catch {
+    return `<unserializable:${String(authContext).slice(0, 64)}>`;
+  }
+  return createHash('sha256').update(serialized).digest('hex');
 }
 
 function extractRows<TUpstreamRow>(body: unknown, rowsPath: string | null): TUpstreamRow[] | null {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1158,6 +1158,9 @@ export {
   type CommittedCheckRequest,
   GovernanceAdapterErrorCodes,
   isGovernanceAdapterError,
+  // OAuth pass-through resolver (Shape B accounts.resolve factory)
+  createOAuthPassthroughResolver,
+  type OAuthPassthroughResolverOptions,
 } from './adapters';
 
 // ====== BACKWARD COMPATIBILITY & ENVIRONMENT LOADING ======

--- a/test/server-adapters-oauth-passthrough-resolver.test.js
+++ b/test/server-adapters-oauth-passthrough-resolver.test.js
@@ -307,6 +307,90 @@ describe('createOAuthPassthroughResolver (#1363)', () => {
       await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', principal: 'p1', token: 't_req_2' } });
       assert.strictEqual(http.callCount(), 1);
     });
+
+    it('listing-keyed cache: same buyer querying multiple account_ids costs one upstream hit', async () => {
+      // The listing endpoint returns ALL accounts in one call. Caching at
+      // the listing granularity (vs per-account-id) means a buyer with N
+      // accounts calling N tools costs 1 upstream hit, not N.
+      const http = fakeHttpClient([
+        { id: 'acc_1', name: 'Acme' },
+        { id: 'acc_2', name: 'Nike' },
+        { id: 'acc_3', name: 'Pepsi' },
+      ]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: { ttlMs: 60_000 },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const ctx = { authInfo: { kind: 'oauth', token: 't_a' } };
+      const r1 = await resolve({ account_id: 'acc_1' }, ctx);
+      const r2 = await resolve({ account_id: 'acc_2' }, ctx);
+      const r3 = await resolve({ account_id: 'acc_3' }, ctx);
+      assert.strictEqual(http.callCount(), 1, 'one upstream hit for three account_ids on the same buyer');
+      assert.strictEqual(r1?.id, 'acc_1');
+      assert.strictEqual(r2?.id, 'acc_2');
+      assert.strictEqual(r3?.id, 'acc_3');
+    });
+
+    it('default getCacheKey hashes the auth context (no plaintext token in Map keys)', async () => {
+      // SHA-256 hashing keeps bearer tokens out of Map keys — heap dumps
+      // and util.inspect(cache) won't surface plaintext credentials.
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: { ttlMs: 60_000 },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const distinctiveToken = 'PLAINTEXT_TOKEN_THAT_MUST_NOT_LEAK_INTO_MAP_KEYS';
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: distinctiveToken } });
+      // util.inspect on the closed-over cache would expose Map keys; we
+      // can't reach the cache from here, so assert via a second resolve
+      // with the same token (cache hit confirms the key derivation was
+      // stable) and a different one (cache miss confirms isolation).
+      assert.strictEqual(http.callCount(), 1);
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: distinctiveToken } });
+      assert.strictEqual(http.callCount(), 1, 'identical token → cache hit (stable hash)');
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 'OTHER_TOKEN' } });
+      assert.strictEqual(http.callCount(), 2, 'different token → cache miss (key isolation holds)');
+    });
+
+    it('evicts the LRU entry when maxEntries is reached', async () => {
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: { ttlMs: 60_000, maxEntries: 2 },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      // Three distinct buyers with maxEntries=2 → first buyer's entry evicted.
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_a' } });
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_b' } });
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_c' } });
+      assert.strictEqual(http.callCount(), 3, 'three buyers, three upstream hits');
+      // Buyer A's entry was evicted by buyer C's insertion → re-resolve costs another hit.
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_a' } });
+      assert.strictEqual(http.callCount(), 4, 'evicted buyer must re-fetch');
+      // Buyer C's entry is still warm.
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_c' } });
+      assert.strictEqual(http.callCount(), 4, 'most-recent buyer still cached');
+    });
   });
 
   describe('public re-export', () => {

--- a/test/server-adapters-oauth-passthrough-resolver.test.js
+++ b/test/server-adapters-oauth-passthrough-resolver.test.js
@@ -1,0 +1,319 @@
+// Tests for #1363 — createOAuthPassthroughResolver, the canonical
+// "Shape B" accounts.resolve factory.
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { createOAuthPassthroughResolver } = require('../dist/lib/adapters/oauth-passthrough-resolver');
+
+function fakeHttpClient(rows, opts = {}) {
+  let callCount = 0;
+  let lastPath;
+  let lastAuthContext;
+  return {
+    callCount: () => callCount,
+    lastPath: () => lastPath,
+    lastAuthContext: () => lastAuthContext,
+    get: async (path, _params, _headers, options) => {
+      callCount += 1;
+      lastPath = path;
+      lastAuthContext = options?.authContext;
+      if (opts.throw) throw opts.throw;
+      if (opts.body !== undefined) return { status: 200, body: opts.body };
+      return { status: 200, body: { data: rows } };
+    },
+    post: async () => ({ status: 200, body: null }),
+    put: async () => ({ status: 200, body: null }),
+    delete: async () => ({ status: 200, body: null }),
+  };
+}
+
+describe('createOAuthPassthroughResolver (#1363)', () => {
+  describe('ref shape handling', () => {
+    it('returns null for the brand+operator union arm without calling upstream', async () => {
+      const http = fakeHttpClient([]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me/adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve({ brand: { domain: 'acme.com' }, operator: 'pinnacle.com' }, {});
+      assert.strictEqual(result, null);
+      assert.strictEqual(http.callCount(), 0, 'must not call upstream when ref lacks account_id');
+    });
+
+    it('returns null when ref is undefined without calling upstream', async () => {
+      const http = fakeHttpClient([]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me/adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve(undefined, {});
+      assert.strictEqual(result, null);
+      assert.strictEqual(http.callCount(), 0);
+    });
+  });
+
+  describe('upstream lookup + match', () => {
+    it('returns the mapped account when account_id matches an upstream row', async () => {
+      const http = fakeHttpClient([
+        { id: 'acc_1', name: 'Acme', advertiser: 'acme.com' },
+        { id: 'acc_2', name: 'Nike', advertiser: 'nike.com' },
+      ]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me/adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          advertiser: row.advertiser,
+          ctx_metadata: { upstreamId: row.id },
+        }),
+      });
+      const result = await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_1' } });
+      assert.deepStrictEqual(result, {
+        id: 'acc_1',
+        name: 'Acme',
+        status: 'active',
+        advertiser: 'acme.com',
+        ctx_metadata: { upstreamId: 'acc_1' },
+      });
+      assert.strictEqual(http.lastPath(), '/v1/me/adaccounts');
+      assert.deepStrictEqual(http.lastAuthContext(), { kind: 'oauth', token: 't_buyer_1' });
+    });
+
+    it('returns null when no upstream row matches the requested account_id', async () => {
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me/adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve({ account_id: 'acc_unknown' }, {});
+      assert.strictEqual(result, null);
+    });
+
+    it('returns null when upstream body is empty', async () => {
+      const http = fakeHttpClient(null, { body: null });
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me/adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve({ account_id: 'acc_1' }, {});
+      assert.strictEqual(result, null);
+    });
+
+    it('propagates upstream errors verbatim (4xx/5xx other than 404)', async () => {
+      const http = fakeHttpClient([], {
+        throw: new Error('Upstream GET /me/adaccounts failed: 500 Internal Server Error'),
+      });
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me/adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      await assert.rejects(() => resolve({ account_id: 'acc_1' }, {}), /500 Internal Server Error/);
+    });
+  });
+
+  describe('configurable extraction', () => {
+    it('uses a custom idField', async () => {
+      const http = fakeHttpClient([
+        { account_ref: 'snap_act_42', name: 'Acme' },
+        { account_ref: 'snap_act_43', name: 'Nike' },
+      ]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/adaccounts',
+        idField: 'account_ref',
+        toAccount: row => ({
+          id: row.account_ref,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve({ account_id: 'snap_act_43' }, {});
+      assert.strictEqual(result?.id, 'snap_act_43');
+      assert.strictEqual(result?.name, 'Nike');
+    });
+
+    it('uses a custom rowsPath', async () => {
+      const http = fakeHttpClient(null, {
+        body: { adaccounts: [{ id: 'a1', name: 'Acme' }] },
+      });
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/v1/me',
+        rowsPath: 'adaccounts',
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve({ account_id: 'a1' }, {});
+      assert.strictEqual(result?.id, 'a1');
+    });
+
+    it('rowsPath: null treats body as a flat array', async () => {
+      const http = fakeHttpClient(null, {
+        body: [
+          { id: 'a1', name: 'Acme' },
+          { id: 'a2', name: 'Nike' },
+        ],
+      });
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/customers',
+        rowsPath: null,
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const result = await resolve({ account_id: 'a2' }, {});
+      assert.strictEqual(result?.name, 'Nike');
+    });
+
+    it('threads a custom getAuthContext output to the http client', async () => {
+      const http = fakeHttpClient([{ id: 'a1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        getAuthContext: ctx => ({ tenantId: ctx?.agent?.id, principal: ctx?.authInfo?.principal }),
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      await resolve({ account_id: 'a1' }, { agent: { id: 'agent_1' }, authInfo: { kind: 'oauth', principal: 'p1' } });
+      assert.deepStrictEqual(http.lastAuthContext(), { tenantId: 'agent_1', principal: 'p1' });
+    });
+  });
+
+  describe('caching', () => {
+    it('skips upstream on cache hit within TTL', async () => {
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: { ttlMs: 60_000 },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: { fetchedAt: Date.now() },
+        }),
+      });
+      const ctx = { authInfo: { kind: 'oauth', token: 't_a' } };
+      const r1 = await resolve({ account_id: 'acc_1' }, ctx);
+      const r2 = await resolve({ account_id: 'acc_1' }, ctx);
+      assert.strictEqual(http.callCount(), 1, 'second call should hit cache, not upstream');
+      assert.deepStrictEqual(r1, r2);
+    });
+
+    it('refetches upstream after TTL expires', async () => {
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: { ttlMs: 1 },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      const ctx = { authInfo: { kind: 'oauth', token: 't_a' } };
+      await resolve({ account_id: 'acc_1' }, ctx);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      await resolve({ account_id: 'acc_1' }, ctx);
+      assert.strictEqual(http.callCount(), 2);
+    });
+
+    it('keys cache on auth-context so different buyers do not share entries', async () => {
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: { ttlMs: 60_000 },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_a' } });
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', token: 't_buyer_b' } });
+      assert.strictEqual(http.callCount(), 2, 'different buyers must not share cache entries');
+    });
+
+    it('honors a custom getCacheKey to narrow the auth-context dimension', async () => {
+      const http = fakeHttpClient([{ id: 'acc_1', name: 'Acme' }]);
+      const resolve = createOAuthPassthroughResolver({
+        httpClient: http,
+        listEndpoint: '/me',
+        cache: {
+          ttlMs: 60_000,
+          getCacheKey: authContext => authContext?.principal ?? '<anon>',
+        },
+        toAccount: row => ({
+          id: row.id,
+          name: row.name,
+          status: 'active',
+          ctx_metadata: {},
+        }),
+      });
+      // Same principal, different request id → must hit cache.
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', principal: 'p1', token: 't_req_1' } });
+      await resolve({ account_id: 'acc_1' }, { authInfo: { kind: 'oauth', principal: 'p1', token: 't_req_2' } });
+      assert.strictEqual(http.callCount(), 1);
+    });
+  });
+
+  describe('public re-export', () => {
+    it("exports from '@adcp/sdk' top-level barrel", () => {
+      // Sanity check that the public surface includes the factory.
+      const top = require('../dist/lib/index');
+      assert.strictEqual(typeof top.createOAuthPassthroughResolver, 'function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1363. Standardizes the canonical "Shape B" account-resolution pattern that every adapter wrapping a vendor OAuth + ad-account API (Snap, Meta, TikTok, LinkedIn, Reddit, Pinterest, etc.) re-derives by hand:

> extract bearer from `ctx.authInfo` → GET `/me/adaccounts` (or equivalent) → match upstream row by `account_id` → return tenant with `ctx_metadata` populated

Without the factory, each adapter writes ~30 LOC of boilerplate. The doha-v20 (`scope3data/agentic-adapters`) monorepo had this pattern repeated across **13 of 14** adapters when #1363 was filed.

## Usage

```ts
import {
  createUpstreamHttpClient,
  createOAuthPassthroughResolver,
  defineSalesPlatform,
} from '@adcp/sdk/server';

const snap = createUpstreamHttpClient({
  baseUrl: 'https://adsapi.snapchat.com',
  auth: {
    kind: 'dynamic_bearer',
    getToken: async (ctx) => ctx?.authInfo?.credential?.token,
  },
});

const resolve = createOAuthPassthroughResolver({
  httpClient: snap,
  listEndpoint: '/v1/me/adaccounts',
  idField: 'id',
  rowsPath: 'adaccounts',
  toAccount: (row, ctx) => ({
    id: row.id,
    name: row.name,
    status: 'active',
    advertiser: row.advertiser_url,
    ctx_metadata: {
      upstreamId: row.id,
      accessToken: ctx?.authInfo?.credential?.token,
    },
  }),
  cache: { ttlMs: 60_000 },
});

defineSalesPlatform({
  accounts: { resolve, /* upsert omitted — Shape B doesn't manage account lifecycle */ },
  // ...
});
```

## Configurable shape

| Option | Default | Notes |
|---|---|---|
| `idField` | `'id'` | Match column on each upstream row |
| `rowsPath` | `'data'` | Path to the array; `null` = body is flat array |
| `getAuthContext` | `(ctx) => ctx?.authInfo` | Auth-context to forward to `dynamic_bearer.getToken` |
| `toAccount` | required | Adapter-supplied row → `Account<TCtxMeta>` mapper |
| `cache.ttlMs` | unset (no cache) | Opt-in TTL cache; recommended 30s–5min in prod |
| `cache.getCacheKey` | `JSON.stringify(authContext)` | Narrow when authContext has request-id noise |

## Behavior

- **Only handles `{ account_id }` arm** — `{ brand, operator }` and `undefined` ref return `null` without calling upstream
- **Cache is auth-context keyed** — different buyers never share cache entries (security boundary)
- **Upstream errors propagate verbatim** — adopters compose `composeMethod` over the result for typed envelope mapping (e.g. `AUTH_REQUIRED` on 401)

## Test plan

- [x] 15 new tests in `test/server-adapters-oauth-passthrough-resolver.test.js` covering: ref-arm short-circuits, upstream lookup + match, no-match returns null, empty body returns null, error propagation, custom `idField`/`rowsPath`/`getAuthContext`, cache hit/miss, TTL expiry, multi-buyer isolation, custom `getCacheKey`, public re-export from `@adcp/sdk`
- [x] `npm run build:lib` clean
- [x] `npm run format:check` clean
- [x] Changeset (minor — additive surface)

## Source

#1340 triage thread → #1363 spin-off. The 8–12 line snippet in the planned `docs/guides/account-resolution.md` (PR #1357) is fine for one or two adopters; for a multi-adapter monorepo it's pure repetition. This factory is the ergonomic answer for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)