### PR TITLE
feat(runner): webhook-receiver fallback for task_completion. captures (#1431)

### DIFF
--- a/.changeset/storyboard-runner-webhook-fallback.md
+++ b/.changeset/storyboard-runner-webhook-fallback.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': minor
+---
+
+Storyboard runner — `task_completion.<path>` resolution now races `tasks/get` polling against the active webhook receiver, whichever arrives first.
+
+Per `tasks-get-response.json:75-85`, sellers MAY use webhook-only HITL completion (the spec's `submitted` enumDescription explicitly says _"Client should poll with tasks/get **or provide webhook_url at protocol level**"_). Pre-this-release, `task_completion.<path>` captures fail-closed against webhook-only sellers because the runner only polled. With this release, when `--webhook-receiver` is active, the runner waits for either (a) terminal `tasks/get` response, or (b) a webhook payload whose body's `task_id` matches the originating step. The first to resolve provides the artifact data; the runner extracts the captured field from there.
+
+The `task_completion.` syntax is unchanged — adoption is forward-compatible. Storyboard authors don't need to declare their preferred resolution source; runner picks whatever arrives.
+
+Failure modes preserved from the prior `task_completion.` implementation:
+
+- `capture_poll_timeout` — neither poll nor webhook resolved within the bounded timeout
+- `capture_task_failed` — poll returned a terminal failure OR webhook delivered a non-completed terminal status (`failed` / `canceled` / `rejected`)
+- `capture_path_not_resolvable` — task succeeded but the artifact (from poll OR webhook) didn't carry the requested field
+
+Closes #1431.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -46,7 +46,7 @@ import {
 import { validateTestKit } from './test-kit';
 import { validateStoryboardShape } from './loader';
 import { probeRequestSigningVector } from './request-signing/probe-dispatch';
-import { createWebhookReceiver, type WebhookReceiver } from './webhook-receiver';
+import { createWebhookReceiver, type WebhookReceiver, type WebhookWaitResult } from './webhook-receiver';
 import { WEBHOOK_ASSERTION_TASKS, armWebhookAssertions, executeWebhookAssertionStep } from './webhook-assertions';
 import { CONTROLLER_SEEDING_PHASE_ID, runControllerSeeding, type ControllerSeedingResult } from './seeding';
 
@@ -396,7 +396,8 @@ function remapTaskCompletionOutputs<T extends { path?: string | undefined }>(out
 async function resolveTaskCompletionOutputs(
   taskResult: TaskResult | undefined,
   outputs: readonly { path?: string | undefined }[],
-  client: TestClient
+  client: TestClient,
+  webhookReceiver: WebhookReceiver | undefined
 ): Promise<TaskCompletionResolution> {
   const hasTaskCompletionPath = outputs.some(
     o => typeof o.path === 'string' && o.path.startsWith(TASK_COMPLETION_PATH_PREFIX)
@@ -424,36 +425,82 @@ async function resolveTaskCompletionOutputs(
   const dynamicClient = client as any;
   const executor = dynamicClient?.executor;
   const agent = dynamicClient?.agent;
-  if (!executor?.pollTaskCompletion || !agent) {
-    return { attempted: false };
+  const canPoll = !!(executor?.pollTaskCompletion && agent);
+  const canWebhook = !!webhookReceiver;
+  if (!canPoll && !canWebhook) return { attempted: false };
+
+  type PollWin = { kind: 'poll'; result: TaskResult };
+  type WebhookWin = { kind: 'webhook'; result: WebhookWaitResult };
+  type TimeoutWin = { kind: 'timeout' };
+  type Winner = PollWin | WebhookWin | TimeoutWin;
+
+  const racers: Promise<Winner>[] = [];
+
+  // Poll path. Note: when the outer race resolves first, the SDK's
+  // `pollTaskCompletion` keeps polling internally until it observes a
+  // terminal state. The runner's outer timeout is enough to bound the
+  // *step* duration; the inner loop continuation is a known limitation
+  // pending an AbortSignal addition to the SDK.
+  if (canPoll) {
+    racers.push(
+      executor.pollTaskCompletion(agent, taskId, pollIntervalMs).then(
+        (result: TaskResult): PollWin => ({
+          kind: 'poll',
+          result,
+        })
+      )
+    );
   }
 
-  // Note: when the outer race resolves on timeout, the SDK's
-  // `pollTaskCompletion` keeps polling internally until it observes a
-  // terminal state. For a stuck task that means `tasks/get` continues
-  // hitting the agent every `pollIntervalMs` until the process exits.
-  // The runner's outer timeout is enough to bound the *step* duration;
-  // the inner loop continuation is a known limitation pending an
-  // AbortSignal addition to the SDK.
+  // Webhook path. Per `tasks-get-response.json`, sellers MAY use webhook-
+  // only HITL completion (no polling). When a `--webhook-receiver` is
+  // active, race the receiver's `wait` (filtered by `task_id`) against
+  // the poll. The webhook payload's `result` field is the artifact's
+  // `data` (per the framework's task webhook payload shape, mirroring
+  // the HITL completion shape from `from-platform.ts`).
+  if (canWebhook) {
+    racers.push(
+      webhookReceiver!
+        .wait({ body: { task_id: taskId } }, timeoutMs)
+        .then((result): WebhookWin => ({ kind: 'webhook', result }))
+    );
+  }
+
   let timer: NodeJS.Timeout | undefined;
-  const timeoutPromise = new Promise<{ timedOut: true }>(resolve => {
-    timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
+  const timeoutRacer = new Promise<TimeoutWin>(resolve => {
+    timer = setTimeout(() => resolve({ kind: 'timeout' }), timeoutMs);
     // Don't keep the event loop alive on this handle — the runner's
     // wall-clock budget is already enforced by the storyboard runner
     // shell, and a hung task shouldn't delay process exit by `timeoutMs`.
     timer.unref?.();
   });
+  racers.push(timeoutRacer);
 
   try {
-    const polled = await Promise.race([executor.pollTaskCompletion(agent, taskId, pollIntervalMs), timeoutPromise]);
-    if (polled && typeof polled === 'object' && 'timedOut' in polled && polled.timedOut === true) {
+    const winner = await Promise.race(racers);
+    if (winner.kind === 'timeout') {
       return { attempted: true, timedOut: true, pollTimeoutMs: timeoutMs };
     }
-    const polledTaskResult = polled as TaskResult;
-    if (polledTaskResult.success === false) {
+    if (winner.kind === 'poll') {
+      const polled = winner.result;
+      if (polled.success === false) return { attempted: true, taskFailed: true };
+      return { attempted: true, data: polled.data };
+    }
+    // Webhook win.
+    const waitResult = winner.result;
+    if (waitResult.timed_out) {
+      return { attempted: true, timedOut: true, pollTimeoutMs: timeoutMs };
+    }
+    const webhookBody = waitResult.webhook.body as
+      | { status?: unknown; result?: unknown; task_status?: unknown }
+      | undefined;
+    // Treat any non-completed terminal status (failed/canceled/rejected)
+    // surfaced via webhook the same as a poll-side `success: false`.
+    const status = webhookBody?.status ?? webhookBody?.task_status;
+    if (typeof status === 'string' && status !== 'completed') {
       return { attempted: true, taskFailed: true };
     }
-    return { attempted: true, data: polledTaskResult.data };
+    return { attempted: true, data: webhookBody?.result };
   } catch {
     return { attempted: true, taskFailed: true };
   } finally {
@@ -2188,14 +2235,22 @@ export async function runStoryboardStep(
   const context: StoryboardContext = { ...options.context };
   if (options.context) forwardAliasCache(options.context, context);
 
-  const webhookReceiver = options.webhook_receiver
-    ? await createWebhookReceiver({
-        ...(options.webhook_receiver.mode && { mode: options.webhook_receiver.mode }),
-        ...(options.webhook_receiver.host !== undefined && { host: options.webhook_receiver.host }),
-        ...(options.webhook_receiver.port !== undefined && { port: options.webhook_receiver.port }),
-        ...(options.webhook_receiver.public_url !== undefined && { public_url: options.webhook_receiver.public_url }),
-      })
-    : undefined;
+  // `_webhookReceiver` is a test-only injection point; production callers
+  // pass `webhook_receiver` and the runner constructs the listener.
+  const injectedReceiver = options._webhookReceiver as WebhookReceiver | undefined;
+  const webhookReceiver: WebhookReceiver | undefined =
+    injectedReceiver ??
+    (options.webhook_receiver
+      ? await createWebhookReceiver({
+          ...(options.webhook_receiver.mode && { mode: options.webhook_receiver.mode }),
+          ...(options.webhook_receiver.host !== undefined && { host: options.webhook_receiver.host }),
+          ...(options.webhook_receiver.port !== undefined && { port: options.webhook_receiver.port }),
+          ...(options.webhook_receiver.public_url !== undefined && {
+            public_url: options.webhook_receiver.public_url,
+          }),
+        })
+      : undefined);
+  const ownsWebhookReceiver = !injectedReceiver && !!webhookReceiver;
   const runnerVars = createRunnerVariables({
     ...(webhookReceiver && { webhookBase: webhookReceiver.base_url }),
   });
@@ -2205,7 +2260,7 @@ export async function runStoryboardStep(
   const allSteps = flattenSteps(storyboard);
   const found = allSteps.find(s => s.step.id === stepId);
   if (!found) {
-    if (webhookReceiver) await webhookReceiver.close();
+    if (ownsWebhookReceiver && webhookReceiver) await webhookReceiver.close();
     throw new Error(
       `Step "${stepId}" not found in storyboard "${storyboard.id}". ` +
         `Available steps: ${allSteps.map(s => s.step.id).join(', ')}`
@@ -2233,7 +2288,7 @@ export async function runStoryboardStep(
     await closeConnections(options.protocol);
   }
 
-  if (webhookReceiver) await webhookReceiver.close();
+  if (ownsWebhookReceiver && webhookReceiver) await webhookReceiver.close();
 
   return result;
 }
@@ -2823,7 +2878,12 @@ async function executeStep(
     // `capture_poll_timeout` instead of recycling
     // `capture_path_not_resolvable` so the failure-class is distinct from
     // the original "field absent in immediate response" diagnostic.
-    const taskCompletionResolution = await resolveTaskCompletionOutputs(taskResult, step.context_outputs, client);
+    const taskCompletionResolution = await resolveTaskCompletionOutputs(
+      taskResult,
+      step.context_outputs,
+      client,
+      runState.webhookReceiver
+    );
     // `'data' in resolution` distinguishes "polled, artifact had no data"
     // (use undefined → outputs fail with capture_path_not_resolvable) from
     // "did not poll" (fall back to the immediate response data).

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -458,9 +458,15 @@ async function resolveTaskCompletionOutputs(
   // the poll. The webhook payload's `result` field is the artifact's
   // `data` (per the framework's task webhook payload shape, mirroring
   // the HITL completion shape from `from-platform.ts`).
-  if (canWebhook) {
+  //
+  // Note: `webhook.wait` keeps an internal `setTimeout(timeout_ms)` that
+  // we can't cancel from here. When the poll wins or the outer timeout
+  // fires first, that internal timer continues until `timeout_ms`
+  // elapses. Acceptable because the receiver is process-scoped (closed
+  // on storyboard exit) and runner-owned receivers aren't injected.
+  if (webhookReceiver) {
     racers.push(
-      webhookReceiver!
+      webhookReceiver
         .wait({ body: { task_id: taskId } }, timeoutMs)
         .then((result): WebhookWin => ({ kind: 'webhook', result }))
     );
@@ -491,16 +497,17 @@ async function resolveTaskCompletionOutputs(
     if (waitResult.timed_out) {
       return { attempted: true, timedOut: true, pollTimeoutMs: timeoutMs };
     }
-    const webhookBody = waitResult.webhook.body as
-      | { status?: unknown; result?: unknown; task_status?: unknown }
-      | undefined;
-    // Treat any non-completed terminal status (failed/canceled/rejected)
-    // surfaced via webhook the same as a poll-side `success: false`.
-    const status = webhookBody?.status ?? webhookBody?.task_status;
-    if (typeof status === 'string' && status !== 'completed') {
-      return { attempted: true, taskFailed: true };
+    const webhookBody = waitResult.webhook.body as { status?: unknown; result?: unknown } | undefined;
+    // Fail-closed on the success path: require `status === 'completed'`.
+    // The framework's `buildTaskWebhookPayload` always emits `status`, so a
+    // missing or non-completed value means either a malformed webhook or a
+    // genuine terminal-failed/canceled/rejected outcome — both should
+    // attribute to `capture_task_failed`, not silently fall through to a
+    // capture against an undefined `result`.
+    if (webhookBody?.status === 'completed') {
+      return { attempted: true, data: webhookBody.result };
     }
-    return { attempted: true, data: webhookBody?.result };
+    return { attempted: true, taskFailed: true };
   } catch {
     return { attempted: true, taskFailed: true };
   } finally {
@@ -2237,7 +2244,7 @@ export async function runStoryboardStep(
 
   // `_webhookReceiver` is a test-only injection point; production callers
   // pass `webhook_receiver` and the runner constructs the listener.
-  const injectedReceiver = options._webhookReceiver as WebhookReceiver | undefined;
+  const injectedReceiver = options._webhookReceiver;
   const webhookReceiver: WebhookReceiver | undefined =
     injectedReceiver ??
     (options.webhook_receiver

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -4,6 +4,7 @@
 
 import type { FormatReferenceStructuredObject as FormatID } from '../types/core.generated';
 import type { ControllerDetection } from './test-controller';
+import type { WebhookReceiver } from './storyboard/webhook-receiver';
 
 // Test scenarios that can be run
 export type TestScenario =
@@ -208,7 +209,7 @@ export interface TestOptions {
    *  present, the runner skips creating its own listener and does NOT close
    *  the receiver after the run (caller-owned). Production callers pass
    *  `webhook_receiver` instead. */
-  _webhookReceiver?: unknown;
+  _webhookReceiver?: WebhookReceiver;
 }
 
 export interface TestStepResult {

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -204,6 +204,11 @@ export interface TestOptions {
   _profile?: AgentProfile;
   /** @internal Test controller capabilities from comply() — set when comply_test_controller detected */
   _controllerCapabilities?: ControllerDetection;
+  /** @internal Pre-created webhook receiver, used for unit-test injection. When
+   *  present, the runner skips creating its own listener and does NOT close
+   *  the receiver after the run (caller-owned). Production callers pass
+   *  `webhook_receiver` instead. */
+  _webhookReceiver?: unknown;
 }
 
 export interface TestStepResult {

--- a/test/lib/storyboard-runner-task-completion-capture.test.js
+++ b/test/lib/storyboard-runner-task-completion-capture.test.js
@@ -75,6 +75,10 @@ function buildWebhookReceiver({ payload, deliverAfterMs = 0, deliverStatus = 'co
       if (deliverAfterMs > 0) {
         await new Promise(r => setTimeout(r, deliverAfterMs));
       }
+      // `status: deliverStatus` first lets a test override status by
+      // setting it explicitly on `payload` if needed; spreading `payload`
+      // last makes that explicit override authoritative.
+      const body = { status: deliverStatus, ...payload };
       return {
         webhook: {
           id: 'wh1',
@@ -85,8 +89,8 @@ function buildWebhookReceiver({ payload, deliverAfterMs = 0, deliverStatus = 'co
           method: 'POST',
           path: '/',
           headers: {},
-          raw_body: JSON.stringify(payload),
-          body: { ...payload, status: deliverStatus },
+          raw_body: JSON.stringify(body),
+          body,
           response_status: 200,
         },
       };

--- a/test/lib/storyboard-runner-task-completion-capture.test.js
+++ b/test/lib/storyboard-runner-task-completion-capture.test.js
@@ -21,20 +21,22 @@ const assert = require('node:assert/strict');
 
 const { runStoryboardStep } = require('../../dist/lib/testing/storyboard/runner');
 
-function buildHitlClient({ immediateData, pollResult, pollDelay = 0, recordPollCall }) {
+function buildHitlClient({ immediateData, pollResult, pollDelay = 0, recordPollCall, omitExecutor = false }) {
   const calls = [];
   const agent = { id: 'stub', agent_uri: 'https://stub.example/mcp' };
-  const executor = {
-    pollTaskCompletion: async (agentArg, taskId, _pollInterval) => {
-      calls.push({ kind: 'poll', taskId, agentId: agentArg?.id });
-      if (recordPollCall) recordPollCall(taskId);
-      if (pollDelay > 0) await new Promise(r => setTimeout(r, pollDelay));
-      return pollResult ?? { success: false, error: 'no poll result configured' };
-    },
-  };
+  const executor = omitExecutor
+    ? undefined
+    : {
+        pollTaskCompletion: async (agentArg, taskId, _pollInterval) => {
+          calls.push({ kind: 'poll', taskId, agentId: agentArg?.id });
+          if (recordPollCall) recordPollCall(taskId);
+          if (pollDelay > 0) await new Promise(r => setTimeout(r, pollDelay));
+          return pollResult ?? { success: false, error: 'no poll result configured' };
+        },
+      };
   const client = {
     agent,
-    executor,
+    ...(executor && { executor }),
     getAgentInfo: async () => ({ name: 'stub', tools: ['create_media_buy'] }),
     executeTask: async (name, _params) => {
       calls.push({ kind: 'execute', name });
@@ -43,6 +45,56 @@ function buildHitlClient({ immediateData, pollResult, pollDelay = 0, recordPollC
     },
   };
   return { client, calls };
+}
+
+/**
+ * Stub WebhookReceiver matching the runtime contract — only `wait` is
+ * exercised by `resolveTaskCompletionOutputs`. Resolves with the configured
+ * payload after `deliverAfterMs` (default: synchronous resolve), or
+ * `{ timed_out: true }` if `timeout_ms` elapses first.
+ */
+function buildWebhookReceiver({ payload, deliverAfterMs = 0, deliverStatus = 'completed' }) {
+  const calls = [];
+  return {
+    base_url: 'http://stub-webhook.example',
+    mode: 'loopback_mock',
+    all: () => [],
+    matching: () => [],
+    set_retry_replay: () => {},
+    wait: async (filter, timeout_ms) => {
+      calls.push({ filter, timeout_ms });
+      if (payload === undefined) {
+        // Simulate "webhook never arrives" — resolve as timed_out after timeout.
+        await new Promise(r => setTimeout(r, timeout_ms));
+        return { timed_out: true };
+      }
+      if (deliverAfterMs >= timeout_ms) {
+        await new Promise(r => setTimeout(r, timeout_ms));
+        return { timed_out: true };
+      }
+      if (deliverAfterMs > 0) {
+        await new Promise(r => setTimeout(r, deliverAfterMs));
+      }
+      return {
+        webhook: {
+          id: 'wh1',
+          step_id: 'create',
+          operation_id: 'op1',
+          delivery_index: 1,
+          received_at: Date.now(),
+          method: 'POST',
+          path: '/',
+          headers: {},
+          raw_body: JSON.stringify(payload),
+          body: { ...payload, status: deliverStatus },
+          response_status: 200,
+        },
+      };
+    },
+    wait_all: async () => [],
+    close: async () => {},
+    _calls: calls,
+  };
 }
 
 const stubProfile = { name: 'stub', tools: ['create_media_buy'] };
@@ -220,6 +272,78 @@ describe('runStoryboardStep — task_completion. context_outputs', () => {
 
     assert.equal(calls.filter(c => c.kind === 'poll').length, 1, 'poll fires for working status with task_id');
     assert.equal(result.context.media_buy_id, 'mb_from_working');
+  });
+
+  test('webhook receiver wins the race when payload arrives before poll terminal', async () => {
+    const { client, calls } = buildHitlClient({
+      immediateData: { status: 'submitted', task_id: 'task_webhook_first' },
+      pollResult: { success: true, data: { media_buy_id: 'mb_from_poll' } },
+      pollDelay: 500, // poll resolves slowly
+    });
+    const webhookReceiver = buildWebhookReceiver({
+      payload: { task_id: 'task_webhook_first', result: { media_buy_id: 'mb_from_webhook' } },
+      deliverAfterMs: 10, // webhook beats the poll
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      _webhookReceiver: webhookReceiver,
+    });
+
+    assert.equal(result.context.media_buy_id, 'mb_from_webhook', 'webhook payload result.media_buy_id captured');
+    assert.equal(webhookReceiver._calls.length, 1, 'webhookReceiver.wait was called');
+    assert.deepEqual(
+      webhookReceiver._calls[0].filter,
+      { body: { task_id: 'task_webhook_first' } },
+      'wait filter targeted task_id'
+    );
+    void calls;
+  });
+
+  test('webhook fallback works when executor.pollTaskCompletion is unavailable', async () => {
+    const { client } = buildHitlClient({
+      immediateData: { status: 'submitted', task_id: 'task_webhook_only' },
+      omitExecutor: true,
+    });
+    const webhookReceiver = buildWebhookReceiver({
+      payload: { task_id: 'task_webhook_only', result: { media_buy_id: 'mb_webhook_only' } },
+      deliverAfterMs: 5,
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      _webhookReceiver: webhookReceiver,
+    });
+
+    assert.equal(result.context.media_buy_id, 'mb_webhook_only');
+  });
+
+  test('emits capture_task_failed when webhook delivers a non-completed terminal status', async () => {
+    const { client } = buildHitlClient({
+      immediateData: { status: 'submitted', task_id: 'task_webhook_failed' },
+      pollResult: { success: true, data: { media_buy_id: 'mb_should_not_be_used' } },
+      pollDelay: 500,
+    });
+    const webhookReceiver = buildWebhookReceiver({
+      payload: { task_id: 'task_webhook_failed', result: { error: { code: 'INVALID_REQUEST' } } },
+      deliverAfterMs: 5,
+      deliverStatus: 'failed',
+    });
+
+    const result = await runStoryboardStep('https://stub.example/mcp', baseStoryboard, 'create', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      _webhookReceiver: webhookReceiver,
+    });
+
+    const taskFailed = result.validations.find(v => v.check === 'capture_task_failed');
+    assert.ok(taskFailed, 'capture_task_failed when webhook payload status is non-completed');
+    assert.equal(result.context.media_buy_id, undefined);
   });
 
   test('plain path captures still work without prefix (no regression)', async () => {


### PR DESCRIPTION
## Summary

Closes #1431. Follow-up to PR #1426 (#1417) per the protocol-expert review caveat.

`task_completion.<path>` resolution now races `tasks/get` polling against the active webhook receiver, whichever arrives first. Per `tasks-get-response.json:75-85`, sellers MAY use webhook-only HITL completion (spec's `submitted` enumDescription: _"Client should poll with tasks/get **or provide webhook_url at protocol level**"_). Pre-this-release, `task_completion.` captures fail-closed against webhook-only sellers because the runner only polled.

## Resolution model

When the runner has a webhook receiver active (`--webhook-receiver` CLI flag), the runner registers a `wait({ body: { task_id } })` against the receiver alongside the existing `executor.pollTaskCompletion`. Both race against the bounded outer timeout. First to resolve wins.

| Source | Artifact data field | Status interpretation |
|---|---|---|
| Poll (`success: true`) | `polled.data` | success |
| Poll (`success: false`) | (none) | `capture_task_failed` |
| Webhook (`status: 'completed'`) | `body.result` | success |
| Webhook (other terminal status) | (none) | `capture_task_failed` |
| Outer timeout | (none) | `capture_poll_timeout` |

Webhook payload shape mirrors the framework's task webhook shape from `from-platform.ts`: top-level `task_id`, `status: 'completed'`, `result` carrying the projected sync response. `body.result` is the artifact data the runner resolves the prefix-stripped path against.

## What this does NOT change

- `task_completion.<path>` syntax unchanged. Storyboard authors don't declare their preferred resolution source.
- The `submitted` / `working` / `input-required` non-terminal-status trigger logic from #1426 is unchanged.
- `task_id` validation (length cap + control-char rejection) before SDK call is preserved.

## Test plan

- [x] `node --test test/lib/storyboard-runner-task-completion-capture.test.js` — 10/10 pass:
  - **NEW** webhook receiver wins the race when payload arrives before poll terminal
  - **NEW** webhook fallback works when executor.pollTaskCompletion is unavailable
  - **NEW** capture_task_failed when webhook delivers non-completed terminal status
  - All prior #1417 tests (poll-success, poll-timeout, capture_task_failed, working trigger, sync-arm fallthrough, invalid task_id, plain path) still pass
- [x] `npx tsc --noEmit -p tsconfig.lib.json` clean
- [x] `npm run format:check` clean
- [ ] End-to-end against `hello_seller_adapter_guaranteed` once an upstream storyboard adopts the prefix (deferred)

## Test infrastructure addition

Adds `_webhookReceiver` to `TestOptions` as a test-only injection point. Production callers pass `webhook_receiver`; the runner tracks ownership so test-injected receivers aren't closed by the runner. Equivalent to the existing `_client` / `_profile` injection pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)