### PR TITLE
fix(storyboard): synthetic AccountReference always carries operator (#1419)

### DIFF
--- a/.changeset/storyboard-runner-natural-key-operator.md
+++ b/.changeset/storyboard-runner-natural-key-operator.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+Storyboard runner: ensure synthetic `AccountReference` natural-key refs always carry `operator` so a strict-validating seller can't reject them. Closes #1419.
+
+The natural-key arm of `AccountReference` requires `operator` per `core/account-ref.json`. Three runner-side synthesis sites could previously produce `{brand, sandbox}` without `operator` — the SDK's loose runtime decoder hid the gap, but a spec-conformant seller running schema-strict validation would reject the ref:
+
+- `applyBrandInvariant` (`runner.ts`) — when merging brand into a fixture's natural-key account, default `operator` to `brand.domain` if absent.
+- `comply_test_controller` enricher (`request-builder.ts`) — when `context.account` was a natural-key ref missing `operator`, default to `brand.domain` before forcing `sandbox: true`.
+- `sync_accounts` context extractor (`context.ts`) — drop `operator` from the propagated account ref when the response leaves it undefined, instead of writing `operator: undefined` (which `JSON.stringify` silently strips on the wire). The `{account_id}` arm and adopter-supplied operators are unaffected.

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -29,11 +29,15 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     const extracted: Record<string, unknown> = {};
     if (first.account_id) extracted.account_id = first.account_id;
     if (first.status) extracted.account_status = first.status;
-    // Build an account reference for downstream steps
-    extracted.account = {
-      brand: first.brand,
-      operator: first.operator,
-    };
+    // Build an account reference for downstream steps. Only include fields
+    // the response actually carries — propagating `operator: undefined`
+    // would serialize away on the wire (JSON.stringify drops undefined),
+    // leaving the natural-key arm short of its required `operator` field
+    // (#1419). The brand/operator pair stays paired or both absent.
+    const accountRef: Record<string, unknown> = {};
+    if (first.brand) accountRef.brand = first.brand;
+    if (first.operator) accountRef.operator = first.operator;
+    extracted.account = accountRef;
     return extracted;
   },
 

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -757,7 +757,20 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
 
   comply_test_controller(step, context, options) {
     // The test controller requires account.sandbox: true to be set.
-    const account = { ...(context.account ?? resolveAccount(options)), sandbox: true };
+    const account: Record<string, unknown> = {
+      ...(context.account ?? resolveAccount(options)),
+      sandbox: true,
+    };
+    // Natural-key arm of AccountReference requires `operator` per the spec
+    // schema. If `context.account` came from a sync_accounts response that
+    // omitted `operator` (#1419), fall back to brand.domain so the synthetic
+    // ref the controller receives is spec-valid.
+    if (typeof account.account_id !== 'string' && typeof account.operator !== 'string') {
+      const brand = account.brand as { domain?: unknown } | undefined;
+      if (brand && typeof brand.domain === 'string') {
+        account.operator = brand.domain;
+      }
+    }
     if (step.sample_request) {
       return { ...injectContext({ ...step.sample_request }, context), account };
     }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3225,7 +3225,17 @@ export function applyBrandInvariant(
       const acct = existingAccount as Record<string, unknown>;
       const isNaturalKeyVariant = 'brand' in acct || 'operator' in acct;
       if (isNaturalKeyVariant) {
-        result.account = { ...acct, brand };
+        const merged: Record<string, unknown> = { ...acct, brand };
+        // The natural-key arm of AccountReference requires `operator` (per
+        // schemas/cache/{version}/core/account-ref.json). A fixture or earlier
+        // context-extraction step that produced `{brand, sandbox}` without
+        // operator would otherwise be passed through and rejected by a
+        // strict-validating seller. Default operator to brand.domain — same
+        // convention `resolveAccount` uses for synthetic refs.
+        if (typeof merged.operator !== 'string' && typeof brand.domain === 'string') {
+          merged.operator = brand.domain;
+        }
+        result.account = merged;
       }
     }
   } else if (topAccountOk) {

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -118,6 +118,41 @@ describe('context extractors', () => {
     });
   });
 
+  describe('sync_accounts', () => {
+    it('extracts account_id, status, and a paired brand/operator account ref', () => {
+      const data = {
+        accounts: [
+          {
+            account_id: 'acct_1',
+            status: 'active',
+            brand: { domain: 'acme.example' },
+            operator: 'pinnacle-agency.example',
+          },
+        ],
+      };
+      const result = extractContext('sync_accounts', data);
+      assert.equal(result.account_id, 'acct_1');
+      assert.equal(result.account_status, 'active');
+      assert.deepStrictEqual(result.account, {
+        brand: { domain: 'acme.example' },
+        operator: 'pinnacle-agency.example',
+      });
+    });
+
+    // Issue #1419 — extractor must not propagate `operator: undefined`. The
+    // natural-key arm of AccountReference requires `operator`; an undefined
+    // value would JSON.stringify away to a missing field and a strict-
+    // validating seller would reject the synthetic ref. The extractor leaves
+    // `operator` off the account ref entirely when the response omits it,
+    // letting downstream synthesis sites supply a fallback.
+    it('omits operator when the response leaves it undefined (no operator: undefined leak)', () => {
+      const data = { accounts: [{ brand: { domain: 'acme.example' } }] };
+      const result = extractContext('sync_accounts', data);
+      assert.deepStrictEqual(result.account, { brand: { domain: 'acme.example' } });
+      assert.strictEqual('operator' in result.account, false);
+    });
+  });
+
   describe('report_plan_outcome', () => {
     it('extracts outcome_id and outcome_status', () => {
       const data = { status: 'completed', outcome_id: 'out_456' };

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -524,6 +524,26 @@ describe('Request Builder', () => {
       const result = buildRequest(s, {}, DEFAULT_OPTIONS);
       assert.strictEqual(result.account.sandbox, true);
     });
+
+    // Issue #1419 — natural-key arm of AccountReference requires `operator`.
+    // When context.account came from a sync_accounts response that omitted
+    // operator (or was authored without it), the controller call would ship
+    // a synthetic ref missing operator and fail strict-validating sellers.
+    test('fills in operator when context.account is a natural-key ref missing operator (#1419)', () => {
+      const context = { account: { brand: { domain: 'acme.example' } } };
+      const result = buildRequest(step('comply_test_controller'), context, DEFAULT_OPTIONS);
+      assert.deepStrictEqual(result.account.brand, { domain: 'acme.example' });
+      assert.strictEqual(result.account.operator, 'acme.example');
+      assert.strictEqual(result.account.sandbox, true);
+    });
+
+    test('does not add operator when context.account uses the {account_id} arm (#1419)', () => {
+      const context = { account: { account_id: 'acct-1' } };
+      const result = buildRequest(step('comply_test_controller'), context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.account.account_id, 'acct-1');
+      assert.strictEqual(result.account.operator, undefined);
+      assert.strictEqual(result.account.sandbox, true);
+    });
   });
 
   describe('get_signals', () => {

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -185,6 +185,22 @@ describe('applyBrandInvariant', () => {
     assert.deepStrictEqual(result.account, { operator: 'pinnacle-agency.example', brand: BRAND });
   });
 
+  // Issue #1419 — natural-key arm of AccountReference requires `operator`.
+  // A fixture or sync_accounts extractor that produced `{brand, sandbox}`
+  // without operator would otherwise pass through and be rejected by a
+  // strict-validating seller. The merge must default operator to brand.domain.
+  test('fills in operator when the natural-key account omits it (#1419)', () => {
+    const result = applyBrandInvariant(
+      { account: { brand: { domain: 'other.example' }, sandbox: true } },
+      { brand: BRAND }
+    );
+    assert.deepStrictEqual(result.account, {
+      brand: BRAND,
+      operator: BRAND.domain,
+      sandbox: true,
+    });
+  });
+
   test('merges brand into a natural-key account that already carries brand', () => {
     const result = applyBrandInvariant(
       { account: { brand: { domain: 'other.example' }, operator: 'pinnacle-agency.example' } },


### PR DESCRIPTION
## Summary

Fixes #1419. Three runner-side synthesis sites could produce a natural-key `AccountReference` without `operator`, which a strict-validating seller would reject per `core/account-ref.json` (`operator` is required on the natural-key arm). The SDK's loose runtime decoder hid the gap.

- `applyBrandInvariant` — when merging brand into a fixture's natural-key account, default `operator` to `brand.domain` if absent.
- `comply_test_controller` enricher — when `context.account` is a natural-key ref missing `operator`, default to `brand.domain` before forcing `sandbox: true`.
- `sync_accounts` context extractor — omit `operator` from the propagated account ref when the response leaves it undefined, instead of writing `operator: undefined` (which `JSON.stringify` silently strips on the wire). The `{account_id}` arm and adopter-supplied operators are unaffected.

## Test plan

- [x] New unit test in `storyboard-brand-invariant.test.js` covers a fixture `account: {brand, sandbox}` (no operator) → invariant fills in operator from brand.domain.
- [x] New unit tests in `request-builder.test.js` cover (a) `comply_test_controller` filling operator when `context.account` is natural-key without operator, and (b) leaving the `{account_id}` arm untouched.
- [x] New unit tests in `context-extractors.test.js` cover the sync_accounts extractor (a) propagating brand+operator when present, and (b) omitting the operator key when the response leaves it undefined.
- [x] `node --test test/lib/storyboard-brand-invariant.test.js test/lib/context-extractors.test.js test/lib/request-builder.test.js` — 113/113 pass.
- [x] Full storyboard test suite — 2782/2783 pass; one unrelated failure (`storyboard-rejection-hints-e2e.test.js` — needs `NODE_ENV=test`, passes when set; pre-existing).
- [x] `npm run format:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)