### PR TITLE
feat(idempotency,storyboard): IDEMPOTENCY_IN_FLIGHT + parallel_dispatch_runner

### DIFF
--- a/.changeset/parallel-dispatch-runner.md
+++ b/.changeset/parallel-dispatch-runner.md
@@ -1,0 +1,24 @@
+---
+'@adcp/sdk': minor
+---
+
+Add the `parallel_dispatch_runner` test-kit contract and swap the in-flight branch to `IDEMPOTENCY_IN_FLIGHT` (#1686, #1687).
+
+**Storyboard runner** (#1686):
+
+- New `parallel_dispatch` step field: fans out N concurrent dispatches against the same agent (process_local mode, via `Promise.all`) and grades the cross-response set. Drives the AdCP 3.1 concurrent-retry phase of the idempotency storyboard (rule 9 / first-insert-wins).
+- Two new check kinds:
+  - `cross_response_field_equal { path }` — every resolved dispatch carries the same value at the named path.
+  - `cross_response_count_distinct { path, allowed_values }` — distinct cardinality across resolved dispatches is in `allowed_values`. Use `allowed_values: [1]` to assert "exactly one resource created" on a race.
+- In-flight retry resolution: dispatches that return `IDEMPOTENCY_IN_FLIGHT` or legacy `SERVICE_UNAVAILABLE` retry with the same `idempotency_key` after the seller's `retry_after` hint elapses, up to the per-dispatch retry budget and the outer `barrier_timeout_ms` (default 5000 ms).
+- Per-response checks (`response_schema`, `field_present`, `error_code`, …) run once per dispatch and aggregate. Cross-response checks run once with the resolved set.
+- The step grades `not_applicable` when the `parallel_dispatch_runner` contract is not in `options.contracts`, when `mode: distributed` is requested (out of scope for this SDK), or on a single-dispatch step that accidentally declared a `cross_response_*` check.
+- Forward-compat unknown check kinds continue to grade `not_applicable` per the existing runner-output-contract behavior.
+
+**Server middleware** (#1687):
+
+- The idempotency middleware's in-flight branch now returns `IDEMPOTENCY_IN_FLIGHT` (AdCP 3.1 wire code) instead of `SERVICE_UNAVAILABLE`, with `recovery: transient`. Buyer SDKs that auto-retry transient + `retry_after` are unchanged.
+- `retry_after` is derived from the in-flight claim's age rather than hardcoded `1` — short hint for fresh claims, longer for slow handlers, capped at 5 s so a long-running handler doesn't stall buyer retries past the outer barrier.
+- The `IdempotencyCheckResult.kind === 'in-flight'` variant now carries `retryAfterSeconds` so custom store implementations can drive the same hint.
+
+**Test impact**: `server-idempotency` tests updated to expect `IDEMPOTENCY_IN_FLIGHT` on parallel-retry paths. New `storyboard-parallel-dispatch` test covers the cross-response validators, the in-flight retry loop, barrier timeout, and `same_idempotency_key` opt-out.

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -3799,15 +3799,16 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             }
             if (checkResult.kind === 'in-flight') {
               // A parallel request is currently executing this same key.
-              // Tell the client to retry — returning SERVICE_UNAVAILABLE
-              // with a short retry_after is transient-classified and the
-              // buyer SDK auto-retries. Eventually the other request
-              // completes and this retry either replays the cached
-              // response or hits IDEMPOTENCY_CONFLICT.
+              // Surface AdCP 3.1's `IDEMPOTENCY_IN_FLIGHT` with a transient
+              // recovery + store-derived `retry_after`. Buyer SDKs that
+              // already auto-retry transient + retry_after replay shortly;
+              // the prior request either lands the cached response or
+              // (different payload) triggers IDEMPOTENCY_CONFLICT.
               return finalize(
-                adcpError('SERVICE_UNAVAILABLE', {
+                adcpError('IDEMPOTENCY_IN_FLIGHT', {
                   message: 'A parallel request with the same idempotency_key is still in flight. Retry shortly.',
-                  retry_after: 1,
+                  recovery: 'transient',
+                  retry_after: checkResult.retryAfterSeconds,
                 })
               );
             }

--- a/src/lib/server/envelope-allowlist.ts
+++ b/src/lib/server/envelope-allowlist.ts
@@ -106,6 +106,23 @@ export const ERROR_ENVELOPE_FIELD_ALLOWLIST: Readonly<Record<string, ReadonlySet
  */
 export const ADCP_ERROR_FIELD_ALLOWLIST: Readonly<Record<string, ReadonlySet<string>>> = Object.freeze({
   IDEMPOTENCY_CONFLICT: new Set(['code', 'message', 'status', 'correlation_id', 'request_id', 'operation_id']),
+  // `IDEMPOTENCY_IN_FLIGHT` (AdCP 3.1) carries `recovery: transient` plus a
+  // store-derived `retry_after` so transient-aware buyer SDKs can replay
+  // shortly. Allowlist registration is defense-in-depth — `adcpError()` at
+  // the in-flight call site only assembles framework-controlled keys today,
+  // but the registration forces any future caller that tries to attach
+  // payload fingerprints onto the in-flight envelope to land here in code
+  // review first.
+  IDEMPOTENCY_IN_FLIGHT: new Set([
+    'code',
+    'message',
+    'recovery',
+    'retry_after',
+    'status',
+    'correlation_id',
+    'request_id',
+    'operation_id',
+  ]),
 });
 
 /**

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -161,6 +161,14 @@ export type IdempotencyCheckResult =
   | {
       /** A parallel request is currently executing the same key — the caller should retry the check. */
       kind: 'in-flight';
+      /**
+       * Suggested retry delay in seconds, derived from how long the first
+       * request has been running. The middleware surfaces this as the
+       * `retry_after` hint on the `IDEMPOTENCY_IN_FLIGHT` response so a
+       * buyer's transient-retry doesn't slam back instantly when the first
+       * call is long-running. Always `>= 1`.
+       */
+      retryAfterSeconds: number;
     }
   | {
       /** No prior execution for this key — caller should run the handler and save. */
@@ -319,6 +327,29 @@ const TRANSIENT_ERROR_TTL_SECONDS = 10;
  * valid cached response).
  */
 const IN_FLIGHT_HASH = '__adcp_in_flight__';
+/**
+ * Soft cap on the retry hint surfaced to buyers on the in-flight branch.
+ * Even if the first request still has 100s left on its claim, telling a
+ * buyer to wait 100s is worse than the spec's "retry shortly" intent. 5s
+ * is a balance — long enough to amortize a slow handler's tail latency,
+ * short enough that a healthy seller's fast handlers don't stall buyer
+ * retries.
+ */
+const IN_FLIGHT_RETRY_HINT_CAP_SECONDS = 5;
+
+/**
+ * Derive the buyer-facing `retry_after` hint from how long the first
+ * request has been running. Elapsed since claim = `IN_FLIGHT_TTL_SECONDS - (expiresAt - now)`.
+ * We assume the first call is roughly halfway done and suggest the buyer
+ * retry after an additional `elapsed` seconds, capped at
+ * `IN_FLIGHT_RETRY_HINT_CAP_SECONDS`. Always clamped to `>= 1`.
+ */
+function inFlightRetryAfter(expiresAt: number, nowSeconds: number): number {
+  const remaining = expiresAt - nowSeconds;
+  const elapsed = IN_FLIGHT_TTL_SECONDS - remaining;
+  const hint = Math.max(1, Math.min(IN_FLIGHT_RETRY_HINT_CAP_SECONDS, Math.ceil(elapsed)));
+  return hint;
+}
 
 /**
  * Create an idempotency store bound to a specific backend and replay window.
@@ -359,7 +390,7 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
           return { kind: 'expired' };
         }
         if (cached.payloadHash === IN_FLIGHT_HASH) {
-          return { kind: 'in-flight' };
+          return { kind: 'in-flight', retryAfterSeconds: inFlightRetryAfter(cached.expiresAt, nowSeconds) };
         }
         if (cached.payloadHash !== payloadHash) {
           return { kind: 'conflict' };
@@ -381,8 +412,11 @@ export function createIdempotencyStore(config: IdempotencyStoreConfig): Idempote
       if (!claimed) {
         // Someone beat us to the claim — re-read to find out what they did.
         const recheck = await backend.get(scopedKey);
-        if (!recheck) return { kind: 'in-flight' };
-        if (recheck.payloadHash === IN_FLIGHT_HASH) return { kind: 'in-flight' };
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        if (!recheck) return { kind: 'in-flight', retryAfterSeconds: 1 };
+        if (recheck.payloadHash === IN_FLIGHT_HASH) {
+          return { kind: 'in-flight', retryAfterSeconds: inFlightRetryAfter(recheck.expiresAt, nowSeconds) };
+        }
         if (recheck.payloadHash !== payloadHash) return { kind: 'conflict' };
         return { kind: 'replay', response: recheck.response };
       }

--- a/src/lib/testing/storyboard/parallel-dispatch.ts
+++ b/src/lib/testing/storyboard/parallel-dispatch.ts
@@ -1,0 +1,300 @@
+/**
+ * Parallel-dispatch runner support for the `parallel_dispatch_runner`
+ * test-kit contract. Drives the concurrent-retry phase of the idempotency
+ * storyboard (rule 9 / first-insert-wins): two `create_media_buy` calls
+ * with the same `idempotency_key` race the seller's INSERT and must
+ * resolve to one resource. Spec:
+ * `test-kits/parallel-dispatch-runner.yaml`.
+ *
+ * Modes:
+ *   - `process_local` (default): fan out N requests via `Promise.all`. Event-
+ *     loop concurrent, sufficient to exercise the seller's INSERT race per
+ *     the contract YAML's `not_required_to_synthesize_packet_schedule`.
+ *   - `distributed`: barrier-synced workers across processes — out of scope
+ *     for this module. Callers grade the step `not_applicable` when the
+ *     storyboard requests `distributed` and the runner cannot satisfy it.
+ *
+ * In-flight resolution: a dispatch that returns `IDEMPOTENCY_IN_FLIGHT` or
+ * (legacy) `SERVICE_UNAVAILABLE` with a `retry_after` hint retries with the
+ * SAME idempotency_key after the hint elapses. The runner caps retries so
+ * a stuck seller can't pin a barrier indefinitely; the outer barrier
+ * timeout is the second line of defense.
+ */
+
+import type { TaskResult } from '../types';
+import { executeStoryboardTask } from './task-map';
+import type { CrossResponseDispatch, CrossResponseSet } from './validations';
+import type { ParallelDispatchSpec } from './types';
+
+/**
+ * Minimum and maximum parallel dispatches per the contract YAML. The
+ * `count_max: 10` is a soft ceiling — every runner mode MUST support up to
+ * 10 parallel dispatches per the spec's
+ * `every_runner_mode_supports_up_to_10` note.
+ */
+export const PARALLEL_DISPATCH_COUNT_MIN = 2;
+export const PARALLEL_DISPATCH_COUNT_MAX = 10;
+/** Default barrier timeout when the storyboard omits `barrier_timeout_ms`. */
+export const PARALLEL_DISPATCH_DEFAULT_BARRIER_MS = 5000;
+/**
+ * Per-dispatch retry budget for the in-flight branch. Sized so a slow
+ * seller's first request can finish within a 5-second barrier even when
+ * the SDK's retry-after hint caps at the store's 5-second hint ceiling —
+ * any larger and the barrier timeout would fire first anyway.
+ */
+const IN_FLIGHT_RETRY_BUDGET = 5;
+/** Floor for the in-flight retry sleep so a misbehaving seller can't busy-loop the runner. */
+const IN_FLIGHT_MIN_SLEEP_MS = 50;
+
+/**
+ * The contract id storyboards declare on `requires_contract` to opt into
+ * parallel-dispatch grading. Runners without the contract in scope grade
+ * the step `not_applicable`.
+ */
+export const PARALLEL_DISPATCH_CONTRACT = 'parallel_dispatch_runner';
+
+/**
+ * In-flight resolution: error codes the runner treats as "retry with the
+ * same idempotency_key after retry_after." `IDEMPOTENCY_IN_FLIGHT` is the
+ * AdCP 3.1 wire code; `SERVICE_UNAVAILABLE` is accepted as a legacy
+ * fallback so the runner grades SDKs that haven't migrated yet against
+ * the same contract.
+ */
+const IN_FLIGHT_ERROR_CODES = new Set(['IDEMPOTENCY_IN_FLIGHT', 'SERVICE_UNAVAILABLE']);
+
+/** Parsed `(code, retry_after_seconds)` from a TaskResult, when present. */
+interface AdcpErrorInfo {
+  code: string;
+  retry_after_seconds?: number;
+}
+
+function extractAdcpError(tr: TaskResult): AdcpErrorInfo | undefined {
+  const data = tr.data as Record<string, unknown> | undefined;
+  const err = data?.adcp_error as Record<string, unknown> | undefined;
+  if (!err || typeof err.code !== 'string') return undefined;
+  const retry = err.retry_after;
+  return {
+    code: err.code,
+    ...(typeof retry === 'number' && Number.isFinite(retry) ? { retry_after_seconds: retry } : {}),
+  };
+}
+
+/**
+ * Configuration accepted by {@link dispatchOnceWithInflightRetry}.
+ */
+export interface DispatchOnceOptions {
+  /**
+   * Cooperative deadline (epoch ms) past which retries are abandoned. Set by
+   * the caller to align with the outer barrier — a dispatch that's still
+   * IDEMPOTENCY_IN_FLIGHT at the deadline returns its most recent
+   * TaskResult so the barrier-timeout grading path can record the seller's
+   * last-seen error code.
+   */
+  deadlineMs: number;
+}
+
+/**
+ * Validate a {@link ParallelDispatchSpec} or return a structured authoring
+ * error. Returns `null` when the spec is well-formed. The runner surfaces
+ * the error as a `parallel_dispatch_misconfigured` step result rather than
+ * silently clamping — silent clamping would let a storyboard advertise a
+ * `count_max: 50` test that the runner only partially executed.
+ */
+export function validateParallelDispatchSpec(spec: ParallelDispatchSpec): string | null {
+  if (!Number.isInteger(spec.count)) {
+    return `parallel_dispatch.count must be an integer; received ${spec.count}`;
+  }
+  if (spec.count < PARALLEL_DISPATCH_COUNT_MIN || spec.count > PARALLEL_DISPATCH_COUNT_MAX) {
+    return (
+      `parallel_dispatch.count must be in [${PARALLEL_DISPATCH_COUNT_MIN}, ${PARALLEL_DISPATCH_COUNT_MAX}] ` +
+      `per test-kits/parallel-dispatch-runner.yaml; received ${spec.count}`
+    );
+  }
+  if (spec.barrier_timeout_ms !== undefined) {
+    if (!Number.isFinite(spec.barrier_timeout_ms) || spec.barrier_timeout_ms <= 0) {
+      return `parallel_dispatch.barrier_timeout_ms must be a positive finite number; received ${spec.barrier_timeout_ms}`;
+    }
+  }
+  if (spec.mode !== undefined && spec.mode !== 'process_local' && spec.mode !== 'distributed') {
+    return `parallel_dispatch.mode must be 'process_local' or 'distributed'; received '${spec.mode}'`;
+  }
+  return null;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, Math.max(0, ms)));
+
+/**
+ * Run one dispatch and retry on the in-flight branch. Returns the dispatch's
+ * terminal `TaskResult` (success, terminal error, or last-seen in-flight
+ * after the deadline). Catches thrown errors and shapes them into a
+ * synthetic error TaskResult so callers see a uniform `TaskResult`-shaped
+ * outcome.
+ */
+export async function dispatchOnceWithInflightRetry(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- client surface varies (TestClient)
+  client: any,
+  taskName: string,
+  request: Record<string, unknown>,
+  opts: DispatchOnceOptions
+): Promise<{ taskResult: TaskResult; error?: string }> {
+  let lastTaskResult: TaskResult | undefined;
+  let lastError: string | undefined;
+  for (let attempt = 0; attempt < IN_FLIGHT_RETRY_BUDGET; attempt++) {
+    try {
+      const tr = await executeStoryboardTask(client, taskName, request);
+      lastTaskResult = tr;
+      lastError = undefined;
+      if (tr.success) {
+        return { taskResult: tr };
+      }
+      const err = extractAdcpError(tr);
+      if (!err || !IN_FLIGHT_ERROR_CODES.has(err.code)) {
+        return { taskResult: tr };
+      }
+      // Honor the seller's retry hint when present (clamped to [50ms, 3600s]
+      // per spec retry_after range). Default to 200 ms — enough headroom
+      // for the first request's INSERT to commit on a healthy seller, short
+      // enough that the barrier timeout dominates on a stuck one.
+      const hintMs = err.retry_after_seconds !== undefined ? Math.floor(err.retry_after_seconds * 1000) : 200;
+      const sleepMs = Math.max(IN_FLIGHT_MIN_SLEEP_MS, Math.min(3_600_000, hintMs));
+      const remaining = opts.deadlineMs - Date.now();
+      if (remaining <= 0) {
+        return { taskResult: tr };
+      }
+      await sleep(Math.min(sleepMs, remaining));
+    } catch (e) {
+      lastError = e instanceof Error ? e.message : String(e);
+      const remaining = opts.deadlineMs - Date.now();
+      if (remaining <= 0) break;
+      // Thrown SDK errors aren't `IDEMPOTENCY_IN_FLIGHT` by definition (the
+      // SDK only throws on transport / parse failures); stop retrying so we
+      // surface the thrown error rather than masking it as a retry storm.
+      break;
+    }
+  }
+  if (lastTaskResult) {
+    return { taskResult: lastTaskResult, ...(lastError ? { error: lastError } : {}) };
+  }
+  return {
+    taskResult: {
+      success: false,
+      ...(lastError !== undefined && { error: lastError }),
+    },
+    ...(lastError !== undefined && { error: lastError }),
+  };
+}
+
+/**
+ * Fan out N concurrent dispatches and collect the resolved set.
+ *
+ * Every dispatch shares the caller's `baseRequest` (so the canonical
+ * payload hash matches across dispatches and the seller's idempotency
+ * store sees a single logical request). Per-dispatch ergonomics:
+ *
+ *   - `context.correlation_id` is rewritten to a per-dispatch suffix so
+ *     trace logs can attribute a delivery to a specific arm. Per the
+ *     spec, `context` (object form) is excluded from the canonical
+ *     payload hash, so distinct correlation_ids don't trip
+ *     IDEMPOTENCY_CONFLICT.
+ *   - `same_idempotency_key !== false` (default `true`): every dispatch
+ *     shares `baseRequest.idempotency_key`. The runner does NOT mint
+ *     fresh keys per arm — that defeats the test.
+ *   - `same_idempotency_key: false`: each dispatch gets its own
+ *     idempotency_key minted via `keyMinter`. Used by soak tests that
+ *     want parallelism without the race semantics.
+ */
+export interface RunParallelDispatchesOptions {
+  /** Spec block from the storyboard step. */
+  spec: ParallelDispatchSpec;
+  /**
+   * Mint a fresh idempotency_key. Only invoked when `same_idempotency_key`
+   * is explicitly `false`. Callers thread the runner's existing
+   * `generateIdempotencyKey()` here.
+   */
+  keyMinter: () => string;
+  /**
+   * Correlation prefix; the runner suffixes `#<dispatch_index>` to produce
+   * the per-arm correlation_id written to `context.correlation_id`. Defaults
+   * to the storyboard step id.
+   */
+  correlationPrefix?: string;
+}
+
+export async function runParallelDispatches(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- client surface varies (TestClient)
+  client: any,
+  taskName: string,
+  baseRequest: Record<string, unknown>,
+  opts: RunParallelDispatchesOptions
+): Promise<CrossResponseSet> {
+  const { spec, keyMinter, correlationPrefix = 'parallel_dispatch' } = opts;
+  const barrierMs = spec.barrier_timeout_ms ?? PARALLEL_DISPATCH_DEFAULT_BARRIER_MS;
+  const sameKey = spec.same_idempotency_key !== false;
+  const deadlineMs = Date.now() + barrierMs;
+
+  const dispatchPromises = Array.from({ length: spec.count }, (_, index) => {
+    const correlationId = `${correlationPrefix}#${index}`;
+    const request: Record<string, unknown> = { ...baseRequest };
+    if (!sameKey) {
+      request.idempotency_key = keyMinter();
+    }
+    // Replace context.correlation_id without touching other fields. context
+    // is hash-excluded only in object form; if a storyboard supplied a
+    // string context (SI tools), leave it alone — the runner won't tag
+    // those arms but the dispatch still functions.
+    const existingContext = request.context;
+    if (existingContext && typeof existingContext === 'object' && !Array.isArray(existingContext)) {
+      request.context = { ...(existingContext as Record<string, unknown>), correlation_id: correlationId };
+    } else if (existingContext === undefined) {
+      request.context = { correlation_id: correlationId };
+    }
+
+    const started = Date.now();
+    return dispatchWithBarrier(client, taskName, request, deadlineMs).then(outcome => {
+      const dispatch: CrossResponseDispatch = {
+        correlation_id: correlationId,
+        duration_ms: Date.now() - started,
+        ...(outcome.taskResult && { taskResult: outcome.taskResult }),
+        ...(outcome.error !== undefined && { error: outcome.error }),
+        ...(outcome.timed_out && { timed_out: true }),
+      };
+      return dispatch;
+    });
+  });
+
+  const dispatches = await Promise.all(dispatchPromises);
+  const resolved = dispatches
+    .filter(d => d.taskResult?.success === true && !d.timed_out)
+    .map(d => d.taskResult as TaskResult);
+  return { dispatches, resolved };
+}
+
+interface DispatchOutcome {
+  taskResult?: TaskResult;
+  error?: string;
+  timed_out?: boolean;
+}
+
+async function dispatchWithBarrier(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- client surface varies (TestClient)
+  client: any,
+  taskName: string,
+  request: Record<string, unknown>,
+  deadlineMs: number
+): Promise<DispatchOutcome> {
+  const work = dispatchOnceWithInflightRetry(client, taskName, request, { deadlineMs });
+  const remaining = deadlineMs - Date.now();
+  if (remaining <= 0) {
+    return { timed_out: true };
+  }
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<DispatchOutcome>(resolve => {
+    timeoutHandle = setTimeout(() => resolve({ timed_out: true }), remaining);
+  });
+  try {
+    const result = await Promise.race([work.then(r => r as DispatchOutcome), timeoutPromise]);
+    return result;
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
+}

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -25,9 +25,11 @@ import { detectStrictValidationHints } from './strict-validation-hints';
 import {
   runValidations,
   type ValidationContext,
+  type CrossResponseSet,
   type UpstreamTrafficValidationContext,
   type UpstreamTrafficQueryResult,
 } from './validations';
+import { PARALLEL_DISPATCH_CONTRACT, runParallelDispatches, validateParallelDispatchSpec } from './parallel-dispatch';
 import { toJsonPointer } from './path';
 import { redactSecrets } from '../../utils/redact-secrets';
 import { queryUpstreamTraffic, type ControllerScenario, type UpstreamTrafficSuccess } from '../test-controller';
@@ -2884,6 +2886,85 @@ async function executeStep(
   let httpResult: HttpProbeResult | undefined;
   let responseRecord: RunnerResponseRecord | undefined;
   let a2aEnvelope: A2ATaskEnvelope | undefined;
+  let crossResponses: CrossResponseSet | undefined;
+
+  // Parallel-dispatch fan-out: when the storyboard step declares
+  // `parallel_dispatch`, the runner fires N concurrent dispatches against
+  // the same agent with the same idempotency_key (default) and grades the
+  // cross-response set instead of a single response. Gated on the
+  // `parallel_dispatch_runner` test-kit contract — runners (or runs) without
+  // it grade the step `not_applicable` so older runners don't fail on
+  // newer storyboard contracts.
+  if (step.parallel_dispatch && !useRawProbe) {
+    const contractsInScope = new Set(options.contracts ?? []);
+    if (!contractsInScope.has(PARALLEL_DISPATCH_CONTRACT)) {
+      const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+      const detail = `Test-kit contract "${PARALLEL_DISPATCH_CONTRACT}" is not configured on this runner; concurrent-retry grading requires it.`;
+      return {
+        step_id: step.id,
+        phase_id: phaseId,
+        title: step.title,
+        task: step.task,
+        passed: true,
+        skipped: true,
+        skip_reason: 'not_applicable',
+        skip: buildSkip('not_applicable', detail),
+        duration_ms: 0,
+        validations: [],
+        context,
+        next,
+        extraction: { path: 'none' },
+      };
+    }
+    const specError = validateParallelDispatchSpec(step.parallel_dispatch);
+    if (specError) {
+      const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+      return {
+        step_id: step.id,
+        phase_id: phaseId,
+        title: step.title,
+        task: step.task,
+        passed: false,
+        duration_ms: 0,
+        validations: [
+          {
+            check: 'parallel_dispatch_misconfigured',
+            passed: false,
+            description: specError,
+            json_pointer: null,
+            expected: 'a well-formed parallel_dispatch spec',
+            actual: step.parallel_dispatch,
+            schema_id: null,
+            schema_url: null,
+          },
+        ],
+        context,
+        error: specError,
+        next,
+        extraction: { path: 'none' },
+      };
+    }
+    if (step.parallel_dispatch.mode === 'distributed') {
+      const next = getNextStepPreview(step.id, allSteps, context, runState.runnerVars);
+      const detail =
+        'parallel_dispatch.mode: distributed is not implemented in @adcp/sdk; use process_local for in-process grading.';
+      return {
+        step_id: step.id,
+        phase_id: phaseId,
+        title: step.title,
+        task: step.task,
+        passed: true,
+        skipped: true,
+        skip_reason: 'not_applicable',
+        skip: buildSkip('not_applicable', detail),
+        duration_ms: 0,
+        validations: [],
+        context,
+        next,
+        extraction: { path: 'none' },
+      };
+    }
+  }
 
   // Capture the ISO timestamp immediately before the step's AdCP request
   // dispatch. `upstream_traffic` validations use this as the default
@@ -2941,38 +3022,87 @@ async function executeStep(
     // lands, key the capture off the negotiated transport instead.
     const captureA2a = options.protocol === 'a2a';
     let a2aCaptures: RawHttpCapture[] | undefined;
-    const dispatch = () =>
-      executeStoryboardTask(client, effectiveStep.task, request, {
-        skipIdempotencyAutoInject: testsMissingIdempotencyKey,
+    if (step.parallel_dispatch) {
+      // Fan out N concurrent dispatches via the SDK client. All dispatches
+      // share the runner-minted idempotency_key (default) so the seller
+      // sees one logical request and resolves the race deterministically.
+      //
+      // Known limitation: `dispatchWithBarrier` uses `Promise.race` against a
+      // timer; when the barrier wins, the underlying SDK request is NOT
+      // aborted — it continues to completion against the seller. The runner
+      // reports the dispatch as `timed_out`, but a late-arriving success
+      // can still land on the seller's idempotency cache. Storyboard
+      // authors writing follow-up steps that observe seller state after a
+      // barrier timeout should account for this race.
+      const started = Date.now();
+      crossResponses = await runParallelDispatches(client, effectiveStep.task, request, {
+        spec: step.parallel_dispatch,
+        keyMinter: generateIdempotencyKey,
+        correlationPrefix: step.id,
       });
-    const run = await runStep(step.title, effectiveStep.task, async () => {
-      if (!captureA2a) return dispatch();
-      try {
-        const { result: dispatchResult, captures } = await withRawResponseCapture(dispatch);
-        a2aCaptures = captures;
-        return dispatchResult;
-      } catch (err) {
-        // `withRawResponseCapture` attaches partial captures to the
-        // thrown error so we still get the wire-shape envelope when
-        // the SDK threw mid-parse (e.g. agent emitted malformed JSON).
-        // Bare-throw cases (network errors, no captures attached)
-        // leave `a2aCaptures` undefined and the validator self-skips.
-        const partial = getCapturesFromError(err);
-        if (partial) a2aCaptures = partial;
-        throw err;
-      }
-    });
-    taskResult = run.result;
-    stepResult = run.step;
-    if (captureA2a && a2aCaptures) {
-      a2aEnvelope = parseLastA2aMessageSendCapture(a2aCaptures);
-    }
-    if (taskResult) {
-      responseRecord = {
-        transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
-        payload: redactSecrets(taskResult.data ?? taskResult.error ?? null),
-        duration_ms: stepResult.duration_ms,
+      const durationMs = Date.now() - started;
+      // Representative TaskResult is ALWAYS `dispatches[0]` — pinning the
+      // representative to a fixed index keeps the aggregation loop's `i=1`
+      // start aligned (every dispatch graded exactly once). Picking the
+      // "best" resolved arm would double-count whichever dispatch won and
+      // skip dispatches[0] from per-response grading entirely.
+      const firstDispatch = crossResponses.dispatches[0];
+      const allTimedOut = crossResponses.dispatches.every(d => d.timed_out);
+      const barrierTimeoutError = 'parallel_dispatch_barrier_timeout: no dispatch resolved within barrier_timeout_ms';
+      taskResult = firstDispatch?.taskResult ?? {
+        success: false,
+        ...(allTimedOut && { error: barrierTimeoutError }),
       };
+      // Pass/fail is derived from the cross-response set rather than any
+      // single arm: the step passes when at least one dispatch resolved
+      // (cross-response validations then grade the race outcome). All-
+      // timed-out is a hard failure regardless of validations.
+      stepResult = {
+        duration_ms: durationMs,
+        passed: !allTimedOut && crossResponses.resolved.length > 0,
+        ...(allTimedOut && { error: barrierTimeoutError }),
+      };
+      if (taskResult) {
+        responseRecord = {
+          transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
+          payload: redactSecrets(taskResult.data ?? taskResult.error ?? null),
+          duration_ms: durationMs,
+        };
+      }
+    } else {
+      const dispatch = () =>
+        executeStoryboardTask(client, effectiveStep.task, request, {
+          skipIdempotencyAutoInject: testsMissingIdempotencyKey,
+        });
+      const run = await runStep(step.title, effectiveStep.task, async () => {
+        if (!captureA2a) return dispatch();
+        try {
+          const { result: dispatchResult, captures } = await withRawResponseCapture(dispatch);
+          a2aCaptures = captures;
+          return dispatchResult;
+        } catch (err) {
+          // `withRawResponseCapture` attaches partial captures to the
+          // thrown error so we still get the wire-shape envelope when
+          // the SDK threw mid-parse (e.g. agent emitted malformed JSON).
+          // Bare-throw cases (network errors, no captures attached)
+          // leave `a2aCaptures` undefined and the validator self-skips.
+          const partial = getCapturesFromError(err);
+          if (partial) a2aCaptures = partial;
+          throw err;
+        }
+      });
+      taskResult = run.result;
+      stepResult = run.step;
+      if (captureA2a && a2aCaptures) {
+        a2aEnvelope = parseLastA2aMessageSendCapture(a2aCaptures);
+      }
+      if (taskResult) {
+        responseRecord = {
+          transport: options.protocol === 'a2a' ? 'a2a' : 'mcp',
+          payload: redactSecrets(taskResult.data ?? taskResult.error ?? null),
+          duration_ms: stepResult.duration_ms,
+        };
+      }
     }
   }
 
@@ -3021,6 +3151,13 @@ async function executeStep(
   if (step.expect_error) {
     // Step passes when the task fails (returns an error)
     passed = !taskResult?.success || !!stepResult.error;
+  } else if (crossResponses) {
+    // Parallel-dispatch step: pass/fail is driven by the cross-response
+    // set, not the representative arm. The representative is pinned to
+    // `dispatches[0]` (which may itself have failed under the race) so
+    // gating on its `.success` would false-fail steps where later arms
+    // resolved correctly. Validations grade the actual race outcome.
+    passed = stepResult.passed;
   } else {
     passed = stepResult.passed && (taskResult?.success ?? false);
   }
@@ -3071,6 +3208,7 @@ async function executeStep(
       ...(a2aEnvelope && { a2aEnvelope }),
       ...(upstreamTraffic && { upstreamTraffic }),
       ...(step.sample_request && { storyboardStep: { sample_request: step.sample_request } }),
+      ...(crossResponses && { crossResponses }),
       ...(() => {
         // Walk back through the run's captured A2A envelopes and use
         // the most recent prior step's envelope as the comparison
@@ -3091,6 +3229,45 @@ async function executeStep(
       })(),
     };
     validations = runValidations(resolvedValidations, vctx);
+
+    // Parallel-dispatch aggregation: per-response checks (`response_schema`,
+    // `field_present`, `error_code`, etc.) declared by the storyboard MUST
+    // grade against every dispatch's resolved response, not just the
+    // representative one. Re-run each non-cross-response validation against
+    // each dispatch's TaskResult and append the additional results so the
+    // step's overall pass/fail reflects the full fan-out. The first run
+    // (above) already covers dispatch[0]; this loop covers dispatches[1..N].
+    if (crossResponses && crossResponses.dispatches.length > 1) {
+      const perResponseValidations = resolvedValidations.filter(
+        v => v.check !== 'cross_response_field_equal' && v.check !== 'cross_response_count_distinct'
+      );
+      for (let i = 1; i < crossResponses.dispatches.length; i++) {
+        const d = crossResponses.dispatches[i];
+        if (!d || !d.taskResult) continue;
+        const dispatchCtx: ValidationContext = {
+          ...vctx,
+          taskResult: d.taskResult,
+          // Per-dispatch responseRecord stays minimal — the redacted payload
+          // captures enough for failure attribution without bloating success.
+          ...(responseRecord && {
+            response: {
+              ...responseRecord,
+              payload: redactSecrets(d.taskResult.data ?? d.taskResult.error ?? null),
+              duration_ms: d.duration_ms,
+            },
+          }),
+        };
+        // Drop crossResponses on the per-dispatch context so cross-response
+        // checks don't re-fire here (they already ran once above on the
+        // representative dispatch and produced their single result).
+        delete dispatchCtx.crossResponses;
+        const dispatchResults = runValidations(perResponseValidations, dispatchCtx).map(r => ({
+          ...r,
+          description: `[dispatch ${d.correlation_id}] ${r.description}`,
+        }));
+        validations.push(...dispatchResults);
+      }
+    }
   }
 
   // Persist the captured A2A envelope keyed by step id so cross-step

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -523,6 +523,17 @@ export interface StoryboardStep {
   expect_min_deliveries?: number;
   /** Signature-tag sanity check for `expect_webhook_signature_valid`. Default `adcp/webhook-signing/v1`. */
   require_tag?: string;
+  /**
+   * Fan-out spec for parallel-dispatch steps. When set, the runner fires
+   * `count` concurrent dispatches of this step (single-process,
+   * `Promise.all`) against the same agent, then aggregates per-response
+   * checks across the resolved set and grades the `cross_response_*`
+   * checks declared in `validations`. Requires the
+   * `parallel_dispatch_runner` test-kit contract to be in scope — runners
+   * (or runs) without it grade the step `not_applicable`. See
+   * {@link ParallelDispatchSpec}.
+   */
+  parallel_dispatch?: ParallelDispatchSpec;
 }
 
 export type StoryboardValidationCheck =
@@ -601,7 +612,77 @@ export type StoryboardValidationCheck =
    * runner-output-contract.yaml v2.0.0, storyboard-schema.yaml >
    * "upstream_traffic".
    */
-  | 'upstream_traffic';
+  | 'upstream_traffic'
+  /**
+   * Cross-response: every resolved response from a `parallel_dispatch` step
+   * carries the same value at the named `path`. Used to assert
+   * first-insert-wins on a concurrent retry — two parallel `create_media_buy`
+   * calls with the same `idempotency_key` must resolve to the same
+   * `media_buy_id`. Fails when any two resolved responses disagree, or when
+   * fewer than 2 dispatches resolved successfully. Spec:
+   * test-kits/parallel-dispatch-runner.yaml; adcp#4435 (rule 9 / rule 10).
+   */
+  | 'cross_response_field_equal'
+  /**
+   * Cross-response: the cardinality of distinct values at `path` across all
+   * resolved responses from a `parallel_dispatch` step is in
+   * `allowed_values`. Used to assert "exactly one resource was created" —
+   * `allowed_values: [1]` with `path: media_buy_id` catches a seller that
+   * raced the INSERT and created two resources from one logical create.
+   * Fails when the distinct count is outside `allowed_values`, or when no
+   * dispatch resolved successfully. Spec:
+   * test-kits/parallel-dispatch-runner.yaml.
+   */
+  | 'cross_response_count_distinct';
+
+/**
+ * Configuration for a step that fans out to N concurrent dispatches against
+ * the same agent, returning the cross-response set for assertion. Drives the
+ * `concurrent_retry` phase of the idempotency storyboard (rule 9 /
+ * first-insert-wins), where two `create_media_buy` calls with the same
+ * `idempotency_key` race the seller's INSERT and must resolve to one
+ * resource.
+ *
+ * Modes:
+ *   - `process_local` (default): fire all dispatches via `Promise.all`
+ *     through the SDK's batch primitive before awaiting any response.
+ *     Single-process, event-loop concurrent — sufficient to exercise the
+ *     seller's INSERT race per the contract YAML's
+ *     `not_required_to_synthesize_packet_schedule` note.
+ *   - `distributed` (future): barrier-synced workers across processes for
+ *     true network-level concurrency. Defers to a later spec phase; runners
+ *     that do not implement it grade the step `not_applicable`.
+ *
+ * Spec source: `test-kits/parallel-dispatch-runner.yaml`.
+ */
+export interface ParallelDispatchSpec {
+  /**
+   * How many parallel dispatches to fire. Per spec, `count_min: 2`,
+   * `count_max: 10`. Values outside that range are rejected at run time as a
+   * `parallel_dispatch_misconfigured` step error rather than silently clamped.
+   */
+  count: number;
+  /**
+   * When `true` (default), every dispatch shares the same fresh
+   * `idempotency_key` (the runner mints one UUID and reuses it across the
+   * fan-out). When `false`, every dispatch gets its own fresh key — useful
+   * for soak tests that need parallelism without the race semantics.
+   */
+  same_idempotency_key?: boolean;
+  /**
+   * Maximum total wall-clock time, in milliseconds, the runner waits for all
+   * dispatches to resolve (including any IDEMPOTENCY_IN_FLIGHT retries).
+   * Defaults to `5000`. A dispatch that doesn't terminate within the budget
+   * is marked timed-out; the step grades the surviving set and reports
+   * `parallel_dispatch_barrier_timeout` for the missing arms.
+   */
+  barrier_timeout_ms?: number;
+  /**
+   * Dispatch coordination mode (see interface JSDoc). Defaults to
+   * `'process_local'`.
+   */
+  mode?: 'process_local' | 'distributed';
+}
 
 /**
  * Path/value match predicate for `upstream_traffic.payload_must_contain`.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -103,6 +103,46 @@ export interface ValidationContext {
    * `buyer_identifier_echo: true` is asserted.
    */
   storyboardStep?: { sample_request?: Record<string, unknown> };
+  /**
+   * Resolved set of dispatch outcomes for a `parallel_dispatch` step.
+   * Populated only when the runner fanned out N concurrent requests through
+   * the `parallel_dispatch_runner` contract. `cross_response_field_equal`
+   * and `cross_response_count_distinct` read this to grade against the
+   * cross-response set; single-dispatch steps leave it undefined and those
+   * two checks grade `not_applicable`.
+   */
+  crossResponses?: CrossResponseSet;
+}
+
+/**
+ * Aggregated cross-response data for `cross_response_*` validations on a
+ * `parallel_dispatch` step. Carries per-dispatch outcomes plus a derived
+ * `resolved` list of `TaskResult`s for paths that succeeded (after any
+ * in-flight retry resolution). The cross-response checks operate against
+ * `resolved`; per-response checks operate against the individual entries
+ * via the dispatcher's aggregation pass.
+ */
+export interface CrossResponseSet {
+  /** Every dispatch's terminal outcome, in fan-out order. */
+  dispatches: CrossResponseDispatch[];
+  /** Resolved task results for dispatches that terminated successfully. */
+  resolved: TaskResult[];
+}
+
+/**
+ * One dispatch's terminal record after any in-flight retry loop.
+ */
+export interface CrossResponseDispatch {
+  /** Per-dispatch correlation_id the runner attached. Excluded from the canonical hash. */
+  correlation_id: string;
+  /** Terminal task result, when the dispatch resolved within the barrier window. */
+  taskResult?: TaskResult;
+  /** Terminal error string, when the dispatch failed at the wire layer. */
+  error?: string;
+  /** True when the barrier window expired before the dispatch terminated. */
+  timed_out?: boolean;
+  /** Per-dispatch wall-clock duration in milliseconds. */
+  duration_ms: number;
 }
 
 /**
@@ -225,6 +265,10 @@ function runValidation(validation: StoryboardValidation, ctx: ValidationContext)
       return validateFieldEqualsContext(validation, ctx);
     case 'upstream_traffic':
       return validateUpstreamTraffic(validation, ctx);
+    case 'cross_response_field_equal':
+      return validateCrossResponseFieldEqual(validation, ctx);
+    case 'cross_response_count_distinct':
+      return validateCrossResponseCountDistinct(validation, ctx);
     default:
       // Forward-compat default per runner-output-contract.yaml v2.0.0:
       // when the runner does not implement an authored check kind (e.g. a
@@ -2662,6 +2706,149 @@ function deepEqual(a: unknown, b: unknown): boolean {
     if (!deepEqual(ao[k], bo[k])) return false;
   }
   return true;
+}
+
+/**
+ * Cross-response: every resolved dispatch carries the same value at `path`.
+ * Spec: test-kits/parallel-dispatch-runner.yaml (rule 9 / first-insert-wins).
+ *
+ * Grading rules:
+ *   - `ctx.crossResponses` absent → not_applicable (single-dispatch step).
+ *   - Fewer than 2 dispatches resolved → fail (the assertion requires a
+ *     cross-response comparison; one survivor doesn't prove the seller
+ *     deterministically resolved the race).
+ *   - All resolved values equal → pass.
+ *   - Any disagreement → fail; the result lists the distinct values observed
+ *     so reviewers can spot the duplicate-resource case at a glance.
+ */
+function validateCrossResponseFieldEqual(validation: StoryboardValidation, ctx: ValidationContext): ValidationResult {
+  const cr = ctx.crossResponses;
+  const path = validation.path ?? '';
+  if (!cr) {
+    return {
+      check: validation.check,
+      passed: true,
+      not_applicable: true,
+      description: validation.description,
+      note: 'step has no parallel_dispatch fan-out; cross-response checks grade not_applicable on single-dispatch steps',
+      json_pointer: toJsonPointer(path),
+    };
+  }
+  if (cr.resolved.length < 2) {
+    return {
+      check: validation.check,
+      passed: false,
+      description: validation.description,
+      json_pointer: toJsonPointer(path),
+      expected: 'at least 2 resolved dispatches with equal values at the path',
+      actual: `${cr.resolved.length} dispatch(es) resolved out of ${cr.dispatches.length}`,
+      schema_id: null,
+      schema_url: null,
+    };
+  }
+  const values = cr.resolved.map(tr => resolvePath(tr.data as Record<string, unknown> | undefined, path));
+  const first = values[0];
+  const allEqual = values.every(v => deepEqual(v, first));
+  if (allEqual) {
+    return {
+      check: validation.check,
+      passed: true,
+      description: validation.description,
+      json_pointer: toJsonPointer(path),
+      actual: first,
+    };
+  }
+  return {
+    check: validation.check,
+    passed: false,
+    description: validation.description,
+    json_pointer: toJsonPointer(path),
+    expected: 'all resolved dispatches return the same value at the path',
+    actual: values,
+    schema_id: null,
+    schema_url: null,
+  };
+}
+
+/**
+ * Cross-response: the cardinality of distinct values at `path` across all
+ * resolved dispatches is in `allowed_values`. Spec:
+ * test-kits/parallel-dispatch-runner.yaml.
+ *
+ * Grading rules:
+ *   - `ctx.crossResponses` absent → not_applicable.
+ *   - No dispatch resolved → fail.
+ *   - `allowed_values` missing or non-array → fail (authoring error).
+ *   - Distinct count ∈ allowed_values → pass.
+ *   - Otherwise → fail.
+ */
+function validateCrossResponseCountDistinct(
+  validation: StoryboardValidation,
+  ctx: ValidationContext
+): ValidationResult {
+  const cr = ctx.crossResponses;
+  const path = validation.path ?? '';
+  if (!cr) {
+    return {
+      check: validation.check,
+      passed: true,
+      not_applicable: true,
+      description: validation.description,
+      note: 'step has no parallel_dispatch fan-out; cross-response checks grade not_applicable on single-dispatch steps',
+      json_pointer: toJsonPointer(path),
+    };
+  }
+  if (!Array.isArray(validation.allowed_values) || validation.allowed_values.length === 0) {
+    return {
+      check: validation.check,
+      passed: false,
+      description: validation.description,
+      json_pointer: toJsonPointer(path),
+      expected: 'allowed_values: [<integer>, ...] declaring acceptable distinct counts',
+      actual: validation.allowed_values,
+      schema_id: null,
+      schema_url: null,
+    };
+  }
+  if (cr.resolved.length === 0) {
+    return {
+      check: validation.check,
+      passed: false,
+      description: validation.description,
+      json_pointer: toJsonPointer(path),
+      expected: 'at least one resolved dispatch',
+      actual: `0 / ${cr.dispatches.length} dispatches resolved`,
+      schema_id: null,
+      schema_url: null,
+    };
+  }
+  const distinct = new Set<string>();
+  for (const tr of cr.resolved) {
+    const v = resolvePath(tr.data as Record<string, unknown> | undefined, path);
+    if (v === undefined || v === null) continue;
+    distinct.add(JSON.stringify(v));
+  }
+  const distinctCount = distinct.size;
+  const allowed = validation.allowed_values as number[];
+  if (allowed.includes(distinctCount)) {
+    return {
+      check: validation.check,
+      passed: true,
+      description: validation.description,
+      json_pointer: toJsonPointer(path),
+      actual: distinctCount,
+    };
+  }
+  return {
+    check: validation.check,
+    passed: false,
+    description: validation.description,
+    json_pointer: toJsonPointer(path),
+    expected: `distinct count ∈ ${JSON.stringify(allowed)}`,
+    actual: distinctCount,
+    schema_id: null,
+    schema_url: null,
+  };
 }
 
 // resolvePath re-exported from ./path for backwards compat

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '6.19.0';
+export const LIBRARY_VERSION = '6.19.1';
 
 /**
  * AdCP specification version this library is built for
@@ -52,10 +52,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '6.19.0',
+  library: '6.19.1',
   adcp: '3.0.11',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-11T09:13:25.348Z',
+  generatedAt: '2026-05-11T14:19:39.941Z',
 } as const;
 
 /**

--- a/test/lib/storyboard-parallel-dispatch.test.js
+++ b/test/lib/storyboard-parallel-dispatch.test.js
@@ -1,0 +1,375 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { runValidations } = require('../../dist/lib/testing/storyboard/validations');
+const {
+  validateParallelDispatchSpec,
+  runParallelDispatches,
+  dispatchOnceWithInflightRetry,
+  PARALLEL_DISPATCH_DEFAULT_BARRIER_MS,
+} = require('../../dist/lib/testing/storyboard/parallel-dispatch');
+
+const baseCtx = {
+  taskName: 'create_media_buy',
+  agentUrl: 'https://example.com/mcp',
+  contributions: new Set(),
+};
+
+describe('validateParallelDispatchSpec', () => {
+  it('accepts a well-formed spec', () => {
+    assert.strictEqual(
+      validateParallelDispatchSpec({ count: 2, same_idempotency_key: true, barrier_timeout_ms: 5000 }),
+      null
+    );
+  });
+
+  it('rejects non-integer count', () => {
+    const err = validateParallelDispatchSpec({ count: 2.5 });
+    assert.ok(err && err.includes('must be an integer'));
+  });
+
+  it('rejects count below the spec minimum', () => {
+    const err = validateParallelDispatchSpec({ count: 1 });
+    assert.ok(err && err.includes('must be in [2, 10]'));
+  });
+
+  it('rejects count above the spec maximum', () => {
+    const err = validateParallelDispatchSpec({ count: 11 });
+    assert.ok(err && err.includes('must be in [2, 10]'));
+  });
+
+  it('rejects a non-positive barrier_timeout_ms', () => {
+    const err = validateParallelDispatchSpec({ count: 2, barrier_timeout_ms: 0 });
+    assert.ok(err && err.includes('barrier_timeout_ms'));
+  });
+
+  it('rejects an unknown mode', () => {
+    const err = validateParallelDispatchSpec({ count: 2, mode: 'multi_process' });
+    assert.ok(err && err.includes('mode must be'));
+  });
+});
+
+describe('cross_response_field_equal', () => {
+  function check(description = 'all dispatches return the same media_buy_id') {
+    return { check: 'cross_response_field_equal', path: 'media_buy_id', description };
+  }
+
+  it('grades not_applicable on a single-dispatch step (no crossResponses)', () => {
+    const [r] = runValidations([check()], baseCtx);
+    assert.strictEqual(r.passed, true);
+    assert.strictEqual(r.not_applicable, true);
+  });
+
+  it('passes when every resolved dispatch carries the same value at the path', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+      ],
+      resolved: [
+        { success: true, data: { media_buy_id: 'mb_1' } },
+        { success: true, data: { media_buy_id: 'mb_1' } },
+      ],
+    };
+    const [r] = runValidations([check()], { ...baseCtx, crossResponses });
+    assert.strictEqual(r.passed, true);
+    assert.strictEqual(r.actual, 'mb_1');
+  });
+
+  it('fails when resolved dispatches disagree', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: { media_buy_id: 'mb_2' } } },
+      ],
+      resolved: [
+        { success: true, data: { media_buy_id: 'mb_1' } },
+        { success: true, data: { media_buy_id: 'mb_2' } },
+      ],
+    };
+    const [r] = runValidations([check()], { ...baseCtx, crossResponses });
+    assert.strictEqual(r.passed, false);
+    assert.deepStrictEqual(r.actual, ['mb_1', 'mb_2']);
+  });
+
+  it('fails when fewer than 2 dispatches resolved', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+        { correlation_id: 'b', duration_ms: 12, timed_out: true },
+      ],
+      resolved: [{ success: true, data: { media_buy_id: 'mb_1' } }],
+    };
+    const [r] = runValidations([check()], { ...baseCtx, crossResponses });
+    assert.strictEqual(r.passed, false);
+    assert.ok(String(r.actual).includes('1 dispatch'));
+  });
+});
+
+describe('cross_response_count_distinct', () => {
+  function check(allowed_values = [1]) {
+    return {
+      check: 'cross_response_count_distinct',
+      path: 'media_buy_id',
+      allowed_values,
+      description: 'exactly one resource created',
+    };
+  }
+
+  it('grades not_applicable when crossResponses is absent', () => {
+    const [r] = runValidations([check()], baseCtx);
+    assert.strictEqual(r.passed, true);
+    assert.strictEqual(r.not_applicable, true);
+  });
+
+  it('passes when the distinct count is in allowed_values', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+      ],
+      resolved: [
+        { success: true, data: { media_buy_id: 'mb_1' } },
+        { success: true, data: { media_buy_id: 'mb_1' } },
+      ],
+    };
+    const [r] = runValidations([check([1])], { ...baseCtx, crossResponses });
+    assert.strictEqual(r.passed, true);
+    assert.strictEqual(r.actual, 1);
+  });
+
+  it('fails when two resources were created (race not resolved)', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: { media_buy_id: 'mb_2' } } },
+      ],
+      resolved: [
+        { success: true, data: { media_buy_id: 'mb_1' } },
+        { success: true, data: { media_buy_id: 'mb_2' } },
+      ],
+    };
+    const [r] = runValidations([check([1])], { ...baseCtx, crossResponses });
+    assert.strictEqual(r.passed, false);
+    assert.strictEqual(r.actual, 2);
+  });
+
+  it('fails when no dispatch resolved successfully', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, timed_out: true },
+        { correlation_id: 'b', duration_ms: 12, timed_out: true },
+      ],
+      resolved: [],
+    };
+    const [r] = runValidations([check([1])], { ...baseCtx, crossResponses });
+    assert.strictEqual(r.passed, false);
+  });
+
+  it('fails when allowed_values is missing (authoring error)', () => {
+    const [r] = runValidations(
+      [{ check: 'cross_response_count_distinct', path: 'media_buy_id', description: 'missing allowed_values' }],
+      {
+        ...baseCtx,
+        crossResponses: {
+          dispatches: [
+            { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: { media_buy_id: 'mb_1' } } },
+          ],
+          resolved: [{ success: true, data: { media_buy_id: 'mb_1' } }],
+        },
+      }
+    );
+    assert.strictEqual(r.passed, false);
+    assert.ok(String(r.expected).includes('allowed_values'));
+  });
+});
+
+describe('runParallelDispatches (process_local)', () => {
+  function makeStubClient(handler) {
+    // executeStoryboardTask falls back to client.executeTask for unmapped task
+    // names. Stub that path so the runner can drive arbitrary fake tasks.
+    return { executeTask: handler };
+  }
+
+  it('fires N concurrent dispatches and collects them in fan-out order', async () => {
+    let calls = 0;
+    const client = makeStubClient(async () => {
+      calls++;
+      return { success: true, data: { media_buy_id: 'mb_only', call: calls } };
+    });
+    const cr = await runParallelDispatches(
+      client,
+      'fake_task',
+      { idempotency_key: 'k1' },
+      {
+        spec: { count: 3, same_idempotency_key: true },
+        keyMinter: () => 'should_not_be_called',
+        correlationPrefix: 'step_x',
+      }
+    );
+    assert.strictEqual(cr.dispatches.length, 3);
+    assert.strictEqual(cr.resolved.length, 3);
+    assert.strictEqual(calls, 3);
+    assert.deepStrictEqual(
+      cr.dispatches.map(d => d.correlation_id),
+      ['step_x#0', 'step_x#1', 'step_x#2']
+    );
+  });
+
+  it('retries IDEMPOTENCY_IN_FLIGHT with the same idempotency_key until terminal', async () => {
+    let attempt = 0;
+    const seenKeys = new Set();
+    const client = makeStubClient(async (taskName, params) => {
+      seenKeys.add(params.idempotency_key);
+      attempt++;
+      if (attempt < 3) {
+        return {
+          success: false,
+          data: { adcp_error: { code: 'IDEMPOTENCY_IN_FLIGHT', message: 'wait', retry_after: 0.06 } },
+        };
+      }
+      return { success: true, data: { media_buy_id: 'mb_winner' } };
+    });
+    const cr = await runParallelDispatches(
+      client,
+      'fake_task',
+      { idempotency_key: 'shared_key', context: { correlation_id: 'will_be_overridden' } },
+      {
+        spec: { count: 2, same_idempotency_key: true, barrier_timeout_ms: 5000 },
+        keyMinter: () => 'should_not_be_called',
+        correlationPrefix: 'concurrent_retry',
+      }
+    );
+    // All dispatches see the same key — that's the contract.
+    assert.strictEqual(seenKeys.size, 1);
+    assert.ok(seenKeys.has('shared_key'));
+    // The retrying dispatch eventually terminates with the success body.
+    const resolvedIds = cr.resolved.map(r => r.data.media_buy_id);
+    assert.ok(resolvedIds.length >= 1);
+    assert.ok(resolvedIds.every(id => id === 'mb_winner'));
+  });
+
+  it('mints distinct idempotency_keys when same_idempotency_key is false', async () => {
+    const seenKeys = new Set();
+    const client = makeStubClient(async (taskName, params) => {
+      seenKeys.add(params.idempotency_key);
+      return { success: true, data: { media_buy_id: `mb_${params.idempotency_key}` } };
+    });
+    let counter = 0;
+    const cr = await runParallelDispatches(
+      client,
+      'fake_task',
+      { idempotency_key: 'base_key' },
+      {
+        spec: { count: 3, same_idempotency_key: false },
+        keyMinter: () => `minted_${counter++}`,
+        correlationPrefix: 'soak',
+      }
+    );
+    assert.strictEqual(cr.dispatches.length, 3);
+    assert.strictEqual(seenKeys.size, 3);
+    assert.ok([...seenKeys].every(k => k.startsWith('minted_')));
+  });
+
+  it('honors barrier_timeout_ms and marks lagging dispatches timed_out', async () => {
+    const client = makeStubClient(async () => {
+      await new Promise(r => setTimeout(r, 200));
+      return { success: true, data: { media_buy_id: 'mb_slow' } };
+    });
+    const cr = await runParallelDispatches(
+      client,
+      'fake_task',
+      { idempotency_key: 'shared' },
+      {
+        spec: { count: 2, same_idempotency_key: true, barrier_timeout_ms: 50 },
+        keyMinter: () => 'unused',
+        correlationPrefix: 'slow',
+      }
+    );
+    assert.strictEqual(cr.dispatches.length, 2);
+    assert.ok(cr.dispatches.every(d => d.timed_out === true));
+    assert.strictEqual(cr.resolved.length, 0);
+  });
+});
+
+describe('dispatchOnceWithInflightRetry', () => {
+  it('returns the success TaskResult on first try when seller terminates cleanly', async () => {
+    const client = {
+      executeTask: async () => ({ success: true, data: { media_buy_id: 'mb_x' } }),
+    };
+    const out = await dispatchOnceWithInflightRetry(
+      client,
+      'fake_task',
+      { idempotency_key: 'k' },
+      {
+        deadlineMs: Date.now() + 5000,
+      }
+    );
+    assert.strictEqual(out.taskResult.success, true);
+  });
+
+  it('returns immediately on a terminal non-in-flight error', async () => {
+    let calls = 0;
+    const client = {
+      executeTask: async () => {
+        calls++;
+        return { success: false, data: { adcp_error: { code: 'IDEMPOTENCY_CONFLICT', message: 'no' } } };
+      },
+    };
+    const out = await dispatchOnceWithInflightRetry(
+      client,
+      'fake_task',
+      { idempotency_key: 'k' },
+      {
+        deadlineMs: Date.now() + 5000,
+      }
+    );
+    assert.strictEqual(out.taskResult.success, false);
+    assert.strictEqual(out.taskResult.data.adcp_error.code, 'IDEMPOTENCY_CONFLICT');
+    assert.strictEqual(calls, 1);
+  });
+
+  it('treats SERVICE_UNAVAILABLE as an in-flight signal for legacy SDKs', async () => {
+    let calls = 0;
+    const client = {
+      executeTask: async () => {
+        calls++;
+        if (calls === 1) {
+          return {
+            success: false,
+            data: { adcp_error: { code: 'SERVICE_UNAVAILABLE', retry_after: 0.05 } },
+          };
+        }
+        return { success: true, data: { media_buy_id: 'mb_legacy' } };
+      },
+    };
+    const out = await dispatchOnceWithInflightRetry(
+      client,
+      'fake_task',
+      { idempotency_key: 'k' },
+      {
+        deadlineMs: Date.now() + 5000,
+      }
+    );
+    assert.strictEqual(out.taskResult.success, true);
+    assert.strictEqual(calls, 2);
+  });
+
+  it('stops retrying when the deadline passes and returns the last in-flight error', async () => {
+    const client = {
+      executeTask: async () => ({
+        success: false,
+        data: { adcp_error: { code: 'IDEMPOTENCY_IN_FLIGHT', retry_after: 0.05 } },
+      }),
+    };
+    const deadlineMs = Date.now() + 120;
+    const out = await dispatchOnceWithInflightRetry(client, 'fake_task', { idempotency_key: 'k' }, { deadlineMs });
+    assert.strictEqual(out.taskResult.success, false);
+    assert.strictEqual(out.taskResult.data.adcp_error.code, 'IDEMPOTENCY_IN_FLIGHT');
+  });
+});
+
+describe('default barrier timeout', () => {
+  it('exports a 5s default per the contract YAML', () => {
+    assert.strictEqual(PARALLEL_DISPATCH_DEFAULT_BARRIER_MS, 5000);
+  });
+});

--- a/test/server-idempotency.test.js
+++ b/test/server-idempotency.test.js
@@ -345,11 +345,18 @@ describe('createAdcpServer with idempotency', () => {
     const results = await Promise.all(Array.from({ length: 5 }, () => callTool(server, 'create_media_buy', req)));
 
     assert.equal(calls, 1, 'handler must run exactly once under concurrent retry');
-    // Winners: one got a fresh response, others got SERVICE_UNAVAILABLE (in-flight)
+    // Winners: one got a fresh response, others got IDEMPOTENCY_IN_FLIGHT
     const winners = results.filter(r => r.media_buy_id);
-    const inFlights = results.filter(r => r.adcp_error?.code === 'SERVICE_UNAVAILABLE');
+    const inFlights = results.filter(r => r.adcp_error?.code === 'IDEMPOTENCY_IN_FLIGHT');
     assert.ok(winners.length >= 1, 'at least one call must return the fresh response');
     assert.equal(winners.length + inFlights.length, 5);
+    for (const f of inFlights) {
+      assert.equal(f.adcp_error.recovery, 'transient', 'in-flight branch must be transient');
+      assert.ok(
+        typeof f.adcp_error.retry_after === 'number' && f.adcp_error.retry_after >= 1,
+        'in-flight branch must carry a retry_after hint'
+      );
+    }
   });
 
   it('strict-mode VALIDATION_ERROR short-circuits retry storm on same key + payload', async () => {
@@ -423,7 +430,7 @@ describe('createAdcpServer with idempotency', () => {
   it('strict-mode parallel retries of a drifted handler see in-flight, not re-execution', async () => {
     // Concurrency guard: while call A is still inside the handler
     // producing the drifted response, a parallel call B with the same
-    // key + payload must hit the IN_FLIGHT claim (SERVICE_UNAVAILABLE)
+    // key + payload must hit the IN_FLIGHT claim (IDEMPOTENCY_IN_FLIGHT)
     // rather than re-entering the handler. Once A completes and writes
     // the transient-error entry, a subsequent retry hits the cached
     // VALIDATION_ERROR — not the handler.
@@ -457,7 +464,7 @@ describe('createAdcpServer with idempotency', () => {
     await new Promise(r => setImmediate(r));
     const b = await callTool(server, 'create_media_buy', req);
 
-    assert.equal(b.adcp_error?.code, 'SERVICE_UNAVAILABLE', 'parallel retry must see in-flight, not re-execute');
+    assert.equal(b.adcp_error?.code, 'IDEMPOTENCY_IN_FLIGHT', 'parallel retry must see in-flight, not re-execute');
     assert.equal(calls, 1, 'handler must not re-execute for parallel retry');
 
     releaseHandler();


### PR DESCRIPTION
## Summary

Closes #1686 (parallel_dispatch_runner contract implementation — gates the new storyboard phase from running anywhere) and #1687 (SDK middleware swap SERVICE_UNAVAILABLE → IDEMPOTENCY_IN_FLIGHT on the in-flight branch).

### #1687 — In-flight branch swap

- `create-adcp-server.ts` returns `IDEMPOTENCY_IN_FLIGHT` (AdCP 3.1) with `recovery: transient`. Buyer SDKs auto-retrying transient + retry_after are unchanged on the wire.
- `retry_after` is derived from the in-flight claim's age (5s cap so a slow handler doesn't stall buyer retries past the outer barrier).
- `IdempotencyCheckResult.kind === 'in-flight'` now carries `retryAfterSeconds` so custom store implementations can drive the same hint.
- `IDEMPOTENCY_IN_FLIGHT` registered in `ADCP_ERROR_FIELD_ALLOWLIST` — defense-in-depth, mirrors the `IDEMPOTENCY_CONFLICT` precedent.

### #1686 — parallel_dispatch_runner contract

- **New module** `src/lib/testing/storyboard/parallel-dispatch.ts` — `runParallelDispatches()` fans out N concurrent dispatches via `Promise.all` with per-dispatch correlation_ids (hash-excluded), shared idempotency_key by default, and an in-flight retry wrapper that honors `IDEMPOTENCY_IN_FLIGHT` (and legacy `SERVICE_UNAVAILABLE`) `retry_after` hints up to the barrier.
- **New step field** `parallel_dispatch?: ParallelDispatchSpec` on `StoryboardStep`.
- **Two new check kinds** — `cross_response_field_equal { path }` and `cross_response_count_distinct { path, allowed_values }`. Both grade `not_applicable` on single-dispatch steps.
- **Runner integration** — gated on `options.contracts ∋ 'parallel_dispatch_runner'`; validates count ∈ `[2, 10]`; rejects `mode: distributed` with `not_applicable`. Per-response checks run once per dispatch and aggregate; cross-response checks run once with the resolved set. Representative pinned to `dispatches[0]` so the `i=1` aggregation loop covers every arm exactly once.

## Expert review

Ran ad-tech-protocol, security, and code-correctness reviewers in parallel. Convergence:

- **Code-reviewer (P0)**: representative double-count when picking `resolved[0]` as the main pass target — fixed by pinning to `dispatches[0]` and deriving step pass/fail from the cross-response set rather than the representative arm's `.success`.
- **Code-reviewer**: transport hardcoded to `mcp` on the parallel responseRecord — fixed.
- **Code-reviewer**: barrier-timeout error not mirrored onto `taskResult.error` — fixed.
- **Code-reviewer**: `Promise.race` doesn't abort the in-flight SDK request on barrier timeout — documented as a known race in runner.ts JSDoc.
- **Security**: register `IDEMPOTENCY_IN_FLIGHT` in `ADCP_ERROR_FIELD_ALLOWLIST` for defense-in-depth — done.
- **Security (Medium, deferred)**: run-level dispatch budget for hostile storyboards — `count_max: 10` already bounds per-step; per-run budget is a follow-up worth tracking as a separate hardening.
- **Protocol**: IDEMPOTENCY_IN_FLIGHT pre-manifest emission is wire-compat-safe (transient recovery fallback already handles unknown codes); SERVICE_UNAVAILABLE in IN_FLIGHT_ERROR_CODES is symmetric with `buyer-retry-policy.ts`'s existing `retry-with-same-key` policy.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run format:check` — clean
- [x] `NODE_ENV=test npx mocha test/server-idempotency.test.js test/lib/idempotency-*.test.js test/lib/storyboard-parallel-dispatch.test.js test/lib/storyboard-validations*.test.js` — 168/168 pass
- [x] Broader storyboard sweep — 306/306 pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)