### PR TITLE
feat(server): createDynamicRegistry — atomic hot-reloadable multi-registry bundles (#1531)

### DIFF
--- a/.changeset/create-dynamic-registry.md
+++ b/.changeset/create-dynamic-registry.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): add `createDynamicRegistry` for atomic hot-reloadable multi-registry bundles
+
+Adds `createDynamicRegistry<TRegistries>()` — a factory for adopters that maintain multiple correlated Maps (adapters, v6 platforms, operational platforms, etc.) refreshed together from a config store. Centralises three atomicity lessons learned through repeated hand-rolled implementations:
+
+1. Single-pointer bundle swap — `bundle = pending` in one synchronous statement; readers never see a half-rebuilt mix across multiple Maps.
+2. In-flight refresh guard — concurrent `refresh()` calls coalesce onto the same Promise; the guard is cleared in `finally` so a thrown refresh never permanently freezes the registry.
+3. Static-id carry-forward with `unregister()` denylist — `staticIds()` is polled on each refresh for ids to preserve; `unregister(id)` removes from the live bundle AND suppresses from future carry-forward.
+
+Exported from `@adcp/sdk/server`. Replaces ~150 LOC of multi-registry plumbing per adopter deployment.

--- a/src/lib/server/dynamic-registry.ts
+++ b/src/lib/server/dynamic-registry.ts
@@ -1,0 +1,259 @@
+/**
+ * `createDynamicRegistry` — atomic hot-reload helper for adopters that manage
+ * multiple correlated Maps of platform objects (adapters, v6 platforms,
+ * operational platforms, etc.) refreshed together from a config store.
+ *
+ * ## The problem this solves
+ *
+ * Any adopter that hot-reloads tenants from a database maintains multiple
+ * parallel Maps that must be swapped together — a reader must never see
+ * `adapters` at version N+1 while `v6Platforms` is still at N. Three
+ * atomicity pitfalls appear in every hand-rolled implementation:
+ *
+ *   1. `clear() + for-set` looks atomic but is not across `await`.
+ *   2. Three separate pointer reassignments are not atomic across `await`.
+ *   3. Concurrent `refresh()` calls without an in-flight guard race
+ *      (last-writer-wins regardless of which snapshot is fresher).
+ *
+ * This factory bakes in the correct idioms: single-pointer bundle swap,
+ * in-flight coalescing guard (with `finally`-based release so a thrown
+ * refresh never freezes the registry), and static-id carry-forward with a
+ * denylist that respects explicit `unregister()` calls.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { createDynamicRegistry } from '@adcp/sdk/server';
+ * import type { PlatformIdentity, DecisioningPlatform } from '@adcp/sdk/server';
+ *
+ * const registry = createDynamicRegistry<{
+ *   adapters: PlatformIdentity;
+ *   v6: DecisioningPlatform;
+ * }>({
+ *   registries: ['adapters', 'v6'],
+ *   staticIds: () => Array.from(hardcodedPlatformIds),   // optional
+ *   refresh: async (pending) => {
+ *     const configs = await store.list();
+ *     for (const config of configs) {
+ *       pending.adapters.set(config.platformId, buildAdapter(config));
+ *       pending.v6.set(config.platformId, buildPlatform(config));
+ *     }
+ *   },
+ * });
+ *
+ * // Per-request lookups — typed per registry name:
+ * const adapter = registry.get('adapters', platformId); // PlatformIdentity | undefined
+ * const v6      = registry.get('v6', platformId);       // DecisioningPlatform | undefined
+ *
+ * // Hot-reload — overlapping calls coalesce onto the same Promise:
+ * await registry.refresh();
+ * ```
+ *
+ * ## Before the first `refresh()`
+ *
+ * All Maps are empty; `get()` returns `undefined` for every id. Callers
+ * that dispatch requests before the first refresh completes must handle
+ * `undefined` (or await the first `refresh()` during startup).
+ *
+ * ## Error behavior
+ *
+ * When `refresh()` throws, the previous bundle is preserved — the registry
+ * continues serving the last known-good state. The error is re-thrown to all
+ * callers that were coalesced onto that refresh Promise. The in-flight guard
+ * is cleared in `finally` so subsequent `refresh()` calls start fresh rather
+ * than remaining permanently frozen.
+ *
+ * ## `staticIds` carry-forward
+ *
+ * `staticIds()` is called on **each** `refresh()` so the adopter can update
+ * the static set at runtime. For each id returned by `staticIds()`, if
+ * `refresh` did not populate that id's entry in a named Map, the factory
+ * carries the previous bundle's entry forward. If an id has been explicitly
+ * `unregister()`-ed, it is suppressed from carry-forward even if
+ * `staticIds()` still returns it.
+ *
+ * ## `unregister(id)`
+ *
+ * Removes `id` from every named Map in the current bundle atomically
+ * (single-turn deletion, synchronous). Returns `true` if `id` was present
+ * in at least one Map. Also adds `id` to an internal denylist so future
+ * `refresh()` cycles do not carry it forward via `staticIds`. The denylist
+ * is permanent for the registry's lifetime — there is no "re-register a
+ * formerly unregistered id" path; if you need that, `refresh()` to a fresh
+ * bundle that includes the id.
+ *
+ * **Memory note.** The denylist grows by one entry per `unregister()` call
+ * and is never pruned. In long-lived processes with high tenant churn,
+ * recreate the registry periodically or manage the static-id list instead
+ * of relying on `unregister()` for large-scale eviction.
+ *
+ * @public
+ */
+
+/**
+ * Type-map from registry name to the value type stored in that registry's
+ * Map. Provide as the type parameter to `createDynamicRegistry`:
+ *
+ * ```ts
+ * createDynamicRegistry<{
+ *   adapters: PlatformIdentity;
+ *   v6: DecisioningPlatform;
+ * }>({ ... })
+ * ```
+ *
+ * @public
+ */
+export type RegistryTypeMap = Record<string, unknown>;
+
+/** @public */
+export interface DynamicRegistryOptions<TRegistries extends RegistryTypeMap> {
+  /**
+   * Names of the registries to manage. Must be a subset of `keyof TRegistries`.
+   * Each name gets its own `Map<string, TRegistries[name]>` in every bundle.
+   */
+  registries: ReadonlyArray<keyof TRegistries & string>;
+
+  /**
+   * Optional thunk returning ids that should be preserved across `refresh()`
+   * cycles. Called on every `refresh()` so you can update the set at runtime.
+   * Ids that `refresh()` already populated are unaffected; the carry-forward
+   * only applies to ids missing from the new pending Maps. Ids in the
+   * `unregister()` denylist are suppressed even if `staticIds()` returns them.
+   */
+  staticIds?: () => string[];
+
+  /**
+   * Populate the `pending` Maps for the next bundle. Called on every
+   * non-coalesced `refresh()`. The `pending` Maps are pre-allocated, fresh,
+   * and empty — do not hold references to them after `refresh` resolves;
+   * they become the live bundle and later modifications would race with
+   * concurrent readers.
+   *
+   * The callback's return value is ignored. Use closures to pass metadata
+   * (e.g. record count) to outer scope if needed.
+   */
+  refresh: (pending: { [K in keyof TRegistries]: Map<string, TRegistries[K]> }) => Promise<unknown>;
+}
+
+/** @public */
+export interface DynamicRegistry<TRegistries extends RegistryTypeMap> {
+  /**
+   * Look up an id in the named registry. Returns the value or `undefined` if
+   * the id is not in the current bundle. Type-safe per registry name.
+   */
+  get<K extends keyof TRegistries>(name: K, id: string): TRegistries[K] | undefined;
+
+  /**
+   * Trigger a hot-reload. Builds a fresh set of Maps by calling
+   * `opts.refresh(pending)`, carries forward any `staticIds` not populated by
+   * the callback, then atomically swaps the bundle with a single pointer
+   * assignment. Concurrent calls are coalesced — all callers share the same
+   * in-flight Promise. Sequential calls each get a fresh refresh.
+   *
+   * On throw: the previous bundle survives unchanged; the in-flight guard is
+   * cleared so subsequent calls succeed.
+   */
+  refresh(): Promise<void>;
+
+  /**
+   * Remove `id` from every named registry in the current bundle. Returns
+   * `true` if `id` was present in at least one registry. Also adds `id` to
+   * the denylist, suppressing it from `staticIds()` carry-forward on all
+   * future refreshes.
+   */
+  unregister(id: string): boolean;
+}
+
+/**
+ * Build a {@link DynamicRegistry} that manages multiple correlated Maps with
+ * atomic bundle-swap and in-flight refresh coalescing.
+ *
+ * @public
+ */
+export function createDynamicRegistry<TRegistries extends RegistryTypeMap>(
+  opts: DynamicRegistryOptions<TRegistries>
+): DynamicRegistry<TRegistries> {
+  type Bundle = { [K in keyof TRegistries]: Map<string, TRegistries[K]> };
+
+  const names = opts.registries;
+
+  function makeBundle(): Bundle {
+    const b = {} as Bundle;
+    for (const name of names) {
+      b[name] = new Map<string, TRegistries[typeof name]>();
+    }
+    return b;
+  }
+
+  // Live bundle — all reads go through this single pointer.
+  // Atomic because JavaScript is single-threaded: `bundle = pending`
+  // executes in one synchronous step between microtasks; concurrent
+  // readers are never mid-assignment.
+  let bundle: Bundle = makeBundle();
+
+  // In-flight guard — concurrent refresh() calls return the same Promise.
+  // Cleared in `finally` so a thrown refresh never permanently freezes
+  // the registry.
+  let inflight: Promise<void> | null = null;
+
+  // Ids explicitly removed via unregister() are suppressed from staticIds()
+  // carry-forward on all future refreshes.
+  const denylist = new Set<string>();
+
+  return {
+    get<K extends keyof TRegistries>(name: K, id: string): TRegistries[K] | undefined {
+      return bundle[name].get(id);
+    },
+
+    refresh(): Promise<void> {
+      if (inflight !== null) {
+        return inflight;
+      }
+
+      const pending = makeBundle();
+
+      const p: Promise<void> = (async () => {
+        await opts.refresh(pending);
+
+        // Carry forward static ids that refresh() didn't populate,
+        // unless they're in the unregister() denylist.
+        const staticIds = opts.staticIds?.() ?? [];
+        for (const id of staticIds) {
+          if (denylist.has(id)) continue;
+          for (const name of names) {
+            if (!pending[name].has(id)) {
+              const prev = bundle[name].get(id);
+              if (prev !== undefined) {
+                pending[name].set(id, prev);
+              }
+            }
+          }
+        }
+
+        // Atomic swap — single statement, executes synchronously between
+        // microtasks. All subsequent reads see the new bundle in full;
+        // no reader can observe a half-rebuilt mix.
+        bundle = pending;
+      })().finally(() => {
+        if (inflight === p) {
+          inflight = null;
+        }
+      });
+
+      inflight = p;
+      return p;
+    },
+
+    unregister(id: string): boolean {
+      let removed = false;
+      for (const name of names) {
+        if (bundle[name].delete(id)) {
+          removed = true;
+        }
+      }
+      // Suppress from staticIds() carry-forward on all future refreshes.
+      denylist.add(id);
+      return removed;
+    },
+  };
+}

--- a/src/lib/server/dynamic-registry.ts
+++ b/src/lib/server/dynamic-registry.ts
@@ -78,9 +78,8 @@
  * (single-turn deletion, synchronous). Returns `true` if `id` was present
  * in at least one Map. Also adds `id` to an internal denylist so future
  * `refresh()` cycles do not carry it forward via `staticIds`. The denylist
- * is permanent for the registry's lifetime — there is no "re-register a
- * formerly unregistered id" path; if you need that, `refresh()` to a fresh
- * bundle that includes the id.
+ * only suppresses carry-forward via `staticIds` — a future `refresh()` that
+ * explicitly populates the id in `pending` will make it available again.
  *
  * **Memory note.** The denylist grows by one entry per `unregister()` call
  * and is never pruned. In long-lived processes with high tenant churn,
@@ -202,7 +201,7 @@ export function createDynamicRegistry<TRegistries extends RegistryTypeMap>(
 
   return {
     get<K extends keyof TRegistries>(name: K, id: string): TRegistries[K] | undefined {
-      return bundle[name].get(id);
+      return bundle[name]?.get(id);
     },
 
     refresh(): Promise<void> {

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -440,6 +440,13 @@ export { createRosterAccountStore, type RosterAccountStoreOptions } from '../ada
 
 export { createDerivedAccountStore, type DerivedAccountStoreOptions } from '../adapters/derived-account-store';
 
+export {
+  createDynamicRegistry,
+  type DynamicRegistryOptions,
+  type DynamicRegistry,
+  type RegistryTypeMap,
+} from './dynamic-registry';
+
 // ---------------------------------------------------------------------------
 // Socket Mode — outbound WebSocket bridge for adopter dev environments
 // ---------------------------------------------------------------------------

--- a/test/lib/dynamic-registry.test.js
+++ b/test/lib/dynamic-registry.test.js
@@ -1,0 +1,254 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+const { createDynamicRegistry } = require('../../dist/lib/server/dynamic-registry.js');
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeDeferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// ── Atomicity guarantees ───────────────────────────────────────────────────
+
+describe('createDynamicRegistry — atomicity guarantees', () => {
+  test('concurrent refresh() calls return the same Promise', async () => {
+    const deferred = makeDeferred();
+    const registry = createDynamicRegistry({
+      registries: ['adapters', 'v6'],
+      refresh: async pending => {
+        await deferred.promise;
+        pending.adapters.set('p1', { type: 'adapter' });
+        pending.v6.set('p1', { type: 'v6' });
+      },
+    });
+
+    const p1 = registry.refresh();
+    const p2 = registry.refresh();
+    assert.strictEqual(p1, p2, 'concurrent calls must return the same Promise identity');
+
+    deferred.resolve();
+    await p1;
+
+    assert.deepStrictEqual(registry.get('adapters', 'p1'), { type: 'adapter' });
+    assert.deepStrictEqual(registry.get('v6', 'p1'), { type: 'v6' });
+  });
+
+  test('sequential refresh() calls each get a fresh Promise', async () => {
+    let callCount = 0;
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      refresh: async pending => {
+        callCount++;
+        pending.adapters.set('p1', { version: callCount });
+      },
+    });
+
+    const p1 = registry.refresh();
+    await p1;
+    const p2 = registry.refresh();
+    await p2;
+
+    assert.notStrictEqual(p1, p2, 'sequential calls must return distinct Promises');
+    assert.strictEqual(callCount, 2);
+    assert.deepStrictEqual(registry.get('adapters', 'p1'), { version: 2 });
+  });
+
+  test('thrown refresh() clears in-flight guard; previous bundle survives', async () => {
+    let callCount = 0;
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      refresh: async pending => {
+        callCount++;
+        if (callCount === 1) throw new Error('first refresh fails');
+        pending.adapters.set('p1', { version: 2 });
+      },
+    });
+
+    // First refresh throws — bundle stays empty, guard is cleared
+    await assert.rejects(() => registry.refresh(), /first refresh fails/);
+    assert.strictEqual(registry.get('adapters', 'p1'), undefined, 'bundle unchanged on throw');
+
+    // Guard must be cleared so subsequent refresh succeeds
+    await registry.refresh();
+    assert.deepStrictEqual(registry.get('adapters', 'p1'), { version: 2 });
+    assert.strictEqual(callCount, 2);
+  });
+
+  test('concurrent callers both receive the thrown error', async () => {
+    const deferred = makeDeferred();
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      refresh: async () => {
+        await deferred.promise;
+        throw new Error('shared failure');
+      },
+    });
+
+    const p1 = registry.refresh();
+    const p2 = registry.refresh();
+    assert.strictEqual(p1, p2);
+
+    deferred.resolve(); // let the callback proceed to the explicit throw
+
+    const [r1, r2] = await Promise.allSettled([p1, p2]);
+    assert.strictEqual(r1.status, 'rejected');
+    assert.strictEqual(r2.status, 'rejected');
+    assert.match(r1.reason.message, /shared failure/);
+    assert.match(r2.reason.message, /shared failure/);
+  });
+
+  test('bundle swap is atomic — readers see new bundle in full, never half-rebuilt', async () => {
+    // This tests the single-pointer swap guarantee. Two registries must
+    // always be in sync — a reader can never see adapters at version N+1
+    // while v6 is at version N.
+    const registry = createDynamicRegistry({
+      registries: ['adapters', 'v6'],
+      refresh: async pending => {
+        pending.adapters.set('p1', { v: 2 });
+        pending.v6.set('p1', { v: 2 });
+      },
+    });
+
+    await registry.refresh(); // initial state v=2
+
+    // Simulate a reader that checks both registries synchronously
+    const adapterEntry = registry.get('adapters', 'p1');
+    const v6Entry = registry.get('v6', 'p1');
+    assert.deepStrictEqual(adapterEntry?.v, v6Entry?.v, 'both registries must reflect the same version');
+  });
+});
+
+// ── unregister() ──────────────────────────────────────────────────────────
+
+describe('createDynamicRegistry — unregister()', () => {
+  test('unregister() removes id from all named registries atomically', async () => {
+    const registry = createDynamicRegistry({
+      registries: ['adapters', 'v6'],
+      refresh: async pending => {
+        pending.adapters.set('p1', { type: 'adapter' });
+        pending.v6.set('p1', { type: 'v6' });
+        pending.adapters.set('p2', { type: 'adapter' });
+      },
+    });
+    await registry.refresh();
+
+    const removed = registry.unregister('p1');
+    assert.strictEqual(removed, true);
+    assert.strictEqual(registry.get('adapters', 'p1'), undefined);
+    assert.strictEqual(registry.get('v6', 'p1'), undefined);
+    // p2 unaffected
+    assert.deepStrictEqual(registry.get('adapters', 'p2'), { type: 'adapter' });
+  });
+
+  test('unregister() returns false when id was not present', async () => {
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      refresh: async () => {},
+    });
+    await registry.refresh();
+    assert.strictEqual(registry.unregister('nonexistent'), false);
+  });
+});
+
+// ── staticIds carry-forward ───────────────────────────────────────────────
+
+describe('createDynamicRegistry — staticIds carry-forward', () => {
+  test('staticIds are preserved when refresh does not repopulate them', async () => {
+    let firstRun = true;
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      staticIds: () => ['static-1'],
+      refresh: async pending => {
+        if (firstRun) {
+          firstRun = false;
+          pending.adapters.set('static-1', { v: 1 });
+        }
+        // second run: does not populate static-1
+        pending.adapters.set('dynamic-1', { v: 2 });
+      },
+    });
+
+    await registry.refresh();
+    assert.deepStrictEqual(registry.get('adapters', 'static-1'), { v: 1 });
+
+    await registry.refresh();
+    assert.deepStrictEqual(registry.get('adapters', 'static-1'), { v: 1 }, 'carried forward');
+    assert.deepStrictEqual(registry.get('adapters', 'dynamic-1'), { v: 2 });
+  });
+
+  test('staticIds are polled on each refresh so the set can change at runtime', async () => {
+    const staticSet = new Set(['s1']);
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      staticIds: () => Array.from(staticSet),
+      refresh: async pending => {
+        // always seeds s1 first run; subsequent runs seed s2 only
+      },
+    });
+
+    // First refresh — s1 has no prior value, nothing to carry forward
+    await registry.refresh();
+    assert.strictEqual(registry.get('adapters', 's1'), undefined);
+
+    // Prime s1 directly via refresh populating it
+    const registry2 = createDynamicRegistry({
+      registries: ['adapters'],
+      staticIds: () => Array.from(staticSet),
+      refresh: async pending => {
+        pending.adapters.set('s1', { first: true });
+      },
+    });
+    await registry2.refresh();
+    staticSet.add('s2'); // expand the static set at runtime
+    await registry2.refresh(); // second refresh: s1 carried forward, s2 not (no prior value)
+    assert.deepStrictEqual(registry2.get('adapters', 's1'), { first: true }, 's1 carried forward');
+  });
+
+  test('unregistered static id is suppressed from carry-forward', async () => {
+    let call = 0;
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      staticIds: () => ['static-1'],
+      refresh: async pending => {
+        call++;
+        if (call === 1) pending.adapters.set('static-1', { v: 1 });
+        // call 2: does NOT populate static-1, but staticIds still returns it
+      },
+    });
+
+    await registry.refresh();
+    assert.deepStrictEqual(registry.get('adapters', 'static-1'), { v: 1 });
+
+    registry.unregister('static-1');
+    await registry.refresh();
+    // staticIds() still returns 'static-1' but unregister() denylist suppresses carry-forward
+    assert.strictEqual(registry.get('adapters', 'static-1'), undefined);
+  });
+});
+
+// ── initial state ─────────────────────────────────────────────────────────
+
+describe('createDynamicRegistry — initial state', () => {
+  test('before first refresh(), get() returns undefined for all ids', () => {
+    const registry = createDynamicRegistry({
+      registries: ['adapters', 'v6'],
+      refresh: async () => {},
+    });
+    assert.strictEqual(registry.get('adapters', 'any-id'), undefined);
+    assert.strictEqual(registry.get('v6', 'any-id'), undefined);
+  });
+
+  test('unregister() before first refresh() returns false and does not throw', () => {
+    const registry = createDynamicRegistry({
+      registries: ['adapters'],
+      refresh: async () => {},
+    });
+    assert.strictEqual(registry.unregister('nonexistent'), false);
+  });
+});


### PR DESCRIPTION
Closes #1531

Adds `createDynamicRegistry<TRegistries>()` — a factory for adopters that maintain multiple correlated Maps of platform objects (adapters, v6 platforms, operational platforms, etc.) refreshed atomically from a config store. Centralises three atomicity lessons learned through repeated hand-rolled implementations in scope3data/agentic-adapters#248.

## What this does

**Single-pointer bundle swap.** All reads go through one `let bundle` pointer. The swap `bundle = pending` executes in one synchronous microtask-boundary step — readers never observe a half-rebuilt state where, e.g., `adapters` is at version N+1 while `v6` is at version N.

**In-flight refresh coalescing with `finally`-guarded release.** Concurrent `refresh()` calls return the same in-flight Promise. The guard is cleared in `finally`, so a thrown refresh never permanently freezes the registry. The previous bundle survives unchanged on any throw; the error is re-thrown to all coalesced callers.

**Static-id carry-forward with `unregister()` denylist.** `staticIds()` is polled on each `refresh()` (so the static set can change at runtime). For each id returned, if the `refresh` callback didn't populate it, the previous bundle's entry is preserved. `unregister(id)` removes from all Maps atomically and adds to a permanent denylist that suppresses `staticIds` carry-forward on all future refreshes. A future `refresh()` that explicitly populates the id in `pending` will make it available again.

## Type-safe API

```ts
import { createDynamicRegistry } from '@adcp/sdk/server';

const registry = createDynamicRegistry<{
  adapters: PlatformIdentity;
  v6: DecisioningPlatform;
  operational: OperationalPlatform;
}>({
  registries: ['adapters', 'v6', 'operational'],
  staticIds: () => Array.from(hardcodedPlatformIds),   // optional
  refresh: async (pending) => {
    const configs = await store.list();
    for (const config of configs) {
      pending.adapters.set(config.platformId, buildAdapter(config));
      pending.v6.set(config.platformId, buildPlatform(config));
      pending.operational.set(config.platformId, deriveOperational(config));
    }
  },
});

// Per-request lookups — typed per registry name:
const adapter = registry.get('adapters', platformId); // PlatformIdentity | undefined
const v6      = registry.get('v6', platformId);       // DecisioningPlatform | undefined

// Hot-reload — overlapping calls coalesce:
await registry.refresh();
```

Type parameter `TRegistries` is the value-type map per registry name. The `pending` callback parameter is typed `{ [K in keyof TRegistries]: Map<string, TRegistries[K]> }` — no `as const` footgun, no casting at call sites.

## What was tested

- `npm run format:check` — passed
- `npx tsc --project tsconfig.lib.json` — pre-existing `@types/node` / `moduleResolution=node10` errors only (same as PR #1528; not introduced by this PR)
- `npm run build:lib` — `tsx` unavailable in this environment; ran `tsc` directly, output verified in `dist/`
- `node --test test/lib/dynamic-registry.test.js` — **12/12 tests pass**

Test coverage:
- Concurrent `refresh()` → same Promise identity (atomicity of in-flight guard)
- Sequential `refresh()` → distinct Promises
- Thrown `refresh()` → inflight guard cleared via `finally`, previous bundle survives, error rethrown to all callers
- Concurrent callers both receive the thrown error (callback's explicit `throw` after resolved deferred)
- Bundle swap atomicity — both registries reflect the same version synchronously
- `unregister()` removes from all Maps, returns `true/false`
- `staticIds` carry-forward on second refresh
- `staticIds` polled per refresh (set can expand at runtime)
- Unregistered static id suppressed from carry-forward
- Initial state: `get()` returns `undefined` before first `refresh()`
- `unregister()` before `refresh()` returns `false` without throwing

**Known nits (not fixed — out of scope):**
- Test for "staticIds polled per refresh" creates `registry2` mid-test; could be split into two focused tests for clarity.
- `registries: []` (empty array) is not guarded — `get()` on any name returns `undefined` safely (optional chaining), but `refresh()` produces an empty bundle silently. Document-only fix if desired.
- `createDynamicRegistry` not yet in `docs/llms.txt` or `docs/TYPE-SUMMARY.md` — post-merge housekeeping.

## Pre-PR review

- **code-reviewer:** approved — no blockers; flagged one test dead-code defect (concurrent-error test was testing rejected-deferred propagation rather than the callback's explicit `throw`) and a denylist memory note. Both fixed before PR open.
- **dx-expert:** approved with nits — confirmed all three original blockers resolved (type-map API shape, `staticIds` semantics, error recovery); two nits applied as fixup commit: doc correction on `unregister` re-registration semantics and `get()` optional-chaining safe-miss guard.

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1533` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01TX1rajPsAv3z64R4Y9DBPk