### PR TITLE
docs(server): canonicalize cross-specialism dispatch (DecisioningPlatform + holdco skill)

### DIFF
--- a/.changeset/cross-specialism-dispatch-docs.md
+++ b/.changeset/cross-specialism-dispatch-docs.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Documentation: cross-specialism dispatch on `DecisioningPlatform`. JSDoc on the platform interface and an expanded `skills/build-holdco-agent/SKILL.md § Cross-specialism dispatch` section now make explicit that there is no `ctx.platform.<specialism>` accessor — the canonical patterns are class instance + `this` (used by `examples/hello_seller_adapter_multi_tenant.ts`) or closure capture (for adopters using `define<X>Platform({...})` factories standalone). Both forward the same `RequestContext` so the resolved account / agent / authInfo carry through, and both bypass wire-side validation + idempotency dedup (correct for in-process calls but worth knowing). One of the items tracked in #1387.

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -87,32 +87,67 @@ The canonical gate shape and the fail-OPEN anti-pattern are documented in [`exam
 
 ## Cross-specialism dispatch
 
-When one specialism's handler needs another's logic, extract a private helper instead of calling sibling specialism methods directly:
+When one specialism's handler needs another's logic (canonical case: `brandRights.acquireRights` consulting `campaignGovernance.checkGovernance` before granting rights), there is no `ctx.platform.<specialism>` accessor — the framework does not thread a separate platform handle on `RequestContext`. Two idiomatic patterns; pick by authoring style:
+
+### Pattern A — class instance + `this` (canonical for holdco hubs)
+
+The reference adapter (`examples/hello_seller_adapter_multi_tenant.ts`) takes this path. Author the adapter as a class implementing `DecisioningPlatform<TConfig, TCtxMeta>`. Each specialism is a class field; cross-specialism calls go via `this`:
 
 ```ts
-brandRights = defineBrandRightsPlatform({
-  acquireRights: async (req, ctx) => {
-    /* validation seams up front */
-    const denial = await this.enforceGovernance(tenant, ctx, offering, req);
-    if (denial) return denial;
-    /* rest of acquire flow */
-  },
-});
+class HoldcoAdapter implements DecisioningPlatform<Config, TenantMeta> {
+  campaignGovernance = defineCampaignGovernancePlatform<TenantMeta>({ /* ... */ });
+  brandRights = defineBrandRightsPlatform<TenantMeta>({
+    acquireRights: async (req, ctx) => {
+      /* validation seams up front */
+      const denial = await this.enforceGovernance(tenant, ctx, offering, req);
+      if (denial) return denial;
+      /* rest of acquire flow */
+    },
+  });
 
-private async enforceGovernance(tenant, ctx, offering, req) {
-  // Reads tenant.governanceBindings (registered via sync_governance).
-  // Calls this.campaignGovernance.checkGovernance internally.
-  // Returns AcquireRightsRejected on denial, null otherwise.
+  private async enforceGovernance(tenant, ctx, offering, req) {
+    // Reads tenant.governanceBindings (registered via sync_governance).
+    // Calls this.campaignGovernance.checkGovernance internally.
+    // Returns AcquireRightsRejected on denial, null otherwise.
+  }
 }
 ```
 
-The helper:
+Extracting a `private` method (rather than inlining the 30-line block) gives you:
 
-- Makes the data flow visible at the call site (no inline 30-line block)
-- Gives single-specialism adopters a clean copy target
-- Forces a place to document the **same-tenant invariant**: `getTenant(ctx)` resolves once per request; both specialisms share it. If a future split lets brand-rights and governance live in different tenants, this in-process call no longer applies.
+- Visible data flow at the call site
+- A clean copy target for single-specialism adopters
+- A place to document the **same-tenant invariant**: `getTenant(ctx)` resolves once per request; both specialisms share it. If a future split lets brand-rights and governance live in different tenants, this in-process call no longer applies.
 
-**⚠️ Always document the "DO NOT copy this short-circuit into a single-specialism agent" warning on the helper's JSDoc.** Single-specialism adopters who don't have a co-resident governance handler need to dial out via the @adcp/sdk client to the registered governance agent's URL — supplying credentials that this hello pattern (intentionally) drops.
+### Pattern B — closure capture (functional authoring)
+
+If you'd rather build specialisms as standalone factory results (no class), capture the sibling in the closure passed to the second factory. No runnable example ships for Pattern B — Pattern A is the canonical hub shape, and the multi-tenant adapter exercises the full surface; if you go functional, this snippet is the contract:
+
+```ts
+const campaignGovernance = defineCampaignGovernancePlatform<TenantMeta>({ /* ... */ });
+
+const brandRights = defineBrandRightsPlatform<TenantMeta>({
+  acquireRights: async (req, ctx) => {
+    const govResp = await campaignGovernance.checkGovernance!(checkReq, ctx);
+    /* ... */
+  },
+});
+
+const platform: DecisioningPlatform<Config, TenantMeta> = {
+  capabilities: { /* ... */ },
+  accounts: { /* ... */ },
+  campaignGovernance,
+  brandRights,
+};
+```
+
+The `!` after `checkGovernance` is needed because the spec marks it optional on the interface; you know it's defined here because you defined it three lines up.
+
+### What both patterns share
+
+- The `ctx` you forward to the sibling is the same `RequestContext` you received. Resolved account, agent, and authInfo carry through, so tenant invariants hold transitively.
+- **In-process calls bypass wire-side validation, idempotency dedup, and the framework's mutating-tool annotations.** That's correct — you're inside the seller's code, not handling a buyer request — but it means an in-process `checkGovernance` won't be re-deduped if the originating tool is already idempotency-protected. If you _want_ buyer-side semantics for the call (e.g., the sibling specialism is hosted on a different tenant or a different process), don't reach for `this` — dial out via `@adcp/sdk`'s client to the registered agent URL.
+- **⚠️ Always document the "DO NOT copy this short-circuit into a single-specialism agent" warning** on the helper's JSDoc. Single-specialism adopters who don't have a co-resident governance handler need to dial out via the @adcp/sdk client to the registered governance agent's URL — supplying credentials that this hello pattern (intentionally) drops.
 
 ## What `sync_governance` ACTUALLY persists
 

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -58,6 +58,63 @@ import type { AdCPSpecialism } from '../../types/tools.generated';
  * **What the platform owns**: the business decisions in each `SalesPlatform` /
  * `CreativeBuilderPlatform` / `AudiencePlatform` method. Nothing else.
  *
+ * ### Cross-specialism dispatch
+ *
+ * When one specialism handler needs to consult another (canonical case:
+ * `brandRights.acquireRights` calling `campaignGovernance.checkGovernance`
+ * before granting rights, against a buyer-registered governance binding),
+ * the framework does NOT thread a separate `ctx.platform.<specialism>`
+ * accessor on `RequestContext`. Two idiomatic patterns; pick by authoring
+ * style:
+ *
+ * **Pattern A — class instance + `this`** (canonical for holdco hubs;
+ * `examples/hello_seller_adapter_multi_tenant.ts` is the reference):
+ *
+ * ```ts
+ * class HoldcoAdapter implements DecisioningPlatform<Config, TenantMeta> {
+ *   campaignGovernance = defineCampaignGovernancePlatform<TenantMeta>({  });
+ *   brandRights = defineBrandRightsPlatform<TenantMeta>({
+ *     acquireRights: async (req, ctx) => {
+ *       const denial = await this.enforceGovernance(tenant, ctx, offering, req);
+ *       if (denial) return denial;
+ *
+ *     },
+ *   });
+ *   private async enforceGovernance(...) {
+ *     // calls this.campaignGovernance.checkGovernance(...)
+ *   }
+ * }
+ * ```
+ *
+ * **Pattern B — closure capture** (for adopters using `define<X>Platform({...})`
+ * factories standalone):
+ *
+ * ```ts
+ * const campaignGovernance = defineCampaignGovernancePlatform<TenantMeta>({ ... });
+ * const brandRights = defineBrandRightsPlatform<TenantMeta>({
+ *   acquireRights: async (req, ctx) => {
+ *     const govResp = await campaignGovernance.checkGovernance!(checkReq, ctx);
+ *
+ *   },
+ * });
+ * const platform: DecisioningPlatform<Config, TenantMeta> = {
+ *   capabilities: {  }, accounts: {  }, campaignGovernance, brandRights,
+ * };
+ * ```
+ *
+ * Both patterns forward the same `RequestContext` (resolved account, agent,
+ * authInfo), so tenant invariants hold transitively. Both bypass wire-side
+ * validation, idempotency dedup, and mutating-tool annotations — that's
+ * correct because you're inside the seller's code, not handling a buyer
+ * request, but it means an in-process `checkGovernance` won't be
+ * re-deduped if the originating tool is already idempotency-protected.
+ * Single-specialism adopters MUST NOT copy this short-circuit: without a
+ * co-resident sibling handler, dial out to the registered governance
+ * agent URL via the `@adcp/sdk` client instead.
+ *
+ * Full walkthrough with same-tenant invariant + production caveats:
+ * `skills/build-holdco-agent/SKILL.md` § Cross-specialism dispatch.
+ *
  * @template TConfig Platform-specific config typed at the call site.
  *                   Example: `class GAM implements DecisioningPlatform<{ networkId: string }>`.
  * @template TCtxMeta Shape of the platform's opaque ctx_metadata blob — typed
@@ -164,10 +221,12 @@ export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string
   creative?: CreativeBuilderPlatform<TCtxMeta> | CreativeAdServerPlatform<TCtxMeta>;
   audiences?: AudiencePlatform<TCtxMeta>;
   signals?: SignalsPlatform<TCtxMeta>;
+  /** @see DecisioningPlatform — § Cross-specialism dispatch (used as the canonical example: `brandRights.acquireRights` consulting `checkGovernance` before granting rights). */
   campaignGovernance?: CampaignGovernancePlatform<TCtxMeta>;
   contentStandards?: ContentStandardsPlatform<TCtxMeta>;
   propertyLists?: PropertyListsPlatform<TCtxMeta>;
   collectionLists?: CollectionListsPlatform<TCtxMeta>;
+  /** @see DecisioningPlatform — § Cross-specialism dispatch (`acquireRights` is the canonical caller into `campaignGovernance.checkGovernance`). */
   brandRights?: BrandRightsPlatform<TCtxMeta>;
 
   // v1.1+ specialisms add: creative-review.


### PR DESCRIPTION
## Summary

The `ctx.platform.<specialism>` accessor item from #1387 was a documentation gap, not a missing API — the canonical patterns (class instance + \`this\`, or closure capture for functional adopters) already work, they just weren't explicit anywhere an adopter would look.

## Changes

- **\`src/lib/server/decisioning/platform.ts\`**
  - Adds a \`### Cross-specialism dispatch\` section to the \`DecisioningPlatform\` interface JSDoc (renders on IDE hover of the interface). Shows both patterns with code, calls out that in-process calls bypass wire-side validation / idempotency dedup / mutating-tool annotations.
  - Adds \`@see\` JSDoc pointers on \`campaignGovernance?:\` and \`brandRights?:\` fields — the two symbols an adopter is most likely to hover when stuck on the canonical case (\`acquireRights\` consulting \`checkGovernance\`).

- **\`skills/build-holdco-agent/SKILL.md\`**
  - Expanded \`§ Cross-specialism dispatch\` section. Pattern A (class + \`this\`) shown with the multi-tenant adapter as the reference. Pattern B (closure capture) shown with explicit "no runnable example ships; Pattern A is canonical" note so functional adopters know where to look.

- **\`.changeset/cross-specialism-dispatch-docs.md\`** — patch.

## Path-1 vs Path-2

\`ctx.platform\` as a typed accessor (Path 2) was considered. Rejected because:
- An in-process cross-specialism call bypasses wire validation regardless of how you reach it (\`this\` or \`ctx.platform\`) — the new accessor wouldn't change the safety surface, just shorten the call site.
- Threading a runtime platform handle onto every \`RequestContext\` conflates build-time platform composition with per-request context; existing \`this\` / closure patterns are idiomatic TypeScript and already work.
- The original complaint was "feels undocumented," which reads as a docs gap, not a missing API.

If adopter feedback later signals docs aren't enough, Path 2 remains available — this PR doesn't lock anything out.

## Expert review

- **dx-expert**: confirmed the body content is good; placement was the gap (initial draft had the JSDoc as a `//`-style comment _inside_ the interface body, which doesn't render on TS hover). **Fixed in this PR**: lifted to interface-level \`/** */\`, added \`@see\` on the two field declarations adopters will hover.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run format:check\` — clean
- [ ] CI passes

Tracking: #1387 (item: \`ctx.platform.<specialism>\` accessor for cross-specialism dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)