### PR TITLE
feat(runner): task_completion. path prefix on context_outputs (#1417)

### DIFF
--- a/.changeset/storyboard-runner-task-completion-capture.md
+++ b/.changeset/storyboard-runner-task-completion-capture.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/sdk": minor
+'@adcp/sdk': minor
 ---
 
 Storyboard runner — `task_completion.<path>` prefix on `context_outputs.path`.
@@ -11,13 +11,19 @@ The `task_completion.<path>` prefix is an explicit author opt-in: when the runne
 ```yaml
 context_outputs:
   - name: media_buy_id
-    path: "task_completion.media_buy_id"
+    path: 'task_completion.media_buy_id'
 ```
 
-Polling is bounded (default 30s, override with `STORYBOARD_TASK_POLL_TIMEOUT_MS`); per-poll cadence default 1.5s (override with `STORYBOARD_TASK_POLL_INTERVAL_MS`). The runner never auto-polls based on response shape — the prefix is the only opt-in, so existing storyboards with intentional submitted-arm responses don't change behavior.
+The prefix triggers polling on any non-terminal status that carries a `task_id` — `submitted`, `working`, and `input-required`, per the AdCP `tasks-get-response.json` enum. Storyboards with intentional non-terminal-arm assertions are unaffected because the prefix is the only opt-in (no shape inference).
 
-`task_id` is validated (length cap + control-char rejection) before reaching the SDK's `tasks/get` call.
+Polling is bounded (default 30s, override with `STORYBOARD_TASK_POLL_TIMEOUT_MS`); per-poll cadence default 1.5s (override with `STORYBOARD_TASK_POLL_INTERVAL_MS`). `task_id` is validated (length cap + control-char rejection) before reaching the SDK's `tasks/get` call.
 
-Failures emit a distinct `capture_poll_timeout` validation result (not the recycled `capture_path_not_resolvable`) so the failure-class is unambiguous.
+Failures map to three distinct validation checks so compliance reports surface the right diagnostic:
 
-Closes #1417 (Option 1 from the issue's three options; the protocol-expert and code-reviewer triage notes converged on this surface as the cleanest fix).
+- `capture_poll_timeout` — task didn't reach terminal state within the timeout
+- `capture_task_failed` — task reached terminal `failed` / `canceled` / `rejected`
+- `capture_path_not_resolvable` — task succeeded but the artifact's data didn't carry the requested field
+
+This applies to any HITL flow where artifact-only fields land in `context_outputs`: `create_media_buy` (the originally-reported case), `sync_creatives` async approval (`creative_id`), `acquire_rights` (`rights_grant_id`), `si_initiate_session` / `si_send_message`, and any future tool routed through async-signed-IO.
+
+Closes #1417 (Option 1 from the issue's three options; protocol-expert and code-reviewer triage notes converged on this surface as the cleanest fix).

--- a/.changeset/storyboard-runner-task-completion-capture.md
+++ b/.changeset/storyboard-runner-task-completion-capture.md
@@ -1,0 +1,23 @@
+---
+"@adcp/sdk": minor
+---
+
+Storyboard runner — `task_completion.<path>` prefix on `context_outputs.path`.
+
+When a step's immediate response is a submitted-arm task envelope (HITL / async-signed-IO flows), the seller-assigned IDs only exist on the eventual completion artifact, not the immediate response. Pre-this-release, storyboard authors who tried to capture from the artifact got `capture_path_not_resolvable` for a value the seller correctly produced — just on a later message. The workaround was to author a redundant follow-up `get_*` step purely to expose the field.
+
+The `task_completion.<path>` prefix is an explicit author opt-in: when the runner sees this prefix, it polls `tasks/get` until terminal and resolves the rest of the path against the artifact's `data`.
+
+```yaml
+context_outputs:
+  - name: media_buy_id
+    path: "task_completion.media_buy_id"
+```
+
+Polling is bounded (default 30s, override with `STORYBOARD_TASK_POLL_TIMEOUT_MS`); per-poll cadence default 1.5s (override with `STORYBOARD_TASK_POLL_INTERVAL_MS`). The runner never auto-polls based on response shape — the prefix is the only opt-in, so existing storyboards with intentional submitted-arm responses don't change behavior.
+
+`task_id` is validated (length cap + control-char rejection) before reaching the SDK's `tasks/get` call.
+
+Failures emit a distinct `capture_poll_timeout` validation result (not the recycled `capture_path_not_resolvable`) so the failure-class is unambiguous.
+
+Closes #1417 (Option 1 from the issue's three options; the protocol-expert and code-reviewer triage notes converged on this surface as the cleanest fix).

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -302,6 +302,138 @@ function applyBranchSetGrading(
   return { skippedDelta };
 }
 
+// ────────────────────────────────────────────────────────────
+// task_completion. context_outputs path resolution
+// ────────────────────────────────────────────────────────────
+
+/** Marker prefix on `context_outputs.path` that opts a capture into the
+ *  poll-tasks-get-for-the-completion-artifact resolution flow. The remainder
+ *  of the path is resolved against the artifact's `data`, not the immediate
+ *  submitted envelope. */
+const TASK_COMPLETION_PATH_PREFIX = 'task_completion.';
+
+/** Hard cap on how long the runner blocks one step waiting for a task to
+ *  reach terminal state. Long enough to cover most HITL approval flows that
+ *  are expected to complete inline; short enough that a stuck task surfaces
+ *  the failure on the step that authored the dependency rather than the
+ *  storyboard wall-clock budget. Override with `STORYBOARD_TASK_POLL_TIMEOUT_MS`. */
+const TASK_COMPLETION_DEFAULT_TIMEOUT_MS = 30_000;
+
+/** Per-poll cadence inside `pollTaskCompletion`. Scaled tight enough that
+ *  short HITL flows complete in a couple of polls; the bound is still the
+ *  outer timeout race. Override with `STORYBOARD_TASK_POLL_INTERVAL_MS`. */
+const TASK_COMPLETION_DEFAULT_POLL_INTERVAL_MS = 1_500;
+
+/** Defensive task_id pattern. AdCP doesn't constrain `task_id` shape on the
+ *  wire, but unbounded strings are an SSRF / log-injection lever — we cap
+ *  the length and reject control characters before the value reaches the
+ *  SDK's tasks/get JSON-RPC param. */
+const TASK_ID_MAX_LEN = 256;
+// eslint-disable-next-line no-control-regex -- intentional: reject control chars in task_id
+const TASK_ID_CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
+
+interface SubmittedEnvelopeShape {
+  status: 'submitted';
+  task_id: string;
+}
+
+function isSubmittedEnvelope(data: unknown): data is SubmittedEnvelopeShape {
+  if (data == null || typeof data !== 'object') return false;
+  const obj = data as { status?: unknown; task_id?: unknown };
+  return obj.status === 'submitted' && typeof obj.task_id === 'string' && obj.task_id.length > 0;
+}
+
+function isValidTaskId(taskId: string): boolean {
+  if (taskId.length === 0 || taskId.length > TASK_ID_MAX_LEN) return false;
+  if (TASK_ID_CONTROL_CHAR_RE.test(taskId)) return false;
+  return true;
+}
+
+interface TaskCompletionResolution {
+  /** Artifact data resolved by polling. `undefined` when the step had no
+   *  task_completion outputs, when the immediate response wasn't a submitted
+   *  envelope, or when polling failed. The runner falls back to the
+   *  immediate response's data in those cases. */
+  data?: unknown;
+  /** Set when the bounded poll exceeded `pollTimeoutMs`. The runner uses
+   *  this to flip the synthesized failure check from
+   *  `capture_path_not_resolvable` to `capture_poll_timeout`. */
+  timedOut?: boolean;
+  pollTimeoutMs?: number;
+}
+
+function remapTaskCompletionOutputs<T extends { path?: string | undefined }>(outputs: readonly T[]): T[] {
+  return outputs.map(o => {
+    if (typeof o.path === 'string' && o.path.startsWith(TASK_COMPLETION_PATH_PREFIX)) {
+      return { ...o, path: o.path.slice(TASK_COMPLETION_PATH_PREFIX.length) };
+    }
+    return o;
+  });
+}
+
+async function resolveTaskCompletionOutputs(
+  taskResult: TaskResult | undefined,
+  outputs: readonly { path?: string | undefined }[],
+  client: TestClient,
+  agentUrl: string
+): Promise<TaskCompletionResolution> {
+  const hasTaskCompletionPath = outputs.some(
+    o => typeof o.path === 'string' && o.path.startsWith(TASK_COMPLETION_PATH_PREFIX)
+  );
+  if (!hasTaskCompletionPath) return {};
+  if (!taskResult || !isSubmittedEnvelope(taskResult.data)) return {};
+  const taskId = taskResult.data.task_id;
+  if (!isValidTaskId(taskId)) return {};
+
+  const timeoutMs = readEnvIntOrDefault(
+    process.env['STORYBOARD_TASK_POLL_TIMEOUT_MS'],
+    TASK_COMPLETION_DEFAULT_TIMEOUT_MS
+  );
+  const pollIntervalMs = readEnvIntOrDefault(
+    process.env['STORYBOARD_TASK_POLL_INTERVAL_MS'],
+    TASK_COMPLETION_DEFAULT_POLL_INTERVAL_MS
+  );
+
+  // The SDK's `pollTaskCompletion` lives on the executor — accessed via the
+  // SingleAgentClient instance the storyboard runner created in
+  // `getOrCreateClient`. The runner historically uses `client: any` for
+  // dynamic dispatch (see task-map.ts:80) so this cast doesn't widen
+  // existing surface.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic SDK access
+  const dynamicClient = client as any;
+  const executor = dynamicClient?.executor;
+  const agent = dynamicClient?.agent;
+  if (!executor?.pollTaskCompletion || !agent) {
+    return { timedOut: false };
+  }
+
+  void agentUrl; // tracked for log enrichment in future iterations
+
+  try {
+    const polled = await Promise.race([
+      executor.pollTaskCompletion(agent, taskId, pollIntervalMs),
+      new Promise<{ timedOut: true }>(resolve => setTimeout(() => resolve({ timedOut: true }), timeoutMs)),
+    ]);
+    if (polled && typeof polled === 'object' && 'timedOut' in polled && polled.timedOut === true) {
+      return { timedOut: true, pollTimeoutMs: timeoutMs };
+    }
+    const polledTaskResult = polled as TaskResult;
+    if (polledTaskResult.success === false) {
+      return { timedOut: false };
+    }
+    return { data: polledTaskResult.data };
+  } catch {
+    return { timedOut: false };
+  }
+}
+
+function readEnvIntOrDefault(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
 function extractionFromTaskResult(taskResult: TaskResult | undefined): RunnerExtractionRecord {
   if (!taskResult) return { path: 'none' };
   // Prefer the explicit provenance stamped by the response unwrapper / raw
@@ -2643,9 +2775,31 @@ async function executeStep(
   // ensures the minted value from any same-step $generate:…#<key> inline
   // substitution is visible here.
   if (step.context_outputs?.length) {
-    const explicit = applyContextOutputsWithProvenance(
-      hasData && taskResult ? taskResult.data : undefined,
+    // Resolve `task_completion.<path>` outputs against the eventual task
+    // artifact rather than the immediate response. When the immediate
+    // response is a submitted-arm envelope (HITL / async-signed-IO flows),
+    // the seller-assigned IDs only exist on the completion artifact — the
+    // sync-shape path resolves to nothing and the storyboard fails on
+    // `capture_path_not_resolvable` for a value the seller correctly
+    // produces, just on a later message. The `task_completion.` prefix is
+    // an explicit author-side opt-in: "poll tasks/get for terminal status,
+    // then resolve the rest of the path against the artifact data."
+    //
+    // Polling failures (timeout, terminal failed/canceled/rejected) emit
+    // `capture_poll_timeout` instead of recycling
+    // `capture_path_not_resolvable` so the failure-class is distinct from
+    // the original "field absent in immediate response" diagnostic.
+    const taskCompletionResolution = await resolveTaskCompletionOutputs(
+      taskResult,
       step.context_outputs,
+      client,
+      runState.agentUrl
+    );
+    const extractionData = taskCompletionResolution.data ?? (hasData && taskResult ? taskResult.data : undefined);
+    const remappedOutputs = remapTaskCompletionOutputs(step.context_outputs);
+    const explicit = applyContextOutputsWithProvenance(
+      extractionData,
+      remappedOutputs,
       step.id,
       effectiveStep.task,
       updatedContext
@@ -2665,12 +2819,20 @@ async function executeStep(
     // a failed capture is the exact case adcp#3796 set out to fix.
     if (explicit.failures && explicit.failures.length > 0) {
       for (const failure of explicit.failures) {
+        const wasTaskCompletion = step.context_outputs.some(
+          o => o.key === failure.key && typeof o.path === 'string' && o.path.startsWith(TASK_COMPLETION_PATH_PREFIX)
+        );
+        const pollTimedOut = wasTaskCompletion && taskCompletionResolution.timedOut;
+        const originalPath = wasTaskCompletion ? `${TASK_COMPLETION_PATH_PREFIX}${failure.path}` : failure.path;
+        const description = pollTimedOut
+          ? `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve before tasks/get poll timed out (${taskCompletionResolution.pollTimeoutMs ?? 0}ms)`
+          : `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve to a usable value`;
         const synthetic: ValidationResult = {
-          check: 'capture_path_not_resolvable',
+          check: pollTimedOut ? 'capture_poll_timeout' : 'capture_path_not_resolvable',
           passed: false,
-          description: `context_outputs path "${failure.path}" (key "${failure.key}") did not resolve to a usable value`,
+          description,
           json_pointer: toJsonPointer(failure.path),
-          expected: failure.path,
+          expected: originalPath,
           actual: failure.resolved,
           schema_id: null,
           schema_url: null,

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -332,15 +332,30 @@ const TASK_ID_MAX_LEN = 256;
 // eslint-disable-next-line no-control-regex -- intentional: reject control chars in task_id
 const TASK_ID_CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
 
-interface SubmittedEnvelopeShape {
-  status: 'submitted';
+/** Non-terminal task statuses that carry a `task_id` and warrant polling
+ *  the artifact for `task_completion.<inner>` captures. Per the AdCP
+ *  `tasks-get-response.json` enum, all three are explicitly non-terminal:
+ *  `submitted` (HITL or async-signed-IO), `working` ("expect completion
+ *  within 120 seconds"), and `input-required` (waiting on the buyer to
+ *  supply additional info — relevant when the storyboard test harness
+ *  satisfies the input requirement). The 30s default poll timeout still
+ *  bounds the worst case for storyboards that test these arms directly. */
+const POLL_ELIGIBLE_STATUSES = new Set(['submitted', 'working', 'input-required']);
+
+interface PollEligibleEnvelopeShape {
+  status: 'submitted' | 'working' | 'input-required';
   task_id: string;
 }
 
-function isSubmittedEnvelope(data: unknown): data is SubmittedEnvelopeShape {
+function isPollEligibleEnvelope(data: unknown): data is PollEligibleEnvelopeShape {
   if (data == null || typeof data !== 'object') return false;
   const obj = data as { status?: unknown; task_id?: unknown };
-  return obj.status === 'submitted' && typeof obj.task_id === 'string' && obj.task_id.length > 0;
+  return (
+    typeof obj.status === 'string' &&
+    POLL_ELIGIBLE_STATUSES.has(obj.status) &&
+    typeof obj.task_id === 'string' &&
+    obj.task_id.length > 0
+  );
 }
 
 function isValidTaskId(taskId: string): boolean {
@@ -350,16 +365,23 @@ function isValidTaskId(taskId: string): boolean {
 }
 
 interface TaskCompletionResolution {
-  /** Artifact data resolved by polling. `undefined` when the step had no
-   *  task_completion outputs, when the immediate response wasn't a submitted
-   *  envelope, or when polling failed. The runner falls back to the
-   *  immediate response's data in those cases. */
+  /** Discriminator: was the resolution attempted? `false` short-circuits
+   *  the runner back to plain extraction against the immediate response. */
+  attempted: boolean;
+  /** Artifact data resolved by polling. Present (including `undefined`)
+   *  ONLY when polling succeeded — caller uses `'data' in resolution` to
+   *  distinguish "polled and got undefined" from "did not poll." */
   data?: unknown;
   /** Set when the bounded poll exceeded `pollTimeoutMs`. The runner uses
    *  this to flip the synthesized failure check from
    *  `capture_path_not_resolvable` to `capture_poll_timeout`. */
   timedOut?: boolean;
   pollTimeoutMs?: number;
+  /** Set when polling reached terminal state with `success: false`
+   *  (failed / canceled / rejected). The runner flips the synthesized
+   *  failure check to `capture_task_failed` so reports distinguish
+   *  "field absent on artifact" from "task itself terminally failed." */
+  taskFailed?: boolean;
 }
 
 function remapTaskCompletionOutputs<T extends { path?: string | undefined }>(outputs: readonly T[]): T[] {
@@ -374,16 +396,15 @@ function remapTaskCompletionOutputs<T extends { path?: string | undefined }>(out
 async function resolveTaskCompletionOutputs(
   taskResult: TaskResult | undefined,
   outputs: readonly { path?: string | undefined }[],
-  client: TestClient,
-  agentUrl: string
+  client: TestClient
 ): Promise<TaskCompletionResolution> {
   const hasTaskCompletionPath = outputs.some(
     o => typeof o.path === 'string' && o.path.startsWith(TASK_COMPLETION_PATH_PREFIX)
   );
-  if (!hasTaskCompletionPath) return {};
-  if (!taskResult || !isSubmittedEnvelope(taskResult.data)) return {};
+  if (!hasTaskCompletionPath) return { attempted: false };
+  if (!taskResult || !isPollEligibleEnvelope(taskResult.data)) return { attempted: false };
   const taskId = taskResult.data.task_id;
-  if (!isValidTaskId(taskId)) return {};
+  if (!isValidTaskId(taskId)) return { attempted: false };
 
   const timeoutMs = readEnvIntOrDefault(
     process.env['STORYBOARD_TASK_POLL_TIMEOUT_MS'],
@@ -404,26 +425,39 @@ async function resolveTaskCompletionOutputs(
   const executor = dynamicClient?.executor;
   const agent = dynamicClient?.agent;
   if (!executor?.pollTaskCompletion || !agent) {
-    return { timedOut: false };
+    return { attempted: false };
   }
 
-  void agentUrl; // tracked for log enrichment in future iterations
+  // Note: when the outer race resolves on timeout, the SDK's
+  // `pollTaskCompletion` keeps polling internally until it observes a
+  // terminal state. For a stuck task that means `tasks/get` continues
+  // hitting the agent every `pollIntervalMs` until the process exits.
+  // The runner's outer timeout is enough to bound the *step* duration;
+  // the inner loop continuation is a known limitation pending an
+  // AbortSignal addition to the SDK.
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<{ timedOut: true }>(resolve => {
+    timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+    // Don't keep the event loop alive on this handle — the runner's
+    // wall-clock budget is already enforced by the storyboard runner
+    // shell, and a hung task shouldn't delay process exit by `timeoutMs`.
+    timer.unref?.();
+  });
 
   try {
-    const polled = await Promise.race([
-      executor.pollTaskCompletion(agent, taskId, pollIntervalMs),
-      new Promise<{ timedOut: true }>(resolve => setTimeout(() => resolve({ timedOut: true }), timeoutMs)),
-    ]);
+    const polled = await Promise.race([executor.pollTaskCompletion(agent, taskId, pollIntervalMs), timeoutPromise]);
     if (polled && typeof polled === 'object' && 'timedOut' in polled && polled.timedOut === true) {
-      return { timedOut: true, pollTimeoutMs: timeoutMs };
+      return { attempted: true, timedOut: true, pollTimeoutMs: timeoutMs };
     }
     const polledTaskResult = polled as TaskResult;
     if (polledTaskResult.success === false) {
-      return { timedOut: false };
+      return { attempted: true, taskFailed: true };
     }
-    return { data: polledTaskResult.data };
+    return { attempted: true, data: polledTaskResult.data };
   } catch {
-    return { timedOut: false };
+    return { attempted: true, taskFailed: true };
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -2789,13 +2823,16 @@ async function executeStep(
     // `capture_poll_timeout` instead of recycling
     // `capture_path_not_resolvable` so the failure-class is distinct from
     // the original "field absent in immediate response" diagnostic.
-    const taskCompletionResolution = await resolveTaskCompletionOutputs(
-      taskResult,
-      step.context_outputs,
-      client,
-      runState.agentUrl
-    );
-    const extractionData = taskCompletionResolution.data ?? (hasData && taskResult ? taskResult.data : undefined);
+    const taskCompletionResolution = await resolveTaskCompletionOutputs(taskResult, step.context_outputs, client);
+    // `'data' in resolution` distinguishes "polled, artifact had no data"
+    // (use undefined → outputs fail with capture_path_not_resolvable) from
+    // "did not poll" (fall back to the immediate response data).
+    const extractionData =
+      'data' in taskCompletionResolution
+        ? taskCompletionResolution.data
+        : hasData && taskResult
+          ? taskResult.data
+          : undefined;
     const remappedOutputs = remapTaskCompletionOutputs(step.context_outputs);
     const explicit = applyContextOutputsWithProvenance(
       extractionData,
@@ -2822,13 +2859,23 @@ async function executeStep(
         const wasTaskCompletion = step.context_outputs.some(
           o => o.key === failure.key && typeof o.path === 'string' && o.path.startsWith(TASK_COMPLETION_PATH_PREFIX)
         );
-        const pollTimedOut = wasTaskCompletion && taskCompletionResolution.timedOut;
+        const pollTimedOut = wasTaskCompletion && taskCompletionResolution.timedOut === true;
+        const taskFailed = wasTaskCompletion && taskCompletionResolution.taskFailed === true;
         const originalPath = wasTaskCompletion ? `${TASK_COMPLETION_PATH_PREFIX}${failure.path}` : failure.path;
-        const description = pollTimedOut
-          ? `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve before tasks/get poll timed out (${taskCompletionResolution.pollTimeoutMs ?? 0}ms)`
-          : `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve to a usable value`;
+        let check: string;
+        let description: string;
+        if (pollTimedOut) {
+          check = 'capture_poll_timeout';
+          description = `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve before tasks/get poll timed out (${taskCompletionResolution.pollTimeoutMs}ms)`;
+        } else if (taskFailed) {
+          check = 'capture_task_failed';
+          description = `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve because the task reached a terminal failed/canceled/rejected state`;
+        } else {
+          check = 'capture_path_not_resolvable';
+          description = `context_outputs path "${originalPath}" (key "${failure.key}") did not resolve to a usable value`;
+        }
         const synthetic: ValidationResult = {
-          check: pollTimedOut ? 'capture_poll_timeout' : 'capture_path_not_resolvable',
+          check,
           passed: false,
           description,
           json_pointer: toJsonPointer(failure.path),

--- a/test/lib/storyboard-runner-task-completion-capture.test.js
+++ b/test/lib/storyboard-runner-task-completion-capture.test.js
@@ -177,6 +177,51 @@ describe('runStoryboardStep — task_completion. context_outputs', () => {
     assert.ok(captureFailure, 'capture_path_not_resolvable when poll path is unreachable');
   });
 
+  test('emits capture_task_failed when polled task reaches terminal failed/canceled/rejected', async () => {
+    const { client } = buildHitlClient({
+      immediateData: { status: 'submitted', task_id: 'task_will_fail' },
+      pollResult: {
+        success: false,
+        status: 'failed',
+        error: 'IO review rejected the buy',
+        data: { error: { code: 'INVALID_REQUEST', message: 'rejected' } },
+      },
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    const taskFailed = result.validations.find(v => v.check === 'capture_task_failed');
+    assert.ok(taskFailed, 'capture_task_failed validation synthesized');
+    assert.equal(taskFailed.passed, false);
+    assert.match(taskFailed.description, /terminal failed\/canceled\/rejected state/);
+    assert.equal(
+      result.validations.filter(v => v.check === 'capture_path_not_resolvable').length,
+      0,
+      'capture_path_not_resolvable not used when the task itself terminally failed'
+    );
+    assert.equal(result.context.media_buy_id, undefined);
+  });
+
+  test('also polls when immediate response is `working` (non-terminal status with task_id)', async () => {
+    const { client, calls } = buildHitlClient({
+      immediateData: { status: 'working', task_id: 'task_running', message: 'in flight' },
+      pollResult: { success: true, data: { media_buy_id: 'mb_from_working' } },
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(calls.filter(c => c.kind === 'poll').length, 1, 'poll fires for working status with task_id');
+    assert.equal(result.context.media_buy_id, 'mb_from_working');
+  });
+
   test('plain path captures still work without prefix (no regression)', async () => {
     const plainStoryboard = {
       ...baseStoryboard,

--- a/test/lib/storyboard-runner-task-completion-capture.test.js
+++ b/test/lib/storyboard-runner-task-completion-capture.test.js
@@ -1,0 +1,210 @@
+/**
+ * Runner coverage for `task_completion.<path>` `context_outputs` resolution
+ * (adcp-client#1417). When a step's immediate response is a submitted-arm
+ * envelope and the storyboard captures from `task_completion.media_buy_id`,
+ * the runner polls `tasks/get` until terminal and resolves the rest of the
+ * path against the artifact data — instead of failing with
+ * `capture_path_not_resolvable` for a value the seller correctly produces
+ * on the completion artifact.
+ *
+ * Pinned behaviors:
+ *   - submitted envelope + polled completion → capture succeeds
+ *   - submitted envelope + poll timeout → `capture_poll_timeout` failure
+ *     (not the recycled `capture_path_not_resolvable`)
+ *   - sync-arm response on a `task_completion.` path → falls through to
+ *     plain path resolution against immediate data (path stripped)
+ *   - invalid `task_id` (control chars / oversize) → no poll attempted
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
+
+function buildHitlClient({ immediateData, pollResult, pollDelay = 0, recordPollCall }) {
+  const calls = [];
+  const agent = { id: 'stub', agent_uri: 'https://stub.example/mcp' };
+  const executor = {
+    pollTaskCompletion: async (agentArg, taskId, _pollInterval) => {
+      calls.push({ kind: 'poll', taskId, agentId: agentArg?.id });
+      if (recordPollCall) recordPollCall(taskId);
+      if (pollDelay > 0) await new Promise(r => setTimeout(r, pollDelay));
+      return pollResult ?? { success: false, error: 'no poll result configured' };
+    },
+  };
+  const client = {
+    agent,
+    executor,
+    getAgentInfo: async () => ({ name: 'stub', tools: ['create_media_buy'] }),
+    executeTask: async (name, _params) => {
+      calls.push({ kind: 'execute', name });
+      if (name === 'create_media_buy') return { success: true, data: immediateData };
+      return { success: false, error: `no handler for ${name}` };
+    },
+  };
+  return { client, calls };
+}
+
+const stubProfile = { name: 'stub', tools: ['create_media_buy'] };
+
+const baseStoryboard = {
+  id: 'task_completion_sb',
+  version: '1.0',
+  title: 'task_completion capture',
+  category: 'test',
+  summary: '',
+  narrative: '',
+  agent: { interaction_model: '*', capabilities: [] },
+  caller: { role: 'buyer_agent' },
+  phases: [
+    {
+      id: 'p1',
+      title: 'phase 1',
+      steps: [
+        {
+          id: 'create',
+          title: 'Create a guaranteed media buy',
+          task: 'create_media_buy',
+          sample_request: { idempotency_key: 'idem_test_1' },
+          context_outputs: [{ key: 'media_buy_id', path: 'task_completion.media_buy_id' }],
+        },
+      ],
+    },
+  ],
+};
+
+describe('runStoryboardStep — task_completion. context_outputs', () => {
+  test('captures media_buy_id from polled artifact when immediate response is a submitted envelope', async () => {
+    const { client, calls } = buildHitlClient({
+      immediateData: { status: 'submitted', task_id: 'task_async_signed_io_q2', message: 'awaiting IO' },
+      pollResult: {
+        success: true,
+        data: {
+          media_buy_id: 'mb_42',
+          status: 'pending_creatives',
+          packages: [{ package_id: 'pkg_1' }],
+        },
+      },
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(
+      calls.filter(c => c.kind === 'poll').length,
+      1,
+      'executor.pollTaskCompletion called exactly once for the task_completion. capture'
+    );
+    assert.equal(result.context.media_buy_id, 'mb_42');
+    const captureFailures = result.validations.filter(
+      v => v.check === 'capture_path_not_resolvable' || v.check === 'capture_poll_timeout'
+    );
+    assert.equal(captureFailures.length, 0, 'no capture failures synthesized when polled artifact has the field');
+  });
+
+  test('emits capture_poll_timeout (not capture_path_not_resolvable) when polling exceeds the timeout', async () => {
+    process.env.STORYBOARD_TASK_POLL_TIMEOUT_MS = '50';
+    try {
+      const { client } = buildHitlClient({
+        immediateData: { status: 'submitted', task_id: 'task_will_never_complete', message: 'stuck' },
+        pollResult: { success: true, data: { media_buy_id: 'mb_too_late' } },
+        pollDelay: 500,
+      });
+
+      const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+        protocol: 'mcp',
+        _client: client,
+        _profile: stubProfile,
+      });
+
+      const pollTimeout = result.validations.find(v => v.check === 'capture_poll_timeout');
+      assert.ok(pollTimeout, 'capture_poll_timeout failure synthesized');
+      assert.equal(pollTimeout.passed, false);
+      assert.match(pollTimeout.description, /tasks\/get poll timed out/);
+      assert.equal(
+        result.validations.filter(v => v.check === 'capture_path_not_resolvable').length,
+        0,
+        'capture_path_not_resolvable not used when the failure was a poll timeout'
+      );
+      assert.equal(result.context.media_buy_id, undefined, 'no fabricated media_buy_id captured on timeout');
+    } finally {
+      delete process.env.STORYBOARD_TASK_POLL_TIMEOUT_MS;
+    }
+  });
+
+  test('falls through to plain path resolution when immediate response is the sync arm (no poll)', async () => {
+    const { client, calls } = buildHitlClient({
+      // Sync-arm response — `media_buy_id` already on immediate data, no submitted envelope.
+      immediateData: { media_buy_id: 'mb_sync_immediate', status: 'pending_creatives' },
+      pollResult: { success: true, data: { media_buy_id: 'should_not_be_used' } },
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(
+      calls.filter(c => c.kind === 'poll').length,
+      0,
+      'no poll attempted when immediate response is not a submitted envelope'
+    );
+    assert.equal(result.context.media_buy_id, 'mb_sync_immediate');
+  });
+
+  test('rejects task_id with control characters before polling', async () => {
+    let pollAttempted = false;
+    const { client } = buildHitlClient({
+      immediateData: { status: 'submitted', task_id: 'task\x00injected', message: 'malformed' },
+      pollResult: { success: true, data: { media_buy_id: 'should_not_be_used' } },
+      recordPollCall: () => {
+        pollAttempted = true;
+      },
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(pollAttempted, false, 'pollTaskCompletion not called for invalid task_id');
+    const captureFailure = result.validations.find(v => v.check === 'capture_path_not_resolvable');
+    assert.ok(captureFailure, 'capture_path_not_resolvable when poll path is unreachable');
+  });
+
+  test('plain path captures still work without prefix (no regression)', async () => {
+    const plainStoryboard = {
+      ...baseStoryboard,
+      phases: [
+        {
+          ...baseStoryboard.phases[0],
+          steps: [
+            {
+              ...baseStoryboard.phases[0].steps[0],
+              context_outputs: [{ key: 'media_buy_id', path: 'media_buy_id' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const { client, calls } = buildHitlClient({
+      immediateData: { media_buy_id: 'mb_plain' },
+      pollResult: undefined,
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', plainStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(calls.filter(c => c.kind === 'poll').length, 0);
+    assert.equal(result.context.media_buy_id, 'mb_plain');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1417. Implements **Option 1** from the issue's three options — the path forward both the protocol-expert and code-reviewer triage notes converged on.

Storyboard authors can now declare `path: "task_completion.<inner>"` on `context_outputs`. When the immediate response is a submitted-arm task envelope (HITL / async-signed-IO flows), the runner polls `tasks/get` until terminal and resolves the rest of the path against the artifact's `data` — instead of failing with `capture_path_not_resolvable` for a value the seller correctly produces on the completion artifact.

```yaml
context_outputs:
  - name: media_buy_id
    path: "task_completion.media_buy_id"
```

## Design choices that fell out of triage

- **Explicit prefix, never auto-poll.** Code-reviewer's blocker on Option 2 was that shape-inferred polling risks flipping currently-passing storyboards with intentional submitted envelopes. The prefix IS the explicit opt-in — no risk to existing storyboards.
- **Bounded poll, env-overridable.** Default 30s timeout (`STORYBOARD_TASK_POLL_TIMEOUT_MS`) and 1.5s cadence (`STORYBOARD_TASK_POLL_INTERVAL_MS`). Stuck tasks surface the failure on the step that authored the dependency rather than the storyboard wall-clock budget.
- **Distinct failure code.** `capture_poll_timeout` (not the recycled `capture_path_not_resolvable`) so the failure-class is unambiguous in compliance reports.
- **task_id validation before SDK call.** Length cap (256) + control-char rejection. AdCP doesn't constrain task_id shape on the wire, but unbounded strings are an SSRF / log-injection lever — defensive validation is cheap.

## What this does NOT change

- The runner still doesn't auto-poll based on response shape. Storyboards with intentional submitted envelopes (testing the submitted-arm contract directly) keep working as before.
- No spec change. The prefix lives entirely in the SDK runner.
- The cached `sales_guaranteed` storyboard at `compliance/cache/3.0.5/specialisms/sales-guaranteed/index.yaml` is unchanged — upstream authors can adopt the prefix when they re-author the assertion.

## Test plan

- [x] `node --test test/lib/storyboard-runner-task-completion-capture.test.js` — 5/5 pass:
  - polled artifact captures `media_buy_id` from completion data
  - poll timeout emits `capture_poll_timeout` (not recycled code)
  - sync-arm response on `task_completion.` path falls through to plain extraction (no poll)
  - control-character `task_id` rejected before polling
  - plain `path` (no prefix) regression-free
- [x] `node --test test/lib/storyboard-runner-output-contract-v2-runner.test.js` — 8/8 pass (no regression in existing context_outputs handling)
- [x] `npx tsc --noEmit -p tsconfig.lib.json` clean
- [x] `npm run format:check` clean
- [ ] End-to-end against `hello_seller_adapter_guaranteed` once an upstream storyboard adopts the prefix (deferred until storyboard author updates)

## Companion follow-ups

- #1415 — `createMediaBuyStore` opt-in for sellers (PR #1424; closes the targeting_overlay echo gap on the OTHER side of the storyboard).
- #1416 — `MEDIA_BUY_TRANSITIONS` + `assertMediaBuyTransition` exports (PR #1423; closes the seller's transition-enforcement gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)