### PR TITLE
feat(server): instructions accepts a function form (lazy/per-session) — closes #1347

### DIFF
--- a/.changeset/instructions-function-form.md
+++ b/.changeset/instructions-function-form.md
@@ -1,0 +1,45 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): `instructions` accepts a function form (lazy / per-session)
+
+`createAdcpServer` and `DecisioningPlatform.instructions` now accept either a static `string` (the historical form) or a `(ctx: SessionContext) => string | undefined` function. Under the canonical `serve({ reuseAgent: false })` flow (the default) the factory runs per HTTP request, so the function fires per session — adopters can surface tenant-shaped prose (per-buyer brand manifests, storefront-platform copy, "premium vs standard" partner guidance) without hand-rolling a `Map` shim outside the SDK.
+
+Closes #1347.
+
+**Surface:**
+
+```ts
+import { createAdcpServer, type SessionContext, type OnInstructionsError } from '@adcp/sdk/server';
+
+createAdcpServer({
+  // existing string form still works
+  instructions: 'Publisher-wide brand safety: alcohol disallowed.',
+
+  // or function form — re-evaluated per createAdcpServer invocation
+  instructions: (ctx: SessionContext) => brandManifests.get(currentTenant)?.intro,
+
+  // throw semantics — default 'skip' (best-effort prose; throws resolve to no instructions)
+  onInstructionsError: 'skip', // or 'fail' (rethrow → MCP initialize transport-level failure)
+});
+```
+
+**Three guardrails:**
+
+1. **`reuseAgent: true` + function-form is refused.** The function would only fire once for the lifetime of the shared agent — silently degrading to "instructions are a constant after all" is worse than failing loud. `serve()` returns 500 with a message naming the workaround (drop `reuseAgent: true` or pass a static string).
+2. **Async return is not yet supported.** A function returning a `Promise` throws `ConfigurationError` at construction; pre-resolve before invoking `createAdcpServer` if you need to fetch.
+3. **`SessionContext` is reserved.** `authInfo` and `agent` are typed for forward compatibility but currently always `undefined` — the framework does not yet plumb auth/registry state into the factory before MCP `initialize`. Use closures captured in your factory's HTTP-scoped state for tenant identity today; the function body picks up populated fields when the framework wires them through.
+
+**Throw semantics:**
+
+- `'skip'` (default) — log server-side, treat as `undefined` (no instructions). Right for prose-of-flavor (brand manifests, marketing copy) where a registry fetch failure must not kill the buyer's session.
+- `'fail'` — rethrow. The MCP `initialize` handshake then fails at the transport layer (this is NOT an `adcp_error` envelope — it kills the session). Right for adopters whose instructions carry load-bearing policy where stale/missing guidance is worse than a connection retry.
+
+**New exports** from `@adcp/sdk/server`:
+
+- `SessionContext` — slim `{ authInfo?, agent? }`, both reserved for now.
+- `OnInstructionsError` — `'skip' | 'fail'`.
+- `ADCP_INSTRUCTIONS_FN` — symbol marker `serve()` reads to refuse the `reuseAgent: true` combination.
+
+Plumbed through `DecisioningPlatform.instructions` (v6 surface) and `createAdcpServer.instructions` (v5 escape hatch); platform wins when both are set, same precedence pattern as `agentRegistry`.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1097,14 +1097,22 @@ export const ADCP_INSTRUCTIONS_FN: unique symbol = Symbol.for('@adcp/client.inst
  */
 export interface SessionContext {
   /**
-   * Authenticated principal extracted by `serve({ authenticate })`. Reserved
-   * for forward compatibility; currently always `undefined`.
+   * @reserved Always `undefined` in v6.x. The framework does not yet plumb
+   * `authInfo` into the factory before MCP `initialize` — use closures
+   * captured in your factory's HTTP-scoped state for tenant identity today.
+   * Forward-compatible: when the framework wires this through, your
+   * `ctx.authInfo?.…` reads start returning real values without breaking
+   * existing function bodies.
    */
   readonly authInfo?: ResolvedAuthInfo;
 
   /**
-   * Resolved `BuyerAgent` from `BuyerAgentRegistry`. Reserved for forward
-   * compatibility; currently always `undefined`.
+   * @reserved Always `undefined` in v6.x. The framework does not yet plumb
+   * the resolved `BuyerAgent` into the factory before MCP `initialize` —
+   * use closures captured in your factory's HTTP-scoped state for tenant
+   * identity today. Forward-compatible: when the framework wires this
+   * through, your `ctx.agent?.…` reads start returning real values without
+   * breaking existing function bodies.
    */
   readonly agent?: BuyerAgent;
 }
@@ -1414,22 +1422,37 @@ export interface AdcpServerConfig<TAccount = unknown> {
    *    same value for every session.
    * 2. **Function** `(ctx: SessionContext) => string | undefined` — re-evaluated
    *    each time `createAdcpServer` is called. Under the canonical
-   *    `serve()` flow with `reuseAgent: false` (the default) the factory
-   *    runs per HTTP request, so the function fires per session and the
-   *    closure can surface tenant-shaped prose (per-buyer brand manifests,
-   *    storefront-platform copy, "premium vs standard" partner guidance).
+   *    `serve({ reuseAgent: false })` flow (the default) the factory
+   *    runs per HTTP request, which under streamable-HTTP MCP is per
+   *    session — so the closure can surface tenant-shaped prose (per-buyer
+   *    brand manifests, storefront copy, "premium vs standard" partner
+   *    guidance).
    *
-   * **Eval moment.** Per `createAdcpServer` invocation. Under `reuseAgent: false`
-   * that is per session; under `reuseAgent: true` it would be once for the
-   * lifetime of the shared agent — which defeats the purpose, so `serve()`
-   * refuses that combination.
+   * **Eval moment.** Strictly: once per `createAdcpServer` invocation.
+   * `serve({ reuseAgent: false })` makes that "per HTTP request, which is
+   * per session for streamable-HTTP MCP." Custom transports / hand-rolled
+   * dispatch must invoke `createAdcpServer` per session themselves to
+   * preserve the per-session semantic. `reuseAgent: true` would fire the
+   * function once for the lifetime of the shared agent — which defeats
+   * the purpose, so `serve()` refuses that combination at the first
+   * request.
    *
    * **`SessionContext` is reserved.** `authInfo` and `agent` are typed for
    * forward compatibility but currently always `undefined` — the framework
-   * does not yet plumb auth/registry state into the factory. Use closures
+   * does not yet plumb auth/registry state into the factory. **Use closures
    * captured in your factory's HTTP-scoped state for tenant identity today;
-   * the function body will pick up populated fields when the framework wires
-   * them through.
+   * `ctx.agent`/`ctx.authInfo` reads silently return `undefined` and ship
+   * empty prose to prod.** The function body will pick up populated fields
+   * when the framework wires them through.
+   *
+   * @example Per-tenant prose via factory closure (recommended pattern):
+   * ```ts
+   * serve(({ taskStore, host }) => createAdcpServer({
+   *   // host is HTTP-scoped — captured in the closure, NOT from ctx.
+   *   instructions: () => brandManifests.get(host)?.intro ?? defaultProse,
+   *   // ... rest of config
+   * }));
+   * ```
    *
    * **Async return is not yet supported.** Function MUST return `string |
    * undefined` synchronously. A returned `Promise` throws `ConfigurationError`.
@@ -2788,14 +2811,33 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   } else if (instructionsIsFn) {
     try {
       const result = (instructionsOption as (ctx: SessionContext) => string | undefined)({});
-      if (result !== undefined && typeof (result as { then?: unknown }).then === 'function') {
+      // Promise detection — must guard for null + non-object before reading
+      // `.then`, otherwise `typeof null.then` throws TypeError and the user
+      // sees a confusing framework-internal stack instead of their own bug.
+      const isThenable =
+        result !== null && typeof result === 'object' && typeof (result as { then?: unknown }).then === 'function';
+      if (isThenable) {
         throw new ConfigurationError(
           'createAdcpServer: function-form `instructions` returned a Promise, but async resolution is not yet ' +
             'supported. Pre-resolve before invoking createAdcpServer (e.g., `instructions: await fetchProse()`), ' +
             'or wrap your async loader in a sync cache.'
         );
       }
-      resolvedInstructions = result === undefined ? undefined : String(result);
+      // Reject non-string non-undefined returns instead of silently coercing
+      // (`String({})` → "[object Object]" would ship as instructions otherwise).
+      // The TS signature already constrains return to `string | undefined`;
+      // this catches `as any` escapees and untyped JS callers. Routed through
+      // the same try/catch as user-thrown errors so `onInstructionsError`
+      // governs both — a buggy callback is the same shape of problem either
+      // way (Promise return is the exception: framework can't recover, so
+      // it throws ConfigurationError unconditionally above).
+      if (result !== undefined && typeof result !== 'string') {
+        throw new Error(
+          `function-form \`instructions\` must return string | undefined, got ${result === null ? 'null' : typeof result}. ` +
+            `Return a string for the prose, or undefined for "no instructions on this session."`
+        );
+      }
+      resolvedInstructions = result;
     } catch (err) {
       if (err instanceof ConfigurationError) throw err;
       if (onInstructionsError === 'fail') {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -54,6 +54,7 @@ import {
 import { createTaskCapableServer } from './tasks';
 import type { TaskStore, TaskMessageQueue } from './tasks';
 import { adcpError } from './errors';
+import { ConfigurationError } from '../errors';
 import type { BuyerAgent, BuyerAgentRegistry } from './decisioning/buyer-agent';
 import type { ResolvedAuthInfo } from './decisioning/account';
 import { AdcpError } from './decisioning/async-outcome';
@@ -1068,6 +1069,62 @@ export interface AdcpSignedRequestsState {
 export const ADCP_SIGNED_REQUESTS_STATE: unique symbol = Symbol.for('@adcp/client.signedRequestsState');
 
 /**
+ * Symbol marking that a server's `instructions` was supplied as a function
+ * (lazy / per-session form) rather than a static string. `serve()` reads
+ * this to refuse `reuseAgent: true` — the function is captured once at
+ * construction and would not re-evaluate per session under server reuse.
+ *
+ * Internal contract between `createAdcpServer` and `serve()`. Adopters
+ * who instantiate `McpServer` directly (without `createAdcpServer`) and
+ * want their own marker semantics should not import this symbol.
+ */
+export const ADCP_INSTRUCTIONS_FN: unique symbol = Symbol.for('@adcp/client.instructionsFn');
+
+/**
+ * Pre-resolution session context passed to a function-form `instructions`.
+ * Slim by design — no `account` (resolution hasn't run yet at MCP `initialize`
+ * time, which is the natural eval moment for per-session instructions).
+ *
+ * Both fields are reserved: today they are always `undefined` because the
+ * framework's `serve()` does not yet plumb auth + registry state into the
+ * factory before MCP `initialize`. Adopters who need tenant identity should
+ * use closures captured in their factory's HTTP-scoped state. The shape is
+ * forward-compatible: when the framework wires authInfo/agent through, the
+ * fields will populate without breaking existing function bodies.
+ *
+ * @see AdcpServerConfig.instructions
+ * @public
+ */
+export interface SessionContext {
+  /**
+   * Authenticated principal extracted by `serve({ authenticate })`. Reserved
+   * for forward compatibility; currently always `undefined`.
+   */
+  readonly authInfo?: ResolvedAuthInfo;
+
+  /**
+   * Resolved `BuyerAgent` from `BuyerAgentRegistry`. Reserved for forward
+   * compatibility; currently always `undefined`.
+   */
+  readonly agent?: BuyerAgent;
+}
+
+/**
+ * Behavior when a function-form `instructions` callback throws.
+ *
+ * - `'skip'` (default) — log server-side, treat as `undefined` (no
+ *   instructions). Right for prose-of-flavor (brand manifests, marketing
+ *   copy) where a registry fetch failure must not kill the buyer's session.
+ * - `'fail'` — rethrow. The MCP `initialize` handshake then fails at the
+ *   transport layer (this is NOT an `adcp_error` envelope — it kills the
+ *   session). Right for adopters whose instructions carry load-bearing
+ *   policy where stale/missing guidance is worse than a connection retry.
+ *
+ * @public
+ */
+export type OnInstructionsError = 'skip' | 'fail';
+
+/**
  * Shape of the preTransport function attached by `createAdcpServer` when
  * `signedRequests` is configured. Returns `true` if the middleware has already
  * sent a response (e.g., 401 on verification failure), `false` to continue
@@ -1350,7 +1407,46 @@ export interface AdcpServerConfig<TAccount = unknown> {
     params: IdempotencyPrincipalParams,
     toolName: AdcpServerToolName
   ) => string | undefined;
-  instructions?: string;
+  /**
+   * Server-level prose surfaced on MCP `initialize`. Two forms:
+   *
+   * 1. **Static string** (the historical form) — captured at construction,
+   *    same value for every session.
+   * 2. **Function** `(ctx: SessionContext) => string | undefined` — re-evaluated
+   *    each time `createAdcpServer` is called. Under the canonical
+   *    `serve()` flow with `reuseAgent: false` (the default) the factory
+   *    runs per HTTP request, so the function fires per session and the
+   *    closure can surface tenant-shaped prose (per-buyer brand manifests,
+   *    storefront-platform copy, "premium vs standard" partner guidance).
+   *
+   * **Eval moment.** Per `createAdcpServer` invocation. Under `reuseAgent: false`
+   * that is per session; under `reuseAgent: true` it would be once for the
+   * lifetime of the shared agent — which defeats the purpose, so `serve()`
+   * refuses that combination.
+   *
+   * **`SessionContext` is reserved.** `authInfo` and `agent` are typed for
+   * forward compatibility but currently always `undefined` — the framework
+   * does not yet plumb auth/registry state into the factory. Use closures
+   * captured in your factory's HTTP-scoped state for tenant identity today;
+   * the function body will pick up populated fields when the framework wires
+   * them through.
+   *
+   * **Async return is not yet supported.** Function MUST return `string |
+   * undefined` synchronously. A returned `Promise` throws `ConfigurationError`.
+   * Pre-resolve before invoking `createAdcpServer` if you need to fetch.
+   *
+   * @see SessionContext
+   * @see onInstructionsError
+   */
+  instructions?: string | ((ctx: SessionContext) => string | undefined);
+  /**
+   * Behavior when a function-form `instructions` callback throws. Defaults
+   * to `'skip'` — best-effort prose (brand manifests, marketing copy)
+   * should not kill the buyer's session on a registry fetch failure.
+   * Set `'fail'` for adopters whose instructions carry load-bearing
+   * policy. See {@link OnInstructionsError}.
+   */
+  onInstructionsError?: OnInstructionsError;
   taskStore?: TaskStore;
   taskMessageQueue?: TaskMessageQueue;
   /**
@@ -2418,7 +2514,8 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     capabilities: capConfig,
     idempotency: idempotencyConfig,
     resolveIdempotencyPrincipal,
-    instructions,
+    instructions: instructionsOption,
+    onInstructionsError = 'skip',
     taskStore,
     taskMessageQueue,
     webhooks,
@@ -2679,10 +2776,45 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   // knowing about the emitter's construction or options.
   const webhookEmitter = webhooks ? createWebhookEmitter(webhooks) : undefined;
 
+  // Resolve `instructions` — function form is evaluated at construction.
+  // Under `serve({ reuseAgent: false })` (the default) the factory runs
+  // per HTTP request, so the function fires per session. Under
+  // `reuseAgent: true` the function would fire once and never again —
+  // `serve()` refuses that combination via `ADCP_INSTRUCTIONS_FN`.
+  const instructionsIsFn = typeof instructionsOption === 'function';
+  let resolvedInstructions: string | undefined;
+  if (typeof instructionsOption === 'string') {
+    resolvedInstructions = instructionsOption;
+  } else if (instructionsIsFn) {
+    try {
+      const result = (instructionsOption as (ctx: SessionContext) => string | undefined)({});
+      if (result !== undefined && typeof (result as { then?: unknown }).then === 'function') {
+        throw new ConfigurationError(
+          'createAdcpServer: function-form `instructions` returned a Promise, but async resolution is not yet ' +
+            'supported. Pre-resolve before invoking createAdcpServer (e.g., `instructions: await fetchProse()`), ' +
+            'or wrap your async loader in a sync cache.'
+        );
+      }
+      resolvedInstructions = result === undefined ? undefined : String(result);
+    } catch (err) {
+      if (err instanceof ConfigurationError) throw err;
+      if (onInstructionsError === 'fail') {
+        throw err;
+      }
+      // 'skip' — log server-side, surface no instructions to MCP `initialize`.
+      logger.warn('[adcp/createAdcpServer] instructions() threw; skipping (onInstructionsError: "skip")', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      resolvedInstructions = undefined;
+    }
+  } else {
+    resolvedInstructions = undefined;
+  }
+
   const server = createTaskCapableServer(name, version, {
     taskStore,
     taskMessageQueue,
-    instructions,
+    instructions: resolvedInstructions,
   });
 
   const registeredToolNames = new Set<string>();
@@ -3890,6 +4022,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     configurable: true,
     writable: false,
   });
+  // Mark when `instructions` was supplied as a function, so `serve()` can
+  // refuse `reuseAgent: true` — the function is captured once at construction
+  // and would not re-evaluate per session under server reuse.
+  if (instructionsIsFn) {
+    Object.defineProperty(wrapped, ADCP_INSTRUCTIONS_FN, {
+      value: true,
+      enumerable: false,
+      configurable: true,
+      writable: false,
+    });
+  }
   // Expose the capabilitiesData object so post-registration helpers
   // (registerTestController) can add spec-defined capability blocks
   // — comply_test_controller is registered AFTER createAdcpServer,

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -13,6 +13,7 @@
 import type { DecisioningCapabilities, BrandCapabilities } from './capabilities';
 import type { Account, AccountStore } from './account';
 import type { BuyerAgentRegistry } from './buyer-agent';
+import type { SessionContext, OnInstructionsError } from '../create-adcp-server';
 import type { StatusMappers } from './status-mappers';
 import type { SalesPlatform, SalesCorePlatform, SalesIngestionPlatform } from './specialisms/sales';
 import type { CreativeBuilderPlatform } from './specialisms/creative';
@@ -77,6 +78,17 @@ export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string
    * brand safety: alcohol disallowed", "carbon-aware pricing applies to
    * display impressions only", "weekly cutoff Thursday 17:00 UTC").
    *
+   * Two forms:
+   *
+   * 1. **Static string** — captured once at construction.
+   * 2. **Function** `(ctx: SessionContext) => string | undefined` — re-evaluated
+   *    each time `createAdcpServerFromPlatform` runs. Under the canonical
+   *    `serve({ reuseAgent: false })` flow that is per session, so the
+   *    closure can surface tenant-shaped prose (per-buyer brand manifests,
+   *    storefront-platform copy). `serve()` refuses `reuseAgent: true`
+   *    when this is a function — the function would only fire once for
+   *    the lifetime of the shared agent.
+   *
    * MCP-only today. The A2A `AgentCard` analog is `description` (and
    * per-skill `description`); threading platform.instructions into the
    * agent-card builder is tracked separately so MCP and A2A buyers see
@@ -86,8 +98,20 @@ export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string
    * supplied via `createAdcpServerFromPlatform` opts — same precedence as
    * `agentRegistry`. Adopters with v5 escape-hatch wiring can keep using
    * `opts.instructions`; v6 callers should declare it here.
+   *
+   * @see {@link OnInstructionsError} for `onInstructionsError` (default `'skip'`).
    */
-  instructions?: string;
+  instructions?: string | ((ctx: SessionContext) => string | undefined);
+
+  /**
+   * Behavior when a function-form `instructions` callback throws.
+   * Defaults to `'skip'` — best-effort prose (brand manifests, marketing
+   * copy) should not kill the buyer's session on a registry fetch failure.
+   * Set `'fail'` for adopters whose instructions carry load-bearing policy.
+   *
+   * Threaded through to {@link createAdcpServer} unchanged.
+   */
+  onInstructionsError?: OnInstructionsError;
 
   /**
    * Buyer-agent identity registry — Phase 1 of #1269. Optional. When

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1024,6 +1024,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     // adopters can colocate platform facts / decision policy with the rest
     // of their platform declaration.
     ...(platform.instructions !== undefined && { instructions: platform.instructions }),
+    ...(platform.onInstructionsError !== undefined && { onInstructionsError: platform.onInstructionsError }),
     // Pool-derived stores override the spread above when adopters supplied
     // `pool` but no explicit per-store opt. Explicit values still win.
     ...(effectiveIdempotency !== undefined && { idempotency: effectiveIdempotency }),

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -204,7 +204,13 @@ export { structuredSerialize, structuredDeserialize } from './structured-seriali
 // escape-hatch only). Breaking change: v5 adopters see a hard import error
 // and update their import path. The migration is one line; the LLM-output
 // quality win is significant. See `docs/migration-5.x-to-6.x.md`.
-export { requireSessionKey, ADCP_PRE_TRANSPORT, ADCP_SIGNED_REQUESTS_STATE } from './create-adcp-server';
+export {
+  requireSessionKey,
+  ADCP_PRE_TRANSPORT,
+  ADCP_SIGNED_REQUESTS_STATE,
+  ADCP_INSTRUCTIONS_FN,
+} from './create-adcp-server';
+export type { SessionContext, OnInstructionsError } from './create-adcp-server';
 export type {
   AdcpServer,
   AdcpServerComplianceApi,

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -560,21 +560,32 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
         return;
       }
       // Refuse `reuseAgent: true` + function-form `instructions`. The function
-      // is captured at server construction and would never re-evaluate per
+      // is captured at server construction and would not re-evaluate per
       // session under server reuse — silently degrading to "instructions are
       // a constant after all" is worse than failing loud at the first request.
       // Adopters fix this by removing `reuseAgent: true` (default factory
       // creates a fresh agent per request, which is what the function needs)
       // OR by passing a static string for `instructions`.
+      //
+      // The check fires when `reuseAgent: true` was declared, regardless of
+      // whether the adopter's factory actually caches. The flag is the
+      // adopter's stated intent to reuse; we can't introspect cache behavior.
       if (reuseAgent && (agentServer as unknown as Record<symbol, unknown>)[ADCP_INSTRUCTIONS_FN] === true) {
+        const hint =
+          'Drop `reuseAgent: true` (a fresh agent per request fires the function each session) OR pass a static string for `instructions`.';
         console.error(
           '[adcp/serve] refusing reuseAgent: true with function-form instructions. ' +
-            'The function is captured once at construction and cannot re-evaluate per session under server reuse. ' +
-            'Drop `reuseAgent: true` (a fresh agent per request fires the function each session) OR pass a static string for `instructions`.'
+            'The function is captured once at construction and would not re-evaluate per session under server reuse. ' +
+            hint
         );
         if (!res.headersSent) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'serve(): reuseAgent is incompatible with function-form instructions' }));
+          res.end(
+            JSON.stringify({
+              error: 'serve(): reuseAgent is incompatible with function-form instructions',
+              hint,
+            })
+          );
         }
         return;
       }

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -32,7 +32,7 @@ import {
   respondUnauthorized,
   signatureErrorCodeFromCause,
 } from './auth';
-import { ADCP_PRE_TRANSPORT, type AdcpPreTransport } from './create-adcp-server';
+import { ADCP_PRE_TRANSPORT, ADCP_INSTRUCTIONS_FN, type AdcpPreTransport } from './create-adcp-server';
 import type { AdcpServer } from './adcp-server';
 
 /**
@@ -556,6 +556,25 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
         if (!res.headersSent) {
           res.writeHead(500, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: 'Internal server error' }));
+        }
+        return;
+      }
+      // Refuse `reuseAgent: true` + function-form `instructions`. The function
+      // is captured at server construction and would never re-evaluate per
+      // session under server reuse — silently degrading to "instructions are
+      // a constant after all" is worse than failing loud at the first request.
+      // Adopters fix this by removing `reuseAgent: true` (default factory
+      // creates a fresh agent per request, which is what the function needs)
+      // OR by passing a static string for `instructions`.
+      if (reuseAgent && (agentServer as unknown as Record<symbol, unknown>)[ADCP_INSTRUCTIONS_FN] === true) {
+        console.error(
+          '[adcp/serve] refusing reuseAgent: true with function-form instructions. ' +
+            'The function is captured once at construction and cannot re-evaluate per session under server reuse. ' +
+            'Drop `reuseAgent: true` (a fresh agent per request fires the function each session) OR pass a static string for `instructions`.'
+        );
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'serve(): reuseAgent is incompatible with function-form instructions' }));
         }
         return;
       }

--- a/test/server-instructions-fn.test.js
+++ b/test/server-instructions-fn.test.js
@@ -170,4 +170,55 @@ describe('instructions — async not yet supported', () => {
       /async resolution is not yet supported/
     );
   });
+
+  it('a function returning null does NOT crash on the Promise probe (null safety)', () => {
+    // Regression for code-reviewer finding: the Promise detection used to read
+    // `(result as { then?: unknown }).then` which throws TypeError on null.
+    const server = makeServer(
+      buildPlatform({
+        instructions: () => null,
+      })
+    );
+    // null was a non-string non-undefined return — should be rejected at
+    // construction with a typed ConfigurationError, surfaced through the
+    // 'skip' default as undefined.
+    assert.equal(readInstructions(server), undefined);
+  });
+});
+
+describe('instructions — non-string return type', () => {
+  it('a function returning a number is rejected (with onInstructionsError: fail surfaces ConfigurationError)', () => {
+    assert.throws(
+      () =>
+        makeServer(
+          buildPlatform({
+            instructions: () => /** @type {any} */ (42),
+            onInstructionsError: 'fail',
+          })
+        ),
+      /must return string \| undefined, got number/
+    );
+  });
+
+  it('a function returning an object is rejected (no silent "[object Object]" coercion)', () => {
+    assert.throws(
+      () =>
+        makeServer(
+          buildPlatform({
+            instructions: () => /** @type {any} */ ({ prose: 'oops' }),
+            onInstructionsError: 'fail',
+          })
+        ),
+      /must return string \| undefined, got object/
+    );
+  });
+
+  it("default 'skip' catches bad-type returns and resolves to undefined", () => {
+    const server = makeServer(
+      buildPlatform({
+        instructions: () => /** @type {any} */ (42),
+      })
+    );
+    assert.equal(readInstructions(server), undefined);
+  });
 });

--- a/test/server-instructions-fn.test.js
+++ b/test/server-instructions-fn.test.js
@@ -1,0 +1,173 @@
+'use strict';
+
+// Issue #1347 — `instructions` accepts a function form (lazy / per-session).
+// Covers static/string regression, function evaluation, throw semantics
+// (skip/fail), the async-not-yet-supported guard, and the
+// reuseAgent + function refusal in serve().
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+const { getSdkServer } = require('../dist/lib/server/adcp-server');
+const { ADCP_INSTRUCTIONS_FN } = require('../dist/lib/server/create-adcp-server');
+
+function buildPlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async ref => ({
+        id: ref?.account_id ?? 'acc_1',
+        metadata: {},
+        authInfo: { kind: 'api_key' },
+      }),
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+    },
+    ...overrides,
+  };
+}
+
+function makeServer(platform, opts = {}) {
+  return createAdcpServerFromPlatform(platform, {
+    name: 'gap-1347',
+    version: '0.0.1',
+    validation: { requests: 'off', responses: 'off' },
+    ...opts,
+  });
+}
+
+function readInstructions(server) {
+  const sdk = getSdkServer(server);
+  if (!sdk) throw new Error('readInstructions: not an AdcpServer');
+  return sdk.server._instructions;
+}
+
+describe('instructions — static string (regression)', () => {
+  it('threads a string through unchanged', () => {
+    const server = makeServer(buildPlatform({ instructions: 'static prose' }));
+    assert.equal(readInstructions(server), 'static prose');
+    assert.equal(server[ADCP_INSTRUCTIONS_FN], undefined, 'string form must NOT mark INSTRUCTIONS_FN');
+  });
+
+  it('omits instructions when neither form is set', () => {
+    const server = makeServer(buildPlatform());
+    assert.equal(readInstructions(server), undefined);
+    assert.equal(server[ADCP_INSTRUCTIONS_FN], undefined);
+  });
+});
+
+describe('instructions — function form', () => {
+  it('evaluates the function at construction and uses the returned string', () => {
+    let calls = 0;
+    const fn = () => {
+      calls++;
+      return `prose-${calls}`;
+    };
+    const a = makeServer(buildPlatform({ instructions: fn }));
+    assert.equal(readInstructions(a), 'prose-1');
+    assert.equal(calls, 1);
+
+    // A second createAdcpServer call (which is what `serve({ reuseAgent: false })`
+    // does per request) re-evaluates the function — that is the per-session
+    // re-evaluation contract.
+    const b = makeServer(buildPlatform({ instructions: fn }));
+    assert.equal(readInstructions(b), 'prose-2');
+    assert.equal(calls, 2);
+  });
+
+  it('marks the server with ADCP_INSTRUCTIONS_FN when function form is used', () => {
+    const server = makeServer(buildPlatform({ instructions: () => 'x' }));
+    assert.equal(server[ADCP_INSTRUCTIONS_FN], true);
+  });
+
+  it('treats a function returning undefined as no instructions', () => {
+    const server = makeServer(buildPlatform({ instructions: () => undefined }));
+    assert.equal(readInstructions(server), undefined);
+    assert.equal(server[ADCP_INSTRUCTIONS_FN], true, 'still marked — adopter chose the function form');
+  });
+
+  it('passes a SessionContext object to the callback (currently empty, future-compatible)', () => {
+    let received;
+    makeServer(
+      buildPlatform({
+        instructions: ctx => {
+          received = ctx;
+          return 'ok';
+        },
+      })
+    );
+    assert.ok(received, 'function must receive a ctx argument');
+    // Forward-compatible: authInfo / agent are reserved fields, currently undefined.
+    assert.equal(received.authInfo, undefined);
+    assert.equal(received.agent, undefined);
+  });
+});
+
+describe('instructions — onInstructionsError', () => {
+  it("default 'skip' — function throw resolves to undefined and does NOT propagate", () => {
+    const server = makeServer(
+      buildPlatform({
+        instructions: () => {
+          throw new Error('registry fetch failed');
+        },
+      })
+    );
+    assert.equal(readInstructions(server), undefined);
+  });
+
+  it("'fail' — function throw rethrows so the caller can surface session failure", () => {
+    assert.throws(
+      () =>
+        makeServer(
+          buildPlatform({
+            instructions: () => {
+              throw new Error('load-bearing policy unreachable');
+            },
+            onInstructionsError: 'fail',
+          })
+        ),
+      /load-bearing policy unreachable/
+    );
+  });
+
+  it("'skip' is also the explicit choice — same behavior as default", () => {
+    const server = makeServer(
+      buildPlatform({
+        instructions: () => {
+          throw new Error('boom');
+        },
+        onInstructionsError: 'skip',
+      })
+    );
+    assert.equal(readInstructions(server), undefined);
+  });
+});
+
+describe('instructions — async not yet supported', () => {
+  it('a function returning a Promise throws ConfigurationError (regardless of onInstructionsError)', () => {
+    assert.throws(
+      () =>
+        makeServer(
+          buildPlatform({
+            instructions: () => Promise.resolve('async prose'),
+            onInstructionsError: 'skip', // even with skip, async is a config error
+          })
+        ),
+      /async resolution is not yet supported/
+    );
+  });
+});


### PR DESCRIPTION
Closes #1347.

Lifts the captured-once limitation on `instructions`. `createAdcpServer.instructions` and `DecisioningPlatform.instructions` now accept either a static `string` (historical form) or a `(ctx: SessionContext) => string | undefined` function. Under `serve({ reuseAgent: false })` (the default) the factory runs per HTTP request, so the function fires per session — adopters surface tenant-shaped prose (per-buyer brand manifests, storefront-platform copy, premium-vs-standard partner guidance) without a `Map` shim outside the SDK.

## Surface

```ts
import { createAdcpServer, type SessionContext, type OnInstructionsError } from '@adcp/sdk/server';

createAdcpServer({
  // existing string form still works
  instructions: 'Publisher-wide brand safety: alcohol disallowed.',

  // or function form — re-evaluated per createAdcpServer invocation
  instructions: (ctx: SessionContext) => brandManifests.get(currentTenant)?.intro,

  // throw semantics — default 'skip'
  onInstructionsError: 'skip', // or 'fail'
});
```

## Three design questions resolved (per the #1347 triage thread)

1. **`SessionContext` shape** — slim `{ authInfo?: ResolvedAuthInfo; agent?: BuyerAgent }`. Both reserved; currently always `undefined` because the framework doesn't yet plumb auth/registry state into the factory before MCP `initialize`. Today-pattern for tenant identity is closures captured in HTTP-scoped factory state. Forward-compatible: when the framework wires authInfo/agent through, existing function bodies pick up populated fields without changes.

2. **`reuseAgent: true` + function-form is refused.** The function would only fire once for the lifetime of the shared agent — silently degrading to "constant after all" is worse than failing loud. `serve()` returns 500 with a message naming the workaround (drop `reuseAgent: true` for fresh agent per request, OR pass a static string).

3. **Throw semantics via `onInstructionsError`:**
   - `'skip'` (default) — log server-side, treat as `undefined`. Right for prose-of-flavor (brand manifests, marketing copy) where a registry fetch failure must not kill the buyer's session.
   - `'fail'` — rethrow → MCP `initialize` transport-level failure. Right when instructions carry load-bearing policy where stale/missing guidance is worse than a connection retry.

## What ships

- **`createAdcpServer.instructions`** type extended; `onInstructionsError` option added (default `'skip'`).
- **`DecisioningPlatform.instructions`** type extended; `onInstructionsError` plumbed through `from-platform.ts`. Platform wins over `opts.instructions` when both supplied (same precedence as `agentRegistry`).
- **`SessionContext`** + **`OnInstructionsError`** type exports from `@adcp/sdk/server`.
- **`ADCP_INSTRUCTIONS_FN`** symbol export — `serve()` reads it to detect function-form servers and refuse `reuseAgent: true`.
- **Async return is not yet supported.** A function returning a `Promise` throws `ConfigurationError` at construction (regardless of `onInstructionsError`); pre-resolve before invoking `createAdcpServer` if you need to fetch. Future-compat: type signature accepts only sync return today; future revisions can extend.

## Tests (`test/server-instructions-fn.test.js`)

10 new tests cover:
- string form regression (passes through unchanged)
- function evaluated at construction; re-eval per `createAdcpServer` call drives per-session semantics under `reuseAgent: false`
- `ADCP_INSTRUCTIONS_FN` marker presence (function form) / absence (string form)
- function returning `undefined` → no instructions, marker still set
- `SessionContext` shape (currently empty, future-compatible)
- `onInstructionsError: 'skip'` (default) catches throws — function returning throw resolves to undefined
- `onInstructionsError: 'fail'` rethrows
- explicit `'skip'` matches default
- Promise return → `ConfigurationError` regardless of `onInstructionsError`

214/214 pass across the broader server-config test suite (no regressions).

## Test plan

- [x] `npm run build`
- [x] `npx tsc --noEmit`
- [x] `npm run format:check`
- [x] `node --test test/server-instructions-fn.test.js` (10/10)
- [x] `node --test test/server-decisioning-from-platform.test.js test/server-decisioning-instructions.test.js test/server-create-adcp-server.test.js` (204/204)

🤖 Generated with [Claude Code](https://claude.com/claude-code)