### PR TITLE
feat(types): add Zod schemas for format asset slot shapes

### DIFF
--- a/.changeset/format-asset-slot-schemas.md
+++ b/.changeset/format-asset-slot-schemas.md
@@ -1,0 +1,5 @@
+---
+"@adcp/sdk": minor
+---
+
+Add Zod schemas for format asset slot shapes: `FormatAssetSlotSchema`, `IndividualAssetSlotSchema`, `RepeatableGroupSlotSchema`, all 14 per-type individual slot schemas (`IndividualImageAssetSlotSchema`, `IndividualVideoAssetSlotSchema`, …), and matching group slot schemas. These are hand-authored companions to the existing TS types in `format-asset-slots.ts`, enabling runtime validation of `Format.assets[]` from `listCreativeFormats()` without consumers having to maintain their own Zod union.

--- a/src/lib/types/format-asset-slot-schemas.ts
+++ b/src/lib/types/format-asset-slot-schemas.ts
@@ -1,0 +1,235 @@
+// Hand-authored Zod v4 schemas for format asset slot shapes.
+//
+// Companion to `format-asset-slots.ts` (TS types) and `schemas.generated.ts`
+// (*AssetRequirementsSchema). The Zod codegen pipeline (generate-zod-from-ts.ts)
+// only processes core.generated.ts + tools.generated.ts; format-asset-slots.ts
+// uses mapped types (GroupSlotOf<T>) that ts-to-zod cannot handle, so these
+// schemas are hand-authored and kept in sync with the TS types manually.
+//
+// Consumers:
+//   - Runtime validation of Format.assets[] from listCreativeFormats() responses
+//   - Type narrowing via slot.asset_type after z.union discrimination
+
+import { z } from 'zod';
+import {
+  AudioAssetRequirementsSchema,
+  CSSAssetRequirementsSchema,
+  CatalogRequirementsSchema,
+  DAASTAssetRequirementsSchema,
+  HTMLAssetRequirementsSchema,
+  ImageAssetRequirementsSchema,
+  JavaScriptAssetRequirementsSchema,
+  MarkdownAssetRequirementsSchema,
+  OverlaySchema,
+  TextAssetRequirementsSchema,
+  URLAssetRequirementsSchema,
+  VASTAssetRequirementsSchema,
+  VideoAssetRequirementsSchema,
+  WebhookAssetRequirementsSchema,
+} from './schemas.generated';
+
+// ---------- Shared base schemas ----------
+
+export const BaseIndividualAssetSlotSchema = z
+  .object({
+    item_type: z.literal('individual'),
+    asset_id: z.string(),
+    asset_role: z.string().optional(),
+    required: z.boolean(),
+    overlays: z.array(OverlaySchema).optional(),
+  })
+  .passthrough();
+
+// Group slots inherit BaseGroupAssetSlot fields (asset_id, asset_role, required,
+// overlays) but omit item_type — groups are always inside a RepeatableGroupSlot.
+export const BaseGroupAssetSlotSchema = z
+  .object({
+    asset_id: z.string(),
+    asset_role: z.string().optional(),
+    required: z.boolean(),
+    overlays: z.array(OverlaySchema).optional(),
+  })
+  .passthrough();
+
+// ---------- Per-asset-type individual slot schemas ----------
+
+export const IndividualImageAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('image'), requirements: ImageAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualVideoAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('video'), requirements: VideoAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualAudioAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('audio'), requirements: AudioAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualTextAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('text'), requirements: TextAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualMarkdownAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z
+    .object({ asset_type: z.literal('markdown'), requirements: MarkdownAssetRequirementsSchema.optional() })
+    .passthrough()
+);
+
+export const IndividualHtmlAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('html'), requirements: HTMLAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualCssAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('css'), requirements: CSSAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualJavascriptAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z
+    .object({ asset_type: z.literal('javascript'), requirements: JavaScriptAssetRequirementsSchema.optional() })
+    .passthrough()
+);
+
+export const IndividualVastAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('vast'), requirements: VASTAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualDaastAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('daast'), requirements: DAASTAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualUrlAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('url'), requirements: URLAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualWebhookAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('webhook'), requirements: WebhookAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const IndividualBriefAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('brief') }).passthrough()
+);
+
+export const IndividualCatalogAssetSlotSchema = BaseIndividualAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('catalog'), requirements: CatalogRequirementsSchema.optional() }).passthrough()
+);
+
+// Discriminated union over all individual slot types.
+// Uses z.union (not z.discriminatedUnion) because the members are ZodIntersection,
+// not ZodObject — a limitation of composing with .and().
+export const IndividualAssetSlotSchema = z.union([
+  IndividualImageAssetSlotSchema,
+  IndividualVideoAssetSlotSchema,
+  IndividualAudioAssetSlotSchema,
+  IndividualTextAssetSlotSchema,
+  IndividualMarkdownAssetSlotSchema,
+  IndividualHtmlAssetSlotSchema,
+  IndividualCssAssetSlotSchema,
+  IndividualJavascriptAssetSlotSchema,
+  IndividualVastAssetSlotSchema,
+  IndividualDaastAssetSlotSchema,
+  IndividualUrlAssetSlotSchema,
+  IndividualWebhookAssetSlotSchema,
+  IndividualBriefAssetSlotSchema,
+  IndividualCatalogAssetSlotSchema,
+]);
+
+// ---------- Group asset slot schemas (inside a repeatable_group) ----------
+//
+// GroupSlotOf<T> = Omit<T, 'item_type' | 'overlays'> & BaseGroupAssetSlot
+// The result has asset_type + requirements (from the individual) plus
+// asset_id, asset_role, required, overlays (from BaseGroupAssetSlot).
+
+export const GroupImageAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('image'), requirements: ImageAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupVideoAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('video'), requirements: VideoAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupAudioAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('audio'), requirements: AudioAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupTextAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('text'), requirements: TextAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupMarkdownAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z
+    .object({ asset_type: z.literal('markdown'), requirements: MarkdownAssetRequirementsSchema.optional() })
+    .passthrough()
+);
+
+export const GroupHtmlAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('html'), requirements: HTMLAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupCssAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('css'), requirements: CSSAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupJavascriptAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z
+    .object({ asset_type: z.literal('javascript'), requirements: JavaScriptAssetRequirementsSchema.optional() })
+    .passthrough()
+);
+
+export const GroupVastAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('vast'), requirements: VASTAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupDaastAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('daast'), requirements: DAASTAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupUrlAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('url'), requirements: URLAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupWebhookAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('webhook'), requirements: WebhookAssetRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupBriefAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('brief') }).passthrough()
+);
+
+export const GroupCatalogAssetSlotSchema = BaseGroupAssetSlotSchema.and(
+  z.object({ asset_type: z.literal('catalog'), requirements: CatalogRequirementsSchema.optional() }).passthrough()
+);
+
+export const GroupAssetSlotSchema = z.union([
+  GroupImageAssetSlotSchema,
+  GroupVideoAssetSlotSchema,
+  GroupAudioAssetSlotSchema,
+  GroupTextAssetSlotSchema,
+  GroupMarkdownAssetSlotSchema,
+  GroupHtmlAssetSlotSchema,
+  GroupCssAssetSlotSchema,
+  GroupJavascriptAssetSlotSchema,
+  GroupVastAssetSlotSchema,
+  GroupDaastAssetSlotSchema,
+  GroupUrlAssetSlotSchema,
+  GroupWebhookAssetSlotSchema,
+  GroupBriefAssetSlotSchema,
+  GroupCatalogAssetSlotSchema,
+]);
+
+// ---------- Repeatable group ----------
+
+export const RepeatableGroupSlotSchema = z
+  .object({
+    item_type: z.literal('repeatable_group'),
+    asset_group_id: z.string(),
+    required: z.boolean(),
+    min_count: z.number(),
+    max_count: z.number(),
+    selection_mode: z.enum(['sequential', 'optimize']).optional(),
+    assets: z.array(GroupAssetSlotSchema),
+  })
+  .passthrough();
+
+// ---------- Top-level union for Format.assets[] elements ----------
+
+export const FormatAssetSlotSchema = z.union([IndividualAssetSlotSchema, RepeatableGroupSlotSchema]);

--- a/src/lib/types/format-asset-slot-schemas.ts
+++ b/src/lib/types/format-asset-slot-schemas.ts
@@ -191,14 +191,10 @@ export const GroupWebhookAssetSlotSchema = BaseGroupAssetSlotSchema.and(
   z.object({ asset_type: z.literal('webhook'), requirements: WebhookAssetRequirementsSchema.optional() }).passthrough()
 );
 
-export const GroupBriefAssetSlotSchema = BaseGroupAssetSlotSchema.and(
-  z.object({ asset_type: z.literal('brief') }).passthrough()
-);
-
-export const GroupCatalogAssetSlotSchema = BaseGroupAssetSlotSchema.and(
-  z.object({ asset_type: z.literal('catalog'), requirements: CatalogRequirementsSchema.optional() }).passthrough()
-);
-
+// brief and catalog are intentionally excluded from GroupAssetSlotSchema — they are
+// campaign-input metadata types, not delivery-ready assets suitable for repeatable groups.
+// This mirrors the generated RepeatableGroupAssetSchema in schemas.generated.ts (lines
+// 4121-4131) which also excludes them. Individual brief/catalog slots remain valid.
 export const GroupAssetSlotSchema = z.union([
   GroupImageAssetSlotSchema,
   GroupVideoAssetSlotSchema,
@@ -212,8 +208,6 @@ export const GroupAssetSlotSchema = z.union([
   GroupDaastAssetSlotSchema,
   GroupUrlAssetSlotSchema,
   GroupWebhookAssetSlotSchema,
-  GroupBriefAssetSlotSchema,
-  GroupCatalogAssetSlotSchema,
 ]);
 
 // ---------- Repeatable group ----------

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -317,6 +317,11 @@ export * from './sync-rows';
 // Re-export Zod schemas for runtime validation
 export * from './schemas.generated';
 
+// Hand-authored Zod schemas for format asset slot shapes (IndividualAssetSlotSchema,
+// RepeatableGroupSlotSchema, FormatAssetSlotSchema, and per-type variants).
+// Companion to format-asset-slots.ts (TS types) and schemas.generated.ts (requirements schemas).
+export * from './format-asset-slot-schemas';
+
 // Re-export const-array enum values (e.g., MediaChannelValues, PacingValues)
 // for consumers that need to enumerate or validate against the spec's
 // literal sets without re-deriving them from Zod schemas.

--- a/test/lib/format-asset-slot-schemas.test.js
+++ b/test/lib/format-asset-slot-schemas.test.js
@@ -23,7 +23,10 @@ describe('format-asset-slot-schemas', async () => {
       requirements: { aspect_ratio: '16:9', formats: ['jpg', 'png'] },
     };
     const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
-    assert.ok(result.success, `IndividualAssetSlotSchema should parse image slot: ${JSON.stringify(result.error?.issues)}`);
+    assert.ok(
+      result.success,
+      `IndividualAssetSlotSchema should parse image slot: ${JSON.stringify(result.error?.issues)}`
+    );
   });
 
   test('IndividualAssetSlotSchema parses text slot', async () => {
@@ -36,7 +39,10 @@ describe('format-asset-slot-schemas', async () => {
       requirements: { max_length: 90 },
     };
     const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
-    assert.ok(result.success, `IndividualAssetSlotSchema should parse text slot: ${JSON.stringify(result.error?.issues)}`);
+    assert.ok(
+      result.success,
+      `IndividualAssetSlotSchema should parse text slot: ${JSON.stringify(result.error?.issues)}`
+    );
   });
 
   test('IndividualAssetSlotSchema parses brief slot (no requirements)', async () => {
@@ -48,7 +54,10 @@ describe('format-asset-slot-schemas', async () => {
       asset_type: 'brief',
     };
     const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
-    assert.ok(result.success, `IndividualAssetSlotSchema should parse brief slot: ${JSON.stringify(result.error?.issues)}`);
+    assert.ok(
+      result.success,
+      `IndividualAssetSlotSchema should parse brief slot: ${JSON.stringify(result.error?.issues)}`
+    );
   });
 
   test('RepeatableGroupSlotSchema parses carousel slot', async () => {
@@ -66,7 +75,10 @@ describe('format-asset-slot-schemas', async () => {
       ],
     };
     const result = schemas.RepeatableGroupSlotSchema.safeParse(group);
-    assert.ok(result.success, `RepeatableGroupSlotSchema should parse carousel: ${JSON.stringify(result.error?.issues)}`);
+    assert.ok(
+      result.success,
+      `RepeatableGroupSlotSchema should parse carousel: ${JSON.stringify(result.error?.issues)}`
+    );
   });
 
   test('FormatAssetSlotSchema accepts both individual and group slots', async () => {
@@ -109,13 +121,20 @@ describe('format-asset-slot-schemas', async () => {
   test('all 14 per-type individual slot schemas are exported', async () => {
     if (!schemas) schemas = await import('../../dist/lib/index.js');
     const expectedSchemas = [
-      'IndividualImageAssetSlotSchema', 'IndividualVideoAssetSlotSchema',
-      'IndividualAudioAssetSlotSchema', 'IndividualTextAssetSlotSchema',
-      'IndividualMarkdownAssetSlotSchema', 'IndividualHtmlAssetSlotSchema',
-      'IndividualCssAssetSlotSchema', 'IndividualJavascriptAssetSlotSchema',
-      'IndividualVastAssetSlotSchema', 'IndividualDaastAssetSlotSchema',
-      'IndividualUrlAssetSlotSchema', 'IndividualWebhookAssetSlotSchema',
-      'IndividualBriefAssetSlotSchema', 'IndividualCatalogAssetSlotSchema',
+      'IndividualImageAssetSlotSchema',
+      'IndividualVideoAssetSlotSchema',
+      'IndividualAudioAssetSlotSchema',
+      'IndividualTextAssetSlotSchema',
+      'IndividualMarkdownAssetSlotSchema',
+      'IndividualHtmlAssetSlotSchema',
+      'IndividualCssAssetSlotSchema',
+      'IndividualJavascriptAssetSlotSchema',
+      'IndividualVastAssetSlotSchema',
+      'IndividualDaastAssetSlotSchema',
+      'IndividualUrlAssetSlotSchema',
+      'IndividualWebhookAssetSlotSchema',
+      'IndividualBriefAssetSlotSchema',
+      'IndividualCatalogAssetSlotSchema',
     ];
     for (const name of expectedSchemas) {
       assert.ok(schemas[name], `${name} should be exported`);
@@ -126,5 +145,30 @@ describe('format-asset-slot-schemas', async () => {
     if (!schemas) schemas = await import('../../dist/lib/index.js');
     assert.ok(schemas.GroupAssetSlotSchema, 'GroupAssetSlotSchema should be exported');
     assert.ok(schemas.RepeatableGroupSlotSchema, 'RepeatableGroupSlotSchema should be exported');
+  });
+
+  test('RepeatableGroupSlotSchema rejects group with invalid inner asset_type', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const badGroup = {
+      item_type: 'repeatable_group',
+      asset_group_id: 'product',
+      required: true,
+      min_count: 1,
+      max_count: 5,
+      assets: [{ asset_id: 'item', asset_type: 'unknown_type', required: true }],
+    };
+    const result = schemas.RepeatableGroupSlotSchema.safeParse(badGroup);
+    assert.ok(!result.success, 'RepeatableGroupSlotSchema should reject group with invalid inner asset_type');
+  });
+
+  test('GroupAssetSlotSchema rejects brief and catalog (metadata types not valid in groups)', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const briefSlot = { asset_id: 'b', asset_type: 'brief', required: false };
+    const catalogSlot = { asset_id: 'c', asset_type: 'catalog', required: false };
+    assert.ok(!schemas.GroupAssetSlotSchema.safeParse(briefSlot).success, 'GroupAssetSlotSchema should reject brief');
+    assert.ok(
+      !schemas.GroupAssetSlotSchema.safeParse(catalogSlot).success,
+      'GroupAssetSlotSchema should reject catalog'
+    );
   });
 });

--- a/test/lib/format-asset-slot-schemas.test.js
+++ b/test/lib/format-asset-slot-schemas.test.js
@@ -1,0 +1,130 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+
+// Tests for hand-authored Zod schemas in format-asset-slot-schemas.ts.
+// Validates runtime parsing of Format.assets[] slot shapes from listCreativeFormats().
+
+describe('format-asset-slot-schemas', async () => {
+  let schemas;
+
+  test('FormatAssetSlotSchema is importable from lib index', async () => {
+    schemas = await import('../../dist/lib/index.js');
+    assert.ok(schemas.FormatAssetSlotSchema, 'FormatAssetSlotSchema should be exported');
+    assert.ok(typeof schemas.FormatAssetSlotSchema.safeParse === 'function');
+  });
+
+  test('IndividualAssetSlotSchema parses image slot', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const slot = {
+      item_type: 'individual',
+      asset_id: 'hero_image',
+      required: true,
+      asset_type: 'image',
+      requirements: { aspect_ratio: '16:9', formats: ['jpg', 'png'] },
+    };
+    const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
+    assert.ok(result.success, `IndividualAssetSlotSchema should parse image slot: ${JSON.stringify(result.error?.issues)}`);
+  });
+
+  test('IndividualAssetSlotSchema parses text slot', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const slot = {
+      item_type: 'individual',
+      asset_id: 'headline',
+      required: true,
+      asset_type: 'text',
+      requirements: { max_length: 90 },
+    };
+    const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
+    assert.ok(result.success, `IndividualAssetSlotSchema should parse text slot: ${JSON.stringify(result.error?.issues)}`);
+  });
+
+  test('IndividualAssetSlotSchema parses brief slot (no requirements)', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const slot = {
+      item_type: 'individual',
+      asset_id: 'creative_brief',
+      required: false,
+      asset_type: 'brief',
+    };
+    const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
+    assert.ok(result.success, `IndividualAssetSlotSchema should parse brief slot: ${JSON.stringify(result.error?.issues)}`);
+  });
+
+  test('RepeatableGroupSlotSchema parses carousel slot', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const group = {
+      item_type: 'repeatable_group',
+      asset_group_id: 'product',
+      required: true,
+      min_count: 3,
+      max_count: 10,
+      selection_mode: 'sequential',
+      assets: [
+        { asset_id: 'product_image', asset_type: 'image', required: true },
+        { asset_id: 'product_name', asset_type: 'text', required: true },
+      ],
+    };
+    const result = schemas.RepeatableGroupSlotSchema.safeParse(group);
+    assert.ok(result.success, `RepeatableGroupSlotSchema should parse carousel: ${JSON.stringify(result.error?.issues)}`);
+  });
+
+  test('FormatAssetSlotSchema accepts both individual and group slots', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+
+    const individual = { item_type: 'individual', asset_id: 'logo', required: true, asset_type: 'image' };
+    const group = {
+      item_type: 'repeatable_group',
+      asset_group_id: 'card',
+      required: false,
+      min_count: 1,
+      max_count: 5,
+      assets: [],
+    };
+
+    const r1 = schemas.FormatAssetSlotSchema.safeParse(individual);
+    const r2 = schemas.FormatAssetSlotSchema.safeParse(group);
+
+    assert.ok(r1.success, `FormatAssetSlotSchema should accept individual slot: ${JSON.stringify(r1.error?.issues)}`);
+    assert.ok(r2.success, `FormatAssetSlotSchema should accept group slot: ${JSON.stringify(r2.error?.issues)}`);
+  });
+
+  test('IndividualAssetSlotSchema rejects invalid asset_type', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const slot = {
+      item_type: 'individual',
+      asset_id: 'x',
+      required: true,
+      asset_type: 'unknown_type',
+    };
+    const result = schemas.IndividualAssetSlotSchema.safeParse(slot);
+    assert.ok(!result.success, 'IndividualAssetSlotSchema should reject unknown asset_type');
+  });
+
+  test('BaseIndividualAssetSlotSchema is exported', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    assert.ok(schemas.BaseIndividualAssetSlotSchema, 'BaseIndividualAssetSlotSchema should be exported');
+  });
+
+  test('all 14 per-type individual slot schemas are exported', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    const expectedSchemas = [
+      'IndividualImageAssetSlotSchema', 'IndividualVideoAssetSlotSchema',
+      'IndividualAudioAssetSlotSchema', 'IndividualTextAssetSlotSchema',
+      'IndividualMarkdownAssetSlotSchema', 'IndividualHtmlAssetSlotSchema',
+      'IndividualCssAssetSlotSchema', 'IndividualJavascriptAssetSlotSchema',
+      'IndividualVastAssetSlotSchema', 'IndividualDaastAssetSlotSchema',
+      'IndividualUrlAssetSlotSchema', 'IndividualWebhookAssetSlotSchema',
+      'IndividualBriefAssetSlotSchema', 'IndividualCatalogAssetSlotSchema',
+    ];
+    for (const name of expectedSchemas) {
+      assert.ok(schemas[name], `${name} should be exported`);
+    }
+  });
+
+  test('GroupAssetSlotSchema and RepeatableGroupSlotSchema are exported', async () => {
+    if (!schemas) schemas = await import('../../dist/lib/index.js');
+    assert.ok(schemas.GroupAssetSlotSchema, 'GroupAssetSlotSchema should be exported');
+    assert.ok(schemas.RepeatableGroupSlotSchema, 'RepeatableGroupSlotSchema should be exported');
+  });
+});


### PR DESCRIPTION
Refs #1652

Adds `FormatAssetSlotSchema`, `IndividualAssetSlotSchema`, `RepeatableGroupSlotSchema`, all 14 per-type individual slot schemas (`IndividualImageAssetSlotSchema`, `IndividualVideoAssetSlotSchema`, …), and 12 group slot schemas (`GroupImageAssetSlotSchema`, …) as hand-authored Zod companions to the existing TS types in `format-asset-slots.ts`. The Zod codegen pipeline (`generate-zod-from-ts.ts`) cannot process the `GroupSlotOf<T>` mapped type, so these are maintained manually — referencing the existing `*AssetRequirementsSchema` and `OverlaySchema` from `schemas.generated.ts`. Consumers can now validate `Format.assets[]` from `listCreativeFormats()` at runtime without maintaining their own Zod union.

**This PR ships Part A only.** Part B (tightening `Format.assets` from the incorrect `(IndividualImageAsset | … | RepeatableGroupAsset)[]` creative-instance types to `FormatAssetSlot[]`) is a breaking TypeScript type change — needs a major semver bump decision from `@bokelley`. See #1652 for details.

**Note on type/schema divergence:** `GroupAssetSlot` (the TS union in `format-asset-slots.ts`) still includes `GroupBriefAssetSlot` and `GroupCatalogAssetSlot`, and the builder helpers `briefGroupAsset`/`catalogGroupAsset` remain. `GroupAssetSlotSchema` correctly excludes brief/catalog (matching `RepeatableGroupAssetSchema` in `schemas.generated.ts`). Aligning the TS types and removing the builders is a breaking change — same semver decision required as Part B.

## What was tested

- `npm run format:check` — passes
- `tsc --project tsconfig.lib.json` — only pre-existing env errors (missing `@types/node`, deprecated `moduleResolution=node10`; confirmed same on `main`). No new type errors.
- Build skipped: `npm run sync-schemas` required to populate `schemas/cache/` before `build:lib` can run; this is an environment limitation, not introduced by this PR.

## Pre-PR review

- **code-reviewer:** approved — both blockers (missing rejection tests, GroupBrief/GroupCatalog in union) resolved; nit on `min_count`/`max_count` being `z.number()` vs `.int()` (consistent with generated schemas)
- **ad-tech-protocol-expert:** approved at Zod layer — 12-member `GroupAssetSlotSchema` correctly matches spec and `RepeatableGroupAssetSchema`; pre-existing TS type divergence (`GroupBriefAssetSlot`/`GroupCatalogAssetSlot` in `GroupAssetSlot`) surfaced as follow-up breaking change

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RMZexuDcTbgM96xZQwLSjL

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMZexuDcTbgM96xZQwLSjL)_