### PR TITLE
test(server): lock in seller-response preference for MediaBuyStore (#1430)

### DIFF
--- a/.changeset/mediabuy-store-response-preference-test.md
+++ b/.changeset/mediabuy-store-response-preference-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: lock in MediaBuyStore's preference for `result.packages[i].targeting_overlay` over the buyer-supplied request copy. Closes #1430. No behavior change — the preference shipped in PR #1424; this adds the test that pins it.

--- a/src/lib/server/media-buy-store.test.ts
+++ b/src/lib/server/media-buy-store.test.ts
@@ -69,6 +69,36 @@ describe('createMediaBuyStore — persistFromCreate + backfill', () => {
     });
   });
 
+  it('persists the seller-normalized targeting_overlay from the response when present, not the buyer-supplied request copy', async () => {
+    const { store } = setup();
+    const buyerSupplied: TargetingOverlay = {
+      property_list: { list_id: 'acme_outdoor_allowlist_v1', agent_url: 'https://buyer.example/lists' },
+    };
+    // Sellers commonly resolve `agent_url` to a canonical resolver,
+    // strip unknown fields, or rewrite list_ids to the seller's
+    // namespace before persisting. Per spec, the echoed overlay MUST
+    // reflect what the seller persisted — the buyer-supplied copy is
+    // not authoritative once the seller normalizes.
+    const sellerNormalized: TargetingOverlay = {
+      property_list: { list_id: 'acme_outdoor_allowlist_v1', agent_url: 'https://lists.canonical.example' },
+    };
+
+    await store.persistFromCreate(
+      'acct_a',
+      { packages: [{ buyer_ref: 'pkg_a', targeting_overlay: buyerSupplied }] },
+      {
+        media_buy_id: 'mb_1',
+        packages: [{ package_id: 'seller_pkg_001', buyer_ref: 'pkg_a', targeting_overlay: sellerNormalized }],
+      }
+    );
+
+    const result = await store.backfill('acct_a', {
+      media_buys: [{ media_buy_id: 'mb_1', packages: [{ package_id: 'seller_pkg_001' }] }],
+    });
+
+    expect(result.media_buys?.[0]?.packages?.[0]?.targeting_overlay).toEqual(sellerNormalized);
+  });
+
   it('does not overwrite a targeting_overlay the seller already echoed', async () => {
     const { store } = setup();
     const sellerEchoed: TargetingOverlay = { geo_countries: ['US'] };


### PR DESCRIPTION
## Summary

Closes #1430. PR #1424 already preferred `response.targeting_overlay` over `request.targeting_overlay` in `mediaBuyStore.persistFromCreate` (per protocol-expert review feedback addressed in the rolled-up fixup commit), but no test pinned the behavior. This PR adds one.

The new test simulates a normalizing seller — buyer sends `agent_url: 'https://buyer.example/lists'`, seller canonicalizes to `https://lists.canonical.example` before persisting, response carries the canonicalized form. The store must echo the seller's normalized version, not the buyer's original.

## Test plan

- [x] `npx vitest run src/lib/server/media-buy-store.test.ts` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)