### PR TITLE
feat(server): ConformanceClient Socket Mode primitive

### DIFF
--- a/.changeset/conformance-client-socket-mode.md
+++ b/.changeset/conformance-client-socket-mode.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): `ConformanceClient` — outbound-WebSocket Socket Mode primitive that lets adopter dev/staging MCP servers connect to a remote AdCP runner (today, Addie at agenticadvertising.org) without public DNS or inbound exposure. Three-line integration: `new ConformanceClient({ url, token, server }).start()`. Reverse-RPC at the TCP level only — MCP semantics unchanged. Dev/staging only by design (per AdCP #3986 deployment-scoped controller rule). Exposed from `@adcp/sdk/server`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@types/ws": "^8.18.1",
         "ajv": "^8.18.0",
         "ajv-formats": "^3.0.1",
         "fast-check": "^3.23.2",
@@ -38,7 +39,6 @@
         "@types/node": "^20.19.39",
         "@types/pg": "^8.20.0",
         "@types/tar": "^6.1.13",
-        "@types/ws": "^8.18.1",
         "eslint": "^10.0.3",
         "json-schema-to-typescript": "^15.0.4",
         "json-schema-to-zod": "^2.6.1",
@@ -1218,7 +1218,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1299,7 +1298,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6211,7 +6209,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.7.0",
+  "version": "6.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.7.0",
+      "version": "6.8.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -21,6 +21,7 @@
         "structured-headers": "^2.0.2",
         "tldts": "^7.0.29",
         "undici": "^6.25.0",
+        "ws": "^8.20.0",
         "yaml": "^2.7.1"
       },
       "bin": {
@@ -37,6 +38,7 @@
         "@types/node": "^20.19.39",
         "@types/pg": "^8.20.0",
         "@types/tar": "^6.1.13",
+        "@types/ws": "^8.18.1",
         "eslint": "^10.0.3",
         "json-schema-to-typescript": "^15.0.4",
         "json-schema-to-zod": "^2.6.1",
@@ -1292,6 +1294,16 @@
       "version": "3.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -6335,6 +6347,27 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "dev": true,
@@ -6434,7 +6467,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.7.0"
+        "@adcp/sdk": "^6.8.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/package.json
+++ b/package.json
@@ -305,6 +305,7 @@
     "structured-headers": "^2.0.2",
     "tldts": "^7.0.29",
     "undici": "^6.25.0",
+    "ws": "^8.20.0",
     "yaml": "^2.7.1"
   },
   "peerDependencies": {
@@ -333,6 +334,7 @@
     "@types/node": "^20.19.39",
     "@types/pg": "^8.20.0",
     "@types/tar": "^6.1.13",
+    "@types/ws": "^8.18.1",
     "eslint": "^10.0.3",
     "json-schema-to-typescript": "^15.0.4",
     "json-schema-to-zod": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -297,6 +297,7 @@
     "email": "bugs@adcontextprotocol.org"
   },
   "dependencies": {
+    "@types/ws": "^8.18.1",
     "ajv": "^8.18.0",
     "ajv-formats": "^3.0.1",
     "fast-check": "^3.23.2",
@@ -334,7 +335,6 @@
     "@types/node": "^20.19.39",
     "@types/pg": "^8.20.0",
     "@types/tar": "^6.1.13",
-    "@types/ws": "^8.18.1",
     "eslint": "^10.0.3",
     "json-schema-to-typescript": "^15.0.4",
     "json-schema-to-zod": "^2.6.1",

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -439,3 +439,13 @@ export {
 export { createRosterAccountStore, type RosterAccountStoreOptions } from '../adapters/roster-account-store';
 
 export { createDerivedAccountStore, type DerivedAccountStoreOptions } from '../adapters/derived-account-store';
+
+// ---------------------------------------------------------------------------
+// Socket Mode — outbound WebSocket bridge for adopter dev environments
+// ---------------------------------------------------------------------------
+export {
+  ConformanceClient,
+  WebSocketTransport,
+  type ConformanceClientOptions,
+  type ConformanceStatus,
+} from './socket-mode';

--- a/src/lib/server/socket-mode/conformance-client.test.ts
+++ b/src/lib/server/socket-mode/conformance-client.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server as HttpServer } from 'node:http';
+import WebSocket, { WebSocketServer } from 'ws';
+import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { Client as MCPClient } from '@modelcontextprotocol/sdk/client/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type JSONRPCMessage,
+  JSONRPCMessageSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { ConformanceClient } from './conformance-client';
+
+class TestServerSideTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (msg: JSONRPCMessage) => void;
+  sessionId?: string = 'test';
+  private closed = false;
+
+  constructor(private socket: WebSocket) {}
+
+  async start(): Promise<void> {
+    this.socket.on('message', data => {
+      try {
+        const parsed = JSONRPCMessageSchema.safeParse(JSON.parse(data.toString('utf-8')));
+        if (parsed.success) this.onmessage?.(parsed.data);
+        else this.onerror?.(new Error(parsed.error.message));
+      } catch (err) {
+        this.onerror?.(err as Error);
+      }
+    });
+    this.socket.on('close', () => {
+      if (this.closed) return;
+      this.closed = true;
+      this.onclose?.();
+    });
+  }
+
+  async send(msg: JSONRPCMessage): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.socket.send(JSON.stringify(msg), err => (err ? reject(err) : resolve()));
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.socket.close();
+  }
+}
+
+let httpServer: HttpServer;
+let wss: WebSocketServer;
+let port: number;
+let acceptedConnections: WebSocket[] = [];
+let serverSideClients: MCPClient[] = [];
+
+beforeAll(async () => {
+  httpServer = createServer();
+  wss = new WebSocketServer({ noServer: true });
+  httpServer.on('upgrade', (_req, socket, head) => {
+    wss.handleUpgrade(_req, socket, head, async ws => {
+      acceptedConnections.push(ws);
+      const transport = new TestServerSideTransport(ws);
+      const client = new MCPClient({ name: 'runner-test', version: '0.0.1' }, { capabilities: {} });
+      serverSideClients.push(client);
+      try {
+        await client.connect(transport);
+      } catch {
+        ws.close();
+      }
+    });
+  });
+  await new Promise<void>(resolve => httpServer.listen(0, '127.0.0.1', () => resolve()));
+  const addr = httpServer.address();
+  port = typeof addr === 'object' && addr ? addr.port : 0;
+});
+
+afterAll(async () => {
+  await Promise.all(
+    acceptedConnections.map(
+      c =>
+        new Promise<void>(r => {
+          c.close();
+          r();
+        })
+    )
+  );
+  wss.close();
+  await new Promise<void>(resolve => httpServer.close(() => resolve()));
+});
+
+function buildAdopterServer(): MCPServer {
+  const server = new MCPServer({ name: 'adopter-test', version: '0.0.1' }, { capabilities: { tools: {} } });
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [{ name: 'ping', description: 'health', inputSchema: { type: 'object', properties: {} } }],
+  }));
+  server.setRequestHandler(CallToolRequestSchema, async req => {
+    if (req.params.name === 'ping') {
+      return { content: [{ type: 'text' as const, text: 'pong' }] };
+    }
+    throw new Error(`unknown tool ${req.params.name}`);
+  });
+  return server;
+}
+
+describe('ConformanceClient', () => {
+  it('connects, exposes the adopter MCP server, and serves tools/list + tools/call', async () => {
+    const idx = acceptedConnections.length;
+    const client = new ConformanceClient({
+      url: `ws://127.0.0.1:${port}/conformance/connect`,
+      token: 'irrelevant-for-this-test',
+      server: buildAdopterServer(),
+      reconnect: false,
+    });
+    await client.start();
+    expect(client.getStatus()).toBe('connected');
+
+    // wait for the server-side client to finish initialize
+    const deadline = Date.now() + 2000;
+    while (serverSideClients.length <= idx && Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 20));
+    }
+    const runner = serverSideClients[idx];
+    expect(runner).toBeTruthy();
+
+    const listed = await runner.listTools();
+    expect(listed.tools.map(t => t.name)).toEqual(['ping']);
+
+    const called = await runner.callTool({ name: 'ping', arguments: {} });
+    const content = (called.content as Array<{ text: string }>) ?? [];
+    expect(content[0]?.text).toBe('pong');
+
+    await client.close();
+  });
+
+  it('emits status transitions via onStatus', async () => {
+    const transitions: string[] = [];
+    const client = new ConformanceClient({
+      url: `ws://127.0.0.1:${port}/conformance/connect`,
+      token: 't',
+      server: buildAdopterServer(),
+      reconnect: false,
+      onStatus: s => transitions.push(s),
+    });
+    await client.start();
+    await client.close();
+    expect(transitions).toContain('connecting');
+    expect(transitions).toContain('connected');
+    expect(transitions).toContain('idle');
+  });
+
+  it('reports error status when the URL is unreachable (no reconnect)', async () => {
+    const client = new ConformanceClient({
+      url: `ws://127.0.0.1:1/conformance/connect`,
+      token: 't',
+      server: buildAdopterServer(),
+      reconnect: false,
+    });
+    await expect(client.start()).rejects.toThrow();
+    expect(['error', 'disconnected']).toContain(client.getStatus());
+  });
+});

--- a/src/lib/server/socket-mode/conformance-client.ts
+++ b/src/lib/server/socket-mode/conformance-client.ts
@@ -1,0 +1,156 @@
+/**
+ * Adopter-facing Socket Mode client.
+ *
+ * Opens an outbound WebSocket from your dev/staging environment to a
+ * remote AdCP runner (typically Addie at agenticadvertising.org) and
+ * exposes your existing MCP `Server` over it. The remote runner can
+ * then drive `tools/list`, `tools/call`, etc. against your server
+ * exactly as if it had reached you over HTTP — no public DNS, no
+ * inbound exposure.
+ *
+ * Three-line integration:
+ *
+ * ```ts
+ * import { ConformanceClient } from '@adcp/sdk/server';
+ * import { mcpServer } from './my-mcp-server';
+ *
+ * const client = new ConformanceClient({
+ *   url: 'wss://addie.agenticadvertising.org/conformance/connect',
+ *   token: process.env.ADCP_CONFORMANCE_TOKEN!,
+ *   server: mcpServer,
+ * });
+ * await client.start();
+ * ```
+ *
+ * Reconnect: exponential backoff capped at 30s. Stop via `close()` to
+ * opt out of further reconnect attempts.
+ *
+ * Dev/staging only by design — production deployments must not expose
+ * `comply_test_controller` on any surface, including this channel.
+ * See [adcontextprotocol/adcp#3986](https://github.com/adcontextprotocol/adcp/issues/3986).
+ */
+
+import WebSocket from 'ws';
+import type { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
+import { WebSocketTransport } from './ws-transport';
+
+export type ConformanceStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
+
+export interface ConformanceClientOptions {
+  /**
+   * The remote runner's WebSocket URL. For Addie this is
+   * `wss://addie.agenticadvertising.org/conformance/connect` in
+   * production, `ws://localhost:3000/conformance/connect` in dev.
+   */
+  url: string;
+
+  /**
+   * Adopter-account-bound token issued by the runner. For Addie, ask in
+   * chat ("give me a fresh conformance token") or POST /api/conformance/token.
+   * Tokens are short-lived (typically 1h); on expiry, re-request and
+   * pass the new token via a fresh `ConformanceClient`.
+   */
+  token: string;
+
+  /**
+   * Your existing MCP server. The same instance you'd connect to
+   * `StreamableHTTPServerTransport` for normal traffic — this client
+   * exposes it bidirectionally over the outbound WebSocket.
+   */
+  server: MCPServer;
+
+  /**
+   * If true (default), reconnect on disconnect with exponential backoff
+   * up to 30s. Set false for one-shot connections.
+   */
+  reconnect?: boolean;
+
+  /**
+   * Status callback. Fires on every state transition. Useful for
+   * surfacing connection state in dev tooling or CI logs.
+   */
+  onStatus?: (status: ConformanceStatus, detail?: { error?: Error; attempt?: number }) => void;
+}
+
+const RECONNECT_INITIAL_MS = 1000;
+const RECONNECT_MAX_MS = 30_000;
+
+export class ConformanceClient {
+  private status: ConformanceStatus = 'idle';
+  private socket?: WebSocket;
+  private transport?: WebSocketTransport;
+  private stopped = false;
+  private reconnectAttempt = 0;
+  private readonly opts: Required<Pick<ConformanceClientOptions, 'reconnect'>> & ConformanceClientOptions;
+
+  constructor(opts: ConformanceClientOptions) {
+    this.opts = { reconnect: true, ...opts };
+  }
+
+  async start(): Promise<void> {
+    this.stopped = false;
+    await this.connect();
+  }
+
+  async close(): Promise<void> {
+    this.stopped = true;
+    if (this.transport) {
+      await this.transport.close();
+    } else if (this.socket) {
+      this.socket.close(1000, 'adopter close');
+    }
+    this.setStatus('idle');
+  }
+
+  getStatus(): ConformanceStatus {
+    return this.status;
+  }
+
+  private async connect(): Promise<void> {
+    this.setStatus('connecting');
+    const url = new URL(this.opts.url);
+    url.searchParams.set('token', this.opts.token);
+    const socket = new WebSocket(url.toString());
+    this.socket = socket;
+    const transport = new WebSocketTransport(socket);
+    this.transport = transport;
+
+    socket.once('close', () => {
+      this.setStatus('disconnected');
+      if (!this.stopped && this.opts.reconnect) {
+        void this.scheduleReconnect();
+      }
+    });
+
+    try {
+      await this.opts.server.connect(transport);
+      this.reconnectAttempt = 0;
+      this.setStatus('connected');
+    } catch (err) {
+      this.setStatus('error', { error: err as Error });
+      socket.close(1011, 'connect failed');
+      if (!this.stopped && this.opts.reconnect) {
+        void this.scheduleReconnect();
+      }
+      throw err;
+    }
+  }
+
+  private async scheduleReconnect(): Promise<void> {
+    this.reconnectAttempt += 1;
+    const delay = Math.min(RECONNECT_INITIAL_MS * 2 ** (this.reconnectAttempt - 1), RECONNECT_MAX_MS);
+    this.setStatus('connecting', { attempt: this.reconnectAttempt });
+    await new Promise(r => setTimeout(r, delay));
+    if (this.stopped) return;
+    try {
+      await this.connect();
+    } catch {
+      // setStatus already invoked; loop continues via the close handler
+    }
+  }
+
+  private setStatus(status: ConformanceStatus, detail?: { error?: Error; attempt?: number }): void {
+    this.status = status;
+    this.opts.onStatus?.(status, detail);
+  }
+}

--- a/src/lib/server/socket-mode/index.ts
+++ b/src/lib/server/socket-mode/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Socket Mode — outbound-WebSocket bridge so an adopter's MCP server
+ * can be reached by a remote runner without a public DNS / firewall
+ * hole. Slack Socket Mode pattern.
+ *
+ * Today the canonical consumer is Addie at agenticadvertising.org for
+ * conformance assistance during agent development. The transport is
+ * neutral — any third-party orchestrator that speaks the same handshake
+ * could terminate the other end.
+ *
+ * Dev/staging only — see `ConformanceClient` JSDoc for the policy.
+ */
+
+export { ConformanceClient, type ConformanceClientOptions, type ConformanceStatus } from './conformance-client';
+export { WebSocketTransport } from './ws-transport';

--- a/src/lib/server/socket-mode/ws-transport.ts
+++ b/src/lib/server/socket-mode/ws-transport.ts
@@ -1,0 +1,86 @@
+/**
+ * Adopter-side MCP `Transport` over an outbound WebSocket.
+ *
+ * Wraps a `ws` Node WebSocket as the MCP SDK's `Transport` interface
+ * so an existing `Server` instance can be exposed bidirectionally over
+ * a single outbound connection.
+ *
+ * This is the building block for "Socket Mode" — see `ConformanceClient`
+ * for the high-level adopter-facing class.
+ */
+
+import WebSocket from 'ws';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { JSONRPCMessageSchema, type JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+export class WebSocketTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+  sessionId?: string;
+
+  private closed = false;
+
+  constructor(private readonly socket: WebSocket) {}
+
+  async start(): Promise<void> {
+    this.socket.on('message', (data, isBinary) => {
+      if (isBinary) {
+        this.onerror?.(new Error('binary frames are not supported'));
+        return;
+      }
+      const text = data.toString('utf-8');
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch (err) {
+        this.onerror?.(new Error(`malformed JSON frame: ${(err as Error).message}`));
+        return;
+      }
+      const result = JSONRPCMessageSchema.safeParse(parsed);
+      if (!result.success) {
+        this.onerror?.(new Error(`malformed JSON-RPC message: ${result.error.message}`));
+        return;
+      }
+      this.onmessage?.(result.data);
+    });
+
+    this.socket.on('close', () => {
+      if (this.closed) return;
+      this.closed = true;
+      this.onclose?.();
+    });
+
+    this.socket.on('error', err => {
+      this.onerror?.(err);
+    });
+
+    if (this.socket.readyState === WebSocket.CONNECTING) {
+      await new Promise<void>((resolve, reject) => {
+        this.socket.once('open', () => resolve());
+        this.socket.once('error', reject);
+      });
+    }
+  }
+
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (this.closed) throw new Error('transport closed');
+    return new Promise((resolve, reject) => {
+      this.socket.send(JSON.stringify(message), err => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      this.socket.close(1000, 'transport closed');
+    } catch {
+      // ignore
+    }
+    this.onclose?.();
+  }
+}


### PR DESCRIPTION
## Summary

Adds **`ConformanceClient`** — an outbound-WebSocket Socket Mode primitive that lets adopter dev/staging MCP servers be reached by a remote AdCP runner without public DNS, ngrok, or inbound firewall exposure. Slack Socket Mode pattern.

Three-line integration:

```ts
import { ConformanceClient } from '@adcp/sdk/server';
import { mcpServer } from './my-mcp-server';

const client = new ConformanceClient({
  url: 'wss://addie.agenticadvertising.org/conformance/connect',
  token: process.env.ADCP_CONFORMANCE_TOKEN!,
  server: mcpServer,
});
await client.start();
```

## Why

Adopters who want compliance/conformance assistance during agent development need a way to expose their dev environment to a remote runner. The naive answer (public sandbox endpoint with ngrok/DNS/firewall design) is a real lift for small teams and a non-trivial security review for large ones. Outbound WebSocket from the dev box collapses cert-prep to "install client, run it, done."

Reverse RPC at the TCP level only — the MCP protocol is symmetric (JSON-RPC 2.0, request/response with correlation IDs), so swapping HTTP for WebSocket and flipping connection direction gives the runner a normal MCP `Client` against the adopter's existing MCP `Server`. The SDK already exposes `AgentClient.fromMCPClient()` (line 248 of `core/AgentClient.ts`) so runners can wrap that MCP `Client` for the storyboard pipeline — no further SDK surface needed.

## What's in this PR

- `src/lib/server/socket-mode/ws-transport.ts` — WebSocket-backed MCP `Transport`. Strict JSON-RPC parsing via `JSONRPCMessageSchema`, rejects binary frames, idempotent close, error-without-disconnect on malformed frames.
- `src/lib/server/socket-mode/conformance-client.ts` — high-level adopter-facing class. Status callback, exponential-backoff reconnect capped at 30s, opt-out via `close()`.
- `src/lib/server/socket-mode/index.ts` — module exports.
- `src/lib/server/index.ts` — re-exports `ConformanceClient` + types from the `@adcp/sdk/server` entry alongside the existing server primitives.
- `src/lib/server/socket-mode/conformance-client.test.ts` — 3 tests covering full WebSocket round-trip with `tools/list` + `tools/call`, status transitions, and error path on unreachable URL.
- `ws@^8` added as a regular dep, `@types/ws` as devDep.

Total: ~250 LOC + tests, all in one new directory. Discoverable via the existing `@adcp/sdk/server` entry.

## Privacy/safety posture

Channel is dev/staging only — production deployments must not expose `comply_test_controller` on any surface, including this one. The `ConformanceClient` JSDoc names this constraint and links to [adcontextprotocol/adcp#3986](https://github.com/adcontextprotocol/adcp/issues/3986). The SDK doesn't enforce it (it can't know if a server is "production" or "staging"), but the API surface, naming, and docs steer adopters away from misuse.

## Server-side terminator

The runner accepting these connections is the adopter's choice. Addie ships one in [adcontextprotocol/adcp#4007](https://github.com/adcontextprotocol/adcp/pull/4007) and will host the canonical endpoint at \`addie.agenticadvertising.org\`. The transport is neutral — any orchestrator that speaks the same handshake (token in \`?token=\` query OR \`Sec-WebSocket-Protocol: adcp.conformance, <token>\`) could host the other end.

## Test plan

- [ ] CI green
- [ ] \`npx vitest run src/lib/server/socket-mode/\` — 3 tests pass locally
- [ ] Manual: \`import { ConformanceClient } from '@adcp/sdk/server'\` in a downstream consumer resolves and types check

🤖 Generated with [Claude Code](https://claude.com/claude-code)