### PR TITLE
ci: serialize test:examples to fix EADDRINUSE port-collision flake

### DIFF
--- a/.changeset/test-examples-serialize.md
+++ b/.changeset/test-examples-serialize.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add `--test-concurrency=1` to the `test:examples` npm script. Internal test-runner config change to fix EADDRINUSE port-collision flake; no library or CLI behavior change. Empty changeset signals no release needed.

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "pretest:lib": "npm run schemas:ensure",
     "test:lib": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/*.test.js",
     "pretest:examples": "npm run build",
-    "test:examples": "NODE_ENV=test node --test-timeout=180000 --test-force-exit --test test/examples/*.test.js",
+    "test:examples": "NODE_ENV=test node --test-timeout=180000 --test-force-exit --test-concurrency=1 --test test/examples/*.test.js",
     "test:e2e": "node test/e2e/adcp-e2e.test.js",
     "test:protocols": "node test/run-protocol-tests.js",
     "changeset": "changeset",


### PR DESCRIPTION
## Summary

Fixes the EADDRINUSE flake that bit PR #1390 twice (and would bite every future PR running through `Test & Build`). One-line fix.

## The flake

`test:examples` runs four hello-adapter integration test files in parallel via Node's `--test` worker pool. Each file binds hardcoded ports for its agent + mock:

| File | agent port | upstream port |
|---|---|---|
| `hello-creative-adapter-template.test.js` | 35002 | 41502 |
| `hello-seller-adapter-social.test.js` | 35003 | 41503 |
| `hello-seller-adapter-guaranteed.test.js` | 35004 | 41504 |
| (others) | ... | ... |

Ports are unique across files. So why the collision?

Combined with `--test-force-exit` (which terminates processes without graceful resource release), the worker pool sometimes leaks a bound port to the next file's `before` hook in the same worker. EADDRINUSE on `bootMockServer({ port: 41502 })` reproduces non-deterministically:

- PR #1390 first run: failed on port 41504 (sales-guaranteed mock)
- PR #1390 re-run: failed on port 41502 (creative-template mock)

Different ports each time → not a config conflict, not a hung process from outside the test suite. Worker reuse + force-exit not releasing fast enough is the only consistent explanation.

## Fix

Add `--test-concurrency=1` to the `test:examples` script. Tests serialize, each `after` hook fully releases its port before the next file starts.

```diff
- "test:examples": "NODE_ENV=test node --test-timeout=180000 --test-force-exit --test test/examples/*.test.js",
+ "test:examples": "NODE_ENV=test node --test-timeout=180000 --test-force-exit --test-concurrency=1 --test test/examples/*.test.js",
```

## Cost

~30s slower CI (4 files × ~30s sequential vs parallel). Acceptable trade for stability — the flake was forcing PR re-runs and admin-merges that bypass legitimate signal too.

## Follow-up (not this PR)

The proper fix is ephemeral port 0 in `bootMockServer` + agent `PORT` env, capturing kernel-assigned ports via `server.address()`. The mock servers already call `server.address()` after bind, so the wiring is half-done. Test files would pass `port: 0` instead of hardcoded numbers; the helper would propagate the kernel-assigned port to the agent spawn via env.

Holding that for a follow-up PR — this serialization fix unblocks PRs immediately while we validate the runtime cost is acceptable. If `--test-concurrency=1` proves too slow in practice (or if we need parallel test execution back), we'll switch to ephemeral ports.

## Test plan

- [x] `--test-concurrency=1` is a real Node flag (`node --help | grep test-concurrency`)
- [ ] CI passes on this PR (the same `Test & Build` job that flaked on #1390)
- [ ] No changeset needed — dev tooling (test runner config), not library/CLI code

🤖 Generated with [Claude Code](https://claude.com/claude-code)