### PR TITLE
feat(mock-server): sponsored-intelligence — fifth specialism (brand-agent platform)

### DIFF
--- a/.changeset/feat-mock-server-sponsored-intelligence.md
+++ b/.changeset/feat-mock-server-sponsored-intelligence.md
@@ -66,12 +66,41 @@ product). Cross-brand offering access returns
 `404 offering_not_in_brand`.
 
 **Upstream/AdCP rename pattern** is intentional throughout (exercises
-the adapter's projection): `conversation_id` → `session_id`,
-`assistant_message` → `response.message`, `components` (with `kind`) →
-`ui_elements` (with `type`), `sku` → `product_id`, `hero_image_url` →
-`image_url`, `landing_page_url` → `landing_url`, `pdp_url` → `url`,
-`thumbnail_url` → `image_url`, `inventory_status` →
-`availability_summary`, `transaction_handoff` → `acp_handoff`.
+the adapter's projection):
+
+| upstream field | AdCP field |
+|---|---|
+| `conversation_id` | `session_id` |
+| `assistant_message` | `response.message` |
+| `components[].kind` | `ui_elements[].type` |
+| `client_request_id` | `idempotency_key` |
+| `offering_query_id` | `offering_token` |
+| `transaction_handoff` | `acp_handoff` |
+| `close_recommended.type: txn_ready` | `session_status: 'pending_handoff'` + `handoff.type: 'transaction'` |
+| `close_recommended.type: done` | `session_status: 'pending_handoff'` + `handoff.type: 'complete'` |
+| `close.reason: txn_ready` | `SITerminateSessionRequest.reason: 'handoff_transaction'` |
+| `close.reason: done` | `'handoff_complete'` |
+| `close.reason: user_left` | `'user_exit'` |
+| `close.reason: idle_timeout` | `'session_timeout'` |
+| `close.reason: host_closed` | `'host_terminated'` |
+| `sku` | `product_id` |
+| `hero_image_url`, `thumbnail_url` | `image_url` |
+| `landing_page_url` | `landing_url` |
+| `pdp_url` | `url` |
+| `inventory_status` | `availability_summary` |
+
+The close-reason vocabulary is deliberately distinct from AdCP's enum
+(rather than identity-mapping `complete` to `complete`) so the adapter's
+translation is loud — sending an AdCP reason value to the upstream close
+endpoint returns `400 invalid_close_reason`, forcing the adapter to
+implement the projection rather than accidentally pass-through.
+
+**Offering token correlation** (`offering_query_id`): the brand mints a
+token on every `GET /offerings/{id}` and stores the products-shown
+record keyed on it. A subsequent `POST /conversations` with the same
+token resolves "the second one" against what the user actually saw,
+not the full catalog. Mirrors the AdCP `SIGetOfferingResponse.offering_token`
+→ `SIInitiateSessionRequest.offering_token` correlation primitive.
 
 Run with:
 
@@ -79,12 +108,25 @@ Run with:
 npx @adcp/sdk mock-server sponsored-intelligence --port 4500
 ```
 
-**16 new smoke tests** in
-`test/lib/mock-server/sponsored-intelligence.test.js` cover:
-auth gating, brand lookup, cross-brand offering isolation, conversation
-start with idempotent replay, turn keyword routing (transaction/complete
-hints), idempotency-conflict rejection, transaction close with handoff
-payload, idempotent re-close, post-close turn rejection, and traffic
-counter recording.
+**23 smoke tests** in
+`test/lib/mock-server/sponsored-intelligence.test.js` cover: auth
+gating, brand lookup, cross-brand offering and conversation isolation,
+conversation start with idempotent replay and idempotency-conflict
+rejection (POST /conversations and POST /turns symmetric), turn keyword
+routing (txn_ready/done close hints), close with txn_ready returning a
+transaction_handoff, AdCP-vocabulary reason rejection (400
+`invalid_close_reason`), idempotent re-close, post-close turn
+rejection, GET-after-close, offering_query_id round-trip from GET
+/offerings into POST /conversations, unknown-token rejection, cross-brand
+token rejection, and traffic counter recording.
+
+**Deferred to follow-up branches** (acknowledged limitations of this v1
+fixture): A2UI surface support (`SISendMessageResponse.response.surface`),
+streaming turns (real Agentforce / Assistants emit SSE), consent-version
+gate (a brand with `requires_identity: true`), anonymous_session_id
+assertion, multi-brand catalog overlap (one customer fronting many
+brands with shared products), ACP handoff failure mode, eager
+`pending_handoff` mid-turn path (mock currently surfaces close hints
+lazily — adapter chooses whether to project as eager handoff).
 
 Refs adcontextprotocol/adcp#3961.

--- a/.changeset/feat-mock-server-sponsored-intelligence.md
+++ b/.changeset/feat-mock-server-sponsored-intelligence.md
@@ -1,0 +1,90 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(cli+harness): `adcp mock-server sponsored-intelligence` — fifth specialism (brand-agent platform shape)
+
+Adds the SI mock-server. Brand-agent-platform-shaped upstream (Salesforce
+Agentforce / OpenAI Assistants / custom-brand-chat family) that hosts
+conversational brand offerings and exposes them via a stateful HTTP API.
+Adapter wraps it to project AdCP `si_get_offering`, `si_initiate_session`,
+`si_send_message`, `si_terminate_session`.
+
+This is the first matrix-v2 fixture for SI. Lets adopters dogfood SI ahead
+of `adcontextprotocol.org` standing up a reference SI tenant — and lets
+the SDK exercise the four SI tools end-to-end against a deterministic
+fixture.
+
+**Why a mock now (and not a v6 platform shape):** SI is currently a
+*protocol* in AdCP 3.0 (`supported_protocols: ['sponsored_intelligence']`)
+but not a *specialism* — `sponsored-intelligence` is absent from
+`AdCPSpecialism`. That blocks a v6 `SponsoredIntelligencePlatform`
+interface with parity to the other specialism platforms; adopters wire SI
+through the v5 `createAdcpServer` handler bag
+(`SponsoredIntelligenceHandlers`). The mock server is independent of that
+decision — it represents the upstream brand platform an adapter wraps,
+regardless of which SDK shape the AdCP-side handler uses. Filed as
+adcontextprotocol/adcp#3961.
+
+**Routes** (path-scoped multi-tenancy, parallel to creative-template):
+
+- `GET /_lookup/brand?adcp_brand=<value>` — discovery (no auth)
+- `GET /_debug/traffic` — façade-detection traffic counters
+- `GET /v1/brands/{brand}/offerings/{offering_id}` — `si_get_offering`
+- `POST /v1/brands/{brand}/conversations` — `si_initiate_session`
+- `GET /v1/brands/{brand}/conversations/{conv_id}` — read state
+- `POST /v1/brands/{brand}/conversations/{conv_id}/turns` — `si_send_message`
+- `POST /v1/brands/{brand}/conversations/{conv_id}/close` — `si_terminate_session`
+
+Conversation lifecycle: `active` → `closed` (terminal). Re-closing
+returns the same payload — naturally idempotent on `conversation_id`,
+mirroring AdCP's decision to omit `idempotency_key` on
+`si_terminate_session`. POST `/conversations` and POST `/turns` each
+accept `client_request_id` (the upstream-side translation of AdCP
+`idempotency_key`) for at-most-once execution; mismatched body with
+reused key → `409 idempotency_conflict`.
+
+**Brand-agent canned responses** (deterministic, keyword-routed):
+
+- `buy` / `purchase` / `checkout` / `order` → response with
+  `close_recommended: { type: 'transaction', payload }` — adapter
+  surfaces as AdCP `session_status: 'pending_handoff'` + populated
+  `handoff` block.
+- `thanks` / `bye` / `done` → `close_recommended: { type: 'complete' }`
+- `second` / `next` / `other one` → swap product card to next product
+- otherwise → product card from the configured offering
+
+When `close` is called with `reason=transaction`, the response includes
+a `transaction_handoff` block with `checkout_url`, `checkout_token`, and
+`expires_at` — adapter projects to AdCP `acp_handoff` on
+`SITerminateSessionResponse`.
+
+**Two seeded brands** (multi-tenancy assertion): `brand_acme_outdoor`
+(running shoes, single offering with two products) and
+`brand_summit_books` (independent bookstore, single offering with one
+product). Cross-brand offering access returns
+`404 offering_not_in_brand`.
+
+**Upstream/AdCP rename pattern** is intentional throughout (exercises
+the adapter's projection): `conversation_id` → `session_id`,
+`assistant_message` → `response.message`, `components` (with `kind`) →
+`ui_elements` (with `type`), `sku` → `product_id`, `hero_image_url` →
+`image_url`, `landing_page_url` → `landing_url`, `pdp_url` → `url`,
+`thumbnail_url` → `image_url`, `inventory_status` →
+`availability_summary`, `transaction_handoff` → `acp_handoff`.
+
+Run with:
+
+```bash
+npx @adcp/sdk mock-server sponsored-intelligence --port 4500
+```
+
+**16 new smoke tests** in
+`test/lib/mock-server/sponsored-intelligence.test.js` cover:
+auth gating, brand lookup, cross-brand offering isolation, conversation
+start with idempotent replay, turn keyword routing (transaction/complete
+hints), idempotency-conflict rejection, transaction close with handoff
+payload, idempotent re-close, post-close turn rejection, and traffic
+counter recording.
+
+Refs adcontextprotocol/adcp#3961.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1028,14 +1028,26 @@ ARGUMENTS:
                                             signing tasks, inventory-list
                                             targeting, and CAPI for delivery
                                             validation.
+                       sponsored-intelligence
+                                            Brand-agent platform (Salesforce
+                                            Agentforce / OpenAI Assistants
+                                            shaped) with conversational
+                                            offerings, stateful session
+                                            transcripts, and ACP transaction
+                                            handoff. Adapter wraps it to
+                                            expose si_get_offering /
+                                            si_initiate_session /
+                                            si_send_message /
+                                            si_terminate_session.
 
 OPTIONS:
   --port N           Listen port. Default: 4500.
   --api-key KEY      Override the static bearer credential. Only applies to
                      specialisms with static-bearer auth (signal-marketplace,
-                     creative-template). Ignored for OAuth specialisms
-                     (sales-social) — those issue tokens via the OAuth flow.
-                     Defaults to a stable test key printed at boot.
+                     creative-template, sponsored-intelligence). Ignored for
+                     OAuth specialisms (sales-social) — those issue tokens via
+                     the OAuth flow. Defaults to a stable test key printed at
+                     boot.
 
 NOTES:
   These mock servers represent the *upstream* platform an adopter wraps,

--- a/src/lib/mock-server/index.ts
+++ b/src/lib/mock-server/index.ts
@@ -9,6 +9,8 @@ import { bootSalesSocial } from './sales-social/server';
 import { ADVERTISERS, OAUTH_CLIENTS } from './sales-social/seed-data';
 import { bootSignalMarketplace } from './signal-marketplace/server';
 import { DEFAULT_API_KEY as SIGNAL_MARKETPLACE_DEFAULT_API_KEY, OPERATORS } from './signal-marketplace/seed-data';
+import { bootSponsoredIntelligence } from './sponsored-intelligence/server';
+import { BRANDS as SI_BRANDS, DEFAULT_API_KEY as SI_DEFAULT_API_KEY } from './sponsored-intelligence/seed-data';
 
 export interface MockServerOptions {
   specialism: string;
@@ -163,9 +165,29 @@ export async function bootMockServer(options: MockServerOptions): Promise<MockSe
         })),
       };
     }
+    case 'sponsored-intelligence': {
+      const { url, close } = await bootSponsoredIntelligence({
+        port: options.port,
+        apiKey: options.apiKey,
+      });
+      const apiKey = options.apiKey ?? SI_DEFAULT_API_KEY;
+      return {
+        url,
+        auth: { kind: 'static_bearer', apiKey },
+        close,
+        summary: () => formatSponsoredIntelligenceSummary(url, apiKey),
+        principalScope: 'URL path segment /v1/brands/{brand_id}/...',
+        principalMapping: SI_BRANDS.map(b => ({
+          adcpField: 'account.brand',
+          adcpValue: b.adcp_brand,
+          upstreamField: 'path /v1/brands/{brand_id}/',
+          upstreamValue: b.brand_id,
+        })),
+      };
+    }
     default:
       throw new Error(
-        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace, creative-template, sales-social, sales-guaranteed.`
+        `Unknown mock-server specialism: "${options.specialism}". Supported: signal-marketplace, creative-template, sales-social, sales-guaranteed, sponsored-intelligence.`
       );
   }
 }
@@ -254,6 +276,40 @@ function formatSalesSocialSummary(url: string, client: { client_id: string; clie
     `  POST   ${url}/v1.3/advertiser/{advertiser_id}/delivery_estimate            (forward + reverse forecast)`,
     `  POST   ${url}/v1.3/advertiser/{advertiser_id}/audience_reach_estimate`,
     `  POST   ${url}/v1.3/advertiser/{advertiser_id}/audience/{aud}/lookalike`,
+  ].join('\n');
+}
+
+function formatSponsoredIntelligenceSummary(url: string, apiKey: string): string {
+  const brandLines = SI_BRANDS.map(
+    b =>
+      `  ${b.brand_id}  →  AdCP account.brand: "${b.adcp_brand}"  (offerings: ${b.visible_offering_ids.length}, session_ttl: ${b.session_ttl_seconds}s)`
+  ).join('\n');
+  return [
+    `Mock sponsored-intelligence brand-agent platform running at ${url}`,
+    ``,
+    `Auth:`,
+    `  Authorization: Bearer ${apiKey}`,
+    `  Brand scoping via URL path: /v1/brands/{brand_id}/...`,
+    ``,
+    `Brand mapping:`,
+    brandLines,
+    ``,
+    `OpenAPI spec: src/lib/mock-server/sponsored-intelligence/openapi.yaml`,
+    `Routes:`,
+    `  GET    ${url}/_lookup/brand?adcp_brand=<value>                                (no auth)`,
+    `  GET    ${url}/_debug/traffic                                                  (no auth)`,
+    `  GET    ${url}/v1/brands/{brand}/offerings/{offering_id}                       # si_get_offering`,
+    `  POST   ${url}/v1/brands/{brand}/conversations                                 # si_initiate_session`,
+    `  GET    ${url}/v1/brands/{brand}/conversations/{conv_id}                       # read state`,
+    `  POST   ${url}/v1/brands/{brand}/conversations/{conv_id}/turns                 # si_send_message`,
+    `  POST   ${url}/v1/brands/{brand}/conversations/{conv_id}/close                 # si_terminate_session`,
+    ``,
+    `Conversation lifecycle: active → closed (terminal). Re-closing returns the`,
+    `same payload — naturally idempotent on conversation_id, mirroring AdCP's`,
+    `decision to omit idempotency_key on si_terminate_session. POST /conversations`,
+    `and POST /turns each accept client_request_id for at-most-once execution.`,
+    `Brand "agent" routes user messages by keyword (buy/checkout → transaction`,
+    `handoff hint, thanks/bye → complete hint) — deterministic for fixtures.`,
   ].join('\n');
 }
 

--- a/src/lib/mock-server/sponsored-intelligence/openapi.yaml
+++ b/src/lib/mock-server/sponsored-intelligence/openapi.yaml
@@ -73,6 +73,27 @@ components:
           description: |
             Total products matching the offering, regardless of `product_limit`
             applied to the response. Maps to AdCP `total_matching`.
+        offering_query_id:
+          type: string
+          description: |
+            Token minted on every offering lookup. The brand stores the
+            products-shown record server-side keyed on this token so a
+            subsequent `POST /conversations` can resolve positional
+            references like "the second one" without replaying the
+            transcript. Adapter renames `offering_query_id` ↔ AdCP
+            `offering_token`.
+          example: 'oqt_5f4a2b91c8d36e10'
+        offering_query_expires_at:
+          type: string
+          format: date-time
+          description: |
+            When the query token expires. Adapter projects this into AdCP
+            `SIGetOfferingResponse.ttl_seconds` (relative seconds).
+        offering_query_ttl_seconds:
+          type: integer
+          description: |
+            Convenience integer alongside `offering_query_expires_at`. Maps
+            to AdCP `ttl_seconds`.
         privacy_policy:
           type: object
           properties:
@@ -118,8 +139,17 @@ components:
         offering_id:
           type: string
           description: |
-            Pre-resolved offering context. The brand stores this server-side
-            so subsequent turns can reference products by name or position.
+            Pre-resolved offering identifier. May be sent alone for a fresh
+            conversation against the full catalog, or alongside
+            `offering_query_id` (must agree).
+        offering_query_id:
+          type: string
+          description: |
+            Token previously minted by `GET /offerings/{id}` — the brand uses
+            this to recall the products-shown record for "the second one"
+            references. Adapter renames `offering_query_id` ↔ AdCP
+            `offering_token`. If omitted, the conversation is seeded against
+            the full offering catalog.
         identity:
           type: object
           description: |
@@ -131,8 +161,9 @@ components:
           type: string
           description: |
             Idempotency key. Adapter translates AdCP `idempotency_key` to
-            this. Replaying the same key returns the same conversation
-            rather than starting a new one.
+            this. Replaying the same key with an identical body returns the
+            same conversation; replaying with a different body → 409
+            `idempotency_conflict`.
 
     Conversation:
       type: object
@@ -248,9 +279,25 @@ components:
       properties:
         reason:
           type: string
+          enum: [txn_ready, done, user_left, idle_timeout, host_closed]
           description: |
-            Maps from AdCP `SITerminateSessionRequest.reason`. Common values:
-            transaction, complete, user_exit, session_timeout, host_terminated.
+            Upstream close-reason vocabulary. Deliberately distinct from
+            AdCP's `SITerminateSessionRequest.reason` so the adapter's
+            translation is loud rather than identity-mapped on the
+            `complete` value. Mapping:
+
+            | AdCP reason          | upstream reason  |
+            |----------------------|------------------|
+            | `handoff_transaction`| `txn_ready`      |
+            | `handoff_complete`   | `done`           |
+            | `user_exit`          | `user_left`      |
+            | `session_timeout`    | `idle_timeout`   |
+            | `host_terminated`    | `host_closed`    |
+
+            Sending an AdCP value here returns
+            `400 invalid_close_reason` — adapter must translate before
+            forwarding. When `reason=txn_ready`, the response includes
+            `transaction_handoff` (adapter projects to AdCP `acp_handoff`).
         summary:
           type: string
           description: |

--- a/src/lib/mock-server/sponsored-intelligence/openapi.yaml
+++ b/src/lib/mock-server/sponsored-intelligence/openapi.yaml
@@ -1,0 +1,453 @@
+openapi: 3.1.0
+info:
+  title: Sponsored Intelligence Brand Agent API
+  version: '1.0.0'
+  description: |
+    HTTP API for a fictional brand-agent platform — Salesforce Agentforce /
+    OpenAI Assistants / custom-brand-chat shaped upstream that hosts
+    conversational brand experiences. Adapter wraps this API to expose AdCP
+    `si_get_offering`, `si_initiate_session`, `si_send_message`,
+    `si_terminate_session`.
+
+    Brand-scoped via the URL path (`/v1/brands/{brand_id}/...`) — same
+    multi-tenancy flavor as the creative-template mock. Conversations are
+    stateful: the upstream owns the session transcript and offering context
+    so the brand can resolve back-references like "the second one" without
+    the host having to replay the full transcript.
+
+    This is a fixture for compliance testing; the seed brands and offerings
+    are stable across boots.
+
+servers:
+  - url: http://127.0.0.1:{port}
+    variables:
+      port:
+        default: '4500'
+        description: Port the mock-server boots on (override with --port)
+
+components:
+  securitySchemes:
+    bearerApiKey:
+      type: http
+      scheme: bearer
+      description: |
+        Customer-level credential, shared across all brands owned by that
+        customer. Brand scoping happens via the URL path.
+
+  schemas:
+    Offering:
+      type: object
+      required: [offering_id, brand_id, name, summary, hero_image_url, landing_page_url, available]
+      properties:
+        offering_id:
+          type: string
+          description: |
+            Stable upstream identifier for the offering. Maps to AdCP
+            `SIGetOfferingResponse.offering.offering_id` (rename only — direct
+            projection).
+          example: 'off_acme_trailrun_summer26'
+        brand_id: { type: string, example: 'brand_acme_outdoor' }
+        name: { type: string }
+        summary: { type: string }
+        tagline: { type: string }
+        hero_image_url:
+          type: string
+          description: |
+            Upstream uses `hero_image_url`; AdCP wants `image_url`. Direct
+            rename in the adapter.
+        landing_page_url:
+          type: string
+          description: |
+            Upstream uses `landing_page_url`; AdCP wants `landing_url`.
+        price_hint: { type: string, example: 'from $129' }
+        expires_at: { type: string, format: date-time }
+        available: { type: boolean }
+        products:
+          type: array
+          description: |
+            Present when `?include_products=true`. Each product uses upstream
+            key `sku`; AdCP wants `product_id`. Adapter projects.
+          items: { $ref: '#/components/schemas/Product' }
+        total_matching:
+          type: integer
+          description: |
+            Total products matching the offering, regardless of `product_limit`
+            applied to the response. Maps to AdCP `total_matching`.
+        privacy_policy:
+          type: object
+          properties:
+            url: { type: string }
+            version: { type: string }
+
+    Product:
+      type: object
+      required: [sku, name, display_price, thumbnail_url, pdp_url, inventory_status]
+      properties:
+        sku:
+          type: string
+          description: |
+            Upstream product identifier. Maps to AdCP `product_id` —
+            rename only.
+        name: { type: string }
+        display_price: { type: string, example: '$129' }
+        list_price: { type: string, description: 'Original price if on sale' }
+        thumbnail_url:
+          type: string
+          description: |
+            Upstream uses `thumbnail_url`; AdCP wants `image_url`. Adapter
+            renames.
+        pdp_url:
+          type: string
+          description: |
+            Upstream uses `pdp_url`; AdCP wants `url`. Adapter renames.
+        inventory_status:
+          type: string
+          description: |
+            Free-text upstream summary. Maps to AdCP
+            `availability_summary`.
+
+    StartConversationRequest:
+      type: object
+      required: [intent]
+      properties:
+        intent:
+          type: string
+          description: |
+            Natural language description of the user's need. Maps directly
+            from AdCP `SIInitiateSessionRequest.intent`.
+        offering_id:
+          type: string
+          description: |
+            Pre-resolved offering context. The brand stores this server-side
+            so subsequent turns can reference products by name or position.
+        identity:
+          type: object
+          description: |
+            Optional consented user identity. Maps from AdCP
+            `SIInitiateSessionRequest.identity`. The mock does not validate
+            consent semantics — adopters' adapters are expected to gate on
+            `consent_granted` before forwarding PII.
+        client_request_id:
+          type: string
+          description: |
+            Idempotency key. Adapter translates AdCP `idempotency_key` to
+            this. Replaying the same key returns the same conversation
+            rather than starting a new one.
+
+    Conversation:
+      type: object
+      required: [conversation_id, brand_id, status, intent, turns, created_at, updated_at]
+      properties:
+        conversation_id:
+          type: string
+          description: |
+            Maps to AdCP `session_id`. Adapter renames in the response
+            projection.
+          example: 'conv_5f4a2b91c8d36e10'
+        brand_id: { type: string }
+        status: { type: string, enum: [active, closed] }
+        offering_id: { type: string, nullable: true }
+        intent: { type: string }
+        turns:
+          type: array
+          items: { $ref: '#/components/schemas/Turn' }
+        close:
+          type: object
+          nullable: true
+          description: |
+            Set on closed conversations. Includes the close reason and any
+            transaction handoff payload (when reason='transaction').
+          properties:
+            reason: { type: string }
+            closed_at: { type: string, format: date-time }
+            transaction_handoff:
+              type: object
+              nullable: true
+              description: |
+                When present, maps to AdCP `acp_handoff` on
+                `SITerminateSessionResponse`.
+              properties:
+                checkout_url: { type: string }
+                checkout_token: { type: string }
+                expires_at: { type: string, format: date-time }
+                payload: { type: object }
+        session_ttl_seconds:
+          type: integer
+          description: |
+            Brand-configured inactivity timeout. Maps to AdCP
+            `session_ttl_seconds` on initiate response.
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+
+    SendTurnRequest:
+      type: object
+      properties:
+        message:
+          type: string
+          description: |
+            User's message. Maps from AdCP `SISendMessageRequest.message`.
+        action_response:
+          type: object
+          description: |
+            User's response to a previous action_button. Maps from AdCP
+            `SISendMessageRequest.action_response`.
+          properties:
+            action: { type: string }
+            payload: { type: object }
+        client_request_id:
+          type: string
+          description: |
+            Idempotency key. Adapter translates AdCP `idempotency_key` to
+            this. Same key replayed returns the same turn rather than
+            generating a duplicate. Mismatched body with reused key →
+            409 idempotency_conflict.
+      oneOf:
+        - required: [message]
+        - required: [action_response]
+
+    Turn:
+      type: object
+      required: [turn_id, conversation_id, assistant_message, components, created_at]
+      properties:
+        turn_id: { type: string }
+        conversation_id: { type: string }
+        user_message: { type: string, nullable: true }
+        assistant_message:
+          type: string
+          description: |
+            Brand agent's textual response. Maps to AdCP
+            `SISendMessageResponse.response.message`.
+        components:
+          type: array
+          description: |
+            Visual components to render. Each carries an upstream-shaped
+            `kind` field (`product_card`, `action_button`, `text`, `image`).
+            Adapter projects to AdCP `SIUIElement` (`type` instead of
+            `kind`, plus the AdCP component-specific data shape).
+          items: { type: object }
+        close_recommended:
+          type: object
+          nullable: true
+          description: |
+            Brand-side hint that the conversation is naturally winding down
+            (transaction or complete). Adapter decides whether to surface
+            this as AdCP `session_status: 'pending_handoff'` and populate
+            `handoff` on the response.
+          properties:
+            type: { type: string, enum: [transaction, complete] }
+            payload: { type: object }
+        created_at: { type: string, format: date-time }
+        conversation_status:
+          type: string
+          enum: [active, closed]
+          description: 'Echoed on per-turn responses for convenience.'
+        session_ttl_seconds: { type: integer }
+
+    CloseConversationRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: |
+            Maps from AdCP `SITerminateSessionRequest.reason`. Common values:
+            transaction, complete, user_exit, session_timeout, host_terminated.
+        summary:
+          type: string
+          description: |
+            Optional conversation summary for ACP handoff. Maps from AdCP
+            `termination_context.summary`.
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code: { type: string }
+        message: { type: string }
+
+security:
+  - bearerApiKey: []
+
+paths:
+  /_lookup/brand:
+    get:
+      summary: Resolve AdCP-side brand identifier to upstream brand_id
+      description: |
+        Discovery endpoint — adapter calls this at runtime with the
+        AdCP-side brand value (e.g., `account.brand`) to look up the
+        upstream `brand_id`. No auth required.
+      security: []
+      parameters:
+        - name: adcp_brand
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Resolved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  adcp_brand: { type: string }
+                  brand_id: { type: string }
+                  display_name: { type: string }
+        '400': { description: Missing query parameter }
+        '404': { description: Brand not found }
+
+  /_debug/traffic:
+    get:
+      summary: Per-route hit counters (façade-detection)
+      description: |
+        Test harness reads this after a storyboard run to verify the
+        adapter actually called the upstream. Façade adapters that skip
+        the HTTP layer produce zero counters and fail the assertion.
+      security: []
+      responses:
+        '200':
+          description: Traffic counters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  traffic: { type: object, additionalProperties: { type: integer } }
+
+  /v1/brands/{brand_id}/offerings/{offering_id}:
+    get:
+      summary: Get offering details
+      description: Maps to AdCP `si_get_offering`.
+      parameters:
+        - name: brand_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: offering_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: include_products
+          in: query
+          schema: { type: boolean }
+        - name: product_limit
+          in: query
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Offering
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Offering' }
+        '401': { description: Unauthorized }
+        '404': { description: Offering or brand not found }
+
+  /v1/brands/{brand_id}/conversations:
+    post:
+      summary: Start a conversation
+      description: |
+        Maps to AdCP `si_initiate_session`. Returns the freshly-created
+        conversation including the brand's initial assistant turn.
+      parameters:
+        - name: brand_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/StartConversationRequest' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Conversation' }
+        '200':
+          description: Idempotent replay (same client_request_id)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Conversation' }
+
+  /v1/brands/{brand_id}/conversations/{conversation_id}:
+    get:
+      summary: Read conversation state
+      parameters:
+        - name: brand_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: conversation_id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Conversation
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Conversation' }
+        '404': { description: Conversation not found }
+
+  /v1/brands/{brand_id}/conversations/{conversation_id}/turns:
+    post:
+      summary: Send a turn
+      description: |
+        Maps to AdCP `si_send_message`. Each turn is a mutation of the
+        session transcript — pass `client_request_id` for at-most-once
+        execution.
+      parameters:
+        - name: brand_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: conversation_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/SendTurnRequest' }
+      responses:
+        '200':
+          description: Brand agent's response turn
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Turn' }
+        '404': { description: Conversation not found }
+        '409':
+          description: Conversation closed, or idempotency_conflict
+        '400': { description: Invalid request }
+
+  /v1/brands/{brand_id}/conversations/{conversation_id}/close:
+    post:
+      summary: Close a conversation
+      description: |
+        Maps to AdCP `si_terminate_session`. Idempotent — re-closing an
+        already-closed conversation returns the same payload (mirrors AdCP's
+        decision to omit `idempotency_key` on terminate). When `reason` is
+        `transaction`, the response includes a `transaction_handoff` block
+        the adapter projects to AdCP `acp_handoff`.
+      parameters:
+        - name: brand_id
+          in: path
+          required: true
+          schema: { type: string }
+        - name: conversation_id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CloseConversationRequest' }
+      responses:
+        '200':
+          description: Closed conversation
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Conversation' }
+        '404': { description: Conversation not found }

--- a/src/lib/mock-server/sponsored-intelligence/seed-data.ts
+++ b/src/lib/mock-server/sponsored-intelligence/seed-data.ts
@@ -1,0 +1,132 @@
+export interface MockOffering {
+  offering_id: string;
+  brand_id: string;
+  name: string;
+  summary: string;
+  tagline?: string;
+  hero_image_url: string;
+  landing_page_url: string;
+  price_hint: string;
+  expires_at: string;
+  /** Upstream product catalog tied to this offering. The adapter projects
+   * these to the `matching_products` array on `SIGetOfferingResponse` when
+   * `include_products` is true. Note the upstream key is `sku` and AdCP
+   * wants `product_id` — direct rename, intentional, exercises the
+   * adapter's projection. */
+  products: MockProduct[];
+}
+
+export interface MockProduct {
+  sku: string;
+  name: string;
+  display_price: string;
+  list_price?: string;
+  thumbnail_url: string;
+  pdp_url: string;
+  inventory_status: string;
+}
+
+export interface MockBrand {
+  brand_id: string;
+  display_name: string;
+  /** AdCP-side identifier the adapter receives in `account.brand` (or
+   * however the adopter chooses to project brand identity). The adapter
+   * resolves this to `brand_id` for outbound URL composition. */
+  adcp_brand: string;
+  /** Privacy policy version surfaced in `SIInitiateSessionResponse.identity`
+   * acknowledgment when the host shares user data with consent. */
+  privacy_policy_url: string;
+  privacy_policy_version: string;
+  visible_offering_ids: string[];
+  /** Default session inactivity timeout the brand wants the host to honor.
+   * Mirrors AdCP's `session_ttl_seconds` on the initiate response. */
+  session_ttl_seconds: number;
+}
+
+const NOW = '2026-04-15T12:00:00Z';
+const OFFERING_EXPIRES = '2026-06-30T23:59:59Z';
+
+export const OFFERINGS: MockOffering[] = [
+  {
+    offering_id: 'off_acme_trailrun_summer26',
+    brand_id: 'brand_acme_outdoor',
+    name: 'Trail Runner Summer Collection',
+    summary:
+      'Lightweight trail-running shoes with grippy lugs and breathable mesh — built for the long haul. Free returns within 30 days.',
+    tagline: 'Built for the trail.',
+    hero_image_url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/trailrun-hero.jpg',
+    landing_page_url: 'https://acmeoutdoor.example/trailrun',
+    price_hint: 'from $129',
+    expires_at: OFFERING_EXPIRES,
+    products: [
+      {
+        sku: 'acme_tr_blackgreen_10',
+        name: 'Trail Runner — Black/Green, M10',
+        display_price: '$129',
+        list_price: '$159',
+        thumbnail_url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/tr-blackgreen-10.jpg',
+        pdp_url: 'https://acmeoutdoor.example/trailrun/blackgreen-10',
+        inventory_status: 'In stock',
+      },
+      {
+        sku: 'acme_tr_charcoal_11',
+        name: 'Trail Runner — Charcoal, M11',
+        display_price: '$129',
+        list_price: '$159',
+        thumbnail_url: 'https://test-assets.adcontextprotocol.org/acme-outdoor/tr-charcoal-11.jpg',
+        pdp_url: 'https://acmeoutdoor.example/trailrun/charcoal-11',
+        inventory_status: 'Only 3 left',
+      },
+    ],
+  },
+  {
+    offering_id: 'off_summit_books_summer26',
+    brand_id: 'brand_summit_books',
+    name: 'Summer Reading Picks',
+    summary:
+      'Hand-picked reading list from independent booksellers — fiction, memoir, nature writing. Free shipping on orders over $35.',
+    tagline: 'Your next favorite book is here.',
+    hero_image_url: 'https://test-assets.adcontextprotocol.org/summit-books/summer-hero.jpg',
+    landing_page_url: 'https://summit-books.example/summer',
+    price_hint: 'from $18',
+    expires_at: OFFERING_EXPIRES,
+    products: [
+      {
+        sku: 'sb_book_river_north',
+        name: 'River North — A Novel (paperback)',
+        display_price: '$18',
+        thumbnail_url: 'https://test-assets.adcontextprotocol.org/summit-books/river-north.jpg',
+        pdp_url: 'https://summit-books.example/books/river-north',
+        inventory_status: 'In stock',
+      },
+    ],
+  },
+];
+
+export const BRANDS: MockBrand[] = [
+  {
+    brand_id: 'brand_acme_outdoor',
+    display_name: 'Acme Outdoor',
+    adcp_brand: 'acmeoutdoor.example',
+    privacy_policy_url: 'https://acmeoutdoor.example/privacy',
+    privacy_policy_version: '2026-01-01',
+    visible_offering_ids: ['off_acme_trailrun_summer26'],
+    session_ttl_seconds: 600,
+  },
+  {
+    brand_id: 'brand_summit_books',
+    display_name: 'Summit Books',
+    adcp_brand: 'summit-books.example',
+    privacy_policy_url: 'https://summit-books.example/privacy',
+    privacy_policy_version: '2025-09-15',
+    visible_offering_ids: ['off_summit_books_summer26'],
+    session_ttl_seconds: 900,
+  },
+];
+
+/** Default static API key shared across all brands owned by the customer. */
+export const DEFAULT_API_KEY = 'mock_si_brand_key_do_not_use_in_prod';
+
+/** Stable timestamp returned by `created_at` fields on conversation and turn
+ * records. Tests pin against this for deterministic assertions. */
+export const SEED_NOW = NOW;

--- a/src/lib/mock-server/sponsored-intelligence/server.ts
+++ b/src/lib/mock-server/sponsored-intelligence/server.ts
@@ -1,14 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { randomUUID } from 'node:crypto';
-import {
-  BRANDS,
-  DEFAULT_API_KEY,
-  OFFERINGS,
-  SEED_NOW,
-  type MockBrand,
-  type MockOffering,
-  type MockProduct,
-} from './seed-data';
+import { BRANDS, DEFAULT_API_KEY, OFFERINGS, type MockBrand, type MockOffering, type MockProduct } from './seed-data';
 
 export interface BootOptions {
   port: number;
@@ -24,6 +16,25 @@ export interface BootResult {
 
 type ConversationStatus = 'active' | 'closed';
 
+/** Upstream close reason vocabulary. Deliberately distinct from AdCP's
+ * `SITerminateSessionRequest.reason` enum
+ * (`handoff_transaction|handoff_complete|user_exit|session_timeout|host_terminated`)
+ * so the adapter's translation is loud rather than identity-mapped on the
+ * `complete` value. Adapter rename:
+ *   AdCP `handoff_transaction` ↔ upstream `txn_ready`
+ *   AdCP `handoff_complete`    ↔ upstream `done`
+ *   AdCP `user_exit`           ↔ upstream `user_left`
+ *   AdCP `session_timeout`     ↔ upstream `idle_timeout`
+ *   AdCP `host_terminated`     ↔ upstream `host_closed`
+ */
+type UpstreamCloseReason = 'txn_ready' | 'done' | 'user_left' | 'idle_timeout' | 'host_closed';
+const UPSTREAM_CLOSE_REASONS: UpstreamCloseReason[] = ['txn_ready', 'done', 'user_left', 'idle_timeout', 'host_closed'];
+
+/** Brand-side close hint emitted on per-turn responses. Reuses the upstream
+ * close-reason vocabulary so the adapter's translation menu is the same
+ * regardless of which surface signals it. */
+type CloseHintType = 'txn_ready' | 'done';
+
 interface MockTurn {
   turn_id: string;
   conversation_id: string;
@@ -37,8 +48,23 @@ interface MockTurn {
   /** Brand-side hint to the adapter that the next state should be a
    * close. Adapter decides whether to surface this as AdCP
    * `session_status: 'pending_handoff'` + `handoff: {...}` to the host. */
-  close_recommended: { type: 'transaction' | 'complete'; payload?: Record<string, unknown> } | null;
+  close_recommended: { type: CloseHintType; payload?: Record<string, unknown> } | null;
   created_at: string;
+}
+
+/** Query-context record minted on `GET /offerings/{id}` and consumed on
+ * `POST /conversations`. Mirrors AdCP's `offering_token` correlation
+ * primitive (`SIGetOfferingResponse.offering_token` →
+ * `SIInitiateSessionRequest.offering_token`) so the brand can resolve
+ * "the second one" without the host replaying the full transcript. */
+interface OfferingQuery {
+  query_id: string;
+  brand_id: string;
+  offering_id: string;
+  /** Product SKUs in the order they were shown to the user. The brand's
+   * conversation engine references this to resolve positional language. */
+  shown_product_skus: string[];
+  expires_at: string;
 }
 
 interface MockConversation {
@@ -48,12 +74,18 @@ interface MockConversation {
   /** Offering context resolved at conversation start. The brand stores this
    * server-side so subsequent turns can reference 'the second one' etc. */
   offering_id: string | null;
+  /** offering_query_id this conversation was minted from, if any. Lets
+   * positional language (`the second one`) resolve against the products the
+   * user actually saw rather than the full offering catalog. */
+  offering_query_id: string | null;
+  /** Product SKUs shown to the user at conversation start, ordered. */
+  shown_product_skus: string[];
   intent: string;
   turns: MockTurn[];
   /** Set when the conversation was closed. Includes the reason and any
    * transaction handoff payload. */
   close: {
-    reason: string;
+    reason: UpstreamCloseReason;
     closed_at: string;
     transaction_handoff: Record<string, unknown> | null;
   } | null;
@@ -71,6 +103,9 @@ export async function bootSponsoredIntelligence(options: BootOptions): Promise<B
   // Keyed by `<brand_id>::<scope>::<key>` where scope = "init" or
   // "<conversation_id>".
   const idempotency = new Map<string, string>();
+  // offering_query_id → query record. Minted on GET /offerings, consumed
+  // on POST /conversations (mirrors AdCP `offering_token`).
+  const offeringQueries = new Map<string, OfferingQuery>();
 
   const traffic = new Map<string, number>();
   const bump = (routeTemplate: string): void => {
@@ -78,7 +113,16 @@ export async function bootSponsoredIntelligence(options: BootOptions): Promise<B
   };
 
   const server = createServer((req, res) => {
-    handleRequest(req, res, { apiKey, brands, offerings, conversations, idempotency, traffic, bump }).catch(err => {
+    handleRequest(req, res, {
+      apiKey,
+      brands,
+      offerings,
+      conversations,
+      idempotency,
+      offeringQueries,
+      traffic,
+      bump,
+    }).catch(err => {
       const requestId = (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
       writeJson(res, 500, {
         code: 'internal_error',
@@ -115,6 +159,7 @@ interface HandlerCtx {
   offerings: MockOffering[];
   conversations: Map<string, MockConversation>;
   idempotency: Map<string, string>;
+  offeringQueries: Map<string, OfferingQuery>;
   traffic: Map<string, number>;
   bump: (routeTemplate: string) => void;
 }
@@ -226,6 +271,18 @@ function handleGetOffering(offeringId: string, url: URL, ctx: HandlerCtx, brand:
   const limitParam = url.searchParams.get('product_limit');
   const limit = limitParam ? Math.max(0, Number(limitParam)) : offering.products.length;
   const products = includeProducts ? offering.products.slice(0, limit) : [];
+  // Mint a query token so a subsequent POST /conversations can reference
+  // exactly what was shown. Adapter renames `offering_query_id` → AdCP
+  // `offering_token` in the SIGetOfferingResponse projection.
+  const queryId = `oqt_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+  const queryExpiresAt = new Date(Date.now() + 15 * 60_000).toISOString();
+  ctx.offeringQueries.set(queryId, {
+    query_id: queryId,
+    brand_id: brand.brand_id,
+    offering_id: offering.offering_id,
+    shown_product_skus: products.map(p => p.sku),
+    expires_at: queryExpiresAt,
+  });
   writeJson(res, 200, {
     offering_id: offering.offering_id,
     brand_id: offering.brand_id,
@@ -239,6 +296,9 @@ function handleGetOffering(offeringId: string, url: URL, ctx: HandlerCtx, brand:
     available: true,
     products,
     total_matching: offering.products.length,
+    offering_query_id: queryId,
+    offering_query_expires_at: queryExpiresAt,
+    offering_query_ttl_seconds: 900,
     privacy_policy: {
       url: brand.privacy_policy_url,
       version: brand.privacy_policy_version,
@@ -263,7 +323,7 @@ async function handleStartConversation(
     writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
     return;
   }
-  const { intent, offering_id, identity, client_request_id } = body as Record<string, unknown>;
+  const { intent, offering_id, offering_query_id, identity, client_request_id } = body as Record<string, unknown>;
   if (typeof intent !== 'string' || intent.length === 0) {
     writeJson(res, 400, { code: 'invalid_request', message: 'intent (string) is required.' });
     return;
@@ -272,15 +332,59 @@ async function handleStartConversation(
     writeJson(res, 400, { code: 'invalid_request', message: 'offering_id must be a string when provided.' });
     return;
   }
-  if (offering_id && !brand.visible_offering_ids.includes(offering_id)) {
-    writeJson(res, 404, {
-      code: 'offering_not_in_brand',
-      message: `Offering ${offering_id} is not owned by brand ${brand.brand_id}.`,
-    });
+  if (offering_query_id !== undefined && typeof offering_query_id !== 'string') {
+    writeJson(res, 400, { code: 'invalid_request', message: 'offering_query_id must be a string when provided.' });
     return;
   }
 
-  const fingerprint = JSON.stringify({ brand: brand.brand_id, intent, offering_id: offering_id ?? null, identity });
+  // Resolve offering context: prefer offering_query_id (carries the
+  // products-shown record from a prior GET /offerings); fall back to a
+  // bare offering_id. If both are present they must agree.
+  let resolvedQuery: OfferingQuery | null = null;
+  let resolvedOfferingId: string | null = null;
+  if (typeof offering_query_id === 'string' && offering_query_id.length > 0) {
+    const query = ctx.offeringQueries.get(offering_query_id) ?? null;
+    if (!query) {
+      writeJson(res, 404, {
+        code: 'offering_query_not_found',
+        message: `offering_query_id ${offering_query_id} not found or expired.`,
+      });
+      return;
+    }
+    if (query.brand_id !== brand.brand_id) {
+      writeJson(res, 404, {
+        code: 'offering_query_not_in_brand',
+        message: `offering_query_id ${offering_query_id} does not belong to brand ${brand.brand_id}.`,
+      });
+      return;
+    }
+    if (typeof offering_id === 'string' && offering_id !== query.offering_id) {
+      writeJson(res, 400, {
+        code: 'offering_query_mismatch',
+        message: `offering_query_id resolves to ${query.offering_id}, but offering_id=${offering_id} was sent.`,
+      });
+      return;
+    }
+    resolvedQuery = query;
+    resolvedOfferingId = query.offering_id;
+  } else if (typeof offering_id === 'string' && offering_id.length > 0) {
+    if (!brand.visible_offering_ids.includes(offering_id)) {
+      writeJson(res, 404, {
+        code: 'offering_not_in_brand',
+        message: `Offering ${offering_id} is not owned by brand ${brand.brand_id}.`,
+      });
+      return;
+    }
+    resolvedOfferingId = offering_id;
+  }
+
+  const fingerprint = JSON.stringify({
+    brand: brand.brand_id,
+    intent,
+    offering_id: resolvedOfferingId,
+    offering_query_id: typeof offering_query_id === 'string' ? offering_query_id : null,
+    identity: identity ?? null,
+  });
 
   if (typeof client_request_id === 'string' && client_request_id.length > 0) {
     const idemKey = `${brand.brand_id}::init::${client_request_id}`;
@@ -288,25 +392,45 @@ async function handleStartConversation(
     if (existing) {
       const conv = ctx.conversations.get(existing);
       if (conv) {
+        // Mirror the turns handler: same key + different body → 409.
+        // Same key + same body → idempotent replay (200 instead of 201).
+        const initialTurn = conv.turns[0];
+        if (initialTurn && initialTurn.body_fingerprint !== fingerprint) {
+          writeJson(res, 409, {
+            code: 'idempotency_conflict',
+            message: `client_request_id ${client_request_id} previously used with a different body.`,
+          });
+          return;
+        }
         writeJson(res, 200, serializeConversation(conv, brand));
         return;
       }
     }
   }
 
-  const offering = offering_id ? (ctx.offerings.find(o => o.offering_id === offering_id) ?? null) : null;
+  const offering = resolvedOfferingId ? (ctx.offerings.find(o => o.offering_id === resolvedOfferingId) ?? null) : null;
+  // If a query token resolved, prefer the products-shown record over the full
+  // catalog so "the second one" references what the user actually saw.
+  const shownProducts = offering
+    ? resolvedQuery
+      ? resolvedQuery.shown_product_skus
+          .map(sku => offering.products.find(p => p.sku === sku))
+          .filter((p): p is MockProduct => Boolean(p))
+      : offering.products
+    : [];
   const greeting = offering
     ? `Welcome — happy to help you find the right ${offering.name.toLowerCase()}.`
     : `Hi from ${brand.display_name}. What are you looking for today?`;
+  const now = new Date().toISOString();
   const initialTurn: MockTurn = {
     turn_id: `turn_${randomUUID().replace(/-/g, '').slice(0, 12)}`,
     conversation_id: '',
     body_fingerprint: fingerprint,
     user_message: null,
     assistant_message: greeting,
-    components: offering && offering.products[0] ? [productCardComponent(offering.products[0])] : [],
+    components: shownProducts[0] ? [productCardComponent(shownProducts[0])] : [],
     close_recommended: null,
-    created_at: SEED_NOW,
+    created_at: now,
   };
   const conversationId = `conv_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
   initialTurn.conversation_id = conversationId;
@@ -314,12 +438,14 @@ async function handleStartConversation(
     conversation_id: conversationId,
     brand_id: brand.brand_id,
     status: 'active',
-    offering_id: offering?.offering_id ?? null,
+    offering_id: resolvedOfferingId,
+    offering_query_id: resolvedQuery?.query_id ?? null,
+    shown_product_skus: shownProducts.map(p => p.sku),
     intent,
     turns: [initialTurn],
     close: null,
-    created_at: SEED_NOW,
-    updated_at: SEED_NOW,
+    created_at: now,
+    updated_at: now,
   };
   ctx.conversations.set(conversationId, conversation);
   if (typeof client_request_id === 'string' && client_request_id.length > 0) {
@@ -396,7 +522,15 @@ async function handleSendTurn(
   const offering = conversation.offering_id
     ? (ctx.offerings.find(o => o.offering_id === conversation.offering_id) ?? null)
     : null;
-  const reply = generateReply(userMessage, action_response, offering);
+  const shownProducts = offering
+    ? conversation.shown_product_skus.length > 0
+      ? conversation.shown_product_skus
+          .map(sku => offering.products.find(p => p.sku === sku))
+          .filter((p): p is MockProduct => Boolean(p))
+      : offering.products
+    : [];
+  const reply = generateReply(userMessage, action_response, offering, shownProducts);
+  const now = new Date().toISOString();
   const turn: MockTurn = {
     turn_id: `turn_${randomUUID().replace(/-/g, '').slice(0, 12)}`,
     conversation_id: conversationId,
@@ -405,10 +539,10 @@ async function handleSendTurn(
     assistant_message: reply.assistant_message,
     components: reply.components,
     close_recommended: reply.close_recommended,
-    created_at: SEED_NOW,
+    created_at: now,
   };
   conversation.turns.push(turn);
-  conversation.updated_at = SEED_NOW;
+  conversation.updated_at = now;
   if (typeof client_request_id === 'string' && client_request_id.length > 0) {
     ctx.idempotency.set(`${brand.brand_id}::${conversationId}::${client_request_id}`, turn.turn_id);
   }
@@ -431,16 +565,27 @@ async function handleCloseConversation(
     return;
   }
 
-  let body: unknown = {};
+  let body: unknown;
   try {
     body = await readJson(req);
   } catch {
     writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
     return;
   }
-  if (!isObject(body)) body = {};
+  if (!isObject(body)) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
+    return;
+  }
   const { reason, summary } = body as Record<string, unknown>;
-  const reasonStr = typeof reason === 'string' ? reason : 'host_terminated';
+  const reasonInput = typeof reason === 'string' ? reason : 'host_closed';
+  if (!UPSTREAM_CLOSE_REASONS.includes(reasonInput as UpstreamCloseReason)) {
+    writeJson(res, 400, {
+      code: 'invalid_close_reason',
+      message: `reason must be one of ${UPSTREAM_CLOSE_REASONS.join(', ')}; got ${reasonInput}.`,
+    });
+    return;
+  }
+  const closeReason = reasonInput as UpstreamCloseReason;
 
   // Idempotent close: a second close on an already-closed conversation
   // returns the same payload. session_id is the dedup boundary; AdCP
@@ -453,12 +598,13 @@ async function handleCloseConversation(
   const offering = conversation.offering_id
     ? (ctx.offerings.find(o => o.offering_id === conversation.offering_id) ?? null)
     : null;
+  const closedAt = new Date();
   const transactionHandoff =
-    reasonStr === 'transaction'
+    closeReason === 'txn_ready'
       ? {
           checkout_url: `${offering ? offering.landing_page_url : `https://${brand.adcp_brand}/checkout`}?conv=${conversationId}`,
           checkout_token: `acp_tok_${randomUUID().replace(/-/g, '').slice(0, 16)}`,
-          expires_at: '2026-04-15T13:00:00Z',
+          expires_at: new Date(closedAt.getTime() + 60 * 60_000).toISOString(),
           payload: {
             conversation_summary:
               typeof summary === 'string' && summary.length > 0
@@ -469,13 +615,14 @@ async function handleCloseConversation(
         }
       : null;
 
+  const closedAtIso = closedAt.toISOString();
   conversation.status = 'closed';
   conversation.close = {
-    reason: reasonStr,
-    closed_at: SEED_NOW,
+    reason: closeReason,
+    closed_at: closedAtIso,
     transaction_handoff: transactionHandoff,
   };
-  conversation.updated_at = SEED_NOW;
+  conversation.updated_at = closedAtIso;
   writeJson(res, 200, serializeConversation(conversation, brand));
 }
 
@@ -494,19 +641,21 @@ function handleGetConversation(conversationId: string, ctx: HandlerCtx, brand: M
 function generateReply(
   userMessage: string | null,
   actionResponse: unknown,
-  offering: MockOffering | null
+  offering: MockOffering | null,
+  shownProducts: MockProduct[]
 ): {
   assistant_message: string;
   components: Array<Record<string, unknown>>;
-  close_recommended: { type: 'transaction' | 'complete'; payload?: Record<string, unknown> } | null;
+  close_recommended: { type: CloseHintType; payload?: Record<string, unknown> } | null;
 } {
+  const featured = shownProducts[0] ?? offering?.products[0];
   if (isObject(actionResponse) && (actionResponse as Record<string, unknown>).action === 'checkout') {
     return {
       assistant_message: 'Got it — sending you to checkout now.',
       components: [],
       close_recommended: {
-        type: 'transaction',
-        payload: { product: offering?.products[0] ?? {}, action: 'purchase' },
+        type: 'txn_ready',
+        payload: { product: featured ?? {}, action: 'purchase' },
       },
     };
   }
@@ -516,11 +665,11 @@ function generateReply(
       assistant_message: 'Great — ready when you are. Want me to take you to checkout?',
       components: [
         { kind: 'action_button', label: 'Checkout', action: 'checkout' },
-        ...(offering?.products[0] ? [productCardComponent(offering.products[0])] : []),
+        ...(featured ? [productCardComponent(featured)] : []),
       ],
       close_recommended: {
-        type: 'transaction',
-        payload: offering?.products[0] ? { product: offering.products[0], action: 'purchase' } : { action: 'purchase' },
+        type: 'txn_ready',
+        payload: featured ? { product: featured, action: 'purchase' } : { action: 'purchase' },
       },
     };
   }
@@ -528,13 +677,13 @@ function generateReply(
     return {
       assistant_message: 'Anytime — happy shopping!',
       components: [],
-      close_recommended: { type: 'complete' },
+      close_recommended: { type: 'done' },
     };
   }
-  if (/\b(second|other one|next)\b/.test(lower) && offering && offering.products[1]) {
+  if (/\b(second|other one|next)\b/.test(lower) && shownProducts[1]) {
     return {
-      assistant_message: `Here's a closer look at ${offering.products[1].name}.`,
-      components: [productCardComponent(offering.products[1])],
+      assistant_message: `Here's a closer look at ${shownProducts[1].name}.`,
+      components: [productCardComponent(shownProducts[1])],
       close_recommended: null,
     };
   }
@@ -542,7 +691,7 @@ function generateReply(
     assistant_message: offering
       ? `Here's what I'd recommend from the ${offering.name}.`
       : 'Tell me a bit more about what you have in mind.',
-    components: offering?.products[0] ? [productCardComponent(offering.products[0])] : [],
+    components: featured ? [productCardComponent(featured)] : [],
     close_recommended: null,
   };
 }
@@ -566,6 +715,8 @@ function serializeConversation(conv: MockConversation, brand: MockBrand): Record
     brand_id: conv.brand_id,
     status: conv.status,
     offering_id: conv.offering_id,
+    offering_query_id: conv.offering_query_id,
+    shown_product_skus: conv.shown_product_skus,
     intent: conv.intent,
     turns: conv.turns.map(t => stripInternal(t)),
     close: conv.close,

--- a/src/lib/mock-server/sponsored-intelligence/server.ts
+++ b/src/lib/mock-server/sponsored-intelligence/server.ts
@@ -1,0 +1,622 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import {
+  BRANDS,
+  DEFAULT_API_KEY,
+  OFFERINGS,
+  SEED_NOW,
+  type MockBrand,
+  type MockOffering,
+  type MockProduct,
+} from './seed-data';
+
+export interface BootOptions {
+  port: number;
+  apiKey?: string;
+  brands?: MockBrand[];
+  offerings?: MockOffering[];
+}
+
+export interface BootResult {
+  url: string;
+  close: () => Promise<void>;
+}
+
+type ConversationStatus = 'active' | 'closed';
+
+interface MockTurn {
+  turn_id: string;
+  conversation_id: string;
+  /** Adapter sends `client_request_id` (translated from AdCP idempotency_key)
+   * on POST /turns; same key replayed returns the same turn rather than
+   * generating a duplicate. */
+  body_fingerprint: string;
+  user_message: string | null;
+  assistant_message: string;
+  components: Array<Record<string, unknown>>;
+  /** Brand-side hint to the adapter that the next state should be a
+   * close. Adapter decides whether to surface this as AdCP
+   * `session_status: 'pending_handoff'` + `handoff: {...}` to the host. */
+  close_recommended: { type: 'transaction' | 'complete'; payload?: Record<string, unknown> } | null;
+  created_at: string;
+}
+
+interface MockConversation {
+  conversation_id: string;
+  brand_id: string;
+  status: ConversationStatus;
+  /** Offering context resolved at conversation start. The brand stores this
+   * server-side so subsequent turns can reference 'the second one' etc. */
+  offering_id: string | null;
+  intent: string;
+  turns: MockTurn[];
+  /** Set when the conversation was closed. Includes the reason and any
+   * transaction handoff payload. */
+  close: {
+    reason: string;
+    closed_at: string;
+    transaction_handoff: Record<string, unknown> | null;
+  } | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function bootSponsoredIntelligence(options: BootOptions): Promise<BootResult> {
+  const apiKey = options.apiKey ?? DEFAULT_API_KEY;
+  const brands = options.brands ?? BRANDS;
+  const offerings = options.offerings ?? OFFERINGS;
+
+  const conversations = new Map<string, MockConversation>();
+  // client_request_id idempotency for POST /conversations and POST /turns.
+  // Keyed by `<brand_id>::<scope>::<key>` where scope = "init" or
+  // "<conversation_id>".
+  const idempotency = new Map<string, string>();
+
+  const traffic = new Map<string, number>();
+  const bump = (routeTemplate: string): void => {
+    traffic.set(routeTemplate, (traffic.get(routeTemplate) ?? 0) + 1);
+  };
+
+  const server = createServer((req, res) => {
+    handleRequest(req, res, { apiKey, brands, offerings, conversations, idempotency, traffic, bump }).catch(err => {
+      const requestId = (req.headers['x-request-id'] as string | undefined) ?? randomUUID();
+      writeJson(res, 500, {
+        code: 'internal_error',
+        message: err?.message ?? 'unexpected error',
+        request_id: requestId,
+      });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(options.port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const addr = server.address();
+  const boundPort = typeof addr === 'object' && addr ? addr.port : options.port;
+  const url = `http://127.0.0.1:${boundPort}`;
+
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+interface HandlerCtx {
+  apiKey: string;
+  brands: MockBrand[];
+  offerings: MockOffering[];
+  conversations: Map<string, MockConversation>;
+  idempotency: Map<string, string>;
+  traffic: Map<string, number>;
+  bump: (routeTemplate: string) => void;
+}
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse, ctx: HandlerCtx): Promise<void> {
+  const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+  const path = url.pathname;
+  const method = req.method ?? 'GET';
+
+  if (method === 'GET' && path === '/_debug/traffic') {
+    writeJson(res, 200, { traffic: Object.fromEntries(ctx.traffic) });
+    return;
+  }
+
+  // Discovery — adapter resolves AdCP-side brand identifier to upstream
+  // brand_id at runtime. No auth required (discovery happens before the
+  // agent has a brand context).
+  if (method === 'GET' && path === '/_lookup/brand') {
+    ctx.bump('GET /_lookup/brand');
+    const adcpBrand = url.searchParams.get('adcp_brand');
+    if (!adcpBrand) {
+      writeJson(res, 400, {
+        code: 'invalid_request',
+        message: 'adcp_brand query parameter is required.',
+      });
+      return;
+    }
+    const match = ctx.brands.find(b => b.adcp_brand === adcpBrand);
+    if (!match) {
+      writeJson(res, 404, {
+        code: 'brand_not_found',
+        message: `No upstream brand registered for adcp_brand=${adcpBrand}.`,
+      });
+      return;
+    }
+    writeJson(res, 200, {
+      adcp_brand: match.adcp_brand,
+      brand_id: match.brand_id,
+      display_name: match.display_name,
+    });
+    return;
+  }
+
+  const auth = req.headers['authorization'];
+  if (!auth || !auth.startsWith('Bearer ') || auth.slice(7) !== ctx.apiKey) {
+    writeJson(res, 401, { code: 'unauthorized', message: 'Missing or invalid bearer credential.' });
+    return;
+  }
+
+  const brandMatch = path.match(/^\/v1\/brands\/([^/]+)(\/.*)?$/);
+  if (!brandMatch || !brandMatch[1]) {
+    writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+    return;
+  }
+  const brandId = decodeURIComponent(brandMatch[1]);
+  const subPath = brandMatch[2] ?? '/';
+  const brand = ctx.brands.find(b => b.brand_id === brandId);
+  if (!brand) {
+    writeJson(res, 404, { code: 'brand_not_found', message: `Brand ${brandId} not found.` });
+    return;
+  }
+
+  const offMatch = subPath.match(/^\/offerings\/([^/]+)$/);
+  if (method === 'GET' && offMatch && offMatch[1]) {
+    ctx.bump('GET /v1/brands/{brand}/offerings/{id}');
+    return handleGetOffering(decodeURIComponent(offMatch[1]), url, ctx, brand, res);
+  }
+
+  if (method === 'POST' && subPath === '/conversations') {
+    ctx.bump('POST /v1/brands/{brand}/conversations');
+    return handleStartConversation(req, ctx, brand, res);
+  }
+
+  const turnsMatch = subPath.match(/^\/conversations\/([^/]+)\/turns$/);
+  if (method === 'POST' && turnsMatch && turnsMatch[1]) {
+    ctx.bump('POST /v1/brands/{brand}/conversations/{id}/turns');
+    return handleSendTurn(decodeURIComponent(turnsMatch[1]), req, ctx, brand, res);
+  }
+
+  const closeMatch = subPath.match(/^\/conversations\/([^/]+)\/close$/);
+  if (method === 'POST' && closeMatch && closeMatch[1]) {
+    ctx.bump('POST /v1/brands/{brand}/conversations/{id}/close');
+    return handleCloseConversation(decodeURIComponent(closeMatch[1]), req, ctx, brand, res);
+  }
+
+  const convMatch = subPath.match(/^\/conversations\/([^/]+)$/);
+  if (method === 'GET' && convMatch && convMatch[1]) {
+    ctx.bump('GET /v1/brands/{brand}/conversations/{id}');
+    return handleGetConversation(decodeURIComponent(convMatch[1]), ctx, brand, res);
+  }
+
+  writeJson(res, 404, { code: 'not_found', message: `No route for ${method} ${path}` });
+}
+
+function handleGetOffering(offeringId: string, url: URL, ctx: HandlerCtx, brand: MockBrand, res: ServerResponse): void {
+  const offering = ctx.offerings.find(o => o.offering_id === offeringId);
+  if (!offering) {
+    writeJson(res, 404, { code: 'offering_not_found', message: `Offering ${offeringId} not found.` });
+    return;
+  }
+  if (!brand.visible_offering_ids.includes(offeringId)) {
+    writeJson(res, 404, {
+      code: 'offering_not_in_brand',
+      message: `Offering ${offeringId} is not owned by brand ${brand.brand_id}.`,
+    });
+    return;
+  }
+  const includeProducts = url.searchParams.get('include_products') === 'true';
+  const limitParam = url.searchParams.get('product_limit');
+  const limit = limitParam ? Math.max(0, Number(limitParam)) : offering.products.length;
+  const products = includeProducts ? offering.products.slice(0, limit) : [];
+  writeJson(res, 200, {
+    offering_id: offering.offering_id,
+    brand_id: offering.brand_id,
+    name: offering.name,
+    summary: offering.summary,
+    tagline: offering.tagline,
+    hero_image_url: offering.hero_image_url,
+    landing_page_url: offering.landing_page_url,
+    price_hint: offering.price_hint,
+    expires_at: offering.expires_at,
+    available: true,
+    products,
+    total_matching: offering.products.length,
+    privacy_policy: {
+      url: brand.privacy_policy_url,
+      version: brand.privacy_policy_version,
+    },
+  });
+}
+
+async function handleStartConversation(
+  req: IncomingMessage,
+  ctx: HandlerCtx,
+  brand: MockBrand,
+  res: ServerResponse
+): Promise<void> {
+  let body: unknown;
+  try {
+    body = await readJson(req);
+  } catch {
+    writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
+    return;
+  }
+  if (!isObject(body)) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
+    return;
+  }
+  const { intent, offering_id, identity, client_request_id } = body as Record<string, unknown>;
+  if (typeof intent !== 'string' || intent.length === 0) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'intent (string) is required.' });
+    return;
+  }
+  if (offering_id !== undefined && typeof offering_id !== 'string') {
+    writeJson(res, 400, { code: 'invalid_request', message: 'offering_id must be a string when provided.' });
+    return;
+  }
+  if (offering_id && !brand.visible_offering_ids.includes(offering_id)) {
+    writeJson(res, 404, {
+      code: 'offering_not_in_brand',
+      message: `Offering ${offering_id} is not owned by brand ${brand.brand_id}.`,
+    });
+    return;
+  }
+
+  const fingerprint = JSON.stringify({ brand: brand.brand_id, intent, offering_id: offering_id ?? null, identity });
+
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    const idemKey = `${brand.brand_id}::init::${client_request_id}`;
+    const existing = ctx.idempotency.get(idemKey);
+    if (existing) {
+      const conv = ctx.conversations.get(existing);
+      if (conv) {
+        writeJson(res, 200, serializeConversation(conv, brand));
+        return;
+      }
+    }
+  }
+
+  const offering = offering_id ? (ctx.offerings.find(o => o.offering_id === offering_id) ?? null) : null;
+  const greeting = offering
+    ? `Welcome — happy to help you find the right ${offering.name.toLowerCase()}.`
+    : `Hi from ${brand.display_name}. What are you looking for today?`;
+  const initialTurn: MockTurn = {
+    turn_id: `turn_${randomUUID().replace(/-/g, '').slice(0, 12)}`,
+    conversation_id: '',
+    body_fingerprint: fingerprint,
+    user_message: null,
+    assistant_message: greeting,
+    components: offering && offering.products[0] ? [productCardComponent(offering.products[0])] : [],
+    close_recommended: null,
+    created_at: SEED_NOW,
+  };
+  const conversationId = `conv_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+  initialTurn.conversation_id = conversationId;
+  const conversation: MockConversation = {
+    conversation_id: conversationId,
+    brand_id: brand.brand_id,
+    status: 'active',
+    offering_id: offering?.offering_id ?? null,
+    intent,
+    turns: [initialTurn],
+    close: null,
+    created_at: SEED_NOW,
+    updated_at: SEED_NOW,
+  };
+  ctx.conversations.set(conversationId, conversation);
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    ctx.idempotency.set(`${brand.brand_id}::init::${client_request_id}`, conversationId);
+  }
+  writeJson(res, 201, serializeConversation(conversation, brand));
+}
+
+async function handleSendTurn(
+  conversationId: string,
+  req: IncomingMessage,
+  ctx: HandlerCtx,
+  brand: MockBrand,
+  res: ServerResponse
+): Promise<void> {
+  const conversation = ctx.conversations.get(conversationId);
+  if (!conversation || conversation.brand_id !== brand.brand_id) {
+    writeJson(res, 404, {
+      code: 'conversation_not_found',
+      message: `Conversation ${conversationId} not found in brand ${brand.brand_id}.`,
+    });
+    return;
+  }
+  if (conversation.status !== 'active') {
+    writeJson(res, 409, {
+      code: 'conversation_closed',
+      message: `Conversation ${conversationId} is ${conversation.status}; cannot accept new turns.`,
+    });
+    return;
+  }
+
+  let body: unknown;
+  try {
+    body = await readJson(req);
+  } catch {
+    writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
+    return;
+  }
+  if (!isObject(body)) {
+    writeJson(res, 400, { code: 'invalid_request', message: 'Body must be an object.' });
+    return;
+  }
+  const { message, action_response, client_request_id } = body as Record<string, unknown>;
+  const userMessage = typeof message === 'string' ? message : null;
+  if (!userMessage && !isObject(action_response)) {
+    writeJson(res, 400, {
+      code: 'invalid_request',
+      message: 'Body must include a `message` (string) or `action_response` (object).',
+    });
+    return;
+  }
+
+  const fingerprint = JSON.stringify({ message: userMessage, action_response: action_response ?? null });
+
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    const idemKey = `${brand.brand_id}::${conversationId}::${client_request_id}`;
+    const existingTurnId = ctx.idempotency.get(idemKey);
+    if (existingTurnId) {
+      const replay = conversation.turns.find(t => t.turn_id === existingTurnId);
+      if (replay) {
+        if (replay.body_fingerprint !== fingerprint) {
+          writeJson(res, 409, {
+            code: 'idempotency_conflict',
+            message: `client_request_id ${client_request_id} previously used with a different body.`,
+          });
+          return;
+        }
+        writeJson(res, 200, serializeTurn(replay, conversation, brand));
+        return;
+      }
+    }
+  }
+
+  const offering = conversation.offering_id
+    ? (ctx.offerings.find(o => o.offering_id === conversation.offering_id) ?? null)
+    : null;
+  const reply = generateReply(userMessage, action_response, offering);
+  const turn: MockTurn = {
+    turn_id: `turn_${randomUUID().replace(/-/g, '').slice(0, 12)}`,
+    conversation_id: conversationId,
+    body_fingerprint: fingerprint,
+    user_message: userMessage,
+    assistant_message: reply.assistant_message,
+    components: reply.components,
+    close_recommended: reply.close_recommended,
+    created_at: SEED_NOW,
+  };
+  conversation.turns.push(turn);
+  conversation.updated_at = SEED_NOW;
+  if (typeof client_request_id === 'string' && client_request_id.length > 0) {
+    ctx.idempotency.set(`${brand.brand_id}::${conversationId}::${client_request_id}`, turn.turn_id);
+  }
+  writeJson(res, 200, serializeTurn(turn, conversation, brand));
+}
+
+async function handleCloseConversation(
+  conversationId: string,
+  req: IncomingMessage,
+  ctx: HandlerCtx,
+  brand: MockBrand,
+  res: ServerResponse
+): Promise<void> {
+  const conversation = ctx.conversations.get(conversationId);
+  if (!conversation || conversation.brand_id !== brand.brand_id) {
+    writeJson(res, 404, {
+      code: 'conversation_not_found',
+      message: `Conversation ${conversationId} not found in brand ${brand.brand_id}.`,
+    });
+    return;
+  }
+
+  let body: unknown = {};
+  try {
+    body = await readJson(req);
+  } catch {
+    writeJson(res, 400, { code: 'invalid_json', message: 'Request body must be valid JSON.' });
+    return;
+  }
+  if (!isObject(body)) body = {};
+  const { reason, summary } = body as Record<string, unknown>;
+  const reasonStr = typeof reason === 'string' ? reason : 'host_terminated';
+
+  // Idempotent close: a second close on an already-closed conversation
+  // returns the same payload. session_id is the dedup boundary; AdCP
+  // si_terminate_session has no idempotency_key for exactly this reason.
+  if (conversation.status === 'closed') {
+    writeJson(res, 200, serializeConversation(conversation, brand));
+    return;
+  }
+
+  const offering = conversation.offering_id
+    ? (ctx.offerings.find(o => o.offering_id === conversation.offering_id) ?? null)
+    : null;
+  const transactionHandoff =
+    reasonStr === 'transaction'
+      ? {
+          checkout_url: `${offering ? offering.landing_page_url : `https://${brand.adcp_brand}/checkout`}?conv=${conversationId}`,
+          checkout_token: `acp_tok_${randomUUID().replace(/-/g, '').slice(0, 16)}`,
+          expires_at: '2026-04-15T13:00:00Z',
+          payload: {
+            conversation_summary:
+              typeof summary === 'string' && summary.length > 0
+                ? summary
+                : `User reached transaction handoff in conversation ${conversationId}.`,
+            applied_offers: conversation.offering_id ? [conversation.offering_id] : [],
+          },
+        }
+      : null;
+
+  conversation.status = 'closed';
+  conversation.close = {
+    reason: reasonStr,
+    closed_at: SEED_NOW,
+    transaction_handoff: transactionHandoff,
+  };
+  conversation.updated_at = SEED_NOW;
+  writeJson(res, 200, serializeConversation(conversation, brand));
+}
+
+function handleGetConversation(conversationId: string, ctx: HandlerCtx, brand: MockBrand, res: ServerResponse): void {
+  const conversation = ctx.conversations.get(conversationId);
+  if (!conversation || conversation.brand_id !== brand.brand_id) {
+    writeJson(res, 404, {
+      code: 'conversation_not_found',
+      message: `Conversation ${conversationId} not found in brand ${brand.brand_id}.`,
+    });
+    return;
+  }
+  writeJson(res, 200, serializeConversation(conversation, brand));
+}
+
+function generateReply(
+  userMessage: string | null,
+  actionResponse: unknown,
+  offering: MockOffering | null
+): {
+  assistant_message: string;
+  components: Array<Record<string, unknown>>;
+  close_recommended: { type: 'transaction' | 'complete'; payload?: Record<string, unknown> } | null;
+} {
+  if (isObject(actionResponse) && (actionResponse as Record<string, unknown>).action === 'checkout') {
+    return {
+      assistant_message: 'Got it — sending you to checkout now.',
+      components: [],
+      close_recommended: {
+        type: 'transaction',
+        payload: { product: offering?.products[0] ?? {}, action: 'purchase' },
+      },
+    };
+  }
+  const lower = (userMessage ?? '').toLowerCase();
+  if (/\b(buy|purchase|checkout|order)\b/.test(lower)) {
+    return {
+      assistant_message: 'Great — ready when you are. Want me to take you to checkout?',
+      components: [
+        { kind: 'action_button', label: 'Checkout', action: 'checkout' },
+        ...(offering?.products[0] ? [productCardComponent(offering.products[0])] : []),
+      ],
+      close_recommended: {
+        type: 'transaction',
+        payload: offering?.products[0] ? { product: offering.products[0], action: 'purchase' } : { action: 'purchase' },
+      },
+    };
+  }
+  if (/\b(thanks|thank you|bye|goodbye|done|that's all)\b/.test(lower)) {
+    return {
+      assistant_message: 'Anytime — happy shopping!',
+      components: [],
+      close_recommended: { type: 'complete' },
+    };
+  }
+  if (/\b(second|other one|next)\b/.test(lower) && offering && offering.products[1]) {
+    return {
+      assistant_message: `Here's a closer look at ${offering.products[1].name}.`,
+      components: [productCardComponent(offering.products[1])],
+      close_recommended: null,
+    };
+  }
+  return {
+    assistant_message: offering
+      ? `Here's what I'd recommend from the ${offering.name}.`
+      : 'Tell me a bit more about what you have in mind.',
+    components: offering?.products[0] ? [productCardComponent(offering.products[0])] : [],
+    close_recommended: null,
+  };
+}
+
+function productCardComponent(product: MockProduct): Record<string, unknown> {
+  return {
+    kind: 'product_card',
+    sku: product.sku,
+    name: product.name,
+    display_price: product.display_price,
+    list_price: product.list_price,
+    thumbnail_url: product.thumbnail_url,
+    pdp_url: product.pdp_url,
+    inventory_status: product.inventory_status,
+  };
+}
+
+function serializeConversation(conv: MockConversation, brand: MockBrand): Record<string, unknown> {
+  return {
+    conversation_id: conv.conversation_id,
+    brand_id: conv.brand_id,
+    status: conv.status,
+    offering_id: conv.offering_id,
+    intent: conv.intent,
+    turns: conv.turns.map(t => stripInternal(t)),
+    close: conv.close,
+    session_ttl_seconds: brand.session_ttl_seconds,
+    created_at: conv.created_at,
+    updated_at: conv.updated_at,
+  };
+}
+
+function serializeTurn(turn: MockTurn, conv: MockConversation, brand: MockBrand): Record<string, unknown> {
+  return {
+    ...stripInternal(turn),
+    conversation_status: conv.status,
+    session_ttl_seconds: brand.session_ttl_seconds,
+  };
+}
+
+function stripInternal(turn: MockTurn): Record<string, unknown> {
+  const { body_fingerprint: _bf, ...rest } = turn;
+  return rest;
+}
+
+function readJson(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', c => chunks.push(c));
+    req.on('error', reject);
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      if (!raw) {
+        resolve({});
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null && !Array.isArray(x);
+}

--- a/test/lib/mock-server/sponsored-intelligence.test.js
+++ b/test/lib/mock-server/sponsored-intelligence.test.js
@@ -160,7 +160,7 @@ describe('mock-server sponsored-intelligence', () => {
     });
     assert.equal(turn.status, 200);
     const body = await turn.json();
-    assert.equal(body.close_recommended.type, 'transaction');
+    assert.equal(body.close_recommended.type, 'txn_ready');
     assert.equal(body.conversation_status, 'active');
   });
 
@@ -190,7 +190,7 @@ describe('mock-server sponsored-intelligence', () => {
     assert.equal(body.code, 'idempotency_conflict');
   });
 
-  it('closes conversation with reason=transaction and returns transaction_handoff', async () => {
+  it('closes conversation with reason=txn_ready and returns transaction_handoff', async () => {
     const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
       method: 'POST',
       headers: auth(),
@@ -207,16 +207,36 @@ describe('mock-server sponsored-intelligence', () => {
       {
         method: 'POST',
         headers: auth(),
-        body: JSON.stringify({ reason: 'transaction', summary: 'User chose blackgreen-10.' }),
+        body: JSON.stringify({ reason: 'txn_ready', summary: 'User chose blackgreen-10.' }),
       }
     );
     assert.equal(close.status, 200);
     const body = await close.json();
     assert.equal(body.status, 'closed');
-    assert.equal(body.close.reason, 'transaction');
+    assert.equal(body.close.reason, 'txn_ready');
     assert.ok(body.close.transaction_handoff);
     assert.equal(typeof body.close.transaction_handoff.checkout_url, 'string');
     assert.equal(typeof body.close.transaction_handoff.checkout_token, 'string');
+    assert.equal(typeof body.close.transaction_handoff.expires_at, 'string');
+  });
+
+  it('rejects close with reason outside the upstream enum (loud rename gap with AdCP)', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'invalid reason test', client_request_id: 'init-invalid-reason' }),
+    });
+    const conv = await init.json();
+
+    // 'handoff_transaction' is the AdCP value — adapter must translate to 'txn_ready'.
+    const res = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ reason: 'handoff_transaction' }),
+    });
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.code, 'invalid_close_reason');
   });
 
   it('close is idempotent on repeated calls (mirrors si_terminate_session having no idempotency_key)', async () => {
@@ -229,16 +249,24 @@ describe('mock-server sponsored-intelligence', () => {
 
     const first = await fetch(
       `${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`,
-      { method: 'POST', headers: auth(), body: JSON.stringify({ reason: 'user_exit' }) }
+      {
+        method: 'POST',
+        headers: auth(),
+        body: JSON.stringify({ reason: 'user_left' }),
+      }
     );
     const firstBody = await first.json();
     const second = await fetch(
       `${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`,
-      { method: 'POST', headers: auth(), body: JSON.stringify({ reason: 'host_terminated' }) }
+      {
+        method: 'POST',
+        headers: auth(),
+        body: JSON.stringify({ reason: 'host_closed' }),
+      }
     );
     assert.equal(second.status, 200);
     const secondBody = await second.json();
-    assert.equal(secondBody.close.reason, 'user_exit');
+    assert.equal(secondBody.close.reason, 'user_left');
     assert.equal(secondBody.close.closed_at, firstBody.close.closed_at);
   });
 
@@ -252,7 +280,7 @@ describe('mock-server sponsored-intelligence', () => {
     await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`, {
       method: 'POST',
       headers: auth(),
-      body: JSON.stringify({ reason: 'user_exit' }),
+      body: JSON.stringify({ reason: 'user_left' }),
     });
     const turn = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/turns`, {
       method: 'POST',
@@ -264,6 +292,129 @@ describe('mock-server sponsored-intelligence', () => {
     assert.equal(body.code, 'conversation_closed');
   });
 
+  it('rejects POST /conversations replay with mismatched body (idempotency_conflict)', async () => {
+    const first = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'first intent', client_request_id: 'init-mismatch' }),
+    });
+    assert.equal(first.status, 201);
+
+    const conflict = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'second intent', client_request_id: 'init-mismatch' }),
+    });
+    assert.equal(conflict.status, 409);
+    const body = await conflict.json();
+    assert.equal(body.code, 'idempotency_conflict');
+  });
+
+  it('isolates conversations across brands (cross-brand 404)', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'cross-brand isolation', client_request_id: 'init-xbrand' }),
+    });
+    const conv = await init.json();
+
+    // Same conversation_id under the other brand → 404, not leaked.
+    const sneak = await fetch(`${handle.url}/v1/brands/brand_summit_books/conversations/${conv.conversation_id}`, {
+      headers: auth(),
+    });
+    assert.equal(sneak.status, 404);
+    const body = await sneak.json();
+    assert.equal(body.code, 'conversation_not_found');
+  });
+
+  it('GET conversation after close still returns the closed payload', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'get-after-close', client_request_id: 'init-get-after-close' }),
+    });
+    const conv = await init.json();
+
+    await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ reason: 'done' }),
+    });
+
+    const get = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}`, {
+      headers: auth(),
+    });
+    assert.equal(get.status, 200);
+    const body = await get.json();
+    assert.equal(body.status, 'closed');
+    assert.equal(body.close.reason, 'done');
+    assert.equal(body.close.transaction_handoff, null);
+  });
+
+  it('round-trips offering_query_id from GET /offerings into POST /conversations (offering_token correlation)', async () => {
+    const offeringRes = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/offerings/off_acme_trailrun_summer26?include_products=true`,
+      { headers: auth() }
+    );
+    const offering = await offeringRes.json();
+    assert.equal(typeof offering.offering_query_id, 'string');
+    assert.equal(offering.offering_query_id.startsWith('oqt_'), true);
+
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'follow up on shown products',
+        offering_query_id: offering.offering_query_id,
+        client_request_id: 'init-token-roundtrip',
+      }),
+    });
+    assert.equal(init.status, 201);
+    const conv = await init.json();
+    assert.equal(conv.offering_query_id, offering.offering_query_id);
+    assert.equal(conv.offering_id, 'off_acme_trailrun_summer26');
+    assert.deepEqual(
+      conv.shown_product_skus,
+      offering.products.map(p => p.sku)
+    );
+  });
+
+  it('rejects unknown offering_query_id with 404 offering_query_not_found', async () => {
+    const res = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'bad token',
+        offering_query_id: 'oqt_does_not_exist',
+        client_request_id: 'init-bad-token',
+      }),
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'offering_query_not_found');
+  });
+
+  it('rejects offering_query_id from a different brand', async () => {
+    const offRes = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/offerings/off_acme_trailrun_summer26?include_products=true`,
+      { headers: auth() }
+    );
+    const off = await offRes.json();
+
+    const sneak = await fetch(`${handle.url}/v1/brands/brand_summit_books/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'wrong brand for token',
+        offering_query_id: off.offering_query_id,
+        client_request_id: 'init-token-wrong-brand',
+      }),
+    });
+    assert.equal(sneak.status, 404);
+    const body = await sneak.json();
+    assert.equal(body.code, 'offering_query_not_in_brand');
+  });
+
   it('records traffic counters for façade detection', async () => {
     const res = await fetch(`${handle.url}/_debug/traffic`);
     assert.equal(res.status, 200);
@@ -271,5 +422,6 @@ describe('mock-server sponsored-intelligence', () => {
     assert.ok(body.traffic['POST /v1/brands/{brand}/conversations'] > 0);
     assert.ok(body.traffic['POST /v1/brands/{brand}/conversations/{id}/turns'] > 0);
     assert.ok(body.traffic['POST /v1/brands/{brand}/conversations/{id}/close'] > 0);
+    assert.ok(body.traffic['GET /v1/brands/{brand}/offerings/{id}'] > 0);
   });
 });

--- a/test/lib/mock-server/sponsored-intelligence.test.js
+++ b/test/lib/mock-server/sponsored-intelligence.test.js
@@ -1,0 +1,275 @@
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { bootMockServer } = require('../../../dist/lib/mock-server/index.js');
+const {
+  DEFAULT_API_KEY,
+  BRANDS,
+  OFFERINGS,
+} = require('../../../dist/lib/mock-server/sponsored-intelligence/seed-data.js');
+
+describe('mock-server sponsored-intelligence', () => {
+  let handle;
+  before(async () => {
+    handle = await bootMockServer({ specialism: 'sponsored-intelligence', port: 0 });
+  });
+  after(async () => {
+    if (handle) await handle.close();
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${DEFAULT_API_KEY}`, 'Content-Type': 'application/json' });
+
+  it('exposes the unified handle shape with brand mapping', () => {
+    assert.equal(handle.auth.kind, 'static_bearer');
+    assert.equal(handle.auth.apiKey, DEFAULT_API_KEY);
+    assert.equal(handle.principalScope.includes('/v1/brands/'), true);
+    assert.equal(handle.principalMapping.length, BRANDS.length);
+    assert.equal(handle.principalMapping[0].adcpField, 'account.brand');
+    assert.equal(handle.principalMapping[0].upstreamField.startsWith('path /v1/brands/'), true);
+  });
+
+  it('rejects requests without a Bearer token (401)', async () => {
+    const res = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/offerings/off_acme_trailrun_summer26`);
+    assert.equal(res.status, 401);
+    const body = await res.json();
+    assert.equal(body.code, 'unauthorized');
+  });
+
+  it('resolves AdCP brand identifier via /_lookup/brand (no auth)', async () => {
+    const res = await fetch(`${handle.url}/_lookup/brand?adcp_brand=acmeoutdoor.example`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.brand_id, 'brand_acme_outdoor');
+    assert.equal(body.display_name, 'Acme Outdoor');
+  });
+
+  it('returns 404 for unknown adcp_brand', async () => {
+    const res = await fetch(`${handle.url}/_lookup/brand?adcp_brand=nope.example`);
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'brand_not_found');
+  });
+
+  it('rejects unknown brand_id with 404 brand_not_found', async () => {
+    const res = await fetch(`${handle.url}/v1/brands/brand_does_not_exist/offerings/off_x`, {
+      headers: auth(),
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'brand_not_found');
+  });
+
+  it('returns offering with products when include_products=true', async () => {
+    const res = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/offerings/off_acme_trailrun_summer26?include_products=true`,
+      { headers: auth() }
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.offering_id, 'off_acme_trailrun_summer26');
+    assert.equal(body.available, true);
+    assert.equal(Array.isArray(body.products), true);
+    assert.equal(body.products.length >= 1, true);
+    assert.equal(body.products[0].sku.startsWith('acme_tr_'), true);
+    assert.equal(body.total_matching, OFFERINGS[0].products.length);
+  });
+
+  it('omits products when include_products is not set', async () => {
+    const res = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/offerings/off_acme_trailrun_summer26`, {
+      headers: auth(),
+    });
+    const body = await res.json();
+    assert.equal(body.products.length, 0);
+  });
+
+  it('returns 404 offering_not_in_brand for cross-brand offering access', async () => {
+    const res = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/offerings/off_summit_books_summer26`, {
+      headers: auth(),
+    });
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.code, 'offering_not_in_brand');
+  });
+
+  it('starts a conversation and returns initial assistant turn', async () => {
+    const res = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'looking for trail running shoes for muddy terrain',
+        offering_id: 'off_acme_trailrun_summer26',
+        identity: { consent_granted: false },
+        client_request_id: 'init-test-1',
+      }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(typeof body.conversation_id, 'string');
+    assert.equal(body.status, 'active');
+    assert.equal(body.brand_id, 'brand_acme_outdoor');
+    assert.equal(body.turns.length, 1);
+    assert.equal(typeof body.turns[0].assistant_message, 'string');
+    assert.equal(body.session_ttl_seconds, 600);
+  });
+
+  it('replays the same conversation on identical client_request_id', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'idempotency replay test',
+        offering_id: 'off_acme_trailrun_summer26',
+        client_request_id: 'init-replay-1',
+      }),
+    });
+    assert.equal(init.status, 201);
+    const first = await init.json();
+
+    const replay = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'idempotency replay test',
+        offering_id: 'off_acme_trailrun_summer26',
+        client_request_id: 'init-replay-1',
+      }),
+    });
+    assert.equal(replay.status, 200);
+    const replayed = await replay.json();
+    assert.equal(replayed.conversation_id, first.conversation_id);
+  });
+
+  it('routes "buy" keyword in turn message to a transaction handoff hint', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'shopping',
+        offering_id: 'off_acme_trailrun_summer26',
+        client_request_id: 'init-buy-test',
+      }),
+    });
+    const conv = await init.json();
+
+    const turn = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/turns`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        message: "I'd like to buy the black/green ones in size 10.",
+        client_request_id: 'turn-buy-1',
+      }),
+    });
+    assert.equal(turn.status, 200);
+    const body = await turn.json();
+    assert.equal(body.close_recommended.type, 'transaction');
+    assert.equal(body.conversation_status, 'active');
+  });
+
+  it('rejects mismatched body on reused client_request_id with 409 idempotency_conflict', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'conflict test', client_request_id: 'init-conflict' }),
+    });
+    const conv = await init.json();
+
+    await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/turns`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ message: 'first body', client_request_id: 'turn-conflict' }),
+    });
+    const conflict = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/turns`,
+      {
+        method: 'POST',
+        headers: auth(),
+        body: JSON.stringify({ message: 'second body', client_request_id: 'turn-conflict' }),
+      }
+    );
+    assert.equal(conflict.status, 409);
+    const body = await conflict.json();
+    assert.equal(body.code, 'idempotency_conflict');
+  });
+
+  it('closes conversation with reason=transaction and returns transaction_handoff', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({
+        intent: 'close test',
+        offering_id: 'off_acme_trailrun_summer26',
+        client_request_id: 'init-close',
+      }),
+    });
+    const conv = await init.json();
+
+    const close = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`,
+      {
+        method: 'POST',
+        headers: auth(),
+        body: JSON.stringify({ reason: 'transaction', summary: 'User chose blackgreen-10.' }),
+      }
+    );
+    assert.equal(close.status, 200);
+    const body = await close.json();
+    assert.equal(body.status, 'closed');
+    assert.equal(body.close.reason, 'transaction');
+    assert.ok(body.close.transaction_handoff);
+    assert.equal(typeof body.close.transaction_handoff.checkout_url, 'string');
+    assert.equal(typeof body.close.transaction_handoff.checkout_token, 'string');
+  });
+
+  it('close is idempotent on repeated calls (mirrors si_terminate_session having no idempotency_key)', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'idem close', client_request_id: 'init-idem-close' }),
+    });
+    const conv = await init.json();
+
+    const first = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`,
+      { method: 'POST', headers: auth(), body: JSON.stringify({ reason: 'user_exit' }) }
+    );
+    const firstBody = await first.json();
+    const second = await fetch(
+      `${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`,
+      { method: 'POST', headers: auth(), body: JSON.stringify({ reason: 'host_terminated' }) }
+    );
+    assert.equal(second.status, 200);
+    const secondBody = await second.json();
+    assert.equal(secondBody.close.reason, 'user_exit');
+    assert.equal(secondBody.close.closed_at, firstBody.close.closed_at);
+  });
+
+  it('rejects new turns on a closed conversation with 409 conversation_closed', async () => {
+    const init = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ intent: 'closed turn test', client_request_id: 'init-closed' }),
+    });
+    const conv = await init.json();
+    await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/close`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ reason: 'user_exit' }),
+    });
+    const turn = await fetch(`${handle.url}/v1/brands/brand_acme_outdoor/conversations/${conv.conversation_id}/turns`, {
+      method: 'POST',
+      headers: auth(),
+      body: JSON.stringify({ message: 'hello?', client_request_id: 'turn-after-close' }),
+    });
+    assert.equal(turn.status, 409);
+    const body = await turn.json();
+    assert.equal(body.code, 'conversation_closed');
+  });
+
+  it('records traffic counters for façade detection', async () => {
+    const res = await fetch(`${handle.url}/_debug/traffic`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.traffic['POST /v1/brands/{brand}/conversations'] > 0);
+    assert.ok(body.traffic['POST /v1/brands/{brand}/conversations/{id}/turns'] > 0);
+    assert.ok(body.traffic['POST /v1/brands/{brand}/conversations/{id}/close'] > 0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `sponsored-intelligence` to `npx @adcp/sdk mock-server` — fifth fixture, brand-agent-platform-shaped (Salesforce Agentforce / OpenAI Assistants / custom-brand-chat family) — so adopters can dogfood SI ahead of `adcontextprotocol.org` standing up a reference SI tenant
- Stateful conversational HTTP API (sessions, turns, ACP-style transaction handoff) that an adapter wraps to project AdCP `si_get_offering` / `si_initiate_session` / `si_send_message` / `si_terminate_session`
- 16 smoke tests covering auth, brand isolation, idempotent replay/conflict, transaction close, post-close rejection, traffic counters

## Why a mock now (and not a v6 platform shape)

SI is currently a *protocol* in AdCP 3.0 (`supported_protocols: ['sponsored_intelligence']`) but **not** a *specialism* — `sponsored-intelligence` is absent from `AdCPSpecialism`. That blocks a v6 `SponsoredIntelligencePlatform` with parity to the other specialism platforms; adopters wire SI through the v5 `createAdcpServer` handler bag (`SponsoredIntelligenceHandlers`).

The mock server is independent of that decision — it represents the **upstream brand platform** an adapter wraps, regardless of which SDK shape the AdCP-side handler uses.

**Upstream tracking**: adcontextprotocol/adcp#3961 (spec ask for `sponsored-intelligence` in `AdCPSpecialism`, targeted at 3.1). SDK-side bridge plan posted as a comment on that issue: dispatch the v6 platform off `supported_protocols` (already canonical in 3.0) so adopters get full v6 ergonomics today, with the dispatch becoming additive when 3.1 lands.

## Routes (path-scoped multi-tenancy, parallel to `creative-template`)

| Route | AdCP tool |
|---|---|
| `GET /_lookup/brand?adcp_brand=<value>` | discovery (no auth) |
| `GET /_debug/traffic` | façade-detection counters (no auth) |
| `GET /v1/brands/{brand}/offerings/{offering_id}` | `si_get_offering` |
| `POST /v1/brands/{brand}/conversations` | `si_initiate_session` |
| `GET /v1/brands/{brand}/conversations/{conv_id}` | read state |
| `POST /v1/brands/{brand}/conversations/{conv_id}/turns` | `si_send_message` |
| `POST /v1/brands/{brand}/conversations/{conv_id}/close` | `si_terminate_session` |

## Lifecycle + idempotency

Conversation lifecycle: `active` → `closed` (terminal). Re-closing returns the same payload — naturally idempotent on `conversation_id`, mirroring AdCP's decision to omit `idempotency_key` on `si_terminate_session`. `POST /conversations` and `POST /turns` each accept `client_request_id` (the upstream-side translation of AdCP `idempotency_key`) for at-most-once execution; mismatched body with reused key → `409 idempotency_conflict`.

## Brand-agent canned responses (keyword-routed, deterministic)

- `buy` / `purchase` / `checkout` / `order` → `close_recommended: { type: 'transaction', payload }` — adapter surfaces as AdCP `session_status: 'pending_handoff'` + populated `handoff` block
- `thanks` / `bye` / `done` → `close_recommended: { type: 'complete' }`
- `second` / `next` / `other one` → swap product card to next product
- otherwise → product card from the configured offering

When close is called with `reason=transaction`, the response includes `transaction_handoff: { checkout_url, checkout_token, expires_at, payload }` — adapter projects to AdCP `acp_handoff`.

## Two seeded brands (multi-tenancy assertion)

| Brand | Offering | Products |
|---|---|---|
| `brand_acme_outdoor` (`acmeoutdoor.example`) | trail-runner shoes | 2 |
| `brand_summit_books` (`summit-books.example`) | summer reading | 1 |

Cross-brand offering access returns `404 offering_not_in_brand`.

## Upstream/AdCP rename pattern (exercises adapter projection)

Intentional throughout: `conversation_id` → `session_id`, `assistant_message` → `response.message`, `components` (with `kind`) → `ui_elements` (with `type`), `sku` → `product_id`, `hero_image_url` → `image_url`, `landing_page_url` → `landing_url`, `pdp_url` → `url`, `thumbnail_url` → `image_url`, `inventory_status` → `availability_summary`, `transaction_handoff` → `acp_handoff`.

## Test plan

- [x] `tsc --project tsconfig.lib.json` clean
- [x] `node --test test/lib/mock-server/sponsored-intelligence.test.js` — 16/16 pass
- [x] `node --test test/lib/mock-server/*.test.js` — 122/122 pass (no regressions)
- [x] `npm run format:check` clean
- [x] CLI smoke: `node bin/adcp.js mock-server sponsored-intelligence --port 4599` boots and prints summary
- [x] Changeset added (`@adcp/sdk` minor)

## Follow-ups (separate branches)

1. v6 `SponsoredIntelligencePlatform` interface + dispatch off `supported_protocols` (per #3961 SDK plan)
2. `examples/hello_si_adapter_brand.ts` driving this mock through the v6 platform

Refs adcontextprotocol/adcp#3961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)