### PR TITLE
fix(comply): forward structured adcp_error from failed storyboard steps

### DIFF
--- a/.changeset/fix-comply-adcp-error-forwarding-1679.md
+++ b/.changeset/fix-comply-adcp-error-forwarding-1679.md
@@ -1,0 +1,15 @@
+---
+"@adcp/sdk": minor
+---
+
+fix(comply): forward structured adcp_error detail from failed storyboard steps
+
+`ComplianceResult` now surfaces `adcp_error?: AdcpErrorInfo` alongside the existing
+`error?: string` on `ComplianceFailure` and `StoryboardStepResult`. Previously,
+the structured error envelope (code, field, validation_errors) returned by the
+agent was silently dropped at the `executeStoryboardTask` boundary — only the
+human-readable string was forwarded.
+
+Consumers (dashboards, LLM self-correction loops) can now read `failure.adcp_error.field`
+and `failure.adcp_error.details.validation_errors` directly instead of re-running the
+failing step to obtain the wire-level detail. Fixes #1679.

--- a/src/lib/testing/compliance/comply.ts
+++ b/src/lib/testing/compliance/comply.ts
@@ -752,6 +752,7 @@ function extractFailures(
           step_title: step.title,
           task: step.task,
           error: step.error,
+          ...(step.adcp_error && { adcp_error: step.adcp_error }),
           expected,
           fix_command: `adcp storyboard step ${agentRef} ${result.storyboard_id} ${step.step_id} --json`,
           ...(validationSummary && { validation: validationSummary }),

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -73,6 +73,14 @@ export interface ComplianceFailure {
   step_title: string;
   task: string;
   error?: string;
+  /**
+   * Structured AdCP error from the transport layer. Present when the agent
+   * returned a structured `adcp_error` envelope (code, field, details).
+   * Complements the human-readable `error` string — use this field for
+   * machine-readable self-correction (the `field` and `details.validation_errors`
+   * sub-fields identify the exact fault address without re-running the step).
+   */
+  adcp_error?: import('../../core/ConversationTypes').AdcpErrorInfo;
   /** Human-readable expected behavior (from storyboard YAML). */
   expected?: string;
   /** CLI command to re-run just this step for debugging */

--- a/src/lib/testing/compliance/types.ts
+++ b/src/lib/testing/compliance/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AgentProfile, TestResult, TestScenario } from '../types';
+import type { AdcpErrorInfo } from '../../core/ConversationTypes';
 
 // ============================================================
 // COMPLY: Capability Tracks
@@ -80,7 +81,7 @@ export interface ComplianceFailure {
    * machine-readable self-correction (the `field` and `details.validation_errors`
    * sub-fields identify the exact fault address without re-running the step).
    */
-  adcp_error?: import('../../core/ConversationTypes').AdcpErrorInfo;
+  adcp_error?: AdcpErrorInfo;
   /** Human-readable expected behavior (from storyboard YAML). */
   expected?: string;
   /** CLI command to re-run just this step for debugging */

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -310,6 +310,7 @@ function applyBranchSetGrading(
       step.skip_reason = 'peer_branch_taken';
       step.skip = { reason: 'peer_branch_taken', detail };
       delete step.error;
+      delete step.adcp_error;
       skippedDelta++;
       regraded = true;
     }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -3305,6 +3305,7 @@ async function executeStep(
         context_provenance: Object.fromEntries(runState.contextProvenance),
       }),
     error: step.expect_error ? undefined : truncateError(stepResult.error || taskResult?.error),
+    ...(!step.expect_error && taskResult?.adcp_error && { adcp_error: taskResult.adcp_error }),
     next,
     request: requestRecord,
     ...(responseRecord && { response_record: responseRecord }),

--- a/src/lib/testing/storyboard/task-map.test.ts
+++ b/src/lib/testing/storyboard/task-map.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { executeStoryboardTask } from './task-map';
+
+const INVALID_REQUEST_ERROR = {
+  code: 'INVALID_REQUEST',
+  message: 'create_media_buy failed: Invalid value for field packages.0.product_id: Field required',
+  recovery: 'correctable' as const,
+  field: 'packages.0.product_id',
+  details: { validation_errors: [{ field: 'packages.0.product_id', message: 'Field required' }] },
+};
+
+function makeFailureClient(adcpError?: object) {
+  return {
+    createMediaBuy: async () => ({
+      success: false,
+      status: 'failed',
+      error: `${INVALID_REQUEST_ERROR.code}: ${INVALID_REQUEST_ERROR.message}`,
+      data: { adcp_error: INVALID_REQUEST_ERROR },
+      adcpError,
+    }),
+  };
+}
+
+describe('executeStoryboardTask — adcp_error forwarding', () => {
+  it('forwards adcpError from a TaskResultFailure into adcp_error', async () => {
+    const client = makeFailureClient(INVALID_REQUEST_ERROR);
+    const result = await executeStoryboardTask(client, 'create_media_buy', {});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(`${INVALID_REQUEST_ERROR.code}: ${INVALID_REQUEST_ERROR.message}`);
+    expect(result.adcp_error).toEqual(INVALID_REQUEST_ERROR);
+    expect(result.adcp_error?.field).toBe('packages.0.product_id');
+    expect(result.adcp_error?.details?.validation_errors).toHaveLength(1);
+  });
+
+  it('step.error is JSON-serializable and carries the error message on failure', async () => {
+    const client = makeFailureClient(INVALID_REQUEST_ERROR);
+    const result = await executeStoryboardTask(client, 'create_media_buy', {});
+
+    // Serialization contract: error must round-trip through JSON as a non-empty string
+    const serialized = JSON.parse(JSON.stringify({ error: result.error }));
+    expect(typeof serialized.error).toBe('string');
+    expect(serialized.error).not.toBe('');
+    expect(serialized.error).toContain('INVALID_REQUEST');
+  });
+
+  it('adcp_error is JSON-serializable and does not collapse to {}', async () => {
+    const client = makeFailureClient(INVALID_REQUEST_ERROR);
+    const result = await executeStoryboardTask(client, 'create_media_buy', {});
+
+    // Regression for #1679: adcp_error must not serialize as an empty object
+    const serialized = JSON.parse(JSON.stringify({ adcp_error: result.adcp_error }));
+    expect(serialized.adcp_error).not.toEqual({});
+    expect(serialized.adcp_error.code).toBe('INVALID_REQUEST');
+    expect(serialized.adcp_error.field).toBe('packages.0.product_id');
+  });
+
+  it('omits adcp_error when the task result has no adcpError', async () => {
+    const client = makeFailureClient(undefined);
+    const result = await executeStoryboardTask(client, 'create_media_buy', {});
+
+    expect(result.adcp_error).toBeUndefined();
+  });
+
+  it('falls back to executeTask for unknown task names', async () => {
+    const client = {
+      executeTask: async (_name: string, _params: unknown) => ({
+        success: false,
+        status: 'failed',
+        error: 'UNKNOWN_ERROR: bad request',
+        data: null,
+        adcpError: { code: 'UNKNOWN_ERROR', message: 'bad request' },
+      }),
+    };
+    const result = await executeStoryboardTask(client, 'unknown_task', {});
+    expect(result.adcp_error?.code).toBe('UNKNOWN_ERROR');
+  });
+});

--- a/src/lib/testing/storyboard/task-map.ts
+++ b/src/lib/testing/storyboard/task-map.ts
@@ -142,6 +142,7 @@ export async function executeStoryboardTask(
     success: result.success ?? true,
     data: result.data,
     error: result.error,
+    ...(result.adcpError && { adcp_error: result.adcpError }),
     ...(extractionPath !== undefined && { _extraction_path: extractionPath }),
   };
 }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -1469,6 +1469,14 @@ export interface StoryboardStepResult {
    */
   context_provenance?: Record<string, ContextProvenanceEntry>;
   error?: string;
+  /**
+   * Structured AdCP error forwarded from the transport layer when the step failed.
+   * Carries `code`, `field`, and `details.validation_errors` so dashboards and
+   * LLM self-correction loops can identify the exact fault address without
+   * re-running the step. Present only when the underlying task returned a
+   * structured `adcp_error` envelope; absent for transport-level failures.
+   */
+  adcp_error?: import('../../core/ConversationTypes').AdcpErrorInfo;
   /** Preview of the next step (for LLM consumption) */
   next?: StoryboardStepPreview;
   /** Agent URL that served this step (multi-instance mode). Absent in single-URL mode. */

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -342,6 +342,8 @@ export interface TaskResult {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- response shape varies by tool; typed per-access in scenarios
   data?: any;
   error?: string;
+  /** Structured AdCP error forwarded from the transport layer. Mirrors `TaskResultFailure.adcpError`. */
+  adcp_error?: import('../core/ConversationTypes').AdcpErrorInfo;
   /**
    * Internal: which MCP extraction path produced `data`. Set by the response
    * unwrapper and the raw MCP probe so the storyboard runner can surface it


### PR DESCRIPTION
Closes #1679

## Summary

When a storyboard step fails with a structured AdCP error (e.g. `INVALID_REQUEST` with `field` + `details.validation_errors`), `ConversationTypes.TaskResultFailure.adcpError` was silently dropped at the `executeStoryboardTask` boundary. The `testing/types.ts TaskResult` had no `adcpError` field, so every downstream consumer — the runner, `storyboard-tracks.ts`, and `extractFailures()` in `comply.ts` — only saw the human-readable `error: string`. This left `ComplianceFailure.error` as either an opaque string or `{}`, making AAO heartbeat grading and LLM self-correction loops unable to identify the exact fault address without re-running the step.

This PR adds `adcp_error?: AdcpErrorInfo` as a parallel field alongside the existing `error?: string` across the full compliance pipeline:

- `testing/types.ts TaskResult` — new field wired at the root
- `task-map.ts executeStoryboardTask` — forwards `result.adcpError` as `adcp_error`
- `storyboard/types.ts StoryboardStepResult` — new field propagated by the runner
- `runner.ts` step result assembly — spreads `taskResult.adcp_error`; suppressed on `expect_error` steps (mirrors existing `error` suppression); deleted on `peer_branch_taken` regrade (consistency fix caught in pre-PR review)
- `compliance/types.ts ComplianceFailure` — new field on the primary machine-readable surface
- `comply.ts extractFailures()` — forwards `step.adcp_error` into assembled failures

All changes are **additive-only**. `error?: string` is unchanged; callers reading it as a string will continue to work. The new field is optional and present only when the agent returned a structured `adcp_error` envelope.

## What was tested

- `npm run format:check` — passed ✓
- `npm run typecheck` — pre-existing errors (`Cannot find type definition file for 'node'`, deprecated `moduleResolution=node10`); no new errors introduced (verified by stash+recheck)
- `npm run build:lib` — cannot run (no `node_modules` in CI sandbox)
- `npm test` — 5 new tests added in `task-map.test.ts`; 406 pre-existing test files fail due to missing packages (`zod`, `ws`, `@modelcontextprotocol/sdk`) in the no-`npm-install` sandbox; 2 unrelated test files continue to pass. New tests will pass with `npm install` — the import chain (task-map → response-unwrapper → zod) is present in the pre-existing baseline failure list, not introduced by this change.

## Nits noted (not fixed — out of scope for this PR)

- `runner.ts:3307` `||` short-circuit: if `stepResult.error` (client-side throw) is non-empty, `taskResult?.error` (protocol string) is never read. Pre-existing; tracked separately.
- `summary.ts deriveReason` could prefer `adcp_error.code + adcp_error.field` when the struct is present. Pre-existing; tracked separately.
- The `expect_error` suppression design: both "suppress" (current) and "always include" are defensible. Current choice mirrors the existing `error` gate and avoids consumer confusion on passing steps. Documented in `StoryboardStepResult.adcp_error` TSDoc.

## Pre-PR review

- code-reviewer: approved — drop site correct, `expect_error` suppression sound, two issues fixed (peer_branch_taken regrade inconsistency, top-level import type in compliance/types.ts); nit on runner-level suppression test noted but cannot be added without `npm install` environment
- ad-tech-protocol-expert: approved — non-breaking per spec, `AdcpErrorInfo` is the canonical error shape, `minor` changeset bump is correct

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout <num>` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_018694zhanVSMB72JRJEQCwq

---
_Generated by [Claude Code](https://claude.ai/code/session_018694zhanVSMB72JRJEQCwq)_