### PR TITLE
feat(testing): add queryUpstreamTraffic to ComplyControllerConfig + migrate signals adapter

### DIFF
--- a/.changeset/comply-config-query-upstream-traffic.md
+++ b/.changeset/comply-config-query-upstream-traffic.md
@@ -1,0 +1,25 @@
+---
+"@adcp/sdk": minor
+---
+
+Add `queryUpstreamTraffic` adapter to `ComplyControllerConfig` so adopters using the high-level `complyTest:` opts surface on `createAdcpServerFromPlatform` can wire `query_upstream_traffic` (spec PR adcontextprotocol/adcp#3816) without dropping to the lower-level `registerTestController` API.
+
+```ts
+complyTest: {
+  queryUpstreamTraffic: (params, _ctx) => {
+    const result = recorder.query({
+      principal: RECORDER_PRINCIPAL,
+      ...(params.since_timestamp !== undefined && { sinceTimestamp: params.since_timestamp }),
+      ...(params.endpoint_pattern !== undefined && { endpointPattern: params.endpoint_pattern }),
+      ...(params.limit !== undefined && { limit: params.limit }),
+    });
+    return toQueryUpstreamTrafficResponse(result);
+  },
+}
+```
+
+The adapter forwards through to the existing `TestControllerStore.queryUpstreamTraffic` slot — no wire-shape change, no scenario-projection change. `advertisedScenarios()` includes `'query_upstream_traffic'` when the adapter is set, so `list_scenarios` reports it.
+
+`hello_signals_adapter_marketplace.ts` migrated to use this surface — drops the manual `registerTestController` call after `createAdcpServerFromPlatform`. Closes the Phase 3 follow-up that punted this migration as "non-mechanical because the recorder integration would need a comply-adapter shape upstream." It does now.
+
+The framework gate inside `createAdcpServerFromPlatform` (Phase 2 of #1435) covers `comply_test_controller` end-to-end here too — admits on resolver-stamped `mode: 'sandbox' | 'mock'`, refuses live-mode dispatch.

--- a/examples/hello_signals_adapter_marketplace.ts
+++ b/examples/hello_signals_adapter_marketplace.ts
@@ -28,7 +28,6 @@ import {
   AdcpError,
   BuyerAgentRegistry,
   defineSignalsPlatform,
-  registerTestController,
   type DecisioningPlatform,
   type SignalsPlatform,
   type AccountStore,
@@ -320,6 +319,13 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
   capabilities = {
     specialisms: ['signal-marketplace'] as const,
     config: {},
+    // Declare `compliance_testing` so the framework projects the
+    // `comply_test_controller` capability + scenarios on
+    // `get_adcp_capabilities`. The `complyTest:` opts block on
+    // `createAdcpServerFromPlatform` (below) wires the adapters; the
+    // framework derives the `scenarios` list from which adapters are
+    // present.
+    compliance_testing: {},
   };
 
   /**
@@ -483,8 +489,8 @@ const platform = new SignalMarketplaceAdapter();
 const idempotencyStore = createIdempotencyStore({ backend: memoryBackend(), ttlSeconds: 86_400 });
 
 serve(
-  ({ taskStore }) => {
-    const adcpServer = createAdcpServerFromPlatform(platform, {
+  ({ taskStore }) =>
+    createAdcpServerFromPlatform(platform, {
       name: 'hello-signals-adapter-marketplace',
       version: '1.0.0',
       taskStore,
@@ -494,33 +500,32 @@ serve(
         const acct = ctx.account as Account<OperatorMeta> | undefined;
         return acct?.id ?? 'anonymous';
       },
-    });
-
-    // Register `comply_test_controller` with the recorder-backed
-    // `query_upstream_traffic` scenario. The runner queries this after
-    // each step that declares a `check: upstream_traffic` validation;
-    // adopters who don't advertise the scenario grade `not_applicable`.
-    //
-    // Sandbox-only — production builds 404 the controller entirely
-    // (gate via the `if (process.env.ADCP_SANDBOX === '1')` pattern from
-    // the SKILL). For this example adapter we always register since the
-    // example is itself a fixture for the matrix harness.
-    registerTestController(adcpServer, {
-      // Adapter resolves principal from auth context. The same string
-      // MUST be returned by both record-time (runWithPrincipal) and
-      // query-time — mismatch returns zero per cross-tenant isolation.
-      queryUpstreamTraffic: async params => {
-        const result = recorder.query({
-          principal: RECORDER_PRINCIPAL,
-          ...(params.since_timestamp !== undefined && { sinceTimestamp: params.since_timestamp }),
-          ...(params.endpoint_pattern !== undefined && { endpointPattern: params.endpoint_pattern }),
-          ...(params.limit !== undefined && { limit: params.limit }),
-        });
-        return toQueryUpstreamTrafficResponse(result);
+      // ─── TEST-ONLY: comply_test_controller wiring ──────────────────────
+      // DELETE THIS BLOCK BEFORE DEPLOYING. The conformance runner queries
+      // `query_upstream_traffic` after each step that declares a
+      // `check: upstream_traffic` validation; adopters who don't
+      // advertise the scenario grade `not_applicable`.
+      //
+      // No `sandboxGate` — the framework gate inside
+      // `createAdcpServerFromPlatform` resolves the calling principal
+      // through `accounts.resolve` and admits only when the resolved
+      // account's `mode` is `'sandbox'` or `'mock'` (per `Account.mode`,
+      // AdCP 6.7+). See `docs/proposals/lifecycle-state-and-sandbox-authority.md`.
+      complyTest: {
+        // Adapter resolves principal from auth context. The same string
+        // MUST be returned by both record-time (runWithPrincipal) and
+        // query-time — mismatch returns zero per cross-tenant isolation.
+        queryUpstreamTraffic: async params => {
+          const result = recorder.query({
+            principal: RECORDER_PRINCIPAL,
+            ...(params.since_timestamp !== undefined && { sinceTimestamp: params.since_timestamp }),
+            ...(params.endpoint_pattern !== undefined && { endpointPattern: params.endpoint_pattern }),
+            ...(params.limit !== undefined && { limit: params.limit }),
+          });
+          return toQueryUpstreamTrafficResponse(result);
+        },
       },
-    });
-    return adcpServer;
-  },
+    }),
   {
     port: PORT,
     authenticate: verifyApiKey({

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -54,6 +54,7 @@ import {
   type ControllerScenario,
   type SeedFixtureCache,
   type TestControllerStore,
+  type UpstreamTrafficSuccessResponse,
 } from '../server/test-controller';
 import { getSdkServer, type AdcpServer } from '../server/adcp-server';
 import type {
@@ -193,6 +194,43 @@ export type SimulateAdapter<P> = (
   ctx: ComplyControllerContext
 ) => Promise<SimulationSuccess> | SimulationSuccess;
 
+/** Params for the `query_upstream_traffic` extension scenario (spec PR
+ * adcontextprotocol/adcp#3816). All fields optional; the recorder
+ * filters by these. */
+export interface QueryUpstreamTrafficParams {
+  since_timestamp?: string;
+  endpoint_pattern?: string;
+  limit?: number;
+}
+
+/** Adapter for the `query_upstream_traffic` extension scenario. Returns
+ * the recorded upstream HTTP calls produced during the current
+ * storyboard step — the runner consults this for `check: upstream_traffic`
+ * validations. Adopters typically delegate to the reference recorder
+ * middleware shipped at `@adcp/sdk/upstream-recorder`:
+ *
+ * ```ts
+ * complyTest: {
+ *   queryUpstreamTraffic: (params, _ctx) => {
+ *     const result = recorder.query({
+ *       principal: RECORDER_PRINCIPAL,
+ *       ...(params.since_timestamp !== undefined && { sinceTimestamp: params.since_timestamp }),
+ *       ...(params.endpoint_pattern !== undefined && { endpointPattern: params.endpoint_pattern }),
+ *       ...(params.limit !== undefined && { limit: params.limit }),
+ *     });
+ *     return toQueryUpstreamTrafficResponse(result);
+ *   },
+ * }
+ * ```
+ *
+ * The principal MUST match between record-time (`runWithPrincipal`) and
+ * query-time, or the recorder returns zero rows per cross-tenant
+ * isolation. */
+export type QueryUpstreamTrafficAdapter = (
+  params: QueryUpstreamTrafficParams,
+  ctx: ComplyControllerContext
+) => Promise<UpstreamTrafficSuccessResponse> | UpstreamTrafficSuccessResponse;
+
 // ────────────────────────────────────────────────────────────
 // Controller config
 // ────────────────────────────────────────────────────────────
@@ -247,6 +285,16 @@ export interface ComplyControllerConfig {
     delivery?: SimulateAdapter<SimulateDeliveryParams>;
     budget_spend?: SimulateAdapter<SimulateBudgetSpendParams>;
   };
+
+  /**
+   * `query_upstream_traffic` adapter (spec PR adcontextprotocol/adcp#3816).
+   * Returns the recorded upstream HTTP calls produced during the current
+   * storyboard step so the runner can grade `check: upstream_traffic`
+   * validations. Adopters typically wire the reference recorder from
+   * `@adcp/sdk/upstream-recorder`. When omitted, the scenario reports as
+   * `not_applicable` per the runner's normal capability discovery.
+   */
+  queryUpstreamTraffic?: QueryUpstreamTrafficAdapter;
 
   /** Override the seed idempotency cache (e.g., to scope by tenant or
    * persist across restarts). Defaults to an unbounded in-memory cache. */
@@ -335,7 +383,7 @@ function controllerError(code: ControllerError['error'], detail: string): Contro
  * `handleTestControllerRequest` returns `UNKNOWN_SCENARIO` for the rest. */
 function buildStore(config: ComplyControllerConfig, ctx: ComplyControllerContext): TestControllerStore {
   const store: TestControllerStore = {};
-  const { seed, force, simulate } = config;
+  const { seed, force, simulate, queryUpstreamTraffic } = config;
 
   if (seed?.product) {
     store.seedProduct = async (productId, fixture) => {
@@ -403,6 +451,10 @@ function buildStore(config: ComplyControllerConfig, ctx: ComplyControllerContext
     store.simulateBudgetSpend = params => Promise.resolve(simulate.budget_spend!(params, ctx));
   }
 
+  if (queryUpstreamTraffic) {
+    store.queryUpstreamTraffic = params => Promise.resolve(queryUpstreamTraffic(params, ctx));
+  }
+
   return store;
 }
 
@@ -418,6 +470,14 @@ function advertisedScenarios(config: ComplyControllerConfig): ControllerScenario
   if (config.force?.task_completion) out.push(CONTROLLER_SCENARIOS.FORCE_TASK_COMPLETION);
   if (config.simulate?.delivery) out.push(CONTROLLER_SCENARIOS.SIMULATE_DELIVERY);
   if (config.simulate?.budget_spend) out.push(CONTROLLER_SCENARIOS.SIMULATE_BUDGET_SPEND);
+  // `query_upstream_traffic` is an extension scenario (spec PR
+  // adcontextprotocol/adcp#3816) — not yet in the schema cache's
+  // `ControllerScenario` enum, but the dispatcher accepts it under
+  // `TOOL_INPUT_SHAPE.scenario: z.string()`'s open-extension pattern.
+  // Cast through unknown until the schema lands, then this becomes a
+  // `CONTROLLER_SCENARIOS.QUERY_UPSTREAM_TRAFFIC` reference like the
+  // others above.
+  if (config.queryUpstreamTraffic) out.push('query_upstream_traffic' as unknown as ControllerScenario);
   return out;
 }
 


### PR DESCRIPTION
## Summary

Closes the Phase 3 follow-up that punted `hello_signals_adapter_marketplace`'s migration to the high-level `complyTest:` opts surface as "non-mechanical because the recorder integration would need a comply-adapter shape upstream." It does now — and the migration is mechanical with that change.

## SDK changes

### `src/lib/testing/comply-controller.ts`

- New `QueryUpstreamTrafficAdapter` type + `QueryUpstreamTrafficParams` interface.
- New `queryUpstreamTraffic` field on `ComplyControllerConfig` — sibling to `seed`/`force`/`simulate`/`sandboxGate`.
- `buildStore` forwards to `TestControllerStore.queryUpstreamTraffic` when set.
- `advertisedScenarios()` includes `'query_upstream_traffic'` when the adapter is set, so `list_scenarios` reports it. Cast through `as ControllerScenario` until the schema cache picks up spec PR `adcontextprotocol/adcp#3816` and the literal becomes a first-class `CONTROLLER_SCENARIOS.QUERY_UPSTREAM_TRAFFIC` constant.

```ts
complyTest: {
  queryUpstreamTraffic: (params, _ctx) => {
    const result = recorder.query({
      principal: RECORDER_PRINCIPAL,
      ...(params.since_timestamp !== undefined && { sinceTimestamp: params.since_timestamp }),
      ...(params.endpoint_pattern !== undefined && { endpointPattern: params.endpoint_pattern }),
      ...(params.limit !== undefined && { limit: params.limit }),
    });
    return toQueryUpstreamTrafficResponse(result);
  },
}
```

## Adapter migration

### `examples/hello_signals_adapter_marketplace.ts`

- Drops the lower-level `registerTestController` import + post-`createAdcpServerFromPlatform` registration block.
- Declares `compliance_testing: {}` in `capabilities` so the framework projects the `comply_test_controller` block on `get_adcp_capabilities`.
- Wires the recorder via `complyTest: { queryUpstreamTraffic }` instead.

The signals adapter is now hosted by the **framework gate** (Phase 2 of #1435) end-to-end — admits on resolver-stamped `mode: 'sandbox' | 'mock'`, refuses live-mode dispatch — same posture as the seller-guaranteed and seller-non-guaranteed worked examples.

## Test plan

- [x] `npm run build` clean
- [x] **48/48** comply-controller unit tests green
- [x] **8/8** hello-adapter test files green (incl. signals: 4/4)
- [x] **6055/6055** lib tests pass
- [x] `npm run format:check` clean

## Refs

- #1435 phases 1–4 (the framework gate this builds on)
- adcontextprotocol/adcp#3816 (spec PR for `query_upstream_traffic`)
- adcontextprotocol/adcp#4028 (separately filed: storyboard coverage gap)
- adcontextprotocol/adcp#3986 (separately filed: comply visibility spec question)

🤖 Generated with [Claude Code](https://claude.com/claude-code)