### PR TITLE
feat(sdk/server): export canonical state-machine helpers from @adcp/sdk/server

### DIFF
--- a/.changeset/export-state-machine-helpers.md
+++ b/.changeset/export-state-machine-helpers.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": minor
+---
+
+Export canonical MediaBuy and Creative status transition helpers from `@adcp/sdk/server`: `MEDIA_BUY_TRANSITIONS`, `CREATIVE_ASSET_TRANSITIONS`, `isLegalMediaBuyTransition`, `assertMediaBuyTransition`, `isLegalCreativeTransition`, `assertCreativeTransition`. The canonical graphs are now the single source of truth for both the conformance runner's `status.monotonic` invariant and seller adapter transition enforcement, eliminating copy-paste drift across adopter codebases.

--- a/examples/comply-controller-seller.ts
+++ b/examples/comply-controller-seller.ts
@@ -36,6 +36,7 @@
 
 import { createTaskCapableServer, serve, type ServeContext } from '@adcp/sdk';
 import { createComplyController, TestControllerError, type CreativeStatus } from '@adcp/sdk/testing';
+import { assertCreativeTransition } from '@adcp/sdk/server';
 
 // ---------------------------------------------------------------------------
 // In-memory state. In a real seller this would be Postgres / Firestore /
@@ -58,26 +59,8 @@ interface CreativeRecord {
 const products = new Map<string, ProductFixture>();
 const creatives = new Map<string, CreativeRecord>();
 
-// DEMO POLICY — do not copy this table into a production state machine.
-// It is permissive enough to run the example storyboards; a real seller
-// encodes their approval workflow here (and in production the controller
-// itself is never registered). The point of this table is to show WHERE
-// transition enforcement lives — the controller routes through the same
-// guard as the production path.
-const CREATIVE_TRANSITIONS: Record<CreativeStatus, CreativeStatus[]> = {
-  processing: ['pending_review', 'approved', 'rejected'],
-  pending_review: ['approved', 'rejected'],
-  approved: ['rejected', 'archived'],
-  rejected: ['approved', 'archived'],
-  archived: [],
-};
-
-function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
-  const allowed = CREATIVE_TRANSITIONS[from] ?? [];
-  if (!allowed.includes(to)) {
-    throw new TestControllerError('INVALID_TRANSITION', `Creative cannot move from ${from} to ${to}`, from);
-  }
-}
+// assertCreativeTransition imported from @adcp/sdk/server — canonical graph
+// shared with the conformance runner, enforcing the spec-defined edges.
 
 // ---------------------------------------------------------------------------
 // Controller wiring

--- a/examples/seller-test-controller.ts
+++ b/examples/seller-test-controller.ts
@@ -32,6 +32,10 @@ import {
   type TestControllerStoreFactory,
 } from '@adcp/sdk/testing';
 import { createTaskCapableServer, serve, type ServeContext } from '@adcp/sdk';
+import {
+  assertMediaBuyTransition,
+  assertCreativeTransition,
+} from '@adcp/sdk/server';
 
 // ---------------------------------------------------------------------------
 // Typed domain state.
@@ -126,43 +130,8 @@ function resolveSessionId(input: Record<string, unknown>): string {
   return context?.session_id ?? 'example-default';
 }
 
-// ---------------------------------------------------------------------------
-// State-machine guards live HERE, in the same module your production tools
-// import. The controller routes through the same guards — one source of
-// truth for what transitions are legal. The tables cover every state in
-// the AdCP 3.0.0 status enums; TypeScript will catch a missing state if
-// you swap the `Partial<Record<...>>` signature for `Record<...>`.
-// ---------------------------------------------------------------------------
-
-const MEDIA_BUY_TRANSITIONS: Record<MediaBuyStatus, MediaBuyStatus[]> = {
-  pending_creatives: ['pending_start', 'active', 'paused', 'rejected', 'canceled'],
-  pending_start: ['active', 'paused', 'canceled'],
-  active: ['paused', 'completed', 'canceled'],
-  paused: ['active', 'completed', 'canceled'],
-  completed: [],
-  rejected: [],
-  canceled: [],
-};
-
-const CREATIVE_TRANSITIONS: Record<CreativeStatus, CreativeStatus[]> = {
-  processing: ['pending_review', 'approved', 'rejected', 'archived'],
-  pending_review: ['approved', 'rejected', 'archived'],
-  approved: ['rejected', 'archived'],
-  rejected: ['approved', 'archived'],
-  archived: [],
-};
-
-function assertMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus): void {
-  if (!MEDIA_BUY_TRANSITIONS[from].includes(to)) {
-    throw new TestControllerError('INVALID_TRANSITION', `media buy cannot move from ${from} to ${to}`, from);
-  }
-}
-
-function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus): void {
-  if (!CREATIVE_TRANSITIONS[from].includes(to)) {
-    throw new TestControllerError('INVALID_TRANSITION', `creative cannot move from ${from} to ${to}`, from);
-  }
-}
+// State-machine guards from the SDK — one source of truth for what
+// transitions are legal, shared with the conformance runner.
 
 // ---------------------------------------------------------------------------
 // Per-request store factory.

--- a/examples/seller-test-controller.ts
+++ b/examples/seller-test-controller.ts
@@ -33,6 +33,8 @@ import {
 } from '@adcp/sdk/testing';
 import { createTaskCapableServer, serve, type ServeContext } from '@adcp/sdk';
 import {
+  MEDIA_BUY_TRANSITIONS,
+  CREATIVE_ASSET_TRANSITIONS,
   assertMediaBuyTransition,
   assertCreativeTransition,
 } from '@adcp/sdk/server';
@@ -239,11 +241,11 @@ const storeFactory: TestControllerStoreFactory = {
 };
 
 function isMediaBuyStatus(value: unknown): value is MediaBuyStatus {
-  return typeof value === 'string' && value in MEDIA_BUY_TRANSITIONS;
+  return typeof value === 'string' && MEDIA_BUY_TRANSITIONS.has(value as MediaBuyStatus);
 }
 
 function isCreativeStatus(value: unknown): value is CreativeStatus {
-  return typeof value === 'string' && value in CREATIVE_TRANSITIONS;
+  return typeof value === 'string' && CREATIVE_ASSET_TRANSITIONS.has(value as CreativeStatus);
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -668,7 +668,7 @@ const controller = createComplyController({
 controller.register(server);
 ```
 
-Omit adapters you don't support — they auto-return `UNKNOWN_SCENARIO` (not schema errors). Throw `TestControllerError('INVALID_TRANSITION', msg, currentState)` from an adapter when the state machine disallows the transition; the helper emits the typed error envelope.
+Omit adapters you don't support — they auto-return `UNKNOWN_SCENARIO` (not schema errors). Use `assertMediaBuyTransition(from, to, mediaBuyId?)` from `@adcp/sdk/server` in both your production `update_media_buy` handler and your test-controller adapter — it throws the spec-mandated error codes (`NOT_CANCELLABLE` for re-cancel of a canceled buy, `INVALID_STATE` for other illegal edges). The canonical graph is shared with the conformance runner, so your transition enforcement and the runner's `status.monotonic` invariant can never drift.
 
 Registration auto-emits the `capabilities.compliance_testing.scenarios` block per AdCP 3.0 — `controller.register(server)` wires the tool AND declares capability. Don't add `compliance_testing` to `supported_protocols`; per spec it's a capability block, not a protocol.
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -768,7 +768,7 @@ registerTestController(server, store);
 The storyboard tests state machine correctness:
 
 - `NOT_FOUND` when forcing transitions on unknown entities
-- `INVALID_TRANSITION` when transitioning from terminal states (completed, rejected, canceled for media buys; archived blocks active states like processing/pending_review/approved, but archived → rejected is valid)
+- `INVALID_STATE` when transitioning from terminal states (completed, rejected, canceled for media buys; archived blocks active states like processing/pending_review/approved, but archived → rejected is valid); `NOT_CANCELLABLE` specifically when a buy is already `canceled` and the request tries to cancel it again
 - Successful transitions between valid states
 
 Throw `TestControllerError` from store methods for typed errors. The SDK validates status enum values before calling your store.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -1,6 +1,15 @@
 export { adcpError } from './errors';
 export type { AdcpErrorOptions, AdcpErrorPayload, AdcpErrorResponse } from './errors';
 
+export {
+  MEDIA_BUY_TRANSITIONS,
+  CREATIVE_ASSET_TRANSITIONS,
+  isLegalMediaBuyTransition,
+  assertMediaBuyTransition,
+  isLegalCreativeTransition,
+  assertCreativeTransition,
+} from './state-machine';
+
 export { wrapEnvelope } from './wrap-envelope';
 export type { WrapEnvelopeOptions } from './wrap-envelope';
 

--- a/src/lib/server/state-machine.ts
+++ b/src/lib/server/state-machine.ts
@@ -1,0 +1,95 @@
+import type { MediaBuyStatus, CreativeStatus } from '../types/core.generated';
+import { adcpError } from './errors';
+
+/**
+ * Canonical AdCP MediaBuy status transition graph.
+ *
+ * Source of truth: `static/schemas/source/enums/media-buy-status.json`.
+ * The conformance runner enforces `status.monotonic` using this same graph;
+ * keeping one copy here prevents seller implementations from drifting out
+ * of sync with the runner's enforcement.
+ *
+ * NOTE: `pending_start → rejected` is defensible but not explicit in the
+ * schema prose. Kept for parity with the runner; flagged for spec
+ * clarification.
+ */
+export const MEDIA_BUY_TRANSITIONS: ReadonlyMap<MediaBuyStatus, ReadonlySet<MediaBuyStatus>> = new Map([
+  ['pending_creatives', new Set<MediaBuyStatus>(['pending_start', 'active', 'paused', 'canceled', 'rejected'])],
+  ['pending_start', new Set<MediaBuyStatus>(['active', 'paused', 'canceled', 'rejected'])],
+  ['active', new Set<MediaBuyStatus>(['paused', 'completed', 'canceled'])],
+  ['paused', new Set<MediaBuyStatus>(['active', 'completed', 'canceled'])],
+  ['completed', new Set<MediaBuyStatus>()],
+  ['rejected', new Set<MediaBuyStatus>()],
+  ['canceled', new Set<MediaBuyStatus>()],
+]);
+
+/**
+ * Canonical AdCP CreativeAsset status transition graph.
+ *
+ * Source of truth: `static/schemas/source/enums/creative-status.json`.
+ * `approved ↔ archived` is reversible (buyer archives / unarchives).
+ * `rejected → processing` is allowed on re-sync.
+ */
+export const CREATIVE_ASSET_TRANSITIONS: ReadonlyMap<CreativeStatus, ReadonlySet<CreativeStatus>> = new Map([
+  ['processing', new Set<CreativeStatus>(['pending_review', 'rejected'])],
+  ['pending_review', new Set<CreativeStatus>(['approved', 'rejected'])],
+  ['approved', new Set<CreativeStatus>(['archived', 'rejected'])],
+  ['archived', new Set<CreativeStatus>(['approved'])],
+  ['rejected', new Set<CreativeStatus>(['processing', 'pending_review'])],
+]);
+
+export function isLegalMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus): boolean {
+  return MEDIA_BUY_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+/**
+ * Assert that a MediaBuy status transition is legal, throwing the
+ * spec-mandated AdCP error code if not.
+ *
+ * - `canceled → canceled`: throws `NOT_CANCELLABLE` (idempotency-on-cancel)
+ * - Any other illegal edge: throws `INVALID_STATE`
+ *
+ * The returned error is an `AdcpErrorResponse` shaped for direct `throw`
+ * from a tool handler — the `createAdcpServer` framework auto-unwraps it.
+ *
+ * @param from     Current status of the media buy.
+ * @param to       Desired target status.
+ * @param mediaBuyId  Optional ID included in the error message for diagnostics.
+ */
+export function assertMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus, mediaBuyId?: string): void {
+  if (isLegalMediaBuyTransition(from, to)) return;
+  const label = mediaBuyId ? `Media buy ${mediaBuyId}` : 'Media buy';
+  if (from === 'canceled' && to === 'canceled') {
+    throw adcpError('NOT_CANCELLABLE', {
+      message: `${label} is already canceled; canceled is terminal.`,
+      recovery: 'terminal',
+    });
+  }
+  throw adcpError('INVALID_STATE', {
+    message: `${label}: illegal status transition ${from} → ${to}.`,
+    field: 'status',
+    recovery: 'terminal',
+  });
+}
+
+export function isLegalCreativeTransition(from: CreativeStatus, to: CreativeStatus): boolean {
+  return CREATIVE_ASSET_TRANSITIONS.get(from)?.has(to) ?? false;
+}
+
+/**
+ * Assert that a Creative status transition is legal, throwing the
+ * spec-mandated AdCP error code if not.
+ *
+ * @param from       Current status of the creative.
+ * @param to         Desired target status.
+ * @param creativeId  Optional ID included in the error message for diagnostics.
+ */
+export function assertCreativeTransition(from: CreativeStatus, to: CreativeStatus, creativeId?: string): void {
+  if (isLegalCreativeTransition(from, to)) return;
+  const label = creativeId ? `Creative ${creativeId}` : 'Creative';
+  throw adcpError('INVALID_STATE', {
+    message: `${label}: illegal status transition ${from} → ${to}.`,
+    field: 'status',
+    recovery: 'terminal',
+  });
+}

--- a/src/lib/server/state-machine.ts
+++ b/src/lib/server/state-machine.ts
@@ -59,6 +59,9 @@ export function isLegalMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStat
 export function assertMediaBuyTransition(from: MediaBuyStatus, to: MediaBuyStatus, mediaBuyId?: string): void {
   if (isLegalMediaBuyTransition(from, to)) return;
   const label = mediaBuyId ? `Media buy ${mediaBuyId}` : 'Media buy';
+  // NOT_CANCELLABLE is reserved for cancel-of-already-canceled (duplicate cancel
+  // request). Other terminal→canceled paths (completed→canceled, rejected→canceled)
+  // are not "cancel requests" but illegal state jumps — they use INVALID_STATE.
   if (from === 'canceled' && to === 'canceled') {
     throw adcpError('NOT_CANCELLABLE', {
       message: `${label} is already canceled; canceled is terminal.`,

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -35,6 +35,10 @@
 
 import { ADCP_VERSION } from '../../version';
 import { CONFLICT_ADCP_ERROR_ALLOWLIST } from '../../server/envelope-allowlist';
+import {
+  MEDIA_BUY_TRANSITIONS as MEDIA_BUY_TRANSITION_MAP,
+  CREATIVE_ASSET_TRANSITIONS as CREATIVE_ASSET_TRANSITION_MAP,
+} from '../../server/state-machine';
 import { registerAssertion } from './assertions';
 
 // Register only once per process. `registerAssertion` throws on duplicates —
@@ -537,45 +541,12 @@ function buildEnumSchemaUrl(enumFile: string): string {
 }
 
 const MEDIA_BUY_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/media-buy-status.json`. `active ↔ paused`
-  // is reversible (buyer pauses, seller resumes). `completed | rejected |
-  // canceled` are terminal.
-  //
-  // NOTE: `pending_start → rejected` is defensible but not explicit in the
-  // schema prose — rejected is described as "declined by the seller after
-  // creation", which is ambiguous on whether post-start rejection is in
-  // scope. Kept for now; flagged for spec clarification.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['pending_creatives', new Set(['pending_start', 'active', 'paused', 'canceled', 'rejected'])],
-    ['pending_start', new Set(['active', 'paused', 'canceled', 'rejected'])],
-    ['active', new Set(['paused', 'completed', 'canceled'])],
-    ['paused', new Set(['active', 'completed', 'canceled'])],
-    ['completed', new Set()],
-    ['rejected', new Set()],
-    ['canceled', new Set()],
-  ]),
+  transitions: MEDIA_BUY_TRANSITION_MAP,
   enumFile: 'media-buy-status.json',
 };
 
 const CREATIVE_ASSET_TRANSITIONS: TransitionGraph = {
-  // See `static/schemas/source/enums/creative-status.json`. The schema is
-  // explicit on which edges exist:
-  //   - processing: "Automatically transitions to pending_review when
-  //     processing completes, or to rejected if processing fails." → no
-  //     direct `processing → approved` edge.
-  //   - pending_review: "Transitions to approved or rejected after review."
-  //     → no `pending_review → processing` edge.
-  //   - rejected: "Buyer can re-submit by calling sync_creatives again,
-  //     which moves the creative back to processing." → the re-sync path.
-  //   - approved ↔ archived is reversible (buyer archives / unarchives).
-  // No terminals — everything can recover via re-sync.
-  transitions: new Map<string, ReadonlySet<string>>([
-    ['processing', new Set(['pending_review', 'rejected'])],
-    ['pending_review', new Set(['approved', 'rejected'])],
-    ['approved', new Set(['archived', 'rejected'])],
-    ['archived', new Set(['approved'])],
-    ['rejected', new Set(['processing', 'pending_review'])],
-  ]),
+  transitions: CREATIVE_ASSET_TRANSITION_MAP,
   enumFile: 'creative-status.json',
 };
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '5.25.0';
+export const LIBRARY_VERSION = '5.25.1';
 
 /**
  * AdCP specification version this library is built for
@@ -45,10 +45,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '5.25.0',
+  library: '5.25.1',
   adcp: '3.0.1',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-04-30T09:45:14.937Z',
+  generatedAt: '2026-05-03T03:35:04.632Z',
 } as const;
 
 /**

--- a/test/lib/state-machine.test.js
+++ b/test/lib/state-machine.test.js
@@ -1,0 +1,133 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  MEDIA_BUY_TRANSITIONS,
+  CREATIVE_ASSET_TRANSITIONS,
+  isLegalMediaBuyTransition,
+  assertMediaBuyTransition,
+  isLegalCreativeTransition,
+  assertCreativeTransition,
+} = require('../../dist/lib/server/state-machine');
+
+describe('isLegalMediaBuyTransition', () => {
+  it('allows legal edges', () => {
+    assert.strictEqual(isLegalMediaBuyTransition('active', 'paused'), true);
+    assert.strictEqual(isLegalMediaBuyTransition('paused', 'active'), true);
+    assert.strictEqual(isLegalMediaBuyTransition('active', 'canceled'), true);
+    assert.strictEqual(isLegalMediaBuyTransition('pending_creatives', 'pending_start'), true);
+    assert.strictEqual(isLegalMediaBuyTransition('pending_start', 'active'), true);
+  });
+
+  it('rejects illegal edges', () => {
+    assert.strictEqual(isLegalMediaBuyTransition('completed', 'active'), false);
+    assert.strictEqual(isLegalMediaBuyTransition('canceled', 'active'), false);
+    assert.strictEqual(isLegalMediaBuyTransition('rejected', 'paused'), false);
+    assert.strictEqual(isLegalMediaBuyTransition('active', 'pending_creatives'), false);
+  });
+
+  it('rejects self-transitions on terminal states', () => {
+    assert.strictEqual(isLegalMediaBuyTransition('canceled', 'canceled'), false);
+    assert.strictEqual(isLegalMediaBuyTransition('completed', 'completed'), false);
+    assert.strictEqual(isLegalMediaBuyTransition('rejected', 'rejected'), false);
+  });
+
+  it('handles unknown status gracefully', () => {
+    assert.strictEqual(isLegalMediaBuyTransition('unknown_status', 'active'), false);
+  });
+});
+
+describe('assertMediaBuyTransition', () => {
+  it('passes on legal transition', () => {
+    assert.doesNotThrow(() => assertMediaBuyTransition('active', 'paused'));
+    assert.doesNotThrow(() => assertMediaBuyTransition('pending_creatives', 'pending_start'));
+  });
+
+  it('throws NOT_CANCELLABLE for canceled → canceled', () => {
+    try {
+      assertMediaBuyTransition('canceled', 'canceled');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err?.structuredContent?.adcp_error?.code, 'NOT_CANCELLABLE');
+    }
+  });
+
+  it('throws NOT_CANCELLABLE with mediaBuyId in message when provided', () => {
+    try {
+      assertMediaBuyTransition('canceled', 'canceled', 'buy-123');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.ok(err?.structuredContent?.adcp_error?.message?.includes('buy-123'), 'message should include mediaBuyId');
+    }
+  });
+
+  it('throws INVALID_STATE for other illegal edges', () => {
+    try {
+      assertMediaBuyTransition('completed', 'active');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err?.structuredContent?.adcp_error?.code, 'INVALID_STATE');
+    }
+  });
+
+  it('throws INVALID_STATE for canceled → active (not NOT_CANCELLABLE)', () => {
+    try {
+      assertMediaBuyTransition('canceled', 'active');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err?.structuredContent?.adcp_error?.code, 'INVALID_STATE');
+    }
+  });
+});
+
+describe('isLegalCreativeTransition', () => {
+  it('allows spec-defined edges', () => {
+    assert.strictEqual(isLegalCreativeTransition('processing', 'pending_review'), true);
+    assert.strictEqual(isLegalCreativeTransition('pending_review', 'approved'), true);
+    assert.strictEqual(isLegalCreativeTransition('approved', 'archived'), true);
+    assert.strictEqual(isLegalCreativeTransition('archived', 'approved'), true);
+    assert.strictEqual(isLegalCreativeTransition('rejected', 'processing'), true);
+  });
+
+  it('rejects edges absent from spec', () => {
+    assert.strictEqual(isLegalCreativeTransition('processing', 'approved'), false);
+    assert.strictEqual(isLegalCreativeTransition('pending_review', 'archived'), false);
+    assert.strictEqual(isLegalCreativeTransition('archived', 'rejected'), false);
+  });
+});
+
+describe('assertCreativeTransition', () => {
+  it('passes on legal transition', () => {
+    assert.doesNotThrow(() => assertCreativeTransition('processing', 'pending_review'));
+    assert.doesNotThrow(() => assertCreativeTransition('rejected', 'processing'));
+  });
+
+  it('throws INVALID_STATE for illegal edge', () => {
+    try {
+      assertCreativeTransition('processing', 'approved');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.strictEqual(err?.structuredContent?.adcp_error?.code, 'INVALID_STATE');
+    }
+  });
+
+  it('throws INVALID_STATE with creativeId in message when provided', () => {
+    try {
+      assertCreativeTransition('processing', 'approved', 'cr-42');
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.ok(err?.structuredContent?.adcp_error?.message?.includes('cr-42'), 'message should include creativeId');
+    }
+  });
+});
+
+describe('exported maps have correct types', () => {
+  it('MEDIA_BUY_TRANSITIONS is a ReadonlyMap', () => {
+    assert.ok(MEDIA_BUY_TRANSITIONS instanceof Map);
+    assert.ok(MEDIA_BUY_TRANSITIONS.get('active') instanceof Set);
+  });
+
+  it('CREATIVE_ASSET_TRANSITIONS is a ReadonlyMap', () => {
+    assert.ok(CREATIVE_ASSET_TRANSITIONS instanceof Map);
+    assert.ok(CREATIVE_ASSET_TRANSITIONS.get('processing') instanceof Set);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1416.

Exports `MEDIA_BUY_TRANSITIONS`, `CREATIVE_ASSET_TRANSITIONS`, `isLegalMediaBuyTransition`, `assertMediaBuyTransition`, `isLegalCreativeTransition`, and `assertCreativeTransition` from `@adcp/sdk/server` as the single canonical source of truth for status transition enforcement.

- **`src/lib/server/state-machine.ts`** (new) — canonical graphs and helpers. `assertMediaBuyTransition` throws `NOT_CANCELLABLE` for `canceled → canceled` (duplicate cancel) and `INVALID_STATE` for all other illegal edges. `assertCreativeTransition` throws `INVALID_STATE`.
- **`src/lib/server/index.ts`** — re-exports all six symbols from `state-machine.ts`.
- **`src/lib/testing/storyboard/default-invariants.ts`** — `status.monotonic` invariant now imports from `state-machine.ts` instead of maintaining a duplicate graph; eliminates the primary drift vector.
- **`examples/seller-test-controller.ts`** and **`examples/comply-controller-seller.ts`** — removed ~55 lines of copy-paste graph definitions; now import `assert*Transition` from `@adcp/sdk/server`.
- **`skills/build-seller-agent/SKILL.md`** — updated transition error code guidance from `INVALID_TRANSITION` (non-standard) to `INVALID_STATE` / `NOT_CANCELLABLE`.
- **`test/lib/state-machine.test.js`** — 16 tests covering all exported functions and both error codes.

## Test plan

- [ ] `node --test test/lib/state-machine.test.js` → 16/16 pass
- [ ] `node --test test/lib/context-extractors.test.js` → 18/18 pass (no regression)
- [ ] `npx tsc --project tsconfig.lib.json` → pre-existing TS2688/TS5107 only, no new errors
- [ ] `npx tsx examples/seller-test-controller.ts` starts without `ReferenceError`
- [ ] `npx tsx examples/comply-controller-seller.ts` starts without `ReferenceError`

https://claude.ai/code/session_01GDzUJwimmWqWrWGVaTh1rd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDzUJwimmWqWrWGVaTh1rd)_