### PR TITLE
fix(unwrapper): extract DataPart from terminal A2A states (closes #1571)

### DIFF
--- a/.changeset/a2a-failed-task-unwrap.md
+++ b/.changeset/a2a-failed-task-unwrap.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Unwrap A2A failed-task DataPart so storyboard `error_code` validators read `adcp_error.code` from the artifact instead of falling back to `Task.status.state`. Per AdCP transport-errors §A2A Binding, failed tasks carry the same `result.artifacts[].parts[].data` envelope as completed tasks (with `adcp_error` keyed in the DataPart); the unwrapper now extracts that payload for any terminal state (`completed`, `failed`, `rejected`, `canceled`) and only rejects genuinely intermediate states (`working`, `submitted`, `input-required`, `auth-required`). Fixes spec-compliant A2A errors being mis-reported as `Expected error code "<code>", got "Task failed"`. (#1571)

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -370,21 +370,23 @@ export function readExtractionPath(data: unknown): McpExtractionPath | undefined
 /**
  * Unwrap A2A response
  *
- * NOTE: This function should only be called when status is "completed".
- * Intermediate statuses ("working", "submitted", "input-required") are handled
- * at the response level (not in artifacts) and should not reach this function.
+ * Called for terminal task states ("completed", "failed", "rejected",
+ * "canceled"). All four carry the same artifact + DataPart envelope per
+ * AdCP transport-errors §A2A Binding — failed tasks place `adcp_error`
+ * into the DataPart alongside an optional terse TextPart.
  *
- * A2A response flow:
- * - Intermediate: { status: "working", message: "..." } - NO artifacts yet
- * - Completed: { status: "completed", result: { artifacts: [...] } } - Parse artifacts here
+ * Intermediate statuses ("working", "submitted", "input-required",
+ * "auth-required") do not yet have AdCP artifacts and are rejected here
+ * so callers handle them at the response level.
  */
+const TERMINAL_A2A_STATES: ReadonlySet<string> = new Set(['completed', 'failed', 'rejected', 'canceled']);
+
 function unwrapA2AResponse(response: any): AdCPResponse {
-  // Validate that we're not processing intermediate statuses
-  // Task status check: only completed tasks should reach artifact extraction
-  if (response.result?.status?.state && response.result.status.state !== 'completed') {
+  const taskState = response.result?.status?.state;
+  if (taskState && !TERMINAL_A2A_STATES.has(taskState)) {
     throw new Error(
-      `Cannot unwrap A2A response with intermediate status: ${response.result.status.state}. ` +
-        'Only completed responses should be unwrapped.'
+      `Cannot unwrap A2A response with intermediate status: ${taskState}. ` +
+        'Only terminal responses (completed, failed, rejected, canceled) should be unwrapped.'
     );
   }
   // A2A error response (JSON-RPC error)
@@ -400,22 +402,22 @@ function unwrapA2AResponse(response: any): AdCPResponse {
     };
   }
 
-  // A2A completed response - simple requirements per AdCP spec:
-  // - MUST have result.artifacts array with at least one completed artifact
-  // - Completed artifact MUST have at least one DataPart (kind: 'data') with the AdCP response
+  // A2A terminal response — same shape regardless of success or failure:
+  // - MUST have result.artifacts array with at least one artifact
+  // - Artifact MUST have at least one DataPart (kind: 'data') with the AdCP payload
+  //   (success payload for `completed`, `adcp_error` envelope for `failed`)
   // - MAY have TextParts (kind: 'text') with optional messages
 
   const artifacts = response.result?.artifacts;
   if (!Array.isArray(artifacts) || artifacts.length === 0) {
-    throw new Error('A2A completed response must have at least one artifact');
+    throw new Error('A2A response must have at least one artifact');
   }
 
   // Take last artifact (conversational protocols append artifacts over time)
   // Note: A2A artifacts don't have a status field - only Tasks have status.
-  // If the Task status is "completed", all artifacts in result.artifacts are completed.
   const artifact = artifacts[artifacts.length - 1];
   if (!artifact) {
-    throw new Error('A2A completed response must have at least one artifact');
+    throw new Error('A2A response must have at least one artifact');
   }
 
   if (!artifact.parts || !Array.isArray(artifact.parts)) {
@@ -427,7 +429,7 @@ function unwrapA2AResponse(response: any): AdCPResponse {
   const dataParts = artifact.parts.filter((p: any) => p.kind === 'data');
   const dataPart = dataParts[dataParts.length - 1];
   if (!dataPart?.data) {
-    throw new Error('A2A completed response must have a DataPart with AdCP data');
+    throw new Error('A2A response must have a DataPart with AdCP data');
   }
 
   const textParts = artifact.parts.filter((p: any) => p.kind === 'text' && p.text).map((p: any) => p.text);

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -541,6 +541,74 @@ describe('Response Unwrapper', () => {
       );
     });
 
+    test('should unwrap A2A failed task carrying adcp_error DataPart', () => {
+      // Per AdCP transport-errors §A2A Binding: a failed task carries an
+      // artifact with a DataPart containing `adcp_error` plus a TextPart
+      // for human/LLM consumption. The unwrapper must surface the DataPart
+      // so storyboard validators (`error_code`, `field_value`) can read
+      // `adcp_error.code` / `context.correlation_id` from the unwrapped
+      // payload instead of falling back to `Task.status.state`.
+      const a2aFailedResponse = {
+        jsonrpc: '2.0',
+        result: {
+          kind: 'task',
+          status: { state: 'failed' },
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    context: { correlation_id: 'invalid_transitions--update_unknown_media_buy' },
+                    adcp_error: {
+                      code: 'MEDIA_BUY_NOT_FOUND',
+                      message: "Media buy 'does-not-exist' not found.",
+                      recovery: 'correctable',
+                    },
+                  },
+                },
+                { kind: 'text', text: "Media buy 'does-not-exist' not found." },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(a2aFailedResponse, undefined, 'a2a');
+
+      assert.ok(result.adcp_error, 'should surface adcp_error from DataPart');
+      assert.strictEqual(result.adcp_error.code, 'MEDIA_BUY_NOT_FOUND');
+      assert.strictEqual(result.adcp_error.recovery, 'correctable');
+      assert.ok(result.context, 'should surface context from DataPart');
+      assert.strictEqual(result.context.correlation_id, 'invalid_transitions--update_unknown_media_buy');
+      // TextPart joined onto _message for human/LLM consumption
+      assert.ok(result._message?.includes('not found'));
+    });
+
+    test('should unwrap A2A rejected task with DataPart payload', () => {
+      const a2aRejectedResponse = {
+        result: {
+          kind: 'task',
+          status: { state: 'rejected' },
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    adcp_error: { code: 'POLICY_VIOLATION', message: 'rejected by policy' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(a2aRejectedResponse, undefined, 'a2a');
+      assert.strictEqual(result.adcp_error.code, 'POLICY_VIOLATION');
+    });
+
     test('should include text snippet in error for unparseable MCP JSON', () => {
       const mcpResponse = {
         content: [{ type: 'text', text: 'This is not JSON, just plain text that should be included in error' }],


### PR DESCRIPTION
## Summary

- A2A failed tasks carry the same `result.artifacts[].parts[].data` envelope as completed tasks per AdCP transport-errors §A2A Binding (with `adcp_error` keyed in the DataPart). The unwrapper rejected any non-`completed` state, so `extractResponseData` fell back to the raw response and storyboard `error_code` / `field_value` validators read `Task.status.state` ("Task failed") instead of `adcp_error.code` / `context.correlation_id`.
- Allow `unwrapA2AResponse` to extract DataPart contents for any **terminal** state (`completed`, `failed`, `rejected`, `canceled`); only throw for genuinely intermediate states (`working`, `submitted`, `input-required`, `auth-required`) which carry no AdCP artifact.
- After this fix, the storyboard runner sees `MEDIA_BUY_NOT_FOUND` (and friends) on A2A error responses, matching MCP behavior on the same steps.

Fixes #1571.

## Test plan

- [x] `node --test test/lib/response-unwrapper.test.js` (57/57 pass — adds two new cases: failed-task adcp_error extraction, rejected-task DataPart extraction)
- [x] `node --test test/lib/storyboard-validations.test.js` (30/30 pass)
- [x] `node --test test/error-extraction.test.js` (39/39 pass)
- [x] `npm test` — full suite (8288/8288 pass; 3 skipped)
- [x] `npm run format:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)