### PR TITLE
fix(conformance): add governance tools to PROBE_TASK_ALLOWLIST

### DIFF
--- a/.changeset/probe-task-governance-allowlist.md
+++ b/.changeset/probe-task-governance-allowlist.md
@@ -1,0 +1,7 @@
+---
+"@adcp/sdk": patch
+---
+
+Adds `list_property_lists`, `list_collection_lists`, and `list_content_standards` to the `PROBE_TASK_ALLOWLIST` in the storyboard runner. These governance read-only tools have all-optional request parameters and satisfy the three allowlist criteria (auth-required, read-only, accept empty body), so adopters running per-specialism governance tenants can now declare them as `test_kit.auth.probe_task` without the runner rejecting the kit.
+
+`get_brand_identity` and `get_rights` are intentionally excluded: both have required fields (`brand_id` and `query`/`uses` respectively), so an empty-body probe would receive a schema-validation 400 before the auth layer runs, causing `security_baseline` to misreport auth failures.

--- a/src/lib/testing/storyboard/test-kit.ts
+++ b/src/lib/testing/storyboard/test-kit.ts
@@ -38,6 +38,10 @@ export const PROBE_TASK_ALLOWLIST: readonly string[] = Object.freeze([
   'list_authorized_properties',
   'get_signals',
   'list_si_sessions',
+  // Governance read-only tools — all params optional, no required fields
+  'list_property_lists',
+  'list_collection_lists',
+  'list_content_standards',
 ]);
 
 /**


### PR DESCRIPTION
Closes #1558

Adds `list_property_lists`, `list_collection_lists`, and `list_content_standards` to `PROBE_TASK_ALLOWLIST` in `src/lib/testing/storyboard/test-kit.ts`. These governance read-only tools have all-optional request parameters and satisfy every criterion the allowlist enforces (auth-required, read-only, accept empty body), so adopters running per-specialism governance tenants can now declare them as `test_kit.auth.probe_task` without the runner rejecting the kit at load time.

**`get_brand_identity` and `get_rights` are intentionally excluded.** `GetBrandIdentityRequestSchema` requires `brand_id`; `GetRightsRequestSchema` requires `query` and `uses`. An empty-body probe against either would produce a schema-validation 400 before the auth layer runs — exactly the masking failure the allowlist prevents. Brand-tenant adopters still need a workaround (e.g. a custom test kit that passes a valid `brand_id`); a follow-up issue on `adcontextprotocol/adcp` should address whether `x-probe-safe` annotations belong in the spec.

**`list_content_standards` discriminated-union response shape is not a concern.** The probe evaluator (`validations.ts:1052–1106`) only inspects `hr.status` as an integer; it never parses the response body, so the union shape is irrelevant.

**Upstream storyboard narrative:** `test-kit.ts` line 31 notes that allowlist additions should be mirrored in the upstream adcp storyboard narrative (`adcontextprotocol/adcp`). A companion issue should be filed before this merges.

## What was tested

- `npm run format:check` — passed
- `npm run build:lib` and `npm test` could not run locally (no `node_modules` in triage environment; `tsx` not in PATH). Pre-existing typecheck failure (`TS2688: Cannot find type definition file for 'node'`) confirmed unrelated to this diff. CI will validate.
- Change is purely additive: three string literals appended to a `readonly string[]` array. All three schemas (`ListPropertyListsRequestSchema`, `ListCollectionListsRequestSchema`, `ListContentStandardsRequestSchema`) verified to have zero required fields in `src/lib/types/schemas.generated.ts`.

## Pre-PR review

- **code-reviewer:** approved — all three schemas confirmed all-optional, changeset bump (patch) appropriate, error message expansion reads naturally, no blockers
- **ad-tech-protocol-expert:** approved — probe evaluator checks status integer only (union response non-issue), no spec rule requires cross-domain completeness, exclusion of brand tools is correct and spec-consistent; nit: open companion issue on `adcontextprotocol/adcp` for narrative update before merge

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01MavUc6BiAUhJ542ce5Ruem

---
_Generated by [Claude Code](https://claude.ai/code/session_01MavUc6BiAUhJ542ce5Ruem)_