### PR TITLE
fix(comply): autodetect webhook_receiver requirement from token presence

### DIFF
--- a/.changeset/webhook-receiver-autodetect-1678.md
+++ b/.changeset/webhook-receiver-autodetect-1678.md
@@ -1,0 +1,15 @@
+---
+'@adcp/sdk': minor
+---
+
+fix(comply): autodetect `webhook_receiver` requirement from storyboard token presence
+
+`comply()` was shipping the literal mustache token `{{runner.webhook_url:<step_id>}}` on the wire whenever a webhook-emitting storyboard ran without a configured receiver. 3.0-strict sellers reject the resulting payload as `INVALID_REQUEST: Input should be a valid URL, relative URL without a base`, cascading 5 distinct first-step failures across `webhook_emission/*` and `idempotency/replay_same_payload`.
+
+This PR adds `'webhook_receiver'` to `RequirementName` and `KNOWN_REQUIREMENTS`, maps it to `requirement_unmet` in the runner's skip-reason table, and adds a structural pre-pass (`detectImplicitRequires`) that scans every step's `sample_request` for `{{runner.webhook_url:…}}` or `{{runner.webhook_base}}` tokens. When any are found and `options.webhook_receiver` is unset, the storyboard grades `not_applicable` with `skip.requirement: 'webhook_receiver'` — matching the spec contract at `compliance/{version}/universal/webhook-emission.yaml` (L34, L62–70, L331–332).
+
+**Authoring impact:** none. Storyboard authors do not need to add `requires: [webhook_receiver]` — the token presence is the declaration. Existing storyboards that reference the runner's webhook URL automatically inherit the gate.
+
+**Behavior change:** runs that previously failed with `INVALID_REQUEST` from a strict seller now grade `not_applicable` and surface `requirement_unmet:webhook_receiver` in the structured skip block. Runs that already configure `webhook_receiver` are unchanged.
+
+Fixes #1678. Part of the coordinated stance at #1685.

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -872,6 +872,7 @@ const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
   controller: 'missing_test_controller',
   seeded_state: 'requirement_unmet',
   real_wire: 'requirement_unmet',
+  webhook_receiver: 'requirement_unmet',
 };
 
 /**
@@ -951,6 +952,10 @@ function buildRequirementUnmetResult(
  *   - `real_wire` — always available; the runner is hitting a real wire
  *     by definition. The tag is a no-op gate today, reserved for a
  *     future `--mock-only` mode.
+ *   - `webhook_receiver` — operator supplied `options.webhook_receiver`.
+ *     Autodetected from step `sample_request` token presence (see
+ *     `detectImplicitRequires`); authors don't write this tag manually.
+ *     Spec: adcp-client#1678.
  */
 function checkRequires(
   requires: readonly RequirementName[],
@@ -984,9 +989,75 @@ function checkRequires(
       case 'real_wire':
         // Always available — reserved for a future --mock-only mode.
         break;
+      case 'webhook_receiver': {
+        if (options.webhook_receiver === undefined) {
+          return {
+            requirement,
+            detail:
+              'Storyboard references `{{runner.webhook_url:…}}` or `{{runner.webhook_base}}` but no ' +
+              'webhook receiver is configured. Pass `webhook_receiver` in StoryboardRunOptions ' +
+              '(or `--webhook-receiver` on the CLI) to host a receiver, or omit this storyboard. ' +
+              'Required by the webhook-emission universal: ' +
+              'compliance/{version}/universal/webhook-emission.yaml grades not_applicable when ' +
+              'no receiver is configured (prerequisites section).',
+          };
+        }
+        break;
+      }
     }
   }
   return null;
+}
+
+/**
+ * Webhook-token regex used to autodetect the implicit `webhook_receiver`
+ * requirement. Matches `{{runner.webhook_url:<step_id>}}` and the bare
+ * `{{runner.webhook_base}}`. Same shape as the `MUSTACHE_TOKEN_RE` in
+ * context.ts but scoped to the two webhook-bearing tokens — we only care
+ * whether the storyboard needs a receiver, not what substitution it
+ * would produce. Single `[^{}]+` body avoids the polynomial-redos
+ * backtrack pattern flagged by CodeQL alert #49.
+ */
+const WEBHOOK_TOKEN_RE = /\{\{runner\.(?:webhook_url:[A-Za-z0-9_]+|webhook_base)\}\}/;
+
+/**
+ * Recursively scan a JSON-like value for any webhook receiver token. The
+ * scan only touches strings; objects and arrays are walked structurally
+ * so deeply-nested `push_notification_config.url` entries (or any other
+ * authoring pattern) are discovered without a hard-coded field list.
+ */
+function valueContainsWebhookToken(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return WEBHOOK_TOKEN_RE.test(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some(valueContainsWebhookToken);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(valueContainsWebhookToken);
+  }
+  return false;
+}
+
+/**
+ * Return the implicit requirements a storyboard needs based on its
+ * structure (not its declared `requires:` list). Today: only
+ * `'webhook_receiver'`, autodetected from `{{runner.webhook_url:…}}` /
+ * `{{runner.webhook_base}}` token presence inside any step's
+ * `sample_request`. Token presence is the authoring contract — a
+ * storyboard that names the runner's webhook receiver cannot run
+ * without one — so authors don't need to remember to add
+ * `requires: [webhook_receiver]` separately. Spec: adcp-client#1678.
+ */
+function detectImplicitRequires(storyboard: Storyboard): RequirementName[] {
+  for (const phase of storyboard.phases) {
+    for (const step of phase.steps) {
+      if (step.sample_request && valueContainsWebhookToken(step.sample_request)) {
+        return ['webhook_receiver'];
+      }
+    }
+  }
+  return [];
 }
 
 /**
@@ -1230,8 +1301,20 @@ async function executeStoryboardPass(
   // Spec: adcp-client#1626. The default (no `requires` field) is
   // `[real_wire]`, which is always available — untagged storyboards
   // run unchanged.
-  if (storyboard.requires?.length) {
-    const unmet = checkRequires(storyboard.requires, options);
+  //
+  // Implicit requirements (adcp-client#1678) are unioned with the
+  // declared list: today this means `'webhook_receiver'` is added when
+  // any step's `sample_request` references `{{runner.webhook_url:…}}`
+  // or `{{runner.webhook_base}}`. Authors do not need to retag those
+  // storyboards — the token presence is the declaration. Without the
+  // implicit gate, storyboards that name the receiver but run without
+  // one would silently ship literal mustache tokens on the wire and
+  // get rejected by 3.0-strict sellers as `INVALID_REQUEST: relative URL`.
+  const declared = storyboard.requires ?? [];
+  const implicit = detectImplicitRequires(storyboard);
+  const allRequires = [...declared, ...implicit.filter(r => !declared.includes(r))];
+  if (allRequires.length) {
+    const unmet = checkRequires(allRequires, options);
     if (unmet) {
       if (!options._client) await closeConnections(options.protocol);
       return buildRequirementUnmetResult(agentUrls, storyboard, unmet.requirement, unmet.detail);

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -58,6 +58,14 @@ export interface Storyboard {
    *   - `real_wire` — always available. Tag scenarios that observe
    *     production behavior with this when you want them excluded from
    *     a future `--mock-only` mode; today the tag is a no-op gate.
+   *   - `webhook_receiver` — the runner must be configured with a
+   *     webhook receiver (`StoryboardRunOptions.webhook_receiver`).
+   *     Autodetected from token presence: any step whose
+   *     `sample_request` (or nested fields) references
+   *     `{{runner.webhook_url:<step_id>}}` or `{{runner.webhook_base}}`
+   *     declares this requirement implicitly. Authors do not need to
+   *     write `requires: [webhook_receiver]` — the tokens are
+   *     self-describing.
    *
    * Default when the field is absent: `[real_wire]` (storyboard runs
    * everywhere — matches existing pre-tagging behavior). Tagging is
@@ -1296,7 +1304,7 @@ export interface RunnerSkipResult {
  *
  * Spec: adcp-client#1626.
  */
-export type RequirementName = 'controller' | 'seeded_state' | 'real_wire';
+export type RequirementName = 'controller' | 'seeded_state' | 'real_wire' | 'webhook_receiver';
 
 /**
  * Closed enumeration of every known requirement. Used by the loader to
@@ -1309,6 +1317,7 @@ export const KNOWN_REQUIREMENTS: ReadonlySet<RequirementName> = new Set([
   'controller',
   'seeded_state',
   'real_wire',
+  'webhook_receiver',
 ] as const satisfies readonly RequirementName[]);
 
 /**

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -256,3 +256,158 @@ phases:
     assert.equal(parsed.requires, undefined);
   });
 });
+
+// ────────────────────────────────────────────────────────────
+// adcp-client#1678: implicit webhook_receiver requirement
+// ────────────────────────────────────────────────────────────
+//
+// Storyboards that reference `{{runner.webhook_url:<step_id>}}` or
+// `{{runner.webhook_base}}` in any step's `sample_request` need a
+// webhook receiver to expand the tokens. Without one, the expander
+// would ship literal mustache strings on the wire — rejected by
+// 3.0-strict sellers as `INVALID_REQUEST: relative URL without a
+// base`. The runner autodetects the requirement from token presence
+// (no separate `requires: [webhook_receiver]` declaration needed) and
+// grades the storyboard not_applicable when the operator did not
+// configure a receiver.
+
+function buildWebhookStoryboard(overrides = {}) {
+  return buildStoryboard({
+    phases: [
+      {
+        id: 'p1',
+        title: 'Trigger webhook',
+        steps: [
+          {
+            id: 'trigger_webhook',
+            title: 'Trigger an operation that emits a webhook',
+            task: 'create_media_buy',
+            sample_request: {
+              push_notification_config: {
+                url: '{{runner.webhook_url:trigger_webhook}}',
+              },
+              idempotency_key: 'webhook-test-key',
+            },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  });
+}
+
+describe('Storyboard.requires gate (#1678): implicit webhook_receiver', () => {
+  test('storyboards referencing {{runner.webhook_url:…}} skip when no receiver configured', async () => {
+    const sb = buildWebhookStoryboard();
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    assert.equal(result.overall_passed, true, 'requires-unmet is not a failure');
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'requirement_unmet');
+    assert.equal(step.skip.requirement, 'webhook_receiver');
+    assert.match(step.skip.detail, /webhook receiver is configured/);
+  });
+
+  test('storyboards referencing {{runner.webhook_base}} also trigger the gate', async () => {
+    const sb = buildWebhookStoryboard({
+      phases: [
+        {
+          id: 'p1',
+          title: 'Compose a webhook URL',
+          steps: [
+            {
+              id: 'inspect_base',
+              title: 'A step that interpolates webhook_base',
+              task: 'create_media_buy',
+              sample_request: {
+                meta: { reply_to: '{{runner.webhook_base}}/custom-path' },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip.requirement, 'webhook_receiver');
+  });
+
+  test('storyboards with NO webhook tokens are unaffected by the autodetect gate', async () => {
+    const sb = buildStoryboard(); // no webhook tokens anywhere
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    // Gate did not synthesize requirement_unmet — storyboard proceeded to
+    // phases (and may have failed for transport reasons against the fake URL,
+    // but that's not what we're measuring here).
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(
+      !phaseIds.includes('requirement_unmet'),
+      'gate must not synthesize requirement_unmet when no webhook tokens are present'
+    );
+  });
+
+  test('storyboards referencing webhook tokens nested in deep objects still trigger', async () => {
+    const sb = buildStoryboard({
+      phases: [
+        {
+          id: 'p1',
+          title: 'Deeply-nested token',
+          steps: [
+            {
+              id: 'deep',
+              title: 'A step burying the token under arrays and objects',
+              task: 'create_media_buy',
+              sample_request: {
+                a: { b: { c: [{ d: '{{runner.webhook_url:deep}}' }] } },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutController,
+      agentTools: profileWithoutController.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip.requirement, 'webhook_receiver', 'recursive scan finds nested tokens');
+  });
+
+  test('declared requires: [webhook_receiver] resolves the same way (loader allows the name)', () => {
+    const yaml = `
+id: ok_webhook_declared
+version: "1.0.0"
+title: explicit webhook_receiver tag
+category: test
+summary: ""
+narrative: ""
+requires: [webhook_receiver]
+agent:
+  interaction_model: sync
+  capabilities: []
+caller:
+  role: buyer_agent
+phases:
+  - id: p1
+    title: P
+    steps: []
+`;
+    const parsed = parseStoryboard(yaml);
+    assert.deepEqual(parsed.requires, ['webhook_receiver']);
+  });
+});


### PR DESCRIPTION
Closes #1678. Part of the coordinated stance at #1685.

## Summary

`comply()` was shipping the literal mustache token `{{runner.webhook_url:<step_id>}}` on the wire whenever a webhook-emitting storyboard ran without a configured receiver. 3.0-strict sellers (Wonderstruck) correctly reject the resulting payload as `INVALID_REQUEST: Input should be a valid URL, relative URL without a base`, cascading 5 distinct first-step failures across `webhook_emission/*` and `idempotency/replay_same_payload`.

The spec already answers what should happen:

- `compliance/{version}/universal/webhook-emission.yaml` L34: *"grades not_applicable when the runner does not host a webhook receiver"*
- L62–70 (prerequisites): *"Runners without a receiver grade this universal as not_applicable"*
- L331–332 (grading): *"Runners without a webhook receiver grade the entire universal as not_applicable"*

So the SDK's job is to grade `not_applicable`, not to placeholder a fake URL. The triage thread on #1678 considered synthesizing `https://aao.test/sink/...` and rejected it — that would let `signature_validity` vacuously pass against a sink that never responds, which is exactly the false-certification failure mode #1685 is rejecting.

## What changed

1. **`RequirementName`** — extended with `'webhook_receiver'`; added to `KNOWN_REQUIREMENTS`.
2. **`REQUIREMENT_TO_SKIP_REASON`** — maps `'webhook_receiver' → 'requirement_unmet'`.
3. **`checkRequires()`** — detects `options.webhook_receiver === undefined` and returns a structured unmet requirement with a helpful detail message.
4. **`detectImplicitRequires(storyboard)`** — new helper that recursively scans every step's `sample_request` for `{{runner.webhook_url:<step_id>}}` or `{{runner.webhook_base}}` tokens and returns `['webhook_receiver']` when any are found. Token presence IS the declaration.
5. **Gate** — unions declared (`storyboard.requires`) and implicit requirements before calling `checkRequires`.

## Why autodetection, not a `requires:` retag

The triage thread proposed two options:

- **Option 1** (synthesize an absolute placeholder URL): out — makes `signature_validity` vacuously pass against a sink that never responds. False certification claim.
- **Option 2** (extend `RequirementName` with `'webhook_receiver'` and tag storyboards): correct, but requires every webhook storyboard YAML in `adcontextprotocol/adcp` to be retagged AND new ones to remember the tag.

**This PR takes the third path:** option 2's runtime, with autodetection driving the requirement. Authors don't write `requires: [webhook_receiver]` — the existing `{{runner.webhook_url:…}}` token in their `sample_request` already declares the dependency. New webhook scenarios inherit the gate automatically.

The loader still accepts an explicit `requires: [webhook_receiver]` (the new test confirms this) for authors who want belt-and-suspenders, but no spec change is required.

## What was tested

- 5 new tests in `test/lib/storyboard-requires-gate.test.js`:
  - `{{runner.webhook_url:…}}` tokens trigger the gate (no receiver → `requirement_unmet:webhook_receiver`)
  - `{{runner.webhook_base}}` tokens trigger the gate
  - Storyboards with NO webhook tokens are unaffected
  - Deep-nested tokens (under arrays + objects) are still detected by the recursive scan
  - Loader accepts explicit `requires: [webhook_receiver]`
- All existing requires-gate tests still pass.
- `npx tsc --noEmit --project tsconfig.lib.json` — clean.
- `npx prettier --check` — clean.

## Coordination

**Merge order (#1685):**
1. #1684 (1679 keystone — `adcp_error` forwarding) — ships first, makes wire-level errors observable
2. #1683 (1676 — `account_from_brand` removal) and #1681 (1677 — package normalizer fail-closed) — fabrication twins
3. #1682 (1680 — `not_applicable` routing for missing `required_tools`)
4. **This PR** — autodetect `webhook_receiver`. Lands last; logically depends on #1682's `not_applicable` plumbing for grader-side surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)