### PR TITLE
fix(sync-schemas): preserve SDK-local call-adcp-agent across bundle syncs

### DIFF
--- a/.changeset/sync-schemas-preserve-call-adcp-agent.md
+++ b/.changeset/sync-schemas-preserve-call-adcp-agent.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(sync-schemas): preserve SDK-local `call-adcp-agent/SKILL.md` across protocol bundle syncs
+
+`syncSkillsFromBundle` previously overwrote `skills/call-adcp-agent/` from the upstream protocol tarball whenever the bundle's `manifest.contents.skills` listed it. Because the SDK-maintained copy carries SDK-version-specific addenda (e.g. `SDK ≥6.7` `discriminator`/`schemaId`, `SDK ≥6.8` `hint`), every `npm run sync-schemas` (and every `prepublishOnly`) silently rolled those sections off — letting them ship in the npm package only when the spec bundle happened to include them.
+
+Add a `SDK_LOCAL_SKILLS` allowlist so `call-adcp-agent` is treated like `build-seller-agent/` and friends: present in `skills/`, but never replaced by the protocol bundle. Per-protocol skills (`adcp-{brand,creative,governance,media-buy,si,signals}`) continue to sync normally.
+
+Also synchronizes `package-lock.json` to the committed `package.json` 6.7.0 so workspace setup no longer regenerates it on every `npm install`.

--- a/scripts/sync-schemas.ts
+++ b/scripts/sync-schemas.ts
@@ -254,6 +254,14 @@ function copyTreeFiltered(srcDir: string, destDir: string): void {
 }
 
 /**
+ * Skills the SDK maintains locally even when the protocol bundle ships its
+ * own copy. `call-adcp-agent` carries SDK-version-specific addenda (e.g.
+ * `SDK ≥6.7` discriminator/schemaId, `SDK ≥6.8` hint) that don't belong in
+ * the protocol bundle, so we never overwrite it from upstream.
+ */
+const SDK_LOCAL_SKILLS = new Set(['call-adcp-agent']);
+
+/**
  * Sync protocol-managed skills from the extracted bundle into the SDK's
  * top-level `skills/` tree. Driven by `manifest.contents.skills` (a list of
  * skill directory names) so we only overwrite the entries the spec repo
@@ -282,6 +290,7 @@ function syncSkillsFromBundle(extractRoot: string): void {
     if (typeof name !== 'string' || name.includes('/') || name.includes('..')) {
       continue;
     }
+    if (SDK_LOCAL_SKILLS.has(name)) continue;
     const src = path.join(skillsInBundle, name);
     const dst = path.join(SKILLS_DIR, name);
     if (!existsSync(src) || !statSync(src).isDirectory()) continue;


### PR DESCRIPTION
## Summary

- `syncSkillsFromBundle` was overwriting `skills/call-adcp-agent/` from the upstream protocol tarball whenever the bundle's `manifest.contents.skills` listed it. Because the SDK-maintained copy carries SDK-version-specific addenda (`SDK ≥6.7` `discriminator`/`schemaId`, `SDK ≥6.8` `hint`), every `npm run sync-schemas` (and every `prepublishOnly`) silently rolled those sections off — they only made it into the published npm tarball when the spec bundle happened to include them.
- Add a `SDK_LOCAL_SKILLS` allowlist (currently `['call-adcp-agent']`) so the buyer skill is treated like `build-seller-agent/` and friends: present in `skills/`, but never replaced by the protocol bundle. Per-protocol skills (`adcp-{brand,creative,governance,media-buy,si,signals}`) continue to sync normally.
- Sync `package-lock.json` to the committed `package.json` 6.7.0 so workspace setup no longer regenerates the lockfile on every `npm install`.

Stash refs `stash@{7}` and `stash@{8}` (`skill md drift … — out of scope`) confirm this had been hitting workflows for a while.

## Test plan

- [x] `npm run sync-schemas` — reports `6 protocol-managed` (was 7); `skills/call-adcp-agent/SKILL.md` no longer modified after sync
- [x] `npx tsx scripts/check-skill-sync.ts` — `7 protocol-managed skills present, all path bases resolve`
- [x] `npm run format:check` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)