### PR TITLE
feat(server): variadic composeMethod overload + inline-vs-compose decision matrix

### DIFF
--- a/.changeset/compose-method-variadic-overload.md
+++ b/.changeset/compose-method-variadic-overload.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): variadic `composeMethod(inner, ...hooks)` overload for stacking multiple guards without nesting
+
+Adds a variadic form of `composeMethod` so adopters can write `composeMethod(inner, hookA, hookB, hookC)` instead of `composeMethod(composeMethod(composeMethod(inner, hookC), hookB), hookA)`. Semantics are identical to right-to-left manual nesting: `before` hooks run left-to-right, `after` hooks run right-to-left. The two-argument form is unchanged.
+
+Also adds a "When to use which approach" decision matrix to `docs/recipes/composeMethod-testing.md` covering preset-vs-inline tradeoffs, the `requireOrgScope` undefined-org gotcha, and `onDeny` evaluation-order implications.
+
+Closes #1444.

--- a/docs/recipes/composeMethod-testing.md
+++ b/docs/recipes/composeMethod-testing.md
@@ -345,8 +345,9 @@ const guarded = composeMethod(inner, authGate, synthGate, orgGate);
 const ok = await guarded({ account_id: 'acc_1', expected_org: 'org_A' }, { token: 'tok', orgId: 'org_A' });
 assert.deepStrictEqual(ok, { ok: true, org_checked: true });
 
-// authGate short-circuits — synthGate and orgGate before skipped;
-// orgGate.after and synthGate.after still run (none here), authGate.after not present
+// authGate short-circuits at the outermost wrapper — synthGate and orgGate are
+// never entered, so neither their before nor their after hooks run. authGate has
+// no after, so the short-circuit value is returned unchanged.
 const denied = await guarded({ account_id: 'acc_1', expected_org: 'org_A' }, { token: null, orgId: 'org_A' });
 assert.strictEqual(denied, null);
 ```

--- a/docs/recipes/composeMethod-testing.md
+++ b/docs/recipes/composeMethod-testing.md
@@ -23,6 +23,37 @@ import type { ComposeHooks, ComposeShortCircuit } from '@adcp/sdk/server';
 
 ---
 
+## When to use which approach
+
+| Situation | Recommendation |
+|---|---|
+| Single security gate matching one of the shipped presets exactly | Use the preset via `composeMethod` — see [Pattern 6](#pattern-6--requireadvertisermatch-with-composemethod) |
+| Multiple gates to stack, no per-gate unit testing needed | Consider inlining; chained `composeMethod` nesting is harder to read than equivalent inline guards — see [Pattern 3](#pattern-3--layering-two-composemethod-calls) for the nesting form, [Pattern 7](#pattern-7--variadic-composemethod-hook-chain-sugar) for the variadic sugar |
+| Single gate with policy nuances the preset doesn't express (e.g. public-account fallthrough) | Inline or use `requireAccountMatch` with a custom predicate; presets are for the canonical case |
+| Per-gate testability or reuse across multiple platforms | `composeMethod` per gate — accept the nesting verbosity for the test coverage benefit |
+| `onDeny: 'throw'` needed on a guard | Use the preset with `{ onDeny: 'throw' }` — note that a throwing outer guard bypasses inner guards, making evaluation order load-bearing |
+
+**`requireOrgScope` gotcha:** `requireOrgScope` uses strict equality and denies when _either_ `getAccountOrg` **or** `getCtxOrg` returns `undefined`. An account without an org field is **denied**, not treated as publicly accessible. For a public-account convention (accounts without an org scope are open to any authenticated buyer), use `requireAccountMatch` with a custom predicate instead:
+
+```ts
+import { composeMethod, requireAccountMatch } from '@adcp/sdk/server';
+
+accounts: {
+  resolve: composeMethod(
+    baseResolve,
+    requireAccountMatch((account, ctx) => {
+      // Replace with your account's org field — e.g. account.ctx_metadata?.orgId
+      const accountOrg = account.ctx_metadata?.orgScope;
+      if (!accountOrg) return true; // no org scope → publicly accessible
+      const ctxOrg = ctx?.authInfo?.extra?.orgId as string | undefined;
+      return ctxOrg === accountOrg;
+    })
+  ),
+}
+```
+
+---
+
 ## Pattern 1 — Mock the base, assert pass-through
 
 When neither hook fires the wrapped method is a transparent proxy. Track calls on the inner
@@ -88,7 +119,7 @@ const right = composeMethod(inner, { before: async () => ({ shortCircuit: undefi
 `before` accepts a single function, not an array. To compose independent guards, nest
 `composeMethod` calls. The outer `before` runs first; if it falls through, the inner `before`
 runs. This is how the `requireAdvertiserMatch` / `requireOrgScope` presets are designed to be
-composed.
+composed. For three or more guards, [Pattern 7](#pattern-7--variadic-composemethod-hook-chain-sugar) provides sugar over this nesting.
 
 ```javascript
 const inner = async () => ({ ok: true });
@@ -222,7 +253,7 @@ assert.ok(ok !== null);
 ## Pattern 6 — `requireAdvertiserMatch` with `composeMethod`
 
 The presets shipped in `@adcp/sdk/server` (`requireAccountMatch`, `requireAdvertiserMatch`,
-`requireOrgScope`) are pre-built `ComposeHooks` objects for `accounts.resolve`. Each returns an
+`requireOrgScope`) are pre-built `ComposeHooks` objects for `accounts.resolve`. See [When to use which approach](#when-to-use-which-approach) for guidance on when a preset fits vs. when to inline. Each returns an
 `after` hook that runs _after_ the inner resolver; a null inner result propagates unconditionally
 (no predicate runs on a "not found" account). The snippet below uses `requireAdvertiserMatch`;
 `requireAccountMatch` (general predicate) and `requireOrgScope` (org equality check) follow the
@@ -266,3 +297,60 @@ assert.strictEqual(await guardedNull({}, {}), null);
 ```
 
 The full preset API is documented in the JSDoc of `src/lib/server/decisioning/resolve-presets.ts`.
+
+---
+
+## Pattern 7 — Variadic `composeMethod` (hook-chain sugar)
+
+When stacking three or more independent guards, the nested `composeMethod` calls become
+hard to read. Pass multiple hooks as separate arguments instead — `composeMethod` chains
+them internally, producing the same result as manual nesting.
+
+```ts
+// Equivalent forms:
+composeMethod(inner, hookA, hookB, hookC)
+composeMethod(composeMethod(composeMethod(inner, hookC), hookB), hookA)
+```
+
+**Execution order:** `before` hooks run left-to-right (A first, C last). `after` hooks run
+right-to-left (C first, A last). A short-circuit from a `before` hook skips remaining
+`before` hooks and their corresponding `after` hooks (the inner wrappers that were never
+entered). `after` hooks for wrappers that _were_ entered (the short-circuiting hook itself
+and any outer hooks) still run.
+
+```javascript
+const { composeMethod } = require('@adcp/sdk/server');
+
+const inner = async () => ({ ok: true });
+
+const authGate = {
+  before: async (_params, ctx) =>
+    ctx.token ? undefined : { shortCircuit: null },
+};
+const synthGate = {
+  before: async (params) =>
+    params.account_id?.startsWith('synthetic_') ? { shortCircuit: null } : undefined,
+};
+const orgGate = {
+  before: async (params, ctx) =>
+    ctx.orgId === params.expected_org ? undefined : { shortCircuit: null },
+  after: async (result) => result && { ...result, org_checked: true },
+};
+
+// Sugar: authGate before runs first, orgGate before runs last.
+// orgGate after runs first (closest to inner), authGate after runs last.
+const guarded = composeMethod(inner, authGate, synthGate, orgGate);
+
+// All gates pass — inner result, enriched by orgGate.after
+const ok = await guarded({ account_id: 'acc_1', expected_org: 'org_A' }, { token: 'tok', orgId: 'org_A' });
+assert.deepStrictEqual(ok, { ok: true, org_checked: true });
+
+// authGate short-circuits — synthGate and orgGate before skipped;
+// orgGate.after and synthGate.after still run (none here), authGate.after not present
+const denied = await guarded({ account_id: 'acc_1', expected_org: 'org_A' }, { token: null, orgId: 'org_A' });
+assert.strictEqual(denied, null);
+```
+
+When each gate needs its own unit tests or is reused across multiple platform methods, the
+two-argument form with manual nesting (Pattern 3) keeps the test surface cleaner. Use the
+variadic form when you're stacking gates inline and don't need per-gate isolation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.6.0",
+      "version": "6.7.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6434,7 +6434,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.6.0"
+        "@adcp/sdk": "^6.7.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/server/decisioning/compose.ts
+++ b/src/lib/server/decisioning/compose.ts
@@ -51,6 +51,31 @@ export interface ComposeHooks<TParams, TCtx, TResult> {
   after?: (result: TResult, params: TParams, ctx: TCtx) => Promise<TResult>;
 }
 
+type MethodFn<TParams, TCtx, TResult> = (params: TParams, ctx: TCtx) => Promise<TResult>;
+
+function composeSingle<TParams, TCtx, TResult>(
+  inner: MethodFn<TParams, TCtx, TResult>,
+  hooks: ComposeHooks<TParams, TCtx, TResult>
+): MethodFn<TParams, TCtx, TResult> {
+  return async (params, ctx) => {
+    let result: TResult;
+    if (hooks.before) {
+      const early = await hooks.before(params, ctx);
+      if (early === undefined) {
+        result = await inner(params, ctx);
+      } else {
+        result = early.shortCircuit;
+      }
+    } else {
+      result = await inner(params, ctx);
+    }
+    if (hooks.after) {
+      result = await hooks.after(result, params, ctx);
+    }
+    return result;
+  };
+}
+
 /**
  * Wrap a single platform method with optional `before` / `after` hooks.
  *
@@ -63,7 +88,22 @@ export interface ComposeHooks<TParams, TCtx, TResult> {
  * implemented on the underlying platform get a clear error at module load
  * rather than the first traffic to hit the method.
  *
- * @example Short-circuit + enrichment
+ * **Variadic overload** — pass multiple hooks to chain them without nesting.
+ * `before` hooks run left-to-right (first argument runs first); `after`
+ * hooks run right-to-left (last argument runs first), matching standard
+ * middleware-stack semantics. A short-circuit from a `before` hook skips
+ * remaining `before` hooks and the `after` hooks of inner wrappers that
+ * were never entered; `after` hooks for the short-circuiting wrapper and
+ * any outer wrappers still run. Equivalent to manually nesting
+ * `composeMethod` calls right-to-left:
+ *
+ * ```ts
+ * // These are identical:
+ * composeMethod(inner, hookA, hookB, hookC)
+ * composeMethod(composeMethod(composeMethod(inner, hookC), hookB), hookA)
+ * ```
+ *
+ * @example Short-circuit + enrichment (single hook)
  * ```ts
  * import { composeMethod } from '@adcp/sdk/server';
  *
@@ -90,33 +130,48 @@ export interface ComposeHooks<TParams, TCtx, TResult> {
  * createAdcpServerFromPlatform(wrapped, opts);
  * ```
  *
+ * @example Stacking multiple security gates (variadic)
+ * ```ts
+ * import { composeMethod, requireAdvertiserMatch } from '@adcp/sdk/server';
+ *
+ * accounts: {
+ *   resolve: composeMethod(
+ *     baseResolve,
+ *     { before: async (_p, ctx) => ctx.token ? undefined : { shortCircuit: null } },
+ *     requireAdvertiserMatch(async (ctx) => tenantRoster.for(ctx?.agent)),
+ *   ),
+ * }
+ * ```
+ *
  * @public
  */
 export function composeMethod<TParams, TCtx, TResult>(
-  inner: (params: TParams, ctx: TCtx) => Promise<TResult>,
+  inner: MethodFn<TParams, TCtx, TResult>,
   hooks: ComposeHooks<TParams, TCtx, TResult>
-): (params: TParams, ctx: TCtx) => Promise<TResult> {
+): MethodFn<TParams, TCtx, TResult>;
+export function composeMethod<TParams, TCtx, TResult>(
+  inner: MethodFn<TParams, TCtx, TResult>,
+  first: ComposeHooks<TParams, TCtx, TResult>,
+  ...rest: ComposeHooks<TParams, TCtx, TResult>[]
+): MethodFn<TParams, TCtx, TResult>;
+export function composeMethod<TParams, TCtx, TResult>(
+  inner: MethodFn<TParams, TCtx, TResult>,
+  first: ComposeHooks<TParams, TCtx, TResult>,
+  ...rest: ComposeHooks<TParams, TCtx, TResult>[]
+): MethodFn<TParams, TCtx, TResult> {
   if (typeof inner !== 'function') {
     throw new TypeError(
       `composeMethod: 'inner' must be a function, got ${inner === null ? 'null' : typeof inner}. ` +
         `Did you reference an optional method that wasn't implemented on the platform?`
     );
   }
-  return async (params, ctx) => {
-    let result: TResult;
-    if (hooks.before) {
-      const early = await hooks.before(params, ctx);
-      if (early === undefined) {
-        result = await inner(params, ctx);
-      } else {
-        result = early.shortCircuit;
-      }
-    } else {
-      result = await inner(params, ctx);
-    }
-    if (hooks.after) {
-      result = await hooks.after(result, params, ctx);
-    }
-    return result;
-  };
+  if (rest.length === 0) {
+    return composeSingle(inner, first);
+  }
+  // Fold right so the first argument becomes the outermost wrapper (runs first).
+  // Equivalent to: composeMethod(composeMethod(composeMethod(inner, hookC), hookB), hookA)
+  return [first, ...rest].reduceRight<MethodFn<TParams, TCtx, TResult>>(
+    (acc, hooks) => composeSingle(acc, hooks),
+    inner
+  );
 }

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.6.0';
+export const LIBRARY_VERSION = '6.7.0';
 
 /**
  * AdCP specification version this library is built for
@@ -49,10 +49,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.6.0',
+  library: '6.7.0',
   adcp: '3.0.5',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-03T00:23:15.589Z',
+  generatedAt: '2026-05-03T11:44:57.380Z',
 } as const;
 
 /**

--- a/test/server-decisioning-compose-recipes.test.js
+++ b/test/server-decisioning-compose-recipes.test.js
@@ -220,4 +220,165 @@ describe('composeMethod recipes (#1345)', () => {
       assert.strictEqual(await guardedNull({}, {}), null);
     });
   });
+
+  describe('Pattern 7 — variadic composeMethod (hook-chain sugar)', () => {
+    it('three hooks: before runs A→B→C, after runs C→B→A', async () => {
+      const beforeLog = [];
+      const afterLog = [];
+      const inner = async () => ({ ok: true });
+
+      const hookA = {
+        before: async () => {
+          beforeLog.push('A');
+        },
+        after: async result => {
+          afterLog.push('A');
+          return result;
+        },
+      };
+      const hookB = {
+        before: async () => {
+          beforeLog.push('B');
+        },
+        after: async result => {
+          afterLog.push('B');
+          return result;
+        },
+      };
+      const hookC = {
+        before: async () => {
+          beforeLog.push('C');
+        },
+        after: async result => {
+          afterLog.push('C');
+          return result;
+        },
+      };
+
+      const wrapped = composeMethod(inner, hookA, hookB, hookC);
+      const result = await wrapped({}, {});
+
+      assert.deepStrictEqual(beforeLog, ['A', 'B', 'C'], 'before: A first, C last');
+      assert.deepStrictEqual(afterLog, ['C', 'B', 'A'], 'after: C first, A last');
+      assert.deepStrictEqual(result, { ok: true });
+    });
+
+    it('short-circuit from first hook: remaining befores and their afters are skipped', async () => {
+      const log = [];
+      const inner = async () => {
+        log.push('inner');
+        return { from: 'inner' };
+      };
+
+      const hookA = {
+        before: async () => {
+          log.push('A-before');
+          return { shortCircuit: { blocked: 'A' } };
+        },
+        after: async result => {
+          log.push('A-after');
+          return result;
+        },
+      };
+      const hookB = {
+        before: async () => {
+          log.push('B-before');
+        },
+        after: async result => {
+          log.push('B-after');
+          return result;
+        },
+      };
+      const hookC = {
+        before: async () => {
+          log.push('C-before');
+        },
+        after: async result => {
+          log.push('C-after');
+          return result;
+        },
+      };
+
+      const wrapped = composeMethod(inner, hookA, hookB, hookC);
+      const result = await wrapped({}, {});
+
+      // A short-circuits: wrappedBC never called, so B+C before+after all skipped.
+      // Matches nesting equivalent: composeMethod(composeMethod(composeMethod(inner,C),B),A)
+      assert.deepStrictEqual(log, ['A-before', 'A-after']);
+      assert.deepStrictEqual(result, { blocked: 'A' });
+    });
+
+    it('short-circuit from middle hook: later befores+afters skipped, earlier afters still run', async () => {
+      const log = [];
+      const inner = async () => {
+        log.push('inner');
+        return { from: 'inner' };
+      };
+
+      const hookA = {
+        before: async () => {
+          log.push('A-before');
+        },
+        after: async result => {
+          log.push('A-after');
+          return result;
+        },
+      };
+      const hookB = {
+        before: async () => {
+          log.push('B-before');
+          return { shortCircuit: { blocked: 'B' } };
+        },
+        after: async result => {
+          log.push('B-after');
+          return result;
+        },
+      };
+      const hookC = {
+        before: async () => {
+          log.push('C-before');
+        },
+        after: async result => {
+          log.push('C-after');
+          return result;
+        },
+      };
+
+      const wrapped = composeMethod(inner, hookA, hookB, hookC);
+      const result = await wrapped({}, {});
+
+      // B short-circuits: C (inner of B) never called; B.after and A.after still run.
+      assert.deepStrictEqual(log, ['A-before', 'B-before', 'B-after', 'A-after']);
+      assert.deepStrictEqual(result, { blocked: 'B' });
+    });
+
+    it('variadic with one meaningful hook plus an empty no-op matches two-arg form', async () => {
+      const inner = async params => ({ doubled: params.n * 2 });
+      const hook = { after: async result => ({ ...result, tag: 'enriched' }) };
+
+      const twoArg = composeMethod(inner, hook);
+      // Explicitly exercises the variadic path (rest.length > 0) — empty {} is a no-op
+      const variadic = composeMethod(inner, hook, {});
+
+      const r1 = await twoArg({ n: 3 }, {});
+      const r2 = await variadic({ n: 3 }, {});
+      assert.deepStrictEqual(r1, r2);
+    });
+
+    it('empty {} hook in the array is a no-op at that position', async () => {
+      const inner = async () => ({ value: 42 });
+      const meaningful = { after: async result => ({ ...result, tag: 'enriched' }) };
+
+      const wrapped = composeMethod(inner, {}, meaningful, {});
+      const result = await wrapped({}, {});
+      assert.deepStrictEqual(result, { value: 42, tag: 'enriched' });
+    });
+
+    it('non-function inner with variadic hooks throws TypeError', async () => {
+      assert.throws(
+        () => composeMethod(null, {}, {}),
+        err => err instanceof TypeError && err.message.includes("'inner' must be a function")
+      );
+    });
+  });
 });


### PR DESCRIPTION
Closes #1444

## Summary

Addresses both items from issue #1444:

1. **Variadic `composeMethod` overload** — `composeMethod(inner, hookA, hookB, hookC)` as sugar over manual nesting. Uses `reduceRight` so the first argument is the outermost wrapper (runs first), matching standard middleware-stack semantics and the nesting equivalent `composeMethod(composeMethod(composeMethod(inner, hookC), hookB), hookA)`.

2. **"When to use which approach" decision matrix** — added to `docs/recipes/composeMethod-testing.md` immediately before Pattern 1, covering preset-vs-inline tradeoffs, the `requireOrgScope` undefined-org gotcha (deny, not pass-through), and `onDeny: 'throw'` evaluation-order implications. Pattern 7 added for the variadic form with cross-links from Pattern 3 and Pattern 6.

## What was tested

- `node --test test/server-decisioning-compose-recipes.test.js` — 18/18 pass (6 new Pattern 7 tests)
- `tsc --noEmit` — clean
- `prettier --check` — clean
- `npm run build:lib` — clean (`sync-schemas` skipped; no schema changes)

**Nits from pre-PR review (not fixed — doc/style only):**
- Pattern 7 doc comment `authGate.after not present` could say "authGate has no .after" — left as-is since it's accurate
- `docs/guides/BUILD-AN-AGENT.md` doesn't mention the variadic form yet — cross-repo doc gap, out of scope for this PR

**Pre-PR review:**
- code-reviewer: approved — `reduceRight` semantics correct, overload signatures sound, no blockers after anchor + vacuous-test fixes
- docs-expert: approved — matrix placement correct, gotcha uses `ctx_metadata` (adopter-defined field with clarifying comment), anchors fixed

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Ntf59YyD4JZB6tTD8mEVU3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntf59YyD4JZB6tTD8mEVU3)_