### PR TITLE
feat(decisioning): extend multi-id truncation warn — listCreatives / getCreativeDelivery / getSignals (#1410)

### DIFF
--- a/.changeset/multi-id-truncation-warn-extension.md
+++ b/.changeset/multi-id-truncation-warn-extension.md
@@ -1,0 +1,19 @@
+---
+'@adcp/sdk': patch
+---
+
+feat(decisioning): extend multi-id truncation dev-mode warn to `listCreatives`, `getCreativeDelivery`, and `getSignals`. Closes #1410.
+
+The warn shipped in 6.7 for `getMediaBuyDelivery` and `getMediaBuys` (`media_buy_ids[]`); the same `<id_field>[0]`-truncation hazard applies to every read-by-id surface. The extension fires when adopters' platforms return fewer rows than the buyer's `creative_ids[]` / `signal_ids[]` filter requested, with the same gates: silent in `NODE_ENV=production`, suppressible via `ADCP_SUPPRESS_MULTI_ID_WARN=1`, no-op when the id-array filter is omitted (paginated-list mode).
+
+Wired at four new dispatch sites in `from-platform.ts`:
+
+- `listCreatives` — both the sales-side dispatch (when `SalesPlatform` provides it) and the creative-side ad-server dispatch.
+- `getCreativeDelivery` — creative-side ad-server only.
+- `getSignals` — note `signal_ids` is `SignalID[]` (`{source, data_provider_domain, id}` objects), not bare strings; the helper compares on length only so the element type is irrelevant.
+
+The helper signature gains a typed `idFieldName` parameter so the warn message names the right id field (`media_buy_ids` / `creative_ids` / `signal_ids`); the existing two call sites pass `'media_buy_ids'` explicitly.
+
+Sync / upsert surfaces (`syncCreatives`, `syncCatalogs`, `syncPlans`) remain out of scope per the issue carve-out — those have a different shape where pass-through is the obvious pattern and "did all rows roundtrip?" isn't a clean question.
+
+The 6 existing tests in `test/server-decisioning-multi-id-truncation-warn.test.js` still pass; one new test pins the `getSignals` wiring (the distinctive `SignalID[]` object-array shape).

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -187,18 +187,25 @@ function refuseImplicitAccountId(
 /**
  * Dev-mode warning when a multi-id read tool returns fewer rows than
  * the buyer requested — the canonical signal that the platform is
- * silently truncating to `media_buy_ids[0]` (closes #1342, follow-up
- * #1399). Catches the bug class where adopters write the recommended
- * pattern wrong on first pass; quiet in production where legitimate
- * misses (deleted, archived, cross-account) are routine and warning
- * on every miss would be noise.
+ * silently truncating to `<id_field>[0]` (closes #1342, follow-up
+ * #1399, extended in #1410 to additional read-by-id surfaces). Catches
+ * the bug class where adopters write the recommended pattern wrong on
+ * first pass; quiet in production where legitimate misses (deleted,
+ * archived, cross-account) are routine and warning on every miss would
+ * be noise.
  *
  * Suppressible via `ADCP_SUPPRESS_MULTI_ID_WARN=1` for adopters whose
  * legitimate-miss rate is high (deleted-account-rich datasets, etc.).
+ *
+ * Sync / upsert surfaces (`syncCreatives`, `syncCatalogs`, `syncPlans`)
+ * are intentionally out of scope — those have a different shape where
+ * pass-through is the obvious pattern and "did all rows roundtrip?"
+ * isn't a clean question.
  */
 function warnIfTruncatedMultiIdResponse(
-  toolName: 'getMediaBuyDelivery' | 'getMediaBuys',
-  requestedIds: readonly string[] | undefined,
+  toolName: 'getMediaBuyDelivery' | 'getMediaBuys' | 'listCreatives' | 'getCreativeDelivery' | 'getSignals',
+  idFieldName: 'media_buy_ids' | 'creative_ids' | 'signal_ids',
+  requestedIds: readonly unknown[] | undefined,
   responseArray: readonly unknown[] | undefined,
   logger: AdcpLogger
 ): void {
@@ -207,11 +214,11 @@ function warnIfTruncatedMultiIdResponse(
   if (!requestedIds || requestedIds.length === 0) return;
   const returned = Array.isArray(responseArray) ? responseArray.length : 0;
   if (returned >= requestedIds.length) return;
-  // Empty `media_buy_ids` is filtered above as paginated-mode (no truncation
+  // Empty `<id_field>` is filtered above as paginated-mode (no truncation
   // possible without a request to compare against).
   logger.warn(
-    `[adcp/sdk] ${toolName}: platform returned ${returned} row${returned === 1 ? '' : 's'} for ${requestedIds.length} requested media_buy_ids — ` +
-      `the platform may be silently truncating to media_buy_ids[0]. ` +
+    `[adcp/sdk] ${toolName}: platform returned ${returned} row${returned === 1 ? '' : 's'} for ${requestedIds.length} requested ${idFieldName} — ` +
+      `the platform may be silently truncating to ${idFieldName}[0]. ` +
       `See https://github.com/adcontextprotocol/adcp-client/issues/1342 for the multi-id pass-through contract. ` +
       `Suppress with ADCP_SUPPRESS_MULTI_ID_WARN=1 if legitimate misses (deleted / cross-account) are routine.`
   );
@@ -3321,6 +3328,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
             const result = await sales.getMediaBuyDelivery!(params, reqCtx);
             warnIfTruncatedMultiIdResponse(
               'getMediaBuyDelivery',
+              'media_buy_ids',
               (params as { media_buy_ids?: readonly string[] }).media_buy_ids,
               (result as { media_buy_deliveries?: readonly unknown[] })?.media_buy_deliveries,
               logger
@@ -3353,6 +3361,7 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
             const result = await sales.getMediaBuys!(params, reqCtx);
             warnIfTruncatedMultiIdResponse(
               'getMediaBuys',
+              'media_buy_ids',
               (params as { media_buy_ids?: readonly string[] }).media_buy_ids,
               (result as { media_buys?: readonly unknown[] })?.media_buys,
               logger
@@ -3403,7 +3412,17 @@ function buildMediaBuyHandlers<P extends DecisioningPlatform<any, any>>(
       listCreatives: async (params, ctx) => {
         const reqCtx = ctxFor(ctx);
         return projectSync(
-          () => sales.listCreatives!(params, reqCtx),
+          async () => {
+            const result = await sales.listCreatives!(params, reqCtx);
+            warnIfTruncatedMultiIdResponse(
+              'listCreatives',
+              'creative_ids',
+              (params as { creative_ids?: readonly string[] }).creative_ids,
+              (result as { creatives?: readonly unknown[] })?.creatives,
+              logger
+            );
+            return result;
+          },
           r => r
         );
       },
@@ -3540,7 +3559,17 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
       }
       const reqCtx = ctxFor(ctx);
       return projectSync(
-        () => (creative as CreativeAdServerPlatform).listCreatives(params, reqCtx),
+        async () => {
+          const result = await (creative as CreativeAdServerPlatform).listCreatives(params, reqCtx);
+          warnIfTruncatedMultiIdResponse(
+            'listCreatives',
+            'creative_ids',
+            (params as { creative_ids?: readonly string[] }).creative_ids,
+            (result as { creatives?: readonly unknown[] })?.creatives,
+            logger
+          );
+          return result;
+        },
         r => r
       );
     },
@@ -3553,7 +3582,17 @@ function buildCreativeHandlers<P extends DecisioningPlatform<any, any>>(
       }
       const reqCtx = ctxFor(ctx);
       return projectSync(
-        () => (creative as CreativeAdServerPlatform).getCreativeDelivery(params, reqCtx),
+        async () => {
+          const result = await (creative as CreativeAdServerPlatform).getCreativeDelivery(params, reqCtx);
+          warnIfTruncatedMultiIdResponse(
+            'getCreativeDelivery',
+            'creative_ids',
+            (params as { creative_ids?: readonly string[] }).creative_ids,
+            (result as { creative_deliveries?: readonly unknown[] })?.creative_deliveries,
+            logger
+          );
+          return result;
+        },
         r => r
       );
     },
@@ -3633,6 +3672,16 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
       return projectSync(
         async () => {
           const result = await signals.getSignals(params, reqCtx);
+          // signal_ids is `SignalID[]` (`{source, data_provider_domain, id}`
+          // objects), not bare strings — but the helper's truncation-detection
+          // is purely length-based, so the object element type is irrelevant.
+          warnIfTruncatedMultiIdResponse(
+            'getSignals',
+            'signal_ids',
+            (params as { signal_ids?: readonly unknown[] }).signal_ids,
+            (result as { signals?: readonly unknown[] })?.signals,
+            logger
+          );
           // Auto-store signals so subsequent activate_signal can hydrate
           // `req.signal` from the publisher's prior catalog entry.
           await autoStoreResources(

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -52,7 +52,7 @@ export const VERSION_INFO = {
   library: '6.7.0',
   adcp: '3.0.5',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-03T13:15:51.722Z',
+  generatedAt: '2026-05-03T12:59:24.218Z',
 } as const;
 
 /**

--- a/test/server-decisioning-multi-id-truncation-warn.test.js
+++ b/test/server-decisioning-multi-id-truncation-warn.test.js
@@ -1,6 +1,8 @@
-// Tests for #1399 — dev-mode warning when getMediaBuyDelivery / getMediaBuys
-// returns fewer rows than the buyer requested. Catches the canonical
-// `media_buy_ids[0]`-truncation bug class at adapter-development time.
+// Tests for #1399 (getMediaBuyDelivery / getMediaBuys) and #1410 (extension
+// to listCreatives / getCreativeDelivery / getSignals) — dev-mode warning
+// when a multi-id read tool returns fewer rows than the buyer requested.
+// Catches the canonical `<id_field>[0]`-truncation bug class at
+// adapter-development time.
 
 process.env.NODE_ENV = 'test';
 
@@ -50,7 +52,9 @@ function captureWarnings() {
     debug: () => {},
   };
   const truncationCalls = () =>
-    allCalls.filter(c => c.msg.includes('platform returned') && c.msg.includes('media_buy_ids'));
+    allCalls.filter(
+      c => c.msg.includes('platform returned') && /requested (media_buy_ids|creative_ids|signal_ids)/.test(c.msg)
+    );
   return { logger, truncationCalls, allCalls };
 }
 
@@ -237,6 +241,63 @@ describe('#1399 — dev-mode multi-id truncation warning', () => {
         },
       });
       assert.strictEqual(cap.truncationCalls().length, 0, 'env-suppression must silence the warn');
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #1410 — extend the warn to listCreatives / getCreativeDelivery / getSignals.
+  // The helper is already tested across getMediaBuyDelivery / getMediaBuys
+  // above; one test per new surface is enough to lock the wiring at each
+  // dispatch site. getSignals is distinctive because `signal_ids` is
+  // `SignalID[]` (objects), not bare strings — the helper must compare on
+  // length only.
+  // ---------------------------------------------------------------------
+
+  describe('getSignals (signal_ids — SignalID[] objects)', () => {
+    it('warns when adapter truncates a 3-signal request to 1 signal', async () => {
+      const cap = captureWarnings();
+      const platform = buildPlatform();
+      platform.signals = {
+        getSignals: async req => ({
+          // BUG: only returns the first signal_id's row, regardless of the
+          // 3 SignalID objects the buyer asked for.
+          signals: [
+            {
+              signal_agent_segment_id: 'seg_1',
+              signal_id: req.signal_ids[0],
+              name: 'Demo',
+              description: '...',
+              value_type: 'binary',
+              signal_type: 'owned',
+              data_provider: 'Acme',
+              coverage_percentage: 10,
+              deployments: [],
+              pricing_options: [{ pricing_option_id: 'po_1', model: 'cpm', currency: 'USD', cpm: 1 }],
+            },
+          ],
+        }),
+        activateSignal: async () => ({}),
+      };
+      // Signals-only platforms claim signal-* specialisms; swap the capability claim.
+      platform.capabilities.specialisms = ['signal-marketplace'];
+      const server = createAdcpServerFromPlatform(platform, { ...SERVER_OPTS_BASE, logger: cap.logger });
+      await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'get_signals',
+          arguments: {
+            account: { account_id: 'acc_1' },
+            signal_ids: [
+              { source: 'catalog', data_provider_domain: 'acme.example', id: 'a' },
+              { source: 'catalog', data_provider_domain: 'acme.example', id: 'b' },
+              { source: 'catalog', data_provider_domain: 'acme.example', id: 'c' },
+            ],
+          },
+        },
+      });
+      const warns = cap.truncationCalls();
+      assert.strictEqual(warns.length, 1, `expected exactly one warn, got ${warns.length}`);
+      assert.match(warns[0].msg, /getSignals: platform returned 1 row for 3 requested signal_ids/);
     });
   });
 });


### PR DESCRIPTION
Closes #1410.

## Summary

Extends the existing dev-mode `logger.warn` (which shipped in 6.7 for `getMediaBuyDelivery` / `getMediaBuys` per #1399) to the remaining read-by-id surfaces in the AdCP spec. Catches the `<id_field>[0]`-truncation bug class at adapter-development time on every multi-id read tool, not just the two that shipped in 6.7.

## What changed

`warnIfTruncatedMultiIdResponse` gains a typed `idFieldName` parameter so the warn message names the right id field (`media_buy_ids` / `creative_ids` / `signal_ids`). Wired at four new dispatch sites in `src/lib/server/decisioning/runtime/from-platform.ts`:

- `listCreatives` — both the sales-side dispatch (when `SalesPlatform` provides it) and the creative-side ad-server dispatch.
- `getCreativeDelivery` — creative-side ad-server only.
- `getSignals` — note `signal_ids` is `SignalID[]` (`{source, data_provider_domain, id}` objects), not bare strings. The helper compares on length only so the element type is irrelevant.

The two existing call sites (`getMediaBuyDelivery`, `getMediaBuys`) get the new arg as `'media_buy_ids'` — purely additive at the type level.

## What didn't change

Sync / upsert surfaces (`syncCreatives`, `syncCatalogs`, `syncPlans`) remain out of scope per the #1410 carve-out — those have a different shape where pass-through is the obvious pattern and 'did all rows roundtrip?' isn't a clean question.

`listAuthorizedProperties` (mentioned in the issue title) is a v2.5 tool deprecated in v3 in favor of `get_adcp_capabilities`; not wired.

The same gates apply: silent in `NODE_ENV=production`, suppressible via `ADCP_SUPPRESS_MULTI_ID_WARN=1`, no-op when the id-array filter is omitted (paginated-list mode).

## Test plan

- [x] Existing 6 tests in `test/server-decisioning-multi-id-truncation-warn.test.js` still pass
- [x] One new test pins the `getSignals` wiring with a `SignalID[]` object-array request (the distinctive case)
- [x] `tsc --noEmit` clean
- [x] `npx prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)