### PR TITLE
feat(credential-policy): scanAuthInfo for ctx.authInfo.extra (#1539)

### DIFF
--- a/.changeset/credential-policy-scan-authinfo.md
+++ b/.changeset/credential-policy-scan-authinfo.md
@@ -1,0 +1,20 @@
+---
+'@adcp/sdk': minor
+---
+
+`credentialPolicy.scanAuthInfo` (default `false`) extends the credential-shaped scan to cover `ctx.authInfo.extra` at any depth, using the same pattern set as the args scan. Closes the leak surface where custom authenticators stamp credential-shaped values into `authInfo.extra` (token-introspection responses, JWT claim sets, OAuth scope blobs) and adopter handler code or log lines propagate them.
+
+```ts
+createAdcpServer({
+  credentialPolicy: {
+    policy: 'authInfo-only',
+    scanAuthInfo: true,        // NEW: extend perimeter to authInfo.extra
+  },
+});
+```
+
+**Fully orthogonal to `policy` mode.** Adopters can mix `policy: 'lax' + scanAuthInfo: true` (trust args, defend authInfo log propagation) or any combination. Per-tool `'lax'` overrides only affect the args scan — `scanAuthInfo` fires regardless.
+
+**Wire-envelope discipline.** Args-bag hits report in `details.credential_paths` (existing behavior). `authInfo.extra` hits are LOG-ONLY — paths surface in `logger.warn` server-side; the wire envelope reports a coarse signal (`details.scope: 'credentials'`, `recovery: 'terminal'`) without enumerating which `extra` field tripped the scan. Prevents an info-disclosure oracle on internal authInfo structure the buyer has no read access to.
+
+Default `false` because OAuth introspection blobs and JWT claims in `extra` will false-positive on default patterns like `/_token$/i`. Adopters opt in only when their authenticator keeps `extra` credential-clean. Closes #1539.

--- a/docs/guides/CTX-METADATA-SAFETY.md
+++ b/docs/guides/CTX-METADATA-SAFETY.md
@@ -336,6 +336,51 @@ If you migrate from a hand-rolled `scrubRequestForFanout` (e.g. the
 `scope3data/agentic-adapters` shim), do the swap atomically — both
 helpers in the same diff, same code review, same merge.
 
+### `scanAuthInfo`: extending the perimeter to `ctx.authInfo.extra` (#1539)
+
+`credentialPolicy.policy` enforces the args-bag scan. Custom
+authenticators that stamp values into `authInfo.extra` (token-
+introspection responses, JWT claim sets, OAuth scope blobs) are
+outside that scan — but adopter handler code that reads
+`ctx.authInfo.extra.<credential>` for upstream auth produces a silent
+leak surface, and a buggy `BuyerAgentRegistry.resolve` factory that
+throws an error embedding `extra` lands the value in `logger.error`.
+
+`scanAuthInfo: true` extends the credential-shaped scan to cover
+`ctx.authInfo.extra` at any depth using the same pattern set as the
+args scan. **Orthogonal to `policy`** — adopters can mix-and-match:
+
+```ts
+// Strictest: scan both args and authInfo
+credentialPolicy: { policy: 'authInfo-only', scanAuthInfo: true }
+
+// Trust args, defend authInfo log propagation
+credentialPolicy: { policy: 'lax', scanAuthInfo: true }
+
+// L1 baseline (default — scanAuthInfo omitted)
+credentialPolicy: 'authInfo-only'
+```
+
+Default `false` is deliberate: OAuth introspection blobs and JWT
+claims in `extra` will false-positive on default patterns like
+`/_token$/i` (`id_token`, `access_token` claims that the framework's
+authenticator legitimately stamps). Adopters opt in only when their
+authenticator keeps `extra` credential-clean.
+
+**Wire-envelope discipline.** Args-bag hits report in
+`details.credential_paths` (the buyer already knows what they sent).
+**`authInfo.extra` hits are LOG-ONLY** — paths surface in
+`logger.warn` server-side; the wire envelope reports a coarse signal
+(`details.scope: 'credentials'`, `recovery: 'terminal'`) without
+enumerating which `extra` field tripped the scan. Disclosing
+authInfo paths to buyers would create a probing oracle for an
+internal value the buyer has no read access to.
+
+Per-tool `'lax'` overrides only affect the args scan — `scanAuthInfo`
+fires regardless. Adopters who legitimately stamp credential-shaped
+values into `authInfo.extra` should fix the authenticator, not
+per-tool-disable the scan.
+
 ### What `credentialPolicy` does NOT cover
 
 `credentialPolicy` closes the **credential-smuggling** half of the

--- a/docs/guides/CTX-METADATA-SAFETY.md
+++ b/docs/guides/CTX-METADATA-SAFETY.md
@@ -376,6 +376,18 @@ enumerating which `extra` field tripped the scan. Disclosing
 authInfo paths to buyers would create a probing oracle for an
 internal value the buyer has no read access to.
 
+**Log-sink discipline.** If your logger fans out to a buyer-readable
+destination (multi-tenant log multiplex, shared OTel collector with
+weak tenant routing), the path strings re-enter the disclosure
+surface. Keep `logger.warn` output on a tenant-isolated destination
+— same rule that applies to every other server-side log line per
+the rest of this guide.
+
+**Testing discipline.** The args scan runs first; if your test
+fixtures always carry args-bag credentials, you'll never exercise
+the authInfo path. Cover both independently — a dev test passing
+on the args side is no signal that the authInfo path works.
+
 Per-tool `'lax'` overrides only affect the args scan — `scanAuthInfo`
 fires regardless. Adopters who legitimately stamp credential-shaped
 values into `authInfo.extra` should fix the authenticator, not

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3310,10 +3310,24 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           if (extra !== null && extra !== undefined && typeof extra === 'object') {
             const authInfoHits = scanArgsForCredentials(extra, credentialPolicyPatterns);
             if (authInfoHits.length > 0) {
-              logger.warn('credentialPolicy: authInfo.extra carries credential-shaped keys', {
-                tool: toolName,
-                paths: authInfoHits.map(p => `authInfo.extra.${p}`),
-              });
+              // Wrap the log call defensively. Adopter loggers that throw
+              // on serialization (Pino circular-ref edge cases, custom
+              // transports that reject deep nesting, OTel exporters
+              // mid-flush) would otherwise fault the rejection path and
+              // surface as a generic 500 / unhandled rejection instead of
+              // the intended PERMISSION_DENIED. The asymmetry with the
+              // args-scan rejection (which doesn't log) made this a
+              // logger-misconfig DoS vector before this guard.
+              try {
+                logger.warn('credentialPolicy: authInfo.extra carries credential-shaped keys', {
+                  tool: toolName,
+                  paths: authInfoHits.map(p => `authInfo.extra.${p}`),
+                });
+              } catch {
+                // Swallow — the rejection envelope is the load-bearing
+                // signal; losing the diagnostic log is acceptable when
+                // the alternative is failing the request entirely.
+              }
               return adcpError('PERMISSION_DENIED', {
                 message:
                   'Request authentication context carries credential-shaped keys. Configure your authenticator to keep credentials off authInfo.extra.',

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3276,6 +3276,54 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
         }
 
+        // --- authInfo.extra credential scan (opt-in via #1539) ---
+        // FULLY ORTHOGONAL to the args-bag scan above. Whereas the args
+        // scan branches on `policy` mode and per-tool overrides
+        // (`'lax'` short-circuits), `scanAuthInfo: true` ALWAYS fires
+        // when set. The two settings answer different questions:
+        //
+        //   - `policy` / `tools` — does this server / tool accept buyer
+        //     credentials in the args bag?
+        //   - `scanAuthInfo` — does authInfo.extra carry credential-
+        //     shaped keys that adopter handler code or log lines could
+        //     leak?
+        //
+        // Per-tool `'lax'` opt-out only affects args. authInfo.extra
+        // is server-internal; adopters who legitimately stamp
+        // credential-shaped values into it should restructure the
+        // authenticator (extra is the wrong layer for credentials)
+        // rather than per-tool-disable the scan.
+        //
+        // Wire-envelope discipline (per #1539 design): args-bag hits
+        // surface in `details.credential_paths` (the buyer already
+        // knows what they sent); authInfo.extra hits are LOG-ONLY.
+        // Disclosing authInfo.extra paths to the buyer would create
+        // a probing oracle for an internal value the buyer has no
+        // read access to. The wire envelope reports a coarse signal:
+        // `details.scope: 'credentials'`, generic message, no paths.
+        if (
+          credentialPolicy !== undefined &&
+          typeof credentialPolicy !== 'string' &&
+          credentialPolicy.scanAuthInfo === true
+        ) {
+          const extra = ctx.authInfo?.extra;
+          if (extra !== null && extra !== undefined && typeof extra === 'object') {
+            const authInfoHits = scanArgsForCredentials(extra, credentialPolicyPatterns);
+            if (authInfoHits.length > 0) {
+              logger.warn('credentialPolicy: authInfo.extra carries credential-shaped keys', {
+                tool: toolName,
+                paths: authInfoHits.map(p => `authInfo.extra.${p}`),
+              });
+              return adcpError('PERMISSION_DENIED', {
+                message:
+                  'Request authentication context carries credential-shaped keys. Configure your authenticator to keep credentials off authInfo.extra.',
+                recovery: 'terminal',
+                details: { scope: 'credentials' },
+              });
+            }
+          }
+        }
+
         // --- Request schema validation (opt-in) ---
         // Runs before idempotency so drifted payloads never touch the
         // replay cache. `off` short-circuits without calling AJV.

--- a/src/lib/server/credential-policy.ts
+++ b/src/lib/server/credential-policy.ts
@@ -105,6 +105,48 @@ export interface CredentialPolicyConfig {
    * `'packages.0.extra.tiktok_access_token'` (array element).
    */
   tools?: Record<string, ToolCredentialPolicy>;
+
+  /**
+   * Extend the credential-shaped-key scan to cover `ctx.authInfo.extra`
+   * in addition to the buyer args bag. Default `false`.
+   *
+   * Custom authenticators that stamp values into `authInfo.extra` (token
+   * introspection responses, JWT claim sets, OAuth scope blobs) are
+   * outside L1's args-bag scan. Adopter handler code that reads
+   * `ctx.authInfo.extra.<credential>` for upstream auth produces a
+   * silent leak surface: a buggy `BuyerAgentRegistry.resolve` factory
+   * that throws an error embedding `extra` lands the value in
+   * `logger.error` before `redactCredentialPatterns` (which only catches
+   * labeled `Bearer <token>` shapes and ≥32-char base64 blobs) could
+   * mask it.
+   *
+   * Orthogonal to {@link policy} — adopters can mix-and-match. Common
+   * shapes:
+   *
+   * - `policy: 'authInfo-only', scanAuthInfo: true` — strictest.
+   * - `policy: 'lax', scanAuthInfo: true` — trust args, defend log
+   *   propagation of authInfo extras.
+   * - `policy: 'authInfo-only', scanAuthInfo: false` — current default
+   *   if `scanAuthInfo` is omitted; args-only enforcement.
+   *
+   * **Default `false` is deliberate.** OAuth introspection blobs and
+   * JWT claims in `extra` will false-positive on default patterns
+   * like `/_token$/i` (e.g. `id_token`, `access_token` claims that
+   * the framework's authenticator legitimately stamps).
+   *
+   * **Wire-envelope discipline.** Args-bag hits are reported in
+   * `details.credential_paths` (the buyer already sent these — no
+   * info disclosure). `authInfo.extra` hits are NOT reported on
+   * the wire; they're logged server-side only. Returning paths
+   * to the buyer would create a probing oracle for the structure
+   * of `authInfo.extra` (an internal value the buyer has no read
+   * access to). The wire envelope reports a coarse signal —
+   * `details.scope: 'credentials'` plus a generic message —
+   * without enumerating which `extra` field tripped the scan.
+   *
+   * See adcontextprotocol/adcp-client#1539.
+   */
+  scanAuthInfo?: boolean;
 }
 
 export type CredentialPolicy = CredentialPolicyMode | CredentialPolicyConfig;

--- a/test/server-credential-policy.test.js
+++ b/test/server-credential-policy.test.js
@@ -60,14 +60,17 @@ const BASE_OPTS = {
   validation: { requests: 'off', responses: 'off' },
 };
 
-function callDelivery(server, args) {
-  return server.dispatchTestRequest({
-    method: 'tools/call',
-    params: {
-      name: 'get_media_buy_delivery',
-      arguments: { account: { account_id: 'acc_1' }, ...args },
+function callDelivery(server, args, dispatchOpts) {
+  return server.dispatchTestRequest(
+    {
+      method: 'tools/call',
+      params: {
+        name: 'get_media_buy_delivery',
+        arguments: { account: { account_id: 'acc_1' }, ...args },
+      },
     },
-  });
+    dispatchOpts
+  );
 }
 
 describe('scanArgsForCredentials', () => {
@@ -704,5 +707,187 @@ describe('#1529 L1 — credentialPolicy server-wired enforcement', () => {
       `clean retry should succeed; got ${JSON.stringify(clean.structuredContent)}`
     );
     assert.strictEqual(handlerCalls, 1, 'handler must run on the clean retry');
+  });
+});
+
+describe('#1539 — scanAuthInfo perimeter expansion', () => {
+  // L1 (#1535) scans the buyer args bag. Custom authenticators that
+  // stamp credential-shaped values into authInfo.extra (token-
+  // introspection responses, JWT claim sets, OAuth scope blobs)
+  // bypass that scan entirely. scanAuthInfo extends the perimeter
+  // with two design constraints:
+  //   1. Orthogonal to `policy` mode (mix-and-match permitted).
+  //   2. Wire envelope reports a coarse signal — paths log-only —
+  //      to avoid an info-disclosure oracle on internal authInfo
+  //      structure the buyer has no read access to.
+
+  it('default — undefined scanAuthInfo never inspects authInfo.extra', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: 'authInfo-only', // string shorthand — no scanAuthInfo field
+    });
+    // authInfo.extra carries credential-shaped key — but scanAuthInfo
+    // defaults to false, so the request dispatches normally.
+    const result = await callDelivery(
+      server,
+      { media_buy_ids: ['mb_1'] },
+      {
+        authInfo: {
+          token: 't',
+          clientId: 'b',
+          scopes: [],
+          extra: { upstream_access_token: 'legitimate-introspection-claim' },
+        },
+      }
+    );
+    assert.notStrictEqual(result.isError, true, 'scanAuthInfo defaults off; request proceeds');
+  });
+
+  it('rejects when scanAuthInfo: true and authInfo.extra carries credential-shaped key', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: { policy: 'authInfo-only', scanAuthInfo: true },
+    });
+    const result = await callDelivery(
+      server,
+      { media_buy_ids: ['mb_1'] },
+      {
+        authInfo: {
+          token: 't',
+          clientId: 'b',
+          scopes: [],
+          extra: { upstream_access_token: 'attacker-claim' },
+        },
+      }
+    );
+    assert.strictEqual(result.isError, true);
+    const err = result.structuredContent.adcp_error;
+    assert.strictEqual(err.code, 'PERMISSION_DENIED');
+    assert.strictEqual(err.recovery, 'terminal');
+    assert.strictEqual(err.details.scope, 'credentials');
+  });
+
+  it('wire envelope does NOT enumerate authInfo.extra paths (info-disclosure oracle protection)', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: { policy: 'authInfo-only', scanAuthInfo: true },
+    });
+    const result = await callDelivery(
+      server,
+      { media_buy_ids: ['mb_1'] },
+      {
+        authInfo: {
+          token: 't',
+          clientId: 'b',
+          scopes: [],
+          extra: {
+            INTERNAL_FIELD_BUYER_SHOULD_NOT_PROBE: 'shape',
+            upstream_access_token: 'creds',
+          },
+        },
+      }
+    );
+    assert.strictEqual(result.isError, true);
+    const serialized = JSON.stringify(result);
+    // The internal authInfo.extra structure must NOT leak into the wire
+    // envelope. Buyers must not be able to probe one field at a time.
+    assert.ok(
+      !serialized.includes('INTERNAL_FIELD_BUYER_SHOULD_NOT_PROBE'),
+      'authInfo.extra field names must not appear in the wire envelope'
+    );
+    assert.ok(
+      !serialized.includes('upstream_access_token'),
+      'authInfo.extra credential paths must not appear in the wire envelope either'
+    );
+    // Coarse signal IS present so adopters know it's a credentials issue
+    assert.strictEqual(result.structuredContent.adcp_error.details.scope, 'credentials');
+    // No `credential_paths` array on the wire (paths log-only)
+    assert.ok(
+      !('credential_paths' in (result.structuredContent.adcp_error.details ?? {})),
+      'authInfo.extra rejections must NOT include credential_paths'
+    );
+  });
+
+  it('scanAuthInfo is orthogonal to policy mode — works with policy: lax', async () => {
+    // Adopter trusts args (some legitimate-but-credential-shaped fields
+    // pass through) but wants to defend authInfo.extra against custom-
+    // authenticator stamping. policy:'lax' + scanAuthInfo:true is the
+    // documented orthogonal combination.
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: { policy: 'lax', scanAuthInfo: true },
+    });
+    // Args carry credential-shaped key — passes (policy: lax)
+    const result = await callDelivery(
+      server,
+      { media_buy_ids: ['mb_1'], snap_access_token: 'pass-because-lax' },
+      {
+        authInfo: {
+          token: 't',
+          clientId: 'b',
+          scopes: [],
+          extra: { upstream_access_token: 'rejected-because-scanAuthInfo' },
+        },
+      }
+    );
+    // Rejection is from authInfo, not args
+    assert.strictEqual(result.isError, true);
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+  });
+
+  it('scanAuthInfo is fully orthogonal — per-tool lax disables ARGS scan but NOT authInfo scan', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: {
+        policy: 'authInfo-only',
+        scanAuthInfo: true,
+        tools: { get_media_buy_delivery: 'lax' },
+      },
+    });
+    // Per-tool lax: args scan short-circuits (snap_access_token
+    // passes). authInfo.extra scan still runs because scanAuthInfo
+    // is fully orthogonal — adopters who legitimately stamp
+    // credential-shaped values into authInfo.extra should fix the
+    // authenticator, not per-tool-disable the scan.
+    const result = await callDelivery(
+      server,
+      { media_buy_ids: ['mb_1'], snap_access_token: 'args-passes-because-tool-lax' },
+      {
+        authInfo: {
+          token: 't',
+          clientId: 'b',
+          scopes: [],
+          extra: { upstream_access_token: 'authInfo-still-rejects' },
+        },
+      }
+    );
+    assert.strictEqual(result.isError, true, 'authInfo scan runs even when per-tool lax disables args scan');
+    assert.strictEqual(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+  });
+
+  it('scanAuthInfo with no authInfo present is a no-op (does not fault)', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: { policy: 'authInfo-only', scanAuthInfo: true },
+    });
+    // No `authInfo` passed via dispatchTestRequest — ctx.authInfo undefined
+    const result = await callDelivery(server, { media_buy_ids: ['mb_1'] });
+    assert.notStrictEqual(result.isError, true, 'absent authInfo is not credentials-bearing');
+  });
+
+  it('args scan still runs alongside scanAuthInfo — args hits report paths normally', async () => {
+    const server = createAdcpServerFromPlatform(buildPlatform(), {
+      ...BASE_OPTS,
+      credentialPolicy: { policy: 'authInfo-only', scanAuthInfo: true },
+    });
+    // Args have a credential — args scan runs first and rejects
+    // BEFORE the authInfo scan. Wire envelope reports the args path
+    // (existing behavior — buyer sent it, no info leak).
+    const result = await callDelivery(server, {
+      media_buy_ids: ['mb_1'],
+      snap_access_token: 'attacker',
+    });
+    assert.strictEqual(result.isError, true);
+    assert.deepStrictEqual(result.structuredContent.adcp_error.details.credential_paths, ['snap_access_token']);
   });
 });


### PR DESCRIPTION
Closes #1539.

## Summary

Extends the credential-shaped scan to cover `ctx.authInfo.extra` at any depth. Closes the leak surface where custom authenticators stamp credential-shaped values into `authInfo.extra` (token-introspection responses, JWT claim sets, OAuth scope blobs) and adopter handler code or log lines propagate them.

```ts
createAdcpServer({
  credentialPolicy: {
    policy: 'authInfo-only',
    scanAuthInfo: true,        // NEW
  },
});
```

## Design decisions (per #1539 triage)

**Orthogonal to `policy`.** Adopters mix-and-match — `policy: 'lax' + scanAuthInfo: true` (trust args, defend authInfo log propagation) is a valid combination. Per-tool `'lax'` overrides only affect the args scan; `scanAuthInfo` fires regardless. This was the protocol expert's recommendation in triage.

**Wire-envelope discipline.** Args-bag hits report in `details.credential_paths` (existing behavior — buyer already knows what they sent). `authInfo.extra` hits are **LOG-ONLY** — paths surface via `logger.warn` server-side; the wire envelope reports a coarse signal:

```json
{
  "code": "PERMISSION_DENIED",
  "message": "Request authentication context carries credential-shaped keys. Configure your authenticator to keep credentials off authInfo.extra.",
  "recovery": "terminal",
  "details": { "scope": "credentials" }
}
```

No `credential_paths` array, no field names. Disclosing paths would let buyers probe internal authInfo structure one field at a time — they have no read access to that surface and shouldn't get a free oracle. This was the security reviewer's concern in triage.

**Default `false`.** OAuth introspection blobs and JWT claims in `extra` will false-positive on default patterns like `/_token$/i` (`id_token`, `access_token` claims the framework's authenticator legitimately stamps). Adopters opt in only when their authenticator keeps `extra` credential-clean.

**Stage 4 of #1269 is a parallel track.** That issue scrubs `logger.error` in the registry-resolution error path. This PR scrubs the dispatch-time perimeter. Two layers, both needed.

## Files

- `src/lib/server/credential-policy.ts` — new `scanAuthInfo?: boolean` field on `CredentialPolicyConfig` with extensive JSDoc
- `src/lib/server/create-adcp-server.ts` — second scan block in `toolHandler`, gated on `scanAuthInfo === true`, fully orthogonal to args-scan gating
- `test/server-credential-policy.test.js` — 7 new tests
- `docs/guides/CTX-METADATA-SAFETY.md` — adopter guide section
- `.changeset/credential-policy-scan-authinfo.md` — minor bump

## Test coverage

- Default-undefined doesn't inspect authInfo (back-compat)
- `scanAuthInfo: true` rejects credential-shaped extra fields
- Wire envelope OMITS authInfo paths AND `credential_paths` array
- Orthogonal to `policy: 'lax'` — authInfo still scans
- Per-tool `'lax'` disables args scan but NOT authInfo scan
- Absent authInfo is a no-op (defensive)
- Args scan still runs alongside — args hits report paths normally

## Test plan

- [x] 7 new credential-policy tests pass (60 total, was 53)
- [x] 1312/1312 server suite pass — no regression
- [x] Format / typecheck / lint clean
- [x] Wire-envelope no-leak invariant explicitly asserted via `JSON.stringify(result)` substring check on internal field name

🤖 Generated with [Claude Code](https://claude.com/claude-code)