### PR TITLE
feat(server): re-export createOAuthPassthroughResolver from /server

### DIFF
--- a/.changeset/oauth-passthrough-server-export.md
+++ b/.changeset/oauth-passthrough-server-export.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+chore(server): re-export `createOAuthPassthroughResolver` from `@adcp/sdk/server`. Aligns with the other decisioning-platform adopter helpers (`composeMethod`, `definePlatform*`, `resolve` presets, `InMemoryImplicitAccountStore`) so adopters writing a Shape B `accounts.resolve` don't have to remember the split between root and `/server`. Root export from `@adcp/sdk` remains for backwards compatibility.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -408,3 +408,8 @@ export {
   defaultImplicitKeyFn,
   type ImplicitAccountStoreOptions,
 } from '../adapters/implicit-account-store';
+
+export {
+  createOAuthPassthroughResolver,
+  type OAuthPassthroughResolverOptions,
+} from '../adapters/oauth-passthrough-resolver';


### PR DESCRIPTION
## Summary

- Re-exports `createOAuthPassthroughResolver` and `OAuthPassthroughResolverOptions` from `@adcp/sdk/server`. Previously only available at root `@adcp/sdk`.
- Aligns the Shape B `accounts.resolve` factory with its sibling decisioning-platform helpers (`composeMethod`, `definePlatform*`, resolve presets, `InMemoryImplicitAccountStore`) that all live at `/server`. Adopters writing a Shape B resolver no longer need to remember the split.
- Root `@adcp/sdk` export retained for back-compat. Pure-additive, patch-level changeset.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] `test/server-adapters-oauth-passthrough-resolver.test.js` — 18/18 pass
- [x] `require('@adcp/sdk/server').createOAuthPassthroughResolver` resolves at runtime
- [x] code-reviewer + dx-expert greenlit (no blockers, no nits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)