### PR TITLE
fix(cli): diagnose-auth H1 no longer fires on RFC-9728 parent-path resource identifiers

### DIFF
--- a/.changeset/fix-h1-parent-path-resource-identifier.md
+++ b/.changeset/fix-h1-parent-path-resource-identifier.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(cli): diagnose-auth H1 no longer fires on RFC-9728-correct parent-path resource identifiers
+
+`diagnose-auth` H1 ("Resource URL mismatch") previously flagged any case where the PRM `resource` field did not exactly match the agent URL — including the normative RFC 9728 §3.3 pattern where a single resource server fronts multiple endpoints under a shared parent-path identifier (e.g., `resource: https://api.example.com/figma` covering `https://api.example.com/figma/mcp`).
+
+H1 now returns `[ruled-out]` when the agent URL is the same as, or a sub-path of, the advertised resource identifier. H1 remains `[likely]` for genuine mismatches (different origin, or divergent path not covered by the resource). The `prmDiffersFromAgent` flag in H5 is updated to use the same compatibility predicate so it no longer shows a stale "see H1" cross-reference for spec-correct parent-path configurations.

--- a/src/lib/auth/oauth/diagnose.ts
+++ b/src/lib/auth/oauth/diagnose.ts
@@ -507,16 +507,19 @@ function rankH1(agentUrl: string, prmStep?: DiagnosisStep): Hypothesis {
 
   const normAdvertised = normalizeForCompare(advertised);
   const normAgent = normalizeForCompare(agentUrl);
-  if (normAdvertised === normAgent) {
+  if (isResourceCompatibleWithAgent(normAdvertised, normAgent)) {
     base.verdict = 'ruled_out';
-    base.summary = `Advertised resource matches agent URL (${advertised})`;
+    base.summary =
+      normAgent === normAdvertised
+        ? `Advertised resource matches agent URL (${advertised})`
+        : `Advertised resource is a parent-path identifier that covers the agent URL — valid per RFC 9728 §3.3 (${advertised})`;
   } else {
     base.verdict = 'likely';
     base.summary = `Advertised resource "${advertised}" does not match agent URL "${agentUrl}"`;
     base.evidence = [
       `PRM resource: ${advertised}`,
       `Agent URL: ${agentUrl}`,
-      'Fix: align the agent server config so `.well-known/oauth-protected-resource` advertises the same origin+path as the agent endpoint itself.',
+      'Fix: the PRM `resource` value must match what the AS emits as the `aud` claim. Use either the exact agent URL or a parent-path identifier that covers it (RFC 9728 §3.3). A different origin or divergent path means the AS and resource server disagree on the audience.',
     ];
   }
   return base;
@@ -642,7 +645,8 @@ function rankH5(
       : undefined;
   const expected = prmResource ?? agentUrl;
   const prmDiffersFromAgent =
-    prmResource !== undefined && normalizeForCompare(prmResource) !== normalizeForCompare(agentUrl);
+    prmResource !== undefined &&
+    !isResourceCompatibleWithAgent(normalizeForCompare(prmResource), normalizeForCompare(agentUrl));
   const result = validateTokenAudience(jwtFromDecoded(currentDecoded), expected);
   if (result.ok) {
     base.verdict = 'ruled_out';
@@ -790,6 +794,19 @@ function redactTokenMaterial(capture: HttpCapture): HttpCapture {
     }
   }
   return { ...capture, body: redacted };
+}
+
+/**
+ * Returns true when `normResource` is a valid RFC 9728 §3.3 resource identifier
+ * for `normAgent`: exact match, or `normResource` is a parent-path of `normAgent`.
+ * Both arguments must already be passed through `normalizeForCompare`.
+ */
+function isResourceCompatibleWithAgent(normResource: string, normAgent: string): boolean {
+  // normalizeForCompare keeps the trailing "/" only for root-path URLs
+  // (pathname === "/"). Using a resourceBase that always ends with "/" correctly
+  // handles both root ("/") and non-root ("/foo") cases without double-slashing.
+  const resourceBase = normResource.endsWith('/') ? normResource : normResource + '/';
+  return normAgent === normResource || normAgent.startsWith(resourceBase);
 }
 
 function normalizeForCompare(value: string): string {

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.18.0';
+export const LIBRARY_VERSION = '6.19.0';
 
 /**
  * AdCP specification version this library is built for
@@ -52,10 +52,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.18.0',
+  library: '6.19.0',
   adcp: '3.0.10',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-11T06:18:44.327Z',
+  generatedAt: '2026-05-11T09:40:43.112Z',
 } as const;
 
 /**

--- a/test/lib/oauth-diagnose.test.js
+++ b/test/lib/oauth-diagnose.test.js
@@ -136,6 +136,33 @@ describe('runAuthDiagnosis: H1 resource URL mismatch', () => {
     const h1 = report.hypotheses.find(h => h.id === 'H1');
     assert.strictEqual(h1.verdict, 'ruled_out');
   });
+
+  test('rules out H1 when PRM resource is a parent-path identifier covering the agent URL (RFC 9728 §3.3)', async () => {
+    // agentUrl() = http://127.0.0.1:{port}/mcp
+    // parentResource = http://127.0.0.1:{port}  (no path suffix)
+    // Per RFC 9728 §3.3 a single resource server may front multiple endpoints
+    // under a shared parent-path identifier — H1 must not fire.
+    const parentResource = `http://127.0.0.1:${state.port}`;
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: parentResource, authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'ruled_out');
+    assert.match(h1.summary, /parent-path/);
+  });
 });
 
 describe('runAuthDiagnosis: H4 missing WWW-Authenticate', () => {


### PR DESCRIPTION
Closes #1666

## Summary

`diagnose-auth` H1 ("Resource URL mismatch") fired `[likely]` on any case where the PRM `resource` field did not exactly match the agent URL — including the normative RFC 9728 §3.3 pattern where a single resource server fronts multiple endpoints under a shared parent-path identifier:

```
resource: http://localhost:3000/figma
agent:    http://localhost:3000/figma/mcp
→ H1 [likely]  ← wrong
```

Per RFC 9728 §2/§3.3 the `resource` value is the canonical audience identifier the AS binds tokens to — not required to equal the request URI. Parent-path identifiers are explicitly normative.

**Changes:**

- Extracts `isResourceCompatibleWithAgent(normResource, normAgent)` helper — returns `true` for exact match or when the agent URL is a sub-path of the resource identifier. Handles the root-path edge case (`http://host/` covering `http://host/mcp`) via a trailing-`/` guard.
- `rankH1` uses the new predicate: `[ruled-out]` for compatible, `[likely]` for genuine mismatches (different origin, or divergent path not covered by the resource).
- `rankH5` `prmDiffersFromAgent` updated to use the same predicate, removing a stale "see H1" cross-reference that appeared for spec-correct parent-path configurations.
- Fix hint text rewritten to focus on the actual invariant: the PRM `resource` value must match what the AS emits as the `aud` claim.
- New test: parent-path resource identifier covering `/mcp` → H1 `ruled-out` (root-path case).

**Behaviour matrix:**

| PRM resource | Agent URL | Before | After |
|---|---|---|---|
| `http://host/figma` | `http://host/figma/mcp` | `[likely]` | `[ruled-out]` |
| `http://host` | `http://host/figma/mcp` | `[likely]` | `[ruled-out]` |
| `http://host/figma/mcp` | `http://host/figma/mcp` | `[ruled-out]` | `[ruled-out]` |
| `http://other.com/foo` | `http://host/figma/mcp` | `[likely]` | `[likely]` |
| `http://host/figma/other` | `http://host/figma/mcp` | `[likely]` | `[likely]` |
| `http://host/figma/mcp/deep` | `http://host/figma/mcp` | `[likely]` | `[likely]` |

## What was tested

- `tsc --project tsconfig.lib.json --skipLibCheck --ignoreDeprecations 6.0` — clean (pre-existing env errors: missing @types/node, deprecated moduleResolution=node10; neither caused by this diff, both present on unmodified main)
- Logic verified via inline evaluation of compiled JS against 9 test cases (all pass), including sibling-path prefix-collision (`/figma` vs `/figma-plugin`) and root-path covering sub-path cases
- `npm run typecheck --skipLibCheck --ignoreDeprecations 6.0` — no source-file errors

**Note:** node_modules are not installed in the triage environment; full `node --test` suite requires `npm install`. CI will run the full suite including the new `oauth-diagnose.test.js` case.

## Pre-PR review

- code-reviewer: approved — no blockers; noted H5 `ruled_out` evidence wording is slightly ambiguous for operator UX (non-blocking follow-on), and a negative sibling-path test would be a good addition (nit)
- ad-tech-protocol-expert: approved — fix is sound per RFC 9728 §2/§3.3; updated fix hint is accurate and sufficient; `isResourceCompatibleWithAgent` handles all edge cases correctly

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01YKs1ZLmPBh6vGSiC5yhtv5

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKs1ZLmPBh6vGSiC5yhtv5)_