### PR TITLE
fix(adapters): declare output slot in creative formats per creative-manifest.json:14

### DIFF
--- a/.changeset/output-slot-asset-id.md
+++ b/.changeset/output-slot-asset-id.md
@@ -9,9 +9,12 @@ Per `schemas/cache/3.0.5/core/creative-manifest.json:14`: "Each key MUST match a
 PE caught this in two rounds of expert review on PR #1508 ("the doc-comment slightly oversells `adopter-defined` relative to creative-manifest.json:14"). This patch closes the drift across both creative adapters:
 
 - `examples/hello_creative_adapter_template.ts` — added `outputSlot(t)` helper that returns the right `FormatAsset.{html,javascript,vast,audio}({ asset_id: 'serving_tag', required: false })` based on `template.output_kind`. `templateToFormat` now appends it to the format's `assets[]` alongside the input slots. Tightened the `projectRenderToManifest` doc-comment to reflect that `serving_tag` IS now declared (no longer "adopter-defined diverges from spec").
-- `examples/hello_creative_adapter_ad_server.ts` — `projectFormat` now declares a single `FormatAsset.html({ asset_id: 'tag', required: false })` output slot on every format (the ad-server adapter always renders to HTML serving tags in this worked example). Adopters whose video formats emit VAST should swap in `FormatAsset.vast(...)` instead.
+- `examples/hello_creative_adapter_ad_server.ts` — `projectFormat` now declares a single `FormatAsset.html({ asset_id: 'serving_tag', required: false })` output slot on every format (the ad-server adapter always renders to HTML serving tags in this worked example). Adopters whose video formats emit VAST should swap in `FormatAsset.vast(...)` instead. Asset_id aligned with `hello_creative_adapter_template.ts` so adopters across both worked examples see the same contract — the asset_id is declared by the format, not platform-flavored.
 - `skills/build-creative-agent/SKILL.md` — audio-adopter checklist now includes the `outputSlot` extension as step 2 (was 3 steps; now 4). Each step references the spec source so adopters understand WHY each delta is required.
 
 Adopters forking either adapter inherit a spec-aligned format declaration. fork-matrix 23/23 still green; typecheck + format clean.
 
 Pure additive at the wire — formats grow by one asset slot, no existing fields change shape. Adopters whose buyers already work against these formats see one extra entry in `format.assets[]`; the extra entry is `required: false` so input requests don't change.
+
+**Spec gap filed upstream**: `format.assets[]` doesn't currently distinguish input slots (buyer-provided) from output-only slots (build_creative-produced) — `required: false` is the closest legal expression but understates the constraint. Tracked at [adcontextprotocol/adcp#4021](https://github.com/adcontextprotocol/adcp/issues/4021); when the upstream lands an `output_only` flag or `produced_by` enum, both adapters will adopt it.
+

--- a/.changeset/output-slot-asset-id.md
+++ b/.changeset/output-slot-asset-id.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+Declare output slots in `hello_creative_adapter_*` formats so `build_creative` response keys match declared asset_ids per spec.
+
+Per `schemas/cache/3.0.5/core/creative-manifest.json:14`: "Each key MUST match an asset_id from the format's assets array." Both worked creative adapters were keying their build_creative output (`assets['serving_tag']` and `assets['tag']` respectively) against asset_ids that **weren't declared** in the format — only input slots were declared (image, headline, script, click_url for the template adapter; nothing at all for the ad-server adapter).
+
+PE caught this in two rounds of expert review on PR #1508 ("the doc-comment slightly oversells `adopter-defined` relative to creative-manifest.json:14"). This patch closes the drift across both creative adapters:
+
+- `examples/hello_creative_adapter_template.ts` — added `outputSlot(t)` helper that returns the right `FormatAsset.{html,javascript,vast,audio}({ asset_id: 'serving_tag', required: false })` based on `template.output_kind`. `templateToFormat` now appends it to the format's `assets[]` alongside the input slots. Tightened the `projectRenderToManifest` doc-comment to reflect that `serving_tag` IS now declared (no longer "adopter-defined diverges from spec").
+- `examples/hello_creative_adapter_ad_server.ts` — `projectFormat` now declares a single `FormatAsset.html({ asset_id: 'tag', required: false })` output slot on every format (the ad-server adapter always renders to HTML serving tags in this worked example). Adopters whose video formats emit VAST should swap in `FormatAsset.vast(...)` instead.
+- `skills/build-creative-agent/SKILL.md` — audio-adopter checklist now includes the `outputSlot` extension as step 2 (was 3 steps; now 4). Each step references the spec source so adopters understand WHY each delta is required.
+
+Adopters forking either adapter inherit a spec-aligned format declaration. fork-matrix 23/23 still green; typecheck + format clean.
+
+Pure additive at the wire — formats grow by one asset slot, no existing fields change shape. Adopters whose buyers already work against these formats see one extra entry in `format.assets[]`; the extra entry is `required: false` so input requests don't change.

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -66,6 +66,7 @@ import {
   type DecisioningPlatform,
   type SyncCreativesRow,
 } from '@adcp/sdk/server';
+import { FormatAsset } from '@adcp/sdk';
 import type {
   BuildCreativeRequest,
   BuildCreativeSuccess,
@@ -269,6 +270,15 @@ const FORMAT_AGENT_URL = PUBLIC_AGENT_URL;
  *  `renders[]` per #1325. Adapter consumes `GET /v1/formats` then
  *  projects each entry. */
 function projectFormat(f: UpstreamFormat): ListCreativeFormatsResponse['formats'][number] {
+  // Output slot declared on every format so build_creative's response key
+  // (`assets['tag']`) matches a declared asset_id per
+  // creative-manifest.json:14. `required: false` because the buyer doesn't
+  // supply this — buildCreative generates and returns it. asset_type: 'html'
+  // mirrors the buildCreative response (always renders to an HTML serving
+  // tag in this worked example); video/CTV adapters emitting VAST should
+  // declare `FormatAsset.vast({ asset_id: 'tag', required: false })` instead.
+  const outputAssets = [FormatAsset.html({ asset_id: 'tag', required: false })];
+
   // Display fixed formats: emit dimensions on a single 'main' render.
   if (f.render_kind === 'fixed' && f.channel === 'display' && f.width !== undefined && f.height !== undefined) {
     return {
@@ -280,6 +290,7 @@ function projectFormat(f: UpstreamFormat): ListCreativeFormatsResponse['formats'
           dimensions: { width: f.width, height: f.height, unit: 'px' as const },
         },
       ],
+      assets: outputAssets,
     };
   }
   // Video / CTV: project at 1080p baseline.
@@ -293,6 +304,7 @@ function projectFormat(f: UpstreamFormat): ListCreativeFormatsResponse['formats'
           dimensions: { width: 1920, height: 1080, unit: 'px' as const },
         },
       ],
+      assets: outputAssets,
     };
   }
   // Parameterized — placeholder dimensions for the worked example. Real
@@ -304,6 +316,7 @@ function projectFormat(f: UpstreamFormat): ListCreativeFormatsResponse['formats'
     format_id: { agent_url: FORMAT_AGENT_URL, id: f.format_id },
     name: f.name,
     renders: [{ role: 'main', dimensions: { width: 1, height: 1, unit: 'px' as const } }],
+    assets: outputAssets,
   };
 }
 
@@ -490,8 +503,11 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
       // `additionalProperties: false` constraint excludes `creative_id`
       // and `name` from the manifest body — only `format_id`, `assets`,
       // `rights`, `industry_identifiers`, `provenance`, `ext` are allowed.
-      // Each `assets[key]` is a discriminated AssetVariant — `asset_type`
-      // selects the matching schema (html requires `content`, etc.).
+      // The `tag` asset_id matches the output slot declared in
+      // `projectFormat` (FormatAsset.html({ asset_id: 'tag', ... })),
+      // satisfying creative-manifest.json:14. Each `assets[key]` is a
+      // discriminated AssetVariant — `asset_type` selects the matching
+      // schema (html requires `content`, etc.).
       return {
         creative_manifest: {
           format_id: { agent_url: FORMAT_AGENT_URL, id: creative.format_id },

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -271,13 +271,16 @@ const FORMAT_AGENT_URL = PUBLIC_AGENT_URL;
  *  projects each entry. */
 function projectFormat(f: UpstreamFormat): ListCreativeFormatsResponse['formats'][number] {
   // Output slot declared on every format so build_creative's response key
-  // (`assets['tag']`) matches a declared asset_id per
+  // (`assets['serving_tag']`) matches a declared asset_id per
   // creative-manifest.json:14. `required: false` because the buyer doesn't
   // supply this — buildCreative generates and returns it. asset_type: 'html'
   // mirrors the buildCreative response (always renders to an HTML serving
   // tag in this worked example); video/CTV adapters emitting VAST should
-  // declare `FormatAsset.vast({ asset_id: 'tag', required: false })` instead.
-  const outputAssets = [FormatAsset.html({ asset_id: 'tag', required: false })];
+  // declare `FormatAsset.vast({ asset_id: 'serving_tag', required: false })` instead.
+  // Asset_id `serving_tag` is shared with hello_creative_adapter_template.ts
+  // — keeping the same id across both worked examples teaches adopters that
+  // the asset_id is contractual (declared by the format), not platform-flavored.
+  const outputAssets = [FormatAsset.html({ asset_id: 'serving_tag', required: false })];
 
   // Display fixed formats: emit dimensions on a single 'main' render.
   if (f.render_kind === 'fixed' && f.channel === 'display' && f.width !== undefined && f.height !== undefined) {
@@ -504,7 +507,7 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
       // and `name` from the manifest body — only `format_id`, `assets`,
       // `rights`, `industry_identifiers`, `provenance`, `ext` are allowed.
       // The `tag` asset_id matches the output slot declared in
-      // `projectFormat` (FormatAsset.html({ asset_id: 'tag', ... })),
+      // `projectFormat` (FormatAsset.html({ asset_id: 'serving_tag', ... })),
       // satisfying creative-manifest.json:14. Each `assets[key]` is a
       // discriminated AssetVariant — `asset_type` selects the matching
       // schema (html requires `content`, etc.).
@@ -512,7 +515,7 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
         creative_manifest: {
           format_id: { agent_url: FORMAT_AGENT_URL, id: creative.format_id },
           assets: {
-            tag: { asset_type: 'html', content: rendered.tag_html },
+            serving_tag: { asset_type: 'html', content: rendered.tag_html },
           },
         },
         // CAST: oneOf-emitter — picking variant 0 (single creative_manifest)

--- a/examples/hello_creative_adapter_template.ts
+++ b/examples/hello_creative_adapter_template.ts
@@ -248,6 +248,29 @@ function projectSlot(s: UpstreamTemplate['slots'][number]) {
   }
 }
 
+/** Output asset slot. The format's `assets[]` mixes input slots (image,
+ *  headline, script — what the buyer provides) with the build_creative
+ *  output slot (`serving_tag` — what the adapter returns). Per
+ *  creative-manifest.json:14 every key in `creative_manifest.assets` MUST
+ *  match a declared `assets[].asset_id`; without the output slot here, our
+ *  build_creative response's `serving_tag` would key against an undeclared
+ *  slot. `required: false` because the buyer doesn't supply this — the
+ *  adapter generates it. asset_type is driven by upstream `output_kind` so
+ *  the discriminator in the response (html / javascript / vast / audio)
+ *  matches the slot the buyer can resolve from `get_format`. */
+function outputSlot(t: UpstreamTemplate) {
+  switch (t.output_kind) {
+    case 'html_tag':
+      return FormatAsset.html({ asset_id: 'serving_tag', required: false });
+    case 'javascript_tag':
+      return FormatAsset.javascript({ asset_id: 'serving_tag', required: false });
+    case 'vast_xml':
+      return FormatAsset.vast({ asset_id: 'serving_tag', required: false });
+    case 'audio_url':
+      return FormatAsset.audio({ asset_id: 'serving_tag', required: false });
+  }
+}
+
 function templateToFormat(t: UpstreamTemplate): Format {
   // Each `renders[]` entry MUST be `{ role, dimensions: { width, height } }`
   // OR `{ role, parameters_from_format_id: true }`. A bare `{ role, width,
@@ -263,7 +286,9 @@ function templateToFormat(t: UpstreamTemplate): Format {
     name: t.name,
     description: t.description,
     renders,
-    assets: t.slots.map(projectSlot),
+    // Input slots (what the buyer provides) + the output slot (what the
+    // adapter generates and returns via build_creative).
+    assets: [...t.slots.map(projectSlot), outputSlot(t)],
   };
 }
 
@@ -274,17 +299,12 @@ function templateToFormat(t: UpstreamTemplate): Format {
  *  builders to inject the discriminator — a bare `{ content }` or `{ url }`
  *  fails the asset-union oneOf.
  *
- *  ⚠️ This fixture's `serving_tag` asset_id diverges from
- *  `creative-manifest.json:14`, which mandates: "Each key MUST match an
- *  asset_id from the format's assets array." The format declared by
- *  `templateToFormat` has slot ids (`image`, `headline`, `script`, etc.) —
- *  none of which is `serving_tag`. We use `serving_tag` consistently across
- *  all four output kinds (HTML / JS / VAST / audio) so the fixture exercises
- *  every output branch with one key, but **production adopters MUST echo
- *  declared `assets[].asset_id` values** — pick the slot the buyer expects
- *  the rendered output under (e.g. `output`, `master`) and declare it in
- *  the format. Spec-aligning this fixture is tracked at adcp-client follow-up
- *  to #1496; until then, see SHAPE-GOTCHAS.md before adapting this pattern. */
+ *  The `serving_tag` asset_id matches the output slot declared by
+ *  `outputSlot(t)` in `templateToFormat`, satisfying creative-manifest.json:14
+ *  ("each key MUST match an asset_id from the format's assets array"). All
+ *  four output kinds (HTML / JS / VAST / audio) key under the same id; the
+ *  asset_type discriminator on the value picks the matching slot's typed
+ *  branch. */
 function projectRenderToManifest(
   render: UpstreamRender,
   formatId: { agent_url: string; id: string }

--- a/examples/hello_creative_adapter_template.ts
+++ b/examples/hello_creative_adapter_template.ts
@@ -268,6 +268,14 @@ function outputSlot(t: UpstreamTemplate) {
       return FormatAsset.vast({ asset_id: 'serving_tag', required: false });
     case 'audio_url':
       return FormatAsset.audio({ asset_id: 'serving_tag', required: false });
+    default: {
+      // Exhaustiveness gate. If `output_kind` grows a fifth case (image_url,
+      // daast_xml, etc.) the unreachable assertion fires at compile time so
+      // adopters extending the upstream type can't ship a silent `undefined`
+      // entry into format.assets[].
+      const exhaustive: never = t.output_kind;
+      throw new Error(`unhandled output_kind: ${exhaustive as string}`);
+    }
   }
 }
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -55,17 +55,18 @@ The fork targets cover the baseline + specialism deltas. Quick reference for wha
 
 Audio templates (TTS / mix / master, e.g. AudioStack / ElevenLabs / Resemble) follow the same shape with two deltas: (a) format declares `parameterizedRender({ role: 'primary' })` because audio has no width/height — encode duration/codec/bitrate in `accepts_parameters`, not in render entries; (b) the upstream pipeline is naturally minutes-long (voice-over → mix → master), so the adapter returns a task envelope and emits `creative_review` webhooks on completion.
 
-**Audio adopters extend `hello_creative_adapter_template.ts` with three deltas:**
+**Audio adopters extend `hello_creative_adapter_template.ts` with four deltas:**
 
 1. Add `audio_url?: string` to `UpstreamRender.output` and extend `output_kind` to include `'audio_url'`
-2. Add an audio-output branch to `projectRenderToManifest`:
+2. Add an `audio_url` arm to `outputSlot(t)` returning `FormatAsset.audio({ asset_id: 'serving_tag', required: false })` — declares the output slot in the format so build_creative's response key matches a declared asset_id per `creative-manifest.json:14`.
+3. Add an audio-output branch to `projectRenderToManifest`:
    ```ts
    } else if (out.audio_url) {
      assets['serving_tag'] = audioAsset({ url: out.audio_url });
    }
    ```
    The `audioAsset` builder injects the `asset_type: 'audio'` discriminator the creative-manifest oneOf requires.
-3. Seed an audio template in your upstream platform — see `tpl_audiostack_spot_30s_v1` in `src/lib/mock-server/creative-template/seed-data.ts` for the worked reference.
+4. Seed an audio template in your upstream platform — see `tpl_audiostack_spot_30s_v1` in `src/lib/mock-server/creative-template/seed-data.ts` for the worked reference.
 
 **Storyboard coverage for audio is not yet upstream** — the `creative_template/build_creative` step asserts display-shaped assets, tracked at [adcontextprotocol/adcp#4015](https://github.com/adcontextprotocol/adcp/issues/4015). Until that ships, audio adopters validate via `npm run compliance:fork-matrix -- --test-name-pattern="hello-creative-adapter-template"` (display + video gate inherited) plus a manual round-trip against the seeded audio template:
 


### PR DESCRIPTION
## Summary

Closes the asset-key spec-drift PE flagged in two rounds of expert review on PR #1508.

Per `schemas/cache/3.0.5/core/creative-manifest.json:14`:
> "Each key MUST match an asset_id from the format's assets array."

Both worked creative adapters were violating this:

- `hello_creative_adapter_template.ts` — declared input slots (`image`, `headline`, `script`, `click_through`), then keyed `build_creative` output as `assets['serving_tag']` — never declared.
- `hello_creative_adapter_ad_server.ts` — declared **zero** asset slots in the format, then keyed output as `assets['tag']` — also never declared.

Adopters forking either pattern would inherit non-spec-conformant manifests. The previous PR (#1508) added a doc-comment acknowledging the drift; this PR closes it.

## Changes

**`examples/hello_creative_adapter_template.ts`**
- New `outputSlot(t)` helper. Returns the right `FormatAsset.{html,javascript,vast,audio}({ asset_id: 'serving_tag', required: false })` based on `template.output_kind`.
- `templateToFormat` appends it to `format.assets[]` alongside input slots.
- Doc-comment on `projectRenderToManifest` tightened — `serving_tag` is now a declared slot, no longer "adopter-defined."

**`examples/hello_creative_adapter_ad_server.ts`**
- Imported `FormatAsset` from `@adcp/sdk`.
- `projectFormat` declares `FormatAsset.html({ asset_id: 'tag', required: false })` on every format. The ad-server adapter always renders to HTML serving tags in this worked example; video/CTV adopters emitting VAST swap in `FormatAsset.vast(...)`.
- Doc-comment on `buildCreative` notes the `tag` key matches the declared slot.

**`skills/build-creative-agent/SKILL.md`**
- Audio adopter checklist gains a step 2 covering the `outputSlot` extension. Each step now cites why it's required.

## Adopter impact

Pure additive at the wire — formats grow by one `required: false` slot. Existing input requests don't change shape. Buyers reading `get_format` see the output slot they didn't see before, which is an improvement (now they can resolve the rendered output's `asset_type` from the format).

## Test plan

- [x] `npm run compliance:fork-matrix` — 23/23 in ~10s
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)