### PR TITLE
fix(storyboard): ensure operator always set on natural-key AccountReference (#1419)

### DIFF
--- a/.changeset/fix-account-ref-missing-operator.md
+++ b/.changeset/fix-account-ref-missing-operator.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+Fix storyboard runner emitting spec-invalid `AccountReference` (missing `operator`) for cascade scenarios. Closes #1419.
+
+`applyBrandInvariant` now ensures the `operator` field is always present on natural-key `AccountReference` objects in outgoing storyboard requests. When `operator` is absent or `undefined` (e.g. from a `sync_accounts` context where the upstream response omitted the field), it falls back to `brand.domain` — the same value `resolveAccount()` uses for synthetic sandbox refs, and consistent with the spec's description of the field ("when the brand operates directly, this is the brand's domain").
+
+The companion fix in the `sync_accounts` context extractor avoids storing `{operator: undefined}` in `StoryboardContext.account` in the first place, eliminating a latent footgun for any future code path that consumes `context.account` without going through `applyBrandInvariant`.
+
+**Impact:** Sellers that run strict schema validation (AJV in strict mode, or any validator that honors `account-ref.json`'s `oneOf` `required` constraint) previously rejected synthetic `comply_test_controller` calls in cascade scenarios, causing all cascade scenario steps to fail with a validation error rather than the expected functional response. After this fix, the runner emits a fully spec-valid `AccountReference` on every outgoing request.

--- a/src/lib/testing/storyboard/context.ts
+++ b/src/lib/testing/storyboard/context.ts
@@ -29,11 +29,12 @@ export const CONTEXT_EXTRACTORS: Record<string, ContextExtractor> = {
     const extracted: Record<string, unknown> = {};
     if (first.account_id) extracted.account_id = first.account_id;
     if (first.status) extracted.account_status = first.status;
-    // Build an account reference for downstream steps
-    extracted.account = {
-      brand: first.brand,
-      operator: first.operator,
-    };
+    // Build an account reference for downstream steps.
+    // Omit operator when absent — operator: undefined serialises to absent in JSON,
+    // silently producing a spec-invalid natural-key ref. (#1419)
+    const accountRef: Record<string, unknown> = { brand: first.brand };
+    if (first.operator) accountRef.operator = first.operator;
+    extracted.account = accountRef;
     return extracted;
   },
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3225,7 +3225,10 @@ export function applyBrandInvariant(
       const acct = existingAccount as Record<string, unknown>;
       const isNaturalKeyVariant = 'brand' in acct || 'operator' in acct;
       if (isNaturalKeyVariant) {
-        result.account = { ...acct, brand };
+        // Default operator to brand.domain: cascade-scenario context.account can
+        // arrive with operator: undefined (JSON strips it → spec-invalid ref). (#1419)
+        const operator = (acct.operator as string | undefined | null) ?? brand.domain;
+        result.account = { ...acct, brand, operator };
       }
     }
   } else if (topAccountOk) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3227,7 +3227,7 @@ export function applyBrandInvariant(
       if (isNaturalKeyVariant) {
         // Default operator to brand.domain: cascade-scenario context.account can
         // arrive with operator: undefined (JSON strips it → spec-invalid ref). (#1419)
-        const operator = (acct.operator as string | undefined | null) ?? brand.domain;
+        const operator = (acct.operator as string | undefined) ?? brand.domain;
         result.account = { ...acct, brand, operator };
       }
     }

--- a/test/lib/context-extractors.test.js
+++ b/test/lib/context-extractors.test.js
@@ -129,4 +129,36 @@ describe('context extractors', () => {
       assert.deepStrictEqual(extractContext('report_plan_outcome', {}), {});
     });
   });
+
+  describe('sync_accounts (issue #1419)', () => {
+    it('extracts account_id, account_status, and natural-key account ref', () => {
+      const data = {
+        accounts: [
+          {
+            account_id: 'acct_abc',
+            status: 'active',
+            brand: { domain: 'acme.example' },
+            operator: 'media-co.example',
+          },
+        ],
+      };
+      const result = extractContext('sync_accounts', data);
+      assert.equal(result.account_id, 'acct_abc');
+      assert.equal(result.account_status, 'active');
+      assert.deepStrictEqual(result.account, { brand: { domain: 'acme.example' }, operator: 'media-co.example' });
+    });
+
+    it('omits operator key when absent from response — avoids {operator: undefined} poisoning context (#1419)', () => {
+      const data = {
+        accounts: [{ account_id: 'acct_abc', brand: { domain: 'acme.example' } }],
+      };
+      const result = extractContext('sync_accounts', data);
+      assert.ok(!('operator' in result.account), 'operator key must be absent, not set to undefined');
+      assert.deepStrictEqual(result.account, { brand: { domain: 'acme.example' } });
+    });
+
+    it('returns empty object when accounts array is empty', () => {
+      assert.deepStrictEqual(extractContext('sync_accounts', { accounts: [] }), {});
+    });
+  });
 });

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -193,6 +193,40 @@ describe('applyBrandInvariant', () => {
     assert.deepStrictEqual(result.account.brand, BRAND, 'natural-key brand should be overridden');
     assert.strictEqual(result.account.operator, 'pinnacle-agency.example');
   });
+
+  // ── issue #1419: operator missing from cascade-scenario synthetic refs ──
+  // cascade-scenario comply_test_controller steps can arrive with
+  // account: { brand: {...}, sandbox: true } (no operator), causing strict-
+  // validating sellers to reject the call. applyBrandInvariant must add
+  // operator (= brand.domain) so the natural-key arm is always complete.
+
+  test('adds operator fallback when natural-key account omits it (issue #1419)', () => {
+    const result = applyBrandInvariant(
+      { account: { brand: { domain: 'test.example' }, sandbox: true } },
+      { brand: BRAND }
+    );
+    assert.ok(result.account.operator, 'operator must be present on the natural-key account ref');
+    assert.strictEqual(result.account.operator, BRAND.domain, 'operator should default to brand.domain');
+    assert.deepStrictEqual(result.account.brand, BRAND);
+    assert.strictEqual(result.account.sandbox, true);
+  });
+
+  test('adds operator fallback when context.account.operator is explicitly undefined (issue #1419)', () => {
+    const result = applyBrandInvariant(
+      { account: { brand: { domain: 'test.example' }, operator: undefined, sandbox: true } },
+      { brand: BRAND }
+    );
+    assert.ok(result.account.operator, 'operator must be set even when context.account.operator was undefined');
+    assert.strictEqual(result.account.operator, BRAND.domain);
+  });
+
+  test('preserves explicit operator when it is set (no regression, issue #1419)', () => {
+    const result = applyBrandInvariant(
+      { account: { brand: { domain: 'advertiser.example' }, operator: 'media-co.example', sandbox: true } },
+      { brand: BRAND }
+    );
+    assert.strictEqual(result.account.operator, 'media-co.example', 'explicit operator must not be overwritten');
+  });
 });
 
 // ────────────────────────────────────────────────────────────

--- a/test/lib/storyboard-brand-invariant.test.js
+++ b/test/lib/storyboard-brand-invariant.test.js
@@ -205,7 +205,6 @@ describe('applyBrandInvariant', () => {
       { account: { brand: { domain: 'test.example' }, sandbox: true } },
       { brand: BRAND }
     );
-    assert.ok(result.account.operator, 'operator must be present on the natural-key account ref');
     assert.strictEqual(result.account.operator, BRAND.domain, 'operator should default to brand.domain');
     assert.deepStrictEqual(result.account.brand, BRAND);
     assert.strictEqual(result.account.sandbox, true);


### PR DESCRIPTION
Closes #1419

## Summary

The storyboard runner could emit spec-invalid `AccountReference` objects on the natural-key arm (`{brand, operator, sandbox?}`) with `operator` absent. Per `account-ref.json`, `operator` is in the `required` list alongside `brand`. A strict-validating seller (AJV strict mode, or any validator honouring the `oneOf` constraint) would reject these calls, causing all cascade scenario steps to fail with a validation error rather than a functional response.

**Root cause — two code paths:**

1. **`context.ts` `sync_accounts` extractor** (`src/lib/testing/storyboard/context.ts:33`): stored `{ brand: first.brand, operator: first.operator }` unconditionally. When `first.operator` was absent from the upstream response, this produced `{operator: undefined}` in `StoryboardContext.account`. JSON serialisation strips `undefined` → wire payload silently missing `operator`.

2. **`applyBrandInvariant` natural-key merge** (`src/lib/testing/storyboard/runner.ts:3228`): when merging brand into an existing natural-key account, only overwrote `brand` (`result.account = { ...acct, brand }`). Spreading `{operator: undefined}` preserved the poisoned value.

**Fixes:**

- `context.ts`: omit the `operator` key entirely when absent from the response, rather than storing `undefined`.
- `runner.ts` `applyBrandInvariant`: add `operator ?? brand.domain` fallback when merging into a natural-key account. Uses the same value `resolveAccount()` uses for synthetic sandbox refs; consistent with the spec's field description ("when the brand operates directly, this is the brand's domain"). Explicit `operator` values are preserved — the `??` only fires when the field is absent or `undefined`.

## What was tested

- `npm run format:check` — clean
- `npm run typecheck` — clean (no errors)
- `npm run build:lib` — clean
- `node --test test/lib/storyboard-brand-invariant.test.js` — 19/19 pass (3 new tests); pre-existing `with synced schemas` failures require schema cache (unrelated to this change)
- `node --test test/lib/context-extractors.test.js` — new `sync_accounts` describe block: 3/3 pass

## Pre-PR review

- **code-reviewer**: approved — no blockers; nit (cast width), nit (redundant assert.ok), and test coverage gap (extractor test) all addressed in follow-up commit.
- **ad-tech-protocol-expert**: approved — `brand.domain` fallback is spec-correct and consistent with `resolveAccount()`; both fixes are jointly necessary for clean compliance-report output; no protocol-level blockers.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_013m2KDtJEcoNANAeFVVyJ8G

---
_Generated by [Claude Code](https://claude.ai/code/session_013m2KDtJEcoNANAeFVVyJ8G)_