### PR TITLE
chore(version): add 3.0.6 to COMPATIBLE_ADCP_VERSIONS + bump schema citations

### DIFF
--- a/.changeset/bump-302005-citations-and-version-list.md
+++ b/.changeset/bump-302005-citations-and-version-list.md
@@ -1,0 +1,22 @@
+---
+"@adcp/sdk": patch
+---
+
+Add `3.0.6` to `COMPATIBLE_ADCP_VERSIONS` and bump 3.0.5 → 3.0.6 schema citations across user-facing surfaces.
+
+PR #1510 bumped `ADCP_VERSION` to 3.0.6 but didn't add 3.0.6 to the `COMPATIBLE_ADCP_VERSIONS` literal union in `scripts/sync-version.ts`. Callers passing `{ adcpVersion: '3.0.6' }` to constructor options fell through the literal-union autocomplete to the `(string & {})` escape hatch — still accepted at runtime, but no editor completion or compile-time signal. Closes the gap by appending `'3.0.6'` to the list and regenerating `src/lib/version.ts` via `sync-version`.
+
+Bumped citations elsewhere so the docs / examples / source comments line up with the pinned version:
+
+- `skills/cross-cutting.md` § Spec reference — `schemas/cache/3.0.5/bundled/<protocol>/` → `3.0.6`
+- `skills/SHAPE-GOTCHAS.md` §7 — `schemas/cache/3.0.5/enums/signal-catalog-type.json` → `3.0.6`
+- `examples/hello_seller_adapter_social.ts` — `/schemas/3.0.5/core/audience.json` → `3.0.6`
+- `src/lib/server/decisioning/runtime/from-platform.ts` — `schemas/cache/3.0.5/core/account-ref.json` → `3.0.6`
+
+`docs/migration-6.6-to-6.7.md` 3.0.5 references are historical (the migration target was 3.0.5) and stay unchanged.
+
+Tracked at adcp-client #1523 (waiting on adcp#4015 — audio variant phase for `creative_template` storyboard) and #1525 (waiting on adcp#4021 — `output_only` flag on `format.assets[]`). Both upstream issues remain OPEN.
+
+Validated: fork-matrix 23/23, typecheck + format clean.
+
+Pure additive at the wire and at the type level — `COMPATIBLE_ADCP_VERSIONS` extends backward compatibility, no existing strings change.

--- a/examples/hello_seller_adapter_social.ts
+++ b/examples/hello_seller_adapter_social.ts
@@ -185,7 +185,7 @@ const upstream = {
   // returns deterministic ranges keyed on (advertiser_id, targeting), so the
   // numbers are stable across runs but vary observably with targeting.
   // Surface this on AdCP wire as `SyncAudiencesRow.matched_count` /
-  // `effective_match_rate` (per `/schemas/3.0.6/core/audience.json`).
+  // `effective_match_rate` (per `/schemas/3.0.6/media-buy/sync-audiences-response.json`).
   async audienceReachEstimate(
     advertiserId: string,
     body: { targeting: Record<string, unknown> }

--- a/examples/hello_seller_adapter_social.ts
+++ b/examples/hello_seller_adapter_social.ts
@@ -185,7 +185,7 @@ const upstream = {
   // returns deterministic ranges keyed on (advertiser_id, targeting), so the
   // numbers are stable across runs but vary observably with targeting.
   // Surface this on AdCP wire as `SyncAudiencesRow.matched_count` /
-  // `effective_match_rate` (per `/schemas/3.0.5/core/audience.json`).
+  // `effective_match_rate` (per `/schemas/3.0.6/core/audience.json`).
   async audienceReachEstimate(
     advertiserId: string,
     body: { targeting: Record<string, unknown> }

--- a/scripts/sync-version.ts
+++ b/scripts/sync-version.ts
@@ -113,6 +113,7 @@ export const COMPATIBLE_ADCP_VERSIONS = [
   '3.0.3',
   '3.0.4',
   '3.0.5',
+  '3.0.6',
 ] as const;
 
 /**

--- a/skills/SHAPE-GOTCHAS.md
+++ b/skills/SHAPE-GOTCHAS.md
@@ -217,7 +217,7 @@ The `examples/hello_seller_adapter_social.ts` reference adapter codifies all thr
 
 ## 7. `signal_type`: `marketplace` vs `owned` vs `custom`
 
-`signal_type` is the catalog-type discriminator on every `Signal` returned from `get_signals`. It's a closed enum (`marketplace | custom | owned` per `schemas/cache/3.0.5/enums/signal-catalog-type.json`) and adopters consistently mis-pick because the spec descriptions read like overlapping concepts.
+`signal_type` is the catalog-type discriminator on every `Signal` returned from `get_signals`. It's a closed enum (`marketplace | custom | owned` per `schemas/cache/3.0.6/enums/signal-catalog-type.json`) and adopters consistently mis-pick because the spec descriptions read like overlapping concepts.
 
 The spec definitions:
 

--- a/skills/cross-cutting.md
+++ b/skills/cross-cutting.md
@@ -81,4 +81,4 @@ Async tasks (creative review, IO approval, signal activation, plan outcome repor
 
 ## Spec reference
 
-For exact response shapes, error codes, optional fields, and discriminated unions: `docs/llms.txt` (single-fetch full protocol overview) or `schemas/cache/3.0.5/bundled/<protocol>/`. Don't read the generated TypeScript types — they exist for compile-time enforcement, not for teaching you the shape.
+For exact response shapes, error codes, optional fields, and discriminated unions: `docs/llms.txt` (single-fetch full protocol overview) or `schemas/cache/3.0.6/bundled/<protocol>/`. Don't read the generated TypeScript types — they exist for compile-time enforcement, not for teaching you the shape.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -1451,7 +1451,7 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
       // supported escape hatch.
       //
       // Schema is the full canonical `AccountReference` per
-      // `schemas/cache/3.0.5/core/account-ref.json`: oneOf
+      // `schemas/cache/3.0.6/core/account-ref.json`: oneOf
       //   { account_id }                       — explicit accounts
       //   { brand, operator, sandbox? }        — implicit accounts
       // Modeled here as a single object with all four fields optional so

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -33,6 +33,7 @@ export const COMPATIBLE_ADCP_VERSIONS = [
   '3.0.3',
   '3.0.4',
   '3.0.5',
+  '3.0.6',
 ] as const;
 
 /**
@@ -52,7 +53,7 @@ export const VERSION_INFO = {
   library: '6.8.0',
   adcp: '3.0.6',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-03T18:40:04.275Z',
+  generatedAt: '2026-05-03T22:36:51.437Z',
 } as const;
 
 /**


### PR DESCRIPTION
## Summary

Code-reviewer flagged this in PR #1519 as an "optional follow-up": cross-cutting.md and SHAPE-GOTCHAS §7 cite `schemas/cache/3.0.5/...` while the repo pinned 3.0.6 today (PR #1510). Investigating turned up a real gap — PR #1510 bumped `ADCP_VERSION` to 3.0.6 but didn't add 3.0.6 to the `COMPATIBLE_ADCP_VERSIONS` literal union in `scripts/sync-version.ts`.

## What changed

**Real fix**: `scripts/sync-version.ts` — appended `'3.0.6'` to `COMPATIBLE_ADCP_VERSIONS`. Without this, callers passing `{ adcpVersion: '3.0.6' }` fell through the literal-union autocomplete to the `(string & {})` escape hatch — still accepted at runtime but no editor completion or compile-time signal. `src/lib/version.ts` regenerated via `npm run sync-version`.

**Citation bumps** (3.0.5 → 3.0.6):
- `skills/cross-cutting.md` § Spec reference — `schemas/cache/3.0.5/bundled/<protocol>/`
- `skills/SHAPE-GOTCHAS.md` §7 — `schemas/cache/3.0.5/enums/signal-catalog-type.json`
- `examples/hello_seller_adapter_social.ts` — `/schemas/3.0.5/core/audience.json` comment
- `src/lib/server/decisioning/runtime/from-platform.ts` — `schemas/cache/3.0.5/core/account-ref.json` comment

`docs/migration-6.6-to-6.7.md` 3.0.5 references are **historical** (the migration target was 3.0.5) and stay unchanged.

## Spec follow-ups tracked

While doing this sweep, filed two local tracking issues for the upstream spec gaps from earlier PRs:

- **#1523** — waits on [adcp#4015](https://github.com/adcontextprotocol/adcp/issues/4015) (audio variant phase for `creative_template` storyboard)
- **#1525** — waits on [adcp#4021](https://github.com/adcontextprotocol/adcp/issues/4021) (`output_only` flag on `format.assets[]`)

Both upstream issues remain OPEN. Each local tracking issue lists the SDK call sites that need updating when the upstream lands.

## Test plan

- [x] `npm run compliance:fork-matrix` — 23/23 in ~12s
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean

## Adopter impact

Pure additive at wire and type level. `COMPATIBLE_ADCP_VERSIONS` extends backward compatibility — no existing strings change. Citation bumps are docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)