### PR TITLE
fix(task-executor): descriptive failure when polling an evicted task (#1585 follow-up)

### DIFF
--- a/.changeset/poll-task-not-found-descriptive.md
+++ b/.changeset/poll-task-not-found-descriptive.md
@@ -1,0 +1,22 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(task-executor): return descriptive failed result when polling an evicted task
+
+`TaskExecutor.pollTaskCompletion` now catches `"Task <id> not found"` errors
+from `getTaskStatus` and returns a `TaskResultFailure` with an actionable
+error message rather than letting an opaque exception escape the polling
+loop.
+
+A2A 0.3.x defines no minimum retention TTL for completed tasks, so a seller
+MAY evict a task between the buyer observing the working-state response and
+the first explicit `tasks/get` poll firing. The error suggests using push
+notifications (`reporting_webhook`) instead of polling, or configuring a
+longer task retention TTL on the seller.
+
+Defense-in-depth follow-up to #1585. The cross-storyboard root cause was
+already addressed in #1588 (`resetContext()` per storyboard) and #1593
+(narrowed `pendingTaskId` auto-thread to same-skill same-context); this
+change improves the error surface for any residual case where an evicted
+task is queried.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1397,8 +1397,39 @@ export class TaskExecutor {
     pollInterval = 60000,
     transport?: import('../protocols').TransportOptions
   ): Promise<TaskResult<T>> {
+    const pollStartTime = Date.now();
     while (true) {
-      const status = await this.getTaskStatus(agent, taskId, transport);
+      // adcp-client#1585: A2A 0.3.x defines no minimum retention TTL for
+      // completed tasks. A seller may evict a task between the buyer
+      // observing the working-state response and the first explicit
+      // `tasks/get` poll firing — `getTaskStatus` then throws with a
+      // "Task <id> not found" message. Surface a descriptive `failed`
+      // `TaskResult` so the caller sees an actionable error instead of an
+      // opaque uncaught exception escaping from the polling loop.
+      let status: TaskInfo;
+      try {
+        status = await this.getTaskStatus(agent, taskId, transport);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        // Bounded `\S{1,128}` task-id segment (no `.*`) keeps the match
+        // linear-time on adversarial inputs — CodeQL flags unbounded
+        // polynomial regex on uncontrolled error strings.
+        if (/\btask\s+\S{1,128}\s+not found\b/i.test(msg)) {
+          return attachMatch({
+            success: false as const,
+            status: 'failed' as const,
+            error: `Task ${taskId} is no longer queryable — it may have been completed and evicted by the seller before this poll arrived. Consider using push notifications (reporting_webhook) instead of polling, or configuring a longer task retention TTL on the seller.`,
+            metadata: this.buildMetadata({
+              taskId,
+              taskName: 'unknown',
+              agent,
+              startTime: pollStartTime,
+              status: 'failed',
+            }),
+          });
+        }
+        throw err;
+      }
 
       if (status.status === ADCP_STATUS.COMPLETED) {
         const pollSuccess = this.isOperationSuccess(status.result);

--- a/test/lib/poll-task-completion-not-found.test.js
+++ b/test/lib/poll-task-completion-not-found.test.js
@@ -1,0 +1,92 @@
+// Tests that pollTaskCompletion returns a descriptive failed TaskResult
+// when getTaskStatus throws "Task <id> not found" (A2A 0.3.x defines no
+// minimum retention TTL — sellers may evict completed tasks before the
+// first explicit poll fires). Defense-in-depth for adcp-client#1585.
+
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('pollTaskCompletion handles evicted tasks (#1585)', () => {
+  let TaskExecutor;
+  let ProtocolClient;
+  let originalCallTool;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../../dist/lib/index.js')];
+    const lib = require('../../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    ProtocolClient = lib.ProtocolClient;
+    originalCallTool = ProtocolClient.callTool;
+
+    mockAgent = {
+      id: 'test-agent',
+      name: 'Test Agent',
+      agent_uri: 'https://test.example.com',
+      protocol: 'a2a',
+    };
+  });
+
+  afterEach(() => {
+    if (originalCallTool) {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('returns failed TaskResult with actionable error when getTaskStatus reports task not found', async () => {
+    ProtocolClient.callTool = mock.fn(async () => {
+      throw new Error('A2A agent returned error: Task abc-123 not found');
+    });
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'abc-123', 10);
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.ok(result.error.includes('abc-123'), `Expected error to include the task id, got: ${result.error}`);
+    assert.ok(/no longer queryable/i.test(result.error), `Expected actionable hint, got: ${result.error}`);
+    assert.ok(
+      /reporting_webhook|push notification/i.test(result.error),
+      `Expected suggestion to use push notifications, got: ${result.error}`
+    );
+  });
+
+  test('does not loop on task-not-found — exits on first poll', async () => {
+    let pollCount = 0;
+    ProtocolClient.callTool = mock.fn(async () => {
+      pollCount++;
+      throw new Error('Task xyz-789 not found');
+    });
+
+    const executor = new TaskExecutor();
+    await executor.pollTaskCompletion(mockAgent, 'xyz-789', 10);
+
+    assert.strictEqual(pollCount, 1, 'should exit after a single poll on not-found');
+  });
+
+  test('re-throws unrelated errors from getTaskStatus (does not swallow non-matching failures)', async () => {
+    ProtocolClient.callTool = mock.fn(async () => {
+      throw new Error('Network unreachable: ECONNREFUSED');
+    });
+
+    const executor = new TaskExecutor();
+    await assert.rejects(
+      () => executor.pollTaskCompletion(mockAgent, 'task-network', 10),
+      /ECONNREFUSED/,
+      'unrelated transport errors must propagate, not be coerced into failed TaskResult'
+    );
+  });
+
+  test('failed result carries metadata (taskId, agent) for diagnostics', async () => {
+    ProtocolClient.callTool = mock.fn(async () => {
+      throw new Error('Task task-meta-1 not found');
+    });
+
+    const executor = new TaskExecutor();
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-meta-1', 10);
+
+    assert.ok(result.metadata, 'failed result must include metadata');
+    assert.strictEqual(result.metadata.taskId, 'task-meta-1');
+    assert.strictEqual(result.metadata.status, 'failed');
+  });
+});


### PR DESCRIPTION
## Summary

- Defense-in-depth follow-up to #1585. `TaskExecutor.pollTaskCompletion` now catches `"Task <id> not found"` errors from `getTaskStatus` and returns a `TaskResultFailure` with an actionable error message rather than letting an opaque exception escape the polling loop.
- Cross-storyboard root cause was already addressed in #1588 (`resetContext()` per storyboard) and #1593 (narrowed `pendingTaskId` auto-thread to same-skill same-context). This PR improves the error surface for any residual case where an evicted task is queried — including adopters polling outside `comply()`.

## Why

A2A 0.3.x defines no minimum retention TTL for completed tasks, so a seller MAY evict a task between the buyer observing the working-state response and the first explicit `tasks/get` poll firing. Pre-fix that surfaced as an uncaught exception from the polling loop; post-fix it surfaces as a `failed` `TaskResult` with hints to use push notifications (`reporting_webhook`) or configure a longer task retention TTL on the seller.

## Supersedes #1592

Triage-bot PR #1592 proposed three layered fixes for the same issue:

1. `clearPendingTask()` after `waitForCompletion` in `task-map.ts` — superseded by #1593's `(contextId, taskName)`-keyed narrowing of auto-threading at the SDK level. The aggressive task-map clear would also affect within-storyboard task resumption, which is undesirable.
2. `callA2AToolImpl` retry on "Task not found" — became risky after #1593 narrowed auto-threading. Post-#1593 the only ways a stale `taskId` reaches `callA2AToolImpl` are an explicit caller-supplied `taskId` (e.g., a HITL resume), where silently dropping the id and retrying would mask a real eviction failure the buyer needs to see.
3. **Descriptive `pollTaskCompletion` error** — kept here. Pure ergonomic improvement, independent of #1588/#1593.

## Changes

- `src/lib/core/TaskExecutor.ts` — `pollTaskCompletion` wraps `getTaskStatus` in `try/catch`, recognizes `/task .* not found/i`, returns descriptive failed `TaskResult`. Unrelated errors propagate.
- `test/lib/poll-task-completion-not-found.test.js` — 4 tests pinning the contract: descriptive error shape, exits on first poll (no retry loop), unrelated errors propagate, metadata carries `taskId`/`status`.
- `.changeset/poll-task-not-found-descriptive.md` — patch bump.

## Test plan

- [x] `npm run format:check` clean
- [x] `npx tsc --noEmit` clean
- [x] `node --test test/lib/poll-task-completion-not-found.test.js` — 4/4 pass
- [x] Adjacent suites pass: `poll-task-completion-terminal-states`, `task-executor-async-patterns` — 35/35

🤖 Generated with [Claude Code](https://claude.com/claude-code)