### PR TITLE
fix(storyboard): proposal-mode enricher respects fixture's explicit packages

### DIFF
--- a/.changeset/proposal-mode-respect-explicit-packages.md
+++ b/.changeset/proposal-mode-respect-explicit-packages.md
@@ -1,0 +1,23 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(storyboard): proposal-mode enricher respects fixture's explicit `packages` over auto-captured `context.proposal_id`
+
+PR #1603 introduced proposal-mode in the `create_media_buy` request enricher by reading `context.proposal_id`. `context.proposal_id` is auto-captured by `context.ts::get_products()` from any prior `get_products` response that returned `proposals[0].proposal_id` — which is essentially every brief flow against a seller that supports proposal-mode discovery.
+
+The enricher fell back to `context.proposal_id` whenever the fixture didn't explicitly set `proposal_id`. That meant a storyboard authoring `packages` directly in `sample_request` would still have its packages dropped in favor of the auto-captured proposal — forcing every sales storyboard whose brief returned proposals through the seller's strict proposal-lifecycle validation.
+
+Concrete impact (surfaced when consuming sellers like `test-agent.adcontextprotocol.org` that enforce proposal-status / IO-acceptance / total_budget rules on `proposal_id`-shaped requests): `sales_guaranteed`, `sales_non_guaranteed`, `schema_validation`, `media_buy_seller/*`, `creative_generative/seller`, and similar package-mode storyboards regressed below their step floors with `PROPOSAL_NOT_COMMITTED` errors.
+
+Fix: the enricher now reads `context.proposal_id` only when the fixture authors NEITHER `proposal_id` NOR `packages`. Fixture intent wins:
+
+| Fixture                                  | Mode chosen      |
+|------------------------------------------|------------------|
+| `proposal_id` set                        | proposal-mode    |
+| `packages` set, no `proposal_id`         | package-mode (was: incorrectly proposal-mode via context fallback) |
+| neither                                  | proposal-mode if `context.proposal_id` set; otherwise package-mode |
+
+Tests added for all four cases; existing `hello_seller_adapter_proposal_mode` integration coverage continues to pass (proposal-mode storyboards explicitly author `proposal_id`).
+
+Patch-eligible per the additive-fix rule: behavior aligns with the original PR #1603 intent (proposal-mode for proposal-mode storyboards), only narrows the over-applied fallback that was masking the proposal-validation path entirely.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -325,7 +325,18 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
     // would carry through unexpanded mustache strings.
     const fixtureBody = omitEnvelopeFields(fixture);
 
-    const proposalId: unknown = fixture.proposal_id !== undefined ? fixture.proposal_id : context.proposal_id;
+    // Proposal-mode applies only when the storyboard's fixture explicitly
+    // names a `proposal_id`. `context.proposal_id` is auto-captured from
+    // any prior `get_products` response that returned `proposals[0]` (see
+    // context.ts), which is essentially every brief flow — using it as a
+    // fallback would override a fixture's explicit `packages` direction
+    // and force every sales storyboard through proposal-mode validation,
+    // including ones that intentionally exercise package-mode (sales-
+    // guaranteed, schema_validation, media_buy_seller/*). Fixture is the
+    // storyboard author's intent; respect it.
+    const fixtureHasPackages = Array.isArray(fixture.packages) && (fixture.packages as unknown[]).length > 0;
+    const proposalId: unknown =
+      fixture.proposal_id !== undefined ? fixture.proposal_id : fixtureHasPackages ? undefined : context.proposal_id;
     if (typeof proposalId === 'string') {
       const { packages: _droppedPackages, ...fixtureWithoutPackages } = fixtureBody;
       return {

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -251,6 +251,99 @@ describe('Request Builder', () => {
       );
     });
 
+    test('respects fixture packages over auto-captured context.proposal_id (#1603 follow-up)', () => {
+      // Regression: PR #1603 introduced proposal-mode in the create_media_buy
+      // enricher by reading `context.proposal_id` (auto-captured from any
+      // prior `get_products` response in `context.ts`). When the fixture
+      // explicitly authors `packages` and no `proposal_id`, the enricher
+      // was over-applying proposal-mode — dropping the fixture's packages
+      // and forcing every sales storyboard whose brief returned proposals
+      // through the seller's strict proposal-lifecycle validation. That
+      // broke sales-guaranteed, schema_validation, media_buy_seller/* and
+      // every other storyboard that author `packages` directly.
+      //
+      // Fixture is the storyboard author's intent; respect it. Proposal-
+      // mode applies only when the fixture explicitly names `proposal_id`
+      // (with `total_budget`, no `packages`).
+      const context = {
+        proposal_id: 'autocaptured_proposal_from_brief',
+        products: [
+          {
+            product_id: 'p1',
+            pricing_options: [{ pricing_option_id: 'opt', pricing_model: 'cpm' }],
+          },
+        ],
+      };
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          end_time: FUTURE_END,
+          packages: [{ product_id: 'p1', budget: 5000, pricing_option_id: 'opt' }],
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.ok(Array.isArray(result.packages), 'packages preserved on the wire');
+      assert.strictEqual(result.packages.length, 1, 'exactly one package — fixture intent honored');
+      assert.strictEqual(result.proposal_id, undefined, 'no proposal_id on the wire (fixture has packages)');
+    });
+
+    test('proposal-mode still fires when fixture explicitly authors proposal_id', () => {
+      // The complement of the above test — sales_proposal_mode and
+      // media_buy_seller/proposal_finalize storyboards author proposal_id
+      // explicitly. Those still take the proposal-mode branch.
+      const context = {};
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          end_time: FUTURE_END,
+          proposal_id: 'balanced_reach_q2',
+          total_budget: { amount: 50000, currency: 'USD' },
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.proposal_id, 'balanced_reach_q2', 'proposal-mode branch taken');
+      assert.deepStrictEqual(result.total_budget, { amount: 50000, currency: 'USD' });
+      assert.strictEqual(result.packages, undefined, 'packages omitted in proposal-mode');
+    });
+
+    test('proposal-mode resolves $context.proposal_id reference from fixture', () => {
+      // sample_request can carry `proposal_id: "$context.proposal_id"`
+      // (proposal_finalize storyboard pattern) — the $context substitution
+      // happens before this enricher runs, so by the time we check
+      // fixture.proposal_id, it's the resolved string.
+      const context = { proposal_id: 'committed_proposal_xyz' };
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          end_time: FUTURE_END,
+          proposal_id: '$context.proposal_id',
+          total_budget: { amount: 10000, currency: 'USD' },
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.proposal_id, 'committed_proposal_xyz');
+      assert.strictEqual(result.packages, undefined);
+    });
+
+    test('falls back to context.proposal_id only when fixture has neither proposal_id nor packages', () => {
+      // The narrow case PR #1603 originally targeted: an under-specified
+      // fixture (no proposal_id, no packages) on a storyboard that ran a
+      // brief/refine/finalize sequence beforehand. The enricher uses the
+      // captured proposal_id rather than synthesizing packages.
+      const context = { proposal_id: 'finalized_proposal' };
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          end_time: FUTURE_END,
+          total_budget: { amount: 25000, currency: 'USD' },
+          // No packages, no proposal_id — fall through to context.
+        },
+      });
+      const result = buildRequest(s, context, DEFAULT_OPTIONS);
+      assert.strictEqual(result.proposal_id, 'finalized_proposal', 'context fallback fires');
+      assert.strictEqual(result.packages, undefined);
+    });
+
     test('empty fixture package object {} falls back to discovery cleanly', () => {
       // Some storyboards ship `packages: [{}]` for defaults-only scenarios
       // where every field should come from discovery / enricher synthesis.


### PR DESCRIPTION
## Summary

Follow-up to [PR #1603](https://github.com/adcontextprotocol/adcp-client/pull/1603), which introduced proposal-mode in the `create_media_buy` request enricher by reading `context.proposal_id`. \`context.ts::get_products()\` auto-captures \`proposals[0].proposal_id\` from any \`get_products\` response that returned \`proposals\` — essentially every brief flow against a seller that supports proposal-mode discovery.

The enricher fell back to \`context.proposal_id\` whenever the fixture didn't explicitly set \`proposal_id\`. That meant a storyboard authoring \`packages\` directly in \`sample_request\` would have its packages dropped in favor of the auto-captured proposal — forcing every sales storyboard whose brief returned proposals through the seller's strict proposal-lifecycle validation.

## Concrete impact

Surfaced when consuming sellers like \`test-agent.adcontextprotocol.org\` that enforce proposal-status / IO-acceptance / total_budget rules on \`proposal_id\`-shaped requests. With this branch's SDK packed locally and consumed by the test-agent's storyboard matrix:

| Tenant            | Before fix (SDK 6.18.0) | After fix |
|-------------------|-------------------------|-----------|
| /signals          | ✓ 67 / 58               | ✓ 67 / 58 |
| /sales            | ✗ 50 / 198 _(17 storyboards regressed)_ | ✓ 65 / 254 _(2 remain — pre-existing storyboard authoring issues, see below)_ |
| /governance       | ✓ 65 / 102              | ✓ 65 / 102 |
| /creative         | ✓ 66 / 118              | ✓ 66 / 118 |
| /creative-builder | ✓ 60 / 100              | ✓ 60 / 100 |
| /brand            | ✓ 66 / 45               | ✓ 66 / 45 |

Storyboards restored: \`sales_guaranteed\`, \`sales_non_guaranteed\`, \`schema_validation\` (×3), \`media_buy_seller\` (×11 sub-scenarios), \`creative_generative/seller\`, and others.

## Fix

The enricher reads \`context.proposal_id\` only when the fixture authors NEITHER \`proposal_id\` NOR \`packages\`. Fixture is the storyboard author's intent; respect it.

| Fixture                                  | Mode chosen      |
|------------------------------------------|------------------|
| \`proposal_id\` set                       | proposal-mode    |
| \`packages\` set, no \`proposal_id\`        | package-mode (was: incorrectly proposal-mode via context fallback) |
| neither                                  | proposal-mode if \`context.proposal_id\` set; else package-mode |

## Test plan

- [x] \`node --test test/lib/request-builder.test.js\` (85/85, 4 new cases)
- [x] \`node --test test/lib/request-builder-jsonschema-roundtrip.test.js test/lib/request-builder-schema-roundtrip.test.js test/lib/storyboard-completeness.test.js\` (1731/1731 — no regression on roundtrip / completeness)
- [x] \`node --test test/examples/hello-seller-adapter-proposal-mode.test.js\` (3/3 — original PR #1603 integration coverage still passes)
- [x] \`npm pack\` + install into adcontextprotocol/adcp test-agent + run \`scripts/run-storyboards-matrix.sh\` — 5 of 6 tenants meet floors; /sales restored from 50 → 65 clean storyboards. Two remaining failures (\`sales_proposal_mode\`, \`media_buy_seller/proposal_finalize\`) are spec-side fixture issues PR #1603 was masking — separate PR will address.

## Out-of-scope follow-ups

The two remaining /sales failures are pre-existing storyboard authoring issues that PR #1603's incorrect over-application masked. They live in \`adcontextprotocol/adcp\` and need fixes there:

1. **\`sales_proposal_mode\`** authors \`proposal_id: "balanced_reach_q2"\` as a literal in two places. The training-agent's seed proposals don't include that id (it seeds \`pinnacle_cross_channel\`, \`viewpoint_multi_screen\`, \`sparq_social_amplification\`, \`novamind_ai_audience\`). Switch to \`\$context.proposal_id\` to dynamically follow the brief response, matching the pattern \`media_buy_seller/proposal_finalize\` already uses.
2. **\`media_buy_seller/proposal_finalize\`** doesn't include \`io_acceptance\` in the \`create_media_buy\` fixture, but the test-agent's seed proposals (post-3.0.7) carry \`requires_signature: true\` insertion orders. Either the fixture needs \`io_acceptance\`, or the seed needs to differentiate IO-required vs non-IO proposals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)