### PR TITLE
fix(a2a): reroute SDK polling-path terminal-state error through unwrap pipeline

### DIFF
--- a/.changeset/fix-a2a-polling-terminal-state.md
+++ b/.changeset/fix-a2a-polling-terminal-state.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(a2a): reroute SDK polling-path terminal-state errors through unwrap pipeline
+
+When `@a2a-js/sdk` polls a task to completion on the blocking/SSE path, it
+annotates `result.error` with "Task X is in terminal state: 3" for failed
+tasks — but the `result.artifacts` DataPart still carries the spec-canonical
+`adcp_error`. `callA2AToolImpl` was throwing immediately on `result.error`,
+discarding the artifacts. Now it detects terminal-failed tasks with artifacts
+(`kind: 'task'`, non-empty `artifacts`, state in `failed/rejected/canceled`)
+and returns the full response so `handleAsyncResponse` can extract `adcp_error`
+via `unwrapA2AResponse`. Fixes #1575.
+
+Also exports `TERMINAL_FAILURE_A2A_STATES` from `response-unwrapper` so the
+state membership check is maintained in one place.

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -12,6 +12,7 @@ import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
+import { TERMINAL_FAILURE_A2A_STATES } from '../utils/response-unwrapper';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
 
@@ -353,6 +354,28 @@ async function callA2AToolImpl(
     });
 
     if (messageResponse?.error || messageResponse?.result?.error) {
+      // On the polling/blocking path, the @a2a-js/sdk annotates result.error
+      // ("Task X is in terminal state: 3") when a polled task settles to a
+      // terminal failed/rejected/canceled state — but the artifact DataPart
+      // still carries the spec-canonical adcp_error. Prefer the artifact
+      // extraction pipeline over the raw transport message so callers receive
+      // structured error codes rather than the SDK sentinel string.
+      const taskResult = messageResponse?.result;
+      if (
+        taskResult?.kind === 'task' &&
+        Array.isArray(taskResult?.artifacts) &&
+        taskResult.artifacts.length > 0 &&
+        typeof taskResult?.status?.state === 'string' &&
+        TERMINAL_FAILURE_A2A_STATES.has(taskResult.status.state)
+      ) {
+        debugLogs.push({
+          type: 'info',
+          message: `A2A: Terminal task (${taskResult.status.state}) has artifacts — routing through unwrap pipeline for adcp_error extraction`,
+          timestamp: new Date().toISOString(),
+          skill: toolName,
+        });
+        return messageResponse;
+      }
       const errorObj = messageResponse.error || messageResponse.result?.error;
       const errorMessage = errorObj.message || JSON.stringify(errorObj);
       throw new Error(`A2A agent returned error: ${errorMessage}`);

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -380,6 +380,9 @@ export function readExtractionPath(data: unknown): McpExtractionPath | undefined
  * so callers handle them at the response level.
  */
 const TERMINAL_A2A_STATES: ReadonlySet<string> = new Set(['completed', 'failed', 'rejected', 'canceled']);
+// Failure-only subset — excludes 'completed'. Used by the A2A shim to distinguish
+// terminal-failed tasks (which carry adcp_error in artifacts) from success terminals.
+export const TERMINAL_FAILURE_A2A_STATES: ReadonlySet<string> = new Set(['failed', 'rejected', 'canceled']);
 
 function unwrapA2AResponse(response: any): AdCPResponse {
   const taskState = response.result?.status?.state;

--- a/test/lib/protocol-compliance.test.js
+++ b/test/lib/protocol-compliance.test.js
@@ -275,6 +275,59 @@ describe('A2A Protocol Compliance', { skip: process.env.CI ? 'Slow tests - skipp
         'Should throw error when server returns nested error in result'
       );
     });
+
+    test('should route failed-task with result.error + artifacts through unwrapper (polling path)', async () => {
+      // The @a2a-js/sdk annotates result.error ("Task X is in terminal state: 3")
+      // when its internal polling observes a terminal-failed task, but the
+      // artifact DataPart still carries the spec-canonical adcp_error. The shim
+      // must return the full response rather than throwing so handleAsyncResponse
+      // can extract adcp_error from the DataPart (fixes #1575).
+      closeA2AConnections();
+      const pollingClient = {
+        sendMessage: async () => ({
+          jsonrpc: '2.0',
+          id: 'test-id',
+          result: {
+            kind: 'task',
+            id: 'task-9a364eb3',
+            status: { state: 'failed' },
+            error: { message: 'Task task-9a364eb3 is in terminal state: 3' },
+            artifacts: [
+              {
+                parts: [
+                  {
+                    kind: 'data',
+                    data: {
+                      adcp_error: {
+                        code: 'TERMS_REJECTED',
+                        message: 'Terms rejected for this inventory.',
+                        recovery: 'correctable',
+                        field: 'targeting.age_range',
+                      },
+                      context: { correlation_id: 'test-corr-id' },
+                    },
+                  },
+                  { kind: 'text', text: 'Terms rejected for this inventory.' },
+                ],
+              },
+            ],
+          },
+        }),
+      };
+
+      const originalA2AClient = require('@a2a-js/sdk/client').A2AClient;
+      originalA2AClient.fromCardUrl = async () => pollingClient;
+
+      // Must NOT throw — returns the task envelope so the caller can
+      // extract adcp_error from the artifact DataPart.
+      const response = await callA2ATool('https://test.com', 'get_products_brief', {});
+      assert.strictEqual(response?.result?.kind, 'task', 'should return A2A task response');
+      assert.strictEqual(response?.result?.status?.state, 'failed', 'should preserve failed state');
+      assert.ok(
+        Array.isArray(response?.result?.artifacts) && response.result.artifacts.length > 0,
+        'should preserve artifacts for downstream adcp_error extraction'
+      );
+    });
   });
 
   describe('Debug Logging Integration', () => {


### PR DESCRIPTION
## Summary

Closes #1575

When `@a2a-js/sdk` polls a task to completion on the blocking/SSE path, it annotates `result.error` with `"Task X is in terminal state: 3"` for failed tasks — but `result.artifacts` still carries the spec-canonical `adcp_error` DataPart. `callA2AToolImpl` was throwing immediately on `result.error`, discarding the artifacts and surfacing the opaque SDK sentinel string rather than the structured `adcp_error`.

- **`src/lib/protocols/a2a.ts`**: Before throwing on `messageResponse?.result?.error`, check whether the response is a terminal-failed A2A task (`kind: 'task'`, non-empty `artifacts`, `status.state` in `failed/rejected/canceled`). If so, return `messageResponse` instead of throwing, routing it through the existing `handleAsyncResponse → extractResponseData → unwrapA2AResponse` pipeline that already handles this case (landed in #1572).
- **`src/lib/utils/response-unwrapper.ts`**: Export `TERMINAL_FAILURE_A2A_STATES` (the failure-only subset of terminal states) so the state membership check is maintained in one place rather than inlined separately in `a2a.ts`.
- **`test/lib/protocol-compliance.test.js`**: Add regression test covering the exact response shape `@a2a-js/sdk` produces on the polling path: `{ result: { kind: 'task', status: { state: 'failed' }, error: {...}, artifacts: [...] } }`. Asserts that `callA2ATool` returns (does not throw) and preserves `result.artifacts` for downstream `adcp_error` extraction.

## What was tested

- Unit test added in `test/lib/protocol-compliance.test.js` ("Error Response Handling" describe block) exercises the exact SDK response shape from the polling path.
- Confirmed existing tests in the describe block still cover: bare JSON-RPC `error`, nested `result.error` without artifacts (both must still throw), and the new bypass-and-return path.
- Build environment (`tsx` / `@types/node`) is pre-broken on this host — pre-existing, unrelated to this change. CI will verify.

## Pre-PR review

- **Protocol expert (ad-tech-protocol-expert)**: Confirmed the A2A binding shape (`result.artifacts[].parts[kind=data].data`) is correct per the current spec. The `docs/proposals/transport-error-mapping.md` describing the older `status.message.parts` path is a stale pre-GA proposal, not the current wire contract.
- **Code reviewer (code-reviewer)**: Confirmed fix approach is correct. Actionable findings applied: (1) exported `TERMINAL_FAILURE_A2A_STATES` to avoid state-set drift between `a2a.ts` and `response-unwrapper.ts`; (2) added `debugLogs` entry when taking the artifact-bypass path so operators can observe the reroute; (3) reviewer's catch-block property-cascade concern does not apply to this implementation (the fix is in the `if (messageResponse?.result?.error)` branch, not in `catch`).

---
<!-- triage-managed-pr: issue=1575 -->

https://claude.ai/code/session_01CZWJDUsvc5mSHaGTgnHXsT

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZWJDUsvc5mSHaGTgnHXsT)_