### PR TITLE
fix(server): enforce inline account_id refusal for resolution: 'derived' platforms

### DIFF
--- a/.changeset/derived-resolution-account-id-refusal.md
+++ b/.changeset/derived-resolution-account-id-refusal.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": minor
+---
+
+**breaking** — `accounts.resolution: 'derived'` now enforces inline-`account_id` refusal (closes #1469, mirrors recipe #10 for `'implicit'`).
+
+Pre-6.7, a buyer sending `{ account_id: "foo" }` to a `'derived'`-resolution (single-tenant) agent received the singleton response silently — the field was discarded with no signal. The framework now refuses it with `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` before `accounts.resolve` is called, consistent with the `'implicit'` enforcement added in #1364.
+
+The error message for `'derived'` is distinct from `'implicit'`: it says "single-tenant agent — account is derived from your auth credential" and does not mention `sync_accounts` (which is irrelevant and unsupported for derived-mode agents).
+
+**Migration:** See recipe #10b in `docs/migration-6.6-to-6.7.md`. Adopters whose `resolve()` reads `ref.account_id` under `'derived'` mode must remove that branch — the refusal fires before `resolve()` is called.
+
+Internal rename: `refuseImplicitAccountId` → `refuseInlineAccountIdWhenForbidden` (private function, not exported).

--- a/docs/migration-6.6-to-6.7.md
+++ b/docs/migration-6.6-to-6.7.md
@@ -2,13 +2,17 @@
 
 > **Status: GA in 6.7.** Most changes are additive — adopters running on
 > 6.6 today see no behavior change on `npm update @adcp/sdk` unless they
-> opt in. **Three exceptions** require attention before bumping:
+> opt in. **Four exceptions** require attention before bumping:
 >
 > - **`accounts.resolution: 'implicit'` adopters**: the framework now
 >   actually refuses inline `{account_id}` references (the docstring
 >   was aspirational pre-6.7). If your platform declared `'implicit'`
 >   but accepted inline ids, those calls now reject with
 >   `INVALID_REQUEST`. See recipe **#10** below.
+> - **`accounts.resolution: 'derived'` adopters**: the same inline
+>   `{account_id}` refusal now applies to single-tenant derived-resolution
+>   platforms. Previously the field was silently ignored; it now rejects
+>   with `INVALID_REQUEST`. See recipe **#10b** below.
 > - **Adopters with `: SalesPlatform<Meta>` field annotations claiming
 >   `sales-guaranteed` / `sales-non-guaranteed` / `sales-broadcast-tv` /
 >   `sales-catalog-driven`**: `SalesPlatform` is now structurally
@@ -22,9 +26,9 @@
 >   client probe — including discovery — masquerading as a transport bug.
 >   See recipe **#16**.
 
-## Audit first — the three breaking recipes
+## Audit first — the four breaking recipes
 
-Before bumping, read recipes **#10**, **#11**, and **#16**. Everything
+Before bumping, read recipes **#10**, **#10b**, **#11**, and **#16**. Everything
 else is additive and can be applied incrementally.
 
 - **#10 — `accounts.resolution: 'implicit'` enforces inline-`account_id`
@@ -32,6 +36,9 @@ else is additive and can be applied incrementally.
   `'implicit'`-resolution platform now reject with `INVALID_REQUEST`.
   Pre-6.7 this was aspirational — the docstring claimed the framework
   would refuse, but nothing checked it.
+- **#10b — `accounts.resolution: 'derived'` enforces inline-`account_id`
+  refusal** (runtime). Same enforcement extended to single-tenant derived
+  platforms. Inline `{account_id}` previously silently dropped; now rejects.
 - **#11 — `SalesPlatform` split into `SalesCorePlatform &
   SalesIngestionPlatform`** (TS-only, self-announcing under
   `tsc --noEmit`). Adopters with `: SalesPlatform<Meta>` field

--- a/docs/migration-6.6-to-6.7.md
+++ b/docs/migration-6.6-to-6.7.md
@@ -62,6 +62,7 @@ else is additive and can be applied incrementally.
 | 8  | Buyer-agent identity not modeled / `ctx.authInfo.token` checked everywhere               | Wire `BuyerAgentRegistry` per [`docs/migration-buyer-agent-registry.md`](./migration-buyer-agent-registry.md).            | judgment                     |
 | 9  | One process, multi-tenant — fan out by tenant in your route layer                        | `createTenantRegistry({ ... })` from `@adcp/sdk/server` — one server per tenant, tenant-id keyed lookup.                  | judgment (architectural)     |
 | 10 | `resolution: 'implicit'` declared but inline `{account_id}` requests still working       | The framework now refuses them. Either remove the `'implicit'` declaration or stop emitting inline `account_id`.          | **breaking**                 |
+| 10b | `resolution: 'derived'` declared but inline `{account_id}` requests still working (silent-ignore) | The framework now refuses them with `INVALID_REQUEST`. Remove `account_id` from requests to derived-mode agents, or change `resolution` to `'explicit'`. See recipe **#10b** below. | **breaking** |
 | 11 | `: SalesPlatform<Meta>` annotation + claim sales-non-guaranteed / -guaranteed / etc.     | Switch to `: SalesCorePlatform<Meta> & SalesIngestionPlatform<Meta>` (or `defineSalesCorePlatform` + `defineSalesIngestionPlatform` spread). | **breaking** (TS-only)       |
 | 12 | Adapter wrapping a vendor OAuth + `/me/adaccounts` upstream — Shape B copy-pasted        | `createOAuthPassthroughResolver({ httpClient, listEndpoint, idField, toAccount })`.                                       | mechanical                   |
 | 13 | Hand-rolled `accounts.resolve` + per-entry tenant-isolation gate on `upsert` / `syncGovernance` for a multi-tenant adapter | `createTenantStore({...})` — built-in security gate, fail-closed when auth principal can't be resolved.        | mechanical (security-relevant) |
@@ -584,6 +585,21 @@ const accountStore = new InMemoryImplicitAccountStore({
   },
 });
 ```
+
+### 10b. **breaking** — `accounts.resolution: 'derived'` now enforces inline-`account_id` refusal
+
+`'derived'`-resolution platforms declare "single-tenant — auth principal alone identifies the tenant; there is no `account_id` on the wire at all." Pre-6.7, a buyer that sent `{ account_id: "foo" }` received the singleton response and no error — the field was silently discarded. 6.7 wires the refusal: derived-resolution platforms now reject inline `{account_id}` references with `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` before the request reaches `accounts.resolve`. The `{brand, operator}` arm is still permitted.
+
+**Action required.** Audit `accounts.resolution`:
+
+| Your pre-6.7 setup                                                                      | What to do                                                                                                                |
+|-----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `resolution: 'derived'` declared, no buyers sent `account_id`                          | Nothing — calls flow as before.                                                                                           |
+| `resolution: 'derived'` declared and buyers sent `account_id` (silently ignored)       | **Behavior change.** Fix buyers to omit `account_id`, or change `resolution` to `'explicit'` if buyers must identify accounts by id. |
+| `resolve()` reads `ref.account_id` under `'derived'` mode (e.g. `if (ref?.account_id) ...`) | **Runtime regression.** The refusal fires before `resolve()` is called — `ref.account_id` will never reach your resolver. Remove the branch or switch `resolution` to `'explicit'`. |
+| `resolution: 'explicit'` (default) declared / not declared                             | Nothing — the refusal only applies to declared `'derived'` platforms.                                                     |
+
+---
 
 **Companion: `createRosterAccountStore` for publisher-curated rosters
 (Shape C).** Adopters who own the roster (storefront table,

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -386,7 +386,10 @@ export interface AccountStore<TCtxMeta = Record<string, unknown>> {
    *   `sync_accounts` flow); only `account_id`-shaped references are rejected.
    * - `'derived'` — single-tenant agents where there is no account_id on the
    *   wire at all and the auth principal alone identifies the tenant. Most
-   *   self-hosted broadcasters and retail-media operators in proxy mode.
+   *   self-hosted broadcasters and retail-media operators in proxy mode. The
+   *   framework emits `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })`
+   *   before reaching `accounts.resolve` when a buyer passes an inline
+   *   `account_id` (mirrors the `'implicit'` enforcement added in #1364).
    *
    * Defaults to `'explicit'` when omitted.
    */

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -159,26 +159,37 @@ function normalizeRowErrors<TRow extends { errors?: unknown }>(row: TRow): TRow 
 }
 
 /**
- * Enforce the documented `'implicit'`-resolution refusal. When a platform
- * declares `accounts.resolution: 'implicit'`, the framework refuses inline
- * `account_id` references on the wire — the buyer is expected to call
- * `sync_accounts` first, then the framework resolves the account from the
- * authenticated principal on subsequent calls. Documented at
- * `AccountStore.resolution` in `account.ts`.
+ * Enforce the inline `account_id` refusal for resolution modes that forbid it.
  *
- * Throws `AdcpError('INVALID_REQUEST')` before reaching the adopter's
- * `accounts.resolve`, so each adopter doesn't reimplement the same
- * `if (ref?.account_id) return null` branch and the wire response is
- * consistent across implicit-mode platforms. The brand+operator union arm
- * is permitted — the strict-reading docstring claim only refuses
- * `account_id`-shaped references.
+ * - `'implicit'` — buyers call `sync_accounts` first; the framework resolves
+ *   the account from the authenticated principal on subsequent calls. Passing
+ *   `account_id` inline is refused so adopters don't reimplement the same
+ *   `if (ref?.account_id) return null` guard in every resolver.
+ * - `'derived'` — single-tenant agents where the auth principal alone
+ *   identifies the tenant; there is no `account_id` on the wire at all.
+ *   Passing `account_id` is refused so buyers get a correctable error
+ *   instead of a confusing silent-ignore.
+ *
+ * Both modes: throws `AdcpError('INVALID_REQUEST')` before reaching the
+ * adopter's `accounts.resolve`. The `{brand, operator}` union arm is
+ * permitted in both modes — only `account_id`-shaped references are refused.
+ * `'explicit'` and omitted resolution are unaffected.
  */
-function refuseImplicitAccountId(
+function refuseInlineAccountIdWhenForbidden(
   resolution: 'explicit' | 'implicit' | 'derived' | undefined,
   ref: AccountReference | undefined
 ): void {
-  if (resolution !== 'implicit') return;
+  if (resolution !== 'implicit' && resolution !== 'derived') return;
   if (refAccountId(ref) === undefined) return;
+  if (resolution === 'derived') {
+    throw new AdcpError('INVALID_REQUEST', {
+      message:
+        'This is a single-tenant agent — the account is derived from your auth credential. Do not send account.account_id.',
+      field: 'account.account_id',
+      suggestion:
+        'Remove the account field from your request. The framework resolves the tenant from your bearer token automatically.',
+    });
+  }
   throw new AdcpError('INVALID_REQUEST', {
     message:
       'This platform resolves accounts from the authenticated principal — call sync_accounts first; do not pass account.account_id inline.',
@@ -1139,14 +1150,11 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       let resolved = false;
       let resolvedAccountId: string | undefined;
       try {
-        // Enforce the JSDoc contract documented at
-        // `AccountStore.resolution`: implicit-mode platforms refuse inline
-        // `account_id` references — buyers call sync_accounts first, then
-        // the framework resolves accounts from the auth principal on
-        // subsequent calls. The brand+operator union arm is permitted
-        // (used during the initial sync_accounts onboarding flow); only
-        // the `{ account_id }` arm is refused. Closes adcp-client#1364.
-        refuseImplicitAccountId(platform.accounts.resolution, ref);
+        // Enforce the JSDoc contract documented at `AccountStore.resolution`:
+        // `'implicit'` and `'derived'` platforms refuse inline `account_id`
+        // references — see `refuseInlineAccountIdWhenForbidden` for the
+        // per-mode rationale. Closes adcp-client#1364, adcp-client#1469.
+        refuseInlineAccountIdWhenForbidden(platform.accounts.resolution, ref);
         const account = await platform.accounts.resolve(ref, toResolveCtx(ctx, ctx.toolName));
         resolved = account != null;
         resolvedAccountId = account?.id;
@@ -1673,7 +1681,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
       };
       let resolvedAccountId: string | undefined;
       if (ref) {
-        refuseImplicitAccountId(platform.accounts.resolution, ref as AccountReference);
+        refuseInlineAccountIdWhenForbidden(platform.accounts.resolution, ref as AccountReference);
         try {
           const resolved = await platform.accounts.resolve(ref as AccountReference, resolveCtx);
           if (resolved) resolvedAccountId = resolved.id;
@@ -4332,7 +4340,7 @@ function buildAccountHandlers<P extends DecisioningPlatform<any, any>>(
       // tokens / upstream IDs off `ctx.account.ctx_metadata` without
       // having to re-resolve from `params.account`.
       const resolveCtx = toResolveCtx(ctx, 'get_account_financials');
-      refuseImplicitAccountId(accounts.resolution, params.account);
+      refuseInlineAccountIdWhenForbidden(accounts.resolution, params.account);
       const resolved = await accounts.resolve(params.account, resolveCtx);
       if (!resolved) {
         throw new AdcpError('ACCOUNT_NOT_FOUND', {

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -187,7 +187,7 @@ function refuseInlineAccountIdWhenForbidden(
         'This is a single-tenant agent — the account is derived from your auth credential. Do not send account.account_id.',
       field: 'account.account_id',
       suggestion:
-        'Remove the account field from your request. The framework resolves the tenant from your bearer token automatically.',
+        'Remove account.account_id from your request — or send account as { brand, operator } if you need brand context. The framework derives the tenant from your bearer token automatically.',
     });
   }
   throw new AdcpError('INVALID_REQUEST', {

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -2,6 +2,9 @@
 // against `accounts.resolution: 'implicit'` platforms. Documented behavior
 // at AccountStore.resolution; previously aspirational (docstring claim
 // without enforcement).
+//
+// Also covers #1469 — same refusal extended to `accounts.resolution: 'derived'`
+// (single-tenant agents). Both modes share the enforcement; messages differ.
 
 process.env.NODE_ENV = 'test';
 
@@ -284,5 +287,211 @@ describe("#1364 — accounts.resolution: 'implicit' refuses inline account_id", 
     assert.strictEqual(result.isError, true);
     assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
     assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+});
+
+function buildDerivedPlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolution: 'derived',
+      resolve: async () => ({
+        id: 'acc_singleton',
+        name: 'SingleTenant',
+        status: 'active',
+        ctx_metadata: {},
+        authInfo: { kind: 'oauth', principal: 'p1' },
+      }),
+    },
+    statusMappers: {},
+    sales: {
+      getProducts: async () => ({
+        products: [
+          {
+            product_id: 'p1',
+            name: 'sample',
+            description: 'fixture',
+            format_ids: [{ id: 'standard', agent_url: 'https://example.com/mcp' }],
+            delivery_type: 'non_guaranteed',
+            publisher_properties: { reportable: true },
+            reporting_capabilities: { available_dimensions: ['geo'] },
+            pricing_options: [{ pricing_model: 'cpm', rate: 5.0, currency: 'USD' }],
+          },
+        ],
+      }),
+      createMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      syncCreatives: async () => [],
+      getMediaBuyDelivery: async () => ({ media_buys: [] }),
+    },
+    ...overrides,
+  };
+}
+
+describe("#1469 — accounts.resolution: 'derived' refuses inline account_id", () => {
+  it('rejects { account_id } reference with INVALID_REQUEST and field=account.account_id', async () => {
+    let resolveCalled = false;
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => {
+          resolveCalled = true;
+          return null;
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { account_id: 'acc_foo' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+    assert.ok(
+      !result.structuredContent.adcp_error.message.includes('sync_accounts'),
+      'derived-mode message must not mention sync_accounts'
+    );
+    assert.match(result.structuredContent.adcp_error.message, /single-tenant/i);
+    assert.strictEqual(resolveCalled, false, 'resolve must not be invoked when derived-mode rejects upfront');
+  });
+
+  it('permits the brand+operator union arm — only account_id is refused', async () => {
+    let sawRef;
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async ref => {
+          sawRef = ref;
+          return {
+            id: 'acc_singleton',
+            name: 'SingleTenant',
+            status: 'active',
+            ctx_metadata: {},
+          };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          account: { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' },
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.deepStrictEqual(sawRef, { brand: { domain: 'acme.com' }, operator: 'pinnacle.com' });
+  });
+
+  it('derived + omitted account flows through to resolve (no rejection)', async () => {
+    let resolveCalled = false;
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => {
+          resolveCalled = true;
+          return {
+            id: 'acc_singleton',
+            name: 'SingleTenant',
+            status: 'active',
+            ctx_metadata: {},
+          };
+        },
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: {
+          brief: 'premium',
+          promoted_offering: 'cars',
+          // no account field — auth-derived path
+        },
+      },
+    });
+    assert.notStrictEqual(result.isError, true, `expected success, got ${JSON.stringify(result.structuredContent)}`);
+    assert.strictEqual(resolveCalled, true, 'resolve must be called for the omitted-account path');
+  });
+
+  it('tasks_get rejects { account_id } with INVALID_REQUEST on derived platforms', async () => {
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => null,
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'tasks_get',
+        arguments: {
+          task_id: 'task_does_not_matter',
+          account: { account_id: 'acc_foo' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
+  });
+
+  it("error message for 'derived' is distinct from 'implicit' — no sync_accounts guidance", async () => {
+    const derived = buildDerivedPlatform({
+      accounts: { resolution: 'derived', resolve: async () => null },
+    });
+    const dServer = createAdcpServerFromPlatform(derived, SERVER_OPTS);
+    const dResult = await dServer.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: { brief: 'x', account: { account_id: 'foo' } },
+      },
+    });
+    const implicit = buildImplicitPlatform({
+      accounts: {
+        resolution: 'implicit',
+        resolve: async () => null,
+        upsert: async () => [],
+        list: async () => ({ items: [], nextCursor: null }),
+      },
+    });
+    const iServer = createAdcpServerFromPlatform(implicit, SERVER_OPTS);
+    const iResult = await iServer.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_products',
+        arguments: { brief: 'x', account: { account_id: 'foo' } },
+      },
+    });
+    assert.notStrictEqual(
+      dResult.structuredContent.adcp_error.message,
+      iResult.structuredContent.adcp_error.message,
+      'derived and implicit modes must emit distinct error messages'
+    );
+    assert.ok(
+      !dResult.structuredContent.adcp_error.suggestion.includes('sync_accounts'),
+      'derived suggestion must not reference sync_accounts'
+    );
   });
 });

--- a/test/server-decisioning-implicit-account-id.test.js
+++ b/test/server-decisioning-implicit-account-id.test.js
@@ -493,5 +493,34 @@ describe("#1469 — accounts.resolution: 'derived' refuses inline account_id", (
       !dResult.structuredContent.adcp_error.suggestion.includes('sync_accounts'),
       'derived suggestion must not reference sync_accounts'
     );
+    assert.ok(
+      dResult.structuredContent.adcp_error.suggestion.includes('account.account_id'),
+      'derived suggestion must name the specific field to remove, not the entire account object'
+    );
+  });
+
+  it('get_account_financials rejects { account_id } with INVALID_REQUEST on derived platforms', async () => {
+    const platform = buildDerivedPlatform({
+      accounts: {
+        resolution: 'derived',
+        resolve: async () => null,
+        getAccountFinancials: async () => ({
+          financials: { spend: { amount: 0, currency: 'USD' } },
+        }),
+      },
+    });
+    const server = createAdcpServerFromPlatform(platform, SERVER_OPTS);
+    const result = await server.dispatchTestRequest({
+      method: 'tools/call',
+      params: {
+        name: 'get_account_financials',
+        arguments: {
+          account: { account_id: 'acc_foo' },
+        },
+      },
+    });
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'INVALID_REQUEST');
+    assert.strictEqual(result.structuredContent.adcp_error.field, 'account.account_id');
   });
 });


### PR DESCRIPTION
Closes #1469, Closes #1468

Extends the framework wire-contract enforcement to `'derived'`-resolution (single-tenant) platforms, mirroring the `'implicit'` refusal added in #1364 / recipe #10. Before this change, a buyer sending `{ account_id: "foo" }` to a derived-mode agent received the singleton response silently — the field was discarded with no signal. The framework now rejects it with `AdcpError('INVALID_REQUEST', { field: 'account.account_id' })` before `accounts.resolve` is called. The `{ brand, operator }` arm remains permitted in both modes.

**Implementation:** Renamed private function `refuseImplicitAccountId` → `refuseInlineAccountIdWhenForbidden`; extended the mode guard from `=== 'implicit'` to cover `'derived'` as well; branched error message and suggestion per mode so `'derived'` never emits `sync_accounts` guidance (unsupported in that mode). All 3 existing call sites updated. `account.ts` docstring and inline comments updated to match.

**Migration:** New recipe #10b added to `docs/migration-6.6-to-6.7.md` (callout box, audit list, and full recipe section). Three-row action table covers no-op, behavior-change, and the `resolve()` reads-ref regression case.

## What tested

- `npm run format:check` — clean ✅
- `npm run build:lib` — clean ✅
- Pre-push hook (format + typecheck + build) — passed ✅
- `test/server-decisioning-implicit-account-id.test.js` — 13/13 pass (7 existing `'implicit'` + 6 new `'derived'`; includes `tasks_get`, `get_account_financials`, brand+operator permit, omitted-account path, and message-distinctness assertions) ✅
- Full suite regression: 272 failures after vs 275 before — 3 fewer, no regressions introduced ✅

**Nits noted, not fixed (per reviewer):**
- `buildDerivedPlatform` omits `upsert`/`list` stubs (tests pass without them; parity with `buildImplicitPlatform` optional)
- Guard clause ordering in `refuseInlineAccountIdWhenForbidden` could use a `switch` (current logic is unambiguously correct)

## Pre-PR review

- **code-reviewer**: approved — blockers addressed: resolution-specific error message (no `sync_accounts` in `'derived'` suggestion), migration doc seam between recipe #10b and `createRosterAccountStore` companion note fixed
- **dx-expert**: approved — blockers addressed: suggestion text narrowed to `account.account_id` (brand+operator arm still permitted), migration doc header updated to "Four exceptions" with #10b bullet in callout box and audit list

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01Mg8BhdBSsyHD2Y1FppTYVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mg8BhdBSsyHD2Y1FppTYVB)_