### PR TITLE
feat(server): createTenantStore — multi-tenant AccountStore builder with built-in isolation gate

### DIFF
--- a/.changeset/create-tenant-store.md
+++ b/.changeset/create-tenant-store.md
@@ -1,0 +1,32 @@
+---
+"@adcp/sdk": minor
+---
+
+`createTenantStore<TTenant, TCtxMeta>` — opinionated `AccountStore` builder for multi-tenant adapters. Closes the last library-side item tracked in #1387.
+
+Canonicalizes the two-path resolution shape every multi-tenant adapter writes by hand (operator-routed for tools that carry `account` on the wire; auth-derived for no-account tools like `get_brand_identity` / `get_rights`) AND bakes in the per-entry tenant-isolation gate that adopters historically had to write — and silently fail to write — on `accounts.upsert` / `accounts.syncGovernance`.
+
+```ts
+const accounts = createTenantStore<TenantState, TenantMeta>({
+  resolveByRef(ref)                       => TenantState | null,  // wire ref → tenant
+  resolveFromAuth(ctx)                    => TenantState | null,  // auth principal → tenant
+  tenantId(tenant)                        => string,              // stable id for equality
+  tenantToAccount(tenant, ref, ctx)       => Account<TenantMeta>, // sandbox lives here
+  upsertRow?(tenant, ref, ctx)            => SyncAccountsResultRow,
+  syncGovernanceRow?(tenant, entry, ctx)  => SyncGovernanceResponseRow,
+});
+```
+
+The helper produces a regular `AccountStore<TCtxMeta>`. `accounts.list` / `accounts.reportUsage` / `accounts.getAccountFinancials` are NOT generated — those tools have shapes (cursor pagination; per-row account refs spanning multiple tenants) that don't fit the per-entry-then-row pattern. Adopters who claim those capabilities wire them on top of the returned store.
+
+**Security: the per-entry gate is built in, not opt-in.** On `upsert` / `syncGovernance`, the helper resolves the auth principal's tenant once via `resolveFromAuth(ctx)`, then for each entry resolves the entry's tenant via `resolveByRef(ref)`. Entries whose tenant differs (or whose tenant ref is unknown) are emitted as `'failed'` rows with `code: 'PERMISSION_DENIED'` (cross-tenant) or `code: 'ACCOUNT_NOT_FOUND'` (unknown ref) BEFORE invoking the adopter's `upsertRow` / `syncGovernanceRow` callbacks. **Cross-tenant entries never reach adopter code.** Fail-closed when `resolveFromAuth` returns null: every entry fails `PERMISSION_DENIED` regardless of operator. The original B1 finding from the multi-tenant adapter's security review (where adopters routing by wire-supplied operator without cross-checking the auth principal could write across tenants) is now mitigated by the SDK, not by adopter discipline.
+
+**Sandbox routing lives in `tenantToAccount`.** `AccountReference.sandbox?: boolean` flows through to the projector, where adopters either (a) flag the resolved Account so per-handler code routes reads/writes to a sandbox backend, or (b) resolve to a separate sandbox tenant via `resolveByRef(ref)` reading `ref.sandbox`. No new `sandbox?` parameter on the helper API — the projector subsumes both patterns.
+
+**Gate methods are non-writable.** `accounts.upsert` and `accounts.syncGovernance` on the returned store are defined with `writable: false` so an adopter who writes `accounts.upsert = customHandler` after construction gets a `TypeError` in strict mode instead of silently bypassing the tenant gate. To extend the store with `list` / `reportUsage` / `getAccountFinancials`, use `Object.assign(createTenantStore({...}), { list: ... })` rather than direct mutation. (Adopters who genuinely need a custom `upsert` should write a plain `AccountStore` and own the security surface — the helper's invariant is "use it or don't.")
+
+**Per-entry callbacks run sequentially**, not via `Promise.all`. Adopter `upsertRow` / `syncGovernanceRow` callbacks commonly mutate shared tenant state (`tenant.accounts.set(...)`); the helper preserves the prior code's accidental sequential semantics rather than introducing concurrent invocations against the same tenant. Adopters who want parallel writes can fan out inside their callback against an upstream that tolerates it.
+
+**Behavioral drift vs the prior inlined adapter:** `INVALID_REQUEST` is no longer surfaced for malformed refs (operator/brand missing) — wire schema validation upstream catches this before the adopter sees the request. The helper emits `ACCOUNT_NOT_FOUND` for unknown refs that survive validation and `PERMISSION_DENIED` for cross-tenant entries.
+
+`examples/hello_seller_adapter_multi_tenant.ts` migrated to use the helper. The 200+ lines of inlined `accounts.resolve` / `upsert` / `syncGovernance` collapsed to a single `createTenantStore({...})` call. Cross-tenant attack still rejected with `PERMISSION_DENIED`; credentials still stripped from `sync_governance` echo (5.13's `toWireSyncGovernanceRow`). `skills/build-holdco-agent/SKILL.md` updated to lead with `createTenantStore`; the prior inlined-gate documentation is superseded.

--- a/examples/hello_seller_adapter_multi_tenant.ts
+++ b/examples/hello_seller_adapter_multi_tenant.ts
@@ -64,6 +64,7 @@ import {
   memoryBackend,
   AdcpError,
   BuyerAgentRegistry,
+  createTenantStore,
   defineCampaignGovernancePlatform,
   definePropertyListsPlatform,
   defineBrandRightsPlatform,
@@ -75,7 +76,6 @@ import {
   type Account,
   type BuyerAgent,
   type CachedBuyerAgentRegistry,
-  type ResolveContext,
   type RequestContext,
 } from '@adcp/sdk/server';
 import type {
@@ -185,6 +185,7 @@ interface GovernanceBinding {
 }
 
 interface TenantState {
+  id: string;
   display_name: string;
   brands: Map<string, BrandRecord>;
   rights: Map<string, RightsRecord>;
@@ -206,8 +207,9 @@ interface TenantState {
   active_plan_id?: string;
 }
 
-function makeTenant(displayName: string): TenantState {
+function makeTenant(id: string, displayName: string): TenantState {
   return {
+    id,
     display_name: displayName,
     brands: new Map(),
     rights: new Map(),
@@ -223,8 +225,8 @@ function accountKey(operator: string, brandDomain: string): string {
 }
 
 const TENANTS = new Map<string, TenantState>([
-  ['tenant_pinnacle', makeTenant('Pinnacle Agency (rights + governance)')],
-  ['tenant_meridian', makeTenant('Meridian Media (rights + governance)')],
+  ['tenant_pinnacle', makeTenant('tenant_pinnacle', 'Pinnacle Agency (rights + governance)')],
+  ['tenant_meridian', makeTenant('tenant_meridian', 'Meridian Media (rights + governance)')],
 ]);
 
 // Tenant 1 (Pinnacle) — talent likeness + AI generation rights for the
@@ -439,171 +441,88 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
 
   agentRegistry = agentRegistry;
 
-  accounts: AccountStore<TenantMeta> = {
-    /**
-     * Two resolution paths:
-     *   1. `ref.operator` is set (governance, property-lists, every tool
-     *      with an `account` field) → look up tenant by operator.
-     *   2. `ref` is undefined (no-account tools: `get_brand_identity`,
-     *      `get_rights`) → derive tenant from the resolved buyer agent's
-     *      home tenant. The framework calls this path via
-     *      `resolveAccountFromAuth` so the platform doesn't reimplement
-     *      auth-derived tenancy.
-     */
-    resolve: async (ref, ctx) => {
-      // Path 2: no account on the wire. Derive from buyer agent.
-      if (ref == null) {
-        return resolveFromBuyer(ctx);
-      }
-      // Path 1: account-with-operator on the wire. Read both operator AND
-      // brand off ref — downstream handlers (notably `enforceGovernance`)
-      // index per-account state by `(operator, brand.domain)`, so dropping
-      // brand on the floor here strands those handlers.
-      const refTyped = ref as { operator?: string; brand?: { domain?: string } };
-      const operator = refTyped.operator;
-      if (!operator) return null;
-      const tenantId = OPERATOR_TO_TENANT.get(operator);
-      if (!tenantId) return null;
-      const tenant = TENANTS.get(tenantId);
-      if (!tenant) return null;
-      return makeAccount(tenantId, tenant, operator, refTyped.brand?.domain);
+  /**
+   * Multi-tenant `AccountStore`, built via `createTenantStore`. The helper
+   * canonicalizes the two-path resolution (operator-routed for tools that
+   * carry `account` on the wire; auth-derived for no-account tools) AND
+   * bakes in the per-entry tenant-isolation gate on `sync_accounts` /
+   * `sync_governance` — adopter callbacks (`upsertRow`, `syncGovernanceRow`)
+   * never see a cross-tenant entry.
+   *
+   * Fail-closed: when the auth principal can't be mapped to a tenant
+   * (`resolveFromAuth` returns null), every per-entry call fails
+   * `PERMISSION_DENIED`. Don't fork this around — the prior fail-OPEN
+   * shape (`if (homeTenantId && entryTenant !== homeTenantId)`) silently
+   * disabled isolation for credentials lacking a home tenant.
+   */
+  accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>({
+    resolveByRef: ref => {
+      const refTyped = ref as { operator?: string };
+      if (!refTyped.operator) return null;
+      const tenantId = OPERATOR_TO_TENANT.get(refTyped.operator);
+      return tenantId ? (TENANTS.get(tenantId) ?? null) : null;
     },
-
-    /**
-     * `sync_accounts` — buyers register accounts with us so subsequent
-     * `sync_governance` calls have something to bind to.
-     *
-     * Tenant-isolation gate: derive the buyer's home tenant from
-     * `ctx.agent.agent_url` (registered at onboarding, not buyer-spoofable
-     * here because the bearer-keyed registry stamps the URL) and reject
-     * any per-entry whose operator maps to a DIFFERENT tenant. Without
-     * this check, a Meridian credential could submit
-     * `operator: 'pinnacle-agency.example'` and write into Pinnacle's
-     * tenant state. The spec requires sellers verify the authenticated
-     * agent has authority over each referenced account before persisting.
-     */
-    upsert: async (refs, ctx) => {
-      // Fail-CLOSED: when `homeTenantId` can't be resolved (no agent, or
-      // agent_url not in BUYER_HOME_TENANT), reject everything. The earlier
-      // pattern `if (homeTenantId && tenantId !== homeTenantId)` was fail-
-      // OPEN — an adopter who forks this file and adds a credential without
-      // a BUYER_HOME_TENANT row would silently disable tenant isolation.
-      const homeTenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
-      return refs.map(ref => {
-        const r = ref as { operator?: string; brand?: { domain?: string } };
-        const operator = r.operator;
-        const brandDomain = r.brand?.domain;
-        if (!operator || !brandDomain) {
-          return {
-            brand: { domain: brandDomain ?? 'unknown.example' },
-            operator: operator ?? 'unknown',
-            action: 'failed' as const,
-            status: 'rejected' as const,
-            errors: [{ code: 'INVALID_REQUEST', message: 'operator + brand.domain required' }],
-          };
-        }
-        const tenantId = OPERATOR_TO_TENANT.get(operator);
-        if (!tenantId) {
-          return {
-            brand: { domain: brandDomain },
-            operator,
-            action: 'failed' as const,
-            status: 'rejected' as const,
-            errors: [{ code: 'ACCOUNT_NOT_FOUND', message: `Unknown operator: ${operator}` }],
-          };
-        }
-        // Tenant-isolation gate. Fail-closed: reject when home tenant
-        // can't be resolved OR when the wire operator maps to a different
-        // tenant than the buyer's authenticated home.
-        if (!homeTenantId || tenantId !== homeTenantId) {
-          return {
-            brand: { domain: brandDomain },
-            operator,
-            action: 'failed' as const,
-            status: 'rejected' as const,
-            errors: [
-              {
-                code: 'PERMISSION_DENIED',
-                message: `Buyer agent has no authority over operator '${operator}' (tenant mismatch or home tenant not configured).`,
-              },
-            ],
-          };
-        }
-        const tenant = TENANTS.get(tenantId)!;
-        const key = accountKey(operator, brandDomain);
-        // accountKey collisions are upserts by design — same (operator, brand) = same account.
-        // SWAP: row-level write under tenant transaction.
-        const action = tenant.accounts.has(key) ? ('updated' as const) : ('created' as const);
-        tenant.accounts.set(key, { operator, brand_domain: brandDomain, status: 'active' });
-        return {
-          account_id: tenantId,
-          brand: { domain: brandDomain },
-          operator,
-          action,
-          status: 'active' as const,
-        };
+    resolveFromAuth: ctx => {
+      const tenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
+      return tenantId ? (TENANTS.get(tenantId) ?? null) : null;
+    },
+    tenantId: tenant => tenant.id,
+    tenantToAccount: (tenant, ref, ctx) => {
+      const refTyped = (ref ?? {}) as { operator?: string; brand?: { domain?: string }; sandbox?: boolean };
+      // No-account-tool path: synthesize an operator string from the resolved
+      // buyer agent's URL so account.id stays stable per-buyer-per-tenant.
+      const operator = refTyped.operator ?? ctx?.agent?.agent_url ?? 'derived';
+      return {
+        id: tenant.id,
+        name: refTyped.operator
+          ? `${tenant.display_name} (${operator})`
+          : `${tenant.display_name} (auth-derived for ${ctx?.agent?.display_name ?? 'unknown'})`,
+        status: 'active',
+        operator,
+        ...(refTyped.brand?.domain && { brand: { domain: refTyped.brand.domain } }),
+        ctx_metadata: { tenant_id: tenant.id, display_name: tenant.display_name },
+        // SWAP: read sandbox flag from your backing store. Hello-adapter
+        // honors `ref.sandbox` when present (Path 1) and defaults true on
+        // auth-derived (no-account-tool) lookups since this whole adapter
+        // is a demo.
+        sandbox: refTyped.sandbox ?? true,
+      };
+    },
+    upsertRow: (tenant, ref, _ctx) => {
+      // Cross-tenant entries never reach this callback — the helper's
+      // gate already filtered them. Adopter responsibility: the upsert
+      // itself.
+      const refTyped = ref as { operator: string; brand: { domain: string } };
+      const key = accountKey(refTyped.operator, refTyped.brand.domain);
+      // SWAP: row-level write under tenant transaction.
+      const action = tenant.accounts.has(key) ? ('updated' as const) : ('created' as const);
+      tenant.accounts.set(key, {
+        operator: refTyped.operator,
+        brand_domain: refTyped.brand.domain,
+        status: 'active',
       });
+      return {
+        account_id: tenant.id,
+        brand: refTyped.brand,
+        operator: refTyped.operator,
+        action,
+        status: 'active' as const,
+      };
     },
-
-    /**
-     * `sync_governance` — buyers register governance agent endpoints with
-     * us, scoped per-account. We persist the binding so `acquire_rights`
-     * can later consult the registered agent before granting rights.
-     *
-     * Tenant-isolation gate: each entry's `account.operator` must map to
-     * the same tenant the buyer is authenticated against (auth-derived via
-     * `ctx.agent.agent_url` → BUYER_HOME_TENANT). Per-entry rejection on
-     * mismatch — operation-level throw would fail the whole batch when one
-     * entry crosses tenants.
-     *
-     * Hello-adapter shortcut: we record the first agent's URL and one
-     * plan binding. The wire payload supports up to 10 governance agents
-     * with category scoping and write-only credentials. Production adopters
-     * MUST persist `entry.governance_agents[i].authentication.credentials`
-     * and present them on outbound `check_governance` calls — silently
-     * dropping them ships unauthenticated requests if you wire real cross-
-     * agent calls.
-     */
-    syncGovernance: async (entries, ctx) => {
-      const homeTenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
-      return entries.map(entry => {
-        const operator = entry.account.operator;
-        const brandDomain = entry.account.brand?.domain;
-        const govUrl = entry.governance_agents[0]?.url;
-        if (!operator || !brandDomain) {
-          return {
-            account: entry.account,
-            status: 'failed' as const,
-            errors: [{ code: 'INVALID_REQUEST', message: 'account.operator + account.brand.domain required' }],
-          };
-        }
-        const tenantId = OPERATOR_TO_TENANT.get(operator);
-        if (!tenantId) {
-          return {
-            account: entry.account,
-            status: 'failed' as const,
-            errors: [{ code: 'ACCOUNT_NOT_FOUND', message: `Unknown operator: ${operator}` }],
-          };
-        }
-        if (!homeTenantId || tenantId !== homeTenantId) {
-          return {
-            account: entry.account,
-            status: 'failed' as const,
-            errors: [
-              {
-                code: 'PERMISSION_DENIED',
-                message: `Buyer agent has no authority over operator '${operator}' (tenant mismatch or home tenant not configured).`,
-              },
-            ],
-          };
-        }
-        const tenant = TENANTS.get(tenantId)!;
+    syncGovernanceRow: (tenant, entry, _ctx) => {
+      // Cross-tenant entries never reach this callback. Hello-adapter
+      // shortcut: bind on the brand_domain key, record the first agent's
+      // URL + the most-recently-synced plan as the active binding.
+      // Production adopters MUST persist
+      // `entry.governance_agents[i].authentication.credentials` (the
+      // framework strips them from the response — see
+      // `toWireSyncGovernanceRow` — so the buyer never sees them echoed).
+      const refTyped = entry.account as { brand?: { domain?: string } };
+      const brandDomain = refTyped.brand?.domain;
+      const govUrl = entry.governance_agents[0]?.url;
+      if (brandDomain) {
         if (govUrl) {
-          // SWAP: row-level write under tenant transaction. Real adopters
-          // persist `governance_agents[i].authentication.credentials` —
-          // they're write-only on the wire (NOT echoed back; the response
-          // shape is strictly `{url, categories?}`) but required for
-          // outbound `check_governance` calls.
+          // SWAP: row-level write under tenant transaction.
           tenant.governanceBindings.set(brandDomain, {
             governance_agent_url: govUrl,
             active_plan_id: tenant.active_plan_id,
@@ -611,18 +530,18 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
         } else {
           tenant.governanceBindings.delete(brandDomain);
         }
-        const echoedAgents = entry.governance_agents.map(a => ({
-          url: a.url,
-          ...(a.categories && { categories: a.categories }),
-        }));
-        return {
-          account: entry.account,
-          status: 'synced' as const,
-          ...(echoedAgents.length > 0 && { governance_agents: echoedAgents }),
-        };
-      });
+      }
+      const echoedAgents = entry.governance_agents.map(a => ({
+        url: a.url,
+        ...(a.categories && { categories: a.categories }),
+      }));
+      return {
+        account: entry.account,
+        status: 'synced' as const,
+        ...(echoedAgents.length > 0 && { governance_agents: echoedAgents }),
+      };
     },
-  };
+  });
 
   campaignGovernance: CampaignGovernancePlatform<TenantMeta> = defineCampaignGovernancePlatform<TenantMeta>({
     syncPlans: async (req: SyncPlansRequest, ctx): Promise<SyncPlansResponse> => {
@@ -1065,45 +984,6 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function makeAccount(
-  tenantId: string,
-  tenant: TenantState,
-  operator: string,
-  brandDomain?: string
-): Account<TenantMeta> {
-  return {
-    id: tenantId,
-    name: `${tenant.display_name} (${operator})`,
-    status: 'active',
-    operator,
-    ...(brandDomain && { brand: { domain: brandDomain } }),
-    ctx_metadata: { tenant_id: tenantId, display_name: tenant.display_name },
-    // NOTE(adopter): replace with your real sandbox flag from backing store.
-    sandbox: true,
-  };
-}
-
-function resolveFromBuyer(ctx: ResolveContext | undefined): Account<TenantMeta> | null {
-  const buyer = ctx?.agent;
-  if (!buyer) return null;
-  const tenantId = BUYER_HOME_TENANT.get(buyer.agent_url);
-  if (!tenantId) return null;
-  const tenant = TENANTS.get(tenantId);
-  if (!tenant) return null;
-  // Synthetic operator string — this account is auth-derived, no
-  // operator domain on the wire. Using `buyer.agent_url` as the
-  // pseudo-operator keeps account.id stable across requests from the
-  // same buyer agent.
-  return {
-    id: tenantId,
-    name: `${tenant.display_name} (auth-derived for ${buyer.display_name})`,
-    status: 'active',
-    operator: buyer.agent_url,
-    ctx_metadata: { tenant_id: tenantId, display_name: tenant.display_name },
-    sandbox: true,
-  };
-}
 
 function toDateTime(value: string, edge: 'start' | 'end'): string {
   if (/T/.test(value)) return value;

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -43,7 +43,7 @@ class HoldcoAdapter implements DecisioningPlatform<Config, TenantMeta> {
   };
 
   agentRegistry = /* BuyerAgentRegistry */;
-  accounts: AccountStore<TenantMeta> = { resolve, upsert };
+  accounts: AccountStore<TenantMeta> = createTenantStore({ /* see below */ });
   campaignGovernance = defineCampaignGovernancePlatform({ /* ... */ });
   propertyLists = definePropertyListsPlatform({ /* ... */ });
   brandRights = defineBrandRightsPlatform({ /* ... */ });
@@ -56,34 +56,62 @@ class HoldcoAdapter implements DecisioningPlatform<Config, TenantMeta> {
 
 Each specialism interface is the same shape it would have in a single-specialism agent (reuse `skills/build-governance-agent/`, `skills/build-brand-rights-agent/` for per-handler details). The hub-specific work is everything around them: tenancy, isolation, cross-specialism dispatch.
 
-## The two account-resolution paths
+## Account resolution + tenant-isolation gate (use `createTenantStore`)
 
-The framework calls `accounts.resolve(ref, ctx)` once per request. Hub adapters need both branches:
+The framework calls `accounts.resolve(ref, ctx)` once per request, and hub adapters historically had to hand-write three pieces:
+
+1. **Path 1** — operator-routed resolution for tools that carry `account` on the wire (`sync_accounts`, `sync_governance`, governance, property-lists)
+2. **Path 2** — auth-derived resolution for no-account tools (`get_brand_identity`, `get_rights`)
+3. **Per-entry tenant-isolation gate** on `sync_accounts` / `sync_governance` — verify each entry's `operator` maps to the buyer's authenticated home tenant before persisting, fail-closed when the auth principal isn't registered
+
+All three live in `createTenantStore<TTenant, TCtxMeta>` (`@adcp/sdk/server`). Callbacks the adopter provides; gating logic the SDK owns:
 
 ```ts
-accounts.resolve = async (ref, ctx) => {
-  // Path 2: no account on the wire (`get_brand_identity`, `get_rights`).
-  // Derive tenant from the resolved buyer agent's home tenant.
-  if (ref == null) return resolveFromBuyer(ctx);
-
-  // Path 1: account-with-operator on the wire (governance, property-lists,
-  // sync_accounts, sync_governance). Look up tenant by operator.
-  const operator = (ref as { operator?: string }).operator;
-  const brandDomain = (ref as { brand?: { domain?: string } }).brand?.domain;
-  if (!operator) return null;
-  const tenantId = OPERATOR_TO_TENANT.get(operator);
-  if (!tenantId) return null;
-  return makeAccount(tenantId, TENANTS.get(tenantId)!, operator, brandDomain);
-};
+accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>({
+  resolveByRef: ref => {  // Path 1 — operator (or account_id) on the wire
+    const tenantId = OPERATOR_TO_TENANT.get((ref as { operator?: string }).operator ?? '');
+    return tenantId ? TENANTS.get(tenantId) ?? null : null;
+  },
+  resolveFromAuth: ctx => {  // Path 2 — derive from authenticated buyer agent
+    const tenantId = ctx?.agent ? BUYER_HOME_TENANT.get(ctx.agent.agent_url) : undefined;
+    return tenantId ? TENANTS.get(tenantId) ?? null : null;
+  },
+  tenantId: tenant => tenant.id,  // stable equality for the gate (NOT reference)
+  tenantToAccount: (tenant, ref, ctx) => ({  // project tenant + ref → Account
+    id: tenant.id,
+    name: `${tenant.display_name} (${(ref as any)?.operator ?? ctx?.agent?.agent_url})`,
+    status: 'active',
+    operator: (ref as any)?.operator ?? ctx?.agent?.agent_url ?? 'derived',
+    ctx_metadata: { tenant_id: tenant.id, display_name: tenant.display_name },
+    sandbox: (ref as any)?.sandbox ?? false,  // SWAP: route to your sandbox backend
+  }),
+  upsertRow: (tenant, ref, ctx) => {  // sync_accounts — only in-tenant entries reach here
+    /* row-level upsert under tenant transaction; gate already filtered */
+    return { /* SyncAccountsResultRow */ };
+  },
+  syncGovernanceRow: (tenant, entry, ctx) => {  // sync_governance — same gating
+    /* persist entry.governance_agents on tenant; helper strips credentials on echo */
+    return { /* SyncGovernanceResponseRow */ };
+  },
+});
 ```
 
-`resolveFromBuyer` reads `ctx.agent.agent_url` and looks up the buyer's home tenant via a side map. Without this seam, no-account tools would fall through to a global view and leak data across tenants.
+**What the helper guarantees:**
 
-## Tenant-isolation gates (FAIL-CLOSED)
+- **Cross-tenant entries never reach `upsertRow` / `syncGovernanceRow`.** The helper resolves `authTenant = resolveFromAuth(ctx)` once per request, then for each entry resolves `entryTenant = resolveByRef(ref)` and emits a `'failed'` row with `code: 'PERMISSION_DENIED'` when `tenantId(authTenant) !== tenantId(entryTenant)`. Adopter callbacks see only in-tenant entries.
+- **Fail-closed when `resolveFromAuth` returns null** (unknown principal, no `agentRegistry`, agent_url not in your home-tenant map): every entry fails `PERMISSION_DENIED`. Don't fork around this — the prior fail-OPEN shape (`if (homeTenantId && entryTenant !== homeTenantId)`) silently disabled isolation for credentials lacking a home-tenant binding.
+- **`accounts.upsert` and `accounts.syncGovernance` are non-writable** on the returned store. An adopter who writes `accounts.upsert = customHandler` after construction gets a `TypeError` (in strict mode) instead of silently bypassing the gate. To extend with `list` / `reportUsage` / `getAccountFinancials`, use `Object.assign`:
 
-Every mutating handler that takes a wire-supplied `operator` must verify the operator maps to the buyer's authenticated home tenant — and **fail-closed** when the home tenant can't be resolved. Otherwise an adopter who forks the file and adds a credential without populating the home-tenant map silently disables tenant isolation.
+  ```ts
+  accounts = Object.assign(
+    createTenantStore<TenantState, TenantMeta>({...}),
+    { list: async (filter, ctx) => ... }
+  );
+  ```
 
-The canonical gate shape and the fail-OPEN anti-pattern are documented in [`examples/CONTRIBUTING.md`](../../examples/CONTRIBUTING.md#tenant-isolation-gates-multi-tenant-adapters) (the convention reviewers will check for). Apply that pattern in **`accounts.upsert`** (sync_accounts) and in any v5-escape-hatch handler that takes per-entry account refs (`accounts.syncGovernance`, etc.).
+**Sandbox lives in `tenantToAccount`.** `AccountReference.sandbox?: boolean` flows through the projector. Two patterns: (1) flag the resolved Account so per-handler code routes reads/writes to a sandbox backend; (2) resolve to a separate sandbox tenant via `resolveByRef` reading `ref.sandbox`. Both are adopter-side decisions — the helper API doesn't take a `sandbox` parameter.
+
+The pre-helper version of this skill documented the inlined gate pattern (with the fail-OPEN anti-pattern flagged in `examples/CONTRIBUTING.md`). That pattern is now superseded — adopters who genuinely need a custom gate write a plain `AccountStore` and own the security surface; everyone else uses `createTenantStore`.
 
 ## Cross-specialism dispatch
 

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -93,6 +93,13 @@ export type {
 
 export { AccountNotFoundError, refAccountId } from './account';
 
+// Multi-tenant AccountStore builder. Bakes in the two-path resolution
+// (operator-routed + auth-derived) and the per-entry tenant-isolation gate
+// that adopters historically had to hand-write — and silently fail to
+// hand-write — on `accounts.upsert` / `accounts.syncGovernance`.
+export { createTenantStore } from './tenant-store';
+export type { TenantStoreConfig } from './tenant-store';
+
 // Buyer-agent identity surface — Phase 1 of #1269. Durable commercial
 // relationship records keyed off the request credential. Factory-pattern
 // registry (signing-only / bearer-only / mixed) encodes the implementer

--- a/src/lib/server/decisioning/tenant-store.ts
+++ b/src/lib/server/decisioning/tenant-store.ts
@@ -1,0 +1,310 @@
+/**
+ * `createTenantStore` — opinionated `AccountStore` builder for multi-tenant
+ * adapters. Canonicalizes the two-path resolution shape (operator-routed
+ * for tools that carry `account` on the wire; auth-derived for tools that
+ * don't) and bakes in the tenant-isolation gate that adopters historically
+ * had to write — and silently fail to write — by hand.
+ *
+ * Status: Preview / 6.x.
+ *
+ * @public
+ */
+
+import type { ResolveContext, Account, AccountStore, SyncAccountsResultRow } from './account';
+import type { AccountReference, SyncGovernanceRequest, SyncGovernanceSuccess } from '../../types/tools.generated';
+
+type SyncGovernanceEntry = SyncGovernanceRequest['accounts'][number];
+type SyncGovernanceRow = SyncGovernanceSuccess['accounts'][number];
+
+/**
+ * Adopter contract for `createTenantStore`. Every callback is sync OR async;
+ * the helper awaits.
+ *
+ * Tenant isolation is enforced by comparing `tenantId(authTenant)` against
+ * `tenantId(entryTenant)` per-entry on `sync_accounts` / `sync_governance`.
+ * Mismatches produce a `'failed'` row with `code: 'PERMISSION_DENIED'` —
+ * the adopter's `upsertRow` / `syncGovernanceRow` callbacks NEVER see a
+ * cross-tenant entry. Fail-closed when `resolveFromAuth` returns null
+ * (unknown principal): every entry fails `PERMISSION_DENIED` regardless of
+ * its operator. Don't fork this around to fail-open — adopters who copied
+ * the prior fail-open shape (`if (homeTenantId && tenantId !== homeTenantId)`)
+ * silently disabled isolation when a credential lacked a tenant binding.
+ *
+ * @template TTenant Adopter's tenant model (e.g., `TenantState`, a row
+ *                   from a `tenants` table). Compared via `tenantId`,
+ *                   not by reference.
+ * @template TCtxMeta Shape of `Account.ctx_metadata`. Threads through to
+ *                    every specialism handler via `ctx.account.ctx_metadata`.
+ */
+export interface TenantStoreConfig<TTenant, TCtxMeta = Record<string, unknown>> {
+  /**
+   * Path 1: account ref carries `account_id` OR `(brand, operator)`.
+   * Resolve to the tenant the ref points at — independent of who the
+   * caller is. Return null if the ref is unknown (helper emits
+   * `ACCOUNT_NOT_FOUND` for that row).
+   *
+   * Receives the full `AccountReference` so adopters can route on
+   * `ref.sandbox` (Pattern 2: separate sandbox tenant) or read the
+   * `account_id` arm of the discriminated union.
+   */
+  resolveByRef(ref: AccountReference): TTenant | null | Promise<TTenant | null>;
+
+  /**
+   * Path 2: no account ref on the wire (`get_brand_identity`, `get_rights`,
+   * `provide_performance_feedback`, `list_creative_formats`). Derive the
+   * tenant from the auth principal. Return null if no principal is
+   * resolvable (no auth, no `agentRegistry`, principal not registered).
+   *
+   * Used by both `accounts.resolve(undefined, ctx)` (no-account tools)
+   * AND the tenant-isolation gate on per-entry tools — `null` here
+   * means EVERY entry on `sync_accounts` / `sync_governance` fails
+   * `PERMISSION_DENIED` (fail-closed).
+   */
+  resolveFromAuth(ctx: ResolveContext): TTenant | null | Promise<TTenant | null>;
+
+  /**
+   * Stable identity for tenant-equality checks. The helper compares
+   * `tenantId(authTenant) === tenantId(entryTenant)` to enforce isolation.
+   * Reference equality is fragile (Postgres-backed stores hand back fresh
+   * objects each fetch); a stable string id closes that gap.
+   */
+  tenantId(tenant: TTenant): string;
+
+  /**
+   * Project `(tenant, ref)` to the framework `Account<TCtxMeta>`. Called by
+   * `accounts.resolve` after tenant resolution. Adopters thread sandbox
+   * routing here (`sandbox: ref?.sandbox`), pin `ctx_metadata` for
+   * downstream handlers, and shape `name` / `operator` / `brand` to match
+   * the wire echo conventions their buyers expect.
+   *
+   * `ref` is `undefined` on Path-2 (no-account tools) — adopters returning
+   * a synthetic publisher-wide singleton omit `ref?.sandbox` (no sandbox
+   * boundary applies).
+   */
+  tenantToAccount(
+    tenant: TTenant,
+    ref: AccountReference | undefined,
+    ctx: ResolveContext
+  ): Account<TCtxMeta> | Promise<Account<TCtxMeta>>;
+
+  /**
+   * Per-entry `sync_accounts` storage callback. Called for each entry whose
+   * `(authTenant === entryTenant)` check passed. Receives the resolved
+   * tenant + the original ref + ctx. Returns a `SyncAccountsResultRow`.
+   *
+   * Cross-tenant entries and unknown-ref entries never reach this callback
+   * — the helper builds `PERMISSION_DENIED` / `ACCOUNT_NOT_FOUND` rows for
+   * those before invoking your code. The adopter's only job is the actual
+   * upsert.
+   *
+   * Optional. Omit if your platform doesn't claim `sync_accounts`; the
+   * helper leaves `accounts.upsert` undefined and the framework returns
+   * `UNSUPPORTED_FEATURE`.
+   */
+  upsertRow?(
+    tenant: TTenant,
+    ref: AccountReference,
+    ctx: ResolveContext
+  ): SyncAccountsResultRow | Promise<SyncAccountsResultRow>;
+
+  /**
+   * Per-entry `sync_governance` storage callback. Same gating rules as
+   * `upsertRow` — cross-tenant entries are rejected before reaching this
+   * code. Adopters persist the buyer's governance-agent binding (including
+   * write-only `authentication.credentials`, which the framework strips
+   * from the response automatically — see `toWireSyncGovernanceRow`).
+   *
+   * Optional. Omit if your platform doesn't claim `sync_governance`.
+   */
+  syncGovernanceRow?(
+    tenant: TTenant,
+    entry: SyncGovernanceEntry,
+    ctx: ResolveContext
+  ): SyncGovernanceRow | Promise<SyncGovernanceRow>;
+}
+
+/**
+ * Build an `AccountStore<TCtxMeta>` whose `resolve` / `upsert` /
+ * `syncGovernance` methods enforce tenant isolation.
+ *
+ * The helper produces:
+ *
+ * - `accounts.resolve(ref, ctx)` — calls `resolveByRef(ref)` when `ref` is
+ *   set, otherwise `resolveFromAuth(ctx)`. Projects via `tenantToAccount`.
+ *   Returns `null` if the resolver returned `null` (framework emits
+ *   `ACCOUNT_NOT_FOUND` for tools that require an account, or treats
+ *   absence as "no tenant" for tools that don't).
+ *
+ * - `accounts.upsert(refs, ctx)` — for each ref:
+ *     1. Resolve the entry's tenant via `resolveByRef`.
+ *     2. Resolve the auth principal's tenant via `resolveFromAuth(ctx)`
+ *        (computed once per request).
+ *     3. If the entry tenant is unknown, emit `ACCOUNT_NOT_FOUND`.
+ *     4. If the auth tenant is unknown OR differs from the entry tenant,
+ *        emit `PERMISSION_DENIED` (fail-closed).
+ *     5. Otherwise, invoke the adopter's `upsertRow`.
+ *
+ * - `accounts.syncGovernance(entries, ctx)` — same gating as `upsert`,
+ *   shaped for the `SyncGovernanceResponseRow` arm (`status: 'failed'`
+ *   with per-entry `errors`).
+ *
+ * `accounts.list` and `accounts.reportUsage` / `accounts.getAccountFinancials`
+ * are NOT generated by this helper — those tools have shapes (cursor
+ * pagination; per-row account refs spanning multiple tenants in
+ * `report_usage`) that don't fit the per-entry-then-row pattern. Adopters
+ * who claim those capabilities extend the returned store with
+ * `Object.assign`:
+ *
+ * ```ts
+ * const accounts = Object.assign(
+ *   createTenantStore<TenantState, TenantMeta>({...}),
+ *   { list: async (filter, ctx) => { ... } }
+ * );
+ * ```
+ *
+ * **Direct mutation of `upsert` / `syncGovernance` is locked.** The helper
+ * makes those properties non-writable (`Object.defineProperty`) so an
+ * adopter who writes `accounts.upsert = customHandler` after construction
+ * gets a TypeError instead of silently bypassing the tenant gate. If you
+ * really need a different `upsert`, don't use the helper — write a plain
+ * `AccountStore` and own the gate.
+ */
+export function createTenantStore<TTenant, TCtxMeta = Record<string, unknown>>(
+  config: TenantStoreConfig<TTenant, TCtxMeta>
+): AccountStore<TCtxMeta> {
+  const store: AccountStore<TCtxMeta> = {
+    resolve: async (ref, ctx) => {
+      const resolveCtx = ctx ?? {};
+      const tenant = ref ? await config.resolveByRef(ref) : await config.resolveFromAuth(resolveCtx);
+      if (tenant == null) return null;
+      return await config.tenantToAccount(tenant, ref, resolveCtx);
+    },
+  };
+
+  if (config.upsertRow) {
+    const upsertRow = config.upsertRow;
+    const upsert: NonNullable<AccountStore<TCtxMeta>['upsert']> = async (refs, ctx) => {
+      const resolveCtx = ctx ?? {};
+      const authTenant = await config.resolveFromAuth(resolveCtx);
+      const authTenantKey = authTenant != null ? config.tenantId(authTenant) : undefined;
+      // Sequential, not Promise.all: adopter `upsertRow` callbacks
+      // commonly mutate shared tenant state (the multi-tenant adapter's
+      // `tenant.accounts.set(...)` is the canonical example). Concurrent
+      // invocations against the same tenant are an entropy source the
+      // helper shouldn't introduce. Adopters who want parallel writes
+      // can fan out inside their callback against an upstream that
+      // tolerates it.
+      const rows: SyncAccountsResultRow[] = [];
+      for (const ref of refs) {
+        const entryTenant = await config.resolveByRef(ref);
+        if (entryTenant == null) {
+          rows.push(buildSyncAccountsFailedRow(ref, 'ACCOUNT_NOT_FOUND', accountNotFoundMessage(ref)));
+          continue;
+        }
+        const entryKey = config.tenantId(entryTenant);
+        if (authTenantKey == null || authTenantKey !== entryKey) {
+          rows.push(buildSyncAccountsFailedRow(ref, 'PERMISSION_DENIED', permissionDeniedMessage(ref)));
+          continue;
+        }
+        rows.push(await upsertRow(entryTenant, ref, resolveCtx));
+      }
+      return rows;
+    };
+    Object.defineProperty(store, 'upsert', { value: upsert, writable: false, configurable: false, enumerable: true });
+  }
+
+  if (config.syncGovernanceRow) {
+    const syncGovernanceRow = config.syncGovernanceRow;
+    const syncGovernance: NonNullable<AccountStore<TCtxMeta>['syncGovernance']> = async (entries, ctx) => {
+      const resolveCtx = ctx ?? {};
+      const authTenant = await config.resolveFromAuth(resolveCtx);
+      const authTenantKey = authTenant != null ? config.tenantId(authTenant) : undefined;
+      const rows: SyncGovernanceRow[] = [];
+      for (const entry of entries) {
+        const entryTenant = await config.resolveByRef(entry.account);
+        if (entryTenant == null) {
+          rows.push(buildSyncGovernanceFailedRow(entry, 'ACCOUNT_NOT_FOUND', accountNotFoundMessage(entry.account)));
+          continue;
+        }
+        const entryKey = config.tenantId(entryTenant);
+        if (authTenantKey == null || authTenantKey !== entryKey) {
+          rows.push(buildSyncGovernanceFailedRow(entry, 'PERMISSION_DENIED', permissionDeniedMessage(entry.account)));
+          continue;
+        }
+        rows.push(await syncGovernanceRow(entryTenant, entry, resolveCtx));
+      }
+      return rows;
+    };
+    Object.defineProperty(store, 'syncGovernance', {
+      value: syncGovernance,
+      writable: false,
+      configurable: false,
+      enumerable: true,
+    });
+  }
+
+  return store;
+}
+
+/**
+ * `AccountReference` is a discriminated union (`{account_id} | {brand, operator}`).
+ * The helper's failure-row builders read fields across both arms — schema
+ * validation upstream guarantees one arm is populated, so widening to
+ * "all-optional" here is safe and avoids per-arm casts at four call sites.
+ */
+function narrowAccountRef(ref: AccountReference): {
+  account_id?: string;
+  operator?: string;
+  brand?: { domain?: string };
+} {
+  return ref as { account_id?: string; operator?: string; brand?: { domain?: string } };
+}
+
+/**
+ * Build a failed `sync_accounts` row when the helper rejects an entry
+ * (cross-tenant or unknown ref). The wire schema requires `brand` +
+ * `operator` on every row, so when the input ref is `account_id`-only
+ * we synthesize `'unknown'` placeholders — the buyer's `errors[0].code`
+ * is the actionable signal; `brand` / `operator` here are wire-required
+ * scaffolding, not authoritative echoes.
+ */
+function buildSyncAccountsFailedRow(
+  ref: AccountReference,
+  code: 'ACCOUNT_NOT_FOUND' | 'PERMISSION_DENIED',
+  message: string
+): SyncAccountsResultRow {
+  const r = narrowAccountRef(ref);
+  return {
+    brand: { domain: r.brand?.domain ?? 'unknown.example' },
+    operator: r.operator ?? 'unknown',
+    action: 'failed',
+    status: 'rejected',
+    errors: [{ code, message }],
+    ...(r.account_id != null && { account_id: r.account_id }),
+  };
+}
+
+function buildSyncGovernanceFailedRow(
+  entry: SyncGovernanceEntry,
+  code: 'ACCOUNT_NOT_FOUND' | 'PERMISSION_DENIED',
+  message: string
+): SyncGovernanceRow {
+  return {
+    account: entry.account,
+    status: 'failed',
+    errors: [{ code, message }],
+  };
+}
+
+function accountNotFoundMessage(ref: AccountReference): string {
+  const r = narrowAccountRef(ref);
+  if (r.account_id) return `Unknown account_id: ${r.account_id}`;
+  if (r.operator) return `Unknown operator: ${r.operator}`;
+  return 'Unknown account reference';
+}
+
+function permissionDeniedMessage(ref: AccountReference): string {
+  const r = narrowAccountRef(ref);
+  const subject = r.operator ?? r.account_id ?? 'this account';
+  return `Buyer agent has no authority over '${subject}' (tenant mismatch or auth principal not registered).`;
+}

--- a/test/lib/create-tenant-store.test.js
+++ b/test/lib/create-tenant-store.test.js
@@ -1,0 +1,311 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { createTenantStore } = require('../../dist/lib/server/decisioning/index.js');
+
+// ── Test fixtures ──────────────────────────────────────────────────────────
+
+const TENANTS = new Map([
+  ['t_pinnacle', { id: 't_pinnacle', display_name: 'Pinnacle' }],
+  ['t_meridian', { id: 't_meridian', display_name: 'Meridian' }],
+]);
+
+const OPERATOR_TO_TENANT = new Map([
+  ['pinnacle.example', 't_pinnacle'],
+  ['meridian.example', 't_meridian'],
+]);
+
+const PRINCIPAL_TO_TENANT = new Map([
+  ['buyer@pinnacle', 't_pinnacle'],
+  ['buyer@meridian', 't_meridian'],
+]);
+
+function tenantFromOperator(operator) {
+  const id = OPERATOR_TO_TENANT.get(operator);
+  return id ? (TENANTS.get(id) ?? null) : null;
+}
+
+function tenantFromPrincipal(principal) {
+  if (!principal) return null;
+  const id = PRINCIPAL_TO_TENANT.get(principal);
+  return id ? (TENANTS.get(id) ?? null) : null;
+}
+
+function buildStore(opts = {}) {
+  const cfg = {
+    resolveByRef: ref => {
+      const r = ref ?? {};
+      if (r.account_id) {
+        // For tests, account_id starts with "t_pinnacle:" / "t_meridian:" prefix
+        const tid = String(r.account_id).split(':')[0];
+        return TENANTS.get(tid) ?? null;
+      }
+      return tenantFromOperator(r.operator);
+    },
+    resolveFromAuth: ctx => tenantFromPrincipal(ctx?.authInfo?.credential?.principal),
+    tenantId: t => t.id,
+    tenantToAccount: (tenant, ref) => ({
+      id: tenant.id,
+      name: tenant.display_name,
+      status: 'active',
+      operator: ref?.operator ?? 'derived',
+      sandbox: ref?.sandbox ?? false,
+    }),
+    ...opts,
+  };
+  return createTenantStore(cfg);
+}
+
+function ctxWith(principal) {
+  return { authInfo: { credential: { principal } } };
+}
+
+// ── resolve ────────────────────────────────────────────────────────────────
+
+describe('createTenantStore — resolve', () => {
+  test('Path 1: operator ref → tenant', async () => {
+    const store = buildStore();
+    const acc = await store.resolve(
+      { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(acc.id, 't_pinnacle');
+  });
+
+  test('Path 2: no ref → resolveFromAuth (auth-derived tenant)', async () => {
+    const store = buildStore();
+    const acc = await store.resolve(undefined, ctxWith('buyer@pinnacle'));
+    assert.equal(acc.id, 't_pinnacle');
+  });
+
+  test('returns null when ref is unknown', async () => {
+    const store = buildStore();
+    const acc = await store.resolve(
+      { operator: 'unknown.example', brand: { domain: 'x.example' } },
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(acc, null);
+  });
+
+  test('returns null when auth principal is unknown', async () => {
+    const store = buildStore();
+    const acc = await store.resolve(undefined, ctxWith('not-registered'));
+    assert.equal(acc, null);
+  });
+
+  test('threads sandbox flag through the projector', async () => {
+    const store = buildStore();
+    const acc = await store.resolve(
+      { brand: { domain: 'acme.example' }, operator: 'pinnacle.example', sandbox: true },
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(acc.sandbox, true);
+  });
+});
+
+// ── upsert (sync_accounts) — tenant-isolation gate ─────────────────────────
+
+describe('createTenantStore — upsert tenant-isolation gate', () => {
+  function buildWithUpsert() {
+    const writes = [];
+    const store = buildStore({
+      upsertRow: (tenant, ref, _ctx) => {
+        writes.push({ tenant: tenant.id, ref });
+        return {
+          brand: ref.brand,
+          operator: ref.operator,
+          action: 'created',
+          status: 'active',
+        };
+      },
+    });
+    return { store, writes };
+  }
+
+  test('passes through entries whose tenant matches auth tenant', async () => {
+    const { store, writes } = buildWithUpsert();
+    const rows = await store.upsert(
+      [{ brand: { domain: 'acme.example' }, operator: 'pinnacle.example' }],
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(writes.length, 1);
+    assert.equal(rows[0].action, 'created');
+    assert.equal(rows[0].status, 'active');
+  });
+
+  test('rejects cross-tenant entry with PERMISSION_DENIED (Meridian cred / Pinnacle operator)', async () => {
+    const { store, writes } = buildWithUpsert();
+    const rows = await store.upsert(
+      [{ brand: { domain: 'acme.example' }, operator: 'pinnacle.example' }],
+      ctxWith('buyer@meridian')
+    );
+    assert.equal(writes.length, 0, 'upsertRow MUST NOT run for cross-tenant entries');
+    assert.equal(rows[0].action, 'failed');
+    assert.equal(rows[0].status, 'rejected');
+    assert.equal(rows[0].errors[0].code, 'PERMISSION_DENIED');
+  });
+
+  test('rejects unknown operator with ACCOUNT_NOT_FOUND, not PERMISSION_DENIED', async () => {
+    const { store, writes } = buildWithUpsert();
+    const rows = await store.upsert(
+      [{ brand: { domain: 'x.example' }, operator: 'unknown.example' }],
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(writes.length, 0);
+    assert.equal(rows[0].errors[0].code, 'ACCOUNT_NOT_FOUND');
+  });
+
+  test('fail-closed: unknown auth principal rejects every entry with PERMISSION_DENIED', async () => {
+    const { store, writes } = buildWithUpsert();
+    const rows = await store.upsert(
+      [
+        { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+        { brand: { domain: 'beta.example' }, operator: 'meridian.example' },
+      ],
+      ctxWith('not-registered')
+    );
+    assert.equal(writes.length, 0);
+    assert.equal(rows.length, 2);
+    assert.ok(rows.every(r => r.errors[0].code === 'PERMISSION_DENIED'));
+  });
+
+  test('mixed batch: in-tenant entries pass, cross-tenant fail, unknown ref ACCOUNT_NOT_FOUND', async () => {
+    const { store, writes } = buildWithUpsert();
+    const rows = await store.upsert(
+      [
+        { brand: { domain: 'a.example' }, operator: 'pinnacle.example' }, // pass
+        { brand: { domain: 'b.example' }, operator: 'meridian.example' }, // cross-tenant
+        { brand: { domain: 'c.example' }, operator: 'unknown.example' }, // unknown
+      ],
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(writes.length, 1, 'only the in-tenant entry should reach upsertRow');
+    assert.equal(rows[0].action, 'created');
+    assert.equal(rows[1].errors[0].code, 'PERMISSION_DENIED');
+    assert.equal(rows[2].errors[0].code, 'ACCOUNT_NOT_FOUND');
+  });
+});
+
+// ── syncGovernance — tenant-isolation gate ─────────────────────────────────
+
+describe('createTenantStore — syncGovernance tenant-isolation gate', () => {
+  function buildWithSyncGov() {
+    const writes = [];
+    const store = buildStore({
+      syncGovernanceRow: (tenant, entry, _ctx) => {
+        writes.push({ tenant: tenant.id, entry });
+        return {
+          account: entry.account,
+          status: 'synced',
+          governance_agents: entry.governance_agents.map(a => ({ url: a.url })),
+        };
+      },
+    });
+    return { store, writes };
+  }
+
+  test('passes through in-tenant entries', async () => {
+    const { store, writes } = buildWithSyncGov();
+    const rows = await store.syncGovernance(
+      [
+        {
+          account: { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+          governance_agents: [
+            { url: 'https://gov.example', authentication: { schemes: ['Bearer'], credentials: 'x' } },
+          ],
+        },
+      ],
+      ctxWith('buyer@pinnacle')
+    );
+    assert.equal(writes.length, 1);
+    assert.equal(rows[0].status, 'synced');
+  });
+
+  test('rejects cross-tenant entry with PERMISSION_DENIED', async () => {
+    const { store, writes } = buildWithSyncGov();
+    const rows = await store.syncGovernance(
+      [
+        {
+          account: { brand: { domain: 'acme.example' }, operator: 'pinnacle.example' },
+          governance_agents: [],
+        },
+      ],
+      ctxWith('buyer@meridian')
+    );
+    assert.equal(writes.length, 0);
+    assert.equal(rows[0].status, 'failed');
+    assert.equal(rows[0].errors[0].code, 'PERMISSION_DENIED');
+  });
+});
+
+// ── Optional callbacks ─────────────────────────────────────────────────────
+
+describe('createTenantStore — optional callbacks', () => {
+  test('upsert is undefined when upsertRow is not provided', () => {
+    const store = buildStore();
+    assert.equal(store.upsert, undefined);
+    assert.equal(store.syncGovernance, undefined);
+  });
+
+  test('upsert is wired when upsertRow is provided', () => {
+    const store = buildStore({ upsertRow: () => ({}) });
+    assert.equal(typeof store.upsert, 'function');
+    assert.equal(store.syncGovernance, undefined);
+  });
+});
+
+// ── Security: gate methods are non-writable ────────────────────────────────
+
+describe('createTenantStore — gate methods locked against override', () => {
+  test('cannot reassign accounts.upsert (would bypass tenant gate)', () => {
+    'use strict';
+    const store = buildStore({ upsertRow: () => ({}) });
+    assert.throws(
+      () => {
+        store.upsert = async () => [];
+      },
+      /Cannot assign to read only property/,
+      'upsert MUST be non-writable to prevent silent gate bypass'
+    );
+  });
+
+  test('cannot reassign accounts.syncGovernance', () => {
+    'use strict';
+    const store = buildStore({ syncGovernanceRow: () => ({}) });
+    assert.throws(() => {
+      store.syncGovernance = async () => [];
+    }, /Cannot assign to read only property/);
+  });
+
+  test('list and other extensions still work via Object.assign', () => {
+    const store = Object.assign(buildStore({ upsertRow: () => ({}) }), {
+      list: async () => ({ items: [] }),
+    });
+    assert.equal(typeof store.list, 'function');
+    assert.equal(typeof store.upsert, 'function');
+  });
+});
+
+// ── Concurrency: sequential per-entry callbacks ────────────────────────────
+
+describe('createTenantStore — sequential per-entry execution', () => {
+  test('upsertRow callbacks run in input order, not in parallel', async () => {
+    const observed = [];
+    const store = buildStore({
+      upsertRow: async (_tenant, ref, _ctx) => {
+        observed.push(`start:${ref.brand.domain}`);
+        await new Promise(r => setTimeout(r, 1));
+        observed.push(`end:${ref.brand.domain}`);
+        return { brand: ref.brand, operator: ref.operator, action: 'created', status: 'active' };
+      },
+    });
+    await store.upsert(
+      [
+        { brand: { domain: 'a.example' }, operator: 'pinnacle.example' },
+        { brand: { domain: 'b.example' }, operator: 'pinnacle.example' },
+      ],
+      ctxWith('buyer@pinnacle')
+    );
+    assert.deepEqual(observed, ['start:a.example', 'end:a.example', 'start:b.example', 'end:b.example']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last library-side item tracked in #1387. Replaces 200+ lines of inlined gating in the multi-tenant adapter with a single helper call, and lifts the security-critical tenant-isolation gate from adopter discipline into the SDK.

```ts
const accounts = createTenantStore<TenantState, TenantMeta>({
  resolveByRef(ref)                       => TenantState | null,  // wire ref → tenant
  resolveFromAuth(ctx)                    => TenantState | null,  // auth principal → tenant
  tenantId(tenant)                        => string,              // stable id for equality
  tenantToAccount(tenant, ref, ctx)       => Account<TenantMeta>, // sandbox lives here
  upsertRow?(tenant, ref, ctx)            => SyncAccountsResultRow,
  syncGovernanceRow?(tenant, entry, ctx)  => SyncGovernanceResponseRow,
});
```

## Security posture

- **Cross-tenant entries never reach adopter callbacks.** The helper resolves `authTenant` once per request, then per-entry emits `PERMISSION_DENIED` rows before invoking `upsertRow` / `syncGovernanceRow`. This is the SDK-level mitigation for B1 from the multi-tenant adapter review (where adopters routing on wire-supplied operator without cross-checking the auth principal could write across tenants).
- **Fail-closed when `resolveFromAuth` returns null.** Every entry fails `PERMISSION_DENIED`. No log-then-allow path.
- **`accounts.upsert` and `accounts.syncGovernance` are non-writable.** An adopter who writes `accounts.upsert = customHandler` after construction gets a `TypeError` in strict mode instead of silently bypassing the gate. Use `Object.assign` for `list` / `reportUsage` / `getAccountFinancials` extensions.
- **Per-entry callbacks run sequentially**, not via `Promise.all`. Adopter callbacks commonly mutate shared tenant state; the helper preserves prior accidental sequential semantics rather than introducing concurrent invocations.

## Sandbox

Lives in the `tenantToAccount` projector. `AccountReference.sandbox?: boolean` flows through; adopters either flag the resolved Account so per-handler code routes reads/writes to a sandbox backend, or resolve to a separate sandbox tenant via `resolveByRef` reading `ref.sandbox`. No new helper API parameter.

## Files

- `src/lib/server/decisioning/tenant-store.ts` (new) — helper + `TenantStoreConfig`
- `src/lib/server/decisioning/index.ts` — export
- `examples/hello_seller_adapter_multi_tenant.ts` — migrated; ~200 lines collapsed to one `createTenantStore({...})` call
- `skills/build-holdco-agent/SKILL.md` — leads with `createTenantStore`; prior inlined-gate documentation superseded
- `test/lib/create-tenant-store.test.js` (new) — 18 tests including the `Object.defineProperty` lock and sequential-execution assertions
- `.changeset/create-tenant-store.md` — minor

## Expert review (parallel)

Three reviewers — code, security, DX — fired in parallel. Convergent finding: the original v1 of this PR allowed `accounts.upsert = customHandler` to silently bypass the gate (the helper's whole pitch is "SDK-level mitigation, not adopter discipline"). **Fix landed in this PR**: gate methods now non-writable via `Object.defineProperty`. Code-reviewer's other findings (sequential vs `Promise.all`, fabricated brand/operator placeholders in failed rows, repeated casts) all addressed. DX expert's discoverability concern (SKILL.md still pointed at the inlined pattern) addressed — skill rewritten to lead with the helper.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run build:lib` clean
- [x] `npm test` — 7779 pass / 0 fail / 7 skipped
- [x] New `create-tenant-store.test.js` — 18/18 pass (resolve paths, gate, fail-closed, mixed batch, property freeze, sequential execution)
- [x] E2E: cross-tenant attack rejected with `PERMISSION_DENIED`; valid sync echoes governance_agents without `authentication`; helper's PERMISSION_DENIED message threading correctly
- [ ] CI passes

Tracking: #1387 (item: `createTenantStore` helper + `createMultiTenantPlatform()` runtime isolation gate — collapsed into single helper per design review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)