### PR TITLE
fix(get_products): pass v3 channel names through to v2 servers

### DIFF
--- a/.changeset/pass-v3-channels-to-v2-servers.md
+++ b/.changeset/pass-v3-channels-to-v2-servers.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(get_products): pass v3 channel names through unchanged to v2 servers
+
+`adaptGetProductsRequestForV2` previously rewrote `olv → video`, `ctv → video`, `streaming_audio → audio`, and `retail_media → retail` on the way out. v2.5.3 of the AdCP spec aligned the channel enum with v3 taxonomy, and v2 servers running v2.5.3+ reject the older names with `-32602 Schema validation failed`. We now leave channel filters untouched in the v2 adapter so v3 names reach those servers as-is.
+
+Response-side `normalizeProductChannels` is unchanged: legacy v2 servers that still return `video`/`audio`/`retail` continue to be normalized up to v3 taxonomy on the read path.

--- a/src/lib/utils/pricing-adapter.ts
+++ b/src/lib/utils/pricing-adapter.ts
@@ -243,7 +243,12 @@ export function normalizeProductPricing(product: any): any {
  * Converts v3 fields to their v2 equivalents:
  * - brand (BrandReference) → brand_manifest (base domain URL string)
  * - catalog → promoted_offerings (type='offering') or promoted_offerings.product_selectors (type='product')
- * - channels in filters → v2 channel names
+ *
+ * Channels in filters are passed through unchanged. AdCP v2.5.3 aligned the
+ * channel enum with v3 taxonomy (`olv`, `ctv`, `streaming_audio`, `retail_media`),
+ * so v2 servers running v2.5.3+ reject the older `video`/`audio`/`retail` names
+ * — see /schemas/2.5.3/enums/channels.json which describes itself as the
+ * "AdCP v3 taxonomy".
  *
  * Strips v3-only fields v2 agents don't understand:
  * - buying_mode, buyer_campaign_ref, property_list, account_id, pagination (top-level)
@@ -279,22 +284,6 @@ export function adaptGetProductsRequestForV2(request: any): any {
       };
     }
     delete adapted.catalog;
-  }
-
-  // Map v3 channel names to v2 equivalents
-  if (adapted.filters?.channels) {
-    const v2ChannelMap: Record<string, string> = {
-      olv: 'video',
-      ctv: 'video',
-      streaming_audio: 'audio',
-      retail_media: 'retail',
-    };
-    // Deduplicate after mapping (e.g. olv+ctv both become 'video')
-    const mapped = adapted.filters.channels.map((ch: string) => v2ChannelMap[ch] ?? ch);
-    adapted.filters = {
-      ...adapted.filters,
-      channels: [...new Set(mapped)],
-    };
   }
 
   // Strip v3-only filter fields (format_ids exists in both v2 and v3, keep it)

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -689,6 +689,27 @@ describe('Creative Assignment Adapter', () => {
       assert.strictEqual(result.brand, undefined);
       assert.strictEqual(result.brand_manifest, 'https://acme.com');
     });
+
+    test('should pass v3 channel names through unchanged (v2.5.3 aligned with v3 taxonomy)', () => {
+      const v3Request = {
+        buying_mode: 'brief',
+        brief: 'News content',
+        filters: {
+          channels: ['display', 'olv', 'ctv', 'streaming_audio', 'retail_media'],
+          countries: ['US'],
+        },
+      };
+
+      const result = adaptGetProductsRequestForV2(v3Request);
+
+      assert.deepStrictEqual(result.filters.channels, [
+        'display',
+        'olv',
+        'ctv',
+        'streaming_audio',
+        'retail_media',
+      ]);
+    });
   });
 
   describe('adaptUpdateMediaBuyRequestForV2', () => {


### PR DESCRIPTION
## Summary

`adaptGetProductsRequestForV2` rewrote v3 channel names to v2 equivalents on outgoing get_products requests:

- `olv` → `video`
- `ctv` → `video`
- `streaming_audio` → `audio`
- `retail_media` → `retail`

AdCP v2.5.3 aligned the channel enum with v3 taxonomy, so v2 servers running v2.5.3+ now reject the older v2 names with `MCP error -32602 Schema validation failed`.

This was observed in production against multiple v2 sales agents (Ozone, Yahoo, NewsCorp Australia, Navigator, Planet Nine). Ozone's response payload included the enforcing schema so we could see exactly what failed:

```json
{
  "instancePath": "/filters/channels/1",
  "schemaPath": "/schemas/2.5.3/enums/channels.json/enum",
  "data": "video",
  "params": {
    "allowedValues": ["display", "olv", "social", "search", "ctv", "linear_tv", "streaming_audio", "retail_media", ...]
  }
}
```

The schema at `/schemas/2.5.3/enums/channels.json` describes itself as the "AdCP v3 taxonomy" — same enum as v3, just under a v2.5 `$id`.

## What Changed

- Removed the v3→v2 channel translation block in `adaptGetProductsRequestForV2`. Channel filter values now pass through to v2 servers unchanged.
- Updated the JSDoc to explain why.
- Added a regression test that asserts v3 channel names survive the v2 adaptation.
- Added a `patch` changeset.

Response-side `normalizeProductChannels` is intentionally untouched: any legacy v2 server that still *returns* `video`/`audio`/`retail` continues to be normalized up to v3 taxonomy on the read path.

## Trade-off

The SDK's bundled v2.5 schema (synced from `adcontextprotocol/adcp@2.5-maintenance`) still has the older channel enum (`video`/`audio`/`retail`/`native`). With this change, the warn-only post-adapter validation pass (`validateAdaptedRequestAgainstV2`) will log drift entries when v3-only channel names are sent to a v2 server. Validation is non-fatal — the request still goes out — and the warnings accurately reflect that the bundle has drifted from what real v2.5.3+ deployments accept. A follow-up upstream PR to the spec repo would bring `2.5-maintenance` into line with v3 taxonomy and remove the noise.

Hypothetical v2 servers that strictly validate against the older bundled enum would now reject v3 channel names. We have no evidence such servers exist in real traffic; the five agents currently failing all use the v3-aligned schema.

## Test plan

- [x] `node --test test/lib/v3-compatibility.test.js` — all 171 tests pass, including the new pass-through assertion
- [x] `tsc --project tsconfig.lib.json --noEmit` — clean
- [x] Confirmed wire payload now sends `["display", "olv"]` instead of `["display", "video"]`, which Ozone's reported v2.5.3 enum accepts
- [x] Confirmed warn-only post-adapter validation emits a non-fatal warning entry against the bundled v2.5 enum (expected drift, documented above)