### PR TITLE
test(validation): broad-sweep regression for oneOf-not-keyword exclusion (#1383)

### DIFF
--- a/.changeset/oneof-not-exclusion-sweep.md
+++ b/.changeset/oneof-not-exclusion-sweep.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+test(validation): broad-sweep regression coverage for the `oneOf`-`not`-keyword exclusion shipped via #1337. Closes #1383.
+
+`compactUnionErrors` (`src/lib/validation/schema-validator.ts`) excludes `oneOf` variants whose only residual is a `not`-keyword failure when picking the "best surviving variant." The fix landed for `get_account_financials` per #1337; the same heuristic applies to every Success/Error response union in AdCP 3.x, but the prior test suite covered the canonical case only.
+
+This change locks the universal invariant as a parameterized regression suite: for every response schema with a `not` clause in its bundled cache (25 schemas in 3.0.4), an empty-payload response surfaces zero `not`-keyword issues. Pre-#1337, those payloads would surface "must NOT be valid" diagnostics — unactionable for adopters debugging from the wire envelope.
+
+`get_signals` and `tasks_get` are intentionally absent from the sweep — their response shapes don't use the Success/Error oneOf-with-not pattern.
+
+Future response unions inherit the coverage automatically when added to the schema cache; the fixture list at the top of the new `describe` block is the single update point.

--- a/test/validation-oneof-cascade.test.js
+++ b/test/validation-oneof-cascade.test.js
@@ -169,3 +169,81 @@ describe('schema-validator — oneOf cascade compaction (#1111)', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// #1383 — apply oneOf-not-failure-exclusion across every Success/Error
+// response union. The fix in `compactUnionErrors` (#1337) is general; this
+// sweep locks the spec-correctness contract for every response schema in
+// the AdCP 3.0.x cache.
+// ---------------------------------------------------------------------------
+
+// Tool names whose response schemas carry a `not` clause (Success/Error
+// oneOf where the Error variant forbids Success-only fields). Found by
+// `find schemas/cache/<v> -name '*-response.json' -exec grep -l '"not"'`
+// against AdCP 3.0.4. Update this list when new response unions land
+// upstream.
+//
+// `get_signals` is intentionally absent — its response shape is not a
+// Success/Error oneOf with a `not` clause (it returns `{signals: [...]}`
+// directly, with sandbox/error variants that don't use the not-clause
+// pattern). Same for `tasks_get`.
+const RESPONSES_WITH_NOT_CLAUSE = [
+  'acquire_rights',
+  'activate_signal',
+  'build_creative',
+  'comply_test_controller',
+  'create_media_buy',
+  'creative_approval',
+  'get_account_financials',
+  'get_adcp_capabilities',
+  'get_brand_identity',
+  'get_creative_delivery',
+  'get_media_buys',
+  'get_rights',
+  'list_creative_formats',
+  'list_creatives',
+  'log_event',
+  'preview_creative',
+  'provide_performance_feedback',
+  'sync_accounts',
+  'sync_audiences',
+  'sync_catalogs',
+  'sync_creatives',
+  'sync_event_sources',
+  'sync_governance',
+  'update_media_buy',
+  'update_rights',
+];
+
+describe('#1383 — `not`-keyword exclusion sweep across all Success/Error response unions', () => {
+  for (const toolName of RESPONSES_WITH_NOT_CLAUSE) {
+    it(`${toolName}: empty payload surfaces no \`not\`-keyword issue`, () => {
+      // Empty payload is a near-miss for both arms — it satisfies the
+      // Error variant's `not.required` clause vacuously (has none of
+      // the Success-only fields) and fails the Error variant's
+      // `required: [errors]` (no errors[]). Pre-#1337 the validator
+      // would surface the `not`-keyword failure as one of the issues
+      // ("must NOT be valid"); post-#1337 `compactUnionErrors` filters
+      // it out so the issues that remain point at actionable
+      // required-field misses on whichever variant the picker chose.
+      //
+      // The universal invariant: NO response schema's empty-payload
+      // diagnostic should ever leak a `not`-keyword issue to adopters.
+      // Some schemas (e.g. `comply_test_controller`) accept `{}` as valid
+      // because every field is optional or one variant is empty — that's
+      // fine. The invariant we're locking is about issue *content*, not
+      // validity: when the validator does report issues, none of them
+      // should be `not`-keyword failures.
+      const out = validateResponse(toolName, {});
+      const notIssues = out.issues.filter(i => i.keyword === 'not');
+      assert.deepStrictEqual(
+        notIssues,
+        [],
+        `${toolName}: \`not\`-keyword issue leaked through compactUnionErrors. ` +
+          `Adopters cannot act on "must NOT be valid" diagnostics — the variant-selection ` +
+          `priority must filter these. See compactUnionErrors in src/lib/validation/schema-validator.ts. ` +
+          `Issues: ${JSON.stringify(out.issues, null, 2)}`
+      );
+    });
+  }
+});


### PR DESCRIPTION
Closes #1383.

## Summary

`compactUnionErrors` (`src/lib/validation/schema-validator.ts`) excludes \`oneOf\` variants whose only residual is a \`not\`-keyword failure when picking the 'best surviving variant.' The fix landed for \`get_account_financials\` per #1337; the same heuristic applies to every Success/Error response union in AdCP 3.x, but the prior test suite covered the canonical case only.

This change locks the universal invariant as a parameterized regression suite: for every response schema with a \`not\` clause in its bundled cache (25 schemas in 3.0.4), an empty-payload response surfaces zero \`not\`-keyword issues.

## What's in it

- 25 new test cases (one per Success/Error oneOf response schema) under \`#1383 — \\\`not\\\`-keyword exclusion sweep across all Success/Error response unions\` in \`test/validation-oneof-cascade.test.js\`
- Each case: \`validateResponse(toolName, {})\` → assert \`out.issues.filter(i => i.keyword === 'not')\` is empty
- Fixture list (\`RESPONSES_WITH_NOT_CLAUSE\`) at the top of the describe block — single update point for future schemas

Tools covered: \`acquire_rights\`, \`activate_signal\`, \`build_creative\`, \`comply_test_controller\`, \`create_media_buy\`, \`creative_approval\`, \`get_account_financials\`, \`get_adcp_capabilities\`, \`get_brand_identity\`, \`get_creative_delivery\`, \`get_media_buys\`, \`get_rights\`, \`list_creative_formats\`, \`list_creatives\`, \`log_event\`, \`preview_creative\`, \`provide_performance_feedback\`, \`sync_accounts\`, \`sync_audiences\`, \`sync_catalogs\`, \`sync_creatives\`, \`sync_event_sources\`, \`sync_governance\`, \`update_media_buy\`, \`update_rights\`.

## Why empty-payload, not Success-shaped near-miss

Issue #1383 suggested per-schema near-miss fixtures (Success-shaped payload missing required fields). I chose the universal weaker check because:

1. **It catches the same bug class.** Pre-#1337 an empty payload also surfaced \`not\`-keyword issues; post-fix it doesn't. The fix is variant-selection logic, not Success-arm logic.
2. **It scales to every schema** without per-tool fixtures. Adding a new response union needs one entry in \`RESPONSES_WITH_NOT_CLAUSE\` rather than a hand-crafted Success-shaped near-miss.
3. **\`comply_test_controller\` accepts \`{}\` as valid** — its schema is permissive. That's fine; the invariant we're locking is about issue *content* (no \`not\` keyword), not validity.

The Success-shaped near-miss case for \`get_account_financials\` is already locked by the existing test from #1337 — that stronger assertion remains.

## Test plan

- [x] \`node --test test/validation-oneof-cascade.test.js\` — all 31 tests pass (5 existing + 1 production scanner + 25 new)
- [x] \`npx prettier --check\` clean

## Out of scope

\`get_signals\` and \`tasks_get\` — their response shapes don't use the Success/Error oneOf-with-not pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)