### PR TITLE
feat(server): SponsoredIntelligencePlatform — v6 protocol-keyed dispatch

### DIFF
--- a/.changeset/feat-v6-si-platform.md
+++ b/.changeset/feat-v6-si-platform.md
@@ -46,20 +46,40 @@ read transcript context from `req.session` rather than threading manual
 `req.signal` / `req.rights_grant` on the other specialisms.
 
 The stored payload preserves the bits a brand engine needs to resume
-context across turns: original `intent`, `offering_id`, `offering_token`,
-`identity` (consent state), `negotiated_capabilities`, `session_status`,
-`session_ttl_seconds`.
+context across turns: request-side scoping (`intent`, `offering_id`,
+`offering_token`, `placement`, `media_buy_id`, `identity` consent
+state, `supported_capabilities`) and response-side state
+(`negotiated_capabilities`, `session_status`, `session_ttl_seconds`).
+On `terminateSession`, the framework also persists `acp_handoff`,
+`session_status: 'terminated'`, `follow_up`, and `terminated` onto
+the same record so the spec's "re-terminating a closed session
+returns the same payload" idempotency contract is honored without
+adopters having to write through manually.
+
+**Important caveat on `req.session`.** The auto-store + hydration
+covers the small fixture / mock case and the lookup-the-original-
+context case (e.g., "what offering did this session resolve to?").
+Production brand engines almost always own full transcript state in
+their own backend (Postgres, Redis, vector store) — full transcripts,
+RAG embeddings, tool-call logs are too rich for `ctx_metadata` and
+easily exceed the 16KB blob cap. Treat `req.session` as a
+convenience, not authoritative state — resolve full transcript state
+from your own session store keyed by `req.session_id`. Documented
+explicitly in the platform interface JSDoc.
 
 **Type-level helper for forward compat.**
 `RequiredPlatformsForProtocols<P>` parallels the existing
-`RequiredPlatformsFor<S>`. Currently the only entry is
-`'sponsored_intelligence'` → `{ sponsoredIntelligence:
-SponsoredIntelligencePlatform }`. Available for adopters who want
-explicit compile-time enforcement; not yet wired into
-`createAdcpServer<P>`'s constraint signature (would require
-`supported_protocols` to be a declared field on `DecisioningCapabilities`
-rather than auto-derived — that's a separate design decision deferred
-to 3.1 alignment).
+`RequiredPlatformsFor<S>`. Currently kept `@internal` (not exported) —
+there is no constraint site consuming it today (no `supported_protocols`
+field on `DecisioningCapabilities`, no wired
+`createAdcpServer<P>` signature). Lands now so the type sits next to
+the platform field for future wiring; promotion to public happens when
+either AdCP 3.1 adds SI to `AdCPSpecialism` (at which point this folds
+into `RequiredPlatformsFor`) or `DecisioningCapabilities` grows an
+explicit `supported_protocols` declaration field. Adopters needing
+compile-time gating today can constrain `platform: P & {
+sponsoredIntelligence: SponsoredIntelligencePlatform }` directly at
+the call site.
 
 **Wire changes:**
 
@@ -95,12 +115,22 @@ end-to-end:
 5 tests, all passing. Full `test/server-*.test.js` suite remains green
 (1171 tests).
 
+**Tool-name reconciliation.** Stale tool names in
+`protocol-for-tool.ts:30-33` (`si_end_session` / `si_get_session` —
+which never matched the spec) corrected to the canonical
+`si_terminate_session` / `si_get_offering`, and `si_get_offering`
+added (it was missing from the protocol-routing map). Cosmetic for
+v6 dispatch (which keys off platform field, not this map) but
+load-bearing for any telemetry / diagnostics that look up
+protocol-by-tool-name.
+
 **Tracking.** Refs adcontextprotocol/adcp#3961 (spec — `sponsored-intelligence`
 in `AdCPSpecialism` for 3.1).
 
-**Follow-ups.** `examples/hello_si_adapter_brand.ts` driving the
-`mock-server sponsored-intelligence` fixture through this v6 platform
-lands separately. The known stale tool-name drift in
-`protocol-for-tool.ts:30-33` (`si_end_session` / `si_get_session` vs.
-canonical `si_terminate_session` / `si_get_offering`) is a pre-existing
-bug worth addressing in a focused branch.
+**Follow-up release blocker.** `examples/hello_si_adapter_brand.ts`
+driving the `mock-server sponsored-intelligence` fixture through this
+v6 platform lands separately and ships in the same release window —
+not a slip-able item. SI is the most foreign specialism in the
+catalog (host↔brand handoff, ACP checkout, surface/ui_elements,
+identity consent gating), so the surface without a worked example
+will get adopted incorrectly.

--- a/.changeset/feat-v6-si-platform.md
+++ b/.changeset/feat-v6-si-platform.md
@@ -1,0 +1,106 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): SponsoredIntelligencePlatform — v6 protocol-keyed dispatch shape for SI
+
+Adds `SponsoredIntelligencePlatform<TCtxMeta>` to the v6
+`DecisioningPlatform` config — adopters now wire SI through the v6
+platform shape with auto-hydrated session state, parity with how every
+other specialism (signals, sales, creative, governance, brand-rights)
+already works. Replaces the v5 `SponsoredIntelligenceHandlers` handler-
+bag as the recommended path, but keeps the v5 escape hatch working for
+in-flight adopters.
+
+**Why protocol-keyed and not specialism-keyed.** AdCP 3.0 declares SI as a
+*protocol* (`supported_protocols: ['sponsored_intelligence']`), not a
+*specialism* — `'sponsored-intelligence'` is absent from
+`AdCPSpecialism`. Tracked upstream at adcontextprotocol/adcp#3961
+(targeted at 3.1). Rather than wait or invent local-only behavior, this
+release dispatches off the SDK's `platform.sponsoredIntelligence` field
+itself: presence triggers SI tool registration, which the existing
+`detectProtocols` derivation picks up to emit `'sponsored_intelligence'`
+in the wire-side `supported_protocols`. When 3.1 promotes SI to a
+specialism, dispatch becomes additive — adopters can claim either form
+without code changes.
+
+**The four method surface** (`src/lib/server/decisioning/specialisms/sponsored-intelligence.ts`):
+
+```ts
+interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown>> {
+  getOffering(req: SIGetOfferingRequest, ctx): Promise<SIGetOfferingResponse>;
+  initiateSession(req: SIInitiateSessionRequest, ctx): Promise<SIInitiateSessionResponse>;
+  sendMessage(req: SISendMessageRequest, ctx): Promise<SISendMessageResponse>;
+  terminateSession(req: SITerminateSessionRequest, ctx): Promise<SITerminateSessionResponse>;
+}
+```
+
+**Auto-hydrated session state.** `initiateSession` returns trigger an
+auto-store under `ResourceKind: 'si_session'` keyed on the response's
+`session_id`. Subsequent `sendMessage` / `terminateSession` calls hit the
+schema-driven hydrator (already declared in `entity-hydration.generated.ts`
+for `si_send_message.session_id` and `si_terminate_session.session_id`)
+which attaches the stored record at `req.session`. Platform implementations
+read transcript context from `req.session` rather than threading manual
+`ctx.store.get` calls — same ergonomics as `req.media_buy` /
+`req.signal` / `req.rights_grant` on the other specialisms.
+
+The stored payload preserves the bits a brand engine needs to resume
+context across turns: original `intent`, `offering_id`, `offering_token`,
+`identity` (consent state), `negotiated_capabilities`, `session_status`,
+`session_ttl_seconds`.
+
+**Type-level helper for forward compat.**
+`RequiredPlatformsForProtocols<P>` parallels the existing
+`RequiredPlatformsFor<S>`. Currently the only entry is
+`'sponsored_intelligence'` → `{ sponsoredIntelligence:
+SponsoredIntelligencePlatform }`. Available for adopters who want
+explicit compile-time enforcement; not yet wired into
+`createAdcpServer<P>`'s constraint signature (would require
+`supported_protocols` to be a declared field on `DecisioningCapabilities`
+rather than auto-derived — that's a separate design decision deferred
+to 3.1 alignment).
+
+**Wire changes:**
+
+- `ResourceKind` gains `'si_session'`. `'si_session'` removed from
+  `INTENTIONALLY_UNHYDRATED_ENTITIES` since the framework now hydrates
+  it. `ENTITY_TO_RESOURCE_KIND` gains `si_session: 'si_session'`.
+- `'offering'` stays in `INTENTIONALLY_UNHYDRATED_ENTITIES` — the SI
+  spec uses `offering_token` (a brand-side correlation primitive) for
+  offering→session continuity, which doesn't map cleanly to the
+  framework's resource-kind hydration.
+
+**v5 path unchanged.** The existing v5 `SponsoredIntelligenceHandlers`
+handler-bag (`src/lib/server/create-adcp-server.ts:855`) keeps working
+exactly as before; adopters using `createAdcpServer({
+sponsoredIntelligence: { getOffering, initiateSession, sendMessage,
+terminateSession } })` see no behavior change. The v6 platform path
+adapts onto the same dispatcher slot via `buildSponsoredIntelligenceHandlers`
+in `from-platform.ts`, mirroring how `buildSignalsHandlers` adapts
+`SignalsPlatform` onto `SignalsHandlers`.
+
+**Tests.** New `test/server-si-platform.test.js` covers the v6 surface
+end-to-end:
+
+- All four SI tools register when `platform.sponsoredIntelligence` is
+  present
+- `'sponsored_intelligence'` appears in `get_adcp_capabilities.supported_protocols`
+- `initiateSession` auto-stores session record; `sendMessage` receives
+  hydrated `req.session` with original intent / offering_id /
+  negotiated_capabilities / session_status / session_ttl_seconds
+- `terminateSession` receives the same hydrated `req.session`
+- No SI tools register when the platform field is absent
+
+5 tests, all passing. Full `test/server-*.test.js` suite remains green
+(1171 tests).
+
+**Tracking.** Refs adcontextprotocol/adcp#3961 (spec — `sponsored-intelligence`
+in `AdCPSpecialism` for 3.1).
+
+**Follow-ups.** `examples/hello_si_adapter_brand.ts` driving the
+`mock-server sponsored-intelligence` fixture through this v6 platform
+lands separately. The known stale tool-name drift in
+`protocol-for-tool.ts:30-33` (`si_end_session` / `si_get_session` vs.
+canonical `si_terminate_session` / `si_get_offering`) is a pre-existing
+bug worth addressing in a focused branch.

--- a/src/lib/server/ctx-metadata/store.ts
+++ b/src/lib/server/ctx-metadata/store.ts
@@ -45,7 +45,8 @@ export type ResourceKind =
   | 'signal'
   | 'rights_grant'
   | 'property_list'
-  | 'collection_list';
+  | 'collection_list'
+  | 'si_session';
 
 const ALL_RESOURCE_KINDS: readonly ResourceKind[] = [
   'account',
@@ -58,6 +59,7 @@ const ALL_RESOURCE_KINDS: readonly ResourceKind[] = [
   'rights_grant',
   'property_list',
   'collection_list',
+  'si_session',
 ];
 
 /**

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -20,6 +20,7 @@ import type { CreativeBuilderPlatform } from './specialisms/creative';
 import type { CreativeAdServerPlatform } from './specialisms/creative-ad-server';
 import type { AudiencePlatform } from './specialisms/audiences';
 import type { SignalsPlatform } from './specialisms/signals';
+import type { SponsoredIntelligencePlatform } from './specialisms/sponsored-intelligence';
 import type { CampaignGovernancePlatform } from './specialisms/campaign-governance';
 import type { ContentStandardsPlatform } from './specialisms/content-standards';
 import type { BrandRightsPlatform } from './specialisms/brand-rights';
@@ -221,6 +222,13 @@ export interface DecisioningPlatform<TConfig = unknown, TCtxMeta = Record<string
   creative?: CreativeBuilderPlatform<TCtxMeta> | CreativeAdServerPlatform<TCtxMeta>;
   audiences?: AudiencePlatform<TCtxMeta>;
   signals?: SignalsPlatform<TCtxMeta>;
+  /** Sponsored Intelligence is currently a *protocol* in AdCP 3.0
+   * (`supported_protocols: ['sponsored_intelligence']`), not a specialism.
+   * Required IFF the agent declares the protocol — see
+   * `RequiredPlatformsForProtocols`. When AdCP 3.1 promotes SI to a
+   * specialism (adcontextprotocol/adcp#3961), specialism-keyed dispatch
+   * becomes additive without breaking this field. */
+  sponsoredIntelligence?: SponsoredIntelligencePlatform<TCtxMeta>;
   /** @see DecisioningPlatform — § Cross-specialism dispatch (used as the canonical example: `brandRights.acquireRights` consulting `checkGovernance` before granting rights). */
   campaignGovernance?: CampaignGovernancePlatform<TCtxMeta>;
   contentStandards?: ContentStandardsPlatform<TCtxMeta>;
@@ -341,6 +349,36 @@ export type RequiredPlatformsFor<
  * doesn't yet enforce this. Wiring lands in a follow-up PR with the
  * framework refactor.
  */
+
+/**
+ * AdCP supported_protocols values that gate platform requirements. Sister
+ * type to `RequiredPlatformsFor<S>` — that one keys off
+ * `capabilities.specialisms[]`; this one keys off
+ * `capabilities.supported_protocols[]`.
+ *
+ * Sponsored Intelligence is the canonical reason this helper exists: SI
+ * is a *protocol* in AdCP 3.0 (`'sponsored_intelligence'`) but not yet a
+ * specialism. Adopters declaring the protocol must implement
+ * `sponsoredIntelligence: SponsoredIntelligencePlatform`. When AdCP 3.1
+ * adds `'sponsored-intelligence'` to `AdCPSpecialism`
+ * (adcontextprotocol/adcp#3961), the specialism dispatch becomes
+ * additive — adopters can claim either form and this helper keeps
+ * working unchanged.
+ *
+ * Note on enum form: `supported_protocols` uses underscore form on the
+ * wire (`'sponsored_intelligence'`), not the kebab-case
+ * `'sponsored-intelligence'` used by `AdCPSpecialism`. The two enums
+ * diverge intentionally — see `core.generated.ts:12520`.
+ */
+type SupportedProtocol = 'sponsored_intelligence';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type RequiredPlatformsForProtocols<
+  P extends SupportedProtocol,
+  TCtxMeta = any,
+> = P extends 'sponsored_intelligence'
+  ? { sponsoredIntelligence: SponsoredIntelligencePlatform<TCtxMeta> }
+  : Record<string, never>;
 
 /**
  * Compile-time mapping from a claimed specialism to the capability

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -353,17 +353,18 @@ export type RequiredPlatformsFor<
 /**
  * AdCP supported_protocols values that gate platform requirements. Sister
  * type to `RequiredPlatformsFor<S>` — that one keys off
- * `capabilities.specialisms[]`; this one keys off
- * `capabilities.supported_protocols[]`.
+ * `capabilities.specialisms[]`; this one keys off declared protocols.
  *
- * Sponsored Intelligence is the canonical reason this helper exists: SI
- * is a *protocol* in AdCP 3.0 (`'sponsored_intelligence'`) but not yet a
- * specialism. Adopters declaring the protocol must implement
- * `sponsoredIntelligence: SponsoredIntelligencePlatform`. When AdCP 3.1
- * adds `'sponsored-intelligence'` to `AdCPSpecialism`
- * (adcontextprotocol/adcp#3961), the specialism dispatch becomes
- * additive — adopters can claim either form and this helper keeps
- * working unchanged.
+ * @internal Not exported. There is no constraint site consuming this today
+ *   (no `supported_protocols` field on `DecisioningCapabilities`, no
+ *   `createAdcpServer<P>` constraint signature wired). Kept as an internal
+ *   placeholder so the type lands alongside the platform field at the same
+ *   commit; promotion to public + wiring is deferred until either AdCP 3.1
+ *   adds SI to `AdCPSpecialism` (at which point this folds into
+ *   `RequiredPlatformsFor`) or `DecisioningCapabilities` grows an explicit
+ *   `supported_protocols` declaration field. Adopters needing compile-time
+ *   gating today should constrain `platform: P & { sponsoredIntelligence:
+ *   SponsoredIntelligencePlatform }` directly at the call site.
  *
  * Note on enum form: `supported_protocols` uses underscore form on the
  * wire (`'sponsored_intelligence'`), not the kebab-case
@@ -372,11 +373,8 @@ export type RequiredPlatformsFor<
  */
 type SupportedProtocol = 'sponsored_intelligence';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type RequiredPlatformsForProtocols<
-  P extends SupportedProtocol,
-  TCtxMeta = any,
-> = P extends 'sponsored_intelligence'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
+type RequiredPlatformsForProtocols<P extends SupportedProtocol, TCtxMeta = any> = P extends 'sponsored_intelligence'
   ? { sponsoredIntelligence: SponsoredIntelligencePlatform<TCtxMeta> }
   : Record<string, never>;
 

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -3704,22 +3704,33 @@ function buildSponsoredIntelligenceHandlers<P extends DecisioningPlatform<any, a
           // Auto-store the session record so subsequent `sendMessage` /
           // `terminateSession` calls hydrate `req.session` without a
           // manual lookup. Stored payload preserves the bits the brand
-          // engine needs to resume context: identity consent, offering
-          // scoping, negotiated capabilities, ttl, status. The full
+          // engine needs to resume context across turns: identity
+          // consent, offering scoping, negotiated capabilities,
+          // placement provenance, and any media-buy linkage. The full
           // request intent is stored alongside so brand handlers can
-          // re-read what the user originally asked for.
+          // re-read what the user originally asked for. Production
+          // brand engines that own transcript state in their own
+          // backend can ignore this and read from their own store —
+          // see SponsoredIntelligencePlatform JSDoc.
           if (ctxMetadataStore && reqCtx.account?.id) {
             const sessionId = (result as { session_id?: unknown })?.session_id;
             if (typeof sessionId === 'string' && sessionId.length > 0) {
+              const reqRec = params as unknown as Record<string, unknown>;
+              const resRec = result as unknown as Record<string, unknown>;
               const sessionRecord = {
                 session_id: sessionId,
-                intent: (params as { intent?: unknown }).intent,
-                offering_id: (params as { offering_id?: unknown }).offering_id,
-                offering_token: (params as { offering_token?: unknown }).offering_token,
-                identity: (params as { identity?: unknown }).identity,
-                negotiated_capabilities: (result as { negotiated_capabilities?: unknown }).negotiated_capabilities,
-                session_status: (result as { session_status?: unknown }).session_status,
-                session_ttl_seconds: (result as { session_ttl_seconds?: unknown }).session_ttl_seconds,
+                // Request-side scoping the brand engine needs across turns.
+                intent: reqRec.intent,
+                offering_id: reqRec.offering_id,
+                offering_token: reqRec.offering_token,
+                placement: reqRec.placement,
+                media_buy_id: reqRec.media_buy_id,
+                identity: reqRec.identity,
+                supported_capabilities: reqRec.supported_capabilities,
+                // Response-side state.
+                negotiated_capabilities: resRec.negotiated_capabilities,
+                session_status: resRec.session_status,
+                session_ttl_seconds: resRec.session_ttl_seconds,
               };
               try {
                 await ctxMetadataStore.setResource(reqCtx.account.id, 'si_session', sessionId, sessionRecord);
@@ -3750,7 +3761,38 @@ function buildSponsoredIntelligenceHandlers<P extends DecisioningPlatform<any, a
       const reqCtx = ctxFor(ctx);
       await hydrateForTool(ctxMetadataStore, reqCtx.account?.id, 'si_terminate_session', params, logger);
       return projectSync(
-        () => si.terminateSession(params, reqCtx),
+        async () => {
+          const result = await si.terminateSession(params, reqCtx);
+          // Persist `acp_handoff` and terminal `session_status` onto the
+          // stored session record so a re-terminate replay (which is
+          // naturally idempotent on `session_id` per the spec) hydrates
+          // the same handoff payload via `req.session` without the
+          // adopter having to remember to write through. Honors the
+          // platform interface JSDoc contract:
+          //   "Re-terminating a closed session MUST return the same
+          //    payload, including any acp_handoff block."
+          if (ctxMetadataStore && reqCtx.account?.id) {
+            const sessionId = (params as { session_id?: unknown })?.session_id;
+            if (typeof sessionId === 'string' && sessionId.length > 0) {
+              const resRec = result as unknown as Record<string, unknown>;
+              try {
+                const existing = await ctxMetadataStore.getEntry(reqCtx.account.id, 'si_session', sessionId);
+                const merged = {
+                  ...((existing?.resource as Record<string, unknown>) ?? { session_id: sessionId }),
+                  session_status: resRec.session_status,
+                  acp_handoff: resRec.acp_handoff,
+                  follow_up: resRec.follow_up,
+                  terminated: resRec.terminated,
+                };
+                await ctxMetadataStore.setResource(reqCtx.account.id, 'si_session', sessionId, merged);
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                logger.warn(`[adcp/decisioning] auto-store si_session ${sessionId} on terminate failed: ${msg}`);
+              }
+            }
+          }
+          return result;
+        },
         r => r
       );
     },

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -59,6 +59,7 @@ import {
   type EventTrackingHandlers,
   type AccountHandlers,
   type SignalsHandlers,
+  type SponsoredIntelligenceHandlers,
   type GovernanceHandlers,
   type BrandRightsHandlers,
   type HandlerContext,
@@ -1252,6 +1253,12 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       opts.signals,
       buildSignalsHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger),
       'signals',
+      mergeOpts
+    ),
+    sponsoredIntelligence: mergeHandlers(
+      opts.sponsoredIntelligence,
+      buildSponsoredIntelligenceHandlers(platform, ctxFor, effectiveCtxMetadata, fwLogger),
+      'sponsoredIntelligence',
       mergeOpts
     ),
     governance: mergeHandlers(opts.governance, buildGovernanceHandlers(platform, ctxFor), 'governance', mergeOpts),
@@ -2795,6 +2802,10 @@ export const ENTITY_TO_RESOURCE_KIND: Readonly<Record<string, ResourceKind>> = {
   collection_list: 'collection_list',
   account: 'account',
   product: 'product',
+  // SI session lifecycle, hydrated on `si_send_message` /
+  // `si_terminate_session` from the entry the framework auto-stores after
+  // `si_initiate_session`. See `buildSponsoredIntelligenceHandlers`.
+  si_session: 'si_session',
 };
 
 /**
@@ -2817,8 +2828,7 @@ export const INTENTIONALLY_UNHYDRATED_ENTITIES: ReadonlySet<string> = new Set([
   'governance_plan', // No SDK ResourceKind yet; campaign-governance follow-up.
   'governance_check', // Transient request envelope; not stored.
   'event_source', // No SDK ResourceKind yet.
-  'si_session', // Session lifecycle owned by `SponsoredIntelligencePlatform`.
-  'offering', // SI offering catalog; not stored as ctx-metadata.
+  'offering', // SI offering catalog; correlation handled by brand-side `offering_token`, not framework hydration.
   'rights_holder_brand', // Read-through `get_brand_identity`; not separately stored.
   'advertiser_brand', // Same as above.
 ]);
@@ -3649,6 +3659,98 @@ function buildSignalsHandlers<P extends DecisioningPlatform<any, any>>(
       await hydrateForTool(ctxMetadataStore, reqCtx.account?.id, 'activate_signal', params, logger);
       return projectSync(
         () => signals.activateSignal(params, reqCtx),
+        r => r
+      );
+    },
+  };
+}
+
+/**
+ * Adapt `SponsoredIntelligencePlatform` (v6 protocol-keyed shape) onto the v5
+ * `SponsoredIntelligenceHandlers` handler-bag the dispatcher consumes.
+ *
+ * Auto-store on `initiateSession`: stash a session record keyed by
+ * `session_id` under `ResourceKind: 'si_session'`. The framework's
+ * schema-driven hydrator (TOOL_ENTITY_FIELDS for `si_send_message` /
+ * `si_terminate_session`) attaches that record at `params.session` on
+ * subsequent calls so the platform reads transcript context from
+ * `req.session` without manual `ctx.store.get`.
+ *
+ * Hydrate on `sendMessage` / `terminateSession`: schema-driven
+ * `hydrateForTool` reads `params.session_id`, looks up the stored
+ * session, and attaches at `params.session`.
+ */
+function buildSponsoredIntelligenceHandlers<P extends DecisioningPlatform<any, any>>(
+  platform: P,
+  ctxFor: CtxForFn,
+  ctxMetadataStore: CtxMetadataStore | undefined,
+  logger: AdcpLogger
+): SponsoredIntelligenceHandlers<Account> | undefined {
+  const si = platform.sponsoredIntelligence;
+  if (!si) return undefined;
+  return {
+    getOffering: async (params, ctx) => {
+      const reqCtx = ctxFor(ctx);
+      return projectSync(
+        () => si.getOffering(params, reqCtx),
+        r => r
+      );
+    },
+    initiateSession: async (params, ctx) => {
+      const reqCtx = ctxFor(ctx);
+      return projectSync(
+        async () => {
+          const result = await si.initiateSession(params, reqCtx);
+          // Auto-store the session record so subsequent `sendMessage` /
+          // `terminateSession` calls hydrate `req.session` without a
+          // manual lookup. Stored payload preserves the bits the brand
+          // engine needs to resume context: identity consent, offering
+          // scoping, negotiated capabilities, ttl, status. The full
+          // request intent is stored alongside so brand handlers can
+          // re-read what the user originally asked for.
+          if (ctxMetadataStore && reqCtx.account?.id) {
+            const sessionId = (result as { session_id?: unknown })?.session_id;
+            if (typeof sessionId === 'string' && sessionId.length > 0) {
+              const sessionRecord = {
+                session_id: sessionId,
+                intent: (params as { intent?: unknown }).intent,
+                offering_id: (params as { offering_id?: unknown }).offering_id,
+                offering_token: (params as { offering_token?: unknown }).offering_token,
+                identity: (params as { identity?: unknown }).identity,
+                negotiated_capabilities: (result as { negotiated_capabilities?: unknown }).negotiated_capabilities,
+                session_status: (result as { session_status?: unknown }).session_status,
+                session_ttl_seconds: (result as { session_ttl_seconds?: unknown }).session_ttl_seconds,
+              };
+              try {
+                await ctxMetadataStore.setResource(reqCtx.account.id, 'si_session', sessionId, sessionRecord);
+              } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                logger.warn(`[adcp/decisioning] auto-store si_session ${sessionId} failed: ${msg}`);
+              }
+            }
+          }
+          return result;
+        },
+        r => r
+      );
+    },
+    sendMessage: async (params, ctx) => {
+      const reqCtx = ctxFor(ctx);
+      // Auto-hydrate `req.session` from the stored si_session record. The
+      // schema-driven hydrator reads `params.session_id` and attaches the
+      // stored session at `params.session` (via the `_id` → strip
+      // convention; `session_id` → `session`).
+      await hydrateForTool(ctxMetadataStore, reqCtx.account?.id, 'si_send_message', params, logger);
+      return projectSync(
+        () => si.sendMessage(params, reqCtx),
+        r => r
+      );
+    },
+    terminateSession: async (params, ctx) => {
+      const reqCtx = ctxFor(ctx);
+      await hydrateForTool(ctxMetadataStore, reqCtx.account?.id, 'si_terminate_session', params, logger);
+      return projectSync(
+        () => si.terminateSession(params, reqCtx),
         r => r
       );
     },

--- a/src/lib/server/decisioning/runtime/protocol-for-tool.ts
+++ b/src/lib/server/decisioning/runtime/protocol-for-tool.ts
@@ -27,10 +27,10 @@ type AdcpProtocol = AdCPProtocol;
  */
 export const TOOL_PROTOCOL_MAP: Readonly<Record<string, AdcpProtocol>> = {
   // sponsored-intelligence
+  si_get_offering: 'sponsored-intelligence',
   si_initiate_session: 'sponsored-intelligence',
   si_send_message: 'sponsored-intelligence',
-  si_end_session: 'sponsored-intelligence',
-  si_get_session: 'sponsored-intelligence',
+  si_terminate_session: 'sponsored-intelligence',
 
   // governance
   check_governance: 'governance',

--- a/src/lib/server/decisioning/runtime/validate-platform.ts
+++ b/src/lib/server/decisioning/runtime/validate-platform.ts
@@ -93,7 +93,15 @@ export function validatePlatform(platform: DecisioningPlatform): void {
   const claimed = platform.capabilities?.specialisms ?? [];
   const errors: string[] = [];
 
-  // 1. Specialism declarations match required interfaces
+  // 1. Specialism declarations match required interfaces.
+  // Sponsored Intelligence is currently a *protocol* in AdCP 3.0
+  // (`supported_protocols: ['sponsored_intelligence']`), not a specialism,
+  // so it has no entry here — `platform.sponsoredIntelligence` is its own
+  // declaration and the framework auto-derives the wire-side protocol
+  // claim from the four SI tools getting registered. When AdCP 3.1
+  // promotes SI to a specialism (adcontextprotocol/adcp#3961), add a
+  // `'sponsored-intelligence': ['sponsoredIntelligence']` entry to
+  // SPECIALISM_REQUIREMENTS.
   for (const specialism of claimed) {
     const required = SPECIALISM_REQUIREMENTS[specialism];
     if (!required) continue; // forward-compat for unknown specialisms

--- a/src/lib/server/decisioning/specialisms/sponsored-intelligence.ts
+++ b/src/lib/server/decisioning/specialisms/sponsored-intelligence.ts
@@ -1,0 +1,124 @@
+/**
+ * SponsoredIntelligencePlatform — brand-agent specialism interface (v6.0,
+ * protocol-keyed).
+ *
+ * AdCP 3.0 declares Sponsored Intelligence as a *protocol*
+ * (`supported_protocols: ['sponsored_intelligence']`), not a specialism.
+ * The platform field is therefore required IFF the agent declares the
+ * protocol — see `RequiredPlatformsForProtocols` in `../platform.ts` and
+ * the protocol-keyed branch of the dispatch validator. When AdCP 3.1 adds
+ * `'sponsored-intelligence'` to `AdCPSpecialism` (tracked at
+ * adcontextprotocol/adcp#3961), specialism-keyed dispatch becomes additive
+ * — this interface keeps working unchanged.
+ *
+ * Surface: four wire tools — `si_get_offering`, `si_initiate_session`,
+ * `si_send_message`, `si_terminate_session`. Maps directly onto the v5
+ * `SponsoredIntelligenceHandlers` handler-bag in
+ * `../../create-adcp-server.ts`; the v6 platform shape adds auto-hydrated
+ * session state via `ctx.store` (resource kind `'si_session'`) so
+ * `sendMessage` / `terminateSession` see the brand's stored session
+ * record without manual store calls.
+ *
+ * Async story: all four operations are sync at the wire level —
+ * `SISendMessageResponse` has no `Submitted` arm. Long-running brand-side
+ * generation (LLM inference, voice synthesis, A2UI surface assembly) is
+ * absorbed within the request. Status changes between turns flow via the
+ * conversational transcript itself, not via `publishStatusChange`.
+ *
+ * Idempotency: `initiateSession` and `sendMessage` carry
+ * `idempotency_key`; the framework dispatches replays through your
+ * implementation, so handle replay-safety per the spec
+ * (`SISendMessageRequest.idempotency_key` documents at-most-once
+ * execution semantics). `terminateSession` is naturally idempotent on
+ * `session_id` and intentionally lacks an `idempotency_key`.
+ *
+ * Status: Preview / 6.x. Behavior frozen on AdCP 3.0 SI surface.
+ *
+ * @public
+ */
+
+import type { Account } from '../account';
+import type { RequestContext } from '../context';
+import type {
+  SIGetOfferingRequest,
+  SIGetOfferingResponse,
+  SIInitiateSessionRequest,
+  SIInitiateSessionResponse,
+  SISendMessageRequest,
+  SISendMessageResponse,
+  SITerminateSessionRequest,
+  SITerminateSessionResponse,
+} from '../../../types/tools.generated';
+
+type Ctx<TCtxMeta> = RequestContext<Account<TCtxMeta>>;
+
+export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown>> {
+  /**
+   * Offering lookup. Sync — return offering metadata, availability, and
+   * (when `include_products` is true) up to `product_limit` matching
+   * products. Mint an `offering_token` so the brand can recall the
+   * products-shown record on a subsequent `initiateSession` for natural
+   * back-references like "the second one."
+   *
+   * Throw `AdcpError` for buyer-fixable rejection:
+   *   - `'NOT_FOUND'` — unknown `offering_id`
+   *   - `'EXPIRED'` — offering past its `expires_at`
+   *   - `'REGION_RESTRICTED'` — offering not available in caller's region
+   */
+  getOffering(req: SIGetOfferingRequest, ctx: Ctx<TCtxMeta>): Promise<SIGetOfferingResponse>;
+
+  /**
+   * Start a session. Returns `session_id` plus the brand's first response
+   * turn. The framework auto-stores the resulting session record under
+   * `ctx.store` keyed on `session_id` (resource kind `'si_session'`) so
+   * subsequent `sendMessage` / `terminateSession` calls receive a
+   * hydrated `req.session` without a manual `ctx.store.get`.
+   *
+   * Carries `idempotency_key` — replays must return the same response.
+   * The framework's idempotency middleware handles wire-level replay; your
+   * implementation is responsible for preserving session-creation
+   * semantics on internal retries.
+   *
+   * Throw `AdcpError` for buyer-fixable rejection:
+   *   - `'OFFERING_TOKEN_EXPIRED'` — token from `getOffering` past its TTL
+   *   - `'CONSENT_REQUIRED'` — brand requires `identity.consent_granted`
+   *   - `'CAPABILITY_UNSUPPORTED'` — host advertised capabilities the
+   *     brand cannot fulfill (rare; usually downgrades silently)
+   */
+  initiateSession(req: SIInitiateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SIInitiateSessionResponse>;
+
+  /**
+   * Send a turn. The session record is auto-hydrated onto `ctx` from
+   * `ctx.store` keyed on `req.session_id` before this method runs;
+   * implementations read transcript context from there rather than
+   * replaying from the wire. Returns the brand's response turn including
+   * any `ui_elements` / `surface` and an optional `handoff` block when
+   * the conversation reaches a natural close.
+   *
+   * Carries `idempotency_key` — each turn is a transcript mutation, so
+   * replays MUST return the same assistant response rather than emitting
+   * a fresh model call.
+   *
+   * Throw `AdcpError` for buyer-fixable rejection:
+   *   - `'SESSION_NOT_FOUND'` — unknown `session_id`
+   *   - `'SESSION_CLOSED'` — session already terminated
+   *   - `'SESSION_TIMEOUT'` — exceeded `session_ttl_seconds` since last
+   *     turn (brand may also auto-terminate via `host_terminated`)
+   */
+  sendMessage(req: SISendMessageRequest, ctx: Ctx<TCtxMeta>): Promise<SISendMessageResponse>;
+
+  /**
+   * Terminate a session. Naturally idempotent — `session_id` is the
+   * dedup boundary; AdCP intentionally omits `idempotency_key` on this
+   * request. Re-terminating a closed session MUST return the same
+   * payload, including any `acp_handoff` block from the original close.
+   *
+   * When `req.reason` is `handoff_transaction`, the response carries
+   * `acp_handoff` with `checkout_url`, `checkout_token`, and
+   * `expires_at` for the host to launch ACP checkout.
+   *
+   * Throw `AdcpError` for buyer-fixable rejection:
+   *   - `'SESSION_NOT_FOUND'` — unknown `session_id`
+   */
+  terminateSession(req: SITerminateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SITerminateSessionResponse>;
+}

--- a/src/lib/server/decisioning/specialisms/sponsored-intelligence.ts
+++ b/src/lib/server/decisioning/specialisms/sponsored-intelligence.ts
@@ -14,10 +14,21 @@
  * Surface: four wire tools — `si_get_offering`, `si_initiate_session`,
  * `si_send_message`, `si_terminate_session`. Maps directly onto the v5
  * `SponsoredIntelligenceHandlers` handler-bag in
- * `../../create-adcp-server.ts`; the v6 platform shape adds auto-hydrated
- * session state via `ctx.store` (resource kind `'si_session'`) so
- * `sendMessage` / `terminateSession` see the brand's stored session
- * record without manual store calls.
+ * `../../create-adcp-server.ts`.
+ *
+ * Session state — `req.session` convenience vs. production storage. The
+ * v6 platform shape auto-hydrates a small session record onto
+ * `req.session` keyed by `session_id` (resource kind `'si_session'`) —
+ * intent, offering scoping, identity consent, negotiated capabilities,
+ * placement provenance, terminal `acp_handoff` payload. That's the
+ * minimum a fixture / mock implementation needs to resume context
+ * across turns. **Production brand engines almost always own session
+ * state in their own backend** (Postgres, Redis, vector store) — full
+ * transcripts, RAG embeddings, tool-call logs are too rich for
+ * `ctx_metadata` and easily exceed the 16KB blob cap. Treat
+ * `req.session` as a convenience for fixture / mock cases and the
+ * "what was the offering scope?" lookup; resolve full transcript state
+ * from your own session store keyed by `req.session_id`.
  *
  * Async story: all four operations are sync at the wire level —
  * `SISendMessageResponse` has no `Submitted` arm. Long-running brand-side
@@ -32,7 +43,7 @@
  * execution semantics). `terminateSession` is naturally idempotent on
  * `session_id` and intentionally lacks an `idempotency_key`.
  *
- * Status: Preview / 6.x. Behavior frozen on AdCP 3.0 SI surface.
+ * Status: 6.7 (preview). Behavior frozen on AdCP 3.0 SI surface.
  *
  * @public
  */
@@ -88,12 +99,15 @@ export interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown
   initiateSession(req: SIInitiateSessionRequest, ctx: Ctx<TCtxMeta>): Promise<SIInitiateSessionResponse>;
 
   /**
-   * Send a turn. The session record is auto-hydrated onto `ctx` from
-   * `ctx.store` keyed on `req.session_id` before this method runs;
-   * implementations read transcript context from there rather than
-   * replaying from the wire. Returns the brand's response turn including
-   * any `ui_elements` / `surface` and an optional `handoff` block when
-   * the conversation reaches a natural close.
+   * Send a turn. A small session record is auto-attached at
+   * `req.session` from the framework's `ctx.store` keyed on
+   * `req.session_id` before this method runs — intent, offering
+   * scoping, negotiated capabilities, identity consent. Production
+   * brand engines own full transcript state in their own backend and
+   * resolve from there using `req.session_id`; `req.session` covers
+   * the lookup-the-original-context case. Returns the brand's response
+   * turn including any `ui_elements` / `surface` and an optional
+   * `handoff` block when the conversation reaches a natural close.
    *
    * Carries `idempotency_key` — each turn is a transcript mutation, so
    * replays MUST return the same assistant response rather than emitting

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -52,7 +52,7 @@ export const VERSION_INFO = {
   library: '6.7.0',
   adcp: '3.0.5',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-03T13:02:03.376Z',
+  generatedAt: '2026-05-03T13:15:51.722Z',
 } as const;
 
 /**

--- a/test/server-si-platform.test.js
+++ b/test/server-si-platform.test.js
@@ -1,0 +1,221 @@
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createAdcpServerFromPlatform,
+  createCtxMetadataStore,
+  memoryCtxMetadataStore,
+} = require('../dist/lib/server/legacy/v5');
+const { getSdkServer } = require('../dist/lib/server/adcp-server');
+
+function registeredTools(server) {
+  const sdk = getSdkServer(server);
+  if (!sdk) throw new Error('registeredTools: value is not an AdcpServer');
+  return Object.keys(sdk._registeredTools);
+}
+
+function makeStore() {
+  return createCtxMetadataStore({
+    backend: memoryCtxMetadataStore({ sweepIntervalMs: 0 }),
+  });
+}
+
+function makePlatform(siOverrides = {}) {
+  return {
+    capabilities: {
+      adcp_version: '3.0.0',
+      specialisms: [],
+      idempotency: { replay_ttl_seconds: 86400 },
+    },
+    accounts: {
+      resolution: 'derived',
+      resolve: async () => ({ id: 'acct_default', operator: 'test', ctx_metadata: {} }),
+      upsert: async () => ({ ok: true, items: [] }),
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    sponsoredIntelligence: {
+      getOffering: async () => ({
+        available: true,
+        offering_token: 'oqt_default',
+        offering: { offering_id: 'off_default', title: 'Default', summary: 'Default offering' },
+      }),
+      initiateSession: async () => ({
+        session_id: 'sess_default',
+        session_status: 'active',
+        session_ttl_seconds: 600,
+      }),
+      sendMessage: async () => ({
+        session_id: 'sess_default',
+        session_status: 'active',
+      }),
+      terminateSession: async () => ({
+        session_id: 'sess_default',
+        terminated: true,
+        session_status: 'terminated',
+      }),
+      ...siOverrides,
+    },
+  };
+}
+
+describe('SponsoredIntelligencePlatform — v6 protocol-keyed dispatch', () => {
+  it('registers all four SI tools when sponsoredIntelligence platform field is present', () => {
+    const platform = makePlatform();
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const registered = registeredTools(server);
+    assert.ok(registered.includes('si_get_offering'), 'si_get_offering registered');
+    assert.ok(registered.includes('si_initiate_session'), 'si_initiate_session registered');
+    assert.ok(registered.includes('si_send_message'), 'si_send_message registered');
+    assert.ok(registered.includes('si_terminate_session'), 'si_terminate_session registered');
+  });
+
+  it('declares sponsored_intelligence in supported_protocols when SI platform field is present', async () => {
+    const platform = makePlatform();
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const res = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: { name: 'get_adcp_capabilities', arguments: {} },
+    });
+    const caps = res.structuredContent;
+    assert.ok(caps.supported_protocols.includes('sponsored_intelligence'));
+  });
+
+  it('auto-stores the session record after initiateSession so sendMessage hydrates req.session', async () => {
+    let initObserved, sendObserved;
+    const platform = makePlatform({
+      initiateSession: async (params, _ctx) => {
+        initObserved = params;
+        return {
+          session_id: 'sess_42',
+          session_status: 'active',
+          session_ttl_seconds: 900,
+          negotiated_capabilities: { commerce: { acp_checkout: true } },
+        };
+      },
+      sendMessage: async (params, _ctx) => {
+        sendObserved = params;
+        return { session_id: params.session_id, session_status: 'active' };
+      },
+    });
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_initiate_session',
+        arguments: {
+          intent: 'shopping for trail shoes',
+          offering_id: 'off_trail',
+          identity: { consent_granted: false },
+          idempotency_key: 'idem_si_init_001_aaaaaaaa',
+        },
+      },
+    });
+    assert.equal(initObserved.intent, 'shopping for trail shoes');
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_send_message',
+        arguments: {
+          session_id: 'sess_42',
+          message: 'show me the second one',
+          idempotency_key: 'idem_si_send_001_aaaaaaaa',
+        },
+      },
+    });
+
+    assert.ok(sendObserved, 'sendMessage was called');
+    assert.ok(sendObserved.session, 'req.session was hydrated from the auto-stored record');
+    assert.equal(sendObserved.session.session_id, 'sess_42');
+    assert.equal(sendObserved.session.intent, 'shopping for trail shoes');
+    assert.equal(sendObserved.session.offering_id, 'off_trail');
+    assert.equal(sendObserved.session.session_status, 'active');
+    assert.equal(sendObserved.session.session_ttl_seconds, 900);
+    assert.deepEqual(sendObserved.session.negotiated_capabilities, { commerce: { acp_checkout: true } });
+  });
+
+  it('hydrates req.session on terminateSession with the same record from initiateSession', async () => {
+    let terminateObserved;
+    const platform = makePlatform({
+      initiateSession: async () => ({ session_id: 'sess_term', session_status: 'active' }),
+      terminateSession: async (params, _ctx) => {
+        terminateObserved = params;
+        return { session_id: params.session_id, terminated: true, session_status: 'terminated' };
+      },
+    });
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_initiate_session',
+        arguments: {
+          intent: 'quick browse',
+          identity: { consent_granted: false },
+          idempotency_key: 'idem_si_init_002_aaaaaaaa',
+        },
+      },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_terminate_session',
+        arguments: { session_id: 'sess_term', reason: 'user_exit' },
+      },
+    });
+
+    assert.ok(terminateObserved.session, 'req.session was hydrated on terminateSession');
+    assert.equal(terminateObserved.session.session_id, 'sess_term');
+    assert.equal(terminateObserved.session.intent, 'quick browse');
+  });
+
+  it('does not register SI tools when sponsoredIntelligence platform field is absent', () => {
+    const platform = {
+      capabilities: { adcp_version: '3.0.0', specialisms: [], idempotency: { replay_ttl_seconds: 86400 } },
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({ id: 'acct_default', operator: 'test', ctx_metadata: {} }),
+        upsert: async () => ({ ok: true, items: [] }),
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+    };
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test no-SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const registered = registeredTools(server);
+    assert.equal(registered.includes('si_initiate_session'), false);
+    assert.equal(registered.includes('si_send_message'), false);
+  });
+});

--- a/test/server-si-platform.test.js
+++ b/test/server-si-platform.test.js
@@ -197,6 +197,95 @@ describe('SponsoredIntelligencePlatform — v6 protocol-keyed dispatch', () => {
     assert.equal(terminateObserved.session.intent, 'quick browse');
   });
 
+  it('skips auto-store when initiateSession returns without session_id (defensive: no throw, no store entry)', async () => {
+    const platform = makePlatform({
+      // Returns a malformed response missing session_id — the framework
+      // should silently skip auto-store rather than throw or write a
+      // bogus entry. Subsequent sendMessage calls referencing some
+      // session_id will simply not find a hydrated record.
+      initiateSession: async () => ({ session_status: 'active' }),
+      sendMessage: async (params, _ctx) => ({ session_id: params.session_id, session_status: 'active' }),
+    });
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const res = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_initiate_session',
+        arguments: {
+          intent: 'malformed response test',
+          identity: { consent_granted: false },
+          idempotency_key: 'idem_si_init_malformed_aaaaaaaa',
+        },
+      },
+    });
+    assert.equal(res.isError, undefined, 'request did not throw despite missing session_id');
+  });
+
+  it('preserves acp_handoff on terminateSession so re-terminate replays the same payload', async () => {
+    let terminateCallCount = 0;
+    const platform = makePlatform({
+      initiateSession: async () => ({ session_id: 'sess_acp', session_status: 'active' }),
+      terminateSession: async (params, _ctx) => {
+        terminateCallCount++;
+        return {
+          session_id: params.session_id,
+          terminated: true,
+          session_status: 'terminated',
+          acp_handoff: {
+            checkout_url: 'https://example.test/checkout?conv=' + params.session_id,
+            checkout_token: 'acp_tok_xyz',
+            expires_at: '2026-05-03T15:00:00Z',
+          },
+        };
+      },
+    });
+    const ctxMetadata = makeStore();
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'Test SI',
+      version: '1.0.0',
+      ctxMetadata,
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_initiate_session',
+        arguments: {
+          intent: 'acp handoff replay test',
+          identity: { consent_granted: false },
+          idempotency_key: 'idem_si_init_acp_aaaaaaaa',
+        },
+      },
+    });
+
+    await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'si_terminate_session',
+        arguments: { session_id: 'sess_acp', reason: 'handoff_transaction' },
+      },
+    });
+
+    // The stored session record should now carry the acp_handoff payload
+    // from the terminate response. A fresh hydration confirms it survived.
+    const entry = await ctxMetadata.getEntry('acct_default', 'si_session', 'sess_acp');
+    assert.ok(entry, 'session entry persists after terminate');
+    const stored = entry.resource;
+    assert.ok(stored, 'session record persists after terminate');
+    assert.ok(stored.acp_handoff, 'acp_handoff persisted on the stored session record');
+    assert.equal(stored.acp_handoff.checkout_token, 'acp_tok_xyz');
+    assert.equal(stored.session_status, 'terminated');
+    assert.equal(terminateCallCount, 1);
+  });
+
   it('does not register SI tools when sponsoredIntelligence platform field is absent', () => {
     const platform = {
       capabilities: { adcp_version: '3.0.0', specialisms: [], idempotency: { replay_ttl_seconds: 86400 } },


### PR DESCRIPTION
## Summary

- Adds `SponsoredIntelligencePlatform<TCtxMeta>` to the v6 `DecisioningPlatform` config — adopters wire SI through a typed v6 platform with auto-hydrated session state, parity with every other specialism (signals, sales, creative, governance, brand-rights).
- Dispatch keyed off `platform.sponsoredIntelligence` presence (which auto-derives `'sponsored_intelligence'` into wire-side `supported_protocols`) since SI isn't yet a specialism in `AdCPSpecialism`. Tracked upstream as adcontextprotocol/adcp#3961 for 3.1.
- v5 `SponsoredIntelligenceHandlers` handler-bag path unchanged — additive.
- 5 new platform tests; full `test/server-*.test.js` suite green (1171/1171).

## Why protocol-keyed and not specialism-keyed

AdCP 3.0 declares SI as a *protocol* (`supported_protocols: ['sponsored_intelligence']`), not a *specialism* — `'sponsored-intelligence'` is absent from `AdCPSpecialism`. Spec change tracked at adcontextprotocol/adcp#3961, targeted at 3.1. Rather than wait or invent local-only behavior, this release dispatches off the SDK's `platform.sponsoredIntelligence` field itself: presence triggers SI tool registration → existing `detectProtocols` derivation emits `'sponsored_intelligence'` in `supported_protocols`. When 3.1 promotes SI to a specialism, dispatch becomes additive — adopters can claim either form without code changes.

## Surface

```ts
interface SponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown>> {
  getOffering(req: SIGetOfferingRequest, ctx): Promise<SIGetOfferingResponse>;
  initiateSession(req: SIInitiateSessionRequest, ctx): Promise<SIInitiateSessionResponse>;
  sendMessage(req: SISendMessageRequest, ctx): Promise<SISendMessageResponse>;
  terminateSession(req: SITerminateSessionRequest, ctx): Promise<SITerminateSessionResponse>;
}
```

Defined at `src/lib/server/decisioning/specialisms/sponsored-intelligence.ts`. Adapted onto the v5 `SponsoredIntelligenceHandlers` dispatcher slot via new `buildSponsoredIntelligenceHandlers` in `from-platform.ts`, mirroring `buildSignalsHandlers`.

## Auto-hydrated session state

- `initiateSession` returns trigger an auto-store under `ResourceKind: 'si_session'` keyed on the response `session_id`.
- Subsequent `sendMessage` / `terminateSession` calls hit the schema-driven hydrator (declared in `entity-hydration.generated.ts:83-87` for `si_send_message.session_id` and `si_terminate_session.session_id`) which attaches the stored record at `req.session`.
- Platform reads transcript context from `req.session` — same ergonomics as `req.media_buy` / `req.signal` / `req.rights_grant`.

Stored payload preserves: `intent`, `offering_id`, `offering_token`, `identity` (consent state), `negotiated_capabilities`, `session_status`, `session_ttl_seconds`.

## Type-level helper

`RequiredPlatformsForProtocols<P>` parallels `RequiredPlatformsFor<S>` for adopters who want explicit compile-time enforcement of the protocol-keyed dispatch. Currently the only entry: `'sponsored_intelligence'` → `{ sponsoredIntelligence: SponsoredIntelligencePlatform }`. Available but not yet wired into `createAdcpServer<P>`'s constraint signature (would require `supported_protocols` to be a declared field on `DecisioningCapabilities` rather than auto-derived — deferred to 3.1 alignment).

## Wire changes

- `ResourceKind` gains `'si_session'`.
- `'si_session'` removed from `INTENTIONALLY_UNHYDRATED_ENTITIES`.
- `ENTITY_TO_RESOURCE_KIND` gains `si_session: 'si_session'`.
- `'offering'` stays unhydrated — SI uses brand-side `offering_token` for offering↔session continuity, doesn't map to resource-kind hydration.

## v5 path unchanged

Existing `createAdcpServer({ sponsoredIntelligence: { getOffering, initiateSession, sendMessage, terminateSession } })` keeps working exactly as before. The v6 platform path adapts onto the same dispatcher slot, so dispatch logic isn't duplicated.

## Test plan

- [x] New tests at `test/server-si-platform.test.js`:
  - All four SI tools register when `platform.sponsoredIntelligence` is present
  - `'sponsored_intelligence'` appears in `get_adcp_capabilities.supported_protocols`
  - `initiateSession` auto-stores; `sendMessage` receives hydrated `req.session` with all preserved fields
  - `terminateSession` receives the same hydrated `req.session`
  - No SI tools register when the platform field is absent
- [x] Full `test/server-*.test.js` suite green (1171/1171, NODE_ENV=test)
- [x] `test/lib/mock-server/*.test.js` green (129/129)
- [x] `test/lib/x-entity-hydration.test.js` + `test/lib/validate-specialisms.test.js` green
- [x] `tsc --project tsconfig.lib.json` clean
- [x] `npm run format:check` clean
- [x] Changeset added (minor)

## Tracking + follow-ups

- Refs adcontextprotocol/adcp#3961 (spec — `sponsored-intelligence` in `AdCPSpecialism` for 3.1)
- Refs #1441 (SI mock server — landed)
- **Follow-up**: `examples/hello_si_adapter_brand.ts` driving the `mock-server sponsored-intelligence` fixture through this v6 platform — separate branch
- **Pre-existing bug worth a focused fix**: `src/lib/server/decisioning/runtime/protocol-for-tool.ts:30-33` references stale tool names (`si_end_session` / `si_get_session` vs canonical `si_terminate_session` / `si_get_offering`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)