### PR TITLE
chore(#1381): wire deliverables — hello-cluster live + skill collapse (#1461)

### DIFF
--- a/.changeset/hello-cluster-wireup-1461.md
+++ b/.changeset/hello-cluster-wireup-1461.md
@@ -1,0 +1,14 @@
+---
+'@adcp/sdk': patch
+---
+
+Wire up `examples/hello-cluster.ts` to boot all 7 hello-adapter specialisms + multi-tenant. Closes #1461 (final sub-issue of #1381 hello-adapter-family completion).
+
+Cluster manifest now lists 8 live entries (signals 3001, creative-template 3002, sales-social 3003, sales-guaranteed 3004, sales-non-guaranteed 3005, creative-ad-server 3006, sponsored-intelligence 3007, multi-tenant 3008) plus 3 pending placeholders (governance / brand-rights / retail-media — auto-skipped until those examples land). Universal `/_debug/traffic` probe replaces per-specialism lookup paths; every mock-server already exposes it. `npm run hello-cluster` boots 8 adapters in ~2.2s with mocks running.
+
+Skill prose collapsed onto fork-target pointers per the #1385 collapse pattern:
+
+- `skills/build-seller-agent/specialisms/sales-non-guaranteed.md` reduced from 41 → 17 lines; inline code samples removed (the worked adapter is the canonical reference).
+- `skills/build-creative-agent/SKILL.md` § creative-ad-server reduced from ~100 → ~25 lines; same shape.
+
+Closes #1381 with all five sub-issues (#1457, #1458, #1459, #1460, #1461) merged.

--- a/examples/hello-cluster.ts
+++ b/examples/hello-cluster.ts
@@ -74,55 +74,94 @@ const HEALTH_TIMEOUT_MS = 5_000;
 const SHUTDOWN_GRACE_MS = 3_000;
 const REPO_ROOT = resolvePath(__dirname, '..');
 
+/** Every mock-server exposes auth-free `GET /_debug/traffic` returning a
+ *  JSON object — used as the universal liveness probe across the cluster.
+ *  Matches what the mock-servers ship today; if a future mock drops this
+ *  surface, swap to a specialism-specific lookup path here. */
+const UNIVERSAL_PROBE_PATH = '/_debug/traffic';
+
 const ADAPTERS: AdapterConfig[] = [
   {
     name: 'signals',
     specialism: 'signal-marketplace',
     port: 3001,
     entrypoint: 'examples/hello_signals_adapter_marketplace.ts',
-    upstream: {
-      envVar: 'UPSTREAM_URL',
-      defaultUrl: 'http://127.0.0.1:4150',
-      // /_lookup/operator answers 200 with `{}` when the operator is unknown,
-      // so any HTTP response means the mock-server's listener is up.
-      probePath: '/_lookup/operator?adcp_operator=preflight',
-    },
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4150', probePath: UNIVERSAL_PROBE_PATH },
   },
   {
-    name: 'sales',
-    specialism: 'sales-non-guaranteed',
+    name: 'creative-template',
+    specialism: 'creative-template',
     port: 3002,
-    entrypoint: 'examples/hello_seller_adapter_non_guaranteed.ts',
+    entrypoint: 'examples/hello_creative_adapter_template.ts',
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4250', probePath: UNIVERSAL_PROBE_PATH },
   },
+  {
+    name: 'sales-social',
+    specialism: 'sales-social',
+    port: 3003,
+    entrypoint: 'examples/hello_seller_adapter_social.ts',
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4350', probePath: UNIVERSAL_PROBE_PATH },
+  },
+  {
+    name: 'sales-guaranteed',
+    specialism: 'sales-guaranteed',
+    port: 3004,
+    entrypoint: 'examples/hello_seller_adapter_guaranteed.ts',
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4450', probePath: UNIVERSAL_PROBE_PATH },
+  },
+  {
+    name: 'sales-non-guaranteed',
+    specialism: 'sales-non-guaranteed',
+    port: 3005,
+    entrypoint: 'examples/hello_seller_adapter_non_guaranteed.ts',
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4451', probePath: UNIVERSAL_PROBE_PATH },
+  },
+  {
+    name: 'creative-ad-server',
+    specialism: 'creative-ad-server',
+    port: 3006,
+    entrypoint: 'examples/hello_creative_adapter_ad_server.ts',
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4452', probePath: UNIVERSAL_PROBE_PATH },
+  },
+  {
+    name: 'sponsored-intelligence',
+    specialism: 'sponsored-intelligence',
+    port: 3007,
+    entrypoint: 'examples/hello_si_adapter_brand.ts',
+    upstream: { envVar: 'UPSTREAM_URL', defaultUrl: 'http://127.0.0.1:4504', probePath: UNIVERSAL_PROBE_PATH },
+  },
+  {
+    // The multi-tenant adapter claims governance-spend-authority +
+    // property-lists + brand-rights against in-memory state — no upstream
+    // mock to probe. Useful as the agency / holdco worked example.
+    name: 'multi-tenant',
+    specialism: 'governance-spend-authority+property-lists+brand-rights',
+    port: 3008,
+    entrypoint: 'examples/hello_seller_adapter_multi_tenant.ts',
+  },
+  // ─── Pending-tracking entries — auto-skip until the example file lands.
+  // The `pending:` block in the manifest surfaces them so adopters know
+  // what's coming.
   {
     name: 'governance',
     specialism: 'governance-spend-authority',
-    port: 3003,
+    port: 3010,
     entrypoint: 'examples/hello_governance_adapter_spend_authority.ts',
     tracking: '#1332',
   },
   {
-    name: 'creative',
-    specialism: 'creative-ad-server',
-    port: 3004,
-    entrypoint: 'examples/hello_creative_adapter_ad_server.ts',
-    tracking: '#1333',
-  },
-  {
-    name: 'brand',
+    name: 'brand-rights',
     specialism: 'brand-rights',
-    port: 3005,
+    port: 3011,
     entrypoint: 'examples/hello_brand_adapter_rights.ts',
     tracking: '#1334',
   },
   {
     // `sales-retail-media` is a preview specialism in 3.0 — claiming it
-    // advertises intent; no storyboard backs it yet. A real retail-media
-    // adapter would also claim `sales-catalog-driven`; the manifest's
-    // single-specialism slot is a forced fit at the hello tier.
+    // advertises intent; no storyboard backs it yet.
     name: 'retail-media',
     specialism: 'sales-retail-media',
-    port: 3006,
+    port: 3012,
     entrypoint: 'examples/hello_seller_adapter_retail_media.ts',
   },
 ];

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -595,103 +595,18 @@ Common failure decoder:
 
 Storyboard: `creative_ad_server`. Stateful — the library is pre-loaded; buyers do **not** push assets via `sync_creatives` at runtime. Pricing and billing round-trips are first-class.
 
-**Fork target**: [`examples/hello_creative_adapter_ad_server.ts`](../../examples/hello_creative_adapter_ad_server.ts) is the worked, passing reference adapter for this specialism. It demonstrates the stateful library wrap (`POST /v1/creatives` write, `GET /v1/creatives` read with cursor pagination + multi-id pass-through, `PATCH` mutation), tag generation via macro substitution against a stored snippet template (`{click_url}`, `{impression_pixel}`, `{cb}`, `{advertiser_id}`, `{creative_id}` …), real iframe-embeddable `previewCreative` URLs pointing at the upstream's `/serve/{id}` endpoint, the `NoAccountCtx` narrow on `previewCreative` / `listCreativeFormats`, and `getCreativeDelivery` projection (currency + reporting_period + per-creative impressions/clicks). CI gates strict tsc + storyboard pass + upstream-traffic façade — all 7 storyboard steps pass on the worked build. Replace the `// SWAP:` markers with calls to your real backend.
+**Fork target**: [`examples/hello_creative_adapter_ad_server.ts`](../../examples/hello_creative_adapter_ad_server.ts) is the worked, passing reference adapter for this specialism. CI gates strict tsc + storyboard pass + upstream-traffic façade — all 7 storyboard steps pass on the worked build.
 
-**`list_creatives`** with `include_pricing=true` returns per-creative `pricing_options`:
+The adapter demonstrates the stateful-library deltas vs `creative-template`:
 
-```typescript
-listCreatives: async (params, ctx) => {
-  const { items } = await ctx.store.list('creatives');
-  const creatives = items.map((c) => ({
-    creative_id: c.creative_id,
-    name: c.name,
-    format_id: c.format_id,
-    status: 'approved' as const,
-    created_date: c.created_date,
-    updated_date: c.updated_date,
-    ...(params.include_pricing && {
-      pricing_options: [{
-        pricing_option_id: 'standard_cpm',
-        model: 'cpm' as const,
-        cpm: 2.5,
-        currency: 'USD',
-      }],
-    }),
-  }));
-  return {
-    query_summary: { total_matching: creatives.length, returned: creatives.length, filters_applied: [] },
-    creatives,
-    pagination: { has_more: false },
-  };
-},
-```
+- **Library shape** — `POST /v1/creatives` writes, `GET /v1/creatives` reads (cursor pagination + multi-id pass-through), `PATCH` mutates. Maps directly onto `CreativeAdServerPlatform.{syncCreatives, listCreatives}`. Library state is owned by the adopter's UI / API ingestion; the comply controller's `seed.creative` is the only test path that writes via the adapter.
+- **Tag generation** — `buildCreative` looks up the creative by id, calls upstream `POST /v1/creatives/{id}/render` for macro substitution against a stored snippet template (`{click_url}`, `{impression_pixel}`, `{cb}`, `{advertiser_id}`, `{creative_id}`, `{asset_url}` …), and returns `BuildCreativeSuccess` with `creative_manifest.assets` carrying the rendered tag (HTML / VAST / native). The mock's `tag_url` points at a real iframe-embeddable `/serve/{id}` endpoint adopters can iframe in storyboards.
+- **`previewCreative`** — `NoAccountCtx<TCtxMeta>` no-account tool; returns the same iframe URL as a `preview_url`. The resolver synthesizes a default-listing network so `ctx.account` resolves cleanly inside the no-account handler. See migration recipe #11.
+- **`listCreativeFormats`** — also `NoAccountCtx`. Project upstream catalog to closed-shape `Format.renders[]` (display fixed dims, video/CTV at 1080p baseline, parameterized with `accepts_parameters[]`) per the typed builders from `@adcp/sdk` (#1325).
+- **Per-creative pricing** — when the adopter bills through AdCP, `listCreatives` with `include_pricing=true` surfaces `pricing_options`, `buildCreative` echoes the applied `pricing_option_id`, and `reportUsage` closes the loop. Adopters that bill out of band (CM360-style flat license / SaaS contract) omit these fields and surface `report_usage` records as `not_accepted` rather than fake-accepting.
+- **`getCreativeDelivery`** — multi-id pass-through per #1342 + #1410; required top-level `currency` + `reporting_period` per the response schema.
 
-**`build_creative`** receives `media_buy_id`, `package_id`, `target_format_id`, and `pricing_option_id`. Return a VAST tag with macro placeholders, plus `vendor_cost` at CPM = 0 (billing happens via `report_usage`):
-
-```typescript
-buildCreative: async (params, ctx) => {
-  const creative = await lookupCreativeForFormat(params.target_format_id, ctx);
-  const vast = `<?xml version="1.0"?>
-<VAST version="4.2">
-  <Ad id="${creative.creative_id}"><InLine>
-    <Impression><![CDATA[https://adserver.example/imp?cb=[CACHEBUSTER]&mb=${params.media_buy_id}]]></Impression>
-    <Creatives><Creative>
-      <Linear><Duration>00:00:30</Duration>
-        <MediaFiles><MediaFile type="video/mp4"><![CDATA[${creative.video_url}]]></MediaFile></MediaFiles>
-        <VideoClicks><ClickThrough><![CDATA[[CLICK_URL]https://landing.example]]></ClickThrough></VideoClicks>
-      </Linear>
-    </Creative></Creatives>
-  </InLine></Ad>
-</VAST>`;
-
-  return {
-    creative_manifest: {
-      format_id: params.target_format_id,
-      assets: { serving_tag: { content: vast } },     // HTML asset shape: { content: string }
-    },
-    pricing_option_id: params.pricing_option_id,      // echo
-    vendor_cost: { amount: 0, currency: 'USD' },      // CPM at build time — billing is separate
-    sandbox: true,
-  };
-},
-```
-
-**`report_usage`** is the billing reconciliation tool. Validate `idempotency_key` (return the same response for the same key) and echo `pricing_option_id` + `reporting_period`:
-
-```typescript
-reportUsage: async (params, ctx) => {
-  const existing = await ctx.store.get('usage_reports', params.idempotency_key);
-  if (existing) return existing;    // idempotent
-  const report = {
-    idempotency_key: params.idempotency_key,
-    creative_id: params.creative_id,
-    pricing_option_id: params.pricing_option_id,
-    reporting_period: params.reporting_period,
-    billable_amount: { amount: params.impressions * 2.5 / 1000, currency: 'USD' },
-    status: 'accepted' as const,
-  };
-  await ctx.store.put('usage_reports', params.idempotency_key, report);
-  return report;
-},
-```
-
-**`get_creative_delivery`** returns impressions/spend, optionally broken down by variant and filtered by `media_buy_ids`:
-
-```typescript
-getCreativeDelivery: async (params, ctx) => ({
-  reporting_period: params.reporting_period,
-  currency: 'USD',                                 // required top-level per get-creative-delivery-response.json
-  creatives: (params.creative_ids ?? []).map((id) => ({
-    creative_id: id,
-    impressions: 12500,
-    spend: { amount: 31.25, currency: 'USD' },
-    by_variant: [],
-  })),
-  sandbox: true,
-}),
-```
-
-Output formats returned by `list_creative_formats` for ad servers are **serving-tag formats** (VAST 4.2, display tag HTML, native JSON payload), not input visual formats.
+Output formats returned by `list_creative_formats` for ad servers are **serving-tag formats** (VAST 4.2, display tag HTML, native JSON payload), not input visual formats. Replace the `// SWAP:` markers with calls to your real backend.
 
 ### <a name="specialism-creative-template"></a>creative-template
 

--- a/skills/build-seller-agent/specialisms/sales-non-guaranteed.md
+++ b/skills/build-seller-agent/specialisms/sales-non-guaranteed.md
@@ -4,38 +4,14 @@ Companion to [`../SKILL.md`](../SKILL.md). The SKILL.md baseline applies; this f
 
 Storyboard: `sales_non_guaranteed`. The specialism hinges on `bid_price` and `update_media_buy`, neither of which the baseline example shows.
 
-**Fork target**: [`examples/hello_seller_adapter_non_guaranteed.ts`](../../../examples/hello_seller_adapter_non_guaranteed.ts) is the worked, passing reference adapter for this specialism. It demonstrates **sync confirmation** (no IO handoff — `createMediaBuy` returns `media_buy_id` immediately), floor pricing via `pricing_options[].fixed_price` from upstream `min_cpm`, spend-only forecast surfacing, and pacing propagation (`even` / `asap` / `front_loaded`). Auction mode is the deletion-fork of the guaranteed sibling — if your backend has HITL approval, fork [`hello_seller_adapter_guaranteed.ts`](../../../examples/hello_seller_adapter_guaranteed.ts) instead. Replace the `// SWAP:` markers with calls to your real backend.
+**Fork target**: [`examples/hello_seller_adapter_non_guaranteed.ts`](../../../examples/hello_seller_adapter_non_guaranteed.ts) is the worked, passing reference adapter for this specialism. CI gates strict tsc + storyboard pass + upstream-traffic façade.
 
-**Forecast surface**: `'spend'` (the default). Programmatic forward forecast — points at ascending budget levels show how impressions and clicks scale with spend. This is the planning surface every non-guaranteed buyer expects. Project your forecaster's spend curves directly onto `Product.forecast` points where each point is `{ budget: { mid }, metrics: { impressions: { low, mid, high }, clicks: { mid } } }`. See [Delivery Forecasts § Budget Curve](https://adcontextprotocol.org/docs/media-buy/product-discovery/media-products#budget-curve) for the canonical worked example.
+The adapter demonstrates the auction-mode deltas vs `sales-guaranteed`:
 
-Packages on `create_media_buy` carry `bid_price`. Validate it against the product's `floor_price`:
+- **Sync confirmation** — `createMediaBuy` returns `media_buy_id` immediately with `status: 'active'` (or `pending_creatives` until creatives attach). No `ctx.handoffToTask`, no IO poll, no task envelope. Auction inventory clears at request time.
+- **Floor pricing** — `pricing_options[].fixed_price` projected from upstream `min_cpm`; `min_spend` and `target_cpm` flow through to the wire when the upstream sets them. Reject `bid_price` below `floor_price` with `INVALID_REQUEST`.
+- **Spend-only forecast** — `forecast_range_unit: 'spend'`; no `availability` unit because non-guaranteed inventory isn't pre-committed. See [Delivery Forecasts § Budget Curve](https://adcontextprotocol.org/docs/media-buy/product-discovery/media-products#budget-curve) for the wire shape.
+- **Pacing propagation** — `even` / `asap` / `front_loaded` forwarded to upstream order; reflected in delivery curve. Validate raw input — reject typos rather than silently passing them through.
+- **`update_media_buy`** — bid/budget changes apply in-flight without re-issuing the order. `valid_actions` on an active non-guaranteed buy should include `pause`, `update_bid`, `get_delivery`; the framework auto-populates this when `status: 'active'`.
 
-```typescript
-createMediaBuy: async (params, ctx) => {
-  for (const pkg of params.packages ?? []) {
-    const product = PRODUCTS.find((p) => p.product_id === pkg.product_id);
-    const floor = product?.pricing_options[0].floor_price;
-    if (floor && pkg.bid_price != null && pkg.bid_price < floor) {
-      return adcpError('INVALID_REQUEST', {
-        message: `bid_price ${pkg.bid_price} below floor_price ${floor}`,
-      });
-    }
-  }
-  return {
-    media_buy_id: `mb_${randomUUID()}`,
-    status: 'active' as const,   // instant — no IO
-    packages: /* ... */,
-  };
-},
-
-updateMediaBuy: async (params, ctx) => {
-  const existing = await ctx.store.get('media_buys', params.media_buy_id);
-  if (!existing) return adcpError('NOT_FOUND', { message: `Media buy ${params.media_buy_id} not found` });
-  // Apply bid/budget updates from params.packages
-  const updated = { ...existing, packages: /* merged */ };
-  await ctx.store.put('media_buys', params.media_buy_id, updated);
-  return updated;
-},
-```
-
-`valid_actions` on an active non-guaranteed buy should include `pause`, `update_bid`, `get_delivery`. The framework auto-populates this when `createMediaBuy`/`updateMediaBuy` return with `status: 'active'`.
+Auction mode is the deletion-fork of the guaranteed sibling. If your backend has HITL approval, fork [`hello_seller_adapter_guaranteed.ts`](../../../examples/hello_seller_adapter_guaranteed.ts) instead. Replace the `// SWAP:` markers with calls to your real backend.


### PR DESCRIPTION
## Summary

Closes #1461 — final sub-issue of #1381 hello-adapter-family completion umbrella.

## Three pieces

**1. `examples/hello-cluster.ts` boots all 7 specialisms + multi-tenant.** 8 live entries (signals 3001, creative-template 3002, sales-social 3003, sales-guaranteed 3004, sales-non-guaranteed 3005, creative-ad-server 3006, sponsored-intelligence 3007, multi-tenant 3008) + 3 pending placeholders (governance / brand-rights / retail-media auto-skip until those examples land). Universal `/_debug/traffic` probe replaces per-specialism lookup paths — every mock-server exposes it.

**2. Skill prose collapsed onto fork-target pointers** per the #1385 collapse pattern:
- `skills/build-seller-agent/specialisms/sales-non-guaranteed.md` → 41 → 17 lines (inline code samples removed; worked adapter is the canonical reference).
- `skills/build-creative-agent/SKILL.md` § creative-ad-server → ~100 → ~25 lines (same shape).

**3. `examples/README.md` fork-target table** already updated in PR #1483's docs follow-up.

## Verified

`HELLO_CLUSTER_PORT_BASE=10000 npm run hello-cluster` with all 7 mocks running:
```
hello-cluster: 8 adapter(s) ready in 2223ms · Ctrl+C to stop
```
Manifest emits all 8 live entries + 3 pending; preflight passes for every adapter that declares an upstream.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] `npm run hello-cluster` boots all 8 adapters in 2.2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)