### PR TITLE
fix(server): extend inline account_id refusal to resolution: 'derived' (#1468)

### DIFF
--- a/.changeset/derived-account-id-refusal.md
+++ b/.changeset/derived-account-id-refusal.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Extend framework-side inline `account_id` refusal to `resolution: 'derived'` platforms (#1468). Previously a buyer that sent `{ account_id: "foo" }` to a `'derived'` agent received a silent drop; now the framework returns `INVALID_REQUEST` with `field: account.account_id` before `accounts.resolve` runs — matching the `'implicit'` enforcement added in 6.7 (#1365). Buyers relying on the auth-principal path (no `account_id` on the wire) are unaffected.

--- a/.changeset/derived-account-id-refusal.md
+++ b/.changeset/derived-account-id-refusal.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/sdk": patch
+"@adcp/sdk": minor
 ---
 
 Extend framework-side inline `account_id` refusal to `resolution: 'derived'` platforms (#1468). Previously a buyer that sent `{ account_id: "foo" }` to a `'derived'` agent received a silent drop; now the framework returns `INVALID_REQUEST` with `field: account.account_id` before `accounts.resolve` runs — matching the `'implicit'` enforcement added in 6.7 (#1365). Buyers relying on the auth-principal path (no `account_id` on the wire) are unaffected.

--- a/docs/guides/account-resolution.md
+++ b/docs/guides/account-resolution.md
@@ -12,7 +12,7 @@ How sellers implement the three `AccountStore.resolution` modes — `'explicit'`
 |---|---|---|
 | `'explicit'` (default) | `ext.account_ref` on every request | `ref.account_id` or `ref.brand`/`ref.operator` |
 | `'implicit'` | Nothing (no `ext.account_ref`) — but must call `sync_accounts` first | `ctx.authInfo` credential key |
-| `'derived'` | Nothing | Single-tenant singleton; no per-request resolution needed |
+| `'derived'` | Nothing (sending `account_id` is refused with `INVALID_REQUEST`) | Single-tenant singleton; no per-request resolution needed |
 
 Declare the mode on `AccountStore`:
 
@@ -191,6 +191,12 @@ accounts: {
 
 No `upsert` needed. The framework returns `UNSUPPORTED_FEATURE` to any
 buyer that calls `sync_accounts`.
+
+The framework also refuses inline `account_id` references for `'derived'`
+platforms — a buyer that sends `{ account_id: "..." }` receives
+`AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` before
+`accounts.resolve` is called. Remove `account_id` from buyer requests; the
+account is resolved from the auth principal alone.
 
 ---
 

--- a/docs/migration-6.6-to-6.7.md
+++ b/docs/migration-6.6-to-6.7.md
@@ -2,7 +2,7 @@
 
 > **Status: GA in 6.7.** Most changes are additive — adopters running on
 > 6.6 today see no behavior change on `npm update @adcp/sdk` unless they
-> opt in. **Three exceptions** require attention before bumping:
+> opt in. **Four exceptions** require attention before bumping:
 >
 > - **`accounts.resolution: 'implicit'` adopters**: the framework now
 >   actually refuses inline `{account_id}` references (the docstring
@@ -21,10 +21,15 @@
 >   tool`. The throw is server-side and surfaces as HTTP 500 on every
 >   client probe — including discovery — masquerading as a transport bug.
 >   See recipe **#16**.
+> - **Adopters who switched to `resolution: 'derived'`** (including as a
+>   workaround after recipe #10): `'derived'` platforms now also refuse
+>   inline `account_id` with `INVALID_REQUEST`. If your buyers send
+>   `account_id` to a `'derived'` agent, remove that field before bumping.
+>   See recipe **[#17](#17-breaking--accountsresolution-derived-now-also-enforces-inline-account_id-refusal)**.
 
-## Audit first — the three breaking recipes
+## Audit first — the four breaking recipes
 
-Before bumping, read recipes **#10**, **#11**, and **#16**. Everything
+Before bumping, read recipes **#10**, **#11**, **#16**, and **#17**. Everything
 else is additive and can be applied incrementally.
 
 - **#10 — `accounts.resolution: 'implicit'` enforces inline-`account_id`
@@ -47,8 +52,14 @@ else is additive and can be applied incrementally.
   MCP probe — including discovery — gets an HTTP 500 with an HTML
   error body, which clients report as `discovery_failed`. Audit with
   `grep -rn 'customTools.*update_rights'` before bumping.
+- **#17 — `accounts.resolution: 'derived'` enforces inline-`account_id`
+  refusal** (runtime). The same enforcement from #10 is extended to
+  `'derived'` platforms. Buyers sending `account_id` to a single-tenant
+  derived agent now receive `INVALID_REQUEST` instead of a silent-drop
+  success. Adopters who switched to `'derived'` as a workaround after
+  recipe #10 must audit callers before bumping.
 
-## tl;dr — sixteen recipes to apply
+## tl;dr — seventeen recipes to apply
 
 | #  | If you had 6.6 …                                                                         | Do this in 6.7                                                                                                            | Mechanical?                  |
 |----|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|------------------------------|
@@ -68,6 +79,7 @@ else is additive and can be applied incrementally.
 | 14 | Local copy of the media-buy / creative status-transition graph                           | Import `MEDIA_BUY_TRANSITIONS` / `assertMediaBuyTransition` (and the creative pair) from `@adcp/sdk/server`.              | mechanical                   |
 | 15 | Sellers claiming `property-lists` / `collection-lists` echoing `targeting_overlay` by hand | `mediaBuyStore: createMediaBuyStore({ store })` opt-in framework wiring.                                                | mechanical (narrow)          |
 | 16 | Brand-rights adopter with `customTools: { update_rights: ... }`                          | Drop the customTools entry and wire `BrandRightsPlatform.updateRights` instead. The framework now owns the tool name.   | **breaking**                 |
+| 17 | `resolution: 'derived'` platform, buyer sends `account_id` inline                       | Remove `account_id` from buyer requests. The framework now refuses it with `INVALID_REQUEST` (mirrors recipe #10 for `'implicit'`). | **breaking**           |
 
 `refAccountId` already shipped in 6.6 (recipe #2); it's listed because
 the eight-item list in #1344 included it as a "stop reinventing this"
@@ -560,7 +572,7 @@ initial `sync_accounts` flow).
 |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | `resolution: 'implicit'` declared, all buyers used `sync_accounts` first                 | Nothing — calls flow as before; you no longer need to reimplement the `if (ref?.account_id) return null` branch in your resolver.                |
 | `resolution: 'implicit'` declared but adopters' callers passed inline `account_id`       | **Behavior change.** Either drop to `'explicit'` (callers continue passing inline) or fix callers to use `sync_accounts` first.                  |
-| Wanted "derive account from auth principal, ignore inline ids entirely"                  | Switch to `resolution: 'derived'` — single-tenant agents that always identify the tenant from the auth principal alone. **Note:** as of the SDK version that ships recipe #17, `'derived'` platforms also refuse inline `account_id` with `INVALID_REQUEST`. Ensure callers omit the field before switching. |
+| Wanted "derive account from auth principal, ignore inline ids entirely"                  | Switch to `resolution: 'derived'` — single-tenant agents that always identify the tenant from the auth principal alone. **Note (6.7):** `'derived'` platforms also enforce this refusal. See **[recipe #17](#17-breaking--accountsresolution-derived-now-also-enforces-inline-account_id-refusal)** — ensure callers omit `account_id` before switching. |
 | `resolution: 'explicit'` (default) declared / not declared                               | Nothing — the refusal only applies to declared `'implicit'` and `'derived'` platforms.                                                           |
 | Hand-rolled implicit store                                                               | Consider switching to `InMemoryImplicitAccountStore` or the Postgres pattern in [`docs/guides/account-resolution.md`](./guides/account-resolution.md). |
 
@@ -1191,6 +1203,10 @@ Walk this before declaring 6.6 → 6.7 done:
       declaration is dropped to `'explicit'`, or callers fixed
       (recipe 10). Inline `{account_id}` on `'implicit'` platforms
       now rejects with `INVALID_REQUEST`.
+- [ ] **`accounts.resolution: 'derived'` adopters audited.** Buyers
+      do not send `account_id` on the wire, or callers have been
+      updated to omit it (recipe 17). Inline `{account_id}` on
+      `'derived'` platforms now rejects with `INVALID_REQUEST`.
 - [ ] **Sales-* adopters typecheck.** Either drop the explicit
       `: SalesPlatform<Meta>` annotation, or change it to
       `: SalesCorePlatform<Meta> & SalesIngestionPlatform<Meta>`,

--- a/docs/migration-6.6-to-6.7.md
+++ b/docs/migration-6.6-to-6.7.md
@@ -560,8 +560,8 @@ initial `sync_accounts` flow).
 |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
 | `resolution: 'implicit'` declared, all buyers used `sync_accounts` first                 | Nothing — calls flow as before; you no longer need to reimplement the `if (ref?.account_id) return null` branch in your resolver.                |
 | `resolution: 'implicit'` declared but adopters' callers passed inline `account_id`       | **Behavior change.** Either drop to `'explicit'` (callers continue passing inline) or fix callers to use `sync_accounts` first.                  |
-| Wanted "derive account from auth principal, ignore inline ids entirely"                  | Switch to `resolution: 'derived'` — single-tenant agents and adapters that always identify the tenant from the auth principal alone (LinkedIn-shaped sellers, some retail-media operators). |
-| `resolution: 'explicit'` (default) declared / not declared                               | Nothing — the refusal only applies to declared `'implicit'` platforms.                                                                           |
+| Wanted "derive account from auth principal, ignore inline ids entirely"                  | Switch to `resolution: 'derived'` — single-tenant agents that always identify the tenant from the auth principal alone. **Note:** as of the SDK version that ships recipe #17, `'derived'` platforms also refuse inline `account_id` with `INVALID_REQUEST`. Ensure callers omit the field before switching. |
+| `resolution: 'explicit'` (default) declared / not declared                               | Nothing — the refusal only applies to declared `'implicit'` and `'derived'` platforms.                                                           |
 | Hand-rolled implicit store                                                               | Consider switching to `InMemoryImplicitAccountStore` or the Postgres pattern in [`docs/guides/account-resolution.md`](./guides/account-resolution.md). |
 
 **Companion: `InMemoryImplicitAccountStore` reference adapter.** 6.7
@@ -1030,6 +1030,37 @@ the framework-handler equivalent (`BrandRightsPlatform.updateRights`
 here), so when the next promotion-induced collision lands, follow the
 message: drop the customTools entry, wire the named platform handler.
 The pattern travels even if the migration recipe lags.
+
+### 17. **breaking** — `accounts.resolution: 'derived'` now also enforces inline-`account_id` refusal
+
+The framework's inline-`account_id` refusal (recipe #10, `'implicit'` mode) is
+extended to `'derived'` platforms. A buyer that sends `{ account_id: "foo" }`
+to a `'derived'` agent now receives:
+
+```
+INVALID_REQUEST
+field: account.account_id
+message: "This platform identifies the buyer from the authenticated principal — account.account_id is not accepted on the wire."
+suggestion: "Remove account.account_id from your request; the account is resolved from your auth credentials."
+```
+
+Previously the field was silently dropped and the singleton account was
+returned. The silent-drop was technically correct for single-tenant agents, but
+created a confusing debugging experience for buyers cargo-culting `account_id`
+from Shape B/C calls into Shape D calls.
+
+**Who is affected.** Only `resolution: 'derived'` platforms whose buyers are
+actively sending `account_id` on the wire. If you are running a Shape D adapter
+(audiostack-shaped, flashtalking-shaped, single-namespace retail-media) and your
+buyer integration never sends `account_id`, no action is needed.
+
+**Action required.** Audit `accounts.resolution`:
+
+| Your setup                                                              | What to do                                                                                                                |
+|-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `resolution: 'derived'`, buyers do not send `account_id`                | Nothing — happy path unaffected.                                                                                          |
+| `resolution: 'derived'`, buyers send `account_id` (cargo-culted from B/C) | Fix callers: remove `account_id` from the wire request. The account is resolved from the auth principal.               |
+| Switched to `'derived'` via recipe #10 to "ignore inline ids"           | Same as above — now enforced; fix callers before bumping.                                                                 |
 
 ## Worked diff — `examples/decisioning-platform-mock-seller.ts`
 

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -387,6 +387,9 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * - `'derived'` — single-tenant agents where there is no account_id on the
    *   wire at all and the auth principal alone identifies the tenant. Most
    *   self-hosted broadcasters and retail-media operators in proxy mode.
+   *   Framework refuses inline `account_id` references for these platforms —
+   *   emits `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })`
+   *   before reaching `accounts.resolve`.
    *
    * Defaults to `'explicit'` when omitted.
    */

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -159,33 +159,34 @@ function normalizeRowErrors<TRow extends { errors?: unknown }>(row: TRow): TRow 
 }
 
 /**
- * Enforce the documented `'implicit'`-resolution refusal. When a platform
- * declares `accounts.resolution: 'implicit'`, the framework refuses inline
- * `account_id` references on the wire — the buyer is expected to call
- * `sync_accounts` first, then the framework resolves the account from the
- * authenticated principal on subsequent calls. Documented at
- * `AccountStore.resolution` in `account.ts`.
- *
- * Throws `AdcpError('INVALID_REQUEST')` before reaching the adopter's
- * `accounts.resolve`, so each adopter doesn't reimplement the same
- * `if (ref?.account_id) return null` branch and the wire response is
- * consistent across implicit-mode platforms. The brand+operator union arm
- * is permitted — the strict-reading docstring claim only refuses
- * `account_id`-shaped references.
+ * Refuse inline `account_id` on the wire when the platform's resolution mode
+ * forbids it. Fires for both `'implicit'` (buyer must call `sync_accounts`
+ * first; subsequent requests are resolved from the auth principal) and
+ * `'derived'` (auth principal alone identifies the tenant; no `account_id`
+ * exists on the wire). Throws `AdcpError('INVALID_REQUEST', { field:
+ * 'account.account_id' })` before `accounts.resolve` runs, giving all adopters
+ * consistent wire enforcement without reimplementing the check per-handler.
+ * The brand+operator union arm is permitted for `'implicit'` (used during the
+ * initial `sync_accounts` flow); only the `account_id`-shaped reference is
+ * refused in both modes.
  */
-function refuseImplicitAccountId(
+function refuseInlineAccountIdWhenForbidden(
   resolution: 'explicit' | 'implicit' | 'derived' | undefined,
   ref: AccountReference | undefined
 ): void {
-  if (resolution !== 'implicit') return;
+  if (resolution !== 'implicit' && resolution !== 'derived') return;
   if (refAccountId(ref) === undefined) return;
-  throw new AdcpError('INVALID_REQUEST', {
-    message:
-      'This platform resolves accounts from the authenticated principal — call sync_accounts first; do not pass account.account_id inline.',
-    field: 'account.account_id',
-    suggestion:
-      'Call sync_accounts to associate accounts with your principal, then omit account_id on subsequent calls.',
-  });
+  const [message, suggestion] =
+    resolution === 'implicit'
+      ? [
+          'This platform resolves accounts from the authenticated principal — call sync_accounts first; do not pass account.account_id inline.',
+          'Call sync_accounts to associate accounts with your principal, then omit account_id on subsequent calls.',
+        ]
+      : [
+          'This platform identifies the buyer from the authenticated principal — account.account_id is not accepted on the wire.',
+          'Remove account.account_id from your request; the account is resolved from your auth credentials.',
+        ];
+  throw new AdcpError('INVALID_REQUEST', { message, field: 'account.account_id', suggestion });
 }
 
 /**
@@ -1146,7 +1147,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
         // subsequent calls. The brand+operator union arm is permitted
         // (used during the initial sync_accounts onboarding flow); only
         // the `{ account_id }` arm is refused. Closes adcp-client#1364.
-        refuseImplicitAccountId(platform.accounts.resolution, ref);
+        refuseInlineAccountIdWhenForbidden(platform.accounts.resolution, ref);
         const account = await platform.accounts.resolve(ref, toResolveCtx(ctx, ctx.toolName));
         resolved = account != null;
         resolvedAccountId = account?.id;
@@ -1673,7 +1674,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
       };
       let resolvedAccountId: string | undefined;
       if (ref) {
-        refuseImplicitAccountId(platform.accounts.resolution, ref as AccountReference);
+        refuseInlineAccountIdWhenForbidden(platform.accounts.resolution, ref as AccountReference);
         try {
           const resolved = await platform.accounts.resolve(ref as AccountReference, resolveCtx);
           if (resolved) resolvedAccountId = resolved.id;
@@ -4332,7 +4333,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // tokens / upstream IDs off `ctx.account.ctx_metadata` without
       // having to re-resolve from `params.account`.
       const resolveCtx = toResolveCtx(ctx, 'get_account_financials');
-      refuseImplicitAccountId(accounts.resolution, params.account);
+      refuseInlineAccountIdWhenForbidden(accounts.resolution, params.account);
       const resolved = await accounts.resolve(params.account, resolveCtx);
       if (!resolved) {
         throw new AdcpError('ACCOUNT_NOT_FOUND', {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -166,9 +166,10 @@ function normalizeRowErrors<TRow extends { errors?: unknown }>(row: TRow): TRow 
  * exists on the wire). Throws `AdcpError('INVALID_REQUEST', { field:
  * 'account.account_id' })` before `accounts.resolve` runs, giving all adopters
  * consistent wire enforcement without reimplementing the check per-handler.
- * The brand+operator union arm is permitted for `'implicit'` (used during the
- * initial `sync_accounts` flow); only the `account_id`-shaped reference is
- * refused in both modes.
+ * The brand+operator union arm is permitted for both `'implicit'` and
+ * `'derived'` (used during `sync_accounts` for implicit; harmlessly passed to
+ * the adopter's resolver for derived); only the `account_id`-shaped reference
+ * is refused in both modes.
  */
 function refuseInlineAccountIdWhenForbidden(
   resolution: 'explicit' | 'implicit' | 'derived' | undefined,

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -432,6 +432,33 @@ describe("#1468 — accounts.resolution: 'derived' refuses inline account_id", (
     assert.strictEqual(resolveCalled, true, 'resolve should be called on the auth-derived path');
   });
 
+  it('permits the brand+operator arm on derived platforms — only account_id is refused', async () => {
+    let sawRef;
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async ref => {
+          sawRef = ref;
+          return { id: 'singleton', name: 'My Platform', status: 'active', ctx_metadata: {} };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' },
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.deepStrictEqual(sawRef, { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' });
+  });
+
   it("'implicit' enforcement is unchanged — error message still references sync_accounts", async () => {
     const platform = buildDerivedPlatform({
       accounts: {

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -1,7 +1,6 @@
 // Tests for #1364 — framework refusal of inline account_id references
-// against `accounts.resolution: 'implicit'` platforms. Documented behavior
-// at AccountStore.resolution; previously aspirational (docstring claim
-// without enforcement).
+// against `accounts.resolution: 'implicit'` platforms, and #1468 — same
+// enforcement extended to `accounts.resolution: 'derived'` platforms.
 
 process.env.NODE_ENV = 'test';
 
@@ -284,5 +283,177 @@ describe("#1364 — accounts.resolution: 'implicit' refuses inline account_id", 
     assert.strictEqual(result.isError, true);
     assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
     assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+});
+
+describe("#1468 — accounts.resolution: 'derived' refuses inline account_id", () => {
+  function buildDerivedPlatform(overrides = {}) {
+    return {
+      capabilities: {
+        specialisms: ['sales-non-guaranteed'],
+        creative_agents: [],
+        channels: ['display'],
+        pricingModels: ['cpm'],
+        config: {},
+      },
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({
+          id: 'singleton',
+          name: 'My Platform',
+          status: 'active',
+          ctx_metadata: {},
+          authInfo: { kind: 'api_key', principal: 'k1' },
+        }),
+      },
+      statusMappers: {},
+      sales: {
+        getProducts: async () => ({
+          products: [
+            {
+              product_id: 'p1',
+              name: 'sample',
+              description: 'fixture',
+              format_ids: [{ id: 'standard', agent_url: 'https://example.com/mcp' }],
+              delivery_type: 'non_guaranteed',
+              publisher_properties: { reportable: true },
+              reporting_capabilities: { available_dimensions: ['geo'] },
+              pricing_options: [{ pricing_model: 'cpm', rate: 5.0, currency: 'USD' }],
+            },
+          ],
+        }),
+        createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+        syncCreatives: async () => [],
+        getMediaBuyDelivery: async () => ({ media_buys: [] }),
+      },
+      ...overrides,
+    };
+  }
+
+  it('rejects { account_id } on get_products with INVALID_REQUEST and field=account.account_id', async () => {
+    let resolveCalled = false;
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => {
+          resolveCalled = true;
+          return { id: 'singleton', name: 'My Platform', status: 'active', ctx_metadata: {} };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'buyer_abc' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+    assert.match(result.structuredContent.adcp_error.message, /account\.account_id is not accepted/);
+    assert.strictEqual(resolveCalled, false, 'resolve must not be invoked when derived-mode rejects upfront');
+  });
+
+  it('rejects { account_id } on tasks_get with INVALID_REQUEST', async () => {
+    const platform = buildDerivedPlatform();
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'tasks_get',
+        arguments: {
+          task_id: 'task_does_not_matter',
+          account: { account_id: 'buyer_abc' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+
+  it('rejects { account_id } on get_account_financials with INVALID_REQUEST', async () => {
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({ id: 'singleton', name: 'My Platform', status: 'active', ctx_metadata: {} }),
+        getAccountFinancials: async () => ({
+          financials: { spend: { amount: 0, currency: 'USD' } },
+        }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_account_financials',
+        arguments: {
+          account: { account_id: 'buyer_abc' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+
+  it('omitted account on derived platform succeeds (auth-derived path, no enforcement)', async () => {
+    let resolveCalled = false;
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => {
+          resolveCalled = true;
+          return { id: 'singleton', name: 'My Platform', status: 'active', ctx_metadata: {} };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          // no account field
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.strictEqual(resolveCalled, true, 'resolve should be called on the auth-derived path');
+  });
+
+  it("'implicit' enforcement is unchanged — error message still references sync_accounts", async () => {
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'implicit',
+        resolve: async () => null,
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'snap_act_123' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.match(result.structuredContent.adcp_error.message, /sync_accounts/);
   });
 });

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -358,6 +358,7 @@ describe("#1468 — accounts.resolution: 'derived' refuses inline account_id", (
     assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
     assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
     assert.match(result.structuredContent.adcp_error.message, /account\.account_id is not accepted/);
+    assert.match(result.structuredContent.adcp_error.suggestion, /Remove account\.account_id/);
     assert.strictEqual(resolveCalled, false, 'resolve must not be invoked when derived-mode rejects upfront');
   });
 


### PR DESCRIPTION
Closes #1468

Mirrors the `'implicit'`-mode wire-contract enforcement (#1365, recipe #10) for `resolution: 'derived'` platforms. Previously a buyer sending `{ account_id: "foo" }` to a `'derived'` agent received a silent drop and the singleton response — no signal that the field was meaningless. The framework now throws `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` before `accounts.resolve` runs, consistent with what `'implicit'` has done since 6.7. The auth-principal path (no `account_id` on the wire) is unaffected.

## What changed

- **`src/lib/server/decisioning/runtime/from-platform.ts`** — Renamed `refuseImplicitAccountId` → `refuseInlineAccountIdWhenForbidden`; extended predicate from `=== 'implicit'` to `=== 'implicit' || === 'derived'`; branched error messages (implicit still references `sync_accounts`; derived says `account.account_id is not accepted`). All 3 call sites updated.
- **`src/lib/server/decisioning/account.ts`** — `AccountStore.resolution` JSDoc updated to document the framework-side refusal for `'derived'`.
- **`docs/guides/account-resolution.md`** — Quick-ref table and `'derived'` section updated with enforcement note.
- **`docs/migration-6.6-to-6.7.md`** — Recipe #17 added as a proper breaking-change entry; intro block, audit-first section, tl;dr table, steering-row cross-reference, and self-grade checklist all updated.
- **`test/server-decisioning-implicit-account-id.test.js`** — 6 new tests: `get_products`, `tasks_get`, `get_account_financials` rejections; omitted-account success path; `brand+operator` arm permitted; `'implicit'` message unchanged.
- **`.changeset/derived-account-id-refusal.md`** — `minor` bump (breaking wire behavior for misbehaving buyers).

## What was tested

- `tsc --project tsconfig.lib.json --noEmit` — zero new errors (pre-existing sandbox env errors: missing `@types/node`, deprecated `moduleResolution=node10` — confirmed pre-existing on `main`).
- `npm run format:check` — passes.
- Full `npm run ci:quick` could not complete locally (`tsx` not installed in sandbox; same limitation as PR #1465). CI will run the full suite.

**Nit surfaced (not fixed — reviewer call):** The `comply_test_controller` path (sandbox-only, line ~1469) calls `accounts.resolve` without the guard. Pre-PR code reviewer confirmed this is legitimately exempt — sandbox-only context with fixture resolvers; no production impact.

**Changeset bump note:** Step-4 expert argued `patch` (enforcement of existing documented contract); pre-PR expert argued `minor` (new `INVALID_REQUEST` on a previously-passing path). Set to `minor` as the conservative choice. Reviewer may downgrade to `patch` if consistent with repo semver policy for spec-enforcement changes.

## Pre-PR review

- **code-reviewer:** approved — all 3 call sites correctly renamed; `comply_test_controller` path confirmed legitimately exempt; 1 nit (JSDoc clarity on brand+operator for derived, fixed).
- **dx-expert:** approved — error messages actionable; migration doc blockers (intro block, tl;dr table, self-grade checklist missing #17) fixed.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1469` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_015PvNkxXYjNk7ABsbALFiKp

---
_Generated by [Claude Code](https://claude.ai/code/session_015PvNkxXYjNk7ABsbALFiKp)_