### PR TITLE
feat(server): platform.instructions as async function per MCP session (#1347)

### DIFF
--- a/.changeset/instructions-fn-per-session.md
+++ b/.changeset/instructions-fn-per-session.md
@@ -1,0 +1,19 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): `platform.instructions` accepts an async function evaluated per MCP session (#1347)
+
+`DecisioningPlatform.instructions` now accepts a function in addition to a string:
+
+```ts
+defineSalesPlatform({
+  instructions: async (ctx) => fetchPolicyDoc(ctx.agent?.agent_id),
+});
+```
+
+The function is called once per MCP `initialize` handshake (once per buyer session) and cached for the session lifetime. Existing string adopters are unaffected.
+
+New `InstructionsContext` type (`{ authInfo?, agent? }`) is available in the same import path as `DecisioningPlatform`. New `onInstructionsError: 'skip' | 'fail'` option on `CreateAdcpServerFromPlatformOptions` controls behavior when the function throws (default `'skip'` — session proceeds without instructions).
+
+Function form is incompatible with `reuseAgent: true` in `serve()`; the framework throws at request time when this combination is detected.

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -336,6 +336,15 @@ export const ADCP_STATE_STORE: unique symbol = Symbol.for('@adcp/client.stateSto
  */
 export const ADCP_CAPABILITIES: unique symbol = Symbol.for('@adcp/client.capabilities');
 
+/**
+ * Marker set on `AdcpServer` instances built from a function-form
+ * `platform.instructions`. `serve()` reads this to throw early when
+ * `reuseAgent: true` is combined with function instructions.
+ *
+ * @internal
+ */
+export const FUNCTION_INSTRUCTIONS: unique symbol = Symbol.for('@adcp/client.functionInstructions');
+
 /** @internal */
 export interface AdcpServerInternal extends AdcpServer {
   readonly [ADCP_SDK_SERVER]: McpServer;
@@ -351,6 +360,47 @@ export interface AdcpServerInternal extends AdcpServer {
 export function getSdkServer(server: AdcpServer | McpServer): McpServer | undefined {
   const candidate = (server as unknown as Partial<AdcpServerInternal>)[ADCP_SDK_SERVER];
   return candidate;
+}
+
+/**
+ * Write `_instructions` on the low-level SDK server that backs `mcpServer`.
+ * Used by the function-form instructions hook to inject the resolved string
+ * into the `initialize` response at session time.
+ *
+ * @internal
+ */
+export function setSdkServerInstructions(mcpServer: McpServer, value: string | undefined): void {
+  const priv = mcpServer as unknown as McpServerPrivates;
+  if (priv.server) {
+    priv.server._instructions = value;
+  }
+}
+
+/** @internal */
+type McpRequestHandler = (request: { method: string; params?: unknown }, extra: unknown) => unknown | Promise<unknown>;
+
+/**
+ * Wrap the `initialize` request handler on `mcpServer` with `wrapper`.
+ * The wrapper receives the original handler so it can call-through after
+ * any pre-processing.
+ *
+ * @internal
+ */
+
+export function wrapInitializeHandler(
+  mcpServer: McpServer,
+  wrapper: (
+    origHandler: McpRequestHandler,
+    req: { method: string; params?: unknown },
+    extra: unknown
+  ) => unknown | Promise<unknown>
+): void {
+  const priv = mcpServer as unknown as McpServerPrivates;
+  const handlers = priv.server?._requestHandlers;
+  if (!handlers) return;
+  const orig = handlers.get('initialize');
+  if (!orig) return;
+  handlers.set('initialize', (req, extra) => wrapper(orig, req, extra));
 }
 
 /**
@@ -390,6 +440,7 @@ interface McpServerPrivates {
       string,
       (request: { method: string; params?: unknown }, extra: unknown) => unknown | Promise<unknown>
     >;
+    _instructions?: string;
   };
 }
 

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -130,7 +130,7 @@ export type {
 } from './context';
 
 // Top-level platform + compile-time capability enforcement
-export type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor } from './platform';
+export type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor, InstructionsContext } from './platform';
 
 // Method-level composition (closes #1314) — wrap individual platform methods
 // with `before` / `after` hooks for short-circuit + enrichment patterns.

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -130,7 +130,12 @@ export type {
 } from './context';
 
 // Top-level platform + compile-time capability enforcement
-export type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor, InstructionsContext } from './platform';
+export type {
+  DecisioningPlatform,
+  RequiredPlatformsFor,
+  RequiredCapabilitiesFor,
+  InstructionsContext,
+} from './platform';
 
 // Method-level composition (closes #1314) — wrap individual platform methods
 // with `before` / `after` hooks for short-circuit + enrichment patterns.

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -11,8 +11,8 @@
  */
 
 import type { DecisioningCapabilities, BrandCapabilities } from './capabilities';
-import type { Account, AccountStore } from './account';
-import type { BuyerAgentRegistry } from './buyer-agent';
+import type { Account, AccountStore, ResolvedAuthInfo } from './account';
+import type { BuyerAgent, BuyerAgentRegistry } from './buyer-agent';
 import type { StatusMappers } from './status-mappers';
 import type { SalesPlatform, SalesCorePlatform, SalesIngestionPlatform } from './specialisms/sales';
 import type { CreativeBuilderPlatform } from './specialisms/creative';
@@ -24,6 +24,31 @@ import type { ContentStandardsPlatform } from './specialisms/content-standards';
 import type { BrandRightsPlatform } from './specialisms/brand-rights';
 import type { PropertyListsPlatform, CollectionListsPlatform } from './specialisms/lists';
 import type { AdCPSpecialism } from '../../types/tools.generated';
+
+/**
+ * Context available to a function-form `instructions` during MCP session
+ * initialization. Both fields are optional — the closure form `() => string`
+ * works when you don't need caller identity.
+ *
+ * Populated once per MCP `initialize` handshake; NOT available or re-evaluated
+ * on subsequent tool calls.
+ *
+ * @public
+ */
+export interface InstructionsContext {
+  /**
+   * Auth info extracted from the `initialize` request's HTTP layer, when an
+   * `authenticate` middleware is wired on `serve()`. Absent when the agent
+   * accepts unauthenticated sessions.
+   */
+  authInfo?: ResolvedAuthInfo;
+  /**
+   * Resolved buyer-agent record, populated when `platform.agentRegistry` is
+   * configured and the session's auth principal maps to a known `BuyerAgent`.
+   * Absent when the registry is not configured or resolution returns nothing.
+   */
+  agent?: BuyerAgent;
+}
 
 /**
  * Top-level platform interface. Adopters implement this; framework wires
@@ -86,8 +111,20 @@ export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string
    * supplied via `createAdcpServerFromPlatform` opts — same precedence as
    * `agentRegistry`. Adopters with v5 escape-hatch wiring can keep using
    * `opts.instructions`; v6 callers should declare it here.
+   *
+   * **Function form.** May be an async function called once per MCP
+   * `initialize` handshake (once per buyer session, cached for the
+   * session lifetime). The function is NOT re-evaluated on subsequent
+   * tool calls. When the function throws or returns `undefined`, behavior
+   * is controlled by `onInstructionsError` in
+   * `CreateAdcpServerFromPlatformOptions` (default `'skip'` — session
+   * proceeds without instructions).
+   *
+   * Incompatible with `reuseAgent: true`: a shared server has no
+   * per-session context. When detected at request time, `serve()` logs
+   * an error and returns HTTP 500 for each session — do not combine.
    */
-  instructions?: string;
+  instructions?: string | ((ctx: InstructionsContext) => string | undefined | Promise<string | undefined>);
 
   /**
    * Buyer-agent identity registry — Phase 1 of #1269. Optional. When

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -52,6 +52,12 @@
 import { randomUUID } from 'node:crypto';
 import type { AdcpServer } from '../../adcp-server';
 import {
+  getSdkServer,
+  FUNCTION_INSTRUCTIONS,
+  setSdkServerInstructions,
+  wrapInitializeHandler,
+} from '../../adcp-server';
+import {
   createAdcpServer,
   type AdcpServerConfig,
   type MediaBuyHandlers,
@@ -63,7 +69,12 @@ import {
   type BrandRightsHandlers,
   type HandlerContext,
 } from '../../create-adcp-server';
-import type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor } from '../platform';
+import type {
+  DecisioningPlatform,
+  RequiredPlatformsFor,
+  RequiredCapabilitiesFor,
+  InstructionsContext,
+} from '../platform';
 import type { ComplianceTestingCapabilities } from '../capabilities';
 import type { Account, ResolvedAuthInfo, ResolveContext } from '../account';
 import { AccountNotFoundError, refAccountId, toWireAccount, toWireSyncAccountRow } from '../account';
@@ -539,6 +550,21 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * webhook receiver path stood up.
    */
   autoEmitCompletionWebhooks?: boolean;
+
+  /**
+   * Error-handling policy for function-form `platform.instructions`.
+   * Applies only when `platform.instructions` is a function; ignored for
+   * string-form instructions.
+   *
+   * - `'skip'` *(default)*: when the function throws or returns
+   *   `undefined`, the `instructions` field is **omitted** from the MCP
+   *   `initialize` response for that session and the session proceeds
+   *   normally. A `logger.warn` is emitted so the failure is observable.
+   * - `'fail'`: the thrown error is re-thrown, causing `initialize` to
+   *   fail for this session. Use for load-bearing real-time policy where
+   *   absent or stale instructions are worse than no session.
+   */
+  onInstructionsError?: 'skip' | 'fail';
 
   // ---------------------------------------------------------------------
   // Custom-handler escape hatch (incremental migration seam)
@@ -1023,7 +1049,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     // v5 `opts.instructions` escape hatch when both are present, so v6
     // adopters can colocate platform facts / decision policy with the rest
     // of their platform declaration.
-    ...(platform.instructions !== undefined && { instructions: platform.instructions }),
+    // String-only: function form is handled post-construction via the
+    // initialize-handler hook below. Passing a function here would set
+    // sdk.server._instructions to the function object itself.
+    ...(typeof platform.instructions === 'string' && { instructions: platform.instructions }),
     // Pool-derived stores override the spread above when adopters supplied
     // `pool` but no explicit per-store opt. Explicit values still win.
     ...(effectiveIdempotency !== undefined && { idempotency: effectiveIdempotency }),
@@ -1277,6 +1306,45 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
     const controller = createComplyController(complyConfig);
     controller.register(server);
+  }
+
+  // Function-form instructions (#1347): wrap the initialize handler to
+  // evaluate the function once per session and inject the resolved string
+  // into the initialize response. Construction stays synchronous; the async
+  // call is deferred to the per-session initialize handshake.
+  if (typeof platform.instructions === 'function') {
+    const instructionsFn = platform.instructions;
+    const onError = opts.onInstructionsError ?? 'skip';
+    const sdkServer = getSdkServer(server);
+    if (sdkServer) {
+      wrapInitializeHandler(sdkServer, async (origHandler, _req, extra) => {
+        const authInfo = (extra as { authInfo?: ResolvedAuthInfo } | undefined)?.authInfo;
+        let agent: BuyerAgent | undefined;
+        if (platform.agentRegistry && authInfo) {
+          try {
+            agent = (await platform.agentRegistry.resolve(authInfo)) ?? undefined;
+          } catch {
+            // Agent registry failure: proceed without agent in context.
+          }
+        }
+        const ctx: InstructionsContext = {
+          ...(authInfo !== undefined && { authInfo }),
+          ...(agent !== undefined && { agent }),
+        };
+        try {
+          const resolved = await instructionsFn(ctx);
+          setSdkServerInstructions(sdkServer, resolved);
+        } catch (err) {
+          if (onError === 'fail') throw err;
+          fwLogger.warn('[adcp] platform.instructions threw — session will have no instructions', {
+            error: String(err),
+          });
+        }
+        return origHandler(_req, extra);
+      });
+    }
+    // Mark server so serve() can detect the reuseAgent+function combination.
+    (server as unknown as Record<symbol, boolean>)[FUNCTION_INSTRUCTIONS] = true;
   }
 
   return Object.assign(server, {

--- a/src/lib/server/serve.ts
+++ b/src/lib/server/serve.ts
@@ -34,6 +34,7 @@ import {
 } from './auth';
 import { ADCP_PRE_TRANSPORT, type AdcpPreTransport } from './create-adcp-server';
 import type { AdcpServer } from './adcp-server';
+import { FUNCTION_INSTRUCTIONS } from './adcp-server';
 
 /**
  * Context passed to the agent factory on each request.
@@ -559,6 +560,24 @@ export function serve(createAgent: (ctx: ServeContext) => AdcpServer | McpServer
         }
         return;
       }
+      if (reuseAgent && (agentServer as unknown as Record<symbol, unknown>)[FUNCTION_INSTRUCTIONS]) {
+        // Misconfiguration: function instructions cannot be evaluated per-session
+        // when a single server instance is shared. Detected at first request rather
+        // than at serve() construction because the server instance isn't available
+        // until the factory runs.
+        console.error(
+          '[adcp/serve] Misconfiguration: platform.instructions cannot be a function when ' +
+            'reuseAgent: true — a shared server has no per-session context at initialize time. ' +
+            'Use instructions: string for a static value, or set reuseAgent: false.'
+        );
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Server misconfiguration' }));
+        }
+        await agentServer.close();
+        return;
+      }
+
       const attached = (agentServer as unknown as Record<symbol, unknown>)[ADCP_PRE_TRANSPORT];
       const autoWiredPreTransport = typeof attached === 'function' ? (attached as AdcpPreTransport) : undefined;
       const activePreTransport = explicitPreTransport ?? autoWiredPreTransport;

--- a/test/server-decisioning-instructions.test.js
+++ b/test/server-decisioning-instructions.test.js
@@ -1,13 +1,13 @@
-// Tests for #1312 — `instructions` thread-through on createAdcpServerFromPlatform.
-// Adopters set `platform.instructions` (preferred v6 surface) or pass
-// `opts.instructions` (v5 escape hatch); platform wins when both supplied.
+// Tests for platform.instructions thread-through on createAdcpServerFromPlatform.
+// Covers #1312 (string-form: platform wins over opts) and #1347 (function-form:
+// evaluated once per MCP initialize handshake).
 
 process.env.NODE_ENV = 'test';
 
 const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
-const { getSdkServer } = require('../dist/lib/server/adcp-server');
+const { getSdkServer, FUNCTION_INSTRUCTIONS } = require('../dist/lib/server/adcp-server');
 
 function buildPlatform(overrides = {}) {
   return {
@@ -42,6 +42,25 @@ function readInstructions(server) {
   // McpServer wraps a low-level Server which stashes instructions on
   // `_instructions` (per @modelcontextprotocol/sdk Server constructor).
   return sdk.server._instructions;
+}
+
+/**
+ * Simulate an MCP `initialize` handshake in-process by invoking the
+ * registered handler directly. The handler is keyed on the string
+ * `'initialize'` in `sdk.server._requestHandlers`.
+ */
+async function simulateInitialize(server, extra = {}) {
+  const sdk = getSdkServer(server);
+  if (!sdk) throw new Error('simulateInitialize: value is not an AdcpServer');
+  const handler = sdk.server._requestHandlers?.get('initialize');
+  if (!handler) throw new Error('simulateInitialize: no initialize handler registered');
+  return handler(
+    {
+      method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '0.0.1' } },
+    },
+    extra
+  );
 }
 
 describe('createAdcpServerFromPlatform — server instructions (#1312)', () => {
@@ -89,5 +108,124 @@ describe('createAdcpServerFromPlatform — server instructions (#1312)', () => {
       validation: { requests: 'off', responses: 'off' },
     });
     assert.strictEqual(readInstructions(server), undefined);
+  });
+});
+
+describe('createAdcpServerFromPlatform — function-form instructions (#1347)', () => {
+  it('evaluates a sync function on initialize and sets _instructions', async () => {
+    const platform = buildPlatform({
+      instructions: () => 'dynamic: alcohol disallowed',
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    // Before initialize: _instructions is undefined (function not yet called).
+    assert.strictEqual(readInstructions(server), undefined);
+    await simulateInitialize(server);
+    assert.strictEqual(readInstructions(server), 'dynamic: alcohol disallowed');
+  });
+
+  it('evaluates an async function on initialize', async () => {
+    const platform = buildPlatform({
+      instructions: async () => {
+        // Simulate async registry fetch.
+        await new Promise(resolve => setImmediate(resolve));
+        return 'async: carbon-aware pricing applies';
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await simulateInitialize(server);
+    assert.strictEqual(readInstructions(server), 'async: carbon-aware pricing applies');
+  });
+
+  it('passes authInfo from extra into the InstructionsContext', async () => {
+    let capturedCtx;
+    const platform = buildPlatform({
+      instructions: ctx => {
+        capturedCtx = ctx;
+        return 'ok';
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const fakeAuthInfo = { clientId: 'buyer-123', kind: 'api_key', credential: { kind: 'api_key', apiKey: 'k' } };
+    await simulateInitialize(server, { authInfo: fakeAuthInfo });
+    assert.deepStrictEqual(capturedCtx?.authInfo, fakeAuthInfo);
+  });
+
+  it("onInstructionsError: 'skip' (default) swallows throw and omits instructions", async () => {
+    const platform = buildPlatform({
+      instructions: () => {
+        throw new Error('registry unavailable');
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      // onInstructionsError default is 'skip'
+    });
+    // Should not throw — initialize proceeds without instructions.
+    await assert.doesNotReject(() => simulateInitialize(server));
+    assert.strictEqual(readInstructions(server), undefined);
+  });
+
+  it("onInstructionsError: 'fail' propagates the throw from initialize", async () => {
+    const platform = buildPlatform({
+      instructions: () => {
+        throw new Error('policy-doc unavailable');
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      onInstructionsError: 'fail',
+    });
+    await assert.rejects(() => simulateInitialize(server), /policy-doc unavailable/);
+  });
+
+  it('undefined return from function omits instructions (same as skip)', async () => {
+    const platform = buildPlatform({
+      instructions: () => undefined,
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    await simulateInitialize(server);
+    assert.strictEqual(readInstructions(server), undefined);
+  });
+
+  it('marks server with FUNCTION_INSTRUCTIONS symbol', () => {
+    const platform = buildPlatform({
+      instructions: () => 'marker test',
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    assert.strictEqual(server[FUNCTION_INSTRUCTIONS], true);
+  });
+
+  it('string-form instructions do NOT set FUNCTION_INSTRUCTIONS marker', () => {
+    const platform = buildPlatform({ instructions: 'static string' });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'spike',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    assert.strictEqual(server[FUNCTION_INSTRUCTIONS], undefined);
   });
 });


### PR DESCRIPTION
Closes #1347

## Summary

Widens `DecisioningPlatform.instructions` from `string` to `string | ((ctx: InstructionsContext) => string | undefined | Promise<string | undefined>)`. The function form is evaluated once per MCP `initialize` handshake — deferred to that moment so `ctx.authInfo` (from the session's authentication middleware) and `ctx.agent` (from `platform.agentRegistry`) are both available. The resolved string is written to `sdk.server._instructions` before the original `initialize` handler continues. Throw semantics are controlled by `onInstructionsError: 'skip' | 'fail'` on `CreateAdcpServerFromPlatformOptions` (default `'skip'`). The `reuseAgent: true` + function-form combination is detected at first request time and short-circuits with HTTP 500 + `console.error` rather than silently giving every session the wrong (or no) instructions.

## Changes

- **`platform.ts`** — `InstructionsContext` interface (new, exported); `instructions` field widened; JSDoc updated to describe per-session evaluation and `reuseAgent` incompatibility
- **`adcp-server.ts`** — `FUNCTION_INSTRUCTIONS` unique symbol (internal marker); `setSdkServerInstructions` helper; `McpRequestHandler` type alias; `wrapInitializeHandler` helper (wraps `_requestHandlers.get('initialize')` to slot in async evaluation without touching the low-level SDK)
- **`from-platform.ts`** — `onInstructionsError` option wired; function-form detection + `wrapInitializeHandler` call + `FUNCTION_INSTRUCTIONS` marker set; string-form guard fixed (`typeof === 'string'`, not `!== undefined`, so the function is never passed raw to the MCP constructor)
- **`serve.ts`** — `reuseAgent` + `FUNCTION_INSTRUCTIONS` incompatibility check: HTTP 500 response + `agentServer.close()` + return (no unhandled rejection)
- **`decisioning/index.ts`** — `InstructionsContext` added to barrel export
- **`test/server-decisioning-instructions.test.js`** — 8 new tests: sync fn, async fn, `authInfo` threading, `'skip'` swallows throw, `'fail'` propagates throw, `undefined` return, `FUNCTION_INSTRUCTIONS` marker set, marker absent for string-form

## What was tested

- `npm run build:lib` — passes
- `node --test test/server-decisioning-instructions.test.js` — 12/12 pass (4 pre-existing string-form tests + 8 new function-form tests)
- Pre-push validation passed

## Pre-PR review

- **code-reviewer:** approved after blocker fixes — bare `throw` in async handler replaced with HTTP 500 + `agentServer.close()` + return; `resolved ?? undefined` no-op removed
- **dx-expert:** approved after blocker fixes — `InstructionsContext` exported from barrel; JSDoc aligned with actual runtime behavior (`serve()` logs error + returns HTTP 500, does not throw `PlatformConfigError`)

---

> **Triage-managed PR** — opened by Claude Code in response to issue #1347 comment (design decisions settled by @bokelley). Changes validated by code-reviewer and dx-expert subagents before push. Human review recommended before merge; draft status intentional.

Session: https://claude.ai/code/session_01AiNGeN9SZ131ZYgsqme2qD

---
_Generated by [Claude Code](https://claude.ai/code/session_01AiNGeN9SZ131ZYgsqme2qD)_