### PR TITLE
ci(docs): bump GitHub Pages actions to current majors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,13 +42,13 @@ jobs:
         run: npm run docs
       
       - name: Setup Pages
-        uses: actions/configure-pages@v4
-      
+        uses: actions/configure-pages@v6
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './docs'
-      
+
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
Bumps the three GitHub Pages actions in the docs workflow to their current majors:

- `actions/configure-pages@v4` → `@v6` (Node 20 → Node 24 runtime)
- `actions/upload-pages-artifact@v3` → `@v5`
- `actions/deploy-pages@v4` → `@v5`

## Why
Same Node 20 deprecation pressure as #1663 (forced Node 24 on 2026-06-02). These weren't flagged in the CI warning because the docs workflow only runs on push to main, but they'll hit the same migration.

## Compat check
Inputs unchanged:
- `configure-pages` is called bare (no `enablement`/`token`)
- `upload-pages-artifact` only passes `path`
- `deploy-pages` is called bare

No changeset — workflow-only.

## Test plan
- [ ] CI green
- [ ] Next docs deploy to GitHub Pages succeeds (next push to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)