### PR TITLE
fix(comply): pass extension params through simulate_delivery and simulate_budget_spend dispatchers

### DIFF
--- a/.changeset/fix-comply-simulate-params-passthrough.md
+++ b/.changeset/fix-comply-simulate-params-passthrough.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(comply): pass extension params through simulate_delivery and simulate_budget_spend dispatchers
+
+`comply_test_controller`'s `params` field is spec-canonical `additionalProperties: true`, but the `SIMULATE_DELIVERY` and `SIMULATE_BUDGET_SPEND` dispatcher cases in `handleTestControllerRequest` silently dropped all keys not in their fixed typed sets. Extension params like `vendor_metric_values` (used by the `vendor_metric_accountability` storyboard) never reached seller adapters.
+
+Both cases now spread the full `params` object verbatim. `TestControllerStore.simulateDelivery` and `simulateBudgetSpend`, along with `SimulateDeliveryParams` and `SimulateBudgetSpendParams` in `createComplyController`, gain `[key: string]: unknown` index signatures so extension fields are accessible to adapter authors without casting.

--- a/src/lib/server/test-controller.ts
+++ b/src/lib/server/test-controller.ts
@@ -261,6 +261,7 @@ export interface TestControllerStore {
       clicks?: number;
       reported_spend?: { amount: number; currency: string };
       conversions?: number;
+      [key: string]: unknown;
     }
   ): Promise<SimulationSuccess>;
 
@@ -269,6 +270,7 @@ export interface TestControllerStore {
     account_id?: string;
     media_buy_id?: string;
     spend_percentage: number;
+    [key: string]: unknown;
   }): Promise<SimulationSuccess>;
 
   /** Seed a product fixture. Returns when the fixture is persisted. */
@@ -878,12 +880,10 @@ async function handleTestControllerRequestImpl(
         if (!params?.media_buy_id) {
           return controllerError('INVALID_PARAMS', 'simulate_delivery requires params.media_buy_id');
         }
-        return await store.simulateDelivery(params.media_buy_id as string, {
-          impressions: params.impressions as number | undefined,
-          clicks: params.clicks as number | undefined,
-          reported_spend: params.reported_spend as { amount: number; currency: string } | undefined,
-          conversions: params.conversions as number | undefined,
-        });
+        // Spread params verbatim so extension fields (e.g. vendor_metric_values)
+        // reach the adapter — params is spec-canonical additionalProperties:true.
+        const { media_buy_id: simulateDeliveryId, ...simulateDeliveryRest } = params;
+        return await store.simulateDelivery(simulateDeliveryId as string, simulateDeliveryRest);
       }
 
       case CONTROLLER_SCENARIOS.SIMULATE_BUDGET_SPEND: {
@@ -899,11 +899,15 @@ async function handleTestControllerRequestImpl(
             'simulate_budget_spend requires params.account_id or params.media_buy_id'
           );
         }
-        return await store.simulateBudgetSpend({
-          account_id: params.account_id as string | undefined,
-          media_buy_id: params.media_buy_id as string | undefined,
-          spend_percentage: params.spend_percentage as number,
-        });
+        // Spread params verbatim so extension fields reach the adapter.
+        return await store.simulateBudgetSpend(
+          params as {
+            account_id?: string;
+            media_buy_id?: string;
+            spend_percentage: number;
+            [key: string]: unknown;
+          }
+        );
       }
 
       case CONTROLLER_SCENARIOS.FORCE_CREATE_MEDIA_BUY_ARM: {

--- a/src/lib/testing/comply-controller.ts
+++ b/src/lib/testing/comply-controller.ts
@@ -152,12 +152,14 @@ export interface SimulateDeliveryParams {
   clicks?: number;
   conversions?: number;
   reported_spend?: { amount: number; currency: string };
+  [key: string]: unknown;
 }
 
 export interface SimulateBudgetSpendParams {
   account_id?: string;
   media_buy_id?: string;
   spend_percentage: number;
+  [key: string]: unknown;
 }
 
 // ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1552

## Summary

The `SIMULATE_DELIVERY` and `SIMULATE_BUDGET_SPEND` dispatcher cases in `handleTestControllerRequest` (`src/lib/server/test-controller.ts`) constructed a new fixed-field object when calling seller store adapters, silently dropping every key not in the typed allowlist. Extension params like `vendor_metric_values` (used by the `vendor_metric_accountability` storyboard) never reached seller adapters.

`comply_test_controller.params` is spec-canonical `additionalProperties: true` (`TOOL_INPUT_SHAPE` declares `params` as `z.record(z.string(), z.unknown())`). The dispatcher must not strip unknown keys. This PR:

- **`SIMULATE_DELIVERY`**: destructures `media_buy_id` out of params, spreads the remainder verbatim to `store.simulateDelivery`
- **`SIMULATE_BUDGET_SPEND`**: casts `params` to the expected shape (preserving all keys) rather than constructing a new narrowed object
- **`TestControllerStore.simulateDelivery` / `simulateBudgetSpend`**: adds `[key: string]: unknown` index signatures so extension fields are accessible to adapter authors without casting
- **`SimulateDeliveryParams` / `SimulateBudgetSpendParams`** in `comply-controller.ts`: same index signature addition for `createComplyController` users

The `createComplyController` bridge at `comply-controller.ts:449` already spread `params` via `{ media_buy_id: mediaBuyId, ...params }` — the fix ensures extension fields survive the full dispatch chain.

## What was tested

- `tsc --project tsconfig.lib.json`: only pre-existing `moduleResolution=node10` deprecation warning (confirmed on `main` before changes)
- `prettier --check`: passes
- `node_modules` not installed in this environment; full test suite (`npm test`) requires deps. Pre-PR type check confirms no new TypeScript errors introduced.

**Nits surfaced by pre-PR review (not fixed — deferred to follow-up):**
- The `simulate_budget_spend` cast bypasses TypeScript narrowing on `spend_percentage` (pre-existing pattern matching the original code)
- No new regression tests for extension-field passthrough behavior
- Variable name `simulateDeliveryId` is verbose (cosmetic)

## Pre-PR review

- code-reviewer: approved — no blockers; nits noted (spend_percentage type narrowing gap pre-existing; missing regression test)
- ad-tech-protocol-expert: approved — non-breaking per spec; `params: additionalProperties: true` is the direct normative source; `simulate_budget_spend` asymmetric style is semantically justified

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01E727vDL5nPgrP6t3HZFRSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01E727vDL5nPgrP6t3HZFRSJ)_