### PR TITLE
feat(examples): add hello_seller_adapter_proposal_mode for sole-stateful exemption coverage (#1549)

### DIFF
--- a/.changeset/proposal-mode-sole-stateful-coverage-1549.md
+++ b/.changeset/proposal-mode-sole-stateful-coverage-1549.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+test(examples): wire `comply_test_controller` into `examples/hello_seller_adapter_proposal_mode.ts` and add issue-#1549 invariant assertions to its gate test (#1549)
+
+Test + worked-example change. The proposal-mode reference adapter now declares `compliance_testing.scenarios` and ships `complyTest` adapters (`seed.media_buy`, `force.media_buy_status`, `simulate.delivery`) for parity with the other reference seller adapters — relevant when downstream cascade scenarios in the broader `sales_proposal_mode` storyboard suite drive the controller. The companion gate test (`test/examples/hello-seller-adapter-proposal-mode.test.js`) adds invariant assertions specific to the SDK behavior PR #1545 introduced: sync_accounts skip carries the sole-stateful-step exemption marker, and downstream phases (`brief_with_proposals`, `refine_proposal`, `finalize_proposal`, `accept_proposal`) are not cascade-skipped from the setup-phase skip. Closes the example-tier coverage gap noted by `nodejs-testing-expert` on PR #1545. No library behavior change.

--- a/examples/hello_seller_adapter_proposal_mode.ts
+++ b/examples/hello_seller_adapter_proposal_mode.ts
@@ -529,6 +529,13 @@ const platform: DecisioningPlatform<unknown, NetworkMeta> = {
     channels: ['olv', 'ctv', 'display'],
     pricingModels: ['cpm'],
     config: undefined,
+    // Declare the comply_test_controller surface so the conformance runner
+    // grades missing scenarios as `not_applicable` rather than `failed`. The
+    // framework auto-derives the `scenarios` list from the `complyTest`
+    // adapter set wired below.
+    compliance_testing: {
+      scenarios: ['force_media_buy_status', 'simulate_delivery'],
+    },
   },
   accounts,
   proposalManager,
@@ -543,6 +550,21 @@ const proposalStore = new InMemoryProposalStore<GAMLikeRecipe>();
 // Production adopters swap for `PostgresStateStore({ pool })`.
 const stateStore = new InMemoryStateStore();
 const mediaBuyStore = createMediaBuyStore({ store: stateStore });
+
+// ─── TEST-ONLY: in-memory state for comply_test_controller adapters ─────
+// DELETE THESE MAPS BEFORE DEPLOYING (or scope per-tenant if you keep the
+// controller wired in a sandbox tenant). Module-scope shared maps leak
+// state across accounts — that's fine for a worked example whose only
+// caller is the conformance harness, but unacceptable in production.
+// SWAP: scope by `account.id` (or your tenant key) and persist via the
+// same data layer your production handlers read from. The controller
+// and production tools should share one source of truth for state.
+const seededMediaBuys = new Map<string, { status: string; revision: number }>();
+const simulatedDelivery = new Map<
+  string,
+  { impressions: number; clicks: number; reported_spend: { amount: number; currency: string } }
+>();
+// ─── /TEST-ONLY ──────────────────────────────────────────────────────────
 
 serve(
   ({ taskStore }) =>
@@ -559,6 +581,55 @@ serve(
         const acct = ctx.account as Account<NetworkMeta> | undefined;
         return acct?.id ?? 'anonymous';
       },
+      // ─── TEST-ONLY: comply_test_controller wiring ──────────────────────
+      // DELETE THIS BLOCK BEFORE DEPLOYING. The conformance runner uses
+      // `comply_test_controller` to seed media-buy fixtures and force
+      // state transitions across cascade scenarios in the broader
+      // `sales_proposal_mode` storyboard suite (delivery_reporting,
+      // invalid_transitions, pending_creatives_to_start). The
+      // `proposal_finalize` storyboard itself doesn't invoke the
+      // controller, but the surface is wired here for parity with the
+      // other reference seller adapters.
+      //
+      // No `sandboxGate` here — the framework gate inside
+      // `createAdcpServerFromPlatform` admits via the resolved account's
+      // `mode === 'sandbox'`. Production refs flow through the live path
+      // with the field unset (default `'live'`), so the framework gate
+      // refuses dispatch for them.
+      complyTest: {
+        seed: {
+          media_buy: ({ media_buy_id, fixture }) => {
+            const existing = seededMediaBuys.get(media_buy_id);
+            const status = typeof fixture['status'] === 'string' ? (fixture['status'] as string) : 'pending_creatives';
+            seededMediaBuys.set(media_buy_id, { status, revision: existing?.revision ?? 0 });
+          },
+        },
+        force: {
+          media_buy_status: ({ media_buy_id, status, rejection_reason }) => {
+            const buy = seededMediaBuys.get(media_buy_id);
+            const previous = buy?.status ?? 'pending_creatives';
+            seededMediaBuys.set(media_buy_id, { status, revision: (buy?.revision ?? 0) + 1 });
+            void rejection_reason;
+            return { success: true, previous_state: previous, current_state: status };
+          },
+        },
+        simulate: {
+          delivery: ({ media_buy_id, impressions, clicks, reported_spend }) => {
+            const prev = simulatedDelivery.get(media_buy_id) ?? {
+              impressions: 0,
+              clicks: 0,
+              reported_spend: { amount: 0, currency: 'USD' },
+            };
+            simulatedDelivery.set(media_buy_id, {
+              impressions: prev.impressions + (impressions ?? 0),
+              clicks: prev.clicks + (clicks ?? 0),
+              reported_spend: reported_spend ?? prev.reported_spend,
+            });
+            return { success: true, simulated: { media_buy_id, impressions, clicks, reported_spend } };
+          },
+        },
+      },
+      // ─── /TEST-ONLY ──────────────────────────────────────────────────
     }),
   {
     port: PORT,

--- a/test/examples/hello-seller-adapter-proposal-mode.test.js
+++ b/test/examples/hello-seller-adapter-proposal-mode.test.js
@@ -6,63 +6,156 @@
  * lifecycle endpoints. Validates the design works when an adapter wraps
  * a real upstream proposal API.
  *
- * Storyboard: `media_buy_seller/proposal_finalize` — brief →
- * brief_with_proposals → refine_proposal → finalize_proposal →
- * accept_proposal (create_media_buy with proposal_id).
+ * Storyboard: `media_buy_seller/proposal_finalize` — sync_accounts
+ * (sole-stateful exemption) → brief_with_proposals → refine_proposal →
+ * finalize_proposal → accept_proposal (create_media_buy with proposal_id).
+ *
+ * Issue-#1549 invariant assertions (in addition to the shared three gates)
+ * verify the SDK behavior PR adcp-client#1545 added: a proposal-mode
+ * adopter that doesn't advertise `sync_accounts` (because account state
+ * materializes on the first `get_products` call) MUST NOT trip the
+ * cross-phase cascade. The downstream phases are entitled to run on
+ * their own merits — pass or fail, but never `prerequisite_failed` from
+ * a setup-phase skip.
  */
 
 const path = require('node:path');
 const test = require('node:test');
+const assert = require('node:assert/strict');
 const { runHelloAdapterGates } = require('./_helpers/runHelloAdapterGates');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const STORYBOARD_ID = 'media_buy_seller/proposal_finalize';
 
-// Storyboard scenarios that fail because the `proposal_finalize.yaml`
-// scenario doesn't declare `context_outputs` / `context_inputs` to chain
-// the seller's freshly-minted `proposal_id` from `brief_with_proposals`
-// into subsequent `refine_proposal` / `finalize_proposal` / `accept_proposal`
-// steps. The runner sends the literal placeholder
-// `balanced_reach_q2` from the spec yaml's `sample_request`, my adapter
-// forwards to the upstream where no such proposal exists, the upstream
-// 404s. Smoke-tested separately end-to-end (see commit history) — when
-// a real buyer agent uses the proposal_id from the prior step, the
-// lifecycle works.
+// Storyboard scenarios that fail because `proposal_finalize.yaml` doesn't
+// declare `context_outputs` / `context_inputs` to chain the seller's
+// freshly-minted `proposal_id` from `brief_with_proposals` into the
+// subsequent `refine_proposal` / `finalize_proposal` steps. The runner
+// sends the literal `balanced_reach_q2` from the spec yaml's
+// `sample_request`, the adapter forwards it to the upstream where no
+// such proposal exists, and the upstream 404s. Tracked at
+// adcontextprotocol/adcp#4086 + draft PR #4088 (storyboard fix).
 //
-// Spec-side fix lives at: adcontextprotocol/adcp — author the
-// `proposal_finalize.yaml` scenario with explicit context chaining
-// (mirrors how other multi-step scenarios already declare it).
-const EXPECTED_FAILURES = [{ storyboard_id: 'media_buy_seller/proposal_finalize', step_id: 'get_products_refine' }];
+// When #4088 lands and the schema cache updates, the chained
+// `$context.proposal_id` will replace the placeholder and refine →
+// finalize → accept will pass end-to-end. Drop this allowlist entry then.
+const EXPECTED_FAILURES = [{ storyboard_id: STORYBOARD_ID, step_id: 'get_products_refine' }];
 
 function isExpectedFailure(f) {
   return EXPECTED_FAILURES.some(e => e.storyboard_id === (f.storyboard_id || '') && e.step_id === (f.step_id || ''));
 }
 
-// Target the focused proposal_finalize scenario rather than the full
-// `sales_proposal_mode` storyboard. The full storyboard requires seven
-// scenarios spanning the entire media-buy lifecycle (delivery_reporting,
-// measurement_terms_rejected, invalid_transitions, etc.) — outside the
-// scope of this minimal v1.5 proposal-lifecycle reference. The
-// `proposal_finalize` scenario covers the five lifecycle phases the
-// adapter is built for: setup, brief_with_proposals, refine_proposal,
-// finalize_proposal, accept_proposal.
+// ── Issue-#1549 invariant assertions ───────────────────────────────────
+//
+// The grader emits a per-phase TestResult under the `media_buy` track
+// (one per storyboard phase, scenario id `<storyboard_id>/<phase_id>`).
+// Each step carries `skipped`, `skip_reason`, and a `warnings[0]` line
+// holding the runner's `skip.detail` string when skipped.
+//
+// PR adcp-client#1545's emitted marker for the sole-stateful exemption:
+const EXEMPTION_MARKER = /Sole stateful step exemption applied for phase 'setup'/;
+// Cascade trigger phrase the runner emits when a downstream stateful
+// step skips because a prior step in setup didn't pass:
+const SETUP_CASCADE_PHRASE = /prior stateful step "sync_accounts" (skipped|failed)/;
+
+function findScenario(grader, scenarioId) {
+  for (const track of grader.tracks ?? []) {
+    for (const scn of track.scenarios ?? []) {
+      if (scn.scenario === scenarioId) return scn;
+    }
+  }
+  return undefined;
+}
+
+function assertIssue1549Invariants(grader) {
+  // (a) sync_accounts skip: skipped + exemption-eligible reason + marker.
+  const setup = findScenario(grader, `${STORYBOARD_ID}/setup`);
+  assert.ok(setup, `setup phase scenario missing from grader output`);
+  const syncStep = (setup.steps ?? []).find(s => s.task === 'sync_accounts');
+  assert.ok(syncStep, `setup phase did not emit a sync_accounts step result`);
+  assert.equal(syncStep.skipped, true, `sync_accounts must be skipped (proposal-mode adopters omit the tool)`);
+  // PR adcp-client#1545 expanded the exemption family: `not_applicable`
+  // (account-mode-derived), `missing_tool` (advertised tools omit
+  // sync_accounts), and `missing_test_controller` are all exemption-
+  // eligible. This adapter projects `account.require_operator_auth: true`
+  // via `accounts.resolution: 'explicit'`, so the runner grades the
+  // skip as `not_applicable` here — but the assertion accepts any reason
+  // in the exemption family so a future projection change doesn't flip
+  // the test red without an underlying behavior regression.
+  assert.ok(
+    ['not_applicable', 'missing_tool', 'missing_test_controller'].includes(syncStep.skip_reason),
+    `sync_accounts skip_reason ${JSON.stringify(syncStep.skip_reason)} is not in the exemption family`
+  );
+  const skipDetail = (syncStep.warnings ?? []).join(' | ');
+  assert.match(
+    skipDetail,
+    EXEMPTION_MARKER,
+    `sync_accounts skip detail must carry the sole-stateful exemption marker (PR adcp-client#1545):\n${skipDetail}`
+  );
+
+  // (b) Each downstream phase RAN — no setup-cascade trip. Phases may
+  // pass, fail, or skip on their own merits, but the skip detail must
+  // NOT name sync_accounts as the cascade trigger. With the #1545 fix,
+  // `brief_with_proposals` runs (and passes), `refine_proposal` runs
+  // (and currently fails per #4086), `finalize_proposal` and
+  // `accept_proposal` skip because of refine's failure with detail
+  // "prior stateful step failed." (no step name) — never with detail
+  // referencing sync_accounts.
+  const downstreamPhases = ['brief_with_proposals', 'refine_proposal', 'finalize_proposal', 'accept_proposal'];
+  for (const phaseId of downstreamPhases) {
+    const scn = findScenario(grader, `${STORYBOARD_ID}/${phaseId}`);
+    assert.ok(scn, `downstream phase ${phaseId} missing from grader output`);
+    for (const step of scn.steps ?? []) {
+      const detail = (step.warnings ?? []).join(' | ');
+      assert.doesNotMatch(
+        detail,
+        SETUP_CASCADE_PHRASE,
+        `downstream phase ${phaseId} step ${step.step}: skip detail names sync_accounts as cascade trigger ` +
+          `— sole-stateful exemption regressed (PR adcp-client#1545):\n${detail}`
+      );
+    }
+  }
+}
+
 runHelloAdapterGates({
   suiteName: 'examples/hello_seller_adapter_proposal_mode',
   exampleFile: path.join(REPO_ROOT, 'examples', 'hello_seller_adapter_proposal_mode.ts'),
   specialism: 'sales-guaranteed',
-  storyboardId: 'media_buy_seller/proposal_finalize',
+  storyboardId: STORYBOARD_ID,
   adcpAuthToken: 'sk_harness_do_not_use_in_prod',
   mockOptions: { apiKey: 'mock_sales_guaranteed_key_do_not_use_in_prod' },
   extraEnv: {
     UPSTREAM_API_KEY: 'mock_sales_guaranteed_key_do_not_use_in_prod',
   },
-  // Façade gate: only assert the routes that DO get hit given the
-  // current scenario state-chain gap. Refine + finalize + order routes
-  // are exercised in the manual smoke test (commit history) and the
-  // primitives test suite — they're verified to work end-to-end, just
-  // not driven by the storyboard runner today.
+  // Façade gate: only assert routes that the storyboard actually drives.
+  // refine + finalize + order routes are exercised by the primitives test
+  // suite end-to-end; the `proposal_finalize` storyboard stops at refine
+  // (per the adcp#4086 gap) so they don't appear in upstream traffic here.
   expectedRoutes: ['GET /_lookup/network', 'GET /v1/products', 'POST /v1/proposals'],
-  filterFailures: grader => (grader.failures || []).filter(f => !isExpectedFailure(f)),
-  storyboardSummary: 'proposal lifecycle (brief → refine → finalize → accept) via v1.5 ProposalManager',
+  filterFailures: grader => {
+    // Issue-#1549 invariants run alongside the failure filter so the gate
+    // fires on regressions even when the storyboard pass-count is clean.
+    assertIssue1549Invariants(grader);
+    // Defensive: every entry in EXPECTED_FAILURES must appear in the
+    // pre-filter set. A spec rename or runner fix that eliminates one
+    // of these failures should flip the gate red so we know to drop the
+    // entry — silent green CI on a stale allowlist hides regressions.
+    const failures = grader.failures || [];
+    for (const expected of EXPECTED_FAILURES) {
+      const present = failures.some(f => f.storyboard_id === expected.storyboard_id && f.step_id === expected.step_id);
+      assert.ok(
+        present,
+        `EXPECTED_FAILURES is stale: ${expected.storyboard_id}/${expected.step_id} ` +
+          `(see adcp#4086 / PR #4088) is no longer reported as a failure. ` +
+          `Drop it from the allowlist and re-run; the gate should now pass unfiltered.`
+      );
+    }
+    return failures.filter(f => !isExpectedFailure(f));
+  },
+  storyboardSummary:
+    'sole-stateful exemption (sync_accounts skipped, downstream phases run) + proposal lifecycle through brief',
 });
 
+// Surface assert is a no-op if `node --test` doesn't import it; placed at
+// module top-level to keep the gate self-checking even without invocation.
 void test;


### PR DESCRIPTION
Closes #1549. Companion to PR #1548 (cascade-skip matrix refactor) and PR #1545 (the runner fix that surfaced the coverage gap).

## Summary

Wires `comply_test_controller` into `examples/hello_seller_adapter_proposal_mode.ts` and adds invariant assertions to its gate test that verify the SDK behavior PR adcp-client#1545 introduced: a proposal-mode adopter that doesn't advertise `sync_accounts` (because account state materializes on the first `get_products` call) MUST NOT trip the cross-phase cascade.

`nodejs-testing-expert`'s review on PR #1545 noted that none of the existing `test/examples/hello-*` adapters are shaped like proposal-mode — they all advertise `sync_accounts`, so the example-adapter test layer never exercised the sole-stateful-step pattern that PR adcp-client-python#550 hit. The runner-level invariant test added in PR #1545 covers the unit layer (cascade-skip-on-skip matrix); this PR adds the end-to-end mirror of how a real proposal-mode adopter exercises the SDK.

## What the adapter advertises

Proposal-mode declares `accounts.resolution: 'explicit'`, which the framework projects to `account.require_operator_auth: true`. Buyers discover accounts via `list_accounts`; the adapter doesn't implement `sync_accounts`. Tools advertised:

- `get_products` — returns `proposals[]` alongside `products[]` when a brief is supplied (catalog mode otherwise).
- `get_products` `buying_mode: refine` — refines a proposal (with optional `action: finalize` to commit).
- `create_media_buy` — accepts `proposal_id` to convert a committed proposal into an active buy.
- `update_media_buy` / `get_media_buy_delivery` / `get_media_buys` / `tasks/get`.
- `comply_test_controller` (sandbox-gated via `mode==='sandbox'`) — `seed.media_buy`, `force.media_buy_status`, `simulate.delivery` for parity with the other reference seller adapters; relevant when the broader `sales_proposal_mode` storyboard suite drives cascade scenarios.

Pointedly NOT advertised: `sync_accounts`, `list_accounts`. The adapter's whole point is the implicit-account / proposal-mode shape.

## Proposal lifecycle wiring

- `getProducts` mints a draft via the upstream `/v1/proposals` route when a brief lands; returns the proposals array unchanged.
- `refineProducts` reads `refine[].proposal_id` and POSTs to `/v1/proposals/{id}/refine`.
- `finalizeProposal` POSTs to `/v1/proposals/{id}/finalize`, refreshes recipes with the locked CPM and upstream line-item template ids, and hands the recipe map back to the framework. The framework stores it on the `InMemoryProposalStore` and hydrates `ctx.recipes` for the subsequent `create_media_buy(proposal_id=...)` call.
- `sales.createMediaBuy` reads `ctx.recipes`, splits the budget across allocated products, and creates one upstream order + per-product line items.

State persists in `ctx_metadata` (per `docs/guides/CTX-METADATA-SAFETY.md` — non-secret upstream IDs only; credentials are re-derived per-request via `verifyApiKey`).

## Gate test assertions

Three shared gates via `runHelloAdapterGates` (tsc-strict, storyboard, façade) plus issue-#1549 invariant assertions threaded into `filterFailures` so they run on every storyboard pass:

1. **`sync_accounts` carries the sole-stateful exemption marker.** The setup-phase `sync_accounts` step is `skipped: true`, its `skip_reason` is in the exemption family (`not_applicable` / `missing_tool` / `missing_test_controller` — proposal-mode adopters land on `not_applicable` via the `require_operator_auth` projection), AND its `warnings[0]` matches `/Sole stateful step exemption applied for phase 'setup'/` (the marker PR adcp-client#1545 emits at `runner.ts:145`).
2. **No downstream phase is cascade-skipped from setup.** For each of `brief_with_proposals`, `refine_proposal`, `finalize_proposal`, `accept_proposal`, every step's skip detail must NOT match `/prior stateful step "sync_accounts" (skipped|failed)/`. Phases may pass, fail, or skip on their own merits — but never with detail naming `sync_accounts` as the cascade trigger.
3. **Stale-allowlist defensive check.** `EXPECTED_FAILURES` lists `get_products_refine` (the one step blocked by the storyboard placeholder gap at adcp#4086 / draft PR #4088). When that PR lands and the refine step starts passing, the defensive check flips the gate red so the allowlist gets dropped — silent green CI on a stale entry would hide regressions.

Adversarial-sabotage validated locally: temporarily inverting `EXEMPTION_MARKER` to a synthetic regex makes assertion (1) fire with a clean diagnostic; flipping `assert.doesNotMatch` to `assert.match` on the empty-warnings happy path makes assertion (2) fire.

## Non-obvious decisions

- **Skip reason is `not_applicable`, not `missing_tool`.** The issue text says "missing_tool"; the actual current SDK behavior is `not_applicable` because the proposal-mode adapter declares `accounts.resolution: 'explicit'` which auto-projects `account.require_operator_auth: true`. PR adcp-client#1545 expanded the exemption family to cover both. The assertion accepts any reason in the exemption family so a future projection change doesn't flip the test red without an underlying behavior regression.
- **`comply_test_controller` is wired even though `proposal_finalize.yaml` doesn't invoke it.** The issue requires the controller surface for parity with other reference adapters and for the broader `sales_proposal_mode` storyboard suite (which fans out into `delivery_reporting`, `invalid_transitions`, `pending_creatives_to_start` — all of which DO drive the controller). Wiring it into the proposal-mode adapter completes the reference set.
- **`EXPECTED_FAILURES` accepts `get_products_refine`.** The `proposal_finalize` storyboard sends the literal `balanced_reach_q2` placeholder as `refine[0].proposal_id`. The adapter forwards that id to its upstream which 404s. Tracked at adcp#4086 + draft PR #4088 (storyboard fix to add `context_outputs`/`context_inputs` chaining). Per the implementation guidance in #1549, runner gaps that prevent the test from passing get filed as separate issues rather than worked around in the adapter — adcp#4086 was already filed and PR #4088 is in flight.

## Test plan

- [x] `node --test test/examples/hello-seller-adapter-proposal-mode.test.js` passes (3/3 gates green).
- [x] `node --test test/examples/hello-seller-adapter-guaranteed.test.js` still passes (helper change-free).
- [x] `npx tsc --noEmit` clean across the project.
- [x] `npm run format:check` clean.
- [x] Adversarial sabotage: invert exemption marker → assertion (1) fires; flip downstream-phase doesNotMatch → assertion (2) fires.
- [x] Spot-run: `adcp storyboard run http://127.0.0.1:PORT/mcp media_buy_seller/proposal_finalize --json` returns `overall_status: partial` with the expected `get_products_refine` failure and the cascade-blocked downstream phases — matching the gate test's allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)