### PR TITLE
feat(server): OperationalPlatform interface (#1530)

### DIFF
--- a/.changeset/operational-platform.md
+++ b/.changeset/operational-platform.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': minor
+---
+
+Add `OperationalPlatform` interface and `defineOperationalPlatform` factory for in-process consumers (price-optimization pollers, audience-sync task pollers, scheduled jobs, storefront fan-out paths) that don't carry an MCP request. Distinct from `DecisioningPlatform` (buyer-facing dispatch with `RequestContext`).
+
+Five-method surface: `extractContext` (synthesize per-call context from a stored token), `updateMediaBuy` (required), `getMediaBuyDelivery` (required), `pollAudienceStatus` (optional), `getProducts` (optional). Methods throw `AdcpError` for structured rejection, matching `DecisioningPlatform`'s convention.
+
+Type parameter `OperationalPlatform<TCtx extends OperationalContext>` carries adopter-specific context fields (advertiser id, sandbox mode, region) through every method without escape hatches.
+
+The named contract eliminates the seam every operational adopter would otherwise reinvent. v5 adapters duck-type-satisfy the interface (`extractContext` signature matches v5 `PlatformAdapter.extractContext`) so migration is mechanical. See #1530.

--- a/.changeset/operational-platform.md
+++ b/.changeset/operational-platform.md
@@ -4,8 +4,8 @@
 
 Add `OperationalPlatform` interface and `defineOperationalPlatform` factory for in-process consumers (price-optimization pollers, audience-sync task pollers, scheduled jobs, storefront fan-out paths) that don't carry an MCP request. Distinct from `DecisioningPlatform` (buyer-facing dispatch with `RequestContext`).
 
-Five-method surface: `extractContext` (synthesize per-call context from a stored token), `updateMediaBuy` (required), `getMediaBuyDelivery` (required), `pollAudienceStatus` (optional), `getProducts` (optional). Methods throw `AdcpError` for structured rejection, matching `DecisioningPlatform`'s convention.
+Five-method surface: `extractContext` (synthesize per-call context from a stored token), `updateMediaBuy` (required), `getMediaBuyDelivery` (required, takes `mediaBuyIds: readonly string[]` matching the wire-spec plural field), `pollAudienceStatuses` (optional, returns `Map<string, AudienceStatus>` aligned with `AudiencePlatform.pollAudienceStatuses`), `getProducts` (optional). Methods throw `AdcpError` for structured rejection, matching `DecisioningPlatform`'s convention.
 
 Type parameter `OperationalPlatform<TCtx extends OperationalContext>` carries adopter-specific context fields (advertiser id, sandbox mode, region) through every method without escape hatches.
 
-The named contract eliminates the seam every operational adopter would otherwise reinvent. v5 adapters duck-type-satisfy the interface (`extractContext` signature matches v5 `PlatformAdapter.extractContext`) so migration is mechanical. See #1530.
+The named contract eliminates the seam every operational adopter would otherwise reinvent. v5 adapters duck-type-satisfy `extractContext`'s shape (signature matches v5 `PlatformAdapter.extractContext`); methods that returned `Result<T, E>` in v5 / shim code need a `Result`-to-throw migration during adoption — replace `if (r.err) handle(r.err)` with `try { ... } catch (e) { if (e instanceof AdcpError) handle(e); }`. See #1530.

--- a/docs/guides/OPERATIONAL-PLATFORM.md
+++ b/docs/guides/OPERATIONAL-PLATFORM.md
@@ -1,0 +1,153 @@
+# OperationalPlatform — in-process operational contract
+
+`DecisioningPlatform` covers buyer-facing MCP request dispatch:
+`platform.sales.updateMediaBuy(req, ctx)` etc., with `ctx` built from
+`authInfo` via `AccountStore.resolve` and threading framework concerns
+(`state`, `resolve`, `ctxMetadata`, `handoffToTask`).
+
+In-process consumers are different. The price-optimization poller,
+audience-sync task poller, scheduled jobs, and the storefront fan-out
+path don't have an MCP request to derive auth from. They have a
+stored task with an access token (or no token at all, for
+server-side internal scans). They cannot honestly satisfy
+`RequestContext`.
+
+`OperationalPlatform` is the named contract for that seam.
+
+## When to use
+
+- **Pollers** that scan stored tasks and call upstream APIs on a
+  schedule (price stepping, audience-status polling).
+- **Storefront fan-out** that translates one buyer request into N
+  upstream calls, each with its own resolved tenant.
+- **Scheduled jobs** that perform server-side maintenance against
+  upstream platforms.
+
+If your code dispatches in response to an MCP request, you want
+`DecisioningPlatform`, not this.
+
+## Five methods
+
+```ts
+import { defineOperationalPlatform, type OperationalContext } from '@adcp/sdk/server';
+import { AdcpError } from '@adcp/sdk/server/decisioning';
+
+interface SnapOpCtx extends OperationalContext {
+  advertiserId: string;
+  sandbox: boolean;
+}
+
+export const snapOperational = defineOperationalPlatform<SnapOpCtx>({
+  platformId: 'snap',
+
+  // 1. Synthesize a per-call context from a stored token. The single
+  // documented credential-synthesis path outside `AccountStore.resolve`.
+  extractContext: async (args, sessionToken, requireAuth = true) => {
+    const token = sessionToken ?? String(args.snap_access_token ?? '');
+    if (!token && requireAuth) {
+      throw new AdcpError('AUTH_REQUIRED', { message: 'No Snap token available' });
+    }
+    return {
+      accessToken: token || undefined,
+      advertiserId: String(args.advertiser_id ?? ''),
+      sandbox: Boolean(args.sandbox),
+    };
+  },
+
+  // 2. Required — every operational consumer assumes it.
+  updateMediaBuy: async (ctx, request) => {
+    return upstream.update(ctx, request);
+  },
+
+  // 3. Required.
+  getMediaBuyDelivery: async (ctx, mediaBuyId, startTime, endTime) => {
+    return upstream.delivery(ctx, mediaBuyId, startTime, endTime);
+  },
+
+  // 4. Optional — audience-sync pollers only.
+  pollAudienceStatus: async (platformData, accessToken) => {
+    const map = new Map();
+    for (const audienceId of upstream.listAudiences(platformData, accessToken)) {
+      map.set(audienceId, /* ... */);
+    }
+    return map;
+  },
+
+  // 5. Optional — storefront bundle composition only.
+  getProducts: async (ctx, brief, contextId, brand, sourceChain) => {
+    return upstream.discoverProducts(ctx, { brief, contextId, brand, sourceChain });
+  },
+});
+```
+
+## Three call patterns of `extractContext`
+
+The combined signature `extractContext(args, sessionToken?, requireAuth?)`
+serves three distinct callers. Each passes a different combination:
+
+| Caller | `args` | `sessionToken` | `requireAuth` |
+|---|---|---|---|
+| **Poller** (price opt, audience) | `{}` | stored token | `true` |
+| **Storefront fan-out** | scrubbed buyer args | optional master token | `true` |
+| **Server-side scan** | `{}` | `undefined` | `false` |
+
+The combined signature matches the v5 `PlatformAdapter.extractContext`
+shape so v5 adapters duck-type-satisfy this interface during
+migration without a wrapper. Post-migration, the SDK may split
+into `synthesizeFromToken` / `synthesizeFromArgs` for tighter
+per-caller types — see [#1530](https://github.com/adcontextprotocol/adcp-client/issues/1530)
+for the follow-up.
+
+## Errors
+
+Methods throw `AdcpError` for structured rejection — same convention
+as `DecisioningPlatform`. Generic thrown `Error` / `TypeError`
+propagate to callers; pollers and fan-out code wrap with their own
+error classification.
+
+```ts
+updateMediaBuy: async (ctx, request) => {
+  if (request.canceled && /* already terminal */) {
+    throw new AdcpError('NOT_CANCELLABLE', {
+      message: 'Media buy cannot be canceled in its current state',
+    });
+  }
+  // ...
+},
+```
+
+## Composing with `DecisioningPlatform`
+
+Most adopters ship both: a `DecisioningPlatform` for buyer-facing
+dispatch and an `OperationalPlatform` for in-process consumers. Both
+typically delegate to the same upstream-client module. Keeping them
+as separate contracts (rather than one mega-interface) lets each
+caller carry only the context it actually has.
+
+```ts
+// router.ts (adopter side)
+const decisioning: DecisioningPlatform<Config, SnapMeta> = ...;
+const operational: OperationalPlatform<SnapOpCtx> = snapOperational;
+
+// MCP dispatch
+createAdcpServerFromPlatform(decisioning, opts);
+
+// Poller
+const ctx = await operational.extractContext({}, await tokenStore.get(taskId));
+const result = await operational.updateMediaBuy(ctx, request);
+```
+
+## Credential discipline
+
+`OperationalPlatform.extractContext` is the only credential-synthesis
+path outside `AccountStore.resolve`. Apply the same discipline:
+
+- Re-derive bearers per request from a credential store; don't
+  embed long-lived secrets in args you persist.
+- Treat `args` as buyer-provided input — apply the same scrubbing
+  the buyer-facing path does. The storefront fan-out caller
+  typically scrubs once before invoking `extractContext` for each
+  upstream target.
+
+See [`CTX-METADATA-SAFETY.md`](./CTX-METADATA-SAFETY.md) for the
+full discipline.

--- a/docs/guides/OPERATIONAL-PLATFORM.md
+++ b/docs/guides/OPERATIONAL-PLATFORM.md
@@ -29,8 +29,7 @@ If your code dispatches in response to an MCP request, you want
 ## Five methods
 
 ```ts
-import { defineOperationalPlatform, type OperationalContext } from '@adcp/sdk/server';
-import { AdcpError } from '@adcp/sdk/server/decisioning';
+import { defineOperationalPlatform, type OperationalContext, AdcpError } from '@adcp/sdk/server';
 
 interface SnapOpCtx extends OperationalContext {
   advertiserId: string;
@@ -42,13 +41,22 @@ export const snapOperational = defineOperationalPlatform<SnapOpCtx>({
 
   // 1. Synthesize a per-call context from a stored token. The single
   // documented credential-synthesis path outside `AccountStore.resolve`.
+  //
+  // ⚠️  This signature serves THREE call patterns. Implement each
+  // case explicitly. The `args` argument is buyer-controlled in the
+  // fan-out path, so DO NOT read credential-shaped keys from it
+  // outside the poller path. See "Three call patterns of
+  // extractContext" below for the full discipline.
   extractContext: async (args, sessionToken, requireAuth = true) => {
-    const token = sessionToken ?? String(args.snap_access_token ?? '');
-    if (!token && requireAuth) {
+    // Poller / scheduled job: trust `sessionToken` from the credential
+    // store. Treat `args` as empty / opaque; do NOT read credentials
+    // from it because the same method is invoked by the storefront
+    // fan-out path with a buyer-controlled args bag.
+    if (!sessionToken && requireAuth) {
       throw new AdcpError('AUTH_REQUIRED', { message: 'No Snap token available' });
     }
     return {
-      accessToken: token || undefined,
+      accessToken: sessionToken,
       advertiserId: String(args.advertiser_id ?? ''),
       sandbox: Boolean(args.sandbox),
     };
@@ -60,12 +68,12 @@ export const snapOperational = defineOperationalPlatform<SnapOpCtx>({
   },
 
   // 3. Required.
-  getMediaBuyDelivery: async (ctx, mediaBuyId, startTime, endTime) => {
-    return upstream.delivery(ctx, mediaBuyId, startTime, endTime);
+  getMediaBuyDelivery: async (ctx, mediaBuyIds, startTime, endTime) => {
+    return upstream.delivery(ctx, mediaBuyIds, startTime, endTime);
   },
 
   // 4. Optional — audience-sync pollers only.
-  pollAudienceStatus: async (platformData, accessToken) => {
+  pollAudienceStatuses: async (platformData, accessToken) => {
     const map = new Map();
     for (const audienceId of upstream.listAudiences(platformData, accessToken)) {
       map.set(audienceId, /* ... */);
@@ -142,12 +150,22 @@ const result = await operational.updateMediaBuy(ctx, request);
 `OperationalPlatform.extractContext` is the only credential-synthesis
 path outside `AccountStore.resolve`. Apply the same discipline:
 
-- Re-derive bearers per request from a credential store; don't
+- **Re-derive bearers per request** from a credential store; don't
   embed long-lived secrets in args you persist.
-- Treat `args` as buyer-provided input — apply the same scrubbing
+- **Treat `args` as buyer-provided input** — apply the same scrubbing
   the buyer-facing path does. The storefront fan-out caller
   typically scrubs once before invoking `extractContext` for each
-  upstream target.
+  upstream target. The poller path passes `args = {}` so this is
+  moot for pollers.
+- **`platformData` (passed to `pollAudienceStatuses`) is for opaque
+  upstream IDs only — never for bearer tokens.** The contract passes
+  a fresh `accessToken` as a separate argument precisely because the
+  original auth principal that initiated the sync may be expired by
+  the time the poller runs. An adopter who stashed a bearer in
+  `platformData` at sync-init time and reads it from there in the
+  poll method will hit upstream with stale credentials. Best case:
+  401 noise. Worst case: requests land unauthenticated against
+  adopters that have a fallback path on 401.
 
 See [`CTX-METADATA-SAFETY.md`](./CTX-METADATA-SAFETY.md) for the
 full discipline.

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -34,6 +34,9 @@ export type {
   RegistryShape,
 } from './dynamic-registry';
 
+export { defineOperationalPlatform } from './operational-platform';
+export type { OperationalPlatform, OperationalContext } from './operational-platform';
+
 export {
   capabilitiesResponse,
   productsResponse,

--- a/src/lib/server/operational-platform.ts
+++ b/src/lib/server/operational-platform.ts
@@ -27,7 +27,7 @@
  *    these per upstream target.
  * 3. `getMediaBuyDelivery` — required. Pollers read delivery metrics
  *    here.
- * 4. `pollAudienceStatus` — optional. Audience-sync pollers only.
+ * 4. `pollAudienceStatuses` — optional. Audience-sync pollers only.
  * 5. `getProducts` — optional. Storefront bundle composition only;
  *    server-side internal call, not buyer-facing dispatch.
  *
@@ -154,12 +154,20 @@ export interface OperationalPlatform<TCtx extends OperationalContext = Operation
    * the same reason as `updateMediaBuy`: every operational consumer
    * assumes it.
    *
+   * `mediaBuyIds` is plural — matches the wire-spec
+   * `GetMediaBuyDeliveryRequest.media_buy_ids` field (per AdCP 3.0
+   * and PR #1342). Pollers that batch-query N buys in one upstream
+   * call pass an array; single-buy callers pass `[id]`. Decomposed
+   * here (vs. taking the full request shape) because pollers
+   * synthesize requests internally and don't have a typed wire
+   * payload to thread.
+   *
    * `args` carries optional adopter-specific pass-through (e.g.
    * tenant-scoped query parameters); pollers leave it `undefined`.
    */
   getMediaBuyDelivery(
     ctx: TCtx,
-    mediaBuyId: string,
+    mediaBuyIds: readonly string[],
     startTime: string,
     endTime: string,
     args?: Record<string, unknown>
@@ -175,12 +183,25 @@ export interface OperationalPlatform<TCtx extends OperationalContext = Operation
    * initiated under a now-expired auth principal; the poller carries
    * a freshly-resolved token from its own credential store.
    *
+   * **`platformData` is for opaque upstream IDs only — never for
+   * bearer tokens.** The fresh `accessToken` argument is the blessed
+   * credential channel; reading a stale token from `platformData`
+   * defeats the design and lands requests with revoked auth.
+   *
    * Returns a `Map<audience_id, AudienceStatus>`. Audiences not
    * resolvable upstream are omitted from the map. Throw
    * `AdcpError('REFERENCE_NOT_FOUND')` only when the entire batch
    * is unresolvable for the tenant.
+   *
+   * Plural method name aligns with `AudiencePlatform.pollAudienceStatuses`
+   * (the buyer-facing analog), which also returns
+   * `Map<string, AudienceStatus>`. Signature differs because operational
+   * callers don't have a `RequestContext` to thread.
    */
-  pollAudienceStatus?(platformData: Record<string, unknown>, accessToken: string): Promise<Map<string, AudienceStatus>>;
+  pollAudienceStatuses?(
+    platformData: Record<string, unknown>,
+    accessToken: string
+  ): Promise<Map<string, AudienceStatus>>;
 
   /**
    * Discover advertising products. Used by storefront bundle services

--- a/src/lib/server/operational-platform.ts
+++ b/src/lib/server/operational-platform.ts
@@ -1,0 +1,250 @@
+/**
+ * `OperationalPlatform` — in-process operational contract.
+ *
+ * `DecisioningPlatform` covers buyer-facing MCP request dispatch:
+ * `platform.sales.updateMediaBuy(req, ctx)` etc., where `ctx` is a
+ * `RequestContext` built by the framework from `authInfo` via
+ * `AccountStore.resolve`, threading `state`, `resolve`, `ctxMetadata`,
+ * and `handoffToTask`.
+ *
+ * In-process consumers are different. The price-optimization poller,
+ * audience-sync task poller, scheduled jobs, and the storefront
+ * fan-out path do NOT have an MCP request to derive auth from. They
+ * have a stored task with an access token (or, for fan-out, no token
+ * — the storefront synthesizes one per upstream target). They cannot
+ * honestly satisfy `RequestContext`. Every adopter doing operational
+ * work would otherwise reinvent this seam.
+ *
+ * `OperationalPlatform` is the named contract for that seam. Five
+ * methods covering the real operational surface:
+ *
+ * 1. `extractContext` — synthesize a per-call platform context from
+ *    a stored token (and optional request args, for fan-out callers).
+ *    The single CTX-METADATA-SAFETY boundary outside
+ *    `AccountStore.resolve`: anything touching credentials in an
+ *    in-process consumer flows through here.
+ * 2. `updateMediaBuy` — required. Fan-out callers dispatch one of
+ *    these per upstream target.
+ * 3. `getMediaBuyDelivery` — required. Pollers read delivery metrics
+ *    here.
+ * 4. `pollAudienceStatus` — optional. Audience-sync pollers only.
+ * 5. `getProducts` — optional. Storefront bundle composition only;
+ *    server-side internal call, not buyer-facing dispatch.
+ *
+ * Naming the contract honestly — "operational" rather than "adapter"
+ * — separates it from any v5 `PlatformAdapter` baggage and from
+ * `DecisioningPlatform`'s MCP-request flow. Tests mock
+ * `OperationalPlatform`, not the broader v6 interface.
+ *
+ * Errors: methods throw `AdcpError` for structured rejection, matching
+ * `DecisioningPlatform`'s convention. Generic thrown `Error` /
+ * `TypeError` propagate; callers catch and log per their needs.
+ *
+ * Status: 6.10. See adcontextprotocol/adcp-client#1530.
+ *
+ * @see DecisioningPlatform — buyer-facing MCP dispatch
+ * @see docs/guides/CTX-METADATA-SAFETY.md — credential discipline
+ * @public
+ */
+
+import type {
+  GetMediaBuyDeliveryResponse,
+  GetProductsResponse,
+  UpdateMediaBuyRequest,
+  UpdateMediaBuyResponse,
+} from '../types/tools.generated';
+import type { AudienceStatus } from './decisioning/specialisms/audiences';
+
+/**
+ * Minimal context for in-process operational calls. Adopters extend
+ * with platform-specific fields (advertiser id, sandbox mode, region,
+ * etc.); the type parameter on `OperationalPlatform<TCtx>` carries
+ * the extension through.
+ *
+ * `accessToken` is the only field shared across adopters: the rest of
+ * the context shape is platform-internal. Pollers and scheduled jobs
+ * that legitimately have no token (server-side internal scans) leave
+ * it `undefined`.
+ *
+ * @example
+ * ```ts
+ * interface SnapOpCtx extends OperationalContext {
+ *   advertiserId: string;
+ *   sandbox: boolean;
+ * }
+ *
+ * const snapOps = defineOperationalPlatform<SnapOpCtx>({
+ *   platformId: 'snap',
+ *   extractContext: async (args, sessionToken) => ({
+ *     accessToken: sessionToken,
+ *     advertiserId: String(args.advertiser_id ?? ''),
+ *     sandbox: Boolean(args.sandbox),
+ *   }),
+ *   // ...
+ * });
+ * ```
+ */
+export interface OperationalContext {
+  /**
+   * The access token used by upstream HTTP calls. `undefined` for
+   * server-side internal scans that don't authenticate against a
+   * specific tenant.
+   */
+  accessToken: string | undefined;
+}
+
+/**
+ * In-process operational contract. Implementations dispatch to
+ * upstream platform APIs from pollers, scheduled jobs, fan-out paths,
+ * and other contexts that don't carry an MCP request.
+ *
+ * Type parameter `TCtx` extends {@link OperationalContext} to carry
+ * platform-specific context fields through every method.
+ */
+export interface OperationalPlatform<TCtx extends OperationalContext = OperationalContext> {
+  /**
+   * Stable platform identifier matching `DecisioningPlatform`'s
+   * registered name. Used by registries and routing layers to look up
+   * the operational delegate by platform.
+   */
+  readonly platformId: string;
+
+  /**
+   * Synthesize an operational context from a stored token (and
+   * optional request args for fan-out callers). The single
+   * documented credential-synthesis path outside
+   * `AccountStore.resolve` — so the only place adopters need
+   * CTX-METADATA-SAFETY review on the operational side.
+   *
+   * Three call patterns this method serves:
+   *   - **Poller / scheduled job**: `args` is `{}`, `sessionToken` is
+   *     the stored token. Returns a context bound to that token.
+   *   - **Storefront fan-out**: `args` is the (scrubbed) buyer
+   *     request body, `sessionToken` is the storefront's master
+   *     credential. Returns a context for one upstream target.
+   *   - **Server-side internal scan**: `args` is `{}`, `sessionToken`
+   *     is `undefined`, `requireAuth` is `false`. Returns a
+   *     no-token context.
+   *
+   * @param args - Optional request args (storefront fan-out path)
+   * @param sessionToken - Stored access token (poller path)
+   * @param requireAuth - Throw `AdcpError('AUTH_REQUIRED')` when no
+   *   token is available. Defaults to `true`.
+   *
+   * @remarks Post-migration the SDK will likely split this into
+   * `synthesizeFromToken` / `synthesizeFromArgs` (see #1530 for the
+   * follow-up). The combined signature today matches the v5
+   * `PlatformAdapter.extractContext` shape so v5 adapters duck-type
+   * satisfy this interface during migration without a wrapper.
+   */
+  extractContext(args: Record<string, unknown>, sessionToken?: string, requireAuth?: boolean): Promise<TCtx>;
+
+  /**
+   * Update a media buy upstream. Required because every operational
+   * consumer assumes it — adapters that can't update media buys have
+   * no business registering as operational.
+   *
+   * Throw `AdcpError` for structured rejection (`NOT_CANCELLABLE`,
+   * `CONFLICT`, etc.). Generic thrown errors propagate to the caller.
+   */
+  updateMediaBuy(ctx: TCtx, request: UpdateMediaBuyRequest): Promise<UpdateMediaBuyResponse>;
+
+  /**
+   * Fetch delivery metrics for one or more media buys. Required for
+   * the same reason as `updateMediaBuy`: every operational consumer
+   * assumes it.
+   *
+   * `args` carries optional adopter-specific pass-through (e.g.
+   * tenant-scoped query parameters); pollers leave it `undefined`.
+   */
+  getMediaBuyDelivery(
+    ctx: TCtx,
+    mediaBuyId: string,
+    startTime: string,
+    endTime: string,
+    args?: Record<string, unknown>
+  ): Promise<GetMediaBuyDeliveryResponse>;
+
+  /**
+   * Poll upstream for the current status of one or more audiences.
+   * Optional — only audience-sync pollers need this.
+   *
+   * Takes opaque `platformData` (whatever the adapter stored when
+   * initiating the sync) plus a fresh access token. No operational
+   * context is threaded because the original sync may have been
+   * initiated under a now-expired auth principal; the poller carries
+   * a freshly-resolved token from its own credential store.
+   *
+   * Returns a `Map<audience_id, AudienceStatus>`. Audiences not
+   * resolvable upstream are omitted from the map. Throw
+   * `AdcpError('REFERENCE_NOT_FOUND')` only when the entire batch
+   * is unresolvable for the tenant.
+   */
+  pollAudienceStatus?(platformData: Record<string, unknown>, accessToken: string): Promise<Map<string, AudienceStatus>>;
+
+  /**
+   * Discover advertising products. Used by storefront bundle services
+   * to query upstream platforms for products available for bundling
+   * — server-side internal call, not buyer-facing dispatch.
+   *
+   * Optional: bundle-search is opt-in per storefront, and not every
+   * upstream platform exposes a product-discovery surface.
+   *
+   * Signature differs from `SalesPlatform.getProducts` because the
+   * caller is a storefront bundle service, not an MCP request
+   * handler — they have a brief and brand context, not a typed
+   * `GetProductsRequest` wire payload.
+   */
+  getProducts?(
+    ctx: TCtx,
+    brief: string,
+    contextId?: string,
+    brand?: Record<string, unknown>,
+    sourceChain?: readonly string[]
+  ): Promise<GetProductsResponse>;
+}
+
+/**
+ * Type-level identity for an `OperationalPlatform` object literal.
+ * Forces the contextual type so handler bodies get typed `ctx` and
+ * `request` parameters in TypeScript without an explicit annotation.
+ *
+ * Mirrors the `definePlatform` family for `DecisioningPlatform`
+ * sub-interfaces — see `decisioning/platform-helpers.ts`.
+ *
+ * @example
+ * ```ts
+ * import { defineOperationalPlatform } from '@adcp/sdk/server';
+ * import { AdcpError } from '@adcp/sdk/server';
+ *
+ * interface SnapOpCtx extends OperationalContext {
+ *   advertiserId: string;
+ * }
+ *
+ * export const snapOperational = defineOperationalPlatform<SnapOpCtx>({
+ *   platformId: 'snap',
+ *   extractContext: async (args, sessionToken, requireAuth = true) => {
+ *     const token = sessionToken ?? String(args.snap_access_token ?? '');
+ *     if (!token && requireAuth) {
+ *       throw new AdcpError('AUTH_REQUIRED', { message: 'No Snap token available' });
+ *     }
+ *     return {
+ *       accessToken: token || undefined,
+ *       advertiserId: String(args.advertiser_id ?? ''),
+ *     };
+ *   },
+ *   updateMediaBuy: async (ctx, request) => {
+ *     // ctx.advertiserId typed ✓; request: UpdateMediaBuyRequest ✓
+ *     return upstream.update(ctx, request);
+ *   },
+ *   getMediaBuyDelivery: async (ctx, id, start, end) => {
+ *     return upstream.delivery(ctx, id, start, end);
+ *   },
+ * });
+ * ```
+ */
+export function defineOperationalPlatform<TCtx extends OperationalContext = OperationalContext>(
+  ops: OperationalPlatform<TCtx>
+): OperationalPlatform<TCtx> {
+  return ops;
+}

--- a/test/server-operational-platform.test.js
+++ b/test/server-operational-platform.test.js
@@ -1,0 +1,183 @@
+// Tests for #1530 — OperationalPlatform interface.
+//
+// `OperationalPlatform` is the named contract for in-process consumers
+// (pollers, scheduled jobs, storefront fan-out paths) that don't carry
+// an MCP request. Distinct from `DecisioningPlatform` (buyer-facing
+// MCP dispatch with `RequestContext`).
+//
+// The interface is type-shaped — there's no runtime dispatcher to test.
+// `defineOperationalPlatform` is a type-level identity helper, so its
+// behavioral contract is "returns the input unchanged." Most of the
+// value lives in the type system; these tests pin the runtime
+// guarantees and the public-surface shape.
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { defineOperationalPlatform } = require('../dist/lib/server/operational-platform');
+const { AdcpError } = require('../dist/lib/server/decisioning/async-outcome');
+
+describe('defineOperationalPlatform', () => {
+  it('returns the input platform object unchanged', () => {
+    const ops = {
+      platformId: 'test',
+      extractContext: async () => ({ accessToken: undefined }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    };
+    const result = defineOperationalPlatform(ops);
+    assert.strictEqual(result, ops, 'identity helper must not clone or wrap');
+  });
+
+  it('preserves optional methods when present', async () => {
+    const platformData = { ad_account_id: 'act_123' };
+    const ops = defineOperationalPlatform({
+      platformId: 'test',
+      extractContext: async () => ({ accessToken: 'tok' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+      pollAudienceStatus: async data => {
+        const m = new Map();
+        m.set(String(data.ad_account_id), 'active');
+        return m;
+      },
+      getProducts: async () => ({ products: [] }),
+    });
+    assert.strictEqual(typeof ops.pollAudienceStatus, 'function');
+    assert.strictEqual(typeof ops.getProducts, 'function');
+    assert.deepStrictEqual([...(await ops.pollAudienceStatus(platformData, 'tok')).entries()], [['act_123', 'active']]);
+  });
+
+  it('platforms without optional methods omit them entirely (not undefined-stub)', () => {
+    const ops = defineOperationalPlatform({
+      platformId: 'test',
+      extractContext: async () => ({ accessToken: 'tok' }),
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    });
+    assert.strictEqual('pollAudienceStatus' in ops, false);
+    assert.strictEqual('getProducts' in ops, false);
+  });
+});
+
+describe('OperationalPlatform — error contract', () => {
+  it('extractContext throws AdcpError(AUTH_REQUIRED) when token absent and requireAuth=true', async () => {
+    const ops = defineOperationalPlatform({
+      platformId: 'test',
+      extractContext: async (_args, sessionToken, requireAuth = true) => {
+        if (!sessionToken && requireAuth) {
+          throw new AdcpError('AUTH_REQUIRED', { message: 'No token available' });
+        }
+        return { accessToken: sessionToken };
+      },
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    });
+
+    await assert.rejects(
+      () => ops.extractContext({}, undefined, true),
+      err => err instanceof AdcpError && err.code === 'AUTH_REQUIRED'
+    );
+  });
+
+  it('extractContext returns no-token context when requireAuth=false', async () => {
+    const ops = defineOperationalPlatform({
+      platformId: 'test',
+      extractContext: async (_args, sessionToken, requireAuth = true) => {
+        if (!sessionToken && requireAuth) {
+          throw new AdcpError('AUTH_REQUIRED', { message: 'No token available' });
+        }
+        return { accessToken: sessionToken };
+      },
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    });
+
+    const ctx = await ops.extractContext({}, undefined, false);
+    assert.strictEqual(ctx.accessToken, undefined);
+  });
+
+  it('updateMediaBuy throws AdcpError on structured rejection (matches DecisioningPlatform convention)', async () => {
+    const ops = defineOperationalPlatform({
+      platformId: 'test',
+      extractContext: async () => ({ accessToken: 'tok' }),
+      updateMediaBuy: async () => {
+        throw new AdcpError('NOT_CANCELLABLE', {
+          message: 'Media buy cannot be canceled in its current state',
+        });
+      },
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    });
+
+    await assert.rejects(
+      () =>
+        ops.updateMediaBuy({ accessToken: 'tok' }, { media_buy_id: 'mb_1', canceled: true, idempotency_key: 'uuid-1' }),
+      err => err instanceof AdcpError && err.code === 'NOT_CANCELLABLE'
+    );
+  });
+});
+
+describe('OperationalPlatform — three call patterns of extractContext', () => {
+  // The shim-derived `extractContext(args, sessionToken?, requireAuth?)`
+  // serves three distinct patterns. These tests exercise each so the
+  // contract is locked in before the post-migration split into
+  // `synthesizeFromToken` / `synthesizeFromArgs`.
+
+  function buildOps(impl) {
+    return defineOperationalPlatform({
+      platformId: 'test',
+      extractContext: impl,
+      updateMediaBuy: async () => ({ media_buy_id: 'mb_1' }),
+      getMediaBuyDelivery: async () => ({
+        reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+        media_buy_deliveries: [],
+      }),
+    });
+  }
+
+  it('poller path — empty args, sessionToken provided', async () => {
+    const ops = buildOps(async (args, sessionToken) => {
+      assert.deepStrictEqual(args, {}, 'poller passes empty args');
+      assert.strictEqual(sessionToken, 'stored-token');
+      return { accessToken: sessionToken };
+    });
+    const ctx = await ops.extractContext({}, 'stored-token');
+    assert.strictEqual(ctx.accessToken, 'stored-token');
+  });
+
+  it('storefront fan-out — scrubbed args, optional master token', async () => {
+    const ops = buildOps(async (args, sessionToken) => ({
+      accessToken: sessionToken ?? String(args.context?.managed_access_token ?? ''),
+    }));
+    const ctx = await ops.extractContext({ context: { managed_access_token: 'storefront-creds' } }, undefined);
+    assert.strictEqual(ctx.accessToken, 'storefront-creds');
+  });
+
+  it('server-side scan — no args, no token, requireAuth=false', async () => {
+    const ops = buildOps(async (_args, sessionToken, requireAuth = true) => {
+      assert.strictEqual(requireAuth, false);
+      return { accessToken: sessionToken };
+    });
+    const ctx = await ops.extractContext({}, undefined, false);
+    assert.strictEqual(ctx.accessToken, undefined);
+  });
+});

--- a/test/server-operational-platform.test.js
+++ b/test/server-operational-platform.test.js
@@ -43,16 +43,19 @@ describe('defineOperationalPlatform', () => {
         reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
         media_buy_deliveries: [],
       }),
-      pollAudienceStatus: async data => {
+      pollAudienceStatuses: async data => {
         const m = new Map();
         m.set(String(data.ad_account_id), 'active');
         return m;
       },
       getProducts: async () => ({ products: [] }),
     });
-    assert.strictEqual(typeof ops.pollAudienceStatus, 'function');
+    assert.strictEqual(typeof ops.pollAudienceStatuses, 'function');
     assert.strictEqual(typeof ops.getProducts, 'function');
-    assert.deepStrictEqual([...(await ops.pollAudienceStatus(platformData, 'tok')).entries()], [['act_123', 'active']]);
+    assert.deepStrictEqual(
+      [...(await ops.pollAudienceStatuses(platformData, 'tok')).entries()],
+      [['act_123', 'active']]
+    );
   });
 
   it('platforms without optional methods omit them entirely (not undefined-stub)', () => {
@@ -65,7 +68,7 @@ describe('defineOperationalPlatform', () => {
         media_buy_deliveries: [],
       }),
     });
-    assert.strictEqual('pollAudienceStatus' in ops, false);
+    assert.strictEqual('pollAudienceStatuses' in ops, false);
     assert.strictEqual('getProducts' in ops, false);
   });
 });


### PR DESCRIPTION
Closes #1530.

## Summary

Adds a first-class SDK contract for in-process operational consumers — price-optimization pollers, audience-sync task pollers, scheduled jobs, storefront fan-out paths — that don't carry an MCP request and therefore can't honestly satisfy `RequestContext`.

Distinct from `DecisioningPlatform` (buyer-facing MCP dispatch). Five-method interface:

| Method | Required | Purpose |
|---|---|---|
| `extractContext(args, sessionToken?, requireAuth?)` | ✅ | Synthesize per-call context. Single credential-synthesis path outside `AccountStore.resolve`. |
| `updateMediaBuy(ctx, request)` | ✅ | Storefront fan-out + price-step pollers. |
| `getMediaBuyDelivery(ctx, id, start, end, args?)` | ✅ | Pollers + dashboards. |
| `pollAudienceStatus?(platformData, accessToken)` | optional | Audience-sync pollers only. |
| `getProducts?(ctx, brief, contextId?, brand?, sourceChain?)` | optional | Storefront bundle composition only. |

## Design calls

- **Throw `AdcpError`, not `Result<T, E>`** (per the post-merge sequencing decision on PR #1535). Matches `DecisioningPlatform`'s convention. Avoids forcing `neverthrow` as a peer dep on every adopter — the shim used `Result` for storefront-internal ergonomics, but for an SDK contract that an adopter learns once, throw-based aligns with everything else they touch.

- **Sibling of `DecisioningPlatform`, not a field on it.** Operational fan-out is a wiring pattern inside an adopter's sales handler (or a poller's main loop), not a separate AdCP surface. Keeping `OperationalPlatform` as a top-level interface avoids baking it into the `DecisioningPlatform` surface until a second pattern wants it.

- **Combined `extractContext(args, sessionToken?, requireAuth?)` signature.** Tests pin the three call patterns (poller / storefront fan-out / server-side scan). Per the [follow-up comment on #1530](https://github.com/adcontextprotocol/adcp-client/issues/1530#issuecomment-4367741058), the post-migration split into `synthesizeFromToken` / `synthesizeFromArgs` ships as a follow-up once v5 shells are retired. Today's combined shape lets v5 adapters duck-type-satisfy without a wrapper.

- **`OperationalContext` extends a minimal base type with `accessToken`.** Adopters extend with platform-specific fields (advertiser id, sandbox mode); the type parameter on `OperationalPlatform<TCtx>` carries the extension through every method.

## What this unblocks

- **#1529 L2** (typed wire-spec args / `WireSafe<T>` brand at the operational boundary) — this PR ships the boundary; L2 ships the typing.
- **scope3data/agentic-adapters#248** — that PR's shim can be replaced by the SDK type, dropping the parallel maintenance.
- Every future adopter that does anything beyond pure buyer-facing dispatch.

## Files

- `src/lib/server/operational-platform.ts` (new) — interface + factory
- `src/lib/server/index.ts` — re-exports
- `test/server-operational-platform.test.js` (new) — 9 tests
- `docs/guides/OPERATIONAL-PLATFORM.md` (new) — adopter guide
- `.changeset/operational-platform.md` (new) — minor bump

## Test plan

- [x] 9/9 new operational-platform tests pass
- [x] 1230/1230 server suite pass — no regression
- [x] format / typecheck / lint clean
- [x] Tests exercise: factory identity, optional method preservation, three `extractContext` call patterns, error propagation through `AdcpError`

## What this is NOT

- A migration of v5 `PlatformAdapter` → `OperationalPlatform`. v5 adapters duck-type-satisfy this interface (`extractContext` signature matches v5 by design); migration is mechanical at the adopter's pace.
- A change to `DecisioningPlatform`. Sibling, not field.
- The `extractContext` split into `synthesizeFromToken` / `synthesizeFromArgs` — that's the follow-up after v5 shells retire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)