### PR TITLE
docs(proposals): trust-boundary section + deprecate Account.sandbox

### DIFF
--- a/.changeset/sandbox-authority-doc-tidy.md
+++ b/.changeset/sandbox-authority-doc-tidy.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": patch
+---
+
+Doc + deprecation tidy from PR #1453's expert reviews.
+
+Three changes, no behavior change:
+
+- `docs/proposals/lifecycle-state-and-sandbox-authority.md` — adds an explicit "Trust boundary" section at the top of the cross-implementation story. Names what the boundary IS (resolver-stamped `Account.mode`) and what it is NOT (wire `AccountReference.sandbox`, account-id prefix shape, env vars). Calls out the resolver-discipline gotcha: spreading buyer input into the resolved account effectively moves the trust boundary onto the wire, defeating the framework gate.
+- `Account.sandbox` (server-side resolved-account interface in `src/lib/server/decisioning/account.ts`) is now `@deprecated` in favor of `Account.mode`. Existing adopters stamping `sandbox: true` continue to work via `getAccountMode`'s legacy fallback. The field will be removed in a future major. Wire-side `AccountReference.sandbox` is unchanged — it's part of AdCP's natural-key disambiguation per the spec's `core/account-ref.json`.
+- This changeset itself documents the deprecation queue so the next major bump knows what to drop.
+
+Filed upstream separately: `adcontextprotocol/adcp#4028` (storyboard coverage gap — no scenario exercises comply_test_controller denial against live-mode accounts) and the open question on the protocol-docs `adcp-stack` page about mock-server normative status.

--- a/docs/proposals/lifecycle-state-and-sandbox-authority.md
+++ b/docs/proposals/lifecycle-state-and-sandbox-authority.md
@@ -217,6 +217,77 @@ lives in the mock-server's per-specialism fixtures, not in adopter
 code. The adapter runs unchanged against a fixture-shaped upstream;
 storyboards drive scenarios through fixture state.
 
+## Trust boundary
+
+The trust boundary that makes this whole model load-bearing is **the
+resolved account's `mode`, returned from `platform.accounts.resolve` on
+the seller side**. Nothing else.
+
+In particular, the boundary is **NOT**:
+
+- The wire `AccountReference.sandbox` flag. This is buyer input. A buyer
+  can stuff `sandbox: true` into any natural-key request — the spec
+  defines the field, the schema accepts it, the framework validates it.
+  But buyer-controlled fields cannot be the basis for "is this a
+  test-only context?" because the buyer has every incentive to claim
+  sandbox status when calling test-only surfaces against a live tenant.
+- The presence of a sandbox-shaped account-id prefix (e.g.,
+  `sandbox_<id>`) the seller happens to use. Account-id shapes are
+  internal seller convention; an attacker who learned the prefix could
+  not forge a live account into one that admits the gate, but a
+  seller-side bug that branches on prefix shape can drift from the
+  resolver's actual mode answer.
+- An environment variable (historically `ADCP_SANDBOX=1`). The SDK's
+  legacy bridge accepts this for back-compat, but a process-scoped flag
+  cannot answer "is *this caller* test-only" — it answers "did the
+  operator run with the sandbox flag set?", which is the wrong scope.
+  The bridge fail-closes once any explicit `mode: 'live'` account has
+  been observed (`@adcp/sdk` 6.7+ ships this guard; see
+  `src/lib/server/decisioning/runtime/observed-modes.ts`).
+
+The framework gate inside `createAdcpServerFromPlatform` reads `mode`
+exclusively from the `Account` object the resolver returns. The
+resolver is the seller's authoritative call site for "who is this
+caller, and what tenancy do they have access to?" — answered against
+the seller's tenant store, keyed by the authenticated principal.
+
+Adopters' resolvers MUST NOT spread untrusted input into the resolved
+account. Specifically, an adopter resolver implementation like:
+
+```ts
+resolve: async (ref, ctx) => {
+  return { id: ref.account_id, sandbox: ref.sandbox, mode: 'sandbox', ... };
+  // ↑ wrong — `mode: 'sandbox'` is buyer-controllable via this shape
+}
+```
+
+…has effectively put the trust boundary on the wire. The right shape:
+
+```ts
+resolve: async (ref, ctx) => {
+  const tenantRow = await myDb.findByCredential(ctx?.authInfo?.credential);
+  if (!tenantRow) return null;
+  return {
+    id: tenantRow.id,
+    mode: tenantRow.is_sandbox ? 'sandbox' : 'live', // ← from tenant store
+    ctx_metadata: { ... },
+  };
+}
+```
+
+The `mode` field is sourced from the seller's own tenant store, which
+the buyer cannot influence. This is what makes the framework gate's
+refusal of live-mode dispatch a real security property rather than a
+soft hint.
+
+The same discipline applies to anything else the gate reads
+transitively. `assertSandboxAccount` is exposed for adopters who want
+to compose the gate inside custom dispatch paths; its `opts.message`
+field MUST be a static string literal (echoed on the wire inside the
+error envelope — interpolating user-controlled values creates a
+reflection sink). See the JSDoc on
+`src/lib/server/account-mode.ts:assertSandboxAccount`.
+
 ## Cross-implementation story
 
 This is the part that makes the model hold up across SDKs.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -153,6 +153,20 @@ export interface Account<TCtxMeta = Record<string, unknown>> {
    * separate production and sandbox accounts. For explicit accounts, sandbox
    * accounts are pre-existing test accounts the seller surfaces via
    * `list_accounts`.
+   *
+   * @deprecated Use {@link Account.mode} instead. As of AdCP 6.7+ the
+   * three-mode `mode: 'live' | 'sandbox' | 'mock'` field is the canonical
+   * signal the framework gate consults — see
+   * `docs/proposals/lifecycle-state-and-sandbox-authority.md`. Adopters
+   * stamping this `sandbox` flag continue to work via
+   * `getAccountMode`'s legacy fallback (`sandbox: true` reads as
+   * `mode: 'sandbox'`); new code should set `mode` directly. This
+   * field will be removed in the next major version.
+   *
+   * The wire-side `AccountReference.sandbox` flag (per
+   * `core/account-ref.json`) stays — it's part of the spec's natural-key
+   * disambiguation for implicit accounts. The deprecation is on the
+   * SERVER-side resolved `Account.sandbox` only.
    */
   sandbox?: boolean;
 


### PR DESCRIPTION
## Summary

Three doc-tidy items from PR #1453's expert reviews. No behavior change.

### `docs/proposals/lifecycle-state-and-sandbox-authority.md`

Adds an explicit **Trust boundary** section at the top of the cross-implementation story. Names what the boundary IS (resolver-stamped `Account.mode`, sourced from the seller's tenant store keyed by authenticated principal) and what it is NOT:

- The wire `AccountReference.sandbox` flag (buyer input — buyer has every incentive to claim sandbox status when calling test-only surfaces against a live tenant).
- The presence of a `sandbox_<id>` prefix or similar seller-internal convention.
- An environment variable like `ADCP_SANDBOX=1` (process-scoped, wrong granularity).

Calls out the resolver-discipline gotcha — spreading buyer input into the resolved account effectively moves the trust boundary onto the wire and defeats the framework gate. Includes a wrong/right code example.

### `Account.sandbox` deprecation

Server-side `Account.sandbox` (in `src/lib/server/decisioning/account.ts`) is now `@deprecated` in favor of `Account.mode`. Existing adopters stamping `sandbox: true` keep working via `getAccountMode`'s legacy fallback. The field will be removed in a future major.

Wire-side `AccountReference.sandbox` is **unchanged** — it's part of AdCP's natural-key disambiguation per the spec's `core/account-ref.json`. Deprecation is server-side only.

### Changeset

Documents the deprecation queue so the next major-version bump knows what to drop.

## Out of scope

Two related items the protocol-expert review flagged that don't fit this PR:

- **Mock-server normative-status statement** in `docs/architecture/adcp-stack.md` — that doc lives upstream on adcontextprotocol.org's protocol docs site, not in this repo. Filing as a separate upstream issue.
- **Storyboard coverage gap** for live-mode denial — filed as `adcontextprotocol/adcp#4028`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] No code-behavior changes — pure docs + JSDoc deprecation marker

## Refs

- PR #1453 (Phase 2: framework gate)
- adcontextprotocol/adcp#4028 (storyboard coverage gap, filed separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)