### PR TITLE
fix(a2a): handle stale pendingTaskId causing "Task not found" in batch storyboard runs

### DIFF
--- a/.changeset/fix-a2a-task-not-found-batch-race.md
+++ b/.changeset/fix-a2a-task-not-found-batch-race.md
@@ -1,0 +1,29 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(a2a): handle stale pendingTaskId causing "Task not found" in batch storyboard runs
+
+When multiple storyboard scenarios share a single `AgentClient` instance, the client's
+`pendingTaskId` can be left set from a prior scenario's async working-state response if
+the poll path (via `waitForCompletion`) bypasses `absorbServerSideMetadata`. The next
+scenario then includes this stale task ID in its `message/send` call; if the seller has
+already completed and evicted that task (A2A 0.3.x defines no minimum retention TTL),
+the agent returns "Task <uuid> not found" and the scenario fails.
+
+Three fixes:
+
+1. **Root cause** — `AgentClient.clearPendingTask()` (`src/lib/core/AgentClient.ts`) +
+   `task-map.ts` `finally` block: after `waitForCompletion` resolves, `clearPendingTask()`
+   is called so the stale `pendingTaskId` is cleared before the next scenario starts.
+   This is the primary fix; the two below are defense-in-depth.
+
+2. `callA2AToolImpl` (`src/lib/protocols/a2a.ts`): when a "Task not found" error is
+   returned and `session.taskId` is set, retry once without the stale task ID so the
+   call starts a fresh server-side task. (Guard is self-limiting: the retry passes
+   `taskId: undefined`, so the guard cannot fire a second time.)
+
+3. `pollTaskCompletion` (`src/lib/core/TaskExecutor.ts`): when explicit polling
+   (`tasks/get`) receives a "Task not found" error, return a descriptive `failed`
+   `TaskResult` with an actionable error message rather than letting the error
+   propagate as an uncaught exception.

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -216,6 +216,18 @@ export class AgentClient {
   }
 
   /**
+   * Clear any retained `pendingTaskId` without requiring a new round-trip.
+   * Called by the storyboard poll path (`task-map.ts`) after `waitForCompletion`
+   * resolves, because that path bypasses `retainSession` and would otherwise
+   * leave a stale task ID on the session (adcp-client#1585).
+   *
+   * @internal
+   */
+  clearPendingTask(): void {
+    this.pendingTaskId = undefined;
+  }
+
+  /**
    * Returns the AdCP protocol version this client speaks. Mirrors
    * `SingleAgentClient.getAdcpVersion()`. See {@link SingleAgentClientConfig.adcpVersion}.
    */

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1397,8 +1397,33 @@ export class TaskExecutor {
     pollInterval = 60000,
     transport?: import('../protocols').TransportOptions
   ): Promise<TaskResult<T>> {
+    const pollStartTime = Date.now();
     while (true) {
-      const status = await this.getTaskStatus(agent, taskId, transport);
+      // adcp-client#1585: sellers MAY evict completed tasks before the first
+      // explicit poll fires (A2A 0.3.x defines no minimum retention TTL).
+      // Catch "not found" transport errors and surface a descriptive failure
+      // rather than an opaque uncaught exception from the polling loop.
+      let status: TaskInfo;
+      try {
+        status = await this.getTaskStatus(agent, taskId, transport);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (/task .* not found/i.test(msg)) {
+          return attachMatch({
+            success: false as const,
+            status: 'failed' as const,
+            error: `Task ${taskId} is no longer queryable — it may have been completed and evicted by the seller before this poll arrived. Consider using push notifications (reporting_webhook) instead of polling, or configuring a longer task retention TTL on the seller.`,
+            metadata: this.buildMetadata({
+              taskId,
+              taskName: 'unknown',
+              agent,
+              startTime: pollStartTime,
+              status: 'failed',
+            }),
+          });
+        }
+        throw err;
+      }
 
       if (status.status === ADCP_STATUS.COMPLETED) {
         const pollSuccess = this.isOperationSuccess(status.result);

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -355,6 +355,34 @@ async function callA2AToolImpl(
     if (messageResponse?.error || messageResponse?.result?.error) {
       const errorObj = messageResponse.error || messageResponse.result?.error;
       const errorMessage = errorObj.message || JSON.stringify(errorObj);
+      // adcp-client#1585: in batch storyboard runs the AgentClient carries
+      // `pendingTaskId` from a prior scenario's working-state response. When
+      // the seller has already completed and evicted that task, it returns
+      // "Task <uuid> not found". Retry once without the stale taskId so the
+      // call starts a fresh server-side task rather than trying to resume a
+      // completed one. A2A 0.3.x defines no minimum retention TTL for
+      // completed tasks, so the seller is spec-conformant; the SDK must
+      // handle this race gracefully.
+      // Guard is self-limiting: the retry passes `taskId: undefined`, so
+      // `session?.taskId` is falsy on the second call and this branch is skipped.
+      if (session?.taskId && /task .* not found/i.test(errorMessage)) {
+        debugLogs.push({
+          type: 'info',
+          message: `A2A: session.taskId ${session.taskId} not found — retrying without taskId (stale pendingTaskId, adcp-client#1585)`,
+          timestamp: new Date().toISOString(),
+          skill: toolName,
+        });
+        return callA2AToolImpl(
+          agentUrl,
+          toolName,
+          parameters,
+          authToken,
+          debugLogs,
+          pushNotificationConfig,
+          context,
+          { ...session, taskId: undefined }
+        );
+      }
       throw new Error(`A2A agent returned error: ${errorMessage}`);
     }
 

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -134,6 +134,12 @@ export async function executeStoryboardTask(
       result = await Promise.race([result.submitted.waitForCompletion(2000), timeout]);
     } catch {
       // Polling failed or timed out — return the intermediate result as-is
+    } finally {
+      // adcp-client#1585: waitForCompletion bypasses AgentClient.retainSession,
+      // so pendingTaskId is never cleared after the poll completes. In batch
+      // storyboard runs all scenarios share a single AgentClient instance; the
+      // stale ID bleeds into the next scenario's message/send. Clear it here.
+      if (typeof client.clearPendingTask === 'function') client.clearPendingTask();
     }
   }
 


### PR DESCRIPTION
Closes #1585

In batch storyboard runs, all scenarios share a single `AgentClient` instance (via `getOrCreateClient` caching). When a prior scenario ends with an A2A working-state response, `AgentClient.retainSession` sets `pendingTaskId`. The storyboard poll path (`waitForCompletion` in `task-map.ts`) bypasses `retainSession`, so that task ID is never cleared. The next scenario inherits it; A2A 0.3.x defines no minimum retention TTL for completed tasks, so a seller that has evicted the completed task responds with "Task \<uuid\> not found" and the scenario fails.

**Three fixes (root cause + two defense-in-depth):**

1. **Root cause** — `AgentClient.clearPendingTask()` (`@internal`) + `task-map.ts` `finally` block. After `waitForCompletion` resolves (or throws / times out), `clearPendingTask()` is called so the stale `pendingTaskId` is gone before the next scenario starts.

2. **Defense-in-depth** — `callA2AToolImpl` (`a2a.ts`): when `session.taskId` is set and the seller returns "Task not found", retry once without the task ID. The guard is self-limiting: the recursive call passes `taskId: undefined`, so the guard cannot fire again.

3. **Defense-in-depth** — `pollTaskCompletion` (`TaskExecutor.ts`): catch "Task not found" from `getTaskStatus` and return a descriptive `failed` `TaskResult` with an actionable error message rather than an opaque uncaught exception.

## What-tested

- `npx tsc --noEmit`: 2 pre-existing errors only (`@types/node` not installed, `moduleResolution=node10` deprecation warning). No new errors introduced. Verified by running before and after changes.
- `npm run ci:quick`: pre-existing environment failure (`tsx: not found`). Confirmed pre-existing by stashing changes and re-running.
- Nits from second expert pass addressed: changeset body updated to describe all three fixes; one-line self-limiting comment added on the retry guard.

## Pre-PR review

- **code-reviewer**: approved — no blockers after second pass; nits addressed (changeset body updated, self-limiting comment added)
- **ad-tech-protocol-expert**: approved — root-cause fix satisfies the spec-level concern; defense-in-depth retry correctly framed (dropping a stale prior-scenario `taskId`, not the current call's own ID); `pollStartTime` fix is sound

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01NXzCFi3jJDNqXaDgQrPzKK

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXzCFi3jJDNqXaDgQrPzKK)_