### PR TITLE
docs: layered architecture, decision page, version-adaptation guide

### DIFF
--- a/.changeset/sdk-stack-doc-set.md
+++ b/.changeset/sdk-stack-doc-set.md
@@ -21,3 +21,25 @@ can pick the right starting layer:
 Callouts added to `index.md`, `getting-started.md`, and
 `guides/BUILD-AN-AGENT.md` route mis-aimed readers to the decision page
 without blocking on-target ones.
+
+Follow-up additions (post-persona-feedback):
+
+- `docs/guides/MIGRATE-FROM-HAND-ROLLED.md` — incremental migration path
+  for adopters with a working hand-rolled agent: inventory step,
+  lowest-risk-first swap order, conflict modes (idempotency,
+  account-mode, webhook signing, state-machine drift, schema
+  validation), intermediate states that pass conformance, when not to
+  migrate.
+- Decomposed the "~4 person-months for L0–L3" claim in `adcp-stack.md`
+  into a per-component breakdown table (state machines, idempotency,
+  async tasks, error catalog, conformance controller, webhooks, RFC
+  9421, integration). Stated assumptions and excluded version-adaptation
+  work explicitly.
+- Filled the SDK coverage matrix with current rows for `@adcp/sdk` 6.6.x
+  (GA, 6.7 in flight), `adcp` Python 4.x in flight, and `adcp-go` in
+  development. Added a "last updated" line so it's clear the table needs
+  refreshing on SDK majors.
+- Softened the "going lower is almost always a scope mistake disguised as
+  a control preference" line in `where-to-start.md` to name the
+  legitimate cases (SDK author / language porter / special-purpose proxy
+  / stack that already owns L0–L2).

--- a/.changeset/sdk-stack-doc-set.md
+++ b/.changeset/sdk-stack-doc-set.md
@@ -1,0 +1,23 @@
+---
+---
+
+docs: layered architecture reference + decision page + version-adaptation guide
+
+Adds three new docs and wires them into the existing entry points so adopters
+can pick the right starting layer:
+
+- `docs/architecture/adcp-stack.md` — full L0–L4 reference: what each layer
+  does, what an SDK at each layer should provide, version-adaptation summary,
+  and a "what early implementers underestimate" punch list.
+- `docs/where-to-start.md` — short decision page. Three questions
+  (caller/agent, value-add, pre-existing hand-rolled agent), recommended
+  path, and a "what you give up by going lower" cost table.
+- `docs/guides/VERSION-ADAPTATION.md` — code-level recipes for the three
+  version-handling mechanisms: per-call `adcpVersion` pinning,
+  `@adcp/sdk/server/legacy/v5` subpath co-existence imports, and wire-level
+  `supported_versions` declaration with `VERSION_UNSUPPORTED` /
+  `VersionUnsupportedError` handling.
+
+Callouts added to `index.md`, `getting-started.md`, and
+`guides/BUILD-AN-AGENT.md` route mis-aimed readers to the decision page
+without blocking on-target ones.

--- a/docs/architecture/adcp-stack.md
+++ b/docs/architecture/adcp-stack.md
@@ -142,7 +142,9 @@ What's in it:
   retry, idempotency, and signature.
 - **Conformance test surface**: `comply_test_controller` (sandbox-only)
   exposes `seed_*` / `force_*` / `simulate_*` so storyboards can drive
-  state deterministically.
+  state deterministically. See
+  [`docs/guides/CONFORMANCE.md`](../guides/CONFORMANCE.md) for the
+  storyboard + fuzzer model.
 - **Response envelope**: `context`, `task_id`, `status` field, error
   envelope shape, `adcp_version` echo, capability advertisement.
 
@@ -238,6 +240,13 @@ Different language SDKs cover different subsets of L0–L3. There is no
 single SDK every implementer must use; what matters is that an
 implementation reaches the conformance bar at L3, regardless of how
 much hand-rolling it took to get there.
+
+Within a given language, the full-stack SDK is the default starting
+point. The layered model in this doc exists to explain what you'd be
+reimplementing if you went lower (special-purpose proxies,
+custom-stack integrations) or ported the SDK to a new language —
+not to suggest there's a meaningful win in starting lower for a
+typical agent build.
 
 A coverage matrix template:
 
@@ -361,8 +370,10 @@ much:
 1. **L3 is most of the work.** State machines, idempotency, error
    catalog, async tasks — ~4 person-months before any L4 differentiation.
 2. **Conformance is L3-driven.** Storyboards probe state transitions
-   and error shapes. Without an SDK's transition validators you
-   re-derive the spec from test failures.
+   and error shapes (see
+   [`docs/guides/CONFORMANCE.md`](../guides/CONFORMANCE.md)). Without
+   an SDK's transition validators you re-derive the spec from test
+   failures.
 3. **Versioning compounds.** Each spec rev that adds a tool, a
    lifecycle edge, or an error code is a new translation row your
    adapters carry. Bypassing the SDK means owning that matrix

--- a/docs/architecture/adcp-stack.md
+++ b/docs/architecture/adcp-stack.md
@@ -253,11 +253,11 @@ typical agent build.
 Snapshot of what each language SDK ships today. Refresh this table on
 SDK majors and on AdCP spec revs.
 
-*Last updated: 2026-05-03 — `@adcp/sdk` 6.6.x GA, 6.7 in flight; `adcp` (Python) 4.x in flight; `adcp-go` in active development.*
+*Last updated: 2026-05-03 — `@adcp/sdk` 6.7.0 GA on npm; `adcp` (Python) 4.x in flight; `adcp-go` in active development.*
 
 | SDK | Version | L0 | L1 | L2 | L3 | Adopter writes |
 |---|---|---|---|---|---|---|
-| **`@adcp/sdk`** (TypeScript) | 6.6.x GA, 6.7 in flight | ✅ | ✅ | ✅ | ✅ | L4 only |
+| **`@adcp/sdk`** (TypeScript) | 6.7.0 GA | ✅ | ✅ | ✅ | ✅ | L4 only |
 | **`adcp`** (Python) | 4.x in flight | ✅ | ⚠️ | ⚠️ | ⚠️ | Row to refresh on 4.0 GA |
 | **`adcp-go`** | dev | ⚠️ | ❌ | ❌ | ❌ | Types + transport only today; L1–L3 in scope |
 

--- a/docs/architecture/adcp-stack.md
+++ b/docs/architecture/adcp-stack.md
@@ -248,16 +248,39 @@ custom-stack integrations) or ported the SDK to a new language —
 not to suggest there's a meaningful win in starting lower for a
 typical agent build.
 
-A coverage matrix template:
+### Current SDK coverage
 
-| SDK | L0 | L1 | L2 | L3 | Adopter writes |
+Snapshot of what each language SDK ships today. Refresh this table on
+SDK majors and on AdCP spec revs.
+
+*Last updated: 2026-05-03 — `@adcp/sdk` 6.6.x GA, 6.7 in flight; `adcp` (Python) 4.x in flight; `adcp-go` in active development.*
+
+| SDK | Version | L0 | L1 | L2 | L3 | Adopter writes |
+|---|---|---|---|---|---|---|
+| **`@adcp/sdk`** (TypeScript) | 6.6.x GA, 6.7 in flight | ✅ | ✅ | ✅ | ✅ | L4 only |
+| **`adcp`** (Python) | 4.x in flight | ✅ | ⚠️ | ⚠️ | ⚠️ | Row to refresh on 4.0 GA |
+| **`adcp-go`** | dev | ⚠️ | ❌ | ❌ | ❌ | Types + transport only today; L1–L3 in scope |
+
+Legend: ✅ shipped · ⚠️ partial / in flight · ❌ not yet covered.
+
+What "shipped" means at each layer is the L0–L3 checklist above —
+these rows should not claim ✅ until every checklist item is satisfied
+in the published SDK build.
+
+For coverage detail beyond this snapshot, see each SDK's repo:
+
+- `@adcp/sdk` — [adcontextprotocol/adcp-client](https://github.com/adcontextprotocol/adcp-client)
+- `adcp` (Python) — [adcontextprotocol/adcp-client-python](https://github.com/adcontextprotocol/adcp-client-python)
+- `adcp-go` — [adcontextprotocol/adcp-go](https://github.com/adcontextprotocol/adcp-go)
+
+For shape comparison purposes, here are the three coverage archetypes
+an SDK can land in regardless of language:
+
+| Archetype | L0 | L1 | L2 | L3 | Adopter writes |
 |---|---|---|---|---|---|
 | Full-stack SDK | ✅ | ✅ | ✅ | ✅ | L4 only |
 | Transport + signing only | ✅ | ✅ | ⚠️ | ❌ | L2 + L3 + L4 |
 | Types-only / generated bindings | ✅ | ❌ | ❌ | ❌ | L1 + L2 + L3 + L4 |
-
-(Specific SDKs and their current coverage live in each SDK's repo;
-this template is the framing.)
 
 The choice is a tradeoff between leverage and control. A full-stack
 SDK ships you the most code for free but couples you to its choices.
@@ -307,9 +330,30 @@ AdCP's L3 is large:
   surface.
 - **Webhook emission**: signed, retried, idempotent.
 
-A from-scratch AdCP agent is ~4 person-months of L3 alone, before any
-L4 differentiation. Most teams that say *"I'll build from scratch"*
-underestimate L3 by an order of magnitude.
+A from-scratch AdCP agent is ~3–4 person-months of L3 work alone,
+before any L4 differentiation. The breakdown, for one senior engineer
+to a mock-mode conformance bar, is roughly:
+
+| L3 component | Honest estimate |
+|---|---|
+| 7 lifecycle state machines (define edges, validate transitions, emit the right `NOT_CANCELLABLE` / `INVALID_STATE` codes) | ~1 week each = **6–7 weeks** |
+| Idempotency cache (cross-payload conflict detection + no-payload-echo invariant) | **1 week** |
+| Async-task store + dispatcher (correct terminal-artifact contract per tool) | **1–2 weeks** |
+| Error-code catalog wiring (47 codes, recovery classification, code precedence) | **1–2 weeks** |
+| `comply_test_controller` conformance surface (`seed_*` / `force_*` / `simulate_*`) | **1–2 weeks** |
+| Webhook emission (signed, retried, idempotent, dedup-keyed) | **1 week** |
+| RFC 9421 signing + verification + replay-window + key rotation (counted separately as L1, but commonly bundled in the same scope) | **2–3 weeks** |
+| Integration, conformance debugging, spec re-reading | **2–3 weeks** |
+
+That's **~14–18 weeks**, depending on team familiarity with HTTP
+message-signatures and lifecycle modeling. The estimate excludes
+**version-adaptation work** — every spec rev that adds a tool, an
+edge, or an error code adds rows to a translation matrix you carry
+forever. SDK adopters get those for free; from-scratch implementers
+pay them every release.
+
+Most teams that say *"I'll build from scratch"* count the wire
+shape (L0) and underestimate L3 by an order of magnitude.
 
 ## Version adaptation
 
@@ -354,8 +398,8 @@ The spec itself has already done one of these crossings:
   `comply_test_controller` conformance surface, published lifecycle
   state machines, RFC 9421 signatures as a baseline, and an expanded
   error catalog with recovery classifications. A from-scratch 2.5
-  agent was tractable; a from-scratch 3.0 agent is roughly 4
-  person-months of L3 alone.
+  agent was tractable; a from-scratch 3.0 agent is the
+  ~3–4 person-month L3 build [decomposed above](#why-sdks-matter-more-in-adcp-than-in-eg-http).
 
 The from-scratch path that worked for 2.5 doesn't scale to 3.0, and
 3.0 isn't where the spec stops. SDKs exist because L3 grew faster
@@ -368,7 +412,10 @@ Rough order of pain, for adopters who built before the SDKs covered
 much:
 
 1. **L3 is most of the work.** State machines, idempotency, error
-   catalog, async tasks — ~4 person-months before any L4 differentiation.
+   catalog, async tasks — ~3–4 person-months before any L4
+   differentiation. See the
+   [decomposition](#why-sdks-matter-more-in-adcp-than-in-eg-http) for
+   the per-component breakdown.
 2. **Conformance is L3-driven.** Storyboards probe state transitions
    and error shapes (see
    [`docs/guides/CONFORMANCE.md`](../guides/CONFORMANCE.md)). Without

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,10 @@
 # Getting Started with @adcp/sdk
 
+> **Building a server (an agent), not just calling one?** This page
+> covers the client side. Start with
+> [Where to start](./where-to-start.md) to pick the right entry
+> point for your role and intended layer of integration.
+
 ## Installation
 
 ```bash

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -1,5 +1,14 @@
 # Build an AdCP Agent
 
+> **Should you be reading this?** This guide assumes you've decided
+> to build an agent at **L4** — using the SDK to handle L0–L3 of the
+> protocol stack so your code only owns business logic. If you're
+> still weighing whether to use the SDK at all, or whether to start
+> at a lower layer, read [Where to start](../where-to-start.md)
+> first. The [architecture deep-dive](../architecture/adcp-stack.md)
+> covers what each layer of the SDK provides and what *"from scratch"*
+> would actually require.
+
 ## Overview
 
 This guide walks through building an AdCP agent (server) using `@adcp/sdk`. While most documentation covers the client side — calling existing agents — this guide covers the server side: implementing an agent that other clients can discover and call.

--- a/docs/guides/MIGRATE-FROM-HAND-ROLLED.md
+++ b/docs/guides/MIGRATE-FROM-HAND-ROLLED.md
@@ -177,6 +177,48 @@ conformance suite enforces.
 
 You ship after each step. Production traffic stays up.
 
+### Rollback per step
+
+Every step in the swap order should be reversible inside ~5 minutes.
+The general pattern: each swap is a **feature-flagged switch between
+your hand-rolled component and the SDK's**, not a deletion. You ship
+the swap behind a per-account flag, observe, then flip the default.
+Rollback is the same flag in the other direction.
+
+What to plan for, swap by swap:
+
+| Step | Revert mechanism | What state may have leaked | First thing to verify on rollback |
+|---|---|---|---|
+| 1. Conformance controller | Disable the SDK route on mock-mode accounts | None — mock-mode is sandbox-only by design | Mock storyboards still pass against your hand-rolled L3 |
+| 2. Error envelopes | Flip back to your error builder | Outbound envelopes from the swap window may carry SDK-shape error codes; downstream consumers that key off your old codes may have logged them | Your error-monitoring dashboard is reading the right envelope shape again |
+| 3. Idempotency cache | Flip back to your cache | **Both caches saw traffic during the swap window.** Same `idempotency_key` may now exist in both stores with different envelopes. After rollback, your cache is authoritative; flush the SDK's cache on revert | No `IDEMPOTENCY_CONFLICT` storms from the dual-cache window |
+| 4. Async-task contract | Flip back to your task store | Outstanding tasks that started under the SDK's contract may have a different terminal-artifact shape than your worker expects | Drain or abort tasks created during the swap window before the revert lands |
+| 5. State machines | Flip back to your state machine | The SDK may have rejected transitions your machine would have accepted (or vice versa). Affected resources are in a state your code may not know how to advance | Run a one-shot reconciliation query: "any resources in a state that's legal under both machines? Any in a state that's only legal under one?" |
+| 6. Webhook envelope | Flip back to your emitter | Receivers got SDK-shape webhooks during the swap window. They may have already acked. Don't re-emit on rollback | Your dedup table accepts both old and new `idempotency_key` shapes (transitional) |
+| 7. RFC 9421 signing | Flip back to your signer | Receivers got SDK-signed webhooks/responses during the window. Their key registry must still resolve your old `keyid` | Your old `keyid` is still published in your JWKS |
+| 8. Account store | Flip back to your store | Account resolution decisions made under the SDK's store may have routed traffic to different tenants than your store would have | Run a reconciliation on accounts that were resolved during the swap window before fully reverting |
+
+### The 2 a.m. production failure
+
+If swap N fails in production at 2 a.m., the on-call recipe:
+
+1. **Flip the per-account flag back** to your hand-rolled component
+   for the affected accounts (or globally if you can't isolate the
+   blast radius). This is the only step required to stop the
+   bleeding.
+2. **Confirm the leakage row** above for that step. Most steps
+   leave residual state somewhere — note what it is so the morning
+   debug doesn't start cold.
+3. **Don't rerun the conformance suite mid-incident.** It runs
+   against mock-mode; production failures are a different signal.
+4. **File the incident against the swap step**, not against the SDK
+   in general. The migration guide's swap-order is the unit of
+   investigation; the SDK's coverage matrix is downstream of that.
+
+**Don't plan for irreversible swaps.** If a step doesn't fit the
+flag-and-flip pattern (e.g., a destructive schema migration), do it
+as a separate, named project — not as part of the swap order.
+
 ## 5. What you can leave hand-rolled
 
 The SDK is opinionated where the spec is opinionated, and pluggable
@@ -210,6 +252,74 @@ Two version axes you'll be juggling:
   time on `createAdcpServerFromPlatform` while the rest stays on the
   v5 entry point. Greenfield code in the same project uses the v6
   framework directly.
+
+### Worked example: two buyers, mid-swap
+
+You're on step 3 (idempotency), buyer A is on AdCP 2.5, buyer B is
+on AdCP 3.0. You've adopted the SDK's controller, error envelopes,
+and idempotency cache for the accounts you've cut over. Buyer A is
+mid-flight to the SDK; buyer B is greenfield on the SDK.
+
+Your inbound side: identify each peer's spec version up front (from
+the agent registry, the agent card, or the `adcp_version` field if
+present), pin `adcpVersion` on the agent / per call, and let the
+SDK adapt the wire shape:
+
+```ts
+import { ADCPMultiAgentClient } from '@adcp/sdk';
+
+const buyerA = new ADCPMultiAgentClient([{
+  id: 'buyer-a',
+  agent_uri: 'https://buyer-a.example.com/mcp/',
+  protocol: 'mcp',
+  auth_token: process.env.BUYER_A_TOKEN,
+  adcpVersion: 'v2.5',  // ← per-agent pin, no fork in handlers
+}]);
+
+const buyerB = new ADCPMultiAgentClient([{
+  id: 'buyer-b',
+  agent_uri: 'https://buyer-b.example.com/a2a',
+  protocol: 'a2a',
+  auth_token: process.env.BUYER_B_TOKEN,
+  adcpVersion: '3.0.5', // ← canonical / current
+}]);
+```
+
+Your outbound (server) side, declaring what *you* accept:
+
+```ts
+import { createAdcpServer } from '@adcp/sdk/server';
+
+createAdcpServer({
+  capabilities: {
+    major_versions: [2, 3],
+    supported_versions: ['v2.5', '3.0.5'],
+  },
+  // …handlers, all on the canonical 3.0 shape;
+  // 2.5 callers are translated by adapters at the SDK boundary.
+});
+```
+
+What this looks like for one call from each buyer, mid-step-3:
+
+| | Buyer A (2.5 wire) | Buyer B (3.0 wire) |
+|---|---|---|
+| **Inbound shape** | 2.5 `create_media_buy` | 3.0 `create_media_buy` |
+| **Adapter does** | Translates 2.5 → 3.0 shape | Pass-through |
+| **Your handler sees** | 3.0 typed object | 3.0 typed object (same) |
+| **Idempotency cache** | SDK's (you're on step 3) | SDK's |
+| **Error envelope** | SDK's, translated back to 2.5 on outbound | SDK's |
+| **Outbound shape** | 2.5 (translated by adapter on the way out) | 3.0 |
+
+One handler codebase. Two wire versions. Both buyers see the
+envelope shape they expect. Adopting `adcpVersion` pinning at step 3
+is cheap — most of the version work is in the adapter folder
+(`src/lib/adapters/legacy/v2-5/`), which the SDK already ships.
+
+If you fall back (rollback step 3 to your hand-rolled cache), buyer
+A still goes through the SDK's translation adapters — the version
+machinery and the idempotency machinery are independent. You don't
+re-fork your handler code on rollback.
 
 ## 7. When to *not* migrate
 

--- a/docs/guides/MIGRATE-FROM-HAND-ROLLED.md
+++ b/docs/guides/MIGRATE-FROM-HAND-ROLLED.md
@@ -1,0 +1,244 @@
+# Migrating from a hand-rolled AdCP agent
+
+This guide is for adopters with a **working AdCP agent in production**
+who want to move to `@adcp/sdk` without a flag-day rewrite. Your agent
+serves real traffic; you have engineers who built the current stack and
+will defend it; you can't afford a multi-week freeze. The path is
+incremental — swap one layer at a time, ship after each step, re-certify
+as you go.
+
+If you're greenfield, you're in the wrong doc — see
+[Build an Agent](./BUILD-AN-AGENT.md). If you're still deciding whether
+to migrate at all, see
+[Where to start, Q3](../where-to-start.md#three-questions-to-pick-your-layer).
+
+## 0. Inventory what you own today
+
+Before swapping anything, write down what your hand-rolled stack
+provides at each layer of [the AdCP stack](../architecture/adcp-stack.md).
+Use the L0–L3 checklists in that doc as the rubric. Mark each row:
+*shipped* / *partial* / *not yet*.
+
+This determines order of operations. The lowest-risk swap is usually
+the layer where you have the **least** coverage today, because there's
+the least existing behavior to reconcile.
+
+## 1. Get to spec compliance first, before changing any code
+
+Single most important step:
+
+1. Stand up a **mock-mode account** in your agent. (If you don't have
+   the live/sandbox/mock distinction yet, see
+   [Account-mode mismatch](#account-mode-mismatch) below — add the
+   flag at your boundary first.)
+2. Route mock-mode traffic to the reference mock-server.
+3. Run the AdCP storyboards against your agent.
+4. Read the pass/fail report.
+
+The failure list is your migration backlog, ordered. It converts "I
+think the SDK adds value" into "here are the 23 storyboards we fail
+and which L3 component each one points at." Without this step you're
+buying an SDK based on a sales pitch instead of measured gap.
+
+You may discover you're more conformant than you thought (in which
+case the migration is smaller than you expected) or less (in which
+case the case for adopting the SDK strengthens). Either outcome is
+useful.
+
+## 2. Order of operations (lowest risk first)
+
+Recommended swap order:
+
+1. **Conformance test surface** (`comply_test_controller`). Pure
+   additive — mock-mode traffic now goes through the SDK; live traffic
+   untouched. Earns spec-compliance certification on the spot.
+2. **Error code catalog**. Replace your error-envelope construction
+   with the SDK's error builders. Recovery classifications and code
+   precedence (e.g., `NOT_CANCELLABLE` over `INVALID_STATE`) come for
+   free.
+3. **Idempotency cache**. Riskiest swap — see
+   [Two idempotency caches in series](#two-idempotency-caches-in-series).
+4. **Async-task store + dispatcher**. Adopt the SDK's `task_id`
+   + terminal-artifact contract. Often touches your worker queue.
+5. **State machines**, one resource at a time. MediaBuy first if it's
+   where you spend the most maintenance time. Re-run lifecycle
+   storyboards after each.
+6. **Webhook emission** (signed, retried, idempotent). Independent of
+   1–5; can be parallelized.
+7. **RFC 9421 signing + verification**. Independent of everything
+   above; can be parallelized.
+8. **Auth / account store**. Last. Your hand-rolled L2 probably
+   encodes business decisions that don't move easily.
+
+You can stop at any step. Adopting at L3 (steps 1–6) without L2 is a
+perfectly valid endpoint — your auth layer keeps doing what it does,
+the SDK takes over protocol semantics. See
+[What you can leave hand-rolled](#what-you-can-leave-hand-rolled).
+
+## 3. Conflict modes to watch for
+
+These are the "two stacks fighting each other" failure modes that
+make incremental migration painful if you don't see them coming.
+
+### Two idempotency caches in series
+
+Your existing cache fields requests at the perimeter; the SDK's cache
+fields requests at the protocol boundary. Symptoms: same
+`idempotency_key` returns different envelopes depending on which
+cache hit first; cross-payload reuse is detected by one and not the
+other.
+
+**Resolution.** Pick one, retire the other. Usually retire yours —
+the SDK's enforces the *no-payload-echo* invariant on
+`IDEMPOTENCY_CONFLICT` (stolen-key read-oracle threat) and the
+cross-payload conflict detection that the spec mandates. If you
+need to keep your storage backend (Redis, Postgres), point the
+SDK's cache contract at it as a custom backend instead of forking
+the SDK.
+
+### Account-mode mismatch
+
+The SDK distinguishes `live` / `sandbox` / `mock` accounts. If your
+hand-rolled stack lacks the distinction, mock-mode storyboards may
+dispatch to live handlers. Symptoms: storyboards mutate production
+state; conformance certification refuses to dispatch.
+
+**Resolution.** Add the account-mode flag at your boundary before
+adopting the SDK's conformance controller. The SDK's
+`comply_test_controller` refuses to run against any account that
+isn't sandbox or mock — that refusal is a feature, not a bug.
+
+### Webhook signature ownership
+
+If both stacks try to sign outbound webhooks, the receiver sees two
+`Signature` headers (or one wins and the other is silently
+overwritten by the proxy). Either way, signatures don't verify.
+
+**Resolution.** Pick one signer at the boundary; usually the SDK's,
+since it tracks key rotation against the public key registry and
+handles the RFC 9421 canonicalization correctly. Keep your
+KMS-backed key material; configure the SDK's signing-provider
+abstraction to use it.
+
+### State machine drift
+
+Your hand-rolled state machine probably has edges the SDK rejects
+(e.g., direct `pending_creatives → completed` skipping `active`,
+or `active → canceled` without distinguishing the
+`NOT_CANCELLABLE` vs `INVALID_STATE` precedence). Symptoms:
+lifecycle storyboards fail with `INVALID_STATE` where you expected
+to succeed.
+
+**Resolution.** Run the lifecycle storyboards against your agent
+*before* swapping the state machine. Reconcile your edge set to
+the spec — fix obvious bugs, file spec issues for ambiguities.
+Then swap the SDK's state machine in; it'll enforce what you just
+hand-converged on.
+
+### Webhook delivery transport
+
+If your queue/worker stack delivers webhooks today, the SDK's
+emitter would double-deliver if you wire it on without retiring
+yours. Symptoms: receivers see duplicate idempotency keys with the
+same payload at slightly different times.
+
+**Resolution.** The SDK builds the envelope; how you ship it is
+yours. Configure the SDK to hand off to your existing transport
+instead of running its built-in HTTP delivery — that's the seam.
+
+### Schema validation collisions
+
+If you validate inbound payloads against your own schema bundle,
+and the SDK validates again at its boundary, you get either
+duplicate work (cheap) or contradictory verdicts (a real bug —
+your bundle drifted from the published schemas).
+
+**Resolution.** Retire your local validator after the SDK is in.
+While both run, treat any discrepancy as your bundle being stale,
+not the SDK being wrong.
+
+## 4. Intermediate states that pass conformance
+
+After each step, you can re-run mock-mode storyboards and re-certify.
+You don't need to finish the migration to claim conformance — you
+only need to pass the storyboards at whatever cut-line the SDK's
+conformance suite enforces.
+
+| After step | What you have | Conformance status |
+|---|---|---|
+| 1 | Conformance controller wired; agent unchanged | **Spec compliance** (mock-mode storyboards run against your unchanged L3) |
+| 2 | + SDK error envelopes | Same; better recovery semantics |
+| 3 | + SDK idempotency | Same; tighter security on cross-payload reuse |
+| 4 | + SDK async-task contract | Same; uniform task lifecycle |
+| 5 | + SDK state machines | Same; transition validation no longer your problem |
+| 6 | + SDK webhook envelope | Same; signed, retried, dedup-keyed |
+| 7 | + SDK signing | **Live compliance** (when that storyboard set ships) |
+| 8 | + SDK account store | Full L4-on-SDK |
+
+You ship after each step. Production traffic stays up.
+
+## 5. What you can leave hand-rolled
+
+The SDK is opinionated where the spec is opinionated, and pluggable
+where it isn't. You don't have to give up your existing infra:
+
+- **Signing provider.** Keep your KMS integration. The SDK accepts
+  a custom signer.
+- **Account store.** Keep your multi-tenant routing. The SDK's
+  `AccountStore` interface is the seam.
+- **Idempotency backend.** Keep your Redis / Postgres. The SDK's
+  cache contract is pluggable.
+- **Webhook delivery transport.** Keep your queue. The SDK builds
+  the envelope; how you ship it is yours.
+- **Schema validation library.** Keep AJV / your validator if you
+  want; the SDK uses its own at its boundary, not yours.
+
+If your hand-rolled stack has good answers to these, swap them in
+as **configuration**, not as forks.
+
+## 6. Versioning during the migration
+
+Two version axes you'll be juggling:
+
+- **Spec version of your buyers.** A migration is a great moment to
+  add `adcpVersion` per-call pinning so you stop forking handlers
+  by buyer-version. See
+  [Version Adaptation](./VERSION-ADAPTATION.md).
+- **SDK version.** Don't migrate to the legacy subpath
+  (`@adcp/sdk/server/legacy/v5`) as a final state — migrate *through*
+  it. The legacy subpath exists so you can adopt one specialism at a
+  time on `createAdcpServerFromPlatform` while the rest stays on the
+  v5 entry point. Greenfield code in the same project uses the v6
+  framework directly.
+
+## 7. When to *not* migrate
+
+If your agent serves a frozen wire surface for a small set of named
+buyers and your engineers spend ~zero time on protocol maintenance,
+the migration ROI is low. Reasonable holds:
+
+- You're on AdCP 2.5, none of your buyers want 3.x, and you're
+  willing to deprecate when they do.
+- Your conformance gap (from step 1) is small enough to fix in
+  place without adopting the SDK.
+- You have a hard regulatory or operational reason for owning every
+  layer end-to-end.
+
+In those cases, do step 1 anyway — route mock-mode through the
+reference mock-server for spec compliance certification — and revisit
+the migration question at AdCP 4.0 or when your buyer mix moves.
+
+The migration is for adopters whose **maintenance load is real and
+growing**. The cost claim
+([~3–4 person-months for L0–L3 from scratch](../architecture/adcp-stack.md#why-sdks-matter-more-in-adcp-than-in-eg-http))
+is what you're *buying back* by adopting incrementally — but only if
+that maintenance load actually exists.
+
+## See also
+
+- [The AdCP stack (architecture)](../architecture/adcp-stack.md)
+- [Where to start](../where-to-start.md)
+- [Version Adaptation](./VERSION-ADAPTATION.md)
+- [Conformance](./CONFORMANCE.md)
+- [Build an Agent](./BUILD-AN-AGENT.md) (greenfield path; useful as a
+  reference for what the L4-on-SDK end state looks like)

--- a/docs/guides/VERSION-ADAPTATION.md
+++ b/docs/guides/VERSION-ADAPTATION.md
@@ -1,0 +1,272 @@
+# Version Adaptation
+
+Three versions move at the same time when you ship an AdCP agent or
+client:
+
+| Axis | Example | What changes |
+|---|---|---|
+| **Spec version** | AdCP `2.5 → 3.0.5 → 3.1` | Wire shapes, error codes, lifecycle states, new tools |
+| **SDK version** | `@adcp/sdk` 5.x → 6.x | API surface, ergonomics, compile-time guarantees |
+| **Peer version** (per call) | Buyer at v3.0, seller at v2.5 | A single conversation crosses versions |
+
+`@adcp/sdk` ships three concrete mechanisms so adopters don't carry the
+translation matrix in handler code. This guide is the recipe per
+mechanism. For the conceptual background see
+[the architecture deep-dive](../architecture/adcp-stack.md#version-adaptation).
+
+## Mechanism 1 — Pin the spec version per call
+
+Use this when you're a **client** talking to a peer that's pinned to
+an older (or newer beta) spec version. The SDK runs your request and
+the peer's response through adapter modules so your handler code stays
+on the canonical (current) shape.
+
+### Pin the version on a single agent
+
+```ts
+import { ADCPMultiAgentClient } from '@adcp/sdk';
+
+const client = ADCPMultiAgentClient.simple(
+  'https://legacy-agent.example.com/mcp/',
+  {
+    authToken: process.env.AGENT_TOKEN,
+    adcpVersion: 'v2.5', // ← pin here
+  },
+);
+
+const agent = client.agent('default-agent');
+const result = await agent.getProducts({ brief: 'CTV inventory' });
+```
+
+The `adcpVersion` field accepts any value from `COMPATIBLE_ADCP_VERSIONS`
+in `src/lib/version.ts`. Editors autocomplete the canonical list;
+forward-compatible strings (e.g., a beta channel that hasn't been
+added yet) are still accepted.
+
+### Validate the version up front
+
+`adcpVersion` is validated at construction time. The SDK only accepts
+versions whose **schema bundle ships with the build** — if the bundle
+isn't present (e.g., you pinned a beta channel that hasn't been
+synced into your installed SDK), `resolveAdcpVersion` throws a typed
+`ConfigurationError` at construction with a pointer to
+`sync-schemas` + `build:lib`.
+
+Type-level vs runtime: `AdcpVersion | (string & {})` lets editors
+autocomplete canonical values from `COMPATIBLE_ADCP_VERSIONS` while
+still accepting any string at the type level. Runtime acceptance is
+gated on the bundled schema set — the type system won't catch a
+forward-compatible string that has no schema bundle, but the
+constructor will, before any wire traffic.
+
+To see what your installed SDK actually has bundled:
+
+```ts
+import { COMPATIBLE_ADCP_VERSIONS, ADCP_VERSION } from '@adcp/sdk';
+
+console.log(ADCP_VERSION); // GA version this build targets, e.g. '3.0.5'
+console.log(COMPATIBLE_ADCP_VERSIONS); // declared compatibility list
+```
+
+### What the adapters actually do
+
+Look in `src/lib/adapters/legacy/v2-5/` for the per-tool translation
+modules: `create_media_buy.ts`, `get_products.ts`,
+`sync_creatives.ts`, etc. Each is a pure shape translation
+(field renames, default population, structural reshaping). The SDK
+applies them transparently when `adcpVersion` is set; your handler
+sees the current shape regardless of which version the peer speaks.
+
+When AdCP 3.1 ships and you bump `@adcp/sdk`, a new adapter folder
+appears for the now-legacy 3.0. Your handlers don't move.
+
+## Mechanism 2 — Migrate SDK majors via subpath imports
+
+Use this when you bump `@adcp/sdk` from one major to the next and
+don't want to rewrite every handler the day you upgrade. The SDK
+keeps the prior major's surface available at a legacy subpath.
+
+### Example: 5.x → 6.x
+
+In v6.0, `createAdcpServer` was hard-removed from the top-level and
+`@adcp/sdk/server` exports. Your existing v5 code keeps working by
+swapping one import:
+
+```ts
+// v5 code — change only the import path
+import { createAdcpServer } from '@adcp/sdk/server/legacy/v5';
+
+serve(() => createAdcpServer({
+  name: 'My Agent',
+  version: '1.0.0',
+  // …existing v5 handler bag — unchanged
+}));
+```
+
+Greenfield code in the same project uses the platform entry point
+side by side. The signature is `(platform, opts)` — two positional
+args, with the typed `DecisioningPlatform` first and runtime options
+second:
+
+```ts
+import { createAdcpServerFromPlatform } from '@adcp/sdk/server';
+
+const platform = new MyPlatform(); // implements DecisioningPlatform
+const server = createAdcpServerFromPlatform(platform, {
+  name: 'my-agent',
+  version: '1.0.0',
+  // …other runtime options
+});
+```
+
+Both compile, both run, both pass conformance. You migrate one
+handler — or one specialism — at a time. The legacy subpath is a
+documented co-existence path, not a deprecation warning.
+
+For a complete platform example, see
+[`examples/decisioning-platform-mock-seller.ts`](https://github.com/adcontextprotocol/adcp-client/blob/main/examples/decisioning-platform-mock-seller.ts).
+
+### One-shot search-replace for a 5.x → 6.0 bump
+
+See [`docs/migration-5.x-to-6.x.md`](../migration-5.x-to-6.x.md) for
+the full cumulative migration. The "tl;dr — five breaking changes to
+search-replace" table is the fastest path if you've skipped rounds.
+
+### When to actually migrate
+
+Stay on the legacy subpath as long as the surface keeps compiling
+and passing conformance. Migrate a specialism when you want the new
+features (compile-time specialism enforcement, capability
+projection, idempotency / signing / async-task / status-normalization
+pre-wiring on greenfield code). There's no rush.
+
+## Mechanism 3 — Wire-level negotiation
+
+Use this when you're a **server** and you want to be explicit about
+which spec versions you accept.
+
+### Declare what you support
+
+`supported_versions` (release-precision strings) and/or
+`major_versions` go on the `AdcpCapabilitiesConfig` passed to
+`createAdcpServer`. Use release-precision strings — `'3.0.5'`,
+`'3.1.0'` — not the legacy aliases (`'v2.5'`, `'v3'`) used for
+client-side pinning. A 3.x server with no v2.5 handler logic should
+not declare `'v2.5'` here — its 2.5 callers go through *client-side*
+adapters at the buyer end, not the server's accepted-version set.
+
+```ts
+import { createAdcpServer } from '@adcp/sdk/server';
+
+const server = createAdcpServer({
+  name: 'My Agent',
+  version: '1.0.0',
+  capabilities: {
+    major_versions: [3],
+    supported_versions: ['3.0.5', '3.1.0'],
+    // …other capability fields
+  },
+  // …handlers
+});
+```
+
+The union of `supported_versions` (parsed to majors) and
+`major_versions` defines the seller's accepted set on inbound
+`adcp_major_version` / `adcp_version` claims.
+
+### What happens on a mismatch
+
+If a buyer's request carries an `adcp_major_version` (or
+`adcp_version`) that isn't in the accepted set, the SDK returns a
+`VERSION_UNSUPPORTED` error envelope. The envelope echoes the
+seller's `supported_versions` so the buyer can downgrade their pin
+without an out-of-band lookup.
+
+### Buyer side: two surfaces
+
+There are two places version mismatch can surface on the client, and
+they fire in different conditions:
+
+**1. `VersionUnsupportedError` thrown pre-flight.** When the client
+already has the peer's capabilities cached and knows up front that
+the call won't go through (synthetic mismatch, version mismatch,
+idempotency mismatch), the SDK throws `VersionUnsupportedError`
+*before* sending the request. Catch it from the call site:
+
+```ts
+import { VersionUnsupportedError } from '@adcp/sdk';
+
+try {
+  const result = await agent.getProducts({ brief: '…' });
+} catch (err) {
+  if (err instanceof VersionUnsupportedError) {
+    // peer doesn't support this call at the pinned version —
+    // re-pin adcpVersion or switch agents
+  }
+  throw err;
+}
+```
+
+**2. `VERSION_UNSUPPORTED` envelope from the wire.** When the
+mismatch is only detected on the server side (e.g., the buyer's
+`adcp_major_version` parses different than the buyer's `adcp_version`
+string), the response carries a typed `VERSION_UNSUPPORTED` error
+envelope that echoes the seller's `supported_versions`:
+
+```ts
+const result = await agent.getProducts({ brief: '…' });
+
+if (!result.success && result.adcpError?.code === 'VERSION_UNSUPPORTED') {
+  const supported = result.adcpError.details?.supported_versions ?? [];
+  // pick a version you also support, then re-issue with adcpVersion pinned
+}
+```
+
+`VERSION_UNSUPPORTED` is recovery-classified `correctable` — clients
+that handle it programmatically retry against a supported version.
+
+This is the third mechanism rather than a fallback to the first:
+negotiation tells you *what's possible*; per-call pinning tells the
+SDK *which one to use*.
+
+## Putting it together
+
+A typical multi-version production setup:
+
+1. **Server**: declare `supported_versions: ['3.0.5', '3.1.0']` in
+   capabilities. The SDK accepts both on the wire and returns
+   `VERSION_UNSUPPORTED` to anyone outside the set. (Only declare a
+   version your handlers actually satisfy.)
+2. **Client (per peer)**: pin `adcpVersion` (e.g., `'v2.5'`) based on
+   what the registry or peer's capabilities advertise. The
+   client-side adapters translate the wire shape so your application
+   code stays on the current spec.
+3. **SDK upgrades**: bump `@adcp/sdk` on your schedule; switch to
+   `createAdcpServerFromPlatform` per specialism over time; keep the
+   rest on `@adcp/sdk/server/legacy/v5` until you're ready.
+
+The combined effect: **one handler codebase, three version axes, no
+fork.**
+
+## What this saves you from building
+
+A from-scratch agent has to:
+
+- Maintain a translation matrix between every spec version it claims
+  to support, and update it every time a release ships.
+- Hand-roll API stability across its own internal refactors.
+- Implement the negotiation handshake (`adcp_major_version` parsing,
+  `adcp_version` cross-checks, `VERSION_UNSUPPORTED` envelope shaping
+  with the supported-versions echo).
+- Keep its conformance test surface in sync as new versions ship.
+
+Each of these compounds at every spec revision. The SDK absorbs
+them so your team's effort goes into L4 differentiation, not into
+versioning plumbing.
+
+See also:
+
+- [Architecture: the AdCP stack](../architecture/adcp-stack.md)
+- [Where to start](../where-to-start.md)
+- [Migration 5.x → 6.x](../migration-5.x-to-6.x.md)
+- [Migration 4.x → 5.x](../migration-4.x-to-5.x.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,11 @@
 
 Welcome to the official documentation for `@adcp/sdk`, the TypeScript/JavaScript client library for the Ad Context Protocol.
 
+> **New here?** Start with [Where to start](./where-to-start.md) — a
+> short decision page that picks the right entry point based on what
+> you're building (caller, agent, or both) and how much of the
+> protocol you want to inherit.
+
 ## Quick Navigation
 
 ### 🤖 For AI Agents
@@ -11,16 +16,21 @@ Welcome to the official documentation for `@adcp/sdk`, the TypeScript/JavaScript
 
 ### 🛠 Building a Server-Side Agent
 
+- [Where to start](./where-to-start.md) — pick your starting layer (caller / agent / SDK author)
+- [The AdCP stack (architecture)](./architecture/adcp-stack.md) — the five layers, what each SDK provides, and how versioning works
 - [Build an Agent](./guides/BUILD-AN-AGENT.md) — `createAdcpServerFromPlatform` + `definePlatform` family
+- [Migrate from a hand-rolled agent](./guides/MIGRATE-FROM-HAND-ROLLED.md) — incremental swap-one-layer-at-a-time path
 - [Validate Your Agent](./guides/VALIDATE-YOUR-AGENT.md) — five-command checklist + storyboard runner
 - [Account Resolution](./guides/account-resolution.md) — `'explicit'` vs `'implicit'` vs `'derived'` mode selection
 - [ctx_metadata Safety](./guides/CTX-METADATA-SAFETY.md) — don't store secrets there
 - [Signing Guide](./guides/SIGNING-GUIDE.md) — RFC 9421 request signing + JWKS
 - [Conformance](./guides/CONFORMANCE.md) — property-based fuzzing against bundled JSON schemas
+- [Version Adaptation](./guides/VERSION-ADAPTATION.md) — talk to peers on any supported spec version
 - Worked reference adapters: `examples/hello_*` family (pick by specialism)
 
 ### 📈 Migration Guides
 
+- [Migrate from a hand-rolled agent](./guides/MIGRATE-FROM-HAND-ROLLED.md) — for adopters with a working AdCP agent in production
 - [6.6 → 6.7](./migration-6.6-to-6.7.md) — fifteen adopter recipes; two breaking (`'implicit'` refusal, `SalesPlatform` split)
 - [5.x → 6.x](./migration-5.x-to-6.x.md) — `createAdcpServerFromPlatform` framework shape
 - [4.x → 5.x](./migration-4.x-to-5.x.md) — `TaskResult` discriminated union + `createAdcpServer`

--- a/docs/where-to-start.md
+++ b/docs/where-to-start.md
@@ -35,11 +35,13 @@ protocol you write yourself —
 for the full breakdown of "what you write vs. what's done for you" at
 each entry point.
 
-A from-scratch L0 → L3 build is roughly **4 person-months** before
-any L4 differentiation, and that scope grows every time the spec
-revs. Within a given language, the full-stack SDK is the default
-entry point; the layered model exists to explain what you'd be
-reimplementing if you went lower or ported to a new language.
+A from-scratch L0 → L3 build is roughly **3–4 person-months** before
+any L4 differentiation —
+[see the per-component breakdown](./architecture/adcp-stack.md#why-sdks-matter-more-in-adcp-than-in-eg-http) —
+and that scope grows every time the spec revs. Within a given
+language, the full-stack SDK is the default entry point; the layered
+model exists to explain what you'd be reimplementing if you went
+lower or ported to a new language.
 
 ## Three questions to pick your layer
 
@@ -59,12 +61,16 @@ reimplementing if you went lower or ported to a new language.
   start at L4. Your competitive surface is what you build on top of
   the protocol, not the protocol itself.
   → [Build an Agent](./guides/BUILD-AN-AGENT.md).
-- **You are an SDK author / language porter** → start at L0–L1 and
-  build up. The
+- **You are an SDK author / language porter, building a special-purpose
+  proxy, or integrating into a stack that already owns L0–L2** →
+  start lower and build up. The
   [architecture deep-dive](./architecture/adcp-stack.md) tells you
   what each layer must provide.
-- **Anything else** → start at L4. Going lower is almost always a
-  scope mistake disguised as a control preference.
+- **Anything else** → start at L4. Going lower is rarely the win it
+  looks like — see [what you give up](#what-you-give-up-by-going-lower)
+  for the concrete scope. If you can name a specific reason to go
+  lower, go ahead; otherwise default to L4 and reach down only when
+  you hit a wall you can name.
 
 **3. Do you already have a working agent built before the SDK was
 mature?**
@@ -77,9 +83,11 @@ expanded error catalog) was added with AdCP 3.0. Hand-rolled 2.5
 agents inherit the entire delta — and the
 [version-adaptation surface](./architecture/adcp-stack.md#version-adaptation)
 that lets a 3.x agent talk to a 2.5 caller without forking handler
-code. If your stack predates these, the cheapest thing to do is
-often **adopt the SDK at L2 or L3** rather than continue hand-rolling
-forward.
+code. The
+[migration guide](./guides/MIGRATE-FROM-HAND-ROLLED.md) walks the
+swap-one-layer-at-a-time path: which layer to swap first, what
+conflict modes to watch for (idempotency, account-mode, webhook
+signing), and which intermediate states still pass conformance.
 
 ## Recommended path
 
@@ -91,7 +99,9 @@ For ~95% of adopters: **start at L4 with the full-stack SDK.**
   `DecisioningPlatform`, pre-wires L0–L3) and `createAdcpServer`
   (handler-bag API for finer control or in-flight v5 migrations).
 - New caller → [Getting Started](./getting-started.md).
-- Migrating from v5 → see [the 5.x → 6.x migration](./migration-5.x-to-6.x.md);
+- **Already have a hand-rolled agent in production →
+  [Migrate from a hand-rolled agent](./guides/MIGRATE-FROM-HAND-ROLLED.md).**
+- Migrating SDK majors (v5 → v6) → see [the 5.x → 6.x migration](./migration-5.x-to-6.x.md);
   the legacy subpath lets you co-exist while you migrate.
 - Talking to peers on a different spec version →
   [Version Adaptation](./guides/VERSION-ADAPTATION.md).

--- a/docs/where-to-start.md
+++ b/docs/where-to-start.md
@@ -1,0 +1,124 @@
+# Where to start
+
+You're about to write AdCP code. Before picking a tutorial, answer
+this: **how much of the protocol do you want to inherit, and how much
+do you want to write yourself?**
+
+This page is the decision. The
+[architecture deep-dive](./architecture/adcp-stack.md) is the
+reasoning. The
+[Getting Started](./getting-started.md) and
+[Build an Agent](./guides/BUILD-AN-AGENT.md) guides are the next
+clicks once you've chosen.
+
+## The five layers, in one paragraph
+
+Every AdCP request crosses five layers between the wire and your
+business logic:
+
+- **L0** — wire: bytes, JSON, schema validation, type generation.
+- **L1** — signing: RFC 9421 message signatures, key rotation.
+- **L2** — auth & registry: principal resolution, multi-tenant routing.
+- **L3** — protocol semantics: lifecycle state machines, idempotency,
+  error catalog, async tasks, conformance test surface, webhooks.
+- **L4** — your business logic: inventory, pricing, creative review,
+  upstream ad-server calls.
+
+A full-stack SDK ships L0–L3 and leaves L4 to you. Picking a starting
+layer = picking how much of L0–L3 you take on yourself.
+
+## Where can you start?
+
+You can enter at any layer. The lower you start, the more of the
+protocol you write yourself —
+[see the layer table](./architecture/adcp-stack.md#where-can-you-start)
+for the full breakdown of "what you write vs. what's done for you" at
+each entry point.
+
+A from-scratch L0 → L3 build is roughly **4 person-months** before
+any L4 differentiation, and that scope grows every time the spec
+revs. Within a given language, the full-stack SDK is the default
+entry point; the layered model exists to explain what you'd be
+reimplementing if you went lower or ported to a new language.
+
+## Three questions to pick your layer
+
+**1. Are you building a caller, an agent, or both?**
+
+- **Caller only** (a buyer-side app calling existing agents) →
+  start at L4 with [Getting Started](./getting-started.md). The
+  client API is small; you don't own L1–L3 at all.
+- **Agent (server)** → keep reading; the rest of this page is for
+  you.
+- **Both** → start with the agent decision below; the client side
+  is additive.
+
+**2. What's your team's value-add?**
+
+- **Inventory, pricing, creative review, decisioning** (i.e., L4) →
+  start at L4. Your competitive surface is what you build on top of
+  the protocol, not the protocol itself.
+  → [Build an Agent](./guides/BUILD-AN-AGENT.md).
+- **You are an SDK author / language porter** → start at L0–L1 and
+  build up. The
+  [architecture deep-dive](./architecture/adcp-stack.md) tells you
+  what each layer must provide.
+- **Anything else** → start at L4. Going lower is almost always a
+  scope mistake disguised as a control preference.
+
+**3. Do you already have a working agent built before the SDK was
+mature?**
+
+If yes: re-evaluate against
+[today's SDK coverage](./architecture/adcp-stack.md#what-an-sdk-at-each-layer-should-provide),
+not the SDK you remember. Most of L3 (lifecycle state machines,
+idempotency, the conformance test surface, RFC 9421 baseline,
+expanded error catalog) was added with AdCP 3.0. Hand-rolled 2.5
+agents inherit the entire delta — and the
+[version-adaptation surface](./architecture/adcp-stack.md#version-adaptation)
+that lets a 3.x agent talk to a 2.5 caller without forking handler
+code. If your stack predates these, the cheapest thing to do is
+often **adopt the SDK at L2 or L3** rather than continue hand-rolling
+forward.
+
+## Recommended path
+
+For ~95% of adopters: **start at L4 with the full-stack SDK.**
+
+- New agent → [Build an Agent](./guides/BUILD-AN-AGENT.md). The
+  guide's [Two paths](./guides/BUILD-AN-AGENT.md#two-paths) section
+  picks between `createAdcpServerFromPlatform` (typed
+  `DecisioningPlatform`, pre-wires L0–L3) and `createAdcpServer`
+  (handler-bag API for finer control or in-flight v5 migrations).
+- New caller → [Getting Started](./getting-started.md).
+- Migrating from v5 → see [the 5.x → 6.x migration](./migration-5.x-to-6.x.md);
+  the legacy subpath lets you co-exist while you migrate.
+- Talking to peers on a different spec version →
+  [Version Adaptation](./guides/VERSION-ADAPTATION.md).
+
+For the small set of adopters going lower (porting the SDK to a new
+language, building a special-purpose proxy, integrating into an
+existing stack that owns L0–L2 already): start with the
+[architecture deep-dive](./architecture/adcp-stack.md) — it's the
+reference for what each layer must satisfy to reach the conformance
+bar.
+
+## What you give up by going lower
+
+| You skip | Cost |
+|---|---|
+| L0 (use a generic JSON toolkit) | Hand-roll the schema validation matrix, the MCP/A2A transport adapters, the per-version type bundles. ~weeks. |
+| L1 (use a generic crypto library) | Build the RFC 9421 canonicalization, replay-window enforcement, key-rotation handling, KMS integration. ~month. |
+| L2 (own your own auth) | Build principal resolution, brand resolution, sandbox/live routing, account scoping. ~month. |
+| L3 (own protocol semantics) | Build seven lifecycle state machines with legal-edge enforcement, idempotency cache with cross-payload conflict detection, async-task store + dispatcher, webhook emitter, the `comply_test_controller` conformance surface, and pick the right error code for every failure mode out of 47. **Most of the SDK's value is here.** ~3 months minimum. |
+
+L4 is yours regardless of where you start. The choice is how much of
+L0–L3 you want to own forever, including the version-adaptation work
+each new spec rev brings.
+
+## Still not sure?
+
+Read [the architecture deep-dive](./architecture/adcp-stack.md). It
+walks each layer end-to-end, names what an SDK at each layer must
+provide, and covers the version-adaptation model in detail. Then
+come back here and pick a starting layer.


### PR DESCRIPTION
## Summary

Reorients adopters around how much of L0–L3 they want to inherit from `@adcp/sdk` vs. write themselves. Targets two recurring wrong conclusions:

1. **Early implementers** who built before the SDKs were mature and have a frozen-in-time picture of "what the SDK does." Most of L3 (lifecycle state machines, idempotency, conformance test surface, RFC 9421 baseline, expanded error catalog) was added with AdCP 3.0.
2. **New implementers** who say "I'll roll my own AdCP agent, I don't need an SDK" without seeing the L0–L3 scope.

## What's in it

- **`docs/architecture/adcp-stack.md` (new)** — full L0–L4 reference. Each layer: what it does, what's in it, what an SDK at that layer should provide, what you give up by skipping it. Includes the version-adaptation summary and a "what early implementers underestimate" punch list.
- **`docs/where-to-start.md` (new)** — short decision page. Three questions (caller vs. agent / value-add / pre-existing hand-rolled), recommended path for ~95% of adopters, "what you give up by going lower" cost table.
- **`docs/guides/VERSION-ADAPTATION.md` (new)** — code-level recipes for the three version-handling mechanisms:
  1. Per-call `adcpVersion` pinning + bundle-gated runtime acceptance + `ConfigurationError` semantics
  2. `@adcp/sdk/server/legacy/v5` subpath co-existence imports
  3. Wire-level `supported_versions` declaration with `VERSION_UNSUPPORTED` envelope and `VersionUnsupportedError` typed throw
- **Wiring** — top-of-page callouts on `index.md`, `getting-started.md`, `guides/BUILD-AN-AGENT.md` route mis-aimed readers to `where-to-start.md` without blocking on-target ones. Cross-link to `CONFORMANCE.md` from L3 + early-implementer item #2.

## Reviewed by

- DX expert: caught three signature/semantics errors in the version-adaptation code samples (`createAdcpServerFromPlatform(platform, opts)` two positional args, bundle-gated vs. major-gated runtime acceptance, `VersionUnsupportedError` pre-flight throw alongside the envelope read). All addressed.
- Docs expert: caught the redundant layer table between `where-to-start.md` and `adcp-stack.md` (resolved by single-sourcing in the architecture doc), the "no single SDK" / "95% start at L4" tone tension (resolved with a bridge sentence), and a broken `protocol-overview.md` link in `index.md` (resolved by removal). Cross-linking gaps to `CONFORMANCE.md` filled.

## Notes for reviewers

- Code samples were verified against `src/lib/version.ts`, `src/lib/utils/adcp-version-config.ts`, `src/lib/core/SingleAgentClient.ts`, `src/lib/server/create-adcp-server.ts`, `src/lib/server/decisioning/runtime/from-platform.ts`, and `examples/decisioning-platform-mock-seller.ts`.
- `docs/architecture/adcp-stack.md` was originally drafted on a sibling feature branch; this PR brings the file (with the reviewer-driven edits) into main directly. Order with that branch is fine either way — feature branch will rebase cleanly.

## Test plan

- [ ] Markdown renders cleanly on the docs site
- [ ] All internal links resolve (`./architecture/adcp-stack.md`, `./guides/VERSION-ADAPTATION.md`, `./where-to-start.md`, `./guides/CONFORMANCE.md`, `./guides/BUILD-AN-AGENT.md#two-paths`)
- [ ] No conflict with the Account.mode feature branch on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)