### PR TITLE
feat(mock-server): sales-guaranteed forecast endpoints + hello_seller_adapter_guaranteed example

### DIFF
--- a/.changeset/mock-server-guaranteed-forecast.md
+++ b/.changeset/mock-server-guaranteed-forecast.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": minor
+---
+
+mock-server/sales-guaranteed: add forecast endpoints and hello_seller_adapter_guaranteed example
+
+Adds `POST /v1/forecast` to the sales-guaranteed mock server and extends `GET /v1/products` to accept `?start_date=&end_date=` query params that populate a deterministic `DeliveryForecast` on each product. Both paths use a `createHash`-based seed so storyboard runners get reproducible numbers.
+
+Also adds `examples/hello_seller_adapter_guaranteed.ts` — a worked GAM-style seller adapter that calls the enriched `GET /v1/products` endpoint and maps the inline forecast onto `Product.forecast`, exercising the `AdCP Product.forecast` field that was previously never populated in any example.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -6,11 +6,12 @@
  * client. The AdCP-facing platform methods stay the same.
  *
  * Demo:
- *   npx @adcp/sdk@latest mock-server sales-guaranteed --port 4503
+ *   npx @adcp/sdk@latest mock-server sales-guaranteed --port 4503  # keep running
  *   UPSTREAM_URL=http://127.0.0.1:4503 \
  *     npx tsx examples/hello_seller_adapter_guaranteed.ts
  *   adcp storyboard run http://127.0.0.1:3001/mcp sales_guaranteed \
  *     --auth sk_harness_do_not_use_in_prod
+ *   curl http://127.0.0.1:4503/_debug/traffic  # verify upstream was hit
  *
  * Production:
  *   UPSTREAM_URL=https://my-gam.example/api UPSTREAM_API_KEY=… \
@@ -284,13 +285,19 @@ function toAdcpProduct(p: UpstreamProduct, publisherDomain: string): GetProducts
       expected_delay_minutes: 60,
     },
     // Map upstream forecast when present (populated by GET /v1/products?start_date=&end_date=).
-    // The upstream shape is already compatible with AdCP DeliveryForecast — field names match.
+    // Explicit field mapping: method, currency, forecast_range_unit, generated_at, points.
+    // valid_until is intentionally omitted — the mock does not emit it.
+    // SWAP: add `...(p.forecast.valid_until && { valid_until: p.forecast.valid_until })` if
+    // your upstream returns an expiry timestamp.
     ...(p.forecast && {
       forecast: {
         method: p.forecast.method as 'estimate' | 'modeled' | 'guaranteed',
         currency: p.forecast.currency,
+        // All eight ForecastRangeUnit values are valid; cast from string.
         ...(p.forecast.forecast_range_unit && {
-          forecast_range_unit: p.forecast.forecast_range_unit as 'availability' | 'spend',
+          forecast_range_unit: p.forecast.forecast_range_unit as
+            | 'spend' | 'availability' | 'reach_freq' | 'weekly'
+            | 'daily' | 'clicks' | 'conversions' | 'package',
         }),
         ...(p.forecast.generated_at && { generated_at: p.forecast.generated_at }),
         points: p.forecast.points.map(pt => ({
@@ -363,8 +370,15 @@ class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, neve
       const order = await upstream.createOrder(networkCode, {
         name: `adcp_${Date.now()}`,
         advertiser_id: ctx.account.id,
-        currency: (req as { currency?: string }).currency ?? 'USD',
-        budget: typeof req.total_budget === 'number' ? req.total_budget : 50_000,
+        // total_budget is { amount, currency } in AdCP 3.x; also accept legacy flat number.
+        budget:
+          typeof req.total_budget === 'number'
+            ? req.total_budget
+            : ((req.total_budget as { amount?: number })?.amount ?? 50_000),
+        currency:
+          typeof req.total_budget === 'object' && req.total_budget !== null
+            ? ((req.total_budget as { currency?: string }).currency ?? 'USD')
+            : 'USD',
         client_request_id: req.idempotency_key,
       });
 
@@ -411,9 +425,9 @@ class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, neve
     // a re-approval flow on the upstream (not modeled here).
     // --------------------------------------------------------------------
     updateMediaBuy: async (buyId: string, patch: UpdateMediaBuyRequest): Promise<UpdateMediaBuySuccess> => {
-      // Real implementations: PATCH /v1/orders/{orderId} and re-poll if
-      // the platform requires re-approval.
-      void patch; // SWAP: apply patch to upstream order
+      // FIXME(adopter): PATCH /v1/orders/{orderId} and re-poll if re-approval is required.
+      // Leaving this as a no-op stub means pauses and budget updates are silently ignored.
+      void patch;
       return { media_buy_id: buyId, status: 'active' };
     },
 
@@ -421,7 +435,9 @@ class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, neve
     // get_media_buys — return active orders for this account.
     // --------------------------------------------------------------------
     getMediaBuys: async (_req: GetMediaBuysRequest, ctx): Promise<GetMediaBuysResponse> => {
-      void ctx; // SWAP: GET /v1/orders?network_code=...
+      // FIXME(adopter): GET /v1/orders?network_code=... and map to AdCP MediaBuy shape.
+      // Leaving as empty stub means buyers always see zero active buys.
+      void ctx;
       return { media_buys: [] };
     },
 

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -329,7 +329,7 @@ class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, neve
         status: 'active',
         operator: adcpPublisher,
         ctx_metadata: { network_code: network.network_code },
-        sandbox: true, // FIXME(adopter): replace with real sandbox flag from backing store
+        sandbox: true, // TODO(adopter): replace with real sandbox flag from your backing store
       };
     },
   };
@@ -358,7 +358,7 @@ class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, neve
     // create_media_buy — HITL path. Guaranteed inventory always requires IO
     // review before activation; ctx.handoffToTask handles the polling loop.
     // --------------------------------------------------------------------
-    createMediaBuy: async (req: CreateMediaBuyRequest, ctx): Promise<CreateMediaBuySuccess | ReturnType<typeof ctx.handoffToTask<CreateMediaBuySuccess>>> => {
+    createMediaBuy: async (req: CreateMediaBuyRequest, ctx) => {
       const networkCode = ctx.account.ctx_metadata.network_code;
       const order = await upstream.createOrder(networkCode, {
         name: `adcp_${Date.now()}`,
@@ -372,7 +372,7 @@ class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, neve
         // Order was auto-approved (possible on some platforms). Return sync.
         return {
           media_buy_id: order.order_id,
-          status: 'active',
+          status: 'active' as const,
           confirmed_at: new Date().toISOString(),
           packages: [],
         };

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -1,0 +1,540 @@
+/**
+ * hello_seller_adapter_guaranteed — worked starting point for an AdCP
+ * sales-guaranteed seller adapter wrapping a GAM-style upstream.
+ *
+ * Fork this. Replace `UpstreamClient` with your real backend's HTTP/SDK
+ * client. The AdCP-facing platform methods stay the same.
+ *
+ * Demo:
+ *   npx @adcp/sdk@latest mock-server sales-guaranteed --port 4503
+ *   UPSTREAM_URL=http://127.0.0.1:4503 \
+ *     npx tsx examples/hello_seller_adapter_guaranteed.ts
+ *   adcp storyboard run http://127.0.0.1:3001/mcp sales_guaranteed \
+ *     --auth sk_harness_do_not_use_in_prod
+ *
+ * Production:
+ *   UPSTREAM_URL=https://my-gam.example/api UPSTREAM_API_KEY=… \
+ *     npx tsx examples/hello_seller_adapter_guaranteed.ts
+ *
+ * Note: specialism ID is `sales-guaranteed` (kebab-case); the storyboard
+ * runner CLI arg uses `sales_guaranteed` (snake_case). Same concept, two
+ * forms — see CLAUDE.md "Naming conventions".
+ */
+
+import {
+  createAdcpServerFromPlatform,
+  serve,
+  verifyApiKey,
+  createIdempotencyStore,
+  createUpstreamHttpClient,
+  memoryBackend,
+  AdcpError,
+  BuyerAgentRegistry,
+  DEFAULT_REPORTING_CAPABILITIES,
+  type DecisioningPlatform,
+  type SalesCorePlatform,
+  type SalesIngestionPlatform,
+  type AccountStore,
+  type Account,
+  type BuyerAgent,
+  type CachedBuyerAgentRegistry,
+  registerTestController,
+} from '@adcp/sdk/server';
+import type {
+  GetProductsRequest,
+  GetProductsResponse,
+  CreateMediaBuyRequest,
+  CreateMediaBuySuccess,
+  UpdateMediaBuyRequest,
+  UpdateMediaBuySuccess,
+  GetMediaBuysRequest,
+  GetMediaBuysResponse,
+  GetMediaBuyDeliveryRequest,
+  GetMediaBuyDeliveryResponse,
+  CreativeAsset,
+  AccountReference,
+} from '@adcp/sdk/types';
+import { createUpstreamRecorder, toQueryUpstreamTrafficResponse } from '@adcp/sdk/upstream-recorder';
+import { createHash, randomUUID } from 'node:crypto';
+
+const UPSTREAM_URL = process.env['UPSTREAM_URL'] ?? 'http://127.0.0.1:4503';
+const UPSTREAM_API_KEY = process.env['UPSTREAM_API_KEY'] ?? 'mock_sales_guaranteed_key_do_not_use_in_prod';
+const PORT = Number(process.env['PORT'] ?? 3001);
+const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use_in_prod';
+
+// ---------------------------------------------------------------------------
+// Upstream types — shapes returned by the GAM-style upstream HTTP API.
+// SWAP: replace with your backend SDK's types or auto-generated OpenAPI types.
+// ---------------------------------------------------------------------------
+
+interface UpstreamNetwork {
+  network_code: string;
+  display_name: string;
+  adcp_publisher: string;
+}
+
+interface UpstreamProduct {
+  product_id: string;
+  name: string;
+  delivery_type: 'guaranteed' | 'non_guaranteed';
+  channel: 'video' | 'ctv' | 'display' | 'audio';
+  format_ids: string[];
+  ad_unit_ids: string[];
+  pricing: { model: 'cpm' | 'cpv'; cpm: number; currency: string; min_spend?: number };
+  availability?: { start_date?: string; end_date?: string; available_impressions?: number };
+  forecast?: UpstreamForecast;
+}
+
+interface UpstreamForecast {
+  method: string;
+  currency: string;
+  forecast_range_unit?: string;
+  generated_at?: string;
+  points: Array<{
+    budget?: number;
+    metrics: {
+      impressions?: { low?: number; mid?: number; high?: number };
+      spend?: { mid?: number };
+    };
+  }>;
+}
+
+interface UpstreamOrder {
+  order_id: string;
+  name: string;
+  status: string;
+  advertiser_id: string;
+  currency: string;
+  budget: number;
+  approval_task_id?: string;
+  rejection_reason?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface UpstreamTask {
+  task_id: string;
+  order_id: string;
+  status: 'submitted' | 'working' | 'completed' | 'rejected';
+  result?: { outcome: 'approved' | 'rejected'; reviewer_note: string };
+}
+
+interface UpstreamCreative {
+  creative_id: string;
+  name: string;
+  format_id: string;
+  advertiser_id: string;
+  status: 'active' | 'paused' | 'archived';
+}
+
+interface UpstreamDelivery {
+  order_id: string;
+  currency: string;
+  reporting_period: { start: string; end: string };
+  totals: {
+    impressions: number;
+    clicks: number;
+    spend: number;
+    viewable_impressions: number;
+    video_completions: number;
+    conversions: number;
+  };
+  line_item_breakdown: Array<{ line_item_id: string; impressions: number; spend: number }>;
+}
+
+// ---------------------------------------------------------------------------
+// Upstream HTTP client — SWAP the base URL and auth for production.
+// ---------------------------------------------------------------------------
+
+const recorder = createUpstreamRecorder({
+  enabled: process.env['NODE_ENV'] !== 'production',
+  strict: process.env['ADCP_RECORDER_STRICT'] === '1',
+});
+
+const RECORDER_PRINCIPAL = 'compliance-runner';
+
+const http = createUpstreamHttpClient({
+  baseUrl: UPSTREAM_URL,
+  auth: { kind: 'static_bearer', token: UPSTREAM_API_KEY },
+  fetch: recorder.wrapFetch(fetch),
+});
+
+const networkHeader = (networkCode: string) => ({ 'X-Network-Code': networkCode });
+
+const upstream = {
+  // SWAP: resolve AdCP publisher domain → upstream network code.
+  async lookupNetwork(adcpPublisher: string): Promise<UpstreamNetwork | null> {
+    const { body } = await http.get<UpstreamNetwork>('/_lookup/network', { adcp_publisher: adcpPublisher });
+    return body;
+  },
+
+  // SWAP: product catalog. Pass start_date/end_date to get per-product
+  // availability forecasts inline — one round-trip instead of N per product.
+  async listProducts(
+    networkCode: string,
+    opts: { delivery_type?: string; start_date?: string; end_date?: string } = {}
+  ): Promise<UpstreamProduct[]> {
+    const query: Record<string, string> = {};
+    if (opts.delivery_type) query['delivery_type'] = opts.delivery_type;
+    if (opts.start_date) query['start_date'] = opts.start_date;
+    if (opts.end_date) query['end_date'] = opts.end_date;
+    const { body } = await http.get<{ products: UpstreamProduct[] }>('/v1/products', query, networkHeader(networkCode));
+    return body?.products ?? [];
+  },
+
+  // SWAP: create order. Returns order_id + approval_task_id for HITL polling.
+  async createOrder(
+    networkCode: string,
+    payload: { name: string; advertiser_id: string; currency: string; budget: number; client_request_id?: string }
+  ): Promise<UpstreamOrder> {
+    const r = await http.post<UpstreamOrder>('/v1/orders', payload, networkHeader(networkCode));
+    if (!r.body) throw new AdcpError('SERVICE_UNAVAILABLE', { message: 'Failed to create order.' });
+    return r.body;
+  },
+
+  // SWAP: poll approval task.
+  async getTask(networkCode: string, taskId: string): Promise<UpstreamTask | null> {
+    const { body } = await http.get<UpstreamTask>(`/v1/tasks/${encodeURIComponent(taskId)}`, undefined, networkHeader(networkCode));
+    return body;
+  },
+
+  // SWAP: create creative.
+  async createCreative(
+    networkCode: string,
+    payload: { name: string; format_id: string; advertiser_id: string; snippet?: string; client_request_id?: string }
+  ): Promise<UpstreamCreative> {
+    const r = await http.post<UpstreamCreative>('/v1/creatives', payload, networkHeader(networkCode));
+    if (!r.body) throw new AdcpError('SERVICE_UNAVAILABLE', { message: 'Failed to create creative.' });
+    return r.body;
+  },
+
+  // SWAP: delivery report for an order.
+  async getDelivery(networkCode: string, orderId: string): Promise<UpstreamDelivery | null> {
+    const { body } = await http.get<UpstreamDelivery>(
+      `/v1/orders/${encodeURIComponent(orderId)}/delivery`,
+      undefined,
+      networkHeader(networkCode)
+    );
+    return body;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Buyer-agent registry — SWAP the in-memory map for a DB query in production.
+// ---------------------------------------------------------------------------
+
+function hashApiKey(token: string): string {
+  return createHash('sha256').update(token).digest('hex').slice(0, 32);
+}
+
+const ONBOARDING_LEDGER = new Map<string, BuyerAgent>([
+  [
+    hashApiKey(ADCP_AUTH_TOKEN),
+    {
+      agent_url: 'https://addie.example.com',
+      display_name: 'Addie (storyboard runner)',
+      status: 'active',
+      billing_capabilities: new Set(['operator']),
+      sandbox_only: true,
+    },
+  ],
+]);
+
+const agentRegistry: CachedBuyerAgentRegistry = BuyerAgentRegistry.cached(
+  BuyerAgentRegistry.bearerOnly({
+    resolveByCredential: async credential => {
+      if (credential.kind !== 'api_key') return null;
+      return ONBOARDING_LEDGER.get(credential.key_id) ?? null;
+    },
+  }),
+  { ttlSeconds: 60 }
+);
+
+// ---------------------------------------------------------------------------
+// AdCP adapter — typed against SalesCorePlatform + SalesIngestionPlatform.
+// ---------------------------------------------------------------------------
+
+interface NetworkMeta {
+  /** Resolved upstream network code for this AdCP account. */
+  network_code: string;
+  [key: string]: unknown;
+}
+
+/** Project an upstream product onto AdCP Product shape. */
+function toAdcpProduct(p: UpstreamProduct, publisherDomain: string): GetProductsResponse['products'][number] {
+  return {
+    product_id: p.product_id,
+    name: p.name,
+    delivery_type: p.delivery_type,
+    // The upstream uses string format IDs; AdCP wraps them as structured objects.
+    format_ids: p.format_ids.map(id => ({ id })),
+    publisher_properties: [{ publisher_domain: publisherDomain, selection_type: 'all' as const }],
+    pricing_options: [
+      {
+        pricing_option_id: `${p.product_id}_${p.pricing.model}`,
+        pricing_model: p.pricing.model,
+        fixed_price: p.pricing.cpm,
+        currency: p.pricing.currency,
+        ...(p.pricing.min_spend !== undefined && { min_budget: p.pricing.min_spend }),
+      },
+    ],
+    reporting_capabilities: {
+      ...DEFAULT_REPORTING_CAPABILITIES,
+      available_reporting_frequencies: ['daily'],
+      expected_delay_minutes: 60,
+    },
+    // Map upstream forecast when present (populated by GET /v1/products?start_date=&end_date=).
+    // The upstream shape is already compatible with AdCP DeliveryForecast — field names match.
+    ...(p.forecast && {
+      forecast: {
+        method: p.forecast.method as 'estimate' | 'modeled' | 'guaranteed',
+        currency: p.forecast.currency,
+        ...(p.forecast.forecast_range_unit && {
+          forecast_range_unit: p.forecast.forecast_range_unit as 'availability' | 'spend',
+        }),
+        ...(p.forecast.generated_at && { generated_at: p.forecast.generated_at }),
+        points: p.forecast.points.map(pt => ({
+          ...(pt.budget !== undefined && { budget: pt.budget }),
+          metrics: {
+            ...(pt.metrics.impressions && { impressions: pt.metrics.impressions }),
+            ...(pt.metrics.spend && { spend: pt.metrics.spend }),
+          },
+        })),
+      },
+    }),
+  };
+}
+
+class GuaranteedSellerAdapter implements DecisioningPlatform<Record<string, never>, NetworkMeta> {
+  capabilities = {
+    specialisms: ['sales-guaranteed'] as const,
+    channels: ['video', 'ctv', 'display', 'audio'] as const,
+    pricingModels: ['cpm'] as const,
+    config: {},
+  };
+
+  statusMappers = {};
+  agentRegistry = agentRegistry;
+
+  accounts: AccountStore<NetworkMeta> = {
+    resolve: async (ref: AccountReference, ctx) => {
+      const adcpPublisher = (ref as { publisher?: string })?.publisher;
+      if (!adcpPublisher) return null;
+      void ctx; // ctx.agent available for buyer-agent gating
+      const network = await upstream.lookupNetwork(adcpPublisher);
+      if (!network) return null;
+      return {
+        id: network.network_code,
+        name: network.display_name,
+        status: 'active',
+        operator: adcpPublisher,
+        ctx_metadata: { network_code: network.network_code },
+        sandbox: true, // FIXME(adopter): replace with real sandbox flag from backing store
+      };
+    },
+  };
+
+  sales: SalesCorePlatform<NetworkMeta> & Pick<SalesIngestionPlatform<NetworkMeta>, 'syncCreatives'> = {
+    // --------------------------------------------------------------------
+    // get_products — one upstream call. Pass flight dates from AdCP filters
+    // so the upstream returns per-product availability forecasts inline,
+    // eliminating the need for N per-product forecast calls.
+    // --------------------------------------------------------------------
+    getProducts: (req: GetProductsRequest, ctx): Promise<GetProductsResponse> =>
+      recorder.runWithPrincipal(RECORDER_PRINCIPAL, async () => {
+        const networkCode = ctx.account.ctx_metadata.network_code;
+        const publisherDomain = ctx.account.operator ?? '';
+        const products = await upstream.listProducts(networkCode, {
+          delivery_type: 'guaranteed',
+          // req.filters.start_date / end_date map to the upstream's date params.
+          // When present, the upstream enriches each product with a forecast field.
+          start_date: req.filters?.start_date,
+          end_date: req.filters?.end_date,
+        });
+        return { products: products.map(p => toAdcpProduct(p, publisherDomain)) };
+      }),
+
+    // --------------------------------------------------------------------
+    // create_media_buy — HITL path. Guaranteed inventory always requires IO
+    // review before activation; ctx.handoffToTask handles the polling loop.
+    // --------------------------------------------------------------------
+    createMediaBuy: async (req: CreateMediaBuyRequest, ctx): Promise<CreateMediaBuySuccess | ReturnType<typeof ctx.handoffToTask<CreateMediaBuySuccess>>> => {
+      const networkCode = ctx.account.ctx_metadata.network_code;
+      const order = await upstream.createOrder(networkCode, {
+        name: `adcp_${Date.now()}`,
+        advertiser_id: ctx.account.id,
+        currency: (req as { currency?: string }).currency ?? 'USD',
+        budget: typeof req.total_budget === 'number' ? req.total_budget : 50_000,
+        client_request_id: req.idempotency_key,
+      });
+
+      if (!order.approval_task_id) {
+        // Order was auto-approved (possible on some platforms). Return sync.
+        return {
+          media_buy_id: order.order_id,
+          status: 'active',
+          confirmed_at: new Date().toISOString(),
+          packages: [],
+        };
+      }
+
+      const taskId = order.approval_task_id;
+      return ctx.handoffToTask(async () => {
+        // Poll the approval task. The mock auto-advances in 2 polls;
+        // real GAM / FreeWheel platforms take minutes to hours.
+        for (let attempt = 0; attempt < 60; attempt++) {
+          await new Promise(r => setTimeout(r, 500));
+          const task = await upstream.getTask(networkCode, taskId);
+          if (!task) continue;
+          if (task.status === 'completed' && task.result?.outcome === 'approved') {
+            return {
+              media_buy_id: order.order_id,
+              status: 'active' as const,
+              confirmed_at: new Date().toISOString(),
+              packages: [],
+            };
+          }
+          if (task.status === 'rejected') {
+            throw new AdcpError('MEDIA_BUY_REJECTED', {
+              recovery: 'terminal',
+              message: task.result?.reviewer_note ?? 'Order rejected by IO review.',
+            });
+          }
+        }
+        throw new AdcpError('SERVICE_UNAVAILABLE', { message: 'Order approval timed out after 30 s.' });
+      });
+    },
+
+    // --------------------------------------------------------------------
+    // update_media_buy — pause/resume only for guaranteed inventory.
+    // Complex line-item mutations (budget change, date shift) go through
+    // a re-approval flow on the upstream (not modeled here).
+    // --------------------------------------------------------------------
+    updateMediaBuy: async (buyId: string, patch: UpdateMediaBuyRequest): Promise<UpdateMediaBuySuccess> => {
+      // Real implementations: PATCH /v1/orders/{orderId} and re-poll if
+      // the platform requires re-approval.
+      void patch; // SWAP: apply patch to upstream order
+      return { media_buy_id: buyId, status: 'active' };
+    },
+
+    // --------------------------------------------------------------------
+    // get_media_buys — return active orders for this account.
+    // --------------------------------------------------------------------
+    getMediaBuys: async (_req: GetMediaBuysRequest, ctx): Promise<GetMediaBuysResponse> => {
+      void ctx; // SWAP: GET /v1/orders?network_code=...
+      return { media_buys: [] };
+    },
+
+    // --------------------------------------------------------------------
+    // get_media_buy_delivery — map upstream delivery report.
+    // --------------------------------------------------------------------
+    getMediaBuyDelivery: async (req: GetMediaBuyDeliveryRequest, ctx): Promise<GetMediaBuyDeliveryResponse> =>
+      recorder.runWithPrincipal(RECORDER_PRINCIPAL, async () => {
+        const networkCode = ctx.account.ctx_metadata.network_code;
+        const delivery = await upstream.getDelivery(networkCode, req.media_buy_id);
+        if (!delivery) {
+          throw new AdcpError('MEDIA_BUY_NOT_FOUND', {
+            message: `No delivery data for media buy ${req.media_buy_id}.`,
+          });
+        }
+        return {
+          currency: delivery.currency,
+          reporting_period: {
+            start: delivery.reporting_period.start,
+            end: delivery.reporting_period.end,
+          },
+          media_buy_deliveries: [
+            {
+              media_buy_id: delivery.order_id,
+              impressions: delivery.totals.impressions,
+              clicks: delivery.totals.clicks,
+              spend: delivery.totals.spend,
+              viewable_impressions: delivery.totals.viewable_impressions,
+              video_completions: delivery.totals.video_completions,
+            },
+          ],
+        };
+      }),
+
+    // --------------------------------------------------------------------
+    // sync_creatives — create or update creatives on the upstream.
+    // --------------------------------------------------------------------
+    syncCreatives: async (creatives: CreativeAsset[], ctx): Promise<{ creative_id: string; action: string; status: string }[]> =>
+      recorder.runWithPrincipal(RECORDER_PRINCIPAL, async () => {
+        const networkCode = ctx.account.ctx_metadata.network_code;
+        return Promise.all(
+          creatives.map(async c => {
+            const asset = c as {
+              creative_id?: string;
+              name?: string;
+              format_id?: { id?: string } | string;
+              snippet?: string;
+            };
+            const formatId =
+              typeof asset.format_id === 'string'
+                ? asset.format_id
+                : asset.format_id?.id ?? 'unknown';
+            const result = await upstream.createCreative(networkCode, {
+              name: asset.name ?? 'Untitled',
+              format_id: formatId,
+              advertiser_id: ctx.account.id,
+              snippet: asset.snippet,
+              client_request_id: randomUUID(),
+            });
+            // Video creatives require review on real GAM platforms;
+            // mirror that here so buyers see the pending_review path.
+            const needsReview = formatId.startsWith('video_');
+            return {
+              creative_id: result.creative_id,
+              action: 'created',
+              status: needsReview ? 'pending_review' : 'approved',
+            };
+          })
+        );
+      }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+const platform = new GuaranteedSellerAdapter();
+const idempotencyStore = createIdempotencyStore(memoryBackend());
+
+serve(
+  ({ taskStore }) => {
+    const adcpServer = createAdcpServerFromPlatform(platform, {
+      name: 'hello-seller-adapter-guaranteed',
+      version: '1.0.0',
+      taskStore,
+      idempotency: idempotencyStore,
+      resolveSessionKey: ctx => {
+        const acct = ctx.account as Account<NetworkMeta> | undefined;
+        return acct?.id ?? 'anonymous';
+      },
+    });
+
+    registerTestController(adcpServer, {
+      queryUpstreamTraffic: async params => {
+        const result = recorder.query({
+          principal: RECORDER_PRINCIPAL,
+          ...(params.since_timestamp !== undefined && { sinceTimestamp: params.since_timestamp }),
+          ...(params.endpoint_pattern !== undefined && { endpointPattern: params.endpoint_pattern }),
+          ...(params.limit !== undefined && { limit: params.limit }),
+        });
+        return toQueryUpstreamTrafficResponse(result);
+      },
+    });
+
+    return adcpServer;
+  },
+  {
+    port: PORT,
+    authenticate: verifyApiKey({
+      keys: { [ADCP_AUTH_TOKEN]: { principal: 'compliance-runner' } },
+    }),
+  }
+);
+
+console.log(`guaranteed seller adapter on http://127.0.0.1:${PORT}/mcp · upstream: ${UPSTREAM_URL}`);

--- a/src/lib/mock-server/sales-guaranteed/openapi.yaml
+++ b/src/lib/mock-server/sales-guaranteed/openapi.yaml
@@ -112,11 +112,12 @@ components:
             end_date: { type: string, format: date }
             available_impressions: { type: integer }
         forecast:
-          $ref: '#/components/schemas/DeliveryForecast'
-          description: |
-            Populated when GET /v1/products is called with ?start_date=&end_date=.
-            Deterministic availability forecast keyed on (product_id, start_date, end_date).
-            Maps directly onto AdCP Product.forecast with forecast_range_unit: 'availability'.
+          allOf:
+            - $ref: '#/components/schemas/DeliveryForecast'
+            - description: |
+                Populated when GET /v1/products is called with ?start_date=&end_date=.
+                Deterministic availability forecast keyed on (product_id, start_date, end_date).
+                Maps directly onto AdCP Product.forecast with forecast_range_unit: 'availability'.
 
     ForecastRange:
       type: object

--- a/src/lib/mock-server/sales-guaranteed/openapi.yaml
+++ b/src/lib/mock-server/sales-guaranteed/openapi.yaml
@@ -111,6 +111,55 @@ components:
             start_date: { type: string, format: date }
             end_date: { type: string, format: date }
             available_impressions: { type: integer }
+        forecast:
+          $ref: '#/components/schemas/DeliveryForecast'
+          description: |
+            Populated when GET /v1/products is called with ?start_date=&end_date=.
+            Deterministic availability forecast keyed on (product_id, start_date, end_date).
+            Maps directly onto AdCP Product.forecast with forecast_range_unit: 'availability'.
+
+    ForecastRange:
+      type: object
+      description: Low/mid/high estimate for a single metric.
+      properties:
+        low: { type: number }
+        mid: { type: number }
+        high: { type: number }
+
+    ForecastPoint:
+      type: object
+      required: [metrics]
+      properties:
+        budget:
+          type: number
+          description: |
+            Present on spend-curve points only. Omit for availability forecasts —
+            in that case, metrics.impressions expresses total available inventory.
+        metrics:
+          type: object
+          properties:
+            impressions: { $ref: '#/components/schemas/ForecastRange' }
+            spend: { $ref: '#/components/schemas/ForecastRange' }
+
+    DeliveryForecast:
+      type: object
+      required: [method, currency, points]
+      properties:
+        method:
+          type: string
+          enum: [estimate, modeled, guaranteed]
+        currency: { type: string }
+        forecast_range_unit:
+          type: string
+          enum: [spend, availability, reach_freq, weekly, daily, clicks, conversions, package]
+          description: |
+            'availability': points represent total available inventory, budget omitted.
+            'spend': points at ascending budget levels form a delivery curve.
+        generated_at: { type: string, format: date-time }
+        valid_until: { type: string, format: date-time }
+        points:
+          type: array
+          items: { $ref: '#/components/schemas/ForecastPoint' }
 
     Order:
       type: object
@@ -283,6 +332,18 @@ paths:
         - in: query
           name: channel
           schema: { type: string }
+        - in: query
+          name: start_date
+          schema: { type: string, format: date }
+          description: |
+            Campaign start date (YYYY-MM-DD). When provided together with end_date,
+            each product in the response includes a `forecast` field with
+            forecast_range_unit: 'availability' — total available impressions for
+            that flight window. Maps to AdCP ProductFilters.start_date.
+        - in: query
+          name: end_date
+          schema: { type: string, format: date }
+          description: Campaign end date (YYYY-MM-DD). See start_date.
       responses:
         '200':
           content:
@@ -296,6 +357,48 @@ paths:
                     },
                 },
             }
+
+  /v1/forecast:
+    post:
+      summary: Get delivery forecast for a product
+      operationId: getForecast
+      description: |
+        Returns a deterministic DeliveryForecast for the given product and flight window.
+        When `budget` is present, returns a spend-curve forecast (forecast_range_unit: 'spend')
+        with four points at 25/50/75/100% of the requested budget. When `budget` is absent,
+        returns an availability forecast (forecast_range_unit: 'availability') expressing
+        total available impressions for the flight window independent of budget.
+        Responses are deterministic given the same (product_id, flight_dates) — storyboard
+        runners get reproducible numbers across runs.
+      parameters: [{ $ref: '#/components/parameters/NetworkCode' }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [product_id]
+              properties:
+                product_id: { type: string }
+                flight_dates:
+                  type: object
+                  properties:
+                    start_date: { type: string, format: date }
+                    end_date: { type: string, format: date }
+                budget:
+                  type: number
+                  description: When present, returns a spend→impressions curve. When absent, returns an availability forecast.
+                targeting:
+                  type: object
+                  description: Targeting overlay (reserved for future use; currently ignored by the mock).
+      responses:
+        '200':
+          description: DeliveryForecast
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DeliveryForecast' }
+        '400': { description: Missing product_id }
+        '404': { description: Product not found }
 
   /v1/orders:
     get:

--- a/src/lib/mock-server/sales-guaranteed/server.ts
+++ b/src/lib/mock-server/sales-guaranteed/server.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
-import { randomUUID } from 'node:crypto';
+import { randomUUID, createHash } from 'node:crypto';
 import {
   AD_UNITS,
   DEFAULT_API_KEY,
@@ -199,6 +199,10 @@ export async function bootSalesGuaranteed(options: BootOptions): Promise<BootRes
       bump('GET /v1/products');
       return handleListProducts(url, network, res);
     }
+    if (method === 'POST' && path === '/v1/forecast') {
+      bump('POST /v1/forecast');
+      return handleGetForecast(req, network, res);
+    }
     if (method === 'GET' && path === '/v1/creatives') {
       bump('GET /v1/creatives');
       return handleListCreatives(network, res);
@@ -274,9 +278,36 @@ export async function bootSalesGuaranteed(options: BootOptions): Promise<BootRes
     let visible = products.filter(p => p.network_code === network.network_code);
     const deliveryType = url.searchParams.get('delivery_type');
     const channel = url.searchParams.get('channel');
+    const startDate = url.searchParams.get('start_date');
+    const endDate = url.searchParams.get('end_date');
     if (deliveryType) visible = visible.filter(p => p.delivery_type === deliveryType);
     if (channel) visible = visible.filter(p => p.channel === channel);
-    writeJson(res, 200, { products: visible });
+    const productList = visible.map(p =>
+      startDate && endDate ? { ...p, forecast: buildAvailabilityForecast(p, startDate, endDate) } : p
+    );
+    writeJson(res, 200, { products: productList });
+  }
+
+  async function handleGetForecast(req: IncomingMessage, network: MockNetwork, res: ServerResponse): Promise<void> {
+    const body = await readJsonObject(req, res);
+    if (!body) return;
+    const { product_id, flight_dates, budget } = body as Record<string, unknown>;
+    if (typeof product_id !== 'string') {
+      writeJson(res, 400, { code: 'invalid_request', message: 'product_id is required.' });
+      return;
+    }
+    const product = products.find(p => p.product_id === product_id && p.network_code === network.network_code);
+    if (!product) {
+      writeJson(res, 404, { code: 'product_not_found', message: `Product ${product_id} not found.` });
+      return;
+    }
+    const dates = (flight_dates as Record<string, string> | undefined) ?? {};
+    const startDate = typeof dates['start_date'] === 'string' ? dates['start_date'] : new Date().toISOString().slice(0, 10);
+    const endDate = typeof dates['end_date'] === 'string' ? dates['end_date'] : new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const forecast = typeof budget === 'number'
+      ? buildSpendCurve(product, budget, startDate, endDate)
+      : buildAvailabilityForecast(product, startDate, endDate);
+    writeJson(res, 200, forecast);
   }
 
   function handleListCreatives(network: MockNetwork, res: ServerResponse): void {
@@ -656,6 +687,49 @@ export async function bootSalesGuaranteed(options: BootOptions): Promise<BootRes
     const { body_fingerprint, line_items, conversions, ...rest } = order;
     return rest;
   }
+}
+
+function deterministicSeed(productId: string, startDate: string, endDate: string): number {
+  return parseInt(createHash('sha256').update(`${productId}::${startDate}::${endDate}`).digest('hex').slice(0, 8), 16);
+}
+
+function buildAvailabilityForecast(product: MockProduct, startDate: string, endDate: string): object {
+  const seed = deterministicSeed(product.product_id, startDate, endDate);
+  const factor = 0.65 + (seed % 10000) / 28571; // 0.65–1.0, varies per product+dates
+  const available = product.availability?.available_impressions ?? 10_000_000;
+  const mid = Math.floor(available * factor);
+  return {
+    method: 'estimate',
+    currency: product.pricing.currency,
+    forecast_range_unit: 'availability',
+    generated_at: new Date().toISOString(),
+    points: [
+      {
+        metrics: {
+          impressions: { low: Math.floor(mid * 0.85), mid, high: Math.floor(mid * 1.12) },
+        },
+      },
+    ],
+  };
+}
+
+function buildSpendCurve(product: MockProduct, budget: number, startDate: string, endDate: string): object {
+  const seed = deterministicSeed(product.product_id, startDate, endDate);
+  const factor = 0.65 + (seed % 10000) / 28571;
+  const maxImpressions = Math.floor((product.availability?.available_impressions ?? 10_000_000) * factor);
+  const cpm = product.pricing.cpm;
+  const steps = [0.25, 0.5, 0.75, 1.0] as const;
+  return {
+    method: 'estimate',
+    currency: product.pricing.currency,
+    forecast_range_unit: 'spend',
+    generated_at: new Date().toISOString(),
+    points: steps.map(pct => {
+      const b = Math.round(budget * pct);
+      const impressions = Math.min(Math.floor((b / cpm) * 1000), maxImpressions);
+      return { budget: b, metrics: { impressions: { mid: impressions }, spend: { mid: b } } };
+    }),
+  };
 }
 
 function stripBodyFingerprint<T extends { body_fingerprint?: string }>(record: T): Omit<T, 'body_fingerprint'> {

--- a/src/lib/mock-server/sales-guaranteed/server.ts
+++ b/src/lib/mock-server/sales-guaranteed/server.ts
@@ -693,6 +693,12 @@ function deterministicSeed(productId: string, startDate: string, endDate: string
   return parseInt(createHash('sha256').update(`${productId}::${startDate}::${endDate}`).digest('hex').slice(0, 8), 16);
 }
 
+/** Derive a stable ISO timestamp from the seed so responses are fully deterministic. */
+function seedToTimestamp(seed: number): string {
+  // Anchor to 2026-01-01 and offset by up to ~30 days (seed mod 2592000 seconds).
+  return new Date(1767225600000 + (seed % 2592000) * 1000).toISOString();
+}
+
 function buildAvailabilityForecast(product: MockProduct, startDate: string, endDate: string): object {
   const seed = deterministicSeed(product.product_id, startDate, endDate);
   const factor = 0.65 + (seed % 10000) / 28571; // 0.65–1.0, varies per product+dates
@@ -702,7 +708,7 @@ function buildAvailabilityForecast(product: MockProduct, startDate: string, endD
     method: 'estimate',
     currency: product.pricing.currency,
     forecast_range_unit: 'availability',
-    generated_at: new Date().toISOString(),
+    generated_at: seedToTimestamp(seed),
     points: [
       {
         metrics: {
@@ -723,7 +729,7 @@ function buildSpendCurve(product: MockProduct, budget: number, startDate: string
     method: 'estimate',
     currency: product.pricing.currency,
     forecast_range_unit: 'spend',
-    generated_at: new Date().toISOString(),
+    generated_at: seedToTimestamp(seed),
     points: steps.map(pct => {
       const b = Math.round(budget * pct);
       const impressions = Math.min(Math.floor((b / cpm) * 1000), maxImpressions);


### PR DESCRIPTION
Closes #1375

## Summary

The `sales-guaranteed` mock server's `Product.forecast` field was never exercised — `MockProduct.availability` was a static seed value and no adapter example existed for guaranteed sellers. This PR adds the forecast layer and a worked example.

**`src/lib/mock-server/sales-guaranteed/server.ts`**
- Adds `POST /v1/forecast` — accepts `{ product_id, flight_dates, budget? }`. When `budget` is absent returns an availability forecast (`forecast_range_unit: 'availability'`); when present returns a spend curve (`forecast_range_unit: 'spend'`). All response fields are deterministic given the same inputs via `createHash` + `seedToTimestamp`.
- Extends `GET /v1/products` to accept `?start_date=&end_date=` — when both are present, each product carries an inline `DeliveryForecast` (availability shape), eliminating N per-product round-trips in the adapter.

**`src/lib/mock-server/sales-guaranteed/openapi.yaml`**
- Documents `POST /v1/forecast`, the new `ForecastRange`/`ForecastPoint`/`DeliveryForecast` schemas, and the new query params on `GET /v1/products`.

**`examples/hello_seller_adapter_guaranteed.ts`** (new file)
- Worked GAM-style guaranteed seller adapter following the same pattern as `hello_seller_adapter_signal_marketplace.ts`.
- `getProducts` calls `GET /v1/products?start_date=&end_date=` (single upstream call) and maps the inline `forecast` field onto `AdCP Product.forecast`.
- `createMediaBuy` uses `ctx.handoffToTask` for IO approval polling.
- `syncCreatives`, `getMediaBuyDelivery` fully implemented.

**`.changeset/mock-server-guaranteed-forecast.md`** — minor bump.

## What was tested

- `npx tsc --noEmit` — clean (pre-existing `moduleResolution` deprecation warning only, present on `main`)
- `node --test test/handler-return-tightness.test.js` — pass
- All other test failures are pre-existing (`dist/` not built in this environment)

## Pre-PR review

- **code-reviewer:** approved after 2 iterations — all blockers resolved: `DeliveryForecast.method` required field populated, `ForecastPoint.budget` absent on availability points, `DeliveryForecast.currency` populated, `generated_at` made deterministic via `seedToTimestamp`, invalid `ReturnType` generic annotation removed
- **dx-expert:** approved after 2 iterations — all blockers resolved: `total_budget` handles AdCP 3.x `{ amount, currency }` shape, misleading "field names match" comment replaced with explicit field-by-field mapping, `valid_until` SWAP hint added, `/_debug/traffic` curl line added to demo, `FIXME(adopter)` on production-silent stubs

**Nits noted but not fixed (surfaced for reviewer):**
- `buildSpendCurve` CPM formula produces `Infinity` if a custom fixture sets `cpm: 0` (no seeded product does today)
- `forecast_range_unit` cast from `string` — widened to all 8 enum values rather than guarded at runtime; adequate for an example file

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Qf2uPL7iSb54kgCRiXUtzP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qf2uPL7iSb54kgCRiXUtzP)_