### PR TITLE
chore(framework): narrow typed handler ctx fields to match dispatch guarantees (#1384)

### DIFF
--- a/.changeset/sweep-typed-handler-ctx-narrow-1384.md
+++ b/.changeset/sweep-typed-handler-ctx-narrow-1384.md
@@ -1,0 +1,11 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(framework): remove duplicate `listCreativeFormats` declarations on `CreativeBuilderPlatform` / `CreativeAdServerPlatform` (#1384)
+
+Both interfaces previously declared `listCreativeFormats` twice — once correctly as `NoAccountCtx<TCtxMeta>` (matching the dispatch reality that no-account tools may receive `ctx.account === undefined`) and a second time as `Ctx<TCtxMeta>` (claiming `account` non-optional). TypeScript overload resolution on the implementation site preserved the narrow (so adopters were not silently exposed to the runtime crash #1327 fixed for `previewCreative`/`providePerformanceFeedback`), but the duplicate was a footgun for adopters reading the interface and a tripwire for future refactors.
+
+Removed the `Ctx`-typed declaration on both interfaces, folded the precedence note into the surviving `NoAccountCtx` declaration on `CreativeBuilderPlatform`, and added regression locks in `decisioning.type-checks.ts` to prevent the duplicate from regressing.
+
+This sweep also re-verified the rest of the typed-handler ctx surface introduced by #1327: `ctx.agent`, `ctx.ctxMetadata`, `ctx.recipes`, `ctx.handoffToTask`, `ctx.state.*`, and `ctx.resolve.*` all match their dispatch guarantees in `to-context.ts` / `from-platform.ts`. `ctx.authInfo`, `ctx.emitWebhook`, and `ctx.publishStatusChange` are not on `RequestContext` (they live on the legacy `HandlerContext` or as module-level exports) — out of scope for the typed-handler surface.

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -452,7 +452,12 @@ function _format_renders_accept_display_render(): void {
 
 // ── NoAccountCtx narrows ctx.account on no-account tools ──
 
-import { defineCreativeBuilderPlatform } from './platform-helpers';
+import { defineCreativeBuilderPlatform, defineCreativeAdServerPlatform } from './platform-helpers';
+import type {
+  ListCreativeFormatsResponse,
+  GetCreativeDeliveryResponse,
+  ListCreativesResponse,
+} from '../../types/tools.generated';
 
 // `previewCreative` handlers must narrow `ctx.account` before reading
 // `ctx_metadata` — the wire schema does not carry an `account` field, so
@@ -481,6 +486,76 @@ function _preview_creative_rejects_unnarrowed_access(): void {
       const _ws: string = ctx.account.ctx_metadata.workspace_id;
       void _ws;
       return {} as PreviewCreativeResponse;
+    },
+  });
+}
+
+// `listCreativeFormats` on `CreativeBuilderPlatform` is a no-account tool.
+// Same dispatch contract as `previewCreative`: wire schema omits `account`,
+// framework dispatches with `ctx.account === undefined` when
+// `accounts.resolve(undefined)` returns null. Regression lock against #1384
+// — a previous version of `CreativeBuilderPlatform` carried two declarations
+// for `listCreativeFormats` (one `NoAccountCtx`, one `Ctx`); TS overload
+// resolution kept the narrow at the implementation site, but the duplicate
+// was a footgun for adopters and a tripwire for future refactors. Removing
+// the duplicate and locking the narrow here.
+function _builder_list_creative_formats_requires_account_narrow(): void {
+  defineCreativeBuilderPlatform<{ catalog_id: string }>({
+    buildCreative: async () => ({}) as never,
+    listCreativeFormats: async (_req, ctx) => {
+      if (ctx.account == null) {
+        return {} as ListCreativeFormatsResponse;
+      }
+      const _catalog: string = ctx.account.ctx_metadata.catalog_id;
+      void _catalog;
+      return {} as ListCreativeFormatsResponse;
+    },
+  });
+}
+
+function _builder_list_creative_formats_rejects_unnarrowed_access(): void {
+  defineCreativeBuilderPlatform<{ catalog_id: string }>({
+    buildCreative: async () => ({}) as never,
+    listCreativeFormats: async (_req, ctx) => {
+      // @ts-expect-error — ctx.account is `Account | undefined`; reading without narrowing fails.
+      const _catalog: string = ctx.account.ctx_metadata.catalog_id;
+      void _catalog;
+      return {} as ListCreativeFormatsResponse;
+    },
+  });
+}
+
+// Same lock for `CreativeAdServerPlatform.listCreativeFormats` — the
+// ad-server interface carried the same duplicate-declaration pattern
+// before #1384. Lock the narrow.
+function _ad_server_list_creative_formats_requires_account_narrow(): void {
+  defineCreativeAdServerPlatform<{ catalog_id: string }>({
+    buildCreative: async () => ({}) as never,
+    previewCreative: async () => ({}) as PreviewCreativeResponse,
+    listCreatives: async () => ({}) as ListCreativesResponse,
+    getCreativeDelivery: async () => ({}) as GetCreativeDeliveryResponse,
+    listCreativeFormats: async (_req, ctx) => {
+      if (ctx.account == null) {
+        return {} as ListCreativeFormatsResponse;
+      }
+      const _catalog: string = ctx.account.ctx_metadata.catalog_id;
+      void _catalog;
+      return {} as ListCreativeFormatsResponse;
+    },
+  });
+}
+
+function _ad_server_list_creative_formats_rejects_unnarrowed_access(): void {
+  defineCreativeAdServerPlatform<{ catalog_id: string }>({
+    buildCreative: async () => ({}) as never,
+    previewCreative: async () => ({}) as PreviewCreativeResponse,
+    listCreatives: async () => ({}) as ListCreativesResponse,
+    getCreativeDelivery: async () => ({}) as GetCreativeDeliveryResponse,
+    listCreativeFormats: async (_req, ctx) => {
+      // @ts-expect-error — ctx.account is `Account | undefined`; reading without narrowing fails.
+      const _catalog: string = ctx.account.ctx_metadata.catalog_id;
+      void _catalog;
+      return {} as ListCreativeFormatsResponse;
     },
   });
 }
@@ -529,4 +604,8 @@ export const _references = [
   _format_renders_accept_display_render,
   _preview_creative_requires_account_narrow,
   _preview_creative_rejects_unnarrowed_access,
+  _builder_list_creative_formats_requires_account_narrow,
+  _builder_list_creative_formats_rejects_unnarrowed_access,
+  _ad_server_list_creative_formats_requires_account_narrow,
+  _ad_server_list_creative_formats_rejects_unnarrowed_access,
 ] as const;

--- a/src/lib/server/decisioning/specialisms/creative-ad-server.ts
+++ b/src/lib/server/decisioning/specialisms/creative-ad-server.ts
@@ -136,15 +136,4 @@ export interface CreativeAdServerPlatform<TCtxMeta = Record<string, unknown>> {
    * cross-cuts omit them; buyers fall back to per-row values.
    */
   getCreativeDelivery(filter: GetCreativeDeliveryRequest, ctx: Ctx<TCtxMeta>): Promise<GetCreativeDeliveryResponse>;
-
-  /**
-   * Format catalog. Same shape as `SalesPlatform.listCreativeFormats` —
-   * ad servers expose what formats their library supports so buyers can
-   * size brief / asset combinations against the platform before pushing.
-   * Optional; adopters who delegate format definitions to external
-   * `creative_agents` declared in capabilities can omit.
-   *
-   * ⚠️  NO-ACCOUNT TOOL — see {@link CreativeBuilderPlatform.listCreativeFormats}.
-   */
-  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativeFormatsResponse>;
 }

--- a/src/lib/server/decisioning/specialisms/creative.ts
+++ b/src/lib/server/decisioning/specialisms/creative.ts
@@ -149,6 +149,13 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
    * (Bannerflow / Celtra-style multi-tenant catalogs), return a synthetic
    * account from `accounts.resolve(undefined)` keyed on
    * `ctx.authInfo.clientId` and narrow `ctx.account` inside the handler.
+   *
+   * **Precedence:** when an adopter ALSO wires `SalesPlatform.listCreativeFormats`
+   * on the same platform, the sales-side handler wins (mediaBuy domain
+   * registers before creative). Don't wire both — pick the surface that
+   * matches your specialism. This creative-side wiring exists for adopters
+   * claiming only creative specialisms (`creative-template`, `creative-
+   * generative`, `creative-ad-server`) without a sales platform attached.
    */
   listCreativeFormats?(
     req: ListCreativeFormatsRequest,
@@ -174,29 +181,6 @@ export interface CreativeBuilderPlatform<TCtxMeta = Record<string, unknown>> {
     creatives: Creative[],
     ctx: Ctx<TCtxMeta>
   ): Promise<SyncCreativesRow[] | TaskHandoff<SyncCreativesRow[]>>;
-
-  /**
-   * Format catalog. Buyers query what creative formats this builder
-   * supports — same wire shape that sellers expose via
-   * `SalesPlatform.listCreativeFormats`. Optional because adopters who
-   * declare external `creative_agents` in their capabilities can let the
-   * framework discover formats via those references; self-hosted creative
-   * builders implement this directly.
-   *
-   * ⚠️  NO-ACCOUNT TOOL. The wire request does not carry an `account` field.
-   * `ctx.account` may be `undefined` for `'explicit'`-resolution adopters
-   * — see {@link AccountStore} JSDoc for safe patterns (`'derived'`
-   * resolution returning a singleton, or returning a synthetic publisher-
-   * wide Account from `accounts.resolve(undefined)`).
-   *
-   * **Precedence:** when an adopter ALSO wires `SalesPlatform.listCreativeFormats`
-   * on the same platform, the sales-side handler wins (mediaBuy domain
-   * registers before creative). Don't wire both — pick the surface that
-   * matches your specialism. This creative-side wiring exists for adopters
-   * claiming only creative specialisms (`creative-template`, `creative-
-   * generative`, `creative-ad-server`) without a sales platform attached.
-   */
-  listCreativeFormats?(req: ListCreativeFormatsRequest, ctx: Ctx<TCtxMeta>): Promise<ListCreativeFormatsResponse>;
 }
 
 /**


### PR DESCRIPTION
## Summary

Sweep follow-up to #1327 for typed handler entrypoints in `src/lib/server/decisioning/`. Audited each ctx field surfaced via `RequestContext` against the dispatch reality in `runtime/to-context.ts` + `runtime/from-platform.ts`. Found and fixed one mismatch: duplicate `listCreativeFormats` declarations on `CreativeBuilderPlatform` and `CreativeAdServerPlatform`.

## Audit table

| ctx field | claimed type (RequestContext) | dispatch guarantee (to-context.ts / from-platform.ts) | verdict |
|---|---|---|---|
| `account` | `TAccount` (non-optional) on Ctx; `Account<TCtxMeta> \| undefined` on NoAccountCtx | wired-or-undefined depending on tool's wire schema; #1327 narrowed the no-account tools via `NoAccountCtx` | ✅ match (post-#1327) |
| `agent` | `BuyerAgent \| undefined` (`agent?: BuyerAgent`) | `to-context.ts:131` spreads only when `handlerCtx.agent != null` | ✅ match |
| `ctxMetadata` | `CtxMetadataAccessor \| undefined` (`ctxMetadata?: CtxMetadataAccessor`) | `to-context.ts:124-127` builds accessor only when store wired AND account scope present; otherwise `undefined` | ✅ match |
| `recipes` | `ReadonlyMap<string, Recipe> \| undefined` (`recipes?: …`) | written only by proposal manager via dispatch-time mutation; sometimes left untouched | ✅ match |
| `handoffToTask` | non-optional `<TResult>(fn, options) => TaskHandoff<TResult>` | `to-context.ts:144-157` always wires the closure | ✅ match |
| `state.*` | non-optional `WorkflowStateReader` | `to-context.ts:132-137` always wires (stub readers in 6.0; live in rc.1+) | ✅ match (stubs are wire contract, not runtime crash) |
| `resolve.*` | non-optional `ResourceResolver` | `to-context.ts:138-142` always wires (stubs that throw on call in 6.0) | ✅ match (stubs throw is documented in JSDoc) |
| `listCreativeFormats` (CreativeBuilderPlatform) | declared TWICE: `NoAccountCtx<TCtxMeta>` AND `Ctx<TCtxMeta>` | wire schema omits `account`; framework dispatches with `account` possibly `undefined` | ❌ **mismatch** — duplicate declaration, fix below |
| `listCreativeFormats` (CreativeAdServerPlatform) | declared TWICE: `NoAccountCtx<TCtxMeta>` AND `Ctx<TCtxMeta>` | same as above | ❌ **mismatch** — duplicate declaration, fix below |

## Out of scope (not on RequestContext)

The issue's audit candidate list mentions `ctx.authInfo`, `ctx.emitWebhook`, and `ctx.publishStatusChange`. These are NOT exposed on the typed `RequestContext` surface:

- `authInfo` lives on the legacy `HandlerContext` (already typed `ResolvedAuthInfo \| undefined`)
- `emitWebhook` lives on the legacy `HandlerContext` (already typed `… | undefined`)
- `publishStatusChange` is a **module-level export** from the framework, not a ctx field

No mismatch in the typed-handler decisioning surface. Documented for future readers in the changeset.

## Fix

Both `CreativeBuilderPlatform` and `CreativeAdServerPlatform` previously declared `listCreativeFormats` twice — once correctly with `NoAccountCtx<TCtxMeta>` (matching dispatch reality: no-account tools may receive `ctx.account === undefined`) and a second time with `Ctx<TCtxMeta>` (claiming `account` non-optional). TypeScript overload resolution preserved the narrow at the implementation site (the parameter type collapses to the most permissive — `Account \| undefined`), so adopters were not silently exposed to the same runtime crash that #1327 fixed for `previewCreative` / `providePerformanceFeedback`. But the duplicate is a footgun: an adopter reading the interface picks the second declaration; a future refactor sees "two ways to spell the same thing" and deletes the narrow.

Removed the `Ctx`-typed declaration on both interfaces, folded the precedence note (sales-side handler wins when both wired) into the surviving `NoAccountCtx` declaration on `CreativeBuilderPlatform`, and added regression locks in `decisioning.type-checks.ts` mirroring the `previewCreative` pattern from #1327.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] Verified the new `@ts-expect-error` directives actually fire — temporarily removed one and confirmed tsc reports `'ctx.account' is possibly 'undefined'`, then restored
- [x] Existing `_preview_creative_*` regression locks unchanged
- [ ] CI green (Changeset Check + tsc + prettier)

## Refs

- closes #1384
- follow-up to #1327 (the original `NoAccountCtx` narrow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)