### PR TITLE
fix(a2a): pass through terminal-state Task with adcp_error DataPart (closes #1575)

### DIFF
--- a/.changeset/a2a-failed-task-passthrough.md
+++ b/.changeset/a2a-failed-task-passthrough.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(a2a): pass through terminal-state Task with adcp_error DataPart instead of throwing
+
+When a seller emits a spec-compliant terminal-state Task (per AdCP
+transport-errors §A2A Binding) carrying the canonical `adcp_error` envelope
+on the artifact's DataPart, the protocol layer now lets the response flow to
+the upstream unwrapper even if the seller also surfaced a transport-level
+`result.error` hint. Previously, the generic "A2A agent returned error: ..."
+throw fired first and swallowed the structured `adcp_error.code` /
+`recovery` / `field` / `correlation_id`, leaving storyboard validators
+reading transport state ("Task ... is in terminal state: 3") instead of the
+AdCP error envelope. Sibling of #1571; fixes #1575.

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -216,12 +216,20 @@ const TERMINAL_A2A_STATES = new Set(['completed', 'failed', 'rejected', 'cancele
 
 /**
  * Detect whether a JSON-RPC response carries a spec-compliant terminal-state
- * Task with an `adcp_error` DataPart (or the success-arm equivalent — any
- * structured `data` payload) on its first artifact. Used to short-circuit the
- * generic "A2A agent returned error" throw when the seller surfaces both a
- * transport-level error hint and the canonical AdCP error envelope side-by-side.
+ * Task with at least one artifact containing a structured DataPart payload.
+ * Per AdCP transport-errors §A2A Binding, the artifact's DataPart is the
+ * canonical envelope for both the success arm (`completed`) and the error
+ * arms (`failed` / `rejected` / `canceled`). The criterion intentionally
+ * matches the unwrapper's terminal-state extraction in
+ * `unwrapA2AResponse` — keeping protocol layer and unwrapper in lockstep
+ * across all terminal states, not just the error arms.
+ *
+ * Used to short-circuit the generic "A2A agent returned error" throw when
+ * a non-conformant seller surfaces both a transport-level `result.error`
+ * hint and the canonical artifact envelope side-by-side. The DataPart is
+ * authoritative; the throw would otherwise swallow it.
  */
-function hasStructuredAdcpErrorArtifact(response: unknown): boolean {
+function hasTerminalTaskWithDataArtifact(response: unknown): boolean {
   if (!response || typeof response !== 'object') return false;
   const result = (response as { result?: unknown }).result;
   if (!result || typeof result !== 'object') return false;
@@ -396,7 +404,7 @@ async function callA2AToolImpl(
       // also surfaced a transport-level error string. Pass the response
       // through so the upstream unwrapper extracts `adcp_error.code` instead
       // of throwing a generic message that loses the AdCP error envelope.
-      if (!hasStructuredAdcpErrorArtifact(messageResponse)) {
+      if (!hasTerminalTaskWithDataArtifact(messageResponse)) {
         const errorObj = messageResponse.error || messageResponse.result?.error;
         const errorMessage = errorObj.message || JSON.stringify(errorObj);
         throw new Error(`A2A agent returned error: ${errorMessage}`);

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -207,6 +207,43 @@ function buildFetchImpl(authToken: string | undefined) {
 }
 
 /**
+ * Terminal A2A task states per A2A 0.3.0 §3.4. Only these can carry the
+ * AdCP-mandated artifact + DataPart envelope (per transport-errors §A2A
+ * Binding); intermediate states (`working`, `submitted`, `input-required`,
+ * `auth-required`) carry no completion artifact.
+ */
+const TERMINAL_A2A_STATES = new Set(['completed', 'failed', 'rejected', 'canceled']);
+
+/**
+ * Detect whether a JSON-RPC response carries a spec-compliant terminal-state
+ * Task with an `adcp_error` DataPart (or the success-arm equivalent — any
+ * structured `data` payload) on its first artifact. Used to short-circuit the
+ * generic "A2A agent returned error" throw when the seller surfaces both a
+ * transport-level error hint and the canonical AdCP error envelope side-by-side.
+ */
+function hasStructuredAdcpErrorArtifact(response: unknown): boolean {
+  if (!response || typeof response !== 'object') return false;
+  const result = (response as { result?: unknown }).result;
+  if (!result || typeof result !== 'object') return false;
+  const r = result as { kind?: unknown; status?: unknown; artifacts?: unknown };
+  if (r.kind !== 'task') return false;
+  const status = r.status as { state?: unknown } | undefined;
+  if (typeof status?.state !== 'string' || !TERMINAL_A2A_STATES.has(status.state)) return false;
+  if (!Array.isArray(r.artifacts) || r.artifacts.length === 0) return false;
+  for (const artifact of r.artifacts) {
+    if (!artifact || typeof artifact !== 'object') continue;
+    const parts = (artifact as { parts?: unknown }).parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (!part || typeof part !== 'object') continue;
+      const p = part as { kind?: unknown; data?: unknown };
+      if (p.kind === 'data' && p.data && typeof p.data === 'object') return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Protocol-level session identifiers that ride on the A2A Message envelope
  * (not in the skill parameters). `contextId` binds sends to a server-side
  * conversation; `taskId` resumes an existing non-terminal task.
@@ -353,9 +390,17 @@ async function callA2AToolImpl(
     });
 
     if (messageResponse?.error || messageResponse?.result?.error) {
-      const errorObj = messageResponse.error || messageResponse.result?.error;
-      const errorMessage = errorObj.message || JSON.stringify(errorObj);
-      throw new Error(`A2A agent returned error: ${errorMessage}`);
+      // adcp-client#1575: when the seller emits a spec-compliant terminal-state
+      // Task carrying an `adcp_error` DataPart (per AdCP transport-errors §A2A
+      // Binding), the structured artifact is canonical — even if the seller
+      // also surfaced a transport-level error string. Pass the response
+      // through so the upstream unwrapper extracts `adcp_error.code` instead
+      // of throwing a generic message that loses the AdCP error envelope.
+      if (!hasStructuredAdcpErrorArtifact(messageResponse)) {
+        const errorObj = messageResponse.error || messageResponse.result?.error;
+        const errorMessage = errorObj.message || JSON.stringify(errorObj);
+        throw new Error(`A2A agent returned error: ${errorMessage}`);
+      }
     }
 
     return messageResponse;

--- a/test/lib/protocol-compliance.test.js
+++ b/test/lib/protocol-compliance.test.js
@@ -335,6 +335,62 @@ describe('A2A Protocol Compliance', { skip: process.env.CI ? 'Slow tests - skipp
       assert.strictEqual(response.result.artifacts[0].parts[0].data.adcp_error.code, 'TERMS_REJECTED');
     });
 
+    // Negative: terminal-state Task without a DataPart (only TextParts) must
+    // still throw — there's no canonical envelope to defer to.
+    test('should still throw when terminal Task has only TextParts (no DataPart)', async () => {
+      closeA2AConnections();
+      const textOnlyClient = {
+        sendMessage: async () => ({
+          jsonrpc: '2.0',
+          id: 'test-id',
+          result: {
+            kind: 'task',
+            id: 'task-x',
+            status: { state: 'failed' },
+            error: { message: 'transport hint' },
+            artifacts: [{ parts: [{ kind: 'text', text: 'sorry' }] }],
+          },
+        }),
+      };
+
+      const originalA2AClient = require('@a2a-js/sdk/client').A2AClient;
+      originalA2AClient.fromCardUrl = async () => textOnlyClient;
+
+      await assert.rejects(
+        async () => callA2ATool('https://test.com', 'test_skill', {}),
+        { message: /A2A agent returned error: transport hint/ },
+        'TextPart-only artifact has no canonical envelope — must throw'
+      );
+    });
+
+    // Negative: terminal-state Task with empty artifacts array must still
+    // throw — no envelope present.
+    test('should still throw when terminal Task has empty artifacts array', async () => {
+      closeA2AConnections();
+      const emptyArtifactsClient = {
+        sendMessage: async () => ({
+          jsonrpc: '2.0',
+          id: 'test-id',
+          result: {
+            kind: 'task',
+            id: 'task-y',
+            status: { state: 'failed' },
+            error: { message: 'no artifact' },
+            artifacts: [],
+          },
+        }),
+      };
+
+      const originalA2AClient = require('@a2a-js/sdk/client').A2AClient;
+      originalA2AClient.fromCardUrl = async () => emptyArtifactsClient;
+
+      await assert.rejects(
+        async () => callA2ATool('https://test.com', 'test_skill', {}),
+        { message: /A2A agent returned error: no artifact/ },
+        'Empty artifacts array — must throw'
+      );
+    });
+
     test('should pass through rejected Task carrying adcp_error DataPart', async () => {
       closeA2AConnections();
       const rejectedTaskClient = {

--- a/test/lib/protocol-compliance.test.js
+++ b/test/lib/protocol-compliance.test.js
@@ -275,6 +275,99 @@ describe('A2A Protocol Compliance', { skip: process.env.CI ? 'Slow tests - skipp
         'Should throw error when server returns nested error in result'
       );
     });
+
+    // Regression: adcp-client#1575
+    // When the seller emits a spec-compliant terminal-state Task carrying an
+    // `adcp_error` DataPart per AdCP transport-errors §A2A Binding, the
+    // protocol layer must let the response through to the upstream unwrapper
+    // — even if the seller also embedded a transport-level `result.error`
+    // hint. Otherwise the structured `adcp_error.code` is lost behind a
+    // generic "A2A agent returned error" throw and storyboard validators
+    // read transport-state instead of the AdCP error envelope.
+    test('should pass through failed Task carrying adcp_error DataPart', async () => {
+      closeA2AConnections();
+      const failedTaskClient = {
+        sendMessage: async () => ({
+          jsonrpc: '2.0',
+          id: 'test-id',
+          result: {
+            kind: 'task',
+            id: 'task-9a364eb3',
+            contextId: 'ctx-abc',
+            status: { state: 'failed', timestamp: new Date().toISOString() },
+            // Some sellers also surface a transport-level error string alongside
+            // the structured artifact. The artifact is canonical per spec; the
+            // protocol layer must prefer it.
+            error: { message: 'Task 9a364eb3 is in terminal state: 3' },
+            artifacts: [
+              {
+                artifactId: 'art-1',
+                parts: [
+                  {
+                    kind: 'data',
+                    data: {
+                      adcp_error: {
+                        code: 'TERMS_REJECTED',
+                        message: 'Brief rejected by policy',
+                        recovery: 'correctable',
+                        field: 'brief',
+                      },
+                      context: { correlation_id: 'corr-123' },
+                    },
+                  },
+                  { kind: 'text', text: 'Rejected.' },
+                ],
+              },
+            ],
+          },
+        }),
+      };
+
+      const originalA2AClient = require('@a2a-js/sdk/client').A2AClient;
+      originalA2AClient.fromCardUrl = async () => failedTaskClient;
+
+      const response = await callA2ATool('https://test.com', 'get_products', { brief: 'x' });
+
+      // Spec-compliant terminal-state Task — must flow through unmodified so
+      // the unwrapper can extract `adcp_error` from the DataPart.
+      assert.strictEqual(response.result.kind, 'task');
+      assert.strictEqual(response.result.status.state, 'failed');
+      assert.strictEqual(response.result.artifacts[0].parts[0].data.adcp_error.code, 'TERMS_REJECTED');
+    });
+
+    test('should pass through rejected Task carrying adcp_error DataPart', async () => {
+      closeA2AConnections();
+      const rejectedTaskClient = {
+        sendMessage: async () => ({
+          jsonrpc: '2.0',
+          id: 'test-id',
+          result: {
+            kind: 'task',
+            id: 'task-rej',
+            status: { state: 'rejected' },
+            artifacts: [
+              {
+                parts: [
+                  {
+                    kind: 'data',
+                    data: {
+                      adcp_error: { code: 'POLICY_VIOLATION', message: 'no' },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      };
+
+      const originalA2AClient = require('@a2a-js/sdk/client').A2AClient;
+      originalA2AClient.fromCardUrl = async () => rejectedTaskClient;
+
+      const response = await callA2ATool('https://test.com', 'get_products', {});
+      assert.strictEqual(response.result.status.state, 'rejected');
+      assert.strictEqual(response.result.artifacts[0].parts[0].data.adcp_error.code, 'POLICY_VIOLATION');
+    });
   });
 
   describe('Debug Logging Integration', () => {


### PR DESCRIPTION
## Summary

Sibling of #1571 / #1572. When a seller emits a spec-compliant terminal-state
A2A Task carrying the canonical `adcp_error` envelope on its artifact's
DataPart (per AdCP transport-errors §A2A Binding), the protocol layer now
lets the response flow through to the upstream unwrapper — even if the
seller also surfaced a transport-level `result.error` hint side-by-side.

Previously the generic `A2A agent returned error: ...` throw at
`src/lib/protocols/a2a.ts:355` fired first and swallowed the structured
`adcp_error.code` / `recovery` / `field` / `correlation_id`, leaving
storyboard validators reading transport state (`Task ... is in terminal
state: 3`) instead of the AdCP error envelope. #1572 fixed `unwrapA2AResponse`
to extract DataPart contents from terminal failed Tasks; this PR ensures the
protocol layer doesn't intercept those responses before the unwrapper runs.

## Repro before fix

Storyboard runner emits:

```
media_buy_seller/inventory_list_targeting/get_products_brief [media_buy]:
  A2A agent returned error: Task 9a364eb3-17c5-467a-8dcb-4d08d41474b3 is in terminal state: 3
```

After fix: validators read `adcp_error.code` (e.g. `MEDIA_BUY_NOT_FOUND`,
`TERMS_REJECTED`).

## Test plan

- [x] `node --test test/lib/protocol-compliance.test.js` — adds 2 regression
      cases (`failed` and `rejected` Tasks with adcp_error DataPart pass
      through; existing JSON-RPC / `result.error`-only error paths still
      throw)
- [x] `npm test` — full suite (8234/8234 pass, 3 skipped, 0 fail)
- [x] `npm run format:check`

Fixes #1575.