### PR TITLE
fix(storyboard-runner): reset retained A2A session ids per storyboard (#1585)

### DIFF
--- a/.changeset/storyboard-runner-session-reset.md
+++ b/.changeset/storyboard-runner-session-reset.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix A2A "Task not found" on first call of every storyboard after the first when running batch compliance suites (#1585).
+
+`comply()` shares one `AgentClient` across every storyboard for transport reuse. The client retains `pendingTaskId` from non-terminal responses (`submitted` / `working` / `input-required`) and auto-threads it into every subsequent A2A `message/send`. Without a per-storyboard reset, a stale `task_id` from a prior storyboard's HITL or working step rode into the next storyboard's first call (typically `get_products`), and spec-compliant sellers correctly returned "Task &lt;uuid&gt; not found" because the buyer was referencing a task it never opened against this seller.
+
+The runner now calls `client.resetContext()` on every shared client at the start of `executeStoryboardPass`, re-establishing the documented one-AgentClient-per-conversation boundary at the storyboard boundary. MCP transports are unaffected (no session ids on the wire). Sibling of #1571, #1575, #1579 — the previous fixes addressed unwrap-layer drops; this one addresses the upstream session-leak that caused the lookups in the first place.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.13.1",
+  "version": "6.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.13.1",
+      "version": "6.13.2",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6466,7 +6466,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.13.1"
+        "@adcp/sdk": "^6.13.2"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -362,6 +362,27 @@ interface PollEligibleEnvelopeShape {
   task_id: string;
 }
 
+/**
+ * Clear retained A2A session state (`contextId`, `pendingTaskId`) on each
+ * shared client at the start of a storyboard run. AgentClient is documented
+ * as one-instance-per-conversation; `comply()` reuses a single instance
+ * across every storyboard for transport caching, so the runner has to
+ * re-establish the "fresh conversation" boundary per storyboard. Without
+ * this, a stale `pendingTaskId` from a prior storyboard's non-terminal
+ * step rides into this storyboard's first call and the seller surfaces
+ * "Task <uuid> not found". See adcp-client#1585.
+ *
+ * Calls go through a duck-typed `resetContext()` accessor so the helper
+ * stays compatible with adapter-built clients that don't subclass
+ * AgentClient directly.
+ */
+function resetClientSessions(clients: readonly TestClient[]): void {
+  for (const client of clients) {
+    const reset = (client as unknown as { resetContext?: () => void }).resetContext;
+    if (typeof reset === 'function') reset.call(client);
+  }
+}
+
 function isPollEligibleEnvelope(data: unknown): data is PollEligibleEnvelopeShape {
   if (data == null || typeof data !== 'object') return false;
   const obj = data as { status?: unknown; task_id?: unknown };
@@ -995,6 +1016,10 @@ async function executeStoryboardPass(
       return buildDiscoveryFailedResult(agentUrls, storyboard, failedStep);
     }
     clients = [...routingContext.clients.values()];
+    // See note on the non-routing branch below: per-storyboard session reset
+    // prevents a stale `pendingTaskId` from a prior storyboard's non-terminal
+    // step from auto-threading into this storyboard's first call. (#1585)
+    resetClientSessions(clients);
     // Pick the first agent's profile as the "primary" for downstream code
     // that reads single-profile fields (library_version on per-step result
     // records, raw_capabilities for `requires_capability`). Per-step
@@ -1017,6 +1042,17 @@ async function executeStoryboardPass(
     // Build one client per URL. In single-URL mode `_client` (from comply()) is
     // honored so the shared MCP transport is reused across storyboards.
     clients = agentUrls.map(url => getOrCreateClient(url, options));
+
+    // Drop any retained A2A session ids before this storyboard's first call.
+    // `comply()` shares one client across N storyboards for transport reuse;
+    // AgentClient.retainSession holds onto `pendingTaskId` from non-terminal
+    // responses (`submitted`/`working`/`input-required`) and auto-threads it
+    // into every subsequent `message/send`. Without a per-storyboard reset, a
+    // prior storyboard's stale `task_id` rides into the next storyboard's
+    // first call (typically `get_products`) and the seller correctly
+    // returns "Task <uuid> not found" on a buyer-side reference to a task it
+    // never opened. (#1585)
+    resetClientSessions(clients);
 
     // Discover agent profile against the first instance; all instances are
     // expected to run the same code behind a shared state store, so one probe

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.11.0';
+export const LIBRARY_VERSION = '6.13.2';
 
 /**
  * AdCP specification version this library is built for
@@ -50,10 +50,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.11.0',
+  library: '6.13.2',
   adcp: '3.0.6',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-05T01:50:22.022Z',
+  generatedAt: '2026-05-08T11:21:57.791Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-runner-session-reset.test.js
+++ b/test/lib/storyboard-runner-session-reset.test.js
@@ -42,7 +42,7 @@ function spyClient() {
     calls,
     getAgentInfo: async () => ({ name: 'Test', tools: [] }),
     resetContext: function () {
-      calls.push(Date.now());
+      calls.push(true);
     },
   };
 }

--- a/test/lib/storyboard-runner-session-reset.test.js
+++ b/test/lib/storyboard-runner-session-reset.test.js
@@ -1,0 +1,83 @@
+/**
+ * Regression test for adcp-client#1585.
+ *
+ * `comply()` shares a single `AgentClient` across every storyboard for
+ * transport reuse. The client retains `pendingTaskId` (and `contextId`) from
+ * non-terminal responses (`submitted`/`working`/`input-required`) and
+ * auto-threads them into every subsequent A2A `message/send`. Without a
+ * per-storyboard reset, a stale `task_id` from a prior storyboard's HITL or
+ * working step rides into the next storyboard's first call (typically
+ * `get_products`); A2A sellers then correctly return "Task <uuid> not found"
+ * because the buyer is referencing a task it never opened against this seller.
+ *
+ * The runner now calls `client.resetContext()` on every shared client at the
+ * start of `executeStoryboardPass`.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/runner.js');
+
+const FAKE_AGENT_URL = 'http://127.0.0.1:1/mcp'; // never reached — empty phases
+const FAKE_PROFILE = { name: 'Test', tools: [] };
+
+function emptyStoryboard() {
+  return {
+    id: 'session_reset_sb',
+    version: '1.0.0',
+    title: 'Session reset',
+    category: 'compliance',
+    summary: '',
+    narrative: '',
+    agent: { interaction_model: '*', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [],
+  };
+}
+
+function spyClient() {
+  const calls = [];
+  return {
+    calls,
+    getAgentInfo: async () => ({ name: 'Test', tools: [] }),
+    resetContext: function () {
+      calls.push(Date.now());
+    },
+  };
+}
+
+describe('runStoryboard: per-storyboard session reset (regression for #1585)', () => {
+  it('clears retained A2A session state on the shared `_client` before any step runs', async () => {
+    const client = spyClient();
+
+    await runStoryboard(FAKE_AGENT_URL, emptyStoryboard(), {
+      protocol: 'mcp',
+      allow_http: true,
+      _client: client,
+      _profile: FAKE_PROFILE,
+    });
+
+    assert.strictEqual(
+      client.calls.length,
+      1,
+      'shared `_client` must have its session reset exactly once per storyboard run'
+    );
+  });
+
+  it('tolerates a client that does not expose `resetContext()` (duck-typed accessor)', async () => {
+    // Adapter-built clients in older tests/integration paths may not subclass
+    // AgentClient. The reset helper must not throw on those.
+    const clientNoReset = {
+      getAgentInfo: async () => ({ name: 'Test', tools: [] }),
+    };
+    await assert.doesNotReject(() =>
+      runStoryboard(FAKE_AGENT_URL, emptyStoryboard(), {
+        protocol: 'mcp',
+        allow_http: true,
+        _client: clientNoReset,
+        _profile: FAKE_PROFILE,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #1585 — A2A "Task X not found" on the first call of every storyboard after the first when running batch compliance suites.
- Sibling of #1571 / #1575 / #1579 — those fixes addressed the unwrap layer; this one addresses the upstream session leak that caused the lookups in the first place.
- Companion: adcp-client#1586 → tracked upstream as adcontextprotocol/adcp#4219 (storyboard yaml fix). No SDK change for that one — see commentary on the issue.

## Root cause

`comply()` shares one `AgentClient` across every storyboard for transport reuse. `AgentClient.retainSession()` holds onto `pendingTaskId` from non-terminal responses (`submitted` / `working` / `input-required`) and `withSession()` auto-threads it into every subsequent A2A `message/send`. Without a per-storyboard reset, a stale `task_id` from a prior storyboard's HITL / working step rides into the next storyboard's first call (typically `get_products`); spec-compliant A2A sellers correctly return "Task &lt;uuid&gt; not found" because the buyer is referencing a task it never opened against this seller.

The fix re-establishes the documented "one AgentClient per conversation" boundary at the storyboard boundary by calling `client.resetContext()` on every shared client at the start of `executeStoryboardPass`. MCP is unaffected — those transports don't carry session ids on the wire.

## Changes

- `src/lib/testing/storyboard/runner.ts` — new `resetClientSessions()` helper; called in both the per-specialism routing branch and the legacy single/multi-instance branch.
- `test/lib/storyboard-runner-session-reset.test.js` — regression test pinning the contract that the runner clears retained session state on every shared `_client` per storyboard, including a tolerance case for adapter-built clients without `resetContext()`.
- `.changeset/storyboard-runner-session-reset.md` — patch bump.

## Test plan

- [x] `npm run format:check`
- [x] `npx tsc --noEmit`
- [x] `node --test test/lib/storyboard-runner-session-reset.test.js` — 2 new tests, both pass.
- [x] Re-ran adjacent runner tests (`storyboard-no-phases`, `storyboard-idempotency-invariant`, `storyboard-runner-contract`, `storyboard-a2a-context-continuity`) — 70 / 70 pass.
- [ ] Validation against Wonderstruck staging is the gating test; once published, `media_buy_seller/inventory_list_targeting/get_products_brief` and `media_buy_seller/creative_fate_after_cancellation/get_products_brief` should pass under A2A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)