### PR TITLE
fix(server): return IDEMPOTENCY_IN_FLIGHT instead of SERVICE_UNAVAILABLE on in-flight idempotency key

### DIFF
--- a/.changeset/idempotency-in-flight-error-code-mp1apy3b.md
+++ b/.changeset/idempotency-in-flight-error-code-mp1apy3b.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': minor
+---
+
+fix(server): return IDEMPOTENCY_IN_FLIGHT instead of SERVICE_UNAVAILABLE on in-flight idempotency key
+
+The idempotency middleware now returns the spec-defined IDEMPOTENCY_IN_FLIGHT error code (AdCP rule 9) when a parallel request holds the same key, instead of the generic SERVICE_UNAVAILABLE. The retry_after hint is derived from the in-flight claim's expiresAt rather than a hardcoded 1s. IdempotencyCheckResult's in-flight branch gains an optional expiresAt field exposing the claim's unix expiry timestamp.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3799,15 +3799,20 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             }
             if (checkResult.kind === 'in-flight') {
               // A parallel request is currently executing this same key.
-              // Tell the client to retry — returning SERVICE_UNAVAILABLE
-              // with a short retry_after is transient-classified and the
-              // buyer SDK auto-retries. Eventually the other request
-              // completes and this retry either replays the cached
-              // response or hits IDEMPOTENCY_CONFLICT.
+              // Return IDEMPOTENCY_IN_FLIGHT (AdCP rule 9 / spec §idempotency) so buyers can
+              // distinguish a concurrency rejection from a generic server failure. recovery:
+              // 'transient' is explicit because IDEMPOTENCY_IN_FLIGHT is held for AdCP 3.1 and
+              // not in ErrorCodeValues yet — adcpError() would otherwise default unknown codes to
+              // 'terminal'. retry_after is derived from the in-flight claim's expiresAt so the
+              // hint decays toward the actual expected completion; fallback to 5s when expiresAt
+              // is absent (entry evicted between store reads on the lost-race re-check path).
+              const retryAfter =
+                checkResult.expiresAt != null ? Math.max(1, checkResult.expiresAt - Math.floor(Date.now() / 1000)) : 5;
               return finalize(
-                adcpError('SERVICE_UNAVAILABLE', {
+                adcpError('IDEMPOTENCY_IN_FLIGHT', {
                   message: 'A parallel request with the same idempotency_key is still in flight. Retry shortly.',
-                  retry_after: 1,
+                  recovery: 'transient',
+                  retry_after: retryAfter,
                 })
               );
             }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3807,7 +3807,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
               // hint decays toward the actual expected completion; fallback to 5s when expiresAt
               // is absent (entry evicted between store reads on the lost-race re-check path).
               const retryAfter =
-                checkResult.expiresAt != null ? Math.max(1, checkResult.expiresAt - Math.floor(Date.now() / 1000)) : 5;
+                checkResult.expiresAt != null
+                  ? Math.min(30, Math.max(1, checkResult.expiresAt - Math.floor(Date.now() / 1000)))
+                  : 5;
               return finalize(
                 adcpError('IDEMPOTENCY_IN_FLIGHT', {
                   message: 'A parallel request with the same idempotency_key is still in flight. Retry shortly.',

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -161,6 +161,12 @@ export type IdempotencyCheckResult =
   | {
       /** A parallel request is currently executing the same key — the caller should retry the check. */
       kind: 'in-flight';
+      /**
+       * Unix timestamp (seconds) at which the in-flight claim expires. Present when the
+       * store has the cached entry; use to compute `retry_after` for `IDEMPOTENCY_IN_FLIGHT`.
+       * Absent on the lost-race re-check path when the backend returns null.
+       */
+      expiresAt?: number;
     }
   | {
       /** No prior execution for this key — caller should run the handler and save. */
@@ -359,7 +365,7 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
           return { kind: 'expired' };
         }
         if (cached.payloadHash === IN_FLIGHT_HASH) {
-          return { kind: 'in-flight' };
+          return { kind: 'in-flight', expiresAt: cached.expiresAt };
         }
         if (cached.payloadHash !== payloadHash) {
           return { kind: 'conflict' };
@@ -381,8 +387,9 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
       if (!claimed) {
         // Someone beat us to the claim — re-read to find out what they did.
         const recheck = await backend.get(scopedKey);
+        // Entry evicted between putIfAbsent and get — expiresAt unknowable; middleware uses fallback.
         if (!recheck) return { kind: 'in-flight' };
-        if (recheck.payloadHash === IN_FLIGHT_HASH) return { kind: 'in-flight' };
+        if (recheck.payloadHash === IN_FLIGHT_HASH) return { kind: 'in-flight', expiresAt: recheck.expiresAt };
         if (recheck.payloadHash !== payloadHash) return { kind: 'conflict' };
         return { kind: 'replay', response: recheck.response };
       }

--- a/src/lib/testing/scenarios/error-compliance.ts
+++ b/src/lib/testing/scenarios/error-compliance.ts
@@ -13,6 +13,14 @@ import { extractAdcpErrorFromMcp, resolveRecovery } from '../../utils/error-extr
 import type { ExtractedAdcpError } from '../../utils/error-extraction';
 import { isStandardErrorCode } from '../../types/error-codes';
 
+/**
+ * AdCP spec-defined codes that are held for a future wire version and therefore
+ * absent from ErrorCodeValues in the current generated enum, but are explicitly
+ * sanctioned by the spec and must not require the X_ vendor prefix.
+ * Remove a code from this set once it lands in ErrorCodeValues via schema codegen.
+ */
+const SPEC_RESERVED_PENDING_CODES = new Set(['IDEMPOTENCY_IN_FLIGHT']);
+
 /** Raw MCP CallToolResult shape */
 interface RawMcpResponse {
   isError?: boolean;
@@ -294,7 +302,11 @@ export async function testErrorStructure(
     }
 
     // Code is standard?
-    if (!isStandardErrorCode(extracted.code) && !extracted.code.startsWith('X_')) {
+    if (
+      !isStandardErrorCode(extracted.code) &&
+      !extracted.code.startsWith('X_') &&
+      !SPEC_RESERVED_PENDING_CODES.has(extracted.code)
+    ) {
       issues.push(`Non-standard code '${extracted.code}' should use X_ vendor prefix`);
     }
 

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -345,9 +345,9 @@ describe('createAdcpServer with idempotency', () => {
     const results = await Promise.all(Array.from({ length: 5 }, () => callTool(server, 'create_media_buy', req)));
 
     assert.equal(calls, 1, 'handler must run exactly once under concurrent retry');
-    // Winners: one got a fresh response, others got SERVICE_UNAVAILABLE (in-flight)
+    // Winners: one got a fresh response, others got IDEMPOTENCY_IN_FLIGHT (in-flight)
     const winners = results.filter(r => r.media_buy_id);
-    const inFlights = results.filter(r => r.adcp_error?.code === 'SERVICE_UNAVAILABLE');
+    const inFlights = results.filter(r => r.adcp_error?.code === 'IDEMPOTENCY_IN_FLIGHT');
     assert.ok(winners.length >= 1, 'at least one call must return the fresh response');
     assert.equal(winners.length + inFlights.length, 5);
   });
@@ -423,7 +423,7 @@ describe('createAdcpServer with idempotency', () => {
   it('strict-mode parallel retries of a drifted handler see in-flight, not re-execution', async () => {
     // Concurrency guard: while call A is still inside the handler
     // producing the drifted response, a parallel call B with the same
-    // key + payload must hit the IN_FLIGHT claim (SERVICE_UNAVAILABLE)
+    // key + payload must hit the IN_FLIGHT claim (IDEMPOTENCY_IN_FLIGHT)
     // rather than re-entering the handler. Once A completes and writes
     // the transient-error entry, a subsequent retry hits the cached
     // VALIDATION_ERROR — not the handler.
@@ -457,7 +457,7 @@ describe('createAdcpServer with idempotency', () => {
     await new Promise(r => setImmediate(r));
     const b = await callTool(server, 'create_media_buy', req);
 
-    assert.equal(b.adcp_error?.code, 'SERVICE_UNAVAILABLE', 'parallel retry must see in-flight, not re-execute');
+    assert.equal(b.adcp_error?.code, 'IDEMPOTENCY_IN_FLIGHT', 'parallel retry must see in-flight, not re-execute');
     assert.equal(calls, 1, 'handler must not re-execute for parallel retry');
 
     releaseHandler();


### PR DESCRIPTION
Closes #1687

## Summary

The idempotency middleware was returning `SERVICE_UNAVAILABLE` when a parallel request held the same key — predating AdCP rule 9 (concurrent retries / first-insert-wins). This PR corrects the wire drift:

- Swaps `SERVICE_UNAVAILABLE` → `IDEMPOTENCY_IN_FLIGHT` on the in-flight branch in `createAdcpServer`.
- Sets `recovery: 'transient'` explicitly — `IDEMPOTENCY_IN_FLIGHT` is held for AdCP 3.1 and not yet in `ErrorCodeValues`, so `adcpError()` would otherwise fall back to `'terminal'` for the unknown code.
- Derives `retry_after` from the in-flight claim's `expiresAt` (capped at 30s, minimum 1s), replacing the hardcoded `1`. Falls back to 5s on the lost-race re-check path where `expiresAt` is unavailable.
- Extends `IdempotencyCheckResult`'s `in-flight` union member with an optional `expiresAt?: number` field so the middleware can compute the hint without a second store read.
- Adds `IDEMPOTENCY_IN_FLIGHT` to `SPEC_RESERVED_PENDING_CODES` in `error-compliance.ts` so the spec-defined (3.1-held) code does not trigger the `X_` vendor-prefix compliance warning.

**Scope not included:** `concurrentRetry: 'reject' | 'wait'` config option — explicitly deferred as non-blocking by issue author.

## What was tested

- `npm run format:check` — passed ✓
- `npm run typecheck` — pre-existing errors only (`TS2688: @types/node`, `TS5107: moduleResolution=node10`); no new errors introduced
- `npm run build:lib` — cannot run (`tsx` not available in this environment; same constraint as #1684 / #1683 / #1682)
- `npm test` — cannot run (no `node_modules`; same constraint); CI will verify

## Pre-PR review

- **code-reviewer:** approved — no blockers; noted uncapped `retry_after` upper bound (capped at 30s in fixup commit) and test coverage gaps for `recovery`/`retry_after` wire shape and store-level `expiresAt` assertion (noted as nits in PR body below)
- **ad-tech-protocol-expert:** approved — `recovery: 'transient'` + `retry_after` combination is correct for a 3.0.x server emitting a 3.1-held code; `expiresAt - now` formula is consistent with AdCP rule 9 decaying-hint guidance; `SPEC_RESERVED_PENDING_CODES` exemption resolves compliance validator mismatch; 30s cap resolves buyer stall concern

## Nits noted (not fixed — out of scope for this PR)

- No test asserts `recovery: 'transient'` or `typeof retry_after === 'number'` on the `IDEMPOTENCY_IN_FLIGHT` response — a future test adding concurrent-pair assertions on the full wire shape would improve confidence
- `idempotency-store.test.js` concurrent-race test does not assert `expiresAt` on in-flight results — store-level unit coverage for the two changed return paths
- `create-adcp-server.ts:3802` "AdCP rule 9 / spec §idempotency" reference could be tightened to a stable spec anchor once 3.1 is ratified

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1688` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01MBVaFVSovfBi7oZpuvLnnv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBVaFVSovfBi7oZpuvLnnv)_