### PR TITLE
feat(cli): add -H/--header flag for arbitrary outbound HTTP headers (#1563)

### DIFF
--- a/.changeset/cli-header-flag.md
+++ b/.changeset/cli-header-flag.md
@@ -1,0 +1,41 @@
+---
+'@adcp/sdk': minor
+---
+
+**CLI: `-H` / `--header KEY=VALUE` flag for arbitrary outbound HTTP headers** (closes adcp-client#1563).
+
+`npx adcp` previously accepted `--auth TOKEN` but had no way to attach the routing/context headers that multi-tenant agents require alongside the bearer. Verify scripts couldn't reach a freshly-provisioned tenant on `http://localhost:8000` because strategy 1 (Host-header → virtual host) falls through on `localhost`, leaving strategy 2 (`x-adcp-tenant`) the only option — and the CLI couldn't send it.
+
+The flag is repeatable, persists via `--save-auth`, and composes with every existing auth method:
+
+```sh
+# Ad-hoc invocation
+npx adcp http://localhost:8000/mcp/ get_products '{...}' \
+  --auth TOKEN \
+  -H x-adcp-tenant=acme \
+  -H Apx-Incoming-Host=tenant-acme.example.com
+
+# Persist on the saved alias
+npx adcp --save-auth tenant-acme http://localhost:8000/mcp/ \
+  --auth TOKEN \
+  -H x-adcp-tenant=acme
+
+# Saved headers flow through every subsequent invocation, including storyboard runs
+npx adcp tenant-acme storyboard run media_buy_seller
+```
+
+`Authorization` and `x-adcp-auth` are reserved — `--auth` always wins on conflict. Custom values for those keys are dropped with a stderr warning rather than silently overriding the bearer (acceptance criterion #3 from the issue).
+
+Saved headers display as NAMES only in `--list-agents` (mirrors the redaction posture for `oauth_client_credentials`); values may carry tenant-routing tokens.
+
+Plumbing details:
+
+- `parseHeaderFlags(args)` (in `bin/adcp.js`) is the shared parser — used by the main one-shot tool call, `--save-auth`, and `parseAgentOptions` (so `storyboard run` and the capability-driven assessment also pick up CLI-supplied headers and merge with the saved alias).
+- `AgentConfig.headers` already existed in the SDK and is plumbed end-to-end through both MCP and A2A transports (`src/lib/protocols/{mcp,a2a}.ts`, `src/lib/core/SingleAgentClient.ts`); the change is purely CLI/config wiring on top.
+- `TestOptions.headers` added so storyboard runs honor saved/CLI headers via `createTestClient` → `agentConfig.headers`. Composes with `auth.basic` (Basic auth still wins on Authorization).
+- Acceptance criteria from the issue:
+  - ✅ `-H K=V` works for ad-hoc invocations (repeatable; both `-H` and `--header`, plus `--header=K=V`).
+  - ✅ Per-agent `headers` field in `~/.adcp/config.json` is honored.
+  - ✅ Auth wins on conflict (Authorization / x-adcp-auth dropped with warning).
+
+Companion gap in the Python SDK (`uvx adcp` and `AgentConfig.headers`) is tracked separately in `adcontextprotocol/adcp-client-python`.

--- a/bin/adcp-config.js
+++ b/bin/adcp-config.js
@@ -171,13 +171,15 @@ async function interactiveSetup(
   protocol = null,
   authToken = null,
   nonInteractive = false,
-  noAuth = false
+  noAuth = false,
+  headers = null
 ) {
   // Non-interactive mode: save immediately without prompts
   if (nonInteractive && url) {
     const agentConfig = { url };
     if (protocol) agentConfig.protocol = protocol;
     if (authToken) agentConfig.auth_token = authToken;
+    if (headers && Object.keys(headers).length > 0) agentConfig.headers = headers;
     // noAuth flag means explicitly don't save auth
 
     saveAgent(alias, agentConfig);
@@ -217,6 +219,10 @@ async function interactiveSetup(
 
   if (authToken) {
     agentConfig.auth_token = authToken;
+  }
+
+  if (headers && Object.keys(headers).length > 0) {
+    agentConfig.headers = headers;
   }
 
   // Save

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -126,6 +126,132 @@ function checkDeprecatedFormats(formats) {
     .map(format => format.format_id?.id || format.format_id || format.id || format.name || 'unknown');
 }
 
+// Headers the SDK manages itself or that fetch/undici normalize at send time.
+// Set lowercase; comparisons must lower the candidate key. Splits the SDK's
+// concerns from user routing context:
+//   - auth/*: the bearer is owned by --auth (auth always wins).
+//   - signature*: RFC 9421 covers these; the signing wrapper at
+//     src/lib/protocols/a2a.ts:194-206 generates them per-request.
+//   - hop-by-hop: managed by the HTTP runtime; user overrides cause subtle
+//     framing bugs in MCP/A2A transports.
+const RESERVED_AUTH_HEADER_KEYS = new Set([
+  'authorization',
+  'x-adcp-auth',
+  // RFC 9421 — request-signing layer owns these.
+  'signature',
+  'signature-input',
+  'signature-agent',
+  'accept-signature',
+  // Hop-by-hop / fetch-managed — overriding causes framing bugs.
+  'content-type',
+  'content-length',
+  'host',
+  'connection',
+  'transfer-encoding',
+  'keep-alive',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'upgrade',
+]);
+
+// RFC 7230 token charset: alnum + !#$%&'*+-.^_`|~. Used for header field names.
+const HEADER_NAME_TOKEN = /^[A-Za-z0-9!#$%&'*+\-.^_`|~]+$/;
+
+/**
+ * Parse repeatable --header / -H KEY=VALUE flags. Accepts:
+ *   --header KEY=VALUE    --header=KEY=VALUE
+ *   -H KEY=VALUE          (short form)
+ *
+ * Returns:
+ *   { customHeaders, consumedTokens } where consumedTokens lists every arg
+ *   that should be excluded from positional resolution (the flag tokens
+ *   themselves and their KEY=VALUE values). Reserved keys (auth, signing,
+ *   hop-by-hop) are dropped with a stderr warning — the SDK owns them.
+ */
+function parseHeaderFlags(args) {
+  const customHeaders = {};
+  const consumedTokens = new Set();
+
+  const consumeKv = (raw, source) => {
+    const eq = raw.indexOf('=');
+    if (eq <= 0) {
+      console.error(`ERROR: ${source} requires KEY=VALUE, got: ${raw}\n`);
+      process.exit(2);
+    }
+    const key = raw.slice(0, eq).trim();
+    const value = raw.slice(eq + 1);
+    if (!key) {
+      console.error(`ERROR: ${source} requires a non-empty header name\n`);
+      process.exit(2);
+    }
+    // RFC 7230 §3.2.6: a token excludes whitespace and CTLs. Reject anything
+    // outside that charset so `-H 'Foo: bar=value'` (key would be "Foo: bar")
+    // and Unicode lookalikes like `-H 'Аuthorization=...'` (Cyrillic А) get
+    // surfaced at parse time rather than smuggled to the wire.
+    if (!HEADER_NAME_TOKEN.test(key)) {
+      console.error(`ERROR: ${source} key '${key}' contains characters outside the RFC 7230 token charset\n`);
+      process.exit(2);
+    }
+    // CR/LF/NUL in a header value is the classic header-splitting / request-
+    // smuggling shape. undici rejects it at send time, but the CLI is the
+    // right place to refuse — clearer error, no half-written config.
+    if (/[\r\n\0]/.test(value)) {
+      console.error(`ERROR: ${source} value for '${key}' contains CR, LF, or NUL\n`);
+      process.exit(2);
+    }
+    if (RESERVED_AUTH_HEADER_KEYS.has(key.toLowerCase())) {
+      console.error(`Warning: ignoring custom ${key} header — reserved for SDK auth/signing/transport.`);
+      return;
+    }
+    customHeaders[key] = value;
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if (tok === '-H' || tok === '--header') {
+      const val = args[i + 1];
+      if (val === undefined || val.startsWith('--') || val === '-H') {
+        console.error(`ERROR: ${tok} requires a KEY=VALUE pair\n`);
+        process.exit(2);
+      }
+      consumedTokens.add(tok);
+      consumedTokens.add(val);
+      consumeKv(val, tok);
+      i++;
+    } else if (tok.startsWith('--header=')) {
+      consumedTokens.add(tok);
+      consumeKv(tok.slice('--header='.length), '--header');
+    } else if (tok.startsWith('-H=')) {
+      // Tolerate `-H=KEY=VALUE` even though the documented form is `-H KEY=VALUE`.
+      consumedTokens.add(tok);
+      consumeKv(tok.slice('-H='.length), '-H');
+    }
+  }
+
+  return { customHeaders, consumedTokens };
+}
+
+/**
+ * Merge saved per-agent headers with CLI-supplied headers. CLI wins on key
+ * conflict so verify scripts can override one-off values without rewriting
+ * the saved alias. Filters reserved keys case-insensitively from BOTH sides
+ * so a hand-edited `~/.adcp/config.json` cannot smuggle an `authorization`
+ * (lowercase) header that shadows the SDK-supplied `Authorization`.
+ */
+function mergeHeaders(savedHeaders, cliHeaders) {
+  const merged = { ...(savedHeaders || {}), ...(cliHeaders || {}) };
+  const filtered = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (RESERVED_AUTH_HEADER_KEYS.has(key.toLowerCase())) {
+      console.error(`Warning: ignoring saved ${key} header — reserved for SDK auth/signing/transport.`);
+      continue;
+    }
+    filtered[key] = value;
+  }
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
 /**
  * Extract human-readable protocol message from conversation
  */
@@ -701,6 +827,10 @@ function parseAgentOptions(args) {
   const summaryOutputValue =
     summaryOutputIdx !== -1 && summaryOutputIdx + 1 < args.length ? args[summaryOutputIdx + 1] : null;
 
+  // --header / -H KEY=VALUE: arbitrary outbound HTTP headers. Repeatable.
+  // Auth-conflicting keys are dropped here with a warning.
+  const { customHeaders, consumedTokens: headerTokens } = parseHeaderFlags(args);
+
   // Filter out flags and their values to find positional args. The `--file=PATH`
   // form is already removed by the `startsWith('--')` check; only the
   // space-separated value needs explicit exclusion. Use explicit nullish check
@@ -725,7 +855,11 @@ function parseAgentOptions(args) {
     summaryOutputValue,
     fileIndex !== -1 ? file : null,
   ].filter(v => v !== null && v !== undefined);
-  const positionalArgs = args.filter(arg => !arg.startsWith('--') && !flagValues.includes(arg));
+  // `-H` short form does NOT start with `--`, so we filter it (and its KEY=VALUE
+  // payload) out of positionals via the explicit `headerTokens` set.
+  const positionalArgs = args.filter(
+    arg => !arg.startsWith('--') && !flagValues.includes(arg) && !headerTokens.has(arg)
+  );
 
   return {
     authToken,
@@ -740,6 +874,7 @@ function parseAgentOptions(args) {
     positionalArgs,
     localAgent: localAgentValue,
     format: formatValue,
+    customHeaders,
   };
 }
 
@@ -956,6 +1091,7 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
   let oauthTokens;
   let oauthClient;
   let oauthClientCredentials;
+  let savedHeaders;
   let aliasId;
 
   if (BUILT_IN_AGENTS[agentArg]) {
@@ -976,6 +1112,9 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
       oauthClient = savedAgent.oauth_client;
     }
     finalAuthToken = finalAuthToken || getEffectiveAuthToken(savedAgent);
+    if (savedAgent.headers && Object.keys(savedAgent.headers).length > 0) {
+      savedHeaders = { ...savedAgent.headers };
+    }
   } else if (agentArg.startsWith('http://') || agentArg.startsWith('https://')) {
     agentUrl = agentArg;
   } else {
@@ -1004,6 +1143,7 @@ async function resolveAgent(agentArg, authToken, protocolFlag, jsonOutput) {
     oauthTokens,
     oauthClient,
     oauthClientCredentials,
+    savedHeaders,
     aliasId,
   };
 }
@@ -1194,6 +1334,8 @@ AGENT MANAGEMENT:
 OPTIONS:
   --protocol PROTO  Force protocol: mcp or a2a (default: auto-detect)
   --auth TOKEN      Authentication token
+  -H, --header K=V  Extra HTTP header on every request (repeatable). Auth wins on conflict.
+                    Common use: -H x-adcp-tenant=<id> for tenant routing behind a reverse proxy.
   --oauth           OAuth authentication (MCP only, opens browser)
   --clear-oauth     Clear saved OAuth tokens
   --wait            Wait for async/webhook responses
@@ -1839,7 +1981,10 @@ async function handleStoryboardRun(args) {
     oauthTokens: resolvedOauthTokens,
     oauthClient: resolvedOauthClient,
     oauthClientCredentials: resolvedOauthClientCredentials,
+    savedHeaders,
   } = await resolveAgent(agentArg, authToken, protocolFlag, jsonOutput);
+
+  const mergedRunHeaders = mergeHeaders(savedHeaders, opts.customHeaders);
 
   // Parse webhook-receiver flags up front so malformed values fail the run
   // before the dry-run short-circuit, not only on a live execution. Auto-tunnel
@@ -1909,6 +2054,7 @@ async function handleStoryboardRun(args) {
     }),
     ...(webhookReceiverOpts ?? {}),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...(mergedRunHeaders && { headers: mergedRunHeaders }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -3401,7 +3547,10 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     oauthTokens,
     oauthClient,
     oauthClientCredentials,
+    savedHeaders,
   } = await resolveAgent(agentArg, opts.authToken, opts.protocolFlag, opts.jsonOutput);
+
+  const mergedAssessmentHeaders = mergeHeaders(savedHeaders, opts.customHeaders);
 
   // Parse --tracks
   const tracksIndex = rawArgs.indexOf('--tracks');
@@ -3472,6 +3621,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(opts.allowHttp && { allow_http: true }),
     ...(webhookReceiverOpts ?? {}),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...(mergedAssessmentHeaders && { headers: mergedAssessmentHeaders }),
   };
 
   if (!opts.jsonOutput) {
@@ -4191,6 +4341,13 @@ AUTH METHODS (pick one):
     --auth <token>            Pre-issued bearer token
     --no-auth                 Agent requires no auth
 
+HEADERS (compose with any auth method):
+    -H, --header K=V          Extra HTTP header on every request to this agent.
+                              Repeatable. Persists in ~/.adcp/config.json.
+                              Common use: -H x-adcp-tenant=<id> for routing behind
+                              a reverse proxy. Authorization headers are reserved
+                              for --auth and dropped here with a warning.
+
   Browser OAuth (authorization code flow):
     --oauth                   Opens a browser to authorize; stores tokens
                               so the SDK can refresh via refresh_token.
@@ -4263,10 +4420,19 @@ credential material — never sync or commit.
     const booleanFlags = new Set(['--no-auth', '--oauth', '--dry-run']);
     const parsedFlags = {};
     const positional = [];
+    // `--header` / `-H KEY=VALUE` pairs accumulate (repeatable) and are persisted
+    // alongside the alias as `agentConfig.headers`.
+    const savedHeadersFromFlags = parseHeaderFlags(args.slice(1));
     {
       const rest = args.slice(1);
       for (let i = 0; i < rest.length; i++) {
         const tok = rest[i];
+        if (savedHeadersFromFlags.consumedTokens.has(tok)) {
+          // --header / -H consumed by parseHeaderFlags above; skip the value too
+          // when it's the long-form `--header KEY=VALUE` or `-H KEY=VALUE` shape.
+          if (tok === '-H' || tok === '--header') i++;
+          continue;
+        }
         if (valueFlags.has(tok)) {
           const val = rest[i + 1];
           if (val === undefined || val.startsWith('--')) {
@@ -4282,6 +4448,7 @@ credential material — never sync or commit.
         }
       }
     }
+    const savedHeaders = savedHeadersFromFlags.customHeaders;
 
     const providedAuthToken = parsedFlags['--auth'] ?? null;
     const noAuthFlag = parsedFlags['--no-auth'] === true;
@@ -4582,6 +4749,7 @@ credential material — never sync or commit.
         protocol: protocol || 'mcp',
         oauth_client_credentials: credentials,
         oauth_tokens: tokens,
+        ...(Object.keys(savedHeaders).length > 0 && { headers: savedHeaders }),
       });
 
       console.log(`✅ Agent '${alias}' saved with client credentials.`);
@@ -4654,7 +4822,11 @@ credential material — never sync or commit.
         console.log('Saving agent without OAuth tokens.\n');
         await oauthProvider.cleanup();
         await mcpClient.close();
-        saveAgent(alias, { url, protocol: 'mcp' });
+        saveAgent(alias, {
+          url,
+          protocol: 'mcp',
+          ...(Object.keys(savedHeaders).length > 0 && { headers: savedHeaders }),
+        });
         console.log(`✅ Agent '${alias}' saved.`);
         console.log(`Use: adcp ${alias} <tool> <payload>\n`);
       } catch (error) {
@@ -4673,6 +4845,7 @@ credential material — never sync or commit.
               protocol: 'mcp',
               oauth_tokens: tempAgent.oauth_tokens,
               oauth_client: tempAgent.oauth_client,
+              ...(Object.keys(savedHeaders).length > 0 && { headers: savedHeaders }),
             };
             saveAgent(alias, agentConfig);
 
@@ -4701,7 +4874,7 @@ credential material — never sync or commit.
     const hasAuthDecision = providedAuthToken !== null || noAuthFlag;
     const nonInteractive = url && hasAuthDecision;
 
-    await interactiveSetup(alias, url, protocol, providedAuthToken, nonInteractive, noAuthFlag);
+    await interactiveSetup(alias, url, protocol, providedAuthToken, nonInteractive, noAuthFlag, savedHeaders);
     process.exit(0);
   }
 
@@ -4737,6 +4910,12 @@ credential material — never sync or commit.
       } else if (agent.oauth_tokens) {
         const hasValid = hasValidOAuthTokens(agent);
         console.log(`    OAuth: ${hasValid ? 'valid tokens' : 'expired (use --oauth to refresh)'}`);
+      }
+      if (agent.headers && Object.keys(agent.headers).length > 0) {
+        // Header NAMES only — values may carry tenant routing tokens or other
+        // sensitive context. Mirrors the CodeQL-driven minimalism applied to
+        // oauth_client_credentials above.
+        console.log(`    Headers: ${Object.keys(agent.headers).join(', ')}`);
       }
       console.log('');
     });
@@ -4817,6 +4996,8 @@ credential material — never sync or commit.
   const useLocalWebhook = args.includes('--local');
   const timeoutIndex = args.indexOf('--timeout');
   const timeout = timeoutIndex !== -1 ? parseInt(args[timeoutIndex + 1]) : 300000;
+  // --header / -H KEY=VALUE: arbitrary outbound headers. Repeatable. Auth wins on conflict.
+  const { customHeaders: cliHeaders, consumedTokens: headerTokens } = parseHeaderFlags(args);
   const useOAuth = args.includes('--oauth');
   const clearOAuth = args.includes('--clear-oauth');
 
@@ -4833,7 +5014,8 @@ credential material — never sync or commit.
       !arg.startsWith('--') &&
       arg !== authToken && // Don't include the auth token value
       arg !== protocolFlag && // Don't include the protocol value
-      arg !== (timeoutIndex !== -1 ? args[timeoutIndex + 1] : null) // Don't include timeout value
+      arg !== (timeoutIndex !== -1 ? args[timeoutIndex + 1] : null) && // Don't include timeout value
+      !headerTokens.has(arg) // Drop -H and its KEY=VALUE payload
   );
 
   // Determine if first arg is alias or URL
@@ -4988,6 +5170,10 @@ credential material — never sync or commit.
     }
   }
 
+  // Merge saved-alias headers (per-agent routing context, e.g. x-adcp-tenant)
+  // with `-H KEY=VALUE` flags from the current invocation. CLI wins on conflict.
+  const mergedHeaders = mergeHeaders(savedAgent && savedAgent.headers, cliHeaders);
+
   // Create agent config
   const agentConfig = {
     id: 'cli-agent',
@@ -4998,6 +5184,7 @@ credential material — never sync or commit.
     ...(agentOAuthTokens && { oauth_tokens: agentOAuthTokens }),
     ...(agentOAuthClient && { oauth_client: agentOAuthClient }),
     ...(agentOAuthClientCredentials && { oauth_client_credentials: agentOAuthClientCredentials }),
+    ...(mergedHeaders && { headers: mergedHeaders }),
   };
 
   // For saved aliases with any OAuth material, attach a file-backed storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.10.0",
+  "version": "6.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.10.0",
+      "version": "6.11.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6464,7 +6464,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.10.0"
+        "@adcp/sdk": "^6.11.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -120,12 +120,19 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
     protocol,
   };
 
+  // Caller-supplied tenant/routing headers carry through to every transport
+  // request. Merged before auth so auth still wins on Authorization conflicts
+  // (the basic-auth branch below intentionally overwrites this).
+  if (options.headers && Object.keys(options.headers).length > 0) {
+    agentConfig.headers = { ...options.headers };
+  }
+
   // Add auth to agent config - the library will use it automatically
   if (options.auth) {
     if (options.auth.type === 'basic') {
       // basic: encode credentials here; library sends the Authorization header as-is
       const encoded = Buffer.from(`${options.auth.username}:${options.auth.password}`).toString('base64');
-      agentConfig.headers = { Authorization: `Basic ${encoded}` };
+      agentConfig.headers = { ...agentConfig.headers, Authorization: `Basic ${encoded}` };
     } else if (options.auth.type === 'oauth') {
       // oauth: attach tokens + client registration; ProtocolClient detects
       // oauth_tokens and routes through the refresh-capable MCP OAuth path.

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -116,6 +116,16 @@ export interface TestOptions {
         credentials: import('../types/adcp').AgentOAuthClientCredentials;
         tokens?: import('../types/adcp').AgentOAuthTokens;
       };
+  /**
+   * Extra HTTP headers applied to every outbound request to the agent.
+   * Forwarded into `AgentConfig.headers`, so MCP and A2A transports both
+   * see them. `Authorization` and `x-adcp-auth` are reserved — auth wins.
+   *
+   * Typical use: tenant-routing headers (`x-adcp-tenant`, `Apx-Incoming-Host`)
+   * for multi-tenant agents fronted by a reverse proxy. The CLI exposes these
+   * via `-H KEY=VALUE` (repeatable) and persists them in `~/.adcp/config.json`.
+   */
+  headers?: Record<string, string>;
   // Brand manifest for creative testing
   brand_manifest?: {
     name: string;

--- a/test/lib/cli-header-flag.test.js
+++ b/test/lib/cli-header-flag.test.js
@@ -1,0 +1,208 @@
+/**
+ * CLI plumbing for `-H/--header KEY=VALUE` (issue #1563).
+ *
+ * Asserts:
+ *   - `-H` and `--header` are repeatable and survive positional filtering.
+ *   - Authorization-class headers are dropped with a stderr warning (auth wins).
+ *   - `--save-auth ... -H k=v` persists `headers` in `~/.adcp/config.json`.
+ *   - `--list-agents` shows the saved header NAMES (values are tenant-routing
+ *     context and treated as sensitive).
+ *
+ * No live network calls — uses `--dry-run` against a saved alias and a custom
+ * HOME pointing at a tmp dir so we don't disturb the developer's real config.
+ */
+
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+
+let tmpHome;
+
+function runCli(args) {
+  return spawnSync('node', [CLI, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, HOME: tmpHome },
+  });
+}
+
+function configPath() {
+  return path.join(tmpHome, '.adcp', 'config.json');
+}
+
+before(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-headers-'));
+});
+
+after(() => {
+  fs.rmSync(tmpHome, { recursive: true, force: true });
+});
+
+test('--save-auth persists -H KEY=VALUE in agent config', () => {
+  const result = runCli([
+    '--save-auth',
+    'tenant-acme',
+    'https://agent.example.com/mcp',
+    '--auth',
+    'tok-abc',
+    '-H',
+    'x-adcp-tenant=acme',
+    '-H',
+    'x-correlation-id=run-42',
+  ]);
+  assert.strictEqual(result.status, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+  const cfg = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
+  assert.deepStrictEqual(cfg.agents['tenant-acme'].headers, {
+    'x-adcp-tenant': 'acme',
+    'x-correlation-id': 'run-42',
+  });
+  assert.strictEqual(cfg.agents['tenant-acme'].auth_token, 'tok-abc');
+});
+
+test('--save-auth supports the --header KEY=VALUE long form', () => {
+  const result = runCli([
+    '--save-auth',
+    'tenant-long',
+    'https://agent.example.com/mcp',
+    '--no-auth',
+    '--header',
+    'x-adcp-tenant=long',
+    '--header=x-extra=eq-form',
+  ]);
+  assert.strictEqual(result.status, 0, `expected exit 0, stderr: ${result.stderr}`);
+
+  const cfg = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
+  assert.deepStrictEqual(cfg.agents['tenant-long'].headers, {
+    'x-adcp-tenant': 'long',
+    'x-extra': 'eq-form',
+  });
+});
+
+test('--save-auth drops reserved headers with a stderr warning (auth/signing/transport)', () => {
+  const result = runCli([
+    '--save-auth',
+    'tenant-conflict',
+    'https://agent.example.com/mcp',
+    '--auth',
+    'tok-real',
+    '-H',
+    'Authorization=Bearer hijack',
+    '-H',
+    'X-ADCP-Auth=hijack-also',
+    '-H',
+    'Signature-Input=evil',
+    '-H',
+    'Content-Type=text/html',
+    '-H',
+    'x-adcp-tenant=ok',
+  ]);
+  assert.strictEqual(result.status, 0, `expected exit 0, stderr: ${result.stderr}`);
+  assert.match(result.stderr, /ignoring custom Authorization header/);
+  assert.match(result.stderr, /ignoring custom X-ADCP-Auth header/);
+  assert.match(result.stderr, /ignoring custom Signature-Input header/);
+  assert.match(result.stderr, /ignoring custom Content-Type header/);
+
+  const cfg = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
+  assert.deepStrictEqual(cfg.agents['tenant-conflict'].headers, { 'x-adcp-tenant': 'ok' });
+  assert.strictEqual(cfg.agents['tenant-conflict'].auth_token, 'tok-real');
+});
+
+test('--save-auth rejects -H without KEY=VALUE', () => {
+  const result = runCli([
+    '--save-auth',
+    'tenant-bad',
+    'https://agent.example.com/mcp',
+    '--no-auth',
+    '-H',
+    'no-equals-here',
+  ]);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /-H requires KEY=VALUE/);
+});
+
+test('-H rejects values containing CR, LF, or NUL (header smuggling defense)', () => {
+  const result = runCli([
+    '--save-auth',
+    'tenant-crlf',
+    'https://agent.example.com/mcp',
+    '--no-auth',
+    '-H',
+    'X-Smuggle=ok\r\nAuthorization: Bearer evil',
+  ]);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /CR, LF, or NUL/);
+  // Config must NOT have been written with the malicious value.
+  const cfg = fs.existsSync(configPath()) ? JSON.parse(fs.readFileSync(configPath(), 'utf8')) : { agents: {} };
+  assert.strictEqual(cfg.agents['tenant-crlf'], undefined);
+});
+
+test('-H rejects keys outside the RFC 7230 token charset', () => {
+  const result = runCli([
+    '--save-auth',
+    'tenant-bad-key',
+    'https://agent.example.com/mcp',
+    '--no-auth',
+    '-H',
+    'Foo: bar=value',
+  ]);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /token charset/);
+});
+
+test('saved headers loaded from disk are filtered against the reserved set', () => {
+  // Hand-edit the saved config to include a smuggled `authorization` (lowercase)
+  // header. The merge step must drop it on read so it can't shadow the SDK's
+  // `Authorization` header during a real request.
+  const cfgFile = configPath();
+  const cfg = JSON.parse(fs.readFileSync(cfgFile, 'utf8'));
+  cfg.agents['tenant-handedited'] = {
+    url: 'https://agent.example.com/mcp',
+    protocol: 'mcp',
+    auth_token: 'tok-real',
+    headers: {
+      authorization: 'Bearer attacker',
+      'x-adcp-tenant': 'real-tenant',
+    },
+  };
+  fs.writeFileSync(cfgFile, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+
+  const result = runCli(['tenant-handedited', '--debug']);
+  // Use --debug so mergeHeaders' warning surfaces. The alias resolves and the
+  // network call fails, but the header filter runs before any network IO.
+  assert.match(result.stderr, /ignoring saved authorization header/);
+});
+
+test('--list-agents shows saved header names but not values', () => {
+  // Reuse 'tenant-acme' saved by the first test in this file. Test order is
+  // explicit (node:test runs in declared order), so this is deterministic.
+  const result = runCli(['--list-agents']);
+  assert.strictEqual(result.status, 0, `expected exit 0, stderr: ${result.stderr}`);
+  assert.match(result.stdout, /tenant-acme/);
+  assert.match(result.stdout, /Headers: x-adcp-tenant, x-correlation-id/);
+  // Values must NOT leak — they may carry tenant-routing tokens.
+  assert.doesNotMatch(result.stdout, /run-42/);
+});
+
+test('-H short form interleaved with positionals does not eat the JSON payload', () => {
+  // The exact shape from the issue: a saved alias, a tool name, an inline JSON
+  // payload, and one or more `-H` flags. Verifies parseHeaderFlags' consumed-
+  // tokens set excludes only the flag and its KEY=VALUE — not the JSON.
+  // We use --debug to surface the parsed payload without making a network call.
+  const result = runCli([
+    'tenant-acme',
+    'get_products',
+    '{"brief":"coffee brands"}',
+    '-H',
+    'x-adcp-tenant=runtime-override',
+    '--debug',
+  ]);
+  // The parser must reach the "Configuration" debug block — proves the JSON
+  // wasn't mis-classified as a flag value.
+  assert.match(result.stderr, /Tool: get_products/);
+  assert.match(result.stderr, /Payload:[\s\S]*"brief"/);
+});


### PR DESCRIPTION
## Summary

- Adds repeatable `-H` / `--header KEY=VALUE` to `npx adcp` for arbitrary outbound HTTP headers — the routing context multi-tenant agents need (`x-adcp-tenant`, `Apx-Incoming-Host`) alongside `--auth TOKEN`.
- Persists via `--save-auth` to `~/.adcp/config.json` as `agentConfig.headers`. Saved headers display as NAMES only in `--list-agents`.
- Reserved keys (auth, RFC 9421 signing, hop-by-hop) dropped at parse AND merge time with a stderr warning. Values validated against CR/LF/NUL; keys must match the RFC 7230 token charset.

The SDK's `AgentConfig.headers` already existed and was already plumbed through both MCP and A2A transports; this PR is purely CLI/config wiring on top of that. `TestOptions.headers` added so storyboard runs honor saved/CLI headers.

Closes adcontextprotocol/adcp-client#1563.

## Acceptance criteria from the issue

- [x] `-H K=V` works for ad-hoc invocations (repeatable; both `-H` and `--header`, plus `--header=K=V`).
- [x] Per-agent `headers` field in `~/.adcp/config.json` is honored.
- [x] Auth wins on conflict — `Authorization` and `x-adcp-auth` dropped with warning.

## Expert review fixes folded in

- **Security (CRLF injection)**: reject `\r`, `\n`, `\0` in header values at parse time. RFC 7230 token validation on keys (catches `Foo: bar=value` and Unicode lookalikes).
- **Security (reserved-key shadowing)**: filter reserved keys case-insensitively on the merged result, so a hand-edited config can't smuggle a lowercase `authorization` header that shadows the SDK's `Authorization`.
- **Protocol expert (reserved list)**: extended to include RFC 9421 (`signature`, `signature-input`, `signature-agent`, `accept-signature`) and hop-by-hop / fetch-managed (`content-type`, `content-length`, `host`, `connection`, `transfer-encoding`, `keep-alive`, `proxy-authorization`, `te`, `trailer`, `upgrade`).
- **Code review (test honesty)**: dropped the weak `notStrictEqual(status, 2)` test. Added real tests for `-H` short-form interleaved with positionals (the issue's exact shape), saved-key reserved filter, CRLF rejection, and bad-key rejection.

## Test plan

- [x] `node --test test/lib/cli-header-flag.test.js` (9 tests) — all pass
- [x] `NODE_ENV=test node --test test/lib/cli-*.test.js` (96 tests) — all pass
- [x] `npm run format:check` clean
- [x] `npm run build` succeeds
- [ ] Manual smoke: `npx adcp ... -H x-adcp-tenant=test get_products '{}'` against a tenant-routing agent (deferred to release verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)