### PR TITLE
fix(client): remove account_from_brand fabrication shim in normalizeRequestParams

### DIFF
--- a/.changeset/remove-account-from-brand-shim-1676.md
+++ b/.changeset/remove-account-from-brand-shim-1676.md
@@ -1,0 +1,9 @@
+---
+"@adcp/sdk": minor
+---
+
+Remove deprecated `account_from_brand` shim in `normalizeRequestParams` (#1676).
+
+The shim silently fabricated `account.operator = brand.domain` when a `create_media_buy` call omitted `account`. This was semantically wrong for any caller with a buying-side intermediary, and caused compliance badges to certify requests with invented data rather than caller-supplied account semantics. With AdCP 3.0 GA (April 2026) sunsetting v2 support, the back-compat rationale no longer applies.
+
+`create_media_buy` calls that omit `account` now throw `ValidationError` (exported as `ADCPValidationError`) with field `account` and a message describing the two valid forms: `{ account_id }` or `{ brand, operator, sandbox? }`. Use `list_accounts` to discover an existing `account_id`, or `sync_accounts` to register a natural-key account first.

--- a/.changeset/remove-account-from-brand-shim-1676.md
+++ b/.changeset/remove-account-from-brand-shim-1676.md
@@ -6,4 +6,8 @@ Remove deprecated `account_from_brand` shim in `normalizeRequestParams` (#1676).
 
 The shim silently fabricated `account.operator = brand.domain` when a `create_media_buy` call omitted `account`. This was semantically wrong for any caller with a buying-side intermediary, and caused compliance badges to certify requests with invented data rather than caller-supplied account semantics. With AdCP 3.0 GA (April 2026) sunsetting v2 support, the back-compat rationale no longer applies.
 
-`create_media_buy` calls that omit `account` now throw `ValidationError` (exported as `ADCPValidationError`) with field `account` and a message describing the two valid forms: `{ account_id }` or `{ brand, operator, sandbox? }`. Use `list_accounts` to discover an existing `account_id`, or `sync_accounts` to register a natural-key account first.
+**Behavior change (two cases):**
+1. `create_media_buy` with `brand.domain` but no `account` — previously fabricated `{ brand, operator: brand.domain }` (wrong for non-direct topologies); now throws `ValidationError`.
+2. `create_media_buy` with neither `account` nor `brand` — previously fell through to seller-side schema rejection; now throws `ValidationError` client-side.
+
+`create_media_buy` calls that omit `account` now throw `ValidationError` (exported as `ADCPValidationError`) with field `account`. Use `list_accounts` to discover an existing `account_id`, or `sync_accounts` to register a natural-key account (implicit-account sellers only).

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -7,6 +7,7 @@
  */
 
 import { brandManifestToBrandReference, promotedProductsToCatalog } from '../types/compat';
+import { ValidationError } from '../errors/index';
 import { warnOnce } from './deprecation';
 import { MUTATING_TASKS, generateIdempotencyKey } from './idempotency';
 
@@ -115,20 +116,23 @@ export function normalizeRequestParams(
     }
   }
 
-  // ── account inference (create_media_buy) ──
-  // Derive account from brand when not provided so callers that pre-date
-  // the required account field keep working.
-  // sandbox is intentionally omitted: the normalizer cannot infer sandbox
-  // intent from brand alone. Callers that need sandbox must provide account explicitly.
-  if (taskType === 'create_media_buy' && !normalized.account && normalized.brand?.domain) {
-    warnOnce(
-      'account_from_brand',
-      'create_media_buy: account is required. Inferring from brand for backward compatibility.'
+  // ── account validation (create_media_buy) ──
+  // account is required per AdCP 3.0 spec. The v2 shim that inferred
+  // operator = brand.domain was removed with the v2 sunset (April 2026):
+  // the fabricated operator value was semantically wrong for any caller
+  // with a buying-side intermediary, and it caused the compliance harness
+  // to issue badges against requests with fabricated account data.
+  // Callers must pass account as { account_id } or { brand, operator, sandbox? }.
+  // Use list_accounts to discover an existing account_id, or sync_accounts
+  // to register a new natural-key account.
+  if (taskType === 'create_media_buy' && !normalized.account) {
+    throw new ValidationError(
+      'account',
+      undefined,
+      'create_media_buy: account is required. ' +
+        'Pass account as { account_id } or { brand, operator, sandbox? }. ' +
+        'Use list_accounts to discover an existing account_id, or sync_accounts to register one.'
     );
-    normalized.account = {
-      brand: normalized.brand,
-      operator: normalized.brand.domain,
-    };
   }
 
   // ── context.buyer_ref → buyer_ref (create_media_buy, update_media_buy) ──

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -131,7 +131,8 @@ export function normalizeRequestParams(
       undefined,
       'create_media_buy: account is required. ' +
         'Pass account as { account_id } or { brand, operator, sandbox? }. ' +
-        'Use list_accounts to discover an existing account_id, or sync_accounts to register one.'
+        'Use list_accounts to discover an existing account_id; ' +
+        'implicit-account sellers also support sync_accounts to register a new one.'
     );
   }
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.19.0';
+export const LIBRARY_VERSION = '6.19.1';
 
 /**
  * AdCP specification version this library is built for
@@ -52,10 +52,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.19.0',
+  library: '6.19.1',
   adcp: '3.0.11',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-11T09:13:25.348Z',
+  generatedAt: '2026-05-11T13:44:47.885Z',
 } as const;
 
 /**

--- a/test/lib/a2a-context-retention.test.js
+++ b/test/lib/a2a-context-retention.test.js
@@ -359,7 +359,7 @@ describe('AgentClient.withSession narrows pendingTaskId auto-thread (regression 
       stub.enqueue(taskResponse({ status: 'completed', contextId: 'ctx-shared', taskId: 'task-B' }));
 
       const client = newClient();
-      await client.executeTask('create_media_buy', {});
+      await client.executeTask('create_media_buy', { account: { account_id: 'test-acc' } });
       assert.strictEqual(client.getPendingTaskId(), 'task-A', 'submitted retains the handle');
       assert.strictEqual(client.getContextId(), 'ctx-shared');
 
@@ -386,10 +386,10 @@ describe('AgentClient.withSession narrows pendingTaskId auto-thread (regression 
       stub.enqueue(taskResponse({ status: 'completed', contextId: 'ctx-hitl', taskId: 'task-hitl' }));
 
       const client = newClient();
-      await client.executeTask('create_media_buy', {});
+      await client.executeTask('create_media_buy', { account: { account_id: 'test-acc' } });
       assert.strictEqual(client.getPendingTaskId(), 'task-hitl');
 
-      await client.executeTask('create_media_buy', {});
+      await client.executeTask('create_media_buy', { account: { account_id: 'test-acc' } });
 
       assert.strictEqual(stub.captured[1].message.contextId, 'ctx-hitl');
       assert.strictEqual(
@@ -412,7 +412,7 @@ describe('AgentClient.withSession narrows pendingTaskId auto-thread (regression 
       stub.enqueue(taskResponse({ status: 'completed', contextId: 'ctx-1', taskId: 'task-orig' }));
 
       const client = newClient();
-      await client.executeTask('create_media_buy', {});
+      await client.executeTask('create_media_buy', { account: { account_id: 'test-acc' } });
 
       await client.executeTask('get_products', {}, undefined, { taskId: 'task-orig' });
 

--- a/test/lib/agent-client-in-process.test.js
+++ b/test/lib/agent-client-in-process.test.js
@@ -159,6 +159,7 @@ describe('AgentClient.fromMCPClient — in-process transport', () => {
     // we'd be asserting against `captured` from a prior tool call, so let any
     // unexpected throw fail the test rather than swallowing it.
     const result = await agent.createMediaBuy({
+      account: { account_id: 'test-acc' },
       brand: { domain: 'test.example' },
       product_id: 'prod-1',
       line_items: [],
@@ -186,6 +187,7 @@ describe('AgentClient.fromMCPClient — in-process transport', () => {
     });
 
     const result = await agent.createMediaBuy({
+      account: { account_id: 'test-acc' },
       brand: { domain: 'test.example' },
       product_id: 'prod-1',
       line_items: [],

--- a/test/lib/execute-task-error-envelope.test.js
+++ b/test/lib/execute-task-error-envelope.test.js
@@ -131,7 +131,7 @@ describe('executeTask error envelope (issue #1148)', () => {
 
     try {
       await assert.rejects(
-        () => agent.executeTask('create_media_buy', { idempotency_key: 'k1' }),
+        () => agent.executeTask('create_media_buy', { account: { account_id: 'acc-1' }, idempotency_key: 'k1' }),
         err => {
           assert.ok(
             err instanceof VersionUnsupportedError,

--- a/test/lib/request-normalizer.test.js
+++ b/test/lib/request-normalizer.test.js
@@ -1,0 +1,122 @@
+// Tests for issue #1676: request-normalizer must not fabricate account from brand.
+//
+// Prior to this fix, create_media_buy calls that omitted `account` but supplied
+// `brand.domain` silently fabricated { brand, operator: brand.domain } — a value
+// the caller never provided and that is semantically wrong for any topology with
+// a buying-side intermediary. The shim was removed with the v2 sunset (AdCP 3.0 GA).
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+
+describe('normalizeRequestParams — account validation (create_media_buy)', () => {
+  let normalizeRequestParams;
+  let ValidationError;
+
+  test('setup', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+    ValidationError = lib.ADCPValidationError;
+    assert.ok(normalizeRequestParams, 'normalizeRequestParams must be exported');
+    assert.ok(ValidationError, 'ADCPValidationError must be exported');
+  });
+
+  test('throws ValidationError when account is absent and brand is present with domain', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+    ValidationError = lib.ADCPValidationError;
+
+    assert.throws(
+      () =>
+        normalizeRequestParams('create_media_buy', {
+          brand: { name: 'Acme', domain: 'acme.com' },
+          packages: [],
+        }),
+      err => {
+        assert.ok(err instanceof ValidationError, `expected ValidationError, got ${err.constructor.name}`);
+        assert.strictEqual(err.code, 'VALIDATION_ERROR');
+        assert.ok(err.message.includes('account'), 'error message should mention account field');
+        return true;
+      }
+    );
+  });
+
+  test('throws ValidationError when account is absent and brand is absent', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+    ValidationError = lib.ADCPValidationError;
+
+    assert.throws(
+      () =>
+        normalizeRequestParams('create_media_buy', {
+          packages: [],
+        }),
+      err => {
+        assert.ok(err instanceof ValidationError, `expected ValidationError, got ${err.constructor.name}`);
+        assert.strictEqual(err.code, 'VALIDATION_ERROR');
+        return true;
+      }
+    );
+  });
+
+  test('does not throw when account is provided as account_id reference', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+
+    assert.doesNotThrow(() =>
+      normalizeRequestParams('create_media_buy', {
+        account: { account_id: 'acc-123' },
+        packages: [],
+      })
+    );
+  });
+
+  test('does not throw when account is provided as natural-key reference', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+
+    assert.doesNotThrow(() =>
+      normalizeRequestParams('create_media_buy', {
+        account: { brand: { name: 'Acme', domain: 'acme.com' }, operator: 'agency.com' },
+        packages: [],
+      })
+    );
+  });
+
+  test('does not throw for other task types that omit account', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+
+    assert.doesNotThrow(() =>
+      normalizeRequestParams('get_products', {
+        brand: { name: 'Acme', domain: 'acme.com' },
+      })
+    );
+
+    assert.doesNotThrow(() =>
+      normalizeRequestParams('update_media_buy', {
+        media_buy_id: 'mb-999',
+      })
+    );
+  });
+
+  test('does not fabricate account.operator from brand.domain', () => {
+    const lib = require('../../dist/lib/index.js');
+    normalizeRequestParams = lib.normalizeRequestParams;
+    ValidationError = lib.ADCPValidationError;
+
+    // Regression: the removed shim set operator = brand.domain, which is
+    // semantically wrong for most topologies. Verify it never fires.
+    let caught = null;
+    try {
+      normalizeRequestParams('create_media_buy', {
+        brand: { name: 'Acme', domain: 'acme.com' },
+        packages: [],
+      });
+    } catch (err) {
+      caught = err;
+    }
+    assert.ok(caught instanceof ValidationError, 'should throw, not fabricate');
+    // The fabricated path would have set operator = 'acme.com'; verify it didn't
+    // by confirming we got the error rather than a modified params object.
+  });
+});

--- a/test/lib/v3-compatibility.test.js
+++ b/test/lib/v3-compatibility.test.js
@@ -1307,10 +1307,15 @@ const { resetWarnings } = require('../../dist/lib/utils/deprecation.js');
 const UUID_V4_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 describe('normalizeRequestParams: idempotency_key auto-inject (MUTATING_TASKS coverage)', () => {
+  // create_media_buy now requires account; provide a minimal fixture when the
+  // task under test is create_media_buy so the iterator doesn't trip the
+  // (separately tested) account-required validation.
+  const baseParamsFor = task => (task === 'create_media_buy' ? { account: { account_id: 'test-acc' } } : {});
+
   test('every MUTATING_TASKS member gets a UUID v4 when the caller omits idempotency_key', () => {
     assert.ok(MUTATING_TASKS.size >= 20, `MUTATING_TASKS set looks empty (${MUTATING_TASKS.size})`);
     for (const task of MUTATING_TASKS) {
-      const result = normalizeRequestParams(task, {});
+      const result = normalizeRequestParams(task, baseParamsFor(task));
       assert.match(
         String(result?.idempotency_key),
         UUID_V4_PATTERN,
@@ -1331,17 +1336,27 @@ describe('normalizeRequestParams: idempotency_key auto-inject (MUTATING_TASKS co
   });
 
   test('preserves a caller-supplied idempotency_key (BYOK)', () => {
-    const result = normalizeRequestParams('create_media_buy', { idempotency_key: 'byok-1234567890abcdef' });
+    const result = normalizeRequestParams('create_media_buy', {
+      account: { account_id: 'test-acc' },
+      idempotency_key: 'byok-1234567890abcdef',
+    });
     assert.strictEqual(result?.idempotency_key, 'byok-1234567890abcdef');
   });
 
   test('treats empty-string idempotency_key as unset and injects a fresh UUID', () => {
-    const result = normalizeRequestParams('create_media_buy', { idempotency_key: '' });
+    const result = normalizeRequestParams('create_media_buy', {
+      account: { account_id: 'test-acc' },
+      idempotency_key: '',
+    });
     assert.match(String(result?.idempotency_key), UUID_V4_PATTERN);
   });
 
   test('skipIdempotencyAutoInject=true leaves the field absent so compliance scenarios can exercise missing-key rejection', () => {
-    const result = normalizeRequestParams('create_media_buy', {}, { skipIdempotencyAutoInject: true });
+    const result = normalizeRequestParams(
+      'create_media_buy',
+      { account: { account_id: 'test-acc' } },
+      { skipIdempotencyAutoInject: true }
+    );
     assert.strictEqual(result?.idempotency_key, undefined);
   });
 });
@@ -1376,7 +1391,10 @@ describe('Request Parameter Normalization', () => {
 
     test('should not convert non-string account_id', () => {
       resetWarnings();
-      const result = normalizeRequestParams('create_media_buy', {
+      // Use a non-mutating task here: when account_id is non-string the shim
+      // skips and `account` stays undefined, which is fine for read-only tools
+      // but would trip the create_media_buy account-required validation.
+      const result = normalizeRequestParams('get_media_buys', {
         account_id: 123,
         buyer_ref: 'ref-1',
       });
@@ -1398,6 +1416,7 @@ describe('Request Parameter Normalization', () => {
     test('should rename campaign_ref to buyer_campaign_ref', () => {
       resetWarnings();
       const result = normalizeRequestParams('create_media_buy', {
+        account: { account_id: 'acc-1' },
         campaign_ref: 'camp_Q2',
         buyer_ref: 'buyer-1',
       });
@@ -1590,6 +1609,7 @@ describe('Request Parameter Normalization', () => {
     test('should not strip removed fields for other tools', () => {
       resetWarnings();
       const result = normalizeRequestParams('create_media_buy', {
+        account: { account_id: 'acc-1' },
         feedback: 'some_data',
       });
 
@@ -1680,6 +1700,7 @@ describe('Request Parameter Normalization', () => {
     test('should derive brand from brand_manifest for create_media_buy', () => {
       resetWarnings();
       const result = normalizeRequestParams('create_media_buy', {
+        account: { account_id: 'acc-1' },
         buyer_ref: 'buyer-1',
         brand_manifest: 'https://acme.com',
         packages: [],
@@ -1712,19 +1733,27 @@ describe('Request Parameter Normalization', () => {
     });
   });
 
-  describe('account inference from brand (create_media_buy)', () => {
-    test('should infer account from brand when account is missing', () => {
-      resetWarnings();
-      const result = normalizeRequestParams('create_media_buy', {
-        buyer_ref: 'buyer-1',
-        brand: { name: 'Acme', domain: 'acme.com' },
-        packages: [],
-      });
+  describe('account validation (create_media_buy)', () => {
+    // The v2 shim that inferred account.operator from brand.domain was removed
+    // with the v2 sunset (April 2026). create_media_buy now requires account
+    // explicitly; the normalizer throws ValidationError when it is missing.
+    const { ADCPValidationError } = require('../../dist/lib/index.js');
 
-      assert.deepStrictEqual(result.account, {
-        brand: { name: 'Acme', domain: 'acme.com' },
-        operator: 'acme.com',
-      });
+    test('should throw ValidationError when account is missing', () => {
+      resetWarnings();
+      assert.throws(
+        () =>
+          normalizeRequestParams('create_media_buy', {
+            buyer_ref: 'buyer-1',
+            brand: { name: 'Acme', domain: 'acme.com' },
+            packages: [],
+          }),
+        err => {
+          assert.ok(err instanceof ADCPValidationError, `expected ADCPValidationError, got ${err.constructor.name}`);
+          assert.ok(err.message.includes('account'), 'error message should mention account');
+          return true;
+        }
+      );
     });
 
     test('should not overwrite existing account', () => {
@@ -1739,17 +1768,22 @@ describe('Request Parameter Normalization', () => {
       assert.deepStrictEqual(result.account, { account_id: 'acct_existing' });
     });
 
-    test('should not infer account when brand is missing', () => {
+    test('should throw ValidationError when both account and brand are missing', () => {
       resetWarnings();
-      const result = normalizeRequestParams('create_media_buy', {
-        buyer_ref: 'buyer-1',
-        packages: [],
-      });
-
-      assert.strictEqual(result.account, undefined);
+      assert.throws(
+        () =>
+          normalizeRequestParams('create_media_buy', {
+            buyer_ref: 'buyer-1',
+            packages: [],
+          }),
+        err => {
+          assert.ok(err instanceof ADCPValidationError, `expected ADCPValidationError, got ${err.constructor.name}`);
+          return true;
+        }
+      );
     });
 
-    test('should not infer account for other task types', () => {
+    test('should not require account for other task types', () => {
       resetWarnings();
       const result = normalizeRequestParams('get_products', {
         brand: { name: 'Acme', domain: 'acme.com' },
@@ -1759,40 +1793,38 @@ describe('Request Parameter Normalization', () => {
       assert.strictEqual(result.account, undefined);
     });
 
-    test('should not infer account when brand has no domain', () => {
+    test('should throw when account is missing even if brand has no domain', () => {
       resetWarnings();
-      const result = normalizeRequestParams('create_media_buy', {
-        buyer_ref: 'buyer-1',
-        brand: { name: 'Acme' },
-        packages: [],
-      });
-
-      assert.strictEqual(result.account, undefined);
+      assert.throws(
+        () =>
+          normalizeRequestParams('create_media_buy', {
+            buyer_ref: 'buyer-1',
+            brand: { name: 'Acme' },
+            packages: [],
+          }),
+        err => {
+          assert.ok(err instanceof ADCPValidationError, `expected ADCPValidationError, got ${err.constructor.name}`);
+          return true;
+        }
+      );
     });
 
-    test('inferred account should not include sandbox field', () => {
+    test('should throw when account is missing even if brand_manifest is provided', () => {
       resetWarnings();
-      const result = normalizeRequestParams('create_media_buy', {
-        buyer_ref: 'buyer-1',
-        brand: { name: 'Acme', domain: 'acme.com' },
-        packages: [],
-      });
-
-      assert.strictEqual(result.account.sandbox, undefined);
-    });
-
-    test('should infer account from brand derived from brand_manifest', () => {
-      resetWarnings();
-      const result = normalizeRequestParams('create_media_buy', {
-        buyer_ref: 'buyer-1',
-        brand_manifest: 'https://acme.com',
-        packages: [],
-      });
-
-      assert.deepStrictEqual(result.account, {
-        brand: { domain: 'acme.com' },
-        operator: 'acme.com',
-      });
+      // Regression: previously this branch fabricated account.operator from
+      // brand_manifest URL. The shim is gone; the call must throw.
+      assert.throws(
+        () =>
+          normalizeRequestParams('create_media_buy', {
+            buyer_ref: 'buyer-1',
+            brand_manifest: 'https://acme.com',
+            packages: [],
+          }),
+        err => {
+          assert.ok(err instanceof ADCPValidationError, `expected ADCPValidationError, got ${err.constructor.name}`);
+          return true;
+        }
+      );
     });
   });
 });


### PR DESCRIPTION
Closes #1676

## Summary

`normalizeRequestParams` contained a v2 backward-compat shim that silently set `account.operator = brand.domain` when a `create_media_buy` call omitted `account`. This PR removes it and throws `ValidationError` instead.

**Why the shim was wrong:**
- `account.operator` identifies the billing account's operator (e.g. `pinnacle-media.com`), not the brand's own domain — the fabricated value was semantically correct only for direct-buy topologies and wrong for any agency/DSP-intermediated call.
- Missing `account` is a caller bug, not a back-compat case. The normalizer was masking it.
- The v2 sunset (AdCP 3.0 GA, April 2026) removes the compat rationale entirely.
- Compliance badges issued through this path certified "handles 3.0 envelope wrapping fabricated account" rather than actual `create_media_buy` account semantics.

**Behavior change (two cases):**
1. `create_media_buy` with `brand.domain` but no `account` — previously fabricated `{ brand, operator: brand.domain }`; now throws `ValidationError(field='account')`.
2. `create_media_buy` with neither `account` nor `brand` — previously fell through to seller-side schema rejection; now throws `ValidationError` client-side.

**Note on `executeAndHandle` vs `executeTask`:** `executeTask` (generic method) wraps all errors in a `TaskResult.failed` return value. `executeAndHandle` (used by typed methods like `createMediaBuy`) does not — `ValidationError` propagates as a thrown exception from typed methods, consistent with how `this.validateRequest` already throws from that path. This pre-existing asymmetry is not addressed in this PR; it's documented here as a known limitation. Callers of typed methods should `try/catch` for pre-flight validation errors.

**Known follow-up:** The `schema_validation` storyboard step that deliberately sends `create_media_buy` without `account` (to test seller error handling) needs an `omit_account` escape hatch analogous to `omit_idempotency_key` — otherwise it tests client-side error behavior rather than seller-side. That storyboard path was already broken by the old shim (shim was fabricating account, seller never saw the missing-account case). Follow-up needed in storyboard runner.

## What was tested

- `npm run format:check` — passed
- `npm run typecheck` — pre-existing errors unrelated to this diff (`TS2688: @types/node`, `TS5107: moduleResolution=node10 deprecated`); both present on `main` before this change
- Build: `dist/` pre-seeded with compiled changes; full build requires `npm install` (CI will verify)
- Tests: `test/lib/request-normalizer.test.js` added with 7 cases covering throw + no-throw paths; full test suite requires `npm install` (CI will verify)

**Pre-PR review:**
- code-reviewer: approved with nits — flagged `executeAndHandle` no-catch (pre-existing, documented above) and missing tests (tests are at `test/lib/request-normalizer.test.js`)
- ad-tech-protocol-expert: approved — "removal is correct and overdue"; `operator = brand.domain` is precisely wrong per `AccountReference` discriminated union; condition widening is correct (explicitly documented in changeset); qualified `sync_accounts` guidance to implicit-account sellers only in error message

**Nits (not fixed):**
- `ValidationError` `constraint` parameter receives a recovery sentence rather than a pure constraint description — pre-existing pattern issue in the error class, out of scope for this PR.

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01WYQpHoctUsoEBa2wuSpnY4

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYQpHoctUsoEBa2wuSpnY4)_