### PR TITLE
feat(examples): hello_si_adapter_brand — worked SI adapter against v6 platform

### DIFF
--- a/.changeset/feat-si-example-hello-brand.md
+++ b/.changeset/feat-si-example-hello-brand.md
@@ -1,0 +1,86 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(examples): hello_si_adapter_brand — worked SI adapter driving the SI mock through the v6 platform
+
+Adds the SI reference adapter that wraps the upstream brand-agent
+mock platform (`mock-server sponsored-intelligence`, #1441) and
+exposes AdCP's four SI tools through the v6
+`SponsoredIntelligencePlatform` shape (#1454).
+
+Demonstrates the full upstream/AdCP rename gap an integrator faces
+when wrapping a Salesforce Agentforce / OpenAI Assistants / custom
+brand-chat platform: `conversation_id` ↔ `session_id`,
+`assistant_message` ↔ `response.message`, `components.kind` ↔
+`ui_elements.type`, `offering_query_id` ↔ `offering_token`,
+`transaction_handoff` ↔ `acp_handoff`, `sku` ↔ `product_id`,
+`hero_image_url` ↔ `image_url`, `pdp_url` ↔ `url`, and the loud
+close-reason rename (`txn_ready` ↔ `handoff_transaction`, `done` ↔
+`handoff_complete`, `user_left` ↔ `user_exit`, `idle_timeout` ↔
+`session_timeout`, `host_closed` ↔ `host_terminated`).
+
+Per-component-type projection — AdCP `SIUIElement.product_card`
+requires `data.title` + `data.price`; upstream emits `name` +
+`display_price`. The example projects per-type so wire validation
+passes. The same gotcha applies to `action_button` (needs
+`label` + `action`).
+
+Eager close-hint projection: upstream `close_recommended.type:
+'txn_ready'` becomes AdCP `session_status: 'pending_handoff'` +
+`handoff: { type: 'transaction', intent: { action: 'purchase', product, price } }`
+on the `si_send_message` response. The host then formally closes
+via `si_terminate_session` to receive the ACP `acp_handoff`
+payload.
+
+**New SDK surface this example uses:**
+
+- `defineSponsoredIntelligencePlatform<TCtxMeta>` — type-level
+  identity helper, parallel to `defineSignalsPlatform` /
+  `defineCreativeBuilderPlatform`. Exported from
+  `@adcp/sdk/server`.
+
+**Bug fix in `RequiredPlatformsFor<S>`** that this example surfaced:
+the fall-through used `Record<string, never>` (rejects any platform
+with handler fields). Distributive conditional over an empty union
+also collapsed to `never`. Both branches now resolve to `{}` (the
+empty-requirements identity, sister-to `RequiredCapabilitiesFor`'s
+fall-through). Adopters with empty `specialisms: []` (legitimate
+when the agent's only declared surface is a *protocol*, like SI
+pre-3.1) now get a working type. Documented inline at the
+fall-through with reasoning.
+
+**Tests** — `test/examples/hello-si-adapter-brand.test.js`. SI is
+preview-only (no compliance storyboard yet), so the test rolls its
+own runtime gates rather than using the shared three-gate helper:
+
+1. **Strict tsc** — `--strict --noUncheckedIndexedAccess
+   --exactOptionalPropertyTypes
+   --noPropertyAccessFromIndexSignature`. Parallel to peer
+   adapter tests.
+2. **End-to-end MCP smoke** — boots mock + adapter, drives all
+   four SI tools through the MCP wire (`StreamableHTTPClientTransport`
+   + `Client.callTool`), verifies upstream→AdCP renames project
+   correctly (offering_query_id round-trip, conversation_id →
+   session_id, transaction_handoff → acp_handoff, txn_ready →
+   pending_handoff projection on send_message).
+3. **Façade gate** — every expected upstream route shows ≥1 hit
+   at `/_debug/traffic`. (`/_lookup/brand` excluded — SI tool
+   schemas don't carry `account` on the wire, so
+   `accounts.resolve(undefined)` falls back to
+   `DEFAULT_LISTING_BRAND` without exercising lookup. That route
+   fires only on production paths binding `account.brand.domain`
+   from `ctx.authInfo`.)
+
+6 tests, all passing.
+
+Run the demo:
+
+```bash
+npx @adcp/sdk@latest mock-server sponsored-intelligence --port 4504
+UPSTREAM_URL=http://127.0.0.1:4504 \
+  npx tsx examples/hello_si_adapter_brand.ts
+curl http://127.0.0.1:4504/_debug/traffic
+```
+
+Refs adcontextprotocol/adcp#3961, #1441, #1454.

--- a/examples/hello_si_adapter_brand.ts
+++ b/examples/hello_si_adapter_brand.ts
@@ -1,0 +1,554 @@
+/**
+ * hello_si_adapter_brand — worked starting point for an AdCP Sponsored
+ * Intelligence agent (protocol `sponsored_intelligence`) that wraps an
+ * upstream brand-agent platform via HTTP.
+ *
+ * Fork this. Replace `upstream` with calls to your real backend
+ * (Salesforce Agentforce, OpenAI Assistants brand mode, custom brand
+ * chat). The AdCP-facing platform methods stay the same.
+ *
+ * **Status**: SI is a *protocol* in AdCP 3.0, not a specialism. Spec change
+ * to add it to `AdCPSpecialism` is tracked at adcontextprotocol/adcp#3961
+ * for 3.1. Until then the SDK dispatches off the
+ * `platform.sponsoredIntelligence` field's presence — which auto-derives
+ * `'sponsored_intelligence'` into the wire-side `supported_protocols`
+ * via `detectProtocols`.
+ *
+ * FORK CHECKLIST
+ *   1. Replace every `// SWAP:` marker with calls to your backend.
+ *   2. Replace `DEFAULT_LISTING_BRAND` with `ctx.authInfo`-derived per-tenant
+ *      binding (the env-driven default is a multi-brand footgun in production).
+ *   3. Production brand engines almost always own full transcript state in
+ *      their own backend (Postgres, Redis, vector DB). The auto-hydrated
+ *      `req.session` covers fixture/mock cases and the
+ *      "what-was-the-original-scope" lookup; do NOT model full transcripts
+ *      into ctx_metadata — you'll hit the 16KB blob cap.
+ *   4. Validate: `node --test test/examples/hello-si-adapter-brand.test.js`
+ *
+ * Demo:
+ *   npx @adcp/sdk@latest mock-server sponsored-intelligence --port 4504
+ *   UPSTREAM_URL=http://127.0.0.1:4504 \
+ *     npx tsx examples/hello_si_adapter_brand.ts
+ *   curl http://127.0.0.1:4504/_debug/traffic
+ *
+ * Production:
+ *   UPSTREAM_URL=https://my-brand-platform.example/api UPSTREAM_API_KEY=… \
+ *     PUBLIC_AGENT_URL=https://my-agent.example.com \
+ *     npx tsx examples/hello_si_adapter_brand.ts
+ */
+
+import {
+  createAdcpServerFromPlatform,
+  definePlatform,
+  defineSponsoredIntelligencePlatform,
+  serve,
+  verifyApiKey,
+  createIdempotencyStore,
+  createUpstreamHttpClient,
+  memoryBackend,
+  AdcpError,
+  type AccountStore,
+  type Account,
+} from '@adcp/sdk/server';
+import type {
+  SIGetOfferingRequest,
+  SIGetOfferingResponse,
+  SIInitiateSessionRequest,
+  SIInitiateSessionResponse,
+  SISendMessageRequest,
+  SISendMessageResponse,
+  SITerminateSessionRequest,
+  SITerminateSessionResponse,
+  SIUIElement,
+  SISessionStatus,
+} from '@adcp/sdk';
+
+const UPSTREAM_URL = process.env['UPSTREAM_URL'] ?? 'http://127.0.0.1:4504';
+const UPSTREAM_API_KEY = process.env['UPSTREAM_API_KEY'] ?? 'mock_si_brand_key_do_not_use_in_prod';
+const PORT = Number(process.env['PORT'] ?? 3004);
+const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use_in_prod';
+// Default brand used when a tool call lacks `account` resolution context.
+// SWAP: production should derive this from `ctx.authInfo` (per-API-key
+// tenant binding). Env-driven default is a multi-brand footgun.
+const DEFAULT_LISTING_BRAND = process.env['DEFAULT_LISTING_BRAND'] ?? 'brand_acme_outdoor';
+
+// ---------------------------------------------------------------------------
+// Upstream client — SWAP for production.
+// ---------------------------------------------------------------------------
+
+interface UpstreamProduct {
+  sku: string;
+  name: string;
+  display_price: string;
+  list_price?: string;
+  thumbnail_url: string;
+  pdp_url: string;
+  inventory_status: string;
+}
+
+interface UpstreamOffering {
+  offering_id: string;
+  brand_id: string;
+  name: string;
+  summary: string;
+  tagline?: string;
+  hero_image_url: string;
+  landing_page_url: string;
+  price_hint: string;
+  expires_at: string;
+  available: boolean;
+  products: UpstreamProduct[];
+  total_matching: number;
+  offering_query_id?: string;
+  offering_query_expires_at?: string;
+  offering_query_ttl_seconds?: number;
+}
+
+/** Upstream component vocabulary — `kind` field discriminates. AdCP uses
+ *  `type` (rename) on `SIUIElement`. */
+interface UpstreamComponent {
+  kind: string;
+  [k: string]: unknown;
+}
+
+interface UpstreamTurn {
+  turn_id: string;
+  conversation_id: string;
+  user_message: string | null;
+  assistant_message: string;
+  components: UpstreamComponent[];
+  close_recommended: { type: 'txn_ready' | 'done'; payload?: Record<string, unknown> } | null;
+  created_at: string;
+  conversation_status?: 'active' | 'closed';
+  session_ttl_seconds?: number;
+}
+
+interface UpstreamConversation {
+  conversation_id: string;
+  brand_id: string;
+  status: 'active' | 'closed';
+  offering_id: string | null;
+  offering_query_id: string | null;
+  shown_product_skus: string[];
+  intent: string;
+  turns: UpstreamTurn[];
+  close: {
+    reason: 'txn_ready' | 'done' | 'user_left' | 'idle_timeout' | 'host_closed';
+    closed_at: string;
+    transaction_handoff: {
+      checkout_url?: string;
+      checkout_token?: string;
+      expires_at?: string;
+      payload?: Record<string, unknown>;
+    } | null;
+  } | null;
+  session_ttl_seconds: number;
+  created_at: string;
+  updated_at: string;
+}
+
+const http = createUpstreamHttpClient({
+  baseUrl: UPSTREAM_URL,
+  auth: { kind: 'static_bearer', token: UPSTREAM_API_KEY },
+});
+
+const upstream = {
+  // SWAP: AdCP-side brand identifier → upstream brand_id. Real platforms
+  // typically expose this through a directory service or per-API-key
+  // tenant binding; the mock has a public discovery endpoint.
+  async lookupBrand(brandIdentifier: string): Promise<string | null> {
+    const { body } = await http.get<{ brand_id?: string }>('/_lookup/brand', { adcp_brand: brandIdentifier });
+    return body?.brand_id ?? null;
+  },
+
+  // SWAP: GET offering details. `include_products=true` causes the upstream
+  // to mint an offering_query_id; pass that to startConversation so the
+  // brand can resolve "the second one" against the products actually shown.
+  async getOffering(
+    brandId: string,
+    offeringId: string,
+    opts: { includeProducts?: boolean; productLimit?: number } = {}
+  ): Promise<UpstreamOffering | null> {
+    const params: Record<string, string> = {};
+    if (opts.includeProducts) params['include_products'] = 'true';
+    if (opts.productLimit !== undefined) params['product_limit'] = String(opts.productLimit);
+    const { body } = await http.get<UpstreamOffering>(
+      `/v1/brands/${encodeURIComponent(brandId)}/offerings/${encodeURIComponent(offeringId)}`,
+      params
+    );
+    return body;
+  },
+
+  // SWAP: start a conversation. `client_request_id` carries the AdCP
+  // idempotency_key — replay protection lives in the upstream.
+  async startConversation(
+    brandId: string,
+    body: {
+      intent: string;
+      offering_id?: string;
+      offering_query_id?: string;
+      identity?: unknown;
+      client_request_id?: string;
+    }
+  ): Promise<UpstreamConversation> {
+    const r = await http.post<UpstreamConversation>(`/v1/brands/${encodeURIComponent(brandId)}/conversations`, body);
+    if (r.body === null) {
+      throw new AdcpError('INVALID_REQUEST', { message: 'conversation creation rejected by upstream' });
+    }
+    return r.body;
+  },
+
+  // SWAP: send a turn. Mismatched body on reused client_request_id → 409.
+  async sendTurn(
+    brandId: string,
+    conversationId: string,
+    body: { message?: string; action_response?: unknown; client_request_id?: string }
+  ): Promise<UpstreamTurn> {
+    const r = await http.post<UpstreamTurn>(
+      `/v1/brands/${encodeURIComponent(brandId)}/conversations/${encodeURIComponent(conversationId)}/turns`,
+      body
+    );
+    if (r.body === null) {
+      throw new AdcpError('INVALID_REQUEST', { message: 'turn rejected by upstream' });
+    }
+    return r.body;
+  },
+
+  // SWAP: close a conversation. Naturally idempotent on conversation_id
+  // (mirrors AdCP's omission of `idempotency_key` on terminate).
+  async closeConversation(
+    brandId: string,
+    conversationId: string,
+    body: { reason: 'txn_ready' | 'done' | 'user_left' | 'idle_timeout' | 'host_closed'; summary?: string }
+  ): Promise<UpstreamConversation> {
+    const r = await http.post<UpstreamConversation>(
+      `/v1/brands/${encodeURIComponent(brandId)}/conversations/${encodeURIComponent(conversationId)}/close`,
+      body
+    );
+    if (r.body === null) {
+      throw new AdcpError('INVALID_REQUEST', { message: 'close rejected by upstream' });
+    }
+    return r.body;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Translation tables — upstream ↔ AdCP renames are deliberate per the SI mock
+// design. Keeping them as small named functions makes the seams explicit.
+// ---------------------------------------------------------------------------
+
+/** AdCP `SITerminateSessionRequest.reason` → upstream close reason. The SI
+ *  mock rejects AdCP values directly (loud rename gap by design). */
+function adcpReasonToUpstream(
+  reason: SITerminateSessionRequest['reason']
+): 'txn_ready' | 'done' | 'user_left' | 'idle_timeout' | 'host_closed' {
+  switch (reason) {
+    case 'handoff_transaction':
+      return 'txn_ready';
+    case 'handoff_complete':
+      return 'done';
+    case 'user_exit':
+      return 'user_left';
+    case 'session_timeout':
+      return 'idle_timeout';
+    case 'host_terminated':
+      return 'host_closed';
+  }
+}
+
+/** Project an upstream component (`{ kind, ... }`) onto an AdCP `SIUIElement`
+ *  (`{ type, data }`). Each type has its own per-data shape required by
+ *  the spec — `product_card` needs `title` + `price`, `action_button`
+ *  needs `label` + `action`, etc. We project per-type rather than a flat
+ *  spread so wire-validation passes. */
+function projectComponent(c: UpstreamComponent): SIUIElement {
+  switch (c.kind) {
+    case 'product_card': {
+      // Upstream → AdCP renames inside data: name → title, display_price →
+      // price, list_price → subtitle (or badge if you prefer), thumbnail_url →
+      // image_url. AdCP requires title + price.
+      const data: Record<string, unknown> = {
+        title: typeof c['name'] === 'string' ? c['name'] : '(unnamed product)',
+        price: typeof c['display_price'] === 'string' ? c['display_price'] : '',
+      };
+      if (typeof c['thumbnail_url'] === 'string') data['image_url'] = c['thumbnail_url'];
+      if (typeof c['list_price'] === 'string') data['subtitle'] = c['list_price'];
+      if (typeof c['inventory_status'] === 'string') data['badge'] = c['inventory_status'];
+      return { type: 'product_card', data };
+    }
+    case 'action_button': {
+      const data: Record<string, unknown> = {
+        label: typeof c['label'] === 'string' ? c['label'] : 'OK',
+        action: typeof c['action'] === 'string' ? c['action'] : 'noop',
+      };
+      if (c['payload'] !== undefined) data['payload'] = c['payload'];
+      return { type: 'action_button', data };
+    }
+    case 'text':
+    case 'link':
+    case 'image':
+    case 'carousel':
+    case 'app_handoff':
+    case 'integration_actions': {
+      // Pass-through: the upstream produces the spec-correct data shape
+      // for these kinds, or the data shape is permissive enough that
+      // additional properties don't fail wire validation.
+      const { kind: _k, ...data } = c;
+      void _k;
+      return { type: c.kind, data };
+    }
+    default: {
+      // Unknown upstream kind → safe fallback to `text` so wire validation
+      // doesn't reject a legitimate response. Production adapters should
+      // log + map every upstream-specific kind explicitly.
+      return { type: 'text', data: { text: `[unsupported upstream kind: ${c.kind}]` } };
+    }
+  }
+}
+
+/** Project an upstream `close_recommended` hint onto AdCP
+ *  `session_status: 'pending_handoff'` + `handoff: { type, ... }` on a
+ *  `si_send_message` response. The brand emits the hint mid-conversation;
+ *  this adapter chooses the eager projection (surface as pending_handoff
+ *  immediately) over lazy (wait for terminate). Either is spec-valid. */
+function projectCloseHint(hint: NonNullable<UpstreamTurn['close_recommended']>): {
+  status: SISessionStatus;
+  handoff: NonNullable<SISendMessageResponse['handoff']>;
+} {
+  if (hint.type === 'txn_ready') {
+    const product = (hint.payload?.['product'] as Record<string, unknown> | undefined) ?? {};
+    return {
+      status: 'pending_handoff',
+      handoff: {
+        type: 'transaction',
+        intent: {
+          action: 'purchase',
+          product,
+          ...(typeof product['display_price'] === 'string'
+            ? { price: { amount: parsePriceAmount(product['display_price']), currency: 'USD' } }
+            : {}),
+        },
+      },
+    };
+  }
+  return { status: 'pending_handoff', handoff: { type: 'complete' } };
+}
+
+function parsePriceAmount(displayPrice: string): number {
+  // Upstream display_price is "$129" / "$89.99" — strip non-numeric and parse.
+  const numeric = displayPrice.replace(/[^0-9.]/g, '');
+  const value = Number(numeric);
+  return Number.isFinite(value) ? value : 0;
+}
+
+// ---------------------------------------------------------------------------
+// AdCP-side adapter — typed against SponsoredIntelligencePlatform.
+// ---------------------------------------------------------------------------
+
+interface SiBrandMeta {
+  /** Resolved upstream brand_id, cached on the Account by accounts.resolve. */
+  brand_id: string;
+  /** AdCP-side brand identifier — preserved for logging / debugging. */
+  brand_identifier: string;
+  [key: string]: unknown;
+}
+
+// SI isn't yet a specialism (adcp#3961). The platform field's presence
+// is the declaration; framework auto-derives 'sponsored_intelligence'
+// into supported_protocols from the four SI tools getting registered.
+// Build with `definePlatform` so the empty-`specialisms[]` flows through
+// `RequiredPlatformsFor`'s `[S] extends [never]` short-circuit cleanly.
+
+const accounts: AccountStore<SiBrandMeta> = {
+  resolve: async ref => {
+    if (!ref) {
+      // No-account tools (the SI surface tools all carry account context
+      // via session_id correlation, but `resolve(undefined)` may still
+      // fire on capability discovery). Default-listing-brand fallback so
+      // ctx.account is non-null at runtime.
+      return {
+        id: DEFAULT_LISTING_BRAND,
+        name: DEFAULT_LISTING_BRAND,
+        status: 'active',
+        ctx_metadata: { brand_id: DEFAULT_LISTING_BRAND, brand_identifier: '' },
+      };
+    }
+    if ('account_id' in ref) {
+      // SWAP: production lookup keyed by your seller-assigned account_id.
+      return null;
+    }
+    const brandIdentifier = ref.brand.domain;
+    const brandId = await upstream.lookupBrand(brandIdentifier);
+    if (!brandId) return null;
+    return {
+      id: brandId,
+      name: brandIdentifier,
+      status: 'active',
+      ctx_metadata: { brand_id: brandId, brand_identifier: brandIdentifier },
+    };
+  },
+};
+
+const sponsoredIntelligence = defineSponsoredIntelligencePlatform<SiBrandMeta>({
+  getOffering: async (req: SIGetOfferingRequest, ctx): Promise<SIGetOfferingResponse> => {
+    const brandId = ctx.account?.ctx_metadata.brand_id ?? DEFAULT_LISTING_BRAND;
+    const offering = await upstream.getOffering(brandId, req.offering_id, {
+      includeProducts: req.include_products === true,
+      ...(req.product_limit !== undefined ? { productLimit: req.product_limit } : {}),
+    });
+    if (!offering) {
+      throw new AdcpError('NOT_FOUND', {
+        message: `Offering ${req.offering_id} not found in brand ${brandId}.`,
+        field: 'offering_id',
+      });
+    }
+    // Project upstream → AdCP. The rename pattern: hero_image_url → image_url,
+    // landing_page_url → landing_url, sku → product_id, thumbnail_url →
+    // image_url, pdp_url → url, inventory_status → availability_summary,
+    // offering_query_id → offering_token.
+    const matching = req.include_products
+      ? offering.products.map(p => ({
+          product_id: p.sku,
+          name: p.name,
+          price: p.display_price,
+          ...(p.list_price ? { original_price: p.list_price } : {}),
+          image_url: p.thumbnail_url,
+          availability_summary: p.inventory_status,
+          url: p.pdp_url,
+        }))
+      : undefined;
+    return {
+      available: offering.available,
+      ...(offering.offering_query_id !== undefined ? { offering_token: offering.offering_query_id } : {}),
+      ...(offering.offering_query_ttl_seconds !== undefined
+        ? { ttl_seconds: offering.offering_query_ttl_seconds }
+        : {}),
+      checked_at: new Date().toISOString(),
+      offering: {
+        offering_id: offering.offering_id,
+        title: offering.name,
+        summary: offering.summary,
+        ...(offering.tagline !== undefined ? { tagline: offering.tagline } : {}),
+        expires_at: offering.expires_at,
+        price_hint: offering.price_hint,
+        image_url: offering.hero_image_url,
+        landing_url: offering.landing_page_url,
+      },
+      ...(matching ? { matching_products: matching } : {}),
+      total_matching: offering.total_matching,
+    };
+  },
+
+  initiateSession: async (req: SIInitiateSessionRequest, ctx): Promise<SIInitiateSessionResponse> => {
+    const brandId = ctx.account?.ctx_metadata.brand_id ?? DEFAULT_LISTING_BRAND;
+    const conversation = await upstream.startConversation(brandId, {
+      intent: req.intent,
+      ...(req.offering_id !== undefined ? { offering_id: req.offering_id } : {}),
+      ...(req.offering_token !== undefined ? { offering_query_id: req.offering_token } : {}),
+      ...(req.identity !== undefined ? { identity: req.identity } : {}),
+      client_request_id: req.idempotency_key,
+    });
+    const initial = conversation.turns[0];
+    return {
+      // conversation_id → session_id (rename only — the brand-side and
+      // AdCP-side identifiers are the same opaque token).
+      session_id: conversation.conversation_id,
+      ...(initial
+        ? {
+            response: {
+              message: initial.assistant_message,
+              ui_elements: initial.components.map(projectComponent),
+            },
+          }
+        : {}),
+      session_status: conversation.status === 'active' ? 'active' : 'terminated',
+      session_ttl_seconds: conversation.session_ttl_seconds,
+    };
+  },
+
+  sendMessage: async (req: SISendMessageRequest, ctx): Promise<SISendMessageResponse> => {
+    const brandId = ctx.account?.ctx_metadata.brand_id ?? DEFAULT_LISTING_BRAND;
+    // `req.session` is auto-hydrated by the framework when a prior
+    // initiateSession landed via this same SDK instance — useful for
+    // recalling original intent / offering scope without a separate
+    // store call. Production brand engines own full transcripts in
+    // their own backend; the upstream call below replays through the
+    // brand's session-keyed API which is the source of truth for
+    // transcript state.
+    const turn = await upstream.sendTurn(brandId, req.session_id, {
+      ...(typeof req.message === 'string' ? { message: req.message } : {}),
+      ...(req.action_response !== undefined ? { action_response: req.action_response } : {}),
+      client_request_id: req.idempotency_key,
+    });
+    // Eager close-hint projection: surface `pending_handoff` mid-conversation
+    // when the brand signals txn_ready / done. The host then calls
+    // `si_terminate_session` to formally close.
+    const closeProjection = turn.close_recommended ? projectCloseHint(turn.close_recommended) : null;
+    return {
+      session_id: turn.conversation_id,
+      response: {
+        message: turn.assistant_message,
+        ui_elements: turn.components.map(projectComponent),
+      },
+      session_status: closeProjection?.status ?? (turn.conversation_status === 'closed' ? 'terminated' : 'active'),
+      ...(closeProjection ? { handoff: closeProjection.handoff } : {}),
+    };
+  },
+
+  terminateSession: async (req: SITerminateSessionRequest, ctx): Promise<SITerminateSessionResponse> => {
+    const brandId = ctx.account?.ctx_metadata.brand_id ?? DEFAULT_LISTING_BRAND;
+    const conversation = await upstream.closeConversation(brandId, req.session_id, {
+      reason: adcpReasonToUpstream(req.reason),
+      ...(req.termination_context?.summary ? { summary: req.termination_context.summary } : {}),
+    });
+    const handoff = conversation.close?.transaction_handoff ?? null;
+    return {
+      session_id: conversation.conversation_id,
+      terminated: conversation.status === 'closed',
+      session_status: 'terminated',
+      ...(handoff
+        ? {
+            acp_handoff: {
+              ...(handoff.checkout_url ? { checkout_url: handoff.checkout_url } : {}),
+              ...(handoff.checkout_token ? { checkout_token: handoff.checkout_token } : {}),
+              ...(handoff.expires_at ? { expires_at: handoff.expires_at } : {}),
+              ...(handoff.payload ? { payload: handoff.payload } : {}),
+            },
+          }
+        : {}),
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Boot
+// ---------------------------------------------------------------------------
+
+const platform = definePlatform<Record<string, never>, SiBrandMeta>({
+  capabilities: { specialisms: [] as const, config: {} },
+  accounts,
+  sponsoredIntelligence,
+});
+const idempotencyStore = createIdempotencyStore({ backend: memoryBackend(), ttlSeconds: 86_400 });
+
+serve(
+  ({ taskStore }) =>
+    createAdcpServerFromPlatform(platform, {
+      name: 'hello-si-adapter-brand',
+      version: '1.0.0',
+      taskStore,
+      idempotency: idempotencyStore,
+      resolveSessionKey: ctx => {
+        const acct = ctx.account as Account<SiBrandMeta> | undefined;
+        return acct?.id ?? 'anonymous';
+      },
+    }),
+  {
+    port: PORT,
+    authenticate: verifyApiKey({
+      keys: { [ADCP_AUTH_TOKEN]: { principal: 'compliance-runner' } },
+    }),
+  }
+);
+
+console.log(`sponsored-intelligence adapter on http://127.0.0.1:${PORT}/mcp · upstream: ${UPSTREAM_URL}`);

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -176,6 +176,8 @@ export type { AudiencePlatform, Audience, SyncAudiencesRow, AudienceStatus } fro
 
 export type { SignalsPlatform } from './specialisms/signals';
 
+export type { SponsoredIntelligencePlatform } from './specialisms/sponsored-intelligence';
+
 export type { BrandRightsPlatform } from './specialisms/brand-rights';
 
 // Brand-rights wire types — re-exported from `@adcp/sdk/server/decisioning`
@@ -286,6 +288,7 @@ export {
   defineSalesIngestionPlatform,
   defineAudiencePlatform,
   defineSignalsPlatform,
+  defineSponsoredIntelligencePlatform,
   defineCreativeBuilderPlatform,
   defineCreativeAdServerPlatform,
   defineCampaignGovernancePlatform,

--- a/src/lib/server/decisioning/platform-helpers.ts
+++ b/src/lib/server/decisioning/platform-helpers.ts
@@ -48,6 +48,7 @@ import type { ComplianceTestingCapabilities } from './capabilities';
 import type { SalesPlatform, SalesCorePlatform, SalesIngestionPlatform } from './specialisms/sales';
 import type { AudiencePlatform } from './specialisms/audiences';
 import type { SignalsPlatform } from './specialisms/signals';
+import type { SponsoredIntelligencePlatform } from './specialisms/sponsored-intelligence';
 import type { CreativeBuilderPlatform } from './specialisms/creative';
 import type { CreativeAdServerPlatform } from './specialisms/creative-ad-server';
 import type { CampaignGovernancePlatform } from './specialisms/campaign-governance';
@@ -239,6 +240,28 @@ export function defineAudiencePlatform<TCtxMeta = Record<string, unknown>>(
 export function defineSignalsPlatform<TCtxMeta = Record<string, unknown>>(
   platform: SignalsPlatform<TCtxMeta>
 ): SignalsPlatform<TCtxMeta> {
+  return platform;
+}
+
+/**
+ * Type-level identity for a `SponsoredIntelligencePlatform` sub-object.
+ * SI is currently a *protocol* in AdCP 3.0, not a specialism — adopters
+ * declare SI by providing this field; the framework auto-derives
+ * `'sponsored_intelligence'` into the wire-side `supported_protocols`.
+ *
+ * @example
+ * ```ts
+ * sponsoredIntelligence: defineSponsoredIntelligencePlatform<BrandMeta>({
+ *   getOffering: async (req, ctx) => { ... },
+ *   initiateSession: async (req, ctx) => { ... },
+ *   sendMessage: async (req, ctx) => { ... },
+ *   terminateSession: async (req, ctx) => { ... },
+ * }),
+ * ```
+ */
+export function defineSponsoredIntelligencePlatform<TCtxMeta = Record<string, unknown>>(
+  platform: SponsoredIntelligencePlatform<TCtxMeta>
+): SponsoredIntelligencePlatform<TCtxMeta> {
   return platform;
 }
 

--- a/src/lib/server/decisioning/platform.ts
+++ b/src/lib/server/decisioning/platform.ts
@@ -298,42 +298,61 @@ type CampaignGovernanceSpecialism = 'governance-spend-authority' | 'governance-d
 // soundness escape — adopters declare metadata inside `DecisioningPlatform<_,
 // TCtxMeta>` directly; this constraint exists only to compile-check that
 // claimed specialisms have a matching sub-interface field on the platform.
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export type RequiredPlatformsFor<
   S extends AdCPSpecialism,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TCtxMeta = any,
-> = S extends 'creative-template' | 'creative-generative'
-  ? { creative: CreativeBuilderPlatform<TCtxMeta> }
-  : S extends 'creative-ad-server'
-    ? { creative: CreativeAdServerPlatform<TCtxMeta> }
-    : S extends SalesCoreSpecialism
-      ? { sales: SalesCorePlatform<TCtxMeta> & SalesIngestionPlatform<TCtxMeta> }
-      : S extends SalesIngestionSpecialism
-        ? // Walled-garden specialisms (sales-social, today). Bidding owned upstream
-          // — only the ingestion surface is required. Adopters can voluntarily
-          // implement core methods on the same `sales` object; the SalesPlatform
-          // alias accepts both shapes.
-          { sales: SalesIngestionPlatform<TCtxMeta> }
-        : S extends SalesProposalSpecialism
-          ? // Proposal-mode adopters only need `getProducts` — the rest of the
-            // lifecycle flows through `publishStatusChange` on
-            // `resource_type: 'proposal'`. Ingestion is optional.
-            { sales: Required<Pick<SalesPlatform<TCtxMeta>, 'getProducts'>> & SalesIngestionPlatform<TCtxMeta> }
-          : S extends 'audience-sync'
-            ? { audiences: AudiencePlatform<TCtxMeta> }
-            : S extends SignalSpecialism
-              ? { signals: SignalsPlatform<TCtxMeta> }
-              : S extends CampaignGovernanceSpecialism
-                ? { campaignGovernance: CampaignGovernancePlatform<TCtxMeta> }
-                : S extends 'property-lists'
-                  ? { propertyLists: PropertyListsPlatform<TCtxMeta> }
-                  : S extends 'collection-lists'
-                    ? { collectionLists: CollectionListsPlatform<TCtxMeta> }
-                    : S extends 'content-standards'
-                      ? { contentStandards: ContentStandardsPlatform<TCtxMeta> }
-                      : S extends 'brand-rights'
-                        ? { brandRights: BrandRightsPlatform<TCtxMeta> }
-                        : Record<string, never>;
+> = [S] extends [never]
+  ? // Empty specialisms[] (legitimate when the agent's only declared
+    // surface is a *protocol* like sponsored-intelligence pre-3.1).
+    // `[S] extends [never]` short-circuits the distributive conditional —
+    // without this, a generic `S extends ...` over `never` yields `never`,
+    // collapsing `P & RequiredPlatformsFor<...>` to `never` and rejecting
+    // every platform value at the call site.
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    {}
+  : S extends 'creative-template' | 'creative-generative'
+    ? { creative: CreativeBuilderPlatform<TCtxMeta> }
+    : S extends 'creative-ad-server'
+      ? { creative: CreativeAdServerPlatform<TCtxMeta> }
+      : S extends SalesCoreSpecialism
+        ? { sales: SalesCorePlatform<TCtxMeta> & SalesIngestionPlatform<TCtxMeta> }
+        : S extends SalesIngestionSpecialism
+          ? // Walled-garden specialisms (sales-social, today). Bidding owned upstream
+            // — only the ingestion surface is required. Adopters can voluntarily
+            // implement core methods on the same `sales` object; the SalesPlatform
+            // alias accepts both shapes.
+            { sales: SalesIngestionPlatform<TCtxMeta> }
+          : S extends SalesProposalSpecialism
+            ? // Proposal-mode adopters only need `getProducts` — the rest of the
+              // lifecycle flows through `publishStatusChange` on
+              // `resource_type: 'proposal'`. Ingestion is optional.
+              { sales: Required<Pick<SalesPlatform<TCtxMeta>, 'getProducts'>> & SalesIngestionPlatform<TCtxMeta> }
+            : S extends 'audience-sync'
+              ? { audiences: AudiencePlatform<TCtxMeta> }
+              : S extends SignalSpecialism
+                ? { signals: SignalsPlatform<TCtxMeta> }
+                : S extends CampaignGovernanceSpecialism
+                  ? { campaignGovernance: CampaignGovernancePlatform<TCtxMeta> }
+                  : S extends 'property-lists'
+                    ? { propertyLists: PropertyListsPlatform<TCtxMeta> }
+                    : S extends 'collection-lists'
+                      ? { collectionLists: CollectionListsPlatform<TCtxMeta> }
+                      : S extends 'content-standards'
+                        ? { contentStandards: ContentStandardsPlatform<TCtxMeta> }
+                        : S extends 'brand-rights'
+                          ? { brandRights: BrandRightsPlatform<TCtxMeta> }
+                          : // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+                            {};
+// `{}` (not `Record<string, never>`) is the right "no extra requirements"
+// fallthrough — intersects to identity (`P & {} = P`) for specialisms
+// without platform constraints. Same reasoning RequiredCapabilitiesFor
+// documents at its own fall-through. `Record<string, never>` would force
+// the platform to have NO extra properties, collapsing `P & Record<string,
+// never>` to `never` for any platform with handler fields. Hits adopters
+// with empty `specialisms: []` (legitimate when the agent's only declared
+// surface is a *protocol*, like sponsored-intelligence pre-3.1).
 
 /**
  * The framework's createAdcpServer<P> signature uses this intersection to

--- a/test/examples/hello-si-adapter-brand.test.js
+++ b/test/examples/hello-si-adapter-brand.test.js
@@ -1,0 +1,289 @@
+/**
+ * CI gates for `examples/hello_si_adapter_brand.ts`.
+ *
+ * SI is currently a *protocol* in AdCP 3.0, not a specialism, so there is
+ * no compliance storyboard to drive. The shared three-gate runner expects
+ * a storyboard, so this file rolls its own runtime gates while keeping
+ * gate 1 (strict tsc) and gate 3 (façade detection) parallel to peer
+ * adapter tests.
+ *
+ *   1. The example typechecks under the strictest realistic adopter config.
+ *   2. The booted adapter answers all four AdCP SI tools end-to-end through
+ *      the MCP wire — `si_get_offering`, `si_initiate_session`,
+ *      `si_send_message`, `si_terminate_session`. Verifies
+ *      upstream-to-AdCP rename gaps (conversation_id → session_id,
+ *      offering_query_id → offering_token, transaction_handoff →
+ *      acp_handoff, handoff_transaction → upstream txn_ready) project
+ *      correctly through the adapter.
+ *   3. Every expected upstream route shows ≥1 hit at /_debug/traffic
+ *      (façade-resistance gate).
+ */
+
+const path = require('node:path');
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn, spawnSync } = require('node:child_process');
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
+const { bootMockServer } = require('@adcp/sdk/mock-server');
+const net = require('node:net');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const EXAMPLE_FILE = path.join(REPO_ROOT, 'examples', 'hello_si_adapter_brand.ts');
+const ADCP_AUTH_TOKEN = 'sk_harness_do_not_use_in_prod';
+
+function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const s = net.createServer();
+    s.unref();
+    s.on('error', reject);
+    s.listen(0, () => {
+      const port = s.address().port;
+      s.close(() => resolve(port));
+    });
+  });
+}
+
+function waitForPort(host, port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const tick = () => {
+      const s = net.connect(port, host, () => {
+        s.end();
+        resolve();
+      });
+      s.on('error', () => {
+        if (Date.now() >= deadline) reject(new Error(`timed out waiting for ${host}:${port}`));
+        else setTimeout(tick, 100);
+      });
+    };
+    tick();
+  });
+}
+
+describe('examples/hello_si_adapter_brand', () => {
+  // ── Gate 1 — strict tsc ──
+  it('passes tsc with --strict + noUncheckedIndexedAccess + exactOptionalPropertyTypes + noPropertyAccessFromIndexSignature', () => {
+    const res = spawnSync(
+      'npx',
+      [
+        'tsc',
+        '--noEmit',
+        EXAMPLE_FILE,
+        '--target',
+        'ES2022',
+        '--module',
+        'commonjs',
+        '--moduleResolution',
+        'node',
+        '--esModuleInterop',
+        '--skipLibCheck',
+        '--strict',
+        '--noUncheckedIndexedAccess',
+        '--exactOptionalPropertyTypes',
+        '--noImplicitOverride',
+        '--noFallthroughCasesInSwitch',
+        '--noPropertyAccessFromIndexSignature',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8', timeout: 120_000 }
+    );
+    assert.equal(res.status, 0, `tsc reported errors:\n${(res.stdout || '') + (res.stderr || '')}`);
+  });
+
+  // ── Gates 2 + 3 — runtime ──
+  let mockHandle;
+  let agent;
+  let agentPort;
+  let mcpClient;
+
+  before(async () => {
+    agentPort = await pickFreePort();
+    mockHandle = await bootMockServer({
+      specialism: 'sponsored-intelligence',
+      port: 0,
+      apiKey: 'mock_si_brand_key_do_not_use_in_prod',
+    });
+    agent = spawn('npx', ['tsx', EXAMPLE_FILE], {
+      cwd: REPO_ROOT,
+      env: {
+        ...process.env,
+        PORT: String(agentPort),
+        UPSTREAM_URL: mockHandle.url,
+        UPSTREAM_API_KEY: 'mock_si_brand_key_do_not_use_in_prod',
+        ADCP_AUTH_TOKEN,
+        NODE_ENV: 'development',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    agent.stdout.on('data', () => {});
+    agent.stderr.on('data', () => {});
+    await waitForPort('127.0.0.1', agentPort, 30_000);
+
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${agentPort}/mcp`), {
+      requestInit: { headers: { 'x-adcp-auth': ADCP_AUTH_TOKEN } },
+    });
+    mcpClient = new Client({ name: 'si-test-harness', version: '1.0.0' }, { capabilities: {} });
+    await mcpClient.connect(transport);
+  });
+
+  after(async () => {
+    if (mcpClient) {
+      try {
+        await mcpClient.close();
+      } catch {
+        // ignore close errors
+      }
+    }
+    if (agent && agent.exitCode === null) {
+      agent.kill('SIGTERM');
+      await new Promise(r => setTimeout(r, 500));
+      if (agent.exitCode === null) agent.kill('SIGKILL');
+    }
+    if (mockHandle) await mockHandle.close();
+  });
+
+  function callSiTool(name, args) {
+    return mcpClient.callTool({ name, arguments: args });
+  }
+
+  function structured(result) {
+    if (result.structuredContent) return result.structuredContent;
+    const text = result.content?.find(c => c.type === 'text')?.text;
+    return text ? JSON.parse(text) : null;
+  }
+
+  it('si_get_offering projects upstream offering shape onto AdCP SIGetOfferingResponse', async () => {
+    const result = await callSiTool('si_get_offering', {
+      offering_id: 'off_acme_trailrun_summer26',
+      include_products: true,
+    });
+    const body = structured(result);
+    assert.equal(body.available, true);
+    // offering_query_id → offering_token rename
+    assert.equal(typeof body.offering_token, 'string');
+    assert.equal(body.offering_token.startsWith('oqt_'), true);
+    // hero_image_url → image_url, landing_page_url → landing_url
+    assert.equal(body.offering.title, 'Trail Runner Summer Collection');
+    assert.equal(typeof body.offering.image_url, 'string');
+    assert.equal(typeof body.offering.landing_url, 'string');
+    // sku → product_id, thumbnail_url → image_url, pdp_url → url
+    assert.ok(Array.isArray(body.matching_products) && body.matching_products.length >= 1);
+    const p0 = body.matching_products[0];
+    assert.equal(typeof p0.product_id, 'string');
+    assert.equal(p0.product_id.startsWith('acme_tr_'), true);
+    assert.equal(typeof p0.image_url, 'string');
+    assert.equal(typeof p0.url, 'string');
+    // inventory_status → availability_summary
+    assert.equal(typeof p0.availability_summary, 'string');
+  });
+
+  it('si_initiate_session round-trips offering_token and projects conversation_id → session_id', async () => {
+    const offering = await callSiTool('si_get_offering', {
+      offering_id: 'off_acme_trailrun_summer26',
+      include_products: true,
+    });
+    const offeringBody = structured(offering);
+
+    const init = await callSiTool('si_initiate_session', {
+      intent: 'looking for muddy-trail running shoes',
+      offering_id: 'off_acme_trailrun_summer26',
+      offering_token: offeringBody.offering_token,
+      identity: { consent_granted: false },
+      idempotency_key: 'idem_si_init_e2e_aaaaaaaa',
+    });
+    const body = structured(init);
+    if (!body || typeof body.session_id !== 'string') {
+      throw new Error('initiate_session returned unexpected shape: ' + JSON.stringify(init, null, 2));
+    }
+    assert.equal(typeof body.session_id, 'string');
+    assert.equal(body.session_id.startsWith('conv_'), true);
+    assert.equal(body.session_status, 'active');
+    assert.equal(typeof body.session_ttl_seconds, 'number');
+    // First turn from the brand greets the user.
+    assert.equal(typeof body.response.message, 'string');
+    assert.ok(Array.isArray(body.response.ui_elements));
+  });
+
+  it('si_send_message routes "buy" keyword to a pending_handoff projection (eager hint)', async () => {
+    const init = await callSiTool('si_initiate_session', {
+      intent: 'shopping',
+      offering_id: 'off_acme_trailrun_summer26',
+      identity: { consent_granted: false },
+      idempotency_key: 'idem_si_init_buy_aaaaaaaa',
+    });
+    const initBody = structured(init);
+    if (!initBody || typeof initBody.session_id !== 'string') {
+      throw new Error('initiate_session returned unexpected shape: ' + JSON.stringify(init, null, 2));
+    }
+    const sessionId = initBody.session_id;
+
+    const turn = await callSiTool('si_send_message', {
+      session_id: sessionId,
+      message: "I'd like to buy the black/green ones in size 10.",
+      idempotency_key: 'idem_si_send_buy_aaaaaaaa',
+    });
+    const body = structured(turn);
+    if (!body || body.session_id === undefined) {
+      throw new Error('si_send_message returned unexpected shape: ' + JSON.stringify(turn, null, 2));
+    }
+    assert.equal(body.session_id, sessionId);
+    // Adapter projects upstream close_recommended.type=txn_ready into AdCP
+    // session_status: 'pending_handoff' + handoff: { type: 'transaction' }.
+    assert.equal(body.session_status, 'pending_handoff');
+    assert.equal(body.handoff?.type, 'transaction');
+    assert.equal(body.handoff?.intent?.action, 'purchase');
+  });
+
+  it('si_terminate_session projects AdCP reason → upstream + transaction_handoff → acp_handoff', async () => {
+    const init = await callSiTool('si_initiate_session', {
+      intent: 'shopping',
+      offering_id: 'off_acme_trailrun_summer26',
+      identity: { consent_granted: false },
+      idempotency_key: 'idem_si_init_term_aaaaaaaa',
+    });
+    const initBody = structured(init);
+    if (!initBody || typeof initBody.session_id !== 'string') {
+      throw new Error('initiate_session returned unexpected shape: ' + JSON.stringify(init, null, 2));
+    }
+    const sessionId = initBody.session_id;
+
+    const term = await callSiTool('si_terminate_session', {
+      session_id: sessionId,
+      reason: 'handoff_transaction',
+      termination_context: { summary: 'User chose blackgreen-10.' },
+    });
+    const body = structured(term);
+    assert.equal(body.session_id, sessionId);
+    assert.equal(body.terminated, true);
+    assert.equal(body.session_status, 'terminated');
+    // transaction_handoff → acp_handoff rename
+    assert.ok(body.acp_handoff, 'acp_handoff present when AdCP reason maps to upstream txn_ready');
+    assert.equal(typeof body.acp_handoff.checkout_url, 'string');
+    assert.equal(typeof body.acp_handoff.checkout_token, 'string');
+  });
+
+  it('façade gate — every expected upstream route shows ≥1 hit', async () => {
+    // SI tool requests don't carry `account` on the wire (the schema omits
+    // it — session continuity flows through `session_id` instead), so
+    // `accounts.resolve(undefined)` falls back to DEFAULT_LISTING_BRAND
+    // without exercising `/_lookup/brand`. That route fires only on
+    // production paths that resolve `account.brand.domain` from
+    // `ctx.authInfo` per-tenant binding, which this fixture flow doesn't
+    // simulate. Test the four tool-driven routes here.
+    const expectedRoutes = [
+      'GET /v1/brands/{brand}/offerings/{id}',
+      'POST /v1/brands/{brand}/conversations',
+      'POST /v1/brands/{brand}/conversations/{id}/turns',
+      'POST /v1/brands/{brand}/conversations/{id}/close',
+    ];
+    const res = await fetch(`${mockHandle.url}/_debug/traffic`);
+    const body = await res.json();
+    const traffic = body.traffic || {};
+    const missing = expectedRoutes.filter(r => (traffic[r] || 0) < 1);
+    assert.deepEqual(
+      missing,
+      [],
+      `These upstream routes had zero hits — the adapter is a façade for them:\n  ${missing.join('\n  ')}\n\nFull traffic:\n${JSON.stringify(traffic, null, 2)}`
+    );
+  });
+});

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -26,7 +26,8 @@
     "examples/hello_signals_adapter_marketplace.ts",
     "examples/hello_creative_adapter_template.ts",
     "examples/hello_seller_adapter_social.ts",
-    "examples/hello_seller_adapter_guaranteed.ts"
+    "examples/hello_seller_adapter_guaranteed.ts",
+    "examples/hello_si_adapter_brand.ts"
   ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

- Adds the worked SI reference adapter that wraps the SI mock server (#1441) and exposes the four SI tools through the v6 `SponsoredIntelligencePlatform` shape (#1454). Demonstrates the upstream/AdCP rename gap end-to-end.
- Lands `defineSponsoredIntelligencePlatform<TCtxMeta>` type-level helper (parallel to `defineSignalsPlatform` / `defineCreativeBuilderPlatform`).
- Fixes a latent bug in `RequiredPlatformsFor<S>` fall-through that surfaced when an adopter declares `specialisms: []` (legitimate for protocol-only agents like SI pre-3.1).
- 6 tests covering strict tsc, end-to-end MCP smoke against the booted mock + adapter, and façade detection.

## Why

The SI v6 platform PR (#1454) committed `examples/hello_si_adapter_brand.ts` as a release-window blocker, not a slip-able follow-up. Per the adtech-product-expert review on that PR: SI is the most foreign specialism in the catalog (host↔brand handoff, ACP checkout, surface/ui_elements, identity consent), so the surface without a worked example would get adopted incorrectly.

This branch fulfills that commitment.

## What it demonstrates

The adapter handles the full rename surface an integrator faces when wrapping a real brand-chat platform (Salesforce Agentforce, OpenAI Assistants brand mode, custom brand chat):

| Upstream | AdCP |
|---|---|
| `conversation_id` | `session_id` |
| `assistant_message` | `response.message` |
| `components[].kind` | `ui_elements[].type` |
| `client_request_id` | `idempotency_key` |
| `offering_query_id` | `offering_token` |
| `transaction_handoff` | `acp_handoff` |
| `close_recommended.type: 'txn_ready'` | `session_status: 'pending_handoff'` + `handoff: { type: 'transaction' }` |
| `close.reason: 'txn_ready'` | `'handoff_transaction'` |
| `close.reason: 'done'` | `'handoff_complete'` |
| `close.reason: 'user_left'` | `'user_exit'` |
| `close.reason: 'idle_timeout'` | `'session_timeout'` |
| `close.reason: 'host_closed'` | `'host_terminated'` |
| `sku` | `product_id` |
| `hero_image_url`, `thumbnail_url` | `image_url` |
| `landing_page_url` | `landing_url` |
| `pdp_url` | `url` |
| `inventory_status` | `availability_summary` |

Per-component-type projection: `product_card` requires `data.title` + `data.price`; upstream emits `name` + `display_price`. The `projectComponent()` helper handles this per-type so wire validation passes. Same gotcha for `action_button` (requires `label` + `action`).

Eager close-hint projection: upstream `close_recommended.type: 'txn_ready'` becomes AdCP `session_status: 'pending_handoff'` + `handoff: { type: 'transaction', intent: { action: 'purchase', product, price } }` on the `si_send_message` response. Host then formally closes via `si_terminate_session` to receive the ACP `acp_handoff` payload.

## Bonus: latent bug fix in `RequiredPlatformsFor<S>`

This example surfaced two issues with the constraint type:

1. **Fall-through used `Record<string, never>`** — rejects any platform with handler fields. Sister type `RequiredCapabilitiesFor` documents this exact gotcha at line 393-396 ("`{}` (not `Record<string, never>`) is the right 'no extra requirements' fallthrough"). `RequiredPlatformsFor` had it wrong.
2. **Distributive conditional collapse on empty union** — when `specialisms: [] as const`, `[number]` evaluates to `never` and a generic `S extends ...` over `never` distributes to nothing → empty union → the constraint resolves to `never`. Adding `[S] extends [never] ? {} : ...` short-circuits the distributive conditional.

Both branches now resolve to `{}` (identity under intersection). Adopters with empty `specialisms: []` get a working type. Comment at the fall-through documents the reasoning.

## Demo

```bash
npx @adcp/sdk@latest mock-server sponsored-intelligence --port 4504
UPSTREAM_URL=http://127.0.0.1:4504 \
  npx tsx examples/hello_si_adapter_brand.ts
curl http://127.0.0.1:4504/_debug/traffic
```

## Test plan

- [x] `npm run typecheck:examples` clean (example added to `tsconfig.examples.json` include list)
- [x] Strict tsc gate — `--strict --noUncheckedIndexedAccess --exactOptionalPropertyTypes --noPropertyAccessFromIndexSignature`
- [x] `node --test test/examples/hello-si-adapter-brand.test.js` — 6/6 pass
  - All four SI tools answer end-to-end through the MCP wire
  - Upstream→AdCP renames project correctly (offering_query_id round-trip, conversation_id → session_id, transaction_handoff → acp_handoff, txn_ready → pending_handoff projection)
  - Façade gate hits all four tool-driven upstream routes
- [x] `NODE_ENV=test node --test test/server-*.test.js` — 1158/1158 pass (no regressions from `RequiredPlatformsFor` fix)
- [x] `NODE_ENV=test node --test test/server-si-platform.test.js` — 7/7 pass (the v6 platform tests still green)
- [x] `npm run format:check` clean
- [x] Changeset added (minor)

## Tracking

- Refs adcontextprotocol/adcp#3961 (spec — `sponsored-intelligence` in `AdCPSpecialism` for 3.1)
- Refs adcontextprotocol/adcp-client#1441 (SI mock server — landed)
- Refs adcontextprotocol/adcp-client#1454 (v6 SI platform — landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)