### PR TITLE
fix(conformance): widen probe_task allowlist to include governance specialism tools

### DIFF
--- a/.changeset/probe-task-allowlist-governance.md
+++ b/.changeset/probe-task-allowlist-governance.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": patch
+---
+
+Widen `PROBE_TASK_ALLOWLIST` to include governance specialism read-only tools (`list_property_lists`, `list_collection_lists`, `list_content_standards`), fixing `security_baseline` grade failures for agents that expose only governance endpoints.

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -51,6 +51,7 @@ export const TASK_TO_METHOD: Record<string, string> = {
   update_property_list: 'updatePropertyList',
   list_property_lists: 'listPropertyLists',
   delete_property_list: 'deletePropertyList',
+  list_collection_lists: 'listCollectionLists',
   list_content_standards: 'listContentStandards',
   get_content_standards: 'getContentStandards',
   create_content_standards: 'createContentStandards',

--- a/src/lib/testing/storyboard/test-kit.ts
+++ b/src/lib/testing/storyboard/test-kit.ts
@@ -38,6 +38,10 @@ export const PROBE_TASK_ALLOWLIST: readonly string[] = Object.freeze([
   'list_authorized_properties',
   'get_signals',
   'list_si_sessions',
+  // governance specialism tools — all fields optional, auth-required, read-only
+  'list_property_lists',
+  'list_collection_lists',
+  'list_content_standards',
 ]);
 
 /**

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -1467,6 +1467,9 @@ describe('validateTestKit', () => {
         'list_authorized_properties',
         'get_signals',
         'list_si_sessions',
+        'list_property_lists',
+        'list_collection_lists',
+        'list_content_standards',
       ])
     );
   });


### PR DESCRIPTION
Closes #1558

Governance-specialism tenants (`list_property_lists`, `list_collection_lists`, `list_content_standards`) could not run `security_baseline` cleanly because none of their tools appeared in the hardcoded `PROBE_TASK_ALLOWLIST` in `src/lib/testing/storyboard/test-kit.ts`. The runner requires adopters to set `test_kit.auth.probe_task` to an allowlisted value; with no matching governance tool available, the probe_task configuration was impossible for governance-only deployments and the storyboard graded fail even when auth was working correctly.

This PR adds the three qualifying governance tools to the allowlist (all fields optional, auth-required, read-only), updates the `TASK_TO_METHOD` dispatch map in `task-map.ts` to include the previously-missing `list_collection_lists` entry, and updates the guard test that validates the allowlist contents.

`get_brand_identity` and `get_rights` are intentionally excluded: both have required fields (`brand_id`; `query`/`uses`) that cause Zod schema-validation 400s before auth is evaluated, which would cause the probe to misattribute schema rejection as an auth failure — exactly the failure mode the allowlist exists to prevent.

**What was tested:**
- `npx vitest run src/` — 17 tests pass, 2 pre-existing failures (missing `ws` package, missing `dist/` build) unchanged on both main and this branch
- `prettier --check` — clean
- `tsc --noEmit` — pre-existing TS config warnings (moduleResolution deprecation, missing `@types/node`) unchanged on both main and this branch; no new errors introduced
- Manually verified Zod schemas for all five candidate tools against the three allowlist criteria

**Pre-PR review:**
- code-reviewer: approved — correctly identified and fixed missing `list_collection_lists` in `TASK_TO_METHOD`; changeset bump (patch) correct
- ad-tech-protocol-expert: approved — governance tools are spec-confirmed auth-required; `get_brand_identity`/`get_rights` exclusion is correct per generated schemas; test assertion updated

**Nits surfaced (not fixed in this PR):**
- `list_si_sessions` in the existing allowlist has no schema, task-map entry, or scenario backing — appears to be forward-declared for a not-yet-shipped tool. Pre-existing; tracked separately.
- `list_collection_lists` also absent from `TASK_FEATURE_MAP` in `capabilities.ts`. Pre-existing gap, out of scope here.

---

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01QTsm9TC7m2am2kXPxawN24

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTsm9TC7m2am2kXPxawN24)_