### PR TITLE
feat(server): refuse inline account_id for resolution: 'derived' (#1468)

### DIFF
--- a/.changeset/derived-account-id-refusal.md
+++ b/.changeset/derived-account-id-refusal.md
@@ -1,0 +1,27 @@
+---
+'@adcp/sdk': minor
+---
+
+Framework-side refusal of inline `account_id` for `resolution: 'derived'`
+agents (closes adcp-client#1468). Mirrors the long-standing `'implicit'`
+enforcement (#1364): the framework now throws
+`AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` *before*
+reaching `accounts.resolve` whenever a `'derived'`-mode platform receives
+a buyer-supplied `account_id` on the wire.
+
+Single-tenant agents (audiostack, flashtalking, single-namespace
+retail-media) declare `account_id` is meaningless on the wire; previously
+the framework silently dropped buyer-supplied ids and the resolver
+returned the singleton anyway, leaving cargo-culted requests undetectable.
+The refusal makes the wire-contract violation surface cleanly to the
+buyer with a single-tenant message (no `sync_accounts`-first guidance,
+since that step does not exist in derived mode).
+
+Hand-rolled `'derived'` stores get the enforcement automatically — not
+just users of `createDerivedAccountStore`. The brand+operator union arm
+is still permitted.
+
+Implementation: `refuseImplicitAccountId` (closed #1364) renamed to
+`refuseInlineAccountIdWhenForbidden` and extended to fire on both
+`'implicit'` and `'derived'` resolution modes with mode-specific error
+messaging.

--- a/docs/guides/account-resolution.md
+++ b/docs/guides/account-resolution.md
@@ -213,6 +213,16 @@ accounts: {
 No `upsert` needed. The framework returns `UNSUPPORTED_FEATURE` to any
 buyer that calls `sync_accounts`.
 
+**Inline `account_id` refusal.** Since adcp-client#1468, the framework
+refuses inline `{ account_id }` references for `'derived'` platforms with
+`AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` *before*
+reaching `accounts.resolve` — same shape as `'implicit'`'s refusal (#1364),
+with a single-tenant message instead of the `sync_accounts`-first guidance.
+Hand-rolled `'derived'` stores get this for free; the
+`createDerivedAccountStore` factory's defensive ignore is a belt + braces
+fallback. The brand+operator union arm is still permitted (route through
+your resolver verbatim).
+
 ---
 
 ## `'explicit'` (default)

--- a/src/lib/adapters/derived-account-store.ts
+++ b/src/lib/adapters/derived-account-store.ts
@@ -141,13 +141,16 @@ export interface DerivedAccountStoreOptions<TCtxMeta = Record<string, unknown>> 
  * };
  * ```
  *
- * **Buyer-supplied `account_id` is ignored, not refused.** A `'derived'`
- * adapter that receives an inline `account_id` simply ignores it (the
- * resolver returns the singleton regardless). This matches the wire spec —
- * `'derived'` agents declare the field is meaningless. If you want to
- * surface a wire-shape error when a buyer sends `account_id` to a derived
- * adapter, wrap the resolver and throw `AdcpError('INVALID_REQUEST',
- * { field: 'account.account_id' })` from a `resolve` override.
+ * **Buyer-supplied `account_id` is refused at the framework boundary.**
+ * Since adcp-client#1468, the framework throws `AdcpError('INVALID_REQUEST',
+ * { field: 'account.account_id' })` BEFORE reaching this resolver when a
+ * `'derived'`-mode platform receives an inline `account_id` — same shape
+ * as `'implicit'`'s long-standing refusal (#1364), with a single-tenant
+ * message instead of the `sync_accounts`-first guidance. The factory
+ * itself ignores any `account_id` that does reach it (defensive belt +
+ * braces), but adopters can rely on the framework refusal as the
+ * canonical surface. Hand-rolled `'derived'` stores get the same
+ * enforcement automatically.
  *
  * @public
  */

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -387,6 +387,11 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    * - `'derived'` — single-tenant agents where there is no account_id on the
    *   wire at all and the auth principal alone identifies the tenant. Most
    *   self-hosted broadcasters and retail-media operators in proxy mode.
+   *   Framework refuses inline `account_id` references for these platforms —
+   *   same `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })`
+   *   shape as `'implicit'`, but with a single-tenant message instead of the
+   *   `sync_accounts`-first guidance (no `sync_accounts` step exists in
+   *   derived mode). The brand+operator union arm is permitted.
    *
    * Defaults to `'explicit'` when omitted.
    */

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -159,32 +159,46 @@ function normalizeRowErrors<TRow extends { errors?: unknown }>(row: TRow): TRow 
 }
 
 /**
- * Enforce the documented `'implicit'`-resolution refusal. When a platform
- * declares `accounts.resolution: 'implicit'`, the framework refuses inline
- * `account_id` references on the wire — the buyer is expected to call
- * `sync_accounts` first, then the framework resolves the account from the
- * authenticated principal on subsequent calls. Documented at
- * `AccountStore.resolution` in `account.ts`.
+ * Enforce the documented inline-`account_id` refusal for resolution modes
+ * that declare the field meaningless on the wire — `'implicit'` (since
+ * #1364) and `'derived'` (since adcp-client#1468). Both modes share the
+ * same wire contract: the buyer does not pass `account_id` inline; the
+ * framework derives the tenant from the authenticated principal (after a
+ * `sync_accounts` step for `'implicit'`; directly for `'derived'`).
  *
  * Throws `AdcpError('INVALID_REQUEST')` before reaching the adopter's
  * `accounts.resolve`, so each adopter doesn't reimplement the same
  * `if (ref?.account_id) return null` branch and the wire response is
- * consistent across implicit-mode platforms. The brand+operator union arm
- * is permitted — the strict-reading docstring claim only refuses
- * `account_id`-shaped references.
+ * consistent across both modes. The brand+operator union arm is
+ * permitted — only `account_id`-shaped references are refused.
+ *
+ * Mode-specific message and suggestion: `'implicit'` adopters get the
+ * `sync_accounts`-first guidance; `'derived'` adopters get the single-
+ * tenant explanation (no `sync_accounts` step exists in derived mode —
+ * the auth principal alone identifies the tenant).
+ *
+ * Documented at `AccountStore.resolution` in `account.ts`.
  */
-function refuseImplicitAccountId(
+function refuseInlineAccountIdWhenForbidden(
   resolution: 'explicit' | 'implicit' | 'derived' | undefined,
   ref: AccountReference | undefined
 ): void {
-  if (resolution !== 'implicit') return;
+  if (resolution !== 'implicit' && resolution !== 'derived') return;
   if (refAccountId(ref) === undefined) return;
+  if (resolution === 'implicit') {
+    throw new AdcpError('INVALID_REQUEST', {
+      message:
+        'This platform resolves accounts from the authenticated principal — call sync_accounts first; do not pass account.account_id inline.',
+      field: 'account.account_id',
+      suggestion:
+        'Call sync_accounts to associate accounts with your principal, then omit account_id on subsequent calls.',
+    });
+  }
   throw new AdcpError('INVALID_REQUEST', {
     message:
-      'This platform resolves accounts from the authenticated principal — call sync_accounts first; do not pass account.account_id inline.',
+      'This single-tenant agent identifies the tenant from the authenticated principal alone — do not pass account.account_id inline; the field is meaningless on the wire for derived-resolution agents.',
     field: 'account.account_id',
-    suggestion:
-      'Call sync_accounts to associate accounts with your principal, then omit account_id on subsequent calls.',
+    suggestion: 'Omit the account field; the framework derives the tenant from your authenticated credential.',
   });
 }
 
@@ -1139,14 +1153,15 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       let resolved = false;
       let resolvedAccountId: string | undefined;
       try {
-        // Enforce the JSDoc contract documented at
-        // `AccountStore.resolution`: implicit-mode platforms refuse inline
-        // `account_id` references — buyers call sync_accounts first, then
-        // the framework resolves accounts from the auth principal on
-        // subsequent calls. The brand+operator union arm is permitted
-        // (used during the initial sync_accounts onboarding flow); only
-        // the `{ account_id }` arm is refused. Closes adcp-client#1364.
-        refuseImplicitAccountId(platform.accounts.resolution, ref);
+        // Enforce the JSDoc contract documented at `AccountStore.resolution`:
+        // implicit-mode and derived-mode platforms refuse inline `account_id`
+        // references. Implicit: buyers call sync_accounts first, then the
+        // framework resolves from the auth principal. Derived: single-tenant;
+        // the principal alone identifies the tenant. The brand+operator union
+        // arm is permitted (implicit's sync_accounts onboarding flow); only
+        // the `{ account_id }` arm is refused. Closes adcp-client#1364
+        // (implicit) and adcp-client#1468 (derived).
+        refuseInlineAccountIdWhenForbidden(platform.accounts.resolution, ref);
         const account = await platform.accounts.resolve(ref, toResolveCtx(ctx, ctx.toolName));
         resolved = account != null;
         resolvedAccountId = account?.id;
@@ -1673,7 +1688,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
       };
       let resolvedAccountId: string | undefined;
       if (ref) {
-        refuseImplicitAccountId(platform.accounts.resolution, ref as AccountReference);
+        refuseInlineAccountIdWhenForbidden(platform.accounts.resolution, ref as AccountReference);
         try {
           const resolved = await platform.accounts.resolve(ref as AccountReference, resolveCtx);
           if (resolved) resolvedAccountId = resolved.id;
@@ -4332,7 +4347,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // tokens / upstream IDs off `ctx.account.ctx_metadata` without
       // having to re-resolve from `params.account`.
       const resolveCtx = toResolveCtx(ctx, 'get_account_financials');
-      refuseImplicitAccountId(accounts.resolution, params.account);
+      refuseInlineAccountIdWhenForbidden(accounts.resolution, params.account);
       const resolved = await accounts.resolve(params.account, resolveCtx);
       if (!resolved) {
         throw new AdcpError('ACCOUNT_NOT_FOUND', {

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -286,3 +286,181 @@ describe("#1364 — accounts.resolution: 'implicit' refuses inline account_id", 
     assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
   });
 });
+
+describe("#1468 — accounts.resolution: 'derived' refuses inline account_id (mirrors #1364)", () => {
+  it('rejects { account_id } reference with INVALID_REQUEST and field=account.account_id', async () => {
+    let resolveCalled = false;
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => {
+          resolveCalled = true;
+          return null;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'audiostack_singleton' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+    assert.strictEqual(resolveCalled, false, 'resolve must not be invoked when derived-mode rejects upfront');
+  });
+
+  it('derived-mode error message names single-tenant / derived (not sync_accounts, which does not exist in derived mode)', async () => {
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => ({ id: 'singleton', name: 'Singleton', status: 'active', ctx_metadata: {} }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'foo' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.match(
+      result.structuredContent.adcp_error.message,
+      /single-tenant|derived/i,
+      'derived-mode message should explain single-tenant semantics, not point at sync_accounts'
+    );
+    assert.doesNotMatch(
+      result.structuredContent.adcp_error.message,
+      /sync_accounts/,
+      'derived-mode message must not suggest sync_accounts (no such step in derived mode)'
+    );
+  });
+
+  it('derived + omitted account flows to auth-derived resolution (no enforcement, no rejection)', async () => {
+    let sawRef;
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async ref => {
+          sawRef = ref;
+          return {
+            id: 'singleton',
+            name: 'Singleton',
+            status: 'active',
+            ctx_metadata: {},
+          };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          // no `account` field — auth-derived path
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.strictEqual(sawRef, undefined, 'auth-derived path passes undefined ref');
+  });
+
+  it('tasks_get rejects { account_id } with INVALID_REQUEST on derived platforms', async () => {
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => null,
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'tasks_get',
+        arguments: {
+          task_id: 'task_does_not_matter',
+          account: { account_id: 'audiostack_singleton' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+
+  it('get_account_financials rejects { account_id } with INVALID_REQUEST on derived platforms', async () => {
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => null,
+        getAccountFinancials: async () => ({
+          financials: { spend: { amount: 0, currency: 'USD' } },
+        }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_account_financials',
+        arguments: {
+          account: { account_id: 'audiostack_singleton' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+
+  it('derived-mode permits brand+operator union arm (no account_id present)', async () => {
+    // Brand+operator refs are not refused by the framework regardless of
+    // resolution mode — only the `{ account_id }` arm is refused. Adopters
+    // who want to additionally reject brand-arm refs do so in their resolver.
+    let sawRef;
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async ref => {
+          sawRef = ref;
+          return {
+            id: 'singleton',
+            name: 'Singleton',
+            status: 'active',
+            ctx_metadata: {},
+          };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' },
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.deepStrictEqual(sawRef, { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' });
+  });
+});

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -463,4 +463,44 @@ describe("#1468 — accounts.resolution: 'derived' refuses inline account_id (mi
     assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
     assert.deepStrictEqual(sawRef, { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' });
   });
+
+  it('refusal fires regardless of auth posture — authenticated requests with inline account_id still rejected', async () => {
+    // Locks the contract: an authenticated buyer that sends inline account_id
+    // to a derived agent gets the same INVALID_REQUEST as an unauthenticated
+    // one. Prevents future drift where someone might soften the refusal "for
+    // authenticated principals only" — the field is meaningless on the wire
+    // for derived-mode regardless of who's asking.
+    let resolveCalled = false;
+    const platform = buildImplicitPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => {
+          resolveCalled = true;
+          return null;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      ...SERVER_OPTS,
+      authenticate: () => ({
+        kind: 'oauth',
+        credential: { kind: 'oauth', client_id: 'authed-buyer', scopes: [] },
+      }),
+    });
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'foo' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+    assert.strictEqual(resolveCalled, false, 'authed principal does not soften the refusal');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #1468. Mirrors the long-standing `'implicit'` enforcement (#1364) for the parallel `'derived'` resolution mode — single-tenant agents (audiostack, flashtalking, single-namespace retail-media) where there is no `account_id` on the wire and the auth principal alone identifies the tenant.

Pre-this-PR, buyer-supplied `account_id` on a `'derived'` agent was silently dropped and the resolver returned the singleton anyway — cargo-culted requests went undetected. The framework now throws `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` *before* reaching `accounts.resolve`, with a single-tenant message instead of the `sync_accounts`-first guidance (since `sync_accounts` does not exist in derived mode).

| Mode | Before | After |
|---|---|---|
| `'implicit'` | refused with `sync_accounts` guidance (#1364) | unchanged |
| `'derived'` | silently dropped, singleton returned anyway | refused with single-tenant guidance |
| `'explicit'` | accepted | unchanged |

Hand-rolled `'derived'` stores get this automatically — not just users of `createDerivedAccountStore`. The brand+operator union arm is still permitted (only the `{ account_id }` arm is refused, matching `'implicit'`).

## Implementation

- `refuseImplicitAccountId` (introduced in #1364) renamed to `refuseInlineAccountIdWhenForbidden` and extended to fire on both `'implicit'` and `'derived'` resolution modes with mode-specific error messaging. Per Option 1 from #1468 — single predicate, both modes.
- Three call sites updated: `resolveAccount`, `tasks_get`, `get_account_financials` (all in `from-platform.ts`).
- `account.ts` JSDoc on `AccountStore.resolution` updated to describe the framework refusal for `'derived'` (previously only documented for `'implicit'`).
- `createDerivedAccountStore` JSDoc updated: the factory's defensive ignore-inline-id behavior is now documented as "belt + braces" — the framework refusal is the canonical surface.
- `docs/guides/account-resolution.md` `'derived'` section gains an "Inline `account_id` refusal" callout pointing at this PR.

## Test plan

Extended `test/server-decisioning-implicit-account-id.test.js` with a `#1468 — derived` block covering:

- [x] `get_products` rejects `{ account_id }` with `INVALID_REQUEST` + `field=account.account_id`
- [x] Error message names single-tenant / derived (not `sync_accounts`, which does not exist in derived mode)
- [x] Omitted account flows to auth-derived resolution (no enforcement, no rejection)
- [x] `tasks_get` rejects `{ account_id }` with `INVALID_REQUEST`
- [x] `get_account_financials` rejects `{ account_id }` with `INVALID_REQUEST`
- [x] Brand+operator union arm still permitted (only the `{ account_id }` arm refused)
- [x] `resolve` not invoked when refusal fires (defensive — the singleton-return path can't mask the refusal)

13/13 pass in this file; 89/89 across the full AccountStore factory regression suite (`derived-account-store`, `roster-account-store`, `in-memory-implicit-account-store`, `server-adapters-oauth-passthrough-resolver`, `server-decisioning-implicit-account-id`).

## Backwards compatibility

- **Buyer-side:** any buyer that was sending `account_id` to a `'derived'` agent and getting silent-success is now refused. This is the intended fix — the prior behavior masked a wire-contract violation. Buyers update by omitting the field (the resolver behavior is unchanged).
- **Adopter-side:** no API change for `'derived'` adopters. Hand-rolled stores that today early-return `null` on `ref.account_id` can drop that branch (the framework now refuses upstream); not required.

## Downstream signal

Surfaced in the audiostack rebuild thread (scope3data/agentic-adapters#245). The audiostack adapter is on track to swap to `createDerivedAccountStore` once 6.8 ships; this PR closes the framework-side gap so hand-rolled `'derived'` stores get the same wire contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)