### PR TITLE
fix(storyboard): emit spec-valid AccountReference when seller omits operator

### DIFF
--- a/.changeset/fix-storyboard-account-ref-operator.md
+++ b/.changeset/fix-storyboard-account-ref-operator.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Fix storyboard runner sending spec-invalid AccountReference when seller omits operator in sync_accounts response. The natural-key arm of AccountReference requires both brand and operator; the extractor now falls back to brand.domain when operator is absent, and omits the account field entirely when brand is not present, letting request-builder.ts fall through to resolveAccount(options).

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -29,11 +29,20 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     const extracted: Record<string, unknown> = {};
     if (first.account_id) extracted.account_id = first.account_id;
     if (first.status) extracted.account_status = first.status;
-    // Build an account reference for downstream steps
-    extracted.account = {
-      brand: first.brand,
-      operator: first.operator,
-    };
+    // Build a natural-key AccountReference for downstream steps only when
+    // brand is present. operator falls back to brand.domain — sellers are
+    // not required to echo operator in every sync_accounts response, but
+    // AccountReference's natural-key arm requires it per the spec (account-
+    // ref.json: both brand AND operator are required on that arm). Omitting
+    // operator causes JSON serialization to drop the key and produces a
+    // spec-invalid ref that strict-validating sellers reject.
+    if (first.brand && typeof first.brand === 'object' && first.brand !== null) {
+      const brand = first.brand as Record<string, unknown>;
+      const operator = first.operator ?? brand.domain;
+      if (operator) {
+        extracted.account = { brand: first.brand, operator };
+      }
+    }
     return extracted;
   },
 

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -36,7 +36,7 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     // ref.json: both brand AND operator are required on that arm). Omitting
     // operator causes JSON serialization to drop the key and produces a
     // spec-invalid ref that strict-validating sellers reject.
-    if (first.brand && typeof first.brand === 'object' && first.brand !== null) {
+    if (typeof first.brand === 'object' && first.brand !== null) {
       const brand = first.brand as Record<string, unknown>;
       const operator = first.operator ?? brand.domain;
       if (operator) {

--- a/test/lib/storyboard-context-extractors.test.js
+++ b/test/lib/storyboard-context-extractors.test.js
@@ -1,0 +1,84 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { extractContext } = require('../../dist/lib/testing/storyboard/context');
+
+describe('CONTEXT_EXTRACTORS.sync_accounts', () => {
+  it('builds natural-key account when both brand and operator are present', () => {
+    const result = extractContext('sync_accounts', {
+      accounts: [
+        {
+          account_id: 'acct-1',
+          status: 'active',
+          brand: { domain: 'example.com' },
+          operator: 'operator.com',
+        },
+      ],
+    });
+    assert.deepStrictEqual(result.account, {
+      brand: { domain: 'example.com' },
+      operator: 'operator.com',
+    });
+    assert.strictEqual(result.account_id, 'acct-1');
+    assert.strictEqual(result.account_status, 'active');
+  });
+
+  it('falls back to brand.domain when seller omits operator', () => {
+    // Sellers are not required to echo operator back; the natural-key arm
+    // requires it, so we derive it from brand.domain.
+    const result = extractContext('sync_accounts', {
+      accounts: [
+        {
+          account_id: 'acct-2',
+          brand: { domain: 'direct.example.com' },
+          // operator intentionally absent
+        },
+      ],
+    });
+    assert.deepStrictEqual(result.account, {
+      brand: { domain: 'direct.example.com' },
+      operator: 'direct.example.com',
+    });
+  });
+
+  it('does not set account when brand is absent (account_id-only response)', () => {
+    // When only account_id is returned, context.account is omitted so
+    // downstream request-builders fall through to resolveAccount(options),
+    // which always produces a valid natural-key ref.
+    const result = extractContext('sync_accounts', {
+      accounts: [{ account_id: 'acct-3' }],
+    });
+    assert.strictEqual(result.account, undefined);
+    assert.strictEqual(result.account_id, 'acct-3');
+  });
+
+  it('does not set account when brand is absent and operator is present', () => {
+    const result = extractContext('sync_accounts', {
+      accounts: [{ account_id: 'acct-4', operator: 'op.example.com' }],
+    });
+    assert.strictEqual(result.account, undefined);
+  });
+
+  it('does not set account when brand is non-object (null)', () => {
+    const result = extractContext('sync_accounts', {
+      accounts: [{ account_id: 'acct-5', brand: null }],
+    });
+    assert.strictEqual(result.account, undefined);
+  });
+
+  it('does not set account when brand has no domain and operator is absent', () => {
+    const result = extractContext('sync_accounts', {
+      accounts: [{ brand: {} }],
+    });
+    assert.strictEqual(result.account, undefined);
+  });
+
+  it('returns empty object when accounts array is empty', () => {
+    const result = extractContext('sync_accounts', { accounts: [] });
+    assert.deepStrictEqual(result, {});
+  });
+
+  it('returns empty object when data is null', () => {
+    const result = extractContext('sync_accounts', null);
+    assert.deepStrictEqual(result, {});
+  });
+});


### PR DESCRIPTION
Closes #1419

The `sync_accounts` context extractor unconditionally built `{ brand, operator }` from the seller response. When the seller omits `operator` (sellers aren't required to echo it back), `first.operator` is `undefined`, which JSON serializes away — producing a natural-key `AccountReference` missing the required `operator` field. Strict-validating sellers correctly reject this ref, breaking cascade scenarios.

**Fix:** guard the `extracted.account` write on brand being a non-null object, derive `operator` from `first.operator ?? brand.domain` (spec-compliant for the direct-operation case: "when the brand operates directly, this is the brand's domain"), and skip the write entirely when operator still can't be derived — downstream `request-builder.ts` call sites already do `context.account ?? resolveAccount(options)`, so the fallthrough path is safe and always yields a valid ref.

## What was tested

- `npm run format:check` — clean
- `npx tsc --project tsconfig.lib.json` — only pre-existing TS deprecation warnings, no new errors
- `node --test test/lib/storyboard-context-extractors.test.js` — 8/8 pass (new tests; all branches covered: operator present, operator absent+brand.domain fallback, brand absent, brand null, brand with no domain, empty array, null data)
- Pre-existing test failures on `main` are unchanged (verified by stash comparison)

## Pre-PR review

- code-reviewer: approved — no blockers; one redundant null-guard nit fixed before push
- ad-tech-protocol-expert: approved — `operator` requirement confirmed from generated Zod/TS types; fallthrough to `resolveAccount(options)` is safe for all downstream enrichers

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01GDzUJwimmWqWrWGVaTh1rd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDzUJwimmWqWrWGVaTh1rd)_