### PR TITLE
feat(comply): fire-and-forget A2A tasks/cancel when pollTaskCompletion aborts (#1617)

### DIFF
--- a/.changeset/a2a-cancel-on-abort.md
+++ b/.changeset/a2a-cancel-on-abort.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(comply): fire-and-forget A2A tasks/cancel when pollTaskCompletion aborts (adcp-client#1617)
+
+When `comply()` or `waitForCompletion()` is aborted via `AbortSignal` against an A2A seller, the SDK now dispatches a `tasks/cancel` JSON-RPC call to the seller before returning the failed `TaskResult`. This prevents orphan tasks from continuing to run (and billing the seller) after the buyer has given up.
+
+Per A2A 0.3.0 §7.4. Cancel failure is non-fatal — network errors, `TaskNotCancelableError`, and terminal-state races are swallowed. The caller's `TaskResult` is unchanged (`{ status: 'failed', error: '...cancelled' }`).

--- a/.changeset/a2a-cancel-on-abort.md
+++ b/.changeset/a2a-cancel-on-abort.md
@@ -4,6 +4,27 @@
 
 feat(comply): fire-and-forget A2A tasks/cancel when pollTaskCompletion aborts (adcp-client#1617)
 
-When `comply()` or `waitForCompletion()` is aborted via `AbortSignal` against an A2A seller, the SDK now dispatches a `tasks/cancel` JSON-RPC call to the seller before returning the failed `TaskResult`. This prevents orphan tasks from continuing to run (and billing the seller) after the buyer has given up.
+When `comply()` or `waitForCompletion()` is aborted via `AbortSignal` against an
+A2A seller, the SDK now dispatches a `tasks/cancel` JSON-RPC call to the seller
+before returning the failed `TaskResult`. This prevents orphan tasks from
+continuing to run (and billing the seller) after the buyer has given up.
 
-Per A2A 0.3.0 §7.4. Cancel failure is non-fatal — network errors, `TaskNotCancelableError`, and terminal-state races are swallowed. The caller's `TaskResult` is unchanged (`{ status: 'failed', error: '...cancelled' }`).
+Per A2A 0.3.0 §7.4. Cancel failure is non-fatal — network errors,
+`TaskNotCancelableError`, terminal-state races, and the 5s wall-clock cap on
+the cancel POST are all swallowed silently. The caller's `TaskResult` is
+unchanged (`{ status: 'failed', error: '...cancelled' }`).
+
+Implementation detail (from #1620 expert review):
+- `id` field is a real UUID, not `null`. JSON-RPC 2.0 §4.1.3 reserves null
+  for notifications; A2A 0.3.0 §7.4 defines `tasks/cancel` as
+  request/response. Fire-and-forget is the caller's discipline, not a
+  wire-protocol claim.
+- `AbortSignal.timeout(5000)` bounds the cancel POST so a hung seller can't
+  pin the buyer's event loop past the original abort.
+- Silent `.catch()` on rejection: an aborted buyer must not have
+  seller-controlled `Error.message` strings echoed into their logs (same
+  trust-boundary concern as `raceWithSignal` in `discoverAgentProfile`).
+- Phase 2 work (#1617): `signed-requests` sellers will 401 the unsigned
+  cancel because `signingContextStorage` is not active inside
+  `pollTaskCompletion`. Phase 2 wires explicit context capture at task
+  submission and replays it at cancel time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.14.0",
+  "version": "6.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.14.0",
+      "version": "6.15.1",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6466,7 +6466,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.14.0"
+        "@adcp/sdk": "^6.15.1"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -275,6 +275,8 @@ export interface SubmittedContinuation<T> {
    * Wait for completion with polling. Transport cap is fixed at task-submission time; use `track` for per-poll override.
    * Pass `signal` to cancel the polling loop early (e.g. `AbortSignal.timeout(ms)`); the loop exits cleanly on abort
    * rather than continuing to issue `tasks/get` requests after the caller has moved on. (adcp-client#1612)
+   * On abort with an A2A seller, a `tasks/cancel` is also dispatched as a protocol courtesy (A2A 0.3.0 §7.4)
+   * — fire-and-forget; the buyer does not wait for acknowledgment and the outcome does not affect the returned `TaskResult`.
    */
   waitForCompletion: (pollInterval?: number, signal?: AbortSignal) => Promise<TaskResult<T>>;
 }

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1430,13 +1430,24 @@ export class TaskExecutor {
         // (TaskNotCancelable, network error, terminal-state race) is non-fatal.
         // TODO(adcp-client#1617-phase2): upgrade to awaited cancel once AdCP
         // spec defines a cross-protocol cancel verb.
+        //
+        // SECURITY: silent on rejection. The orphan rejection's `Error.message`
+        // can carry an echoed transport response body — same trust-boundary
+        // concern as `raceWithSignal` in `src/lib/testing/client.ts`. A buyer
+        // who has already aborted MUST NOT see seller-controlled text leak
+        // into their logs/telemetry. The outer try AND the `.catch(() => {})`
+        // are both intentional: a malformed `agent_uri` could throw
+        // synchronously from `fetch(...)` before the promise chain catches
+        // it, so the try guards the dispatch path; the `.catch()` guards the
+        // async settlement path.
         if (agent.protocol === 'a2a' && taskId && agent.agent_uri) {
-          void cancelA2ATask(agent.agent_uri, taskId, getAuthToken(agent)).catch((err: unknown) => {
-            console.warn(
-              `A2A tasks/cancel for task ${taskId} failed (non-fatal):`,
-              err instanceof Error ? err.message : 'unknown error'
-            );
-          });
+          try {
+            void cancelA2ATask(agent.agent_uri, taskId, getAuthToken(agent)).catch(() => {
+              /* see SECURITY note above */
+            });
+          } catch {
+            /* see SECURITY note above */
+          }
         }
         return attachMatch({
           success: false as const,

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -21,6 +21,7 @@ import { unwrapProtocolResponse, isAdcpError } from '../utils/response-unwrapper
 import { extractAdcpErrorInfo, extractCorrelationId } from '../utils/error-extraction';
 import { generateIdempotencyKey, isMutatingTask, redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { normalizeGetProductsResponse } from '../utils/pricing-adapter';
+import { cancelA2ATask } from '../protocols/a2a';
 import type {
   Message,
   InputRequest,
@@ -1423,6 +1424,20 @@ export class TaskExecutor {
       if (signal?.aborted) {
         const reason =
           signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'polling cancelled');
+        // adcp-client#1617: Phase 1 — notify the seller so it can stop doing
+        // work for a buyer that has already given up. A2A 0.3.0 §7.4 defines
+        // tasks/cancel for exactly this case. Fire-and-forget: cancel failure
+        // (TaskNotCancelable, network error, terminal-state race) is non-fatal.
+        // TODO(adcp-client#1617-phase2): upgrade to awaited cancel once AdCP
+        // spec defines a cross-protocol cancel verb.
+        if (agent.protocol === 'a2a' && taskId && agent.agent_uri) {
+          void cancelA2ATask(agent.agent_uri, taskId, getAuthToken(agent)).catch((err: unknown) => {
+            console.warn(
+              `A2A tasks/cancel for task ${taskId} failed (non-fatal):`,
+              err instanceof Error ? err.message : 'unknown error'
+            );
+          });
+        }
         return attachMatch({
           success: false as const,
           status: 'failed' as const,

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -63,6 +63,67 @@ export function closeA2AConnections(): void {
   pendingA2AClients.clear();
 }
 
+/**
+ * Fire-and-forget A2A tasks/cancel for an in-flight task (A2A 0.3.0 §7.4).
+ *
+ * Sends a raw JSON-RPC 2.0 POST directly to the agent endpoint. Uses the same
+ * auth header shape as `callA2AToolImpl` (Bearer + x-adcp-auth) and applies
+ * request signing when a signing context is active (required for `signed-requests`
+ * sellers that verify signatures on mutating operations). Does NOT enter
+ * `callContextStorage` — debug-log capture and 401-cache-eviction are
+ * intentionally skipped for best-effort cancellation.
+ *
+ * **Auth-code OAuth gap:** `authToken` is resolved by `getAuthToken(agent)`,
+ * which returns `undefined` for authorization-code-flow sellers (those tokens are
+ * managed by the OAuth provider path in `ProtocolClient.callTool`, not accessible
+ * here). Cancel calls to those sellers go out unauthenticated and will likely 401.
+ * This is acceptable — the cancel is best-effort and the buyer is already
+ * abandoning the task.
+ *
+ * The caller is responsible for swallowing errors: cancel failure
+ * (TaskNotCancelable, network error, auth rejection) is non-fatal because
+ * the buyer is already abandoning the task.
+ *
+ * @param agentUrl  The A2A agent endpoint URL (agent.agent_uri).
+ * @param taskId    The server-assigned A2A Task.id to cancel.
+ * @param authToken Bearer token for the seller, if available.
+ */
+export async function cancelA2ATask(agentUrl: string, taskId: string, authToken: string | undefined): Promise<void> {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json',
+  };
+  if (authToken) {
+    headers['Authorization'] = `Bearer ${authToken}`;
+    headers['x-adcp-auth'] = authToken;
+  }
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    id: null,
+    method: 'tasks/cancel',
+    params: { id: taskId },
+  });
+  // Apply request signing when a signing context is active. Sellers claiming
+  // `signed-requests` verify signatures on mutating operations including
+  // tasks/cancel — without this, the cancel would be rejected with 401/403,
+  // leaving the task orphaned even though the buyer dispatched a cancel.
+  // Note: the `callA2ATool` → `signingContextStorage.run()` ALS context is
+  // NOT active during `pollTaskCompletion` (different execution context), so
+  // `getStore()` returns undefined here unless the caller explicitly wraps
+  // `pollTaskCompletion` in `signingContextStorage.run()`. The signing branch
+  // is a forward-compatibility hook; in practice Phase 1 cancel calls are
+  // unsigned for signed-requests sellers and will 401 non-fatally.
+  const signingContext = signingContextStorage.getStore();
+  const fetchFn = signingContext
+    ? buildAgentSigningFetch({
+        upstream: (input, init) => fetch(input as any, init),
+        signing: signingContext.signing,
+        getCapability: signingContext.getCapability,
+      })
+    : fetch;
+  await fetchFn(agentUrl as any, { method: 'POST', headers, body });
+}
+
 async function getOrCreateA2AClient(
   agentUrl: string,
   authToken: string | undefined

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -3,7 +3,7 @@ const clientModule = require('@a2a-js/sdk/client');
 const A2AClient = clientModule.A2AClient;
 
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import type { PushNotificationConfig } from '../types/tools.generated';
 import type { DebugLogEntry } from '../types/adcp';
 import { AuthenticationRequiredError, is401Error } from '../errors';
@@ -64,25 +64,38 @@ export function closeA2AConnections(): void {
 }
 
 /**
+ * Wall-clock cap on a fire-and-forget cancel. A2A sellers that accept the
+ * TCP connect but never respond would otherwise pin the event loop past the
+ * buyer's abort, which defeats the whole point of fire-and-forget.
+ */
+const CANCEL_TIMEOUT_MS = 5000;
+
+/**
  * Fire-and-forget A2A tasks/cancel for an in-flight task (A2A 0.3.0 §7.4).
  *
- * Sends a raw JSON-RPC 2.0 POST directly to the agent endpoint. Uses the same
- * auth header shape as `callA2AToolImpl` (Bearer + x-adcp-auth) and applies
- * request signing when a signing context is active (required for `signed-requests`
- * sellers that verify signatures on mutating operations). Does NOT enter
- * `callContextStorage` — debug-log capture and 401-cache-eviction are
+ * Sends a raw JSON-RPC 2.0 POST directly to the agent endpoint with the same
+ * auth header shape as `callA2AToolImpl` (Bearer + x-adcp-auth). Does NOT
+ * enter `callContextStorage` — debug-log capture and 401-cache-eviction are
  * intentionally skipped for best-effort cancellation.
  *
  * **Auth-code OAuth gap:** `authToken` is resolved by `getAuthToken(agent)`,
- * which returns `undefined` for authorization-code-flow sellers (those tokens are
- * managed by the OAuth provider path in `ProtocolClient.callTool`, not accessible
- * here). Cancel calls to those sellers go out unauthenticated and will likely 401.
- * This is acceptable — the cancel is best-effort and the buyer is already
- * abandoning the task.
+ * which returns `undefined` for authorization-code-flow sellers (those tokens
+ * are managed by the OAuth provider path in `ProtocolClient.callTool`, not
+ * accessible here). Cancel calls to those sellers go out unauthenticated and
+ * will likely 401 non-fatally.
+ *
+ * **Signing gap (Phase 1 known limitation):** `signed-requests` sellers
+ * verify signatures on mutating operations including `tasks/cancel`. The
+ * `signingContextStorage` ALS scope is set up around `callA2AToolImpl`, NOT
+ * around `pollTaskCompletion` — those are sibling execution contexts in the
+ * runner's promise tree, so `getStore()` returns `undefined` here. Phase 1
+ * cancel calls go unsigned for signed-requests sellers and will 401
+ * non-fatally. Phase 2 (tracked under #1617) wires explicit context capture
+ * at task-submission time and replays it here via `signingContextStorage.run()`.
  *
  * The caller is responsible for swallowing errors: cancel failure
- * (TaskNotCancelable, network error, auth rejection) is non-fatal because
- * the buyer is already abandoning the task.
+ * (TaskNotCancelable, network error, auth rejection, network timeout) is
+ * non-fatal because the buyer is already abandoning the task.
  *
  * @param agentUrl  The A2A agent endpoint URL (agent.agent_uri).
  * @param taskId    The server-assigned A2A Task.id to cancel.
@@ -97,31 +110,28 @@ export async function cancelA2ATask(agentUrl: string, taskId: string, authToken:
     headers['Authorization'] = `Bearer ${authToken}`;
     headers['x-adcp-auth'] = authToken;
   }
+  // JSON-RPC 2.0 §4.1.3: `id: null` flags the request as a *notification*,
+  // and the server MUST NOT respond. A2A 0.3.0 §7.4 defines `tasks/cancel`
+  // as a request/response method (returns the canceled `Task` or
+  // `TaskNotCancelableError`), so a strict A2A server can legitimately
+  // reject `id: null` as a protocol violation. Use a real id and just drop
+  // the response on the floor — fire-and-forget is the caller's discipline,
+  // not a wire-protocol claim.
   const body = JSON.stringify({
     jsonrpc: '2.0',
-    id: null,
+    id: randomUUID(),
     method: 'tasks/cancel',
     params: { id: taskId },
   });
-  // Apply request signing when a signing context is active. Sellers claiming
-  // `signed-requests` verify signatures on mutating operations including
-  // tasks/cancel — without this, the cancel would be rejected with 401/403,
-  // leaving the task orphaned even though the buyer dispatched a cancel.
-  // Note: the `callA2ATool` → `signingContextStorage.run()` ALS context is
-  // NOT active during `pollTaskCompletion` (different execution context), so
-  // `getStore()` returns undefined here unless the caller explicitly wraps
-  // `pollTaskCompletion` in `signingContextStorage.run()`. The signing branch
-  // is a forward-compatibility hook; in practice Phase 1 cancel calls are
-  // unsigned for signed-requests sellers and will 401 non-fatally.
-  const signingContext = signingContextStorage.getStore();
-  const fetchFn = signingContext
-    ? buildAgentSigningFetch({
-        upstream: (input, init) => fetch(input as any, init),
-        signing: signingContext.signing,
-        getCapability: signingContext.getCapability,
-      })
-    : fetch;
-  await fetchFn(agentUrl as any, { method: 'POST', headers, body });
+  // Bound the cancel: a hung fetch would orphan-pin the event loop past the
+  // buyer's abort, defeating fire-and-forget. AbortSignal.timeout() is the
+  // standard primitive; the caller's `.catch()` swallows the AbortError.
+  await fetch(agentUrl, {
+    method: 'POST',
+    headers,
+    body,
+    signal: AbortSignal.timeout(CANCEL_TIMEOUT_MS),
+  });
 }
 
 async function getOrCreateA2AClient(

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.14.0';
+export const LIBRARY_VERSION = '6.15.1';
 
 /**
  * AdCP specification version this library is built for
@@ -52,10 +52,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.14.0',
+  library: '6.15.1',
   adcp: '3.0.8',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-08T15:47:08.092Z',
+  generatedAt: '2026-05-09T13:46:01.397Z',
 } as const;
 
 /**

--- a/test/lib/poll-task-completion-a2a-cancel.test.js
+++ b/test/lib/poll-task-completion-a2a-cancel.test.js
@@ -1,0 +1,112 @@
+// Tests that pollTaskCompletion fires A2A tasks/cancel when the AbortSignal
+// fires — Phase 1 of adcp-client#1617. The cancel is fire-and-forget:
+// failure is non-fatal and the caller's TaskResult is unaffected.
+
+const { test, describe, beforeEach, afterEach, mock } = require('node:test');
+const assert = require('node:assert');
+
+describe('pollTaskCompletion A2A cancel-on-abort (#1617)', () => {
+  let TaskExecutor;
+  let originalFetch;
+  let mockAgent;
+
+  beforeEach(() => {
+    delete require.cache[require.resolve('../../dist/lib/index.js')];
+    const lib = require('../../dist/lib/index.js');
+    TaskExecutor = lib.TaskExecutor;
+    originalFetch = global.fetch;
+
+    mockAgent = {
+      id: 'test-agent',
+      name: 'Test Agent',
+      agent_uri: 'https://test.example.com/a2a',
+      protocol: 'a2a',
+    };
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('fires tasks/cancel JSON-RPC call to seller when A2A poll aborts', async () => {
+    const cancelCalls = [];
+    global.fetch = mock.fn(async (url, options) => {
+      cancelCalls.push({ url, body: JSON.parse(options.body) });
+      return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { id: 'task-xyz' } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    const executor = new TaskExecutor();
+    const signal = AbortSignal.abort('test cancelled');
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-xyz', 10, undefined, signal);
+
+    // The caller's result is the clean failed outcome — cancel is transparent
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.ok(result.error.includes('cancelled'), `Expected cancelled error, got: ${result.error}`);
+
+    // Allow fire-and-forget promise to settle
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(cancelCalls.length, 1, 'should have fired exactly one cancel request');
+    const [call] = cancelCalls;
+    assert.strictEqual(call.url, mockAgent.agent_uri, 'should POST to agent_uri');
+    assert.strictEqual(call.body.jsonrpc, '2.0');
+    assert.strictEqual(call.body.id, null, 'fire-and-forget uses null id per JSON-RPC 2.0 spec');
+    assert.strictEqual(call.body.method, 'tasks/cancel');
+    assert.strictEqual(call.body.params.id, 'task-xyz', 'should address cancel by server task id');
+  });
+
+  test('does NOT fire tasks/cancel for MCP agents on abort', async () => {
+    let fetchCalled = false;
+    global.fetch = mock.fn(async () => {
+      fetchCalled = true;
+      return new Response('{}', { status: 200 });
+    });
+
+    const mcpAgent = { ...mockAgent, protocol: 'mcp' };
+    const executor = new TaskExecutor();
+    const signal = AbortSignal.abort('test cancelled');
+    const result = await executor.pollTaskCompletion(mcpAgent, 'task-mcp', 10, undefined, signal);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(fetchCalled, false, 'should not fire cancel for MCP protocol');
+  });
+
+  test('cancel failure does not affect the TaskResult returned to caller', async () => {
+    global.fetch = mock.fn(async () => {
+      throw new Error('simulated network unreachable');
+    });
+
+    const executor = new TaskExecutor();
+    const signal = AbortSignal.abort('test cancelled');
+    const result = await executor.pollTaskCompletion(mockAgent, 'task-cancel-fail', 10, undefined, signal);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    // Cancel failed but the poll result is unaffected — non-fatal by design
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.status, 'failed');
+    assert.ok(result.error.includes('cancelled'), `Expected cancelled error, got: ${result.error}`);
+  });
+
+  test('skips cancel when taskId is empty', async () => {
+    let fetchCalled = false;
+    global.fetch = mock.fn(async () => {
+      fetchCalled = true;
+      return new Response('{}', { status: 200 });
+    });
+
+    const executor = new TaskExecutor();
+    const signal = AbortSignal.abort('test cancelled');
+    await executor.pollTaskCompletion(mockAgent, '', 10, undefined, signal);
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(fetchCalled, false, 'should not fire cancel when taskId is empty string');
+  });
+});

--- a/test/lib/poll-task-completion-a2a-cancel.test.js
+++ b/test/lib/poll-task-completion-a2a-cancel.test.js
@@ -54,9 +54,42 @@ describe('pollTaskCompletion A2A cancel-on-abort (#1617)', () => {
     const [call] = cancelCalls;
     assert.strictEqual(call.url, mockAgent.agent_uri, 'should POST to agent_uri');
     assert.strictEqual(call.body.jsonrpc, '2.0');
-    assert.strictEqual(call.body.id, null, 'fire-and-forget uses null id per JSON-RPC 2.0 spec');
+    // A2A 0.3.0 §7.4 defines tasks/cancel as request/response, so the wire
+    // request must carry a real (non-null) id — JSON-RPC 2.0 §4.1.3 reserves
+    // null for notifications. Fire-and-forget is the caller's discipline
+    // (we don't await/parse the response), not a wire-protocol claim.
+    assert.match(
+      call.body.id,
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      `expected a UUID v4 id, got: ${JSON.stringify(call.body.id)}`
+    );
     assert.strictEqual(call.body.method, 'tasks/cancel');
     assert.strictEqual(call.body.params.id, 'task-xyz', 'should address cancel by server task id');
+  });
+
+  // code-reviewer follow-up on #1620: confirm the auth-header shape matches
+  // callA2AToolImpl (Bearer + x-adcp-auth). Without this test, a refactor
+  // that drops one of the two headers could ship undetected — Phase 1
+  // sellers split on which header they recognize.
+  test('cancel POST carries Bearer + x-adcp-auth headers when agent has auth_token', async () => {
+    let lastHeaders;
+    global.fetch = mock.fn(async (_url, options) => {
+      lastHeaders = options.headers;
+      return new Response('{}', { status: 200 });
+    });
+
+    const authedAgent = { ...mockAgent, auth_token: 'tok-secret-abc' };
+    const executor = new TaskExecutor();
+    const signal = AbortSignal.abort('test cancelled');
+    await executor.pollTaskCompletion(authedAgent, 'task-auth', 10, undefined, signal);
+
+    // Two microtask ticks — the fire-and-forget chain settles via
+    // Promise.then chained inside .catch(), so a single tick is racy.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.strictEqual(lastHeaders.Authorization, 'Bearer tok-secret-abc');
+    assert.strictEqual(lastHeaders['x-adcp-auth'], 'tok-secret-abc');
   });
 
   test('does NOT fire tasks/cancel for MCP agents on abort', async () => {


### PR DESCRIPTION
Refs #1617

## Summary

- Adds `cancelA2ATask(agentUrl, taskId, authToken)` to `src/lib/protocols/a2a.ts` — a raw JSON-RPC 2.0 POST (`method: "tasks/cancel"`, `params: { id }`, `id: null`) as required by A2A 0.3.0 §7.4.
- Wires it into `pollTaskCompletion` (`TaskExecutor.ts`) at the top-of-loop abort check: when `signal.aborted` and the agent is A2A and `taskId` is non-empty, fires the cancel as fire-and-forget; network errors, `TaskNotCancelableError`, and terminal-state races are swallowed.
- The caller's `TaskResult` is unchanged (`{ success: false, status: 'failed', error: '…cancelled' }`).
- Updates `SubmittedContinuation.waitForCompletion` JSDoc to document the new behavior.
- Adds changeset `a2a-cancel-on-abort.md` (minor).

## Signing note

`signingContextStorage` AsyncLocalStorage is **not active** during `pollTaskCompletion` (different call stack from `callA2ATool`). The signing branch in `cancelA2ATask` is a forward-compatibility hook. In practice Phase 1 cancel calls are unsigned; a `signed-requests` seller will 401 non-fatally. Phase 2 (tracked on the issue) can address this.

## What was tested

- `npm run typecheck` — passes
- `npm run format:check` — passes
- `npm run build:lib` — passes (with local stub schemas; CI will use real schemas)
- 4 unit tests in `test/lib/poll-task-completion-a2a-cancel.test.js` covering:
  - cancel fired with correct JSON-RPC body (`method`, `params.id`, `id: null`)
  - cancel NOT fired for MCP protocol agents
  - cancel failure is non-fatal (TaskResult unaffected)
  - cancel skipped when `taskId` is empty string

## Pre-PR review

Three expert subagents (protocol, product, security) consulted before implementation.

**Protocol expert:** Confirmed `tasks/cancel` is the correct A2A 0.3.0 §7.4 verb; `id: null` is correct JSON-RPC 2.0 notification form; raw fetch needed since `@a2a-js/sdk` buyer client has no `cancelTask()` method.

**Product expert:** Approved fire-and-forget framing; confirmed cancel prevents seller billing for abandoned tasks; Phase 1 scope (A2A only) is appropriate.

**Security expert:** No new attack surface — cancel is outbound-only, payload is server-controlled taskId (never reflected to DOM), auth token flows same as existing `callA2ATool` path.

---

> **Triaged and drafted by Claude Code (triage agent).**
> Session: https://claude.ai/code/session_012rJRM5v5caY3STG9E6E6oi

---
_Generated by [Claude Code](https://claude.ai/code/session_012rJRM5v5caY3STG9E6E6oi)_