### PR TITLE
fix(examples): wire assertMediaBuyTransition into hello_seller_adapter_non_guaranteed (#1499)

### DIFF
--- a/.changeset/fix-1499-non-guaranteed-state-machine.md
+++ b/.changeset/fix-1499-non-guaranteed-state-machine.md
@@ -1,0 +1,25 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(examples): wire `assertMediaBuyTransition` into `hello_seller_adapter_non_guaranteed` (closes #1499)
+
+The non-guaranteed worked-reference adapter previously had no
+state-machine enforcement on `update_media_buy` — the cascade
+scenario `media_buy_seller/invalid_transitions/second_cancel`
+failed because the adapter accepted a re-cancel instead of
+rejecting with `NOT_CANCELLABLE`. SDK-side helpers shipped in 6.7
+(`MEDIA_BUY_TRANSITIONS` + `assertMediaBuyTransition`, closes #1416)
+but the example didn't wire them.
+
+This change adds a per-buy `localBuyStatus` Map for paused / canceled
+states (the mock upstream models pending → active progression but
+not these terminal/reversible states) and calls
+`assertMediaBuyTransition` on every cancel/pause path. Matches the
+pattern already in `hello_seller_adapter_guaranteed`.
+
+Drops the `adcp-client#1416` mask from the non-guaranteed gate test;
+the gate now passes the storyboard unfiltered against the full
+cascade.
+
+No SDK behavior change — example-only fix.

--- a/examples/hello_seller_adapter_non_guaranteed.ts
+++ b/examples/hello_seller_adapter_non_guaranteed.ts
@@ -61,11 +61,13 @@ import {
   AdcpError,
   createMediaBuyStore,
   InMemoryStateStore,
+  assertMediaBuyTransition,
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
   type AccountStore,
   type Account,
+  type AdcpMediaBuyStatus,
   type SyncCreativesRow,
   type SyncAccountsResultRow,
 } from '@adcp/sdk/server';
@@ -440,6 +442,16 @@ function mapMediaBuyStatus(
 const adapterStatusOverrides = new Map<string, 'pending_start' | 'active'>();
 const overrideKey = (networkCode: string, orderId: string): string => `${networkCode}::${orderId}`;
 
+// Local pause / cancel tracker. The mock upstream models the create →
+// pending → active progression; pause and cancel are seller-side state-machine
+// concerns the spec's `core/state-machine.yaml` declares as terminal sinks
+// (canceled) or reversible (paused). Production sellers swap this Map for
+// a single durable lookup against their order DB and check
+// `MEDIA_BUY_TRANSITIONS` against the current status before issuing the
+// upstream PATCH. The local Map here exists only because the worked-example
+// mock doesn't model these states upstream.
+const localBuyStatus = new Map<string, 'paused' | 'canceled'>();
+
 class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, never>, NetworkMeta> {
   capabilities = {
     specialisms: ['sales-non-guaranteed'] as const,
@@ -735,10 +747,29 @@ class SalesNonGuaranteedAdapter implements DecisioningPlatform<Record<string, ne
       // → pending_start (or active if the flight already started). Production
       // backends would also persist the assignment to the upstream line item;
       // the worked example just advances the response state.
+      //
+      // State-machine enforcement for pause / cancel. The spec's
+      // `core/state-machine.yaml` declares `canceled` as a terminal sink and
+      // a re-cancel as illegal — `assertMediaBuyTransition` throws
+      // `NOT_CANCELLABLE` on `canceled → canceled`, which is the
+      // `media_buy_seller/invalid_transitions` storyboard's contract. The
+      // local Map covers the gap between upstream (which doesn't model these)
+      // and the spec; production sellers read the canonical transitions
+      // exported by `@adcp/sdk/server` against their own status column.
+      const local = localBuyStatus.get(overrideKey(networkCode, id));
       const baseStatus = mapMediaBuyStatus(existing.status);
-      let nextStatus: ReturnType<typeof mapMediaBuyStatus> =
-        adapterStatusOverrides.get(overrideKey(networkCode, id)) ?? baseStatus;
-      if (hasCreativeAssignment && nextStatus === 'pending_creatives') {
+      const currentStatus: AdcpMediaBuyStatus =
+        local ?? adapterStatusOverrides.get(overrideKey(networkCode, id)) ?? baseStatus;
+      let nextStatus: AdcpMediaBuyStatus = currentStatus;
+      if ((patch as { canceled?: boolean }).canceled === true) {
+        assertMediaBuyTransition(currentStatus, 'canceled');
+        nextStatus = 'canceled';
+        localBuyStatus.set(overrideKey(networkCode, id), nextStatus);
+      } else if ((patch as { paused?: boolean }).paused === true && currentStatus === 'active') {
+        assertMediaBuyTransition(currentStatus, 'paused');
+        nextStatus = 'paused';
+        localBuyStatus.set(overrideKey(networkCode, id), nextStatus);
+      } else if (hasCreativeAssignment && nextStatus === 'pending_creatives') {
         const flightStarted = existing.flight_start !== undefined && Date.parse(existing.flight_start) <= Date.now();
         nextStatus = flightStarted ? 'active' : 'pending_start';
         adapterStatusOverrides.set(overrideKey(networkCode, id), nextStatus);

--- a/test/examples/hello-seller-adapter-non-guaranteed.test.js
+++ b/test/examples/hello-seller-adapter-non-guaranteed.test.js
@@ -3,16 +3,8 @@
  *
  * Three independent assertions via the shared helper. The adapter wires
  * `comply_test_controller` so cascade scenarios under `media_buy_seller/*`
- * get the controller-driven setup they need. One expected-failure entry
- * remains:
- *
- *   - #1416 (NOT_CANCELLABLE state machine export)
- *
- * Drop the corresponding entry from `EXPECTED_FAILURES` when each issue
- * lands. The helper enforces that every entry in the allowlist actually
- * appears in the pre-filter failure set — a spec rename that silently
- * eliminates the gap-failure flips the gate to red so the allowlist
- * stays in sync with reality.
+ * get the controller-driven setup they need. The storyboard runs
+ * unfiltered against the full cascade.
  */
 
 const path = require('node:path');
@@ -22,14 +14,7 @@ const { runHelloAdapterGates } = require('./_helpers/runHelloAdapterGates');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
-const EXPECTED_FAILURES = [
-  {
-    storyboard_id: 'media_buy_seller/invalid_transitions',
-    step_id: 'second_cancel',
-    issue: 'adcp-client#1416',
-    reason: 'NOT_CANCELLABLE on re-cancel — needs SDK-exported MEDIA_BUY_TRANSITIONS / assertMediaBuyTransition',
-  },
-];
+const EXPECTED_FAILURES = [];
 
 function isExpectedFailure(f) {
   return EXPECTED_FAILURES.some(e => e.storyboard_id === (f.storyboard_id || '') && e.step_id === (f.step_id || ''));
@@ -46,20 +31,28 @@ runHelloAdapterGates({
     UPSTREAM_API_KEY: 'mock_sales_non_guaranteed_key_do_not_use_in_prod',
   },
   expectedRoutes: ['GET /_lookup/network', 'GET /v1/products', 'POST /v1/orders', 'GET /v1/orders/{id}'],
-  filterFailures: grader => {
-    const failures = grader.failures || [];
-    for (const expected of EXPECTED_FAILURES) {
-      const present = failures.some(f => f.storyboard_id === expected.storyboard_id && f.step_id === expected.step_id);
-      assert.ok(
-        present,
-        `EXPECTED_FAILURES is stale: ${expected.storyboard_id}/${expected.step_id} (${expected.issue}) ` +
-          `is no longer reported as a failure. Drop it from the allowlist and re-run; the gate should now ` +
-          `pass unfiltered for this case.`
-      );
-    }
-    return failures.filter(f => !isExpectedFailure(f));
-  },
-  storyboardSummary: `${EXPECTED_FAILURES.length} SDK-side gaps deferred (see ${EXPECTED_FAILURES.map(e => e.issue).join(', ')})`,
+  filterFailures:
+    EXPECTED_FAILURES.length === 0
+      ? undefined
+      : grader => {
+          const failures = grader.failures || [];
+          for (const expected of EXPECTED_FAILURES) {
+            const present = failures.some(
+              f => f.storyboard_id === expected.storyboard_id && f.step_id === expected.step_id
+            );
+            assert.ok(
+              present,
+              `EXPECTED_FAILURES is stale: ${expected.storyboard_id}/${expected.step_id} (${expected.issue}) ` +
+                `is no longer reported as a failure. Drop it from the allowlist and re-run; the gate should now ` +
+                `pass unfiltered for this case.`
+            );
+          }
+          return failures.filter(f => !isExpectedFailure(f));
+        },
+  storyboardSummary:
+    EXPECTED_FAILURES.length === 0
+      ? undefined
+      : `${EXPECTED_FAILURES.length} SDK-side gaps deferred (see ${EXPECTED_FAILURES.map(e => e.issue).join(', ')})`,
 });
 
 void test;


### PR DESCRIPTION
Closes #1499.

## Why
The non-guaranteed worked-reference adapter had no state-machine enforcement on `update_media_buy`. The cascade `media_buy_seller/invalid_transitions/second_cancel` failed because the adapter accepted a re-cancel instead of rejecting with `NOT_CANCELLABLE`. SDK-side helpers shipped in 6.7 (`MEDIA_BUY_TRANSITIONS` + `assertMediaBuyTransition`, closing #1416) but this example didn't wire them.

## What
- Import `assertMediaBuyTransition` and `AdcpMediaBuyStatus` from `@adcp/sdk/server`
- Add per-buy `localBuyStatus` Map for `paused | canceled` (mock upstream doesn't model these)
- In `updateMediaBuy`, call `assertMediaBuyTransition(currentStatus, 'canceled')` on cancel and `assertMediaBuyTransition(currentStatus, 'paused')` on pause-of-active. Matches the guaranteed adapter's pattern
- Drop `adcp-client#1416` mask from the gate test; storyboard now passes unfiltered

## Test plan
- [x] `npm run format:check` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build:lib` — clean
- [x] `node --test test/examples/hello-seller-adapter-non-guaranteed.test.js` — 3/3 pass with EXPECTED_FAILURES = []

🤖 Generated with [Claude Code](https://claude.com/claude-code)