### PR TITLE
feat(builders): typed factories for 5 discriminated unions (#1386)

### DIFF
--- a/.changeset/typed-factories-1386.md
+++ b/.changeset/typed-factories-1386.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': minor
+---
+
+Five new typed-factory namespaces for discriminator-injecting builders, mirroring the asset-builders / render-builders pattern. Each prevents a discriminator-missing wire-shape mistake at write time:
+
+- `activationKey.{segment, keyValue}` — `ActivationKey` `oneOf` on `type` (SHAPE-GOTCHAS §1)
+- `signalId.{catalog, agent}` — `SignalID` `oneOf` on `source` (SHAPE-GOTCHAS §2)
+- `buildCreativeReturn.{single, multi, singleEnveloped, multiEnveloped}` — `BuildCreativeReturn` 4-arm union (SHAPE-GOTCHAS §5)
+- `previewCreativeResponse.{single, batch, variant}` — `PreviewCreativeResponse` 3-arm `oneOf` on `response_type` (SHAPE-GOTCHAS §4)
+- `mediaBuyDeliveryNotification.{scheduled, final, delayed, adjusted, windowUpdate}` — webhook `notification_type` discriminator on `GetMediaBuyDeliveryResponse`
+
+Reference adapters (`examples/hello_creative_adapter_*.ts`, `hello_signals_adapter_marketplace.ts`, `signals-agent.ts`) migrated to use the new factories. The deprecated v5 helper `previewCreativeResponse` is no longer re-exported from the top-level `@adcp/sdk` entry; it remains available via `@adcp/sdk/server`.
+
+Closes #1386.

--- a/.changeset/typed-factories-1386.md
+++ b/.changeset/typed-factories-1386.md
@@ -7,9 +7,9 @@ Five new typed-factory namespaces for discriminator-injecting builders, mirrorin
 - `activationKey.{segment, keyValue}` — `ActivationKey` `oneOf` on `type` (SHAPE-GOTCHAS §1)
 - `signalId.{catalog, agent}` — `SignalID` `oneOf` on `source` (SHAPE-GOTCHAS §2)
 - `buildCreativeReturn.{single, multi, singleEnveloped, multiEnveloped}` — `BuildCreativeReturn` 4-arm union (SHAPE-GOTCHAS §5)
-- `previewCreativeResponse.{single, batch, variant}` — `PreviewCreativeResponse` 3-arm `oneOf` on `response_type` (SHAPE-GOTCHAS §4)
+- `previewCreative.{single, batch, variant}` — `PreviewCreativeResponse` 3-arm `oneOf` on `response_type` (SHAPE-GOTCHAS §4)
 - `mediaBuyDeliveryNotification.{scheduled, final, delayed, adjusted, windowUpdate}` — webhook `notification_type` discriminator on `GetMediaBuyDeliveryResponse`
 
-Reference adapters (`examples/hello_creative_adapter_*.ts`, `hello_signals_adapter_marketplace.ts`, `signals-agent.ts`) migrated to use the new factories. The deprecated v5 helper `previewCreativeResponse` is no longer re-exported from the top-level `@adcp/sdk` entry; it remains available via `@adcp/sdk/server`.
+Reference adapters (`examples/hello_creative_adapter_*.ts`, `hello_signals_adapter_marketplace.ts`, `signals-agent.ts`) migrated to use the new factories. Top-level `previewCreativeResponse` v5 server-helper export retained for backwards compatibility; the new factory ships under `previewCreative` to avoid collision with the v5 function.
 
 Closes #1386.

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -66,7 +66,7 @@ import {
   type DecisioningPlatform,
   type SyncCreativesRow,
 } from '@adcp/sdk/server';
-import { FormatAsset, buildCreativeReturn, previewCreativeResponse, urlRender } from '@adcp/sdk';
+import { FormatAsset, buildCreativeReturn, previewCreative, urlRender } from '@adcp/sdk';
 import type {
   BuildCreativeRequest,
   BuildCreativeSuccess,
@@ -554,9 +554,9 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
         });
       }
       const rendered = await upstream.renderCreative(networkCode, creativeId, {});
-      // `previewCreativeResponse.single({...})` injects
+      // `previewCreative.single({...})` injects
       // `response_type: 'single'`. SHAPE-GOTCHAS §4.
-      return previewCreativeResponse.single({
+      return previewCreative.single({
         previews: [
           {
             preview_id: `prv_${creative.creative_id}`,

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -66,7 +66,7 @@ import {
   type DecisioningPlatform,
   type SyncCreativesRow,
 } from '@adcp/sdk/server';
-import { FormatAsset } from '@adcp/sdk';
+import { FormatAsset, buildCreativeReturn, previewCreativeResponse, urlRender } from '@adcp/sdk';
 import type {
   BuildCreativeRequest,
   BuildCreativeSuccess,
@@ -511,16 +511,17 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
       // satisfying creative-manifest.json:14. Each `assets[key]` is a
       // discriminated AssetVariant — `asset_type` selects the matching
       // schema (html requires `content`, etc.).
-      return {
-        creative_manifest: {
+      // `buildCreativeReturn.singleEnveloped({...})` injects the wire-shape
+      // discriminator: takes a flat `manifest` field (renamed to
+      // `creative_manifest` on the wire). SHAPE-GOTCHAS §5.
+      return buildCreativeReturn.singleEnveloped({
+        manifest: {
           format_id: { agent_url: FORMAT_AGENT_URL, id: creative.format_id },
           assets: {
             serving_tag: { asset_type: 'html', content: rendered.tag_html },
           },
         },
-        // CAST: oneOf-emitter — picking variant 0 (single creative_manifest)
-        // of the BuildCreativeResponse oneOf. Adopters keep this cast.
-      } as unknown as BuildCreativeSuccess;
+      });
     },
 
     /**
@@ -553,26 +554,24 @@ class CreativeAdServerAdapter implements DecisioningPlatform<Record<string, neve
         });
       }
       const rendered = await upstream.renderCreative(networkCode, creativeId, {});
-      return {
-        response_type: 'single',
+      // `previewCreativeResponse.single({...})` injects
+      // `response_type: 'single'`. SHAPE-GOTCHAS §4.
+      return previewCreativeResponse.single({
         previews: [
           {
             preview_id: `prv_${creative.creative_id}`,
             renders: [
-              {
+              urlRender({
                 render_id: `rnd_${creative.creative_id}`,
                 preview_url: rendered.preview_url,
                 role: 'primary',
-              },
+              }),
             ],
             input: { name: 'default' },
           },
         ],
         expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-        // CAST: oneOf-emitter — picking the `single` discriminator branch
-        // of the PreviewCreativeResponse 3-way union (single | batch | variant).
-        // See SHAPE-GOTCHAS §4. Adopters keep this cast.
-      } as unknown as PreviewCreativeResponse;
+      });
     },
 
     listCreativeFormats: async (_req, _ctx): Promise<ListCreativeFormatsResponse> => {

--- a/examples/hello_creative_adapter_template.ts
+++ b/examples/hello_creative_adapter_template.ts
@@ -52,6 +52,8 @@ import {
   javascriptAsset,
   audioAsset,
   urlRender,
+  buildCreativeReturn,
+  previewCreativeResponse,
   type Format,
   type ListCreativeFormatsResponse,
   type BuildCreativeRequest,
@@ -446,12 +448,13 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
         return projectRenderToManifest(completed, { agent_url: PUBLIC_AGENT_URL, id: target.id });
       };
 
-      // Multi-format request — return `CreativeManifest[]`; framework wraps
-      // as `{ creative_manifests: [...] }`. See BuildCreativeReturn (4-arm
-      // discriminated union) — returning the wrong arm fails wire-schema
-      // validation. SHAPE-GOTCHAS.md §5.
+      // `buildCreativeReturn.multi(...)` / `.single(...)` pin which arm of
+      // the 4-shape `BuildCreativeReturn` union you're emitting. The framework
+      // wraps `multi` into `{ creative_manifests: [...] }` and `single` into
+      // `{ creative_manifest: <obj> }` on the wire. SHAPE-GOTCHAS §5.
       if (req.target_format_ids && req.target_format_ids.length > 0) {
-        return Promise.all(req.target_format_ids.map((t, i) => buildOne(t, i)));
+        const manifests = await Promise.all(req.target_format_ids.map((t, i) => buildOne(t, i)));
+        return buildCreativeReturn.multi(manifests);
       }
 
       // Single-format request.
@@ -461,7 +464,7 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
           field: 'target_format_id',
         });
       }
-      return buildOne(req.target_format_id, 0);
+      return buildCreativeReturn.single(await buildOne(req.target_format_id, 0));
     },
 
     previewCreative: async (req: PreviewCreativeRequest, ctx): Promise<PreviewCreativeResponse> => {
@@ -516,12 +519,11 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
         throw new AdcpError('INVALID_REQUEST', { message: 'upstream returned no preview_url' });
       }
 
-      // PreviewCreativeResponse is a 3-way discriminated union (single |
-      // batch | variant). Single mode requires `previews[].renders[]` even
-      // for one preview — and each render needs the `output_format`
-      // discriminator. urlRender({...}) injects it. SHAPE-GOTCHAS.md §4.
-      return {
-        response_type: 'single',
+      // `previewCreativeResponse.single({...})` injects
+      // `response_type: 'single'`. The render slot's `output_format`
+      // discriminator is in turn injected by `urlRender({...})`.
+      // SHAPE-GOTCHAS §4.
+      return previewCreativeResponse.single({
         previews: [
           {
             preview_id: `prv_${created.render_id}`,
@@ -539,7 +541,7 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
           },
         ],
         expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
-      };
+      });
     },
   });
 }

--- a/examples/hello_creative_adapter_template.ts
+++ b/examples/hello_creative_adapter_template.ts
@@ -53,7 +53,7 @@ import {
   audioAsset,
   urlRender,
   buildCreativeReturn,
-  previewCreativeResponse,
+  previewCreative,
   type Format,
   type ListCreativeFormatsResponse,
   type BuildCreativeRequest,
@@ -519,11 +519,11 @@ class CreativeTemplateAdapter implements DecisioningPlatform<Record<string, neve
         throw new AdcpError('INVALID_REQUEST', { message: 'upstream returned no preview_url' });
       }
 
-      // `previewCreativeResponse.single({...})` injects
+      // `previewCreative.single({...})` injects
       // `response_type: 'single'`. The render slot's `output_format`
       // discriminator is in turn injected by `urlRender({...})`.
       // SHAPE-GOTCHAS §4.
-      return previewCreativeResponse.single({
+      return previewCreative.single({
         previews: [
           {
             preview_id: `prv_${created.render_id}`,

--- a/examples/hello_signals_adapter_marketplace.ts
+++ b/examples/hello_signals_adapter_marketplace.ts
@@ -36,6 +36,7 @@ import {
   type CachedBuyerAgentRegistry,
 } from '@adcp/sdk/server';
 import type { GetSignalsResponse, ActivateSignalRequest, ActivateSignalSuccess } from '@adcp/sdk/types';
+import { activationKey, signalId } from '@adcp/sdk';
 import { createUpstreamRecorder, toQueryUpstreamTrafficResponse } from '@adcp/sdk/upstream-recorder';
 import { createHash, randomUUID } from 'node:crypto';
 
@@ -292,11 +293,10 @@ function toAdcpSignal(c: UpstreamCohort): GetSignalsResponse['signals'][number] 
   const coverage = c.total_universe > 0 ? Math.round((c.member_count / c.total_universe) * 100) : 0;
   return {
     signal_agent_segment_id: c.cohort_id,
-    signal_id: {
-      source: 'catalog',
+    signal_id: signalId.catalog({
       data_provider_domain: c.data_provider_domain,
       id: c.data_provider_id,
-    },
+    }),
     name: c.name,
     description: c.description,
     value_type: c.value_type,
@@ -449,18 +449,16 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
               client_request_id: `${idempotency}.${i}`,
             });
             if (dest.type === 'agent') {
-              // ActivationKey oneOf — for `type: 'key_value'`, `key` and `value`
-              // sit at the TOP level (not nested under a `key_value` field).
-              // `value` MUST be string. See skills/SHAPE-GOTCHAS.md §1.
+              // `activationKey.keyValue({...})` injects `type: 'key_value'`
+              // and accepts the flat `{ key, value }` shape. SHAPE-GOTCHAS §1.
               return {
                 type: 'agent' as const,
                 agent_url: dest.agent_url,
                 is_live: true,
-                activation_key: {
-                  type: 'key_value' as const,
+                activation_key: activationKey.keyValue({
                   key: 'agent_segment',
                   value: activation.agent_activation_key?.agent_segment ?? activation.activation_id,
-                },
+                }),
                 deployed_at: new Date().toISOString(),
               };
             }
@@ -468,10 +466,9 @@ class SignalMarketplaceAdapter implements DecisioningPlatform<Record<string, nev
               type: 'platform' as const,
               platform: dest.platform,
               is_live: false,
-              activation_key: {
-                type: 'segment_id' as const,
+              activation_key: activationKey.segment({
                 segment_id: activation.segment_id ?? activation.activation_id,
-              },
+              }),
               estimated_activation_duration_minutes: 30,
             };
           })

--- a/examples/signals-agent.ts
+++ b/examples/signals-agent.ts
@@ -18,6 +18,7 @@
 
 import { createAdcpServer, serve } from '@adcp/sdk/server/legacy/v5';
 import { createIdempotencyStore, memoryBackend } from '@adcp/sdk/server';
+import { activationKey, signalId } from '@adcp/sdk';
 import type { GetSignalsResponse, ServeContext } from '@adcp/sdk';
 
 // ---------------------------------------------------------------------------
@@ -28,11 +29,10 @@ type Signal = GetSignalsResponse['signals'][number];
 const SEGMENTS: Signal[] = [
   {
     signal_agent_segment_id: 'high_intent_shoppers',
-    signal_id: {
-      source: 'catalog',
+    signal_id: signalId.catalog({
       data_provider_domain: 'example-signals.com',
       id: 'high_intent_shoppers',
-    },
+    }),
     name: 'High Intent Shoppers',
     description: 'Users who visited product pages 3+ times in the last 7 days without purchasing.',
     value_type: 'binary',
@@ -51,11 +51,10 @@ const SEGMENTS: Signal[] = [
   },
   {
     signal_agent_segment_id: 'lapsed_subscribers',
-    signal_id: {
-      source: 'catalog',
+    signal_id: signalId.catalog({
       data_provider_domain: 'example-signals.com',
       id: 'lapsed_subscribers',
-    },
+    }),
     name: 'Lapsed Subscribers',
     description: 'Email subscribers who have not opened in 90+ days but previously had high engagement.',
     value_type: 'binary',
@@ -74,11 +73,10 @@ const SEGMENTS: Signal[] = [
   },
   {
     signal_agent_segment_id: 'geo_urban_commuters',
-    signal_id: {
-      source: 'catalog',
+    signal_id: signalId.catalog({
       data_provider_domain: 'example-signals.com',
       id: 'geo_urban_commuters',
-    },
+    }),
     name: 'Urban Commuters',
     description: 'Users whose location data indicates daily commute patterns through major metro areas.',
     value_type: 'binary',
@@ -171,21 +169,19 @@ function createSignalsAgent({ taskStore }: ServeContext) {
               platform: dest.platform,
               is_live: false,
               estimated_activation_duration_minutes: 30,
-              activation_key: {
-                type: 'segment_id' as const,
+              activation_key: activationKey.segment({
                 segment_id: `${dest.platform}_${params.signal_agent_segment_id}`,
-              },
+              }),
             };
           }
           return {
             type: 'agent' as const,
             agent_url: dest.agent_url,
             is_live: true,
-            activation_key: {
-              type: 'key_value' as const,
+            activation_key: activationKey.keyValue({
               key: 'audience',
               value: params.signal_agent_segment_id,
-            },
+            }),
             deployed_at: new Date().toISOString(),
           };
         });

--- a/skills/SHAPE-GOTCHAS.md
+++ b/skills/SHAPE-GOTCHAS.md
@@ -150,13 +150,13 @@ Same pattern applies to `DAASTAsset` (audio).
 
 Each `PreviewRender` requires `render_id`, `output_format: 'url'` (or `'inline_html'`), `preview_url`, and `role`. Don't omit `role` — the validator requires it.
 
-**Prevent at write time:** import `previewCreativeResponse` from
+**Prevent at write time:** import `previewCreative` from
 `@adcp/sdk`. The typed factory injects the `response_type` discriminator
 and pairs naturally with `urlRender({...})` / `htmlRender({...})` /
 `bothRender({...})` for the per-render `output_format`:
 
 ```ts
-previewCreativeResponse.single({
+previewCreative.single({
   previews: [
     {
       preview_id: 'prv_abc',
@@ -166,8 +166,8 @@ previewCreativeResponse.single({
   ],
   expires_at: '2026-05-03T00:00:00Z',
 });
-previewCreativeResponse.batch({ results: [...] });
-previewCreativeResponse.variant({ variant_id, creative_id, previews });
+previewCreative.batch({ results: [...] });
+previewCreative.variant({ variant_id, creative_id, previews });
 ```
 
 A flat `{ preview: {...} }` shape doesn't typecheck.

--- a/skills/SHAPE-GOTCHAS.md
+++ b/skills/SHAPE-GOTCHAS.md
@@ -10,7 +10,7 @@ Six patterns surfaced repeatedly while building reference adapters (`examples/he
 
 When returning `activate_signal` deployments with `type: 'key_value'` activation keys, `key` and `value` sit at the TOP level of `activation_key`. NOT nested under a `key_value` sub-field.
 
-✗ Wrong (intuitive — the discriminator name *suggests* nesting):
+✗ Wrong (intuitive — the discriminator name _suggests_ nesting):
 
 ```ts
 activation_key: {
@@ -37,6 +37,17 @@ activation_key: { type: 'segment_id', segment_id: 'plat_seg_xyz' }
 
 — same flatness, single string ID under the discriminator.
 
+**Prevent at write time:** import `activationKey` from `@adcp/sdk`. The
+typed factory injects the `type` discriminator and accepts the flat shape:
+
+```ts
+activation_key: activationKey.keyValue({ key: 'segment', value: 'abc123' });
+activation_key: activationKey.segment({ segment_id: 'plat_seg_xyz' });
+```
+
+The nested-`key_value` mistake doesn't typecheck — `activationKey.keyValue`
+takes `{ key, value }`, not `{ key_value: {...} }`.
+
 ---
 
 ## 2. `signal_ids` is `signal_id[]` (provenance objects), not `string[]`
@@ -46,7 +57,9 @@ activation_key: { type: 'segment_id', segment_id: 'plat_seg_xyz' }
 ✗ Wrong:
 
 ```ts
-{ signal_ids: ['cohort_abc', 'cohort_xyz'] }
+{
+  signal_ids: ['cohort_abc', 'cohort_xyz'];
+}
 ```
 
 ✓ Right (matches `/schemas/3.0/core/signal-id.json`):
@@ -62,11 +75,23 @@ activation_key: { type: 'segment_id', segment_id: 'plat_seg_xyz' }
 
 `SignalID` is a discriminated union: `source: 'catalog'` (with `data_provider_domain` + `id`) or `source: 'agent'` (with `agent_url` + `id`). When implementing the filter on the seller side, narrow on `source` before reading `data_provider_domain` — only the catalog variant has it.
 
+**Prevent at write time:** import `signalId` from `@adcp/sdk`. The typed
+factory injects the `source` discriminator and only takes the fields the
+selected variant requires:
+
+```ts
+signalId.catalog({ data_provider_domain: 'tridentauto.example', id: 'likely_ev_buyers' });
+signalId.agent({ agent_url: 'https://liveramp.com/.well-known/adcp/signals', id: 'custom_auto_intenders' });
+```
+
+A bare-string `signal_ids` filter is rejected by the request type as soon
+as you stop typing it as `any`.
+
 ---
 
 ## 3. `VASTAsset` requires an embedded `delivery_type` discriminator
 
-`asset_type: 'vast'` is itself a discriminator at the asset level. A *second* discriminator (`delivery_type`) picks between inline VAST XML and a redirect URL. Both are required; you can't pass `content` or `vast_url` without `delivery_type`.
+`asset_type: 'vast'` is itself a discriminator at the asset level. A _second_ discriminator (`delivery_type`) picks between inline VAST XML and a redirect URL. Both are required; you can't pass `content` or `vast_url` without `delivery_type`.
 
 ✗ Wrong (flat `content` without `delivery_type`):
 
@@ -125,6 +150,28 @@ Same pattern applies to `DAASTAsset` (audio).
 
 Each `PreviewRender` requires `render_id`, `output_format: 'url'` (or `'inline_html'`), `preview_url`, and `role`. Don't omit `role` — the validator requires it.
 
+**Prevent at write time:** import `previewCreativeResponse` from
+`@adcp/sdk`. The typed factory injects the `response_type` discriminator
+and pairs naturally with `urlRender({...})` / `htmlRender({...})` /
+`bothRender({...})` for the per-render `output_format`:
+
+```ts
+previewCreativeResponse.single({
+  previews: [
+    {
+      preview_id: 'prv_abc',
+      renders: [urlRender({ render_id: 'rnd_1', preview_url: 'https://...', role: 'primary' })],
+      input: { name: 'default' },
+    },
+  ],
+  expires_at: '2026-05-03T00:00:00Z',
+});
+previewCreativeResponse.batch({ results: [...] });
+previewCreativeResponse.variant({ variant_id, creative_id, previews });
+```
+
+A flat `{ preview: {...} }` shape doesn't typecheck.
+
 ---
 
 ## 5. `BuildCreativeReturn` has 4 valid shapes — framework auto-wraps the bare manifest
@@ -133,13 +180,13 @@ Each `PreviewRender` requires `render_id`, `output_format: 'url'` (or `'inline_h
 
 ```ts
 type BuildCreativeReturn =
-  | CreativeManifest                    // bare single — framework wraps as { creative_manifest: <obj> }
-  | CreativeManifest[]                  // bare multi  — framework wraps as { creative_manifests: <arr> }
-  | BuildCreativeSuccess                // shaped single — passthrough; you set sandbox/expires_at/preview
-  | BuildCreativeMultiSuccess           // shaped multi  — passthrough
+  | CreativeManifest // bare single — framework wraps as { creative_manifest: <obj> }
+  | CreativeManifest[] // bare multi  — framework wraps as { creative_manifests: <arr> }
+  | BuildCreativeSuccess // shaped single — passthrough; you set sandbox/expires_at/preview
+  | BuildCreativeMultiSuccess; // shaped multi  — passthrough
 ```
 
-Easy mistake: return a bare `CreativeManifest` and confirm the response *seems* fine via tests that read `response.format_id` directly. The wire shape after framework wrapping is `response.creative_manifest.format_id` — a level deeper. Storyboards check the wire path; if you didn't go through the framework wrapper in your test, the storyboard will surface "field missing at `creative_manifest.format_id`" while your local test passes.
+Easy mistake: return a bare `CreativeManifest` and confirm the response _seems_ fine via tests that read `response.format_id` directly. The wire shape after framework wrapping is `response.creative_manifest.format_id` — a level deeper. Storyboards check the wire path; if you didn't go through the framework wrapper in your test, the storyboard will surface "field missing at `creative_manifest.format_id`" while your local test passes.
 
 If you need to set `sandbox: true` or attach `preview` previews, return the shaped envelope directly:
 
@@ -151,16 +198,29 @@ return {
 };
 ```
 
+**Prevent at write time:** import `buildCreativeReturn` from `@adcp/sdk`.
+The typed factory pins which arm of the 4-shape union you're emitting and
+handles the singular/plural manifest-field rename for the shaped envelopes:
+
+```ts
+return buildCreativeReturn.single(manifest); // bare — framework wraps as { creative_manifest }
+return buildCreativeReturn.multi(manifests); // bare — framework wraps as { creative_manifests }
+return buildCreativeReturn.singleEnveloped({ manifest, sandbox: true, expires_at });
+return buildCreativeReturn.multiEnveloped({ manifests, sandbox: true });
+```
+
+Mixing `manifest` / `manifests` arms doesn't typecheck.
+
 ---
 
 ## 6. `log_event` projection for walled-garden CAPIs
 
 Sales-social adopters fronting walled-garden conversion APIs translate AdCP's `log_event` wire shape onto the upstream CAPI's. Three projections trip every walled-garden integration on the first pass — the upstream returns `400` and the AdCP wire surface gives no hint that the field name or encoding was the problem.
 
-| AdCP wire (`Event`)                                                            | Walled-garden CAPI                                                                          | Translation                                                                  |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `event_type` (string)                                                          | `event_name` (string)                                                                       | rename on the way out                                                        |
-| `event_time` (ISO 8601 string)                                                 | `event_time` (UNIX seconds, number)                                                         | `Math.floor(new Date(t).getTime() / 1000)`                                   |
+| AdCP wire (`Event`)                                                                                      | Walled-garden CAPI                                                       | Translation                                                                  |
+| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| `event_type` (string)                                                                                    | `event_name` (string)                                                    | rename on the way out                                                        |
+| `event_time` (ISO 8601 string)                                                                           | `event_time` (UNIX seconds, number)                                      | `Math.floor(new Date(t).getTime() / 1000)`                                   |
 | `user_match` (`hashed_email` / `hashed_phone` / `uids[]` / `click_id` / `client_ip`+`client_user_agent`) | `user_data.{email_sha256,phone_sha256,external_id_sha256}` (≥1 required) | map per the upstream's identifier types; drop events with empty `user_match` |
 
 ### 6.1 `event_name`, not `event_type`
@@ -187,13 +247,17 @@ upstream.trackEvents({
 ✗ Wrong:
 
 ```ts
-{ event_time: e.event_time }                 // '2026-04-05T14:30:00Z'
+{
+  event_time: e.event_time;
+} // '2026-04-05T14:30:00Z'
 ```
 
 ✓ Right:
 
 ```ts
-{ event_time: Math.floor(new Date(e.event_time).getTime() / 1000) }
+{
+  event_time: Math.floor(new Date(e.event_time).getTime() / 1000);
+}
 ```
 
 ### 6.3 Hashed-identifier requirement — read `Event.user_match`, drop on empty
@@ -221,11 +285,11 @@ The `examples/hello_seller_adapter_social.ts` reference adapter codifies all thr
 
 The spec definitions:
 
-| Value | Use when | Example adopter |
-| --- | --- | --- |
-| `marketplace` | Resold third-party segments. Provider's authorization is verifiable via their `adagents.json`. | LiveRamp marketplace; Oracle Data Cloud catalog; reseller of third-party panels |
-| `owned` | First-party segments derived from data the signal agent **directly owns**. | Retailer purchase data (Kroger 84.51°, Walmart Connect); publisher behavioral data (NYT subscribers); telco data |
-| `custom` | Agent-native segment built **on demand** from models, composites, or buyer inputs. Not attributable to a standing upstream provider. | Contextual classifier you train per-request; lookalike model output computed from a buyer's seed audience |
+| Value         | Use when                                                                                                                             | Example adopter                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `marketplace` | Resold third-party segments. Provider's authorization is verifiable via their `adagents.json`.                                       | LiveRamp marketplace; Oracle Data Cloud catalog; reseller of third-party panels                                  |
+| `owned`       | First-party segments derived from data the signal agent **directly owns**.                                                           | Retailer purchase data (Kroger 84.51°, Walmart Connect); publisher behavioral data (NYT subscribers); telco data |
+| `custom`      | Agent-native segment built **on demand** from models, composites, or buyer inputs. Not attributable to a standing upstream provider. | Contextual classifier you train per-request; lookalike model output computed from a buyer's seed audience        |
 
 **`owned` is the default for first-party data agents.** Most non-marketplace adopters mis-classify their segments as `custom` because the segment was "built" — but the test is provenance, not lifecycle. If you can point at a stable data-asset you own (a customer table, a pixel, a panel), it's `owned`. `custom` is reserved for segments that don't have a standing data asset behind them — the agent computed them per-call.
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -542,7 +542,6 @@ export {
   performanceFeedbackResponse,
   buildCreativeResponse,
   buildCreativeMultiResponse,
-  previewCreativeResponse,
   creativeDeliveryResponse,
   listCreativesResponse,
   listPropertyListsResponse,
@@ -974,6 +973,56 @@ export {
   type ParameterizedRender,
   type RenderItem,
 } from './utils/format-render-builders';
+
+// ====== ACTIVATION KEY BUILDERS ======
+// Typed factories that inject the `type` discriminator on `ActivationKey`.
+// SHAPE-GOTCHAS §1 — `key`/`value` flatten on the activation key itself.
+export { activationKey, segmentIdActivationKey, keyValueActivationKey } from './utils/activation-key-builders';
+
+// ====== SIGNAL ID BUILDERS ======
+// Typed factories that inject the `source` discriminator on `SignalID`.
+// Used in `signal_ids` filter arrays and as the `signal_id` provenance
+// field on every `Signal` returned by `get_signals`. SHAPE-GOTCHAS §2.
+export { signalId, catalogSignalId, agentSignalId } from './utils/signal-id-builders';
+
+// ====== BUILD CREATIVE RETURN BUILDERS ======
+// Typed factories for the four return shapes accepted by the framework
+// from `build_creative` handlers. `.single` / `.multi` emit bare manifests
+// the framework auto-wraps; `.singleEnveloped` / `.multiEnveloped` emit
+// the shaped envelope when the handler needs to attach `sandbox` /
+// `expires_at` / `preview`. SHAPE-GOTCHAS §5.
+export {
+  buildCreativeReturn,
+  singleBuildCreativeReturn,
+  multiBuildCreativeReturn,
+  singleEnvelopedBuildCreativeReturn,
+  multiEnvelopedBuildCreativeReturn,
+} from './utils/build-creative-return-builders';
+
+// ====== PREVIEW CREATIVE RESPONSE BUILDERS ======
+// Typed factories that inject the `response_type` discriminator on
+// `PreviewCreativeResponse`. Three-way oneOf — `single | batch | variant`.
+// Pair with `urlRender` / `htmlRender` / `bothRender` for the per-render
+// `output_format`. SHAPE-GOTCHAS §4.
+export {
+  previewCreativeResponse,
+  singlePreviewCreativeResponse,
+  batchPreviewCreativeResponse,
+  variantPreviewCreativeResponse,
+} from './utils/preview-creative-response-builders';
+
+// ====== MEDIA BUY DELIVERY NOTIFICATION BUILDERS ======
+// Typed factories that inject the `notification_type` discriminator on
+// `GetMediaBuyDeliveryResponse` for webhook deliveries. Five variants:
+// `scheduled` / `final` / `delayed` / `adjusted` / `window_update`.
+export {
+  mediaBuyDeliveryNotification,
+  scheduledMediaBuyDeliveryNotification,
+  finalMediaBuyDeliveryNotification,
+  delayedMediaBuyDeliveryNotification,
+  adjustedMediaBuyDeliveryNotification,
+  windowUpdateMediaBuyDeliveryNotification,
+} from './utils/media-buy-delivery-notification-builders';
 
 // ====== V3.0 COMPATIBILITY UTILITIES ======
 // Capabilities detection, version negotiation, and v3 enforcement.

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -542,6 +542,7 @@ export {
   performanceFeedbackResponse,
   buildCreativeResponse,
   buildCreativeMultiResponse,
+  previewCreativeResponse,
   creativeDeliveryResponse,
   listCreativesResponse,
   listPropertyListsResponse,
@@ -999,17 +1000,17 @@ export {
   multiEnvelopedBuildCreativeReturn,
 } from './utils/build-creative-return-builders';
 
-// ====== PREVIEW CREATIVE RESPONSE BUILDERS ======
+// ====== PREVIEW CREATIVE BUILDERS ======
 // Typed factories that inject the `response_type` discriminator on
 // `PreviewCreativeResponse`. Three-way oneOf — `single | batch | variant`.
 // Pair with `urlRender` / `htmlRender` / `bothRender` for the per-render
 // `output_format`. SHAPE-GOTCHAS §4.
 export {
-  previewCreativeResponse,
+  previewCreative,
   singlePreviewCreativeResponse,
   batchPreviewCreativeResponse,
   variantPreviewCreativeResponse,
-} from './utils/preview-creative-response-builders';
+} from './utils/preview-creative-builders';
 
 // ====== MEDIA BUY DELIVERY NOTIFICATION BUILDERS ======
 // Typed factories that inject the `notification_type` discriminator on

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -550,7 +550,7 @@ function _ad_server_list_creative_formats_requires_account_narrow(): void {
 import { activationKey, segmentIdActivationKey, keyValueActivationKey } from '../../utils/activation-key-builders';
 import { signalId, catalogSignalId, agentSignalId } from '../../utils/signal-id-builders';
 import { buildCreativeReturn, singleEnvelopedBuildCreativeReturn } from '../../utils/build-creative-return-builders';
-import { previewCreativeResponse, singlePreviewCreativeResponse } from '../../utils/preview-creative-response-builders';
+import { previewCreative, singlePreviewCreativeResponse } from '../../utils/preview-creative-builders';
 import {
   mediaBuyDeliveryNotification,
   scheduledMediaBuyDeliveryNotification,
@@ -579,8 +579,8 @@ function _signal_id_factories_inject_discriminator(): void {
   agentSignalId({ source: 'catalog', agent_url: 'https://x', id: 'y' });
 }
 
-function _preview_creative_response_factories_inject_discriminator(): void {
-  const single = previewCreativeResponse.single({
+function _preview_creative_factories_inject_discriminator(): void {
+  const single = previewCreative.single({
     previews: [{ preview_id: 'p', renders: [], input: { name: 'default' } }],
     expires_at: '2026-05-03T00:00:00Z',
   });
@@ -684,7 +684,7 @@ export const _references = [
   _ad_server_list_creative_formats_rejects_unnarrowed_access,
   _activation_key_factories_inject_discriminator,
   _signal_id_factories_inject_discriminator,
-  _preview_creative_response_factories_inject_discriminator,
+  _preview_creative_factories_inject_discriminator,
   _build_creative_return_factories_pin_arm,
   _media_buy_delivery_notification_factories_inject_discriminator,
 ] as const;

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -545,6 +545,80 @@ function _ad_server_list_creative_formats_requires_account_narrow(): void {
   });
 }
 
+// ── Discriminator-injecting builders are non-overridable (#1386) ──
+
+import { activationKey, segmentIdActivationKey, keyValueActivationKey } from '../../utils/activation-key-builders';
+import { signalId, catalogSignalId, agentSignalId } from '../../utils/signal-id-builders';
+import { buildCreativeReturn, singleEnvelopedBuildCreativeReturn } from '../../utils/build-creative-return-builders';
+import { previewCreativeResponse, singlePreviewCreativeResponse } from '../../utils/preview-creative-response-builders';
+import {
+  mediaBuyDeliveryNotification,
+  scheduledMediaBuyDeliveryNotification,
+} from '../../utils/media-buy-delivery-notification-builders';
+import type { ActivationKey, SignalID, CreativeManifest } from '../../types/core.generated';
+
+function _activation_key_factories_inject_discriminator(): void {
+  const seg: ActivationKey = activationKey.segment({ segment_id: 'plat_seg_xyz' });
+  const kv: ActivationKey = activationKey.keyValue({ key: 'segment', value: 'abc123' });
+  void seg;
+  void kv;
+  // @ts-expect-error — `type` is omitted from the parameter type; passing it must fail.
+  segmentIdActivationKey({ type: 'key_value', segment_id: 'x' });
+  // @ts-expect-error — same: cannot smuggle a conflicting discriminator via fields.
+  keyValueActivationKey({ type: 'segment_id', key: 'k', value: 'v' });
+}
+
+function _signal_id_factories_inject_discriminator(): void {
+  const cat: SignalID = signalId.catalog({ data_provider_domain: 'example.com', id: 'seg' });
+  const agt: SignalID = signalId.agent({ agent_url: 'https://x/.well-known/adcp/signals', id: 'seg' });
+  void cat;
+  void agt;
+  // @ts-expect-error — `source` is omitted from the parameter type.
+  catalogSignalId({ source: 'agent', data_provider_domain: 'x', id: 'y' });
+  // @ts-expect-error — same: agent factory rejects a `source: 'catalog'`.
+  agentSignalId({ source: 'catalog', agent_url: 'https://x', id: 'y' });
+}
+
+function _preview_creative_response_factories_inject_discriminator(): void {
+  const single = previewCreativeResponse.single({
+    previews: [{ preview_id: 'p', renders: [], input: { name: 'default' } }],
+    expires_at: '2026-05-03T00:00:00Z',
+  });
+  void single;
+  singlePreviewCreativeResponse({
+    // @ts-expect-error — `response_type` is omitted from the parameter type.
+    response_type: 'batch',
+    previews: [],
+    expires_at: '2026-05-03T00:00:00Z',
+  });
+}
+
+function _build_creative_return_factories_pin_arm(): void {
+  const m: CreativeManifest = {} as CreativeManifest;
+  const bare = buildCreativeReturn.single(m);
+  const enveloped = buildCreativeReturn.singleEnveloped({ manifest: m, sandbox: true });
+  void bare;
+  void enveloped;
+  // @ts-expect-error — `creative_manifest` is the wire field, not the helper input.
+  singleEnvelopedBuildCreativeReturn({ creative_manifest: m });
+}
+
+function _media_buy_delivery_notification_factories_inject_discriminator(): void {
+  const scheduled = mediaBuyDeliveryNotification.scheduled({
+    reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+    currency: 'USD',
+    media_buy_deliveries: [],
+  });
+  void scheduled;
+  scheduledMediaBuyDeliveryNotification({
+    // @ts-expect-error — `notification_type` is omitted from the parameter type.
+    notification_type: 'final',
+    reporting_period: { start: '2026-05-01T00:00:00Z', end: '2026-05-02T00:00:00Z' },
+    currency: 'USD',
+    media_buy_deliveries: [],
+  });
+}
+
 function _ad_server_list_creative_formats_rejects_unnarrowed_access(): void {
   defineCreativeAdServerPlatform<{ catalog_id: string }>({
     buildCreative: async () => ({}) as never,
@@ -608,4 +682,9 @@ export const _references = [
   _builder_list_creative_formats_rejects_unnarrowed_access,
   _ad_server_list_creative_formats_requires_account_narrow,
   _ad_server_list_creative_formats_rejects_unnarrowed_access,
+  _activation_key_factories_inject_discriminator,
+  _signal_id_factories_inject_discriminator,
+  _preview_creative_response_factories_inject_discriminator,
+  _build_creative_return_factories_pin_arm,
+  _media_buy_delivery_notification_factories_inject_discriminator,
 ] as const;

--- a/src/lib/utils/activation-key-builders.ts
+++ b/src/lib/utils/activation-key-builders.ts
@@ -1,0 +1,31 @@
+// Typed factory helpers for `ActivationKey` — schema oneOf on
+// `type: "segment_id" | "key_value"`. The `key_value` arm is consistently
+// mis-shaped: adopters intuit a nested `{ key_value: { key, value } }` and
+// write that, even though the schema flattens `key`/`value` onto the
+// `ActivationKey` itself. SHAPE-GOTCHAS §1.
+//
+// Same pattern as `asset-builders.ts` / `render-builders.ts`: spread order
+// writes the discriminator last, so a runtime cast that smuggles `type`
+// in via `fields` cannot clobber it.
+
+import type { ActivationKey } from "../types/core.generated";
+
+type SegmentIdKey = Extract<ActivationKey, { type: "segment_id" }>;
+type KeyValueKey = Extract<ActivationKey, { type: "key_value" }>;
+type Tagged<T, Tag extends string> = Omit<T, "type"> & { type: Tag };
+
+/** Build a `segment_id`-variant `ActivationKey`. */
+export function segmentIdActivationKey(fields: Omit<SegmentIdKey, "type">): Tagged<SegmentIdKey, "segment_id"> {
+  return { ...fields, type: "segment_id" };
+}
+
+/** Build a `key_value`-variant `ActivationKey`. `key`/`value` flatten on the top level. SHAPE-GOTCHAS §1. */
+export function keyValueActivationKey(fields: Omit<KeyValueKey, "type">): Tagged<KeyValueKey, "key_value"> {
+  return { ...fields, type: "key_value" };
+}
+
+/** Grouped accessor for both `ActivationKey` variants. */
+export const activationKey = {
+  segment: segmentIdActivationKey,
+  keyValue: keyValueActivationKey,
+} as const;

--- a/src/lib/utils/activation-key-builders.ts
+++ b/src/lib/utils/activation-key-builders.ts
@@ -8,20 +8,20 @@
 // writes the discriminator last, so a runtime cast that smuggles `type`
 // in via `fields` cannot clobber it.
 
-import type { ActivationKey } from "../types/core.generated";
+import type { ActivationKey } from '../types/core.generated';
 
-type SegmentIdKey = Extract<ActivationKey, { type: "segment_id" }>;
-type KeyValueKey = Extract<ActivationKey, { type: "key_value" }>;
-type Tagged<T, Tag extends string> = Omit<T, "type"> & { type: Tag };
+type SegmentIdKey = Extract<ActivationKey, { type: 'segment_id' }>;
+type KeyValueKey = Extract<ActivationKey, { type: 'key_value' }>;
+type Tagged<T, Tag extends string> = Omit<T, 'type'> & { type: Tag };
 
 /** Build a `segment_id`-variant `ActivationKey`. */
-export function segmentIdActivationKey(fields: Omit<SegmentIdKey, "type">): Tagged<SegmentIdKey, "segment_id"> {
-  return { ...fields, type: "segment_id" };
+export function segmentIdActivationKey(fields: Omit<SegmentIdKey, 'type'>): Tagged<SegmentIdKey, 'segment_id'> {
+  return { ...fields, type: 'segment_id' };
 }
 
 /** Build a `key_value`-variant `ActivationKey`. `key`/`value` flatten on the top level. SHAPE-GOTCHAS §1. */
-export function keyValueActivationKey(fields: Omit<KeyValueKey, "type">): Tagged<KeyValueKey, "key_value"> {
-  return { ...fields, type: "key_value" };
+export function keyValueActivationKey(fields: Omit<KeyValueKey, 'type'>): Tagged<KeyValueKey, 'key_value'> {
+  return { ...fields, type: 'key_value' };
 }
 
 /** Grouped accessor for both `ActivationKey` variants. */

--- a/src/lib/utils/build-creative-return-builders.ts
+++ b/src/lib/utils/build-creative-return-builders.ts
@@ -1,0 +1,44 @@
+// Typed factory helpers for `build_creative` return values. Four shapes:
+//   1. bare `CreativeManifest`            — auto-wrapped as `{ creative_manifest }`
+//   2. bare `CreativeManifest[]`          — auto-wrapped as `{ creative_manifests }`
+//   3. shaped `BuildCreativeSuccess`      — passthrough
+//   4. shaped `BuildCreativeMultiSuccess` — passthrough multi-format
+//
+// Adopters writing the shaped envelope by hand consistently miss the
+// distinction between single (`creative_manifest`) and multi
+// (`creative_manifests`) field names. SHAPE-GOTCHAS §5.
+
+import type { BuildCreativeSuccess, BuildCreativeMultiSuccess, CreativeManifest } from "../types/core.generated";
+
+type SingleEnvelopeFields = Omit<BuildCreativeSuccess, "creative_manifest"> & { manifest: CreativeManifest };
+type MultiEnvelopeFields = Omit<BuildCreativeMultiSuccess, "creative_manifests"> & { manifests: CreativeManifest[] };
+
+/** Bare single-format manifest. Framework wraps as `{ creative_manifest }`. */
+export function singleBuildCreativeReturn(manifest: CreativeManifest): CreativeManifest {
+  return manifest;
+}
+
+/** Bare multi-format manifest array. Framework wraps as `{ creative_manifests }`. */
+export function multiBuildCreativeReturn(manifests: CreativeManifest[]): CreativeManifest[] {
+  return manifests;
+}
+
+/** Shaped `BuildCreativeSuccess`. `manifest` field renamed to `creative_manifest` on wire. */
+export function singleEnvelopedBuildCreativeReturn(fields: SingleEnvelopeFields): BuildCreativeSuccess {
+  const { manifest, ...rest } = fields;
+  return { ...rest, creative_manifest: manifest };
+}
+
+/** Shaped `BuildCreativeMultiSuccess`. `manifests` renamed to `creative_manifests` on wire. */
+export function multiEnvelopedBuildCreativeReturn(fields: MultiEnvelopeFields): BuildCreativeMultiSuccess {
+  const { manifests, ...rest } = fields;
+  return { ...rest, creative_manifests: manifests };
+}
+
+/** Grouped accessor for the four `build_creative` return shapes. */
+export const buildCreativeReturn = {
+  single: singleBuildCreativeReturn,
+  multi: multiBuildCreativeReturn,
+  singleEnveloped: singleEnvelopedBuildCreativeReturn,
+  multiEnveloped: multiEnvelopedBuildCreativeReturn,
+} as const;

--- a/src/lib/utils/build-creative-return-builders.ts
+++ b/src/lib/utils/build-creative-return-builders.ts
@@ -8,10 +8,10 @@
 // distinction between single (`creative_manifest`) and multi
 // (`creative_manifests`) field names. SHAPE-GOTCHAS §5.
 
-import type { BuildCreativeSuccess, BuildCreativeMultiSuccess, CreativeManifest } from "../types/core.generated";
+import type { BuildCreativeSuccess, BuildCreativeMultiSuccess, CreativeManifest } from '../types/core.generated';
 
-type SingleEnvelopeFields = Omit<BuildCreativeSuccess, "creative_manifest"> & { manifest: CreativeManifest };
-type MultiEnvelopeFields = Omit<BuildCreativeMultiSuccess, "creative_manifests"> & { manifests: CreativeManifest[] };
+type SingleEnvelopeFields = Omit<BuildCreativeSuccess, 'creative_manifest'> & { manifest: CreativeManifest };
+type MultiEnvelopeFields = Omit<BuildCreativeMultiSuccess, 'creative_manifests'> & { manifests: CreativeManifest[] };
 
 /** Bare single-format manifest. Framework wraps as `{ creative_manifest }`. */
 export function singleBuildCreativeReturn(manifest: CreativeManifest): CreativeManifest {

--- a/src/lib/utils/media-buy-delivery-notification-builders.ts
+++ b/src/lib/utils/media-buy-delivery-notification-builders.ts
@@ -3,34 +3,34 @@
 // re-send / supersession semantics:
 //   `scheduled` / `final` / `delayed` / `adjusted` / `window_update`.
 
-import type { GetMediaBuyDeliveryResponse } from "../types/core.generated";
+import type { GetMediaBuyDeliveryResponse } from '../types/core.generated';
 
-type NotificationFields = Omit<GetMediaBuyDeliveryResponse, "notification_type">;
+type NotificationFields = Omit<GetMediaBuyDeliveryResponse, 'notification_type'>;
 type Tagged<Tag extends string> = NotificationFields & { notification_type: Tag };
 
 /** Regular periodic delivery update. Set `sequence_number` and `next_expected_at`. */
-export function scheduledMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"scheduled"> {
-  return { ...fields, notification_type: "scheduled" };
+export function scheduledMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<'scheduled'> {
+  return { ...fields, notification_type: 'scheduled' };
 }
 
 /** Campaign completed; no further notifications. Omit `next_expected_at`. */
-export function finalMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"final"> {
-  return { ...fields, notification_type: "final" };
+export function finalMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<'final'> {
+  return { ...fields, notification_type: 'final' };
 }
 
 /** Data not yet available. Set `partial_data: true` and `unavailable_count`. */
-export function delayedMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"delayed"> {
-  return { ...fields, notification_type: "delayed" };
+export function delayedMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<'delayed'> {
+  return { ...fields, notification_type: 'delayed' };
 }
 
 /** Re-send with corrected data, SAME measurement window. Distinct from `window_update`. */
-export function adjustedMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"adjusted"> {
-  return { ...fields, notification_type: "adjusted" };
+export function adjustedMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<'adjusted'> {
+  return { ...fields, notification_type: 'adjusted' };
 }
 
 /** Re-send with WIDER measurement window (e.g. C7 superseding C3). */
-export function windowUpdateMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"window_update"> {
-  return { ...fields, notification_type: "window_update" };
+export function windowUpdateMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<'window_update'> {
+  return { ...fields, notification_type: 'window_update' };
 }
 
 /** Grouped accessor for all five `MediaBuyDeliveryNotification` variants. */

--- a/src/lib/utils/media-buy-delivery-notification-builders.ts
+++ b/src/lib/utils/media-buy-delivery-notification-builders.ts
@@ -1,0 +1,43 @@
+// Typed factory helpers for `get_media_buy_delivery` webhook notifications.
+// `notification_type` discriminator carries five values, each with distinct
+// re-send / supersession semantics:
+//   `scheduled` / `final` / `delayed` / `adjusted` / `window_update`.
+
+import type { GetMediaBuyDeliveryResponse } from "../types/core.generated";
+
+type NotificationFields = Omit<GetMediaBuyDeliveryResponse, "notification_type">;
+type Tagged<Tag extends string> = NotificationFields & { notification_type: Tag };
+
+/** Regular periodic delivery update. Set `sequence_number` and `next_expected_at`. */
+export function scheduledMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"scheduled"> {
+  return { ...fields, notification_type: "scheduled" };
+}
+
+/** Campaign completed; no further notifications. Omit `next_expected_at`. */
+export function finalMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"final"> {
+  return { ...fields, notification_type: "final" };
+}
+
+/** Data not yet available. Set `partial_data: true` and `unavailable_count`. */
+export function delayedMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"delayed"> {
+  return { ...fields, notification_type: "delayed" };
+}
+
+/** Re-send with corrected data, SAME measurement window. Distinct from `window_update`. */
+export function adjustedMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"adjusted"> {
+  return { ...fields, notification_type: "adjusted" };
+}
+
+/** Re-send with WIDER measurement window (e.g. C7 superseding C3). */
+export function windowUpdateMediaBuyDeliveryNotification(fields: NotificationFields): Tagged<"window_update"> {
+  return { ...fields, notification_type: "window_update" };
+}
+
+/** Grouped accessor for all five `MediaBuyDeliveryNotification` variants. */
+export const mediaBuyDeliveryNotification = {
+  scheduled: scheduledMediaBuyDeliveryNotification,
+  final: finalMediaBuyDeliveryNotification,
+  delayed: delayedMediaBuyDeliveryNotification,
+  adjusted: adjustedMediaBuyDeliveryNotification,
+  windowUpdate: windowUpdateMediaBuyDeliveryNotification,
+} as const;

--- a/src/lib/utils/preview-creative-builders.ts
+++ b/src/lib/utils/preview-creative-builders.ts
@@ -32,7 +32,7 @@ export function variantPreviewCreativeResponse(
 }
 
 /** Grouped accessor for the three `PreviewCreativeResponse` variants. */
-export const previewCreativeResponse = {
+export const previewCreative = {
   single: singlePreviewCreativeResponse,
   batch: batchPreviewCreativeResponse,
   variant: variantPreviewCreativeResponse,

--- a/src/lib/utils/preview-creative-response-builders.ts
+++ b/src/lib/utils/preview-creative-response-builders.ts
@@ -6,29 +6,29 @@ import type {
   PreviewCreativeSingleResponse,
   PreviewCreativeBatchResponse,
   PreviewCreativeVariantResponse,
-} from "../types/core.generated";
+} from '../types/core.generated';
 
-type Tagged<T, Tag extends string> = Omit<T, "response_type"> & { response_type: Tag };
+type Tagged<T, Tag extends string> = Omit<T, 'response_type'> & { response_type: Tag };
 
 /** Build a `single`-variant `PreviewCreativeResponse`. */
 export function singlePreviewCreativeResponse(
-  fields: Omit<PreviewCreativeSingleResponse, "response_type">,
-): Tagged<PreviewCreativeSingleResponse, "single"> {
-  return { ...fields, response_type: "single" };
+  fields: Omit<PreviewCreativeSingleResponse, 'response_type'>
+): Tagged<PreviewCreativeSingleResponse, 'single'> {
+  return { ...fields, response_type: 'single' };
 }
 
 /** Build a `batch`-variant `PreviewCreativeResponse`. */
 export function batchPreviewCreativeResponse(
-  fields: Omit<PreviewCreativeBatchResponse, "response_type">,
-): Tagged<PreviewCreativeBatchResponse, "batch"> {
-  return { ...fields, response_type: "batch" };
+  fields: Omit<PreviewCreativeBatchResponse, 'response_type'>
+): Tagged<PreviewCreativeBatchResponse, 'batch'> {
+  return { ...fields, response_type: 'batch' };
 }
 
 /** Build a `variant`-variant `PreviewCreativeResponse`. */
 export function variantPreviewCreativeResponse(
-  fields: Omit<PreviewCreativeVariantResponse, "response_type">,
-): Tagged<PreviewCreativeVariantResponse, "variant"> {
-  return { ...fields, response_type: "variant" };
+  fields: Omit<PreviewCreativeVariantResponse, 'response_type'>
+): Tagged<PreviewCreativeVariantResponse, 'variant'> {
+  return { ...fields, response_type: 'variant' };
 }
 
 /** Grouped accessor for the three `PreviewCreativeResponse` variants. */

--- a/src/lib/utils/preview-creative-response-builders.ts
+++ b/src/lib/utils/preview-creative-response-builders.ts
@@ -1,0 +1,39 @@
+// Typed factory helpers for `preview_creative` responses. Schema oneOf is a
+// three-way switch on `response_type: "single" | "batch" | "variant"`.
+// SHAPE-GOTCHAS §4.
+
+import type {
+  PreviewCreativeSingleResponse,
+  PreviewCreativeBatchResponse,
+  PreviewCreativeVariantResponse,
+} from "../types/core.generated";
+
+type Tagged<T, Tag extends string> = Omit<T, "response_type"> & { response_type: Tag };
+
+/** Build a `single`-variant `PreviewCreativeResponse`. */
+export function singlePreviewCreativeResponse(
+  fields: Omit<PreviewCreativeSingleResponse, "response_type">,
+): Tagged<PreviewCreativeSingleResponse, "single"> {
+  return { ...fields, response_type: "single" };
+}
+
+/** Build a `batch`-variant `PreviewCreativeResponse`. */
+export function batchPreviewCreativeResponse(
+  fields: Omit<PreviewCreativeBatchResponse, "response_type">,
+): Tagged<PreviewCreativeBatchResponse, "batch"> {
+  return { ...fields, response_type: "batch" };
+}
+
+/** Build a `variant`-variant `PreviewCreativeResponse`. */
+export function variantPreviewCreativeResponse(
+  fields: Omit<PreviewCreativeVariantResponse, "response_type">,
+): Tagged<PreviewCreativeVariantResponse, "variant"> {
+  return { ...fields, response_type: "variant" };
+}
+
+/** Grouped accessor for the three `PreviewCreativeResponse` variants. */
+export const previewCreativeResponse = {
+  single: singlePreviewCreativeResponse,
+  batch: batchPreviewCreativeResponse,
+  variant: variantPreviewCreativeResponse,
+} as const;

--- a/src/lib/utils/signal-id-builders.ts
+++ b/src/lib/utils/signal-id-builders.ts
@@ -4,20 +4,20 @@
 // strings for `signal_ids` filters even though the wire shape is an array
 // of provenance objects. SHAPE-GOTCHAS §2.
 
-import type { SignalID } from "../types/core.generated";
+import type { SignalID } from '../types/core.generated';
 
-type CatalogSignal = Extract<SignalID, { source: "catalog" }>;
-type AgentSignal = Extract<SignalID, { source: "agent" }>;
-type Tagged<T, Tag extends string> = Omit<T, "source"> & { source: Tag };
+type CatalogSignal = Extract<SignalID, { source: 'catalog' }>;
+type AgentSignal = Extract<SignalID, { source: 'agent' }>;
+type Tagged<T, Tag extends string> = Omit<T, 'source'> & { source: Tag };
 
 /** Build a `catalog`-variant `SignalID`. Verifiable via the providers adagents.json. */
-export function catalogSignalId(fields: Omit<CatalogSignal, "source">): Tagged<CatalogSignal, "catalog"> {
-  return { ...fields, source: "catalog" };
+export function catalogSignalId(fields: Omit<CatalogSignal, 'source'>): Tagged<CatalogSignal, 'catalog'> {
+  return { ...fields, source: 'catalog' };
 }
 
 /** Build an `agent`-variant `SignalID`. Agent-native segments not in a catalog. */
-export function agentSignalId(fields: Omit<AgentSignal, "source">): Tagged<AgentSignal, "agent"> {
-  return { ...fields, source: "agent" };
+export function agentSignalId(fields: Omit<AgentSignal, 'source'>): Tagged<AgentSignal, 'agent'> {
+  return { ...fields, source: 'agent' };
 }
 
 /** Grouped accessor for both `SignalID` variants. */

--- a/src/lib/utils/signal-id-builders.ts
+++ b/src/lib/utils/signal-id-builders.ts
@@ -1,0 +1,27 @@
+// Typed factory helpers for `SignalID` — provenance tuple used in
+// `signal_ids` filters and as the `signal_id` field on `Signal` records.
+// Schema oneOf on `source: "catalog" | "agent"`. Adopters emit bare ID
+// strings for `signal_ids` filters even though the wire shape is an array
+// of provenance objects. SHAPE-GOTCHAS §2.
+
+import type { SignalID } from "../types/core.generated";
+
+type CatalogSignal = Extract<SignalID, { source: "catalog" }>;
+type AgentSignal = Extract<SignalID, { source: "agent" }>;
+type Tagged<T, Tag extends string> = Omit<T, "source"> & { source: Tag };
+
+/** Build a `catalog`-variant `SignalID`. Verifiable via the providers adagents.json. */
+export function catalogSignalId(fields: Omit<CatalogSignal, "source">): Tagged<CatalogSignal, "catalog"> {
+  return { ...fields, source: "catalog" };
+}
+
+/** Build an `agent`-variant `SignalID`. Agent-native segments not in a catalog. */
+export function agentSignalId(fields: Omit<AgentSignal, "source">): Tagged<AgentSignal, "agent"> {
+  return { ...fields, source: "agent" };
+}
+
+/** Grouped accessor for both `SignalID` variants. */
+export const signalId = {
+  catalog: catalogSignalId,
+  agent: agentSignalId,
+} as const;


### PR DESCRIPTION
## Summary

Five new typed-factory namespaces, mirroring the existing
[`asset-builders`](https://github.com/adcontextprotocol/adcp-client/blob/main/src/lib/utils/asset-builders.ts) /
[`render-builders`](https://github.com/adcontextprotocol/adcp-client/blob/main/src/lib/utils/render-builders.ts) /
[`format-asset-slot-builders`](https://github.com/adcontextprotocol/adcp-client/blob/main/src/lib/utils/format-asset-slot-builders.ts)
pattern. Each injects the discriminator at the typed-builder level using the
spread-order trick from `asset-builders.ts:34`, so adopters can't write a
missing-discriminator value at compile time and a runtime cast that smuggles
a conflicting discriminator via `fields` cannot clobber it.

| Factory                          | Wire shape                                  | Variants                                                       | SHAPE-GOTCHAS |
| -------------------------------- | ------------------------------------------- | -------------------------------------------------------------- | ------------- |
| `activationKey`                  | `ActivationKey` (`type` discriminator)      | `.segment` / `.keyValue`                                       | §1            |
| `signalId`                       | `SignalID` (`source` discriminator)         | `.catalog` / `.agent`                                          | §2            |
| `previewCreative`                | 3-way oneOf on `response_type`              | `.single` / `.batch` / `.variant`                              | §4            |
| `buildCreativeReturn`            | 4-arm `BuildCreativeReturn` union           | `.single` / `.multi` / `.singleEnveloped` / `.multiEnveloped`  | §5            |
| `mediaBuyDeliveryNotification`   | webhook `notification_type` on `GetMediaBuyDeliveryResponse` | `.scheduled` / `.final` / `.delayed` / `.adjusted` / `.windowUpdate` | (new) |

### Adapter migrations

Reference adapters now use the new factories where applicable (4 files,
several call sites each):

- `examples/signals-agent.ts` — `signal_id` × 3, `activation_key` × 2
- `examples/hello_signals_adapter_marketplace.ts` — `signal_id` × 1, `activation_key` × 2
- `examples/hello_creative_adapter_template.ts` — `buildCreative` 2-arm + `previewCreative.single`
- `examples/hello_creative_adapter_ad_server.ts` — `buildCreative` shaped envelope + `previewCreative.single`

The two `as unknown as PreviewCreativeResponse` / `as unknown as BuildCreativeSuccess` casts in the
ad-server adapter are gone — the typed factories return the wire shape directly.

### Naming: avoid collision with v5 server helper

The new factory namespace is `previewCreative` (not `previewCreativeResponse`)
to avoid colliding with the v5 server-helper *function* of the same name that
is still re-exported at the top level of `@adcp/sdk`. Following the existing
`urlRender` / `htmlRender` precedent, the namespace is named after the wire
concept (no `Response` suffix) and reads naturally:
`previewCreative.single({...})` — "build a preview-creative single response".

The top-level `previewCreativeResponse` v5 server-helper export is retained
as-is. Adopters who imported `previewCreativeResponse` and called it as a
function continue to work unchanged. The new factory namespace is a strictly
additive export under a non-colliding name.

### Type-only regression tests

`src/lib/server/decisioning/decisioning.type-checks.ts` gains five new
`@ts-expect-error` blocks — one per factory — that pin the discriminator
as non-overridable. If the spread-order trick regresses (e.g. someone
removes the `Omit<>` from the parameter type), `tsc --noEmit` fails.

### SHAPE-GOTCHAS recommendations

§1, §2, §4, §5 each gain a "Prevent at write time" block referencing the
new factory as the prevent-at-write-time fix.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run format:check` clean
- [x] `npm test` — full suite passes
- [x] Type-checks regression: each factory's `@ts-expect-error` directive verified to fire when removed
- [x] Reference-adapter migrations compile and pass their existing storyboard tests
- [x] No top-level export collision: `previewCreativeResponse` (v5 helper function) and `previewCreative` (new factory namespace) coexist

Closes #1386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
