### PR TITLE
docs: skills + contributing guide for adopter examples (follow-up to #1390)

### DIFF
--- a/.changeset/skills-and-contributing-followup.md
+++ b/.changeset/skills-and-contributing-followup.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `skills/triage-storyboard-failure/`, `skills/run-by-experts/`, `skills/build-holdco-agent/`, and `examples/CONTRIBUTING.md`. Pure documentation; no library or CLI behavior change. Empty changeset signals no release needed.

--- a/examples/CONTRIBUTING.md
+++ b/examples/CONTRIBUTING.md
@@ -1,0 +1,171 @@
+# Contributing to `examples/`
+
+The `examples/` directory ships **fork-target reference adapters**: working code that adopters clone, modify, and ship. They double as integration test surface (each `hello_*` adapter is paired with a CI gate). Adopter trust in this directory is load-bearing — a copy-paste anti-pattern landed here propagates across the ecosystem.
+
+This file documents the conventions that make the directory adopter-friendly. Apply them when adding or modifying any `hello_*_adapter_*.ts` file.
+
+## SWAP-marker convention
+
+Every place an adopter must replace something for production gets a `// SWAP:` marker. The convention is:
+
+```ts
+// SWAP: <one-line description of what to replace, in adopter terms>
+const OPERATOR_TO_TENANT = new Map([
+  /* ... */
+]);
+```
+
+Adopters grep for `// SWAP:` to find seams. The density is the convention — under-marking forces adopters to read the whole file; over-marking buries the structural seams.
+
+**Always mark:**
+
+- Routing tables (operator → tenant, user → workspace, brand → catalog) — the lookup that ties wire input to your backend
+- Upstream HTTP client construction (base URL, auth, header overrides) — the network seam
+- Per-handler write sites (`tenant.X.set(...)`, `db.insert(...)`) — where row-level transactions go
+- Auth-info → principal extraction (the bridge between transport credential and your user/account model)
+- Hardcoded sandbox/dev defaults that production must override (sandbox booleans, dev-mode flags, in-memory stores)
+
+**Optional but useful:**
+
+- Error message text that adopters might localize
+- Pricing/rate-card values that vary by deployment
+- Test-data seeds (clearly labeled as fixture-only)
+
+**Don't mark:**
+
+- Schema-driven response shapes (those follow the spec, not adopter taste)
+- Framework wiring (`createAdcpServerFromPlatform`, `serve()` calls) — adopters don't touch these
+- Type definitions and interfaces — adopters extend, not replace
+
+## "DO NOT DEPLOY AS-IS" banner
+
+Hello adapters seed credentials, sandbox-only flags, and in-memory stores in plaintext. Every adapter that ships any of these gets a top-of-file banner:
+
+```ts
+/**
+ * <adapter_name>
+ *
+ * ⚠️  DO NOT DEPLOY AS-IS. This file seeds <list-of-things> in plaintext
+ *    for local exploration. Production adopters: <one-line-fix-summary>.
+ *
+ * <rest of header doc>
+ */
+```
+
+Banner emphasis must scale to actual production risk:
+
+- **No credentials, no in-memory state** → no banner; adopter conventions in the file body suffice
+- **Hardcoded credentials OR in-memory state** → required banner with specific risks called out
+- **Multi-tenant data models** → required banner mentioning tenant-isolation specifically
+
+## File header doc
+
+Every `hello_*` adapter starts with a JSDoc block covering:
+
+1. **What it demonstrates** — the patterns this file teaches (e.g., "account-routed multi-tenant", "OAuth pass-through resolver", "creative-template build/preview")
+2. **What it doesn't** — patterns explicitly NOT in this file that adopters might mistakenly think are here (e.g., "host-routed tenancy lives in `decisioning-platform-multi-tenant.ts`")
+3. **How to run it** — `NODE_ENV=development npx tsx ...` plus any `adcp storyboard run` invocation that exercises it
+4. **What to swap for production** — the FORK CHECKLIST: routing tables, credentials, in-memory stores, sandbox flags
+
+Header verbosity earns its keep when the adapter introduces a non-obvious pattern (multi-tenancy, cross-specialism dispatch, OAuth pass-through). Don't trim header docs to look minimal — adopters cloning the file see the header before anything else.
+
+## Naming convention
+
+`hello_<role>_adapter_<specialism>.ts`
+
+- `<role>` — AdCP protocol layer: `seller` (media-buy), `creative`, `signals`, `governance`, `brand`
+- `<specialism>` — strips the role-implied prefix (`creative-template` → `_template`, `sales-guaranteed` → `_guaranteed`)
+
+Examples: `hello_seller_adapter_guaranteed.ts`, `hello_creative_adapter_template.ts`, `hello_signals_adapter_marketplace.ts`
+
+**Multi-role adapters** (e.g., the multi-tenant holdco adapter spans governance + brand-rights + property-lists) sit outside the convention. Name them after the deployment shape: `hello_seller_adapter_multi_tenant.ts`, `hello_<deployment>_adapter_<shape>.ts`. Note the exception in the README naming-convention paragraph.
+
+## Cross-specialism dispatch
+
+When an adapter hosts multiple specialisms (e.g., the multi-tenant holdco adapter), one specialism's handler may need to call another's. The canonical pattern is a private helper extracted from the calling specialism, not a direct sibling-method call:
+
+```ts
+class MyAdapter implements DecisioningPlatform {
+  brandRights = defineBrandRightsPlatform({
+    acquireRights: async (req, ctx) => {
+      const denial = await this.enforceGovernance(tenant, ctx, offering, req);
+      if (denial) return denial;
+      // ... rest of acquire flow
+    },
+  });
+
+  campaignGovernance = defineCampaignGovernancePlatform({
+    checkGovernance: async (req, ctx) => {
+      /* ... */
+    },
+  });
+
+  private async enforceGovernance(tenant, ctx, offering, req): Promise<AcquireRightsRejected | null> {
+    // Calls this.campaignGovernance.checkGovernance internally.
+    // Documents the same-tenant invariant + the "do not copy into
+    // single-specialism agents" warning.
+  }
+}
+```
+
+The helper extraction:
+
+- Makes the data flow visible at the call site (no reading 30 lines of inline logic)
+- Gives single-specialism adopters a clean copy target (they can lift just the helper they need)
+- Forces an explicit place to document the in-process-call assumption (so adopters who copy into a single-specialism file see the warning)
+
+Always include a "DO NOT copy into a single-specialism agent" warning on cross-specialism helpers.
+
+## Tenant-isolation gates (multi-tenant adapters)
+
+Multi-tenant adapters must fail-closed, not fail-open. The pattern:
+
+```ts
+// FAIL-CLOSED: reject when home tenant can't be resolved OR when wire
+// operator maps to a different tenant than the buyer's authenticated home.
+if (!homeTenantId || tenantId !== homeTenantId) {
+  return {
+    /* PERMISSION_DENIED */
+  };
+}
+```
+
+NOT this:
+
+```ts
+// FAIL-OPEN: skips the check entirely when homeTenantId is undefined.
+// An adopter who forks and adds a credential without populating the
+// home-tenant lookup silently disables tenant isolation.
+if (homeTenantId && tenantId !== homeTenantId) {
+  return {
+    /* PERMISSION_DENIED */
+  };
+}
+```
+
+The canonical security review (`bokelley/hello-adapters-gov-rights` PR #1390 round 2) caught this exact pattern. Adopters WILL copy fail-open gates if you ship them.
+
+## CI gate
+
+Each `hello_*_adapter_*.ts` is paired with a three-gate CI test:
+
+1. **Strict tsc** — file compiles against the published `dist/` types (matches what an external adopter sees)
+2. **Storyboard** — boots the adapter, runs the matching specialism storyboard, asserts pass
+3. **Upstream-traffic** — replays a recorded upstream-fixture trace and asserts the adapter's HTTP-out shape matches
+
+A regression in any of these fails CI. When adding an adapter, add the three CI hooks; when modifying an adapter, run all three locally before pushing (`npm run typecheck`, `npx adcp storyboard run`, the upstream-recorder verify).
+
+## Format check
+
+`npm run format:check` is a hard CI gate. Run `npm run format:write` before pushing.
+
+## Changeset
+
+Every example change that ships as part of an adapter (file rename, new adapter, breaking change to an adapter's exported types) needs a changeset. Pure documentation changes (this file, README) don't.
+
+## See also
+
+- `examples/README.md` — the adopter-facing matrix of "if you're claiming X, fork Y"
+- `skills/triage-storyboard-failure/SKILL.md` — when a storyboard fails on your fork
+- `skills/build-seller-agent/`, `skills/build-creative-agent/`, etc. — per-specialism teaching surface adopters read alongside the example file
+- CLAUDE.md (repo root) — protocol-wide conventions and the storyboard-triage rubric this skill expands

--- a/examples/CONTRIBUTING.md
+++ b/examples/CONTRIBUTING.md
@@ -165,7 +165,9 @@ Every example change that ships as part of an adapter (file rename, new adapter,
 
 ## See also
 
+- Repo-root [`CONTRIBUTING.md`](../CONTRIBUTING.md) — general dev process, IPR, commit conventions; this file scopes to `examples/` conventions only
 - `examples/README.md` — the adopter-facing matrix of "if you're claiming X, fork Y"
 - `skills/triage-storyboard-failure/SKILL.md` — when a storyboard fails on your fork
+- `skills/build-holdco-agent/SKILL.md` — multi-tenant + multi-specialism adopter pattern (cross-references the FAIL-CLOSED gate convention from this file)
 - `skills/build-seller-agent/`, `skills/build-creative-agent/`, etc. — per-specialism teaching surface adopters read alongside the example file
 - CLAUDE.md (repo root) — protocol-wide conventions and the storyboard-triage rubric this skill expands

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -81,29 +81,9 @@ accounts.resolve = async (ref, ctx) => {
 
 ## Tenant-isolation gates (FAIL-CLOSED)
 
-Every mutating handler that takes a wire-supplied `operator` must verify the operator maps to the buyer's authenticated home tenant. Fail-closed shape:
+Every mutating handler that takes a wire-supplied `operator` must verify the operator maps to the buyer's authenticated home tenant — and **fail-closed** when the home tenant can't be resolved. Otherwise an adopter who forks the file and adds a credential without populating the home-tenant map silently disables tenant isolation.
 
-```ts
-const homeTenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
-if (!homeTenantId || tenantId !== homeTenantId) {
-  return {
-    /* PERMISSION_DENIED row */
-  };
-}
-```
-
-NOT this:
-
-```ts
-// FAIL-OPEN: if homeTenantId is undefined, the check skips and any
-// operator is accepted. Adopters who add a credential without populating
-// BUYER_HOME_TENANT silently disable tenant isolation.
-if (homeTenantId && tenantId !== homeTenantId) {
-  /* ... */
-}
-```
-
-This applies to **`accounts.upsert`** (sync_accounts) and to any v5-escape-hatch handler that takes per-entry account refs (`accounts.syncGovernance`, etc.).
+The canonical gate shape and the fail-OPEN anti-pattern are documented in [`examples/CONTRIBUTING.md`](../../examples/CONTRIBUTING.md#tenant-isolation-gates-multi-tenant-adapters) (the convention reviewers will check for). Apply that pattern in **`accounts.upsert`** (sync_accounts) and in any v5-escape-hatch handler that takes per-entry account refs (`accounts.syncGovernance`, etc.).
 
 ## Cross-specialism dispatch
 

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: build-holdco-agent
+description: Use when building an AdCP agency / holdco hub — one server hosting multiple specialism agents (governance + brand-rights + property-lists, etc.) with per-tenant data isolation. Distinct from `skills/build-seller-agent/` (single-specialism) and `decisioning-platform-multi-tenant.ts` (host-routed tenancy).
+---
+
+# Build an Agency / Holdco Hub Agent
+
+## What you're building
+
+One AdCP server, multiple specialism interfaces, multiple tenants whose data never crosses. The agency holdco shape: a parent company hosts governance, brand-rights, property-lists, and sometimes signals, all on one endpoint, with per-operator tenant routing so each operating company sees only its own data.
+
+Distinct from two adjacent patterns — pick by deployment shape:
+
+| Pattern                                             | Surface                                                            | When                                                                |
+| --------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| **Single-specialism, single-tenant**                | `skills/build-seller-agent/`, `skills/build-signals-agent/`, etc.  | One agent, one role, one tenant                                     |
+| **Multi-specialism, single-tenant**                 | This skill                                                         | One process, multiple specialism interfaces, no tenant partitioning |
+| **Single-specialism, multi-tenant (host-routed)**   | `examples/decisioning-platform-multi-tenant.ts` + `TenantRegistry` | One specialism, vhost-per-tenant (different agentUrls)              |
+| **Multi-specialism, multi-tenant (account-routed)** | This skill (full pattern)                                          | Holdco hub: one URL, account.operator routes to tenant              |
+
+The reference adapter is `examples/hello_seller_adapter_multi_tenant.ts` — fork it.
+
+## When to use
+
+- User wants one server hosting governance + brand-rights together (or any combination of specialisms)
+- User describes an "agency hub", "holdco", "shared services platform", or "agency operating multiple brands"
+- User mentions "tenant isolation" + "shared catalog" / "shared codebase" / "single deployment"
+
+**Not this skill:**
+
+- One specialism, multi-tenant via vhosts → `examples/decisioning-platform-multi-tenant.ts`
+- Multiple specialisms but no tenant partitioning (single-tenant SaaS) → drop the tenant routing and follow the per-specialism skill for each interface
+- One agent acting on behalf of multiple brands without specialism overlap → that's a multi-account single-specialism agent; use the per-specialism skill
+
+## The shape: one DecisioningPlatform, three specialism interfaces
+
+```ts
+class HoldcoAdapter implements DecisioningPlatform<Config, TenantMeta> {
+  capabilities = {
+    specialisms: ['governance-spend-authority', 'property-lists', 'brand-rights'] as const,
+    config: {},
+    brand: { /* RequiredCapabilitiesFor<'brand-rights'> */ },
+  };
+
+  agentRegistry = /* BuyerAgentRegistry */;
+  accounts: AccountStore<TenantMeta> = { resolve, upsert };
+  campaignGovernance = defineCampaignGovernancePlatform({ /* ... */ });
+  propertyLists = definePropertyListsPlatform({ /* ... */ });
+  brandRights = defineBrandRightsPlatform({ /* ... */ });
+
+  private async enforceGovernance(tenant, ctx, offering, req): Promise<AcquireRightsRejected | null> {
+    /* cross-specialism dispatch — see below */
+  }
+}
+```
+
+Each specialism interface is the same shape it would have in a single-specialism agent (reuse `skills/build-governance-agent/`, `skills/build-brand-rights-agent/` for per-handler details). The hub-specific work is everything around them: tenancy, isolation, cross-specialism dispatch.
+
+## The two account-resolution paths
+
+The framework calls `accounts.resolve(ref, ctx)` once per request. Hub adapters need both branches:
+
+```ts
+accounts.resolve = async (ref, ctx) => {
+  // Path 2: no account on the wire (`get_brand_identity`, `get_rights`).
+  // Derive tenant from the resolved buyer agent's home tenant.
+  if (ref == null) return resolveFromBuyer(ctx);
+
+  // Path 1: account-with-operator on the wire (governance, property-lists,
+  // sync_accounts, sync_governance). Look up tenant by operator.
+  const operator = (ref as { operator?: string }).operator;
+  const brandDomain = (ref as { brand?: { domain?: string } }).brand?.domain;
+  if (!operator) return null;
+  const tenantId = OPERATOR_TO_TENANT.get(operator);
+  if (!tenantId) return null;
+  return makeAccount(tenantId, TENANTS.get(tenantId)!, operator, brandDomain);
+};
+```
+
+`resolveFromBuyer` reads `ctx.agent.agent_url` and looks up the buyer's home tenant via a side map. Without this seam, no-account tools would fall through to a global view and leak data across tenants.
+
+## Tenant-isolation gates (FAIL-CLOSED)
+
+Every mutating handler that takes a wire-supplied `operator` must verify the operator maps to the buyer's authenticated home tenant. Fail-closed shape:
+
+```ts
+const homeTenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
+if (!homeTenantId || tenantId !== homeTenantId) {
+  return {
+    /* PERMISSION_DENIED row */
+  };
+}
+```
+
+NOT this:
+
+```ts
+// FAIL-OPEN: if homeTenantId is undefined, the check skips and any
+// operator is accepted. Adopters who add a credential without populating
+// BUYER_HOME_TENANT silently disable tenant isolation.
+if (homeTenantId && tenantId !== homeTenantId) {
+  /* ... */
+}
+```
+
+This applies to **`accounts.upsert`** (sync_accounts) and to any v5-escape-hatch handler that takes per-entry account refs (`accounts.syncGovernance`, etc.).
+
+## Cross-specialism dispatch
+
+When one specialism's handler needs another's logic, extract a private helper instead of calling sibling specialism methods directly:
+
+```ts
+brandRights = defineBrandRightsPlatform({
+  acquireRights: async (req, ctx) => {
+    /* validation seams up front */
+    const denial = await this.enforceGovernance(tenant, ctx, offering, req);
+    if (denial) return denial;
+    /* rest of acquire flow */
+  },
+});
+
+private async enforceGovernance(tenant, ctx, offering, req) {
+  // Reads tenant.governanceBindings (registered via sync_governance).
+  // Calls this.campaignGovernance.checkGovernance internally.
+  // Returns AcquireRightsRejected on denial, null otherwise.
+}
+```
+
+The helper:
+
+- Makes the data flow visible at the call site (no inline 30-line block)
+- Gives single-specialism adopters a clean copy target
+- Forces a place to document the **same-tenant invariant**: `getTenant(ctx)` resolves once per request; both specialisms share it. If a future split lets brand-rights and governance live in different tenants, this in-process call no longer applies.
+
+**⚠️ Always document the "DO NOT copy this short-circuit into a single-specialism agent" warning on the helper's JSDoc.** Single-specialism adopters who don't have a co-resident governance handler need to dial out via the @adcp/sdk client to the registered governance agent's URL — supplying credentials that this hello pattern (intentionally) drops.
+
+## What `sync_governance` ACTUALLY persists
+
+The wire payload supports up to 10 governance agents per account, with category scoping and write-only `authentication.credentials`. Hello-adapter convention is to record only the first agent's URL + plan binding. Production adopters MUST persist credentials and present them on outbound calls — silently dropping them ships unauthenticated cross-agent requests if real dial-out is added later.
+
+## Spec-correct denial
+
+When governance denies an `acquire_rights`, return `AcquireRightsRejected` (the spec's first-class denial arm), NOT a thrown `GOVERNANCE_DENIED` error code:
+
+```ts
+return {
+  rights_id: offering.rights_id,
+  status: 'rejected',
+  brand_id: offering.brand_id,
+  reason: `Denied by governance plan ${planId}: ${govResp.explanation}`,
+  ...(govResp.findings?.length && {
+    suggestions: govResp.findings.map(f => `[${f.severity}] ${f.category_id}: ${f.explanation}`),
+  }),
+};
+```
+
+`GOVERNANCE_DENIED` as a thrown error code is for buy-side flows where the governance agent itself is unreachable or returned a system error — not for adopter-controlled policy decisions.
+
+## Validation seams (request boundary)
+
+Spec-correct validation MUSTs sit at the request boundary, not nested under enforcement helpers. Example for `acquire_rights` under a registered governance binding:
+
+```ts
+acquireRights: async (req, ctx) => {
+  /* ... pricing + offering validation ... */
+
+  // Validation seam: governance enforcement will project CPM spend, which
+  // requires estimated_impressions per spec. Throw INVALID_REQUEST here.
+  const hasBinding = tenant.governanceBindings.has(req.buyer.domain);
+  if (hasBinding && (req.campaign.estimated_impressions == null || req.campaign.estimated_impressions <= 0)) {
+    throw new AdcpError('INVALID_REQUEST', {
+      message:
+        'campaign.estimated_impressions is required when acquiring CPM-priced rights under a registered governance plan.',
+      field: 'campaign.estimated_impressions',
+    });
+  }
+
+  const denial = await this.enforceGovernance(tenant, ctx, offering, req);
+  if (denial) return denial;
+
+  /* rest of flow */
+};
+```
+
+The spec MUSTs `estimated_impressions` only under intent-phase `governance_context` + CPM. The broader gate above is conservative — when the agent holds a registered binding, projecting spend without impressions silently grants under-priced rights. Production adopters with mixed pricing or `governance_context`-driven flows can tighten.
+
+## Common gotchas
+
+- **`AcquireRightsRequest` has no `account` field on the wire.** Bind by `req.buyer.domain` (a brand reference, not the buyer's account). Track adcontextprotocol/adcp#3918 for the request-shape extension that would let agents bind on (operator, brand) — until it lands, in-tenant collision case is a known limitation.
+- **`sync_governance` request has no top-level `account` field.** Framework auth-derives `ctx.account` via `resolveAccountFromAuth`; per-entry tenant gate runs against `entry.account.operator` cross-checked against `ctx.account.ctx_metadata.tenant_id`.
+- **`v6` doesn't model `sync_governance` on `AccountStore` yet.** Wire via `opts.accounts.syncGovernance` v5 escape-hatch; promotion tracked at adcontextprotocol/adcp-client#1387.
+- **Schema requires `^https://` for `governance_agent_url`.** Local-dev adopters can't register their own server's URL via `sync_governance` without a TLS terminator. Loopback-pattern relaxation tracked at adcontextprotocol/adcp#3918.
+
+## See also
+
+- `examples/hello_seller_adapter_multi_tenant.ts` — the working reference
+- `examples/CONTRIBUTING.md` — SWAP-marker convention, fail-closed gate pattern, cross-specialism helper extraction
+- `skills/build-governance-agent/`, `skills/build-brand-rights-agent/`, `skills/build-seller-agent/` — per-specialism handler details
+- `examples/decisioning-platform-multi-tenant.ts` + `skills/build-decisioning-platform/` — host-routed multi-tenant pattern (different shape; use when each tenant has its own subdomain)
+- `skills/triage-storyboard-failure/` — when storyboards fail on your fork
+- `skills/run-by-experts/` — convergence-of-reviewers pattern for non-trivial PRs (multi-tenant + auth surfaces are exactly the kind of change this skill calls for)

--- a/skills/run-by-experts/SKILL.md
+++ b/skills/run-by-experts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: run-by-experts
-description: Use before opening a PR (especially for protocol/safety/correctness changes). Fires multiple expert reviewers in parallel and uses convergence as the blocker signal — items flagged by 2+ reviewers are real; single-reviewer findings are usually preferences.
+description: Use before opening a SUBSTANTIVE PR (protocol changes, multi-tenant or auth surfaces, adopter-facing examples, refactors that span specialism modules). Fires multiple expert reviewers in parallel and uses convergence as the blocker signal — items flagged by 2+ reviewers are real; single-reviewer findings are usually preferences. Skip for trivial changes (single-line fixes, README typos, mechanical refactors).
 ---
 
 # Run by Experts

--- a/skills/run-by-experts/SKILL.md
+++ b/skills/run-by-experts/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: run-by-experts
+description: Use before opening a PR (especially for protocol/safety/correctness changes). Fires multiple expert reviewers in parallel and uses convergence as the blocker signal — items flagged by 2+ reviewers are real; single-reviewer findings are usually preferences.
+---
+
+# Run by Experts
+
+## Overview
+
+Multi-reviewer parallel review where **convergence is the load-bearing signal**. Items flagged by two or more reviewers are real blockers. Single-reviewer findings are usually preferences worth considering but not gating.
+
+This skill exists because solo Claude review on a non-trivial PR catches obvious bugs but misses domain-specific landmines (multi-tenant isolation, protocol shape, type-system gotchas, adopter-DX cliffs). Each expert reviewer carries different domain priors; running them in parallel and acting on the intersection produces a better signal than any single review.
+
+## When to use
+
+**Always run before opening:**
+
+- Protocol-level changes (request/response shapes, error codes, new specialism interfaces)
+- Multi-tenant or auth surfaces (isolation gates, credential handling, sandbox boundaries)
+- Adopter-facing examples (`examples/hello_*`, skill files, public docs)
+- Bug fixes where the root cause might be either side of an interface boundary
+
+**Optional but high-value:**
+
+- Refactors that span multiple specialism modules
+- API surface changes (export shape, type changes, deprecations)
+- New subagent prompts or skill files
+
+**Skip:**
+
+- Trivial changes (changesets, single-line bug fixes with obvious test coverage, README typos)
+- Pure mechanical refactors (rename, dead-code removal) where you've verified no behavior change
+
+## The reviewer set
+
+Pick the relevant subset for the PR. Default for a substantive change is all four:
+
+| Reviewer                  | Focus                                                                                                       | Fire when                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `ad-tech-protocol-expert` | Wire shape vs spec, error code placement, schema conformance, protocol contract                             | Any protocol-touching change                                                                        |
+| `code-reviewer`           | Correctness, type-safety, dead code, casts, edge cases, hidden control flow                                 | All non-trivial code changes                                                                        |
+| `security-reviewer`       | Tenant isolation, auth/credential handling, prompt-injection surfaces, fail-open vs fail-closed gates, SSRF | Any change that touches auth, multi-tenancy, or buyer-supplied data flowing through error envelopes |
+| `dx-expert`               | Forkability, SWAP markers, header doc clarity, copy-paste anti-patterns, README discoverability             | Any adopter-facing example or doc change                                                            |
+
+For protocol-only / spec-side changes, `adtech-product-expert` (buy-side / sell-side product fit) is often a fifth.
+
+## How to fire
+
+Single message, multiple `Agent` tool calls in parallel — never sequential. Run-in-background unless the PR is so small that you'll wait on the first one. Each prompt is **self-contained**: the agent has no memory of the conversation, so include:
+
+- File paths in scope
+- Branch name
+- Specific items the prior round (if any) claimed to fix — verify each
+- Specific concerns you want flagged (don't ask "what do you think?" — that produces shallow review)
+- Word budget ("Under 500 words")
+- Format expectation ("Report: blockers / concerns / fine, per item")
+
+Example brief shape (excerpted from `bokelley/hello-adapters-gov-rights` round 2):
+
+> Re-review of PR #XXXX. Prior round flagged 17 findings; all blockers + must-fix concerns claimed addressed. Verify, and flag any NEW issues introduced by the fixes.
+>
+> Files in scope: `examples/foo.ts` (new, ~1200 lines).
+>
+> Prior-round items that should be fixed — verify each:
+>
+> 1. ...
+> 2. ...
+>
+> New questions for this round:
+>
+> 1. ...
+>
+> Report: blockers / suggestions / nits. Under 500 words. Don't restate prior-round findings unless the fix introduces a new issue.
+
+## Reading the results
+
+**Convergence (2+ reviewers same finding) = real blocker.** Act on these unconditionally.
+
+**Single-reviewer must-fix = should-fix.** Read the reasoning; usually it's worth doing but defensibly skippable. Push back if the finding contradicts the convergent signals.
+
+**Advisory = nice-to-have.** Roll into a follow-up issue or comment-only fix.
+
+The convergence signal is doing real work. From the production example (round 1 of the multi-tenant adapter PR):
+
+- The `as unknown as { account?: ... }` cast was flagged by THREE of four reviewers (code: "may be reading a runtime-undefined field"; DX: "cargo-cult-bait"; protocol: implicitly endorsed by saying "should pull from `ctx.account`"). All three independently spotted that the cast was a real bug, not a style preference.
+- Single-reviewer concerns were mostly preferences (helper extraction style, comment placement nits). Worth doing but not gating.
+
+## Two-round pattern
+
+For substantive PRs, run **two rounds**:
+
+1. **Round 1 — initial review.** Fire all relevant reviewers on the unreviewed code. Consolidate findings by convergence. Apply blockers + must-fix.
+2. **Round 2 — re-review of fixes.** Fire the same reviewers again, asking each to (a) verify each prior-round finding is fixed and (b) flag any NEW issues the fix introduced.
+
+Round-2 finds the regressions fix-blindness misses. Production example: round 2 caught a fail-OPEN tenant gate that round 1's fix had introduced (the gate was `if (homeTenantId && tenantId !== homeTenantId)` — when `homeTenantId` is undefined, the check skips; round 1 hadn't considered that path).
+
+## Process artifacts to ship with the PR
+
+After all rounds land, the PR description should include:
+
+- A consolidated "Expert review" section listing each round's blockers and how each was addressed
+- The reviewer convergence signal (e.g., "3 of 4 flagged X" → "this was the real bug")
+- Any single-reviewer items that were intentionally NOT fixed, with reasoning
+- Cross-links to upstream-spec issues filed during review (if storyboards or spec gaps surfaced — see `skills/triage-storyboard-failure/`)
+
+## What this skill is NOT
+
+- A replacement for human reviewers — convergent expert review surfaces issues fast, but humans make the final call on whether to merge
+- An excuse to skip writing tests — reviewers can't verify behavior they can't run
+- A substitute for `npm run typecheck` / `npm run format:check` / CI — those gate-before-review
+
+## See also
+
+- `skills/triage-storyboard-failure/` — when an expert review (or your own testing) surfaces a storyboard-vs-spec mismatch
+- `examples/CONTRIBUTING.md` — the SWAP-marker and DO-NOT-DEPLOY-AS-IS conventions DX reviewers will check for
+- `~/.claude/commands/prep-for-pr.md` (personal command) — calls this skill plus the build/test/security-review chain

--- a/skills/triage-storyboard-failure/SKILL.md
+++ b/skills/triage-storyboard-failure/SKILL.md
@@ -85,9 +85,9 @@ Cross-link to the adapter PR that surfaced it. The storyboard maintainers see th
 
 Real triage walks from this codebase:
 
-- **adcontextprotocol/adcp#3892**: brand-rights storyboard's `acquire_rights` step captured `rights_grant_id` via `context_outputs`. Spec field is `rights_id`. Cascading skip on next step. **Resolution**: spec → field is `rights_id`; storyboard is wrong; filed; merged in 3.0.5.
-- **adcontextprotocol/adcp#3914**: brand-rights/governance_denied storyboard's `acquire_rights_denied` step expected thrown `code: GOVERNANCE_DENIED`. Spec gives `AcquireRightsRejected` arm with `reason`. **Resolution**: storyboard is asserting a non-spec convention; filed upstream; adapter ships spec-correct shape.
-- **adcontextprotocol/adcp#3913**: `brand_rights/governance_denied` storyboard step `sync_governance` skips because `$context.governance_agent_url` is unresolved; runner has no `--context` flag for full `storyboard run` mode. **Resolution**: runner gap, not adapter or spec gap; filed upstream.
+- **adcontextprotocol/adcp#3892** (closed): brand-rights storyboard's `acquire_rights` step captured `rights_grant_id` via `context_outputs`. Spec field is `rights_id`. Cascading skip on next step. **Resolution**: spec → field is `rights_id`; storyboard is wrong; filed; closed.
+- **adcontextprotocol/adcp#3914** (open): brand-rights/governance_denied storyboard's `acquire_rights_denied` step expected thrown `code: GOVERNANCE_DENIED`. Spec gives `AcquireRightsRejected` arm with `reason`. **Resolution**: storyboard is asserting a non-spec convention; filed upstream; adapter ships spec-correct shape.
+- **adcontextprotocol/adcp#3913** (open): `brand_rights/governance_denied` storyboard step `sync_governance` skips because `$context.governance_agent_url` is unresolved; runner has no `--context` flag for full `storyboard run` mode. **Resolution**: runner gap, not adapter or spec gap; filed upstream.
 
 ## See also
 

--- a/skills/triage-storyboard-failure/SKILL.md
+++ b/skills/triage-storyboard-failure/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: triage-storyboard-failure
+description: Use when an AdCP compliance storyboard fails on an adapter you believe is spec-correct. Walks the rubric for deciding whether to fix the SDK, the adapter, or file upstream against the spec/storyboard.
+---
+
+# Triage a Storyboard Failure
+
+## Overview
+
+Storyboards in `compliance/cache/<version>/` are assertions about adopter behavior. They are **not** the spec — they are tests authored against the spec. Storyboards drift. When one fails, the question is _which side is wrong_: the adapter, the SDK, or the storyboard itself.
+
+This skill is the rubric for that decision. It exists because adopter-facing failures look identical regardless of cause, and the wrong-direction fix (changing the SDK to satisfy a storyboard that disagrees with the spec) compounds drift across the ecosystem.
+
+## When to Use
+
+- A `storyboard run` step fails on an adapter you believe satisfies the spec
+- The runner reports `expect_error.code` mismatch, `context_outputs path did not resolve`, or a `response_schema` failure on a response that round-trips through the generated TS types
+- You're tempted to add a field, change an error code, or adjust a response shape "to make the test pass"
+
+**Not this skill:**
+
+- Real adopter bugs (your handler returns malformed data, throws unexpectedly, ignores a required field) — fix the adapter
+- Wire-schema validation failures (`additionalProperties`, missing required) on requests YOU sent — fix the request
+
+## The rubric
+
+For any failing step, work the three checks in order. **Stop at the first answer.**
+
+### 1. Does the spec define the contract the storyboard is asserting?
+
+Open the schema the storyboard's step references (`schemas/cache/<version>/<protocol>/<tool>-response.json` or similar). Find the field, error code, or shape the storyboard expects.
+
+- **Field exists in the spec, with the shape the storyboard expects** → continue to step 2.
+- **Field exists in the spec but with a different shape** → spec or storyboard mismatch; the storyboard is wrong. File upstream against `adcontextprotocol/adcp`. Cite the schema file path + line.
+- **Field does NOT exist in the spec** → the storyboard authored an opinion that has no spec basis. The storyboard is wrong. File upstream.
+- **Spec is silent** (the contract is ambiguous) → flag the spec gap upstream. The storyboard's interpretation may be reasonable, but adopters can't know which interpretation to follow without spec clarity.
+
+### 2. Does the SDK shape match the spec?
+
+If the spec defines the contract correctly, check whether the SDK's generated TS types and runtime validators match it. Read the relevant `src/lib/types/*.generated.ts` interface and confirm:
+
+- Every `required` field in the schema is present and non-optional in the TS type
+- Every discriminator (e.g., `asset_type`, `status`) is preserved (codegen sometimes strips `oneOf` discriminators when generating union types)
+- Format constraints (date vs date-time, URL pattern, idempotency_key length/pattern) are reflected in either the TS type or the framework's runtime validator
+
+- **TS type matches spec, runtime validation works** → continue to step 3.
+- **TS type allows what spec rejects (or vice versa)** → SDK bug. Fix the codegen or hand-fix the type. File against `adcp-client`.
+
+### 3. Is the storyboard's expectation actually testable from the request the runner sent?
+
+Run the failing step in step mode (`adcp storyboard step <agent> <storyboard_id> <step_id> --json`) and inspect:
+
+- The actual request payload the runner sent
+- The actual response your adapter returned
+- Each `validations[]` entry's pass/fail
+
+Common patterns:
+
+- **`context_outputs path did not resolve`** → the runner couldn't capture a value from your response under the expected path. Check whether the path matches what the spec defines (e.g., adcp#3892 captured `rights_grant_id` but the spec field is `rights_id` — storyboard was wrong).
+- **`expect_error: code: X`** but your adapter returned a structured success response (e.g., `AcquireRightsRejected` with `reason`) → storyboard is asserting a thrown-error shape when the spec gives a first-class denial arm. Storyboard convention, not spec contract. File upstream.
+- **`unresolved context variables from prior steps`** → the runner can't seed a variable the storyboard requires. Runner gap. File upstream against the storyboard runner.
+
+## Heuristics
+
+- **Generated TS types** are not always tighter than the schema. Discriminator fields, `additionalProperties: false` constraints, and `oneOf` arms can be loosened during codegen. Trust the JSON Schema as ground truth.
+- **`response_schema` validation passes but the step still fails** → almost always a storyboard `context_outputs` or `expect_error` mismatch. Your response is correct; the test's assertion is wrong.
+- **A storyboard expects a thrown error code** (`expect_error: true` + `code: X`) when the spec defines a structured denial arm → the storyboard is shipping a non-spec convention. The Rejected/Pending/Acquired union is the canonical shape; thrown error codes are for system failures (timeout, unreachable), not policy decisions.
+- **`requires_scenarios:`** in a storyboard YAML lists prerequisite scenarios that must run first. Step-mode runs lose this dependency; use full `storyboard run` mode to verify, then re-step the failing piece for diagnostics.
+
+## What to file
+
+When the rubric points upstream, file with this template:
+
+> **Title**: `<storyboard_id>` step `<step_id>`: `<assertion>` is non-spec — `<canonical_shape>` is the canonical wire shape
+>
+> **Repro**: Run any spec-compliant adapter; show the failing step's `--json` output.
+>
+> **Root cause**: Cite the spec schema file path + line that defines (or is silent on) the contract the storyboard asserts.
+>
+> **Fix**: Update the storyboard YAML (or the spec doc-comment, if the spec is genuinely ambiguous).
+
+Cross-link to the adapter PR that surfaced it. The storyboard maintainers see the convergent signal across adopters and can prioritize.
+
+## Examples from production
+
+Real triage walks from this codebase:
+
+- **adcontextprotocol/adcp#3892**: brand-rights storyboard's `acquire_rights` step captured `rights_grant_id` via `context_outputs`. Spec field is `rights_id`. Cascading skip on next step. **Resolution**: spec → field is `rights_id`; storyboard is wrong; filed; merged in 3.0.5.
+- **adcontextprotocol/adcp#3914**: brand-rights/governance_denied storyboard's `acquire_rights_denied` step expected thrown `code: GOVERNANCE_DENIED`. Spec gives `AcquireRightsRejected` arm with `reason`. **Resolution**: storyboard is asserting a non-spec convention; filed upstream; adapter ships spec-correct shape.
+- **adcontextprotocol/adcp#3913**: `brand_rights/governance_denied` storyboard step `sync_governance` skips because `$context.governance_agent_url` is unresolved; runner has no `--context` flag for full `storyboard run` mode. **Resolution**: runner gap, not adapter or spec gap; filed upstream.
+
+## See also
+
+- CLAUDE.md (this repo): "When a compliance storyboard fails, triage before patching" — the inline guidance this skill expands.
+- `docs/guides/VALIDATE-YOUR-AGENT.md` — adopter-facing validation flow that runs storyboards.
+- `docs/development/WIRE-VERSION-COMPAT.md` — storyboard cache layout per spec version.


### PR DESCRIPTION
## Summary

Codifies the meta/process learnings from PR #1390's two-round expert review into discoverable skills + a CONTRIBUTING guide for adopter examples. Pure documentation — no library or example code changes.

## What ships

**New skills**:

- **`skills/triage-storyboard-failure/`** — three-step rubric for when a storyboard fails on a spec-correct adapter. Cites real triage walks from #1390:
  - `adcontextprotocol/adcp#3892` — rights_grant_id storyboard capture (storyboard wrong, fixed in 3.0.5)
  - `adcontextprotocol/adcp#3914` — GOVERNANCE_DENIED storyboard convention vs spec-correct AcquireRightsRejected arm
  - `adcontextprotocol/adcp#3913` — storyboard runner context seeding gap
- **`skills/run-by-experts/`** — convergence-of-reviewers pattern. 2+ reviewers same finding = real blocker. Documents the two-round pattern (initial + re-review) that caught the fail-OPEN tenant gate in #1390 round 2. Lists canonical reviewer set.
- **`skills/build-holdco-agent/`** — agency / holdco hub adapter pattern (multi-specialism + multi-tenant, account-routed). Reference adapter is `hello_seller_adapter_multi_tenant.ts` from #1390.

**New convention doc**:

- **`examples/CONTRIBUTING.md`** — SWAP-marker convention, DO-NOT-DEPLOY-AS-IS banner, file header doc requirements, naming convention, cross-specialism dispatch pattern, and the FAIL-CLOSED tenant gate (canonical security-review finding from #1390 round 2 that adopters WILL copy if shipped fail-OPEN).

## Closes

- Tracks `adcontextprotocol/adcp-client#1387` — SDK ergonomics meta-issue. Covers the "skills/build-holdco-agent + skills/triage-storyboard-failure + skills/run-by-experts + examples/CONTRIBUTING.md" bullets.
- No new spec issues — `adcontextprotocol/adcp#3918` (spec gaps meta-issue) is the parent for upstream items already filed.

## Why these are skills/ and not CLAUDE.md

CLAUDE.md is loaded into every session as a system-reminder, so it should be tight pointers, not playbooks. Workflow patterns (run-by-experts, compliance triage) live in `skills/`. Example-file conventions (SWAP markers, hello-adapter patterns) live in `examples/CONTRIBUTING.md`. CLAUDE.md already has a one-line pointer to "When a compliance storyboard fails, triage before patching" — the new triage skill expands that.

## Test plan

- [x] `npm run format:check` — clean
- [x] All four files render correctly (markdown + frontmatter)
- [ ] CI passes (no code changes; only `commitlint`, `Check for changeset`, `IPR Policy / Signature` should run; no changeset needed for docs-only)
- [ ] Skills load via `Skill` tool (validate by running them in a follow-up session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)