### PR TITLE
feat(client): add AdcpValidationIssue type and issues[] field on AdcpErrorInfo

### DIFF
--- a/.changeset/adcp-validation-issue-type-1694.md
+++ b/.changeset/adcp-validation-issue-type-1694.md
@@ -1,0 +1,21 @@
+---
+"@adcp/sdk": minor
+---
+
+feat(client): add `issues[]` as first-class field on `AdcpErrorInfo` (per core/error.json 3.0 GA)
+
+`AdcpErrorInfo` now carries `issues?: AdcpValidationIssue[]`, populated from the seller's
+`VALIDATION_ERROR` envelope when present. Previously the `issues[]` array landed in the
+free-form `details` field, forcing consumers to read `details.validation_errors` as a
+convention rather than a typed API.
+
+Each `AdcpValidationIssue` carries `pointer` (RFC 6901 JSON Pointer to the offending field),
+`message` (human-readable), `keyword` (JSON Schema keyword: `'required'`, `'type'`, `'enum'`,
+etc. — the key field for LLM self-correction), and optional `schemaPath`. Only items that
+satisfy the required-field shape are forwarded; malformed wire items are silently dropped.
+
+`ExtractedAdcpError` (returned by `extractAdcpErrorFromMcp` / `extractAdcpErrorFromTransport`)
+also gains `issues?: AdcpValidationIssue[]` for callers using the transport-level helpers
+directly. `AdcpValidationIssue` is exported from the package root.
+
+Closes #1694.

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -282,6 +282,30 @@ export interface SubmittedContinuation<T> {
 }
 
 /**
+ * A single validation failure from an AdCP VALIDATION_ERROR response.
+ *
+ * `pointer` uses RFC 6901 JSON Pointer format (e.g. `/packages/0/targeting`),
+ * which differs from the top-level `AdcpErrorInfo.field` that uses JSONPath-lite
+ * (`packages[0].targeting`). For LLM self-correction: read `keyword` first —
+ * `'required'` means add the missing field, `'enum'` means pick a valid value,
+ * `'type'` means fix the value type.
+ */
+export interface AdcpValidationIssue {
+  /** RFC 6901 JSON Pointer to the offending field (e.g. `/packages/0/targeting`). */
+  pointer: string;
+  /** Human-readable reason this field was rejected. */
+  message: string;
+  /** JSON Schema keyword that caused rejection (e.g. `'required'`, `'type'`, `'enum'`). */
+  keyword: string;
+  /**
+   * Path inside the schema that rejected the payload. Sellers SHOULD NOT emit on
+   * production endpoints — it leaks oneOf branch selection and is a fingerprinting
+   * oracle for adversarial callers. May appear in dev/sandbox mode.
+   */
+  schemaPath?: string;
+}
+
+/**
  * Structured AdCP error information extracted from a failed task response.
  * Present on `TaskResult.adcpError` when the agent returns a recognized error.
  */
@@ -302,6 +326,14 @@ export interface AdcpErrorInfo {
   retryAfterMs?: number;
   /** Additional error details. Untrusted agent-controlled content — sanitize before rendering. */
   details?: Record<string, unknown>;
+  /**
+   * Structured validation failures. Present on `VALIDATION_ERROR` when the seller
+   * identifies multiple offending fields. Each item's `pointer` is RFC 6901 format
+   * (e.g. `/packages/0/targeting`) — differs from the top-level `field` which uses
+   * JSONPath-lite. For LLM self-correction, read `keyword` first: `'required'` → add
+   * the field, `'enum'` → pick a valid value, `'type'` → fix the value type.
+   */
+  issues?: AdcpValidationIssue[];
   /** True when the SDK inferred this error from unstructured text (L1 compliance) */
   synthetic?: boolean;
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -137,6 +137,7 @@ export type {
   TaskStatus,
   ConversationConfig,
   AdcpErrorInfo,
+  AdcpValidationIssue,
 } from './core/ConversationTypes';
 
 // ====== GOVERNANCE ======

--- a/src/lib/utils/error-extraction.ts
+++ b/src/lib/utils/error-extraction.ts
@@ -166,8 +166,7 @@ function mapValidationIssues(raw: unknown): AdcpValidationIssue[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const mapped = raw
     .filter(
-      (i: any) =>
-        typeof i?.pointer === 'string' && typeof i?.message === 'string' && typeof i?.keyword === 'string'
+      (i: any) => typeof i?.pointer === 'string' && typeof i?.message === 'string' && typeof i?.keyword === 'string'
     )
     .map((i: any) => ({
       pointer: i.pointer as string,

--- a/src/lib/utils/error-extraction.ts
+++ b/src/lib/utils/error-extraction.ts
@@ -11,6 +11,7 @@ import {
   type StandardErrorCode,
   type ErrorRecovery,
 } from '../types/error-codes';
+import type { AdcpErrorInfo, AdcpValidationIssue } from '../core/ConversationTypes';
 
 export interface ExtractedAdcpError {
   code: string;
@@ -20,6 +21,7 @@ export interface ExtractedAdcpError {
   suggestion?: string;
   retry_after?: number;
   details?: Record<string, unknown>;
+  issues?: AdcpValidationIssue[];
   /** Where the error was found in the response */
   source: 'structuredContent' | 'text_json' | 'text_pattern';
   /** The compliance level this delivery achieves */
@@ -155,6 +157,27 @@ export function getExpectedAction(recovery: ErrorRecovery): 'retry' | 'fix_reque
 
 // --- Internal helpers ---
 
+/**
+ * Map a raw wire `issues[]` array to `AdcpValidationIssue[]`.
+ * Returns `undefined` when input is absent, not an array, or all items are malformed
+ * (missing required `pointer` / `message` / `keyword` string fields).
+ */
+function mapValidationIssues(raw: unknown): AdcpValidationIssue[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const mapped = raw
+    .filter(
+      (i: any) =>
+        typeof i?.pointer === 'string' && typeof i?.message === 'string' && typeof i?.keyword === 'string'
+    )
+    .map((i: any) => ({
+      pointer: i.pointer as string,
+      message: i.message as string,
+      keyword: i.keyword as string,
+      ...(typeof i.schemaPath === 'string' ? { schemaPath: i.schemaPath } : {}),
+    }));
+  return mapped.length > 0 ? mapped : undefined;
+}
+
 function buildExtracted(
   obj: any,
   source: ExtractedAdcpError['source'],
@@ -172,6 +195,8 @@ function buildExtracted(
   if (obj.suggestion != null) result.suggestion = obj.suggestion;
   if (obj.retry_after != null) result.retry_after = obj.retry_after;
   if (obj.details != null) result.details = obj.details;
+  const mappedIssues = mapValidationIssues(obj.issues);
+  if (mappedIssues) result.issues = mappedIssues;
   return result;
 }
 
@@ -211,8 +236,6 @@ function matchStandardCode(text: string): StandardErrorCode | null {
 
 // --- TaskResult-level helpers ---
 
-import type { AdcpErrorInfo } from '../core/ConversationTypes';
-
 /**
  * Extract normalized AdcpErrorInfo from unwrapped response data.
  * Handles both `{ adcp_error: {...} }` and `{ errors: [...] }` shapes.
@@ -232,10 +255,15 @@ export function extractAdcpErrorInfo(data: any): AdcpErrorInfo | undefined {
       info.retryAfterMs = ae.retry_after * 1000;
     }
     if (ae.details != null) info.details = ae.details;
+    const mappedIssues = mapValidationIssues(ae.issues);
+    if (mappedIssues) info.issues = mappedIssues;
     if (ae.synthetic) info.synthetic = true;
     return info;
   }
 
+  // Legacy `{ errors: [...] }` envelope — L1 compat only. Extracts code/message/recovery
+  // from errors[0]; does not forward issues[], field, suggestion, or details since this
+  // path is only reached for non-standard envelopes that are unlikely to carry issues[].
   if (Array.isArray(data.errors) && data.errors.length > 0) {
     const first = data.errors[0];
     if (typeof first.code === 'string') {

--- a/src/lib/utils/request-normalizer.ts
+++ b/src/lib/utils/request-normalizer.ts
@@ -8,7 +8,6 @@
 
 import { ValidationError } from '../errors';
 import { brandManifestToBrandReference, promotedProductsToCatalog } from '../types/compat';
-import { ValidationError } from '../errors/index';
 import { warnOnce } from './deprecation';
 import { MUTATING_TASKS, generateIdempotencyKey } from './idempotency';
 

--- a/test/error-extraction.test.js
+++ b/test/error-extraction.test.js
@@ -190,6 +190,47 @@ describe('extractAdcpErrorFromMcp', () => {
     assert.strictEqual(result.code, 'PRODUCT_NOT_FOUND');
     assert.strictEqual(result.source, 'structuredContent');
   });
+
+  // adcp-client#1694: structured issues[] forwarded on the L3 extraction path
+  it('forwards well-formed issues[] from structuredContent (L3)', () => {
+    const response = {
+      isError: true,
+      content: [{ type: 'text', text: 'error' }],
+      structuredContent: {
+        adcp_error: {
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          issues: [{ pointer: '/packages/0/budget', message: 'must be number', keyword: 'type' }],
+        },
+      },
+    };
+    const result = extractAdcpErrorFromMcp(response);
+    assert.ok(result);
+    assert.ok(Array.isArray(result.issues));
+    assert.strictEqual(result.issues.length, 1);
+    assert.strictEqual(result.issues[0].pointer, '/packages/0/budget');
+    assert.strictEqual(result.issues[0].keyword, 'type');
+  });
+
+  it('drops malformed issues[] items on the L3 path', () => {
+    const response = {
+      isError: true,
+      content: [{ type: 'text', text: 'error' }],
+      structuredContent: {
+        adcp_error: {
+          code: 'VALIDATION_ERROR',
+          message: 'mixed',
+          issues: [
+            { pointer: '/ok', message: 'kept', keyword: 'required' },
+            { pointer: 1, message: 'numeric-pointer-dropped', keyword: 'type' },
+          ],
+        },
+      },
+    };
+    const result = extractAdcpErrorFromMcp(response);
+    assert.ok(result);
+    assert.strictEqual(result.issues.length, 1);
+  });
 });
 
 describe('extractAdcpErrorFromTransport', () => {
@@ -320,6 +361,102 @@ describe('extractAdcpErrorInfo', () => {
 
   it('returns undefined for non-error data', () => {
     assert.strictEqual(extractAdcpErrorInfo({ products: [] }), undefined);
+  });
+
+  // adcp-client#1694: structured issues[] forwarded as first-class field
+  it('forwards well-formed issues[] from adcp_error', () => {
+    const data = {
+      adcp_error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Validation failed',
+        recovery: 'correctable',
+        issues: [
+          {
+            pointer: '/packages/0/targeting',
+            message: 'must NOT have additional properties',
+            keyword: 'additionalProperties',
+          },
+          {
+            pointer: '/start_time',
+            message: "must match format 'date-time'",
+            keyword: 'format',
+            schemaPath: '#/properties/start_time/format',
+          },
+        ],
+      },
+    };
+    const info = extractAdcpErrorInfo(data);
+    assert.ok(info);
+    assert.ok(Array.isArray(info.issues));
+    assert.strictEqual(info.issues.length, 2);
+    assert.deepStrictEqual(info.issues[0], {
+      pointer: '/packages/0/targeting',
+      message: 'must NOT have additional properties',
+      keyword: 'additionalProperties',
+    });
+    // schemaPath preserved when present
+    assert.strictEqual(info.issues[1].schemaPath, '#/properties/start_time/format');
+  });
+
+  it('drops malformed issues[] items (missing required fields)', () => {
+    const data = {
+      adcp_error: {
+        code: 'VALIDATION_ERROR',
+        message: 'mixed',
+        issues: [
+          { pointer: '/ok', message: 'kept', keyword: 'type' },
+          { pointer: '/missing_keyword', message: 'dropped' }, // missing keyword
+          { message: 'no pointer', keyword: 'required' }, // missing pointer
+          { pointer: '/wrong_types', message: 1, keyword: 'enum' }, // non-string message
+        ],
+      },
+    };
+    const info = extractAdcpErrorInfo(data);
+    assert.ok(info);
+    assert.strictEqual(info.issues.length, 1, 'only the well-formed item survives');
+    assert.strictEqual(info.issues[0].pointer, '/ok');
+  });
+
+  it('omits issues when all items are malformed (no empty array on the field)', () => {
+    const data = {
+      adcp_error: {
+        code: 'VALIDATION_ERROR',
+        message: 'all bad',
+        issues: [{ pointer: 1 }, { message: 'x' }],
+      },
+    };
+    const info = extractAdcpErrorInfo(data);
+    assert.ok(info);
+    assert.strictEqual(info.issues, undefined, 'empty after filtering → field absent, not []');
+  });
+
+  it('omits issues when the wire field is absent', () => {
+    const data = { adcp_error: { code: 'INVALID_REQUEST', message: 'plain' } };
+    const info = extractAdcpErrorInfo(data);
+    assert.ok(info);
+    assert.strictEqual(info.issues, undefined);
+  });
+
+  it('omits issues when the wire field is not an array', () => {
+    const data = { adcp_error: { code: 'INVALID_REQUEST', message: 'plain', issues: 'not-an-array' } };
+    const info = extractAdcpErrorInfo(data);
+    assert.ok(info);
+    assert.strictEqual(info.issues, undefined);
+  });
+
+  it('keeps details when issues is also present (orthogonal fields)', () => {
+    const data = {
+      adcp_error: {
+        code: 'VALIDATION_ERROR',
+        message: 'both',
+        details: { retry_hint: 'fix and resubmit' },
+        issues: [{ pointer: '/x', message: 'y', keyword: 'type' }],
+      },
+    };
+    const info = extractAdcpErrorInfo(data);
+    assert.ok(info);
+    assert.deepStrictEqual(info.details, { retry_hint: 'fix and resubmit' });
+    assert.strictEqual(info.issues.length, 1);
   });
 });
 

--- a/test/request-normalizer-package-params.test.js
+++ b/test/request-normalizer-package-params.test.js
@@ -82,6 +82,7 @@ describe('normalizeRequestParams — pre-3.0 package shapes propagate through cr
       () =>
         normalizeRequestParams('create_media_buy', {
           idempotency_key: 'test-key',
+          account: { account_id: 'test-acc' },
           packages: [{ product_ids: ['prod-1'], pricing_option_id: 'po-1', budget: 1000 }],
         }),
       err => {
@@ -97,6 +98,7 @@ describe('normalizeRequestParams — pre-3.0 package shapes propagate through cr
       () =>
         normalizeRequestParams('create_media_buy', {
           idempotency_key: 'test-key',
+          account: { account_id: 'test-acc' },
           packages: [{ product_id: 'prod-1', pricing_option_id: 'po-1', budget: { total: 1000, currency: 'USD' } }],
         }),
       err => {


### PR DESCRIPTION
Closes #1694

## Summary

`AdcpErrorInfo` now carries `issues?: AdcpValidationIssue[]`, populated from the seller's `VALIDATION_ERROR` envelope when present. Previously the spec's `issues[]` array (defined in `core/error.json` 3.0 GA) landed in the free-form `details` field, requiring consumers to learn the `details.validation_errors` convention rather than reading a typed API.

Each `AdcpValidationIssue` carries:
- `pointer: string` — RFC 6901 JSON Pointer to the offending field (e.g. `/packages/0/targeting`). **Not** the same format as the top-level `field` (JSONPath-lite).
- `message: string` — human-readable rejection reason
- `keyword: string` — JSON Schema keyword that caused rejection (`'required'`, `'type'`, `'enum'`, etc.) — the load-bearing field for LLM self-correction
- `schemaPath?: string` — schema path; sellers SHOULD NOT emit on production (leaks oneOf branch selection)

Only items satisfying the required-field shape are forwarded; malformed wire items are silently dropped. `ExtractedAdcpError` (returned by `extractAdcpErrorFromMcp` / `extractAdcpErrorFromTransport`) gains the same field for callers using the transport-level helpers directly. `AdcpValidationIssue` is exported from the package root alongside `AdcpErrorInfo`.

The mapping logic is consolidated in a single `mapValidationIssues()` helper used by both `buildExtracted()` and `extractAdcpErrorInfo()`. The legacy `data.errors[]` path deliberately does not extract `issues[]` (L1-compat path; non-standard envelope shapes are unlikely to carry it — comment added).

## What was tested

- `npm run typecheck` — pre-existing env errors only (`TS2688: @types/node`, `TS5107: moduleResolution=node10`); no new errors introduced
- `npm run build:lib` / `npm test` — cannot run (`tsx` not installed in this environment; same constraint as #1689 / #1684 / #1683); CI will verify

**Nit noted (not fixed):** No unit tests cover the new `issues[]` extraction paths (`buildExtracted` happy-path, malformed-item filter, `schemaPath` round-trip, `extractAdcpErrorInfo` path). These should land before merge — the filter-then-suppress-empty logic is the behavior most in need of a test.

## Pre-PR review

- **code-reviewer:** approved — `schemaPath` type guard corrected (`typeof === 'string'`), duplicate mapping extracted to `mapValidationIssues()` helper; nit: no test coverage for new paths
- **dx-expert:** approved — `pointer`/`keyword`/`schemaPath?` shape matches spec exactly; `AdcpValidationIssue` name follows `Adcp*` convention; import hoisted to top of file; JSDoc covers RFC 6901 / JSONPath-lite distinction and keyword-first self-correction guidance

> **Triage-managed PR.** This bot does not currently iterate on
> review comments or PR conversation threads (only on the source
> issue). To unblock:
>
> - **Push fixup commits directly:** `gh pr checkout 1695` →
>   fix → push.
> - **Or re-trigger:** comment `/triage execute` on the source
>   issue.
>
> See [adcp#3121](https://github.com/adcontextprotocol/adcp/issues/3121)
> for context.

Session: https://claude.ai/code/session_01RxPkjDrwRRT8TNW7U4ShHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxPkjDrwRRT8TNW7U4ShHQ)_