### PR TITLE
chore(comply): #1612 review follow-ups (parse-site parity, raceWithSignal security note, second-call coverage)

### DIFF
--- a/.changeset/fix-1612-followups.md
+++ b/.changeset/fix-1612-followups.md
@@ -1,0 +1,33 @@
+---
+"@adcp/sdk": patch
+---
+
+chore(comply): #1612 review follow-ups
+
+Three small follow-ups from the expert reviews of #1613:
+
+1. **CLI `--protocol` / `--transport` parse-site 3** (`bin/adcp.js`) now
+   matches the trailing-flag-validation pattern at the other two parse
+   sites — a trailing `--transport` no longer slips past the truthiness
+   gate as `protocolFlag === undefined`. Pre-existing parity bug,
+   surfaced by the parallel review of #1613.
+
+2. **`raceWithSignal`** (`src/lib/testing/client.ts`) gains a security
+   warning in its JSDoc and an inline comment on the orphan-promise
+   resolver: do not log `v` from inside that branch, since the orphaned
+   promise still carries an authenticated agent response after the buyer
+   has moved past the abort. Behavior unchanged; commentary only.
+
+3. **Test coverage** for the second `getAdcpCapabilities` call in
+   `discoverAgentProfile`. The existing tests covered abort during the
+   first `getAgentInfo` call only; the new test exercises an abort
+   firing while the second `raceWithSignal`-wrapped call is in flight,
+   asserts that `capabilities_probe_error` records the abort reason,
+   and bounds the wait. Closes the coverage gap surfaced by the
+   `code-reviewer` review of #1613.
+
+Two larger follow-ups from the same review round are tracked separately:
+- `tasks/cancel` integration so comply abort doesn't orphan billed
+  seller work — adcp-client#1617.
+- SSRF denylist on `detectProtocol` / `discoverAgentProfile` for the
+  future server-side comply runner — adcp-client#1618.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -5196,17 +5196,22 @@ credential material — never sync or commit.
   const authIndex = args.indexOf('--auth');
   let authToken = authIndex !== -1 ? args[authIndex + 1] : process.env.ADCP_AUTH_TOKEN;
   // adcp-client#1612: accept `--transport` as an alias for `--protocol`.
-  // Match the validation pattern at the other two CLI parse sites: skip the
-  // flag if it has no value or is followed by another flag, so a trailing
-  // `--transport` doesn't produce a `protocolFlag === undefined` that
-  // sneaks past the truthiness gate downstream.
+  // Hard-fail when the flag is present without a value, matching sites 1
+  // and 2 — security review of #1619 flagged the silent-fallthrough as a
+  // UX asymmetry: `adcp <cmd> --protocol` would auto-detect here while
+  // exiting 2 with a clear error elsewhere.
   const protocolIndex = args.indexOf('--protocol');
   const transportIndex = args.indexOf('--transport');
   const flagIndex = protocolIndex !== -1 ? protocolIndex : transportIndex;
-  const protocolFlag =
-    flagIndex !== -1 && flagIndex + 1 < args.length && !args[flagIndex + 1].startsWith('--')
-      ? args[flagIndex + 1]
-      : null;
+  const flagName = protocolIndex !== -1 ? '--protocol' : '--transport';
+  let protocolFlag = null;
+  if (flagIndex !== -1) {
+    if (flagIndex + 1 >= args.length || args[flagIndex + 1].startsWith('--')) {
+      console.error(`ERROR: ${flagName} requires a value (mcp or a2a)\n`);
+      process.exit(2);
+    }
+    protocolFlag = args[flagIndex + 1];
+  }
   const jsonOutput = args.includes('--json');
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const waitForAsync = args.includes('--wait');

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -5196,10 +5196,17 @@ credential material — never sync or commit.
   const authIndex = args.indexOf('--auth');
   let authToken = authIndex !== -1 ? args[authIndex + 1] : process.env.ADCP_AUTH_TOKEN;
   // adcp-client#1612: accept `--transport` as an alias for `--protocol`.
+  // Match the validation pattern at the other two CLI parse sites: skip the
+  // flag if it has no value or is followed by another flag, so a trailing
+  // `--transport` doesn't produce a `protocolFlag === undefined` that
+  // sneaks past the truthiness gate downstream.
   const protocolIndex = args.indexOf('--protocol');
   const transportIndex = args.indexOf('--transport');
   const flagIndex = protocolIndex !== -1 ? protocolIndex : transportIndex;
-  const protocolFlag = flagIndex !== -1 ? args[flagIndex + 1] : null;
+  const protocolFlag =
+    flagIndex !== -1 && flagIndex + 1 < args.length && !args[flagIndex + 1].startsWith('--')
+      ? args[flagIndex + 1]
+      : null;
   const jsonOutput = args.includes('--json');
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const waitForAsync = args.includes('--wait');

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -197,6 +197,19 @@ export async function getOrDiscoverProfile(
  * orphaned in-flight request finish on its own. (adcp-client#1612)
  *
  * Throws the signal's reason on abort.
+ *
+ * **SECURITY (security-reviewer follow-up on #1612):** the orphaned
+ * promise's `.then` handlers below stay attached until the underlying
+ * transport call settles. The resolved value `v` carries an authenticated
+ * agent response — `getAgentInfo()` and `getAdcpCapabilities()` round-trip
+ * through the bearer-token transport, so the promise body holds the wire
+ * response in memory until GC'd. **Do not log `v` from inside this
+ * resolver** (or any future `console.error` / telemetry hook on the
+ * orphaned path) — the buyer has already moved on past the abort, and
+ * logging here would leak agent-side data after the caller stopped
+ * trusting it. The early `resolve(v)` is intentionally a no-op on the
+ * already-rejected race-promise; `v` becomes unreferenced and GC-eligible
+ * the moment this `.then` returns.
  */
 function raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
   if (!signal) return promise;
@@ -209,6 +222,8 @@ function raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T
     promise.then(
       v => {
         signal.removeEventListener('abort', onAbort);
+        // INTENTIONAL: no-op on an already-rejected race-promise. Do NOT
+        // log `v` here — see security note in the JSDoc above.
         resolve(v);
       },
       e => {

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -228,6 +228,9 @@ function raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T
       },
       e => {
         signal.removeEventListener('abort', onAbort);
+        // INTENTIONAL: no-op on an already-rejected race-promise. Do NOT
+        // log `e` here either — `Error.message` from a transport rejection
+        // can carry an echoed response body, see security note above.
         reject(e);
       }
     );

--- a/test/lib/discover-agent-profile-signal.test.js
+++ b/test/lib/discover-agent-profile-signal.test.js
@@ -88,4 +88,52 @@ describe('discoverAgentProfile: AbortSignal honored (#1612)', () => {
     assert.strictEqual(profile.name, 'Slow');
     client.cleanup();
   });
+
+  // code-reviewer follow-up on #1612: the wrapper covers the second
+  // `getAdcpCapabilities()` call, not just the first `getAgentInfo()`.
+  // Cover that path explicitly so a future refactor that bypasses
+  // `raceWithSignal` on the second call gets caught.
+  test('aborts the getAdcpCapabilities call too, not just getAgentInfo', async () => {
+    let capabilitiesCalls = 0;
+    let pendingTimers = [];
+    const cleanup = () => {
+      pendingTimers.forEach(t => clearTimeout(t));
+      pendingTimers = [];
+    };
+    const client = {
+      // Fast getAgentInfo so the second call (capabilities) is the one
+      // racing the abort.
+      getAgentInfo: async () => ({
+        name: 'Fast',
+        tools: [{ name: 'get_adcp_capabilities' }],
+      }),
+      getAdcpCapabilities: () => {
+        capabilitiesCalls += 1;
+        return new Promise(resolve => {
+          const t = setTimeout(() => resolve({ success: true, data: {} }), 5000);
+          pendingTimers.push(t);
+        });
+      },
+    };
+
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(new Error('mid-capabilities')), 30);
+
+    const t0 = Date.now();
+    const { profile } = await discoverAgentProfile(client, controller.signal);
+    const elapsed = Date.now() - t0;
+    cleanup();
+
+    assert.strictEqual(capabilitiesCalls, 1, 'capabilities should have been invoked once');
+    assert.ok(elapsed < 1000, `expected fast abort exit, took ${elapsed}ms`);
+    // capabilities never resolved, so capabilities-derived fields stay unset.
+    assert.strictEqual(profile.adcp_version, undefined);
+    assert.strictEqual(profile.specialisms, undefined);
+    // The capabilities_probe_error is set in the catch path — it should
+    // mention the abort, not silently succeed.
+    assert.ok(
+      profile.capabilities_probe_error?.includes('mid-capabilities'),
+      `expected capabilities_probe_error to mention abort, got: ${profile.capabilities_probe_error}`
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Three small follow-ups from the parallel expert review of #1613 (which shipped in `@adcp/sdk@6.15.1`). Larger follow-ups from the same review round are tracked separately as #1617 (`tasks/cancel` integration) and #1618 (SSRF denylist).

### Changes

1. **`bin/adcp.js` — parse-site 3 trailing-flag validation.** The third `--protocol` / `--transport` parse site now matches the validation pattern at the other two: a trailing `--transport` no longer slips through as `protocolFlag === undefined`. Pre-existing parity bug surfaced by the code-review of #1613.

2. **`src/lib/testing/client.ts` — `raceWithSignal` security warning.** The orphan-promise resolver's `v` argument carries an authenticated agent response after the buyer has moved past the abort. New JSDoc warning + inline `// INTENTIONAL: no-op … Do NOT log v` comment so a future maintainer doesn't add a logging hook there. Behavior unchanged.

3. **`test/lib/discover-agent-profile-signal.test.js` — second-call coverage.** Existing tests covered abort during the first `getAgentInfo` call only. New test exercises an abort firing while the second `raceWithSignal`-wrapped `getAdcpCapabilities` call is in flight, asserts `capabilities_probe_error` records the abort reason, and bounds the wait.

## Out of scope (filed as separate issues)

- **#1617** — wire A2A `tasks/cancel` so comply abort doesn't orphan billed seller work. Real ad-tech concern (seller continues holding inventory after buyer gives up); spec-dependent.
- **#1618** — SSRF denylist on `detectProtocol` / `discoverAgentProfile` for the future server-side comply runner.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] All three #1612 test files pass: 16/16 (`protocol-detection-1612` + `discover-agent-profile-signal` + `storyboard-runner-signal-abort`)
- [x] Full suite: 8385/8389 pass (3 pre-existing skips, 1 known-flaky network test under suite load — unrelated to this PR, fails on main too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)