### PR TITLE
feat(storyboard): per-storyboard requires gate + --asserts-seeded-state flag

### DIFF
--- a/.changeset/storyboard-requires-gate.md
+++ b/.changeset/storyboard-requires-gate.md
@@ -1,0 +1,55 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(storyboard): per-storyboard `requires:` gate + `--asserts-seeded-state` flag
+
+Storyboards can now declare runtime requirements at the storyboard level, and the
+runner skips the whole storyboard with a structured `requirement_unmet` skip when
+a required runtime is unavailable — replacing the per-step
+`missing_test_controller` cascade with a single, clearly-attributed skip.
+
+```yaml
+# Storyboard-level tag (additive — omitted is treated as [real_wire])
+requires: [controller]
+```
+
+Recognised requirements:
+- `controller` — agent must advertise `comply_test_controller`. Detected from
+  `options.agentTools`.
+- `seeded_state` — operator must pass `--asserts-seeded-state` declaring that
+  initial state has been provisioned out-of-band (HTTP admin endpoint,
+  pre-test script, staging fixture). The runner does NOT verify the
+  assertion; scenarios still fail naturally if state isn't actually present.
+- `real_wire` — always available; reserved for a future `--mock-only` mode.
+
+Loader rejects unknown requirement names and `requires: []` so authoring
+mistakes fail loud rather than silently dropping coverage.
+
+`requires: [controller]` unmet maps to existing `skip_reason:
+'missing_test_controller'` for back-compat — skip-cause aggregators and
+dashboards keyed on the existing string keep grouping controller-driven
+skips into the same bucket they already track. `requires: [seeded_state]`
+unmet uses the new `requirement_unmet` skip reason. `RunnerSkipResult.requirement`
+carries the unmet requirement name for consumers wanting per-requirement
+granularity.
+
+```
+── Without --asserts-seeded-state ──
+  Steps: 26 passed, 0 failed, 28 skipped
+  Skip causes:
+    [22] missing_test_controller — agent doesn't advertise comply_test_controller
+    [ 6] requirement_unmet: seeded_state — pass --asserts-seeded-state
+```
+
+Migration:
+- SDK-internal storyboard tagging is opt-in. Untagged storyboards keep their
+  existing per-step `missing_test_controller` cascade behavior.
+- Upstream storyboards in `compliance/cache/` are auto-synced from
+  `adcontextprotocol/adcp` and should NOT be tagged locally — tagging will be
+  proposed upstream once the schema has bedded in.
+- Per-step `requires_tool` (#933) is unchanged and still applies for
+  fine-grained per-step gating.
+
+Spec: adcp-client#1626. The schema may be proposed upstream as an additive
+storyboard contract once it has bedded in across SDK adopters.

--- a/.changeset/storyboard-requires-gate.md
+++ b/.changeset/storyboard-requires-gate.md
@@ -1,5 +1,5 @@
 ---
-"@adcp/sdk": minor
+'@adcp/sdk': minor
 ---
 
 feat(storyboard): per-storyboard `requires:` gate + `--asserts-seeded-state` flag
@@ -15,6 +15,7 @@ requires: [controller]
 ```
 
 Recognised requirements:
+
 - `controller` — agent must advertise `comply_test_controller`. Detected from
   `options.agentTools`.
 - `seeded_state` — operator must pass `--asserts-seeded-state` declaring that
@@ -43,6 +44,7 @@ granularity.
 ```
 
 Migration:
+
 - SDK-internal storyboard tagging is opt-in. Untagged storyboards keep their
   existing per-step `missing_test_controller` cascade behavior.
 - Upstream storyboards in `compliance/cache/` are auto-synced from
@@ -51,5 +53,25 @@ Migration:
 - Per-step `requires_tool` (#933) is unchanged and still applies for
   fine-grained per-step gating.
 
+Downstream consumers — `controller` unmet emits BOTH the existing
+`skip_reason: 'missing_test_controller'` AND the new
+`skip.requirement: 'controller'` field on the same skip event. The
+intent is back-compat for skip-cause aggregators keyed on the string
+plus richer per-requirement grouping for new consumers. **Do not
+double-count**: pick one channel. Treat them as the same event seen
+through two lenses, not two separate skips.
+
+`--asserts-seeded-state` is operator-attested with no runner-side
+verification. Trust signals (verified-live badges, scoreboards,
+ecosystem dashboards) MUST NOT consume `requires: [seeded_state]`
+pass results without independent verification — a malicious or
+mistaken operator can flip the flag to widen the graded set without
+the underlying state actually existing. Self-correcting for
+assessment use (scenarios fail naturally if state isn't present),
+but not for trust propagation.
+
 Spec: adcp-client#1626. The schema may be proposed upstream as an additive
-storyboard contract once it has bedded in across SDK adopters.
+storyboard contract once it has bedded in across SDK adopters. If upstream
+picks an `applicable_modes`-style runtime axis instead, `requires` may be
+subsumed by a rename + namespace shift on this SDK-internal field — no
+wire break.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -798,6 +798,14 @@ function parseAgentOptions(args) {
   // makes the production intent explicit on the wire.
   const noSandbox = args.includes('--no-sandbox');
 
+  // `--asserts-seeded-state` declares that the operator has provisioned
+  // initial test state out-of-band (HTTP admin endpoint, pre-test script,
+  // staging fixture). Storyboards declaring `requires: [seeded_state]`
+  // run instead of skipping with `requirement_unmet`. The runner does
+  // NOT verify the assertion; if state is not actually seeded, scenarios
+  // fail naturally on first stateful step. Spec: adcp-client#1626.
+  const assertsSeededState = args.includes('--asserts-seeded-state');
+
   // Webhook-receiver flags are captured here solely so their values are excluded
   // from `positionalArgs`. The authoritative parse lives in
   // `extractWebhookReceiverOptions(args)` which validates and exits on error.
@@ -913,6 +921,7 @@ function parseAgentOptions(args) {
     dryRun,
     allowHttp,
     noSandbox,
+    assertsSeededState,
     positionalArgs,
     localAgent: localAgentValue,
     format: formatValue,
@@ -1443,6 +1452,15 @@ RUN OPTIONS (full assessment):
                       fallbacks, brand-domain heuristics, fixture
                       substitutes). Agents that don't recognize the
                       ext.adcp.disable_sandbox field ignore it.
+  --asserts-seeded-state
+                      Declare that initial test state has been
+                      provisioned out-of-band (HTTP admin, pre-test
+                      script, staging fixture). Storyboards declaring
+                      requires: [seeded_state] grade instead of
+                      skipping with requirement_unmet. The runner does
+                      not verify the assertion — scenarios still fail
+                      naturally if state isn't actually present
+                      (#1626).
   --summary-output PATH
                       Write a narrow, schema-stable summary artifact
                       to PATH (JSON: { schema_version, passed, failed,
@@ -2199,6 +2217,7 @@ async function handleStoryboardRun(args) {
     }),
     ...(webhookReceiverOpts ?? {}),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(mergedRunHeaders && { headers: mergedRunHeaders }),
   };
 
@@ -3028,7 +3047,14 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
     result = await runAgainstLocalAgent({
       createAgent,
       storyboards: storyboardsSpec,
-      ...(opts.noSandbox && { runStoryboardOptions: { sandbox: false, disable_sandbox: true } }),
+      ...(opts.noSandbox || opts.assertsSeededState
+        ? {
+            runStoryboardOptions: {
+              ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+              ...(opts.assertsSeededState && { assertsSeededState: true }),
+            },
+          }
+        : {}),
       onStoryboardComplete:
         jsonOutput || format === 'junit'
           ? undefined
@@ -3365,6 +3391,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...(opts.assertsSeededState && { assertsSeededState: true }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -3623,6 +3650,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     ...(routing.default_agent ? { default_agent: routing.default_agent } : {}),
     ...(webhookReceiverOpts ?? {}),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...(opts.assertsSeededState && { assertsSeededState: true }),
   };
 
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
@@ -3821,6 +3849,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(opts.allowHttp && { allow_http: true }),
     ...(webhookReceiverOpts ?? {}),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
+    ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(mergedAssessmentHeaders && { headers: mergedAssessmentHeaders }),
   };
 

--- a/src/lib/testing/storyboard/loader.ts
+++ b/src/lib/testing/storyboard/loader.ts
@@ -8,7 +8,8 @@
 
 import { readFileSync } from 'fs';
 import { parse } from 'yaml';
-import type { Storyboard } from './types';
+import type { RequirementName, Storyboard } from './types';
+import { KNOWN_REQUIREMENTS } from './types';
 import { MUTATING_TASKS } from '../../utils/idempotency';
 
 /**
@@ -58,6 +59,7 @@ export function loadStoryboardFile(filePath: string): Storyboard {
  * `contributes_to`) and is idempotent on already-validated inputs.
  */
 export function validateStoryboardShape(storyboard: Storyboard): void {
+  validateRequires(storyboard);
   validatePhaseDependsOn(storyboard);
   for (const phase of storyboard.phases) {
     validateBranchSet(storyboard.id, phase);
@@ -108,6 +110,42 @@ function validatePhaseDependsOn(storyboard: Storyboard): void {
       }
     }
     phaseIdsSeen.add(phase.id);
+  }
+}
+
+/**
+ * Authoring-time validation for `Storyboard.requires` (#1626). The field is
+ * a closed enumeration over `RequirementName` so typos and stale tags fail
+ * loud rather than silently dropping coverage:
+ *
+ *   - `requires: []` is rejected — an empty array reads as "no
+ *     requirements," which is the same as omitting the field; failing
+ *     load forces the author to omit it explicitly.
+ *   - Each entry must be a known `RequirementName` (see
+ *     `KNOWN_REQUIREMENTS`). Unknown values fail load with the offending
+ *     name and the full set of recognised values.
+ *
+ * Future SDK versions may grow `KNOWN_REQUIREMENTS`; storyboards built
+ * against an older SDK that name a requirement the runner doesn't know
+ * about would silently skip every run, so we fail-load instead.
+ */
+function validateRequires(storyboard: Storyboard): void {
+  if (storyboard.requires === undefined) return;
+  if (!Array.isArray(storyboard.requires)) {
+    throw new Error(
+      `[${storyboard.id}] requires: must be an array of requirement names (got ${typeof storyboard.requires})`
+    );
+  }
+  if (storyboard.requires.length === 0) {
+    throw new Error(`[${storyboard.id}] requires: [] is not allowed — omit the field to use the default ([real_wire])`);
+  }
+  for (const name of storyboard.requires) {
+    if (typeof name !== 'string' || !KNOWN_REQUIREMENTS.has(name as RequirementName)) {
+      const known = [...KNOWN_REQUIREMENTS].sort().join(', ');
+      throw new Error(
+        `[${storyboard.id}] requires: unknown requirement '${String(name)}' — recognised values are [${known}]`
+      );
+    }
   }
 }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -892,7 +892,7 @@ function buildRequirementUnmetResult(
   const reason = REQUIREMENT_TO_SKIP_REASON[requirement];
   const syntheticStep: StoryboardStepResult = {
     storyboard_id: storyboard.id,
-    step_id: 'requirement_unmet',
+    step_id: `requirement_unmet:${requirement}`,
     phase_id: 'requirement_unmet',
     title: `Storyboard skipped: requires '${requirement}'`,
     task: '',

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -74,6 +74,7 @@ import type {
   RunnerExtractionRecord,
   RunnerRequestRecord,
   RunnerResponseRecord,
+  RequirementName,
   RunnerSkipReason,
   StepAuthDirective,
   Storyboard,
@@ -120,6 +121,8 @@ const SKIP_DETAILS: Record<RunnerSkipReason, string> = {
   missing_test_controller:
     'Skipped: deterministic_testing phase requires comply_test_controller, which the agent did not advertise.',
   unsatisfied_contract: 'Skipped: test-kit contract is out of scope for this grading run.',
+  requirement_unmet:
+    'Skipped: a requires: tag named a runtime requirement that is not available on this run (see RunnerSkipResult.requirement).',
   peer_branch_taken: 'Skipped: a peer branch in the same any_of branch set already contributed the aggregation flag.',
   peer_substituted: 'Skipped: a same-phase peer step established equivalent state via `provides_state_for`.',
 };
@@ -853,6 +856,140 @@ function buildCapabilityUnsupportedResult(
 }
 
 /**
+ * Map a `requires:` requirement onto the canonical `RunnerSkipReason` to
+ * emit when that requirement is unmet. `controller` reuses the existing
+ * `missing_test_controller` value so back-compat consumers (skip-cause
+ * aggregators, dashboards keyed on the existing string) keep grouping
+ * controller-driven skips into the same bucket they already track. Other
+ * requirements use the new `requirement_unmet` reason; consumers that
+ * want per-requirement granularity read `RunnerSkipResult.requirement`.
+ *
+ * Spec: adcp-client#1626 (no-rename design — keep existing skip_reason
+ * values stable as the back-compat surface; add `requirement_unmet` only
+ * for requirement names that have no existing canonical reason).
+ */
+const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
+  controller: 'missing_test_controller',
+  seeded_state: 'requirement_unmet',
+  real_wire: 'requirement_unmet',
+};
+
+/**
+ * Build a minimal StoryboardResult for a storyboard skipped because a
+ * `requires:` tag named a requirement that isn't available on this run
+ * (e.g. `controller` when the agent doesn't advertise
+ * `comply_test_controller`, or `seeded_state` when the operator didn't
+ * pass `--asserts-seeded-state`). Mirrors `buildCapabilityUnsupportedResult`
+ * but carries the structured `requirement` field so consumers can group
+ * not-applicable scenarios by cause. Spec: adcp-client#1626.
+ */
+function buildRequirementUnmetResult(
+  agentUrls: string[],
+  storyboard: Storyboard,
+  requirement: RequirementName,
+  detail: string
+): StoryboardResult {
+  const reason = REQUIREMENT_TO_SKIP_REASON[requirement];
+  const syntheticStep: StoryboardStepResult = {
+    storyboard_id: storyboard.id,
+    step_id: 'requirement_unmet',
+    phase_id: 'requirement_unmet',
+    title: `Storyboard skipped: requires '${requirement}'`,
+    task: '',
+    passed: true,
+    skipped: true,
+    skip_reason: reason,
+    skip: { reason, detail, requirement },
+    duration_ms: 0,
+    validations: [],
+    context: {},
+    extraction: { path: 'none' },
+  };
+  return {
+    storyboard_id: storyboard.id,
+    storyboard_title: storyboard.title,
+    agent_url: agentUrls[0]!,
+    overall_passed: true,
+    phases: [
+      {
+        phase_id: 'requirement_unmet',
+        phase_title: `Requirement unmet: ${requirement}`,
+        passed: true,
+        steps: [syntheticStep],
+        duration_ms: 0,
+      },
+    ],
+    context: {},
+    total_duration_ms: 0,
+    passed_count: 0,
+    failed_count: 0,
+    skipped_count: 1,
+    tested_at: new Date().toISOString(),
+    strict_validation_summary: {
+      observable: false,
+      checked: 0,
+      passed: 0,
+      failed: 0,
+      strict_only_failures: 0,
+      lenient_also_failed: 0,
+    },
+  };
+}
+
+/**
+ * Resolve a storyboard's `requires:` tags against the runtime environment.
+ * Returns the first unmet requirement (with a human-readable detail) or
+ * `null` when every requirement is available. Spec: adcp-client#1626.
+ *
+ * Detection rules:
+ *   - `controller` — agent advertises `comply_test_controller` (read from
+ *     `options.agentTools`). When `options.agentTools` is undefined the
+ *     gate is a no-op — the caller accepted responsibility for tool
+ *     compatibility by reusing an external client.
+ *   - `seeded_state` — operator passed `assertsSeededState: true`
+ *     (CLI: `--asserts-seeded-state`).
+ *   - `real_wire` — always available; the runner is hitting a real wire
+ *     by definition. The tag is a no-op gate today, reserved for a
+ *     future `--mock-only` mode.
+ */
+function checkRequires(
+  requires: readonly RequirementName[],
+  options: StoryboardRunOptions
+): { requirement: RequirementName; detail: string } | null {
+  for (const requirement of requires) {
+    switch (requirement) {
+      case 'controller': {
+        if (!options.agentTools) continue;
+        if (!options.agentTools.includes('comply_test_controller')) {
+          return {
+            requirement,
+            detail:
+              `Storyboard requires 'controller'; agent does not advertise comply_test_controller. ` +
+              `Agent tools: [${options.agentTools.join(', ')}].`,
+          };
+        }
+        break;
+      }
+      case 'seeded_state': {
+        if (options.assertsSeededState !== true) {
+          return {
+            requirement,
+            detail:
+              "Storyboard requires 'seeded_state'; pass --asserts-seeded-state to declare " +
+              'that initial state has been provisioned out-of-band.',
+          };
+        }
+        break;
+      }
+      case 'real_wire':
+        // Always available — reserved for a future --mock-only mode.
+        break;
+    }
+  }
+  return null;
+}
+
+/**
  * Build a hard-failure StoryboardResult for when agent capability
  * discovery (`get_agent_info` / MCP `tools/list`) failed. Surfacing
  * discovery errors as a hard storyboard failure prevents the silent
@@ -1083,6 +1220,21 @@ async function executeStoryboardPass(
       }
     } else {
       profile = options._profile;
+    }
+  }
+
+  // Evaluate `requires` tags before any phase setup. The runner detects
+  // which requirements are available on this run; an unmet requirement
+  // skips the whole storyboard with `requirement_unmet` rather than
+  // producing a cascade of `missing_test_controller` per-step skips.
+  // Spec: adcp-client#1626. The default (no `requires` field) is
+  // `[real_wire]`, which is always available — untagged storyboards
+  // run unchanged.
+  if (storyboard.requires?.length) {
+    const unmet = checkRequires(storyboard.requires, options);
+    if (unmet) {
+      if (!options._client) await closeConnections(options.protocol);
+      return buildRequirementUnmetResult(agentUrls, storyboard, unmet.requirement, unmet.detail);
     }
   }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -32,6 +32,36 @@ export interface Storyboard {
   /** Tools that make this storyboard applicable (at least one must be present) */
   required_tools?: string[];
   /**
+   * Runtime requirements this storyboard depends on. Each name describes
+   * something the runner detects from the agent or from operator-supplied
+   * options; an unmet requirement skips the whole storyboard with
+   * `skip_reason: 'requirement_unmet'` rather than producing a cascade of
+   * misleading per-step `missing_test_controller` skips.
+   *
+   * Recognised names:
+   *   - `controller` — the agent must advertise `comply_test_controller`.
+   *     Detected from `options.agentTools`.
+   *   - `seeded_state` — the operator must pass `--asserts-seeded-state`
+   *     (or set `assertsSeededState: true`) declaring that initial state
+   *     has been provisioned out-of-band (HTTP admin, pre-test script,
+   *     staging fixture). The runner does not verify the assertion;
+   *     scenarios that need state still fail naturally if the seed is
+   *     not actually present.
+   *   - `real_wire` — always available. Tag scenarios that observe
+   *     production behavior with this when you want them excluded from
+   *     a future `--mock-only` mode; today the tag is a no-op gate.
+   *
+   * Default when the field is absent: `[real_wire]` (storyboard runs
+   * everywhere — matches existing pre-tagging behavior). Tagging is
+   * additive opt-in; loader rejects unknown requirement names and an
+   * empty array (`requires: []`) so authoring mistakes fail loud.
+   *
+   * Spec: adcp-client#1626. The schema may be proposed upstream to
+   * `adcontextprotocol/adcp` once it has bedded in across SDK
+   * storyboards.
+   */
+  requires?: RequirementName[];
+  /**
    * Predicate evaluated against the agent's declared capabilities before any
    * phase runs. When the predicate is false, the runner emits a single
    * `{ skipped: true, skip_reason: 'capability_unsupported' }` storyboard
@@ -880,6 +910,17 @@ export interface StoryboardRunOptions extends TestOptions {
    */
   allow_http?: boolean;
   /**
+   * Operator assertion that initial state has been provisioned out-of-band
+   * (HTTP admin, pre-test script, staging fixture) — flips the
+   * `seeded_state` requirement to available so storyboards declaring
+   * `requires: [seeded_state]` run instead of skipping with
+   * `requirement_unmet`. Default false. The runner does NOT verify the
+   * assertion; if state isn't actually seeded the scenario fails
+   * naturally on its first stateful step, which is the right signal.
+   * CLI: `--asserts-seeded-state`. Spec: adcp-client#1626.
+   */
+  assertsSeededState?: boolean;
+  /**
    * Request-signing grader knobs (applied when the runner encounters
    * synthesized `request_signing_probe` steps from the signed-requests
    * specialism).
@@ -1137,6 +1178,16 @@ export type RunnerSkipReason =
   | 'missing_test_controller'
   | 'unsatisfied_contract'
   /**
+   * A storyboard-level `requires:` tag named a requirement that is not
+   * available on the current run (e.g. `controller` when the agent doesn't
+   * advertise `comply_test_controller`, or `seeded_state` when the operator
+   * didn't pass `--asserts-seeded-state`). Distinct from `missing_tool` /
+   * `missing_test_controller` (per-step tool gates) and `unsatisfied_contract`
+   * (capability predicate). The `RunnerSkipResult.requirement` field carries
+   * the unmet requirement name. Spec: adcp-client#1626.
+   */
+  | 'requirement_unmet'
+  /**
    * A peer optional phase in the same `branch_set` already contributed the
    * aggregation flag, so this non-chosen branch's failing steps are moot
    * (see storyboard-schema.yaml > "Per-step grading in any_of branch
@@ -1219,7 +1270,38 @@ export const DETAILED_SKIP_TO_CANONICAL: Record<RunnerDetailedSkipReason, Runner
 export interface RunnerSkipResult {
   reason: RunnerSkipReason;
   detail: string;
+  /**
+   * Set when `reason === 'requirement_unmet'` to name the storyboard-level
+   * requirement that was not available on this run. Carries the same value
+   * authored in `Storyboard.requires`. Consumers (skip-cause aggregation,
+   * dashboards) key on this field to group not-applicable scenarios by
+   * cause. Absent for every other skip reason. Spec: adcp-client#1626.
+   */
+  requirement?: RequirementName;
 }
+
+/**
+ * Recognised values for `Storyboard.requires`. See `Storyboard.requires`
+ * for what each name detects from. Adding a new value here is a wire
+ * surface change; coordinate with the upstream spec proposal before
+ * extending.
+ *
+ * Spec: adcp-client#1626.
+ */
+export type RequirementName = 'controller' | 'seeded_state' | 'real_wire';
+
+/**
+ * Closed enumeration of every known requirement. Used by the loader to
+ * reject typos in `Storyboard.requires` (`requires: [contoller]` fails
+ * load rather than silently dropping coverage) and by the runner to
+ * compute available requirements for the gate. Keep in sync with
+ * `RequirementName`.
+ */
+export const KNOWN_REQUIREMENTS: ReadonlySet<RequirementName> = new Set([
+  'controller',
+  'seeded_state',
+  'real_wire',
+] as const satisfies readonly RequirementName[]);
 
 /**
  * Machine-readable Zod/AJV-style validation error. Emitted in

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -40,7 +40,15 @@ export interface Storyboard {
    *
    * Recognised names:
    *   - `controller` — the agent must advertise `comply_test_controller`.
-   *     Detected from `options.agentTools`.
+   *     Detected from `options.agentTools`. Callers reusing an external
+   *     client without supplying `agentTools` (the `_client`-without-tools
+   *     escape hatch — same shape as the `required_tools` gate) bypass
+   *     this check; their storyboard runs into the per-step
+   *     `missing_test_controller` cascade instead. The gate degrades
+   *     rather than false-fails — by design — but adopters relying on
+   *     `requires: [controller]` for whole-storyboard skip semantics
+   *     should populate `agentTools` (the standard `comply()` path
+   *     always does).
    *   - `seeded_state` — the operator must pass `--asserts-seeded-state`
    *     (or set `assertsSeededState: true`) declaring that initial state
    *     has been provisioned out-of-band (HTTP admin, pre-test script,

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -1,0 +1,258 @@
+/**
+ * Tests for the storyboard-level `requires:` gate (adcp-client#1626).
+ *
+ * The gate runs before any phase setup. A storyboard whose `requires` tag
+ * names a runtime requirement that isn't available on this run skips the
+ * whole storyboard with a structured `skip.requirement` field — distinct
+ * from the per-step `requires_tool` cascade that today produces a chain of
+ * `missing_test_controller` skips.
+ *
+ * Uses `_profile` injection so the tests run without the schema cache; the
+ * gate fires before any phase or network call.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboard } = require('../../dist/lib/testing/storyboard/index.js');
+const { parseStoryboard, validateStoryboardShape } = require('../../dist/lib/testing/storyboard/loader.js');
+
+function buildStoryboard(overrides = {}) {
+  return {
+    id: 'requires_gate_test',
+    version: '1.0.0',
+    title: 'requires gate test',
+    category: 'test',
+    summary: 'Skipped when a requires tag is unmet.',
+    narrative: '',
+    agent: { interaction_model: 'sync', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'p1',
+        title: 'Phase 1',
+        steps: [
+          {
+            id: 'step1',
+            title: 'A trivial read',
+            task: 'get_products',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+const profileWithoutController = {
+  name: 'Test Agent (no controller)',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: {},
+};
+
+const profileWithController = {
+  name: 'Test Agent (controller present)',
+  tools: ['get_adcp_capabilities', 'get_products', 'comply_test_controller'],
+  raw_capabilities: {},
+};
+
+describe('Storyboard.requires gate (#1626)', () => {
+  test('requires: [controller] skips with missing_test_controller when agent lacks it', async () => {
+    const sb = buildStoryboard({ requires: ['controller'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    assert.equal(result.overall_passed, true, 'requires-unmet is not a failure');
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.passed_count, 0);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(
+      step.skip_reason,
+      'missing_test_controller',
+      'controller maps to existing missing_test_controller skip_reason for back-compat'
+    );
+    assert.ok(step.skip, 'structured skip block present');
+    assert.equal(step.skip.reason, 'missing_test_controller');
+    assert.equal(step.skip.requirement, 'controller', 'requirement field carries the unmet requirement name');
+    assert.match(step.skip.detail, /comply_test_controller/);
+  });
+
+  test('requires: [controller] runs storyboard normally when agent advertises it', async () => {
+    const sb = buildStoryboard({ requires: ['controller'] });
+    // The synthetic phase has no executable wire calls; we only need to
+    // observe that the gate did NOT short-circuit. Discovery would have
+    // failed on the fake URL otherwise.
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithController,
+      agentTools: profileWithController.tools,
+    });
+
+    // The gate passed — phases ran. The single phase fails on transport
+    // (fake URL), but that's a separate signal: the synthetic
+    // requirement_unmet phase is NOT present.
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(!phaseIds.includes('requirement_unmet'), 'gate must not synthesize requirement_unmet phase');
+  });
+
+  test('requires: [seeded_state] skips with requirement_unmet when flag absent', async () => {
+    const sb = buildStoryboard({ requires: ['seeded_state'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip_reason, 'requirement_unmet', 'seeded_state uses the new requirement_unmet skip_reason');
+    assert.equal(step.skip.reason, 'requirement_unmet');
+    assert.equal(step.skip.requirement, 'seeded_state');
+    assert.match(step.skip.detail, /--asserts-seeded-state/);
+  });
+
+  test('requires: [seeded_state] passes when assertsSeededState: true', async () => {
+    const sb = buildStoryboard({ requires: ['seeded_state'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+      assertsSeededState: true,
+    });
+
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(!phaseIds.includes('requirement_unmet'), 'flag flips seeded_state to available');
+  });
+
+  test('requires: [real_wire] is always available (no-op gate)', async () => {
+    const sb = buildStoryboard({ requires: ['real_wire'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(!phaseIds.includes('requirement_unmet'), 'real_wire never blocks');
+  });
+
+  test('multiple requires: first unmet wins', async () => {
+    // Both controller and seeded_state are unmet; the gate reports the
+    // first one in the array order, not a synthesized aggregate.
+    const sb = buildStoryboard({ requires: ['controller', 'seeded_state'] });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip.requirement, 'controller', 'first unmet requirement is reported');
+  });
+});
+
+describe('Storyboard.requires loader validation (#1626)', () => {
+  test('rejects empty requires: []', () => {
+    const yaml = `
+id: bad_empty
+version: "1.0.0"
+title: empty requires
+category: test
+summary: ""
+narrative: ""
+requires: []
+agent:
+  interaction_model: sync
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: p1
+    title: P
+    steps: []
+`;
+    assert.throws(() => parseStoryboard(yaml), /requires: \[\] is not allowed/);
+  });
+
+  test('rejects unknown requirement names', () => {
+    const yaml = `
+id: bad_unknown
+version: "1.0.0"
+title: bad name
+category: test
+summary: ""
+narrative: ""
+requires: [contoller]
+agent:
+  interaction_model: sync
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: p1
+    title: P
+    steps: []
+`;
+    assert.throws(() => parseStoryboard(yaml), /unknown requirement 'contoller'/);
+  });
+
+  test('rejects non-array requires', () => {
+    const sb = {
+      id: 'bad_shape',
+      version: '1.0.0',
+      title: 'bad shape',
+      category: 'test',
+      summary: '',
+      narrative: '',
+      requires: 'controller', // string, not array
+      agent: { interaction_model: 'sync', capabilities: [] },
+      caller: { role: 'buyer_agent' },
+      phases: [{ id: 'p1', title: 'P', steps: [] }],
+    };
+    assert.throws(() => validateStoryboardShape(sb), /requires: must be an array/);
+  });
+
+  test('accepts known requirement names', () => {
+    const yaml = `
+id: ok_known
+version: "1.0.0"
+title: known names
+category: test
+summary: ""
+narrative: ""
+requires: [controller, seeded_state, real_wire]
+agent:
+  interaction_model: sync
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: p1
+    title: P
+    steps: []
+`;
+    const parsed = parseStoryboard(yaml);
+    assert.deepEqual(parsed.requires, ['controller', 'seeded_state', 'real_wire']);
+  });
+
+  test('omitted requires field parses fine (default behavior)', () => {
+    const yaml = `
+id: ok_omitted
+version: "1.0.0"
+title: no requires
+category: test
+summary: ""
+narrative: ""
+agent:
+  interaction_model: sync
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: p1
+    title: P
+    steps: []
+`;
+    const parsed = parseStoryboard(yaml);
+    assert.equal(parsed.requires, undefined);
+  });
+});


### PR DESCRIPTION
## Summary

Implements adcp-client#1626 — per-storyboard `requires:` runtime requirements with a structured skip reason and a `--asserts-seeded-state` operator flag.

Storyboards now declare their runtime requirements at the storyboard level. When a required runtime isn't available on the run, the runner emits a single, clearly-attributed skip with a structured `RunnerSkipResult.requirement` field — replacing the per-step `missing_test_controller` cascade with one whole-storyboard skip.

```yaml
requires: [controller]   # storyboard skips when agent doesn't advertise comply_test_controller
requires: [seeded_state] # storyboard skips unless --asserts-seeded-state is passed
requires: [real_wire]    # always available; reserved for a future --mock-only mode
```

## Design

Per the design discussion in #1626 (comments) and locked-in via @bokelley sign-off:

| Concept | Decision |
|---|---|
| Mode framing (`controlled-test` / `live-sandbox` / `controlled-other`) | **dropped** — replaced by per-scenario `requires` (Alt A) |
| Renaming `missing_test_controller` | **no rename** — `requires: [controller]` unmet maps to existing skip_reason for back-compat |
| New skip reason | `requirement_unmet` — used only for new requirement names without a canonical reason (e.g. `seeded_state`) |
| Unknown / empty requires | fail-load at parse time (no silent coverage drops) |
| Operator assertion | single flag `--asserts-seeded-state`; default off; runner does not verify |
| Anti-gaming | `controller` is agent-declared (via capability); `seeded_state` only makes scenarios run *more*, scenarios fail naturally if asserted state isn't seeded |
| Cross-language | `requires` lives in YAML + runner; agent never sees it |
| Default when absent | `[real_wire]` — untagged storyboards behave unchanged |

## Surface

- `Storyboard.requires?: RequirementName[]` (storyboard-level tag)
- `RequirementName = 'controller' | 'seeded_state' | 'real_wire'`
- `KNOWN_REQUIREMENTS` exported set for runtime/loader checks
- `RunnerSkipReason` extended with additive `'requirement_unmet'`
- `RunnerSkipResult.requirement?: RequirementName`
- `StoryboardRunOptions.assertsSeededState?: boolean`
- CLI: `--asserts-seeded-state` flag (threaded through every `runOptions`-building site)

## Migration

- SDK-internal storyboard tagging is opt-in. Untagged storyboards keep the existing per-step `missing_test_controller` cascade behavior.
- Upstream storyboards in `compliance/cache/` are auto-synced from `adcontextprotocol/adcp` and intentionally **not** tagged in this PR — tagging will be proposed upstream once the schema has bedded in across SDK adopters.
- Per-step `requires_tool` (#933) is unchanged and still applies for fine-grained per-step gating.

## Skip-cause aggregation follow-up (#1623 / PR #1629)

`requires: [controller]` unmet emits `missing_test_controller` so PR #1629's existing `ACTIONABLE_SKIP_REASONS` set picks it up unchanged. `requires: [seeded_state]` emits the new `requirement_unmet` reason; folding it into the skip-cause aggregator is a separate follow-up tracked as adcp-client#1626 task 8.

## Test plan

- [x] 11 new tests in `test/lib/storyboard-requires-gate.test.js`:
  - `requires: [controller]` skips with `missing_test_controller` (back-compat) when agent lacks it
  - `requires: [controller]` runs storyboard normally when agent advertises it
  - `requires: [seeded_state]` skips with `requirement_unmet` when flag absent
  - `requires: [seeded_state]` passes when `assertsSeededState: true`
  - `requires: [real_wire]` always available (no-op gate)
  - Multiple requirements: first unmet wins
  - Loader rejects `requires: []`
  - Loader rejects unknown requirement names
  - Loader rejects non-array requires
  - Loader accepts known names + omitted field
- [x] 1600/1600 existing storyboard tests pass (regression smoke)
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [ ] Manual smoke against a live agent with / without `comply_test_controller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)