### PR TITLE
feat(comply): surface skip causes in always-on storyboard summary

### DIFF
--- a/.changeset/skip-cause-summary.md
+++ b/.changeset/skip-cause-summary.md
@@ -28,7 +28,27 @@ Non-actionable runner-routing reasons (`peer_branch_taken`, `not_applicable`,
 Additive: `ComplianceSummaryArtifact` gains an optional `skip_causes` field
 (`schema_version` stays at 1; treat unknown fields as ignorable per the
 existing contract). `buildCrashSummary` omits `skip_causes` — the runner
-never reached storyboard execution on crash paths.
+never reached storyboard execution on crash paths. `TestStepResult` gains
+an optional `requirement?` field carrying the unmet requirement name when
+`skip_reason === 'requirement_unmet'` (per adcp-client#1626).
+
+Aggregator handles three signal sources cleanly:
+
+- **Detailed skip reasons.** The runner writes `RunnerDetailedSkipReason`
+  values directly to `step.skip_reason` (e.g. `controller_seeding_failed`,
+  `capability_unsupported`). Detailed forms are normalized via
+  `DETAILED_SKIP_TO_CANONICAL` before the actionability check, so they
+  surface alongside canonical ones rather than being silently dropped.
+- **Storyboard-level missing-tool warnings** name multiple tools in one
+  warning (`agent does not advertise any of [sync_accounts, list_accounts]`).
+  Each tool gets its own cause entry rather than a comma-joined string.
+- **`requirement_unmet` skips** sub-group by the unmet requirement name
+  (`requirement_unmet: seeded_state`) using the propagated `step.requirement`
+  field — no warning-text parsing.
+
+`affected[]` is capped at `SKIP_CAUSE_AFFECTED_LIMIT` in the aggregator so
+JSON consumers see the same bound the text/markdown renderers honor (the
+JSDoc claimed the cap but only renderers enforced it).
 
 Follow-up: a `--max-skip-causes N` gate flag for CI ratcheting was proposed
 in #1623 but is deferred to give the naming and semantics proper design time.

--- a/.changeset/skip-cause-summary.md
+++ b/.changeset/skip-cause-summary.md
@@ -1,0 +1,34 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(comply): surface skip causes in always-on storyboard summary
+
+The always-on storyboard summary now includes a grouped "Skip causes" block
+when steps are skipped. Previously only the skip count was shown; now each
+actionable cause is listed with a step count, human-readable description, and
+the affected scenario IDs — matching what the issue author's internal script
+already scraped from `--json` output.
+
+```
+  Steps:     26 passed, 3 failed, 30 skipped
+  Skip causes:
+    [26] missing_test_controller — agent doesn't expose comply_test_controller
+         Affected: capability_discovery/setup, account_setup/setup, … 21 more
+    [ 2] missing_tool: sync_accounts — agent doesn't advertise tool
+         Affected: refine_products/setup
+    [ 2] missing_tool: list_accounts — agent doesn't advertise tool
+         Affected: refine_products/setup
+```
+
+Non-actionable runner-routing reasons (`peer_branch_taken`, `not_applicable`,
+`probe_skipped`, etc.) are excluded. The same block appears in the
+`$GITHUB_STEP_SUMMARY` markdown output as a collapsible `<details>` table.
+
+Additive: `ComplianceSummaryArtifact` gains an optional `skip_causes` field
+(`schema_version` stays at 1; treat unknown fields as ignorable per the
+existing contract). `buildCrashSummary` omits `skip_causes` — the runner
+never reached storyboard execution on crash paths.
+
+Follow-up: a `--max-skip-causes N` gate flag for CI ratcheting was proposed
+in #1623 but is deferred to give the naming and semantics proper design time.

--- a/src/lib/testing/compliance/storyboard-tracks.ts
+++ b/src/lib/testing/compliance/storyboard-tracks.ts
@@ -126,6 +126,7 @@ function mapStepToTestStep(stepResult: StoryboardStepResult): TestStepResult {
       : undefined,
     ...(stepResult.skipped && { skipped: true as const }),
     ...(stepResult.skip_reason && { skip_reason: stepResult.skip_reason }),
+    ...(stepResult.skip?.requirement && { requirement: stepResult.skip.requirement }),
   };
 }
 

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -18,6 +18,7 @@
  */
 
 import type { ComplianceFailure, ComplianceResult, ComplianceTrack, OverallStatus } from './types';
+import { DETAILED_SKIP_TO_CANONICAL, type RunnerDetailedSkipReason } from '../storyboard/types';
 
 const SUMMARY_SCHEMA_VERSION = 1;
 
@@ -133,25 +134,53 @@ function truncate(s: string, max: number): string {
 
 const SKIP_CAUSE_AFFECTED_LIMIT = 5;
 
-// Actionable reasons — gaps the adopter can close. Internal runner-routing
-// reasons (peer_branch_taken, not_applicable, probe_skipped, …) are excluded
-// because they are expected behavior, not agent deficiencies.
-const ACTIONABLE_SKIP_REASONS = new Set([
+// Actionable canonical reasons — gaps the adopter can close. Internal
+// runner-routing reasons (peer_branch_taken, not_applicable, …) are excluded
+// because they are expected behavior, not agent deficiencies. Detailed
+// skip reasons (e.g. `controller_seeding_failed`, `capability_unsupported`,
+// `requirement_unmet` per adcp-client#1626) are normalized via
+// `DETAILED_SKIP_TO_CANONICAL` before this lookup; the runner writes
+// detailed forms to `step.skip_reason` directly per types.ts so consumers
+// of `step.skip_reason` see the more specific value.
+const ACTIONABLE_CANONICAL_REASONS = new Set<string>([
   'missing_tool',
   'missing_test_controller',
   'prerequisite_failed',
   'unsatisfied_contract',
   'no_phases',
+  'requirement_unmet',
 ]);
 
-function extractMissingToolName(warning: string): string | undefined {
+/**
+ * True when the skip reason is something the adopter can act on.
+ * Accepts both canonical `RunnerSkipReason` and detailed
+ * `RunnerDetailedSkipReason` strings — detailed forms are mapped to their
+ * canonical equivalent before the actionability check, so e.g.
+ * `controller_seeding_failed` (detailed) → `prerequisite_failed`
+ * (canonical, actionable) is correctly surfaced rather than silently
+ * dropped.
+ */
+function isActionableSkipReason(reason: string): boolean {
+  if (ACTIONABLE_CANONICAL_REASONS.has(reason)) return true;
+  const canonical = DETAILED_SKIP_TO_CANONICAL[reason as RunnerDetailedSkipReason];
+  return canonical !== undefined && ACTIONABLE_CANONICAL_REASONS.has(canonical);
+}
+
+function extractMissingToolNames(warning: string): string[] {
   // Step-level: `Agent did not advertise tool "sync_accounts"; agent tools: [...]`
   const stepMatch = warning.match(/Agent did not advertise tool "([^"]+)"/i);
-  if (stepMatch) return stepMatch[1];
+  if (stepMatch) return [stepMatch[1]!];
   // Storyboard-level: `agent does not advertise any of [sync_accounts, list_accounts]`
+  // Each tool is a separate gap — emit one cause per tool so dashboards see
+  // the full list, not a single comma-joined "tool name".
   const sbMatch = warning.match(/agent does not advertise any of \[([^\]]+)\]/i);
-  if (sbMatch) return sbMatch[1];
-  return undefined;
+  if (sbMatch) {
+    return sbMatch[1]!
+      .split(/,\s*/)
+      .map(t => t.trim())
+      .filter(Boolean);
+  }
+  return [];
 }
 
 function skipCauseDetail(reason: string): string {
@@ -166,6 +195,12 @@ function skipCauseDetail(reason: string): string {
       return 'test-kit contract out of scope';
     case 'no_phases':
       return 'storyboard has no executable phases';
+    case 'requirement_unmet':
+      return 'storyboard requires a runtime that is not available on this run';
+    case 'controller_seeding_failed':
+      return 'pre-flight controller seeding failed';
+    case 'capability_unsupported':
+      return 'agent self-declared capability unsupported';
     default:
       return reason;
   }
@@ -174,29 +209,52 @@ function skipCauseDetail(reason: string): string {
 function buildSkipCauses(result: ComplianceResult): ComplianceSummarySkipCause[] {
   const causeMap = new Map<string, { count: number; detail: string; affectedSet: Set<string> }>();
 
+  const recordCause = (causeKey: string, baseReason: string, scenarioId: string) => {
+    if (!causeMap.has(causeKey)) {
+      causeMap.set(causeKey, {
+        count: 0,
+        detail: skipCauseDetail(baseReason),
+        affectedSet: new Set(),
+      });
+    }
+    const entry = causeMap.get(causeKey)!;
+    entry.count++;
+    entry.affectedSet.add(scenarioId);
+  };
+
   for (const track of result.tracks) {
     for (const scenario of track.scenarios) {
       const scenarioId = String(scenario.scenario);
       for (const step of scenario.steps ?? []) {
         if (!step.skipped || !step.skip_reason) continue;
-        if (!ACTIONABLE_SKIP_REASONS.has(step.skip_reason)) continue;
+        if (!isActionableSkipReason(step.skip_reason)) continue;
 
-        let causeKey = step.skip_reason;
+        // missing_tool: sub-group by tool name. Storyboard-level matches
+        // can carry multiple tools (one cause per tool); step-level matches
+        // are always single-tool. extractMissingToolNames returns [] when
+        // the warning text doesn't match either pattern, in which case we
+        // fall through to the un-grouped reason.
         if (step.skip_reason === 'missing_tool' && step.warnings?.[0]) {
-          const toolName = extractMissingToolName(step.warnings[0]);
-          if (toolName) causeKey = `missing_tool: ${toolName}`;
+          const toolNames = extractMissingToolNames(step.warnings[0]);
+          if (toolNames.length > 0) {
+            for (const toolName of toolNames) {
+              recordCause(`missing_tool: ${toolName}`, 'missing_tool', scenarioId);
+            }
+            continue;
+          }
         }
 
-        if (!causeMap.has(causeKey)) {
-          causeMap.set(causeKey, {
-            count: 0,
-            detail: skipCauseDetail(step.skip_reason),
-            affectedSet: new Set(),
-          });
+        // requirement_unmet: sub-group by the unmet requirement name
+        // (adcp-client#1626). The runner emits `step.skip.requirement`
+        // which `toComplianceStep` propagates as `step.requirement` on
+        // the flattened `TestStepResult`, so per-requirement aggregation
+        // works without parsing the warning text.
+        if (step.skip_reason === 'requirement_unmet' && step.requirement) {
+          recordCause(`requirement_unmet: ${step.requirement}`, 'requirement_unmet', scenarioId);
+          continue;
         }
-        const entry = causeMap.get(causeKey)!;
-        entry.count++;
-        entry.affectedSet.add(scenarioId);
+
+        recordCause(step.skip_reason, step.skip_reason, scenarioId);
       }
     }
   }
@@ -207,7 +265,10 @@ function buildSkipCauses(result: ComplianceResult): ComplianceSummarySkipCause[]
       cause,
       count,
       detail,
-      affected: Array.from(affectedSet),
+      // Cap at aggregator level so JSON consumers see the same bound the
+      // text/markdown renderers honor — keeps the JSON contract truthful
+      // about the cap documented on `ComplianceSummarySkipCause.affected`.
+      affected: Array.from(affectedSet).slice(0, SKIP_CAUSE_AFFECTED_LIMIT),
     }));
 }
 
@@ -245,8 +306,14 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
     for (const cause of s.skip_causes) {
       const count = String(cause.count).padStart(countWidth);
       lines.push(`    [${count}] ${cause.cause} — ${cause.detail}`);
+      // Overflow is the difference between the total count for this cause
+      // and how many distinct scenario IDs we kept after the aggregator's
+      // SKIP_CAUSE_AFFECTED_LIMIT cap. The slice here is defensive — the
+      // aggregator already caps, but if a future caller hands us an
+      // uncapped artifact (e.g. JSON re-input from an older runner), we
+      // still bound the visible list.
       const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
-      const overflow = cause.affected.length - visible.length;
+      const overflow = cause.count - visible.length;
       const affectedText = overflow > 0 ? `${visible.join(', ')}, … ${overflow} more` : visible.join(', ');
       lines.push(`${affectedIndent}Affected: ${affectedText}`);
     }
@@ -320,7 +387,7 @@ export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): s
     lines.push('| --- | --- | --- | --- |');
     for (const cause of s.skip_causes) {
       const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
-      const overflow = cause.affected.length - visible.length;
+      const overflow = cause.count - visible.length;
       const affectedText =
         overflow > 0
           ? `${visible.map(escapeTableCell).join(', ')}, … ${overflow} more`

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -239,6 +239,8 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
   lines.push(`Steps:     ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped`);
   if (s.skip_causes?.length) {
     const countWidth = String(Math.max(...s.skip_causes.map(c => c.count))).length;
+    // "    [" + countWidth chars + "] " — derived so Affected: aligns under the cause text
+    const affectedIndent = ' '.repeat(4 + 1 + countWidth + 1 + 1);
     lines.push(`  Skip causes:`);
     for (const cause of s.skip_causes) {
       const count = String(cause.count).padStart(countWidth);
@@ -246,7 +248,7 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
       const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
       const overflow = cause.affected.length - visible.length;
       const affectedText = overflow > 0 ? `${visible.join(', ')}, … ${overflow} more` : visible.join(', ');
-      lines.push(`           Affected: ${affectedText}`);
+      lines.push(`${affectedIndent}Affected: ${affectedText}`);
     }
   }
   lines.push(`Duration:  ${(s.total_duration_ms / 1000).toFixed(1)}s`);

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -245,9 +245,7 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
       lines.push(`    [${count}] ${cause.cause} — ${cause.detail}`);
       const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
       const overflow = cause.affected.length - visible.length;
-      const affectedText = overflow > 0
-        ? `${visible.join(', ')}, … ${overflow} more`
-        : visible.join(', ');
+      const affectedText = overflow > 0 ? `${visible.join(', ')}, … ${overflow} more` : visible.join(', ');
       lines.push(`           Affected: ${affectedText}`);
     }
   }
@@ -312,17 +310,22 @@ export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): s
   if (s.skip_causes?.length) {
     const total = s.skip_causes.reduce((n, c) => n + c.count, 0);
     lines.push(`<details>`);
-    lines.push(`<summary>Skip causes (${s.skip_causes.length} cause${s.skip_causes.length === 1 ? '' : 's'}, ${total} skipped step${total === 1 ? '' : 's'})</summary>`);
+    lines.push(
+      `<summary>Skip causes (${s.skip_causes.length} cause${s.skip_causes.length === 1 ? '' : 's'}, ${total} skipped step${total === 1 ? '' : 's'})</summary>`
+    );
     lines.push('');
     lines.push('| Count | Cause | Detail | Affected |');
     lines.push('| --- | --- | --- | --- |');
     for (const cause of s.skip_causes) {
       const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
       const overflow = cause.affected.length - visible.length;
-      const affectedText = overflow > 0
-        ? `${visible.map(escapeTableCell).join(', ')}, … ${overflow} more`
-        : visible.map(escapeTableCell).join(', ');
-      lines.push(`| ${cause.count} | \`${escapeTableCell(cause.cause)}\` | ${escapeTableCell(cause.detail)} | ${affectedText} |`);
+      const affectedText =
+        overflow > 0
+          ? `${visible.map(escapeTableCell).join(', ')}, … ${overflow} more`
+          : visible.map(escapeTableCell).join(', ');
+      lines.push(
+        `| ${cause.count} | \`${escapeTableCell(cause.cause)}\` | ${escapeTableCell(cause.detail)} | ${affectedText} |`
+      );
     }
     lines.push('');
     lines.push('</details>');

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -10,11 +10,29 @@
  *   - `buildComplianceSummary`        → ComplianceSummaryArtifact (the JSON contract)
  *   - `formatComplianceSummaryText`   → stderr block with greppable `STORYBOARD-FAIL` prefix
  *   - `formatComplianceSummaryMarkdown` → table for $GITHUB_STEP_SUMMARY
+ *
+ * The `skip_causes` field on `ComplianceSummaryArtifact` is an additive v1
+ * extension — treat unknown fields as ignorable per schema_version semantics.
+ * Crash-path summaries built by `buildCrashSummary` omit `skip_causes`
+ * because the runner never reached the storyboard execution phase.
  */
 
 import type { ComplianceFailure, ComplianceResult, ComplianceTrack, OverallStatus } from './types';
 
 const SUMMARY_SCHEMA_VERSION = 1;
+
+/**
+ * A grouped skip-cause entry for the always-on summary block.
+ * Only actionable causes are included — internal runner routing skips
+ * (peer_branch_taken, not_applicable, etc.) are filtered out.
+ */
+export interface ComplianceSummarySkipCause {
+  cause: string;
+  count: number;
+  detail: string;
+  /** Scenario IDs affected (capped at SKIP_CAUSE_AFFECTED_LIMIT; remainder noted in text output). */
+  affected: string[];
+}
 
 /**
  * Stable, schema-versioned summary. Adopters depending on this shape should
@@ -33,6 +51,8 @@ export interface ComplianceSummaryArtifact {
   tested_at: string;
   storyboards_executed: string[];
   failures: ComplianceSummaryFailure[];
+  /** Actionable skip causes grouped by reason. Present only when skipped > 0. */
+  skip_causes?: ComplianceSummarySkipCause[];
 }
 
 /**
@@ -59,6 +79,7 @@ export interface BuildSummaryOptions {
 }
 
 export function buildComplianceSummary(result: ComplianceResult, opts: BuildSummaryOptions): ComplianceSummaryArtifact {
+  const skipCauses = buildSkipCauses(result);
   return {
     schema_version: SUMMARY_SCHEMA_VERSION,
     agent_url: result.agent_url,
@@ -72,6 +93,7 @@ export function buildComplianceSummary(result: ComplianceResult, opts: BuildSumm
     tested_at: result.tested_at,
     storyboards_executed: result.storyboards_executed ?? [],
     failures: (result.failures ?? []).map(toSummaryFailure),
+    ...(skipCauses.length > 0 ? { skip_causes: skipCauses } : {}),
   };
 }
 
@@ -105,6 +127,90 @@ function truncate(s: string, max: number): string {
   return s.length > max ? `${s.slice(0, max - 1)}…` : s;
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Skip-cause aggregation
+// ────────────────────────────────────────────────────────────────────────────
+
+const SKIP_CAUSE_AFFECTED_LIMIT = 5;
+
+// Actionable reasons — gaps the adopter can close. Internal runner-routing
+// reasons (peer_branch_taken, not_applicable, probe_skipped, …) are excluded
+// because they are expected behavior, not agent deficiencies.
+const ACTIONABLE_SKIP_REASONS = new Set([
+  'missing_tool',
+  'missing_test_controller',
+  'prerequisite_failed',
+  'unsatisfied_contract',
+  'no_phases',
+]);
+
+function extractMissingToolName(warning: string): string | undefined {
+  // Step-level: `Agent did not advertise tool "sync_accounts"; agent tools: [...]`
+  const stepMatch = warning.match(/Agent did not advertise tool "([^"]+)"/i);
+  if (stepMatch) return stepMatch[1];
+  // Storyboard-level: `agent does not advertise any of [sync_accounts, list_accounts]`
+  const sbMatch = warning.match(/agent does not advertise any of \[([^\]]+)\]/i);
+  if (sbMatch) return sbMatch[1];
+  return undefined;
+}
+
+function skipCauseDetail(reason: string): string {
+  switch (reason) {
+    case 'missing_test_controller':
+      return "agent doesn't expose comply_test_controller";
+    case 'missing_tool':
+      return "agent doesn't advertise tool";
+    case 'prerequisite_failed':
+      return 'prerequisite step did not pass';
+    case 'unsatisfied_contract':
+      return 'test-kit contract out of scope';
+    case 'no_phases':
+      return 'storyboard has no executable phases';
+    default:
+      return reason;
+  }
+}
+
+function buildSkipCauses(result: ComplianceResult): ComplianceSummarySkipCause[] {
+  const causeMap = new Map<string, { count: number; detail: string; affectedSet: Set<string> }>();
+
+  for (const track of result.tracks) {
+    for (const scenario of track.scenarios) {
+      const scenarioId = String(scenario.scenario);
+      for (const step of scenario.steps ?? []) {
+        if (!step.skipped || !step.skip_reason) continue;
+        if (!ACTIONABLE_SKIP_REASONS.has(step.skip_reason)) continue;
+
+        let causeKey = step.skip_reason;
+        if (step.skip_reason === 'missing_tool' && step.warnings?.[0]) {
+          const toolName = extractMissingToolName(step.warnings[0]);
+          if (toolName) causeKey = `missing_tool: ${toolName}`;
+        }
+
+        if (!causeMap.has(causeKey)) {
+          causeMap.set(causeKey, {
+            count: 0,
+            detail: skipCauseDetail(step.skip_reason),
+            affectedSet: new Set(),
+          });
+        }
+        const entry = causeMap.get(causeKey)!;
+        entry.count++;
+        entry.affectedSet.add(scenarioId);
+      }
+    }
+  }
+
+  return Array.from(causeMap.entries())
+    .sort((a, b) => b[1].count - a[1].count)
+    .map(([cause, { count, detail, affectedSet }]) => ({
+      cause,
+      count,
+      detail,
+      affected: Array.from(affectedSet),
+    }));
+}
+
 /**
  * Hard-failure statuses — runs that should never look green to CI. `partial`
  * is intentionally not in this set: it means some tracks ran silent (wired
@@ -131,6 +237,20 @@ export function formatComplianceSummaryText(s: ComplianceSummaryArtifact): strin
   lines.push(`SDK:       @adcp/sdk ${s.sdk_version} (AdCP ${s.adcp_version})`);
   lines.push(`Status:    ${s.overall_status}`);
   lines.push(`Steps:     ${s.passed} passed, ${s.failed} failed, ${s.skipped} skipped`);
+  if (s.skip_causes?.length) {
+    const countWidth = String(Math.max(...s.skip_causes.map(c => c.count))).length;
+    lines.push(`  Skip causes:`);
+    for (const cause of s.skip_causes) {
+      const count = String(cause.count).padStart(countWidth);
+      lines.push(`    [${count}] ${cause.cause} — ${cause.detail}`);
+      const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
+      const overflow = cause.affected.length - visible.length;
+      const affectedText = overflow > 0
+        ? `${visible.join(', ')}, … ${overflow} more`
+        : visible.join(', ');
+      lines.push(`           Affected: ${affectedText}`);
+    }
+  }
   lines.push(`Duration:  ${(s.total_duration_ms / 1000).toFixed(1)}s`);
   lines.push('');
 
@@ -186,6 +306,26 @@ export function formatComplianceSummaryMarkdown(s: ComplianceSummaryArtifact): s
     for (const f of s.failures) {
       lines.push(`| \`${f.track}\` | \`${f.storyboard_id}\` | \`${f.step_id}\` | ${escapeTableCell(f.reason)} |`);
     }
+    lines.push('');
+  }
+
+  if (s.skip_causes?.length) {
+    const total = s.skip_causes.reduce((n, c) => n + c.count, 0);
+    lines.push(`<details>`);
+    lines.push(`<summary>Skip causes (${s.skip_causes.length} cause${s.skip_causes.length === 1 ? '' : 's'}, ${total} skipped step${total === 1 ? '' : 's'})</summary>`);
+    lines.push('');
+    lines.push('| Count | Cause | Detail | Affected |');
+    lines.push('| --- | --- | --- | --- |');
+    for (const cause of s.skip_causes) {
+      const visible = cause.affected.slice(0, SKIP_CAUSE_AFFECTED_LIMIT);
+      const overflow = cause.affected.length - visible.length;
+      const affectedText = overflow > 0
+        ? `${visible.map(escapeTableCell).join(', ')}, … ${overflow} more`
+        : visible.map(escapeTableCell).join(', ');
+      lines.push(`| ${cause.count} | \`${escapeTableCell(cause.cause)}\` | ${escapeTableCell(cause.detail)} | ${affectedText} |`);
+    }
+    lines.push('');
+    lines.push('</details>');
     lines.push('');
   }
 

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -240,6 +240,14 @@ export interface TestStepResult {
   skipped?: boolean;
   /** Canonical skip reason when `skipped` is true; maps to `RunnerSkipReason`. */
   skip_reason?: string;
+  /**
+   * Names the unmet runtime requirement when `skip_reason` is
+   * `'requirement_unmet'` (per adcp-client#1626). Carries the same value
+   * the storyboard authored in `Storyboard.requires`. Lets skip-cause
+   * aggregators sub-group not-applicable scenarios per-requirement
+   * without parsing the warning text. Absent for every other skip reason.
+   */
+  requirement?: string;
 }
 
 export interface AgentProfile {

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -201,6 +201,262 @@ describe('formatComplianceSummaryMarkdown', () => {
   });
 });
 
+function resultWithSkips() {
+  const base = passingResult();
+  return {
+    ...base,
+    overall_status: 'partial',
+    summary: {
+      ...base.summary,
+      steps_skipped: 3,
+    },
+    tracks: [
+      {
+        track: 'media_buy',
+        status: 'skip',
+        label: 'Media Buy',
+        observations: [],
+        duration_ms: 0,
+        scenarios: [
+          {
+            agent_url: 'https://agent.example/mcp',
+            scenario: 'refine_products/setup',
+            overall_passed: true,
+            summary: 'ok',
+            total_duration_ms: 0,
+            tested_at: base.tested_at,
+            steps: [
+              {
+                step: 'sync_accounts',
+                task: 'sync_accounts',
+                passed: true,
+                skipped: true,
+                skip_reason: 'missing_tool',
+                duration_ms: 0,
+                warnings: ['Agent did not advertise tool "sync_accounts"; agent tools: [get_adcp_capabilities].'],
+              },
+              {
+                step: 'list_accounts',
+                task: 'list_accounts',
+                passed: true,
+                skipped: true,
+                skip_reason: 'missing_tool',
+                duration_ms: 0,
+                warnings: ['Agent did not advertise tool "list_accounts"; agent tools: [get_adcp_capabilities].'],
+              },
+            ],
+          },
+          {
+            agent_url: 'https://agent.example/mcp',
+            scenario: 'create_buy/deterministic',
+            overall_passed: true,
+            summary: 'ok',
+            total_duration_ms: 0,
+            tested_at: base.tested_at,
+            steps: [
+              {
+                step: 'seed',
+                task: 'comply_test_controller',
+                passed: true,
+                skipped: true,
+                skip_reason: 'missing_test_controller',
+                duration_ms: 0,
+                warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'],
+              },
+            ],
+          },
+        ],
+        skipped_scenarios: [],
+      },
+    ],
+  };
+}
+
+describe('buildComplianceSummary — skip causes', () => {
+  test('no skip_causes field when steps_skipped is zero', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.skip_causes, undefined);
+  });
+
+  test('aggregates missing_tool causes by tool name', () => {
+    const result = resultWithSkips();
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    const missingSync = s.skip_causes.find(c => c.cause === 'missing_tool: sync_accounts');
+    assert.ok(missingSync, 'missing_tool: sync_accounts should be present');
+    assert.strictEqual(missingSync.count, 1);
+    assert.deepStrictEqual(missingSync.affected, ['refine_products/setup']);
+  });
+
+  test('aggregates missing_test_controller as its own cause', () => {
+    const result = resultWithSkips();
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    const mtc = s.skip_causes.find(c => c.cause === 'missing_test_controller');
+    assert.ok(mtc, 'missing_test_controller should be present');
+    assert.strictEqual(mtc.count, 1);
+    assert.ok(mtc.detail.includes('comply_test_controller'));
+  });
+
+  test('excludes non-actionable skip reasons (peer_branch_taken, not_applicable)', () => {
+    const base = passingResult();
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios: [
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'foo/bar',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                {
+                  step: 'peer-skip',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'peer_branch_taken',
+                  duration_ms: 0,
+                },
+                {
+                  step: 'na-skip',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'not_applicable',
+                  duration_ms: 0,
+                },
+              ],
+            },
+          ],
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.strictEqual(s.skip_causes, undefined);
+  });
+
+  test('sorts causes by count descending', () => {
+    const base = passingResult();
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios: [
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'a/setup',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                { step: 's1', passed: true, skipped: true, skip_reason: 'missing_test_controller', duration_ms: 0, warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'] },
+                { step: 's2', passed: true, skipped: true, skip_reason: 'missing_test_controller', duration_ms: 0, warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'] },
+                { step: 's3', passed: true, skipped: true, skip_reason: 'missing_tool', duration_ms: 0, warnings: ['Agent did not advertise tool "sync_accounts"; agent tools: [].'] },
+              ],
+            },
+          ],
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    assert.strictEqual(s.skip_causes[0].cause, 'missing_test_controller');
+    assert.strictEqual(s.skip_causes[0].count, 2);
+    assert.strictEqual(s.skip_causes[1].cause, 'missing_tool: sync_accounts');
+    assert.strictEqual(s.skip_causes[1].count, 1);
+  });
+});
+
+describe('formatComplianceSummaryText — skip causes', () => {
+  test('renders Skip causes block when causes are present', () => {
+    const result = resultWithSkips();
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /Skip causes:/);
+    assert.match(text, /missing_tool: sync_accounts/);
+    assert.match(text, /missing_test_controller/);
+    assert.match(text, /Affected:/);
+  });
+
+  test('no Skip causes block when skips are zero', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.doesNotMatch(text, /Skip causes:/);
+  });
+
+  test('truncates Affected list beyond SKIP_CAUSE_AFFECTED_LIMIT', () => {
+    const base = passingResult();
+    const scenarios = Array.from({ length: 8 }, (_, i) => ({
+      agent_url: 'https://agent.example/mcp',
+      scenario: `storyboard_${i}/setup`,
+      overall_passed: true,
+      summary: 'ok',
+      total_duration_ms: 0,
+      tested_at: base.tested_at,
+      steps: [
+        {
+          step: 'seed',
+          passed: true,
+          skipped: true,
+          skip_reason: 'missing_test_controller',
+          duration_ms: 0,
+          warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'],
+        },
+      ],
+    }));
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios,
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const text = formatComplianceSummaryText(s);
+    assert.match(text, /… 3 more/);
+  });
+});
+
+describe('formatComplianceSummaryMarkdown — skip causes', () => {
+  test('renders <details> block for skip causes', () => {
+    const result = resultWithSkips();
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const md = formatComplianceSummaryMarkdown(s);
+    assert.match(md, /<details>/);
+    assert.match(md, /Skip causes/);
+    assert.match(md, /missing_tool: sync_accounts/);
+    assert.match(md, /<\/details>/);
+  });
+
+  test('no skip causes block when causes absent', () => {
+    const s = buildComplianceSummary(passingResult(), { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    const md = formatComplianceSummaryMarkdown(s);
+    assert.doesNotMatch(md, /<details>/);
+  });
+});
+
 describe('buildCrashSummary', () => {
   test('produces a schema_version-1 artifact when comply() throws', () => {
     const summary = buildCrashSummary({

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -261,7 +261,9 @@ function resultWithSkips() {
                 skipped: true,
                 skip_reason: 'missing_test_controller',
                 duration_ms: 0,
-                warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'],
+                warnings: [
+                  'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
+                ],
               },
             ],
           },
@@ -363,9 +365,34 @@ describe('buildComplianceSummary — skip causes', () => {
               total_duration_ms: 0,
               tested_at: base.tested_at,
               steps: [
-                { step: 's1', passed: true, skipped: true, skip_reason: 'missing_test_controller', duration_ms: 0, warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'] },
-                { step: 's2', passed: true, skipped: true, skip_reason: 'missing_test_controller', duration_ms: 0, warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'] },
-                { step: 's3', passed: true, skipped: true, skip_reason: 'missing_tool', duration_ms: 0, warnings: ['Agent did not advertise tool "sync_accounts"; agent tools: [].'] },
+                {
+                  step: 's1',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'missing_test_controller',
+                  duration_ms: 0,
+                  warnings: [
+                    'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
+                  ],
+                },
+                {
+                  step: 's2',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'missing_test_controller',
+                  duration_ms: 0,
+                  warnings: [
+                    'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
+                  ],
+                },
+                {
+                  step: 's3',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'missing_tool',
+                  duration_ms: 0,
+                  warnings: ['Agent did not advertise tool "sync_accounts"; agent tools: [].'],
+                },
               ],
             },
           ],
@@ -415,7 +442,9 @@ describe('formatComplianceSummaryText — skip causes', () => {
           skipped: true,
           skip_reason: 'missing_test_controller',
           duration_ms: 0,
-          warnings: ['Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.'],
+          warnings: [
+            'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
+          ],
         },
       ],
     }));

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -407,6 +407,198 @@ describe('buildComplianceSummary — skip causes', () => {
     assert.strictEqual(s.skip_causes[1].cause, 'missing_tool: sync_accounts');
     assert.strictEqual(s.skip_causes[1].count, 1);
   });
+
+  test('aggregates requirement_unmet causes by requirement name (#1626)', () => {
+    const base = passingResult();
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios: [
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'a/setup',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                {
+                  step: 'requires-seed',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'requirement_unmet',
+                  requirement: 'seeded_state',
+                  duration_ms: 0,
+                },
+              ],
+            },
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'b/setup',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                {
+                  step: 'requires-seed-2',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'requirement_unmet',
+                  requirement: 'seeded_state',
+                  duration_ms: 0,
+                },
+              ],
+            },
+          ],
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    const seeded = s.skip_causes.find(c => c.cause === 'requirement_unmet: seeded_state');
+    assert.ok(seeded, 'requirement_unmet: seeded_state should be present');
+    assert.strictEqual(seeded.count, 2);
+    assert.strictEqual(seeded.affected.length, 2);
+  });
+
+  test('storyboard-level missing-tool emits one cause per tool (#1623)', () => {
+    // Per #1624: "agent does not advertise any of [sync_accounts, list_accounts]"
+    // is one warning that names two distinct gaps. Each tool gets its own
+    // cause entry rather than a comma-joined "missing_tool: sync_accounts, list_accounts".
+    const base = passingResult();
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios: [
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'refine_products/setup',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                {
+                  step: 'discover',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'missing_tool',
+                  duration_ms: 0,
+                  warnings: [
+                    'Required: agent does not advertise any of [sync_accounts, list_accounts]; agent tools: [].',
+                  ],
+                },
+              ],
+            },
+          ],
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    const sync = s.skip_causes.find(c => c.cause === 'missing_tool: sync_accounts');
+    const list = s.skip_causes.find(c => c.cause === 'missing_tool: list_accounts');
+    assert.ok(sync, 'missing_tool: sync_accounts should be present');
+    assert.ok(list, 'missing_tool: list_accounts should be present');
+  });
+
+  test('detailed skip reasons normalize to canonical actionability (controller_seeding_failed)', () => {
+    // The runner writes detailed RunnerDetailedSkipReason values directly
+    // to step.skip_reason. The aggregator must map them through
+    // DETAILED_SKIP_TO_CANONICAL — controller_seeding_failed maps to
+    // prerequisite_failed (actionable) so the cause should appear.
+    const base = passingResult();
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios: [
+            {
+              agent_url: 'https://agent.example/mcp',
+              scenario: 'pre/setup',
+              overall_passed: true,
+              summary: 'ok',
+              total_duration_ms: 0,
+              tested_at: base.tested_at,
+              steps: [
+                {
+                  step: 'seed',
+                  passed: true,
+                  skipped: true,
+                  skip_reason: 'controller_seeding_failed',
+                  duration_ms: 0,
+                },
+              ],
+            },
+          ],
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    const csf = s.skip_causes.find(c => c.cause === 'controller_seeding_failed');
+    assert.ok(csf, 'controller_seeding_failed should be present (maps canonical prerequisite_failed)');
+  });
+
+  test('caps affected list at SKIP_CAUSE_AFFECTED_LIMIT in the JSON artifact', () => {
+    const base = passingResult();
+    const steps = Array.from({ length: 10 }, (_, i) => ({
+      step: `s${i}`,
+      passed: true,
+      skipped: true,
+      skip_reason: 'missing_test_controller',
+      duration_ms: 0,
+    }));
+    const scenarios = steps.map((step, i) => ({
+      agent_url: 'https://agent.example/mcp',
+      scenario: `sb${i}/setup`,
+      overall_passed: true,
+      summary: 'ok',
+      total_duration_ms: 0,
+      tested_at: base.tested_at,
+      steps: [step],
+    }));
+    const result = {
+      ...base,
+      tracks: [
+        {
+          track: 'media_buy',
+          status: 'skip',
+          label: 'Media Buy',
+          observations: [],
+          duration_ms: 0,
+          scenarios,
+          skipped_scenarios: [],
+        },
+      ],
+    };
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    const cause = s.skip_causes[0];
+    assert.strictEqual(cause.count, 10, 'count reflects the full population');
+    assert.ok(cause.affected.length <= 5, `affected[] should be capped at 5 (got ${cause.affected.length})`);
+  });
 });
 
 describe('formatComplianceSummaryText — skip causes', () => {


### PR DESCRIPTION
Closes #1623

## Summary

- Adds `skip_causes?: ComplianceSummarySkipCause[]` to `ComplianceSummaryArtifact` (schema-stable v1 extension; unknown-field-ignorable per `schema_version` semantics)
- `buildSkipCauses()` walks `ComplianceResult.tracks[].scenarios[].steps[]` and aggregates actionable skip reasons — `missing_tool`, `missing_test_controller`, `prerequisite_failed`, `unsatisfied_contract`, `no_phases` — sorted by frequency descending
- `missing_tool` entries are further keyed by tool name (extracted from `warnings[0]` prose) so adopters see `missing_tool: sync_accounts` rather than a collapsed `missing_tool` pile
- Text renderer (`formatComplianceSummaryText`) gains an aligned `Skip causes:` block under the Steps line; `Affected:` indent is derived from `countWidth` so it stays aligned at any step-count magnitude
- Markdown renderer (`formatComplianceSummaryMarkdown`) gains a `<details>` skip-causes table for `$GITHUB_STEP_SUMMARY`
- `buildCrashSummary` unchanged — crash-path summaries omit `skip_causes` (runner never reached storyboard execution)
- Internal routing skips (`peer_branch_taken`, `not_applicable`, `probe_skipped`, …) remain filtered; the block only surfaces actionable gaps the adopter can close

## What was tested

- 10 new unit tests across 4 describe blocks added to `test/lib/compliance-summary.test.js` — all 25 tests pass
- `tsc --project tsconfig.lib.json` clean (pre-existing TS5107 deprecation warning only, unrelated to this change)
- Prettier clean

## Pre-PR review

This PR was reviewed by `code-reviewer` and `dx-expert` before being pushed. The hardcoded `Affected:` indent issue they flagged (would misalign at step counts ≥ 100) was fixed in commit `78483e3` prior to push.

---

<!-- triage-managed -->
*Opened by the adcp-client triage agent · session https://claude.ai/code/session_018A5o3LgC2gkQhtUFGbdWuT*

---
_Generated by [Claude Code](https://claude.ai/code/session_018A5o3LgC2gkQhtUFGbdWuT)_