### PR TITLE
fix(build): run schemas:ensure before wire-spec-fields codegen

### DIFF
--- a/.changeset/build-schemas-ensure.md
+++ b/.changeset/build-schemas-ensure.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+`npm run build:lib` now runs `schemas:ensure` before the wire-spec-fields codegen. The codegen reads from `schemas/cache/{version}/` (gitignored, populated by `sync-schemas`), so building on a fresh checkout — or from a CI workflow that doesn't explicitly sync schemas first — would fail with `schema cache not found`. `schemas:ensure` is the idempotent guard the pretest hook already uses; ~10ms when the cache is present, syncs only when missing. Fixes the Release workflow which calls `build:lib` directly.

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "prepare": "node scripts/install-hooks.js 2>/dev/null || true",
     "prepublishOnly": "npm run clean && npm run sync-schemas:all && (test -f src/lib/types/tools.generated.ts || npm run generate-types) && npm run build:lib && node --test-timeout=60000 --test-force-exit --test test/lib/adcp-client.test.js test/lib/validation.test.js test/lib/zod-schemas.test.js",
     "build": "npm run build:lib",
-    "build:lib": "npm run sync-version && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
+    "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
     "pretest": "npm run schemas:ensure",
     "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js",


### PR DESCRIPTION
## Problem

The Release workflow at `.github/workflows/release.yml:32` runs `npm run build:lib` directly with no `sync-schemas` step. Since `schemas/cache/` is gitignored AND the new `generate-wire-spec-fields.ts` codegen (added in #1544) reads from it, the release CI has been failing on every push to main since #1544 landed:

```
Error: generate-wire-spec-fields: schema cache not found at /home/runner/work/adcp-client/adcp-client/schemas/cache/3.0.6
```

This blocks the auto-generated Release PR from updating, blocking the 6.10.0 release.

## Fix

Add `schemas:ensure` to `build:lib` before the codegen. `schemas:ensure` is the idempotent guard the `pretest` hook already uses — ~10ms when the cache is present, syncs only when missing.

## Verified

- Build still succeeds locally with cache present (sync is a no-op)
- Deleting `schemas/cache/3.0.6/` and rebuilding triggers sync correctly
- Format / typecheck clean
- Tests still pass

## Patch bump

Build-pipeline fix; no library surface change. Patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)