### PR TITLE
docs(migration): warn that customTools["update_rights"] must be removed when upgrading to 6.7.0

### DIFF
--- a/docs/migration-6.6-to-6.7.md
+++ b/docs/migration-6.6-to-6.7.md
@@ -1071,6 +1071,11 @@ Walk this before declaring 6.6 → 6.7 done:
       persisted list reference inside the overlay. Storyboard step
       `media_buy_seller/inventory_list_targeting/get_after_create`
       passes.
+- [ ] **Brand-rights adopters: no `customTools["update_rights"]`
+      registration.** `grep -rn 'customTools.*update_rights' src/`
+      returns zero hits — the framework registers the tool in 6.7.0; a
+      duplicate throws on the first request (not at boot) and surfaces
+      as a discovery failure rather than a startup error.
 - [ ] **`Account` v3 wire fields are populated** for billing /
       lifecycle adopters. `billing_entity` (with `bank` stripped on
       emit), `setup` (`pending_approval` → `active` lifecycle),
@@ -1126,6 +1131,14 @@ These ride along in 6.7 and don't need any adopter action:
   `BrandRightsPlatform.updateRights` instead of the v5 raw-handler
   bag. Per-arm builders for `creativeApproved` /
   `creativeApprovalRejected` / `creativeApprovalRevoked`.
+  **Breaking for `customTools` registrations:** if your
+  `createAdcpServer()` call passed `update_rights` via `customTools`,
+  remove that entry — the framework now registers the tool itself, and
+  a duplicate throws
+  `Error: createAdcpServer: customTools["update_rights"] collides with a framework-registered tool.`
+  on the first request (not at boot), which surfaces as a discovery
+  failure rather than a startup error. Audit with:
+  `grep -rn 'customTools.*update_rights' src/`
 - **Auto-hydration is now spec-driven.** Hydration call sites read
   `x-entity` annotations from the manifest instead of hand-rolled
   `(field_name, ResourceKind)` literals. Future spec field renames

--- a/docs/migration-6.6-to-6.7.md
+++ b/docs/migration-6.6-to-6.7.md
@@ -1074,8 +1074,9 @@ Walk this before declaring 6.6 → 6.7 done:
 - [ ] **Brand-rights adopters: no `customTools["update_rights"]`
       registration.** `grep -rn 'customTools.*update_rights' src/`
       returns zero hits — the framework registers the tool in 6.7.0; a
-      duplicate throws on the first request (not at boot) and surfaces
-      as a discovery failure rather than a startup error.
+      duplicate causes `createAdcpServer()` to throw at construction time
+      (which for lazy-init registry patterns surfaces as a discovery
+      failure on the first request rather than at startup).
 - [ ] **`Account` v3 wire fields are populated** for billing /
       lifecycle adopters. `billing_entity` (with `bank` stripped on
       emit), `setup` (`pending_approval` → `active` lifecycle),
@@ -1093,7 +1094,7 @@ are breaking and require auditing before bumping.
 
 ## What else changed (no recipe required)
 
-These ride along in 6.7 and don't need any adopter action:
+These ride along in 6.7 and don't need any adopter action unless noted inline:
 
 - **`Account.authInfo` is now optional.** Adopters who don't persist
   a principal can omit the field and pass strict typecheck. Adopters
@@ -1134,11 +1135,12 @@ These ride along in 6.7 and don't need any adopter action:
   **Breaking for `customTools` registrations:** if your
   `createAdcpServer()` call passed `update_rights` via `customTools`,
   remove that entry — the framework now registers the tool itself, and
-  a duplicate throws
-  `Error: createAdcpServer: customTools["update_rights"] collides with a framework-registered tool.`
-  on the first request (not at boot), which surfaces as a discovery
-  failure rather than a startup error. Audit with:
-  `grep -rn 'customTools.*update_rights' src/`
+  a duplicate causes `createAdcpServer()` to throw:
+  `createAdcpServer: customTools["update_rights"] collides with a framework-registered tool. Rename the custom tool or remove the handler from the conflicting domain group.`
+  For server setups that build tenants lazily (e.g., registry patterns),
+  this error surfaces on the first inbound request as an MCP discovery
+  failure rather than at startup. (See self-grade checklist item above
+  for the audit grep.)
 - **Auto-hydration is now spec-driven.** Hydration call sites read
   `x-entity` annotations from the manifest instead of hand-rolled
   `(field_name, ResourceKind)` literals. Future spec field renames


### PR DESCRIPTION
Refs #1438

`docs/migration-6.6-to-6.7.md` mentioned the `update_rights` promotion to a framework-registered first-class tool but didn't call out that adopters with a pre-existing `customTools["update_rights"]` registration must remove it. Without the note, a duplicate registration causes `createAdcpServer()` to throw at construction time — and for server setups that build tenants lazily (e.g., registry patterns), that error surfaces on the first inbound request as an MCP discovery failure rather than a startup error, making the root cause hard to diagnose. The issue was surfaced by root-cause analysis of #1438.

**Changes:**
- Add `**Breaking for customTools registrations:**` note to the `update_rights` feature bullet in "What else changed," quoting the full error message and explaining the lazy-init discovery-failure symptom
- Add a self-grade checklist item with a `grep` audit recipe so upgrading adopters have an actionable pre-flight check
- Qualify the section header from "don't need any adopter action" to "don't need any adopter action unless noted inline" to avoid the header misdirecting the very adopters the note targets

No changeset needed (docs-only change, per CLAUDE.md).

**What tested:**
- `npm run format:check` — clean
- `npm run ci:docs-check` — blocked by missing `tsx` in environment (pre-existing; same gap noted in PR #1442 body); docs content verified by manual read

**Pre-PR review:**
- code-reviewer: approved — no blockers; nit on section-header contradiction (addressed in this diff)
- docs-expert: approved after two fix passes — prior blockers (truncated error message, throw-timing ambiguity, duplicated grep) all resolved

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1443` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01V1MgRaahiwFFgpMc66eD2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1MgRaahiwFFgpMc66eD2k)_