### PR TITLE
feat(server): createMediaBuyStore — opt-in targeting_overlay echo (#1415)

### DIFF
--- a/.changeset/media-buy-store-targeting-overlay-echo.md
+++ b/.changeset/media-buy-store-targeting-overlay-echo.md
@@ -1,0 +1,35 @@
+---
+"@adcp/sdk": minor
+---
+
+`createMediaBuyStore` + `mediaBuyStore` option — opt-in framework support for the `packages[].targeting_overlay` echo contract on `get_media_buys`.
+
+Per `schemas/cache/3.0.5/media-buy/get-media-buys-response.json`, sellers SHOULD echo persisted targeting overlays so buyers can verify what was stored without replaying their own request. Sellers claiming `property-lists` or `collection-lists` MUST include the persisted `PropertyListReference` / `CollectionListReference` inside the echoed `targeting_overlay`. Pre-this-release, satisfying the contract meant every adapter persisted + merged + echoed by hand — `examples/hello_seller_adapter_guaranteed.ts` shipped without the wiring and any fork inherited a silent storyboard failure on `media_buy_seller/inventory_list_targeting/get_after_create`.
+
+```ts
+import {
+  createAdcpServerFromPlatform,
+  createMediaBuyStore,
+  InMemoryStateStore,
+} from '@adcp/sdk/server';
+
+const stateStore = new InMemoryStateStore();
+
+createAdcpServerFromPlatform(myPlatform, {
+  mediaBuyStore: createMediaBuyStore({ store: stateStore }),
+});
+```
+
+When wired, the framework:
+
+- Persists `packages[].targeting_overlay` from `create_media_buy` requests, joined with the seller-assigned `package_id` (or `buyer_ref` when supplied). Persistence runs in the createMediaBuy projection, so it covers both the sync arm and the HITL completion arm.
+- On `get_media_buys`, backfills missing `packages[].targeting_overlay` from the store. Packages the seller already echoed are left untouched.
+- On `update_media_buy`, deep-merges the patched overlay against the prior persisted overlay: omitted keys keep prior, non-null values replace, explicit `null` clears. `new_packages[]` are persisted as fresh entries.
+
+Backed by any `AdcpStateStore` — `InMemoryStateStore` for development, `PostgresStateStore` for production. Account-scoped per-tenant via `scopedStore`. Failures are logged + swallowed: a successful seller response is never turned into an error by the auto-echo plumbing.
+
+`hello_seller_adapter_guaranteed.ts` now wires `mediaBuyStore` by default — every fork inherits the echo contract for free.
+
+Removes four stale `UPSTREAM_SCHEMA_DRIFT` suppressors in `test/lib/storyboard-drift.test.js`. The cited `adcontextprotocol/adcp#2488` was resolved by the AdCP 3.0 GA schema update — `PackageStatus.targeting_overlay` is present on the wire response shape, so the storyboard assertions are now valid and the SDK is positioned to satisfy them.
+
+Closes #1415.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -47,6 +47,8 @@
 
 import {
   createAdcpServerFromPlatform,
+  createMediaBuyStore,
+  InMemoryStateStore,
   serve,
   verifyApiKey,
   createIdempotencyStore,
@@ -995,6 +997,15 @@ const simulatedDelivery = new Map<
 >();
 // ─── /TEST-ONLY ──────────────────────────────────────────────────────────
 
+// Persist `packages[].targeting_overlay` from create_media_buy and echo it
+// on get_media_buys. The seller spec MANDATES this echo for any seller
+// claiming property-lists / collection-lists, and SHOULD echo any persisted
+// targeting regardless. SWAP `InMemoryStateStore` for `PostgresStateStore`
+// in production — in-memory loss after restart silently strips the echo
+// from buyers who created buys before the bounce.
+const stateStore = new InMemoryStateStore();
+const mediaBuyStore = createMediaBuyStore({ store: stateStore });
+
 serve(
   ({ taskStore }) =>
     createAdcpServerFromPlatform(platform, {
@@ -1002,6 +1013,7 @@ serve(
       version: '1.0.0',
       taskStore,
       idempotency: idempotencyStore,
+      mediaBuyStore,
       resolveSessionKey: ctx => {
         const acct = ctx.account as Account<NetworkMeta> | undefined;
         return acct?.id ?? 'anonymous';

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3234,6 +3234,15 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
               allowPrivateWebhookUrls: pushOpts.allowPrivateWebhookUrls,
             });
             const result = await sales.updateMediaBuy!(media_buy_id, params, reqCtx);
+            // Persist optimistically: the platform method returned without
+            // throwing, so the patch was accepted at the seam. If the
+            // publisher returned an error envelope on the success path
+            // (rare but possible — `update_media_buy` can return a Failed
+            // status arm in the wire schema), the persisted overlay
+            // diverges from the seller's view of the buy. Adopters who
+            // need stricter coupling should not return error-shaped
+            // success arms; the spec's preferred shape is to throw an
+            // `AdcpError` for genuine failures.
             await persistTargetingOverlayFromUpdate(mediaBuyStore, reqCtx.account?.id, media_buy_id, params, logger);
             // F12 sync auto-emit. updateMediaBuy is sync-only on the
             // platform interface (no TaskHandoff arm — spec response

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -102,6 +102,13 @@ import {
 } from '../../ctx-metadata';
 import { createIdempotencyStore, type IdempotencyStore } from '../../idempotency';
 import { pgBackend, getIdempotencyMigration } from '../../idempotency/backends/pg';
+import type {
+  MediaBuyStore,
+  CreateMediaBuyInputForStore,
+  CreateMediaBuyResultForStore,
+  UpdateMediaBuyInputForStore,
+  GetMediaBuysResultForStore,
+} from '../../media-buy-store';
 import { createPostgresTaskRegistry, getDecisioningTaskRegistryMigration } from './postgres-task-registry';
 import type { PgQueryable } from '../../postgres-task-store';
 import { isTaskHandoff, _extractTaskFn, type TaskHandoff } from '../async-outcome';
@@ -512,6 +519,40 @@ export interface CreateAdcpServerFromPlatformOptions extends Omit<
    * @see docs/proposals/decisioning-platform-v6-1-ctx-metadata.md
    */
   ctxMetadata?: CtxMetadataStore;
+
+  /**
+   * Opinionated media-buy store that satisfies the seller spec contract for
+   * `targeting_overlay` echo: persist `packages[].targeting_overlay` from
+   * `create_media_buy`, echo it on `get_media_buys`, deep-merge across
+   * `update_media_buy` without dropping prior `property_list` /
+   * `collection_list` references.
+   *
+   * Wire to honor the
+   * `schemas/cache/<v>/media-buy/get-media-buys-response.json` contract
+   * without each adapter persisting + merging by hand. Sellers claiming
+   * `property-lists` / `collection-lists` MUST echo the persisted refs;
+   * `mediaBuyStore` is the framework-side way to do it.
+   *
+   * Backed by any `AdcpStateStore` — `InMemoryStateStore` for dev,
+   * `PostgresStateStore` for production. Failures are logged and swallowed
+   * (auto-echo MUST NOT break a successful seller response).
+   *
+   * @example
+   * ```ts
+   * import {
+   *   createAdcpServerFromPlatform,
+   *   createMediaBuyStore,
+   *   InMemoryStateStore,
+   * } from '@adcp/sdk/server';
+   *
+   * const stateStore = new InMemoryStateStore();
+   *
+   * createAdcpServerFromPlatform(myPlatform, {
+   *   mediaBuyStore: createMediaBuyStore({ store: stateStore }),
+   * });
+   * ```
+   */
+  mediaBuyStore?: MediaBuyStore;
 
   /**
    * Allow `push_notification_config.url` to point at loopback / private-IP
@@ -1178,7 +1219,8 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           autoEmitCompletionWebhooks: opts.autoEmitCompletionWebhooks !== false,
         },
         ctxFor,
-        effectiveCtxMetadata
+        effectiveCtxMetadata,
+        opts.mediaBuyStore
       ),
       'mediaBuy',
       mergeOpts
@@ -1992,7 +2034,7 @@ async function routeIfHandoff<TInner, TWire>(
   taskRegistry: TaskRegistry,
   opts: DispatchHitlOpts,
   result: TInner | TaskHandoff<TInner>,
-  project: (inner: TInner) => TWire
+  project: (inner: TInner) => TWire | Promise<TWire>
 ): Promise<TWire | SubmittedEnvelope> {
   if (isTaskHandoff<TInner>(result)) {
     const taskFn = _extractTaskFn(result);
@@ -2001,11 +2043,11 @@ async function routeIfHandoff<TInner, TWire>(
       // but didn't go through ctx.handoffToTask. Treat as a sync
       // success arm with an empty body (caller-supplied projection
       // shapes the result; this branch is defensive).
-      return project(result as unknown as TInner);
+      return await project(result as unknown as TInner);
     }
     return dispatchHitl(taskRegistry, opts, async taskId => {
       const inner = await taskFn(buildHandoffContext(taskRegistry, taskId));
-      return project(inner);
+      return await project(inner);
     });
   }
   // Catch the most common LLM-scaffolded mistake: hand-rolling a
@@ -2031,7 +2073,7 @@ async function routeIfHandoff<TInner, TWire>(
         `never registered.`
     );
   }
-  const projected = project(result);
+  const projected = await project(result);
   if (opts.autoEmitCompletion === true && opts.pushNotificationUrl) {
     // Auto-emit completion webhook on sync-success arm — fire-and-forget.
     // Awaiting inline would let an attacker-controlled
@@ -2472,6 +2514,85 @@ async function autoStoreResources(
         `record(s) missing required '${idField}' — buyers will not be able ` +
         `to reference these resources on a subsequent mutating call.`
     );
+  }
+}
+
+/**
+ * Persist `packages[].targeting_overlay` from a successful
+ * `create_media_buy`. Called from the createMediaBuy projection so the
+ * persistence applies to both the sync arm and the HITL completion arm
+ * (the projection runs after the handoff fn resolves).
+ *
+ * Failures are logged + swallowed: a successful seller response must
+ * never be turned into an error by the auto-echo plumbing.
+ */
+async function persistTargetingOverlayFromCreate(
+  store: MediaBuyStore | undefined,
+  accountId: string | undefined,
+  request: unknown,
+  result: unknown,
+  logger: AdcpLogger
+): Promise<void> {
+  if (!store || !accountId) return;
+  if (result == null || typeof result !== 'object') return;
+  try {
+    await store.persistFromCreate(
+      accountId,
+      request as CreateMediaBuyInputForStore,
+      result as CreateMediaBuyResultForStore
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[adcp/decisioning] mediaBuyStore.persistFromCreate failed: ${msg}`);
+  }
+}
+
+/**
+ * Apply an `update_media_buy` patch to the persisted media-buy store.
+ * Per-field merge inside `targeting_overlay`: omitted keeps prior,
+ * present-non-null replaces, present-null clears.
+ *
+ * Failures are logged + swallowed for the same reason as the create
+ * path — the seller's update succeeded; auto-merge is best-effort.
+ */
+async function persistTargetingOverlayFromUpdate(
+  store: MediaBuyStore | undefined,
+  accountId: string | undefined,
+  mediaBuyId: string,
+  patch: unknown,
+  logger: AdcpLogger
+): Promise<void> {
+  if (!store || !accountId) return;
+  try {
+    await store.mergeFromUpdate(accountId, mediaBuyId, patch as UpdateMediaBuyInputForStore);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[adcp/decisioning] mediaBuyStore.mergeFromUpdate failed: ${msg}`);
+  }
+}
+
+/**
+ * Backfill missing `packages[].targeting_overlay` on a `get_media_buys`
+ * response from the persisted store. Mutates the response. Packages the
+ * seller already echoed are left alone.
+ *
+ * Failures are logged + swallowed: a partial-echo response is strictly
+ * better than a hard error wiping out the seller's correctly-returned
+ * media-buy data.
+ */
+async function backfillTargetingOverlay(
+  store: MediaBuyStore | undefined,
+  accountId: string | undefined,
+  result: unknown,
+  logger: AdcpLogger
+): Promise<void> {
+  if (!store || !accountId) return;
+  if (result == null || typeof result !== 'object') return;
+  try {
+    await store.backfill(accountId, result as GetMediaBuysResultForStore);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(`[adcp/decisioning] mediaBuyStore.backfill failed: ${msg}`);
   }
 }
 
@@ -3004,7 +3125,8 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
   logger: AdcpLogger,
   pushOpts: { allowPrivateWebhookUrls: boolean; autoEmitCompletionWebhooks: boolean },
   ctxFor: CtxForFn,
-  ctxMetadataStore: CtxMetadataStore | undefined
+  ctxMetadataStore: CtxMetadataStore | undefined,
+  mediaBuyStore: MediaBuyStore | undefined
 ): MediaBuyHandlers<Account> | undefined {
   const sales = platform.sales;
   if (!sales) return undefined;
@@ -3076,7 +3198,10 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
                 logger,
               },
               result,
-              r => r // identity projection for createMediaBuy
+              async r => {
+                await persistTargetingOverlayFromCreate(mediaBuyStore, reqCtx.account?.id, params, r, logger);
+                return r;
+              }
             );
           },
           r => r
@@ -3109,6 +3234,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
               allowPrivateWebhookUrls: pushOpts.allowPrivateWebhookUrls,
             });
             const result = await sales.updateMediaBuy!(media_buy_id, params, reqCtx);
+            await persistTargetingOverlayFromUpdate(mediaBuyStore, reqCtx.account?.id, media_buy_id, params, logger);
             // F12 sync auto-emit. updateMediaBuy is sync-only on the
             // platform interface (no TaskHandoff arm — spec response
             // doesn't include Submitted), so we don't route through
@@ -3220,6 +3346,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
               'media_buy_id',
               logger
             );
+            await backfillTargetingOverlay(mediaBuyStore, reqCtx.account?.id, result, logger);
             return result;
           },
           r => r

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -61,6 +61,16 @@ export type { McpToolResponse } from './responses';
 export { validActionsForStatus } from './media-buy-helpers';
 export type { ValidAction, CancelMediaBuyInput } from './media-buy-helpers';
 
+export { createMediaBuyStore, DEFAULT_MEDIA_BUY_STORE_COLLECTION } from './media-buy-store';
+export type {
+  MediaBuyStore,
+  CreateMediaBuyStoreOptions,
+  CreateMediaBuyInputForStore,
+  CreateMediaBuyResultForStore,
+  UpdateMediaBuyInputForStore,
+  GetMediaBuysResultForStore,
+} from './media-buy-store';
+
 export {
   taskToolResponse,
   registerAdcpTaskTool,

--- a/src/lib/server/media-buy-store.test.ts
+++ b/src/lib/server/media-buy-store.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'vitest';
+import { createMediaBuyStore, type MediaBuyStore } from './media-buy-store';
+import { InMemoryStateStore } from './state-store';
+import type { TargetingOverlay } from '../types/core.generated';
+
+function setup(): { store: MediaBuyStore; backing: InMemoryStateStore } {
+  const backing = new InMemoryStateStore();
+  return { store: createMediaBuyStore({ store: backing }), backing };
+}
+
+const PROPERTY_LIST: TargetingOverlay['property_list'] = {
+  list_id: 'acme_outdoor_allowlist_v1',
+  agent_url: 'https://lists.example.com',
+};
+
+const COLLECTION_LIST: TargetingOverlay['collection_list'] = {
+  list_id: 'sports_collections_v3',
+  agent_url: 'https://lists.example.com',
+};
+
+describe('createMediaBuyStore — persistFromCreate + backfill', () => {
+  it('persists targeting_overlay from request and echoes it on get', async () => {
+    const { store } = setup();
+    await store.persistFromCreate(
+      'acct_a',
+      {
+        packages: [
+          {
+            buyer_ref: 'pkg_a',
+            targeting_overlay: { property_list: PROPERTY_LIST, collection_list: COLLECTION_LIST },
+          },
+        ],
+      },
+      {
+        media_buy_id: 'mb_1',
+        packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }],
+      }
+    );
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual({
+      property_list: PROPERTY_LIST,
+      collection_list: COLLECTION_LIST,
+    });
+  });
+
+  it('falls back to positional matching when buyer_ref is absent', async () => {
+    const { store } = setup();
+    await store.persistFromCreate(
+      'acct_a',
+      {
+        packages: [{ targeting_overlay: { property_list: PROPERTY_LIST } }],
+      },
+      {
+        media_buy_id: 'mb_1',
+        packages: [{ package_id: 'seller_pkg_001' }],
+      }
+    );
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual({
+      property_list: PROPERTY_LIST,
+    });
+  });
+
+  it('does not overwrite a targeting_overlay the seller already echoed', async () => {
+    const { store } = setup();
+    const sellerEchoed: TargetingOverlay = { geo_countries: ['US'] };
+
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg_a', targeting_overlay: { property_list: PROPERTY_LIST } }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }] }
+    );
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [
+        {
+          media_buy_id: 'mb_1',
+          packages: [{ package_id: 'seller_pkg_001', targeting_overlay: sellerEchoed }],
+        },
+      ],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toBe(sellerEchoed);
+  });
+
+  it('account-scopes records — same media_buy_id in different accounts does not collide', async () => {
+    const { store } = setup();
+    const overlayA: TargetingOverlay = { property_list: PROPERTY_LIST };
+    const overlayB: TargetingOverlay = { collection_list: COLLECTION_LIST };
+
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg', targeting_overlay: overlayA }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg' }] }
+    );
+    await store.persistFromCreate(
+      'acct_b',
+      { packages: [{ buyer_ref: 'pkg', targeting_overlay: overlayB }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg' }] }
+    );
+
+    const a = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+    const b = await store.backfill('acct_b', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(a.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual(overlayA);
+    expect(b.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual(overlayB);
+  });
+});
+
+describe('createMediaBuyStore — mergeFromUpdate', () => {
+  it('preserves prior fields when patch omits them', async () => {
+    const { store } = setup();
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg_a', targeting_overlay: { property_list: PROPERTY_LIST } }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }] }
+    );
+
+    await store.mergeFromUpdate('acct_a', 'mb_1', {
+      packages: [
+        {
+          package_id: 'seller_pkg_001',
+          targeting_overlay: { collection_list: COLLECTION_LIST },
+        },
+      ],
+    });
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual({
+      property_list: PROPERTY_LIST,
+      collection_list: COLLECTION_LIST,
+    });
+  });
+
+  it('clears a field when patch sets it to null', async () => {
+    const { store } = setup();
+    await store.persistFromCreate(
+      'acct_a',
+      {
+        packages: [
+          {
+            buyer_ref: 'pkg_a',
+            targeting_overlay: { property_list: PROPERTY_LIST, collection_list: COLLECTION_LIST },
+          },
+        ],
+      },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }] }
+    );
+
+    await store.mergeFromUpdate('acct_a', 'mb_1', {
+      packages: [
+        {
+          package_id: 'seller_pkg_001',
+          targeting_overlay: { property_list: null as unknown as TargetingOverlay['property_list'] },
+        },
+      ],
+    });
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual({
+      collection_list: COLLECTION_LIST,
+    });
+  });
+
+  it('does not modify the persisted overlay when patch omits targeting_overlay key entirely', async () => {
+    const { store } = setup();
+    const overlay: TargetingOverlay = { property_list: PROPERTY_LIST };
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg_a', targeting_overlay: overlay }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }] }
+    );
+
+    await store.mergeFromUpdate('acct_a', 'mb_1', {
+      packages: [{ package_id: 'seller_pkg_001' }],
+    });
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual(overlay);
+  });
+
+  it('clears the entire overlay when patch sets targeting_overlay to null', async () => {
+    const { store } = setup();
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg_a', targeting_overlay: { property_list: PROPERTY_LIST } }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }] }
+    );
+
+    await store.mergeFromUpdate('acct_a', 'mb_1', {
+      packages: [{ package_id: 'seller_pkg_001', targeting_overlay: null }],
+    });
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toBeUndefined();
+  });
+
+  it('persists new_packages from update_media_buy', async () => {
+    const { store } = setup();
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg_a', targeting_overlay: { property_list: PROPERTY_LIST } }] },
+      { media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a' }] }
+    );
+
+    await store.mergeFromUpdate('acct_a', 'mb_1', {
+      new_packages: [
+        {
+          package_id: 'seller_pkg_002',
+          buyer_ref: 'pkg_b',
+          targeting_overlay: { collection_list: COLLECTION_LIST },
+        },
+      ],
+    });
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [
+        {
+          media_buy_id: 'mb_1',
+          packages: [{ package_id: 'seller_pkg_001' }, { package_id: 'seller_pkg_002' }],
+        },
+      ],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual({
+      property_list: PROPERTY_LIST,
+    });
+    expect(result.media_buys?.[0]?.packages?.[1]?.targeting_overlay).toEqual({
+      collection_list: COLLECTION_LIST,
+    });
+  });
+});

--- a/src/lib/server/media-buy-store.ts
+++ b/src/lib/server/media-buy-store.ts
@@ -71,6 +71,7 @@ export interface CreateMediaBuyResultForStore {
   packages?: Array<{
     package_id?: string;
     buyer_ref?: string;
+    targeting_overlay?: TargetingOverlay;
   }>;
 }
 
@@ -188,7 +189,7 @@ export function createMediaBuyStore(options: CreateMediaBuyStoreOptions): MediaB
 
         persistedPackages.push({
           package_id: packageId,
-          targeting_overlay: reqPkg.targeting_overlay,
+          targeting_overlay: respPkg?.targeting_overlay ?? reqPkg.targeting_overlay,
         });
       }
 

--- a/src/lib/server/media-buy-store.ts
+++ b/src/lib/server/media-buy-store.ts
@@ -1,0 +1,277 @@
+/**
+ * Opinionated media-buy store that satisfies the seller's spec contract:
+ * persist `packages[].targeting_overlay` from `create_media_buy`, echo it on
+ * `get_media_buys`, and deep-merge updates without dropping prior
+ * `property_list` / `collection_list` references.
+ *
+ * Per `schemas/cache/<v>/media-buy/get-media-buys-response.json` the seller
+ * SHOULD echo persisted targeting; sellers claiming `property-lists` or
+ * `collection-lists` MUST include the persisted references inside the
+ * echoed `targeting_overlay`. Wiring this store is the framework-side
+ * way to honor that contract without each adapter persisting + merging
+ * by hand.
+ *
+ * Adopters opt in by passing `mediaBuyStore` to
+ * `createAdcpServerFromPlatform`. Backed by any `AdcpStateStore` —
+ * `InMemoryStateStore` for development, `PostgresStateStore` for
+ * production.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   createAdcpServerFromPlatform,
+ *   createMediaBuyStore,
+ *   InMemoryStateStore,
+ * } from '@adcp/sdk/server';
+ *
+ * const stateStore = new InMemoryStateStore();
+ *
+ * createAdcpServerFromPlatform(platform, {
+ *   mediaBuyStore: createMediaBuyStore({ store: stateStore }),
+ * });
+ * ```
+ */
+
+import type { TargetingOverlay } from '../types/core.generated';
+import type { AdcpStateStore } from './state-store';
+import { scopedStore } from './state-store';
+
+/** Default state-store collection name. Adopters can override per-store. */
+export const DEFAULT_MEDIA_BUY_STORE_COLLECTION = 'media_buys_targeting';
+
+interface PersistedPackage {
+  package_id: string;
+  targeting_overlay: TargetingOverlay;
+}
+
+interface PersistedRecord extends Record<string, unknown> {
+  media_buy_id: string;
+  packages: PersistedPackage[];
+}
+
+/**
+ * Subset of `CreateMediaBuyRequest` the store cares about. Typed loosely
+ * so the wrapper code in `from-platform.ts` doesn't have to upcast the
+ * request to the full generated type just to thread it through.
+ */
+export interface CreateMediaBuyInputForStore {
+  packages?: Array<{
+    package_id?: string;
+    buyer_ref?: string;
+    targeting_overlay?: TargetingOverlay;
+  }>;
+}
+
+/**
+ * Subset of `CreateMediaBuyResponse` (the success arm) the store needs to
+ * pin persisted-from-request packages to seller-assigned `package_id`s.
+ */
+export interface CreateMediaBuyResultForStore {
+  media_buy_id: string;
+  packages?: Array<{
+    package_id?: string;
+    buyer_ref?: string;
+  }>;
+}
+
+export interface UpdateMediaBuyInputForStore {
+  packages?: Array<{
+    package_id?: string;
+    targeting_overlay?: TargetingOverlay | null;
+  }>;
+  new_packages?: Array<{
+    package_id?: string;
+    buyer_ref?: string;
+    targeting_overlay?: TargetingOverlay;
+  }>;
+}
+
+/**
+ * Subset of `GetMediaBuysResponse` mirroring the fields the store reads
+ * + writes. Echoing is non-mutating from the buyer's perspective: every
+ * package the seller already returned with `targeting_overlay` is left
+ * alone.
+ */
+export interface GetMediaBuysResultForStore {
+  media_buys?: Array<{
+    media_buy_id?: string;
+    packages?: Array<{
+      package_id?: string;
+      targeting_overlay?: TargetingOverlay;
+    }>;
+  }>;
+}
+
+export interface MediaBuyStore {
+  /**
+   * Persist `packages[].targeting_overlay` from a successful
+   * `create_media_buy`. Joins the request's per-package targeting
+   * overlay with the response's seller-assigned `package_id` (or
+   * `buyer_ref` when the request used buyer-supplied refs).
+   */
+  persistFromCreate(
+    accountId: string,
+    request: CreateMediaBuyInputForStore,
+    result: CreateMediaBuyResultForStore
+  ): Promise<void>;
+
+  /**
+   * Apply an `update_media_buy` patch to the persisted record.
+   *
+   * Per-field merge semantics inside `targeting_overlay`:
+   * - field omitted from the patch → keep prior value
+   * - field present with a non-null value → replace
+   * - field present and `null` → clear (drop the field)
+   *
+   * `new_packages` from the patch are persisted as fresh entries.
+   */
+  mergeFromUpdate(accountId: string, mediaBuyId: string, patch: UpdateMediaBuyInputForStore): Promise<void>;
+
+  /**
+   * Fill in missing `packages[].targeting_overlay` on the seller's
+   * `get_media_buys` response from the persisted store. Mutates and
+   * returns the response. Packages the seller already echoed are left
+   * untouched.
+   */
+  backfill<T extends GetMediaBuysResultForStore>(accountId: string, result: T): Promise<T>;
+}
+
+export interface CreateMediaBuyStoreOptions {
+  /** Backing state store. Reuses your existing `InMemoryStateStore` / `PostgresStateStore`. */
+  store: AdcpStateStore;
+  /** Override the logical collection name. Defaults to {@link DEFAULT_MEDIA_BUY_STORE_COLLECTION}. */
+  collection?: string;
+}
+
+export function createMediaBuyStore(options: CreateMediaBuyStoreOptions): MediaBuyStore {
+  const collection = options.collection ?? DEFAULT_MEDIA_BUY_STORE_COLLECTION;
+
+  function viewFor(accountId: string): AdcpStateStore {
+    return scopedStore(options.store, accountId);
+  }
+
+  async function loadRecord(accountId: string, mediaBuyId: string): Promise<PersistedRecord | null> {
+    const view = viewFor(accountId);
+    return view.get<PersistedRecord>(collection, mediaBuyId);
+  }
+
+  async function writeRecord(accountId: string, record: PersistedRecord): Promise<void> {
+    const view = viewFor(accountId);
+    await view.put(collection, record.media_buy_id, record);
+  }
+
+  return {
+    async persistFromCreate(accountId, request, result) {
+      const requestPackages = request.packages ?? [];
+      const responsePackages = result.packages ?? [];
+      if (requestPackages.length === 0 || !result.media_buy_id) return;
+
+      const persistedPackages: PersistedPackage[] = [];
+      for (let i = 0; i < requestPackages.length; i++) {
+        const reqPkg = requestPackages[i];
+        if (!reqPkg?.targeting_overlay) continue;
+
+        // Resolve the seller's assigned package_id. Prefer matching by
+        // buyer_ref (deterministic across reorderings); fall back to
+        // positional alignment which is the wire convention when the
+        // request did not supply buyer refs.
+        const buyerRef = reqPkg.buyer_ref;
+        const matchedByRef =
+          buyerRef && buyerRef.length > 0 ? responsePackages.find(p => p?.buyer_ref === buyerRef) : undefined;
+        const respPkg = matchedByRef ?? responsePackages[i];
+        const packageId = respPkg?.package_id;
+        if (!packageId) continue;
+
+        persistedPackages.push({
+          package_id: packageId,
+          targeting_overlay: reqPkg.targeting_overlay,
+        });
+      }
+
+      if (persistedPackages.length === 0) return;
+      await writeRecord(accountId, {
+        media_buy_id: result.media_buy_id,
+        packages: persistedPackages,
+      });
+    },
+
+    async mergeFromUpdate(accountId, mediaBuyId, patch) {
+      const prior = (await loadRecord(accountId, mediaBuyId)) ?? {
+        media_buy_id: mediaBuyId,
+        packages: [],
+      };
+
+      const byId = new Map(prior.packages.map(p => [p.package_id, p.targeting_overlay]));
+
+      for (const pkg of patch.packages ?? []) {
+        const packageId = pkg?.package_id;
+        if (!packageId) continue;
+        // `'targeting_overlay' in pkg` distinguishes "patch did not mention
+        // overlay" (keep prior) from "patch sent null/empty overlay"
+        // (process the clear). With the wire-shape coming through JSON
+        // parse, omitted fields are absent from the object entirely.
+        if (!('targeting_overlay' in pkg)) continue;
+        const incoming = pkg.targeting_overlay;
+        if (incoming === null) {
+          byId.delete(packageId);
+          continue;
+        }
+        if (incoming === undefined) continue;
+        const priorOverlay = byId.get(packageId);
+        byId.set(packageId, mergeOverlay(priorOverlay, incoming));
+      }
+
+      for (const pkg of patch.new_packages ?? []) {
+        if (!pkg?.targeting_overlay || !pkg.package_id) continue;
+        byId.set(pkg.package_id, pkg.targeting_overlay);
+      }
+
+      await writeRecord(accountId, {
+        media_buy_id: mediaBuyId,
+        packages: Array.from(byId.entries()).map(([package_id, targeting_overlay]) => ({
+          package_id,
+          targeting_overlay,
+        })),
+      });
+    },
+
+    async backfill(accountId, result) {
+      const buys = result.media_buys;
+      if (!buys || buys.length === 0) return result;
+      for (const buy of buys) {
+        if (!buy?.media_buy_id || !buy.packages) continue;
+        const record = await loadRecord(accountId, buy.media_buy_id);
+        if (!record) continue;
+        const overlayById = new Map(record.packages.map(p => [p.package_id, p.targeting_overlay]));
+        for (const pkg of buy.packages) {
+          if (!pkg?.package_id || pkg.targeting_overlay !== undefined) continue;
+          const persisted = overlayById.get(pkg.package_id);
+          if (persisted) pkg.targeting_overlay = persisted;
+        }
+      }
+      return result;
+    },
+  };
+}
+
+/**
+ * Per-key merge of an incoming `TargetingOverlay` patch against the prior
+ * persisted overlay. Each key the patch sets to `null` is dropped; each
+ * key the patch sets to a value replaces the prior; keys absent from the
+ * patch are preserved.
+ *
+ * The merge is one level deep — `property_list` / `collection_list` are
+ * reference objects keyed by `list_id`, so a "partial" property-list
+ * update is meaningless and a top-level replace is the right semantics.
+ */
+function mergeOverlay(prior: TargetingOverlay | undefined, patch: TargetingOverlay): TargetingOverlay {
+  const merged: Record<string, unknown> = { ...(prior ?? {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete merged[key];
+    } else if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+  return merged as TargetingOverlay;
+}

--- a/src/lib/server/media-buy-store.ts
+++ b/src/lib/server/media-buy-store.ts
@@ -123,15 +123,19 @@ export interface MediaBuyStore {
    * - field present with a non-null value → replace
    * - field present and `null` → clear (drop the field)
    *
-   * `new_packages` from the patch are persisted as fresh entries.
+   * `new_packages` from the patch are persisted as fresh entries when
+   * they declare `targeting_overlay`. Entries that omit it are
+   * intentionally NOT tracked — this store is overlay-only, and a
+   * later patch can still seed an overlay onto the package_id when
+   * one becomes relevant.
    */
   mergeFromUpdate(accountId: string, mediaBuyId: string, patch: UpdateMediaBuyInputForStore): Promise<void>;
 
   /**
    * Fill in missing `packages[].targeting_overlay` on the seller's
-   * `get_media_buys` response from the persisted store. Mutates and
-   * returns the response. Packages the seller already echoed are left
-   * untouched.
+   * `get_media_buys` response from the persisted store. **Mutates the
+   * response in place** (and returns it for fluent chaining). Packages
+   * the seller already echoed are left untouched.
    */
   backfill<T extends GetMediaBuysResultForStore>(accountId: string, result: T): Promise<T>;
 }

--- a/test/lib/storyboard-drift.test.js
+++ b/test/lib/storyboard-drift.test.js
@@ -288,16 +288,7 @@ describe('storyboard schema drift', () => {
   // actually define. Each entry MUST cite an open upstream issue — if the
   // citation closes without the field landing, the entry is stale and
   // should be removed or re-evaluated.
-  const UPSTREAM_SCHEMA_DRIFT = new Set([
-    // adcontextprotocol/adcp#2488 — PackageStatus lacks `targeting_overlay`,
-    // so get_media_buys can't echo the property_list / collection_list the
-    // seller persisted. Storyboard media_buy_seller/inventory_list_targeting
-    // asserts both read paths post-create and post-update (4 entries total).
-    'media_buy_seller/inventory_list_targeting/get_after_create:media_buys[0].packages[0].targeting_overlay.property_list.list_id',
-    'media_buy_seller/inventory_list_targeting/get_after_create:media_buys[0].packages[0].targeting_overlay.collection_list.list_id',
-    'media_buy_seller/inventory_list_targeting/get_after_update:media_buys[0].packages[0].targeting_overlay.property_list.list_id',
-    'media_buy_seller/inventory_list_targeting/get_after_update:media_buys[0].packages[0].targeting_overlay.collection_list.list_id',
-  ]);
+  const UPSTREAM_SCHEMA_DRIFT = new Set([]);
 
   function skipReason(key) {
     if (KNOWN_FORWARD_DRIFT.has(key)) return 'known forward-drift pending schema regen';


### PR DESCRIPTION
## Summary

Closes #1415.

`createAdcpServerFromPlatform` gains a `mediaBuyStore` opt-in. When wired, the framework satisfies the seller spec contract for `targeting_overlay` echo on `get_media_buys` without each adapter persisting + merging by hand.

```ts
import { createAdcpServerFromPlatform, createMediaBuyStore, InMemoryStateStore } from '@adcp/sdk/server';

createAdcpServerFromPlatform(myPlatform, {
  mediaBuyStore: createMediaBuyStore({ store: new InMemoryStateStore() }),
});
```

The framework then:

- Persists `packages[].targeting_overlay` from `create_media_buy` requests, joined with seller-assigned `package_id` (or `buyer_ref` when supplied). Runs in the createMediaBuy projection so it covers both the sync arm AND the HITL completion arm.
- On `get_media_buys`, backfills missing `packages[].targeting_overlay` from the store. Packages the seller already echoed are left untouched.
- On `update_media_buy`, deep-merges the patched overlay against prior persisted: omitted keys keep prior, non-null values replace, explicit `null` clears. `new_packages[]` are persisted as fresh entries.

Backed by any `AdcpStateStore` (`InMemoryStateStore` for dev, `PostgresStateStore` for production). Account-scoped per-tenant via `scopedStore`. Failures logged + swallowed — auto-echo never breaks a successful seller response.

`hello_seller_adapter_guaranteed.ts` now wires `mediaBuyStore` by default — every fork inherits the contract for free.

## Triage resolution: drops four stale suppressors

Triage flagged that `test/lib/storyboard-drift.test.js:291–299` suppressed the four `media_buy_seller/inventory_list_targeting/get_after_*` assertions as `UPSTREAM_SCHEMA_DRIFT` per `adcontextprotocol/adcp#2488`. Verified directly: `schemas/cache/3.0.5/media-buy/get-media-buys-response.json` includes `targeting_overlay` on `PackageStatus` with prose mandating echo for sellers claiming property-lists/collection-lists. adcp#2488 is resolved by the 3.0 GA schema update; the suppressors are stale and dropped in this PR.

## Test plan

- [x] `npx vitest run src/lib/server/media-buy-store.test.ts` — 9/9 pass
- [x] `node --test test/lib/storyboard-drift.test.js` — 498/499 pass (1 unrelated skip), 0 fail
- [x] `npx tsc --noEmit -p tsconfig.lib.json` clean
- [x] `npm run format:check` clean
- [ ] Storyboard `media_buy_seller/inventory_list_targeting/get_after_create` passes against the worked example (manual repro)

## Companion follow-ups

- #1416 — export `MEDIA_BUY_TRANSITIONS` + `assertMediaBuyTransition` (still triaging at PR open).
- #1417 — runner HITL `context_outputs.path` capture from task completion artifact (deferred; triage suggests Option 1 explicit-prefix or Option 4 storyboard YAML redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)