### PR TITLE
docs(credential-policy): document operational-metadata false-positive class for scanAuthInfo

### DIFF
--- a/docs/guides/CTX-METADATA-SAFETY.md
+++ b/docs/guides/CTX-METADATA-SAFETY.md
@@ -361,11 +361,28 @@ credentialPolicy: { policy: 'lax', scanAuthInfo: true }
 credentialPolicy: 'authInfo-only'
 ```
 
-Default `false` is deliberate: OAuth introspection blobs and JWT
-claims in `extra` will false-positive on default patterns like
-`/_token$/i` (`id_token`, `access_token` claims that the framework's
-authenticator legitimately stamps). Adopters opt in only when their
-authenticator keeps `extra` credential-clean.
+Default `false` is deliberate. Two false-positive classes warrant
+the opt-in rather than opt-out shape:
+
+1. **JWT / OAuth introspection claims** — `id_token`, `access_token`,
+   `refresh_token` claims that the framework's authenticator
+   legitimately stamps into `extra` will match `/_token$/i`. Default-
+   true would reject every adopter running an OAuth-introspection
+   authenticator on first deploy.
+2. **Adopter-stashed operational metadata with credential-shaped
+   names** — fields like `account_secret`, `tenant_password`, or
+   `partner_api_key` used as opaque routing/lookup metadata (not
+   actual credentials) match the runtime patterns. Two ways to fix
+   when you opt in: (a) rename the field to something the matcher
+   doesn't catch (`account_external_id`, `tenant_lookup_key`), or
+   (b) extend the runtime matcher with `credentialPolicy.patterns.matcher`
+   to define a custom predicate that excludes your specific names.
+   Renaming is preferred — credential-shaped names in operational
+   metadata are themselves a code-review smell.
+
+Adopters opt in only when their authenticator keeps `extra`
+credential-clean and their operational-metadata field names don't
+overlap the matcher set.
 
 **Wire-envelope discipline.** Args-bag hits report in
 `details.credential_paths` (the buyer already knows what they sent).


### PR DESCRIPTION
Doc-only follow-up to #1546.

## Summary

Downstream review of #1546 (scanAuthInfo) flagged a real false-positive case the existing doc didn't cover: adopters who legitimately stash sensitive operational metadata in `authInfo.extra` (e.g., `account_secret`, `tenant_password`, `partner_api_key`) used as opaque routing keys, not as actual credentials. The runtime matcher would flag these.

The existing doc only called out the JWT / OAuth introspection-claim case. This PR adds the operational-metadata case.

## What changed

CTX-METADATA-SAFETY.md `scanAuthInfo` section now distinguishes **two** opt-in-blocker classes:

1. **JWT / OAuth introspection claims** — `id_token`, `access_token` stamped by the authenticator. (Already documented.)
2. **Adopter-stashed operational metadata** — credential-shaped field names used for non-credential routing/lookup. (NEW.) Two fixes documented: (a) rename to a non-matching name, or (b) extend the matcher via `credentialPolicy.patterns.matcher`. Renaming preferred — credential-shaped names in operational metadata are themselves a code-review smell.

## No code change

Pure doc. No tests, no changeset (per repo conventions, doc-only changes don't require a changeset).

## Test plan

- [x] `npm run format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)