### PR TITLE
fix(diagnose-auth): downgrade H1 for spec-correct parent-path resource identifiers

### DIFF
--- a/.changeset/diagnose-auth-h1-spec-correctness.md
+++ b/.changeset/diagnose-auth-h1-spec-correctness.md
@@ -1,0 +1,14 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(diagnose-auth): downgrade H1 for spec-correct parent-path resource identifiers (#1666)
+
+`adcp diagnose-auth` H1 ("Resource URL mismatch between well-known and agent host") previously fired as `[likely]` whenever the PRM `resource` didn't string-equal the agent URL. Per **RFC 9728 §2 + §3.2** the `resource` value is the canonical resource identifier the AS binds tokens to (the **RFC 9068 §3** `aud` claim target), not the request URI — and **RFC 8707 §2** allows any absolute URI with an optional path component. A parent-path resource identifier covering multiple endpoints is the canonical pattern, not a bug. H1 now distinguishes four cases:
+
+- **origin mismatch** (different scheme/host/port) → still `likely` (real bug).
+- **agent URL is a sub-path under the advertised resource identifier** → `ruled_out` with an explanation that this is the intended pattern (e.g. PRM `resource=http://localhost:3000/figma` for an agent at `http://localhost:3000/figma/mcp`).
+- **same origin, agent path is a sibling/disjoint segment** → `possible` with non-prescriptive evidence (the AS may legitimately host multiple resource identifiers on the same origin; we can't tell without inspecting AS aud-binding policy).
+- **`resource` is not a parseable URL** (e.g. opaque URN) → `possible` with a pointer to RFC 8707 §2's absolute-URI requirement.
+
+Exact match continues to be `ruled_out`. Surfaced during PR #1665 verification against a figma seller agent whose RFC-9728-compliant PRM was flagged as a likely issue.

--- a/src/lib/auth/oauth/diagnose.ts
+++ b/src/lib/auth/oauth/diagnose.ts
@@ -510,15 +510,70 @@ function rankH1(agentUrl: string, prmStep?: DiagnosisStep): Hypothesis {
   if (normAdvertised === normAgent) {
     base.verdict = 'ruled_out';
     base.summary = `Advertised resource matches agent URL (${advertised})`;
-  } else {
-    base.verdict = 'likely';
-    base.summary = `Advertised resource "${advertised}" does not match agent URL "${agentUrl}"`;
+    return base;
+  }
+
+  // RFC 9728 §2 + §3.2 — `resource` is the canonical resource identifier the
+  // AS binds tokens to (the `aud` claim target per RFC 9068 §3), not the
+  // request URI. RFC 8707 §2 requires only an absolute URI with optional path
+  // component, so a parent-path resource ID covering the agent's sub-path is
+  // spec-correct, not a mismatch.
+  const advertisedOrigin = originForCompare(advertised);
+  const agentOrigin = originForCompare(agentUrl);
+
+  // Unparseable resource (e.g. AS returned an opaque URN like `urn:foo`). We
+  // can't classify origin/path containment without parsing, and falling
+  // through would misleadingly evaluate `isPathPrefix` against raw strings.
+  // Surface as `possible` so the operator sees the actual advertisement
+  // without us inventing a fix hint we can't justify.
+  if (!advertisedOrigin) {
+    base.verdict = 'possible';
+    base.summary = `Advertised resource is not a parseable URL: "${advertised}"`;
     base.evidence = [
       `PRM resource: ${advertised}`,
       `Agent URL: ${agentUrl}`,
-      'Fix: align the agent server config so `.well-known/oauth-protected-resource` advertises the same origin+path as the agent endpoint itself.',
+      'RFC 8707 §2 requires `resource` to be an absolute URI. Check the AS configuration if this should be a URL identifier.',
     ];
+    return base;
   }
+
+  if (agentOrigin && advertisedOrigin !== agentOrigin) {
+    base.verdict = 'likely';
+    base.summary = `Advertised resource origin "${advertisedOrigin}" does not match agent origin "${agentOrigin}"`;
+    base.evidence = [
+      `PRM resource: ${advertised}`,
+      `Agent URL: ${agentUrl}`,
+      "Fix: point the agent at the same origin (scheme+host+port) the PRM advertises, or fix the PRM `resource` to advertise the agent's own origin.",
+    ];
+    return base;
+  }
+
+  if (isUrlPrefix(normAdvertised, normAgent)) {
+    // Agent endpoint is a sub-path under the advertised resource identifier.
+    // RFC 9728 §3.2 leaves this open; RFC 9068 §3 + RFC 8707 §2 together
+    // make it the canonical pattern for a single resource server fronting
+    // multiple endpoints under a shared `aud` identifier.
+    base.verdict = 'ruled_out';
+    base.summary = `Agent URL is a sub-path under advertised resource identifier (spec-correct per RFC 9728 §2/§3.2)`;
+    base.evidence = [
+      `PRM resource: ${advertised}`,
+      `Agent URL: ${agentUrl}`,
+      `The AS will issue tokens with \`aud=${advertised}\`; the agent at \`${agentUrl}\` validates that aud against its own resource identifier, not the request URI. This is the intended pattern for a single resource server fronting multiple endpoints.`,
+    ];
+    return base;
+  }
+
+  // Same origin, agent is not a sub-path of advertised resource. The AS may
+  // legitimately host multiple resource identifiers on the same origin, each
+  // covering a disjoint set of endpoints; without inspecting AS aud-binding
+  // policy we can't tell whether this is intended or a misconfiguration.
+  base.verdict = 'possible';
+  base.summary = `Advertised resource "${advertised}" does not contain agent URL "${agentUrl}" as a sub-path (both on origin ${agentOrigin ?? '(unknown)'})`;
+  base.evidence = [
+    `PRM resource: ${advertised}`,
+    `Agent URL: ${agentUrl}`,
+    'If the AS binds tokens with `aud=<advertised resource>`, this agent endpoint may be outside that audience — confirm the AS aud-binding policy or that the operator advertised the correct resource identifier for this endpoint.',
+  ];
   return base;
 }
 
@@ -801,6 +856,38 @@ function normalizeForCompare(value: string): string {
   } catch {
     return value;
   }
+}
+
+/**
+ * Scheme + lowercased host + non-default port. Returns `null` when the input
+ * has no host (e.g. `urn:foo`, `mailto:bar@x`) or fails to parse. RFC 8707 §2
+ * allows any absolute URI as `resource`, but origin-based comparisons only
+ * make sense for hierarchical http(s)-style URLs.
+ */
+function originForCompare(value: string): string | null {
+  try {
+    const u = new URL(value);
+    if (!u.hostname) return null;
+    const port = u.port && !isDefaultPort(u.protocol, u.port) ? `:${u.port}` : '';
+    return `${u.protocol.toLowerCase()}//${u.hostname.toLowerCase()}${port}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether `candidate` is `prefix` itself or a strict URL descendant (same
+ * scheme+host+port plus a path segment under `prefix`'s path). Inputs come
+ * from {@link normalizeForCompare}; trailing slashes are stripped for paths
+ * longer than `/`, but the root path `/` is preserved. We require a `/`
+ * boundary after the prefix so `.../foo` does not match `.../foobar/...`.
+ * Path comparison is case-sensitive per RFC 3986 §6.2.2.1; only scheme/host
+ * are lowercased upstream in {@link normalizeForCompare}.
+ */
+function isUrlPrefix(prefix: string, candidate: string): boolean {
+  if (prefix === candidate) return true;
+  const trimmed = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+  return candidate.startsWith(trimmed + '/');
 }
 
 function isDefaultPort(scheme: string, port: string): boolean {

--- a/test/lib/oauth-diagnose.test.js
+++ b/test/lib/oauth-diagnose.test.js
@@ -91,7 +91,7 @@ function jsonRes(res, status, body, extraHeaders = {}) {
 // ---------------------------------------------------------------------------
 
 describe('runAuthDiagnosis: H1 resource URL mismatch', () => {
-  test('flags H1 when PRM advertises a different resource URL', async () => {
+  test('flags H1 likely when PRM resource is on a different origin', async () => {
     setHandlers({
       '/.well-known/oauth-protected-resource/mcp': (req, res) =>
         jsonRes(res, 200, {
@@ -113,10 +113,10 @@ describe('runAuthDiagnosis: H1 resource URL mismatch', () => {
 
     const h1 = report.hypotheses.find(h => h.id === 'H1');
     assert.strictEqual(h1.verdict, 'likely');
-    assert.match(h1.summary, /does not match agent URL/);
+    assert.match(h1.summary, /origin/);
   });
 
-  test('rules out H1 when PRM resource matches agent URL', async () => {
+  test('rules out H1 when PRM resource matches agent URL exactly', async () => {
     setHandlers({
       '/.well-known/oauth-protected-resource/mcp': (req, res) =>
         jsonRes(res, 200, { resource: agentUrl(), authorization_servers: [issuer()] }),
@@ -135,6 +135,106 @@ describe('runAuthDiagnosis: H1 resource URL mismatch', () => {
 
     const h1 = report.hypotheses.find(h => h.id === 'H1');
     assert.strictEqual(h1.verdict, 'ruled_out');
+  });
+
+  test('rules out H1 when agent URL is a sub-path under the advertised resource identifier (RFC 9728 §3.3)', async () => {
+    // PRM advertises the parent path as the canonical resource identifier;
+    // agent endpoint lives at a sub-path under it. This is the figma-style
+    // configuration and is spec-correct per RFC 9728 §3.3.
+    const resourceId = `http://127.0.0.1:${state.port}`;
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: resourceId, authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'ruled_out');
+    assert.match(h1.summary, /sub-path/);
+    assert.match(h1.summary, /RFC 9728/);
+  });
+
+  test('rules out H1 when advertised resource has a trailing slash (e.g. http://host/figma/)', async () => {
+    // `normalizeForCompare` strips trailing slashes for paths longer than `/`,
+    // so `/figma/` and `/figma` both end up as `/figma`. Both should still
+    // recognize the agent's `/mcp` sub-path as a descendant.
+    const resourceWithSlash = `http://127.0.0.1:${state.port}/`;
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: resourceWithSlash, authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'ruled_out');
+  });
+
+  test('flags H1 possible when advertised resource is not a parseable URL', async () => {
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: 'urn:example:opaque', authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'possible');
+    assert.match(h1.summary, /not a parseable URL/);
+  });
+
+  test('flags H1 possible when agent URL is a sibling sub-path on the same origin', async () => {
+    // Same origin, but the agent's path is not under the advertised resource
+    // identifier — could be intentional (separate resource on same origin) or
+    // a misconfiguration. Downgrade to `possible`, not `likely`.
+    const siblingResource = `http://127.0.0.1:${state.port}/other`;
+    setHandlers({
+      '/.well-known/oauth-protected-resource/mcp': (req, res) =>
+        jsonRes(res, 200, { resource: siblingResource, authorization_servers: [issuer()] }),
+      '/.well-known/oauth-authorization-server': (req, res) => jsonRes(res, 200, { token_endpoint: tokenEndpoint() }),
+      '/mcp': (req, res) => {
+        res.statusCode = 401;
+        res.setHeader('www-authenticate', 'Bearer error="invalid_token"');
+        res.end();
+      },
+    });
+
+    const report = await runAuthDiagnosis(
+      { id: 'test', name: 'test', agent_uri: agentUrl(), protocol: 'mcp' },
+      { allowPrivateIp: true, skipToolCall: true }
+    );
+
+    const h1 = report.hypotheses.find(h => h.id === 'H1');
+    assert.strictEqual(h1.verdict, 'possible');
+    assert.match(h1.summary, /does not contain agent URL.*as a sub-path/);
   });
 });
 


### PR DESCRIPTION
Closes #1666.

## Summary

`adcp diagnose-auth` H1 ("Resource URL mismatch between well-known and agent host") previously fired as `[likely]` whenever the PRM `resource` didn't string-equal the agent URL. Per **RFC 9728 §2 + §3.2** the `resource` value is the canonical resource identifier the AS binds tokens to (the **RFC 9068 §3** `aud` claim target), not the request URI — and **RFC 8707 §2** allows any absolute URI with an optional path component. A parent-path resource identifier covering multiple endpoints is the canonical pattern, not a bug.

**Real-world trigger** (figma seller agent):
```json
{
  "resource": "http://localhost:3000/figma",
  "authorization_servers": ["http://localhost:3000/figma"]
}
```
Against an agent at `http://localhost:3000/figma/mcp`, the AS issues tokens with `aud=http://localhost:3000/figma`; the agent validates that `aud` against its own resource identifier. RFC-9728-correct configuration that the SDK was incorrectly flagging.

## Verdict matrix

| Case | Verdict | Change |
|---|---|---|
| Exact match | `ruled_out` | unchanged |
| Origin mismatch (scheme/host/port differ) | `likely` | summary now says \"origin\" instead of \"URL\" |
| Agent URL is sub-path under advertised resource | `ruled_out` | **new** (was `likely`) |
| Same origin, agent path is sibling/disjoint | `possible` | **new** (was `likely`); non-prescriptive evidence |
| Resource is not a parseable URL (e.g. URN) | `possible` | **new** edge case |

## Expert review (run in parallel)

**code-reviewer** flagged two real issues, both addressed:
- Unparseable resource (URN) silently fell through to `isUrlPrefix` against raw strings → now bails to `possible` with a pointer to RFC 8707 §2's absolute-URI requirement.
- Helper named `isPathPrefix` but operating on full URLs → renamed `isUrlPrefix`, docstring updated to note RFC 3986 §6.2.2.1 case-sensitivity for path components.

**ad-tech-protocol-expert** confirmed:
- The matrix is protocol-correct (RFC 9728 §2 + §3.2 + RFC 9068 §3 + RFC 8707 §2 — corrected from §3.3 in initial draft).
- Sibling-disjoint as `possible` is right; softened prose so we don't push operators to edit PRM when multi-resource-per-origin is legitimate (\"If the AS binds tokens with `aud=<advertised resource>`, this agent endpoint may be outside that audience\" instead of \"Fix: PRM `resource` should equal …\").
- No 9728 normative MUST is violated by this change.

## Files

- `src/lib/auth/oauth/diagnose.ts` — `rankH1` rewrite + `originForCompare` / `isUrlPrefix` helpers
- `test/lib/oauth-diagnose.test.js` — updated 2 existing tests (regex change); added 4 new tests (sub-path ruled_out, sibling possible, trailing-slash sub-path, unparseable URN)
- `.changeset/diagnose-auth-h1-spec-correctness.md` — patch changeset

## Test plan

- [x] `node --test test/lib/oauth-diagnose.test.js test/lib/oauth.test.js` — 67/67 pass
- [x] `npm run typecheck` clean
- [x] `npm run format:check` clean
- [x] Schema version (`AUTH_DIAGNOSIS_SCHEMA_VERSION = 1`) unchanged — `Hypothesis.id`/`title` are stable; `verdict` is documented as ranked output, not a switch key; grep finds zero downstream consumers switching on `verdict === 'likely'` for H1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)