### PR TITLE
feat(credential-policy): per-tool granular allow allowlist (#1538)

### DIFF
--- a/.changeset/credential-policy-allow-list.md
+++ b/.changeset/credential-policy-allow-list.md
@@ -1,0 +1,21 @@
+---
+'@adcp/sdk': minor
+---
+
+`credentialPolicy.tools` now accepts a granular `{ allow: string[] }` shape per-tool. Storefronts that legitimately accept ONE specific buyer-presented credential field (e.g. `delivery.api_token` on `activate_signal`) can permit only that path while still rejecting other credential-shaped keys — defense-in-depth scaling with the size of the exception, instead of opening the entire tool with `'lax'`.
+
+```ts
+credentialPolicy: {
+  policy: 'authInfo-only',
+  tools: {
+    // Coarse: every credential-shaped key passes
+    legacy_tool: 'lax',
+
+    // Granular: ONLY the listed paths pass; other credential-shaped
+    // keys still reject. Recommended over 'lax' wherever feasible.
+    activate_signal: { allow: ['delivery.api_token'] },
+  },
+}
+```
+
+Allowlist entries are exact-match dotted paths (the same shape the scanner emits in `details.credential_paths`). Construction-time validation throws on empty allow lists, non-string entries, or unregistered tool names. Closes #1538.

--- a/docs/guides/CTX-METADATA-SAFETY.md
+++ b/docs/guides/CTX-METADATA-SAFETY.md
@@ -213,14 +213,37 @@ credentialPolicy: {
 }
 ```
 
-Per-tool overrides for the rare legitimate buyer-creds tool:
+Per-tool overrides for the rare legitimate buyer-creds tool. Two
+shapes — pick the narrowest exception that works:
 
 ```ts
+// Coarse: this tool legitimately reads multiple credential keys.
+// Every credential-shaped key passes the scan (including names you
+// didn't anticipate — `password`, `client_secret`, etc.).
 credentialPolicy: {
   policy: 'authInfo-only',
-  tools: { activate_signal: 'lax' },  // adopter-specific carve-out
+  tools: { legacy_tool: 'lax' },
+}
+
+// Granular: this tool reads ONE specific credential field, by name.
+// Only the listed paths pass the scan; other credential-shaped keys
+// still reject. Recommended over 'lax' wherever feasible — defense
+// in depth scales with the size of the exception.
+credentialPolicy: {
+  policy: 'authInfo-only',
+  tools: {
+    activate_signal: { allow: ['delivery.api_token'] },
+    legacy_partner: { allow: ['partner_secret', 'context.partner_secret'] },
+  },
 }
 ```
+
+Allowlist entries are exact-match dotted paths — the same shape the
+scanner emits in `details.credential_paths`. Top-level fields are bare
+names; nested fields use dots; array elements use numeric indices.
+A typo in the allowlist won't match the actual path the scanner
+produces, so the reject still fires (the adopter sees the rejection
+in dev and notices the typo).
 
 The blessed credential channel remains `authInfo` (resolved by the
 framework's authenticator). Anything that arrives on the args bag is

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3242,9 +3242,16 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // / version injection on this path.
         if (credentialPolicy !== undefined) {
           const effectivePolicy = resolveCredentialPolicyForTool(credentialPolicy, toolName);
-          if (effectivePolicy === 'authInfo-only') {
+          if (effectivePolicy !== 'lax') {
             const hits = scanArgsForCredentials(params, credentialPolicyPatterns);
-            if (hits.length > 0) {
+            // Granular allow-list: filter hits by the per-tool
+            // allowlist. Adopters whose tool legitimately accepts a
+            // specific buyer-presented credential field list it here;
+            // other credential-shaped keys still reject. String mode
+            // ('authInfo-only') means no allowlist — every hit blocks.
+            const blockedPaths =
+              typeof effectivePolicy === 'object' ? hits.filter(p => !effectivePolicy.allow.includes(p)) : hits;
+            if (blockedPaths.length > 0) {
               // Spec-correct code: the caller is authenticated and the
               // payload is schema-valid (every AdCP request schema sets
               // `additionalProperties: true`). What's refused is the
@@ -3263,7 +3270,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                 message:
                   'Request args carry credential-shaped keys. Credentials must arrive on authInfo, not in the request body.',
                 recovery: 'correctable',
-                details: { scope: 'credentials', credential_paths: hits },
+                details: { scope: 'credentials', credential_paths: blockedPaths },
               });
             }
           }

--- a/src/lib/server/credential-policy.ts
+++ b/src/lib/server/credential-policy.ts
@@ -54,6 +54,23 @@ export interface CredentialPatternsConfig {
 }
 
 /**
+ * Per-tool override shape. Adopters specify either a mode string for
+ * coarse-grained override (`'lax'` lets every credential-shaped key
+ * through; `'authInfo-only'` rejects them all) or a granular
+ * `{ allow: [...] }` allowlist that permits specific credential paths
+ * while still rejecting unlisted ones.
+ *
+ * The `allow` shape is the recommended choice for storefronts that
+ * legitimately accept ONE specific buyer-presented credential per
+ * tool — `tools: { activate_signal: 'lax' }` opens the tool to every
+ * credential-shaped key (including `password=`, `client_secret=`),
+ * while `tools: { activate_signal: { allow: ['delivery.api_token'] } }`
+ * permits only the spec-blessed field and still rejects everything
+ * else.
+ */
+export type ToolCredentialPolicy = CredentialPolicyMode | { readonly allow: readonly string[] };
+
+/**
  * Full credential-policy configuration. Pass a string for the simple
  * case (`credentialPolicy: 'authInfo-only'`) or this shape for
  * pattern customization or per-tool overrides.
@@ -69,11 +86,25 @@ export interface CredentialPolicyConfig {
    * ```ts
    * credentialPolicy: {
    *   policy: 'authInfo-only',
-   *   tools: { activate_signal: 'lax' },
+   *   tools: {
+   *     // Coarse: lets every credential-shaped key through
+   *     legacy_tool: 'lax',
+   *
+   *     // Granular: only the listed paths are allowlisted; other
+   *     // credential-shaped keys still reject. Recommended for
+   *     // tools where the legitimate buyer-presented credential is
+   *     // a known, named field.
+   *     activate_signal: { allow: ['delivery.api_token'] },
+   *   },
    * }
    * ```
+   *
+   * Allowlist entries are exact path matches against the
+   * dot-notation path the scanner emits — e.g. `'snap_access_token'`
+   * (top-level), `'context.linkedin_access_token'` (nested),
+   * `'packages.0.extra.tiktok_access_token'` (array element).
    */
-  tools?: Record<string, CredentialPolicyMode>;
+  tools?: Record<string, ToolCredentialPolicy>;
 }
 
 export type CredentialPolicy = CredentialPolicyMode | CredentialPolicyConfig;
@@ -228,14 +259,31 @@ export function scanArgsForCredentials(value: unknown, patterns?: CredentialPatt
 }
 
 /**
- * Normalize a `CredentialPolicy` (string or object) plus a tool name to
- * the effective {@link CredentialPolicyMode} for that tool. Per-tool
+ * Normalize a `CredentialPolicy` (string or object) plus a tool name
+ * to the effective {@link ToolCredentialPolicy} for that tool —
+ * either a mode string or an `{ allow: [...] }` allowlist. Per-tool
  * overrides win; otherwise the server-wide policy applies.
+ *
+ * Caller dispatch:
+ *
+ * ```ts
+ * const effective = resolveCredentialPolicyForTool(policy, toolName);
+ * if (effective === 'lax') return; // skip scan
+ * const hits = scanArgsForCredentials(args, patterns);
+ * if (typeof effective === 'object') {
+ *   // Granular allow — filter hits by the allowlist
+ *   const blocked = hits.filter(p => !effective.allow.includes(p));
+ *   if (blocked.length > 0) reject(blocked);
+ * } else {
+ *   // 'authInfo-only' — every hit blocks
+ *   if (hits.length > 0) reject(hits);
+ * }
+ * ```
  */
 export function resolveCredentialPolicyForTool(
   policy: CredentialPolicy | undefined,
   toolName: string
-): CredentialPolicyMode {
+): ToolCredentialPolicy {
   if (policy === undefined) return 'lax';
   if (typeof policy === 'string') return policy;
   return policy.tools?.[toolName] ?? policy.policy;
@@ -286,5 +334,33 @@ export function validateCredentialPolicy(
         `which fails-closed on tools that needed an opt-out. ` +
         `Known tool names: ${known}.`
     );
+  }
+
+  // Validate granular allow-shape entries — each must be a non-empty
+  // array of strings. An empty `allow` is the same as 'authInfo-only'
+  // for that tool (no path is permitted) and is almost certainly a
+  // bug — surface it at construction. Non-string entries would
+  // silently never match the dotted-path strings the scanner emits.
+  for (const [toolName, toolPolicy] of Object.entries(policy.tools)) {
+    if (typeof toolPolicy === 'string') continue;
+    if (!Array.isArray(toolPolicy.allow)) {
+      throw new Error(
+        `createAdcpServer: credentialPolicy.tools[${JSON.stringify(toolName)}].allow must be an array of path strings.`
+      );
+    }
+    if (toolPolicy.allow.length === 0) {
+      throw new Error(
+        `createAdcpServer: credentialPolicy.tools[${JSON.stringify(toolName)}].allow is empty. ` +
+          `An empty allow list is equivalent to 'authInfo-only' for this tool — drop the entry or use the string shorthand.`
+      );
+    }
+    const nonStrings = toolPolicy.allow.filter(p => typeof p !== 'string');
+    if (nonStrings.length > 0) {
+      throw new Error(
+        `createAdcpServer: credentialPolicy.tools[${JSON.stringify(toolName)}].allow contains non-string entries: ` +
+          `${nonStrings.map(n => JSON.stringify(n)).join(', ')}. ` +
+          `Allowlist entries are exact-match path strings (e.g. 'context.snap_access_token').`
+      );
+    }
   }
 }

--- a/test/server-credential-policy.test.js
+++ b/test/server-credential-policy.test.js
@@ -314,6 +314,15 @@ describe('resolveCredentialPolicyForTool', () => {
     assert.strictEqual(resolveCredentialPolicyForTool(cfg, 'get_products'), 'authInfo-only');
     assert.strictEqual(resolveCredentialPolicyForTool(cfg, 'activate_signal'), 'lax');
   });
+
+  it('returns granular allow shape verbatim', () => {
+    const cfg = {
+      policy: 'authInfo-only',
+      tools: { activate_signal: { allow: ['delivery.api_token'] } },
+    };
+    const resolved = resolveCredentialPolicyForTool(cfg, 'activate_signal');
+    assert.deepStrictEqual(resolved, { allow: ['delivery.api_token'] });
+  });
 });
 
 describe('validateCredentialPolicy', () => {
@@ -346,6 +355,44 @@ describe('validateCredentialPolicy', () => {
           KNOWN
         ),
       /cannot set both/
+    );
+  });
+
+  it('passes when granular allow lists are well-formed', () => {
+    assert.doesNotThrow(() =>
+      validateCredentialPolicy(
+        { policy: 'authInfo-only', tools: { activate_signal: { allow: ['delivery.api_token'] } } },
+        KNOWN
+      )
+    );
+  });
+
+  it('throws when allow is not an array', () => {
+    assert.throws(
+      () =>
+        validateCredentialPolicy(
+          { policy: 'authInfo-only', tools: { activate_signal: { allow: 'delivery.api_token' } } },
+          KNOWN
+        ),
+      /must be an array/
+    );
+  });
+
+  it('throws on empty allow list', () => {
+    assert.throws(
+      () => validateCredentialPolicy({ policy: 'authInfo-only', tools: { activate_signal: { allow: [] } } }, KNOWN),
+      /empty allow list/
+    );
+  });
+
+  it('throws on non-string entries in allow', () => {
+    assert.throws(
+      () =>
+        validateCredentialPolicy(
+          { policy: 'authInfo-only', tools: { activate_signal: { allow: ['ok', 42, null] } } },
+          KNOWN
+        ),
+      /non-string entries/
     );
   });
 });
@@ -466,6 +513,101 @@ describe('#1529 L1 — credentialPolicy server-wired enforcement', () => {
       snap_access_token: 'legitimate-buyer-presented',
     });
     assert.notStrictEqual(result.isError, true, `per-tool lax should allow credential-shaped key on opted-out tool`);
+  });
+
+  it('per-tool granular allow list permits listed paths only', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: {
+        policy: 'authInfo-only',
+        tools: {
+          get_media_buy_delivery: { allow: ['snap_access_token'] },
+        },
+      },
+    });
+    // snap_access_token is allowlisted — passes
+    const ok = await callDelivery(server, {
+      media_buy_ids: ['mb_1'],
+      snap_access_token: 'legitimate',
+    });
+    assert.notStrictEqual(ok.isError, true, 'allowlisted credential key passes');
+  });
+
+  it('per-tool granular allow list still rejects unlisted credential keys', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: {
+        policy: 'authInfo-only',
+        tools: {
+          get_media_buy_delivery: { allow: ['snap_access_token'] },
+        },
+      },
+    });
+    // tiktok_access_token is NOT allowlisted — rejects (defense in
+    // depth: opening one tool to a specific creds field doesn't open
+    // it to ALL creds fields)
+    const blocked = await callDelivery(server, {
+      media_buy_ids: ['mb_1'],
+      tiktok_access_token: 'attacker',
+    });
+    assert.strictEqual(blocked.isError, true);
+    assert.deepStrictEqual(blocked.structuredContent.adcp_error.details.credential_paths, ['tiktok_access_token']);
+  });
+
+  it('per-tool granular allow list filters mixed payloads — listed pass, unlisted reject together', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: {
+        policy: 'authInfo-only',
+        tools: {
+          get_media_buy_delivery: { allow: ['snap_access_token', 'context.partner_secret'] },
+        },
+      },
+    });
+    const result = await callDelivery(server, {
+      media_buy_ids: ['mb_1'],
+      snap_access_token: 'allowed',
+      context: { partner_secret: 'allowed-too' },
+      ext: { tiktok_access_token: 'blocked' },
+    });
+    // Only the unlisted hit reports back; the two allowlisted paths
+    // pass the scan and don't appear in `credential_paths`.
+    assert.strictEqual(result.isError, true);
+    assert.deepStrictEqual(result.structuredContent.adcp_error.details.credential_paths, ['ext.tiktok_access_token']);
+  });
+
+  it('per-tool granular allow on the wrong tool does not affect other tools', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: {
+        policy: 'authInfo-only',
+        tools: {
+          // Allow on get_products only — get_media_buy_delivery still
+          // strictly authInfo-only.
+          get_products: { allow: ['snap_access_token'] },
+        },
+      },
+    });
+    const result = await callDelivery(server, {
+      media_buy_ids: ['mb_1'],
+      snap_access_token: 'attacker',
+    });
+    assert.strictEqual(result.isError, true);
+    assert.deepStrictEqual(result.structuredContent.adcp_error.details.credential_paths, ['snap_access_token']);
+  });
+
+  it('server construction throws on malformed allow list', () => {
+    assert.throws(
+      () =>
+        createAdcpServerFromPlatform(buildPlatform(), {
+          ...BASE_OPTS,
+          credentialPolicy: {
+            policy: 'authInfo-only',
+            tools: { get_media_buy_delivery: { allow: [] } }, // empty — meaningless
+          },
+        }),
+      /empty allow list/
+    );
   });
 
   it('server construction throws on typo in credentialPolicy.tools key', () => {


### PR DESCRIPTION
Closes #1538.

## Summary

L1 (#1535) shipped `credentialPolicy.tools` as `Record<string, 'lax' | 'authInfo-only'>`. Coarse: storefronts that legitimately accept ONE buyer-presented credential field had to open the tool entirely with `'lax'`, letting every credential-shaped key through.

This PR adds a granular `{ allow: string[] }` shape per tool — only the listed paths pass the scan; other credential-shaped keys still reject. Defense-in-depth scales with the size of the exception.

## Usage

```ts
credentialPolicy: {
  policy: 'authInfo-only',
  tools: {
    // Coarse: every credential-shaped key passes
    legacy_tool: 'lax',

    // Granular: ONLY listed paths pass; other credential keys still reject
    activate_signal: { allow: ['delivery.api_token'] },
    legacy_partner: { allow: ['partner_secret', 'context.partner_secret'] },
  },
}
```

Allowlist entries are exact-match dotted paths — same shape the scanner emits in `details.credential_paths`. Top-level fields are bare names; nested fields use dots; array elements use numeric indices.

## Construction-time validation

`validateCredentialPolicy` (already runs at server construction post-#1535) now also throws on:
- Empty `allow` list (equivalent to `'authInfo-only'` — almost certainly a bug).
- Non-array `allow`.
- Non-string entries (would silently never match the scanner's dotted-path strings).

## Files

- `src/lib/server/credential-policy.ts` — new `ToolCredentialPolicy` type, `resolveCredentialPolicyForTool` return widened, allow-list validation
- `src/lib/server/create-adcp-server.ts` — dispatcher branches on resolved policy type, filters `hits` by allowlist when present
- `test/server-credential-policy.test.js` — 10 new tests
- `docs/guides/CTX-METADATA-SAFETY.md` — coarse vs. granular guidance
- `.changeset/credential-policy-allow-list.md` — minor bump

## Backward compatibility

100% — `'lax'` / `'authInfo-only'` string shorthands still work. Adopters using existing per-tool overrides see no behavior change. The `resolveCredentialPolicyForTool` return type widened from `CredentialPolicyMode` to `ToolCredentialPolicy` (union); the function is `@internal` per #1535's review pass, so this isn't a public-API break.

## Test plan

- [x] 53/53 credential-policy tests pass (was 43, +10 new)
- [x] 1284/1284 server suite pass — no regression
- [x] Format / typecheck clean
- [x] Construction-time validation throws on empty allow, non-array, non-string entries (3 dedicated tests)
- [x] Server-wired dispatch tests: granular allow permits listed, rejects unlisted, filters mixed payloads, doesn't bleed across tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)