### PR TITLE
feat(examples): collapse adapter-side comply gates onto framework gate (#1435 phase 3)

### DIFF
--- a/.changeset/phase-3-collapse-adapter-comply-gates.md
+++ b/.changeset/phase-3-collapse-adapter-comply-gates.md
@@ -1,0 +1,21 @@
+---
+"@adcp/sdk": patch
+---
+
+Collapse `examples/hello_seller_adapter_guaranteed.ts` onto the framework-side comply gate (Phase 3 of #1435).
+
+The Hello seller-guaranteed adapter no longer carries any in-adapter `comply_test_controller` gate logic — it's a worked example of the zero-boilerplate posture Phase 2 made possible.
+
+Three changes:
+
+1. **`accounts.resolve` synthesis branch** — the `if (ref.sandbox === true && process.env.ADCP_SANDBOX === '1')` cascade-scenario synthesis now gates only on `ref.sandbox === true` (the spec-defined `AccountReference.sandbox` flag) and stamps `mode: 'sandbox'` on the returned `Account`. The framework gate's resolver-path admit fires on that mode; no env var is consulted.
+2. **HITL bypass** — `ctx.account.id.startsWith(SANDBOX_ID_PREFIX) && process.env.ADCP_SANDBOX === '1'` is now `getAccountMode(ctx.account) === 'sandbox'`. Same trust signal, no env var, more robust against any production account whose id happens to share the sandbox prefix.
+3. **`complyTest:` opts** — dropped `sandboxGate: () => process.env.ADCP_SANDBOX === '1'`. Phase 2's framework gate is strictly stronger; the in-adapter callback was redundant.
+
+`test/examples/hello-seller-adapter-guaranteed.test.js` no longer sets `ADCP_SANDBOX: '1'` in `extraEnv`. The storyboard now passes purely on the resolver-stamped mode.
+
+**Other Hello adapters were already clean.** `hello_seller_adapter_social.ts`, `hello_seller_adapter_multi_tenant.ts`, and `hello_creative_adapter_template.ts` did not wire the controller. `hello_signals_adapter_marketplace.ts` uses the lower-level `registerTestController` (which Phase 2's gate doesn't intercept) and is left on the legacy path; migration to `complyTest:` opts is non-mechanical because the recorder integration would need a comply-adapter shape upstream.
+
+**Mock-server is unchanged.** Account synthesis happens inside the Hello adapter's `resolve`; the mock-server is only the upstream HTTP backend (returns `network_code` / `operator_id`). Stamping `mode: 'sandbox'` lives in the resolver, where it belongs.
+
+**Existing legacy-path coverage retained.** `test/server-decisioning-comply-test.test.js` continues to exercise the `process.env.ADCP_SANDBOX === '1'` admit path so the deprecated env-fallback bridge stays tested through its life.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -55,6 +55,7 @@ import {
   createUpstreamHttpClient,
   memoryBackend,
   AdcpError,
+  getAccountMode,
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
@@ -502,10 +503,15 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       // sandbox tenant their IO desk owns; either way, this in-example
       // synthesis isn't appropriate for prod traffic.
       //
-      // Gate is `ADCP_SANDBOX === '1'` exclusively — single-source so
-      // accidentally setting `ADCP_SANDBOX` in any non-sandbox environment
-      // is the only way this branch fires.
-      if (ref.sandbox === true && process.env['ADCP_SANDBOX'] === '1') {
+      // Gate is `ref.sandbox === true` from the wire `AccountReference`
+      // (per `core/account-ref.json`). Stamping `mode: 'sandbox'` on the
+      // returned `Account` is what admits the framework's
+      // `comply_test_controller` gate — see
+      // `src/lib/server/decisioning/runtime/from-platform.ts` and
+      // `docs/proposals/lifecycle-state-and-sandbox-authority.md`. No env
+      // var is consulted; production traffic that doesn't set
+      // `sandbox: true` on the wire never hits this branch.
+      if (ref.sandbox === true) {
         const sandboxDomain = 'acmeoutdoor.example';
         const network = await upstream.lookupNetwork(sandboxDomain);
         if (!network) return null;
@@ -513,6 +519,7 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
           id: `${SANDBOX_ID_PREFIX}${network.network_code}`,
           name: `Sandbox: ${network.display_name}`,
           status: 'active',
+          mode: 'sandbox',
           ...(ref.operator !== undefined && { operator: ref.operator }),
           brand: { domain: ref.brand.domain ?? sandboxDomain },
           ctx_metadata: {
@@ -805,13 +812,15 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
       // BASE `sales_guaranteed` storyboard tests the IO-signing async
       // path. Production sellers route every buy through the same path —
       // either always-HITL or always-sync, never both based on a runtime
-      // flag. Belt-and-suspenders env re-check below: if the env flag
-      // isn't set even though the id flowed in marked sandbox, fall
-      // through to the production HITL path. Defends against an
-      // upstream-resolved account that somehow carries the sandbox prefix
-      // without the env being sandbox-mode.
-      const isSandbox = ctx.account.id.startsWith(SANDBOX_ID_PREFIX) && process.env['ADCP_SANDBOX'] === '1';
-      if (isSandbox) {
+      // flag.
+      //
+      // Trust signal is the resolver-stamped `mode: 'sandbox'` on the
+      // resolved account (per `Account.mode`, AdCP 6.7+). The synthesis
+      // branch in `accounts.resolve` is the only path that stamps it, so
+      // a production account whose id happens to share the sandbox prefix
+      // would still flow through the HITL path because its mode would be
+      // unset (defaults to `'live'`).
+      if (getAccountMode(ctx.account) === 'sandbox') {
         return completeIoAndCreateLineItems();
       }
       // ─── /TEST-ONLY ──────────────────────────────────────────────────
@@ -1024,17 +1033,18 @@ serve(
       // state transitions deterministically across cascade scenarios.
       // Production sellers don't need this surface — and shouldn't ship
       // it. Per `examples/comply-controller-seller.ts`, the recommended
-      // production posture is "don't register the controller at all";
-      // a seller running their own sandbox tenant gates registration on
-      // an env flag controlled by the deploy pipeline (`ADCP_SANDBOX=1`).
+      // production posture is "don't register the controller at all".
       //
-      // SECURITY: gate is `ADCP_SANDBOX === '1'` exclusively — single env
-      // var. Don't add an `|| NODE_ENV === 'test'` clause — staging boxes
-      // commonly run with `NODE_ENV=test` and the controller would open
-      // there too. The gate test (`test/examples/hello-seller-adapter-
-      // guaranteed.test.js`) sets `ADCP_SANDBOX=1` in `extraEnv`.
+      // No `sandboxGate` here — the framework gate inside
+      // `createAdcpServerFromPlatform` resolves the calling principal
+      // through `accounts.resolve` and admits only when the resolved
+      // account's `mode` is `'sandbox'` or `'mock'` (per `Account.mode`
+      // in AdCP 6.7+). The synthesis branch in `accounts.resolve` above
+      // stamps `mode: 'sandbox'` on cascade-scenario refs; production
+      // refs flow through the live path with the field unset (default
+      // `'live'`), so the framework gate refuses dispatch for them.
+      // See `docs/proposals/lifecycle-state-and-sandbox-authority.md`.
       complyTest: {
-        sandboxGate: () => process.env['ADCP_SANDBOX'] === '1',
         seed: {
           media_buy: ({ media_buy_id, fixture }) => {
             const existing = seededMediaBuys.get(media_buy_id);

--- a/test/examples/hello-seller-adapter-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-guaranteed.test.js
@@ -66,10 +66,10 @@ runHelloAdapterGates({
   mockOptions: { apiKey: 'mock_sales_guaranteed_key_do_not_use_in_prod' },
   extraEnv: {
     UPSTREAM_API_KEY: 'mock_sales_guaranteed_key_do_not_use_in_prod',
-    // Opens the comply_test_controller surface for the storyboard runner.
-    // Production sellers gate on this same flag; the storyboard env sets it
-    // explicitly so non-test deployments stay closed.
-    ADCP_SANDBOX: '1',
+    // No ADCP_SANDBOX — the framework gate inside
+    // `createAdcpServerFromPlatform` admits comply_test_controller via the
+    // resolver-stamped `mode: 'sandbox'` on the synthesis branch. Phase 3 of
+    // #1435 collapsed the env-fallback admit onto the resolver-mode signal.
   },
   expectedRoutes: [
     'GET /_lookup/network',


### PR DESCRIPTION
## Summary

Phase 3 of #1435 — closes the loop on the framework-side `comply_test_controller` gate that landed in #1453 (Phase 2). The `hello_seller_adapter_guaranteed` example now carries **zero** in-adapter comply gate logic. It's the worked zero-boilerplate adopter posture.

## What changed

### `examples/hello_seller_adapter_guaranteed.ts`

1. **`accounts.resolve` synthesis branch** — gate is now `if (ref.sandbox === true)` (the spec-defined `AccountReference.sandbox` flag from `core/account-ref.json`). Stamps `mode: 'sandbox'` on the returned `Account`. The framework gate's resolver-path admit fires on that mode; no `process.env.ADCP_SANDBOX` is consulted.
2. **HITL bypass** — `getAccountMode(ctx.account) === 'sandbox'` replaces `ctx.account.id.startsWith(SANDBOX_ID_PREFIX) && process.env.ADCP_SANDBOX === '1'`. Same trust signal but no env var; more robust against any production account whose id happens to share the sandbox prefix.
3. **`complyTest:` opts** — dropped `sandboxGate: () => process.env.ADCP_SANDBOX === '1'`. The framework gate inside `createAdcpServerFromPlatform` is strictly stronger.

### `test/examples/hello-seller-adapter-guaranteed.test.js`

Dropped `ADCP_SANDBOX: '1'` from `extraEnv`. The storyboard now passes purely on the resolver-stamped mode.

## Out of scope

- **`hello_signals_adapter_marketplace.ts`** — uses the lower-level `registerTestController` (not the `complyTest:` opts surface). Phase 2's gate doesn't intercept that path. Migration is non-mechanical (would need the recorder integration to fit a comply-adapter shape upstream); leaving on the legacy path. Tracked as a follow-up.
- **Mock-server** — unchanged. Account synthesis happens in the adapter's `resolve`; the mock-server is the upstream HTTP backend (returns `network_code` / `operator_id`). Stamping `mode: 'sandbox'` lives in the resolver, where it belongs.
- **`test/server-decisioning-comply-test.test.js`** — left alone. It intentionally exercises the deprecated env-fallback admit path so the bridge stays tested through its life.
- **`hello_seller_adapter_social.ts`, `hello_seller_adapter_multi_tenant.ts`, `hello_creative_adapter_template.ts`** — none wire the controller. Nothing to do.

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:lib` — 6041 pass / 0 fail / 3 skipped (unchanged)
- [x] `node --test test/examples/hello-seller-adapter-guaranteed.test.js` — 3/3 pass without `ADCP_SANDBOX=1`
- [x] All 5 hello-adapter test files — 19/19 pass
- [x] `npm run format:check` clean
- [x] Verified: post-Phase-3, the only `ADCP_SANDBOX` / `sandboxGate` references in the guaranteed example are in explanatory comments pointing at the framework gate

## Refs

- #1435 — umbrella
- #1436 — Phase 1 (helpers): `Account.mode`, `getAccountMode`, `assertSandboxAccount`
- #1453 — Phase 2 (framework gate auto-wired in `createAdcpServerFromPlatform`)
- `docs/proposals/lifecycle-state-and-sandbox-authority.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)