### PR TITLE
feat(server): export canonical state-machine transition maps and assert helpers

### DIFF
--- a/.changeset/export-state-machine-helpers.md
+++ b/.changeset/export-state-machine-helpers.md
@@ -1,0 +1,20 @@
+---
+"@adcp/sdk": minor
+---
+
+Export canonical state-machine transition maps and helpers from `@adcp/sdk/server`.
+
+`MEDIA_BUY_TRANSITIONS`, `isLegalMediaBuyTransition`, `assertMediaBuyTransition`,
+`CREATIVE_ASSET_TRANSITIONS`, `isLegalCreativeTransition`, `assertCreativeTransition`,
+`CREATIVE_APPROVAL_TRANSITIONS`, `isLegalCreativeApprovalTransition`, and
+`assertCreativeApprovalTransition` are now public exports.
+
+The assertion helpers throw the spec-correct `AdcpError` codes: `NOT_CANCELLABLE`
+for cancel-on-terminal-state, `INVALID_STATE` for all other illegal transitions.
+These are the same maps used by the conformance runner's `status.monotonic`
+invariant, so sellers who guard handlers with `assertMediaBuyTransition` are
+guaranteed to agree with the storyboard runner.
+
+The three example files that previously copy-pasted their own (diverged) transition
+tables now import from the SDK. `skills/build-seller-agent/SKILL.md` is updated to
+use the helpers in both the test-controller sketch and the production-handler example.

--- a/examples/comply-controller-seller.ts
+++ b/examples/comply-controller-seller.ts
@@ -34,7 +34,7 @@
  *     --params '{"creative_id":"cr-1","status":"rejected","rejection_reason":"Brand safety"}'
  */
 
-import { createTaskCapableServer, serve, type ServeContext } from '@adcp/sdk';
+import { createTaskCapableServer, serve, isLegalCreativeTransition, type ServeContext } from '@adcp/sdk';
 import { createComplyController, TestControllerError, type CreativeStatus } from '@adcp/sdk/testing';
 
 // ---------------------------------------------------------------------------
@@ -58,23 +58,10 @@ interface CreativeRecord {
 const products = new Map<string, ProductFixture>();
 const creatives = new Map<string, CreativeRecord>();
 
-// DEMO POLICY — do not copy this table into a production state machine.
-// It is permissive enough to run the example storyboards; a real seller
-// encodes their approval workflow here (and in production the controller
-// itself is never registered). The point of this table is to show WHERE
-// transition enforcement lives — the controller routes through the same
-// guard as the production path.
-const CREATIVE_TRANSITIONS: Record<CreativeStatus, CreativeStatus[]> = {
-  processing: ['pending_review', 'approved', 'rejected'],
-  pending_review: ['approved', 'rejected'],
-  approved: ['rejected', 'archived'],
-  rejected: ['approved', 'archived'],
-  archived: [],
-};
-
+// Creative transition guard uses the canonical SDK helper so the controller
+// and production handlers share the same transition table.
 function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
-  const allowed = CREATIVE_TRANSITIONS[from] ?? [];
-  if (!allowed.includes(to)) {
+  if (!isLegalCreativeTransition(from, to)) {
     throw new TestControllerError('INVALID_TRANSITION', `Creative cannot move from ${from} to ${to}`, from);
   }
 }

--- a/examples/comply-controller-seller.ts
+++ b/examples/comply-controller-seller.ts
@@ -58,9 +58,9 @@ interface CreativeRecord {
 const products = new Map<string, ProductFixture>();
 const creatives = new Map<string, CreativeRecord>();
 
-// Creative transition guard uses the canonical SDK helper so the controller
-// and production handlers share the same transition table.
-function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
+// Test controller guard wraps the SDK predicate and throws TestControllerError
+// (not AdcpError) — the correct error class for controller-layer enforcement.
+function requireLegalCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
   if (!isLegalCreativeTransition(from, to)) {
     throw new TestControllerError('INVALID_TRANSITION', `Creative cannot move from ${from} to ${to}`, from);
   }
@@ -105,7 +105,7 @@ const controller = createComplyController({
       if (!record) {
         throw new TestControllerError('NOT_FOUND', `Creative ${creative_id} not found`);
       }
-      assertCreativeTransition(record.status, status);
+      requireLegalCreativeTransition(record.status, status);
       const previous = record.status;
       record.status = status;
       if (rejection_reason) record.rejection_reason = rejection_reason;

--- a/examples/seller-test-controller.ts
+++ b/examples/seller-test-controller.ts
@@ -31,7 +31,15 @@ import {
   type TestControllerStore,
   type TestControllerStoreFactory,
 } from '@adcp/sdk/testing';
-import { createTaskCapableServer, serve, type ServeContext } from '@adcp/sdk';
+import {
+  createTaskCapableServer,
+  serve,
+  isLegalMediaBuyTransition,
+  isLegalCreativeTransition,
+  MEDIA_BUY_TRANSITIONS,
+  CREATIVE_ASSET_TRANSITIONS,
+  type ServeContext,
+} from '@adcp/sdk';
 
 // ---------------------------------------------------------------------------
 // Typed domain state.
@@ -127,42 +135,9 @@ function resolveSessionId(input: Record<string, unknown>): string {
 }
 
 // ---------------------------------------------------------------------------
-// State-machine guards live HERE, in the same module your production tools
-// import. The controller routes through the same guards — one source of
-// truth for what transitions are legal. The tables cover every state in
-// the AdCP 3.0.0 status enums; TypeScript will catch a missing state if
-// you swap the `Partial<Record<...>>` signature for `Record<...>`.
+// State-machine guards use the canonical SDK helpers so the test controller
+// and production handlers share the same transition tables.
 // ---------------------------------------------------------------------------
-
-const MEDIA_BUY_TRANSITIONS: Record<MediaBuyStatus, MediaBuyStatus[]> = {
-  pending_creatives: ['pending_start', 'active', 'paused', 'rejected', 'canceled'],
-  pending_start: ['active', 'paused', 'canceled'],
-  active: ['paused', 'completed', 'canceled'],
-  paused: ['active', 'completed', 'canceled'],
-  completed: [],
-  rejected: [],
-  canceled: [],
-};
-
-const CREATIVE_TRANSITIONS: Record<CreativeStatus, CreativeStatus[]> = {
-  processing: ['pending_review', 'approved', 'rejected', 'archived'],
-  pending_review: ['approved', 'rejected', 'archived'],
-  approved: ['rejected', 'archived'],
-  rejected: ['approved', 'archived'],
-  archived: [],
-};
-
-function assertMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus): void {
-  if (!MEDIA_BUY_TRANSITIONS[from].includes(to)) {
-    throw new TestControllerError('INVALID_TRANSITION', `media buy cannot move from ${from} to ${to}`, from);
-  }
-}
-
-function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
-  if (!CREATIVE_TRANSITIONS[from].includes(to)) {
-    throw new TestControllerError('INVALID_TRANSITION', `creative cannot move from ${from} to ${to}`, from);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Per-request store factory.
@@ -226,7 +201,13 @@ const storeFactory: TestControllerStoreFactory = {
             `force_media_buy_status: ${mediaBuyId} not found — seed it first with seed_media_buy`
           );
         }
-        assertMediaBuyTransition(record.status, status);
+        if (!isLegalMediaBuyTransition(record.status, status)) {
+          throw new TestControllerError(
+            'INVALID_TRANSITION',
+            `media buy cannot move from ${record.status} to ${status}`,
+            record.status
+          );
+        }
         const previous = record.status;
         record.status = status;
         record.revision += 1;
@@ -255,7 +236,13 @@ const storeFactory: TestControllerStoreFactory = {
             `force_creative_status: ${creativeId} not found — seed it first with seed_creative`
           );
         }
-        assertCreativeTransition(record.status, status);
+        if (!isLegalCreativeTransition(record.status, status)) {
+          throw new TestControllerError(
+            'INVALID_TRANSITION',
+            `creative cannot move from ${record.status} to ${status}`,
+            record.status
+          );
+        }
         const previous = record.status;
         record.status = status;
         if (status === 'rejected' && rejectionReason) {
@@ -270,11 +257,11 @@ const storeFactory: TestControllerStoreFactory = {
 };
 
 function isMediaBuyStatus(value: unknown): value is MediaBuyStatus {
-  return typeof value === 'string' && value in MEDIA_BUY_TRANSITIONS;
+  return typeof value === 'string' && MEDIA_BUY_TRANSITIONS.has(value as MediaBuyStatus);
 }
 
 function isCreativeStatus(value: unknown): value is CreativeStatus {
-  return typeof value === 'string' && value in CREATIVE_TRANSITIONS;
+  return typeof value === 'string' && CREATIVE_ASSET_TRANSITIONS.has(value as CreativeStatus);
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -806,6 +806,7 @@ See [`examples/seller-test-controller.ts`](../../examples/seller-test-controller
 
 ```
 import { registerTestController, type TestControllerStore } from '@adcp/sdk/testing';
+import { isLegalMediaBuyTransition, isLegalCreativeTransition } from '@adcp/sdk';
 
 const store: TestControllerStore = {
   async forceAccountStatus(accountId, status) {
@@ -817,19 +818,16 @@ const store: TestControllerStore = {
   async forceMediaBuyStatus(mediaBuyId, status) {
     const prev = mediaBuys.get(mediaBuyId);
     if (!prev) throw new TestControllerError('NOT_FOUND', `Media buy ${mediaBuyId} not found`);
-    const terminal = ['completed', 'rejected', 'canceled'];
-    if (terminal.includes(prev))
-      throw new TestControllerError('INVALID_TRANSITION', `Cannot transition from ${prev}`, prev);
+    if (!isLegalMediaBuyTransition(prev, status))
+      throw new TestControllerError('INVALID_TRANSITION', `Cannot transition from ${prev} to ${status}`, prev);
     mediaBuys.set(mediaBuyId, status);
     return { success: true, previous_state: prev, current_state: status };
   },
   async forceCreativeStatus(creativeId, status, rejectionReason) {
     const prev = creatives.get(creativeId);
     if (!prev) throw new TestControllerError('NOT_FOUND', `Creative ${creativeId} not found`);
-    // archived blocks transitions to active states, but archived → rejected is valid (compliance override)
-    const activeStatuses = ['processing', 'pending_review', 'approved'];
-    if (prev === 'archived' && activeStatuses.includes(status))
-      throw new TestControllerError('INVALID_TRANSITION', `Cannot transition from archived to ${status}`, prev);
+    if (!isLegalCreativeTransition(prev, status))
+      throw new TestControllerError('INVALID_TRANSITION', `Cannot transition from ${prev} to ${status}`, prev);
     creatives.set(creativeId, status);
     return { success: true, previous_state: prev, current_state: status };
   },
@@ -845,12 +843,22 @@ const store: TestControllerStore = {
 registerTestController(server, store);
 ```
 
+For **production handlers** (`cancel_media_buy`, `update_media_buy`) use `assertMediaBuyTransition` from `@adcp/sdk/server` — it throws `AdcpError('NOT_CANCELLABLE')` for cancel-on-terminal and `AdcpError('INVALID_STATE')` for other illegal transitions, matching the error codes the storyboard runner expects:
+
+```ts
+import { assertMediaBuyTransition } from '@adcp/sdk/server';
+
+// inside cancel_media_buy handler:
+assertMediaBuyTransition(buy.status, 'canceled');
+// → throws NOT_CANCELLABLE if buy is already completed/rejected/canceled
+```
+
 `registerTestController` auto-emits the `capabilities.compliance_testing.scenarios` block per AdCP 3.0 — scenarios come from the factory's static list or are inferred from the plain store's method presence. Don't add `compliance_testing` to `supported_protocols`; per spec it's a capability block, not a protocol. Unimplemented methods are excluded from `list_scenarios` automatically.
 
 The storyboard tests state machine correctness:
 
 - `NOT_FOUND` when forcing transitions on unknown entities
-- `INVALID_TRANSITION` when transitioning from terminal states (completed, rejected, canceled for media buys; archived blocks active states like processing/pending_review/approved, but archived → rejected is valid)
+- `INVALID_TRANSITION` when the transition is illegal per the canonical SDK state machine (see `MEDIA_BUY_TRANSITIONS` / `CREATIVE_ASSET_TRANSITIONS` in `@adcp/sdk`)
 - Successful transitions between valid states
 
 Throw `TestControllerError` from store methods for typed errors. The SDK validates status enum values before calling your store.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -514,6 +514,7 @@ export type {
 } from './types/tools.generated';
 export type {
   AccountStatus,
+  CreativeApprovalStatus,
   CreativeStatus,
   DelegationAuthority,
   CatalogAction,
@@ -561,6 +562,15 @@ export {
   syncGovernanceResponse,
   reportUsageResponse,
   validActionsForStatus,
+  MEDIA_BUY_TRANSITIONS,
+  isLegalMediaBuyTransition,
+  assertMediaBuyTransition,
+  CREATIVE_ASSET_TRANSITIONS,
+  isLegalCreativeTransition,
+  assertCreativeTransition,
+  CREATIVE_APPROVAL_TRANSITIONS,
+  isLegalCreativeApprovalTransition,
+  assertCreativeApprovalTransition,
   taskToolResponse,
   registerAdcpTaskTool,
   createTaskCapableServer,

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -62,6 +62,18 @@ export { validActionsForStatus } from './media-buy-helpers';
 export type { ValidAction, CancelMediaBuyInput } from './media-buy-helpers';
 
 export {
+  MEDIA_BUY_TRANSITIONS,
+  isLegalMediaBuyTransition,
+  assertMediaBuyTransition,
+  CREATIVE_ASSET_TRANSITIONS,
+  isLegalCreativeTransition,
+  assertCreativeTransition,
+  CREATIVE_APPROVAL_TRANSITIONS,
+  isLegalCreativeApprovalTransition,
+  assertCreativeApprovalTransition,
+} from './state-machine';
+
+export {
   taskToolResponse,
   registerAdcpTaskTool,
   createTaskCapableServer,

--- a/src/lib/server/state-machine.ts
+++ b/src/lib/server/state-machine.ts
@@ -1,0 +1,177 @@
+/**
+ * Canonical AdCP state-machine transition maps for server-side enforcement.
+ *
+ * These maps are the single source of truth for which status transitions are
+ * legal. The conformance runner's `status.monotonic` invariant uses the same
+ * maps, so sellers who guard their handlers with `assertMediaBuyTransition` /
+ * `assertCreativeTransition` are guaranteed to agree with the runner.
+ *
+ * ## Usage in production handlers
+ *
+ * ```ts
+ * import { assertMediaBuyTransition, assertCreativeTransition } from '@adcp/sdk/server';
+ *
+ * // cancel_media_buy handler:
+ * assertMediaBuyTransition(buy.status, 'canceled');
+ * // → throws AdcpError('NOT_CANCELLABLE') if buy is already in a terminal state
+ * // → throws AdcpError('INVALID_STATE')   for any other illegal transition
+ *
+ * // update_media_buy handler (status change):
+ * assertMediaBuyTransition(buy.status, newStatus);
+ * ```
+ *
+ * ## Usage in test controllers
+ *
+ * Test controllers throw `TestControllerError`, not `AdcpError`. Use the
+ * boolean predicate `isLegalMediaBuyTransition` and throw `TestControllerError`
+ * yourself:
+ *
+ * ```ts
+ * import { isLegalMediaBuyTransition } from '@adcp/sdk/server';
+ * import { TestControllerError } from '@adcp/sdk/testing';
+ *
+ * if (!isLegalMediaBuyTransition(prev, status))
+ *   throw new TestControllerError('INVALID_TRANSITION', `${prev} → ${status}`, prev);
+ * ```
+ */
+
+import { AdcpError } from './decisioning/async-outcome';
+import type { MediaBuyStatus, CreativeStatus, CreativeApprovalStatus } from '../types/core.generated';
+
+// ---------------------------------------------------------------------------
+// MediaBuy state machine
+// ---------------------------------------------------------------------------
+
+/**
+ * Legal MediaBuy status transitions per AdCP 3.0.
+ *
+ * `active ↔ paused` is reversible. `completed | rejected | canceled` are
+ * terminal — no outbound edges.
+ *
+ * Note: `pending_start → rejected` is defensible but not explicit in the
+ * schema prose — `rejected` is described as "declined by the seller after
+ * creation", which is ambiguous on whether post-start rejection is in scope.
+ * Kept for now; flagged in adcp#3121 for spec clarification.
+ */
+export const MEDIA_BUY_TRANSITIONS: ReadonlyMap<MediaBuyStatus, ReadonlySet<MediaBuyStatus>> = new Map<
+  MediaBuyStatus,
+  ReadonlySet<MediaBuyStatus>
+>([
+  ['pending_creatives', new Set<MediaBuyStatus>(['pending_start', 'active', 'paused', 'canceled', 'rejected'])],
+  ['pending_start', new Set<MediaBuyStatus>(['active', 'paused', 'canceled', 'rejected'])],
+  ['active', new Set<MediaBuyStatus>(['paused', 'completed', 'canceled'])],
+  ['paused', new Set<MediaBuyStatus>(['active', 'completed', 'canceled'])],
+  ['completed', new Set<MediaBuyStatus>()],
+  ['rejected', new Set<MediaBuyStatus>()],
+  ['canceled', new Set<MediaBuyStatus>()],
+]);
+
+/** Returns `true` if the `from → to` MediaBuy transition is legal. */
+export function isLegalMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus): boolean {
+  return MEDIA_BUY_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+/**
+ * Asserts that the `from → to` MediaBuy transition is legal.
+ *
+ * Throws `AdcpError` on failure:
+ * - `NOT_CANCELLABLE` — `to` is `'canceled'` but `from` is a terminal state
+ *   (the buy is already completed, rejected, or canceled)
+ * - `INVALID_STATE` — any other illegal transition
+ *
+ * For test-controller methods (which must throw `TestControllerError`), use
+ * `isLegalMediaBuyTransition` + `TestControllerError` instead.
+ */
+export function assertMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus): void {
+  if (isLegalMediaBuyTransition(from, to)) return;
+  if (to === 'canceled') {
+    throw new AdcpError('NOT_CANCELLABLE', {
+      message: `Media buy cannot be canceled; it is already in a terminal state ('${from}').`,
+    });
+  }
+  throw new AdcpError('INVALID_STATE', {
+    message: `Illegal media buy transition: '${from}' → '${to}'.`,
+    field: 'status',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Creative asset state machine
+// ---------------------------------------------------------------------------
+
+/**
+ * Legal CreativeAsset status transitions per AdCP 3.0.
+ *
+ * Key edges:
+ * - `processing` only advances to `pending_review` (success) or `rejected`
+ *   (processing failure) — no direct `processing → approved` edge.
+ * - `rejected` is recoverable: buyer re-submits via `sync_creatives`, which
+ *   moves the creative back to `processing` or directly to `pending_review`.
+ * - `approved ↔ archived` is reversible (buyer archives / unarchives).
+ */
+export const CREATIVE_ASSET_TRANSITIONS: ReadonlyMap<CreativeStatus, ReadonlySet<CreativeStatus>> = new Map<
+  CreativeStatus,
+  ReadonlySet<CreativeStatus>
+>([
+  ['processing', new Set<CreativeStatus>(['pending_review', 'rejected'])],
+  ['pending_review', new Set<CreativeStatus>(['approved', 'rejected'])],
+  ['approved', new Set<CreativeStatus>(['archived', 'rejected'])],
+  ['archived', new Set<CreativeStatus>(['approved'])],
+  ['rejected', new Set<CreativeStatus>(['processing', 'pending_review'])],
+]);
+
+/** Returns `true` if the `from → to` CreativeAsset transition is legal. */
+export function isLegalCreativeTransition(from: CreativeStatus, to: CreativeStatus): boolean {
+  return CREATIVE_ASSET_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+/**
+ * Asserts that the `from → to` CreativeAsset transition is legal.
+ * Throws `AdcpError('INVALID_STATE')` on failure.
+ *
+ * For test-controller methods, use `isLegalCreativeTransition` +
+ * `TestControllerError` instead.
+ */
+export function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
+  if (isLegalCreativeTransition(from, to)) return;
+  throw new AdcpError('INVALID_STATE', {
+    message: `Illegal creative asset transition: '${from}' → '${to}'.`,
+    field: 'status',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Creative approval state machine (per-package assignment approval_status)
+// ---------------------------------------------------------------------------
+
+/**
+ * Legal CreativeApproval status transitions per AdCP 3.0.
+ *
+ * Per-assignment approval state on a package. `rejected → pending_review`
+ * is allowed on re-sync.
+ */
+export const CREATIVE_APPROVAL_TRANSITIONS: ReadonlyMap<
+  CreativeApprovalStatus,
+  ReadonlySet<CreativeApprovalStatus>
+> = new Map<CreativeApprovalStatus, ReadonlySet<CreativeApprovalStatus>>([
+  ['pending_review', new Set<CreativeApprovalStatus>(['approved', 'rejected'])],
+  ['approved', new Set<CreativeApprovalStatus>(['rejected'])],
+  ['rejected', new Set<CreativeApprovalStatus>(['pending_review'])],
+]);
+
+/** Returns `true` if the `from → to` CreativeApproval transition is legal. */
+export function isLegalCreativeApprovalTransition(from: CreativeApprovalStatus, to: CreativeApprovalStatus): boolean {
+  return CREATIVE_APPROVAL_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+/**
+ * Asserts that the `from → to` CreativeApproval transition is legal.
+ * Throws `AdcpError('INVALID_STATE')` on failure.
+ */
+export function assertCreativeApprovalTransition(from: CreativeApprovalStatus, to: CreativeApprovalStatus): void {
+  if (isLegalCreativeApprovalTransition(from, to)) return;
+  throw new AdcpError('INVALID_STATE', {
+    message: `Illegal creative approval transition: '${from}' → '${to}'.`,
+    field: 'approval_status',
+  });
+}

--- a/src/lib/server/state-machine.ts
+++ b/src/lib/server/state-machine.ts
@@ -75,18 +75,25 @@ export function isLegalMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStat
  * Asserts that the `from → to` MediaBuy transition is legal.
  *
  * Throws `AdcpError` on failure:
- * - `NOT_CANCELLABLE` — `to` is `'canceled'` but `from` is a terminal state
- *   (the buy is already completed, rejected, or canceled)
- * - `INVALID_STATE` — any other illegal transition
+ * - `NOT_CANCELLABLE` — re-cancel of an already-canceled buy (`from === 'canceled'`);
+ *   matches the storyboard `media_buy_seller/invalid_transitions/second_cancel`
+ * - `INVALID_STATE` — any other illegal transition (including `completed → canceled`
+ *   and `rejected → canceled`)
  *
  * For test-controller methods (which must throw `TestControllerError`), use
  * `isLegalMediaBuyTransition` + `TestControllerError` instead.
  */
 export function assertMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus): void {
   if (isLegalMediaBuyTransition(from, to)) return;
-  if (to === 'canceled') {
+  // Re-cancel of an already-canceled buy: the spec explicitly names this case
+  // with NOT_CANCELLABLE ("cannot be canceled in its current state"). The storyboard
+  // `media_buy_seller/invalid_transitions/second_cancel` asserts this code.
+  // All other illegal transitions — including completed → canceled and
+  // rejected → canceled — use INVALID_STATE per the manifest example
+  // ("updating a completed or canceled media buy").
+  if (from === 'canceled' && to === 'canceled') {
     throw new AdcpError('NOT_CANCELLABLE', {
-      message: `Media buy cannot be canceled; it is already in a terminal state ('${from}').`,
+      message: `Media buy is already canceled; 'canceled' is a terminal state.`,
     });
   }
   throw new AdcpError('INVALID_STATE', {

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -35,6 +35,11 @@
 
 import { ADCP_VERSION } from '../../version';
 import { CONFLICT_ADCP_ERROR_ALLOWLIST } from '../../server/envelope-allowlist';
+import {
+  MEDIA_BUY_TRANSITIONS as MEDIA_BUY_GRAPH,
+  CREATIVE_ASSET_TRANSITIONS as CREATIVE_ASSET_GRAPH,
+  CREATIVE_APPROVAL_TRANSITIONS as CREATIVE_APPROVAL_GRAPH,
+} from '../../server/state-machine';
 import { registerAssertion } from './assertions';
 
 // Register only once per process. `registerAssertion` throws on duplicates —
@@ -536,58 +541,21 @@ function buildEnumSchemaUrl(enumFile: string): string {
   return `${SCHEMA_URL_BASE}/schemas/${ADCP_VERSION}/enums/${enumFile}`;
 }
 
+// Canonical transition maps are defined in `../../server/state-machine` and
+// re-used here so the runner and production handlers share the same source of
+// truth. See that module for edge-by-edge spec citations.
 const MEDIA_BUY_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/media-buy-status.json`. `active ↔ paused`
-  // is reversible (buyer pauses, seller resumes). `completed | rejected |
-  // canceled` are terminal.
-  //
-  // NOTE: `pending_start → rejected` is defensible but not explicit in the
-  // schema prose — rejected is described as "declined by the seller after
-  // creation", which is ambiguous on whether post-start rejection is in
-  // scope. Kept for now; flagged for spec clarification.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['pending_creatives', new Set(['pending_start', 'active', 'paused', 'canceled', 'rejected'])],
-    ['pending_start', new Set(['active', 'paused', 'canceled', 'rejected'])],
-    ['active', new Set(['paused', 'completed', 'canceled'])],
-    ['paused', new Set(['active', 'completed', 'canceled'])],
-    ['completed', new Set()],
-    ['rejected', new Set()],
-    ['canceled', new Set()],
-  ]),
+  transitions: MEDIA_BUY_GRAPH as ReadonlyMap<string, ReadonlySet<string>>,
   enumFile: 'media-buy-status.json',
 };
 
 const CREATIVE_ASSET_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/creative-status.json`. The schema is
-  // explicit on which edges exist:
-  //   - processing: "Automatically transitions to pending_review when
-  //     processing completes, or to rejected if processing fails." → no
-  //     direct `processing → approved` edge.
-  //   - pending_review: "Transitions to approved or rejected after review."
-  //     → no `pending_review → processing` edge.
-  //   - rejected: "Buyer can re-submit by calling sync_creatives again,
-  //     which moves the creative back to processing." → the re-sync path.
-  //   - approved ↔ archived is reversible (buyer archives / unarchives).
-  // No terminals — everything can recover via re-sync.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['processing', new Set(['pending_review', 'rejected'])],
-    ['pending_review', new Set(['approved', 'rejected'])],
-    ['approved', new Set(['archived', 'rejected'])],
-    ['archived', new Set(['approved'])],
-    ['rejected', new Set(['processing', 'pending_review'])],
-  ]),
+  transitions: CREATIVE_ASSET_GRAPH as ReadonlyMap<string, ReadonlySet<string>>,
   enumFile: 'creative-status.json',
 };
 
 const CREATIVE_APPROVAL_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/creative-approval-status.json`.
-  // Per-assignment approval state on a package. `rejected → pending_review`
-  // is allowed on re-sync.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['pending_review', new Set(['approved', 'rejected'])],
-    ['approved', new Set(['rejected'])],
-    ['rejected', new Set(['pending_review'])],
-  ]),
+  transitions: CREATIVE_APPROVAL_GRAPH as ReadonlyMap<string, ReadonlySet<string>>,
   enumFile: 'creative-approval-status.json',
 };
 


### PR DESCRIPTION
Closes #1416

## Summary

Exports the canonical AdCP state-machine transition maps from `@adcp/sdk/server` so sellers don't copy-paste the graph (three examples already had diverged copies). The conformance runner's `status.monotonic` invariant uses the same maps, so sellers who guard handlers with `assertMediaBuyTransition` are guaranteed to agree with the storyboard runner.

**New public exports (available from both `@adcp/sdk` and `@adcp/sdk/server`):**

| Symbol | Purpose |
|---|---|
| `MEDIA_BUY_TRANSITIONS` | `ReadonlyMap<MediaBuyStatus, ReadonlySet<MediaBuyStatus>>` |
| `isLegalMediaBuyTransition(from, to)` | boolean predicate |
| `assertMediaBuyTransition(from, to)` | throws `NOT_CANCELLABLE` (re-cancel) or `INVALID_STATE` |
| `CREATIVE_ASSET_TRANSITIONS` | `ReadonlyMap<CreativeStatus, ReadonlySet<CreativeStatus>>` |
| `isLegalCreativeTransition(from, to)` | boolean predicate |
| `assertCreativeTransition(from, to)` | throws `INVALID_STATE` |
| `CREATIVE_APPROVAL_TRANSITIONS` | `ReadonlyMap<CreativeApprovalStatus, ReadonlySet<CreativeApprovalStatus>>` |
| `isLegalCreativeApprovalTransition(from, to)` | boolean predicate |
| `assertCreativeApprovalTransition(from, to)` | throws `INVALID_STATE` |

`CreativeApprovalStatus` is also newly exported from the root barrel.

**Error code semantics for `assertMediaBuyTransition`:**
- `NOT_CANCELLABLE` (recovery: correctable) — only for `canceled → canceled` re-cancel; matches storyboard `media_buy_seller/invalid_transitions/second_cancel`
- `INVALID_STATE` — all other illegal transitions including `completed → canceled` and `rejected → canceled` (per manifest example: "updating a completed or canceled media buy")

**Structural change:** `src/lib/testing/storyboard/default-invariants.ts` now imports the three exported maps from `server/state-machine.ts` instead of maintaining its own copies. Import direction is `testing → server`, which already existed via `server/envelope-allowlist`. No circular dependency.

**Examples updated:** `seller-test-controller.ts` and `comply-controller-seller.ts` replace inline copy-pasted tables with SDK imports. `skills/build-seller-agent/SKILL.md` updates the test-controller sketch and adds a production-handler code sample.

## What was tested

- `npm run format:check` — clean
- `npm run typecheck` — 2 pre-existing tsconfig warnings only, no new errors (verified by stash comparison)
- `npx vitest run` — same pass/fail as `main` (all failures are pre-existing `dist/` not-built integration tests)

## Pre-PR review

- **code-reviewer:** approved — no blockers; flagged shadow naming (fixed: `assertCreativeTransition` → `requireLegalCreativeTransition` in comply example) and noted absence of unit tests for `state-machine.ts` (pre-existing low test density pattern; tracked separately)
- **ad-tech-protocol-expert:** approved with one blocker addressed — initial `NOT_CANCELLABLE` scope was too broad (`to === 'canceled'`); tightened to `from === 'canceled' && to === 'canceled'` only, per spec manifest distinction between "cannot be canceled" and "wrong lifecycle state"

**Nit noted but not fixed (deferred):** `TransitionGraph`-wrapped local variable names in `default-invariants.ts` shadow the import aliases — cosmetic only, no runtime impact; can be addressed in a follow-up.

**Out of scope for this PR:** `ACCOUNT_TRANSITIONS`, `SI_SESSION_TRANSITIONS`, `CATALOG_ITEM_TRANSITIONS`, `PROPOSAL_TRANSITIONS`, `AUDIENCE_TRANSITIONS` — specialized specialisms, low immediate impact. `state-machine.ts` unit tests — pre-existing low test density; should be added in a dedicated test PR.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Dd2cvBgL7mZiLFHqTMb7pj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dd2cvBgL7mZiLFHqTMb7pj)_