### PR TITLE
feat(auth): add web (server-side) OAuth flow helpers

### DIFF
--- a/.changeset/web-oauth-flow.md
+++ b/.changeset/web-oauth-flow.md
@@ -1,0 +1,52 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(auth): add web (server-side) OAuth flow helpers
+
+`@adcp/sdk` already shipped `CLIFlowHandler` for single-process loopback
+flows and `NonInteractiveFlowHandler` for refresh-only contexts. There
+was no helper for **web servers** where `/oauth/start` and
+`/oauth/callback` may hit different processes. Every server consumer
+reinvented this layer and several got it wrong — skipping
+`/.well-known/oauth-protected-resource` (RFC 9728), guessing the RFC
+8707 `resource` indicator locally instead of reading PRM, forgetting to
+forward `resource` on token exchange, etc.
+
+This release adds:
+
+- `startWebOAuthFlow(opts)` → `{ authorizationUrl, state, expiresAt }`
+- `completeWebOAuthFlow(opts)` → `{ tokens, carry, persisted, agentId, agentUrl }`
+- `safeReturnTo(value, opts?)` — open-redirect guard for `carry.return_to`
+- `PendingWebFlowStore` interface (consumer-supplied — Postgres, Redis, KV)
+- `InMemoryPendingFlowStore` reference impl for tests / single-instance dev
+- `DEFAULT_WEB_FLOW_TTL_MS` exported constant
+- Error classes: `InvalidOrExpiredFlowError`, `StateMismatchError`,
+  `TokenExchangeError` (carries `oauthErrorCode`, redacted `body`),
+  `ProtectedResourceMetadataError`, `AgentVanishedDuringFlowError`,
+  `ConfidentialClientNotAllowedError`
+
+Discovery, PKCE, URL construction, and token exchange are delegated to
+the MCP SDK's `client/auth.js` primitives, so PRM-first resolution,
+SEP-835 scope priority, and `resource` forwarding on refresh come for
+free.
+
+Security defaults the design enforces:
+
+- PRM `resource` validated against agent origin via
+  `checkResourceAllowed` — a poisoned PRM cannot point the audience at
+  a third-party origin.
+- PRM 404s fall back to local resource derivation; connection / parse /
+  5xx errors throw rather than silently downgrade.
+- Dynamic client registration that returns `client_secret` is rejected
+  unless the caller opts in via `allowConfidentialClient: true`.
+- `expectedState` parameter on `completeWebOAuthFlow` binds the flow to
+  the caller's browser session (CSRF defense).
+- `TokenExchangeError.body` is redacted for `access_token`,
+  `refresh_token`, `id_token`, `token` field names.
+- `agentStorage.loadAgent` returning undefined after a successful
+  exchange throws `AgentVanishedDuringFlowError` rather than silently
+  dropping tokens.
+
+Pure addition — no changes to `MCPOAuthProvider`, `CLIFlowHandler`, or
+`NonInteractiveFlowHandler`.

--- a/docs/guides/WEB-OAUTH.md
+++ b/docs/guides/WEB-OAUTH.md
@@ -1,0 +1,178 @@
+# Web (server-side) OAuth flow
+
+`@adcp/sdk` provides three OAuth flow shapes:
+
+| Helper                                       | Shape                | When to use                                                                  |
+| -------------------------------------------- | -------------------- | ---------------------------------------------------------------------------- |
+| `CLIFlowHandler`                             | class (`OAuthFlowHandler`) | Single-process loopback (`localhost:8766`) — CLIs and dev tools.       |
+| `NonInteractiveFlowHandler`                  | class (`OAuthFlowHandler`) | Refresh-only contexts — storyboard runs, scheduled jobs, cron.         |
+| `startWebOAuthFlow` / `completeWebOAuthFlow` | standalone functions | **Web servers** where `/oauth/start` and `/oauth/callback` may hit different processes. |
+
+The web flow is **not** a class implementing `OAuthFlowHandler` — its
+contract spans two HTTP requests and (typically) two processes, which the
+flow-handler interface cannot model. Pass it to your router, not to
+`MCPOAuthProvider`.
+
+## What the SDK handles
+
+1. PRM (`/.well-known/oauth-protected-resource{path}`) discovery.
+2. AS resolution: `prm.authorization_servers[0]` falling back to the agent
+   origin when PRM is genuinely absent (404 — RFC 9728 §3 marks the
+   metadata document as optional). Connection / parse / 5xx errors are
+   surfaced as `ProtectedResourceMetadataError`; we do **not** silently
+   downgrade to local guessing on a transient failure.
+3. Resource indicator: `prm.resource` (validated against the agent origin
+   via `checkResourceAllowed`) falling back to
+   `resourceUrlFromServerUrl(agent.agent_uri)`. Never guessed locally
+   when PRM is present.
+4. Scope: caller `scopeHint` > `prm.scopes_supported` > `clientMetadata.scope`.
+5. Dynamic client registration when the agent has no `oauth_client` and
+   the AS advertises `registration_endpoint`. By default we **reject**
+   registrations that return `client_secret` (i.e. confidential clients);
+   pass `allowConfidentialClient: true` if you intend to persist a
+   long-lived AS credential to your agent storage.
+6. PKCE generation, authorization URL construction, and token exchange via
+   the MCP SDK's `client/auth.js` primitives. Refresh runs through
+   `MCPOAuthProvider` on the next agent call and forwards `resource`
+   automatically.
+
+## Express integration
+
+```ts
+import {
+  startWebOAuthFlow,
+  completeWebOAuthFlow,
+  safeReturnTo,
+  type PendingWebFlowStore,
+} from '@adcp/sdk';
+
+// Generate a session-bound state cookie at /start, verify at /callback.
+// Without this, the state we store in the pending row is replay-protected
+// but not browser-bound — anyone with the link can finish your flow.
+const STATE_COOKIE = 'adcp_oauth_state';
+
+router.get('/oauth/start', async (req, res) => {
+  const agent = await loadAgent(String(req.query.agent_id)); // adopter's agent loader
+  const { authorizationUrl, state } = await startWebOAuthFlow({
+    agent,
+    redirectUri: `${baseUrl}/oauth/callback`,
+    pendingFlowStore: pgPendingFlowStore, // your PendingWebFlowStore
+    agentStorage: pgAgentStorage, // your OAuthConfigStorage (optional)
+    carry: { user_id: req.user.id, return_to: req.query.return_to },
+    // Optional: forward the scope hint from a prior 401 challenge (SEP-835).
+    // scopeHint: req.query.scope,
+  });
+  res.cookie(STATE_COOKIE, state, { httpOnly: true, secure: true, sameSite: 'lax' });
+  res.redirect(authorizationUrl);
+});
+
+router.get('/oauth/callback', async (req, res) => {
+  try {
+    const { carry } = await completeWebOAuthFlow({
+      state: String(req.query.state),
+      code: String(req.query.code),
+      pendingFlowStore: pgPendingFlowStore,
+      agentStorage: pgAgentStorage,
+      // Browser-binding: the state we set on the cookie at /start MUST
+      // match the state the AS sends back to /callback.
+      expectedState: req.cookies[STATE_COOKIE],
+    });
+    res.clearCookie(STATE_COOKIE);
+    // safeReturnTo defaults to path-only redirects; pass allowedReturnHosts
+    // if you need to support absolute URLs against an allowlist.
+    res.redirect(safeReturnTo(carry?.return_to) ?? '/');
+  } catch (err) {
+    res.redirect(`/oauth-failed?reason=${encodeURIComponent(err.code ?? 'oauth_error')}`);
+  }
+});
+```
+
+## What you bring
+
+- **`loadAgent(agentId)`** — your code; not provided by the SDK. The
+  `/start` route uses it to look up the `AgentConfig`. The `/callback`
+  route does not need it: `agentId` is round-tripped in the pending row,
+  and `completeWebOAuthFlow` will call `agentStorage.loadAgent(agentId)`
+  itself when persisting tokens.
+
+- **`pendingFlowStore`** — implements `PendingWebFlowStore`. Two methods:
+  `put(flow)` and `consume(state)`. `consume` MUST be a single atomic
+  operation; canonical implementations:
+
+  Postgres:
+
+  ```sql
+  -- put
+  INSERT INTO pending_oauth_flows (state, payload, expires_at)
+    VALUES ($1, $2::jsonb, $3);
+
+  -- consume (atomic — DELETE … RETURNING)
+  DELETE FROM pending_oauth_flows
+    WHERE state = $1 AND expires_at > now()
+    RETURNING payload;
+  ```
+
+  Redis:
+
+  ```
+  SET pending:flow:<state> <payload> EX 600 NX     # put
+  GETDEL pending:flow:<state>                      # consume
+  ```
+
+  A `SELECT` followed by a separate `DELETE` is a replay vulnerability and
+  DOES NOT satisfy this contract. The SDK ships a `PendingWebFlowStore`
+  contract test (`describe('PendingWebFlowStore contract …')` in
+  `test/lib/oauth-web-flow.test.js`) you can run against your store.
+
+- **`agentStorage`** (optional) — implements `OAuthConfigStorage` (the
+  same interface used by `MCPOAuthProvider`). Omit it if you'd rather
+  handle persistence yourself; `completeWebOAuthFlow` returns the issued
+  tokens and a `persisted: false` flag in that case.
+
+`InMemoryPendingFlowStore` ships for tests and single-instance dev. Do
+not use it in production — restarts lose every in-flight flow.
+
+## Errors
+
+- `InvalidOrExpiredFlowError` — `state` not present or past TTL. Treat as
+  user-recoverable: prompt to re-authorize.
+- `StateMismatchError` — caller passed `expectedState` and it didn't
+  match the AS-supplied `state`. Almost always CSRF or a stale cookie.
+- `TokenExchangeError` — AS rejected the code exchange. Carries
+  `oauthErrorCode` (`invalid_grant`, `invalid_client`, …), `status`, and
+  a redacted `body` for diagnostics. Treat `body` as sensitive — do not
+  reflect it to the browser or write it to access logs unredacted.
+- `ProtectedResourceMetadataError` — PRM fetch failed (network / parse /
+  non-404 HTTP) or PRM advertised a `resource` whose origin does not
+  match the agent. Either is a configuration bug worth surfacing.
+- `AgentVanishedDuringFlowError` — `agentStorage.loadAgent(agentId)`
+  returned undefined after a successful token exchange. The user's auth
+  succeeded but you have no agent to attach it to; usually an
+  inter-process delete race.
+- `ConfidentialClientNotAllowedError` — DCR returned a `client_secret`
+  and you did not opt into `allowConfidentialClient: true`. Either flip
+  the flag (and store the secret carefully) or pre-register a public
+  client and put the result in `agent.oauth_client`.
+- `OAuthError` — generic catch-all; check `err.code` for the discriminator.
+
+## Operational notes
+
+- **TTL.** Defaults to `DEFAULT_WEB_FLOW_TTL_MS` (10 minutes). Lower if
+  you want a tighter recovery window; do not raise without a reason.
+- **PKCE verifier is a secret.** Encrypt it at rest if your store crosses
+  a trust boundary.
+- **Atomic consume is load-bearing.** Without it, a replayed callback
+  (e.g. user double-clicks the AS redirect) can mint two tokens and
+  burn the authorization code on the second attempt.
+- **CSRF.** `expectedState` binds the flow to the user's browser. The
+  SDK cannot do this for you because it can't see your session
+  middleware — you stash `state` in a cookie at `/start` and pass it
+  back in at `/callback`.
+- **`carry` is attacker-influenced.** It's whatever the caller of
+  `/oauth/start` put in the request. Always validate before reflecting
+  (use `safeReturnTo` for redirect targets).
+- **Refresh is not this module's job.** Once `oauth_tokens` are
+  persisted, `MCPOAuthProvider` handles refresh on the next agent call
+  and forwards `resource` into the refresh request automatically.
+  Callers who DIY refresh against `oauth_tokens` are responsible for
+  forwarding `resource` themselves.

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -60,6 +60,31 @@ export {
 export { CLIFlowHandler, type CLIFlowHandlerConfig } from './CLIFlowHandler';
 export { NonInteractiveFlowHandler, type NonInteractiveFlowHandlerConfig } from './NonInteractiveFlowHandler';
 
+// Web (server-side) OAuth flow — companion to CLIFlowHandler for environments
+// where /oauth/start and /oauth/callback may be served by different processes.
+// Note: standalone functions, NOT a class implementing OAuthFlowHandler — see
+// docs/guides/WEB-OAUTH.md for the rationale (the contract spans two requests).
+export {
+  startWebOAuthFlow,
+  completeWebOAuthFlow,
+  safeReturnTo,
+  InMemoryPendingFlowStore,
+  InvalidOrExpiredFlowError,
+  StateMismatchError,
+  TokenExchangeError,
+  ProtectedResourceMetadataError,
+  AgentVanishedDuringFlowError,
+  ConfidentialClientNotAllowedError,
+  DEFAULT_WEB_FLOW_TTL_MS,
+  type PendingWebFlow,
+  type PendingWebFlowStore,
+  type PendingFlowStore,
+  type StartWebFlowOptions,
+  type StartWebFlowResult,
+  type CompleteWebFlowOptions,
+  type CompleteWebFlowResult,
+} from './web-flow';
+
 // Main provider
 export { MCPOAuthProvider } from './MCPOAuthProvider';
 

--- a/src/lib/auth/oauth/web-flow.ts
+++ b/src/lib/auth/oauth/web-flow.ts
@@ -114,6 +114,15 @@ export interface PendingWebFlow {
  *
  * `consume` MUST treat expired rows as absent (return null) and SHOULD
  * delete them on read so a separate sweep is not strictly required.
+ *
+ * **Tradeoff: consume runs before token exchange.** `completeWebOAuthFlow`
+ * consumes the pending row before attempting `exchangeAuthorization`. If
+ * the AS returns a transient 5xx (or the network blips between us and the
+ * AS), the row is gone and the user must restart from `/oauth/start`.
+ * This is the right call for `invalid_grant` (replay protection — the
+ * authorization code is one-shot at the AS regardless), but it means
+ * transient AS failures cost the user a click. Revisit only if you see
+ * real retry-loss in the field.
  */
 export interface PendingWebFlowStore {
   /** Insert a new flow. MUST reject duplicate `state`. */
@@ -360,6 +369,11 @@ export async function startWebOAuthFlow(opts: StartWebFlowOptions): Promise<Star
  * the authorization code for tokens, and (if storage is provided)
  * persists tokens to `agent.oauth_tokens`. Returns whatever the caller
  * stashed in `carry` so the consumer can route the user appropriately.
+ *
+ * The pending row is consumed BEFORE `exchangeAuthorization` runs. A
+ * transient AS failure leaves the user with no row to retry against and
+ * they must restart from `/oauth/start`. See {@link PendingWebFlowStore}
+ * for the full tradeoff discussion.
  */
 export async function completeWebOAuthFlow(opts: CompleteWebFlowOptions): Promise<CompleteWebFlowResult> {
   const { state, code, pendingFlowStore, agentStorage, fetch: fetchFn, expectedState } = opts;
@@ -494,9 +508,19 @@ export class InMemoryPendingFlowStore implements PendingWebFlowStore {
 // ============================================================
 
 /**
- * The MCP SDK reports a 404 PRM lookup with this message; treat it as
- * "PRM is genuinely absent" and fall back. Anything else is a connection,
- * parse, or 5xx error and is allowed to bubble.
+ * The MCP SDK reports a 404 PRM lookup with this exact message; treat it
+ * as "PRM is genuinely absent" and fall back. Anything else is a
+ * connection, parse, or 5xx error and is allowed to bubble.
+ *
+ * Source (verified against `@modelcontextprotocol/sdk@1.29.0`):
+ *   `dist/esm/client/auth.js` → `discoverOAuthProtectedResourceMetadata`
+ *   throws `new Error(`Resource server does not implement OAuth 2.0 Protected Resource Metadata.`)`
+ *   when `response.status === 404` (or no response was returned).
+ *
+ * If a future MCP SDK reword this message, the test
+ * "falls back to server-derived resource on a 404 PRM" at
+ * `test/lib/oauth-web-flow.test.js` will fail — that test calls the real
+ * SDK against a 404 fixture and is the canary for this regression.
  */
 const PRM_ABSENT_MARKER = 'does not implement OAuth 2.0 Protected Resource Metadata';
 

--- a/src/lib/auth/oauth/web-flow.ts
+++ b/src/lib/auth/oauth/web-flow.ts
@@ -1,0 +1,623 @@
+/**
+ * Web (server-side) OAuth flow helpers for `@adcp/sdk`.
+ *
+ * Companion to `CLIFlowHandler` for environments where `/oauth/start` and
+ * `/oauth/callback` may be served by different processes. Discovery, PKCE,
+ * URL construction, and token exchange are delegated to the MCP SDK's
+ * `client/auth.js` primitives so this module is glue plus a pending-flow
+ * store interface — not reimplemented protocol logic.
+ *
+ * Wire contract:
+ *   - PRM (RFC 9728) is consulted first; `prm.resource` is the source of
+ *     truth for the RFC 8707 `resource` indicator. We fall back to
+ *     `resourceUrlFromServerUrl(agent.agent_uri)` only when the resource
+ *     server does not implement PRM (404). Connection / parse / 5xx
+ *     errors throw `ProtectedResourceMetadataError` — never silently
+ *     downgrade to local guessing.
+ *   - `prm.resource` must share an origin with the agent URL; the MCP
+ *     SDK's `checkResourceAllowed` guards against a poisoned PRM
+ *     pointing the audience at a third party.
+ *   - AS URL = `prm.authorization_servers[0]` when PRM is present, else
+ *     the agent origin.
+ *   - Scope priority: caller-supplied `scopeHint` (e.g. from a 401
+ *     `WWW-Authenticate` challenge, per SEP-835) > `prm.scopes_supported`
+ *     > `clientMetadata.scope`.
+ *   - Refresh is NOT this module's concern. Once `oauth_tokens` are
+ *     persisted, `MCPOAuthProvider` handles refresh on the next agent
+ *     call and the MCP SDK forwards `resource` into the refresh request.
+ *     Callers who DIY refresh against `oauth_tokens` are responsible for
+ *     forwarding `resource` themselves.
+ */
+
+import { randomBytes } from 'crypto';
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  exchangeAuthorization,
+  registerClient,
+  startAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import { checkResourceAllowed, resourceUrlFromServerUrl } from '@modelcontextprotocol/sdk/shared/auth-utils.js';
+import type {
+  AuthorizationServerMetadata,
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthProtectedResourceMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+
+import type { AgentConfig, OAuthConfigStorage } from './types';
+import { DEFAULT_CLIENT_METADATA, fromMCPClientInfo, fromMCPTokens, OAuthError, toMCPClientInfo } from './types';
+
+/**
+ * Default TTL for a pending web flow row. RFC 6749 §10.12 recommends
+ * short-lived state; 10 minutes covers slow-typing users without leaving
+ * the PKCE verifier on disk longer than necessary.
+ */
+export const DEFAULT_WEB_FLOW_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * State persisted between `/oauth/start` and `/oauth/callback`.
+ *
+ * `codeVerifier` is a PKCE secret. Store implementations MUST encrypt it
+ * at rest if persistence crosses a trust boundary (shared DB, cross-tenant
+ * Redis, etc.).
+ *
+ * `carry` is preserved verbatim and round-tripped to the callback. It
+ * MUST be JSON-serializable, MUST NOT contain secrets, and MUST be
+ * treated as attacker-influenced data (the caller typically populates it
+ * from the `/start` request).
+ */
+export interface PendingWebFlow {
+  state: string;
+  agentId: string;
+  agentUrl: string;
+  codeVerifier: string;
+  redirectUri: string;
+  resource?: string;
+  scope?: string;
+  authorizationServerUrl: string;
+  /** Persist as JSON (e.g. Postgres `jsonb`); contents are MCP SDK-typed. */
+  clientInformation: OAuthClientInformation;
+  createdAt: Date;
+  expiresAt: Date;
+  /** JSON-serializable, no secrets, attacker-influenced. */
+  carry?: Record<string, unknown>;
+}
+
+/**
+ * Persistence interface for in-flight web OAuth flows.
+ *
+ * Canonical implementations:
+ *
+ * Postgres:
+ * ```sql
+ * INSERT INTO pending_oauth_flows (state, payload, expires_at)
+ *   VALUES ($1, $2, $3);
+ * -- consume:
+ * DELETE FROM pending_oauth_flows
+ *   WHERE state = $1 AND expires_at > now()
+ *   RETURNING payload;
+ * ```
+ *
+ * Redis:
+ * ```
+ * SET pending:flow:<state> <payload> EX 600 NX     -- put
+ * GETDEL pending:flow:<state>                      -- consume
+ * ```
+ *
+ * `consume` MUST be a single atomic operation that deletes and returns the
+ * row (or returns null). A `SELECT` followed by a separate `DELETE` is a
+ * replay vulnerability and DOES NOT satisfy this contract — a callback
+ * replayed before the first one commits would mint two tokens.
+ *
+ * `consume` MUST treat expired rows as absent (return null) and SHOULD
+ * delete them on read so a separate sweep is not strictly required.
+ */
+export interface PendingWebFlowStore {
+  /** Insert a new flow. MUST reject duplicate `state`. */
+  put(flow: PendingWebFlow): Promise<void>;
+  /**
+   * Atomic delete-and-return. MUST NOT return the same row twice.
+   * Returns null if the row is absent or expired.
+   */
+  consume(state: string): Promise<PendingWebFlow | null>;
+  /** Optional housekeeping for expired rows that were never claimed. */
+  cleanupExpired?(): Promise<number>;
+}
+
+/** @deprecated Renamed to `PendingWebFlowStore`. */
+export type PendingFlowStore = PendingWebFlowStore;
+
+export class InvalidOrExpiredFlowError extends OAuthError {
+  constructor(state: string) {
+    super(`OAuth flow not found or expired (state=${state})`, 'invalid_or_expired_flow');
+    this.name = 'InvalidOrExpiredFlowError';
+  }
+}
+
+export class StateMismatchError extends OAuthError {
+  constructor() {
+    super('OAuth state does not match the value the caller bound to this session', 'state_mismatch');
+    this.name = 'StateMismatchError';
+  }
+}
+
+export class TokenExchangeError extends OAuthError {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: string,
+    /**
+     * RFC 6749 §5.2 error code when the authorization server returned a
+     * standard error envelope (`invalid_grant`, `invalid_client`, etc.).
+     * Undefined when the AS returned a non-OAuth-shaped failure.
+     */
+    public readonly oauthErrorCode?: string
+  ) {
+    super(message, 'token_exchange_failed');
+    this.name = 'TokenExchangeError';
+  }
+}
+
+export class ProtectedResourceMetadataError extends OAuthError {
+  constructor(message: string) {
+    super(message, 'protected_resource_metadata_error');
+    this.name = 'ProtectedResourceMetadataError';
+  }
+}
+
+export class AgentVanishedDuringFlowError extends OAuthError {
+  constructor(agentId: string) {
+    super(
+      `Agent ${agentId} could not be loaded from storage during token persistence; tokens were not saved`,
+      'agent_vanished_during_flow',
+      agentId
+    );
+    this.name = 'AgentVanishedDuringFlowError';
+  }
+}
+
+export class ConfidentialClientNotAllowedError extends OAuthError {
+  constructor(agentId: string | undefined) {
+    super(
+      'Authorization server issued a confidential client (client_secret) during dynamic registration. ' +
+        'Pass `allowConfidentialClient: true` if you intend to persist a long-lived AS credential to your agent storage.',
+      'confidential_client_not_allowed',
+      agentId
+    );
+    this.name = 'ConfidentialClientNotAllowedError';
+  }
+}
+
+export interface StartWebFlowOptions {
+  /** Agent the flow is for. Must include `agent_uri`. */
+  agent: AgentConfig;
+  /** Absolute URL of the consumer's `/callback` route (must match what the AS sees). */
+  redirectUri: string;
+  /** Where to persist the pending flow until callback. */
+  pendingFlowStore: PendingWebFlowStore;
+  /** When provided, dynamic-registration results land in `agent.oauth_client`. */
+  agentStorage?: OAuthConfigStorage;
+  /**
+   * Free-form caller payload, round-tripped to `completeWebOAuthFlow`.
+   * Must be JSON-serializable. Do not store secrets here. Treated as
+   * attacker-influenced — validate before reflecting (e.g. via
+   * {@link safeReturnTo} for redirect targets).
+   */
+  carry?: Record<string, unknown>;
+  /**
+   * Scope hint (highest priority per SEP-835). Pass through the `scope`
+   * value from a prior 401 `WWW-Authenticate` challenge if you have one.
+   */
+  scopeHint?: string;
+  /** Override flow TTL. Default: {@link DEFAULT_WEB_FLOW_TTL_MS}. */
+  ttlMs?: number;
+  /** Override the random-state generator (defaults to 32 bytes base64url). */
+  generateState?: () => string;
+  /** Override `fetch` (timeouts, signing, mocks). */
+  fetch?: typeof fetch;
+  /**
+   * Override base client metadata. `redirect_uris` is always replaced
+   * with `[redirectUri]` regardless of what's passed here.
+   */
+  clientMetadata?: Partial<OAuthClientMetadata>;
+  /**
+   * Permit the AS to register a confidential client (i.e. one that
+   * returns a `client_secret` from dynamic registration). Default false:
+   * if the AS issues a secret we throw {@link ConfidentialClientNotAllowedError}
+   * rather than silently persisting a long-lived credential to your
+   * agent storage.
+   */
+  allowConfidentialClient?: boolean;
+}
+
+export interface StartWebFlowResult {
+  authorizationUrl: string;
+  state: string;
+  expiresAt: Date;
+}
+
+export interface CompleteWebFlowOptions {
+  state: string;
+  code: string;
+  pendingFlowStore: PendingWebFlowStore;
+  /** When provided, the issued tokens are persisted to `agent.oauth_tokens`. */
+  agentStorage?: OAuthConfigStorage;
+  fetch?: typeof fetch;
+  /**
+   * The caller-bound expected state (e.g. from a session cookie set at
+   * `/oauth/start`). When provided, must equal `state`; mismatch throws
+   * {@link StateMismatchError}. Without this, `state` is replay-protected
+   * but not browser-bound — see WEB-OAUTH.md.
+   */
+  expectedState?: string;
+}
+
+export interface CompleteWebFlowResult {
+  agentId: string;
+  agentUrl: string;
+  tokens: OAuthTokens;
+  carry?: Record<string, unknown>;
+  /** True if `agentStorage` was provided AND `saveAgent` succeeded. */
+  persisted: boolean;
+}
+
+/**
+ * Begin a web OAuth flow. Returns the authorization URL the consumer
+ * should redirect the browser to. Persists the PKCE verifier and other
+ * flow state via `pendingFlowStore.put` so a different process can complete it.
+ */
+export async function startWebOAuthFlow(opts: StartWebFlowOptions): Promise<StartWebFlowResult> {
+  const {
+    agent,
+    redirectUri,
+    pendingFlowStore,
+    agentStorage,
+    carry,
+    scopeHint,
+    ttlMs = DEFAULT_WEB_FLOW_TTL_MS,
+    generateState,
+    fetch: fetchFn,
+    clientMetadata: clientMetadataOverrides,
+    allowConfidentialClient = false,
+  } = opts;
+
+  if (!agent.agent_uri) {
+    throw new OAuthError('Agent missing agent_uri', 'invalid_agent', agent.id);
+  }
+
+  const prm = await tryDiscoverPRM(agent.agent_uri, fetchFn);
+  if (prm?.resource) {
+    assertPrmResourceMatchesAgentOrigin(agent.agent_uri, prm.resource);
+  }
+
+  const asUrl = resolveAuthorizationServerUrl(agent.agent_uri, prm);
+
+  const asMetadata = await discoverAuthorizationServerMetadata(asUrl.toString(), { fetchFn });
+  if (!asMetadata) {
+    throw new OAuthError(`No OAuth metadata at ${asUrl.toString()}`, 'no_authorization_server_metadata', agent.id);
+  }
+
+  const resource = prm?.resource ? new URL(prm.resource) : resourceUrlFromServerUrl(new URL(agent.agent_uri));
+
+  const baseClientMetadata: OAuthClientMetadata = {
+    ...DEFAULT_CLIENT_METADATA,
+    ...clientMetadataOverrides,
+    redirect_uris: [redirectUri],
+  };
+
+  const scope = scopeHint ?? prm?.scopes_supported?.join(' ') ?? baseClientMetadata.scope;
+
+  const clientInformation = await resolveClientInformation({
+    agent,
+    agentStorage,
+    asUrl,
+    asMetadata,
+    clientMetadata: baseClientMetadata,
+    fetchFn,
+    allowConfidentialClient,
+  });
+
+  const state = (generateState ?? defaultGenerateState)();
+  const { authorizationUrl, codeVerifier } = await startAuthorization(asUrl.toString(), {
+    metadata: asMetadata,
+    clientInformation,
+    redirectUrl: redirectUri,
+    scope,
+    state,
+    resource,
+  });
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + ttlMs);
+  const flow: PendingWebFlow = {
+    state,
+    agentId: agent.id,
+    agentUrl: agent.agent_uri,
+    codeVerifier,
+    redirectUri,
+    resource: resource.href,
+    scope,
+    authorizationServerUrl: asUrl.toString(),
+    clientInformation,
+    createdAt: now,
+    expiresAt,
+    carry,
+  };
+  await pendingFlowStore.put(flow);
+
+  return {
+    authorizationUrl: authorizationUrl.toString(),
+    state,
+    expiresAt,
+  };
+}
+
+/**
+ * Finish a web OAuth flow. Atomically consumes the pending row, exchanges
+ * the authorization code for tokens, and (if storage is provided)
+ * persists tokens to `agent.oauth_tokens`. Returns whatever the caller
+ * stashed in `carry` so the consumer can route the user appropriately.
+ */
+export async function completeWebOAuthFlow(opts: CompleteWebFlowOptions): Promise<CompleteWebFlowResult> {
+  const { state, code, pendingFlowStore, agentStorage, fetch: fetchFn, expectedState } = opts;
+
+  if (expectedState !== undefined && expectedState !== state) {
+    throw new StateMismatchError();
+  }
+
+  const flow = await pendingFlowStore.consume(state);
+  if (!flow || flow.expiresAt.getTime() < Date.now()) {
+    throw new InvalidOrExpiredFlowError(state);
+  }
+
+  const asMetadata = await discoverAuthorizationServerMetadata(flow.authorizationServerUrl, {
+    fetchFn,
+  });
+
+  let tokens: OAuthTokens;
+  try {
+    tokens = await exchangeAuthorization(flow.authorizationServerUrl, {
+      metadata: asMetadata ?? undefined,
+      clientInformation: flow.clientInformation,
+      authorizationCode: code,
+      codeVerifier: flow.codeVerifier,
+      redirectUri: flow.redirectUri,
+      resource: flow.resource ? new URL(flow.resource) : undefined,
+      fetchFn,
+    });
+  } catch (err) {
+    throw wrapTokenExchangeError(err);
+  }
+
+  let persisted = false;
+  if (agentStorage) {
+    const agent = await agentStorage.loadAgent(flow.agentId);
+    if (!agent) {
+      throw new AgentVanishedDuringFlowError(flow.agentId);
+    }
+    agent.oauth_tokens = fromMCPTokens(tokens);
+    delete agent.oauth_code_verifier;
+    await agentStorage.saveAgent(agent);
+    persisted = true;
+  }
+
+  return {
+    agentId: flow.agentId,
+    agentUrl: flow.agentUrl,
+    tokens,
+    carry: flow.carry,
+    persisted,
+  };
+}
+
+/**
+ * Validate a redirect target supplied via `carry`.
+ *
+ * Treats `value` as attacker-influenced. Returns a string that is safe to
+ * pass to `res.redirect`, or `undefined` if the value is invalid.
+ *
+ * Defaults to **path-only** redirects (must start with a single `/` and
+ * not be protocol-relative `//evil.example`). Pass `allowedReturnHosts`
+ * to permit absolute URLs against an allowlist.
+ *
+ * @example
+ * ```ts
+ * res.redirect(safeReturnTo(carry?.return_to) ?? '/');
+ * res.redirect(safeReturnTo(carry?.return_to, { allowedReturnHosts: ['app.example.com'] }) ?? '/');
+ * ```
+ */
+export function safeReturnTo(value: unknown, options: { allowedReturnHosts?: string[] } = {}): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+
+  // Path-only: must be `/...` but not `//...` (protocol-relative) or `/\...`.
+  if (value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\')) {
+    return value;
+  }
+
+  const allowed = options.allowedReturnHosts;
+  if (!allowed || allowed.length === 0) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return undefined;
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return undefined;
+  if (!allowed.includes(parsed.host)) return undefined;
+  return parsed.toString();
+}
+
+/**
+ * In-memory pending-flow store for tests and single-instance dev.
+ *
+ * Production deployments MUST implement `PendingWebFlowStore` against a
+ * shared store (Postgres `DELETE … RETURNING`, Redis `GETDEL`) so
+ * `/start` and `/callback` can hit different processes.
+ */
+export class InMemoryPendingFlowStore implements PendingWebFlowStore {
+  private readonly flows = new Map<string, PendingWebFlow>();
+
+  async put(flow: PendingWebFlow): Promise<void> {
+    if (this.flows.has(flow.state)) {
+      throw new Error(`Pending flow already exists for state ${flow.state}`);
+    }
+    this.flows.set(flow.state, flow);
+  }
+
+  async consume(state: string): Promise<PendingWebFlow | null> {
+    const flow = this.flows.get(state);
+    if (!flow) return null;
+    this.flows.delete(state);
+    if (flow.expiresAt.getTime() < Date.now()) return null;
+    return flow;
+  }
+
+  async cleanupExpired(): Promise<number> {
+    const now = Date.now();
+    let removed = 0;
+    for (const [state, flow] of this.flows) {
+      if (flow.expiresAt.getTime() < now) {
+        this.flows.delete(state);
+        removed++;
+      }
+    }
+    return removed;
+  }
+}
+
+// ============================================================
+// Internals
+// ============================================================
+
+/**
+ * The MCP SDK reports a 404 PRM lookup with this message; treat it as
+ * "PRM is genuinely absent" and fall back. Anything else is a connection,
+ * parse, or 5xx error and is allowed to bubble.
+ */
+const PRM_ABSENT_MARKER = 'does not implement OAuth 2.0 Protected Resource Metadata';
+
+async function tryDiscoverPRM(
+  agentUrl: string,
+  fetchFn: typeof fetch | undefined
+): Promise<OAuthProtectedResourceMetadata | undefined> {
+  try {
+    return await discoverOAuthProtectedResourceMetadata(agentUrl, undefined, fetchFn);
+  } catch (err) {
+    if (err instanceof Error && err.message.includes(PRM_ABSENT_MARKER)) {
+      // PRM is optional under RFC 9728 — fall back to local resource
+      // derivation. Connection/parse/5xx errors fall through.
+      return undefined;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ProtectedResourceMetadataError(`PRM discovery failed: ${message}`);
+  }
+}
+
+function assertPrmResourceMatchesAgentOrigin(agentUrl: string, prmResource: string): void {
+  const requested = resourceUrlFromServerUrl(new URL(agentUrl));
+  if (!checkResourceAllowed({ requestedResource: requested, configuredResource: prmResource })) {
+    throw new ProtectedResourceMetadataError(
+      `PRM advertises resource ${prmResource} which does not share an origin/path with agent ${agentUrl}`
+    );
+  }
+}
+
+function resolveAuthorizationServerUrl(agentUrl: string, prm: OAuthProtectedResourceMetadata | undefined): URL {
+  const first = prm?.authorization_servers?.[0];
+  if (first) {
+    return new URL(first);
+  }
+  return new URL(new URL(agentUrl).origin);
+}
+
+async function resolveClientInformation(args: {
+  agent: AgentConfig;
+  agentStorage?: OAuthConfigStorage;
+  asUrl: URL;
+  asMetadata: AuthorizationServerMetadata;
+  clientMetadata: OAuthClientMetadata;
+  fetchFn?: typeof fetch;
+  allowConfidentialClient: boolean;
+}): Promise<OAuthClientInformation> {
+  const { agent, agentStorage, asUrl, asMetadata, clientMetadata, fetchFn, allowConfidentialClient } = args;
+
+  if (agent.oauth_client) {
+    return toMCPClientInfo(agent.oauth_client);
+  }
+
+  if (!asMetadata.registration_endpoint) {
+    throw new OAuthError(
+      'Agent has no oauth_client and authorization server does not advertise dynamic client registration',
+      'no_client_credentials',
+      agent.id
+    );
+  }
+
+  const registered: OAuthClientInformationFull = await registerClient(asUrl.toString(), {
+    metadata: asMetadata,
+    clientMetadata,
+    fetchFn,
+  });
+
+  if (registered.client_secret && !allowConfidentialClient) {
+    throw new ConfidentialClientNotAllowedError(agent.id);
+  }
+
+  if (agentStorage) {
+    // Load fresh and save fresh so two concurrent /start calls for the
+    // same agentId do not trample each other's `oauth_client` via a
+    // shared in-memory reference.
+    const fresh = (await agentStorage.loadAgent(agent.id)) ?? agent;
+    fresh.oauth_client = fromMCPClientInfo(registered);
+    await agentStorage.saveAgent(fresh);
+  }
+
+  return registered;
+}
+
+function defaultGenerateState(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Map an MCP SDK token-exchange failure to {@link TokenExchangeError},
+ * redacting bearer/refresh tokens that some authorization servers echo
+ * back in error responses for debugging.
+ */
+function wrapTokenExchangeError(err: unknown): TokenExchangeError {
+  // The MCP SDK's `parseErrorResponse` decodes a well-formed OAuth error
+  // envelope into an `OAuthError` subclass with `errorCode` (e.g.
+  // `InvalidGrantError`). Malformed responses come through as
+  // `ServerError` with the raw body in `message`, so the redaction pass
+  // covers both cases.
+  const oauthErrorCode = (err as { errorCode?: string })?.errorCode;
+  const message = err instanceof Error ? err.message : String(err);
+  const status = (err as { status?: number })?.status ?? 0;
+  const rawBody = (err as { body?: string })?.body ?? message;
+  const body = redactTokens(rawBody);
+  const display = oauthErrorCode ? `${oauthErrorCode}: ${message}` : message;
+  return new TokenExchangeError(`Token exchange failed: ${redactTokens(display)}`, status, body, oauthErrorCode);
+}
+
+const SENSITIVE_TOKEN_KEYS = ['access_token', 'refresh_token', 'id_token', 'token'];
+
+/**
+ * Best-effort redaction of bearer/refresh tokens from an AS error body
+ * (which may be JSON, form-encoded, or freeform). Adopters MUST still
+ * treat `TokenExchangeError.body` as sensitive — do not reflect it to
+ * the browser or write it to access logs unredacted.
+ */
+function redactTokens(input: string): string {
+  let out = input;
+  for (const key of SENSITIVE_TOKEN_KEYS) {
+    // JSON form: "key":"…"
+    out = out.replace(new RegExp(`("${key}"\\s*:\\s*")[^"]*(")`, 'gi'), '$1<redacted>$2');
+    // form-encoded: key=…
+    out = out.replace(new RegExp(`(\\b${key}=)[^&\\s]+`, 'gi'), '$1<redacted>');
+  }
+  return out;
+}

--- a/test/lib/oauth-web-flow.test.js
+++ b/test/lib/oauth-web-flow.test.js
@@ -1,0 +1,707 @@
+/**
+ * Tests for the web (server-side) OAuth flow helpers.
+ *
+ * Drives `startWebOAuthFlow` and `completeWebOAuthFlow` against an
+ * in-process HTTP server that plays the AS + PRM endpoints. The goal
+ * is to lock in the bits the SDK is responsible for — PRM resolution,
+ * scope priority, resource forwarding into token exchange, atomic
+ * consume, error envelope plumbing — without re-testing the MCP SDK
+ * primitives underneath.
+ */
+
+const { test, describe, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const {
+  startWebOAuthFlow,
+  completeWebOAuthFlow,
+  safeReturnTo,
+  InMemoryPendingFlowStore,
+  InvalidOrExpiredFlowError,
+  StateMismatchError,
+  TokenExchangeError,
+  ProtectedResourceMetadataError,
+  AgentVanishedDuringFlowError,
+  ConfidentialClientNotAllowedError,
+} = require('../../dist/lib/auth/oauth');
+
+const state = {
+  server: null,
+  port: 0,
+  handlers: {},
+  lastTokenRequest: null,
+  lastRegisterRequest: null,
+};
+
+before(async () => {
+  state.server = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const handler = state.handlers[url.pathname];
+    if (!handler) {
+      res.statusCode = 404;
+      res.end();
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        handler(req, res, body, url);
+      } catch (err) {
+        console.error('test fixture handler threw:', err);
+        res.statusCode = 500;
+        res.end('test fixture error');
+      }
+    });
+  });
+  await new Promise(r => state.server.listen(0, '127.0.0.1', r));
+  state.port = state.server.address().port;
+});
+
+after(async () => {
+  await new Promise(r => state.server.close(r));
+});
+
+beforeEach(() => {
+  state.handlers = {};
+  state.lastTokenRequest = null;
+  state.lastRegisterRequest = null;
+});
+
+function origin() {
+  return `http://127.0.0.1:${state.port}`;
+}
+function agentUrl() {
+  return `${origin()}/mcp`;
+}
+function jsonRes(res, status, body) {
+  res.statusCode = status;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+function makeAgent(overrides = {}) {
+  return {
+    id: 'test-agent',
+    name: 'Test Agent',
+    agent_uri: agentUrl(),
+    protocol: 'mcp',
+    oauth_client: { client_id: 'pre-registered-client' },
+    ...overrides,
+  };
+}
+
+function installStandardASHandlers({ tokenEndpointAuthMethods, registrationEndpoint, registrationResponse } = {}) {
+  state.handlers['/.well-known/oauth-authorization-server'] = (req, res) =>
+    jsonRes(res, 200, {
+      issuer: origin(),
+      authorization_endpoint: `${origin()}/oauth/authorize`,
+      token_endpoint: `${origin()}/oauth/token`,
+      response_types_supported: ['code'],
+      code_challenge_methods_supported: ['S256'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      token_endpoint_auth_methods_supported: tokenEndpointAuthMethods ?? ['none'],
+      ...(registrationEndpoint ? { registration_endpoint: `${origin()}/oauth/register` } : {}),
+      scopes_supported: ['mcp.read', 'mcp.write'],
+    });
+  state.handlers['/oauth/token'] = (req, res, body) => {
+    const params = new URLSearchParams(body);
+    state.lastTokenRequest = {
+      headers: req.headers,
+      params: Object.fromEntries(params),
+    };
+    jsonRes(res, 200, {
+      access_token: 'issued-access-token',
+      refresh_token: 'issued-refresh-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: params.get('scope') ?? undefined,
+    });
+  };
+  if (registrationEndpoint) {
+    state.handlers['/oauth/register'] = (req, res, body) => {
+      state.lastRegisterRequest = JSON.parse(body);
+      const merged = { ...JSON.parse(body), ...(registrationResponse ?? {}) };
+      jsonRes(res, 201, {
+        client_id: 'dyn-registered-client',
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        ...merged,
+      });
+    };
+  }
+}
+
+describe('startWebOAuthFlow', () => {
+  test('prefers PRM.resource over the server-derived fallback', async () => {
+    // The agent_uri carries a trailing slash; the PRM advertises the
+    // canonical no-slash form. The local-guess path would be `/mcp/`
+    // and PRM is `/mcp` — different strings so we can verify which one
+    // landed on the wire. (`checkResourceAllowed` allows requested-longer
+    // -than-configured paths.)
+    const slashedAgentUrl = `${origin()}/mcp/`;
+    const prmResource = `${origin()}/mcp`;
+    // The MCP SDK strips the trailing slash from agent_uri's pathname
+    // when building the well-known URL — handler registers at /mcp not /mcp/.
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, {
+        resource: prmResource,
+        authorization_servers: [origin()],
+      });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const result = await startWebOAuthFlow({
+      agent: makeAgent({ agent_uri: slashedAgentUrl }),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    const url = new URL(result.authorizationUrl);
+    assert.strictEqual(url.searchParams.get('resource'), prmResource);
+    assert.strictEqual(url.searchParams.get('state'), result.state);
+    assert.strictEqual(url.searchParams.get('redirect_uri'), 'http://localhost:9999/callback');
+    assert.ok(url.searchParams.get('code_challenge'), 'PKCE code_challenge missing');
+  });
+
+  test('falls back to server-derived resource on a 404 PRM (RFC 9728 optional)', async () => {
+    installStandardASHandlers();
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const result = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    const resource = new URL(result.authorizationUrl).searchParams.get('resource');
+    assert.ok(resource, 'resource indicator missing');
+    assert.ok(resource.startsWith(origin()), `expected resource to start with ${origin()}, got ${resource}`);
+  });
+
+  test('throws ProtectedResourceMetadataError on a malformed PRM body', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) => {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end('{not valid json');
+    };
+    installStandardASHandlers();
+
+    await assert.rejects(
+      () =>
+        startWebOAuthFlow({
+          agent: makeAgent(),
+          redirectUri: 'http://localhost:9999/callback',
+          pendingFlowStore: new InMemoryPendingFlowStore(),
+        }),
+      err => err instanceof ProtectedResourceMetadataError
+    );
+  });
+
+  test('throws ProtectedResourceMetadataError when PRM advertises a foreign resource origin', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, {
+        resource: 'https://victim-bank.example/',
+        authorization_servers: [origin()],
+      });
+    installStandardASHandlers();
+
+    await assert.rejects(
+      () =>
+        startWebOAuthFlow({
+          agent: makeAgent(),
+          redirectUri: 'http://localhost:9999/callback',
+          pendingFlowStore: new InMemoryPendingFlowStore(),
+        }),
+      err => err instanceof ProtectedResourceMetadataError && /does not share an origin/.test(err.message)
+    );
+  });
+
+  test('caller scopeHint overrides PRM.scopes_supported (SEP-835)', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, {
+        resource: agentUrl(),
+        authorization_servers: [origin()],
+        scopes_supported: ['mcp.read', 'mcp.write'],
+      });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const result = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+      scopeHint: 'mcp.read',
+    });
+
+    assert.strictEqual(new URL(result.authorizationUrl).searchParams.get('scope'), 'mcp.read');
+  });
+
+  test('uses PRM.scopes_supported when no scopeHint is provided', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, {
+        resource: agentUrl(),
+        authorization_servers: [origin()],
+        scopes_supported: ['mcp.read', 'mcp.write'],
+      });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const result = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    assert.strictEqual(new URL(result.authorizationUrl).searchParams.get('scope'), 'mcp.read mcp.write');
+  });
+
+  test('persists the pending flow keyed by state with PKCE verifier and resource', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const result = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+      carry: { return_to: '/dashboard' },
+    });
+
+    const flow = await pendingFlowStore.consume(result.state);
+    assert.ok(flow, 'flow not found in store');
+    assert.strictEqual(flow.agentId, 'test-agent');
+    assert.strictEqual(flow.agentUrl, agentUrl());
+    assert.strictEqual(flow.redirectUri, 'http://localhost:9999/callback');
+    assert.strictEqual(flow.resource, agentUrl());
+    assert.strictEqual(flow.authorizationServerUrl, `${origin()}/`);
+    assert.deepStrictEqual(flow.carry, { return_to: '/dashboard' });
+    assert.ok(flow.codeVerifier && flow.codeVerifier.length > 0, 'code verifier missing');
+  });
+
+  test('runs dynamic client registration when agent has no oauth_client', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers({ registrationEndpoint: true });
+
+    const agent = makeAgent({ oauth_client: undefined });
+    const savedAgents = [];
+    const agentStorage = {
+      loadAgent: async () => agent,
+      saveAgent: async a => {
+        savedAgents.push(JSON.parse(JSON.stringify(a)));
+      },
+    };
+
+    const result = await startWebOAuthFlow({
+      agent,
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore: new InMemoryPendingFlowStore(),
+      agentStorage,
+    });
+
+    assert.ok(state.lastRegisterRequest, 'DCR not invoked');
+    assert.deepStrictEqual(state.lastRegisterRequest.redirect_uris, ['http://localhost:9999/callback']);
+    assert.strictEqual(new URL(result.authorizationUrl).searchParams.get('client_id'), 'dyn-registered-client');
+    assert.ok(savedAgents.length >= 1, 'agentStorage.saveAgent not called');
+    assert.strictEqual(savedAgents[0].oauth_client.client_id, 'dyn-registered-client');
+  });
+
+  test('throws ConfidentialClientNotAllowedError when DCR returns a client_secret without opt-in', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers({
+      registrationEndpoint: true,
+      registrationResponse: { client_secret: 'oh-no-its-confidential', client_secret_expires_at: 0 },
+    });
+
+    await assert.rejects(
+      () =>
+        startWebOAuthFlow({
+          agent: makeAgent({ oauth_client: undefined }),
+          redirectUri: 'http://localhost:9999/callback',
+          pendingFlowStore: new InMemoryPendingFlowStore(),
+        }),
+      err => err instanceof ConfidentialClientNotAllowedError
+    );
+  });
+
+  test('allowConfidentialClient: true permits the secret and persists it', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers({
+      registrationEndpoint: true,
+      registrationResponse: { client_secret: 'consenting-secret', client_secret_expires_at: 0 },
+    });
+
+    const agent = makeAgent({ oauth_client: undefined });
+    const savedAgents = [];
+    const agentStorage = {
+      loadAgent: async () => agent,
+      saveAgent: async a => savedAgents.push(JSON.parse(JSON.stringify(a))),
+    };
+
+    await startWebOAuthFlow({
+      agent,
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore: new InMemoryPendingFlowStore(),
+      agentStorage,
+      allowConfidentialClient: true,
+    });
+
+    assert.strictEqual(savedAgents[0].oauth_client.client_secret, 'consenting-secret');
+  });
+
+  test('throws when agent has no oauth_client and AS does not advertise DCR', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers({ registrationEndpoint: false });
+
+    await assert.rejects(
+      () =>
+        startWebOAuthFlow({
+          agent: makeAgent({ oauth_client: undefined }),
+          redirectUri: 'http://localhost:9999/callback',
+          pendingFlowStore: new InMemoryPendingFlowStore(),
+        }),
+      /dynamic client registration/i
+    );
+  });
+});
+
+describe('completeWebOAuthFlow', () => {
+  test('exchanges the code, forwards resource, persists tokens via agentStorage', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers();
+
+    const agent = makeAgent();
+    const savedAgents = [];
+    const agentStorage = {
+      loadAgent: async () => agent,
+      saveAgent: async a => savedAgents.push(JSON.parse(JSON.stringify(a))),
+    };
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+
+    const start = await startWebOAuthFlow({
+      agent,
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+      carry: { return_to: '/dashboard' },
+    });
+
+    const completion = await completeWebOAuthFlow({
+      state: start.state,
+      code: 'auth-code-from-as',
+      pendingFlowStore,
+      agentStorage,
+    });
+
+    assert.strictEqual(completion.tokens.access_token, 'issued-access-token');
+    assert.strictEqual(completion.tokens.refresh_token, 'issued-refresh-token');
+    assert.deepStrictEqual(completion.carry, { return_to: '/dashboard' });
+    assert.strictEqual(completion.persisted, true);
+
+    assert.ok(state.lastTokenRequest, 'token endpoint never hit');
+    assert.strictEqual(state.lastTokenRequest.params.grant_type, 'authorization_code');
+    assert.strictEqual(state.lastTokenRequest.params.code, 'auth-code-from-as');
+    assert.strictEqual(state.lastTokenRequest.params.resource, agentUrl());
+    assert.strictEqual(state.lastTokenRequest.params.redirect_uri, 'http://localhost:9999/callback');
+    assert.ok(state.lastTokenRequest.params.code_verifier, 'PKCE verifier missing on token exchange');
+
+    assert.ok(savedAgents.length >= 1);
+    const last = savedAgents[savedAgents.length - 1];
+    assert.strictEqual(last.oauth_tokens.access_token, 'issued-access-token');
+  });
+
+  test('returns persisted=false when no agentStorage is provided', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const start = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+    const completion = await completeWebOAuthFlow({
+      state: start.state,
+      code: 'c',
+      pendingFlowStore,
+    });
+    assert.strictEqual(completion.persisted, false);
+  });
+
+  test('throws AgentVanishedDuringFlowError when agentStorage.loadAgent returns undefined', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const agent = makeAgent();
+    const start = await startWebOAuthFlow({
+      agent,
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    const agentStorage = {
+      loadAgent: async () => undefined,
+      saveAgent: async () => {
+        throw new Error('should never be called');
+      },
+    };
+
+    await assert.rejects(
+      () =>
+        completeWebOAuthFlow({
+          state: start.state,
+          code: 'c',
+          pendingFlowStore,
+          agentStorage,
+        }),
+      err => err instanceof AgentVanishedDuringFlowError && err.agentId === 'test-agent'
+    );
+  });
+
+  test('throws StateMismatchError when expectedState differs', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const start = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    await assert.rejects(
+      () =>
+        completeWebOAuthFlow({
+          state: start.state,
+          code: 'c',
+          pendingFlowStore,
+          expectedState: 'different-cookie-value',
+        }),
+      err => err instanceof StateMismatchError
+    );
+  });
+
+  test('expectedState matching the supplied state succeeds', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    installStandardASHandlers();
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const start = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    const completion = await completeWebOAuthFlow({
+      state: start.state,
+      code: 'c',
+      pendingFlowStore,
+      expectedState: start.state,
+    });
+    assert.strictEqual(completion.tokens.access_token, 'issued-access-token');
+  });
+
+  test('throws TokenExchangeError carrying status + body on AS rejection (with token redaction)', async () => {
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+    state.handlers['/.well-known/oauth-authorization-server'] = (req, res) =>
+      jsonRes(res, 200, {
+        issuer: origin(),
+        authorization_endpoint: `${origin()}/oauth/authorize`,
+        token_endpoint: `${origin()}/oauth/token`,
+        response_types_supported: ['code'],
+        code_challenge_methods_supported: ['S256'],
+        grant_types_supported: ['authorization_code'],
+        token_endpoint_auth_methods_supported: ['none'],
+        scopes_supported: ['mcp.read'],
+      });
+    state.handlers['/oauth/token'] = (req, res) => {
+      // AS error response that *also* echoes a refresh token in the body
+      // — we want to confirm redaction does its job.
+      jsonRes(res, 400, {
+        error: 'invalid_grant',
+        error_description: 'authorization code expired',
+        refresh_token: 'leaked-refresh-token',
+      });
+    };
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const start = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+    });
+
+    await assert.rejects(
+      () =>
+        completeWebOAuthFlow({
+          state: start.state,
+          code: 'expired-code',
+          pendingFlowStore,
+        }),
+      err => {
+        if (!(err instanceof TokenExchangeError)) return false;
+        assert.strictEqual(err.oauthErrorCode, 'invalid_grant');
+        assert.match(err.message, /invalid_grant/);
+        assert.doesNotMatch(err.body, /leaked-refresh-token/);
+        assert.doesNotMatch(err.message, /leaked-refresh-token/);
+        return true;
+      }
+    );
+  });
+
+  test('throws InvalidOrExpiredFlowError on unknown state', async () => {
+    await assert.rejects(
+      () =>
+        completeWebOAuthFlow({
+          state: 'never-existed',
+          code: 'x',
+          pendingFlowStore: new InMemoryPendingFlowStore(),
+        }),
+      err => err instanceof InvalidOrExpiredFlowError
+    );
+  });
+
+  test('throws InvalidOrExpiredFlowError on expired flow', async () => {
+    installStandardASHandlers();
+    state.handlers['/.well-known/oauth-protected-resource/mcp'] = (req, res) =>
+      jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [origin()] });
+
+    const pendingFlowStore = new InMemoryPendingFlowStore();
+    const start = await startWebOAuthFlow({
+      agent: makeAgent(),
+      redirectUri: 'http://localhost:9999/callback',
+      pendingFlowStore,
+      ttlMs: 1,
+    });
+
+    await new Promise(r => setTimeout(r, 10));
+
+    await assert.rejects(
+      () =>
+        completeWebOAuthFlow({
+          state: start.state,
+          code: 'auth-code',
+          pendingFlowStore,
+        }),
+      err => err instanceof InvalidOrExpiredFlowError
+    );
+  });
+});
+
+describe('PendingWebFlowStore contract (run against any implementation)', () => {
+  /**
+   * Reusable contract test. Adopters implementing a Postgres or Redis
+   * `PendingWebFlowStore` SHOULD run this against their store to prove
+   * the atomic-consume contract. The in-memory reference passes by
+   * construction; a `SELECT then DELETE` Postgres impl will fail it.
+   */
+  function runContract(name, factory) {
+    describe(name, () => {
+      test('consume returns null for absent state', async () => {
+        const store = await factory();
+        assert.strictEqual(await store.consume('does-not-exist'), null);
+      });
+
+      test('consume returns the row exactly once', async () => {
+        const store = await factory();
+        const flow = makePendingFlow('one-shot', 60_000);
+        await store.put(flow);
+
+        const first = await store.consume('one-shot');
+        assert.ok(first);
+        assert.strictEqual(first.agentId, 'test-agent');
+
+        const second = await store.consume('one-shot');
+        assert.strictEqual(second, null);
+      });
+
+      test('consume returns null for expired rows', async () => {
+        const store = await factory();
+        await store.put(makePendingFlow('expired', -1));
+        assert.strictEqual(await store.consume('expired'), null);
+      });
+
+      test('put rejects duplicate state', async () => {
+        const store = await factory();
+        await store.put(makePendingFlow('dup', 60_000));
+        await assert.rejects(() => store.put(makePendingFlow('dup', 60_000)));
+      });
+
+      test('parallel consume of the same state yields exactly one non-null', async () => {
+        const store = await factory();
+        await store.put(makePendingFlow('race', 60_000));
+        const results = await Promise.all([store.consume('race'), store.consume('race')]);
+        const wins = results.filter(r => r !== null);
+        assert.strictEqual(wins.length, 1, 'two consumers won the race');
+      });
+    });
+  }
+
+  function makePendingFlow(stateValue, ttlMs) {
+    const now = new Date();
+    return {
+      state: stateValue,
+      agentId: 'test-agent',
+      agentUrl: 'https://agent.example/mcp',
+      codeVerifier: 'pkce-verifier',
+      redirectUri: 'https://callback.example/cb',
+      resource: 'https://agent.example/mcp',
+      scope: 'mcp.read',
+      authorizationServerUrl: 'https://as.example/',
+      clientInformation: { client_id: 'c' },
+      createdAt: now,
+      expiresAt: new Date(now.getTime() + ttlMs),
+      carry: undefined,
+    };
+  }
+
+  runContract('InMemoryPendingFlowStore', async () => new InMemoryPendingFlowStore());
+});
+
+describe('safeReturnTo', () => {
+  test('accepts simple absolute paths', () => {
+    assert.strictEqual(safeReturnTo('/dashboard'), '/dashboard');
+    assert.strictEqual(safeReturnTo('/foo?bar=1'), '/foo?bar=1');
+  });
+
+  test('rejects protocol-relative URLs (//evil.example)', () => {
+    assert.strictEqual(safeReturnTo('//evil.example/'), undefined);
+  });
+
+  test('rejects path-traversal protocol smuggling (/\\\\evil)', () => {
+    assert.strictEqual(safeReturnTo('/\\evil.example'), undefined);
+  });
+
+  test('rejects absolute URLs by default', () => {
+    assert.strictEqual(safeReturnTo('https://evil.example/dashboard'), undefined);
+  });
+
+  test('rejects non-string and empty values', () => {
+    assert.strictEqual(safeReturnTo(undefined), undefined);
+    assert.strictEqual(safeReturnTo(null), undefined);
+    assert.strictEqual(safeReturnTo(''), undefined);
+    assert.strictEqual(safeReturnTo({ foo: 'bar' }), undefined);
+  });
+
+  test('honors allowedReturnHosts allowlist for absolute URLs', () => {
+    assert.strictEqual(
+      safeReturnTo('https://app.example.com/dashboard', { allowedReturnHosts: ['app.example.com'] }),
+      'https://app.example.com/dashboard'
+    );
+    assert.strictEqual(safeReturnTo('https://evil.example/', { allowedReturnHosts: ['app.example.com'] }), undefined);
+  });
+
+  test('rejects non-http(s) schemes even if host appears in allowlist', () => {
+    assert.strictEqual(safeReturnTo('javascript:alert(1)', { allowedReturnHosts: ['app.example.com'] }), undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `startWebOAuthFlow` / `completeWebOAuthFlow` to `@adcp/sdk` for web servers where `/oauth/start` and `/oauth/callback` may be served by different processes — companion to the existing `CLIFlowHandler` (loopback) and `NonInteractiveFlowHandler` (refresh-only) shapes.

The motivation: every server consumer (e.g. `adcp`'s `agent-oauth.ts`) reinvents this layer and ships bugs around RFC 9728 PRM, RFC 8707 `resource` indicators, SEP-835 scope priority, and atomic state consumption. Discovery, PKCE, URL construction, and token exchange now delegate to the MCP SDK's `client/auth.js` primitives so the wire behavior comes for free.

## What's exported

- `startWebOAuthFlow(opts)` → `{ authorizationUrl, state, expiresAt }`
- `completeWebOAuthFlow(opts)` → `{ tokens, carry, persisted, agentId, agentUrl }`
- `safeReturnTo(value, opts?)` — open-redirect guard for `carry.return_to`
- `PendingWebFlowStore` interface (consumer-supplied — Postgres `DELETE … RETURNING`, Redis `GETDEL`)
- `InMemoryPendingFlowStore` for tests / single-instance dev
- `DEFAULT_WEB_FLOW_TTL_MS` exported constant
- Typed errors: `InvalidOrExpiredFlowError`, `StateMismatchError`, `TokenExchangeError` (carries `oauthErrorCode`, redacted `body`), `ProtectedResourceMetadataError`, `AgentVanishedDuringFlowError`, `ConfidentialClientNotAllowedError`

## Security defaults

- PRM `resource` validated against agent origin via the MCP SDK's `checkResourceAllowed` — a poisoned PRM cannot point the audience at a third-party.
- PRM 404 → fall back to local resource derivation (RFC 9728 §3 marks PRM as optional). Parse / 5xx / connection errors throw rather than silently downgrade.
- Dynamic client registration that returns `client_secret` is rejected unless the caller opts in via `allowConfidentialClient: true`.
- `expectedState` parameter on `completeWebOAuthFlow` binds the flow to the caller's browser session (CSRF defense). The guide shows the cookie pattern.
- `TokenExchangeError.body` redacts `access_token`, `refresh_token`, `id_token`, `token` field names.
- `agentStorage.loadAgent` returning undefined after a successful exchange throws `AgentVanishedDuringFlowError` rather than silently dropping tokens.

## Process

Implementation went through four parallel expert reviews (security, code, DX, testing). All 17 prioritized findings were addressed before this PR. Notable design adjustments from those reviews:

- `store` / `storage` renamed to `pendingFlowStore` / `agentStorage` (DX disambiguation).
- `PendingFlowStore` renamed to `PendingWebFlowStore` (kept as deprecated alias).
- `consume()` interface contract tightened with canonical Postgres / Redis snippets in the JSDoc.
- The "atomic consume" test was reframed as a reusable contract test that adopters can run against their own store.

Pure addition — `MCPOAuthProvider`, `CLIFlowHandler`, `NonInteractiveFlowHandler` are untouched.

## Test plan

- [x] `npm run build:lib` succeeds, `tsc --noEmit` clean
- [x] `prettier --check` passes on touched files
- [x] All 31 new web-flow tests pass (`test/lib/oauth-web-flow.test.js`)
- [x] All 92 pre-existing OAuth tests still pass (123 / 123 across the OAuth suite)
- [x] Changeset added (minor)
- [ ] Reviewer: spot-check the Express integration in `docs/guides/WEB-OAUTH.md` against your mental model of cookie-bound state
- [ ] Reviewer: confirm the `PendingWebFlowStore` JSDoc is unambiguous enough that a Postgres adopter won't ship `SELECT … then DELETE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)