### PR TITLE
test(storyboard): lock unified not_applicable note across all payload_must_contain modes

### DIFF
--- a/test/lib/storyboard-runner-output-contract-v2.test.js
+++ b/test/lib/storyboard-runner-output-contract-v2.test.js
@@ -150,6 +150,13 @@ describe('applyContextOutputs (non-provenance) — semantics aligned with v2.0.0
 // ────────────────────────────────────────────────────────────
 
 describe('upstream_traffic — controller-backed anti-façade assertion', () => {
+  // Locks the unified `not_applicable` posture across all `payload_must_contain`
+  // match modes (present / equals / contains_any) per adcp#3987. If the runner's
+  // note string changes, every non-JSON test below must update — a deliberate
+  // forcing function so a future refactor can't silently weaken the contract by
+  // emitting a different note for one mode.
+  const NON_JSON_NA_NOTE = 'payload_must_contain paths only matched non-JSON content_types — graded not_applicable';
+
   function makeCall(overrides = {}) {
     return {
       method: 'POST',
@@ -425,7 +432,7 @@ describe('upstream_traffic — controller-backed anti-façade assertion', () => 
     );
     assert.equal(result.passed, true);
     assert.equal(result.not_applicable, true);
-    assert.match(result.note, /non-JSON content_types/);
+    assert.equal(result.note, NON_JSON_NA_NOTE);
   });
 
   test('non-JSON content_type + match: equals — grades not_applicable, validation passes overall', () => {
@@ -453,7 +460,33 @@ describe('upstream_traffic — controller-backed anti-façade assertion', () => 
     // path-based assertion downgraded to non-JSON-skip and count + echo passed.
     assert.equal(result.passed, true);
     assert.equal(result.not_applicable, true);
-    assert.match(result.note, /non-JSON content_types/);
+    assert.equal(result.note, NON_JSON_NA_NOTE);
+  });
+
+  test('non-JSON content_type + match: contains_any — grades not_applicable, validation passes overall', () => {
+    const ctx = ctxWithTraffic({
+      success: true,
+      total_count: 1,
+      recorded_calls: [
+        makeCall({
+          content_type: 'application/x-www-form-urlencoded',
+          payload: 'region=us-east',
+        }),
+      ],
+    });
+    const [result] = runValidations(
+      [
+        {
+          check: 'upstream_traffic',
+          description: 'contains_any impossible on non-JSON',
+          payload_must_contain: [{ path: 'region', match: 'contains_any', allowed_values: ['us-east', 'us-west'] }],
+        },
+      ],
+      ctx
+    );
+    assert.equal(result.passed, true);
+    assert.equal(result.not_applicable, true);
+    assert.equal(result.note, NON_JSON_NA_NOTE);
   });
 
   test('identifier_paths fails when storyboard vector is not echoed', () => {


### PR DESCRIPTION
## Summary

Follow-up to #1485 (which aligned the runner with adcp#3987). Acts on the security-reviewer nit from the parallel review pass: lock the unified `not_applicable` posture so a future refactor can't silently emit a different `note` string for one match mode and weaken the contract.

## Changes

- Extract `NON_JSON_NA_NOTE` constant matching the runner string verbatim.
- Replace `assert.match(result.note, /non-JSON content_types/)` with `assert.equal(result.note, NON_JSON_NA_NOTE)` at both existing test sites (`present`, `equals`).
- Add the missing `contains_any` non-JSON test to complete the 3-mode matrix — same fixture shape as `equals`, asserts identical note.

## Why this matters

The runner emits the `not_applicable` note once at the validation level (validations.ts:2432), shared across all match modes. A regex-substring assertion would silently keep passing if someone refactored only one branch's wording. Exact-equality forces every test to update in lockstep.

## Test plan

- [x] Targeted: 36/36 pass (3 non-JSON `payload_must_contain` subtests + 33 existing).
- [x] `npm run format:check` clean.
- [x] No runtime behavior change — test-only.
- [ ] CI passes.

## Cross-link

- #1485 — runner alignment with adcp#3987 (merged).
- adcp#3987 — spec PR ratifying the unified `not_applicable` posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)