### PR TITLE
docs(skills): SHAPE-GOTCHAS §7 signal_type + build-* deep-link cross-cutting anchors

### DIFF
--- a/.changeset/skill-deep-links-shape-gotchas.md
+++ b/.changeset/skill-deep-links-shape-gotchas.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+Two follow-ups from the PR #1515 expert review:
+
+**SHAPE-GOTCHAS §7 — `signal_type: marketplace` vs `owned` vs `custom`** (`skills/SHAPE-GOTCHAS.md`)
+
+dx-expert + docs-expert both flagged that the `signal_type` discrimination clarification appeared twice in `skills/build-signals-agent/SKILL.md` (~30 lines apart) and was a known footgun better captured as a SHAPE-GOTCHAS entry than skill-prose repetition. Added entry §7 with a decision table covering the three values, the spec definitions (per `schemas/cache/3.0.5/enums/signal-catalog-type.json`), and the most common adopter mistake — first-party data agents mis-classifying their segments as `custom` when they have a standing data asset behind them (it's `owned`). Replaced both inline clarifications in the signals SKILL with pointers to §7.
+
+**Build-* skills deep-link cross-cutting.md anchors** (`skills/build-*-agent/SKILL.md`)
+
+docs-expert deferred from #1515: build-* skills had bare `[../cross-cutting.md](../cross-cutting.md)` references with no per-rule deep-links, so adopters fetching the file pulled the whole 73-line file even when only one rule was relevant. Each build-* skill's "Cross-cutting rules" section now lists the high-traffic rules for that skill domain with anchor links to the specific rule (e.g., the seller skill links `[idempotency_key](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call)` directly). Adopters can land on a 5-line block instead of the full file.
+
+Eight skills updated: seller, creative, signals, governance, brand-rights, generative-seller, retail-media, si, holdco. Each surfaces the 3-5 rules most relevant to that adopter persona; the bare cross-cutting.md link is preserved as the "read it once cold" pointer.
+
+Validated: fork-matrix 23/23, typecheck + format clean.

--- a/skills/SHAPE-GOTCHAS.md
+++ b/skills/SHAPE-GOTCHAS.md
@@ -215,6 +215,24 @@ The `examples/hello_seller_adapter_social.ts` reference adapter codifies all thr
 
 ---
 
+## 7. `signal_type`: `marketplace` vs `owned` vs `custom`
+
+`signal_type` is the catalog-type discriminator on every `Signal` returned from `get_signals`. It's a closed enum (`marketplace | custom | owned` per `schemas/cache/3.0.5/enums/signal-catalog-type.json`) and adopters consistently mis-pick because the spec descriptions read like overlapping concepts.
+
+The spec definitions:
+
+| Value | Use when | Example adopter |
+| --- | --- | --- |
+| `marketplace` | Resold third-party segments. Provider's authorization is verifiable via their `adagents.json`. | LiveRamp marketplace; Oracle Data Cloud catalog; reseller of third-party panels |
+| `owned` | First-party segments derived from data the signal agent **directly owns**. | Retailer purchase data (Kroger 84.51°, Walmart Connect); publisher behavioral data (NYT subscribers); telco data |
+| `custom` | Agent-native segment built **on demand** from models, composites, or buyer inputs. Not attributable to a standing upstream provider. | Contextual classifier you train per-request; lookalike model output computed from a buyer's seed audience |
+
+**`owned` is the default for first-party data agents.** Most non-marketplace adopters mis-classify their segments as `custom` because the segment was "built" — but the test is provenance, not lifecycle. If you can point at a stable data-asset you own (a customer table, a pixel, a panel), it's `owned`. `custom` is reserved for segments that don't have a standing data asset behind them — the agent computed them per-call.
+
+**`marketplace` requires `data_provider_domain` to resolve.** Buyers fetch `https://{data_provider_domain}/adagents.json` to verify the provider's authorization. If you can't surface a verifiable provider domain (the segment is yours, or it's synthetic), the value isn't `marketplace`.
+
+---
+
 ## How to debug a "Field not found at path: …" error fast
 
 The validator's path naming is precise. When you see:

--- a/skills/build-brand-rights-agent/SKILL.md
+++ b/skills/build-brand-rights-agent/SKILL.md
@@ -45,7 +45,13 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every brand-rights agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). One brand-rights-specific note:
+Every brand-rights agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The high-traffic ones for brand-rights (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `acquire_rights` and `update_rights`
+- [Authentication](../cross-cutting.md#authentication-is-mandatory) — `serve({ authenticate })` baseline
+- [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — `creative_approval.${creative_id}` operation_id must be stable across retries; the `creative_approval` webhook receiver itself validates idempotency manually (the framework's auto-idempotency middleware applies to MCP/A2A tools, not arbitrary HTTP receivers)
+
+One brand-rights-specific note:
 
 ### `creative_approval` is webhook-only
 

--- a/skills/build-creative-agent/SKILL.md
+++ b/skills/build-creative-agent/SKILL.md
@@ -33,7 +33,13 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every creative agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). Two creative-specific notes on top of those:
+Every creative agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The high-traffic ones for creative agents (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `sync_creatives`, `build_creative`, `report_usage`
+- [Authentication](../cross-cutting.md#authentication-is-mandatory) — `serve({ authenticate })` baseline
+- [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — `creative_review.${creative_id}` and `report_usage.${report_batch_id}` operation_ids must be stable across retries
+
+Two creative-specific notes on top of those:
 
 ### Webhooks for async review pipelines
 

--- a/skills/build-generative-seller-agent/SKILL.md
+++ b/skills/build-generative-seller-agent/SKILL.md
@@ -37,7 +37,10 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every generative seller hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). Plus the seller cross-cutting from [`../build-seller-agent/SKILL.md`](../build-seller-agent/SKILL.md) — generative-seller is additive on top of the seller baseline.
+Every generative seller hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). Plus the seller cross-cutting from [`../build-seller-agent/SKILL.md`](../build-seller-agent/SKILL.md) — generative-seller is additive on top of the seller baseline. The high-traffic ones for generative-seller (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `build_creative` and `sync_creatives` (in addition to the seller-side mutating tools)
+- [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — for async generation completions, use `creative_review.${creative_id}` as a stable `operation_id`
 
 ## Specialism deltas at a glance
 

--- a/skills/build-governance-agent/SKILL.md
+++ b/skills/build-governance-agent/SKILL.md
@@ -53,7 +53,13 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every governance agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). One governance-specific rule on top:
+Every governance agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The high-traffic ones for governance (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `sync_plans`, `sync_governance`, `report_plan_outcome`, `create_property_list` / `update_property_list` / `delete_property_list`, `create_collection_list` / `update_collection_list` / `delete_collection_list`, `create_content_standards` / `update_content_standards` / `calibrate_content`
+- [Resolve-then-authorize](../cross-cutting.md#resolve-then-authorize--uniform-errors-for-not-found--not-yours) — byte-equivalent errors on `property_list_id` / `collection_list_id` / `plan_id` cross-tenant lookups
+- [Account resolution](../cross-cutting.md#account-resolution-pick-a-security-preset) — `createTenantStore` for multi-tenant policy hubs
+
+One governance-specific rule on top:
 
 ### `comply_test_controller` is required
 

--- a/skills/build-holdco-agent/SKILL.md
+++ b/skills/build-holdco-agent/SKILL.md
@@ -34,7 +34,11 @@ The reference adapter is `examples/hello_seller_adapter_multi_tenant.ts` — for
 
 ## Cross-cutting rules
 
-Every holdco hub hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The most relevant for a holdco is **account resolution: pick a security preset** — `createTenantStore` (covered in detail below) is the right answer for any multi-tenant adopter.
+Every holdco hub hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The most relevant for a holdco (deep-linked to the rule):
+
+- [Account resolution](../cross-cutting.md#account-resolution-pick-a-security-preset) — `createTenantStore` is the right answer for any multi-tenant adopter (covered in detail below)
+- [Resolve-then-authorize](../cross-cutting.md#resolve-then-authorize--uniform-errors-for-not-found--not-yours) — byte-equivalent errors on cross-tenant id lookups; the multi-tenant attack surface makes this load-bearing
+- [`ctx_metadata` is not for credentials](../cross-cutting.md#ctx_metadata-is-not-for-credentials) — particularly important for holdcos because per-tenant credentials must NOT travel through `ctx_metadata`; re-derive from `ctx.authInfo` per request
 
 ## The shape: one DecisioningPlatform, three specialism interfaces
 

--- a/skills/build-retail-media-agent/SKILL.md
+++ b/skills/build-retail-media-agent/SKILL.md
@@ -36,7 +36,10 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every retail-media agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). Plus all the seller cross-cutting from [`../build-seller-agent/SKILL.md`](../build-seller-agent/SKILL.md) — retail-media is additive on top of the seller baseline.
+Every retail-media agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). Plus all the seller cross-cutting from [`../build-seller-agent/SKILL.md`](../build-seller-agent/SKILL.md) — retail-media is additive on top of the seller baseline. The high-traffic ones for retail-media (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `sync_catalogs`, `sync_event_sources`, `log_event`, `provide_performance_feedback` (in addition to the seller-side mutating tools)
+- [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — for catalog-ingestion completions, use `catalog_sync.${catalog_id}.${batch_id}` as a stable `operation_id`
 
 ## Specialism deltas at a glance
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -38,7 +38,15 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every sales-* seller hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md) — `idempotency_key` on every mutating request, resolve-then-authorize uniform errors, mandatory authentication, signed-requests transparency, `ctx_metadata` is not for credentials, account-resolution security presets, webhook `operation_id` stability. Read it once.
+Every sales-* seller hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The high-traffic ones for sellers (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on every mutating request — `create_media_buy`, `update_media_buy`, `sync_creatives`, `sync_audiences`, etc.
+- [Resolve-then-authorize](../cross-cutting.md#resolve-then-authorize--uniform-errors-for-not-found--not-yours) — byte-equivalent errors for `media_buy_id` cross-tenant lookups
+- [Authentication](../cross-cutting.md#authentication-is-mandatory) — `serve({ authenticate })` baseline
+- [Account resolution](../cross-cutting.md#account-resolution-pick-a-security-preset) — `createTenantStore` for multi-advertiser sellers
+- [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — stable `operation_id` for IO-approval / delivery-completion notifications
+
+Read the file once cold; deep-link from your code reviews afterward.
 
 ## Specialism deltas
 

--- a/skills/build-seller-agent/SKILL.md
+++ b/skills/build-seller-agent/SKILL.md
@@ -46,8 +46,6 @@ Every sales-* seller hits the cross-cutting rules in [`../cross-cutting.md`](../
 - [Account resolution](../cross-cutting.md#account-resolution-pick-a-security-preset) — `createTenantStore` for multi-advertiser sellers
 - [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — stable `operation_id` for IO-approval / delivery-completion notifications
 
-Read the file once cold; deep-link from your code reviews afterward.
-
 ## Specialism deltas
 
 The fork target covers the baseline. Specialism subpages cover the deltas — what to add when you claim that specialism on top of the baseline. Each entry below is **specialism → when to read it → what's in it**.

--- a/skills/build-si-agent/SKILL.md
+++ b/skills/build-si-agent/SKILL.md
@@ -41,7 +41,13 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every SI agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). One SI-specific note on idempotency:
+Every SI agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The high-traffic ones for SI (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `si_initiate_session` and `si_send_message`
+- [Authentication](../cross-cutting.md#authentication-is-mandatory) — `serve({ authenticate })` baseline
+- [`ctx_metadata` is not for credentials](../cross-cutting.md#ctx_metadata-is-not-for-credentials) — important for SI because session state is naturally rich; production engines own full transcripts in their own backend, not in `ctx_metadata`
+
+One SI-specific note on idempotency:
 
 `si_initiate_session` and `si_send_message` are mutating and require `idempotency_key`. `si_terminate_session` is naturally idempotent on `session_id` and intentionally lacks the key (re-terminating a closed session must return the same payload). `si_get_offering` is read-only.
 

--- a/skills/build-signals-agent/SKILL.md
+++ b/skills/build-signals-agent/SKILL.md
@@ -22,7 +22,7 @@ Both specialisms share the same tool surface (`get_signals`, `activate_signal`, 
 
 - Replace the multi-provider seed (the `UpstreamCohort` array seeded with multiple `data_provider_domain` / `data_provider_id` / `data_provider_name` triples) with your single-provider catalog. Every cohort gets the same `data_provider_domain` (your domain) and `data_provider_name` (your brand).
 - Strip the marketplace-discovery code paths in `getSignals` that filter `signals[]` by `(data_provider_domain, data_provider_id)` pairs — single-provider adopters either return everything or filter on signal id alone.
-- Set `signal_type: 'owned'` (not `'marketplace'`) in the `toAdcpSignal` projection. `signal_type: 'custom'` is reserved for first-party signals that don't fit the user-identity model (e.g., contextual signals derived from page content); use `'owned'` by default.
+- Set `signal_type: 'owned'` (not `'marketplace'`) in the `toAdcpSignal` projection. See [SHAPE-GOTCHAS §7](../SHAPE-GOTCHAS.md#7-signal_type-marketplace-vs-owned-vs-custom) for the `marketplace`/`owned`/`custom` decision table.
 - Drop the marketplace governance sub-scenario in your storyboard run if you don't model multi-provider consent flows — `signal_owned` storyboard is simpler.
 
 **Keep**: the `accounts` / `createTenantStore` block (single-tenant adapters pass one tenant entry), `agentRegistry`, the `signals` SignalsPlatform block (`getSignals`, `activateSignal`, `listAccounts`), platform vs agent activation polling logic, `forceDeploymentStatus` for compliance-test determinism.
@@ -42,7 +42,14 @@ For exact response shapes, error codes, and optional fields, `docs/llms.txt` is 
 
 ## Cross-cutting rules
 
-Every signals agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). Two signals-specific notes on top of those:
+Every signals agent hits the cross-cutting rules in [`../cross-cutting.md`](../cross-cutting.md). The high-traffic ones for signals (deep-linked to the rule):
+
+- [`idempotency_key`](../cross-cutting.md#idempotency_key-is-required-on-every-mutating-call) on `activate_signal`
+- [Authentication](../cross-cutting.md#authentication-is-mandatory) — `serve({ authenticate })` baseline
+- [Resolve-then-authorize](../cross-cutting.md#resolve-then-authorize--uniform-errors-for-not-found--not-yours) — byte-equivalent errors on `signal_agent_segment_id` lookups across tenants
+- [Webhooks](../cross-cutting.md#webhooks-stable-operation_id-across-retries) — for async platform-activation completions, use `signal_activation.${signal_agent_segment_id}.${platform}` as the stable `operation_id`
+
+Two signals-specific notes on top of those:
 
 ### Async platform activation
 
@@ -58,7 +65,7 @@ Buyers fetch `https://{domain}/adagents.json` out-of-band to verify the provider
 
 **`signal-marketplace`** — multi-provider directory (`signals[].data_provider_domain` varies), platform-activation polling pattern, marketplace governance sub-scenario in the storyboard exercises consent flows.
 
-**`signal-owned`** — single `data_provider_domain` across all signals. `value_type` drives targeting semantics: `binary` (in/out), `categorical` (with `allowed_values: [...]`), `numeric` (with `min`, `max`, optional `units`). `signal_type: 'custom'` is for first-party signals outside the `owned` user-identity model (e.g. contextual signals from page content) — use `owned` by default.
+**`signal-owned`** — single `data_provider_domain` across all signals. `value_type` drives targeting semantics: `binary` (in/out), `categorical` (with `allowed_values: [...]`), `numeric` (with `min`, `max`, optional `units`). For the `signal_type` value (`marketplace`/`owned`/`custom`) decision, see [SHAPE-GOTCHAS §7](../SHAPE-GOTCHAS.md#7-signal_type-marketplace-vs-owned-vs-custom).
 
 ## Validate locally
 


### PR DESCRIPTION
## Summary

Two follow-ups from PR #1515 expert review.

**1. SHAPE-GOTCHAS §7 — `signal_type` decision table** (`skills/SHAPE-GOTCHAS.md`)

dx-expert and docs-expert both flagged that the `signal_type: 'custom'` clarification appeared twice in `build-signals-agent/SKILL.md` (~30 lines apart) and was a known footgun better captured as a SHAPE-GOTCHAS entry than skill-prose repetition. Added entry §7 with a decision table covering the three enum values (`marketplace` / `owned` / `custom` per `schemas/cache/3.0.5/enums/signal-catalog-type.json`), spec definitions, and the most common adopter mistake: first-party data agents (Kroger 84.51°, Walmart Connect, publisher behavioral data) mis-classifying their segments as `custom` when they have a standing data asset behind them. The test is **provenance, not lifecycle** — if you can point at a customer table / pixel / panel, it's `owned`. `custom` is reserved for per-call agent-native segments without standing provenance.

Replaced both inline clarifications in signals SKILL with pointers to §7.

**2. Build-* skills deep-link cross-cutting.md anchors** (8 skills)

docs-expert deferred from #1515: build-* skills had bare `[../cross-cutting.md](../cross-cutting.md)` references with no per-rule deep-links, so adopters fetching the file pulled the whole 73-line file even when only one rule was relevant. Each build-*-agent skill's "Cross-cutting rules" section now lists the high-traffic rules for that skill domain with anchor deep-links to the specific cross-cutting.md rule. Adopters land on a 5-line block instead of the full file.

Per-skill deep-link tables:

| Skill | Top deep-links |
| --- | --- |
| seller | idempotency_key, resolve-then-authorize, authentication, account-resolution, webhooks |
| creative | idempotency_key, authentication, webhooks |
| signals | idempotency_key, authentication, resolve-then-authorize, webhooks |
| governance | idempotency_key, resolve-then-authorize, account-resolution |
| brand-rights | idempotency_key, authentication, webhooks |
| generative-seller | idempotency_key, webhooks |
| retail-media | idempotency_key, webhooks |
| si | idempotency_key, authentication, ctx_metadata |
| holdco | account-resolution, resolve-then-authorize, ctx_metadata |

Bare `cross-cutting.md` link kept as the "read it once cold" pointer.

## Test plan

- [x] `npm run compliance:fork-matrix` — 23/23 in ~13s
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)