### PR TITLE
fix(conformance): thread AbortSignal through complyImpl storyboard loop

### DIFF
--- a/.changeset/comply-signal-threading.md
+++ b/.changeset/comply-signal-threading.md
@@ -1,0 +1,17 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(conformance): thread complyImpl AbortSignal through runStoryboard into per-phase and per-step execution
+
+`comply()` built a combined `AbortSignal` (from `timeout_ms` and/or an external signal) but only checked it between storyboards (`signal?.throwIfAborted()` before each `runStoryboard` call), not inside them. On agents with many storyboards, a single long-running `runStoryboard` call could consume the entire timeout budget without the signal ever firing mid-storyboard — the exact failure mode causing `storyboard run` to time out at pre-flight on both MCP and A2A transports against healthy agents.
+
+Fixes the binding constraint in three changes:
+
+- `StoryboardRunOptions` gains an optional `signal?: AbortSignal` field.
+- `complyImpl` threads its combined signal into the `runOptions` passed to every `runStoryboard` call.
+- `executeStoryboardPass` checks `options.signal?.throwIfAborted()` at the start of each phase loop iteration and each step loop iteration so the abort fires at the next phase/step boundary rather than waiting for the current storyboard to finish.
+
+`runMultiPass` gains the same per-pass check for consistency.
+
+Existing callers of `runStoryboard()` directly are unaffected — `signal` is optional and defaults to no-op.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -403,7 +403,10 @@ export interface ComplyOptions extends TestOptions {
   storyboards?: string[];
   /** Post-filter reported tracks to only these. Applied after execution. */
   tracks?: ComplianceTrack[];
-  /** Timeout in milliseconds — stops new storyboards from starting when exceeded. */
+  /**
+   * Timeout in milliseconds. When exceeded, cancels the run at the next phase
+   * or step boundary inside the active storyboard (not just between storyboards).
+   */
   timeout_ms?: number;
   /** AbortSignal for external cancellation (e.g., graceful shutdown). */
   signal?: AbortSignal;
@@ -1149,6 +1152,7 @@ async function runWithDegradedProfile(
     agentTools: [],
     ...(options.webhook_receiver !== undefined && { webhook_receiver: options.webhook_receiver }),
     ...(options.contracts !== undefined && { contracts: options.contracts }),
+    ...(signal !== undefined && { signal }),
   };
 
   for (const sb of storyboards) {

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -922,6 +922,7 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
       agentTools: profile.tools,
       ...(webhook_receiver !== undefined && { webhook_receiver }),
       ...(contracts !== undefined && { contracts }),
+      ...(signal !== undefined && { signal }),
     };
 
     for (const sb of applicableStoryboards) {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1361,6 +1361,7 @@ async function executeStoryboardPass(
   }
 
   for (const phase of storyboard.phases) {
+    options.signal?.throwIfAborted();
     const phaseStart = Date.now();
     const stepResults: StoryboardStepResult[] = [];
     let phasePassed = true;
@@ -1501,6 +1502,7 @@ async function executeStoryboardPass(
     }
 
     for (const step of phase.steps) {
+      options.signal?.throwIfAborted();
       // Cascade-skip when the PRM presence probe declared the phase absent.
       if (phaseAbsent) {
         const cascadeResult: StoryboardStepResult = {
@@ -2106,6 +2108,7 @@ async function runMultiPass(
   const passes: StoryboardPassResult[] = [];
   const passResults: StoryboardResult[] = [];
   for (let passIdx = 0; passIdx < agentUrls.length; passIdx++) {
+    options.signal?.throwIfAborted();
     const passSeeded: PreSeededInput = { result: preSeededResult, attach: passIdx === 0 };
     const result = await executeStoryboardPass(agentUrls, storyboard, options, passIdx, passSeeded);
     passResults.push(result);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1019,6 +1019,17 @@ export interface StoryboardRunOptions extends TestOptions {
     public_url?: string;
   };
   /**
+   * Abort signal forwarded from `comply()`. When the signal fires,
+   * `executeStoryboardPass` throws at the start of the next phase or step,
+   * unwinding the run mid-storyboard rather than waiting for the current
+   * storyboard to complete before the between-storyboard check in
+   * `complyImpl` can fire.
+   *
+   * Callers of `runStoryboard()` directly may pass their own signal to
+   * bound a single storyboard run.
+   */
+  signal?: AbortSignal;
+  /**
    * Test-kit contract ids that are in scope for this run. A step with
    * `requires_contract: <id>` grades `not_applicable` when the id is not
    * listed here. Storyboards that assert webhook behavior typically declare

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1019,14 +1019,17 @@ export interface StoryboardRunOptions extends TestOptions {
     public_url?: string;
   };
   /**
-   * Abort signal forwarded from `comply()`. When the signal fires,
-   * `executeStoryboardPass` throws at the start of the next phase or step,
-   * unwinding the run mid-storyboard rather than waiting for the current
-   * storyboard to complete before the between-storyboard check in
-   * `complyImpl` can fire.
+   * Abort signal for the storyboard run. When the signal fires,
+   * `executeStoryboardPass` throws (`AbortError`) at the start of the next
+   * phase or step boundary — the caller receives a rejected promise, not a
+   * partial `StoryboardResult`. This matches `complyImpl`'s existing
+   * between-storyboard abort behavior; threading the signal here lets the
+   * abort fire mid-storyboard rather than waiting for the full storyboard
+   * to complete.
    *
+   * `comply()` forwards its combined timeout+external signal automatically.
    * Callers of `runStoryboard()` directly may pass their own signal to
-   * bound a single storyboard run.
+   * bound a single storyboard run independently of `comply()`.
    */
   signal?: AbortSignal;
   /**


### PR DESCRIPTION
Closes #1612

`comply()` builds a combined `AbortSignal` from `timeout_ms` and an optional external signal, but only checked it *between* storyboards — via `signal?.throwIfAborted()` before each `runStoryboard()` call. A single storyboard with many sequential MCP or A2A calls could consume the entire timeout budget without the signal firing inside it. This is the binding constraint behind the reported 307s wall-clock on both MCP and A2A transports against healthy agents (benchmark from @bokelley: PR #1613 head is wall-clock-identical to baseline because `complyImpl`'s loop is the bottleneck, not `pollTaskCompletion`).

Three-part fix:

1. **`StoryboardRunOptions.signal?: AbortSignal`** — new optional field. `comply()` forwards its combined timeout+external signal automatically; direct `runStoryboard()` callers can pass their own signal to bound a single storyboard run independently.
2. **`complyImpl` and `runWithDegradedProfile`** — both now spread `signal` into the `runOptions` passed to `runStoryboard()`. The auth-degraded path had the same gap (`signal` was checked between storyboards but not forwarded into the runner's options).
3. **`executeStoryboardPass`** — adds `options.signal?.throwIfAborted()` at the start of each phase loop iteration and each step loop iteration. `runMultiPass` gains the same check at each pass boundary.

When the signal fires, `executeStoryboardPass` throws (AbortError) at the next phase/step boundary — the caller receives a rejected promise, not a partial result. This is consistent with `complyImpl`'s existing between-storyboard abort behavior; we're just firing at finer granularity.

**Known nit (not in this PR):** The abort fires at the scheduler level (between steps), not inside an in-flight MCP/A2A transport call. A single step that hangs for longer than the remaining timeout will still block until the call resolves. Forwarding `signal` into `runStep`/`executeStep` at the transport level is the remaining follow-up.

## What tested

- `npm run format:check` — clean
- `npm run typecheck` — no new errors across changed files (pre-existing `TS2688`/`TS5107` environment-level errors unrelated to these changes, same baseline as PR #1613)
- Build toolchain (`tsx`) unavailable in CI environment; `tsc --noEmit` confirmed zero new errors in `comply.ts`, `runner.ts`, `types.ts`

## Pre-PR review

- **code-reviewer**: approved — 1 blocker addressed (JSDoc updated to document throw-on-abort behavior; `runWithDegradedProfile` gap not flagged here but caught by protocol expert); 1 nit noted (transport-layer signal forwarding, out of scope per issue author guidance)
- **ad-tech-protocol-expert**: approved — 1 blocker addressed (`runWithDegradedProfile` runOptions signal gap closed; same fix pattern as `complyImpl`); `ComplyOptions.timeout_ms` JSDoc updated to reflect per-phase/step cancellation; confirmed non-breaking optional field addition on `StoryboardRunOptions`

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018PoRAJU4sTKWvxz6MYf8L7

---
_Generated by [Claude Code](https://claude.ai/code/session_018PoRAJU4sTKWvxz6MYf8L7)_