### PR TITLE
feat(cli): --soft-fail, --summary-file, storyboard show --specialism (#1527)

### DIFF
--- a/.changeset/storyboard-ci-ux-1527.md
+++ b/.changeset/storyboard-ci-ux-1527.md
@@ -1,0 +1,13 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(cli): storyboard CI UX improvements — soft-fail, summary file, specialism resolution
+
+Adds three improvements to `adcp storyboard` surfaced by silent CI failures in reference adopter repos:
+
+- **`--soft-fail`**: exit 0 even when storyboards fail, printing a `STORYBOARD FAILURES (N): scenario1, …` block to stderr. Eliminates the `continue-on-error: true` / `|| true` silent-failure pattern — adopters get "non-blocking but visible" without regressions going unnoticed. Applies to all run modes (capability-driven, bundle, `--file`, `--local-agent`, multi-instance, agents-map). Exit 1 (runner crash) and 2 (usage error) are not suppressed.
+
+- **`--summary-file [PATH]`**: write a Markdown run summary to a file after the run. Defaults to `storyboard-result-summary.md` when `PATH` is omitted. Auto-activates when `$GITHUB_STEP_SUMMARY` is set so the summary appears in the GitHub Actions job summary tab without an extra upload step.
+
+- **`adcp storyboard show --specialism <slug>`**: resolve which storyboards are graded when an agent claims a specialism (e.g. `adcp storyboard show --specialism sales-guaranteed`). Shows the full scenario list including protocol baseline and universal storyboards, with capability-gating annotations.

--- a/bin/adcp-storyboard-summary.js
+++ b/bin/adcp-storyboard-summary.js
@@ -1,0 +1,152 @@
+/**
+ * Markdown summary writers + soft-fail helpers for the storyboard CLI runners
+ * (issue adcp-client#1527).
+ *
+ * Extracted from bin/adcp.js so the formatting / file-write / soft-fail surfaces
+ * are unit-testable without spawning the CLI. The runner commands import these
+ * to render `--summary-file` outputs and to print the always-on
+ * "STORYBOARD FAILURES" block when `--soft-fail` swallows a failing exit code.
+ *
+ * Two markdown shapes exist because the runner has two underlying result
+ * shapes: `comply()` returns a `ComplianceResult` (with `summary.steps_passed`,
+ * `summary.steps_failed`, `failures[]`) while `runStoryboard()` returns one or
+ * more `StoryboardResult`s (with `phases[].steps[]` and per-step `passed` /
+ * `validations[]`). Each shape gets its own renderer; the column layout and
+ * cell-escape rules are shared via `escapeMarkdownCell`.
+ */
+
+const { writeFileSync } = require('node:fs');
+
+function escapeMarkdownCell(s) {
+  return String(s ?? '')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ');
+}
+
+/**
+ * Renders a `comply()` `ComplianceResult` as a Markdown summary suitable for
+ * `--summary-file` or `$GITHUB_STEP_SUMMARY`. Always emits a heading, an
+ * "Overall" line, and (when present) a per-failure table. A non-passing run
+ * with no `failures[]` array prints a placeholder so reviewers know failure
+ * details are unavailable rather than the run actually being clean.
+ */
+function buildComplianceSummaryMarkdown(result, agentUrl) {
+  const lines = [];
+  const s = result.summary || {};
+  lines.push(`# Storyboard run: ${agentUrl}`);
+  lines.push('');
+  lines.push(
+    `**Overall:** ${result.overall_status} — ` +
+      `${s.steps_passed ?? 0} passed / ${s.steps_failed ?? 0} failed / ${s.steps_skipped ?? 0} skipped`
+  );
+  const specialisms = result.agent_profile?.specialisms;
+  if (specialisms?.length) {
+    lines.push(`**Specialisms:** ${specialisms.join(', ')}`);
+  }
+  lines.push('');
+  const failures = result.failures;
+  if (failures?.length) {
+    lines.push('## Failures');
+    lines.push('');
+    lines.push('| Storyboard | Step | Reason |');
+    lines.push('|---|---|---|');
+    for (const f of failures) {
+      const reason = f.error || f.validation?.description || '';
+      lines.push(
+        `| ${escapeMarkdownCell(f.storyboard_id)} | ${escapeMarkdownCell(f.step_id)} | ${escapeMarkdownCell(reason)} |`
+      );
+    }
+    lines.push('');
+  } else if (result.overall_status !== 'passing') {
+    lines.push('_No per-step failure details available._');
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Renders one or more `StoryboardResult`s (the shape `runStoryboard()` and
+ * `runFullAssessment()` produce) as a Markdown summary. Walks every
+ * `phase.steps[]` for failed steps and emits one row per failure. Failed
+ * steps with a `validations[]` array surface the concatenated validation
+ * descriptions; otherwise the renderer falls back to `step.error` and
+ * finally the literal "failed" so the column is never empty.
+ */
+function buildStoryboardSummaryMarkdown(results, agentUrl, overallPassed) {
+  const lines = [];
+  lines.push(`# Storyboard run: ${agentUrl || 'local agent'}`);
+  lines.push('');
+  const totalPassed = results.reduce((n, r) => n + (r.passed_count ?? 0), 0);
+  const totalFailed = results.reduce((n, r) => n + (r.failed_count ?? 0), 0);
+  const totalSkipped = results.reduce((n, r) => n + (r.skipped_count ?? 0), 0);
+  lines.push(
+    `**Overall:** ${overallPassed ? 'passed' : 'failed'} — ` +
+      `${totalPassed} passed / ${totalFailed} failed / ${totalSkipped} skipped`
+  );
+  lines.push('');
+  const failures = [];
+  for (const r of results) {
+    for (const phase of r.phases || []) {
+      for (const step of phase.steps || []) {
+        if (!step.skipped && !step.passed) {
+          const reason =
+            step.validations
+              ?.filter(v => !v.passed)
+              .map(v => v.error || v.description)
+              .join('; ') ||
+            step.error ||
+            'failed';
+          failures.push({ storyboard: r.storyboard_id || '', step: step.id || step.title || '', reason });
+        }
+      }
+    }
+  }
+  if (failures.length > 0) {
+    lines.push('## Failures');
+    lines.push('');
+    lines.push('| Storyboard | Step | Reason |');
+    lines.push('|---|---|---|');
+    for (const f of failures) {
+      lines.push(
+        `| ${escapeMarkdownCell(f.storyboard)} | ${escapeMarkdownCell(f.step)} | ${escapeMarkdownCell(f.reason)} |`
+      );
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Writes `content` to `summaryFile`. Failures are downgraded to a stderr
+ * warning rather than exiting the process — the markdown summary is a
+ * convenience output, never a contract surface, so a permission denied on
+ * a CI volume must not mask the underlying run's exit code.
+ */
+function writeSummaryFile(summaryFile, content) {
+  try {
+    writeFileSync(summaryFile, content, 'utf-8');
+  } catch (err) {
+    console.error(`WARNING: Could not write summary file ${summaryFile}: ${err.message}`);
+  }
+}
+
+/**
+ * Print the "STORYBOARD FAILURES" block on stderr after a soft-fail-suppressed
+ * run. Suppressed under `--json` so machine-readable stdout consumers
+ * (e.g. JUnit + JSON pipelines) don't get unexpected stderr lines mixed in
+ * with their result envelope. A zero-length list is a no-op.
+ */
+function printSoftFailBlock(failedScenarios, jsonOutput) {
+  if (!jsonOutput && failedScenarios.length > 0) {
+    console.error(`\nSTORYBOARD FAILURES (${failedScenarios.length}): ${failedScenarios.join(', ')}`);
+    console.error('  --soft-fail set: exiting 0');
+  }
+}
+
+module.exports = {
+  escapeMarkdownCell,
+  buildComplianceSummaryMarkdown,
+  buildStoryboardSummaryMarkdown,
+  writeSummaryFile,
+  printSoftFailBlock,
+};

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -15,7 +15,7 @@
  */
 
 const { AdCPClient, detectProtocol, usesDeprecatedAssetsField } = require('../dist/lib/index.js');
-const { readFileSync, statSync } = require('fs');
+const { readFileSync, statSync, writeFileSync } = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
 const net = require('net');
@@ -33,6 +33,105 @@ const {
 const { handleRegistryCommand } = require('./adcp-registry.js');
 const { captureStdoutLogs, writeJsonOutput } = require('./adcp-json-stdout.js');
 const { printStepHints, countHintsInResult } = require('./adcp-step-hints.js');
+
+function escapeMarkdownCell(s) {
+  return String(s || '')
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ');
+}
+
+function buildComplianceSummaryMarkdown(result, agentUrl) {
+  const lines = [];
+  const s = result.summary;
+  lines.push(`# Storyboard run: ${agentUrl}`);
+  lines.push('');
+  lines.push(
+    `**Overall:** ${result.overall_status} — ` +
+      `${s.steps_passed ?? 0} passed / ${s.steps_failed ?? 0} failed / ${s.steps_skipped ?? 0} skipped`
+  );
+  const specialisms = result.agent_profile?.specialisms;
+  if (specialisms?.length) {
+    lines.push(`**Specialisms:** ${specialisms.join(', ')}`);
+  }
+  lines.push('');
+  const failures = result.failures;
+  if (failures?.length) {
+    lines.push('## Failures');
+    lines.push('');
+    lines.push('| Storyboard | Step | Reason |');
+    lines.push('|---|---|---|');
+    for (const f of failures) {
+      const reason = f.error || f.validation?.description || '';
+      lines.push(
+        `| ${escapeMarkdownCell(f.storyboard_id)} | ${escapeMarkdownCell(f.step_id)} | ${escapeMarkdownCell(reason)} |`
+      );
+    }
+    lines.push('');
+  } else if (result.overall_status !== 'passing') {
+    lines.push('_No per-step failure details available._');
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function buildStoryboardSummaryMarkdown(results, agentUrl, overallPassed) {
+  const lines = [];
+  lines.push(`# Storyboard run: ${agentUrl || 'local agent'}`);
+  lines.push('');
+  const totalPassed = results.reduce((n, r) => n + r.passed_count, 0);
+  const totalFailed = results.reduce((n, r) => n + r.failed_count, 0);
+  const totalSkipped = results.reduce((n, r) => n + r.skipped_count, 0);
+  lines.push(
+    `**Overall:** ${overallPassed ? 'passed' : 'failed'} — ` +
+      `${totalPassed} passed / ${totalFailed} failed / ${totalSkipped} skipped`
+  );
+  lines.push('');
+  const failures = [];
+  for (const r of results) {
+    for (const phase of r.phases || []) {
+      for (const step of phase.steps || []) {
+        if (!step.skipped && !step.passed) {
+          const reason =
+            step.validations
+              ?.filter(v => !v.passed)
+              .map(v => v.error || v.description)
+              .join('; ') ||
+            step.error ||
+            'failed';
+          failures.push({ storyboard: r.storyboard_id || '', step: step.id || step.title || '', reason });
+        }
+      }
+    }
+  }
+  if (failures.length > 0) {
+    lines.push('## Failures');
+    lines.push('');
+    lines.push('| Storyboard | Step | Reason |');
+    lines.push('|---|---|---|');
+    for (const f of failures) {
+      lines.push(
+        `| ${escapeMarkdownCell(f.storyboard)} | ${escapeMarkdownCell(f.step)} | ${escapeMarkdownCell(f.reason)} |`
+      );
+    }
+    lines.push('');
+  }
+  return lines.join('\n');
+}
+
+function writeSummaryFile(summaryFile, content) {
+  try {
+    writeFileSync(summaryFile, content, 'utf-8');
+  } catch (err) {
+    console.error(`WARNING: Could not write summary file ${summaryFile}: ${err.message}`);
+  }
+}
+
+function printSoftFailBlock(failedScenarios, jsonOutput) {
+  if (!jsonOutput && failedScenarios.length > 0) {
+    console.error(`\nSTORYBOARD FAILURES (${failedScenarios.length}): ${failedScenarios.join(', ')}`);
+    console.error('  --soft-fail set: exiting 0');
+  }
+}
 const { scheduleVersionCheck } = require('./adcp-version-check.js');
 const { formatStoryboardResultsAsJUnit } = require('../dist/lib/testing/storyboard/junit.js');
 const { LIBRARY_VERSION } = require('../dist/lib/version.js');
@@ -831,6 +930,26 @@ function parseAgentOptions(args) {
   // Auth-conflicting keys are dropped here with a warning.
   const { customHeaders, consumedTokens: headerTokens } = parseHeaderFlags(args);
 
+  // --summary-file [PATH]: write a Markdown run summary to a file after the run.
+  // If present without a value, defaults to 'storyboard-result-summary.md'.
+  // Auto-activates when $GITHUB_STEP_SUMMARY is set (GitHub Actions native job summary).
+  const summaryFileIdx = args.indexOf('--summary-file');
+  let summaryFileFlagValue = null;
+  let summaryFile = null;
+  if (summaryFileIdx !== -1) {
+    if (summaryFileIdx + 1 < args.length && !args[summaryFileIdx + 1].startsWith('--')) {
+      summaryFileFlagValue = args[summaryFileIdx + 1];
+      summaryFile = summaryFileFlagValue;
+    } else {
+      summaryFile = 'storyboard-result-summary.md';
+    }
+  } else if (process.env.GITHUB_STEP_SUMMARY) {
+    summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  }
+
+  // --soft-fail: exit 0 even when storyboards fail (replaces continue-on-error: true pattern).
+  const softFail = args.includes('--soft-fail');
+
   // Filter out flags and their values to find positional args. The `--file=PATH`
   // form is already removed by the `startsWith('--')` check; only the
   // space-separated value needs explicit exclusion. Use explicit nullish check
@@ -854,6 +973,7 @@ function parseAgentOptions(args) {
     formatValue,
     summaryOutputValue,
     fileIndex !== -1 ? file : null,
+    summaryFileFlagValue,
   ].filter(v => v !== null && v !== undefined);
   // `-H` short form does NOT start with `--`, so we filter it (and its KEY=VALUE
   // payload) out of positionals via the explicit `headerTokens` set.
@@ -875,6 +995,8 @@ function parseAgentOptions(args) {
     localAgent: localAgentValue,
     format: formatValue,
     customHeaders,
+    summaryFile,
+    softFail,
   };
 }
 
@@ -1367,6 +1489,7 @@ Storyboard-driven testing
 USAGE:
   adcp storyboard list [--json]
   adcp storyboard show <id> [--json]
+  adcp storyboard show --specialism <slug> [--json]
   adcp storyboard run <agent> [id|bundle] [options]
   adcp storyboard run <agent> --file <path.yaml> [options]
   adcp storyboard run --local-agent <module> [id|bundle] [options]
@@ -1375,6 +1498,10 @@ USAGE:
 SUBCOMMANDS:
   list                Enumerate storyboards in the compliance cache
   show <id>           Show storyboard structure (phases, steps)
+  show --specialism <slug>
+                      Resolve which storyboards are graded when an agent claims
+                      a specialism (e.g. sales-guaranteed). Includes protocol
+                      baseline and universal storyboards.
   run <agent> [id]    Run storyboards. With id, run one bundle/storyboard; otherwise
                       the agent's get_adcp_capabilities drives selection.
   step <agent> <id> <step_id>  Run a single step (stateless, LLM-friendly)
@@ -1465,6 +1592,18 @@ OPTIONS:
                       runs. One of: table (default), json, junit. junit
                       emits a JUnit XML report to stdout — each storyboard
                       becomes a testsuite, each step a testcase.
+  --soft-fail         Exit 0 even when storyboards fail. Prints a
+                      STORYBOARD FAILURES (N) block to stderr so failures
+                      are visible without blocking CI. Replaces the
+                      continue-on-error: true pattern. Exit 1 (runner
+                      crash) and 2 (usage error) are not suppressed.
+  --summary-file [PATH]
+                      Write a Markdown run summary to PATH after the run.
+                      If PATH is omitted, defaults to
+                      storyboard-result-summary.md in the current directory.
+                      Auto-activates when \$GITHUB_STEP_SUMMARY is set so
+                      the summary appears in the GitHub Actions job summary
+                      tab without an extra upload step.
 
 OUTPUT:
   If you see a \`💡 Hint: …\` line in a failing step, the runner has
@@ -1496,6 +1635,9 @@ EXAMPLES:
     --invariants ./my-invariants.js,@adcp/invariants  # register cross-step invariants
   adcp storyboard list
   adcp storyboard show media_buy_seller
+  adcp storyboard show --specialism sales-guaranteed
+  adcp storyboard run test-mcp --soft-fail              # exit 0 on failures, print summary
+  adcp storyboard run test-mcp --summary-file           # write storyboard-result-summary.md
   adcp storyboard step test-mcp media_buy_seller sync_accounts --json
 `);
     process.exit(0);
@@ -1770,14 +1912,86 @@ async function handleStoryboardList(args) {
 }
 
 async function handleStoryboardShow(args) {
-  const { resolveBundleOrStoryboard, findBundleById, listAllComplianceStoryboards } =
-    await import('../dist/lib/testing/storyboard/index.js');
+  const {
+    resolveBundleOrStoryboard,
+    findBundleById,
+    listAllComplianceStoryboards,
+    loadComplianceIndex,
+    resolveStoryboardsForCapabilities,
+    PROTOCOL_TO_PATH,
+  } = await import('../dist/lib/testing/storyboard/index.js');
   const jsonOutput = args.includes('--json');
-  const positionalArgs = args.filter(a => !a.startsWith('--'));
+
+  // --specialism <slug>: resolve which storyboards are graded for a given specialism claim.
+  const specialismIdx = args.indexOf('--specialism');
+  let specialismSlug = null;
+  if (specialismIdx !== -1 && specialismIdx + 1 < args.length && !args[specialismIdx + 1].startsWith('--')) {
+    specialismSlug = args[specialismIdx + 1];
+  }
+
+  // Exclude --specialism value from positional args to avoid treating it as a storyboard ID.
+  const positionalArgs = args.filter((a, i) => !a.startsWith('--') && i !== specialismIdx + 1);
   const storyboardId = positionalArgs[0];
 
+  if (specialismSlug) {
+    const index = loadComplianceIndex();
+    const entry = index.specialisms.find(s => s.id === specialismSlug);
+    if (!entry) {
+      const known = index.specialisms.map(s => s.id).join(', ');
+      console.error(`Unknown specialism: ${specialismSlug}`);
+      console.error(`Known specialisms: ${known}`);
+      process.exit(2);
+    }
+    // entry.protocol is kebab-case (e.g. 'media-buy'); supported_protocols uses snake_case.
+    const snakeCaseProtocol = Object.entries(PROTOCOL_TO_PATH).find(([, v]) => v === entry.protocol)?.[0];
+    if (!snakeCaseProtocol) {
+      console.error(
+        `Cannot map specialism protocol "${entry.protocol}" to a supported_protocols value. Compliance cache may be stale.`
+      );
+      process.exit(2);
+    }
+    let resolved;
+    try {
+      resolved = resolveStoryboardsForCapabilities({
+        specialisms: [specialismSlug],
+        supported_protocols: [snakeCaseProtocol],
+      });
+    } catch (err) {
+      console.error(`Failed to resolve specialism "${specialismSlug}": ${err.message}`);
+      process.exit(1);
+    }
+    if (jsonOutput) {
+      await writeJsonOutput({
+        specialism: specialismSlug,
+        protocol: entry.protocol,
+        storyboards: resolved.storyboards.map(s => ({ id: s.id, title: s.title, track: s.track ?? null })),
+        not_applicable: resolved.not_applicable,
+      });
+    } else {
+      console.log(`\nSpecialism: ${specialismSlug}  (protocol: ${entry.protocol})`);
+      console.log(`Resolves to ${resolved.storyboards.length} storyboard(s):`);
+      for (const sb of resolved.storyboards) {
+        const gating = sb.requires_capability
+          ? ` (gated on ${sb.requires_capability.path} = ${sb.requires_capability.equals})`
+          : ' (always graded)';
+        const trackTag = sb.track ? ` [track: ${sb.track}]` : '';
+        console.log(`  - ${sb.id}${trackTag}${gating}`);
+      }
+      if (resolved.not_applicable.length > 0) {
+        console.log(`\n${resolved.not_applicable.length} storyboard(s) not applicable (version gated):`);
+        for (const na of resolved.not_applicable) {
+          console.log(`  ⏭️  ${na.storyboard_id} — ${na.reason}`);
+        }
+      }
+      console.log(`\nNote: also includes universal storyboards and ${snakeCaseProtocol} protocol baseline.`);
+    }
+    return;
+  }
+
   if (!storyboardId) {
-    console.error('Usage: adcp storyboard show <id>');
+    console.error(
+      'Usage: adcp storyboard show <id> [--json]\n       adcp storyboard show --specialism <slug> [--json]'
+    );
     process.exit(2);
   }
 
@@ -2065,9 +2279,14 @@ async function handleStoryboardRun(args) {
     if (restoreLogs) restoreLogs();
   }
 
+  if (opts.summaryFile) {
+    writeSummaryFile(opts.summaryFile, buildStoryboardSummaryMarkdown([result], agentUrl, result.overall_passed));
+  }
+
   if (format === 'junit') {
     process.stdout.write(formatStoryboardResultsAsJUnit([result]));
-    process.exit(result.overall_passed ? 0 : 3);
+    if (opts.softFail && !result.overall_passed) printSoftFailBlock([result.storyboard_id], jsonOutput);
+    process.exit(opts.softFail ? 0 : result.overall_passed ? 0 : 3);
   }
 
   if (jsonOutput) {
@@ -2132,7 +2351,8 @@ async function handleStoryboardRun(args) {
     printStrictSummary(result.strict_validation_summary);
   }
 
-  process.exit(result.overall_passed ? 0 : 3);
+  if (opts.softFail && !result.overall_passed) printSoftFailBlock([result.storyboard_id], jsonOutput);
+  process.exit(opts.softFail ? 0 : result.overall_passed ? 0 : 3);
 }
 
 /**
@@ -2897,13 +3117,32 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
     if (restoreLogs) restoreLogs();
   }
 
+  if (opts.summaryFile) {
+    writeSummaryFile(
+      opts.summaryFile,
+      buildStoryboardSummaryMarkdown(result.results, result.agent_url, result.overall_passed)
+    );
+  }
+
   if (format === 'junit') {
     process.stdout.write(formatStoryboardResultsAsJUnit(result.results));
-    process.exit(result.overall_passed ? 0 : 3);
+    if (opts.softFail && !result.overall_passed) {
+      printSoftFailBlock(
+        result.results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
+        jsonOutput
+      );
+    }
+    process.exit(opts.softFail ? 0 : result.overall_passed ? 0 : 3);
   }
   if (jsonOutput) {
     await writeJsonOutput(result);
-    process.exit(result.overall_passed ? 0 : 3);
+    if (opts.softFail && !result.overall_passed) {
+      printSoftFailBlock(
+        result.results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
+        jsonOutput
+      );
+    }
+    process.exit(opts.softFail ? 0 : result.overall_passed ? 0 : 3);
   }
 
   // Human-readable summary
@@ -2928,7 +3167,13 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
     `\n${overallIcon} ${result.passed_count} passed, ${result.failed_count} failed, ${result.skipped_count} skipped across ${result.results.length} storyboard(s)${hintTail}`
   );
   printStrictSummary(aggregateStrictSummaries(result.results.map(r => r.strict_validation_summary)));
-  process.exit(result.overall_passed ? 0 : 3);
+  if (opts.softFail && !result.overall_passed) {
+    printSoftFailBlock(
+      result.results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
+      jsonOutput
+    );
+  }
+  process.exit(opts.softFail ? 0 : result.overall_passed ? 0 : 3);
 }
 
 /**
@@ -3271,7 +3516,13 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     );
   }
 
-  process.exit(hadFailure ? 3 : 0);
+  if (opts.softFail && hadFailure) {
+    printSoftFailBlock(
+      results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
+      opts.jsonOutput
+    );
+  }
+  process.exit(opts.softFail ? 0 : hadFailure ? 3 : 0);
 }
 
 /**
@@ -3456,7 +3707,13 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
 
   if (format === 'junit') {
     process.stdout.write(formatStoryboardResultsAsJUnit(results));
-    process.exit(hadFailure ? 3 : 0);
+    if (opts.softFail && hadFailure) {
+      printSoftFailBlock(
+        results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
+        jsonOutput
+      );
+    }
+    process.exit(opts.softFail ? 0 : hadFailure ? 3 : 0);
   }
 
   if (jsonOutput) {
@@ -3533,7 +3790,13 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     );
   }
 
-  process.exit(hadFailure ? 3 : 0);
+  if (opts.softFail && hadFailure) {
+    printSoftFailBlock(
+      results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
+      opts.jsonOutput
+    );
+  }
+  process.exit(opts.softFail ? 0 : hadFailure ? 3 : 0);
 }
 
 // Shared implementation: run all matching storyboards against an agent
@@ -3698,6 +3961,10 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 
     const result = await comply(agentUrl, testOptions);
 
+    if (opts.summaryFile) {
+      writeSummaryFile(opts.summaryFile, buildComplianceSummaryMarkdown(result, agentUrl));
+    }
+
     if (opts.jsonOutput) {
       restoreLogs();
       await writeJsonOutput(formatComplianceResultsJSON(result));
@@ -3718,13 +3985,16 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     // exercised its tracks and they passed" is a CI failure. `partial`
     // is preserved as exit 0 because some tracks were silent (wired but
     // unexercised) — that's a reportable observation, not a hard failure.
-    const exitCode =
+    const isFailingExit =
       result.overall_status === 'failing' ||
       result.overall_status === 'unreachable' ||
-      result.overall_status === 'auth_required'
-        ? 3
-        : 0;
-    process.exit(exitCode);
+      result.overall_status === 'auth_required';
+
+    if (opts.softFail && isFailingExit) {
+      const failedNames = result.failures?.map(f => f.storyboard_id).filter((v, i, a) => a.indexOf(v) === i) ?? [];
+      printSoftFailBlock(failedNames, opts.jsonOutput);
+    }
+    process.exit(opts.softFail ? 0 : isFailingExit ? 3 : 0);
   } catch (error) {
     if (restoreLogs) restoreLogs();
     console.error(`\nAssessment failed: ${error.message}`);

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -936,7 +936,9 @@ function parseAgentOptions(args) {
   const summaryFileIdx = args.indexOf('--summary-file');
   let summaryFileFlagValue = null;
   let summaryFile = null;
+  let summaryFileExplicit = false;
   if (summaryFileIdx !== -1) {
+    summaryFileExplicit = true;
     if (summaryFileIdx + 1 < args.length && !args[summaryFileIdx + 1].startsWith('--')) {
       summaryFileFlagValue = args[summaryFileIdx + 1];
       summaryFile = summaryFileFlagValue;
@@ -996,6 +998,7 @@ function parseAgentOptions(args) {
     format: formatValue,
     customHeaders,
     summaryFile,
+    summaryFileExplicit,
     softFail,
   };
 }
@@ -3522,13 +3525,13 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     );
   }
 
-  if (opts.summaryFile) {
+  if (opts.summaryFile && opts.summaryFileExplicit) {
     console.error(`WARNING: --summary-file is not supported for multi-instance runs; skipping.`);
   }
   if (opts.softFail && hadFailure) {
     printSoftFailBlock(
       results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
-      opts.jsonOutput
+      jsonOutput
     );
   }
   process.exit(opts.softFail ? 0 : hadFailure ? 3 : 0);
@@ -3799,13 +3802,13 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     );
   }
 
-  if (opts.summaryFile) {
+  if (opts.summaryFile && opts.summaryFileExplicit) {
     console.error(`WARNING: --summary-file is not supported for agents-map runs; skipping.`);
   }
   if (opts.softFail && hadFailure) {
     printSoftFailBlock(
       results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
-      opts.jsonOutput
+      jsonOutput
     );
   }
   process.exit(opts.softFail ? 0 : hadFailure ? 3 : 0);

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -15,7 +15,7 @@
  */
 
 const { AdCPClient, detectProtocol, usesDeprecatedAssetsField } = require('../dist/lib/index.js');
-const { readFileSync, statSync, writeFileSync } = require('fs');
+const { readFileSync, statSync } = require('fs');
 const path = require('path');
 const { pathToFileURL } = require('url');
 const net = require('net');
@@ -33,105 +33,12 @@ const {
 const { handleRegistryCommand } = require('./adcp-registry.js');
 const { captureStdoutLogs, writeJsonOutput } = require('./adcp-json-stdout.js');
 const { printStepHints, countHintsInResult } = require('./adcp-step-hints.js');
-
-function escapeMarkdownCell(s) {
-  return String(s || '')
-    .replace(/\|/g, '\\|')
-    .replace(/\n/g, ' ');
-}
-
-function buildComplianceSummaryMarkdown(result, agentUrl) {
-  const lines = [];
-  const s = result.summary;
-  lines.push(`# Storyboard run: ${agentUrl}`);
-  lines.push('');
-  lines.push(
-    `**Overall:** ${result.overall_status} — ` +
-      `${s.steps_passed ?? 0} passed / ${s.steps_failed ?? 0} failed / ${s.steps_skipped ?? 0} skipped`
-  );
-  const specialisms = result.agent_profile?.specialisms;
-  if (specialisms?.length) {
-    lines.push(`**Specialisms:** ${specialisms.join(', ')}`);
-  }
-  lines.push('');
-  const failures = result.failures;
-  if (failures?.length) {
-    lines.push('## Failures');
-    lines.push('');
-    lines.push('| Storyboard | Step | Reason |');
-    lines.push('|---|---|---|');
-    for (const f of failures) {
-      const reason = f.error || f.validation?.description || '';
-      lines.push(
-        `| ${escapeMarkdownCell(f.storyboard_id)} | ${escapeMarkdownCell(f.step_id)} | ${escapeMarkdownCell(reason)} |`
-      );
-    }
-    lines.push('');
-  } else if (result.overall_status !== 'passing') {
-    lines.push('_No per-step failure details available._');
-    lines.push('');
-  }
-  return lines.join('\n');
-}
-
-function buildStoryboardSummaryMarkdown(results, agentUrl, overallPassed) {
-  const lines = [];
-  lines.push(`# Storyboard run: ${agentUrl || 'local agent'}`);
-  lines.push('');
-  const totalPassed = results.reduce((n, r) => n + r.passed_count, 0);
-  const totalFailed = results.reduce((n, r) => n + r.failed_count, 0);
-  const totalSkipped = results.reduce((n, r) => n + r.skipped_count, 0);
-  lines.push(
-    `**Overall:** ${overallPassed ? 'passed' : 'failed'} — ` +
-      `${totalPassed} passed / ${totalFailed} failed / ${totalSkipped} skipped`
-  );
-  lines.push('');
-  const failures = [];
-  for (const r of results) {
-    for (const phase of r.phases || []) {
-      for (const step of phase.steps || []) {
-        if (!step.skipped && !step.passed) {
-          const reason =
-            step.validations
-              ?.filter(v => !v.passed)
-              .map(v => v.error || v.description)
-              .join('; ') ||
-            step.error ||
-            'failed';
-          failures.push({ storyboard: r.storyboard_id || '', step: step.id || step.title || '', reason });
-        }
-      }
-    }
-  }
-  if (failures.length > 0) {
-    lines.push('## Failures');
-    lines.push('');
-    lines.push('| Storyboard | Step | Reason |');
-    lines.push('|---|---|---|');
-    for (const f of failures) {
-      lines.push(
-        `| ${escapeMarkdownCell(f.storyboard)} | ${escapeMarkdownCell(f.step)} | ${escapeMarkdownCell(f.reason)} |`
-      );
-    }
-    lines.push('');
-  }
-  return lines.join('\n');
-}
-
-function writeSummaryFile(summaryFile, content) {
-  try {
-    writeFileSync(summaryFile, content, 'utf-8');
-  } catch (err) {
-    console.error(`WARNING: Could not write summary file ${summaryFile}: ${err.message}`);
-  }
-}
-
-function printSoftFailBlock(failedScenarios, jsonOutput) {
-  if (!jsonOutput && failedScenarios.length > 0) {
-    console.error(`\nSTORYBOARD FAILURES (${failedScenarios.length}): ${failedScenarios.join(', ')}`);
-    console.error('  --soft-fail set: exiting 0');
-  }
-}
+const {
+  buildComplianceSummaryMarkdown,
+  buildStoryboardSummaryMarkdown,
+  writeSummaryFile,
+  printSoftFailBlock,
+} = require('./adcp-storyboard-summary.js');
 const { scheduleVersionCheck } = require('./adcp-version-check.js');
 const { formatStoryboardResultsAsJUnit } = require('../dist/lib/testing/storyboard/junit.js');
 const { LIBRARY_VERSION } = require('../dist/lib/version.js');

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1597,6 +1597,8 @@ OPTIONS:
                       are visible without blocking CI. Replaces the
                       continue-on-error: true pattern. Exit 1 (runner
                       crash) and 2 (usage error) are not suppressed.
+                      In --json mode the stderr block is suppressed;
+                      failures are present in the JSON output.
   --summary-file [PATH]
                       Write a Markdown run summary to PATH after the run.
                       If PATH is omitted, defaults to
@@ -1930,7 +1932,11 @@ async function handleStoryboardShow(args) {
   }
 
   // Exclude --specialism value from positional args to avoid treating it as a storyboard ID.
-  const positionalArgs = args.filter((a, i) => !a.startsWith('--') && i !== specialismIdx + 1);
+  // Guard: only exclude index specialismIdx+1 when --specialism was actually present (specialismIdx !== -1),
+  // otherwise -1+1=0 would silently drop the first positional (the storyboard ID) on plain `show <id>` calls.
+  const positionalArgs = args.filter(
+    (a, i) => !a.startsWith('--') && (specialismSlug === null || i !== specialismIdx + 1)
+  );
   const storyboardId = positionalArgs[0];
 
   if (specialismSlug) {
@@ -1983,7 +1989,7 @@ async function handleStoryboardShow(args) {
           console.log(`  ⏭️  ${na.storyboard_id} — ${na.reason}`);
         }
       }
-      console.log(`\nNote: also includes universal storyboards and ${snakeCaseProtocol} protocol baseline.`);
+      console.log(`\nNote: also includes universal storyboards and ${entry.protocol} protocol baseline.`);
     }
     return;
   }
@@ -3516,6 +3522,9 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     );
   }
 
+  if (opts.summaryFile) {
+    console.error(`WARNING: --summary-file is not supported for multi-instance runs; skipping.`);
+  }
   if (opts.softFail && hadFailure) {
     printSoftFailBlock(
       results.filter(r => !r.overall_passed).map(r => r.storyboard_id),
@@ -3790,6 +3799,9 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     );
   }
 
+  if (opts.summaryFile) {
+    console.error(`WARNING: --summary-file is not supported for agents-map runs; skipping.`);
+  }
   if (opts.softFail && hadFailure) {
     printSoftFailBlock(
       results.filter(r => !r.overall_passed).map(r => r.storyboard_id),

--- a/test/lib/cli-soft-fail.test.js
+++ b/test/lib/cli-soft-fail.test.js
@@ -1,0 +1,151 @@
+// CLI plumbing for `--soft-fail` and `--summary-file` (issue adcp-client#1527).
+//
+// `parseAgentOptions` is internal to `bin/adcp.js`, so we observe its parsing
+// effects through the runner's exit code and side effects rather than calling
+// the parser directly. The two contracts under test:
+//
+//   --soft-fail              ⇒ a failing storyboard exits 0 instead of 3,
+//                              and `STORYBOARD FAILURES (...)` may print on
+//                              stderr (only when there are named failures —
+//                              `unreachable` runs have no per-storyboard
+//                              entries, so the block stays silent).
+//   --summary-file [PATH]    ⇒ writes the run's Markdown summary to PATH;
+//                              defaults to `storyboard-result-summary.md`
+//                              when invoked bare.
+//   $GITHUB_STEP_SUMMARY=...  ⇒ auto-activates --summary-file with the env
+//                              var as the path. No CLI flag required.
+//
+// We use an unreachable URL to drive a deterministic failing run without
+// any network egress (DNS fails before TCP). Exit 3 is the runner's
+// failure-without-soft-fail exit code; `--soft-fail` must collapse it to 0.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { mkdtempSync, rmSync, existsSync, readFileSync } = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+// Reserved `.invalid` TLD: never resolves, never reaches the network.
+// Suffix the test number so concurrent runs of different tests don't
+// collide on cached DNS NXDOMAIN entries.
+const UNREACHABLE = 'https://this-host-does-not-exist-1527.example.invalid';
+// Storyboard ID is universal — present in every shipped compliance cache.
+const STORYBOARD = 'capability_discovery';
+
+function runCli(args, env) {
+  return spawnSync('node', [CLI, ...args], {
+    encoding: 'utf8',
+    timeout: 45_000,
+    env: { ...process.env, ...env },
+  });
+}
+
+test('failing run without --soft-fail exits 3 (baseline)', () => {
+  // Baseline: confirm the runner exits non-zero on an unreachable agent.
+  // Without this anchor, the next test's exit-0 assertion proves nothing.
+  const res = runCli(['storyboard', 'run', UNREACHABLE, STORYBOARD]);
+  assert.strictEqual(res.status, 3, `expected exit 3, got ${res.status}. stderr: ${res.stderr}`);
+});
+
+test('failing run with --soft-fail exits 0', () => {
+  const res = runCli(['storyboard', 'run', UNREACHABLE, STORYBOARD, '--soft-fail']);
+  assert.strictEqual(res.status, 0, `expected exit 0 under --soft-fail, got ${res.status}. stderr: ${res.stderr}`);
+});
+
+test('--soft-fail does not affect a passing storyboard ID parse (positional intact)', () => {
+  // Regression guard: --soft-fail's flag-parsing must not consume the
+  // storyboard positional. If parseAgentOptions's flagValues ever picks up
+  // a stray non-null entry, the storyboard ID would be filtered out and
+  // the runner would fall back to the all-storyboards path.
+  const res = runCli(['storyboard', 'run', UNREACHABLE, STORYBOARD, '--soft-fail']);
+  // The "Running storyboard assessment" line lists the requested storyboards.
+  // We don't care about pass/fail here, only that the ID survived parsing.
+  assert.match(res.stdout, /Storyboards:\s+capability_discovery/);
+});
+
+test('--summary-file PATH writes the Markdown summary to PATH', () => {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-soft-fail-'));
+  try {
+    const summary = path.join(tmpDir, 'run.md');
+    const res = runCli([
+      'storyboard',
+      'run',
+      UNREACHABLE,
+      STORYBOARD,
+      '--soft-fail', // collapse the exit code so this test only verifies file writing
+      '--summary-file',
+      summary,
+    ]);
+    assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}. stderr: ${res.stderr}`);
+    assert.ok(existsSync(summary), `expected ${summary} to exist after the run`);
+    const body = readFileSync(summary, 'utf-8');
+    assert.match(body, /^# Storyboard run:/m);
+    assert.match(body, /\*\*Overall:\*\*/);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('--summary-file without an argument defaults to storyboard-result-summary.md (cwd)', () => {
+  // Verify the default-path branch of parseAgentOptions: bare --summary-file
+  // (followed by another --flag, so the next token isn't a positional value).
+  // The default path is relative to the CLI's cwd, so we run inside a tmpdir
+  // and check for the file there.
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-soft-fail-default-'));
+  try {
+    const res = spawnSync(
+      'node',
+      [CLI, 'storyboard', 'run', UNREACHABLE, STORYBOARD, '--summary-file', '--soft-fail'],
+      {
+        encoding: 'utf8',
+        timeout: 45_000,
+        cwd: tmpDir,
+      }
+    );
+    assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}. stderr: ${res.stderr}`);
+    const defaultPath = path.join(tmpDir, 'storyboard-result-summary.md');
+    assert.ok(existsSync(defaultPath), `expected default summary file at ${defaultPath}`);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('$GITHUB_STEP_SUMMARY auto-activates --summary-file (env-driven CI integration)', () => {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-soft-fail-gha-'));
+  try {
+    const summary = path.join(tmpDir, 'gha-step-summary.md');
+    const res = runCli(['storyboard', 'run', UNREACHABLE, STORYBOARD, '--soft-fail'], {
+      GITHUB_STEP_SUMMARY: summary,
+    });
+    assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}. stderr: ${res.stderr}`);
+    assert.ok(existsSync(summary), `expected ${summary} to exist after env-driven activation`);
+    const body = readFileSync(summary, 'utf-8');
+    assert.match(body, /^# Storyboard run:/m);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('no --summary-file and no $GITHUB_STEP_SUMMARY ⇒ no file is written', () => {
+  // Sanity: the env-auto-activation must not leak from an unrelated env
+  // var or from a parser bug that defaults `summaryFile` to a truthy
+  // value. We check that no `storyboard-result-summary.md` appears in the
+  // working directory after a run with neither flag nor env set.
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-soft-fail-nofile-'));
+  try {
+    const res = spawnSync('node', [CLI, 'storyboard', 'run', UNREACHABLE, STORYBOARD, '--soft-fail'], {
+      encoding: 'utf8',
+      timeout: 45_000,
+      cwd: tmpDir,
+      // Strip GITHUB_STEP_SUMMARY in case the harness has it set.
+      env: { ...process.env, GITHUB_STEP_SUMMARY: '' },
+    });
+    assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}. stderr: ${res.stderr}`);
+    const defaultPath = path.join(tmpDir, 'storyboard-result-summary.md');
+    assert.ok(!existsSync(defaultPath), `did not expect a default summary file at ${defaultPath}`);
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/test/lib/cli-storyboard-show-specialism.test.js
+++ b/test/lib/cli-storyboard-show-specialism.test.js
@@ -1,0 +1,93 @@
+// Regression coverage for the `storyboard show --specialism <slug>` flow
+// (issue adcp-client#1527). The command exists in two modes:
+//   1. `show <id>`               — render one storyboard
+//   2. `show --specialism <slug>` — resolve all storyboards an agent
+//                                    claiming `<slug>` would be graded on
+//
+// The original implementation had a `-1+1=0` bug: when `--specialism` was
+// absent, `args.indexOf('--specialism')` returns -1, and the positional
+// filter checked `i !== specialismIdx + 1` (i.e. `i !== 0`), silently
+// dropping the FIRST positional arg — which is the storyboard ID. Mode 1
+// would then fall back to the usage line as if the user forgot to pass
+// an ID.
+//
+// This test pins the fix: plain `show <id>` must render the storyboard,
+// AND `show --specialism <slug>` must still resolve the specialism, AND
+// `show <id> --specialism <slug>` (mixed) must prefer the specialism
+// branch (matching the existing behavior the runner picks).
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+
+function runCli(args) {
+  return spawnSync('node', [CLI, ...args], { encoding: 'utf8', timeout: 15_000 });
+}
+
+test('show <id> without --specialism renders the storyboard (the -1+1=0 regression)', () => {
+  // `capability_discovery` is shipped in every compliance cache snapshot —
+  // pinning a universal storyboard ID keeps this test stable across schema
+  // bumps. If that ever stops being true, swap it for any other ID listed
+  // by `adcp storyboard list`.
+  const result = runCli(['storyboard', 'show', 'capability_discovery']);
+
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  // Storyboard renderer prints the ID on the metadata line. If the
+  // positional filter dropped the arg, we'd see the usage line instead.
+  assert.match(result.stdout, /ID:\s+capability_discovery/);
+  assert.doesNotMatch(result.stdout, /Usage: adcp storyboard show/);
+});
+
+test('show <id> --json without --specialism renders the storyboard as JSON', () => {
+  // Same regression, JSON branch — the positional filter runs upstream of
+  // the rendering split, so verify both surfaces.
+  const result = runCli(['storyboard', 'show', 'capability_discovery', '--json']);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  // The JSON renderer emits `"id": "capability_discovery"` somewhere in
+  // its envelope. Match on the field rather than parse — JSON output may
+  // include CLI prelude lines we don't want to depend on.
+  assert.match(result.stdout, /"id"\s*:\s*"capability_discovery"/);
+});
+
+test('show without an ID and without --specialism prints the usage line (exit 2)', () => {
+  // Sanity: the regression must not have flipped the empty-args case to
+  // exit 0. No positional ID + no --specialism = usage error.
+  const result = runCli(['storyboard', 'show']);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /Usage: adcp storyboard show/);
+});
+
+test('show --specialism <slug> resolves the slug to its graded storyboards', () => {
+  // `sales-guaranteed` is a stable AdCP-3.0-GA specialism that resolves to
+  // a non-trivial storyboard list. The exact count drifts with each spec
+  // release, so we assert structure (heading + at least one storyboard
+  // bullet) rather than counts.
+  const result = runCli(['storyboard', 'show', '--specialism', 'sales-guaranteed']);
+
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.match(result.stdout, /Specialism: sales-guaranteed/);
+  assert.match(result.stdout, /Resolves to \d+ storyboard\(s\)/);
+  // `capability_discovery` is universal — it must show up under every
+  // specialism that maps to a known protocol. Pin it as a sanity anchor.
+  assert.match(result.stdout, /capability_discovery/);
+});
+
+test('show --specialism <unknown> exits 2 with a "Known specialisms" hint', () => {
+  // The validator surface should fail loud + give the operator a copy-
+  // paste-able list of valid slugs.
+  const result = runCli(['storyboard', 'show', '--specialism', 'this-is-not-a-real-specialism']);
+  assert.strictEqual(result.status, 2);
+  assert.match(result.stderr, /Unknown specialism: this-is-not-a-real-specialism/);
+  assert.match(result.stderr, /Known specialisms:/);
+});
+
+test('show --specialism <slug> --json emits structured envelope', () => {
+  // JSON branch must include the specialism slug + a storyboards array.
+  const result = runCli(['storyboard', 'show', '--specialism', 'sales-guaranteed', '--json']);
+  assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+  assert.match(result.stdout, /"specialism"\s*:\s*"sales-guaranteed"/);
+  assert.match(result.stdout, /"storyboards"\s*:\s*\[/);
+});

--- a/test/lib/cli-summary-markdown.test.js
+++ b/test/lib/cli-summary-markdown.test.js
@@ -1,0 +1,248 @@
+// Unit coverage for the markdown writers used by `--summary-file` and the
+// $GITHUB_STEP_SUMMARY auto-activation path (issue adcp-client#1527). The
+// helpers are extracted to `bin/adcp-storyboard-summary.js` so they can be
+// imported without spawning the CLI.
+//
+// Each renderer has three regimes that must stay correct:
+//   - `failures: undefined`     — happens for crash-path / partial results
+//   - `failures: []`            — passing run, no per-step rows
+//   - `failures: [...]`         — at least one row, table must render
+//
+// Plus the cell-escape contract: `|` and newlines inside reasons must not
+// break the table layout.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const {
+  buildComplianceSummaryMarkdown,
+  buildStoryboardSummaryMarkdown,
+  escapeMarkdownCell,
+} = require('../../bin/adcp-storyboard-summary.js');
+
+// ----------------------------------------------------------------------------
+// buildComplianceSummaryMarkdown — `comply()` / ComplianceResult shape
+// ----------------------------------------------------------------------------
+
+test('compliance summary: passing result with no failures field omits the table', () => {
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'passing',
+      summary: { steps_passed: 8, steps_failed: 0, steps_skipped: 1 },
+    },
+    'https://agent.example.com'
+  );
+
+  assert.match(md, /^# Storyboard run: https:\/\/agent\.example\.com$/m);
+  assert.match(md, /\*\*Overall:\*\* passing — 8 passed \/ 0 failed \/ 1 skipped/);
+  assert.doesNotMatch(md, /## Failures/);
+  assert.doesNotMatch(md, /No per-step failure details/);
+});
+
+test('compliance summary: failing result with undefined failures emits placeholder', () => {
+  // Crash-path / partial-eval shapes leave `failures` undefined. The
+  // renderer must signal "no detail available" rather than render an empty
+  // table or pretend the run was clean.
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'failing',
+      summary: { steps_passed: 2, steps_failed: 3, steps_skipped: 0 },
+    },
+    'https://agent.example.com'
+  );
+
+  assert.match(md, /\*\*Overall:\*\* failing — 2 passed \/ 3 failed \/ 0 skipped/);
+  assert.match(md, /_No per-step failure details available\._/);
+  assert.doesNotMatch(md, /## Failures/);
+});
+
+test('compliance summary: empty failures array on non-passing run still emits placeholder', () => {
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'partial',
+      summary: { steps_passed: 1, steps_failed: 0, steps_skipped: 4 },
+      failures: [],
+    },
+    'https://agent.example.com'
+  );
+
+  assert.match(md, /_No per-step failure details available\._/);
+  assert.doesNotMatch(md, /## Failures/);
+});
+
+test('compliance summary: populated failures render a Markdown table', () => {
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'failing',
+      summary: { steps_passed: 1, steps_failed: 2, steps_skipped: 0 },
+      failures: [
+        { storyboard_id: 'sb-1', step_id: 'step-a', error: 'boom' },
+        { storyboard_id: 'sb-2', step_id: 'step-b', validation: { description: 'schema mismatch' } },
+      ],
+    },
+    'https://agent.example.com'
+  );
+
+  assert.match(md, /## Failures/);
+  assert.match(md, /\| Storyboard \| Step \| Reason \|/);
+  assert.match(md, /\|---\|---\|---\|/);
+  assert.match(md, /\| sb-1 \| step-a \| boom \|/);
+  assert.match(md, /\| sb-2 \| step-b \| schema mismatch \|/);
+});
+
+test('compliance summary: surfaces specialisms when present on the agent profile', () => {
+  const md = buildComplianceSummaryMarkdown(
+    {
+      overall_status: 'passing',
+      summary: { steps_passed: 5, steps_failed: 0, steps_skipped: 0 },
+      agent_profile: { specialisms: ['sales-non-guaranteed', 'creative-template'] },
+    },
+    'https://agent.example.com'
+  );
+
+  assert.match(md, /\*\*Specialisms:\*\* sales-non-guaranteed, creative-template/);
+});
+
+// ----------------------------------------------------------------------------
+// buildStoryboardSummaryMarkdown — runStoryboard()/StoryboardResult shape
+// ----------------------------------------------------------------------------
+
+test('storyboard summary: empty results array still renders a header + overall line', () => {
+  const md = buildStoryboardSummaryMarkdown([], 'https://agent.example.com', true);
+
+  assert.match(md, /^# Storyboard run: https:\/\/agent\.example\.com$/m);
+  assert.match(md, /\*\*Overall:\*\* passed — 0 passed \/ 0 failed \/ 0 skipped/);
+  assert.doesNotMatch(md, /## Failures/);
+});
+
+test('storyboard summary: agentUrl falsy → falls back to "local agent"', () => {
+  // When `--local-agent` runs the storyboard, there is no remote URL.
+  const md = buildStoryboardSummaryMarkdown([], '', true);
+  assert.match(md, /^# Storyboard run: local agent$/m);
+});
+
+test('storyboard summary: passing storyboard with no failed steps omits the table', () => {
+  const md = buildStoryboardSummaryMarkdown(
+    [
+      {
+        storyboard_id: 'sb-1',
+        passed_count: 3,
+        failed_count: 0,
+        skipped_count: 0,
+        phases: [{ steps: [{ id: 'step-1', passed: true, skipped: false }] }],
+      },
+    ],
+    'https://agent.example.com',
+    true
+  );
+
+  assert.match(md, /\*\*Overall:\*\* passed — 3 passed \/ 0 failed \/ 0 skipped/);
+  assert.doesNotMatch(md, /## Failures/);
+});
+
+test('storyboard summary: failed step with validations[] joins descriptions with "; "', () => {
+  const md = buildStoryboardSummaryMarkdown(
+    [
+      {
+        storyboard_id: 'sb-1',
+        passed_count: 0,
+        failed_count: 1,
+        skipped_count: 0,
+        phases: [
+          {
+            steps: [
+              {
+                id: 'step-a',
+                passed: false,
+                skipped: false,
+                validations: [
+                  { passed: true, description: 'first ok' },
+                  { passed: false, description: 'second broke' },
+                  { passed: false, error: 'third blew up' },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    'https://agent.example.com',
+    false
+  );
+
+  assert.match(md, /\*\*Overall:\*\* failed — 0 passed \/ 1 failed \/ 0 skipped/);
+  assert.match(md, /## Failures/);
+  assert.match(md, /\| sb-1 \| step-a \| second broke; third blew up \|/);
+});
+
+test('storyboard summary: failed step without validations falls back to step.error', () => {
+  const md = buildStoryboardSummaryMarkdown(
+    [
+      {
+        storyboard_id: 'sb-1',
+        passed_count: 0,
+        failed_count: 1,
+        skipped_count: 0,
+        phases: [{ steps: [{ id: 'step-a', passed: false, skipped: false, error: 'transport reset' }] }],
+      },
+    ],
+    'https://agent.example.com',
+    false
+  );
+
+  assert.match(md, /\| sb-1 \| step-a \| transport reset \|/);
+});
+
+test('storyboard summary: skipped steps are excluded from the failure table', () => {
+  const md = buildStoryboardSummaryMarkdown(
+    [
+      {
+        storyboard_id: 'sb-1',
+        passed_count: 1,
+        failed_count: 0,
+        skipped_count: 1,
+        phases: [
+          {
+            steps: [
+              { id: 'step-a', passed: true, skipped: false },
+              { id: 'step-b', passed: false, skipped: true }, // skipped, not a failure
+            ],
+          },
+        ],
+      },
+    ],
+    'https://agent.example.com',
+    true
+  );
+
+  assert.doesNotMatch(md, /## Failures/);
+  assert.doesNotMatch(md, /step-b/);
+});
+
+test('storyboard summary: missing passed_count / failed_count default to 0 (no NaN propagation)', () => {
+  const md = buildStoryboardSummaryMarkdown([{ storyboard_id: 'sb-1', phases: [] }], 'https://agent.example.com', true);
+
+  assert.match(md, /0 passed \/ 0 failed \/ 0 skipped/);
+  assert.doesNotMatch(md, /NaN/);
+});
+
+// ----------------------------------------------------------------------------
+// escapeMarkdownCell — pipe + newline escaping
+// ----------------------------------------------------------------------------
+
+test('escapeMarkdownCell: pipes are backslash-escaped so they do not split cells', () => {
+  assert.strictEqual(escapeMarkdownCell('a | b | c'), 'a \\| b \\| c');
+});
+
+test('escapeMarkdownCell: newlines collapse to spaces so a multi-line reason stays on one row', () => {
+  assert.strictEqual(escapeMarkdownCell('first line\nsecond line'), 'first line second line');
+});
+
+test('escapeMarkdownCell: null / undefined coerce to empty string', () => {
+  assert.strictEqual(escapeMarkdownCell(null), '');
+  assert.strictEqual(escapeMarkdownCell(undefined), '');
+});
+
+test('escapeMarkdownCell: non-string values stringify', () => {
+  assert.strictEqual(escapeMarkdownCell(42), '42');
+});


### PR DESCRIPTION
Closes #1527. Re-opens after #1528 closed unmerged.

Adds three additive CLI features to `adcp storyboard` to address the silent-CI-failure pattern surfaced by `examples/multi_platform_seller/` having 14 masked storyboard failures across several PRs. All changes are in `bin/` only; no library surface touched.

## Changes

**A. `--summary-file [PATH]`** — write a Markdown run summary to disk after the run. Defaults to `storyboard-result-summary.md` when `PATH` is omitted. Auto-activates from `$GITHUB_STEP_SUMMARY` for GitHub Actions job summary integration. Implemented for capability-driven (`comply()`), single-storyboard (`--file`), and `--local-agent` run paths. Multi-instance and agents-map paths emit a warning when the flag is passed explicitly (env-var activation is silenced to avoid noise in every CI run).

**B. `adcp storyboard show --specialism <slug>`** — resolves which storyboards are graded when an agent claims a specialism. Looks up the parent protocol from the compliance index (required by `resolveStoryboardsForCapabilities` to avoid `specialism_parent_protocol_missing` throw), then renders the full list with `[track]` labels and capability-gating annotations. `--json` output is structured. The positional-filter uses an index guard (`specialismSlug === null || i !== specialismIdx + 1`) to avoid dropping the storyboard ID on plain `show <id>` calls.

**C. `--soft-fail`** — exit 0 even when storyboards fail (suppresses exit 3 only; exit 1 and 2 are preserved). Prints `STORYBOARD FAILURES (N): scenario1, …` to stderr; silent in `--json` mode (failures already present in the JSON payload). Threaded through all 8 exit-code-3 sites: capability-driven, single `--file`, `--local-agent` (×3), multi-instance, agents-map (×2).

## Tests added

Addresses the dx-expert review nit on the prior PR. `bin/adcp-storyboard-summary.js` extracted from `bin/adcp.js` so the markdown writers and soft-fail printer can be unit-imported (same pattern as `bin/adcp-step-hints.js`).

- **`test/lib/cli-summary-markdown.test.js`** (16 tests): both renderers across `failures: undefined` (crash-path), `failures: []`, and populated arrays; cell-escape contract for pipes / newlines / null / non-strings; fallback to "local agent" when agentUrl is empty; specialism row emission.
- **`test/lib/cli-storyboard-show-specialism.test.js`** (6 tests): pins the `-1+1=0` regression — `show <id>` without `--specialism` must render the storyboard, not silently drop the positional. Also covers `show --specialism <slug>` happy-path, unknown-slug error message, and `--json` envelope.
- **`test/lib/cli-soft-fail.test.js`** (7 tests): drives an unreachable URL (`*.invalid` TLD — never resolves) to deterministically fail a run, then verifies `--soft-fail` collapses exit 3 → 0; `--summary-file PATH` writes the file; bare `--summary-file` defaults to `storyboard-result-summary.md`; `$GITHUB_STEP_SUMMARY` auto-activates the writer; absent flag + env writes nothing.

## What was tested

- `npm run format:check` — passed
- `node --check bin/adcp.js` — passed
- `npm test -- test/lib/cli-soft-fail.test.js test/lib/cli-storyboard-show-specialism.test.js test/lib/cli-summary-markdown.test.js` — 29/29 pass
- Other CLI tests (`cli-storyboard-file-flag`, `cli-removed-flags`, `cli-step-hints`) — 37/37 pass after the helpers extraction

## Pre-PR review (carried over from #1528)

- **code-reviewer:** approved — no blockers; flagged `$GITHUB_STEP_SUMMARY` noise on multi-instance runs (fixed: `summaryFileExplicit` gate) and `opts.jsonOutput` style inconsistency (fixed: use locally-destructured `jsonOutput`).
- **dx-expert:** approved — one blocker fixed (positional filter `-1+1=0` bug); nits addressed (snake_case protocol display corrected to `entry.protocol`, JSON-mode `--soft-fail` behavior documented in help text).