### PR TITLE
fix(a2a): sign tasks/cancel POST against signed-requests sellers (#1617 Phase 2)

### DIFF
--- a/.changeset/fix-1617-phase2-cancel-signing.md
+++ b/.changeset/fix-1617-phase2-cancel-signing.md
@@ -1,0 +1,42 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(a2a): sign tasks/cancel POST against signed-requests sellers (#1617 Phase 2)
+
+Phase 1 (`@adcp/sdk@6.16.0`) sent the A2A `tasks/cancel` POST unsigned —
+documented limitation. A `signed-requests` seller that enforces signing on
+the cancel path would 401 it, defeating the orphan-prevention goal of
+cancel-on-abort.
+
+`cancelA2ATask` now takes the full `AgentConfig` and, when
+`agent.request_signing` is configured, routes the cancel POST through
+`createSigningFetch` (inline keys) or `createSigningFetchAsync` (provider
+keys). The signing wrapper is rebuilt per cancel rather than replayed from
+`signingContextStorage` — that ALS scope is set around `callA2AToolImpl`
+and doesn't extend into `pollTaskCompletion`'s sibling promise tree, so
+capture-and-replay isn't viable. Rebuilding from `agent.request_signing`
+is equivalent: that's the same source of truth `buildAgentSigningContext`
+reads from at submission time.
+
+**Bypass `buildAgentSigningFetch`'s capability gate**: that path consults
+the seller's `request_signing.supported_for` to decide whether to sign,
+but `tasks/cancel` is an A2A protocol method, not an AdCP tool. Sellers
+typically list AdCP tool names there, not protocol-level methods. The
+shape that matches actual seller behavior: if the agent claims signing
+at all, sign every mutating POST we send. Sellers with uniform "must be
+signed" policies accept this; sellers that only check signing on specific
+AdCP tools simply ignore the extra signature.
+
+**Test fixture**: in-process loopback HTTP server runs the SDK's own
+`verifyRequestSignature` against incoming `tasks/cancel` POSTs (mirrors
+what a real signed-requests seller does at the verifier seam). Three
+tests: signed-and-accepted, unsigned-still-works (regression guard for
+agents without `request_signing`), and bearer-still-attached-on-signed.
+
+Upstream `adcp#4314` requests test-agent add per-session strict-mode
+header opt-in so we can also exercise this against the production
+fixture once that lands.
+
+**API change**: `cancelA2ATask(agentUrl, taskId, authToken)` →
+`cancelA2ATask(agent, taskId)`. Internal helper; no public API impact.

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1442,7 +1442,10 @@ export class TaskExecutor {
         // async settlement path.
         if (agent.protocol === 'a2a' && taskId && agent.agent_uri) {
           try {
-            void cancelA2ATask(agent.agent_uri, taskId, getAuthToken(agent)).catch(() => {
+            // adcp-client#1617 Phase 2: pass the full agent so cancelA2ATask
+            // can sign the POST when agent.request_signing is configured.
+            // signed-requests sellers no longer 401 the cancel.
+            void cancelA2ATask(agent, taskId).catch(() => {
               /* see SECURITY note above */
             });
           } catch {

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -160,6 +160,14 @@ export async function cancelA2ATask(agent: AgentConfig, taskId: string): Promise
   // we send to it on the cancel path. Sellers with uniform "must be
   // signed" policies accept this; sellers that only check signing on
   // specific AdCP tools simply ignore the extra signature.
+  //
+  // TODO(adcp#4318, adcp-client#1617): when the AdCP spec adds explicit
+  // verifier coverage for A2A protocol methods (likely in 3.1 as a new
+  // `protocol_methods_supported_for` / `protocol_methods_required_for`
+  // field on `request_signing`), narrow this default by reading the
+  // seller's advertised coverage from `getCapability()` and gating on
+  // the `tasks/cancel` membership. The over-sign default stays as the
+  // fallback for spec-silent sellers (3.0.x and earlier).
   if (agent.request_signing) {
     const upstream: FetchLike = (input, ini) => fetch(input as RequestInfo, ini);
     if (isInlineSigningConfig(agent.request_signing)) {

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -12,7 +12,7 @@ import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
 import { toSignerKey, isInlineSigningConfig, isProviderSigningConfig } from '../signing/agent-fetch';
-import { createSigningFetch } from '../signing/fetch';
+import { createSigningFetch, type FetchLike } from '../signing/fetch';
 import { createSigningFetchAsync } from '../signing/fetch-async';
 import type { AgentConfig } from '../types/adcp';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
@@ -108,6 +108,15 @@ const CANCEL_TIMEOUT_MS = 5000;
  * @param taskId    The server-assigned A2A Task.id to cancel.
  */
 export async function cancelA2ATask(agent: AgentConfig, taskId: string): Promise<void> {
+  // Defense-in-depth (ad-tech-protocol-expert review of #1640): the cancel
+  // POST is JSON-RPC at the bare A2A endpoint. Calling this on an MCP agent
+  // would POST `tasks/cancel` JSON-RPC at an MCP endpoint and 404. The
+  // single call site (`pollTaskCompletion`) already gates on
+  // `agent.protocol === 'a2a'`; this assertion catches future call sites
+  // that forget the gate.
+  if (agent.protocol !== 'a2a') {
+    return;
+  }
   const agentUrl = agent.agent_uri;
   const authToken = agent.auth_token;
 
@@ -152,20 +161,14 @@ export async function cancelA2ATask(agent: AgentConfig, taskId: string): Promise
   // signed" policies accept this; sellers that only check signing on
   // specific AdCP tools simply ignore the extra signature.
   if (agent.request_signing) {
-    const upstream = (input: string, ini?: RequestInit) => fetch(input, ini) as unknown as Promise<Response>;
+    const upstream: FetchLike = (input, ini) => fetch(input as RequestInfo, ini);
     if (isInlineSigningConfig(agent.request_signing)) {
-      const signed = createSigningFetch(
-        upstream as Parameters<typeof createSigningFetch>[0],
-        toSignerKey(agent.request_signing)
-      );
+      const signed = createSigningFetch(upstream, toSignerKey(agent.request_signing));
       await signed(agentUrl, init);
       return;
     }
     if (isProviderSigningConfig(agent.request_signing)) {
-      const signed = createSigningFetchAsync(
-        upstream as Parameters<typeof createSigningFetchAsync>[0],
-        agent.request_signing.provider
-      );
+      const signed = createSigningFetchAsync(upstream, agent.request_signing.provider);
       await signed(agentUrl, init);
       return;
     }

--- a/src/lib/protocols/a2a.ts
+++ b/src/lib/protocols/a2a.ts
@@ -11,6 +11,10 @@ import { discoverOAuthMetadata } from '../auth/oauth/discovery';
 import { withSpan, injectTraceHeaders } from '../observability/tracing';
 import { isAgentCardPath, buildCardUrls } from '../utils/a2a-discovery';
 import { buildAgentSigningFetch, signingContextStorage, type AgentSigningContext } from '../signing/client';
+import { toSignerKey, isInlineSigningConfig, isProviderSigningConfig } from '../signing/agent-fetch';
+import { createSigningFetch } from '../signing/fetch';
+import { createSigningFetchAsync } from '../signing/fetch-async';
+import type { AgentConfig } from '../types/adcp';
 import { redactIdempotencyKeyInArgs } from '../utils/idempotency';
 import { wrapFetchWithCapture } from './rawResponseCapture';
 import { wrapFetchWithSizeLimit } from './responseSizeLimit';
@@ -84,24 +88,29 @@ const CANCEL_TIMEOUT_MS = 5000;
  * accessible here). Cancel calls to those sellers go out unauthenticated and
  * will likely 401 non-fatally.
  *
- * **Signing gap (Phase 1 known limitation):** `signed-requests` sellers
- * verify signatures on mutating operations including `tasks/cancel`. The
- * `signingContextStorage` ALS scope is set up around `callA2AToolImpl`, NOT
- * around `pollTaskCompletion` — those are sibling execution contexts in the
- * runner's promise tree, so `getStore()` returns `undefined` here. Phase 1
- * cancel calls go unsigned for signed-requests sellers and will 401
- * non-fatally. Phase 2 (tracked under #1617) wires explicit context capture
- * at task-submission time and replays it here via `signingContextStorage.run()`.
+ * **Phase 2 (adcp-client#1617 follow-up):** when `agent.request_signing` is
+ * configured, the cancel POST is signed with the agent's signer key. The
+ * `signingContextStorage` ALS scope around `callA2AToolImpl` does NOT extend
+ * into `pollTaskCompletion` (sibling promise trees), so we can't replay the
+ * captured ALS context — instead we rebuild a one-shot signer fetch from
+ * `agent.request_signing` directly and use it for this single POST. Inline
+ * keys go through `createSigningFetch` (sync); provider-backed configs use
+ * `createSigningFetchAsync`. A `signed-requests` seller that requires
+ * signing on `tasks/cancel` (or applies a uniform "all mutating POSTs must
+ * be signed" policy) now accepts the cancel; one without signing config on
+ * the agent gets the Phase 1 unsigned path.
  *
  * The caller is responsible for swallowing errors: cancel failure
  * (TaskNotCancelable, network error, auth rejection, network timeout) is
  * non-fatal because the buyer is already abandoning the task.
  *
- * @param agentUrl  The A2A agent endpoint URL (agent.agent_uri).
+ * @param agent     The agent config (used for URL, auth token, signing).
  * @param taskId    The server-assigned A2A Task.id to cancel.
- * @param authToken Bearer token for the seller, if available.
  */
-export async function cancelA2ATask(agentUrl: string, taskId: string, authToken: string | undefined): Promise<void> {
+export async function cancelA2ATask(agent: AgentConfig, taskId: string): Promise<void> {
+  const agentUrl = agent.agent_uri;
+  const authToken = agent.auth_token;
+
   const headers: Record<string, string> = {
     'content-type': 'application/json',
     accept: 'application/json',
@@ -126,12 +135,43 @@ export async function cancelA2ATask(agentUrl: string, taskId: string, authToken:
   // Bound the cancel: a hung fetch would orphan-pin the event loop past the
   // buyer's abort, defeating fire-and-forget. AbortSignal.timeout() is the
   // standard primitive; the caller's `.catch()` swallows the AbortError.
-  await fetch(agentUrl, {
+  const init: RequestInit = {
     method: 'POST',
     headers,
     body,
     signal: AbortSignal.timeout(CANCEL_TIMEOUT_MS),
-  });
+  };
+
+  // adcp-client#1617 Phase 2: sign the cancel POST when the agent has a
+  // signer configured. We bypass the `buildAgentSigningFetch` capability-
+  // gate path because `tasks/cancel` is an A2A protocol method, not an
+  // AdCP tool — the seller's `request_signing.supported_for` typically
+  // lists AdCP tool names, not protocol-level methods. The right model
+  // here: if the agent claims signing AT ALL, sign every mutating POST
+  // we send to it on the cancel path. Sellers with uniform "must be
+  // signed" policies accept this; sellers that only check signing on
+  // specific AdCP tools simply ignore the extra signature.
+  if (agent.request_signing) {
+    const upstream = (input: string, ini?: RequestInit) => fetch(input, ini) as unknown as Promise<Response>;
+    if (isInlineSigningConfig(agent.request_signing)) {
+      const signed = createSigningFetch(
+        upstream as Parameters<typeof createSigningFetch>[0],
+        toSignerKey(agent.request_signing)
+      );
+      await signed(agentUrl, init);
+      return;
+    }
+    if (isProviderSigningConfig(agent.request_signing)) {
+      const signed = createSigningFetchAsync(
+        upstream as Parameters<typeof createSigningFetchAsync>[0],
+        agent.request_signing.provider
+      );
+      await signed(agentUrl, init);
+      return;
+    }
+  }
+
+  await fetch(agentUrl, init);
 }
 
 async function getOrCreateA2AClient(

--- a/src/lib/signing/fetch.ts
+++ b/src/lib/signing/fetch.ts
@@ -14,7 +14,12 @@ export interface SigningFetchOptions extends Omit<SignRequestOptions, 'coverCont
   coverContentDigest?: boolean | CoverContentDigestPredicate;
 }
 
-type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+/**
+ * Minimal fetch shape that the signing wrappers compose around. Exported
+ * so external call sites (`src/lib/protocols/a2a.ts:cancelA2ATask`) can
+ * type their upstream wrapper without resorting to casts.
+ */
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
 /**
  * Header names whose wire values are produced by the signer itself. Any

--- a/test/lib/cancel-a2a-task-signing.test.js
+++ b/test/lib/cancel-a2a-task-signing.test.js
@@ -1,0 +1,238 @@
+/**
+ * Phase 2 cancel-signing tests for adcp-client#1617.
+ *
+ * Phase 1 sent the A2A `tasks/cancel` POST unsigned. A `signed-requests`
+ * seller that enforces signing on the cancel path would 401 it, defeating
+ * the orphan-prevention goal of cancel-on-abort. Phase 2 signs the POST
+ * when `agent.request_signing` is configured.
+ *
+ * Test fixture: a minimal HTTP server that runs the SDK's own
+ * `verifyRequestSignature` against incoming `tasks/cancel` POSTs. Returns
+ * 200 on valid signature, 401 on missing/invalid. Mirrors what a real
+ * signed-requests seller does at the verifier seam.
+ *
+ * upstream issue adcp#4314 asks test-agent to add a per-session strict-mode
+ * header so we can also exercise this against the production fixture once
+ * that lands. Until then, this in-process fixture covers the regression
+ * surface.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+
+const { cancelA2ATask } = require('../../dist/lib/protocols/a2a.js');
+const { verifyRequestSignature } = require('../../dist/lib/signing/verifier.js');
+const {
+  StaticJwksResolver,
+  InMemoryReplayStore,
+  InMemoryRevocationStore,
+} = require('../../dist/lib/signing/server.js');
+
+// Reuse the compliance cache's ed25519 test keypair — same one
+// `server-auto-signed-requests.test.js` exercises end-to-end.
+const KEYS_PATH = path.join(
+  __dirname,
+  '..',
+  '..',
+  'compliance',
+  'cache',
+  'latest',
+  'test-vectors',
+  'request-signing',
+  'keys.json'
+);
+const keys = JSON.parse(readFileSync(KEYS_PATH, 'utf8')).keys;
+const edRaw = keys.find(k => k.kid === 'test-ed25519-2026');
+const edPublic = { ...edRaw };
+delete edPublic._private_d_for_test_only;
+delete edPublic.d;
+const edPrivateJwk = { ...edRaw, d: edRaw._private_d_for_test_only };
+delete edPrivateJwk._private_d_for_test_only;
+delete edPrivateJwk.key_ops;
+delete edPrivateJwk.use;
+
+/**
+ * Minimal A2A-shaped seller that requires signing on the cancel POST.
+ * Runs `verifyRequestSignature` from the SDK against incoming requests
+ * and rejects unsigned / invalid-signed POSTs with 401. Records each
+ * request so tests can assert the wire shape.
+ */
+function startStrictSigningSeller() {
+  const requests = [];
+  const jwks = new StaticJwksResolver([edPublic]);
+  const replayStore = new InMemoryReplayStore({ maxEntriesPerKeyid: 100 });
+  const revocationStore = new InMemoryRevocationStore({
+    issuer: 'http://test-strict-seller',
+    updated: new Date().toISOString(),
+    next_update: new Date(Date.now() + 3600_000).toISOString(),
+    revoked_kids: [],
+    revoked_jtis: [],
+  });
+
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const chunks = [];
+      req.on('data', c => chunks.push(c));
+      req.on('end', async () => {
+        const body = Buffer.concat(chunks).toString('utf8');
+        const headers = {};
+        for (const [k, v] of Object.entries(req.headers)) {
+          headers[k.toLowerCase()] = Array.isArray(v) ? v[0] : v;
+        }
+        // Inferred URL — tests construct against the loopback server's URL.
+        const url = `http://127.0.0.1:${server.address().port}${req.url}`;
+        requests.push({ method: req.method, url, headers, body });
+
+        try {
+          const result = await verifyRequestSignature({
+            method: req.method,
+            url,
+            headers,
+            body,
+            jwks,
+            replayStore,
+            revocationStore,
+          });
+          if (!result.verified) {
+            res.writeHead(401, { 'content-type': 'application/json' });
+            res.end(
+              JSON.stringify({ error: 'signature_required', detail: result.reason ?? 'missing or invalid signature' })
+            );
+            return;
+          }
+          // Accept the cancel — return a synthetic success body. Phase 2
+          // doesn't care about the response shape; cancel is fire-and-forget.
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: JSON.parse(body).id,
+              result: { id: 'task-id', status: { state: 'canceled' } },
+            })
+          );
+        } catch (err) {
+          res.writeHead(401, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: 'verifier_error', detail: err?.message }));
+        }
+      });
+    });
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        url: `http://127.0.0.1:${server.address().port}/`,
+        requests,
+        close: () => new Promise(r => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe('cancelA2ATask: Phase 2 signing (#1617)', () => {
+  test('signs the cancel POST when agent.request_signing is configured (inline ed25519)', async () => {
+    const seller = await startStrictSigningSeller();
+    try {
+      const agent = {
+        id: 'test',
+        name: 'Test Strict Seller',
+        agent_uri: seller.url,
+        protocol: 'a2a',
+        auth_token: 'test-bearer',
+        request_signing: {
+          kind: 'inline',
+          alg: 'ed25519',
+          kid: edRaw.kid,
+          private_key: edPrivateJwk,
+        },
+      };
+
+      await cancelA2ATask(agent, 'task-being-cancelled');
+
+      assert.strictEqual(seller.requests.length, 1, 'cancel POST should hit the seller exactly once');
+      const req = seller.requests[0];
+      assert.ok(req.headers['signature'], 'Signature header MUST be present (Phase 2 fix)');
+      assert.ok(req.headers['signature-input'], 'Signature-Input header MUST be present');
+      // Verifier inside the test server already checks the signature is valid;
+      // reaching the verified branch (=> the test server returns 200) means
+      // the cancel was accepted. No assertion on response body — cancel is
+      // fire-and-forget at the buyer side.
+    } finally {
+      await seller.close();
+    }
+  });
+
+  test('Phase 1 unsigned path still works when agent has no request_signing (regression guard)', async () => {
+    // Tiny accept-anything seller — confirms Phase 1 behavior is preserved
+    // when the agent is unsigned.
+    const requests = [];
+    const server = await new Promise(resolve => {
+      const s = http.createServer((req, res) => {
+        const chunks = [];
+        req.on('data', c => chunks.push(c));
+        req.on('end', () => {
+          requests.push({ headers: req.headers, body: Buffer.concat(chunks).toString('utf8') });
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end('{"jsonrpc":"2.0","id":"x","result":{"id":"task","status":{"state":"canceled"}}}');
+        });
+      });
+      s.listen(0, '127.0.0.1', () =>
+        resolve({ url: `http://127.0.0.1:${s.address().port}/`, close: () => new Promise(r => s.close(() => r())) })
+      );
+    });
+    try {
+      const agent = {
+        id: 'test',
+        name: 'Test Unsigned Seller',
+        agent_uri: server.url,
+        protocol: 'a2a',
+        auth_token: 'test-bearer',
+        // No request_signing — Phase 1 unsigned path
+      };
+
+      await cancelA2ATask(agent, 'task-being-cancelled');
+
+      assert.strictEqual(requests.length, 1);
+      assert.strictEqual(
+        requests[0].headers['signature'],
+        undefined,
+        'Unsigned agent should NOT send a Signature header'
+      );
+      assert.strictEqual(requests[0].headers['signature-input'], undefined);
+      assert.ok(requests[0].headers['authorization'], 'Bearer auth still attached');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('signed cancel includes the auth bearer alongside the signature', async () => {
+    // Confirms the bearer header is still attached on the signed path
+    // (signing wraps the existing fetch, doesn't replace auth headers).
+    const seller = await startStrictSigningSeller();
+    try {
+      const agent = {
+        id: 'test',
+        name: 'Test Strict Seller',
+        agent_uri: seller.url,
+        protocol: 'a2a',
+        auth_token: 'phase2-bearer',
+        request_signing: {
+          kind: 'inline',
+          alg: 'ed25519',
+          kid: edRaw.kid,
+          private_key: edPrivateJwk,
+        },
+      };
+
+      await cancelA2ATask(agent, 'task-x');
+
+      assert.strictEqual(seller.requests.length, 1);
+      const req = seller.requests[0];
+      assert.strictEqual(req.headers['authorization'], 'Bearer phase2-bearer');
+      assert.strictEqual(req.headers['x-adcp-auth'], 'phase2-bearer');
+      assert.ok(req.headers['signature'], 'signed AND authenticated');
+    } finally {
+      await seller.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes the Phase 2 follow-up from #1617. Phase 1 (6.16.0) sent the A2A `tasks/cancel` POST unsigned — documented limitation. A `signed-requests` seller that enforces signing on the cancel path would 401 it, defeating the orphan-prevention goal of cancel-on-abort.

## Change

`cancelA2ATask(agentUrl, taskId, authToken)` → `cancelA2ATask(agent, taskId)`. When `agent.request_signing` is configured, routes the cancel POST through `createSigningFetch` (inline keys) or `createSigningFetchAsync` (provider keys). When unset, falls through to the unsigned Phase 1 path.

## Why rebuild signer per cancel (not replay ALS)

`signingContextStorage` is set around `callA2AToolImpl` and doesn't extend into `pollTaskCompletion`'s sibling promise tree, so capture-and-replay isn't viable from the cancel call site. Rebuilding from `agent.request_signing` is equivalent — that's the same source of truth `buildAgentSigningContext` reads at submission time, and the agent's signer key is the right primitive to grab here.

## Why bypass `buildAgentSigningFetch`'s capability gate

That path consults `request_signing.supported_for` to decide whether to sign, but `tasks/cancel` is an A2A 0.3.0 §7.4 protocol method, not an AdCP tool. Sellers typically list AdCP tool names in `supported_for` (test-agent's 28 entries are all AdCP tool names — none of them `tasks/cancel`). Real-world sellers either (a) check signing on every mutating POST uniformly at the HTTP layer, or (b) only check on specific AdCP tools. Behavior the buyer wants in both cases: if the agent claims signing at all, sign the cancel.

## Test fixture

In-process loopback HTTP server runs the SDK's own `verifyRequestSignature` against incoming `tasks/cancel` POSTs. Mirrors what a real signed-requests seller does at the verifier seam. Three tests:

1. **Signed and accepted** — the Phase 2 fix. Verifier inside the test server returns 200 → cancel succeeds.
2. **Unsigned regression guard** — agent without `request_signing` still goes through the Phase 1 unsigned path; no Signature headers attached.
3. **Bearer + signature coexistence** — confirms `Authorization: Bearer` and `x-adcp-auth` stay on the signed path (signing wraps the auth-injecting fetch, doesn't replace it).

## Upstream coordination

Filed [`adcontextprotocol/adcp#4314`](https://github.com/adcontextprotocol/adcp/issues/4314) asking test-agent to add a per-session strict-mode header (`X-Test-Require-Signing`). Once that lands, an integration test can exercise this fix against the production fixture too. Until then, this in-process fixture covers the regression surface.

## API change

`cancelA2ATask` is an internal helper. The single call site (`TaskExecutor.pollTaskCompletion`) is updated; no public API impact.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run format:check` — clean
- [x] New `cancel-a2a-task-signing.test.js`: 3/3 pass
- [x] Full suite: 8401/8449 pass (1 known order-dependent flake in `server-a2a-adapter`, passes in isolation)
- [ ] Expert review (security-reviewer + ad-tech-protocol-expert) — to be triggered after this PR opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)