### PR TITLE
feat(server): AccountStore.syncGovernance typed surface + write-only credential strip

### DIFF
--- a/.changeset/account-store-sync-governance.md
+++ b/.changeset/account-store-sync-governance.md
@@ -1,0 +1,39 @@
+---
+"@adcp/sdk": minor
+---
+
+`AccountStore.syncGovernance` — typed `sync_governance` surface promoted to v6 platform. Closes one of the items tracked in #1387.
+
+Buyers register governance agent endpoints per-account via `sync_governance`; the seller persists the binding and consults the registered agents during media buy lifecycle events via `check_governance`. Pre-this-release, adopters wired this through the v5 escape-hatch (`opts.accounts.syncGovernance`), which forced `as any` casts to satisfy the framework's merge-seam types. Now it's a typed method on `AccountStore` symmetric with `upsert` / `list`:
+
+```ts
+accounts: AccountStore<TenantMeta> = {
+  resolve: async (ref, ctx) => { /* ... */ },
+  upsert: async (refs, ctx) => { /* sync_accounts */ },
+  syncGovernance: async (entries, ctx) => {
+    // Per-entry tenant-isolation gate. ctx.agent is the auth-resolved
+    // BuyerAgent — assert each entry's account.operator maps to the same
+    // tenant before persisting. Per-entry rejection (vs. operation-level
+    // throw) so a single bad entry doesn't fail the whole batch.
+    const homeTenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
+    return entries.map(entry => {
+      const tenantId = OPERATOR_TO_TENANT.get(entry.account.operator);
+      if (!homeTenantId || tenantId !== homeTenantId) {
+        return {
+          account: entry.account,
+          status: 'failed',
+          errors: [{ code: 'PERMISSION_DENIED', message: '...' }],
+        };
+      }
+      // persist binding...
+      return { account: entry.account, status: 'synced', governance_agents: [...] };
+    });
+  },
+};
+```
+
+The signature takes the wire entries (`SyncGovernanceRequest['accounts']`) directly — each entry pairs an `AccountReference` with its `governance_agents[]`. Framework strips `idempotency_key` / `adcp_major_version` / `context` / `ext` (already deduped) and wraps the returned rows in `{ accounts: rows }` for the wire response.
+
+**Security: write-only credentials are stripped at the wire boundary.** Per spec, each `governance_agents[i].authentication.credentials` is the bearer the seller will present on outbound `check_governance` calls — the buyer sends it, the seller persists it, but it MUST NOT echo back. The framework now strips `authentication` from every `governance_agents[i]` of every row before serialization, in both `syncGovernanceResponse` (the wire-emit boundary that covers v5 escape-hatch adopters) and the v6 dispatcher (`toWireSyncGovernanceRow`). Adopters can return loosely-typed rows or spread the input agent without leaking credentials over the wire OR into the idempotency replay cache. Defense-in-depth — TypeScript narrowing alone is insufficient because excess-property checks don't fire on assigned variables and the response Zod schema uses `.passthrough()`.
+
+Backwards-compatible: `syncGovernance` is optional on `AccountStore`. Adopters using the v5 escape-hatch (`opts.accounts.syncGovernance`) keep working unchanged — the v6 typed surface takes precedence when both are set. Adopters who haven't wired `sync_governance` at all continue to see the framework's `UNSUPPORTED_FEATURE` envelope.

--- a/examples/hello_seller_adapter_multi_tenant.ts
+++ b/examples/hello_seller_adapter_multi_tenant.ts
@@ -77,7 +77,6 @@ import {
   type CachedBuyerAgentRegistry,
   type ResolveContext,
   type RequestContext,
-  type AccountHandlers,
 } from '@adcp/sdk/server';
 import type {
   CheckGovernanceRequest,
@@ -542,6 +541,84 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
           operator,
           action,
           status: 'active' as const,
+        };
+      });
+    },
+
+    /**
+     * `sync_governance` — buyers register governance agent endpoints with
+     * us, scoped per-account. We persist the binding so `acquire_rights`
+     * can later consult the registered agent before granting rights.
+     *
+     * Tenant-isolation gate: each entry's `account.operator` must map to
+     * the same tenant the buyer is authenticated against (auth-derived via
+     * `ctx.agent.agent_url` → BUYER_HOME_TENANT). Per-entry rejection on
+     * mismatch — operation-level throw would fail the whole batch when one
+     * entry crosses tenants.
+     *
+     * Hello-adapter shortcut: we record the first agent's URL and one
+     * plan binding. The wire payload supports up to 10 governance agents
+     * with category scoping and write-only credentials. Production adopters
+     * MUST persist `entry.governance_agents[i].authentication.credentials`
+     * and present them on outbound `check_governance` calls — silently
+     * dropping them ships unauthenticated requests if you wire real cross-
+     * agent calls.
+     */
+    syncGovernance: async (entries, ctx) => {
+      const homeTenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
+      return entries.map(entry => {
+        const operator = entry.account.operator;
+        const brandDomain = entry.account.brand?.domain;
+        const govUrl = entry.governance_agents[0]?.url;
+        if (!operator || !brandDomain) {
+          return {
+            account: entry.account,
+            status: 'failed' as const,
+            errors: [{ code: 'INVALID_REQUEST', message: 'account.operator + account.brand.domain required' }],
+          };
+        }
+        const tenantId = OPERATOR_TO_TENANT.get(operator);
+        if (!tenantId) {
+          return {
+            account: entry.account,
+            status: 'failed' as const,
+            errors: [{ code: 'ACCOUNT_NOT_FOUND', message: `Unknown operator: ${operator}` }],
+          };
+        }
+        if (!homeTenantId || tenantId !== homeTenantId) {
+          return {
+            account: entry.account,
+            status: 'failed' as const,
+            errors: [
+              {
+                code: 'PERMISSION_DENIED',
+                message: `Buyer agent has no authority over operator '${operator}' (tenant mismatch or home tenant not configured).`,
+              },
+            ],
+          };
+        }
+        const tenant = TENANTS.get(tenantId)!;
+        if (govUrl) {
+          // SWAP: row-level write under tenant transaction. Real adopters
+          // persist `governance_agents[i].authentication.credentials` —
+          // they're write-only on the wire (NOT echoed back; the response
+          // shape is strictly `{url, categories?}`) but required for
+          // outbound `check_governance` calls.
+          tenant.governanceBindings.set(brandDomain, {
+            governance_agent_url: govUrl,
+            active_plan_id: tenant.active_plan_id,
+          });
+        } else {
+          tenant.governanceBindings.delete(brandDomain);
+        }
+        const echoedAgents = entry.governance_agents.map(a => ({
+          url: a.url,
+          ...(a.categories && { categories: a.categories }),
+        }));
+        return {
+          account: entry.account,
+          status: 'synced' as const,
+          ...(echoedAgents.length > 0 && { governance_agents: echoedAgents }),
         };
       });
     },
@@ -1034,136 +1111,6 @@ function toDateTime(value: string, edge: 'start' | 'end'): string {
 }
 
 // ---------------------------------------------------------------------------
-// `sync_governance` handler — wired via the v5 escape-hatch (opts.accounts.
-// syncGovernance) since v6's AccountStore doesn't model this surface yet.
-// Records the buyer's governance agent registration on the tenant so
-// `acquire_rights` can consult it.
-// ---------------------------------------------------------------------------
-
-/**
- * `sync_governance` — buyers register governance agent endpoints
- * with us, scoped per-account. We persist the binding so
- * `acquire_rights` can later consult the registered agent before
- * granting rights.
- *
- * Tenant-isolation gate: the wire request has no top-level `account`
- * field, so the framework auth-derives `ctx.account` via
- * `resolveAccountFromAuth`. Before mutating per-entry state, we
- * assert each entry's `account.operator` maps to the same tenant the
- * buyer is authenticated against. Spec: "the seller MUST verify that
- * the authenticated agent has authority over each referenced account
- * before persisting governance agents."
- *
- * Hello-adapter shortcut: we record the first agent's URL and one
- * plan binding. The wire payload supports up to 10 governance agents
- * with category scoping (`budget_authority`, `brand_policy`, ...) and
- * write-only credentials. Production adopters MUST persist
- * `entry.governance_agents[i].authentication.credentials` and
- * present them on outbound calls — silently dropping them ships
- * unauthenticated requests if you later add real cross-agent calls.
- */
-// Wired via opts.accounts.syncGovernance — the v6 platform surface
-// doesn't model `sync_governance` on `AccountStore` yet, so we use the
-// v5 escape-hatch `AccountHandlers` signature. The handler still gets
-// the framework-resolved `ctx.account` (auth-derived for this no-account
-// tool), so the tenant-isolation gate works the same way as
-// `accounts.upsert`. Promotion of this surface to v6 tracked in
-// adcontextprotocol/adcp-client#1387.
-//
-// Each row is cast to AccountReference at the row site (the buyer's
-// echo can't cleanly narrow to the discriminated union without a cast),
-// keeping the handler-level return type tight.
-type SyncGovernanceRow = {
-  account: { account_id: string } | { brand: { domain: string }; operator: string; sandbox?: boolean };
-  status: 'synced' | 'failed';
-  governance_agents?: Array<{ url: string; categories?: string[] }>;
-  errors?: Array<{ code: string; message: string }>;
-};
-const syncGovernanceHandler: NonNullable<AccountHandlers['syncGovernance']> = async (
-  params,
-  ctx
-): Promise<{ accounts: SyncGovernanceRow[] }> => {
-  const homeTenantId = (ctx.account as Account<TenantMeta> | undefined)?.ctx_metadata?.tenant_id;
-  const accounts = (
-    (params.accounts ?? []) as Array<{
-      account?: { operator?: string; brand?: { domain?: string } };
-      governance_agents?: Array<{ url: string }>;
-    }>
-  ).map((entry): SyncGovernanceRow => {
-    const operator = entry.account?.operator;
-    const brandDomain = entry.account?.brand?.domain;
-    const govUrl = entry.governance_agents?.[0]?.url;
-    // Cast at the row site: the spec's AccountReference is a strict
-    // discriminated union; the buyer's echo may not narrow without help.
-    const accountEcho = (entry.account ?? { account_id: 'unknown' }) as SyncGovernanceRow['account'];
-    if (!operator || !brandDomain) {
-      return {
-        account: accountEcho,
-        status: 'failed',
-        errors: [{ code: 'INVALID_REQUEST', message: 'account.operator + account.brand.domain required' }],
-      };
-    }
-    const tenantId = OPERATOR_TO_TENANT.get(operator);
-    if (!tenantId) {
-      return {
-        account: accountEcho,
-        status: 'failed',
-        errors: [{ code: 'ACCOUNT_NOT_FOUND', message: `Unknown operator: ${operator}` }],
-      };
-    }
-    // Tenant-isolation gate. Fail-closed (same shape as `accounts.upsert`):
-    // reject when home tenant can't be resolved OR when the wire operator
-    // maps to a different tenant than the buyer's authenticated home.
-    if (!homeTenantId || tenantId !== homeTenantId) {
-      return {
-        account: accountEcho,
-        status: 'failed',
-        errors: [
-          {
-            code: 'PERMISSION_DENIED',
-            message: `Buyer agent has no authority over operator '${operator}' (tenant mismatch or home tenant not configured).`,
-          },
-        ],
-      };
-    }
-    const tenant = TENANTS.get(tenantId)!;
-    if (govUrl) {
-      // SWAP: row-level write under tenant transaction.
-      // Bind to the most-recently-synced plan in this tenant. Real
-      // adopters bind plan_id to account explicitly via the buyer's
-      // compliance configuration; the wire `sync_governance` payload
-      // doesn't carry plan_id, so the convention has to live somewhere.
-      // Key by brand_domain only — `acquire_rights` won't have an
-      // operator to match against.
-      tenant.governanceBindings.set(brandDomain, {
-        governance_agent_url: govUrl,
-        active_plan_id: tenant.active_plan_id,
-      });
-    } else {
-      tenant.governanceBindings.delete(brandDomain);
-    }
-    // Echo back persisted governance_agents so the buyer can verify
-    // what was retained (replace-semantics — what the buyer sent IS
-    // the new state). The response schema strips write-only fields
-    // (`authentication.credentials`) and accepts only `{url, categories?}`
-    // — sanitize before echoing.
-    const echoedAgents = (entry.governance_agents ?? []).map(a => {
-      const agent = a as { url: string; categories?: string[] };
-      return {
-        url: agent.url,
-        ...(agent.categories && { categories: agent.categories }),
-      };
-    });
-    return {
-      account: accountEcho,
-      status: 'synced',
-      ...(echoedAgents.length > 0 && { governance_agents: echoedAgents }),
-    };
-  });
-  return { accounts };
-};
-
-// ---------------------------------------------------------------------------
 // Boot
 // ---------------------------------------------------------------------------
 
@@ -1177,9 +1124,6 @@ serve(
       version: '1.0.0',
       taskStore,
       idempotency: idempotencyStore,
-      accounts: {
-        syncGovernance: syncGovernanceHandler,
-      },
       resolveSessionKey: ctx => {
         const acct = ctx.account as Account<TenantMeta> | undefined;
         return acct?.id ?? 'anonymous';

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -24,6 +24,8 @@ import type {
   ReportUsageRequest,
   ReportUsageResponse,
   SyncAccountsSuccess,
+  SyncGovernanceRequest,
+  SyncGovernanceSuccess,
   GetAccountFinancialsRequest,
   GetAccountFinancialsSuccess,
 } from '../../types/tools.generated';
@@ -460,6 +462,48 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
   upsert?(refs: AccountReference[], ctx?: ResolveContext): Promise<SyncAccountsResultRow[]>;
 
   /**
+   * sync_governance API surface. Buyers register governance agent endpoints
+   * per-account; the seller persists the binding and consults the agents
+   * during media buy lifecycle events via `check_governance`.
+   *
+   * **Optional.** Adopters that don't model buyer-supplied governance agents
+   * (most direct sellers) leave this unimplemented and the framework returns
+   * `UNSUPPORTED_FEATURE`.
+   *
+   * `entries` is the wire request's `accounts[]` — each entry pairs an
+   * `AccountReference` with its `governance_agents[]`. The framework has
+   * already deduped on `idempotency_key` and stripped wire metadata
+   * (`adcp_major_version`, `context`, `ext`) before invoking this method.
+   *
+   * **Replace semantics, per spec.** Each call REPLACES the previously
+   * synced governance agents for the referenced account. An entry whose
+   * `governance_agents` is empty clears the binding for that account.
+   *
+   * **Write-only credentials.** Each `governance_agents[i].authentication.credentials`
+   * is the bearer the seller presents to that governance agent on outbound
+   * `check_governance` calls. Persist them — silently dropping ships
+   * unauthenticated requests once cross-agent calls are wired. The framework
+   * strips `authentication` from each `governance_agents[i]` of every row
+   * before serialization (`toWireSyncGovernanceRow`), so credentials never
+   * reach the response wire OR the idempotency replay cache, even if an
+   * adopter returns a loosely-typed row that spreads the input. Do not rely
+   * on TypeScript narrowing alone — the strip is enforced at the dispatcher.
+   *
+   * `ctx.authInfo` and `ctx.agent` carry the caller's principal — same
+   * threading as `upsert`. Adopters MUST gate per-entry persistence by the
+   * caller's tenant: each entry's `account.operator` (or `account_id`) must
+   * map to the same tenant the auth principal authorizes; otherwise return a
+   * `'failed'` row carrying `errors: [{code: 'PERMISSION_DENIED', ...}]` for
+   * that entry. (Operation-level rejection — `throw new AdcpError(...)` —
+   * fails the whole batch, which is the wrong shape when a single entry
+   * fails the gate.)
+   */
+  syncGovernance?(
+    entries: SyncGovernanceRequest['accounts'],
+    ctx?: ResolveContext
+  ): Promise<SyncGovernanceSuccess['accounts']>;
+
+  /**
    * list_accounts API surface. Framework wraps with cursor envelope.
    *
    * **Optional.** Same rationale as `upsert` — stateless platforms can omit.
@@ -739,6 +783,41 @@ export function toWireSyncAccountRow(row: SyncAccountsResultRow): WireSyncAccoun
   if (row.errors !== undefined) wire.errors = row.errors;
   if (row.warnings !== undefined) wire.warnings = row.warnings;
   if (row.sandbox !== undefined) wire.sandbox = row.sandbox;
+  return wire;
+}
+
+type WireSyncGovernanceRow = SyncGovernanceSuccess['accounts'][number];
+
+/**
+ * Project a `sync_governance` response row to the wire shape, stripping
+ * any fields the buyer is NOT entitled to receive. Critically: each
+ * `governance_agents[i]` is reduced to `{url, categories?}` only — the
+ * spec marks `authentication.credentials` write-only (the buyer sends
+ * the bearer; the seller persists it for outbound `check_governance`
+ * calls but MUST NOT echo it back). The natural `{ ...entry.governance_agents[i] }`
+ * echo idiom would compile silently against the typed return shape and
+ * ship credentials over the wire AND into the idempotency replay cache,
+ * arming the buyer (and any subsequent caller hitting the same key) to
+ * impersonate the seller against the governance agent.
+ *
+ * Defense-in-depth: this dispatcher-level strip runs even if an adopter
+ * returns a loosely-typed row, and even if a future codegen change
+ * loosens the response Zod schema's `.passthrough()` for governance
+ * agents.
+ */
+export function toWireSyncGovernanceRow(row: WireSyncGovernanceRow): WireSyncGovernanceRow {
+  const wire: WireSyncGovernanceRow = {
+    account: row.account,
+    status: row.status,
+  };
+  if (row.governance_agents !== undefined) {
+    wire.governance_agents = row.governance_agents.map(a => {
+      const stripped: { url: string; categories?: string[] } = { url: a.url };
+      if (a.categories !== undefined) stripped.categories = a.categories;
+      return stripped;
+    });
+  }
+  if (row.errors !== undefined) wire.errors = row.errors;
   return wire;
 }
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -66,7 +66,13 @@ import {
 import type { DecisioningPlatform, RequiredPlatformsFor, RequiredCapabilitiesFor } from '../platform';
 import type { ComplianceTestingCapabilities } from '../capabilities';
 import type { Account, ResolvedAuthInfo, ResolveContext } from '../account';
-import { AccountNotFoundError, refAccountId, toWireAccount, toWireSyncAccountRow } from '../account';
+import {
+  AccountNotFoundError,
+  refAccountId,
+  toWireAccount,
+  toWireSyncAccountRow,
+  toWireSyncGovernanceRow,
+} from '../account';
 import type { BuyerAgent, BuyerAgentRegistry } from '../buyer-agent';
 import { AdcpError, type AdcpStructuredError } from '../async-outcome';
 import type { CreativeBuilderPlatform } from '../specialisms/creative';
@@ -79,6 +85,7 @@ import type {
   BuildCreativeSuccess,
   CreativeManifest,
   GetAdCPCapabilitiesResponse,
+  SyncGovernanceRequest,
 } from '../../../types/tools.generated';
 import { adcpError, type AdcpErrorResponse } from '../../errors';
 import { validatePlatform, PlatformConfigError } from './validate-platform';
@@ -3752,6 +3759,17 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       return projectSync(
         () => accounts.upsert!(refs, resolveCtx),
         rows => ({ accounts: rows.map(toWireSyncAccountRow) })
+      );
+    };
+  }
+
+  if (accounts.syncGovernance) {
+    handlers.syncGovernance = async (params, ctx) => {
+      const entries = params.accounts as SyncGovernanceRequest['accounts'];
+      const resolveCtx = toResolveCtx(ctx, 'sync_governance');
+      return projectSync(
+        () => accounts.syncGovernance!(entries, resolveCtx),
+        rows => ({ accounts: rows.map(toWireSyncGovernanceRow) })
       );
     };
   }

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -687,12 +687,42 @@ export function syncAccountsResponse(data: SyncAccountsResponse, summary?: strin
 /**
  * Build a sync_governance response. The spec permits two top-level shapes
  * (success / error); the type union enforces discrimination on `status`.
+ *
+ * Strips `governance_agents[i].authentication` from every row before emit:
+ * the spec marks `authentication.credentials` write-only (the buyer sends
+ * the bearer; the seller persists it for outbound `check_governance` calls
+ * but MUST NOT echo it back). The natural `{ ...entry.governance_agents[i] }`
+ * echo idiom would compile silently against the typed return shape and ship
+ * credentials over the wire AND into the idempotency replay cache, arming
+ * the buyer (and any subsequent caller hitting the same key) to impersonate
+ * the seller against the governance agent. Strip is enforced at the wire-
+ * emit boundary so both v5 (`opts.accounts.syncGovernance`) and v6
+ * (`AccountStore.syncGovernance`) paths are protected.
  */
 /** @deprecated v6: `createAdcpServerFromPlatform` constructs wire responses from typed platform returns. Direct use is for v5 raw-handler adopters mid-migration only. */
 export function syncGovernanceResponse(data: SyncGovernanceResponse, summary?: string): McpToolResponse {
+  const stripped = stripGovernanceAgentSecrets(data);
   return {
     content: [{ type: 'text', text: summary ?? 'Governance registration synced' }],
-    structuredContent: toStructuredContent(data),
+    structuredContent: toStructuredContent(stripped),
+  };
+}
+
+function stripGovernanceAgentSecrets(data: SyncGovernanceResponse): SyncGovernanceResponse {
+  if (!('accounts' in data) || !Array.isArray(data.accounts)) return data;
+  return {
+    ...data,
+    accounts: data.accounts.map(row => {
+      if (!row.governance_agents) return row;
+      return {
+        ...row,
+        governance_agents: row.governance_agents.map(a => {
+          const stripped: { url: string; categories?: string[] } = { url: a.url };
+          if (a.categories !== undefined) stripped.categories = a.categories;
+          return stripped;
+        }),
+      };
+    }),
   };
 }
 

--- a/test/lib/sync-governance-credential-strip.test.js
+++ b/test/lib/sync-governance-credential-strip.test.js
@@ -1,0 +1,91 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { syncGovernanceResponse } = require('../../dist/lib/server/responses.js');
+
+describe('syncGovernanceResponse — write-only credential strip', () => {
+  const account = { brand: { domain: 'acme.example' }, operator: 'pinnacle-agency.example' };
+
+  test('strips authentication.credentials from every governance_agents row', () => {
+    const data = {
+      accounts: [
+        {
+          account,
+          status: 'synced',
+          governance_agents: [
+            {
+              url: 'https://gov.acme.example',
+              authentication: { schemes: ['Bearer'], credentials: 'sk_super_secret_dont_leak_me' },
+              categories: ['budget_authority'],
+            },
+          ],
+        },
+      ],
+    };
+
+    const wire = syncGovernanceResponse(data);
+    const echoed = wire.structuredContent.accounts[0].governance_agents[0];
+
+    assert.equal(echoed.url, 'https://gov.acme.example');
+    assert.deepEqual(echoed.categories, ['budget_authority']);
+    assert.equal(echoed.authentication, undefined, 'authentication MUST NOT be echoed');
+    assert.equal(echoed.credentials, undefined);
+    const text = JSON.stringify(wire);
+    assert.ok(!text.includes('sk_super_secret_dont_leak_me'), 'credentials MUST NOT appear anywhere in the response');
+  });
+
+  test('passes through rows without governance_agents (failed status)', () => {
+    const data = {
+      accounts: [{ account, status: 'failed', errors: [{ code: 'PERMISSION_DENIED', message: 'no' }] }],
+    };
+    const wire = syncGovernanceResponse(data);
+    const row = wire.structuredContent.accounts[0];
+    assert.equal(row.status, 'failed');
+    assert.deepEqual(row.errors, [{ code: 'PERMISSION_DENIED', message: 'no' }]);
+  });
+
+  test('passes through operation-level error shape unchanged', () => {
+    const data = { errors: [{ code: 'SERVICE_UNAVAILABLE', message: 'down' }] };
+    const wire = syncGovernanceResponse(data);
+    assert.deepEqual(wire.structuredContent.errors, [{ code: 'SERVICE_UNAVAILABLE', message: 'down' }]);
+  });
+
+  test('strips credentials even when adopter spreads the entire input agent', () => {
+    const inputAgent = {
+      url: 'https://gov.example',
+      authentication: { schemes: ['Bearer'], credentials: 'leaky_bearer' },
+      categories: ['brand_policy'],
+    };
+    const data = {
+      accounts: [{ account, status: 'synced', governance_agents: [{ ...inputAgent }] }],
+    };
+    const wire = syncGovernanceResponse(data);
+    const echoed = wire.structuredContent.accounts[0].governance_agents[0];
+    assert.equal(echoed.authentication, undefined);
+    assert.ok(!JSON.stringify(wire).includes('leaky_bearer'));
+  });
+
+  test('preserves multiple agents per row', () => {
+    const data = {
+      accounts: [
+        {
+          account,
+          status: 'synced',
+          governance_agents: [
+            { url: 'https://gov1.example', authentication: { schemes: ['Bearer'], credentials: 'a' } },
+            {
+              url: 'https://gov2.example',
+              authentication: { schemes: ['Bearer'], credentials: 'b' },
+              categories: ['c'],
+            },
+          ],
+        },
+      ],
+    };
+    const wire = syncGovernanceResponse(data);
+    const agents = wire.structuredContent.accounts[0].governance_agents;
+    assert.equal(agents.length, 2);
+    assert.deepEqual(agents[0], { url: 'https://gov1.example' });
+    assert.deepEqual(agents[1], { url: 'https://gov2.example', categories: ['c'] });
+  });
+});


### PR DESCRIPTION
## Summary

Promotes `sync_governance` from the v5 escape-hatch (`opts.accounts.syncGovernance`) to a typed method on `AccountStore`, mirroring `upsert` / `list`. One of the items tracked in #1387.

```ts
accounts: AccountStore<TenantMeta> = {
  resolve: async (ref, ctx) => { /* ... */ },
  upsert: async (refs, ctx) => { /* sync_accounts */ },
  syncGovernance: async (entries, ctx) => { /* sync_governance — typed */ },
};
```

The signature takes wire entries (`SyncGovernanceRequest['accounts']`) directly. Framework strips `idempotency_key` / `adcp_major_version` / `context` / `ext` before invoking and wraps returned rows in `{accounts: rows}` for emit. Backwards-compatible — the v5 escape-hatch keeps working unchanged.

## Security: write-only credential strip

Surfaced by security-reviewer during expert review. Per spec, each `governance_agents[i].authentication.credentials` is a bearer the seller persists for outbound `check_governance` calls but MUST NOT echo back. **TypeScript narrowing alone is insufficient:**

- TS excess-property checks don't fire on assigned variables — adopters writing the natural \`governance_agents: entry.governance_agents\` echo idiom would compile silently and ship credentials.
- Response Zod schema uses \`.passthrough()\` on the agent object — strict response validation does not strip or reject \`authentication\`.
- Without a strip, leaked bearers would arm the buyer (and any subsequent caller hitting the same idempotency key) to impersonate the seller against the governance agent.

**Mitigation: defense-in-depth strip at the wire boundary.** The framework now strips \`authentication\` from every \`governance_agents[i]\` of every row before serialization in two places:
1. \`syncGovernanceResponse\` (the wrap layer — covers v5 escape-hatch adopters)
2. \`toWireSyncGovernanceRow\` (the v6 dispatcher — covers typed adopters)

5 new unit tests in \`test/lib/sync-governance-credential-strip.test.js\` assert credentials are stripped even when the adopter spreads the entire input agent.

## Files

- \`src/lib/server/decisioning/account.ts\` — adds typed \`syncGovernance?\` method + \`toWireSyncGovernanceRow\` projector. JSDoc updated to be honest about the strip boundary (don't rely on TS narrowing).
- \`src/lib/server/decisioning/runtime/from-platform.ts\` — wires dispatch in \`buildAccountHandlers\`, drops defensive \`?? []\` (spec mandates \`minItems: 1\`).
- \`src/lib/server/responses.ts\` — \`syncGovernanceResponse\` strips credentials at the wrap layer (covers v5 path).
- \`examples/hello_seller_adapter_multi_tenant.ts\` — migrates from escape-hatch to typed surface; drops \`as any\` casts and the row-site \`SyncGovernanceRow\` shim.
- \`.changeset/account-store-sync-governance.md\` — minor.
- \`test/lib/sync-governance-credential-strip.test.js\` — new.

## Expert review (parallel)

- **code-reviewer**: clean. Confirmed merge precedence (v6 wins over v5), idempotency replay short-circuits, return type structurally excludes \`authentication\`.
- **security-reviewer**: flagged H1 credential leakage (response not actually protected by TS alone). **Fix landed in this PR** — runtime strip + JSDoc correction + unit tests.
- **ad-tech-protocol-expert**: aligns with AdCP 3.0.5 \`sync_governance\` on signature, replace semantics, write-only credentials, per-row vs operation-level failure shape, idempotency. JSDoc now mentions replace semantics per spec request description.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run build:lib\` — clean
- [x] \`npm test\` — 7739 pass / 0 fail / 7 skipped
- [x] New \`sync-governance-credential-strip.test.js\` — 5/5 pass
- [x] E2E: \`NODE_ENV=development PORT=3099 npx tsx examples/hello_seller_adapter_multi_tenant.ts\`
  - Valid sync (Pinnacle credential / Pinnacle operator) → \`status: synced\`, \`governance_agents\` echoed without \`authentication\`
  - Cross-tenant attack (Meridian credential / Pinnacle operator) → \`status: failed\`, \`code: PERMISSION_DENIED\`
- [ ] CI passes

Tracking: #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)