### PR TITLE
fix(normalizer): fail closed on pre-3.0 PackageRequest shapes

### DIFF
--- a/.changeset/normalizer-fail-closed-pre3.md
+++ b/.changeset/normalizer-fail-closed-pre3.md
@@ -1,0 +1,11 @@
+---
+"@adcp/sdk": patch
+---
+
+fix(normalizer): throw ValidationError on pre-3.0 PackageRequest shapes instead of silently passing them through
+
+`normalizePackageParams` now throws `ValidationError` (code: `VALIDATION_ERROR`) when it encounters `packages[].product_ids` (plural array, pre-3.0) or `packages[].budget` as an object (pre-3.0 `{ total, currency }` shape). Both shapes cannot be translated to AdCP 3.0 equivalents without data loss (`product_ids[]→product_id`: which id wins? `budget:object→number`: which currency?). Previously they silently reached 3.0-strict sellers and caused `INVALID_REQUEST` rejections. Now callers get an early, actionable error at the client boundary.
+
+Also fixes a TypeScript-only cast in `request-builder.ts` (`baseSample.budget as number | undefined`) that did not guard at runtime — replaced with `typeof baseSample.budget === 'number'` check so storyboard fixtures with object budgets are correctly dropped in favour of discovery-derived values.
+
+v2 sunset policy: v2 unsupported as of 3.0 GA (April 2026); no translation obligation.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -276,7 +276,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
       ...baseSample,
       product_id: fixtureProductId ?? product?.product_id ?? context.product_id ?? 'test-product',
       budget:
-        (baseSample.budget as number | undefined) ??
+        (typeof baseSample.budget === 'number' ? baseSample.budget : undefined) ??
         options.budget ??
         Math.max(1000, (pricingOption?.min_spend_per_package as number) ?? 1000),
       pricing_option_id:

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -6,6 +6,7 @@
  * deprecation warning via warnOnce().
  */
 
+import { ValidationError } from '../errors';
 import { brandManifestToBrandReference, promotedProductsToCatalog } from '../types/compat';
 import { warnOnce } from './deprecation';
 import { MUTATING_TASKS, generateIdempotencyKey } from './idempotency';
@@ -22,6 +23,25 @@ export function normalizePackageParams(pkg: any): any {
   if (!pkg || typeof pkg !== 'object') return pkg;
 
   const normalized = { ...pkg };
+
+  // Fail-closed on pre-3.0 shapes that cannot be translated without data loss.
+  // product_ids[] → product_id: which id wins? No safe answer.
+  // budget: {total, currency} → budget: number: which currency? No safe answer.
+  // v2 sunset: unsupported as of 3.0 GA (April 2026).
+  if (Array.isArray(normalized.product_ids)) {
+    throw new ValidationError(
+      'packages[].product_ids',
+      normalized.product_ids,
+      'pre-3.0 shape not supported in AdCP 3.0. Use product_id (singular string) instead.'
+    );
+  }
+  if (normalized.budget !== undefined && typeof normalized.budget === 'object' && normalized.budget !== null) {
+    throw new ValidationError(
+      'packages[].budget',
+      normalized.budget,
+      'pre-3.0 shape not supported in AdCP 3.0. Use budget as a number instead.'
+    );
+  }
 
   // context.buyer_ref → buyer_ref (backward compat for pre-4.15 AdCP servers)
   // AdCP 4.15 moved buyer_ref into context, but older servers still require it

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -28,14 +28,23 @@ export function normalizePackageParams(pkg: any): any {
   // product_ids[] → product_id: which id wins? No safe answer.
   // budget: {total, currency} → budget: number: which currency? No safe answer.
   // v2 sunset: unsupported as of 3.0 GA (April 2026).
-  if (Array.isArray(normalized.product_ids)) {
+  //
+  // Intentional asymmetry vs get_products.product_ids (lines below), which uses
+  // warnOnce+delete because that field is a query filter that can simply be dropped.
+  // PackageRequest.product_id and .budget are required identifiers — dropping them
+  // produces a different invalid request; throwing early is strictly better.
+  //
+  // This error is thrown at the client boundary before any network call and must not
+  // be forwarded on the wire. It uses ValidationError (VALIDATION_ERROR) as the
+  // nearest semantic fit in the client error hierarchy.
+  if (Array.isArray(normalized.product_ids) && normalized.product_ids.length > 0) {
     throw new ValidationError(
       'packages[].product_ids',
       normalized.product_ids,
       'pre-3.0 shape not supported in AdCP 3.0. Use product_id (singular string) instead.'
     );
   }
-  if (normalized.budget !== undefined && typeof normalized.budget === 'object' && normalized.budget !== null) {
+  if (normalized.budget !== null && typeof normalized.budget === 'object') {
     throw new ValidationError(
       'packages[].budget',
       normalized.budget,

--- a/test/request-normalizer-package-params.test.js
+++ b/test/request-normalizer-package-params.test.js
@@ -1,0 +1,103 @@
+// Tests for pre-3.0 fail-closed guards in normalizePackageParams.
+// AdCP 3.0 PackageRequest uses product_id (singular string) and budget (number).
+// Pre-3.0 shapes product_ids[] and budget:{total,currency} cannot be translated
+// without data loss, so the normalizer throws rather than passing them silently.
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { normalizePackageParams, normalizeRequestParams } = require('../dist/lib/utils/request-normalizer');
+const { ValidationError } = require('../dist/lib/errors');
+
+describe('normalizePackageParams — pre-3.0 fail-closed guards', () => {
+  it('throws ValidationError for product_ids[] (pre-3.0 plural shape)', () => {
+    assert.throws(
+      () => normalizePackageParams({ product_ids: ['prod-1', 'prod-2'], pricing_option_id: 'po-1', budget: 1000 }),
+      err => {
+        assert.ok(err instanceof ValidationError, 'should be ValidationError');
+        assert.strictEqual(err.code, 'VALIDATION_ERROR');
+        assert.ok(err.field === 'packages[].product_ids', `unexpected field: ${err.field}`);
+        return true;
+      }
+    );
+  });
+
+  it('throws ValidationError for budget as object (pre-3.0 {total,currency} shape)', () => {
+    assert.throws(
+      () =>
+        normalizePackageParams({
+          product_id: 'prod-1',
+          pricing_option_id: 'po-1',
+          budget: { total: 1000, currency: 'USD' },
+        }),
+      err => {
+        assert.ok(err instanceof ValidationError, 'should be ValidationError');
+        assert.strictEqual(err.code, 'VALIDATION_ERROR');
+        assert.ok(err.field === 'packages[].budget', `unexpected field: ${err.field}`);
+        return true;
+      }
+    );
+  });
+
+  it('throws ValidationError for budget as {amount,currency} object variant', () => {
+    assert.throws(
+      () =>
+        normalizePackageParams({
+          product_id: 'prod-1',
+          pricing_option_id: 'po-1',
+          budget: { amount: 500, currency: 'EUR' },
+        }),
+      err => {
+        assert.ok(err instanceof ValidationError);
+        assert.strictEqual(err.field, 'packages[].budget');
+        return true;
+      }
+    );
+  });
+
+  it('passes through a valid 3.0-shape package unchanged', () => {
+    const pkg = { product_id: 'prod-1', pricing_option_id: 'po-1', budget: 1000 };
+    const result = normalizePackageParams(pkg);
+    assert.strictEqual(result.product_id, 'prod-1');
+    assert.strictEqual(result.budget, 1000);
+    assert.strictEqual(result.pricing_option_id, 'po-1');
+  });
+
+  it('passes through null/non-object without throwing', () => {
+    assert.strictEqual(normalizePackageParams(null), null);
+    assert.strictEqual(normalizePackageParams(undefined), undefined);
+    assert.strictEqual(normalizePackageParams('string'), 'string');
+  });
+});
+
+describe('normalizeRequestParams — pre-3.0 package shapes propagate through create_media_buy', () => {
+  it('throws when packages[] contain product_ids[]', () => {
+    assert.throws(
+      () =>
+        normalizeRequestParams('create_media_buy', {
+          idempotency_key: 'test-key',
+          packages: [{ product_ids: ['prod-1'], pricing_option_id: 'po-1', budget: 1000 }],
+        }),
+      err => {
+        assert.ok(err instanceof ValidationError);
+        assert.strictEqual(err.field, 'packages[].product_ids');
+        return true;
+      }
+    );
+  });
+
+  it('throws when packages[] contain object budget', () => {
+    assert.throws(
+      () =>
+        normalizeRequestParams('create_media_buy', {
+          idempotency_key: 'test-key',
+          packages: [{ product_id: 'prod-1', pricing_option_id: 'po-1', budget: { total: 1000, currency: 'USD' } }],
+        }),
+      err => {
+        assert.ok(err instanceof ValidationError);
+        assert.strictEqual(err.field, 'packages[].budget');
+        return true;
+      }
+    );
+  });
+});

--- a/test/request-normalizer-package-params.test.js
+++ b/test/request-normalizer-package-params.test.js
@@ -63,6 +63,12 @@ describe('normalizePackageParams — pre-3.0 fail-closed guards', () => {
     assert.strictEqual(result.pricing_option_id, 'po-1');
   });
 
+  it('does not throw for empty product_ids[] (no ambiguity — nothing to pick)', () => {
+    assert.doesNotThrow(() =>
+      normalizePackageParams({ product_ids: [], product_id: 'prod-1', pricing_option_id: 'po-1', budget: 1000 })
+    );
+  });
+
   it('passes through null/non-object without throwing', () => {
     assert.strictEqual(normalizePackageParams(null), null);
     assert.strictEqual(normalizePackageParams(undefined), undefined);


### PR DESCRIPTION
Closes #1677

## Summary

`normalizePackageParams` was silently passing through pre-3.0 `PackageRequest` shapes — `packages[].product_ids: string[]` and `packages[].budget: { total, currency }` — which caused 10 conformance scenarios to fail with `INVALID_REQUEST` from 3.0-strict sellers. Both shapes cannot be translated to AdCP 3.0 equivalents without data loss (which id wins from `product_ids[]`? which currency from `budget.currency`?), so the normalizer now fails closed with an early `ValidationError` at the client boundary rather than letting a malformed payload reach the wire.

Also fixes a TypeScript-only cast in `request-builder.ts` (`baseSample.budget as number | undefined`) that had no runtime effect — replaced with a `typeof` check so storyboard fixtures with object budgets correctly fall through to discovery-derived values instead of flowing into `normalizePackageParams`.

v2 sunset policy: v2 unsupported as of 3.0 GA (April 2026); security-only until Aug 1 2026. No translation obligation.

## What was tested

- `npx prettier --check` ✅
- `npx tsc --project tsconfig.lib.json` — no source-file errors in changed files (2 pre-existing env errors: missing `@types/node`, deprecated `moduleResolution=node10` — both predate this branch)
- New test file `test/request-normalizer-package-params.test.js` — 7 cases covering: `product_ids[]` throw, object-budget throw (`{total,currency}` and `{amount,currency}` variants), empty `product_ids[]` passthrough (no ambiguity), valid 3.0-shape passthrough, null/non-object passthrough, and both throw paths via `normalizeRequestParams('create_media_buy', ...)` integration
- Tests require `npm install` (no `node_modules` in triage env — same constraint as #1671/#1670); will run on CI

## Pre-PR review

- **code-reviewer:** approved — no blockers; noted empty `product_ids[]` edge case (fixed: added `.length > 0` guard), simplified budget null check (`!== null && typeof === 'object'`), TypeScript-only cast fix in request-builder is correct
- **ad-tech-protocol-expert:** approved — no spec-defined backward-compat obligation for these shapes at the client normalizer layer; fail-closed is correct; added comment clarifying `ValidationError` is a client-boundary throw (not wire-forwarded) and documenting the intentional asymmetry vs `get_products.product_ids` (warn+delete) pattern

## Nits noted (not fixed)

- Protocol expert: `adcpErrorToTypedError` does not map `VALIDATION_ERROR` — this is intentional because that function maps server-originated wire errors, not client-thrown errors; no change needed

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1678` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_017bV83EFKqYUQ7LP2nzAzKB

---
_Generated by [Claude Code](https://claude.ai/code/session_017bV83EFKqYUQ7LP2nzAzKB)_