### PR TITLE
fix(runner): align with adcp#3987 — non-JSON payload_must_contain modes grade not_applicable

### DIFF
--- a/.changeset/runner-align-anti-facade-spec-3987.md
+++ b/.changeset/runner-align-anti-facade-spec-3987.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(runner): align with adcp#3987 — non-JSON `payload_must_contain` modes grade `not_applicable` (no terminal-key fallback)
+
+Closes the runner-side gap that adcp#3845 surfaced and adcp#3987 (merged) ratified.
+
+**Before:** `match: present` against non-JSON `content_type` (form-urlencoded, multipart, plain text) fell back to a terminal-key substring search — extract `hashed_email` from `users[*].hashed_email`, substring-match against the raw payload string. That created false positives (a payload mentioning `hashed_email` in any context — URL fragment, comment, unrelated metadata field — would pass), exactly the loophole the anti-façade contract exists to close.
+
+**After:** ALL `payload_must_contain` match modes (`present` / `equals` / `contains_any`) grade `not_applicable` against non-JSON content types, consistent with the `equals` / `contains_any` behavior that already shipped. Storyboards needing a non-JSON value-carried signal use `identifier_paths` — substring-searches storyboard-supplied VALUES (not path-derived strings), which is encoding-agnostic and doesn't suffer the false-positive surface.
+
+**Side effects:**
+- `terminalPathKey` helper deleted (no remaining callers).
+- Existing test asserting the substring-fallback behavior updated to assert `not_applicable: true` (matches the equals-mode test already in the suite).
+- `isJsonContentType` doc updated to reference RFC 6839 §3.1 explicitly — newline-delimited JSON formats (`application/json-seq`, `application/jsonl`) take the non-JSON path; the JSON detection itself was already correct (`application/json` or `*/*+json` suffix).
+- `globToRegExp` doc updated to note adcp#3987 ratified the wildcard grammar (was previously documented as "candidate semantics filed against the spec at adcp#3845") and added the no-escape-mechanism clarification per the merged spec.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -2498,15 +2498,26 @@ function filterByEndpointPattern(calls: RecordedCall[], pattern: string | undefi
 /**
  * Returns whether at least one matched call's payload satisfies the
  * `payload_must_contain` predicate, plus a flag indicating the assertion
- * graded `not_applicable` (every matched call was non-JSON and the spec
- * required JSONPath path-based matching). Per spec PR adcp#3816:
+ * graded `not_applicable` (every matched call was non-JSON; path-based
+ * matching has no portable semantics on non-JSON wire formats).
+ *
+ * Per spec PRs adcp#3816 (initial JSONPath restriction) and adcp#3987
+ * (closes the substring-fallback ambiguity #3845):
+ *
  *   - JSONPath path-based matching is valid ONLY when `content_type` is
- *     `application/json` or `*+json`.
- *   - Non-JSON calls + `match: present`: substring fallback. The terminal
- *     identifier segment of the path is the substring searched against the
- *     raw payload string (e.g. `users[*].hashed_email` → `hashed_email`).
- *   - Non-JSON calls + `match: equals` / `contains_any`: skipped (cannot
- *     resolve a path-based equality without a structured payload).
+ *     `application/json` or `*\/*+json` (RFC 6839 §3.1 structured-syntax
+ *     suffix).
+ *   - Non-JSON calls + ANY match mode (`present` / `equals` /
+ *     `contains_any`): grade `not_applicable`. Earlier sketches downgraded
+ *     `match: present` to a terminal-key substring search of the raw
+ *     payload — that heuristic created false positives (a payload
+ *     mentioning the key name in any context — URL fragment, comment,
+ *     unrelated metadata field — would pass), exactly the kind of
+ *     loophole the anti-façade contract exists to close. Storyboards
+ *     needing a non-JSON value-carried signal use `identifier_paths`
+ *     instead — substring-searches storyboard-supplied VALUES (not
+ *     path-derived strings), encoding-agnostic, no false-positive
+ *     surface.
  *
  * Path syntax is dotted-with-`[*]` only; RFC 9535 descendant operator
  * (`$..foo`) is explicitly NOT supported per the storyboard-schema patch.
@@ -2518,48 +2529,22 @@ function anyMatchedCallSatisfies(
   let sawApplicableCall = false;
   for (const call of calls) {
     const isJson = isJsonContentType(call.content_type);
+    // All match modes require a structured-JSON payload — non-JSON calls
+    // don't contribute regardless of mode (adcp#3987).
+    if (!isJson) continue;
+    sawApplicableCall = true;
+    const candidates = resolveJsonPathLite(call.payload, spec.path);
+    if (candidates.length === 0) continue;
     if (spec.match === 'present') {
-      // present is applicable to every call — JSON via path, non-JSON via
-      // substring fallback. Either way, the assertion can be graded.
-      sawApplicableCall = true;
-      if (isJson) {
-        const candidates = resolveJsonPathLite(call.payload, spec.path);
-        if (candidates.length > 0) return { satisfied: true, not_applicable: false };
-      } else {
-        const raw = typeof call.payload === 'string' ? call.payload : JSON.stringify(call.payload);
-        const needle = terminalPathKey(spec.path);
-        if (needle && raw.includes(needle)) return { satisfied: true, not_applicable: false };
-      }
-    } else {
-      // equals / contains_any require JSON — non-JSON calls don't contribute.
-      if (!isJson) continue;
-      sawApplicableCall = true;
-      const candidates = resolveJsonPathLite(call.payload, spec.path);
-      if (candidates.length === 0) continue;
-      if (spec.match === 'equals') {
-        if (candidates.some(v => deepEqual(v, spec.value))) return { satisfied: true, not_applicable: false };
-      } else if (spec.match === 'contains_any') {
-        const allowed = spec.allowed_values ?? [];
-        if (candidates.some(v => allowed.some(a => deepEqual(v, a)))) return { satisfied: true, not_applicable: false };
-      }
+      return { satisfied: true, not_applicable: false };
+    } else if (spec.match === 'equals') {
+      if (candidates.some(v => deepEqual(v, spec.value))) return { satisfied: true, not_applicable: false };
+    } else if (spec.match === 'contains_any') {
+      const allowed = spec.allowed_values ?? [];
+      if (candidates.some(v => allowed.some(a => deepEqual(v, a)))) return { satisfied: true, not_applicable: false };
     }
   }
   return { satisfied: false, not_applicable: !sawApplicableCall };
-}
-
-/**
- * Extract the terminal identifier-shaped segment of a dotted-with-`[*]`
- * path. Used as the substring-fallback needle when a non-JSON payload is
- * graded against `match: present`. Returns null if the path has no
- * alpha-leading terminal token.
- */
-function terminalPathKey(path: string): string | null {
-  const tokens = path.split(/[.\[\]]/).filter(Boolean);
-  for (let i = tokens.length - 1; i >= 0; i--) {
-    const t = tokens[i]!;
-    if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(t)) return t;
-  }
-  return null;
 }
 
 /**

--- a/src/lib/testing/test-controller.ts
+++ b/src/lib/testing/test-controller.ts
@@ -237,9 +237,15 @@ export interface RecordedCall {
 }
 
 /**
- * Per spec PR adcontextprotocol/adcp#3816: `payload_must_contain` JSONPath
- * is valid only when `content_type` is `application/json` or has a `+json`
- * suffix.
+ * Per spec PRs adcontextprotocol/adcp#3816 (initial restriction) and
+ * adcp#3987 (RFC 6839 §3.1 pin): `payload_must_contain` JSONPath is
+ * valid only when `content_type` is `application/json` or any
+ * structured-syntax-suffix `*\/*+json` (e.g., `application/vnd.api+json`,
+ * `application/scim+json`). Newline-delimited JSON formats
+ * (`application/json-seq`, `application/jsonl`) take the non-JSON path —
+ * they don't carry JSON-document semantics that path matching depends
+ * on. All other types (form-urlencoded, multipart, plain text) likewise
+ * take the non-JSON path.
  */
 export function isJsonContentType(contentType: string | undefined): boolean {
   if (!contentType) return false;

--- a/src/lib/utils/glob.ts
+++ b/src/lib/utils/glob.ts
@@ -11,12 +11,14 @@
  * different calls than the producer-side filter would — different verdict
  * on the same storyboard. One implementation, one test, no drift.
  *
- * Grammar (matches the candidate semantics filed against the spec at
- * adcontextprotocol/adcp#3845):
+ * Grammar (ratified by spec PR adcontextprotocol/adcp#3987):
  *   - `*` matches zero or more characters of any kind, including `/`.
  *   - All other characters are literal — `?`, `[`, `]`, `(`, `)` etc. are
  *     escaped to themselves so a path-component like `?cohort=1` doesn't
  *     accidentally act as a regex quantifier.
+ *   - No escape mechanism — `*` is always a wildcard. Callers needing
+ *     literal-asterisk matching omit `endpoint_pattern` and filter
+ *     response-side.
  *   - Match is anchored (full-string), not substring search.
  *
  * Defense against catastrophic-backtracking on `'**********'`-style

--- a/test/lib/storyboard-runner-output-contract-v2.test.js
+++ b/test/lib/storyboard-runner-output-contract-v2.test.js
@@ -391,7 +391,18 @@ describe('upstream_traffic — controller-backed anti-façade assertion', () => 
     assert.equal(result.passed, false);
   });
 
-  test('non-JSON content_type + match: present — substring fallback against terminal path key', () => {
+  test('non-JSON content_type + match: present — grades not_applicable per adcp#3987', () => {
+    // Earlier behavior: terminal-key substring fallback. The runner
+    // extracted `hashed_email` from `users[*].hashed_email` and
+    // substring-matched it against the raw form-urlencoded body. That
+    // produced false positives — any payload mentioning `hashed_email`
+    // in any context (URL fragment, comment, unrelated metadata field)
+    // would pass, defeating the anti-façade contract. adcp#3987 closes
+    // the loophole: ALL match modes against non-JSON content types
+    // grade `not_applicable`, just like equals / contains_any below.
+    // Storyboards needing a non-JSON value-carried signal use
+    // `identifier_paths` (substring-searches storyboard-supplied VALUES,
+    // encoding-agnostic, no false-positive surface).
     const ctx = ctxWithTraffic({
       success: true,
       total_count: 1,
@@ -406,13 +417,15 @@ describe('upstream_traffic — controller-backed anti-façade assertion', () => 
       [
         {
           check: 'upstream_traffic',
-          description: 'present in form-encoded body',
+          description: 'present graded not_applicable on form-encoded body',
           payload_must_contain: [{ path: 'users[*].hashed_email', match: 'present' }],
         },
       ],
       ctx
     );
     assert.equal(result.passed, true);
+    assert.equal(result.not_applicable, true);
+    assert.match(result.note, /non-JSON content_types/);
   });
 
   test('non-JSON content_type + match: equals — grades not_applicable, validation passes overall', () => {


### PR DESCRIPTION
## Summary

Closes the runner-side gap that [adcp#3845](https://github.com/adcontextprotocol/adcp/issues/3845) surfaced and [adcp#3987](https://github.com/adcontextprotocol/adcp/pull/3987) (merged) ratified.

**Before:** \`match: present\` against non-JSON \`content_type\` (form-urlencoded, multipart, plain text) fell back to a terminal-key substring search — extract \`hashed_email\` from \`users[*].hashed_email\`, substring-match against the raw payload string. That created false positives (a payload mentioning \`hashed_email\` in any context — URL fragment, comment, unrelated metadata field — would pass), exactly the loophole the anti-façade contract exists to close.

**After:** ALL \`payload_must_contain\` match modes (\`present\` / \`equals\` / \`contains_any\`) grade \`not_applicable\` against non-JSON content types, consistent with the \`equals\` / \`contains_any\` behavior that already shipped. Storyboards needing a non-JSON value-carried signal use \`identifier_paths\` — substring-searches storyboard-supplied VALUES (not path-derived strings), encoding-agnostic, no false-positive surface.

## Side effects (all in same diff for coherence)

- \`terminalPathKey\` helper deleted (no remaining callers after the fallback removal).
- Existing test asserting the substring-fallback behavior updated to assert \`not_applicable: true\` — matches the equals-mode test already in the suite.
- \`isJsonContentType\` doc updated to reference RFC 6839 §3.1 explicitly. Newline-delimited JSON formats (\`application/json-seq\`, \`application/jsonl\`) take the non-JSON path. The JSON detection itself was already correct (\`application/json\` or \`*/*+json\` suffix); just the doc reference shifted.
- \`globToRegExp\` doc updated to note adcp#3987 ratified the wildcard grammar (was previously documented as "candidate semantics filed against the spec at adcp#3845") and added the no-escape-mechanism clarification per the merged spec.

## Test plan

- [x] Targeted test pass: 2/2 non-JSON subtests pass — \`match: present\` now grades \`not_applicable\` (was: substring-fallback pass), \`match: equals\` continues to grade \`not_applicable\` (unchanged).
- [x] \`tsc --noEmit\` clean.
- [ ] CI passes.

## Cross-link

- adcp [#3845](https://github.com/adcontextprotocol/adcp/issues/3845) — issue surfacing both ambiguities.
- adcp [#3987](https://github.com/adcontextprotocol/adcp/pull/3987) — spec PR (merged) pinning wildcard grammar + downgrading non-JSON match modes to \`not_applicable\`.
- This PR — runner-side adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)