### PR TITLE
test(examples): kernel-assigned ports for hello-adapter test fixtures

### DIFF
--- a/.changeset/example-test-port-isolation.md
+++ b/.changeset/example-test-port-isolation.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+Test-infrastructure: `runHelloAdapterGates` (the shared CI test runner for `examples/hello_*_adapter_*.ts`) picks free TCP ports per-run instead of taking hardcoded numbers from each test file's config.
+
+Closes the EADDRINUSE-on-41504 + agent-port-timeout-on-35004 flakes hit on adcp-client#1361 CI runs 25266540111 / 25266762789 / 25266848405 — concurrent `node --test` workers were racing on the same hardcoded port across reruns when the previous run left TCP sockets in TIME_WAIT after `--test-force-exit`.
+
+Mock server gets `port: 0` directly (its boot helper surfaces the bound port via `mockHandle.url`); the spawned agent reads `PORT` from env, so the harness uses a small `pickFreePort()` helper that asks the kernel for a free number and hands it to the child process. `agentPort` and `upstreamPort` are gone from the `runHelloAdapterGates` config — every test file using the harness now opts in automatically.
+
+No library/CLI behavior change; this is a `patch` only because the changeset gate doesn't have a "tests-only" semver level today.

--- a/test/examples/_helpers/runHelloAdapterGates.js
+++ b/test/examples/_helpers/runHelloAdapterGates.js
@@ -23,13 +23,16 @@ const CLI = path.join(REPO_ROOT, 'bin', 'adcp.js');
  * @property {Parameters<typeof bootMockServer>[0]['specialism']} specialism
  * @property {string} storyboardId            — storyboard id passed to `adcp storyboard run`
  * @property {string} adcpAuthToken           — bearer the agent verifies + the grader sends
- * @property {number} agentPort               — high port the agent binds to
- * @property {number} upstreamPort            — high port the mock binds to
  * @property {string[]} expectedRoutes        — façade gate: routes that must show ≥1 hit
  * @property {Record<string, string|undefined>} [extraEnv]  — extra env vars for the agent child
  * @property {Parameters<typeof bootMockServer>[0]} [mockOptions] — extra mock-server boot opts
  * @property {(grader: any) => any[]} [filterFailures] — narrow the failures list (default: all)
  * @property {string} [storyboardSummary]     — optional storyboard description for the test name
+ *
+ * Ports are picked dynamically per test run (kernel-assigned via `pickFreePort()`)
+ * so concurrent test-file workers never race on the same hardcoded number. See
+ * adcontextprotocol/adcp-client#1361 CI runs 25266540111 / 25266762789 / 25266848405
+ * for the original EADDRINUSE-on-41504 + agent-port-timeout-on-35004 flakes.
  */
 
 /**
@@ -43,8 +46,6 @@ function runHelloAdapterGates(config) {
     specialism,
     storyboardId,
     adcpAuthToken,
-    agentPort,
-    upstreamPort,
     expectedRoutes,
     extraEnv = {},
     mockOptions = {},
@@ -84,9 +85,20 @@ function runHelloAdapterGates(config) {
     // ── Gates 2 + 3 — runtime: storyboard + traffic ──
     let mockHandle;
     let agent;
+    let agentPort;
 
     before(async () => {
-      mockHandle = await bootMockServer({ specialism, port: upstreamPort, ...mockOptions });
+      // Pick free ports per-run so concurrent test-file workers never race
+      // on a hardcoded number. The mock server gets `port: 0` directly (its
+      // boot helper reads `server.address()` and surfaces the bound port via
+      // `mockHandle.url`); the spawned agent is a child process that reads
+      // `PORT` from env, so we must hand it a concrete number — `pickFreePort`
+      // asks the kernel for one and closes immediately, leaving a small
+      // race window between close and the agent's `listen()`. Acceptable for
+      // tests; the rare collision falls back into `waitForPort`'s timeout
+      // and reports cleanly.
+      agentPort = await pickFreePort();
+      mockHandle = await bootMockServer({ specialism, port: 0, ...mockOptions });
       agent = spawn('npx', ['tsx', exampleFile], {
         cwd: REPO_ROOT,
         env: {
@@ -158,6 +170,27 @@ function waitForPort(host, port, timeoutMs) {
       });
     };
     tick();
+  });
+}
+
+/**
+ * Ask the kernel for a free TCP port on 127.0.0.1: open a server on port 0,
+ * read what was assigned, close it, and hand the number back. There's a small
+ * race window between close and whoever uses the port next — acceptable for
+ * test fixtures, much better than fighting hardcoded numbers across
+ * concurrent test-file workers.
+ */
+function pickFreePort() {
+  const { createServer } = require('node:net');
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.unref();
+    s.once('error', reject);
+    s.listen(0, '127.0.0.1', () => {
+      const addr = s.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      s.close(err => (err ? reject(err) : resolve(port)));
+    });
   });
 }
 

--- a/test/examples/hello-creative-adapter-template.test.js
+++ b/test/examples/hello-creative-adapter-template.test.js
@@ -20,8 +20,6 @@ runHelloAdapterGates({
   specialism: 'creative-template',
   storyboardId: 'creative_template',
   adcpAuthToken: 'sk_harness_do_not_use_in_prod',
-  agentPort: 35002,
-  upstreamPort: 41502,
   mockOptions: { apiKey: 'mock_creative_template_key_do_not_use_in_prod' },
   extraEnv: { UPSTREAM_API_KEY: 'mock_creative_template_key_do_not_use_in_prod' },
   expectedRoutes: [

--- a/test/examples/hello-seller-adapter-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-guaranteed.test.js
@@ -21,8 +21,6 @@ runHelloAdapterGates({
   specialism: 'sales-guaranteed',
   storyboardId: 'sales_guaranteed',
   adcpAuthToken: 'sk_harness_do_not_use_in_prod',
-  agentPort: 35004,
-  upstreamPort: 41504,
   mockOptions: { apiKey: 'mock_sales_guaranteed_key_do_not_use_in_prod' },
   extraEnv: { UPSTREAM_API_KEY: 'mock_sales_guaranteed_key_do_not_use_in_prod' },
   expectedRoutes: [

--- a/test/examples/hello-seller-adapter-social.test.js
+++ b/test/examples/hello-seller-adapter-social.test.js
@@ -26,8 +26,6 @@ runHelloAdapterGates({
   specialism: 'sales-social',
   storyboardId: 'sales_social',
   adcpAuthToken: 'sk_harness_do_not_use_in_prod',
-  agentPort: 35003,
-  upstreamPort: 41503,
   extraEnv: {
     UPSTREAM_OAUTH_CLIENT_ID,
     UPSTREAM_OAUTH_CLIENT_SECRET,


### PR DESCRIPTION
## Summary

Drop hardcoded `agentPort` / `upstreamPort` from each `hello-*-adapter-*.test.js` config and the shared `runHelloAdapterGates` helper. The harness now picks a free TCP port via the kernel (`pickFreePort()`) for the agent and passes `port: 0` to `bootMockServer` for the upstream.

Fixes the flakes that were silently riding alongside #1361's resolver landing — same fix, separated out for cleaner review.

## Why

Three CI runs on adcp-client#1361 hit the same port-binding flake:

- `25266540111` — `EADDRINUSE: 127.0.0.1:41504` (upstream port for `sales-guaranteed`)
- `25266762789` — same as above (rerun)
- `25266848405` — `timed out waiting for 127.0.0.1:35004` (agent port, after a half-fix made upstream dynamic)

Root cause: `node --test test/examples/*.test.js` runs example adapter test files concurrently. With `--test-force-exit` on the prior unit-test step, TCP sockets land in TIME_WAIT for ~60 s. When the example step starts, the kernel sometimes refuses to rebind the hardcoded port a previous test (in this run or the rerun) just released. The `before()` hook fails before any assertion runs.

## What changes

- `test/examples/_helpers/runHelloAdapterGates.js`:
  - New `pickFreePort()` helper — opens a server on port 0, reads what was assigned via `server.address()`, closes it, returns the number.
  - `before()` now calls `pickFreePort()` for the agent and passes `port: 0` to `bootMockServer` (its boot helpers already surface the bound port via `mockHandle.url`, so no race there).
  - `agentPort` and `upstreamPort` removed from the JSDoc config typedef.
- Three call sites stop passing the dropped fields:
  - `test/examples/hello-creative-adapter-template.test.js`
  - `test/examples/hello-seller-adapter-guaranteed.test.js`
  - `test/examples/hello-seller-adapter-social.test.js`

`hello-signals-adapter-marketplace.test.js` uses its own pre-harness implementation and is out of scope here — its hardcoded ports (35001/41500) haven't flaked yet; if they ever do, lift the same change.

## Race-window note

`pickFreePort()` has a microsecond-scale race between close and the agent's `listen()` — the kernel could reassign the port to another caller in that window. Acceptable for tests; the rare collision falls back into `waitForPort`'s 30 s timeout and reports cleanly. The mock server upstream avoids the race entirely because `bootMockServer({ port: 0 })` keeps the port bound continuously.

## Test plan

- [x] `npm run test:examples` passes 19/19 locally on this branch
- [x] All three adapter test files using the harness pass with dynamic ports
- [x] Format check + lint clean
- [x] Changeset added (patch)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)