### PR TITLE
fix(unwrapper): prefer DataPart artifact over top-level JSON-RPC error (sibling of #1575)

### DIFF
--- a/.changeset/unwrap-a2a-error-artifact-symmetry.md
+++ b/.changeset/unwrap-a2a-error-artifact-symmetry.md
@@ -1,0 +1,17 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(unwrapper): prefer DataPart artifact over top-level JSON-RPC error
+
+Sibling of #1575 / #1577 at the unwrap layer. When a non-conformant seller
+surfaces both a top-level JSON-RPC `error` AND a terminal-state Task with a
+structured DataPart artifact, the artifact is canonical per AdCP
+transport-errors §A2A Binding — `unwrapA2AResponse` now defers to the
+artifact-extraction path instead of short-circuiting on the transport-level
+error. Mirrors the protocol-layer guard added in #1577 so direct callers
+(storyboard fixtures, cached responses, webhook normalize paths) inherit
+the same defensive behavior.
+
+Top-level JSON-RPC errors without an accompanying terminal-Task artifact
+continue to flow through the `errors[]` short-circuit.

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -381,6 +381,35 @@ export function readExtractionPath(data: unknown): McpExtractionPath | undefined
  */
 const TERMINAL_A2A_STATES: ReadonlySet<string> = new Set(['completed', 'failed', 'rejected', 'canceled']);
 
+/**
+ * Detect whether a response carries a spec-compliant terminal-state Task
+ * with a structured DataPart artifact. Mirrors the protocol-layer guard in
+ * `src/lib/protocols/a2a.ts` (`hasTerminalTaskWithDataArtifact`) so the
+ * unwrapper defers to the canonical envelope when a non-conformant seller
+ * surfaces both a top-level transport error and the AdCP artifact.
+ */
+function hasTerminalTaskWithDataArtifact(response: unknown): boolean {
+  if (!response || typeof response !== 'object') return false;
+  const result = (response as { result?: unknown }).result;
+  if (!result || typeof result !== 'object') return false;
+  const r = result as { kind?: unknown; status?: unknown; artifacts?: unknown };
+  if (r.kind !== 'task') return false;
+  const status = r.status as { state?: unknown } | undefined;
+  if (typeof status?.state !== 'string' || !TERMINAL_A2A_STATES.has(status.state)) return false;
+  if (!Array.isArray(r.artifacts) || r.artifacts.length === 0) return false;
+  for (const artifact of r.artifacts) {
+    if (!artifact || typeof artifact !== 'object') continue;
+    const parts = (artifact as { parts?: unknown }).parts;
+    if (!Array.isArray(parts)) continue;
+    for (const part of parts) {
+      if (!part || typeof part !== 'object') continue;
+      const p = part as { kind?: unknown; data?: unknown };
+      if (p.kind === 'data' && p.data && typeof p.data === 'object') return true;
+    }
+  }
+  return false;
+}
+
 function unwrapA2AResponse(response: any): AdCPResponse {
   const taskState = response.result?.status?.state;
   if (taskState && !TERMINAL_A2A_STATES.has(taskState)) {
@@ -389,8 +418,15 @@ function unwrapA2AResponse(response: any): AdCPResponse {
         'Only terminal responses (completed, failed, rejected, canceled) should be unwrapped.'
     );
   }
-  // A2A error response (JSON-RPC error)
-  if (response.error) {
+  // A2A error response (JSON-RPC error). adcp-client#1575: when a
+  // non-conformant seller surfaces both a top-level JSON-RPC error AND a
+  // terminal-state Task with a structured DataPart artifact, the artifact
+  // is canonical per AdCP transport-errors §A2A Binding — defer to the
+  // artifact extraction below. Mirrors the protocol-layer guard at
+  // `src/lib/protocols/a2a.ts` so the two layers stay symmetric and
+  // direct callers (storyboard fixtures, cached responses, webhook
+  // payloads) inherit the same defensive behavior.
+  if (response.error && !hasTerminalTaskWithDataArtifact(response)) {
     return {
       errors: [
         {

--- a/test/lib/response-unwrapper.test.js
+++ b/test/lib/response-unwrapper.test.js
@@ -585,6 +585,63 @@ describe('Response Unwrapper', () => {
       assert.ok(result._message?.includes('not found'));
     });
 
+    // Sibling of adcp-client#1575 at the unwrap layer. When a non-conformant
+    // seller surfaces both a top-level JSON-RPC error AND a terminal-state Task
+    // with a structured DataPart artifact, the artifact is canonical per AdCP
+    // transport-errors §A2A Binding. Mirrors the protocol-layer guard added in
+    // PR #1577 so direct callers (storyboard fixtures, cached responses,
+    // webhook normalize paths) inherit the same defensive behavior.
+    test('should prefer DataPart artifact over top-level JSON-RPC error', () => {
+      const dualSignalResponse = {
+        jsonrpc: '2.0',
+        // Transport-level hint — would short-circuit pre-fix.
+        error: { code: -32000, message: 'Task is in terminal state: 3' },
+        // Canonical envelope — must win.
+        result: {
+          kind: 'task',
+          status: { state: 'failed' },
+          artifacts: [
+            {
+              parts: [
+                {
+                  kind: 'data',
+                  data: {
+                    adcp_error: { code: 'TERMS_REJECTED', message: 'rejected', recovery: 'correctable' },
+                    context: { correlation_id: 'corr-1575-sibling' },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      const result = unwrapProtocolResponse(dualSignalResponse, undefined, 'a2a');
+
+      assert.strictEqual(result.adcp_error.code, 'TERMS_REJECTED');
+      assert.strictEqual(result.adcp_error.recovery, 'correctable');
+      assert.strictEqual(result.context.correlation_id, 'corr-1575-sibling');
+      // Errors[] from the JSON-RPC short-circuit must NOT be present.
+      assert.strictEqual(result.errors, undefined);
+    });
+
+    // Negative: top-level JSON-RPC error WITHOUT a structured artifact must
+    // still go through the errors[] short-circuit. Defends the guard's
+    // discriminator (kind === 'task' + terminal state + DataPart) against
+    // accidental over-broadening.
+    test('should keep errors[] short-circuit when no terminal-Task artifact present', () => {
+      const errorOnlyResponse = {
+        jsonrpc: '2.0',
+        error: { code: -32602, message: 'Invalid params', data: { field: 'x' } },
+      };
+
+      const result = unwrapProtocolResponse(errorOnlyResponse, undefined, 'a2a');
+
+      assert.ok(Array.isArray(result.errors));
+      assert.strictEqual(result.errors[0].code, '-32602');
+      assert.strictEqual(result.errors[0].message, 'Invalid params');
+    });
+
     test('should unwrap A2A rejected task with DataPart payload', () => {
       const a2aRejectedResponse = {
         result: {


### PR DESCRIPTION
## Summary

Sibling of #1575 / #1577 at the unwrap layer. PR #1577 added a guard at the protocol layer so non-conformant sellers that surface both a transport-level error hint and a structured DataPart artifact don't lose the canonical AdCP envelope. This PR applies the same guard one layer down in `unwrapA2AResponse` so direct callers (storyboard fixtures, cached responses, webhook normalize paths) inherit the same defensive behavior.

## Why

`unwrapA2AResponse` was short-circuiting on top-level `response.error` and returning `errors:[{...}]` *without* checking `result.artifacts`. Per AdCP transport-errors §A2A Binding, the artifact's DataPart is authoritative for terminal-state Tasks (success and error arms alike). Same shape as #1575 at one layer down.

Not actively triggered today via the standard SDK send path (`invokeJsonRpc` returns either `{error}` *or* `{result}`, mutually exclusive), but reachable by any caller that bypasses the protocol layer with a synthesized response shape — exactly the case PR #1577 just enabled to flow through.

## Changes

- `src/lib/utils/response-unwrapper.ts` — adds `hasTerminalTaskWithDataArtifact` helper (mirrors the one in `src/lib/protocols/a2a.ts`); `unwrapA2AResponse` skips the JSON-RPC `errors[]` short-circuit when a terminal-state Task with a structured DataPart is present.
- `test/lib/response-unwrapper.test.js` — 2 regression cases: dual-signal response (canonical artifact wins), error-only response (errors[] short-circuit preserved).
- Patch changeset.

## Test plan

- [x] `node --test test/lib/response-unwrapper.test.js` — 59/59 pass
- [x] `npm test` — full suite (8288/8288 pass, 3 skipped, 0 fail)
- [x] `npm run format:check`