### PR TITLE
feat(decisioning): dev-mode warn on multi-id truncation in getMediaBuyDelivery / getMediaBuys

### DIFF
--- a/.changeset/dev-mode-multi-id-truncation-warn.md
+++ b/.changeset/dev-mode-multi-id-truncation-warn.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Add dev-mode warning when getMediaBuyDelivery / getMediaBuys returns fewer rows than requested media_buy_ids. Fires in NODE_ENV=test|development only; silent in production and when NODE_ENV is unset. Suppressible via ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION=1. Catches the truncate-to-media_buy_ids[0] footgun at adapter-development time (#1399, follow-up to #1342).

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2956,6 +2956,29 @@ function validatePushNotificationToken(token: string): UrlValidationResult {
   return { ok: true };
 }
 
+function warnMultiIdTruncation(
+  tool: string,
+  requestedIds: readonly string[] | null | undefined,
+  responseRows: readonly unknown[] | null | undefined,
+  logger: AdcpLogger
+): void {
+  const env = process.env.NODE_ENV;
+  const isDevOrTest = env === 'test' || env === 'development';
+  if (!isDevOrTest) return;
+  if (process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION === '1') return;
+  if (!requestedIds || requestedIds.length === 0) return;
+  if (!responseRows || responseRows.length >= requestedIds.length) return;
+  logger.warn(
+    `[adcp/sdk] ${tool}: platform returned ${responseRows.length} row${responseRows.length !== 1 ? 's' : ''} for ${requestedIds.length} requested media_buy_ids — verify your implementation returns one row per id, not only the first. See https://github.com/adcontextprotocol/adcp-client/issues/1342`,
+    {
+      tool,
+      requested: requestedIds.length,
+      returned: responseRows.length,
+      issue: 'https://github.com/adcontextprotocol/adcp-client/issues/1342',
+    }
+  );
+}
+
 function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
   platform: P,
   taskRegistry: TaskRegistry,
@@ -3132,7 +3155,16 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
       getMediaBuyDelivery: async (params, ctx) => {
         const reqCtx = ctxFor(ctx);
         return projectSync(
-          () => sales.getMediaBuyDelivery!(params, reqCtx),
+          async () => {
+            const result = await sales.getMediaBuyDelivery!(params, reqCtx);
+            warnMultiIdTruncation(
+              'getMediaBuyDelivery',
+              (params as { media_buy_ids?: readonly string[] }).media_buy_ids,
+              (result as { media_buy_deliveries?: readonly unknown[] }).media_buy_deliveries,
+              logger
+            );
+            return result;
+          },
           actuals => actuals
         );
       },
@@ -3163,6 +3195,12 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
               'media_buy',
               (result as { media_buys?: readonly unknown[] })?.media_buys,
               'media_buy_id',
+              logger
+            );
+            warnMultiIdTruncation(
+              'getMediaBuys',
+              (params as { media_buy_ids?: readonly string[] }).media_buy_ids,
+              (result as { media_buys?: readonly unknown[] }).media_buys,
               logger
             );
             return result;

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -2969,7 +2969,7 @@ function warnMultiIdTruncation(
   if (!requestedIds || requestedIds.length === 0) return;
   if (!responseRows || responseRows.length >= requestedIds.length) return;
   logger.warn(
-    `[adcp/sdk] ${tool}: platform returned ${responseRows.length} row${responseRows.length !== 1 ? 's' : ''} for ${requestedIds.length} requested media_buy_ids — verify your implementation returns one row per id, not only the first. See https://github.com/adcontextprotocol/adcp-client/issues/1342`,
+    `[adcp/sdk] ${tool}: platform returned ${responseRows.length} row${responseRows.length !== 1 ? 's' : ''} for ${requestedIds.length} requested media_buy_ids — verify your implementation returns one row per id, not only the first. See https://github.com/adcontextprotocol/adcp-client/issues/1342. Set ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION=1 to silence.`,
     {
       tool,
       requested: requestedIds.length,

--- a/test/server-decisioning-multi-id-truncation-warn.test.js
+++ b/test/server-decisioning-multi-id-truncation-warn.test.js
@@ -63,18 +63,6 @@ function basePlatform(overrides = {}) {
   };
 }
 
-function withEnv(key, value, fn) {
-  const saved = process.env[key];
-  if (value === undefined) delete process.env[key];
-  else process.env[key] = value;
-  try {
-    return fn();
-  } finally {
-    if (saved === undefined) delete process.env[key];
-    else process.env[key] = saved;
-  }
-}
-
 // ── getMediaBuyDelivery ──────────────────────────────────────────────────────
 
 describe('#1399 — getMediaBuyDelivery multi-id truncation warn', () => {
@@ -107,6 +95,7 @@ describe('#1399 — getMediaBuyDelivery multi-id truncation warn', () => {
     assert.strictEqual(tw.length, 1, 'expected exactly one truncation warn');
     assert.match(tw[0].msg, /getMediaBuyDelivery/);
     assert.match(tw[0].msg, /1.*row|row.*1/);
+    assert.match(tw[0].msg, /ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION/);
     assert.strictEqual(tw[0].data.requested, 3);
     assert.strictEqual(tw[0].data.returned, 1);
   });
@@ -302,5 +291,50 @@ describe('#1399 — getMediaBuys multi-id truncation warn', () => {
       },
     });
     assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when suppression env var set');
+  });
+
+  it('does not warn when media_buy_ids is omitted (paginated-list contract)', async () => {
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuys: async () => ({ media_buys: [] }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_media_buys', arguments: { account: { account_id: 'acc_1' } } },
+    });
+    assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when media_buy_ids omitted');
+  });
+
+  it('does not warn in production (NODE_ENV=production)', async () => {
+    const origNodeEnv = process.env.NODE_ENV;
+    const origTaskAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+    const origStateAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+    process.env.NODE_ENV = 'production';
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = '1';
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = '1';
+    try {
+      const { logger, calls } = buildLogger();
+      const platform = basePlatform({
+        getMediaBuys: async req => ({
+          media_buys: [{ media_buy_id: (req.media_buy_ids ?? [])[0], status: 'active' }],
+        }),
+      });
+      const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+      await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'get_media_buys',
+          arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+        },
+      });
+      assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn in production');
+    } finally {
+      process.env.NODE_ENV = origNodeEnv;
+      if (origTaskAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = origTaskAck;
+      if (origStateAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = origStateAck;
+    }
   });
 });

--- a/test/server-decisioning-multi-id-truncation-warn.test.js
+++ b/test/server-decisioning-multi-id-truncation-warn.test.js
@@ -1,0 +1,306 @@
+// Tests for #1399 — dev-mode warning when getMediaBuyDelivery / getMediaBuys
+// returns fewer rows than requested media_buy_ids.
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+
+const SERVER_OPTS = {
+  name: 'multi-id-warn-test',
+  version: '0.0.1',
+  validation: { requests: 'off', responses: 'off' },
+};
+
+// Only count warns emitted by warnMultiIdTruncation (have structured `tool` data).
+function truncationWarns(calls) {
+  return calls.filter(c => c.data && (c.data.tool === 'getMediaBuyDelivery' || c.data.tool === 'getMediaBuys'));
+}
+
+function buildLogger() {
+  const calls = [];
+  return {
+    logger: {
+      debug() {},
+      info() {},
+      warn(msg, data) {
+        calls.push({ msg, data });
+      },
+      error() {},
+    },
+    calls,
+  };
+}
+
+function basePlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    statusMappers: {},
+    accounts: {
+      resolve: async ref => ({
+        id: ref?.account_id ?? 'acc_1',
+        name: 'Acme',
+        status: 'active',
+        ctx_metadata: {},
+      }),
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      ...overrides,
+    },
+  };
+}
+
+function withEnv(key, value, fn) {
+  const saved = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  try {
+    return fn();
+  } finally {
+    if (saved === undefined) delete process.env[key];
+    else process.env[key] = saved;
+  }
+}
+
+// ── getMediaBuyDelivery ──────────────────────────────────────────────────────
+
+describe('#1399 — getMediaBuyDelivery multi-id truncation warn', () => {
+  let savedSuppressEnv;
+  beforeEach(() => {
+    savedSuppressEnv = process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION;
+  });
+  afterEach(() => {
+    if (savedSuppressEnv === undefined) delete process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION;
+    else process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION = savedSuppressEnv;
+  });
+
+  it('warns once when platform returns fewer rows than requested ids', async () => {
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuyDelivery: async filter => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [{ media_buy_id: filter.media_buy_ids[0], impressions: 1, spend: 1 }],
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buy_delivery',
+        arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+      },
+    });
+    const tw = truncationWarns(calls);
+    assert.strictEqual(tw.length, 1, 'expected exactly one truncation warn');
+    assert.match(tw[0].msg, /getMediaBuyDelivery/);
+    assert.match(tw[0].msg, /1.*row|row.*1/);
+    assert.strictEqual(tw[0].data.requested, 3);
+    assert.strictEqual(tw[0].data.returned, 1);
+  });
+
+  it('does not warn when platform returns the same number of rows as requested', async () => {
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuyDelivery: async filter => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: (filter.media_buy_ids ?? []).map(id => ({ media_buy_id: id, impressions: 1, spend: 1 })),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buy_delivery',
+        arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2'] },
+      },
+    });
+    assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when row count matches');
+  });
+
+  it('does not warn when media_buy_ids is omitted (paginated-list contract)', async () => {
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_media_buy_delivery', arguments: { account: { account_id: 'acc_1' } } },
+    });
+    assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when media_buy_ids omitted');
+  });
+
+  it('does not warn when suppressed via ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION=1', async () => {
+    process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION = '1';
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuyDelivery: async filter => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [{ media_buy_id: filter.media_buy_ids[0], impressions: 1, spend: 1 }],
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buy_delivery',
+        arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+      },
+    });
+    assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when suppression env var set');
+  });
+
+  it('does not warn in production (NODE_ENV=production)', async () => {
+    const origNodeEnv = process.env.NODE_ENV;
+    const origTaskAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+    const origStateAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+    process.env.NODE_ENV = 'production';
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = '1';
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = '1';
+    try {
+      const { logger, calls } = buildLogger();
+      const platform = basePlatform({
+        getMediaBuyDelivery: async filter => ({
+          reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+          media_buy_deliveries: [{ media_buy_id: filter.media_buy_ids[0], impressions: 1, spend: 1 }],
+        }),
+      });
+      const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+      await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'get_media_buy_delivery',
+          arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+        },
+      });
+      assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn in production');
+    } finally {
+      process.env.NODE_ENV = origNodeEnv;
+      if (origTaskAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = origTaskAck;
+      if (origStateAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = origStateAck;
+    }
+  });
+
+  it('does not warn when NODE_ENV is unset', async () => {
+    const origNodeEnv = process.env.NODE_ENV;
+    const origTaskAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+    const origStateAck = process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+    delete process.env.NODE_ENV;
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = '1';
+    process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = '1';
+    try {
+      const { logger, calls } = buildLogger();
+      const platform = basePlatform({
+        getMediaBuyDelivery: async filter => ({
+          reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+          media_buy_deliveries: [{ media_buy_id: filter.media_buy_ids[0], impressions: 1, spend: 1 }],
+        }),
+      });
+      const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+      await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'get_media_buy_delivery',
+          arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+        },
+      });
+      assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when NODE_ENV unset');
+    } finally {
+      process.env.NODE_ENV = origNodeEnv;
+      if (origTaskAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_TASKS = origTaskAck;
+      if (origStateAck === undefined) delete process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE;
+      else process.env.ADCP_DECISIONING_ALLOW_INMEMORY_STATE = origStateAck;
+    }
+  });
+});
+
+// ── getMediaBuys ─────────────────────────────────────────────────────────────
+
+describe('#1399 — getMediaBuys multi-id truncation warn', () => {
+  let savedSuppressEnv;
+  beforeEach(() => {
+    savedSuppressEnv = process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION;
+  });
+  afterEach(() => {
+    if (savedSuppressEnv === undefined) delete process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION;
+    else process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION = savedSuppressEnv;
+  });
+
+  it('warns once when platform returns fewer rows than requested ids', async () => {
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuys: async req => ({
+        media_buys: [{ media_buy_id: (req.media_buy_ids ?? [])[0], status: 'active' }],
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buys',
+        arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+      },
+    });
+    const tw = truncationWarns(calls);
+    assert.strictEqual(tw.length, 1, 'expected exactly one truncation warn');
+    assert.match(tw[0].msg, /getMediaBuys/);
+    assert.strictEqual(tw[0].data.requested, 3);
+    assert.strictEqual(tw[0].data.returned, 1);
+  });
+
+  it('does not warn when platform returns the same number of rows as requested', async () => {
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuys: async req => ({
+        media_buys: (req.media_buy_ids ?? []).map(id => ({ media_buy_id: id, status: 'active' })),
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buys',
+        arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2'] },
+      },
+    });
+    assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when row count matches');
+  });
+
+  it('does not warn when suppressed via ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION=1', async () => {
+    process.env.ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION = '1';
+    const { logger, calls } = buildLogger();
+    const platform = basePlatform({
+      getMediaBuys: async req => ({
+        media_buys: [{ media_buy_id: (req.media_buy_ids ?? [])[0], status: 'active' }],
+      }),
+    });
+    const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS, logger });
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buys',
+        arguments: { account: { account_id: 'acc_1' }, media_buy_ids: ['mb_1', 'mb_2', 'mb_3'] },
+      },
+    });
+    assert.strictEqual(truncationWarns(calls).length, 0, 'no truncation warn when suppression env var set');
+  });
+});


### PR DESCRIPTION
Refs #1399

Adds a dev-mode `logger.warn` in the dispatch path of `getMediaBuyDelivery` and `getMediaBuys` when the platform returns fewer rows than the buyer's `media_buy_ids[]` requested. This catches the "truncate-to-`media_buy_ids[0]`" footgun at adapter-development time — the class of bug documented in #1342.

## What changed

**`src/lib/server/decisioning/runtime/from-platform.ts`**
- New private helper `warnMultiIdTruncation` — fires `logger.warn` when `requestedIds.length > returnedRows.length` and `NODE_ENV` is `test` or `development`.
- `getMediaBuyDelivery` dispatch: expanded from a one-liner to an `async` body so the result can be inspected before returning.
- `getMediaBuys` dispatch: call added after the existing `autoStoreResources` call.
- Follows the exact `isDevOrTest` guard pattern from lines 756 and 773, and the `ADCP_DECISIONING_ALLOW_*` env-var suppression pattern from lines 757 and 774.

**`test/server-decisioning-multi-id-truncation-warn.test.js`** (new file)
11 tests across both tools covering: warn fires on truncation; no warn on exact-count match; no warn when `media_buy_ids` omitted (paginated-list contract); suppressed by `ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION=1`; silent in `NODE_ENV=production`; silent when `NODE_ENV` unset.

## Test plan

- [x] All 11 new tests pass
- [x] 121 tests in `server-decisioning-from-platform.test.js` + related suites pass (0 failures)
- [x] `npm run format:check` clean
- [x] `npm run build:lib` (pre-push hook: typecheck + format) clean
- [x] Changeset included (patch — additive dev-mode diagnostic only)

## Pre-PR review

- **code-reviewer:** approved — logic correct, `projectSync` error path handled (warn only fires on successful responses), `=== '1'` guard matches file convention, 9 acceptance-criteria tests validated. Issues (fix or explain): issue link points to #1342 (root footgun, deliberate — more stable than the triage PR URL), missing `getMediaBuys` paginated-list + production tests added in fixup commit.
- **dx-expert:** approved with one blocker fixed — warning message now includes `Set ADCP_DECISIONING_ALLOW_MULTI_ID_TRUNCATION=1 to silence.` matching the established pattern at lines 784 and 965.

## Nits surfaced (not fixed — out of PR scope)

- `opts.mediaBuy` legacy merge-seam path silently bypasses the warning (existing migration path, documented comment at line 3178).
- No over-delivery test (`responseRows.length > requestedIds.length` path — the `>=` guard handles it correctly but is untested).

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01QQQayoudDsHqFnpREANjJ2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQQayoudDsHqFnpREANjJ2)_