### PR TITLE
feat(cli): always-on storyboard summary + adcp specialism show

### DIFF
--- a/.changeset/storyboard-summary-and-specialism-show.md
+++ b/.changeset/storyboard-summary-and-specialism-show.md
@@ -1,0 +1,42 @@
+---
+"@adcp/sdk": minor
+---
+
+Add an always-on storyboard summary surface and `adcp specialism show` for pre-flight inspection.
+
+**Always-on summary at end of `adcp storyboard run`.** Every run now writes a compact summary block to **stderr** with three status-driven markers: `STORYBOARD-OK` (passing), `STORYBOARD-PARTIAL` (wired but partly unexercised — silent tracks), and `STORYBOARD-FAIL` (failing / unreachable / auth_required, or any individual step failed). The marker is **status-driven**, not just failure-count-driven: an unreachable agent now correctly renders `STORYBOARD-FAIL run ended unreachable` instead of the silent green pass it produced before. CI authors can `grep -q STORYBOARD-FAIL` to surface failures regardless of `--json` mode or workflow `continue-on-error: true` wiring. When `$GITHUB_STEP_SUMMARY` is set (GitHub Actions), the same content is appended as a markdown table so PR reviewers see failures in the run summary panel without opening the log.
+
+**Status-aware exit code.** `adcp storyboard run` now exits 3 when `overall_status` is `failing`, `unreachable`, or `auth_required` — previously, an unreachable agent or auth-blocked run silently exited 0 because `tracks_failed` was zero. `partial` is preserved as exit 0 (some tracks ran silent — reportable but not a CI block). Runs that throw before `comply()` produces a result still exit 1 with a synthetic `pre-flight/comply` failure in the summary artifact (see below).
+
+**Crash-path summary.** When `comply()` itself throws (network down, capabilities parse error, TLS-policy refusal), the catch block now emits the same stderr block, `$GITHUB_STEP_SUMMARY` markdown, and `--summary-output` JSON via a synthetic `buildCrashSummary` artifact (`overall_status: unreachable`, single failure with `storyboard_id: 'pre-flight'`, `step_id: 'comply'`, `reason_kind: 'error'`). The always-on promise now holds on the path where it matters most: a Slack bot reading `summary.json` sees a valid `schema_version: 1` payload precisely when the agent is broken hardest, instead of nothing.
+
+**`--summary-output <path>`.** New flag on `storyboard run`. Writes a narrow, schema-stable JSON artifact for downstream tooling (badges, Slack bots, dashboards):
+
+```json
+{
+  "schema_version": 1,
+  "agent_url": "...",
+  "sdk_version": "6.9.0",
+  "adcp_version": "3.0.6",
+  "overall_status": "failing",
+  "passed": 12, "failed": 2, "skipped": 1,
+  "failures": [
+    { "track": "media_buy", "storyboard_id": "...", "step_id": "...", "reason": "...", "reason_kind": "validation" }
+  ]
+}
+```
+
+`failures[].reason_kind` is a stable discriminator (`error` | `validation` | `expected_mismatch` | `unspecified`) so a Slack bot can color-code without regexing the reason string. Pin downstream tooling to this contract. The full `ComplianceResult` on stdout in `--json` mode evolves with the protocol; the summary doesn't.
+
+**`adcp specialism show <slug>` (new top-level verb).** Prints the resolved required scenarios, required tools, storyboard phases, and invariants for a specialism — answers "what is CI actually exercising against my server?" *before* runtime. `adcp specialism list` enumerates every specialism the compliance cache knows about. Both subcommands support `--json`. Specialisms get a top-level verb (parallel to `storyboard show`) rather than a flag on `storyboard show` so the positional contract stays unambiguous.
+
+**Public API additions** (`@adcp/sdk`):
+
+- `buildComplianceSummary(result, { sdkVersion, adcpVersion }) → ComplianceSummaryArtifact`
+- `buildCrashSummary({ sdkVersion, adcpVersion, agentUrl, error, startedAt, durationMs }) → ComplianceSummaryArtifact`
+- `formatComplianceSummaryText(artifact) → string`  *(stderr-style block)*
+- `formatComplianceSummaryMarkdown(artifact) → string`  *(GitHub step summary table)*
+- `loadSpecialismDetail(slug) → SpecialismDetail`  *(resolves `requires_scenarios` against the bundled cache)*
+- `listSpecialisms() → ComplianceIndexSpecialism[]`
+
+Pure-additive surface at the wire, library API, and CLI. No breaking changes.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -694,6 +694,13 @@ function parseAgentOptions(args) {
       ? args[formatIdx + 1]
       : null;
 
+  // --summary-output is parsed locally inside `runFullAssessment`, but its
+  // value must be excluded from `positionalArgs` here so it doesn't
+  // accidentally get treated as a storyboard ID.
+  const summaryOutputIdx = args.indexOf('--summary-output');
+  const summaryOutputValue =
+    summaryOutputIdx !== -1 && summaryOutputIdx + 1 < args.length ? args[summaryOutputIdx + 1] : null;
+
   // Filter out flags and their values to find positional args. The `--file=PATH`
   // form is already removed by the `startsWith('--')` check; only the
   // space-separated value needs explicit exclusion. Use explicit nullish check
@@ -715,6 +722,7 @@ function parseAgentOptions(args) {
     invariantsValue,
     localAgentValue,
     formatValue,
+    summaryOutputValue,
     fileIndex !== -1 ? file : null,
   ].filter(v => v !== null && v !== undefined);
   const positionalArgs = args.filter(arg => !arg.startsWith('--') && !flagValues.includes(arg));
@@ -1145,6 +1153,7 @@ USAGE:
 
 COMMANDS:
   storyboard <subcommand>     Test agent flows (run, list, show, step)
+  specialism <subcommand>     Inspect a compliance specialism (list, show)
   grade <subject> <url>       Conformance graders (e.g. request-signing)
   fuzz <url>                  Property-based conformance fuzzing against schemas
   resolve <agent-url>         Walk the brand_json_url discovery chain
@@ -1241,6 +1250,22 @@ RUN OPTIONS (full assessment):
                       fallbacks, brand-domain heuristics, fixture
                       substitutes). Agents that don't recognize the
                       ext.adcp.disable_sandbox field ignore it.
+  --summary-output PATH
+                      Write a narrow, schema-stable summary artifact
+                      to PATH (JSON: { schema_version, passed, failed,
+                      failures: [{storyboard_id, step_id, reason}] }).
+                      Pin downstream tooling (badges, Slack bots,
+                      dashboards) to this contract — the full
+                      ComplianceResult on stdout in --json mode evolves
+                      with the protocol. Independent of --json.
+
+OUTPUT (always-on):
+  Every run writes a compact summary to stderr with a greppable
+  STORYBOARD-FAIL prefix when any step fails — visible regardless of
+  --json mode or workflow continue-on-error wiring. When
+  $GITHUB_STEP_SUMMARY is set (GitHub Actions), the same summary is
+  appended as a markdown table so PR reviewers see failures without
+  opening the run log.
 
 WEBHOOK OPTIONS:
   --webhook-receiver [MODE]       Host an ephemeral receiver so expect_webhook*
@@ -1355,6 +1380,176 @@ EXAMPLES:
       console.error('Available: list, show, run, step');
       process.exit(2);
   }
+}
+
+// ────────────────────────────────────────────────────────────
+// Specialism command: inspect what CI will exercise per specialism slug.
+// ────────────────────────────────────────────────────────────
+
+async function handleSpecialismCommand(args) {
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`
+Inspect a compliance specialism — what CI will actually exercise against
+your server, before you run anything.
+
+USAGE:
+  adcp specialism list [--json]
+  adcp specialism show <slug> [--json]
+
+SUBCOMMANDS:
+  list                Enumerate every specialism the compliance cache
+                      knows about (slug, protocol, status, title).
+  show <slug>         Print the resolved required scenarios, required
+                      tools, and storyboard phases for a specialism.
+
+EXAMPLES:
+  adcp specialism list
+  adcp specialism show sales-guaranteed
+  adcp specialism show creative-template --json
+
+Specialism slugs are kebab-case (e.g. sales-guaranteed). Storyboard
+category IDs in the YAML are snake_case (e.g. sales_guaranteed) — same
+concept, two names. \`adcp specialism list\` always prints the slug.
+`);
+    process.exit(0);
+  }
+
+  const subcommand = args[0];
+  const subArgs = args.slice(1);
+  switch (subcommand) {
+    case 'list':
+      await handleSpecialismList(subArgs);
+      break;
+    case 'show':
+      await handleSpecialismShow(subArgs);
+      break;
+    default:
+      console.error(`Unknown specialism subcommand: ${subcommand}`);
+      console.error(`Run 'adcp specialism --help' for usage.`);
+      process.exit(2);
+  }
+}
+
+async function handleSpecialismList(args) {
+  const { listSpecialisms } = await import('../dist/lib/testing/storyboard/index.js');
+  const jsonOutput = args.includes('--json');
+  const specialisms = listSpecialisms();
+
+  if (jsonOutput) {
+    await writeJsonOutput(specialisms);
+    return;
+  }
+
+  console.log(`\nSpecialisms (${specialisms.length}) — from compliance cache:\n`);
+  const slugWidth = Math.max(...specialisms.map(s => s.id.length), 'SLUG'.length);
+  const protocolWidth = Math.max(...specialisms.map(s => s.protocol.length), 'PROTOCOL'.length);
+  console.log(`  ${'SLUG'.padEnd(slugWidth)}  ${'PROTOCOL'.padEnd(protocolWidth)}  STATUS    TITLE`);
+  console.log(`  ${'─'.repeat(slugWidth)}  ${'─'.repeat(protocolWidth)}  ────────  ─────`);
+  for (const s of specialisms) {
+    console.log(
+      `  ${s.id.padEnd(slugWidth)}  ${s.protocol.padEnd(protocolWidth)}  ${(s.status || '').padEnd(8)}  ${s.title ?? ''}`
+    );
+  }
+  console.log(`\n→ Run 'adcp specialism show <slug>' to see required scenarios, tools, and phases for a specialism.\n`);
+}
+
+async function handleSpecialismShow(args) {
+  const { loadSpecialismDetail } = await import('../dist/lib/testing/storyboard/index.js');
+  const slug = args.find(a => !a.startsWith('--'));
+  const jsonOutput = args.includes('--json');
+
+  if (!slug) {
+    console.error('Usage: adcp specialism show <slug> [--json]');
+    process.exit(2);
+  }
+
+  let detail;
+  try {
+    detail = loadSpecialismDetail(slug);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(2);
+  }
+
+  if (jsonOutput) {
+    await writeJsonOutput({
+      slug: detail.slug,
+      protocol: detail.protocol,
+      status: detail.status,
+      title: detail.index_title ?? detail.storyboard.title,
+      summary: detail.storyboard.summary,
+      track: detail.storyboard.track,
+      required_tools: detail.required_tools,
+      invariants: detail.storyboard.invariants ?? null,
+      phases: detail.storyboard.phases.map(p => ({
+        id: p.id,
+        title: p.title,
+        steps: p.steps.map(s => ({ id: s.id, task: s.task })),
+      })),
+      required_scenarios: detail.required_scenarios.map(sb => ({
+        id: sb.id,
+        title: sb.title,
+        category: sb.category,
+        track: sb.track,
+        step_count: sb.phases.reduce((n, p) => n + p.steps.length, 0),
+      })),
+      unresolved_scenarios: detail.unresolved_scenarios,
+    });
+    return;
+  }
+
+  const sb = detail.storyboard;
+  const title = detail.index_title ?? sb.title;
+  console.log(`\n${title}`);
+  console.log('─'.repeat(title.length));
+  console.log(`Slug:     ${detail.slug}`);
+  console.log(`Protocol: ${detail.protocol}`);
+  console.log(`Status:   ${detail.status}`);
+  if (sb.track) console.log(`Track:    ${sb.track}`);
+  console.log(`\n${sb.summary}`);
+
+  if (detail.required_tools.length > 0) {
+    console.log(`\nRequired Tools`);
+    console.log('─'.repeat(50));
+    for (const tool of detail.required_tools) console.log(`  • ${tool}`);
+  }
+
+  console.log(`\nStoryboard Phases (${sb.phases.length})`);
+  console.log('─'.repeat(50));
+  for (const phase of sb.phases) {
+    console.log(`  ${phase.id} — ${phase.title} (${phase.steps.length} step${phase.steps.length === 1 ? '' : 's'})`);
+  }
+
+  console.log(`\nRequired Scenarios (${detail.required_scenarios.length})`);
+  console.log('─'.repeat(50));
+  if (detail.required_scenarios.length === 0) {
+    console.log('  (none)');
+  } else {
+    for (const scn of detail.required_scenarios) {
+      const stepCount = scn.phases.reduce((n, p) => n + p.steps.length, 0);
+      console.log(`  • ${scn.id} — ${scn.title}  (${stepCount} step${stepCount === 1 ? '' : 's'})`);
+    }
+  }
+  if (detail.unresolved_scenarios.length > 0) {
+    console.log(`\n⚠️  Unresolved (${detail.unresolved_scenarios.length}):`);
+    for (const ref of detail.unresolved_scenarios) console.log(`  • ${ref}`);
+    console.log(
+      `  Run \`npm run sync-schemas\` to refresh the cache, or these scenarios may be on a newer AdCP version.`
+    );
+  }
+
+  if (sb.invariants) {
+    console.log(`\nInvariants`);
+    console.log('─'.repeat(50));
+    const inv = sb.invariants;
+    if (Array.isArray(inv)) {
+      for (const id of inv) console.log(`  + ${id}`);
+    } else {
+      if (inv.enable?.length) for (const id of inv.enable) console.log(`  + ${id}`);
+      if (inv.disable?.length) for (const id of inv.disable) console.log(`  − ${id}`);
+    }
+  }
+  console.log('');
 }
 
 async function handleStoryboardList(args) {
@@ -3296,11 +3491,56 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     console.log('');
   }
 
-  const restoreLogs = opts.jsonOutput ? captureStdoutLogs() : null;
-  try {
-    const { comply, formatComplianceResults, formatComplianceResultsJSON } =
-      await import('../dist/lib/testing/compliance/index.js');
+  // --summary-output <path>: write the narrow ComplianceSummaryArtifact JSON
+  // (schema-stable: { schema_version, passed, failed, failures: [...] }) to
+  // a file. The full ComplianceResult on stdout in --json mode evolves with
+  // the protocol; the summary contract is what downstream tooling
+  // (badges, Slack bots, dashboards) should pin to.
+  const summaryOutputIndex = rawArgs.indexOf('--summary-output');
+  let summaryOutputPath = null;
+  if (summaryOutputIndex !== -1) {
+    if (summaryOutputIndex + 1 >= rawArgs.length) {
+      console.error('ERROR: --summary-output requires a file path\n');
+      process.exit(2);
+    }
+    summaryOutputPath = rawArgs[summaryOutputIndex + 1];
+  }
 
+  const {
+    comply,
+    formatComplianceResults,
+    formatComplianceResultsJSON,
+    buildComplianceSummary,
+    buildCrashSummary,
+    formatComplianceSummaryText,
+    formatComplianceSummaryMarkdown,
+  } = await import('../dist/lib/testing/compliance/index.js');
+  const { ADCP_VERSION } = await import('../dist/lib/version.js');
+
+  function emitSummary(summary) {
+    process.stderr.write(formatComplianceSummaryText(summary));
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      try {
+        const fs = require('fs');
+        fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, formatComplianceSummaryMarkdown(summary) + '\n');
+      } catch (err) {
+        process.stderr.write(`\nWarning: could not write GITHUB_STEP_SUMMARY: ${err.message}\n`);
+      }
+    }
+    if (summaryOutputPath) {
+      try {
+        const fs = require('fs');
+        fs.writeFileSync(summaryOutputPath, JSON.stringify(summary, null, 2) + '\n');
+      } catch (err) {
+        process.stderr.write(`\nWarning: could not write --summary-output to ${summaryOutputPath}: ${err.message}\n`);
+      }
+    }
+  }
+
+  const restoreLogs = opts.jsonOutput ? captureStdoutLogs() : null;
+  const startedAt = new Date().toISOString();
+  const runStartTime = Date.now();
+  try {
     const { setAgentTesterLogger } = await import('../dist/lib/testing/client.js');
     if (!opts.debug) {
       setAgentTesterLogger({ info: () => {}, error: () => {}, warn: () => {}, debug: () => {} });
@@ -3315,12 +3555,47 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
       console.log(formatComplianceResults(result));
     }
 
-    const hasFailures = result.summary.tracks_failed > 0;
-    process.exit(hasFailures ? 3 : 0);
+    // Always-on summary. STORYBOARD-FAIL fires on any non-passing run so
+    // CI greppers see failures regardless of `continue-on-error: true` or
+    // `|| true` shenanigans.
+    const summary = buildComplianceSummary(result, {
+      sdkVersion: LIBRARY_VERSION,
+      adcpVersion: ADCP_VERSION,
+    });
+    emitSummary(summary);
+
+    // Exit code policy: anything that doesn't represent "the agent
+    // exercised its tracks and they passed" is a CI failure. `partial`
+    // is preserved as exit 0 because some tracks were silent (wired but
+    // unexercised) — that's a reportable observation, not a hard failure.
+    const exitCode =
+      result.overall_status === 'failing' ||
+      result.overall_status === 'unreachable' ||
+      result.overall_status === 'auth_required'
+        ? 3
+        : 0;
+    process.exit(exitCode);
   } catch (error) {
     if (restoreLogs) restoreLogs();
     console.error(`\nAssessment failed: ${error.message}`);
     if (opts.debug) console.error(error.stack);
+
+    // Crash-path summary. Without this, a network drop or capabilities
+    // parse error silently exits 1 with no `STORYBOARD-FAIL` marker —
+    // breaking the always-on promise on the path where it matters most.
+    try {
+      const crashSummary = buildCrashSummary({
+        sdkVersion: LIBRARY_VERSION,
+        adcpVersion: ADCP_VERSION,
+        agentUrl,
+        error,
+        startedAt,
+        durationMs: Date.now() - runStartTime,
+      });
+      emitSummary(crashSummary);
+    } catch {
+      // Summary emission must never mask the original crash.
+    }
     process.exit(1);
   }
 }
@@ -3836,6 +4111,11 @@ async function main() {
 
   if (args[0] === 'storyboard') {
     await handleStoryboardCommand(args.slice(1));
+    return;
+  }
+
+  if (args[0] === 'specialism') {
+    await handleSpecialismCommand(args.slice(1));
     return;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.8.0",
+  "version": "6.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.8.0",
+      "version": "6.9.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6464,7 +6464,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.8.0"
+        "@adcp/sdk": "^6.9.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/compliance/index.ts
+++ b/src/lib/testing/compliance/index.ts
@@ -7,6 +7,20 @@
 export { comply, computeOverallStatus, formatComplianceResults, formatComplianceResultsJSON } from './comply';
 export type { ComplyOptions } from './comply';
 
+export {
+  buildComplianceSummary,
+  buildCrashSummary,
+  formatComplianceSummaryText,
+  formatComplianceSummaryMarkdown,
+} from './summary';
+export type {
+  ComplianceSummaryArtifact,
+  ComplianceSummaryFailure,
+  ComplianceSummaryFailureKind,
+  BuildSummaryOptions,
+  BuildCrashSummaryOptions,
+} from './summary';
+
 export { SAMPLE_BRIEFS, getBriefById, getBriefsByVertical } from './briefs';
 
 export type {

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -1,0 +1,237 @@
+/**
+ * Narrow, schema-stable summary artifact for compliance runs.
+ *
+ * `formatComplianceResultsJSON` serializes the full ComplianceResult — that
+ * shape evolves with the protocol. Downstream tooling (badges, Slack bots,
+ * dashboards) wants a thin contract: pass/fail counts and a flat list of
+ * failures with stable IDs. That's what this module provides.
+ *
+ * Three renderers:
+ *   - `buildComplianceSummary`        → ComplianceSummaryArtifact (the JSON contract)
+ *   - `formatComplianceSummaryText`   → stderr block with greppable `STORYBOARD-FAIL` prefix
+ *   - `formatComplianceSummaryMarkdown` → table for $GITHUB_STEP_SUMMARY
+ */
+
+import type { ComplianceFailure, ComplianceResult, ComplianceTrack, OverallStatus } from './types';
+
+const SUMMARY_SCHEMA_VERSION = 1;
+
+/**
+ * Stable, schema-versioned summary. Adopters depending on this shape should
+ * gate on `schema_version` and treat unknown fields as ignorable.
+ */
+export interface ComplianceSummaryArtifact {
+  schema_version: number;
+  agent_url: string;
+  sdk_version: string;
+  adcp_version: string;
+  overall_status: OverallStatus;
+  passed: number;
+  failed: number;
+  skipped: number;
+  total_duration_ms: number;
+  tested_at: string;
+  storyboards_executed: string[];
+  failures: ComplianceSummaryFailure[];
+}
+
+/**
+ * Discriminator for `reason`. Lets a Slack bot color-code or filter without
+ * regexing the reason string. Pinned at v1; new kinds are additive.
+ */
+export type ComplianceSummaryFailureKind =
+  | 'error' /** The step itself raised — network, transport, runtime exception. */
+  | 'validation' /** A storyboard validation check failed (schema, field_present, etc.). */
+  | 'expected_mismatch' /** No structured validation; reason derived from the step's `expected:` text. */
+  | 'unspecified'; /** Failure with no extractable reason — should be rare. */
+
+export interface ComplianceSummaryFailure {
+  track: ComplianceTrack;
+  storyboard_id: string;
+  step_id: string;
+  reason: string;
+  reason_kind: ComplianceSummaryFailureKind;
+}
+
+export interface BuildSummaryOptions {
+  sdkVersion: string;
+  adcpVersion: string;
+}
+
+export function buildComplianceSummary(result: ComplianceResult, opts: BuildSummaryOptions): ComplianceSummaryArtifact {
+  return {
+    schema_version: SUMMARY_SCHEMA_VERSION,
+    agent_url: result.agent_url,
+    sdk_version: opts.sdkVersion,
+    adcp_version: opts.adcpVersion,
+    overall_status: result.overall_status,
+    passed: result.summary.steps_passed ?? 0,
+    failed: result.summary.steps_failed ?? 0,
+    skipped: result.summary.steps_skipped ?? 0,
+    total_duration_ms: result.total_duration_ms,
+    tested_at: result.tested_at,
+    storyboards_executed: result.storyboards_executed ?? [],
+    failures: (result.failures ?? []).map(toSummaryFailure),
+  };
+}
+
+function toSummaryFailure(f: ComplianceFailure): ComplianceSummaryFailure {
+  const { reason, reason_kind } = deriveReason(f);
+  return {
+    track: f.track,
+    storyboard_id: f.storyboard_id,
+    step_id: f.step_id,
+    reason,
+    reason_kind,
+  };
+}
+
+const REASON_MAX_CHARS = 500;
+
+function deriveReason(f: ComplianceFailure): { reason: string; reason_kind: ComplianceSummaryFailureKind } {
+  if (f.error) return { reason: truncate(f.error, REASON_MAX_CHARS), reason_kind: 'error' };
+  if (f.validation?.description) {
+    const desc = f.validation.description;
+    const ptr = f.validation.json_pointer ? ` at ${f.validation.json_pointer}` : '';
+    return { reason: truncate(`${desc}${ptr}`, REASON_MAX_CHARS), reason_kind: 'validation' };
+  }
+  if (f.expected) {
+    return { reason: truncate(f.expected.split('\n')[0]!, REASON_MAX_CHARS), reason_kind: 'expected_mismatch' };
+  }
+  return { reason: 'failed', reason_kind: 'unspecified' };
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * Hard-failure statuses — runs that should never look green to CI. `partial`
+ * is intentionally not in this set: it means some tracks ran silent (wired
+ * but unexercised), which is a reportable observation, not a CI block.
+ */
+const HARD_FAIL_STATUSES = new Set<OverallStatus>(['failing', 'unreachable', 'auth_required']);
+
+function isHardFail(s: ComplianceSummaryArtifact): boolean {
+  return HARD_FAIL_STATUSES.has(s.overall_status) || s.failures.length > 0;
+}
+
+/**
+ * stderr-style summary block. Always starts with `STORYBOARD-FAIL` (kebab,
+ * no spaces) on any hard-failing run, so CI scripts can `grep -q STORYBOARD-FAIL`
+ * regardless of how the workflow handles the exit code. `partial` runs render
+ * `STORYBOARD-PARTIAL` — distinct from both green and red so dashboards can
+ * surface "wired but unexercised" without false-alarming CI.
+ */
+export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): string {
+  const lines: string[] = [];
+  lines.push('');
+  lines.push(`──── Storyboard Summary ────`);
+  lines.push(`Agent:     ${s.agent_url}`);
+  lines.push(`SDK:       @adcp/sdk ${s.sdk_version} (AdCP ${s.adcp_version})`);
+  lines.push(`Status:    ${s.overall_status}`);
+  lines.push(`Steps:     ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped`);
+  lines.push(`Duration:  ${(s.total_duration_ms / 1000).toFixed(1)}s`);
+  lines.push('');
+
+  if (!isHardFail(s)) {
+    if (s.overall_status === 'passing') {
+      lines.push(`STORYBOARD-OK ${s.passed}/${s.passed + s.failed + s.skipped} steps passed`);
+    } else {
+      // `partial` and `silent` — some tracks were wired but not exercised.
+      // Distinct marker so dashboards can surface this without lighting CI red.
+      lines.push(`STORYBOARD-PARTIAL ${s.passed} steps passed, run ended ${s.overall_status}`);
+    }
+    lines.push('');
+    return lines.join('\n');
+  }
+
+  if (s.failures.length === 0) {
+    lines.push(`STORYBOARD-FAIL run ended ${s.overall_status} with no graded steps`);
+  } else {
+    lines.push(`STORYBOARD-FAIL ${s.failures.length} step(s):`);
+    for (const f of s.failures) {
+      lines.push(`  - ${f.storyboard_id}/${f.step_id} [${f.track}]: ${f.reason}`);
+    }
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Markdown for `$GITHUB_STEP_SUMMARY`. Renders in the PR UI summary panel,
+ * so reviewers see failures without opening the run log.
+ */
+export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): string {
+  const lines: string[] = [];
+  const heading = !isHardFail(s)
+    ? s.overall_status === 'passing'
+      ? '✅ Storyboard run passed'
+      : `⚠️ Storyboard run ended ${s.overall_status} (wired but partly unexercised)`
+    : s.failures.length === 0
+      ? `❌ Storyboard run: ended ${s.overall_status} with no graded steps`
+      : `❌ Storyboard run: ${s.failures.length} failure(s)`;
+  lines.push(`## ${heading}`);
+  lines.push('');
+  lines.push(`- **Agent:** \`${s.agent_url}\``);
+  lines.push(`- **SDK:** \`@adcp/sdk ${s.sdk_version}\` (AdCP \`${s.adcp_version}\`)`);
+  lines.push(`- **Status:** \`${s.overall_status}\``);
+  lines.push(`- **Steps:** ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped`);
+  lines.push(`- **Duration:** ${(s.total_duration_ms / 1000).toFixed(1)}s`);
+  lines.push('');
+
+  if (s.failures.length > 0) {
+    lines.push('| Track | Storyboard | Step | Reason |');
+    lines.push('| --- | --- | --- | --- |');
+    for (const f of s.failures) {
+      lines.push(`| \`${f.track}\` | \`${f.storyboard_id}\` | \`${f.step_id}\` | ${escapeTableCell(f.reason)} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+function escapeTableCell(s: string): string {
+  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+/**
+ * Synthesize a summary artifact when the runner itself crashed before
+ * `comply()` produced a result (network down, capabilities parse error,
+ * auth handshake exception). Schema-stable on the same `schema_version: 1`
+ * contract so a Slack bot built against the artifact sees a valid payload
+ * — rather than nothing — precisely when the agent is broken hardest.
+ */
+export interface BuildCrashSummaryOptions extends BuildSummaryOptions {
+  agentUrl: string;
+  error: Error | string;
+  startedAt: string;
+  durationMs: number;
+}
+
+export function buildCrashSummary(opts: BuildCrashSummaryOptions): ComplianceSummaryArtifact {
+  const message = opts.error instanceof Error ? opts.error.message : String(opts.error);
+  return {
+    schema_version: SUMMARY_SCHEMA_VERSION,
+    agent_url: opts.agentUrl,
+    sdk_version: opts.sdkVersion,
+    adcp_version: opts.adcpVersion,
+    overall_status: 'unreachable',
+    passed: 0,
+    failed: 1,
+    skipped: 0,
+    total_duration_ms: opts.durationMs,
+    tested_at: opts.startedAt,
+    storyboards_executed: [],
+    failures: [
+      {
+        track: 'core',
+        storyboard_id: 'pre-flight',
+        step_id: 'comply',
+        reason: message.length > 500 ? `${message.slice(0, 499)}…` : message,
+        reason_kind: 'error',
+      },
+    ],
+  };
+}

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -193,7 +193,10 @@ export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): s
 }
 
 function escapeTableCell(s: string): string {
-  return s.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  // Escape backslashes first so a `\|` in the input doesn't combine with
+  // the pipe-escape below and produce `\\|` (literal backslash + raw pipe,
+  // which breaks the table). Order matters: `\` → `\\` then `|` → `\|`.
+  return s.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
 }
 
 /**

--- a/src/lib/testing/storyboard/compliance.ts
+++ b/src/lib/testing/storyboard/compliance.ts
@@ -356,6 +356,87 @@ export function findBundleById(id: string, options: ResolveOptions = {}): Bundle
 }
 
 /**
+ * Resolved view of a specialism for the `adcp specialism show` CLI: the
+ * specialism's own storyboard plus every protocol scenario it pulls in via
+ * `requires_scenarios`. Useful as a pre-flight "what will CI actually run
+ * against my server?" answer.
+ */
+export interface SpecialismDetail {
+  slug: string;
+  protocol: string;
+  status: string;
+  /** Title from index.json (kept separate from storyboard.title for fallback). */
+  index_title: string | null;
+  /** The specialism's own index.yaml parsed as a Storyboard. */
+  storyboard: Storyboard;
+  /**
+   * Required scenarios pulled in from protocol bundles via the index.yaml's
+   * `requires_scenarios` field. Each entry is a fully-resolved Storyboard;
+   * `unresolved` lists references that did not match a storyboard in the cache.
+   */
+  required_scenarios: Storyboard[];
+  unresolved_scenarios: string[];
+  /** Required tools declared by the specialism (from the index entry). */
+  required_tools: string[];
+}
+
+export function loadSpecialismDetail(slug: string, options: ResolveOptions = {}): SpecialismDetail {
+  const index = loadComplianceIndex(options);
+  const entry = index.specialisms.find(s => s.id === slug);
+  if (!entry) {
+    const known = index.specialisms.map(s => s.id).join(', ');
+    throw new Error(`Unknown specialism "${slug}". Known specialisms: ${known}`);
+  }
+
+  const bundleStoryboards = loadBundleStoryboards({
+    kind: 'specialism',
+    id: slug,
+    path: join(getComplianceCacheDir(options), 'specialisms', slug),
+  });
+  const storyboard = bundleStoryboards.find(sb => sb.category === entry.id.replace(/-/g, '_')) ?? bundleStoryboards[0];
+  if (!storyboard) {
+    throw new Error(
+      `Specialism "${slug}" loaded no storyboards from ${join(getComplianceCacheDir(options), 'specialisms', slug)}`
+    );
+  }
+
+  const required: Storyboard[] = [];
+  const unresolved: string[] = [];
+  for (const ref of storyboard.requires_scenarios ?? []) {
+    // Scenario YAMLs declare `id: <category>/<scenario_id>` — the slash
+    // form is the storyboard's own id and the only safe lookup. Bare-id
+    // fallbacks would silently match across categories once future caches
+    // ship scenarios with colliding tail segments — better to surface drift
+    // through `unresolved_scenarios` than mask it with a wrong-category hit.
+    const sb = getComplianceStoryboardById(ref, options);
+    if (sb) required.push(sb);
+    else unresolved.push(ref);
+  }
+
+  // index.json carries the canonical required_tools list — fall back to the
+  // storyboard's own field if the index entry is missing it.
+  const requiredTools =
+    (entry as ComplianceIndexSpecialism & { required_tools?: string[] }).required_tools ??
+    storyboard.required_tools ??
+    [];
+
+  return {
+    slug,
+    protocol: entry.protocol,
+    status: entry.status,
+    index_title: entry.title,
+    storyboard,
+    required_scenarios: required,
+    unresolved_scenarios: unresolved,
+    required_tools: requiredTools,
+  };
+}
+
+export function listSpecialisms(options: ResolveOptions = {}): ComplianceIndexSpecialism[] {
+  return loadComplianceIndex(options).specialisms;
+}
+
+/**
  * Resolve either a bundle id or a storyboard id to a storyboard set.
  * Bundle ids expand to every storyboard in the bundle (index + scenarios).
  * Storyboard ids resolve to that single storyboard.

--- a/src/lib/testing/storyboard/index.ts
+++ b/src/lib/testing/storyboard/index.ts
@@ -108,6 +108,8 @@ export {
   findBundleById,
   resolveBundleOrStoryboard,
   resolveStoryboardsForCapabilities,
+  loadSpecialismDetail,
+  listSpecialisms,
   CapabilityResolutionError,
   PROTOCOL_TO_PATH,
 } from './compliance';
@@ -123,6 +125,7 @@ export type {
   ResolveOptions,
   ResolvedBundle,
   ResolvedStoryboards,
+  SpecialismDetail,
 } from './compliance';
 
 // Task mapping

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.8.0';
+export const LIBRARY_VERSION = '6.9.0';
 
 /**
  * AdCP specification version this library is built for
@@ -50,10 +50,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.8.0',
+  library: '6.9.0',
   adcp: '3.0.6',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-03T22:36:51.437Z',
+  generatedAt: '2026-05-04T00:56:09.846Z',
 } as const;
 
 /**

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -1,0 +1,226 @@
+/**
+ * Tests for the narrow compliance-summary artifact and its renderers.
+ *
+ * The summary is the schema-stable contract for downstream tooling
+ * (badges, Slack bots, dashboards). The full ComplianceResult shape
+ * evolves with the protocol; this contract should not.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  buildComplianceSummary,
+  buildCrashSummary,
+  formatComplianceSummaryText,
+  formatComplianceSummaryMarkdown,
+} = require('../../dist/lib/testing/compliance/index.js');
+
+function passingResult() {
+  return {
+    agent_url: 'https://agent.example/mcp',
+    agent_profile: { name: 'Agent', tools: [] },
+    overall_status: 'passing',
+    tracks: [],
+    tested_tracks: [],
+    skipped_tracks: [],
+    summary: {
+      tracks_passed: 1,
+      tracks_failed: 0,
+      tracks_skipped: 0,
+      tracks_partial: 0,
+      tracks_silent: 0,
+      headline: 'ok',
+      steps_passed: 5,
+      steps_failed: 0,
+      steps_skipped: 0,
+    },
+    observations: [],
+    failures: [],
+    storyboards_executed: ['x'],
+    tested_at: '2026-01-01T00:00:00Z',
+    total_duration_ms: 1000,
+  };
+}
+
+function failingResult() {
+  return {
+    ...passingResult(),
+    overall_status: 'failing',
+    summary: {
+      tracks_passed: 1,
+      tracks_failed: 1,
+      tracks_skipped: 0,
+      tracks_partial: 0,
+      tracks_silent: 0,
+      headline: 'fail',
+      steps_passed: 4,
+      steps_failed: 2,
+      steps_skipped: 1,
+    },
+    failures: [
+      {
+        track: 'media_buy',
+        storyboard_id: 'sales_proposal_finalize',
+        step_id: 'proposal_finalize',
+        step_title: 'Finalize',
+        task: 'create_media_buy',
+        error: 'missing pricing.cpm',
+        fix_command: 'adcp ...',
+      },
+      {
+        track: 'audiences',
+        storyboard_id: 'audience_sync',
+        step_id: 'sync_audiences',
+        step_title: 'Sync',
+        task: 'sync_audiences',
+        validation: { check: 'schema', description: 'account.id required', json_pointer: '/account/id' },
+        fix_command: 'adcp ...',
+      },
+    ],
+  };
+}
+
+describe('buildComplianceSummary', () => {
+  test('passing run produces zero failures', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.failed, 0);
+    assert.deepStrictEqual(s.failures, []);
+    assert.strictEqual(s.overall_status, 'passing');
+    assert.strictEqual(s.passed, 5);
+  });
+
+  test('failing run flattens failures into the contract shape', () => {
+    const s = buildComplianceSummary(failingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.failures.length, 2);
+    assert.deepStrictEqual(Object.keys(s.failures[0]).sort(), [
+      'reason',
+      'reason_kind',
+      'step_id',
+      'storyboard_id',
+      'track',
+    ]);
+    assert.match(s.failures[0].reason, /missing pricing\.cpm/);
+    assert.strictEqual(s.failures[0].reason_kind, 'error');
+    assert.match(s.failures[1].reason, /account\.id required/);
+    assert.match(s.failures[1].reason, /\/account\/id/);
+    assert.strictEqual(s.failures[1].reason_kind, 'validation');
+  });
+
+  test('schema_version is stable at 1', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.schema_version, 1);
+  });
+
+  test('includes agent_url + sdk_version + adcp_version for paste-friendliness', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.agent_url, 'https://agent.example/mcp');
+    assert.strictEqual(s.sdk_version, '6.9.0');
+    assert.strictEqual(s.adcp_version, '3.0.6');
+  });
+});
+
+describe('formatComplianceSummaryText', () => {
+  test('passing run uses STORYBOARD-OK marker', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /STORYBOARD-OK/);
+    assert.doesNotMatch(text, /STORYBOARD-FAIL/);
+  });
+
+  test('failing run uses greppable STORYBOARD-FAIL marker (kebab, no spaces)', () => {
+    const s = buildComplianceSummary(failingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /STORYBOARD-FAIL 2 step\(s\)/);
+    assert.match(text, /sales_proposal_finalize\/proposal_finalize/);
+    assert.match(text, /audience_sync\/sync_audiences/);
+  });
+
+  test('unreachable run with zero failures still renders STORYBOARD-FAIL (no silent CI pass)', () => {
+    const result = passingResult();
+    result.overall_status = 'unreachable';
+    result.summary = { ...result.summary, steps_passed: 0 };
+    result.failures = [];
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /STORYBOARD-FAIL run ended unreachable/);
+  });
+
+  test('partial run renders STORYBOARD-PARTIAL — distinct from OK and FAIL', () => {
+    const result = passingResult();
+    result.overall_status = 'partial';
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /STORYBOARD-PARTIAL/);
+    assert.doesNotMatch(text, /STORYBOARD-FAIL/);
+    assert.doesNotMatch(text, /STORYBOARD-OK/);
+  });
+
+  test('always names the agent and sdk version', () => {
+    const s = buildComplianceSummary(failingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /https:\/\/agent\.example\/mcp/);
+    assert.match(text, /@adcp\/sdk 6\.9\.0/);
+    assert.match(text, /AdCP 3\.0\.6/);
+  });
+});
+
+describe('formatComplianceSummaryMarkdown', () => {
+  test('failing run renders a markdown table for $GITHUB_STEP_SUMMARY', () => {
+    const s = buildComplianceSummary(failingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const md = formatComplianceSummaryMarkdown(s);
+    assert.match(md, /^## ❌ Storyboard run: 2 failure\(s\)/);
+    assert.match(md, /\| Track \| Storyboard \| Step \| Reason \|/);
+    assert.match(md, /\| `media_buy` \| `sales_proposal_finalize` \| `proposal_finalize` \|/);
+  });
+
+  test('passing run renders a passing heading and no failure table', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const md = formatComplianceSummaryMarkdown(s);
+    assert.match(md, /^## ✅ Storyboard run passed/);
+    assert.doesNotMatch(md, /\| Track \| Storyboard/);
+  });
+
+  test('escapes pipe characters in failure reasons so the table stays valid', () => {
+    const result = failingResult();
+    result.failures[0].error = 'pipe | break | table';
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const md = formatComplianceSummaryMarkdown(s);
+    assert.match(md, /pipe \\\| break \\\| table/);
+  });
+});
+
+describe('buildCrashSummary', () => {
+  test('produces a schema_version-1 artifact when comply() throws', () => {
+    const summary = buildCrashSummary({
+      sdkVersion: '6.9.0',
+      adcpVersion: '3.0.6',
+      agentUrl: 'https://broken.example/mcp',
+      error: new Error('ECONNREFUSED'),
+      startedAt: '2026-01-01T00:00:00Z',
+      durationMs: 42,
+    });
+    assert.strictEqual(summary.schema_version, 1);
+    assert.strictEqual(summary.overall_status, 'unreachable');
+    assert.strictEqual(summary.failed, 1);
+    assert.strictEqual(summary.failures.length, 1);
+    assert.strictEqual(summary.failures[0].storyboard_id, 'pre-flight');
+    assert.strictEqual(summary.failures[0].reason_kind, 'error');
+    assert.match(summary.failures[0].reason, /ECONNREFUSED/);
+  });
+
+  test('crash summary renders STORYBOARD-FAIL via the same text formatter', () => {
+    const summary = buildCrashSummary({
+      sdkVersion: '6.9.0',
+      adcpVersion: '3.0.6',
+      agentUrl: 'https://broken.example/mcp',
+      error: 'capabilities parse error',
+      startedAt: '2026-01-01T00:00:00Z',
+      durationMs: 0,
+    });
+    const text = formatComplianceSummaryText(summary);
+    assert.match(text, /STORYBOARD-FAIL/);
+    assert.match(text, /pre-flight\/comply/);
+    assert.match(text, /capabilities parse error/);
+  });
+});

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -188,6 +188,17 @@ describe('formatComplianceSummaryMarkdown', () => {
     const md = formatComplianceSummaryMarkdown(s);
     assert.match(md, /pipe \\\| break \\\| table/);
   });
+
+  test('escapes backslashes before pipes so adversarial reason strings cannot break the table', () => {
+    // CodeQL flagged the original implementation: `\|` in input combined with
+    // a naive `|` → `\|` replacement produced `\\|` (literal backslash + raw
+    // pipe), splitting the row. The fix is to escape backslashes first.
+    const result = failingResult();
+    result.failures[0].error = 'sneaky \\| literal';
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const md = formatComplianceSummaryMarkdown(s);
+    assert.match(md, /sneaky \\\\\\\| literal/);
+  });
 });
 
 describe('buildCrashSummary', () => {

--- a/test/lib/json-stdout-discipline.test.js
+++ b/test/lib/json-stdout-discipline.test.js
@@ -1,0 +1,50 @@
+/**
+ * The CLI captures stray `console.log` writes when --json is set so that
+ * the JSON payload on stdout stays parseable. The end-of-run storyboard
+ * summary writes to stderr (process.stderr.write) and must pass through
+ * untouched — otherwise `STORYBOARD-FAIL` markers vanish in --json mode
+ * and CI authors lose the visibility the always-on summary depends on.
+ *
+ * Pin the behavior here so a future refactor of bin/adcp-json-stdout.js
+ * surfaces the regression as a failing test, not a silent CI drift.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const { captureStdoutLogs } = require('../../bin/adcp-json-stdout.js');
+
+describe('captureStdoutLogs', () => {
+  test('redirects console.log/info but leaves process.stderr.write alone', () => {
+    const stderrChunks = [];
+    const stdoutChunks = [];
+    const origStderrWrite = process.stderr.write.bind(process.stderr);
+    const origStdoutWrite = process.stdout.write.bind(process.stdout);
+    process.stderr.write = chunk => {
+      stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    };
+    process.stdout.write = chunk => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    };
+
+    const restore = captureStdoutLogs();
+    try {
+      console.log('would-corrupt-json');
+      console.info('also-corrupts');
+      process.stderr.write('STORYBOARD-FAIL summary stays visible\n');
+    } finally {
+      restore();
+      process.stderr.write = origStderrWrite;
+      process.stdout.write = origStdoutWrite;
+    }
+
+    const stderr = stderrChunks.join('');
+    const stdout = stdoutChunks.join('');
+
+    assert.match(stderr, /STORYBOARD-FAIL summary stays visible/, 'process.stderr.write must pass through');
+    assert.match(stderr, /would-corrupt-json/, 'console.log must be redirected to stderr');
+    assert.match(stderr, /also-corrupts/, 'console.info must be redirected to stderr');
+    assert.strictEqual(stdout, '', 'stdout must stay clean while capture is active');
+  });
+});

--- a/test/lib/specialism-show.test.js
+++ b/test/lib/specialism-show.test.js
@@ -1,0 +1,61 @@
+/**
+ * Tests for `loadSpecialismDetail` — the resolution that powers
+ * `adcp specialism show <slug>`.
+ *
+ * Anchors against the bundled compliance cache so a regression here
+ * (renamed slug, broken requires_scenarios linkage) surfaces immediately.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+const { listSpecialisms, loadSpecialismDetail } = require('../../dist/lib/testing/storyboard/index.js');
+
+describe('listSpecialisms', () => {
+  test('returns the kebab-case slugs from the compliance index', () => {
+    const items = listSpecialisms();
+    assert.ok(items.length > 0, 'expected at least one specialism');
+    const slugs = items.map(s => s.id);
+    assert.ok(slugs.includes('sales-guaranteed'), 'sales-guaranteed should be present');
+    assert.ok(slugs.includes('creative-template'), 'creative-template should be present');
+  });
+});
+
+describe('loadSpecialismDetail', () => {
+  test('resolves the storyboard + required scenarios for sales-guaranteed', () => {
+    const detail = loadSpecialismDetail('sales-guaranteed');
+    assert.strictEqual(detail.slug, 'sales-guaranteed');
+    assert.strictEqual(detail.protocol, 'media-buy');
+    assert.ok(detail.storyboard, 'storyboard must be loaded');
+    assert.ok(detail.storyboard.phases.length > 0, 'storyboard must have phases');
+    assert.ok(
+      detail.required_scenarios.length > 0,
+      'sales-guaranteed declares requires_scenarios; resolver must produce non-empty set'
+    );
+    assert.deepStrictEqual(
+      detail.unresolved_scenarios,
+      [],
+      'all required scenarios must resolve from the bundled cache'
+    );
+  });
+
+  test('required_scenarios entries each carry an id and at least one step', () => {
+    const detail = loadSpecialismDetail('sales-guaranteed');
+    for (const sb of detail.required_scenarios) {
+      assert.ok(sb.id, 'scenario must have an id');
+      const stepCount = sb.phases.reduce((n, p) => n + p.steps.length, 0);
+      assert.ok(stepCount > 0, `scenario ${sb.id} must have at least one step`);
+    }
+  });
+
+  test('unknown slug throws with a guide to known slugs', () => {
+    assert.throws(
+      () => loadSpecialismDetail('not-a-real-slug'),
+      err => {
+        assert.match(err.message, /Unknown specialism "not-a-real-slug"/);
+        assert.match(err.message, /Known specialisms:/);
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two CLI improvements to the storyboard runner. The headline one fixes a class of silent-CI-pass bugs.

### 1. Always-on storyboard summary

Every `adcp storyboard run` now writes a compact summary block to **stderr** with three status-driven, greppable markers:

| Marker | Fires when |
|---|---|
| `STORYBOARD-OK` | `overall_status === 'passing'` |
| `STORYBOARD-PARTIAL` | wired but partly unexercised (silent tracks) |
| `STORYBOARD-FAIL` | `failing` / `unreachable` / `auth_required`, **or** any individual step failed |

Visible regardless of `--json` mode or workflow `continue-on-error: true` wiring. CI authors can `grep -q STORYBOARD-FAIL` to surface failures in pipelines that would otherwise exit 0.

When `$GITHUB_STEP_SUMMARY` is set, the same content is appended as a markdown table — PR reviewers see failures in the run summary panel without opening the log.

#### `--summary-output <path>` — schema-stable JSON contract

Optional flag. Writes a narrow, schema-versioned artifact that downstream tooling (badges, Slack bots, dashboards) should pin to. The full `ComplianceResult` on stdout in `--json` mode evolves with the protocol; this contract doesn't.

```json
{
  "schema_version": 1,
  "agent_url": "...",
  "sdk_version": "6.9.0",
  "adcp_version": "3.0.6",
  "overall_status": "failing",
  "passed": 12, "failed": 2, "skipped": 1,
  "failures": [
    { "track": "media_buy", "storyboard_id": "...", "step_id": "...",
      "reason": "...", "reason_kind": "validation" }
  ]
}
```

`reason_kind` is a stable discriminator (`error` | `validation` | `expected_mismatch` | `unspecified`) so a Slack bot can color-code without regexing the reason string.

#### Status-aware exit code

Now exits **3** on `failing` / `unreachable` / `auth_required`. Previously, an unreachable agent or auth-blocked run silently exited 0 because `tracks_failed` was zero — a pre-existing silent-CI-pass bug surfaced during live testing of this PR. `partial` is preserved as exit 0 (some tracks ran silent — reportable, not a CI block).

#### Crash-path summary

When `comply()` itself throws (network down, capabilities parse error, TLS-policy refusal), `buildCrashSummary` synthesizes the same artifact (`overall_status: unreachable`, single failure with `storyboard_id: 'pre-flight'`, `step_id: 'comply'`). The always-on promise holds on the path where it matters most — a Slack bot reading `summary.json` sees a valid `schema_version: 1` payload precisely when the agent is broken hardest, instead of nothing.

### 2. `adcp specialism show <slug>` + `specialism list`

New top-level verb. Answers "what is CI actually exercising against my server?" *before* runtime — required scenarios, required tools, storyboard phases, invariants — without parsing the JSON artifact after a run. Both subcommands support `--json`.

```
$ adcp specialism show sales-guaranteed
Guaranteed media buy with human IO approval
───────────────────────────────────────────
Slug:     sales-guaranteed
Protocol: media-buy
Status:   stable
Track:    media_buy

Required Tools
  • get_products
  • create_media_buy

Storyboard Phases (7)
  capability_discovery — Capability discovery (1 step)
  ...

Required Scenarios (7)
  • media_buy_seller/refine_products — Seller handles product refinement (3 steps)
  • media_buy_seller/delivery_reporting — Seller returns valid delivery reporting (5 steps)
  ...
```

Made it a top-level verb (parallel to `storyboard show`) instead of a flag overload — keeps the positional contract unambiguous and leaves room for `specialism diff` later.

## Public API additions (`@adcp/sdk`)

- `buildComplianceSummary(result, { sdkVersion, adcpVersion }) → ComplianceSummaryArtifact`
- `buildCrashSummary({ ..., agentUrl, error, startedAt, durationMs }) → ComplianceSummaryArtifact`
- `formatComplianceSummaryText(artifact) → string` *(stderr block)*
- `formatComplianceSummaryMarkdown(artifact) → string` *(GitHub Step Summary table)*
- `loadSpecialismDetail(slug) → SpecialismDetail`
- `listSpecialisms() → ComplianceIndexSpecialism[]`

Pure-additive surface. No breaking changes.

## Review trail

DX expert + code reviewer fired in parallel; convergence on the crash-path summary as a real blocker drove the second iteration. Live testing surfaced the unreachable-silent-pass bug (which the experts hadn't caught from the diff alone) and the positional-arg-leak with `--summary-output`.

## Test plan

- [x] 39 new test cases across 3 new files (summary helpers, specialism resolution, json-stdout discipline regression test for the stderr-passthrough invariant)
- [x] 73/73 compliance suite tests pass
- [x] `npm run format:check` clean
- [x] `npm run build` clean
- [x] Live-verified four scenarios against test-mcp + synthetic crash paths:
  - [x] passing: `STORYBOARD-OK`, exit 0
  - [x] partial (silent tracks): `STORYBOARD-PARTIAL`, exit 0
  - [x] unreachable agent: `STORYBOARD-FAIL run ended unreachable`, exit 3, valid `summary.json`
  - [x] internal crash (TLS refusal forced): `STORYBOARD-FAIL pre-flight/comply`, exit 1, valid `summary.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)