### PR TITLE
feat(server): framework-side sandbox gate auto-wired into comply controller (#1435 phase 2)

### DIFF
--- a/.changeset/comply-controller-sandbox-gate.md
+++ b/.changeset/comply-controller-sandbox-gate.md
@@ -1,0 +1,24 @@
+---
+"@adcp/sdk": minor
+---
+
+Auto-wire the framework-side sandbox-authority gate inside `createAdcpServerFromPlatform`. Phase 2 of #1435.
+
+The framework now bypasses `controller.register(server)` for `comply_test_controller` and registers the tool itself, threading `extra.authInfo` through `platform.accounts.resolve` BEFORE dispatching. Under no circumstances does the controller operate on a `live`-mode account, regardless of what the caller claims on the wire — the resolved account is the trust boundary, not buyer-supplied flags like `account.sandbox === true`.
+
+What the gate does, in order:
+
+1. **`list_scenarios` is exempt** — capability probe, no state mutation.
+2. **Resolve the account** through `platform.accounts.resolve(ref, { authInfo, toolName })`. Reads the ref from top-level `account` (extended shape) or `context.account` (canonical AdCP routing).
+3. **Admit when** the resolved account's `mode` is `'sandbox'` or `'mock'` (legacy `sandbox: true` honored).
+4. **Admit when** no account resolves AND `context.sandbox === true` (migration window).
+5. **Admit when** `process.env.ADCP_SANDBOX === '1'` (deprecated env-fallback for back-compat).
+6. **Otherwise refuse** with a `FORBIDDEN` controller envelope.
+
+**Fail-closed guard on the env fallback.** `ADCP_SANDBOX=1` was never meant to coexist with a resolver that names live accounts. The framework tracks every explicit `mode` value returned from `platform.accounts.resolve` in this process; if `ADCP_SANDBOX=1` is set AND any live-mode account has been resolved, the gate THROWS loudly so operators notice in their logs. Remove `ADCP_SANDBOX` from your prod env and gate via `mode: 'sandbox'` on resolved accounts instead.
+
+**Back-compat.** Existing test platforms relying on `process.env.ADCP_SANDBOX === '1'` continue to work without modification — the env-fallback admits when the resolver doesn't stamp an explicit mode. Implicit-default-to-live (legacy adopter shape) does NOT trip the fail-closed guard; only deliberate `mode: 'live'` from the resolver does.
+
+**Migration path.** Stop setting `ADCP_SANDBOX` in production. Stamp `mode: 'sandbox'` (or `'live'`) on accounts your `accounts.resolve` returns; the gate then enforces strictly without the env fallback. The fallback emits no warning yet — a future minor will warn on each gate-permission grant; a future major will remove it entirely.
+
+Non-MCP transports (rare) keep the v5 behavior: when `getSdkServer(server)` returns null, the controller's own `register(server)` runs and the gate is a no-op for that surface. The gate is an MCP-side concern; A2A and other transports are wired separately.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1403,12 +1403,21 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       // Permit a top-level `account` field on the wire so the gate can read
       // the buyer's account ref. The canonical AdCP shape strips it (account
       // routes through `context.account`), but adopters' storyboard fixtures
-      // commonly send it at the top level — accept either.
+      // commonly send it at the top level — `TOOL_INPUT_SHAPE`'s JSDoc in
+      // `src/lib/server/test-controller.ts` documents this extension as the
+      // supported escape hatch. `.strict()` so unknown keys fail validation
+      // rather than `passthrough`-ing into adopter resolvers (a buyer could
+      // otherwise stuff arbitrary payloads into the account ref). `sandbox`
+      // is the spec-defined fallback signal on `AccountReference` per
+      // `schemas/cache/3.0.5/core/account-ref.json`.
       const gatedInputSchema = {
         ...controller.toolDefinition.inputSchema,
         account: z
-          .object({ account_id: z.string().min(1).optional() })
-          .passthrough()
+          .object({
+            account_id: z.string().min(1).optional(),
+            sandbox: z.boolean().optional(),
+          })
+          .strict()
           .optional(),
       };
 
@@ -1437,7 +1446,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
               toolName: 'comply_test_controller',
             });
           } catch {
-            // Resolver failures fall through to the context / env fallbacks.
+            // Resolver failures fall through to the wire-ref / env fallbacks.
             // Treat as "no account resolved" — fail-closed by default unless a
             // fallback admits.
           }
@@ -1447,16 +1456,23 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           recordResolvedAccountMode(resolvedAccount);
 
           const accountIsSandbox = resolvedAccount != null && isSandboxOrMockAccount(resolvedAccount);
-          const contextSandbox = (input.context as { sandbox?: unknown } | undefined)?.sandbox === true;
+          // Spec-defined fallback for the unresolved-account path: read
+          // `sandbox: true` off the wire `AccountReference` (per
+          // `core/account-ref.json`). Only consulted when the resolver
+          // returned `null` — if the resolver names the account, the
+          // resolver wins. The buyer's wire claim never overrides a
+          // resolved live account.
+          const refSandbox = (accountRef as { sandbox?: unknown } | undefined)?.sandbox === true;
           const envSandbox = process.env.ADCP_SANDBOX === '1';
 
-          // Fail-closed guard on the env fallback. If we'd admit purely on
-          // ADCP_SANDBOX=1 (no sandbox/mock account, no context.sandbox), AND
-          // this process has resolved an explicit `mode: 'live'` account from
-          // the resolver at any point, the env var is misconfigured. Refuse
-          // loudly so operators notice, instead of silently downgrading the
-          // gate for live principals.
-          if (envSandbox && !accountIsSandbox && !contextSandbox && hasObservedLiveMode()) {
+          const wouldAdmitOnlyViaEnv = envSandbox && !accountIsSandbox && !(resolvedAccount == null && refSandbox);
+
+          // Fail-closed guard on the env fallback. If the env var is the only
+          // signal that would admit AND this process has ever resolved an
+          // explicit `mode: 'live'` account from the resolver, the env is
+          // misconfigured. Refuse loudly so operators notice, instead of
+          // silently downgrading the gate for live principals.
+          if (wouldAdmitOnlyViaEnv && hasObservedLiveMode()) {
             throw new Error(
               'comply_test_controller: ADCP_SANDBOX=1 is set but this process has resolved at least one ' +
                 'live-mode account from platform.accounts.resolve. Remove ADCP_SANDBOX from your prod ' +
@@ -1465,7 +1481,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
             );
           }
 
-          const allowed = accountIsSandbox || (resolvedAccount == null && contextSandbox) || envSandbox;
+          const allowed = accountIsSandbox || (resolvedAccount == null && refSandbox) || envSandbox;
 
           if (!allowed) {
             return toMcpResponse({

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1405,16 +1405,26 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       // routes through `context.account`), but adopters' storyboard fixtures
       // commonly send it at the top level — `TOOL_INPUT_SHAPE`'s JSDoc in
       // `src/lib/server/test-controller.ts` documents this extension as the
-      // supported escape hatch. `.strict()` so unknown keys fail validation
-      // rather than `passthrough`-ing into adopter resolvers (a buyer could
-      // otherwise stuff arbitrary payloads into the account ref). `sandbox`
-      // is the spec-defined fallback signal on `AccountReference` per
-      // `schemas/cache/3.0.5/core/account-ref.json`.
+      // supported escape hatch.
+      //
+      // Schema is the full canonical `AccountReference` per
+      // `schemas/cache/3.0.5/core/account-ref.json`: oneOf
+      //   { account_id }                       — explicit accounts
+      //   { brand, operator, sandbox? }        — implicit accounts
+      // Modeled here as a single object with all four fields optional so
+      // either arm passes; resolvers narrow on the shape at dispatch.
+      // `brand` content is `unknown()` because the inner `brand-ref.json`
+      // shape is itself a oneOf and resolvers (not the gate) validate it.
+      // Top-level `.strict()` still blocks unknown keys at the framework
+      // boundary so a buyer can't stuff `__proto__` / arbitrary payloads
+      // into adopters' resolvers.
       const gatedInputSchema = {
         ...controller.toolDefinition.inputSchema,
         account: z
           .object({
             account_id: z.string().min(1).optional(),
+            brand: z.unknown().optional(),
+            operator: z.string().optional(),
             sandbox: z.boolean().optional(),
           })
           .strict()

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -136,6 +136,10 @@ import { createInMemoryStatusChangeBus, type StatusChangeBus, type PublishStatus
 import { createComplyController, type ComplyControllerConfig } from '../../../testing/comply-controller';
 import type { TestControllerBridge } from '../../test-controller-bridge';
 import { mergeSeedProduct } from '../../../testing/seed-merge';
+import { getSdkServer } from '../../adcp-server';
+import { isSandboxOrMockAccount } from '../../account-mode';
+import { toMcpResponse } from '../../test-controller';
+import { recordResolvedAccountMode, hasObservedLiveMode } from './observed-modes';
 import type { Product } from '../../../types/tools.generated';
 import { normalizeErrors } from '../../normalize-errors';
 
@@ -1272,10 +1276,13 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
   // Wire `comply_test_controller` if the adopter supplied adapters.
   // `createComplyController` builds the tool definition + handler + raw
-  // dispatch; `register(server)` calls server.registerTool. Sandbox
-  // gating is the adopter's job (per-request via complyTest.sandboxGate
-  // or environment-level by guarding the createAdcpServerFromPlatform
-  // call site itself).
+  // dispatch. The framework registers the tool itself (bypassing
+  // `controller.register(server)`) so the sandbox-authority gate can
+  // resolve the calling account through `platform.accounts.resolve`
+  // BEFORE dispatching — under no circumstances should the controller
+  // operate on a `live`-mode account, regardless of what the caller
+  // claims on the wire. See `docs/proposals/lifecycle-state-and-sandbox-authority.md`
+  // for the full three-mode design and #1435 phase 2.
   if (opts.complyTest != null) {
     let complyConfig = opts.complyTest;
 
@@ -1359,7 +1366,121 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
     }
 
     const controller = createComplyController(complyConfig);
-    controller.register(server);
+
+    // Manual registration with framework-side sandbox-authority gate. See
+    // top-of-block rationale and `docs/proposals/lifecycle-state-and-sandbox-authority.md`.
+    //
+    // Trust boundary: the gate consults the *resolved* account from
+    // `platform.accounts.resolve`, NOT a buyer-supplied claim like
+    // `account.sandbox === true` on the wire. The resolver is the only
+    // thing that names the account's mode; the gate refuses dispatch when
+    // mode is `live` (or the resolver fails to produce an account, modulo
+    // the env / context fallbacks below).
+    //
+    // Fallback paths (deprecated):
+    //   - `context.sandbox === true` admits when no account resolved. Useful
+    //     during the migration window for adopters whose wire shape carries
+    //     sandbox routing in `context` but whose resolver isn't yet returning
+    //     `mode: 'sandbox'`.
+    //   - `process.env.ADCP_SANDBOX === '1'` admits unconditionally — the
+    //     historical pattern. KEPT for back-compat so existing test platforms
+    //     don't break on upgrade. Fails closed if the same process has ever
+    //     resolved an explicit `mode: 'live'` account from the resolver: that
+    //     pairing is a misconfiguration (env var should be unset on prod) and
+    //     leaving it open re-exposes the live principal we just gated against.
+    //
+    // `list_scenarios` is exempt — it's the discovery probe used by buyer
+    // tooling to distinguish "controller wired but locked" from "controller
+    // missing entirely". Read-only and reveals nothing beyond which scenarios
+    // the adopter advertised in capabilities.
+    const mcp = getSdkServer(server);
+    if (mcp == null) {
+      // Non-MCP server — fall back to the controller's own registration so
+      // adopters wiring a custom transport keep the v5 behavior. The gate is
+      // an MCP-side concern; A2A and other transports are wired separately.
+      controller.register(server);
+    } else {
+      // Permit a top-level `account` field on the wire so the gate can read
+      // the buyer's account ref. The canonical AdCP shape strips it (account
+      // routes through `context.account`), but adopters' storyboard fixtures
+      // commonly send it at the top level — accept either.
+      const gatedInputSchema = {
+        ...controller.toolDefinition.inputSchema,
+        account: z
+          .object({ account_id: z.string().min(1).optional() })
+          .passthrough()
+          .optional(),
+      };
+
+      mcp.registerTool(
+        controller.toolDefinition.name,
+        {
+          description: controller.toolDefinition.description,
+          inputSchema: gatedInputSchema,
+        },
+        (async (input: Record<string, unknown>, extra: { authInfo?: ResolvedAuthInfo } | undefined) => {
+          // Probe exempt — capability discovery, no state mutation.
+          if (input.scenario === 'list_scenarios') {
+            return controller.handle(input);
+          }
+
+          // Read account ref from top-level (extended shape) or from
+          // `context.account` (canonical AdCP routing). First non-null wins.
+          const refFromTop = input.account as AccountReference | undefined;
+          const refFromContext = (input.context as { account?: AccountReference } | undefined)?.account;
+          const accountRef = refFromTop ?? refFromContext;
+
+          let resolvedAccount: Account | null = null;
+          try {
+            resolvedAccount = await platform.accounts.resolve(accountRef, {
+              ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+              toolName: 'comply_test_controller',
+            });
+          } catch {
+            // Resolver failures fall through to the context / env fallbacks.
+            // Treat as "no account resolved" — fail-closed by default unless a
+            // fallback admits.
+          }
+
+          // Record the resolved account's explicit mode (if any). Used by the
+          // env-fallback fail-closed guard below.
+          recordResolvedAccountMode(resolvedAccount);
+
+          const accountIsSandbox = resolvedAccount != null && isSandboxOrMockAccount(resolvedAccount);
+          const contextSandbox = (input.context as { sandbox?: unknown } | undefined)?.sandbox === true;
+          const envSandbox = process.env.ADCP_SANDBOX === '1';
+
+          // Fail-closed guard on the env fallback. If we'd admit purely on
+          // ADCP_SANDBOX=1 (no sandbox/mock account, no context.sandbox), AND
+          // this process has resolved an explicit `mode: 'live'` account from
+          // the resolver at any point, the env var is misconfigured. Refuse
+          // loudly so operators notice, instead of silently downgrading the
+          // gate for live principals.
+          if (envSandbox && !accountIsSandbox && !contextSandbox && hasObservedLiveMode()) {
+            throw new Error(
+              'comply_test_controller: ADCP_SANDBOX=1 is set but this process has resolved at least one ' +
+                'live-mode account from platform.accounts.resolve. Remove ADCP_SANDBOX from your prod ' +
+                'environment; gate the controller via mode: "sandbox" on resolved sandbox accounts instead. ' +
+                'See docs/proposals/lifecycle-state-and-sandbox-authority.md.'
+            );
+          }
+
+          const allowed = accountIsSandbox || (resolvedAccount == null && contextSandbox) || envSandbox;
+
+          if (!allowed) {
+            return toMcpResponse({
+              success: false,
+              error: 'FORBIDDEN',
+              error_detail:
+                'comply_test_controller requires a sandbox or mock account; ' +
+                'resolved account is in live mode (or no account resolved).',
+            });
+          }
+
+          return controller.handle(input);
+        }) as Parameters<typeof mcp.registerTool>[2]
+      );
+    }
   }
 
   return Object.assign(server, {

--- a/src/lib/server/decisioning/runtime/observed-modes.ts
+++ b/src/lib/server/decisioning/runtime/observed-modes.ts
@@ -1,0 +1,66 @@
+/**
+ * Process-scoped tracker of explicit `Account.mode` values returned from
+ * `platform.accounts.resolve` during framework-side comply-controller
+ * dispatch. Used by the sandbox gate's deprecated env-fallback path
+ * (`ADCP_SANDBOX === '1'`) to fail closed when a process has resolved
+ * any live-mode account.
+ *
+ * Rationale: the env-fallback exists for back-compat with adopters that
+ * have not yet adopted the per-account `mode` field. If those adopters
+ * have ALSO begun returning explicit `mode: 'live'` from their resolver,
+ * the env var is a misconfiguration — leaving it set would re-open the
+ * gate for live principals after the resolver was meant to close it.
+ *
+ * Implicit-default `live` (resolver returns no mode field) is NOT
+ * observed here — those adopters are exactly who the env-fallback bridge
+ * exists for. Only the own-property `mode === 'live'` shape, set
+ * deliberately by the resolver, trips the guard.
+ *
+ * @internal
+ */
+
+const observed = new Set<string>();
+
+/**
+ * Record an account returned from `platform.accounts.resolve`. Reads
+ * via `Object.hasOwn` so the same prototype-pollution defense as
+ * `getAccountMode` applies — an attacker who reaches a `__proto__`-via-
+ * merge sink can't stamp `Object.prototype.mode = 'sandbox'` to evade
+ * the live observation.
+ *
+ * No-op when `account` is null / not an object / lacks an own `mode`
+ * property / `mode` is not a known string. The set only collects
+ * explicit, deliberate mode values.
+ */
+export function recordResolvedAccountMode(account: unknown): void {
+  if (account == null || typeof account !== 'object') return;
+  if (!Object.hasOwn(account, 'mode')) return;
+  const mode = (account as { mode?: unknown }).mode;
+  if (mode === 'live' || mode === 'sandbox' || mode === 'mock') {
+    observed.add(mode);
+  }
+}
+
+/**
+ * `true` when this process has observed at least one explicit
+ * `mode: 'live'` account from `platform.accounts.resolve`. The
+ * sandbox-gate env-fallback consults this to decide whether
+ * `ADCP_SANDBOX=1` is a safe legacy bridge or a misconfiguration.
+ */
+export function hasObservedLiveMode(): boolean {
+  return observed.has('live');
+}
+
+/**
+ * Test seam — reset the observed-modes set between describe blocks
+ * so a test that intentionally resolves a live account doesn't leak
+ * the observation into subsequent tests in the same process.
+ *
+ * Not part of the public API. Adopter code MUST NOT call this — the
+ * production semantics are explicitly process-scoped.
+ *
+ * @internal
+ */
+export function __resetObservedAccountModes(): void {
+  observed.clear();
+}

--- a/src/lib/server/decisioning/runtime/observed-modes.ts
+++ b/src/lib/server/decisioning/runtime/observed-modes.ts
@@ -56,11 +56,25 @@ export function hasObservedLiveMode(): boolean {
  * so a test that intentionally resolves a live account doesn't leak
  * the observation into subsequent tests in the same process.
  *
- * Not part of the public API. Adopter code MUST NOT call this — the
- * production semantics are explicitly process-scoped.
+ * Refuses to clear when `NODE_ENV` is anything other than `test` or
+ * `development`. The observed-modes set is intentionally process-scoped
+ * — clearing it in production would re-arm the env-fallback admit path
+ * for live principals already seen, defeating the whole point of the
+ * fail-closed guard. The allowlist (rather than `!= 'production'`)
+ * matches the project's broader `feedback_node_env_allowlist.md` policy.
+ *
+ * Not part of the public API. Adopter code MUST NOT call this.
  *
  * @internal
  */
 export function __resetObservedAccountModes(): void {
+  const env = process.env.NODE_ENV;
+  if (env !== 'test' && env !== 'development') {
+    throw new Error(
+      `__resetObservedAccountModes is a test seam; refusing to clear observed account modes ` +
+        `in NODE_ENV=${env ?? '<unset>'}. The set is process-scoped to keep the comply ` +
+        `controller's env-fallback fail-closed guard armed once a live account has been seen.`
+    );
+  }
   observed.clear();
 }

--- a/test/server-decisioning-comply-gate.test.js
+++ b/test/server-decisioning-comply-gate.test.js
@@ -173,22 +173,25 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
   });
 });
 
-describe('createAdcpServerFromPlatform — sandbox-authority gate (context.sandbox path)', () => {
+describe('createAdcpServerFromPlatform — sandbox-authority gate (accountRef.sandbox path)', () => {
+  // Spec-defined fallback at the AdCP wire layer: AccountReference.sandbox
+  // (per schemas/cache/3.0.5/core/account-ref.json). Only honored when the
+  // resolver returns `null` — never overrides a resolved live account.
   beforeEach(() => {
     delete process.env.ADCP_SANDBOX;
     __resetObservedAccountModes();
   });
 
-  it('admits when no account resolves and context.sandbox === true', async () => {
+  it('admits when no account resolves and accountRef.sandbox === true', async () => {
     const server = buildServer(async () => null);
 
-    const result = await callForceCreative(server, { context: { sandbox: true } });
+    const result = await callForceCreative(server, { account: { sandbox: true } });
 
     assert.notStrictEqual(result.isError, true);
     assert.strictEqual(result.structuredContent.success, true);
   });
 
-  it('denies when no account resolves and context.sandbox is absent', async () => {
+  it('denies when no account resolves and accountRef.sandbox is absent', async () => {
     const server = buildServer(async () => null);
 
     const result = await callForceCreative(server);
@@ -197,9 +200,10 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (context.sandb
     assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
   });
 
-  it('does NOT admit on context.sandbox when an account resolved as live', async () => {
-    // context.sandbox is a fallback for the *unresolved* path. Once the
-    // resolver names the account, the resolver wins.
+  it('does NOT admit on accountRef.sandbox when the resolver names a live account', async () => {
+    // The wire flag is a fallback for the *unresolved* path. Once the
+    // resolver names the account, the resolver wins and the buyer's wire
+    // claim is ignored.
     const server = buildServer(async ref => ({
       id: ref?.account_id ?? 'live_acc',
       mode: 'live',
@@ -208,8 +212,7 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (context.sandb
     }));
 
     const result = await callForceCreative(server, {
-      account: { account_id: 'live_acc' },
-      context: { sandbox: true },
+      account: { account_id: 'live_acc', sandbox: true },
     });
 
     assert.strictEqual(result.isError, true);
@@ -257,6 +260,28 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (env fallback)
 
     await assert.rejects(
       () => callForceCreative(server, { account: { account_id: 'live_1' } }),
+      err => /ADCP_SANDBOX=1 is set but this process has resolved at least one live-mode account/.test(err.message)
+    );
+  });
+
+  it('FAILS CLOSED even when the buyer also sets accountRef.sandbox=true alongside ADCP_SANDBOX=1 (no bypass)', async () => {
+    // Regression for the code-reviewer-flagged bypass: with env=1, resolver
+    // returning mode='live', and the buyer adding `account.sandbox: true` on
+    // the wire, an earlier guard predicate that checked `!contextSandbox` (or
+    // any wire-claim suppression) would have admitted the live account via
+    // the env-only signal. The fixed predicate (`wouldAdmitOnlyViaEnv`)
+    // ignores the wire claim because the resolver's live answer pins
+    // `resolvedAccount != null`, so the unresolved-path admit is impossible.
+    process.env.ADCP_SANDBOX = '1';
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'live_1',
+      mode: 'live',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    await assert.rejects(
+      () => callForceCreative(server, { account: { account_id: 'live_1', sandbox: true } }),
       err => /ADCP_SANDBOX=1 is set but this process has resolved at least one live-mode account/.test(err.message)
     );
   });

--- a/test/server-decisioning-comply-gate.test.js
+++ b/test/server-decisioning-comply-gate.test.js
@@ -1,0 +1,305 @@
+// Framework-side sandbox-authority gate for `comply_test_controller`.
+// Phase 2 of #1435 — auto-wires the gate inside `createAdcpServerFromPlatform`
+// so the controller refuses live-mode accounts regardless of what the caller
+// claims on the wire. See docs/proposals/lifecycle-state-and-sandbox-authority.md.
+//
+// 5 admit/deny combinations × 3 modes = 15 assertions covering:
+//   - resolver returns mode 'live' / 'sandbox' / 'mock'
+//   - context.sandbox === true when no account resolves
+//   - process.env.ADCP_SANDBOX === '1' fallback (and its fail-closed guard)
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it, beforeEach, after } = require('node:test');
+const assert = require('node:assert');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+const { __resetObservedAccountModes } = require('../dist/lib/server/decisioning/runtime/observed-modes');
+
+function makePlatform(resolveAccount) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [{ agent_url: 'https://example.com/creative-agent/mcp' }],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+      compliance_testing: {},
+    },
+    statusMappers: {},
+    accounts: {
+      resolve: resolveAccount,
+    },
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      createMediaBuy: async () => ({
+        media_buy_id: 'mb_1',
+        status: 'pending_creatives',
+        confirmed_at: '2026-04-28T00:00:00Z',
+        packages: [],
+      }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1', status: 'active' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({
+        currency: 'USD',
+        reporting_period: { start: '2026-04-01', end: '2026-04-30' },
+        media_buy_deliveries: [],
+      }),
+    },
+  };
+}
+
+function buildServer(resolveAccount) {
+  return createAdcpServerFromPlatform(makePlatform(resolveAccount), {
+    name: 'gate-host',
+    version: '0.0.1',
+    validation: { requests: 'off', responses: 'off' },
+    complyTest: {
+      force: {
+        creative_status: async params => ({
+          success: true,
+          transition: 'forced',
+          resource_type: 'creative',
+          resource_id: params.creative_id,
+          previous_state: 'pending_review',
+          current_state: params.status,
+        }),
+      },
+    },
+  });
+}
+
+async function callForceCreative(server, args = {}) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'comply_test_controller',
+      arguments: {
+        scenario: 'force_creative_status',
+        params: { creative_id: 'cr_1', status: 'approved' },
+        ...args,
+      },
+    },
+  });
+}
+
+async function callListScenarios(server) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'comply_test_controller',
+      arguments: { scenario: 'list_scenarios' },
+    },
+  });
+}
+
+describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path)', () => {
+  beforeEach(() => {
+    delete process.env.ADCP_SANDBOX;
+    __resetObservedAccountModes();
+  });
+
+  it("denies when resolver returns mode: 'live'", async () => {
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'live_acc',
+      mode: 'live',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, { account: { account_id: 'live_acc' } });
+
+    assert.strictEqual(result.isError, true, 'live-mode account must be denied');
+    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+  });
+
+  it("admits when resolver returns mode: 'sandbox'", async () => {
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'sb_acc',
+      mode: 'sandbox',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, { account: { account_id: 'sb_acc' } });
+
+    assert.notStrictEqual(result.isError, true, 'sandbox-mode account must be admitted');
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it("admits when resolver returns mode: 'mock'", async () => {
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'mock_acc',
+      mode: 'mock',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, { account: { account_id: 'mock_acc' } });
+
+    assert.notStrictEqual(result.isError, true, 'mock-mode account must be admitted');
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it('admits via legacy sandbox: true back-compat shape', async () => {
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'legacy_sb',
+      sandbox: true,
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, { account: { account_id: 'legacy_sb' } });
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it('ignores caller-supplied account.sandbox claim when resolver says live', async () => {
+    // Trust boundary: resolver is authoritative, NOT the wire. Buyer cannot
+    // self-promote by stuffing sandbox: true into the account ref.
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'spoof',
+      mode: 'live',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, {
+      account: { account_id: 'spoof', sandbox: true },
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+  });
+});
+
+describe('createAdcpServerFromPlatform — sandbox-authority gate (context.sandbox path)', () => {
+  beforeEach(() => {
+    delete process.env.ADCP_SANDBOX;
+    __resetObservedAccountModes();
+  });
+
+  it('admits when no account resolves and context.sandbox === true', async () => {
+    const server = buildServer(async () => null);
+
+    const result = await callForceCreative(server, { context: { sandbox: true } });
+
+    assert.notStrictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it('denies when no account resolves and context.sandbox is absent', async () => {
+    const server = buildServer(async () => null);
+
+    const result = await callForceCreative(server);
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+  });
+
+  it('does NOT admit on context.sandbox when an account resolved as live', async () => {
+    // context.sandbox is a fallback for the *unresolved* path. Once the
+    // resolver names the account, the resolver wins.
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'live_acc',
+      mode: 'live',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, {
+      account: { account_id: 'live_acc' },
+      context: { sandbox: true },
+    });
+
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.error, 'FORBIDDEN');
+  });
+});
+
+describe('createAdcpServerFromPlatform — sandbox-authority gate (env fallback)', () => {
+  beforeEach(() => {
+    delete process.env.ADCP_SANDBOX;
+    __resetObservedAccountModes();
+  });
+
+  after(() => {
+    delete process.env.ADCP_SANDBOX;
+    __resetObservedAccountModes();
+  });
+
+  it('admits via ADCP_SANDBOX=1 when resolver returns no mode-bearing account (legacy)', async () => {
+    process.env.ADCP_SANDBOX = '1';
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'legacy_acc',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    const result = await callForceCreative(server, { account: { account_id: 'legacy_acc' } });
+
+    assert.notStrictEqual(result.isError, true, 'legacy env-fallback path must continue to admit');
+    assert.strictEqual(result.structuredContent.success, true);
+  });
+
+  it('FAILS CLOSED on a live-mode resolve when ADCP_SANDBOX=1 (catches the misconfig immediately)', async () => {
+    // The env-fallback was never meant to coexist with a resolver that names
+    // live accounts. As soon as such a pairing is observed, the gate throws
+    // loudly so operators notice in their logs — a FORBIDDEN response would
+    // be too quiet for what is fundamentally a deployment-level misconfig.
+    process.env.ADCP_SANDBOX = '1';
+    const server = buildServer(async ref => ({
+      id: ref?.account_id ?? 'live_1',
+      mode: 'live',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    await assert.rejects(
+      () => callForceCreative(server, { account: { account_id: 'live_1' } }),
+      err => /ADCP_SANDBOX=1 is set but this process has resolved at least one live-mode account/.test(err.message)
+    );
+  });
+
+  it('FAILS CLOSED on subsequent env-fallback calls once any live-mode account has been observed', async () => {
+    // Even if a later call's resolver omits the mode field (legacy adopter
+    // shape), the previously-observed live account locks the env fallback.
+    process.env.ADCP_SANDBOX = '1';
+
+    // Step 1: observe a live account via a separate server. The guard fires
+    // on this call too — we drain it (assert.rejects) so the observation
+    // sticks for step 2.
+    const liveServer = buildServer(async ref => ({
+      id: ref?.account_id ?? 'live_1',
+      mode: 'live',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+    await assert.rejects(() => callForceCreative(liveServer, { account: { account_id: 'live_1' } }));
+
+    // Step 2: a server with a legacy resolver (no mode) — would normally hit
+    // env fallback. Guard refuses because the process has observed live.
+    const envServer = buildServer(async ref => ({
+      id: ref?.account_id ?? 'legacy_acc',
+      ctx_metadata: {},
+      authInfo: { kind: 'api_key' },
+    }));
+
+    await assert.rejects(
+      () => callForceCreative(envServer, { account: { account_id: 'legacy_acc' } }),
+      err => /ADCP_SANDBOX=1 is set but this process has resolved at least one live-mode account/.test(err.message)
+    );
+  });
+
+  it('list_scenarios is exempt from the gate (probe always answers)', async () => {
+    // No env, no context.sandbox, resolver returns null. force_creative_status
+    // would deny — list_scenarios admits as a discovery probe.
+    const server = buildServer(async () => null);
+
+    const probe = await callListScenarios(server);
+
+    assert.notStrictEqual(probe.isError, true);
+    assert.ok(Array.isArray(probe.structuredContent.scenarios));
+    assert.ok(probe.structuredContent.scenarios.includes('force_creative_status'));
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of #1435 — closes #1439. `createAdcpServerFromPlatform` now registers `comply_test_controller` itself (bypassing `controller.register`) and threads `extra.authInfo` through `platform.accounts.resolve` before dispatching. **Under no circumstances does the controller operate on a `live`-mode account, regardless of what the caller claims on the wire.** The resolved account is the trust boundary; buyer-supplied flags like `account.sandbox: true` are ignored.

The gate, in order:

1. `list_scenarios` is exempt — capability probe.
2. Resolve via `platform.accounts.resolve(ref, { authInfo, toolName: 'comply_test_controller' })`. Reads ref from top-level `account` (extended shape) or `context.account` (canonical AdCP).
3. Admit when resolved `mode` is `'sandbox'` or `'mock'` (legacy `sandbox: true` honored).
4. Admit when no account resolves AND `context.sandbox === true`.
5. Admit when `process.env.ADCP_SANDBOX === '1'` (deprecated env fallback).
6. Otherwise refuse with a `FORBIDDEN` controller envelope.

## Fail-closed guard on the env fallback

The framework tracks every **explicit** `mode` value returned from `accounts.resolve` in this process (new `observed-modes.ts` module, own-property reads — same prototype-pollution defense as `getAccountMode`). If `ADCP_SANDBOX=1` is set AND any `mode: 'live'` account has been resolved, the gate THROWS loudly. That pairing is a deployment misconfig and a quiet `FORBIDDEN` would let it pass operators by.

Implicit-default-to-live (legacy adopter shape, no `mode` field on the resolver's return) does NOT trip the guard. Only deliberate own-property `mode === 'live'` does, so adopters who haven't migrated to `mode` keep working with the env fallback.

## Test plan

- [x] 5×3 matrix in `test/server-decisioning-comply-gate.test.js` (12 tests, all green):
  - **Resolver path** (5): mode live denies; mode sandbox admits; mode mock admits; legacy `sandbox: true` admits; spoofed wire `account.sandbox: true` ignored when resolver says live.
  - **Context.sandbox path** (3): unresolved + `context.sandbox` admits; unresolved without it denies; resolved-as-live ignores context override.
  - **Env fallback** (4): legacy admit; immediate fail-closed on live mode + ADCP_SANDBOX; post-observation fail-closed on env-only path; `list_scenarios` exempt.
- [x] Existing comply tests (`server-decisioning-comply-test.test.js`, `server-decisioning-comply-auto-seed.test.js`, `comply-controller.test.js`) pass unchanged — their resolvers don't stamp explicit `mode: 'live'`.
- [x] `npm run build` clean
- [x] `npm run test:lib` — 6037 pass / 0 fail
- [x] `npm run format:check` clean

## Refs

- #1435 — umbrella
- #1436 — Phase 1 (helpers): `Account.mode`, `getAccountMode`, `isSandboxOrMockAccount`, `assertSandboxAccount`
- `docs/proposals/lifecycle-state-and-sandbox-authority.md` — full design
- `docs/architecture/adcp-stack.md` — layered-architecture context

🤖 Generated with [Claude Code](https://claude.com/claude-code)