### PR TITLE
feat(server): ctx.handoffToTask accepts optional task_id override

### DIFF
--- a/.changeset/handoff-task-id-option.md
+++ b/.changeset/handoff-task-id-option.md
@@ -1,0 +1,14 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(server): ctx.handoffToTask accepts optional task_id override
+
+Adds `options?: { task_id?: string }` to `ctx.handoffToTask(fn, options?)`.
+When `options.task_id` is set, the framework uses that exact string as the
+submitted task_id instead of minting a fresh one. Validates non-empty, ≤ 128
+characters. Closes #1554.
+
+Required for the `force_create_media_buy_arm` comply_test_controller scenario,
+which asserts the seller echoes the directive-supplied task_id verbatim on
+the create_media_buy submitted arm.

--- a/src/lib/server/decisioning/async-outcome.ts
+++ b/src/lib/server/decisioning/async-outcome.ts
@@ -185,15 +185,37 @@ export class AdcpError extends Error {
 const TASK_HANDOFF_BRAND: unique symbol = Symbol.for('@adcp/decisioning/task-handoff');
 
 /**
- * The handoff function lives in a WeakMap keyed by the `TaskHandoff`
- * marker object — NOT on the marker itself. This means the framework
- * can extract the function (it has the WeakMap reference) but adopters
- * holding only a `TaskHandoff<T>` value cannot invoke or inspect it.
- * Closes round-6 CR-3 / Protocol-L2: `_taskFn` was previously a
- * type-visible field that adopters could forge with their own
+ * Optional overrides for `ctx.handoffToTask`.
+ *
+ * @public
+ */
+export interface TaskHandoffOptions {
+  /**
+   * Use this exact string as the `task_id` instead of letting the framework
+   * mint a fresh one. Required when an upstream system (or a test-controller
+   * directive such as `force_create_media_buy_arm`) has already issued the ID
+   * and the spec contract demands the response echoes it verbatim.
+   *
+   * Constraints: non-empty, ≤ 128 characters. Throws if violated.
+   * The caller is responsible for uniqueness within the account.
+   */
+  task_id?: string;
+}
+
+type TaskHandoffEntry = {
+  fn: (taskCtx: TaskHandoffContext) => Promise<unknown>;
+  options?: TaskHandoffOptions;
+};
+
+/**
+ * The handoff fn and options live in a WeakMap keyed by the `TaskHandoff`
+ * marker object — NOT on the marker itself. Both are stored atomically in a
+ * single entry so `isTaskHandoff` and `_extractHandoffEntry` always see a
+ * consistent pair. Closes round-6 CR-3 / Protocol-L2: `_taskFn` was
+ * previously a type-visible field that adopters could forge with their own
  * `Symbol.for(...)` call.
  */
-const taskHandoffFns = new WeakMap<object, (taskCtx: TaskHandoffContext) => Promise<unknown>>();
+const taskHandoffEntries = new WeakMap<object, TaskHandoffEntry>();
 
 /**
  * Marker the framework recognizes as "promote this call to a task."
@@ -254,21 +276,25 @@ export interface TaskHandoffProgress {
  * Construct a `TaskHandoff<T>` marker. The framework's `ctx.handoffToTask`
  * helper invokes this; adopters don't call it directly.
  *
- * The `fn` is stashed in a module-private WeakMap keyed by the marker
- * object. Adopters can hold the marker and pass it through return
- * values, but cannot extract or invoke `fn` themselves — only the
- * framework's `_extractTaskFn` can.
+ * The `fn` and `options` are stashed atomically in a module-private WeakMap
+ * keyed by the marker object. Adopters can hold the marker and pass it through
+ * return values, but cannot extract or invoke `fn` themselves — only the
+ * framework's `_extractHandoffEntry` can.
  *
  * @internal
  */
 export function _createTaskHandoff<TResult>(
-  fn: (taskCtx: TaskHandoffContext) => Promise<TResult>
+  fn: (taskCtx: TaskHandoffContext) => Promise<TResult>,
+  options?: TaskHandoffOptions
 ): TaskHandoff<TResult> {
   // Frozen object so adopters can't mutate the brand field. Even if
   // they did, the dispatch seam keys on identity (WeakMap), not on
   // mutable structure.
   const marker = Object.freeze({ [TASK_HANDOFF_BRAND]: true as const });
-  taskHandoffFns.set(marker, fn as (taskCtx: TaskHandoffContext) => Promise<unknown>);
+  taskHandoffEntries.set(marker, {
+    fn: fn as (taskCtx: TaskHandoffContext) => Promise<unknown>,
+    options,
+  });
   return marker as TaskHandoff<TResult>;
 }
 
@@ -287,22 +313,22 @@ export function isTaskHandoff<TResult>(value: unknown): value is TaskHandoff<TRe
     typeof value === 'object' &&
     value !== null &&
     (value as Record<symbol, unknown>)[TASK_HANDOFF_BRAND] === true &&
-    taskHandoffFns.has(value as object)
+    taskHandoffEntries.has(value as object)
   );
 }
 
 /**
- * Extract the handoff function from a marker. Framework-only — the
+ * Extract the handoff fn and options from a marker. Framework-only — the
  * dispatch seam in `from-platform.ts` calls this after `isTaskHandoff`.
  * Returns `undefined` if the marker wasn't created by `_createTaskHandoff`
  * (forgery).
  *
  * @internal
  */
-export function _extractTaskFn<TResult>(
+export function _extractHandoffEntry<TResult>(
   handoff: TaskHandoff<TResult>
-): ((taskCtx: TaskHandoffContext) => Promise<TResult>) | undefined {
-  return taskHandoffFns.get(handoff as unknown as object) as
-    | ((taskCtx: TaskHandoffContext) => Promise<TResult>)
-    | undefined;
+): { fn: (taskCtx: TaskHandoffContext) => Promise<TResult>; options?: TaskHandoffOptions } | undefined {
+  const entry = taskHandoffEntries.get(handoff as unknown as object);
+  if (!entry) return undefined;
+  return entry as { fn: (taskCtx: TaskHandoffContext) => Promise<TResult>; options?: TaskHandoffOptions };
 }

--- a/src/lib/server/decisioning/context.ts
+++ b/src/lib/server/decisioning/context.ts
@@ -29,7 +29,7 @@ import type {
   PropertyList,
   CollectionList,
 } from '../../types/tools.generated';
-import type { TaskHandoff, TaskHandoffContext } from './async-outcome';
+import type { TaskHandoff, TaskHandoffContext, TaskHandoffOptions } from './async-outcome';
 import type { CtxMetadataRef, ResourceKind } from '../ctx-metadata';
 import type { BuyerAgent } from './buyer-agent';
 
@@ -128,8 +128,17 @@ export interface RequestContext<TAccount = Account> {
    *   return await this.commitSync(req);
    * }
    * ```
+   *
+   * Pass `options.task_id` when an upstream system or test-controller directive
+   * has already issued the task id and the spec contract requires the response
+   * to echo it verbatim (e.g. `force_create_media_buy_arm`). The framework uses
+   * the supplied id instead of minting a fresh one; `taskCtx.id` reflects it.
+   * Constraints: non-empty, ≤ 128 characters. Throws if violated.
    */
-  handoffToTask<TResult>(fn: (taskCtx: TaskHandoffContext) => Promise<TResult>): TaskHandoff<TResult>;
+  handoffToTask<TResult>(
+    fn: (taskCtx: TaskHandoffContext) => Promise<TResult>,
+    options?: TaskHandoffOptions
+  ): TaskHandoff<TResult>;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/lib/server/decisioning/index.ts
+++ b/src/lib/server/decisioning/index.ts
@@ -21,6 +21,7 @@
 // task primitives — the framework owns task lifecycle and dispatches the
 // `*Task` method in the background.
 export { type AdcpStructuredError, type ErrorCode, AdcpError } from './async-outcome';
+export type { TaskHandoffOptions } from './async-outcome';
 
 // Typed `AdcpError` subclasses — adopter convenience for the highest-traffic
 // error codes. Each class encodes the canonical code/recovery/field shape.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -112,7 +112,7 @@ import type {
 } from '../../media-buy-store';
 import { createPostgresTaskRegistry, getDecisioningTaskRegistryMigration } from './postgres-task-registry';
 import type { PgQueryable } from '../../postgres-task-store';
-import { isTaskHandoff, _extractTaskFn, type TaskHandoff } from '../async-outcome';
+import { isTaskHandoff, _extractHandoffEntry, type TaskHandoff } from '../async-outcome';
 import { TOOL_ENTITY_FIELDS } from './entity-hydration.generated';
 import { z } from 'zod';
 import { createInMemoryTaskRegistry, type TaskRegistry, type TaskRecord, type TaskStatus } from './task-registry';
@@ -2240,18 +2240,24 @@ async function routeIfHandoff<TInner, TWire>(
   project: (inner: TInner) => TWire | Promise<TWire>
 ): Promise<TWire | SubmittedEnvelope> {
   if (isTaskHandoff<TInner>(result)) {
-    const taskFn = _extractTaskFn(result);
-    if (!taskFn) {
+    const entry = _extractHandoffEntry(result);
+    if (!entry) {
       // Forgery — adopter constructed something with the brand symbol
       // but didn't go through ctx.handoffToTask. Treat as a sync
       // success arm with an empty body (caller-supplied projection
       // shapes the result; this branch is defensive).
       return await project(result as unknown as TInner);
     }
-    return dispatchHitl(taskRegistry, opts, async taskId => {
-      const inner = await taskFn(buildHandoffContext(taskRegistry, taskId));
-      return await project(inner);
-    });
+    const { fn: taskFn, options } = entry;
+    return dispatchHitl(
+      taskRegistry,
+      opts,
+      async taskId => {
+        const inner = await taskFn(buildHandoffContext(taskRegistry, taskId));
+        return await project(inner);
+      },
+      options?.task_id
+    );
   }
   // Catch the most common LLM-scaffolded mistake: hand-rolling a
   // `{status: 'submitted', task_id: '...'}` envelope instead of returning
@@ -2362,13 +2368,15 @@ async function emitSyncCompletionWebhook(opts: DispatchHitlOpts, result: unknown
 async function dispatchHitl<TResult>(
   taskRegistry: TaskRegistry,
   opts: DispatchHitlOpts,
-  taskFn: (taskId: string) => Promise<TResult>
+  taskFn: (taskId: string) => Promise<TResult>,
+  overrideTaskId?: string
 ): Promise<SubmittedEnvelope> {
   const createStart = Date.now();
   const { taskId } = await taskRegistry.create({
     tool: opts.tool,
     accountId: opts.accountId,
     hasWebhook: opts.pushNotificationUrl !== undefined,
+    ...(overrideTaskId !== undefined && { overrideTaskId }),
   });
   safeFire(
     opts.observability?.onTaskCreate,

--- a/src/lib/server/decisioning/runtime/postgres-task-registry.ts
+++ b/src/lib/server/decisioning/runtime/postgres-task-registry.ts
@@ -257,7 +257,7 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
         `INSERT INTO ${table} (task_id, tool, account_id, status, has_webhook) VALUES ($1, $2, $3, 'submitted', $4) ON CONFLICT (task_id) DO NOTHING`,
         [taskId, createOpts.tool, createOpts.accountId, createOpts.hasWebhook === true]
       );
-      if (result.rowCount === 0) {
+      if ((result.rowCount ?? 0) === 0) {
         throw new Error(`task_id already registered: ${taskId}`);
       }
       return { taskId };

--- a/src/lib/server/decisioning/runtime/postgres-task-registry.ts
+++ b/src/lib/server/decisioning/runtime/postgres-task-registry.ts
@@ -246,12 +246,20 @@ export function createPostgresTaskRegistry(opts: CreatePostgresTaskRegistryOptio
   const backgrounds = new Map<string, Promise<void>>();
 
   return {
-    async create(createOpts: { tool: string; accountId: string; hasWebhook?: boolean }): Promise<{ taskId: string }> {
-      const taskId = `task_${randomUUID()}`;
-      await pool.query(
-        `INSERT INTO ${table} (task_id, tool, account_id, status, has_webhook) VALUES ($1, $2, $3, 'submitted', $4)`,
+    async create(createOpts: {
+      tool: string;
+      accountId: string;
+      hasWebhook?: boolean;
+      overrideTaskId?: string;
+    }): Promise<{ taskId: string }> {
+      const taskId = createOpts.overrideTaskId ?? `task_${randomUUID()}`;
+      const result = await pool.query(
+        `INSERT INTO ${table} (task_id, tool, account_id, status, has_webhook) VALUES ($1, $2, $3, 'submitted', $4) ON CONFLICT (task_id) DO NOTHING`,
         [taskId, createOpts.tool, createOpts.accountId, createOpts.hasWebhook === true]
       );
+      if (result.rowCount === 0) {
+        throw new Error(`task_id already registered: ${taskId}`);
+      }
       return { taskId };
     },
 

--- a/src/lib/server/decisioning/runtime/task-registry.ts
+++ b/src/lib/server/decisioning/runtime/task-registry.ts
@@ -85,8 +85,17 @@ export interface TaskRegistry {
    *
    * `hasWebhook: true` when the buyer wired `push_notification_config.url`
    * — surfaced via `tasks_get`'s `has_webhook` field. Defaults to `false`.
+   *
+   * `overrideTaskId` — when set, the registry uses this exact string as the
+   * task id instead of minting a fresh one. Throws if the id is already
+   * registered (uniqueness is the caller's responsibility).
    */
-  create(opts: { tool: string; accountId: string; hasWebhook?: boolean }): Promise<{ taskId: string }>;
+  create(opts: {
+    tool: string;
+    accountId: string;
+    hasWebhook?: boolean;
+    overrideTaskId?: string;
+  }): Promise<{ taskId: string }>;
 
   /** Read a task by id. Returns `null` if unknown. */
   getTask<TResult = unknown>(taskId: string): Promise<TaskRecord<TResult> | null>;
@@ -133,8 +142,16 @@ export function createInMemoryTaskRegistry(): TaskRegistry {
   const backgrounds = new Map<string, Promise<void>>();
 
   return {
-    async create(opts: { tool: string; accountId: string; hasWebhook?: boolean }): Promise<{ taskId: string }> {
-      const taskId = `task_${randomUUID()}`;
+    async create(opts: {
+      tool: string;
+      accountId: string;
+      hasWebhook?: boolean;
+      overrideTaskId?: string;
+    }): Promise<{ taskId: string }> {
+      const taskId = opts.overrideTaskId ?? `task_${randomUUID()}`;
+      if (tasks.has(taskId)) {
+        throw new Error(`task_id already registered: ${taskId}`);
+      }
       const now = new Date().toISOString();
       tasks.set(taskId, {
         taskId,

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -31,7 +31,12 @@ import type { HandlerContext } from '../../create-adcp-server';
 import type { Account } from '../account';
 import type { RequestContext, CtxMetadataAccessor } from '../context';
 import type { TaskRegistry } from './task-registry';
-import { _createTaskHandoff, type TaskHandoffContext, type TaskHandoff } from '../async-outcome';
+import {
+  _createTaskHandoff,
+  type TaskHandoffContext,
+  type TaskHandoff,
+  type TaskHandoffOptions,
+} from '../async-outcome';
 import type { CtxMetadataStore, ResourceKind, CtxMetadataRef } from '../../ctx-metadata';
 
 /**
@@ -136,8 +141,19 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
       creativeFormat: stubResolver('creativeFormat'),
     },
     ctxMetadata,
-    handoffToTask<TResult>(fn: (taskCtx: TaskHandoffContext) => Promise<TResult>): TaskHandoff<TResult> {
-      return _createTaskHandoff(fn);
+    handoffToTask<TResult>(
+      fn: (taskCtx: TaskHandoffContext) => Promise<TResult>,
+      options?: TaskHandoffOptions
+    ): TaskHandoff<TResult> {
+      if (options?.task_id !== undefined) {
+        if (typeof options.task_id !== 'string' || options.task_id.length === 0) {
+          throw new Error('handoffToTask options.task_id must be a non-empty string');
+        }
+        if (options.task_id.length > 128) {
+          throw new Error('handoffToTask options.task_id must be ≤ 128 characters');
+        }
+      }
+      return _createTaskHandoff(fn, options);
     },
   };
 }

--- a/test/server-decisioning-handoff-task-id.test.js
+++ b/test/server-decisioning-handoff-task-id.test.js
@@ -1,0 +1,162 @@
+// Tests for ctx.handoffToTask options.task_id — adcp-client#1554.
+//
+// Contract: when a caller passes `options.task_id`, the framework uses that
+// exact string as the task_id on the wire instead of minting a fresh one.
+// Motivated by `force_create_media_buy_arm` which requires the seller to echo
+// a directive-supplied task_id verbatim.
+
+process.env.NODE_ENV = 'test';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
+const { createInMemoryTaskRegistry } = require('../dist/lib/server/decisioning/runtime/task-registry');
+
+function buildPlatform(overrides = {}) {
+  return {
+    capabilities: {
+      specialisms: ['sales-non-guaranteed'],
+      creative_agents: [],
+      channels: ['display'],
+      pricingModels: ['cpm'],
+      config: {},
+    },
+    accounts: {
+      resolve: async ref => ({
+        id: ref?.account_id ?? 'acc_1',
+        metadata: {},
+        authInfo: { kind: 'api_key' },
+      }),
+      upsert: async () => [],
+      list: async () => ({ items: [], nextCursor: null }),
+    },
+    statusMappers: {},
+    sales: {
+      getProducts: async () => ({ products: [] }),
+      getMediaBuy: async () => {
+        throw new Error('not implemented');
+      },
+      listMediaBuys: async () => ({ media_buys: [] }),
+      ...overrides,
+    },
+  };
+}
+
+async function dispatchCreate(server, extra = {}) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'create_media_buy',
+      arguments: {
+        idempotency_key: 'ik-' + Math.random().toString(36).slice(2),
+        packages: [],
+        start_time: '2026-05-01T00:00:00Z',
+        end_time: '2026-06-01T00:00:00Z',
+        account: { account_id: 'acc_1' },
+        ...extra,
+      },
+    },
+  });
+}
+
+describe('ctx.handoffToTask options.task_id (#1554)', () => {
+  it('emits the caller-supplied task_id on the wire verbatim', async () => {
+    const FORCED_ID = 'task_forced-by-directive-abc123';
+    const platform = buildPlatform({
+      createMediaBuy: async (_req, ctx) =>
+        ctx.handoffToTask(
+          async taskCtx => {
+            assert.strictEqual(taskCtx.id, FORCED_ID, 'taskCtx.id reflects the supplied task_id');
+            return { media_buy_id: 'mb_1', status: 'active' };
+          },
+          { task_id: FORCED_ID }
+        ),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'test',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await dispatchCreate(server);
+    assert.strictEqual(result.structuredContent.status, 'submitted');
+    assert.strictEqual(result.structuredContent.task_id, FORCED_ID);
+
+    await server.awaitTask(FORCED_ID);
+    const record = await server.getTaskState(FORCED_ID);
+    assert.strictEqual(record.status, 'completed');
+    assert.strictEqual(record.result.media_buy_id, 'mb_1');
+  });
+
+  it('without options, framework mints a fresh task_ prefixed id', async () => {
+    const platform = buildPlatform({
+      createMediaBuy: async (_req, ctx) =>
+        ctx.handoffToTask(async () => ({ media_buy_id: 'mb_auto', status: 'active' })),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'test',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await dispatchCreate(server);
+    assert.strictEqual(result.structuredContent.status, 'submitted');
+    assert.ok(result.structuredContent.task_id.startsWith('task_'), 'framework-minted id starts with task_');
+  });
+
+  it('rejects empty string task_id at call time', async () => {
+    const platform = buildPlatform({
+      createMediaBuy: async (_req, ctx) =>
+        ctx.handoffToTask(async () => ({ media_buy_id: 'mb_1', status: 'active' }), { task_id: '' }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'test',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await dispatchCreate(server);
+    assert.strictEqual(result.structuredContent.isError, true);
+    assert.match(JSON.stringify(result.structuredContent), /non-empty/);
+  });
+
+  it('rejects task_id longer than 128 characters at call time', async () => {
+    const longId = 'a'.repeat(129);
+    const platform = buildPlatform({
+      createMediaBuy: async (_req, ctx) =>
+        ctx.handoffToTask(async () => ({ media_buy_id: 'mb_1', status: 'active' }), { task_id: longId }),
+    });
+    const server = createAdcpServerFromPlatform(platform, {
+      name: 'test',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+
+    const result = await dispatchCreate(server);
+    assert.strictEqual(result.structuredContent.isError, true);
+    assert.match(JSON.stringify(result.structuredContent), /128/);
+  });
+});
+
+describe('createInMemoryTaskRegistry overrideTaskId collision guard (#1554)', () => {
+  it('throws when the same overrideTaskId is registered twice', async () => {
+    const registry = createInMemoryTaskRegistry();
+    await registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_dup' });
+    await assert.rejects(
+      () => registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_dup' }),
+      /already registered/
+    );
+  });
+
+  it('uses overrideTaskId as the returned taskId', async () => {
+    const registry = createInMemoryTaskRegistry();
+    const { taskId } = await registry.create({ tool: 't', accountId: 'a1', overrideTaskId: 'task_custom' });
+    assert.strictEqual(taskId, 'task_custom');
+  });
+
+  it('generates a task_ prefixed id when overrideTaskId is omitted', async () => {
+    const registry = createInMemoryTaskRegistry();
+    const { taskId } = await registry.create({ tool: 't', accountId: 'a1' });
+    assert.ok(taskId.startsWith('task_'));
+  });
+});

--- a/test/server-decisioning-handoff-task-id.test.js
+++ b/test/server-decisioning-handoff-task-id.test.js
@@ -43,12 +43,14 @@ function buildPlatform(overrides = {}) {
 }
 
 async function dispatchCreate(server, extra = {}) {
+  // Spec idempotency_key pattern: ^[A-Za-z0-9_.:-]{16,255}$. Pad with the
+  // call timestamp so each test run gets a unique value above the minimum.
   return server.dispatchTestRequest({
     method: 'tools/call',
     params: {
       name: 'create_media_buy',
       arguments: {
-        idempotency_key: 'ik-' + Math.random().toString(36).slice(2),
+        idempotency_key: 'ik-handoff-test-' + Date.now() + '-' + Math.random().toString(36).slice(2),
         packages: [],
         start_time: '2026-05-01T00:00:00Z',
         end_time: '2026-06-01T00:00:00Z',
@@ -116,7 +118,7 @@ describe('ctx.handoffToTask options.task_id (#1554)', () => {
     });
 
     const result = await dispatchCreate(server);
-    assert.strictEqual(result.structuredContent.isError, true);
+    assert.strictEqual(result.isError, true);
     assert.match(JSON.stringify(result.structuredContent), /non-empty/);
   });
 
@@ -133,7 +135,7 @@ describe('ctx.handoffToTask options.task_id (#1554)', () => {
     });
 
     const result = await dispatchCreate(server);
-    assert.strictEqual(result.structuredContent.isError, true);
+    assert.strictEqual(result.isError, true);
     assert.match(JSON.stringify(result.structuredContent), /128/);
   });
 });


### PR DESCRIPTION
Closes #1554

## Summary

The framework's `dispatchHitl` always minted a fresh `task_${randomUUID()}` id, making the `force_create_media_buy_arm` storyboard contract unreachable: the spec requires the seller to echo the directive-supplied `task_id` verbatim on the submitted arm.

This PR adds `options?: { task_id?: string }` to `ctx.handoffToTask(fn, options?)`. When set, the framework uses that exact string as the submitted task_id instead of minting a fresh one. `taskCtx.id` reflects the supplied value. Callers without options are unaffected.

**Changed files:**
- `async-outcome.ts` — `TaskHandoffOptions` interface; single `taskHandoffEntries` WeakMap stores `{ fn, options }` atomically; `_extractTaskFn` renamed to `_extractHandoffEntry`
- `context.ts` — `handoffToTask` signature + JSDoc
- `decisioning/index.ts` — exports `TaskHandoffOptions` by name
- `to-context.ts` — validation (non-empty, ≤ 128 chars, throws `Error`); forwards options to `_createTaskHandoff`
- `task-registry.ts` — `overrideTaskId?` on `TaskRegistry.create`; in-memory collision guard
- `postgres-task-registry.ts` — `overrideTaskId?`; `ON CONFLICT DO NOTHING` with `(rowCount ?? 0) === 0` guard
- `from-platform.ts` — `routeIfHandoff` extracts `options` from entry, threads `options.task_id` to `dispatchHitl`
- `test/server-decisioning-handoff-task-id.test.js` — 7 tests: custom id emitted verbatim, no-options regression, empty/long id rejection, registry collision unit tests

## What tested

- `prettier --check` — passed
- `tsc --project tsconfig.lib.json` — pre-existing `@types/node` + `moduleResolution=node10` environment diagnostics only (present on main before this change, exit 2); no new type errors introduced
- `npm test` — requires `node_modules`; CI will validate

**Nits surfaced by pre-PR review (not fixed — deferred):**
- Postgres collision under concurrent multi-instance retry (same `overrideTaskId` race) surfaces as 500 rather than idempotent response; pre-existing for minted IDs too — follow-up issue
- `to-context.ts` `typeof !== 'string'` guard unreachable from TS callers (reachable from plain-JS shims); test coverage gap noted
- `decisioning.type-checks.ts` missing `@ts-expect-error` negative case for `task_id: 42`

**Pre-PR review:**
- code-reviewer: approved after one blocker fixed (`rowCount === 0` → `(rowCount ?? 0) === 0` for pg null-rowCount on conflict)
- ad-tech-protocol-expert: approved — spec contract confirmed normative ("seller MUST emit verbatim"), `taskCtx.id` reflects override correctly, 128-char cap is SDK-defined/consistent with read-side cap, cross-specialism exposure correct

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01L7vuBEvg7NKMCPMW7Pk13q

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7vuBEvg7NKMCPMW7Pk13q)_