### PR TITLE
fix(comply): forward AbortSignal into runWithDegradedProfile runOptions

### DIFF
--- a/.changeset/runWithDegradedProfile-signal-forward.md
+++ b/.changeset/runWithDegradedProfile-signal-forward.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(comply): forward AbortSignal into `runWithDegradedProfile` `runOptions`
+
+`complyImpl` already threads its combined timeout/external `AbortSignal` into the `StoryboardRunOptions` it hands to `runStoryboard()` (so `executeStoryboardPass` can bail at the next phase/step boundary). The auth-degraded fallback path (`runWithDegradedProfile`) checked the signal _between_ storyboards but never forwarded it into the runner's options — a single degraded storyboard could still consume the entire timeout budget without firing mid-storyboard. Closes the gap left by #1612 / completes #1615.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -1186,6 +1186,7 @@ async function runWithDegradedProfile(
     agentTools: [],
     ...(options.webhook_receiver !== undefined && { webhook_receiver: options.webhook_receiver }),
     ...(options.contracts !== undefined && { contracts: options.contracts }),
+    ...(signal !== undefined && { signal }),
   };
 
   for (const sb of storyboards) {


### PR DESCRIPTION
Closes the residual gap left by #1612 (so we can close stale draft #1615).

## What

`complyImpl` already threads its combined timeout/external `AbortSignal` into the `StoryboardRunOptions` it hands to `runStoryboard()` — that lets `executeStoryboardPass` bail at the next phase/step boundary inside a long-running storyboard. The auth-degraded fallback path (`runWithDegradedProfile`) checked the signal *between* storyboards (line 1192) but never forwarded it into the runner's options. A single degraded storyboard could still consume the entire timeout budget without firing mid-storyboard.

One-line fix: spread `signal` into the `runOptions` object the same way `complyImpl` does.

## Why this isn't just rebasing #1615

Most of #1615's work shipped in #1612 (added `signal` field to `StoryboardRunOptions`, threaded it from `complyImpl`, added `throwIfAborted` checks at phase/step boundaries in `executeStoryboardPass`). #1615's branch is hundreds of commits behind main and conflicts on every file it touches. The `runWithDegradedProfile` forward was the only contribution that didn't land — extracted here as a clean patch. #1615 will be closed as superseded.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [ ] CI green (Test & Build, changeset check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)