### PR TITLE
feat(comply): account-discovery spec-conformance gate (#1624)

### DIFF
--- a/.changeset/account-discovery-gate.md
+++ b/.changeset/account-discovery-gate.md
@@ -1,0 +1,56 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(comply): account-discovery spec-conformance gate (#1624)
+
+Closes #1624. AdCP 3.0.9 §accounts/overview (per
+[adcp#4302](https://github.com/adcontextprotocol/adcp/issues/4302)) makes
+explicit a long-standing protocol invariant: every seller agent MUST
+expose at least one of `list_accounts` or `sync_accounts`. The compliance
+runner now enforces this universally — if an agent declares any
+account-bearing specialism (`sales-*`, `audience-sync`, `governance-*`)
+but advertises neither tool, the run produces a structured failure
+distinct from per-step `missing_tool` skips.
+
+Previously the runner skipped each affected scenario individually with
+`overall_passed: true`, letting spec-noncompliant agents pass with a
+green `STORYBOARD-OK` despite missing protocol-required capabilities.
+
+```
+── Without account-discovery tools ──
+  Steps:     X passed, 1 failed, Y skipped
+  STORYBOARD-FAIL 1 step(s):
+    - __spec_conformance__/account_discovery/list_or_sync_accounts [core]:
+        Agent declared account-bearing specialism(s) [sales-guaranteed]
+        but advertises neither list_accounts nor sync_accounts.
+        AdCP 3.0.9 §accounts/overview requires every seller agent to
+        expose at least one of these tools.
+```
+
+The gate fires before track grouping and produces a synthetic
+`StoryboardResult` with stable storyboard ID
+`__spec_conformance__/account_discovery` — dashboards / badges can grep
+for it. The synthetic result flows through the existing failure
+extraction, summary aggregation, and skip-cause pipelines unchanged
+(failures, not skips, so it appears in the failures list rather than the
+skip-cause block).
+
+The gate is a no-op when:
+- Agent doesn't expose `get_adcp_capabilities` (specialisms unknown — a
+  separate observation already surfaces the missing capability call;
+  we don't double-report)
+- Agent declares no account-bearing specialism (signals-only, brand-
+  rights-only, creative-only adopters are unaffected)
+- Agent already advertises `list_accounts` or `sync_accounts`
+
+Will migrate to a per-storyboard `required_any_of_tools` tag once
+[adcp#4325](https://github.com/adcontextprotocol/adcp/issues/4325) lands
+in AdCP 3.1 — see [#1642](https://github.com/adcontextprotocol/adcp-client/issues/1642)
+for the migration checklist. Today's runner-level gate covers the same
+spec invariant against the auto-synced cache without requiring upstream
+schema changes.
+
+Tests: 11 new tests covering pass/fail/no-op cases for every
+account-bearing specialism family (`sales-*`, `audience-sync`,
+`governance-*`) and exempt agent shapes (signals, creative).

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -13,6 +13,7 @@ import type { TestOptions, TestResult, AgentProfile } from '../types';
 import { mapStoryboardResultsToTrackResult, TRACK_LABELS } from './storyboard-tracks';
 import { runStoryboard } from '../storyboard/runner';
 import { validateTestKit } from '../storyboard/test-kit';
+import { checkAccountDiscoveryGate } from './spec-conformance';
 
 // Side-effect import: registers default assertion stubs for invariant ids that
 // upstream storyboards (e.g., `universal/idempotency.yaml` after adcp#2639)
@@ -940,6 +941,17 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     // major_versions.
     for (const na of notApplicable) {
       storyboardResults.push(buildNotApplicableStoryboardResult(agentUrl, na));
+    }
+
+    // Cross-storyboard spec-conformance gates. Push synthetic StoryboardResults
+    // for protocol-level invariants the AdCP spec mandates regardless of which
+    // specialism is being tested. Currently wires the universal account-discovery
+    // gate (adcp-client#1624 / adcp#4302; AdCP 3.0.9 §accounts/overview).
+    // Will migrate to per-storyboard `required_any_of_tools` tags once
+    // adcp#4325 lands; tracked in #1642.
+    const accountDiscoveryFailure = checkAccountDiscoveryGate(profile, agentUrl);
+    if (accountDiscoveryFailure) {
+      storyboardResults.push(accountDiscoveryFailure);
     }
 
     // Group results by track and build TrackResults

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -612,12 +612,31 @@ function groupByTrack(
 
   const grouped = new Map<ComplianceTrack, StoryboardResult[]>();
   for (const result of results) {
-    const track = trackLookup.get(result.storyboard_id);
+    // Synthetic spec-conformance gate results (adcp-client#1624 / #1642)
+    // aren't in `applicableStoryboards`, so they have no track in the
+    // lookup. Route them to `core` so their failures contribute to
+    // `tracks_failed` and `overall_status` flips to `failing` — without
+    // this, the gate hits `failures[]` but the run-level verdict stays
+    // green, masking the spec-noncompliance the gate is supposed to surface.
+    const track = trackLookup.get(result.storyboard_id) ?? specConformanceTrack(result.storyboard_id);
     if (!track) continue;
     if (!grouped.has(track)) grouped.set(track, []);
     grouped.get(track)!.push(result);
   }
   return grouped;
+}
+
+/**
+ * Map a synthetic spec-conformance storyboard ID (`__spec_conformance__/*`)
+ * to a real `ComplianceTrack` so it lands in the track rollup.
+ * Currently routes every spec-conformance gate to `core` — these are
+ * protocol-level invariants, not specialism-specific. Returns `undefined`
+ * for non-synthetic IDs so legitimate-but-unmapped storyboards are still
+ * dropped (the existing fail-loud-on-unknown contract).
+ */
+function specConformanceTrack(storyboardId: string): ComplianceTrack | undefined {
+  if (storyboardId.startsWith('__spec_conformance__/')) return 'core';
+  return undefined;
 }
 
 /**
@@ -964,6 +983,10 @@ async function complyImpl(agentUrl: string, options: ComplyOptions): Promise<Com
     for (const sb of applicableStoryboards) {
       if (sb.track) poolTrackSet.add(sb.track as ComplianceTrack);
     }
+    // Synthetic spec-conformance gates always land in `core`; ensure `core`
+    // is in the pool so its track row renders even when the run targeted a
+    // non-core specialism bundle that excluded universal storyboards.
+    if (accountDiscoveryFailure) poolTrackSet.add('core');
     for (const na of notApplicable) {
       if (na.track) poolTrackSet.add(na.track as ComplianceTrack);
     }

--- a/src/lib/testing/compliance/spec-conformance.ts
+++ b/src/lib/testing/compliance/spec-conformance.ts
@@ -1,0 +1,122 @@
+/**
+ * Cross-storyboard spec conformance gates.
+ *
+ * Some AdCP rules are universal (apply to any seller agent regardless of
+ * which specialism they're testing) rather than per-storyboard. Encoding
+ * them as per-storyboard `required_tools` predicates would mean tagging
+ * every relevant scenario, and the rule would still drift for adopters
+ * authoring third-party storyboards.
+ *
+ * This module emits synthetic `StoryboardResult`s for those rules — the
+ * comply orchestrator pushes them into the storyboard-results array
+ * before track grouping. Pipeline downstream (failure extraction, track
+ * mapping, summary, skip-cause aggregator) treats them as any other
+ * storyboard result.
+ *
+ * Currently wires one gate:
+ *
+ * - **Account discovery (adcp-client#1624 / adcp#4302).** Every seller
+ *   agent (any specialism in `sales-*` / `audience-sync` / `governance-*`)
+ *   MUST advertise at least one of `list_accounts` or `sync_accounts`.
+ *   Spec normative as of AdCP 3.0.9; the requirement existed before the
+ *   explicit MUST landed. Will migrate to a per-storyboard
+ *   `required_any_of_tools` tag once adcp#4325 lands (see #1642).
+ */
+
+import type { AgentProfile } from '../types';
+import type { StoryboardResult } from '../storyboard/types';
+
+/**
+ * Synthetic storyboard ID emitted when the account-discovery gate fails.
+ * Stable across releases — dashboards / badges can grep for it. Distinct
+ * from any real storyboard ID; the gate runs cross-storyboard.
+ */
+export const ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID = '__spec_conformance__/account_discovery';
+
+/**
+ * Specialisms that operate on accounts and therefore require the agent
+ * to expose `list_accounts` OR `sync_accounts`. Per AdCP 3.0.9
+ * `accounts/overview.mdx`. Adopters claiming any of these specialisms
+ * without an account-discovery tool are non-conformant.
+ *
+ * Match rules: `sales-*` prefix, exact `audience-sync`, `governance-*`
+ * prefix.
+ */
+function isAccountBearingSpecialism(specialism: string): boolean {
+  if (specialism.startsWith('sales-')) return true;
+  if (specialism === 'audience-sync') return true;
+  if (specialism.startsWith('governance-')) return true;
+  return false;
+}
+
+/**
+ * Run the account-discovery conformance gate. Returns `null` when the
+ * gate doesn't apply (agent declared no account-bearing specialism,
+ * couldn't enumerate specialisms, or already advertises a discovery
+ * tool). Returns a synthetic failing `StoryboardResult` when the agent
+ * is non-conformant.
+ *
+ * The returned result has:
+ * - `overall_passed: false` so it counts toward `failed` in summaries
+ * - one synthetic phase + step that surfaces the specific specialism(s)
+ *   triggering the gate so operators can act
+ * - `track` is left unset on the synthetic id; `extractFailures` falls
+ *   back to `'core'` for any storyboard not in the applicable-storyboards
+ *   lookup, which is correct — account discovery is a core protocol
+ *   invariant, not a specialism-specific concern
+ *
+ * Note: when the agent doesn't expose `get_adcp_capabilities` (so
+ * `profile.specialisms` is undefined), the gate is a no-op. The runner
+ * separately surfaces an observation about the missing capability call;
+ * we don't double-report.
+ */
+export function checkAccountDiscoveryGate(profile: AgentProfile, agentUrl: string): StoryboardResult | null {
+  const accountBearing = (profile.specialisms ?? []).filter(isAccountBearingSpecialism);
+  if (accountBearing.length === 0) return null;
+
+  if (profile.tools.includes('list_accounts') || profile.tools.includes('sync_accounts')) {
+    return null;
+  }
+
+  const now = new Date().toISOString();
+  const detail =
+    `Agent declared account-bearing specialism(s) [${accountBearing.join(', ')}] but advertises ` +
+    `neither list_accounts nor sync_accounts. AdCP 3.0.9 §accounts/overview requires every seller ` +
+    `agent to expose at least one of these tools. Agent tools: [${profile.tools.join(', ')}].`;
+
+  return {
+    storyboard_id: ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID,
+    storyboard_title: 'Spec conformance: account discovery',
+    agent_url: agentUrl,
+    overall_passed: false,
+    phases: [
+      {
+        phase_id: 'account_discovery_gate',
+        phase_title: 'Account discovery',
+        passed: false,
+        duration_ms: 0,
+        steps: [
+          {
+            storyboard_id: ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID,
+            step_id: 'list_or_sync_accounts',
+            phase_id: 'account_discovery_gate',
+            title: 'Seller agent must advertise list_accounts or sync_accounts',
+            task: '',
+            passed: false,
+            duration_ms: 0,
+            validations: [],
+            context: {},
+            error: detail,
+            extraction: { path: 'none' },
+          },
+        ],
+      },
+    ],
+    context: {},
+    total_duration_ms: 0,
+    passed_count: 0,
+    failed_count: 1,
+    skipped_count: 0,
+    tested_at: now,
+  };
+}

--- a/src/lib/testing/compliance/spec-conformance.ts
+++ b/src/lib/testing/compliance/spec-conformance.ts
@@ -39,13 +39,27 @@ export const ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID = '__spec_conformance__/accoun
  * `accounts/overview.mdx`. Adopters claiming any of these specialisms
  * without an account-discovery tool are non-conformant.
  *
- * Match rules: `sales-*` prefix, exact `audience-sync`, `governance-*`
- * prefix.
+ * Match rules:
+ *   - `sales-*` prefix — every selling specialism operates on accounts.
+ *   - exact `audience-sync` — audiences belong to accounts.
+ *   - `governance-*` prefix — governance applies per-account.
+ *   - exact `creative-generative` — dual-role specialism. A generative
+ *     seller (selling inventory + generating creatives) is an account-
+ *     bearing adopter even if they only claim `creative-generative`,
+ *     not a `sales-*` specialism. The upstream storyboard at
+ *     `compliance/cache/<v>/specialisms/creative-generative/generative-seller.yaml`
+ *     exercises `sync_accounts` directly, confirming this scope.
+ *
+ * Other creative specialisms (`creative-ad-server`, `creative-template`)
+ * are stand-alone — those agents don't sell inventory and don't need
+ * account discovery. Same for `signal-*`, `brand-rights`,
+ * `signed-requests`.
  */
 function isAccountBearingSpecialism(specialism: string): boolean {
   if (specialism.startsWith('sales-')) return true;
   if (specialism === 'audience-sync') return true;
   if (specialism.startsWith('governance-')) return true;
+  if (specialism === 'creative-generative') return true;
   return false;
 }
 
@@ -69,6 +83,11 @@ function isAccountBearingSpecialism(specialism: string): boolean {
  * `profile.specialisms` is undefined), the gate is a no-op. The runner
  * separately surfaces an observation about the missing capability call;
  * we don't double-report.
+ *
+ * TODO(adcp-client#1642): once adcp#4325's `required_any_of_tools` schema
+ * lands in AdCP 3.1, migrate this gate to consume the per-storyboard tag
+ * for richer attribution. Delete this synthesis path when migration is
+ * complete and upstream storyboards in `compliance/cache/` carry the tag.
  */
 export function checkAccountDiscoveryGate(profile: AgentProfile, agentUrl: string): StoryboardResult | null {
   const accountBearing = (profile.specialisms ?? []).filter(isAccountBearingSpecialism);

--- a/test/lib/spec-conformance-account-discovery.test.js
+++ b/test/lib/spec-conformance-account-discovery.test.js
@@ -1,0 +1,159 @@
+/**
+ * Tests for the account-discovery spec-conformance gate (#1624 / adcp#4302).
+ *
+ * AdCP 3.0.9 §accounts/overview: every seller agent (any specialism in
+ * `sales-*`, `audience-sync`, `governance-*`) MUST advertise at least one
+ * of `list_accounts` or `sync_accounts`.
+ *
+ * The gate emits a synthetic failing StoryboardResult that flows through
+ * the existing track-grouping / failure-extraction / summary pipeline.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  checkAccountDiscoveryGate,
+  ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID,
+} = require('../../dist/lib/testing/compliance/spec-conformance.js');
+
+function profile(overrides = {}) {
+  return {
+    name: 'Test Agent',
+    tools: [],
+    specialisms: [],
+    ...overrides,
+  };
+}
+
+describe('checkAccountDiscoveryGate (#1624)', () => {
+  test('seller missing both account-discovery tools → hard fail', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['sales-guaranteed'],
+        tools: ['get_adcp_capabilities', 'get_products', 'create_media_buy'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.ok(result, 'gate should fire');
+    assert.equal(result.overall_passed, false, 'gate failure must not green-light the run');
+    assert.equal(result.failed_count, 1);
+    assert.equal(result.skipped_count, 0);
+    assert.equal(result.storyboard_id, ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.passed, false);
+    assert.notEqual(step.skipped, true, 'fail, not skip — distinct from missing_tool');
+    assert.match(step.error, /list_accounts/);
+    assert.match(step.error, /sync_accounts/);
+    assert.match(step.error, /sales-guaranteed/, 'error names the triggering specialism');
+    assert.match(step.error, /AdCP 3\.0\.9/, 'error cites spec version');
+  });
+
+  test('seller with list_accounts only → gate does not fire', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['sales-guaranteed'],
+        tools: ['get_adcp_capabilities', 'get_products', 'list_accounts'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.equal(result, null);
+  });
+
+  test('seller with sync_accounts only → gate does not fire', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['sales-non-guaranteed'],
+        tools: ['get_adcp_capabilities', 'create_media_buy', 'sync_accounts'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.equal(result, null);
+  });
+
+  test('audience-sync specialism without account tools → fail', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['audience-sync'],
+        tools: ['get_adcp_capabilities', 'sync_audiences'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.ok(result);
+    assert.match(result.phases[0].steps[0].error, /audience-sync/);
+  });
+
+  test('governance specialism without account tools → fail', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['governance-spend-authority'],
+        tools: ['get_adcp_capabilities', 'sync_governance'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.ok(result);
+    assert.match(result.phases[0].steps[0].error, /governance-spend-authority/);
+  });
+
+  test('signal-only agent (no account-bearing specialism) → gate does not fire', () => {
+    // Signal agents don't operate on accounts; the spec rule doesn't apply.
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['signal-marketplace'],
+        tools: ['get_adcp_capabilities', 'get_signals', 'activate_signal'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.equal(result, null);
+  });
+
+  test('creative-only agent → gate does not fire', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['creative-template'],
+        tools: ['get_adcp_capabilities', 'list_creative_formats', 'build_creative'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.equal(result, null);
+  });
+
+  test('agent without get_adcp_capabilities (specialisms unknown) → gate is no-op', () => {
+    // When the agent doesn't expose get_adcp_capabilities, profile.specialisms
+    // is undefined. The gate has nothing to check against. Comply already
+    // surfaces a separate observation about the missing capability — we don't
+    // double-report.
+    const result = checkAccountDiscoveryGate(
+      profile({ specialisms: undefined, tools: ['get_products'] }),
+      'https://agent.example/mcp'
+    );
+    assert.equal(result, null);
+  });
+
+  test('agent declares no specialisms → gate is no-op', () => {
+    const result = checkAccountDiscoveryGate(profile({ specialisms: [], tools: [] }), 'https://agent.example/mcp');
+    assert.equal(result, null);
+  });
+
+  test('multi-specialism seller — all account-bearing specialisms appear in error', () => {
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['sales-guaranteed', 'audience-sync', 'governance-aware-seller', 'signal-owned'],
+        tools: ['get_adcp_capabilities'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.ok(result);
+    const error = result.phases[0].steps[0].error;
+    assert.match(error, /sales-guaranteed/);
+    assert.match(error, /audience-sync/);
+    assert.match(error, /governance-aware-seller/);
+    // signal-owned is NOT account-bearing — should not appear
+    assert.doesNotMatch(error, /signal-owned/);
+  });
+
+  test('synthetic storyboard ID is stable for dashboard greps', () => {
+    assert.equal(ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID, '__spec_conformance__/account_discovery');
+  });
+});

--- a/test/lib/spec-conformance-account-discovery.test.js
+++ b/test/lib/spec-conformance-account-discovery.test.js
@@ -156,4 +156,69 @@ describe('checkAccountDiscoveryGate (#1624)', () => {
   test('synthetic storyboard ID is stable for dashboard greps', () => {
     assert.equal(ACCOUNT_DISCOVERY_GATE_STORYBOARD_ID, '__spec_conformance__/account_discovery');
   });
+
+  test('creative-generative without account tools → fail (dual-role generative seller)', () => {
+    // adcp-client#1624 review (ad-tech-protocol-expert): the
+    // creative-generative specialism is dual-role per CLAUDE.md skill index
+    // — an adopter selling inventory AND generating creatives may claim
+    // creative-generative without a sales-* specialism. The upstream
+    // storyboard exercises sync_accounts directly. Treating
+    // creative-generative as account-bearing closes that gap.
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['creative-generative'],
+        tools: ['get_adcp_capabilities', 'build_creative'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.ok(result);
+    assert.match(result.phases[0].steps[0].error, /creative-generative/);
+  });
+
+  test('creative-template (stand-alone creative) → gate does not fire', () => {
+    // Other creative specialisms are stand-alone, no account discovery needed.
+    const result = checkAccountDiscoveryGate(
+      profile({
+        specialisms: ['creative-template'],
+        tools: ['get_adcp_capabilities', 'list_creative_formats', 'build_creative'],
+      }),
+      'https://agent.example/mcp'
+    );
+    assert.equal(result, null);
+  });
+});
+
+describe('account-discovery gate routes synthetic result to core track (#1624 review fix)', () => {
+  // Code-reviewer flagged: groupByTrack drops storyboards whose IDs aren't in
+  // applicableStoryboards. Without the routing fix, the gate would push a
+  // failure into result.failures[] but tracks_failed would never increment,
+  // computeOverallStatus would return 'passing', and the run would exit 0 —
+  // exactly the silent-conformance bug the gate is supposed to close.
+  // This test pins the wiring fix.
+
+  const { mapStoryboardResultsToTrackResult } = require('../../dist/lib/testing/compliance/storyboard-tracks.js');
+
+  test('synthetic result routed to core via groupByTrack flips track to fail', () => {
+    // We simulate the groupByTrack output by treating a one-result core group
+    // as the input to mapStoryboardResultsToTrackResult — exactly what
+    // comply.ts does for any track with results. The track must end up with
+    // status 'fail' so computeOverallStatus sees tracks_failed > 0.
+    const failure = checkAccountDiscoveryGate(
+      profile({ specialisms: ['sales-guaranteed'], tools: ['get_adcp_capabilities'] }),
+      'https://agent.example/mcp'
+    );
+    assert.ok(failure, 'gate must fire for this fixture');
+
+    const trackResult = mapStoryboardResultsToTrackResult('core', [failure], profile());
+    assert.equal(trackResult.track, 'core');
+    assert.equal(
+      trackResult.status,
+      'fail',
+      `synthetic gate result must produce a failing core track (got '${trackResult.status}')`
+    );
+    // Sanity: the underlying scenarios array carries the failure so downstream
+    // observation collectors / failure summaries see it.
+    const failedSteps = trackResult.scenarios.flatMap(s => s.steps.filter(st => !st.passed));
+    assert.equal(failedSteps.length, 1, 'one failed step from the synthetic gate');
+  });
 });


### PR DESCRIPTION
## Summary

Closes adcp-client#1624. AdCP 3.0.9 §accounts/overview (per [adcp#4302](https://github.com/adcontextprotocol/adcp/issues/4302), filed earlier today and shipped in v3.0.9) makes explicit a universal invariant: every seller agent MUST expose at least one of `list_accounts` or `sync_accounts`.

The compliance runner now enforces this. Previously, agents declaring `sales-*` / `audience-sync` / `governance-*` specialisms but advertising neither tool would skip each affected scenario individually with `overall_passed: true` and pass with a green `STORYBOARD-OK` — exactly the silent-conformance bug #1624 reported.

## Architecture

**Path B from the design discussion.** The 3.0.9 spec rule is universal (every seller, regardless of which storyboard runs), so the gate is implemented as a *cross-storyboard* runner check, not a per-storyboard tag. Synthetic `StoryboardResult` with stable ID `__spec_conformance__/account_discovery` is injected into the run array before track grouping; the existing failure extraction / summary / skip-cause aggregator pipelines handle it as any other storyboard result.

**Path A is the upstream future.** Filed [adcp#4325](https://github.com/adcontextprotocol/adcp/issues/4325) proposing a per-storyboard `required_any_of_tools` schema tag for AdCP 3.1. When that lands, this gate will migrate to consume the per-storyboard tag for richer attribution. Migration tracked in [#1642](https://github.com/adcontextprotocol/adcp-client/issues/1642).

## When the gate fires / no-ops

| Agent shape | Gate behavior |
|---|---|
| Seller specialism + neither tool | **Fails** with `__spec_conformance__/account_discovery` failure |
| Seller specialism + `list_accounts` or `sync_accounts` | No-op |
| No `get_adcp_capabilities` (specialisms unknown) | No-op (separate observation already covers this) |
| Signals-only / creative-only / brand-rights agent | No-op (rule doesn't apply) |
| No specialism declared | No-op |

## Test plan

- [x] 11 new tests in `test/lib/spec-conformance-account-discovery.test.js`:
  - Seller missing both tools → hard fail with structured detail (specialism + tool list + spec citation)
  - Seller with `list_accounts` only → no-op
  - Seller with `sync_accounts` only → no-op
  - `audience-sync` without account tools → fail
  - `governance-*` without account tools → fail
  - Signal-only agent → no-op
  - Creative-only agent → no-op
  - No `get_adcp_capabilities` → no-op
  - Empty specialisms → no-op
  - Multi-specialism: only account-bearing ones surface in the error
  - Synthetic storyboard ID is stable
- [x] 167+ existing tests pass (regression smoke covers `comply.ts` orchestrator changes, summary aggregation, storyboard runner contract, completeness)
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean

## Related

- adcp-client#1624 (this issue)
- adcontextprotocol/adcp#4302 (upstream spec amendment, shipped in v3.0.9)
- adcontextprotocol/adcp#4325 (proposed per-storyboard tag for 3.1)
- adcp-client#1642 (migration tracker)
- adcp-client#1626 / #1635 (sibling work: `Storyboard.requires` runtime gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)