### PR TITLE
docs(recipes): add composeMethod testing recipe and matching tests (#1345)

### DIFF
--- a/.changeset/compose-method-testing-recipes.md
+++ b/.changeset/compose-method-testing-recipes.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Added `docs/recipes/composeMethod-testing.md` with six test patterns for `composeMethod`-wrapped handlers: mocking the base method, short-circuit assertion (including the `{ shortCircuit: undefined }` gotcha), layering two `composeMethod` calls, `after`-hook enrichment, typed-error propagation, and `requireAdvertiserMatch` with `composeMethod`. Every pattern has a corresponding running test in `test/server-decisioning-compose-recipes.test.js`. Added a `composeMethod` cookbook entry and table row to `docs/llms.txt` so agents building decisioning platforms can discover the primitive and its test patterns. Closes #1345.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -43,6 +43,8 @@ Compile-time enforcement: `RequiredPlatformsFor<S>` catches missing specialism m
 
 Lower-level option: `createAdcpServer({ signals: { getSignals: ... } })` from `@adcp/sdk/server/legacy/v5` — handler-bag API. Still fully supported, the substrate the platform path calls into. Use when you need fine control over individual handlers, mid-migration from a v5 codebase, or custom-shaped tools the platform interface doesn't yet model. `wrapEnvelope(inner, { replayed, context, operationId })` from `@adcp/sdk/server` attaches protocol envelope fields with the per-error-code allowlist (IDEMPOTENCY_CONFLICT drops `replayed`).
 
+**`composeMethod` cookbook.** To layer `before`/`after` hooks on a single platform method — short-circuit for caching, enrichment under `ext.*`, typed-error guards — use `composeMethod(inner, { before?, after? })` from `@adcp/sdk/server`. Stacking multiple guards: nest `composeMethod` calls (outer `before` runs first). Test patterns (mocking inner, asserting short-circuit, chained hooks, typed-error propagation): see [`docs/recipes/composeMethod-testing.md`](./recipes/composeMethod-testing.md). Pre-built `accounts.resolve` guards (`requireAccountMatch`, `requireAdvertiserMatch`, `requireOrgScope`) are in the same package.
+
 ## Quick Start (Client)
 
 ```typescript
@@ -1228,6 +1230,7 @@ These docs are available locally in the repo and hosted at https://adcontextprot
 | CLI reference | docs/CLI.md | [link](https://adcontextprotocol.github.io/adcp-client/CLI.md) |
 | Zod runtime validation | docs/ZOD-SCHEMAS.md | [link](https://adcontextprotocol.github.io/adcp-client/ZOD-SCHEMAS.md) |
 | Testing strategy | docs/guides/TESTING-STRATEGY.md | [link](https://adcontextprotocol.github.io/adcp-client/guides/TESTING-STRATEGY.md) |
+| Testing `composeMethod`-wrapped handlers | docs/recipes/composeMethod-testing.md | [link](https://adcontextprotocol.github.io/adcp-client/recipes/composeMethod-testing.md) |
 | Protocol differences (MCP vs A2A) | docs/development/PROTOCOL_DIFFERENCES.md | [link](https://adcontextprotocol.github.io/adcp-client/development/PROTOCOL_DIFFERENCES.md) |
 | TypeDoc API reference | docs/api/index.html | [link](https://adcontextprotocol.github.io/adcp-client/api/index.html) |
 

--- a/docs/recipes/composeMethod-testing.md
+++ b/docs/recipes/composeMethod-testing.md
@@ -1,0 +1,268 @@
+# Testing `composeMethod`-wrapped handlers
+
+`composeMethod` wraps a single platform method with optional `before` / `after` hooks. This
+recipe shows how to write tests for handlers built with it, covering six patterns that adopters
+reach for most often.
+
+All snippets here are running tests in
+[`test/server-decisioning-compose-recipes.test.js`](../../test/server-decisioning-compose-recipes.test.js).
+If a snippet and the test ever diverge, the test is authoritative (the test runs in CI; the
+snippet does not). To verify locally: `node --test test/server-decisioning-compose-recipes.test.js`
+from the repo root after `npm run build:lib`.
+
+**Not this guide:** `docs/guides/HANDLER-PATTERNS-GUIDE.md` covers buyer-side `InputHandler`
+patterns. This guide is for _server-side_ `composeMethod` — a different primitive on a different
+surface, with a different test runner (Node built-in `assert`, not Jest).
+
+## Import
+
+```typescript
+import { composeMethod } from '@adcp/sdk/server';
+import type { ComposeHooks, ComposeShortCircuit } from '@adcp/sdk/server';
+```
+
+---
+
+## Pattern 1 — Mock the base, assert pass-through
+
+When neither hook fires the wrapped method is a transparent proxy. Track calls on the inner
+function with a simple counter — no mocking library needed.
+
+```javascript
+const inner = async (params, ctx) => ({ count: params.limit, region: ctx.region });
+let innerCalls = 0;
+const tracked = async (params, ctx) => { innerCalls++; return inner(params, ctx); };
+
+const wrapped = composeMethod(tracked, {});
+const result = await wrapped({ limit: 5 }, { region: 'us-east-1' });
+
+assert.strictEqual(innerCalls, 1, 'inner called exactly once');
+assert.deepStrictEqual(result, { count: 5, region: 'us-east-1' });
+```
+
+---
+
+## Pattern 2 — Short-circuit from a `before` hook
+
+A `before` hook returning `{ shortCircuit: value }` prevents `inner` from running. The
+short-circuit value flows through `after` (if any) and back to the caller.
+
+```javascript
+let innerCalled = false;
+const inner = async () => { innerCalled = true; return { from: 'inner' }; };
+const cached = { from: 'cache' };
+
+const wrapped = composeMethod(inner, {
+  before: async (params) => params.cached ? { shortCircuit: cached } : undefined,
+});
+
+// Cache hit — inner must be skipped
+innerCalled = false;
+const hit = await wrapped({ cached: true }, {});
+assert.strictEqual(innerCalled, false, 'inner must not run on cache hit');
+assert.deepStrictEqual(hit, { from: 'cache' });
+
+// Cache miss — inner must run
+const miss = await wrapped({ cached: false }, {});
+assert.strictEqual(innerCalled, true);
+assert.deepStrictEqual(miss, { from: 'inner' });
+```
+
+**Gotcha — bare `undefined` is a fall-through, not a short-circuit.** Only the discriminated
+wrapper `{ shortCircuit: value }` signals early exit. A `before` hook that returns `undefined`
+(or nothing) always falls through to `inner`, even when the intended short-circuit value is
+itself `undefined`. To short-circuit with an undefined result, return `{ shortCircuit: undefined }`.
+
+```javascript
+// Wrong: this is a fall-through
+const wrong = composeMethod(inner, { before: async () => undefined });
+
+// Right: this short-circuits with undefined as the result
+const right = composeMethod(inner, { before: async () => ({ shortCircuit: undefined }) });
+```
+
+---
+
+## Pattern 3 — Layering two `composeMethod` calls
+
+`before` accepts a single function, not an array. To compose independent guards, nest
+`composeMethod` calls. The outer `before` runs first; if it falls through, the inner `before`
+runs. This is how the `requireAdvertiserMatch` / `requireOrgScope` presets are designed to be
+composed.
+
+```javascript
+const inner = async () => ({ ok: true });
+const log = [];
+
+// Guard B is closer to inner; Guard A is the outer wrapper
+const withB = composeMethod(inner, {
+  before: async (params) => {
+    log.push('B');
+    return params.blockB ? { shortCircuit: { blocked: 'B' } } : undefined;
+  },
+});
+const withAB = composeMethod(withB, {
+  before: async (params) => {
+    log.push('A');
+    return params.blockA ? { shortCircuit: { blocked: 'A' } } : undefined;
+  },
+});
+
+// A short-circuits — B never runs
+log.length = 0;
+const ra = await withAB({ blockA: true, blockB: false }, {});
+assert.deepStrictEqual(log, ['A'], 'B must not run when A short-circuits');
+assert.deepStrictEqual(ra, { blocked: 'A' });
+
+// A falls through — B short-circuits
+log.length = 0;
+const rb = await withAB({ blockA: false, blockB: true }, {});
+assert.deepStrictEqual(log, ['A', 'B']);
+assert.deepStrictEqual(rb, { blocked: 'B' });
+
+// Both fall through — inner runs
+log.length = 0;
+const rc = await withAB({ blockA: false, blockB: false }, {});
+assert.deepStrictEqual(log, ['A', 'B']);
+assert.deepStrictEqual(rc, { ok: true });
+```
+
+---
+
+## Pattern 4 — `after` hook enrichment
+
+`after` receives `(result, params, ctx)` and must return the (possibly modified) result. Assert
+both that the hook saw the right inner response and that its enrichment arrived at the caller.
+
+```javascript
+const inner = async () => ({ products: [{ id: 'p1', price_cpm: 5.0 }] });
+
+const wrapped = composeMethod(inner, {
+  after: async (result, params, ctx) => ({
+    ...result,
+    ext: { enriched_by: ctx.region, count: result.products.length },
+  }),
+});
+
+const result = await wrapped({ filter: 'active' }, { region: 'eu-west-1' });
+assert.deepStrictEqual(result.products, [{ id: 'p1', price_cpm: 5.0 }]);
+assert.deepStrictEqual(result.ext, { enriched_by: 'eu-west-1', count: 1 });
+```
+
+**Note on placement:** `after` runs before response-schema validation. Fields added outside
+`ext` may fail schema validation — keep vendor-specific enrichment under `ext.*` (the spec's
+typed extension surface).
+
+`after` also runs on short-circuit values from `before`:
+
+```javascript
+const inner2 = async () => ({ products: ['from-inner'] });
+const wrapped2 = composeMethod(inner2, {
+  before: async () => ({ shortCircuit: { products: [] } }),
+  after: async (result) => ({ ...result, ext: { from: 'after' } }),
+});
+const r = await wrapped2({}, {});
+assert.deepStrictEqual(r.ext, { from: 'after' }, 'after runs on short-circuit values too');
+```
+
+---
+
+## Pattern 5 — `composeMethod` + typed errors
+
+`composeMethod` does not catch errors — typed errors thrown from `inner`, `before`, or `after`
+propagate to the caller. This is by design: the AdCP framework translates `AdcpError` subclasses
+to structured wire errors before they reach the buyer.
+
+```javascript
+const { PermissionDeniedError } = require('@adcp/sdk/server');
+
+// Error thrown from inner propagates
+const inner = async (params) => {
+  if (!params.account_id) throw new PermissionDeniedError('accounts.resolve');
+  return { account_id: params.account_id };
+};
+const wrapped = composeMethod(inner, {});
+
+await assert.rejects(
+  () => wrapped({}, {}),
+  (err) => {
+    assert.ok(err instanceof PermissionDeniedError);
+    assert.strictEqual(err.code, 'PERMISSION_DENIED');
+    return true;
+  }
+);
+assert.deepStrictEqual(await wrapped({ account_id: 'acc_1' }, {}), { account_id: 'acc_1' });
+```
+
+A `before` hook may also throw instead of returning `{ shortCircuit: null }` when you want the
+buyer to receive a typed wire error rather than a silent null. Use `{ shortCircuit: null }` to
+look like "not found"; use `throw new PermissionDeniedError(...)` when the buyer is already
+known to be authorized to know the account exists:
+
+```javascript
+const { PermissionDeniedError } = require('@adcp/sdk/server');
+const inner2 = async () => ({ account_id: 'acc_1' });
+
+const wrapped2 = composeMethod(inner2, {
+  before: async (_params, ctx) => {
+    if (!ctx.authorized) throw new PermissionDeniedError('before-hook');
+  },
+});
+
+await assert.rejects(
+  () => wrapped2({}, { authorized: false }),
+  PermissionDeniedError
+);
+const ok = await wrapped2({}, { authorized: true });
+assert.ok(ok !== null);
+```
+
+---
+
+## Pattern 6 — `requireAdvertiserMatch` with `composeMethod`
+
+The presets shipped in `@adcp/sdk/server` (`requireAccountMatch`, `requireAdvertiserMatch`,
+`requireOrgScope`) are pre-built `ComposeHooks` objects for `accounts.resolve`. Each returns an
+`after` hook that runs _after_ the inner resolver; a null inner result propagates unconditionally
+(no predicate runs on a "not found" account). The snippet below uses `requireAdvertiserMatch`;
+`requireAccountMatch` (general predicate) and `requireOrgScope` (org equality check) follow the
+same shape — pass the result of any of them directly as the second argument to `composeMethod`.
+
+```javascript
+const { composeMethod, requireAdvertiserMatch } = require('@adcp/sdk/server');
+
+const baseResolve = async (ref, _ctx) => ({
+  account_id: ref?.account_id ?? 'acc_1',
+  advertiser: 'brand_A',
+  ctx_metadata: {},
+  authInfo: { kind: 'api_key' },
+});
+
+const guarded = composeMethod(baseResolve, requireAdvertiserMatch(
+  async (ctx) => ctx?.allowedAdvertisers ?? []
+));
+
+// Allowed advertiser — resolves
+const allowed = await guarded(
+  { account_id: 'acc_1' },
+  { allowedAdvertisers: ['brand_A'] }
+);
+assert.ok(allowed !== null);
+assert.strictEqual(allowed.advertiser, 'brand_A');
+
+// Disallowed advertiser — silent null (avoids principal enumeration)
+const denied = await guarded(
+  { account_id: 'acc_1' },
+  { allowedAdvertisers: ['brand_B'] }
+);
+assert.strictEqual(denied, null);
+
+// Inner returns null (account not found) — propagates, predicate skipped
+const baseNull = async () => null;
+const guardedNull = composeMethod(baseNull, requireAdvertiserMatch(
+  async () => ['brand_A']
+));
+assert.strictEqual(await guardedNull({}, {}), null);
+```
+
+The full preset API is documented in the JSDoc of `src/lib/server/decisioning/resolve-presets.ts`.

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -552,6 +552,10 @@ function generateLlmsTxt(
     `Lower-level option: \`createAdcpServer({ signals: { getSignals: ... } })\` from \`@adcp/sdk/server/legacy/v5\` — handler-bag API. Still fully supported, the substrate the platform path calls into. Use when you need fine control over individual handlers, mid-migration from a v5 codebase, or custom-shaped tools the platform interface doesn't yet model. \`wrapEnvelope(inner, { replayed, context, operationId })\` from \`@adcp/sdk/server\` attaches protocol envelope fields with the per-error-code allowlist (IDEMPOTENCY_CONFLICT drops \`replayed\`).`
   );
   ln();
+  ln(
+    `**\`composeMethod\` cookbook.** To layer \`before\`/\`after\` hooks on a single platform method — short-circuit for caching, enrichment under \`ext.*\`, typed-error guards — use \`composeMethod(inner, { before?, after? })\` from \`@adcp/sdk/server\`. Stacking multiple guards: nest \`composeMethod\` calls (outer \`before\` runs first). Test patterns (mocking inner, asserting short-circuit, chained hooks, typed-error propagation): see [\`docs/recipes/composeMethod-testing.md\`](./recipes/composeMethod-testing.md). Pre-built \`accounts.resolve\` guards (\`requireAccountMatch\`, \`requireAdvertiserMatch\`, \`requireOrgScope\`) are in the same package.`
+  );
+  ln();
 
   // --- Quick start ---
   ln(`## Quick Start (Client)`);
@@ -992,6 +996,7 @@ function generateLlmsTxt(
     ['CLI reference', 'CLI.md'],
     ['Zod runtime validation', 'ZOD-SCHEMAS.md'],
     ['Testing strategy', 'guides/TESTING-STRATEGY.md'],
+    ['Testing `composeMethod`-wrapped handlers', 'recipes/composeMethod-testing.md'],
     ['Protocol differences (MCP vs A2A)', 'development/PROTOCOL_DIFFERENCES.md'],
     ['TypeDoc API reference', 'api/index.html'],
   ];

--- a/test/server-decisioning-compose-recipes.test.js
+++ b/test/server-decisioning-compose-recipes.test.js
@@ -1,0 +1,223 @@
+// Runnable tests backing the composeMethod testing recipe at
+// docs/recipes/composeMethod-testing.md.
+//
+// Each test corresponds 1-to-1 with a pattern in that doc. If a snippet there
+// diverges from this file, this file is authoritative.
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { composeMethod, requireAdvertiserMatch, PermissionDeniedError } = require('../dist/lib/server');
+
+describe('composeMethod recipes (#1345)', () => {
+  describe('Pattern 1 — mock the base, assert pass-through', () => {
+    it('calls inner exactly once and returns its result unmodified', async () => {
+      const inner = async (params, ctx) => ({ count: params.limit, region: ctx.region });
+      let innerCalls = 0;
+      const tracked = async (params, ctx) => {
+        innerCalls++;
+        return inner(params, ctx);
+      };
+
+      const wrapped = composeMethod(tracked, {});
+      const result = await wrapped({ limit: 5 }, { region: 'us-east-1' });
+
+      assert.strictEqual(innerCalls, 1, 'inner called exactly once');
+      assert.deepStrictEqual(result, { count: 5, region: 'us-east-1' });
+    });
+  });
+
+  describe('Pattern 2 — short-circuit from a before hook', () => {
+    it('skips inner when before returns { shortCircuit: value }', async () => {
+      let innerCalled = false;
+      const inner = async () => {
+        innerCalled = true;
+        return { from: 'inner' };
+      };
+      const cached = { from: 'cache' };
+
+      const wrapped = composeMethod(inner, {
+        before: async params => (params.cached ? { shortCircuit: cached } : undefined),
+      });
+
+      // Cache hit — inner must be skipped
+      innerCalled = false;
+      const hit = await wrapped({ cached: true }, {});
+      assert.strictEqual(innerCalled, false, 'inner must not run on cache hit');
+      assert.deepStrictEqual(hit, { from: 'cache' });
+
+      // Cache miss — inner must run
+      innerCalled = false;
+      const miss = await wrapped({ cached: false }, {});
+      assert.strictEqual(innerCalled, true);
+      assert.deepStrictEqual(miss, { from: 'inner' });
+    });
+
+    it('bare undefined return is a fall-through, not a short-circuit', async () => {
+      let innerCalled = false;
+      const inner = async () => {
+        innerCalled = true;
+        return 'inner-value';
+      };
+
+      const wrong = composeMethod(inner, { before: async () => undefined });
+      innerCalled = false;
+      await wrong({}, {});
+      assert.strictEqual(innerCalled, true, 'undefined return must fall through to inner');
+    });
+
+    it('{ shortCircuit: undefined } short-circuits with undefined result', async () => {
+      let innerCalled = false;
+      const inner = async () => {
+        innerCalled = true;
+        return 'inner-value';
+      };
+
+      const right = composeMethod(inner, { before: async () => ({ shortCircuit: undefined }) });
+      innerCalled = false;
+      const result = await right({}, {});
+      assert.strictEqual(innerCalled, false, 'inner must not run');
+      assert.strictEqual(result, undefined);
+    });
+  });
+
+  describe('Pattern 3 — layering two composeMethod calls', () => {
+    it('outer before fires first; inner before only fires when outer falls through', async () => {
+      const inner = async () => ({ ok: true });
+      const log = [];
+
+      const withB = composeMethod(inner, {
+        before: async params => {
+          log.push('B');
+          return params.blockB ? { shortCircuit: { blocked: 'B' } } : undefined;
+        },
+      });
+      const withAB = composeMethod(withB, {
+        before: async params => {
+          log.push('A');
+          return params.blockA ? { shortCircuit: { blocked: 'A' } } : undefined;
+        },
+      });
+
+      // A short-circuits — B never runs
+      log.length = 0;
+      const ra = await withAB({ blockA: true, blockB: false }, {});
+      assert.deepStrictEqual(log, ['A'], 'B must not run when A short-circuits');
+      assert.deepStrictEqual(ra, { blocked: 'A' });
+
+      // A falls through — B short-circuits
+      log.length = 0;
+      const rb = await withAB({ blockA: false, blockB: true }, {});
+      assert.deepStrictEqual(log, ['A', 'B']);
+      assert.deepStrictEqual(rb, { blocked: 'B' });
+
+      // Both fall through — inner runs
+      log.length = 0;
+      const rc = await withAB({ blockA: false, blockB: false }, {});
+      assert.deepStrictEqual(log, ['A', 'B']);
+      assert.deepStrictEqual(rc, { ok: true });
+    });
+  });
+
+  describe('Pattern 4 — after hook enrichment', () => {
+    it('after receives (result, params, ctx) and its return value reaches the caller', async () => {
+      const inner = async () => ({ products: [{ id: 'p1', price_cpm: 5.0 }] });
+
+      const wrapped = composeMethod(inner, {
+        after: async (result, params, ctx) => ({
+          ...result,
+          ext: { enriched_by: ctx.region, count: result.products.length },
+        }),
+      });
+
+      const result = await wrapped({ filter: 'active' }, { region: 'eu-west-1' });
+      assert.deepStrictEqual(result.products, [{ id: 'p1', price_cpm: 5.0 }]);
+      assert.deepStrictEqual(result.ext, { enriched_by: 'eu-west-1', count: 1 });
+    });
+
+    it('after also runs on short-circuit values from before', async () => {
+      const inner = async () => ({ products: ['from-inner'] });
+
+      const wrapped = composeMethod(inner, {
+        before: async () => ({ shortCircuit: { products: [] } }),
+        after: async result => ({ ...result, ext: { from: 'after' } }),
+      });
+      const r = await wrapped({}, {});
+      assert.deepStrictEqual(r.ext, { from: 'after' }, 'after must run on short-circuit values');
+    });
+  });
+
+  describe('Pattern 5 — composeMethod + typed errors', () => {
+    it('typed error from inner propagates to caller', async () => {
+      const inner = async params => {
+        if (!params.account_id) throw new PermissionDeniedError('accounts.resolve');
+        return { account_id: params.account_id };
+      };
+      const wrapped = composeMethod(inner, {});
+
+      await assert.rejects(
+        () => wrapped({}, {}),
+        err => {
+          assert.ok(err instanceof PermissionDeniedError);
+          assert.strictEqual(err.code, 'PERMISSION_DENIED');
+          return true;
+        }
+      );
+      assert.deepStrictEqual(await wrapped({ account_id: 'acc_1' }, {}), { account_id: 'acc_1' });
+    });
+
+    it('typed error from a before hook propagates to caller', async () => {
+      const inner2 = async () => ({ account_id: 'acc_1' });
+
+      const wrapped2 = composeMethod(inner2, {
+        before: async (_params, ctx) => {
+          if (!ctx.authorized) throw new PermissionDeniedError('before-hook');
+        },
+      });
+
+      await assert.rejects(() => wrapped2({}, { authorized: false }), PermissionDeniedError);
+      const ok = await wrapped2({}, { authorized: true });
+      assert.ok(ok !== null);
+    });
+  });
+
+  describe('Pattern 6 — requireAdvertiserMatch with composeMethod', () => {
+    const baseResolve = async (ref, _ctx) => ({
+      account_id: ref?.account_id ?? 'acc_1',
+      advertiser: 'brand_A',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    });
+
+    it('allowed advertiser resolves', async () => {
+      const guarded = composeMethod(
+        baseResolve,
+        requireAdvertiserMatch(async ctx => ctx?.allowedAdvertisers ?? [])
+      );
+
+      const allowed = await guarded({ account_id: 'acc_1' }, { allowedAdvertisers: ['brand_A'] });
+      assert.ok(allowed !== null);
+      assert.strictEqual(allowed.advertiser, 'brand_A');
+    });
+
+    it('disallowed advertiser resolves to null (silent deny)', async () => {
+      const guarded = composeMethod(
+        baseResolve,
+        requireAdvertiserMatch(async ctx => ctx?.allowedAdvertisers ?? [])
+      );
+
+      const denied = await guarded({ account_id: 'acc_1' }, { allowedAdvertisers: ['brand_B'] });
+      assert.strictEqual(denied, null);
+    });
+
+    it('null inner result propagates without running the predicate', async () => {
+      const baseNull = async () => null;
+      const guardedNull = composeMethod(
+        baseNull,
+        requireAdvertiserMatch(async () => ['brand_A'])
+      );
+      assert.strictEqual(await guardedNull({}, {}), null);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1345

Adopters writing `composeMethod`-wrapped handlers had no canonical test scaffolding — every team reinvented their own. This PR adds a recipe doc with six test patterns and matching running tests so the patterns can't rot independently of the implementation.

## What changed

| File | Change |
|------|--------|
| `docs/recipes/composeMethod-testing.md` | New recipe doc (six patterns) |
| `test/server-decisioning-compose-recipes.test.js` | Matching running tests (node:test, same import style as existing compose tests) |
| `docs/llms.txt` | cookbook entry in server section + table row |
| `scripts/generate-agent-docs.ts` | Same two additions, so the changes survive `npm run generate-agent-docs` regeneration |
| `.changeset/compose-method-testing-recipes.md` | patch changeset (docs/llms.txt is in the published `files`) |

## Six patterns

1. **Mock the base, assert pass-through** — track inner calls with a simple counter; no mocking library needed
2. **Short-circuit from a `before` hook** — including the `{ shortCircuit: undefined }` vs bare `undefined` gotcha
3. **Layering two `composeMethod` calls** — `before` takes a single function (not an array); stacking means nesting calls; outer fires first
4. **`after` hook enrichment** — `after` receives `(result, params, ctx)`; also runs on short-circuit values
5. **`composeMethod` + typed errors** — `PermissionDeniedError` thrown from `inner` or `before` propagates naturally
6. **`requireAdvertiserMatch` with `composeMethod`** — demonstrates resolve-preset shape; `requireAccountMatch` and `requireOrgScope` follow the same pattern

## Notes

- `docs/llms.txt` is auto-generated — both the file and its generator (`scripts/generate-agent-docs.ts`) were updated identically so the content survives `npm run generate-agent-docs`.
- Doc snippets use `require('@adcp/sdk/server')` (public import); test file uses `require('../dist/lib/server')` (repo-internal, consistent with all other test files).

## What tested

- Build: `npm run build:lib` unavailable in this environment (missing `tsc`/`tsx` from node_modules). Test file follows identical import and assertion style as `test/server-decisioning-compose.test.js`. CI will validate.
- No generated files touched (`src/lib/types/*.generated.ts`, `src/lib/agents/index.generated.ts`).

**Pre-PR review:**
- code-reviewer: approved after 2 blockers fixed — `requireAccountMatch` missing from llms.txt preset list; Pattern 6 header scope mismatch with snippet. 1 nit fixed (add run command to authoritative note).
- docs-expert: approved after 2 blockers fixed — changeset filename typo (`composemethid` → `compose-method`); doc snippets used internal dist path instead of `@adcp/sdk/server`. 2 issues fixed (missing `innerCalled` reset; undeclared `inner` in Pattern 4 second snippet). 1 nit fixed (JSDoc cross-reference clarification).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1371` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01NnVDYEAhWe6VoWKzHttBn7