### PR TITLE
test(auth): fix sub-second race in TTL-cap introspection test

### DIFF
--- a/.changeset/empty-test-only-1673.md
+++ b/.changeset/empty-test-only-1673.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only change — fixes the sub-second race in `verifyIntrospection — cache: caps positive TTL at the token's own remaining lifetime` (#1673). No library/CLI behavior change; no release needed.

--- a/test/server-auth-introspection.test.js
+++ b/test/server-auth-introspection.test.js
@@ -429,9 +429,10 @@ describe('verifyIntrospection — cache', () => {
   });
 
   it('caps positive TTL at the token`s own remaining lifetime', async () => {
-    // Token expires in 1 second; configured TTL is 1 hour. Cache entry
-    // must respect the 1-second cap.
-    response = { active: true, sub: 'u', exp: Math.floor(Date.now() / 1000) + 1 };
+    // Token expires in 2 seconds; configured TTL is 1 hour. Cache entry
+    // must respect the 2-second cap. Using +2 (not +1) guarantees the
+    // remaining lifetime is always ≥1 s regardless of sub-second clock offset.
+    response = { active: true, sub: 'u', exp: Math.floor(Date.now() / 1000) + 2 };
     const auth = verifyIntrospection({
       introspectionUrl: upstream.url,
       clientId: 'c',
@@ -444,7 +445,7 @@ describe('verifyIntrospection — cache', () => {
     await auth({ headers: { authorization: 'Bearer tok-short' } });
     assert.strictEqual(callCount, 1);
     // Wait past expiry + a little slack. Next call re-introspects.
-    await new Promise(r => setTimeout(r, 1200));
+    await new Promise(r => setTimeout(r, 2500));
     await auth({ headers: { authorization: 'Bearer tok-short' } });
     assert.strictEqual(callCount, 2, 'cache entry should have expired with the token');
   });


### PR DESCRIPTION
Closes #1673

`exp: Math.floor(Date.now() / 1000) + 1` gave the introspection cache a remaining lifetime window of anywhere from ~1 ms to ~999 ms depending on where in the current second the test started. On slow CI runners (or when the test fired within the last few ms of a second), the cache entry expired before the second `auth()` call landed, causing `callCount` to reach 2 instead of the asserted 1. The fix changes `+1` → `+2`, which guarantees the effective TTL is always between 1000 ms and 2000 ms regardless of sub-second clock offset. The post-expiry sleep is extended from 1200 ms to 2500 ms to give 500 ms of slack over the new ~2-second worst-case window (the original 200 ms slack was the root of the timing fragility).

**What was tested:**
- Formatting: `npm run format:check` — passed ✓
- TypeScript: `npm run typecheck` — passed ✓ (pre-existing `@types/node` / `moduleResolution` deprecation errors present on `main` before this change; unrelated to diff)
- Build + test suite: blocked in this environment by a network-gated `schemas:ensure` step (403 from `adcontextprotocol.org`); schema cache is gitignored and unavailable without network. Change is test-only — no library code touched. CI will run the full suite on push.
- Syntax check of modified file: `node --check test/server-auth-introspection.test.js` — passed ✓

**Pre-PR review:**
- code-reviewer: approved — `+2` guarantees 1000–2000 ms effective TTL; 2500 ms sleep gives ≥500 ms slack over worst-case expiry. One nit: inline comment "Second call within 1s — cached." is slightly imprecise post-fix (token now lives 2 s); no blocker.
- dx-expert: approved — timing-based fix is correct scope; clock-mocking follow-up would require raising Node engine floor or adding `@sinonjs/fake-timers` (separate decision). Nit: `+2` / `2500` are implicitly coupled; a named constant would make the relationship explicit but is not a blocker.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01SSAxWkYWJZyuBy4CXHhzKx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSAxWkYWJZyuBy4CXHhzKx)_