### PR TITLE
fix(cli): make --allow-http work end-to-end for local dev loops

### DIFF
--- a/.changeset/allow-http-oauth-resource-url.md
+++ b/.changeset/allow-http-oauth-resource-url.md
@@ -1,0 +1,12 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(cli): make `--allow-http` work end-to-end for local dev loops
+
+Two paths previously ignored `--allow-http` and broke connections to `http://localhost` agents:
+
+- `MCPOAuthProvider.validateResourceURL` rejected non-HTTPS RFC 9728 resource URLs unconditionally (`Server at http://localhost:.../mcp advertised non-HTTPS resource URL: http://...`). The provider now accepts an `allowHttp` option that lifts the HTTPS check, and the CLI threads `--allow-http` through to `createCLIOAuthProvider` / `ensureOAuthTokensForAlias`.
+- `detectProtocol` refused to probe `http://` agent cards because the probe policy reads `ADCP_ALLOW_INTERNAL_PROBES` once at module load (`Failed to detect protocol: Refusing to fetch non-HTTPS URL: http://localhost:.../.well-known/agent.json`). The CLI now sets that env var before any library require when `--allow-http` is in argv, so the existing well-tested gate widens consistently.
+
+Default behavior is unchanged: HTTPS is required unless the caller explicitly opts in.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -14,6 +14,14 @@
  *   adcp mcp https://agent.example.com/mcp create_media_buy @payload.json --auth $AGENT_TOKEN
  */
 
+// `--allow-http` is the CLI's single switch for local dev loops. The probe
+// policy reads `ADCP_ALLOW_INTERNAL_PROBES` once at module load, so this MUST
+// run before any `require('../dist/lib/...')` below — flipping it later has
+// no effect on `isInternalProbesAllowed()` / `detectProtocol`'s SSRF gate.
+if (process.argv.includes('--allow-http')) {
+  process.env.ADCP_ALLOW_INTERNAL_PROBES = '1';
+}
+
 const { AdCPClient, detectProtocol, usesDeprecatedAssetsField } = require('../dist/lib/index.js');
 const { readFileSync, statSync } = require('fs');
 const path = require('path');
@@ -948,7 +956,10 @@ async function maybeRunInlineOAuth(agentArg, args, { jsonOutput } = {}) {
     const saved = getAgent(agentArg);
     if (!saved) return;
     try {
-      await ensureOAuthTokensForAlias(agentArg, saved.url, { quiet: jsonOutput });
+      await ensureOAuthTokensForAlias(agentArg, saved.url, {
+        quiet: jsonOutput,
+        allowHttp: args.includes('--allow-http'),
+      });
     } catch (err) {
       const hint = `Run: adcp --save-auth ${agentArg} ${saved.url} --oauth to re-register`;
       if (jsonOutput) {
@@ -1006,7 +1017,7 @@ async function maybeRunInlineOAuth(agentArg, args, { jsonOutput } = {}) {
  *
  * @returns The updated saved agent record (with oauth_tokens and oauth_client).
  */
-async function ensureOAuthTokensForAlias(alias, url, { quiet = false } = {}) {
+async function ensureOAuthTokensForAlias(alias, url, { quiet = false, allowHttp = false } = {}) {
   const existing = getAgent(alias);
   if (existing && hasValidOAuthTokens(existing)) {
     if (!quiet) console.log(`Using saved OAuth tokens for '${alias}'.`);
@@ -1030,7 +1041,7 @@ async function ensureOAuthTokensForAlias(alias, url, { quiet = false } = {}) {
   const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
   const { UnauthorizedError } = require('@modelcontextprotocol/sdk/client/auth.js');
 
-  const oauthProvider = createCLIOAuthProvider(tempAgent, { quiet });
+  const oauthProvider = createCLIOAuthProvider(tempAgent, { quiet, allowHttp });
   const mcpClient = new MCPClient({ name: 'adcp-cli', version: '1.0.0' });
   const transport = new StreamableHTTPClientTransport(new URL(url), { authProvider: oauthProvider });
 
@@ -5044,7 +5055,7 @@ credential material — never sync or commit.
       const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
       const { UnauthorizedError } = require('@modelcontextprotocol/sdk/client/auth.js');
 
-      const oauthProvider = createCLIOAuthProvider(tempAgent);
+      const oauthProvider = createCLIOAuthProvider(tempAgent, { allowHttp: args.includes('--allow-http') });
       const mcpClient = new MCPClient({ name: 'adcp-cli', version: '1.0.0' });
       const createTransport = () => new StreamableHTTPClientTransport(new URL(url), { authProvider: oauthProvider });
 
@@ -5464,7 +5475,10 @@ credential material — never sync or commit.
         const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
         const { UnauthorizedError } = require('@modelcontextprotocol/sdk/client/auth.js');
 
-        const oauthProvider = createCLIOAuthProvider(agentConfig, { quiet: jsonOutput });
+        const oauthProvider = createCLIOAuthProvider(agentConfig, {
+          quiet: jsonOutput,
+          allowHttp: args.includes('--allow-http'),
+        });
         const mcpClient = new MCPClient({ name: 'adcp-cli', version: '1.0.0' });
         const createTransport = () =>
           new StreamableHTTPClientTransport(new URL(agentUrl), { authProvider: oauthProvider });
@@ -5594,6 +5608,7 @@ credential material — never sync or commit.
       // Create OAuth provider
       const oauthProvider = createCLIOAuthProvider(agentConfig, {
         quiet: jsonOutput,
+        allowHttp: args.includes('--allow-http'),
       });
 
       // Create MCP client
@@ -5963,7 +5978,10 @@ credential material — never sync or commit.
       const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
       const { UnauthorizedError } = require('@modelcontextprotocol/sdk/client/auth.js');
 
-      const oauthProvider = createCLIOAuthProvider(agentConfig, { quiet: jsonOutput });
+      const oauthProvider = createCLIOAuthProvider(agentConfig, {
+        quiet: jsonOutput,
+        allowHttp: args.includes('--allow-http'),
+      });
       const mcpClient = new MCPClient({ name: 'adcp-cli', version: '1.0.0' });
       const createTransport = () =>
         new StreamableHTTPClientTransport(new URL(agentUrl), { authProvider: oauthProvider });

--- a/src/lib/auth/oauth/MCPOAuthProvider.ts
+++ b/src/lib/auth/oauth/MCPOAuthProvider.ts
@@ -52,12 +52,14 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   private readonly storage?: OAuthConfigStorage;
   private readonly flowHandler: OAuthFlowHandler;
   private readonly _clientMetadata: OAuthClientMetadata;
+  private readonly allowHttp: boolean;
 
   constructor(config: OAuthProviderConfig) {
     this.agent = config.agent;
     this.storage = config.storage;
     this.flowHandler = config.flowHandler;
     this._clientMetadata = config.clientMetadata;
+    this.allowHttp = config.allowHttp === true;
   }
 
   /**
@@ -67,7 +69,8 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     agent: AgentConfig,
     flowHandler: OAuthFlowHandler,
     storage?: OAuthConfigStorage,
-    clientMetadataOverrides?: Partial<OAuthClientMetadata>
+    clientMetadataOverrides?: Partial<OAuthClientMetadata>,
+    options?: { allowHttp?: boolean }
   ): MCPOAuthProvider {
     // Build complete client metadata with required fields
     const clientMetadata: OAuthClientMetadata = {
@@ -81,6 +84,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       flowHandler,
       storage,
       clientMetadata,
+      allowHttp: options?.allowHttp,
     });
   }
 
@@ -104,6 +108,10 @@ export class MCPOAuthProvider implements OAuthClientProvider {
    * We allow cross-origin resource URLs because agent configs are pre-configured
    * by the user, not discovered from untrusted sources. The authorization server
    * remains the final gatekeeper for token audience validation.
+   *
+   * Non-HTTPS resource URLs are rejected by default. Construct the provider
+   * with `allowHttp: true` to lift that restriction for local development —
+   * mirrors the CLI's `--allow-http` flag.
    */
   async validateResourceURL(serverUrl: string | URL, resource?: string): Promise<URL | undefined> {
     if (!resource) {
@@ -112,7 +120,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
 
     const resourceURL = new URL(resource);
 
-    if (resourceURL.protocol !== 'https:') {
+    if (resourceURL.protocol !== 'https:' && !this.allowHttp) {
       throw new Error(`Server at ${serverUrl} advertised non-HTTPS resource URL: ${resource}`);
     }
 

--- a/src/lib/auth/oauth/index.ts
+++ b/src/lib/auth/oauth/index.ts
@@ -146,6 +146,11 @@ export function createCLIOAuthProvider(
     quiet?: boolean;
     /** Storage for persisting agent config */
     storage?: OAuthConfigStorage;
+    /**
+     * Allow non-HTTPS resource URLs advertised in RFC 9728 protected-resource
+     * metadata. Mirrors the CLI's `--allow-http` flag. Defaults to `false`.
+     */
+    allowHttp?: boolean;
   }
 ): MCPOAuthProvider {
   const flowConfig: CLIFlowHandlerConfig = {
@@ -167,6 +172,7 @@ export function createCLIOAuthProvider(
     flowHandler,
     storage: options?.storage,
     clientMetadata,
+    allowHttp: options?.allowHttp,
   });
 }
 
@@ -189,6 +195,11 @@ export function createNonInteractiveOAuthProvider(
     clientMetadata?: Partial<OAuthClientMetadata>;
     /** Storage for persisting refreshed tokens back to disk. */
     storage?: OAuthConfigStorage;
+    /**
+     * Allow non-HTTPS resource URLs advertised in RFC 9728 protected-resource
+     * metadata. Mirrors the CLI's `--allow-http` flag. Defaults to `false`.
+     */
+    allowHttp?: boolean;
   }
 ): MCPOAuthProvider {
   const { NonInteractiveFlowHandler } = require('./NonInteractiveFlowHandler');
@@ -205,6 +216,7 @@ export function createNonInteractiveOAuthProvider(
     flowHandler,
     storage: options?.storage,
     clientMetadata,
+    allowHttp: options?.allowHttp,
   });
 }
 

--- a/src/lib/auth/oauth/types.ts
+++ b/src/lib/auth/oauth/types.ts
@@ -96,6 +96,21 @@ export interface OAuthProviderConfig {
 
   /** OAuth client metadata (required - use DEFAULT_CLIENT_METADATA as base) */
   clientMetadata: OAuthClientMetadata;
+
+  /**
+   * Allow non-HTTPS resource URLs in RFC 9728 protected-resource metadata.
+   * Mirrors the CLI's `--allow-http` flag and matches the operator-driven
+   * trust model used elsewhere in the SDK (`ssrfSafeFetch.allowPrivateIp`,
+   * the agent-entry URL validators). Defaults to `false`.
+   *
+   * Scope: relaxes only the HTTPS-only check on the PRM `resource` value.
+   * Does NOT widen network-layer SSRF posture (that knob is
+   * `ADCP_ALLOW_INTERNAL_PROBES` at module load, fed by the CLI). Intended
+   * for local dev loops; do not enable when talking to remote authorization
+   * servers — the AS remains the audience gatekeeper, but a non-HTTPS
+   * resource URL implies the transport itself is unauthenticated.
+   */
+  allowHttp?: boolean;
 }
 
 /**

--- a/test/lib/oauth.test.js
+++ b/test/lib/oauth.test.js
@@ -572,6 +572,22 @@ describe('MCPOAuthProvider', () => {
     );
   });
 
+  test('validateResourceURL accepts non-HTTPS resource URLs when allowHttp is set', async () => {
+    const provider = new MCPOAuthProvider({
+      agent,
+      flowHandler: mockFlowHandler,
+      clientMetadata: {
+        ...DEFAULT_CLIENT_METADATA,
+        redirect_uris: ['http://localhost:8766/callback'],
+      },
+      allowHttp: true,
+    });
+
+    const result = await provider.validateResourceURL('http://localhost:3000/figma/mcp', 'http://localhost:3000/figma');
+    assert.ok(result instanceof URL);
+    assert.strictEqual(result.toString(), 'http://localhost:3000/figma');
+  });
+
   test('validateResourceURL rejects invalid URL strings', async () => {
     const provider = new MCPOAuthProvider({
       agent,


### PR DESCRIPTION
## Summary

`--allow-http` is the CLI's documented switch for local dev loops (`Allow http:// and private-IP targets (dev loops only)`), but two paths ignored it and broke connections to `http://localhost` agents.

**Bug 1 — `MCPOAuthProvider.validateResourceURL`** rejected non-HTTPS RFC 9728 resource URLs unconditionally:

```
❌ ERROR
Server at http://localhost:3000/figma/mcp advertised non-HTTPS resource URL: http://localhost:3000/figma
```

Fix: added `allowHttp?: boolean` to `OAuthProviderConfig`, threaded through `createCLIOAuthProvider`, `createNonInteractiveOAuthProvider`, `MCPOAuthProvider.forCLI`, and `ensureOAuthTokensForAlias`. The CLI reads `args.includes('--allow-http')` at each call site.

**Bug 2 — `detectProtocol`** called `ssrfSafeFetch` with `allowPrivateIp` from `isInternalProbesAllowed()`, which reads `ADCP_ALLOW_INTERNAL_PROBES` **once at module load**:

```
ERROR: Failed to detect protocol: Refusing to fetch non-HTTPS URL: http://localhost:3000/.well-known/agent.json
```

Fix: in `bin/adcp.js`, before any `require('../dist/lib/...')`, set `process.env.ADCP_ALLOW_INTERNAL_PROBES='1'` when `--allow-http` is in `process.argv`. Piggybacks on the existing well-tested gate instead of adding a parallel knob.

**Default behavior unchanged:** HTTPS is required unless the caller explicitly opts in.

## Files

- `src/lib/auth/oauth/types.ts` — `allowHttp` field on `OAuthProviderConfig` (with scope warning)
- `src/lib/auth/oauth/MCPOAuthProvider.ts` — gate the HTTPS check on `allowHttp`
- `src/lib/auth/oauth/index.ts` — accept `allowHttp` on `createCLIOAuthProvider` + `createNonInteractiveOAuthProvider`
- `bin/adcp.js` — early env set before requires; pass `allowHttp` at all 5 `createCLIOAuthProvider` sites + `ensureOAuthTokensForAlias`
- `test/lib/oauth.test.js` — positive test for `validateResourceURL` with `allowHttp:true`
- `.changeset/allow-http-oauth-resource-url.md` — patch changeset

## Expert review (run in parallel)

**code-reviewer:** No blockers. Ready to push.

**security-reviewer:** Qualified safe. Cloud-metadata IMDS unconditional block at `address-guards.ts` is untouched and still applies via both `classifyProbeUrl` and `ssrfSafeFetch`. The `--allow-http` → env-var widening is in scope for operator-driven CLI invocations and has no propagation path into multi-tenant runtimes (no `bin/adcp.js` entrypoint there). Cited follow-up nit on scope clarity in JSDoc — addressed in the type definition.

**ad-tech-protocol-expert:** Sound. Per RFC 9728 §2/§3.3 the `resource` value is the canonical audience identifier the AS binds tokens to, not necessarily the request URI — parent-path identifiers are normative. RFC 8707 §2 requires only an absolute URI, no HTTPS mandate. The MCP TS SDK delegates to `validateResourceURL` precisely so providers can choose policy. The previous unconditional rejection was over-strict for local dev.

Follow-up filed separately: `diagnose-auth` H1 ("Resource URL mismatch between well-known and agent host") is too aggressive for sub-path-under-resource cases.

## Test plan

- [x] `node --test test/lib/oauth.test.js` — 51/51 pass (new positive test for `allowHttp:true`)
- [x] `node --test test/lib/probe-policy.test.js test/lib/protocol-detection-1612.test.js` — 31/31 pass
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] Manual: `--save-auth figma-local http://localhost:3000/figma/mcp mcp --oauth --allow-http` → reaches browser auth
- [x] Manual: same without `--allow-http` → still rejects (`Server at … advertised non-HTTPS resource URL: …`)
- [x] Manual: `http://localhost:3000/figma/ --allow-http get_products '{}'` → auto-detects MCP, friendly 401 hint
- [x] Manual: `--protocol a2a --allow-http` → reaches agent-card fetch (404 from server is the real answer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)