### PR TITLE
fix(testing/storyboard): symmetric account resolution on update_media_buy enricher (#1505)

### DIFF
--- a/.changeset/fix-1505-update-media-buy-account-resolution.md
+++ b/.changeset/fix-1505-update-media-buy-account-resolution.md
@@ -1,0 +1,27 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(testing/storyboard): symmetric account resolution on `update_media_buy` enricher (closes #1505)
+
+The storyboard runner's `update_media_buy` enricher was not in
+`FIXTURE_AWARE_ENRICHERS`, so the generic `{ ...enriched, ...fixture }`
+merge let storyboard `sample_request.account` override the harness-
+resolved account. When create_media_buy used a runner-synthesized
+sandbox account (e.g. `{ brand: 'test.example', operator: 'test.example', sandbox: true }`)
+and the storyboard's update step authored `account: { brand: 'real.example', operator: '...' }`,
+the update wrote to the prod partition while create wrote to the
+sandbox partition. A subsequent `get_media_buys` reading from the
+sandbox partition (via `context.account`) saw stale create-time
+targeting_overlay — exactly the failure surfaced by the
+`media_buy_seller/inventory_list_targeting/get_after_update` cascade
+step.
+
+This change adds `update_media_buy` to `FIXTURE_AWARE_ENRICHERS` and
+rewrites the enricher to spread fixture fields first then force-override
+`account` to `context.account ?? resolveAccount(options)` — symmetric
+with the `get_media_buys` / `get_media_buy_delivery` fix in #1487.
+
+Legacy storyboards without a `sample_request` still fall back to the
+keyword-based pause / resume / cancel inference; only the fixture-
+authored path changes.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -73,6 +73,7 @@ const FALLBACK_CALLER_AGENT_URL = 'https://e2e-orchestrator.adcontextprotocol.or
 const FIXTURE_AWARE_ENRICHERS = new Set<string>([
   'create_media_buy', // merges discovery-derived product_id / pricing_option_id INTO fixture packages[0]
   'comply_test_controller', // forces account.sandbox: true regardless of fixture
+  'update_media_buy', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
   'get_media_buys', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
   'get_media_buy_delivery', // resolves account via resolveAccount(options) so sandbox routing matches create_media_buy
 ]);
@@ -289,31 +290,39 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
   },
 
   update_media_buy(step, context, options) {
-    // If the storyboard provides a sample_request, honor it — these requests
-    // are hand-authored to exercise specific seller behaviors (creative
-    // assignment, targeting overlay swaps, pause/resume/cancel, etc.) and the
-    // builder should not override the intent.
+    // Fixture-aware: spread the storyboard's sample_request first so hand-authored
+    // intent (targeting_overlay swaps, creative assignments, pause/resume/cancel)
+    // is preserved verbatim, then force `account` to the harness-resolved value so
+    // sandbox routing matches create_media_buy's namespace on every round-trip
+    // (otherwise the fixture's account silently routes update writes to a different
+    // partition than the create wrote to, and a subsequent get_media_buys reading
+    // from the create-time partition surfaces stale data — see adcp-client#1505).
+    const fixtureFields = step.sample_request
+      ? (injectContext({ ...(step.sample_request as Record<string, unknown>) }, context) as Record<string, unknown>)
+      : {};
+    const request: Record<string, unknown> = { ...fixtureFields };
+    request.account = context.account ?? resolveAccount(options);
+    if (request.media_buy_id === undefined) {
+      request.media_buy_id = context.media_buy_id ?? 'unknown';
+    }
 
-    // `account` is required per bundled/media-buy/update-media-buy-request.json —
-    // sellers enforce governance and account resolution against it.
-    const request: Record<string, unknown> = {
-      account: context.account ?? resolveAccount(options),
-      media_buy_id: context.media_buy_id ?? 'unknown',
-    };
-
-    if (step.id.includes('pause')) {
-      request.paused = true;
-    } else if (step.id.includes('resume')) {
-      request.paused = false;
-    } else if (step.id.includes('cancel')) {
-      request.canceled = true;
-    } else {
-      request.packages = [
-        {
-          package_id: (context.package_id as string | undefined) ?? 'unknown',
-          budget: 2000,
-        },
-      ];
+    // No sample_request: fall back to step-id keyword inference so legacy
+    // storyboards without an authored fixture still exercise sensible flows.
+    if (!step.sample_request) {
+      if (step.id.includes('pause')) {
+        request.paused = true;
+      } else if (step.id.includes('resume')) {
+        request.paused = false;
+      } else if (step.id.includes('cancel')) {
+        request.canceled = true;
+      } else {
+        request.packages = [
+          {
+            package_id: (context.package_id as string | undefined) ?? 'unknown',
+            budget: 2000,
+          },
+        ];
+      }
     }
 
     return request;

--- a/test/examples/hello-seller-adapter-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-guaranteed.test.js
@@ -43,15 +43,6 @@ const EXPECTED_FAILURES = [
       'context_outputs (PR #1426), but the upstream sales_guaranteed storyboard fixture in ' +
       'adcontextprotocol/adcp still uses bare `path: media_buy_id`. Fixture migration is upstream.',
   },
-  {
-    storyboard_id: 'media_buy_seller/inventory_list_targeting',
-    step_id: 'get_after_update',
-    issue: 'adcp-client#1505',
-    reason:
-      'createMediaBuyStore handles create→get echo for targeting_overlay (PR #1424) but does not ' +
-      'capture mutations from update_media_buy. Surfaced once the get_media_buys account-resolution ' +
-      'fix in this PR made the create→get round-trip resolve to the same namespace; tracked separately.',
-  },
 ];
 
 function isExpectedFailure(f) {

--- a/test/examples/hello-seller-adapter-non-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-non-guaranteed.test.js
@@ -29,14 +29,6 @@ const EXPECTED_FAILURES = [
     issue: 'adcp-client#1416',
     reason: 'NOT_CANCELLABLE on re-cancel — needs SDK-exported MEDIA_BUY_TRANSITIONS / assertMediaBuyTransition',
   },
-  {
-    storyboard_id: 'media_buy_seller/inventory_list_targeting',
-    step_id: 'get_after_update',
-    issue: 'adcp-client#1505',
-    reason:
-      'createMediaBuyStore handles create→get echo but not update→get echo — surfaced once the ' +
-      'get_media_buys account-resolution fix in this PR made the round-trip resolve to the same namespace.',
-  },
 ];
 
 function isExpectedFailure(f) {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -858,6 +858,88 @@ describe('Request Builder', () => {
     });
   });
 
+  describe('update_media_buy', () => {
+    test('preserves storyboard sample_request fields when fixture-aware path runs (#1505)', () => {
+      // Regression: update_media_buy must spread fixture fields (packages,
+      // targeting_overlay, idempotency_key) so hand-authored intent flows through.
+      const fixturePackages = [
+        {
+          package_id: 'pkg_1',
+          targeting_overlay: {
+            property_list: { agent_url: 'https://gov.example', list_id: 'no_match_v1' },
+          },
+        },
+      ];
+      const result = buildRequest(
+        step('update_media_buy', {
+          sample_request: {
+            account: { account_id: 'prod-acct' },
+            media_buy_id: 'buy-7',
+            packages: fixturePackages,
+            idempotency_key: 'fixture-key',
+          },
+        }),
+        {},
+        DEFAULT_OPTIONS
+      );
+      assert.deepStrictEqual(result.packages, fixturePackages);
+      assert.strictEqual(result.media_buy_id, 'buy-7');
+      assert.strictEqual(result.idempotency_key, 'fixture-key');
+    });
+
+    test('harness account wins over fixture account so update writes match create namespace (#1505)', () => {
+      // Regression: before this fix, update_media_buy was NOT in
+      // FIXTURE_AWARE_ENRICHERS, so the generic merge let the storyboard's
+      // raw account override the harness-resolved one. That routed update
+      // writes to a different partition than create, which surfaced as
+      // stale targeting_overlay on the subsequent get_media_buys.
+      const fixtureAccount = { account_id: 'prod-acct', sandbox: false };
+      const result = buildRequest(
+        step('update_media_buy', {
+          sample_request: { account: fixtureAccount, media_buy_id: 'buy-7' },
+        }),
+        {},
+        DEFAULT_OPTIONS
+      );
+      assert.ok(result.account, 'account must be present');
+      assert.notDeepStrictEqual(
+        result.account,
+        fixtureAccount,
+        'harness-resolved account must win over fixture raw account'
+      );
+    });
+
+    test('uses context.account when set so create→update→get all share namespace (#1505)', () => {
+      const contextAccount = { account_id: 'sandbox-acct-1', sandbox: true };
+      const result = buildRequest(
+        step('update_media_buy', {
+          sample_request: { account: { account_id: 'prod-acct' }, media_buy_id: 'buy-7' },
+        }),
+        { account: contextAccount, media_buy_id: 'buy-7' },
+        DEFAULT_OPTIONS
+      );
+      assert.deepStrictEqual(result.account, contextAccount);
+    });
+
+    test('legacy keyword inference still applies when no sample_request provided', () => {
+      // pause / resume / cancel inference is the fallback for storyboards
+      // without an authored sample_request — must continue to work.
+      const pauseResult = buildRequest(
+        step('update_media_buy', { id: 'pause_buy' }),
+        { media_buy_id: 'b' },
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(pauseResult.paused, true);
+
+      const cancelResult = buildRequest(
+        step('update_media_buy', { id: 'cancel_buy' }),
+        { media_buy_id: 'b' },
+        DEFAULT_OPTIONS
+      );
+      assert.strictEqual(cancelResult.canceled, true);
+    });
+  });
+
   describe('calibrate_content (#989)', () => {
     test("artifact.artifact_id is 'unknown' when context lacks creative_id", () => {
       // Regression guard: was 'test-creative', which could be silently accepted


### PR DESCRIPTION
Closes #1505.

## Root cause

The storyboard runner's `update_media_buy` enricher was not in `FIXTURE_AWARE_ENRICHERS`, so the generic `{ ...enriched, ...fixture }` merge let the storyboard's `sample_request.account` win over the harness-resolved one. That created an asymmetry:

| Step | Account source | Resulting partition |
|---|---|---|
| `create_media_buy` | runner-synthesized sandbox (`{brand: 'test.example', ..., sandbox: true}`) | `sandbox_net_acmeoutdoor` |
| `update_media_buy` | storyboard fixture (`{brand: 'acmeoutdoor.example', operator: 'pinnacle-agency.example'}`) | `net_acmeoutdoor` |
| `get_media_buys` | `context.account` (sandbox, after #1487) | `sandbox_net_acmeoutdoor` |

`mergeFromUpdate` wrote the swapped `targeting_overlay` to the **prod** partition. `backfill` on `get_after_update` read from the **sandbox** partition where only the create-time overlay lived → assertion saw stale `acme_outdoor_allowlist_v1` instead of the swapped `acme_outdoor_no_match_v1`.

## Fix

- Add `update_media_buy` to `FIXTURE_AWARE_ENRICHERS`.
- Rewrite the enricher to spread fixture fields first, then force `account = context.account ?? resolveAccount(options)`. Symmetric with the `get_media_buys` / `get_media_buy_delivery` fix in #1487.
- Legacy storyboards without a `sample_request` still fall back to the keyword-based pause / resume / cancel inference; only the fixture-authored path changes.

## Verification

- Probe instrumentation against the live storyboard run captured the asymmetric accountId for the same `media_buy_id` between create / update / get — confirmed on log capture, not inference.
- Local store unit-test (`/tmp/test-store-flow.js`) showed `createMediaBuyStore` round-trips create → update → get correctly when accountId is consistent (so the store itself was never the bug).
- Drops the `adcp-client#1505` mask in both `test/examples/hello-seller-adapter-{guaranteed,non-guaranteed}.test.js`. Both gate tests pass unfiltered.
- 4 new unit tests in `test/lib/request-builder.test.js` covering: fixture-field preservation, harness-account-wins-over-fixture, context.account-wins, and legacy keyword fallback.

## Test plan

- [x] `npm run format:check`
- [x] `npm run build:lib`
- [x] `node --test test/lib/request-builder.test.js test/lib/request-builder-schema-roundtrip.test.js` — 79 tests pass (4 new)
- [x] `node --test test/examples/hello-seller-adapter-guaranteed.test.js test/examples/hello-seller-adapter-non-guaranteed.test.js` — 6/6 pass with `#1505` mask removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)