### PR TITLE
chore(deps): fix dependabot alerts (ip-address, uuid)

### DIFF
--- a/.changeset/warm-regions-teach.md
+++ b/.changeset/warm-regions-teach.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal-only: `npm audit fix` for moderate Dependabot alerts on dev-only transitive deps (`ip-address` 10.1.0→10.2.0, `uuid` 11.1.0→11.1.1, `express-rate-limit` 8.3.2→8.5.1). No runtime exposure; no API change; no release needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "6.16.1",
+  "version": "6.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "6.16.1",
+      "version": "6.19.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -3320,11 +3320,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -3883,7 +3885,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6256,7 +6260,9 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
@@ -6468,7 +6474,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^6.16.1"
+        "@adcp/sdk": "^6.19.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"


### PR DESCRIPTION
## Summary
`npm audit fix` for both open Dependabot moderate alerts:

- **ip-address** 10.1.0 → 10.2.0 — patches [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g) (XSS in Address6 HTML-emitting methods)
- **uuid** 11.1.0 → 11.1.1 — patches [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check)
- **express-rate-limit** 8.3.2 → 8.5.1 — transitive bump pulled in by the `ip-address` range update

Both vulnerable packages are **dev-only transitives**; no runtime exposure. After this PR, `npm audit` reports 0 vulnerabilities.

Incidentally, the lockfile self-version was stale (6.16.1) vs `package.json` (6.19.0); `npm` resynced it. Pure metadata change.

No changeset — dev-deps only, no published code affected.

## Test plan
- [ ] CI green
- [ ] `npm audit` reports 0 vulnerabilities after merge
- [ ] Dependabot alerts auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)