### PR TITLE
feat(examples): hello-seller-guaranteed enforces MediaBuy state machine (#1416)

### DIFF
--- a/.changeset/phase-4-hello-adapter-state-machine.md
+++ b/.changeset/phase-4-hello-adapter-state-machine.md
@@ -1,0 +1,15 @@
+---
+"@adcp/sdk": patch
+---
+
+`hello_seller_adapter_guaranteed` now enforces the `MediaBuyStatus` state machine on `update_media_buy`. Closes the `media_buy_seller/invalid_transitions/second_cancel` storyboard gap that adcp-client#1416 had been tracking.
+
+Three small changes:
+
+1. New `localBuyStatus: Map<string, MediaBuyStatus>` tracker — production sellers swap this for a query against their order DB.
+2. `createMediaBuy` records `pending_creatives` on success.
+3. `updateMediaBuy` reads current status (preferring the local tracker for `canceled` / `paused` since the upstream mock doesn't model those, otherwise falling through to `mapMediaBuyStatus(order.status)`), calls `assertMediaBuyTransition` (newly imported from `@adcp/sdk/server`) when the patch sets `canceled: true` or `paused: true`, and updates the tracker on success. Re-cancel now throws `NOT_CANCELLABLE` per `core/state-machine.yaml`.
+
+Allowlist in `test/examples/hello-seller-adapter-guaranteed.test.js` shrinks from three entries to two. Remaining entries (#1415, #1417) are upstream-fixture issues — the SDK already shipped both fixes (createMediaBuyStore in PR #1424, runner `task_completion.<path>` capture in PR #1426); the storyboards in `adcontextprotocol/adcp` need migration to consume them. Both entries' `reason` strings updated to spell out which side of the boundary closes them.
+
+The other four hello adapters (`creative-template`, `seller-social`, `signals-marketplace`, `si-brand`) have no allowlist and already pass clean.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -56,6 +56,7 @@ import {
   memoryBackend,
   AdcpError,
   getAccountMode,
+  assertMediaBuyTransition,
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
@@ -796,6 +797,9 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
         // but no creatives have been assigned. Buyers transition to
         // `active` after `sync_creatives` lands, which the framework
         // surfaces via `publishStatusChange` on `resource_type: 'media_buy'`.
+        // Stamp the buy's lifecycle entry so update_media_buy can enforce
+        // the spec's MediaBuyStatus state machine on subsequent patches.
+        localBuyStatus.set(order.order_id, 'pending_creatives');
         return {
           media_buy_id: order.order_id,
           status: 'pending_creatives',
@@ -858,12 +862,36 @@ class SalesGuaranteedAdapter implements DecisioningPlatform<Record<string, never
           }
         }
       }
+
+      // State-machine enforcement. Lifecycle states the upstream mock doesn't
+      // track (`canceled`, `paused`) live in the local tracker; everything else
+      // reads from the upstream order.status mapping. Production sellers swap
+      // this for a single durable lookup against their order DB.
+      //
+      // The spec's `core/state-machine.yaml` declares `canceled` as a sink and
+      // a re-cancel as illegal — `assertMediaBuyTransition` throws
+      // `NOT_CANCELLABLE` on `canceled → canceled`, which is the
+      // `media_buy_seller/invalid_transitions` storyboard's contract.
+      const localStatus = localBuyStatus.get(buyId);
+      const currentStatus: MediaBuyStatus =
+        localStatus === 'canceled' || localStatus === 'paused' ? localStatus : mapMediaBuyStatus(order.status);
+      let nextStatus: MediaBuyStatus = currentStatus;
+      if ((patch as { canceled?: boolean }).canceled === true) {
+        assertMediaBuyTransition(currentStatus, 'canceled');
+        nextStatus = 'canceled';
+        localBuyStatus.set(buyId, nextStatus);
+      } else if ((patch as { paused?: boolean }).paused === true && currentStatus === 'active') {
+        assertMediaBuyTransition(currentStatus, 'paused');
+        nextStatus = 'paused';
+        localBuyStatus.set(buyId, nextStatus);
+      }
+
       // Mock doesn't model partial updates; production wires each patch
       // field onto the upstream's OrderService update endpoint. The
-      // worked example just echoes success.
+      // worked example just echoes success with the post-transition status.
       return {
         media_buy_id: buyId,
-        status: mapMediaBuyStatus(order.status),
+        status: nextStatus,
       };
     },
 
@@ -1005,6 +1033,26 @@ const simulatedDelivery = new Map<
   { impressions: number; clicks: number; reported_spend: { amount: number; currency: string } }
 >();
 // ─── /TEST-ONLY ──────────────────────────────────────────────────────────
+
+// Local per-buy status tracker for state-machine enforcement on
+// `update_media_buy`. The mock-server doesn't model lifecycle transitions
+// (POST /v1/orders/{id} doesn't exist; cancellation is purely an adapter
+// concern in this worked example). Production sellers track buy state in
+// their order DB and check `MEDIA_BUY_TRANSITIONS` against the current
+// status before applying a patch — this Map stands in for that.
+//
+// SWAP: replace with a query against your order/lifecycle service. The
+// `media_buy_seller/invalid_transitions` storyboard exercises NOT_CANCELLABLE
+// on re-cancel (canceled → canceled is illegal per `core/state-machine.yaml`).
+type MediaBuyStatus =
+  | 'pending_creatives'
+  | 'pending_start'
+  | 'active'
+  | 'paused'
+  | 'completed'
+  | 'rejected'
+  | 'canceled';
+const localBuyStatus = new Map<string, MediaBuyStatus>();
 
 // Persist `packages[].targeting_overlay` from create_media_buy and echo it
 // on get_media_buys. The seller spec MANDATES this echo for any seller

--- a/test/examples/hello-seller-adapter-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-guaranteed.test.js
@@ -4,18 +4,27 @@
  * Three independent assertions via the shared helper. The adapter wires
  * `comply_test_controller` so cascade scenarios under `media_buy_seller/*`
  * (driven by `requires_scenarios` in the storyboard yaml) get the
- * controller-driven setup they need. Three remaining failures are
- * filtered out here — each maps to a tracked SDK follow-up issue:
+ * controller-driven setup they need. Two remaining failures are filtered
+ * out here — each maps to a tracked upstream-fixture follow-up:
  *
- *   - #1415 (property_list echo on get_media_buys)
- *   - #1416 (NOT_CANCELLABLE state machine export)
- *   - #1417 (HITL media_buy_id capture in storyboard runner)
+ *   - #1415 (targeting_overlay echo on get_media_buys — fixture-side: every
+ *     step in the storyboard needs `account.sandbox: true` so the create and
+ *     get steps resolve to the same namespace in the adapter's synthesis
+ *     branch. SDK-side coverage shipped via createMediaBuyStore + framework
+ *     auto-echo, PR #1424.)
+ *   - #1417 (HITL media_buy_id capture — fixture-side: upstream
+ *     sales_guaranteed storyboard uses `path: media_buy_id` instead of the
+ *     `task_completion.media_buy_id` prefix the runner now supports per
+ *     PR #1426.)
  *
- * Drop the corresponding entry from `EXPECTED_FAILURES` when each issue
- * lands. The helper enforces that every entry in the allowlist actually
- * appears in the pre-filter failure set — a spec rename that silently
- * eliminates the gap-failure flips the gate to red so the allowlist
- * stays in sync with reality.
+ * #1416 (NOT_CANCELLABLE state machine) closed in this same PR — adapter
+ * now wires `assertMediaBuyTransition` against a local per-buy status tracker.
+ *
+ * Drop the corresponding entry from `EXPECTED_FAILURES` when each upstream
+ * fixture lands. The helper enforces that every entry in the allowlist
+ * actually appears in the pre-filter failure set — a spec rename or fixture
+ * migration that silently eliminates the gap-failure flips the gate to red
+ * so the allowlist stays in sync with reality.
  */
 
 const path = require('node:path');
@@ -37,19 +46,22 @@ const EXPECTED_FAILURES = [
     storyboard_id: 'sales_guaranteed',
     step_id: 'create_media_buy',
     issue: 'adcp-client#1417',
-    reason: 'HITL flow returns task envelope; runner does not poll task completion to capture media_buy_id',
+    reason:
+      'HITL completion-artifact capture — SDK runner now supports `task_completion.<path>` ' +
+      'context_outputs (PR #1426), but the upstream sales_guaranteed storyboard fixture in ' +
+      'adcontextprotocol/adcp still uses bare `path: media_buy_id`. Fixture migration is upstream.',
   },
   {
     storyboard_id: 'media_buy_seller/inventory_list_targeting',
     step_id: 'get_after_create',
     issue: 'adcp-client#1415',
-    reason: 'targeting_overlay.property_list echo on get_media_buys — needs SDK-side mediaBuyStore helper',
-  },
-  {
-    storyboard_id: 'media_buy_seller/invalid_transitions',
-    step_id: 'second_cancel',
-    issue: 'adcp-client#1416',
-    reason: 'NOT_CANCELLABLE on re-cancel — needs SDK-exported MEDIA_BUY_TRANSITIONS / assertMediaBuyTransition',
+    reason:
+      'targeting_overlay echo on get_media_buys — SDK ships createMediaBuyStore + framework ' +
+      'auto-echo (PR #1424) and the Hello adapter wires it. Storyboard still fails because the ' +
+      "create step's account ref (synthesized by the runner with `sandbox: true`) and the get " +
+      "step's account ref (passed through from sample_request without `sandbox`) resolve to " +
+      "different sandbox-vs-prod namespaces in the adapter's synthesis-branch resolver. " +
+      "Fixture migration upstream (every step's account carries `sandbox: true`) closes it.",
   },
 ];
 


### PR DESCRIPTION
## Summary

The user asked: **"do all our hello adapters work? and didn't we do 1415-1417?"**

Audited every hello adapter test file. Only `hello-seller-adapter-guaranteed.test.js` had an `EXPECTED_FAILURES` allowlist (3 entries). The other four (`creative-template`, `seller-social`, `signals-marketplace`, `si-brand`) have no allowlist and already pass clean.

For the three allowlisted entries — investigation:

| Issue | Status | Where the gap lived |
|---|---|---|
| #1415 — targeting_overlay echo | SDK shipped (PR #1424) | Upstream storyboard fixture (every step needs `account.sandbox: true` so create + get resolve to the same synthesis-branch namespace) |
| #1416 — NOT_CANCELLABLE | **Closed in this PR** | Hello adapter: state machine wasn't enforced on `update_media_buy` |
| #1417 — HITL media_buy_id | SDK shipped (PR #1426) | Upstream storyboard fixture (still uses bare `path: media_buy_id` instead of `task_completion.media_buy_id`) |

So 1415 and 1417 are upstream-fixture migrations, not SDK gaps. 1416 was a real adapter gap that hadn't been wired even though the SDK helper landed.

## What changed

**`examples/hello_seller_adapter_guaranteed.ts`**

1. New `localBuyStatus: Map<string, MediaBuyStatus>` tracker — stand-in for a production order-DB lookup.
2. `createMediaBuy` records `pending_creatives` on the success path.
3. `updateMediaBuy` reads current status (preferring the local tracker for `canceled` / `paused` since the upstream mock doesn't model those, otherwise `mapMediaBuyStatus(order.status)`), calls `assertMediaBuyTransition` on cancel / pause patches, updates the tracker on success.

**`test/examples/hello-seller-adapter-guaranteed.test.js`**

Allowlist 3 → 2. Remaining entries (`#1415`, `#1417`) have `reason` strings spelling out which side of the boundary closes each. Header docstring refreshed.

## Test plan

- [x] `npm run build` clean
- [x] `node --test test/examples/hello-seller-adapter-guaranteed.test.js` — 3/3 pass (including the storyboard's `media_buy_seller/invalid_transitions/second_cancel` step)
- [x] All 5 hello-adapter test files green: 19/19 tests pass
- [x] `npm run test:lib` — 6034 pass / 0 fail / 3 skipped
- [x] `npm run format:check` clean
- [x] Allowlist self-check still loud: empty-allowlist run reports `EXPECTED_FAILURES is stale: media_buy_seller/invalid_transitions/second_cancel` would have been the assertion if I'd dropped #1416 without fixing it (verified during investigation).

## Refs

- #1416 — closed by this PR
- #1415, #1417 — SDK side already shipped (PR #1424, PR #1426); upstream fixture migrations needed in `adcontextprotocol/adcp`
- #1435 — phases 1-3 (Account.mode + framework gate + adapter collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)