### PR TITLE
ci(schema-sync): bump peter-evans/create-pull-request to v8

### DIFF
--- a/.github/workflows/schema-sync.yml
+++ b/.github/workflows/schema-sync.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.sync.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: |


### PR DESCRIPTION
## Summary
Bumps `peter-evans/create-pull-request@v5` → `@v8` in the schema-sync workflow.

## Why
v5 ships on Node 16. v8 runs on Node 24 — keeps us on a supported runtime as GitHub Actions migrates.

## Compat check
Verified across v6/v7/v8 release notes: no breaking input-schema changes for the fields we use:
- `token`, `commit-message`, `branch`, `title`, `body`, `labels`

The only "breaking" note across all major bumps (v6.0.1) is about an upstream GitHub API fix, not action config.

No changeset — workflow-only.

## Test plan
- [ ] CI green (this workflow only runs on schedule + workflow_dispatch, so the action itself won't execute on this PR)
- [ ] Next nightly schema-sync run successfully opens a PR (or manually trigger via `gh workflow run schema-sync.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)