### PR TITLE
feat(server): export narrowAccountRef + multi-tenant sandbox / binding-collision warn

### DIFF
--- a/.changeset/tenant-store-followups.md
+++ b/.changeset/tenant-store-followups.md
@@ -1,0 +1,28 @@
+---
+"@adcp/sdk": minor
+---
+
+Three follow-ups to `createTenantStore` (#1387 post-DX review):
+
+- **Export `narrowAccountRef(ref)`** from `@adcp/sdk/server`. The framework already used this internally to read `AccountReference` fields without per-arm narrowing (the wire type is a discriminated union `{account_id} | {brand, operator}` plus optional `sandbox`); adopters writing `tenantToAccount` were cargo-culting `(ref as { operator?: string })` casts at four call sites in the worked example. Single typed accessor consolidates the pattern.
+
+  ```ts
+  tenantToAccount: (tenant, ref, ctx) => {
+    const r = narrowAccountRef(ref);
+    return {
+      id: tenant.id,
+      operator: r?.operator ?? ctx?.agent?.agent_url ?? 'derived',
+      ...(r?.brand?.domain && { brand: { domain: r.brand.domain } }),
+      sandbox: r?.sandbox ?? false,
+      // ...
+    };
+  };
+  ```
+
+  Returns `undefined` on `undefined` input (the no-account-tool path), so adopters can use the same accessor in `tenantToAccount` and in `resolveByRef` without branching.
+
+- **Default sandbox to `false` in the multi-tenant adapter example.** The post-DX review caught an inconsistency: the adapter set `sandbox: ref?.sandbox ?? true` while the skill snippet used `?? false`. Production adopters route reads/writes to a sandbox backend on this flag — defaulting to `true` would silently land buyer requests in sandbox when they didn't ask. Aligned both to `?? false` with an explicit SWAP comment that frames it as an adopter decision.
+
+- **Warn on overwritten governance bindings** in the multi-tenant adapter. The hello-adapter shortcut keys `governanceBindings` by `(tenant, brand_domain)` because `acquire_rights` doesn't carry an operator on the wire (tracked upstream as adcontextprotocol/adcp#3918). Two operators in the same tenant hitting the same brand share one binding — silently. The example now logs a `console.warn` on overwrite that names the symptom and links the upstream issue, so adopters notice the limitation before it bites in production.
+
+Plus a SKILL cross-link in `tenant-store.ts` JSDoc so the helper's IDE hover surfaces the holdco walkthrough.

--- a/examples/hello_seller_adapter_multi_tenant.ts
+++ b/examples/hello_seller_adapter_multi_tenant.ts
@@ -65,6 +65,7 @@ import {
   AdcpError,
   BuyerAgentRegistry,
   createTenantStore,
+  narrowAccountRef,
   defineCampaignGovernancePlatform,
   definePropertyListsPlatform,
   defineBrandRightsPlatform,
@@ -457,9 +458,9 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
    */
   accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>({
     resolveByRef: ref => {
-      const refTyped = ref as { operator?: string };
-      if (!refTyped.operator) return null;
-      const tenantId = OPERATOR_TO_TENANT.get(refTyped.operator);
+      const r = narrowAccountRef(ref);
+      if (!r.operator) return null;
+      const tenantId = OPERATOR_TO_TENANT.get(r.operator);
       return tenantId ? (TENANTS.get(tenantId) ?? null) : null;
     },
     resolveFromAuth: ctx => {
@@ -468,43 +469,42 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
     },
     tenantId: tenant => tenant.id,
     tenantToAccount: (tenant, ref, ctx) => {
-      const refTyped = (ref ?? {}) as { operator?: string; brand?: { domain?: string }; sandbox?: boolean };
+      const r = narrowAccountRef(ref);
       // No-account-tool path: synthesize an operator string from the resolved
       // buyer agent's URL so account.id stays stable per-buyer-per-tenant.
-      const operator = refTyped.operator ?? ctx?.agent?.agent_url ?? 'derived';
+      const operator = r?.operator ?? ctx?.agent?.agent_url ?? 'derived';
       return {
         id: tenant.id,
-        name: refTyped.operator
+        name: r?.operator
           ? `${tenant.display_name} (${operator})`
           : `${tenant.display_name} (auth-derived for ${ctx?.agent?.display_name ?? 'unknown'})`,
         status: 'active',
         operator,
-        ...(refTyped.brand?.domain && { brand: { domain: refTyped.brand.domain } }),
+        ...(r?.brand?.domain && { brand: { domain: r.brand.domain } }),
         ctx_metadata: { tenant_id: tenant.id, display_name: tenant.display_name },
-        // SWAP: read sandbox flag from your backing store. Hello-adapter
-        // honors `ref.sandbox` when present (Path 1) and defaults true on
-        // auth-derived (no-account-tool) lookups since this whole adapter
-        // is a demo.
-        sandbox: refTyped.sandbox ?? true,
+        // SWAP: read sandbox flag from your backing store. Defaults to false
+        // — production adopters route reads/writes to a sandbox backend on
+        // this flag, so an unset wire field MUST NOT silently land in
+        // sandbox. Buyers who want sandbox set `account.sandbox = true`
+        // explicitly.
+        sandbox: r?.sandbox ?? false,
       };
     },
     upsertRow: (tenant, ref, _ctx) => {
       // Cross-tenant entries never reach this callback — the helper's
       // gate already filtered them. Adopter responsibility: the upsert
       // itself.
-      const refTyped = ref as { operator: string; brand: { domain: string } };
-      const key = accountKey(refTyped.operator, refTyped.brand.domain);
+      const r = narrowAccountRef(ref);
+      const operator = r.operator!;
+      const brandDomain = r.brand!.domain!;
+      const key = accountKey(operator, brandDomain);
       // SWAP: row-level write under tenant transaction.
       const action = tenant.accounts.has(key) ? ('updated' as const) : ('created' as const);
-      tenant.accounts.set(key, {
-        operator: refTyped.operator,
-        brand_domain: refTyped.brand.domain,
-        status: 'active',
-      });
+      tenant.accounts.set(key, { operator, brand_domain: brandDomain, status: 'active' });
       return {
         account_id: tenant.id,
-        brand: refTyped.brand,
-        operator: refTyped.operator,
+        brand: { domain: brandDomain },
+        operator,
         action,
         status: 'active' as const,
       };
@@ -517,11 +517,27 @@ class MultiTenantAdapter implements DecisioningPlatform<Record<string, never>, T
       // `entry.governance_agents[i].authentication.credentials` (the
       // framework strips them from the response — see
       // `toWireSyncGovernanceRow` — so the buyer never sees them echoed).
-      const refTyped = entry.account as { brand?: { domain?: string } };
-      const brandDomain = refTyped.brand?.domain;
+      const r = narrowAccountRef(entry.account);
+      const brandDomain = r.brand?.domain;
       const govUrl = entry.governance_agents[0]?.url;
       if (brandDomain) {
         if (govUrl) {
+          // ⚠️ Brand-keyed binding: two operators in the same tenant
+          // hitting the same brand SHARE this binding. `acquire_rights`
+          // doesn't carry an operator on the wire (only `buyer.domain` —
+          // tracked in adcp#3918), so brand is all we have to key on
+          // inside one tenant. Surface a warn when an existing binding
+          // gets overwritten so adopters notice the symptom early —
+          // production adopters either move to per-(operator, brand)
+          // bindings or accept tenant-scoped brand uniqueness as policy.
+          const prior = tenant.governanceBindings.get(brandDomain);
+          if (prior && prior.governance_agent_url !== govUrl) {
+            console.warn(
+              `[multi-tenant] tenant=${tenant.id} brand=${brandDomain} governance binding overwritten ` +
+                `(${prior.governance_agent_url} → ${govUrl}). Two operators sharing one brand within a tenant ` +
+                `share one binding — see adcontextprotocol/adcp#3918.`
+            );
+          }
           // SWAP: row-level write under tenant transaction.
           tenant.governanceBindings.set(brandDomain, {
             governance_agent_url: govUrl,

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -67,9 +67,12 @@ The framework calls `accounts.resolve(ref, ctx)` once per request, and hub adapt
 All three live in `createTenantStore<TTenant, TCtxMeta>` (`@adcp/sdk/server`). Callbacks the adopter provides; gating logic the SDK owns:
 
 ```ts
+import { createTenantStore, narrowAccountRef } from '@adcp/sdk/server';
+
 accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>({
   resolveByRef: ref => {  // Path 1 — operator (or account_id) on the wire
-    const tenantId = OPERATOR_TO_TENANT.get((ref as { operator?: string }).operator ?? '');
+    const r = narrowAccountRef(ref);
+    const tenantId = OPERATOR_TO_TENANT.get(r.operator ?? '');
     return tenantId ? TENANTS.get(tenantId) ?? null : null;
   },
   resolveFromAuth: ctx => {  // Path 2 — derive from authenticated buyer agent
@@ -77,14 +80,17 @@ accounts: AccountStore<TenantMeta> = createTenantStore<TenantState, TenantMeta>(
     return tenantId ? TENANTS.get(tenantId) ?? null : null;
   },
   tenantId: tenant => tenant.id,  // stable equality for the gate (NOT reference)
-  tenantToAccount: (tenant, ref, ctx) => ({  // project tenant + ref → Account
-    id: tenant.id,
-    name: `${tenant.display_name} (${(ref as any)?.operator ?? ctx?.agent?.agent_url})`,
-    status: 'active',
-    operator: (ref as any)?.operator ?? ctx?.agent?.agent_url ?? 'derived',
-    ctx_metadata: { tenant_id: tenant.id, display_name: tenant.display_name },
-    sandbox: (ref as any)?.sandbox ?? false,  // SWAP: route to your sandbox backend
-  }),
+  tenantToAccount: (tenant, ref, ctx) => {  // project tenant + ref → Account
+    const r = narrowAccountRef(ref);
+    return {
+      id: tenant.id,
+      name: `${tenant.display_name} (${r?.operator ?? ctx?.agent?.agent_url})`,
+      status: 'active',
+      operator: r?.operator ?? ctx?.agent?.agent_url ?? 'derived',
+      ctx_metadata: { tenant_id: tenant.id, display_name: tenant.display_name },
+      sandbox: r?.sandbox ?? false,  // SWAP: route to your sandbox backend on this flag
+    };
+  },
   upsertRow: (tenant, ref, ctx) => {  // sync_accounts — only in-tenant entries reach here
     /* row-level upsert under tenant transaction; gate already filtered */
     return { /* SyncAccountsResultRow */ };

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -97,7 +97,7 @@ export { AccountNotFoundError, refAccountId } from './account';
 // (operator-routed + auth-derived) and the per-entry tenant-isolation gate
 // that adopters historically had to hand-write — and silently fail to
 // hand-write — on `accounts.upsert` / `accounts.syncGovernance`.
-export { createTenantStore } from './tenant-store';
+export { createTenantStore, narrowAccountRef } from './tenant-store';
 export type { TenantStoreConfig } from './tenant-store';
 
 // Buyer-agent identity surface — Phase 1 of #1269. Durable commercial

--- a/src/lib/server/decisioning/tenant-store.ts
+++ b/src/lib/server/decisioning/tenant-store.ts
@@ -5,6 +5,10 @@
  * don't) and bakes in the tenant-isolation gate that adopters historically
  * had to write — and silently fail to write — by hand.
  *
+ * Full walkthrough with same-tenant invariant + production caveats:
+ * `skills/build-holdco-agent/SKILL.md`. Worked example:
+ * `examples/hello_seller_adapter_multi_tenant.ts`.
+ *
  * Status: Preview / 6.x.
  *
  * @public
@@ -247,17 +251,51 @@ export function createTenantStore<TTenant, TCtxMeta = Record<string, unknown>>(
 }
 
 /**
- * `AccountReference` is a discriminated union (`{account_id} | {brand, operator}`).
- * The helper's failure-row builders read fields across both arms — schema
- * validation upstream guarantees one arm is populated, so widening to
- * "all-optional" here is safe and avoids per-arm casts at four call sites.
+ * Read fields from an `AccountReference` without per-arm narrowing. The wire
+ * type is a discriminated union (`{account_id} | {brand, operator}`) — schema
+ * validation upstream guarantees one arm is populated, so widening to an
+ * all-optional record is safe and saves a `'in' ref ? ref.x : fallback` dance
+ * inside `tenantToAccount` / `resolveByRef` / failed-row builders.
+ *
+ * Use inside adopter `createTenantStore({...})` callbacks to read
+ * `ref.operator`, `ref.brand?.domain`, or `ref.account_id` without inline
+ * casts. This is the same helper the framework uses internally for its
+ * `PERMISSION_DENIED` / `ACCOUNT_NOT_FOUND` row construction.
+ *
+ * ```ts
+ * tenantToAccount: (tenant, ref, ctx) => {
+ *   const r = narrowAccountRef(ref);
+ *   return {
+ *     id: tenant.id,
+ *     operator: r?.operator ?? ctx?.agent?.agent_url ?? 'derived',
+ *     ...(r?.brand?.domain && { brand: { domain: r.brand.domain } }),
+ *
+ *   };
+ * }
+ * ```
+ *
+ * Returns `undefined` on `undefined` input — the no-account-tool path.
  */
-function narrowAccountRef(ref: AccountReference): {
+export function narrowAccountRef(ref: AccountReference): {
   account_id?: string;
   operator?: string;
   brand?: { domain?: string };
-} {
-  return ref as { account_id?: string; operator?: string; brand?: { domain?: string } };
+  sandbox?: boolean;
+};
+export function narrowAccountRef(ref: undefined): undefined;
+export function narrowAccountRef(ref: AccountReference | undefined):
+  | {
+      account_id?: string;
+      operator?: string;
+      brand?: { domain?: string };
+      sandbox?: boolean;
+    }
+  | undefined;
+export function narrowAccountRef(
+  ref: AccountReference | undefined
+): { account_id?: string; operator?: string; brand?: { domain?: string }; sandbox?: boolean } | undefined {
+  if (ref === undefined) return undefined;
+  return ref as { account_id?: string; operator?: string; brand?: { domain?: string }; sandbox?: boolean };
 }
 
 /**

--- a/test/lib/create-tenant-store.test.js
+++ b/test/lib/create-tenant-store.test.js
@@ -1,7 +1,7 @@
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
 
-const { createTenantStore } = require('../../dist/lib/server/decisioning/index.js');
+const { createTenantStore, narrowAccountRef } = require('../../dist/lib/server/decisioning/index.js');
 
 // ── Test fixtures ──────────────────────────────────────────────────────────
 
@@ -283,6 +283,32 @@ describe('createTenantStore — gate methods locked against override', () => {
     });
     assert.equal(typeof store.list, 'function');
     assert.equal(typeof store.upsert, 'function');
+  });
+});
+
+// ── narrowAccountRef helper ────────────────────────────────────────────────
+
+describe('narrowAccountRef', () => {
+  test('reads operator + brand from the (brand, operator) arm', () => {
+    const r = narrowAccountRef({ brand: { domain: 'acme.example' }, operator: 'pinnacle.example' });
+    assert.equal(r.operator, 'pinnacle.example');
+    assert.equal(r.brand.domain, 'acme.example');
+    assert.equal(r.account_id, undefined);
+  });
+
+  test('reads account_id from the {account_id} arm', () => {
+    const r = narrowAccountRef({ account_id: 'acct_123' });
+    assert.equal(r.account_id, 'acct_123');
+    assert.equal(r.operator, undefined);
+  });
+
+  test('threads sandbox flag through both arms', () => {
+    const r = narrowAccountRef({ account_id: 'acct_123', sandbox: true });
+    assert.equal(r.sandbox, true);
+  });
+
+  test('returns undefined for undefined input (no-account-tool path)', () => {
+    assert.equal(narrowAccountRef(undefined), undefined);
   });
 });
 


### PR DESCRIPTION
Three follow-ups from the post-DX review of the unified four-PR multi-tenant story (#1387). All three are small, self-contained, no open design questions.

## 1. Export \`narrowAccountRef(ref)\`

The framework already used this internally for failure-row construction. Adopters writing \`tenantToAccount\` were cargo-culting \`(ref as { operator?: string })\` casts at four call sites in the worked example.

\`\`\`ts
import { narrowAccountRef } from '@adcp/sdk/server';

tenantToAccount: (tenant, ref, ctx) => {
  const r = narrowAccountRef(ref);
  return {
    id: tenant.id,
    operator: r?.operator ?? ctx?.agent?.agent_url ?? 'derived',
    ...(r?.brand?.domain && { brand: { domain: r.brand.domain } }),
    sandbox: r?.sandbox ?? false,
    // ...
  };
};
\`\`\`

Returns \`undefined\` on \`undefined\` input (no-account-tool path) so the same accessor works in \`tenantToAccount\` and \`resolveByRef\` without branching.

## 2. Default sandbox to \`false\` in the multi-tenant adapter

DX review caught an inconsistency: the adapter set \`sandbox: ref?.sandbox ?? true\` while the skill snippet used \`?? false\`. Production adopters route reads/writes to a sandbox backend on this flag — defaulting to \`true\` would silently land buyer requests in sandbox when they didn't ask. Aligned both to \`?? false\` with an explicit SWAP comment.

## 3. Warn on overwritten governance bindings

The hello-adapter shortcut keys \`governanceBindings\` by \`(tenant, brand_domain)\` because \`acquire_rights\` doesn't carry an operator on the wire (tracked upstream as \`adcontextprotocol/adcp#3918\`). Two operators in the same tenant hitting the same brand share one binding — silently. The example now logs a \`console.warn\` on overwrite naming the symptom and linking the upstream issue.

## 4. SKILL cross-link in JSDoc

\`tenant-store.ts\` JSDoc now points at \`skills/build-holdco-agent/SKILL.md\` and \`examples/hello_seller_adapter_multi_tenant.ts\` so adopters hovering the helper find the full walkthrough.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run format:check\` clean
- [x] \`npm run build:lib\` clean
- [x] \`npm test\` — 7778 pass / 0 fail / 7 skipped
- [x] New \`narrowAccountRef\` test cases (4 in \`create-tenant-store.test.js\`) pass
- [ ] CI passes

Tracking: #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)