### PR TITLE
fix(comply): autodetect request_signer + pre-empt oauth_discovery (#1702)

### DIFF
--- a/.changeset/request-signer-and-oauth-metadata-autodetect-1702.md
+++ b/.changeset/request-signer-and-oauth-metadata-autodetect-1702.md
@@ -1,0 +1,33 @@
+---
+'@adcp/sdk': minor
+---
+
+fix(comply): autodetect `request_signer` and `oauth_metadata` prereqs (#1702)
+
+Extends the implicit-requires pattern shipped in #1678 (`webhook_receiver`)
+to two more requirement surfaces, removing ~44 false-negative step
+failures per `comply()` run on agents that don't claim the underlying
+capability.
+
+- Adds `'request_signer'` to `RequirementName` / `KNOWN_REQUIREMENTS` /
+  `REQUIREMENT_TO_SKIP_REASON` and extends `detectImplicitRequires` to
+  flag any storyboard whose `id === 'signed_requests'` or that contains
+  a `request_signing_probe` step. The gate consults the agent's
+  `get_adcp_capabilities.request_signing.supported` from the discovered
+  profile (not a runner opt-out flag) so an agent that claims the
+  capability but hasn't pre-registered the runner's compliance test
+  keypair still fails — matches the universal storyboard's stated
+  gating contract at
+  `compliance/{version}/universal/signed-requests.yaml` ("absence of
+  advertisement is not a failure").
+- Pre-empts `oauth_discovery` cascade-skip on `security_baseline` when
+  the agent's capabilities don't declare `account.authorization_endpoint`.
+  The existing reactive `phaseAbsent` cascade (#677) only triggers on a
+  404 from `/.well-known/oauth-protected-resource`; non-404 responses
+  from a bearer-only agent (200-HTML, 405, redirect — the Wonderstruck
+  shape) fell through to validation failures inside an `optional: true`
+  phase. The pre-empt is phase-level, not storyboard-level, so the
+  universal `unauth_rejection` and `mechanism_required` checks still run.
+
+Part of the coordinated stance at #1685 (the SDK is a witness, not a
+translator).

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -876,6 +876,7 @@ const REQUIREMENT_TO_SKIP_REASON: Record<RequirementName, RunnerSkipReason> = {
   seeded_state: 'requirement_unmet',
   real_wire: 'requirement_unmet',
   webhook_receiver: 'requirement_unmet',
+  request_signer: 'not_applicable',
 };
 
 /**
@@ -959,10 +960,24 @@ function buildRequirementUnmetResult(
  *     Autodetected from step `sample_request` token presence (see
  *     `detectImplicitRequires`); authors don't write this tag manually.
  *     Spec: adcp-client#1678.
+ *   - `request_signer` — agent advertises `request_signing.supported: true`
+ *     in `get_adcp_capabilities`. Autodetected for any storyboard whose
+ *     id is `'signed_requests'` or that contains a `request_signing_probe`
+ *     step (see `detectImplicitRequires`); authors don't write this tag
+ *     manually. Absence-skip semantics are INVERTED from the general
+ *     `requires_capability` rule: the signed-requests universal
+ *     storyboard's own gating spec (signed-requests.yaml prerequisites)
+ *     declares "agents that do not advertise support are not tested
+ *     against this storyboard — absence of advertisement is not a
+ *     failure". When the runner can't read capabilities (no profile
+ *     threaded through), the gate is a no-op — the caller accepted
+ *     responsibility for capability compatibility by reusing an external
+ *     client. Spec: adcp-client#1702.
  */
 function checkRequires(
   requires: readonly RequirementName[],
-  options: StoryboardRunOptions
+  options: StoryboardRunOptions,
+  profile?: AgentProfile
 ): { requirement: RequirementName; detail: string } | null {
   for (const requirement of requires) {
     switch (requirement) {
@@ -1007,6 +1022,26 @@ function checkRequires(
         }
         break;
       }
+      case 'request_signer': {
+        // Gate is a no-op when no profile is threaded through (external
+        // `_client` mode). The caller has accepted responsibility for
+        // capability compatibility; failing the gate here would surprise
+        // them with a skip they can't explain from CLI options alone.
+        if (!profile?.raw_capabilities) break;
+        const supported = resolveCapabilityPath(profile.raw_capabilities, 'request_signing.supported');
+        if (supported === true) break;
+        return {
+          requirement,
+          detail:
+            'Storyboard requires `request_signing.supported: true` in `get_adcp_capabilities`; ' +
+            `agent declared ${supported === undefined ? 'no request_signing block' : JSON.stringify(supported)}. ` +
+            'Per compliance/{version}/universal/signed-requests.yaml: "Agents that do not advertise ' +
+            'support are not tested against this storyboard — absence of advertisement is not a ' +
+            'failure, it is a declaration that the agent does not offer verified signed requests." ' +
+            'To opt in, advertise `request_signing.supported: true` and pre-register the runner ' +
+            'compliance test keypair per test-kits/signed-requests-runner.yaml.',
+        };
+      }
     }
   }
   return null;
@@ -1044,23 +1079,41 @@ function valueContainsWebhookToken(value: unknown): boolean {
 
 /**
  * Return the implicit requirements a storyboard needs based on its
- * structure (not its declared `requires:` list). Today: only
- * `'webhook_receiver'`, autodetected from `{{runner.webhook_url:…}}` /
- * `{{runner.webhook_base}}` token presence inside any step's
- * `sample_request`. Token presence is the authoring contract — a
- * storyboard that names the runner's webhook receiver cannot run
- * without one — so authors don't need to remember to add
- * `requires: [webhook_receiver]` separately. Spec: adcp-client#1678.
+ * structure (not its declared `requires:` list). Today:
+ *   - `'webhook_receiver'`, autodetected from `{{runner.webhook_url:…}}`
+ *     / `{{runner.webhook_base}}` token presence inside any step's
+ *     `sample_request`. Token presence is the authoring contract — a
+ *     storyboard that names the runner's webhook receiver cannot run
+ *     without one — so authors don't need to remember to add
+ *     `requires: [webhook_receiver]` separately. Spec: adcp-client#1678.
+ *   - `'request_signer'`, autodetected from `storyboard.id ===
+ *     'signed_requests'` or any step using the synthesized
+ *     `request_signing_probe` task. The signed-requests universal
+ *     storyboard's own prerequisites section declares the
+ *     `request_signing.supported: true` capability gate; the runner
+ *     enforces it here so adopters don't see false-negative vector
+ *     failures on bearer-only agents that never claimed signing.
+ *     Spec: adcp-client#1702.
  */
 function detectImplicitRequires(storyboard: Storyboard): RequirementName[] {
+  const requires: RequirementName[] = [];
+  let needsWebhook = false;
+  let needsSigner = storyboard.id === 'signed_requests';
   for (const phase of storyboard.phases) {
     for (const step of phase.steps) {
-      if (step.sample_request && valueContainsWebhookToken(step.sample_request)) {
-        return ['webhook_receiver'];
+      if (!needsWebhook && step.sample_request && valueContainsWebhookToken(step.sample_request)) {
+        needsWebhook = true;
       }
+      if (!needsSigner && step.task === 'request_signing_probe') {
+        needsSigner = true;
+      }
+      if (needsWebhook && needsSigner) break;
     }
+    if (needsWebhook && needsSigner) break;
   }
-  return [];
+  if (needsWebhook) requires.push('webhook_receiver');
+  if (needsSigner) requires.push('request_signer');
+  return requires;
 }
 
 /**
@@ -1317,7 +1370,7 @@ async function executeStoryboardPass(
   const implicit = detectImplicitRequires(storyboard);
   const allRequires = [...declared, ...implicit.filter(r => !declared.includes(r))];
   if (allRequires.length) {
-    const unmet = checkRequires(allRequires, options);
+    const unmet = checkRequires(allRequires, options, profile);
     if (unmet) {
       if (!options._client) await closeConnections(options.protocol);
       return buildRequirementUnmetResult(agentUrls, storyboard, unmet.requirement, unmet.detail);
@@ -1698,6 +1751,19 @@ async function executeStoryboardPass(
         duration_ms: 0,
       });
       continue;
+    }
+
+    // Pre-empt OAuth-metadata probes when the agent's capabilities never
+    // advertised OAuth at all (adcp-client#1702). Without this, an
+    // API-key-only agent (e.g. Wonderstruck) has its PRM endpoint
+    // probed; if the well-known path returns anything other than 404
+    // (the existing reactive cascade trigger in `executeProbeStep`),
+    // validations fail and `oauth_discovery` produces 5 false-negative
+    // step failures even though the phase is `optional: true`. The skip
+    // is phase-level — not storyboard-level — so the universal
+    // `unauth_rejection` and `mechanism_required` phases still run.
+    if (!phaseAbsent && phaseContainsOauthMetadataProbe(phase) && !agentAdvertisesOauth(profile)) {
+      phaseAbsent = true;
     }
 
     // Reset alias cache at this phase boundary (#1657). $generate:uuid_v4#alias
@@ -3828,6 +3894,34 @@ function isTaskShape(result: unknown): boolean {
 // ────────────────────────────────────────────────────────────
 // Phase / step skip predicates
 // ────────────────────────────────────────────────────────────
+
+/**
+ * True when the phase contains an OAuth-metadata probe step
+ * (`protected_resource_metadata` or `oauth_auth_server_metadata`). Used
+ * to pre-emptively trigger the existing `phaseAbsent` cascade when the
+ * agent's capabilities never advertised OAuth in the first place, so we
+ * don't burn step failures probing a well-known path the agent doesn't
+ * claim. Spec: adcp-client#1702.
+ */
+function phaseContainsOauthMetadataProbe(phase: StoryboardPhase): boolean {
+  return phase.steps.some(s => s.task === 'protected_resource_metadata' || s.task === 'oauth_auth_server_metadata');
+}
+
+/**
+ * True when the agent's `get_adcp_capabilities` response declares an
+ * OAuth issuer (today: `account.authorization_endpoint`). When the
+ * profile or its capabilities aren't available — e.g. external
+ * `_client` mode — we conservatively return `true` so the runner falls
+ * through to the existing reactive cascade (`phaseAbsent` flips on a
+ * 404 from the PRM probe). That keeps backward compatibility for
+ * callers that haven't threaded a profile through. Spec: adcp-client#1702.
+ */
+function agentAdvertisesOauth(profile: AgentProfile | undefined): boolean {
+  const rawCaps = profile?.raw_capabilities;
+  if (rawCaps === undefined) return true;
+  const endpoint = resolveCapabilityPath(rawCaps, 'account.authorization_endpoint');
+  return typeof endpoint === 'string' && endpoint.length > 0;
+}
 
 /**
  * Evaluate a phase's `skip_if` expression against the runtime options. Only

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -1039,7 +1039,11 @@ function checkRequires(
             'support are not tested against this storyboard — absence of advertisement is not a ' +
             'failure, it is a declaration that the agent does not offer verified signed requests." ' +
             'To opt in, advertise `request_signing.supported: true` and pre-register the runner ' +
-            'compliance test keypair per test-kits/signed-requests-runner.yaml.',
+            'compliance test keypair per test-kits/signed-requests-runner.yaml. ' +
+            'Forward-readiness: optional in AdCP 3.0; the schema (request_signing block description) ' +
+            'declares request signing required for spend-committing operations in AdCP 4.0. Sellers ' +
+            'that intend to support spend-committing tools SHOULD advertise the capability and ' +
+            'register the test keypair before the 4.0 cut to avoid a hard compliance failure then.',
         };
       }
     }

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -66,6 +66,17 @@ export interface Storyboard {
    *     declares this requirement implicitly. Authors do not need to
    *     write `requires: [webhook_receiver]` — the tokens are
    *     self-describing.
+   *   - `request_signer` — the agent under test MUST advertise
+   *     `request_signing.supported: true` in `get_adcp_capabilities`.
+   *     Autodetected: any storyboard whose `id === 'signed_requests'`
+   *     or contains a `request_signing_probe` step implicitly requires
+   *     this. Skipped (storyboard not applicable) when the agent omits
+   *     the capability claim — absence is a declaration that the agent
+   *     does not offer verified signed requests, per
+   *     `compliance/{version}/universal/signed-requests.yaml` gating
+   *     ("Agents that do not advertise support are not tested against
+   *     this storyboard — absence of advertisement is not a failure").
+   *     Spec: adcp-client#1702.
    *
    * Default when the field is absent: `[real_wire]` (storyboard runs
    * everywhere — matches existing pre-tagging behavior). Tagging is
@@ -1417,7 +1428,7 @@ export interface RunnerSkipResult {
  *
  * Spec: adcp-client#1626.
  */
-export type RequirementName = 'controller' | 'seeded_state' | 'real_wire' | 'webhook_receiver';
+export type RequirementName = 'controller' | 'seeded_state' | 'real_wire' | 'webhook_receiver' | 'request_signer';
 
 /**
  * Closed enumeration of every known requirement. Used by the loader to
@@ -1431,6 +1442,7 @@ export const KNOWN_REQUIREMENTS: ReadonlySet<RequirementName> = new Set([
   'seeded_state',
   'real_wire',
   'webhook_receiver',
+  'request_signer',
 ] as const satisfies readonly RequirementName[]);
 
 /**

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -493,6 +493,10 @@ describe('Storyboard.requires gate (#1702): implicit request_signer', () => {
     assert.equal(step.skip.reason, 'not_applicable');
     assert.equal(step.skip.requirement, 'request_signer');
     assert.match(step.skip.detail, /request_signing\.supported: true/);
+    // Forward-readiness signal — schema declares request_signing required in
+    // AdCP 4.0 for spend-committing operations. Until structured notices
+    // land (adcp-client follow-up), the warning rides in `skip.detail`.
+    assert.match(step.skip.detail, /4\.0/, 'detail surfaces the 4.0 forward-readiness signal');
   });
 
   test('signed_requests storyboard skips when agent declares request_signing.supported: false', async () => {

--- a/test/lib/storyboard-requires-gate.test.js
+++ b/test/lib/storyboard-requires-gate.test.js
@@ -411,3 +411,152 @@ phases:
     assert.deepEqual(parsed.requires, ['webhook_receiver']);
   });
 });
+
+// ────────────────────────────────────────────────────────────
+// adcp-client#1702: implicit request_signer requirement
+// ────────────────────────────────────────────────────────────
+//
+// The signed-requests universal storyboard is capability-gated:
+// `compliance/{version}/universal/signed-requests.yaml` declares that
+// "Agents that do not advertise support are not tested against this
+// storyboard — absence of advertisement is not a failure". The runner
+// enforces that gate by autodetecting `request_signer` on any
+// storyboard whose id is `signed_requests` or that contains a
+// `request_signing_probe` step, and skipping with `not_applicable`
+// when the agent's `get_adcp_capabilities` response lacks
+// `request_signing.supported: true`.
+
+function buildSignedRequestsStoryboard(overrides = {}) {
+  return buildStoryboard({
+    id: 'signed_requests',
+    phases: [
+      {
+        id: 'capability_discovery',
+        title: 'Capability discovery',
+        steps: [
+          {
+            id: 'get_capabilities',
+            title: 'Verify the agent declares request_signing.supported',
+            task: 'get_adcp_capabilities',
+          },
+        ],
+      },
+      {
+        id: 'positive_vectors',
+        title: 'Positive vectors',
+        steps: [
+          {
+            id: 'positive-001-basic-post',
+            title: 'positive 001',
+            task: 'request_signing_probe',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  });
+}
+
+const profileWithoutRequestSigning = {
+  name: 'Bearer-only agent',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: {}, // no request_signing block
+};
+
+const profileWithRequestSigningFalse = {
+  name: 'Agent declaring request_signing.supported: false',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: { request_signing: { supported: false } },
+};
+
+const profileWithRequestSigning = {
+  name: 'Signing-verifier agent',
+  tools: ['get_adcp_capabilities', 'get_products'],
+  raw_capabilities: { request_signing: { supported: true } },
+};
+
+describe('Storyboard.requires gate (#1702): implicit request_signer', () => {
+  test('signed_requests storyboard skips when agent omits request_signing block', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutRequestSigning,
+      agentTools: profileWithoutRequestSigning.tools,
+    });
+
+    assert.equal(result.overall_passed, true, 'capability-gated skip is not a failure');
+    assert.equal(result.skipped_count, 1);
+    assert.equal(result.failed_count, 0);
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skipped, true);
+    assert.equal(step.skip_reason, 'not_applicable');
+    assert.equal(step.skip.reason, 'not_applicable');
+    assert.equal(step.skip.requirement, 'request_signer');
+    assert.match(step.skip.detail, /request_signing\.supported: true/);
+  });
+
+  test('signed_requests storyboard skips when agent declares request_signing.supported: false', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithRequestSigningFalse,
+      agentTools: profileWithRequestSigningFalse.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip.requirement, 'request_signer', 'false is treated the same as absent');
+    assert.match(step.skip.detail, /false/);
+  });
+
+  test('signed_requests storyboard runs when agent declares request_signing.supported: true', async () => {
+    const sb = buildSignedRequestsStoryboard();
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithRequestSigning,
+      agentTools: profileWithRequestSigning.tools,
+    });
+
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(
+      !phaseIds.includes('requirement_unmet'),
+      'gate must not synthesize requirement_unmet when capability is advertised'
+    );
+  });
+
+  test('non-signed_requests storyboard with a request_signing_probe step also triggers the gate', async () => {
+    // Autodetect by step.task, not just storyboard.id, so a future
+    // storyboard that embeds signing probes inherits the gate.
+    const sb = buildStoryboard({
+      id: 'embedded_signing_test',
+      phases: [
+        {
+          id: 'p1',
+          title: 'Signing probe inside a non-signed_requests storyboard',
+          steps: [
+            {
+              id: 'positive-001-basic-post',
+              title: 'embed',
+              task: 'request_signing_probe',
+            },
+          ],
+        },
+      ],
+    });
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutRequestSigning,
+      agentTools: profileWithoutRequestSigning.tools,
+    });
+
+    const step = result.phases[0].steps[0];
+    assert.equal(step.skip.requirement, 'request_signer');
+  });
+
+  test('storyboards with NO signing surface are unaffected by the autodetect gate', async () => {
+    const sb = buildStoryboard(); // no signed_requests id, no request_signing_probe step
+    const result = await runStoryboard('http://fake-local-99999', sb, {
+      _profile: profileWithoutRequestSigning,
+      agentTools: profileWithoutRequestSigning.tools,
+    });
+
+    const phaseIds = result.phases.map(p => p.phase_id);
+    assert.ok(!phaseIds.includes('requirement_unmet'), 'no autodetect on unrelated storyboards');
+  });
+});

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -1094,6 +1094,95 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
       await agent.close();
     }
   });
+
+  // ────────────────────────────────────────────────────────────
+  // adcp-client#1702: pre-emptive oauth_discovery cascade-skip
+  //
+  // The PRM 404 cascade (#677) is reactive — it triggers after the
+  // probe fires. Bearer-only agents that don't return a clean 404 on
+  // the well-known path (200-HTML, 405, 5xx, redirect — the
+  // Wonderstruck shape) fall through to validation failures, producing
+  // 5 false negatives inside an `optional: true` phase. The runner now
+  // pre-empts: when the agent's `get_adcp_capabilities` response lacks
+  // `account.authorization_endpoint`, oauth_discovery cascade-skips
+  // before any PRM call is made.
+  // ────────────────────────────────────────────────────────────
+
+  it('caps without authorization_endpoint + non-404 PRM → oauth_discovery pre-emptively skipped (#1702)', async () => {
+    // Wonderstruck-shape repro: PRM returns 200 with HTML, not 404.
+    // Without #1702 the runner would probe, fail validation, and report
+    // ~5 false negatives. With #1702, oauth_discovery cascade-skips
+    // because the agent never advertised OAuth in capabilities.
+    const agent = createAuthTestAgent({
+      prm: { status: 200, body: '<html>not metadata</html>' },
+    });
+    const agentUrl = await agent.listen();
+    try {
+      const result = await runStoryboard(agentUrl, loadSecurityBaseline(), {
+        ...runOpts(API_KEY_KIT),
+        _profile: {
+          name: 'Bearer-only agent',
+          tools: ['list_creatives'],
+          raw_capabilities: {}, // no account.authorization_endpoint
+        },
+      });
+      assert.strictEqual(result.overall_passed, true, 'api_key path carries the storyboard');
+
+      const oauthPhase = result.phases.find(p => p.phase_id === 'oauth_discovery');
+      assert.ok(oauthPhase, 'oauth_discovery phase present');
+      assert.strictEqual(oauthPhase.passed, true, 'oauth_discovery vacuously passed (pre-empted)');
+      for (const s of oauthPhase.steps) {
+        assert.strictEqual(s.skipped, true, `${s.step_id} should be skipped, not probed`);
+        assert.strictEqual(s.skip_reason, 'oauth_not_advertised');
+      }
+
+      // unauth_rejection MUST still run — it's universal and not gated by
+      // the oauth pre-emption. Reaching this phase at all is what
+      // distinguishes a phase-level skip from a whole-storyboard skip.
+      const unauthPhase = result.phases.find(p => p.phase_id === 'unauth_rejection');
+      assert.ok(unauthPhase, 'unauth_rejection phase present');
+      assert.strictEqual(
+        unauthPhase.steps.some(s => s.skipped),
+        false,
+        'unauth_rejection steps must execute — the whole storyboard is not skipped'
+      );
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it('caps WITH authorization_endpoint → oauth_discovery still runs even on non-404 PRM (#1702)', async () => {
+    // Agent advertised OAuth in capabilities, so the pre-empt does NOT
+    // fire. The reactive cascade (404) doesn't fire either (PRM is 500).
+    // OAuth discovery probes the endpoint, validations fail, and the
+    // optional phase swallows the failure (#677 hardening still applies
+    // separately when PRM returns 2xx).
+    const agent = createAuthTestAgent({ prm: { status: 500, body: 'oops' } });
+    const agentUrl = await agent.listen();
+    try {
+      const result = await runStoryboard(agentUrl, loadSecurityBaseline(), {
+        ...runOpts(API_KEY_KIT),
+        _profile: {
+          name: 'OAuth-capable agent',
+          tools: ['list_creatives'],
+          raw_capabilities: {
+            account: { authorization_endpoint: 'https://auth.example.com/oauth/authorize' },
+          },
+        },
+      });
+
+      const oauthPhase = result.phases.find(p => p.phase_id === 'oauth_discovery');
+      assert.ok(oauthPhase, 'oauth_discovery phase present');
+      const skippedSteps = oauthPhase.steps.filter(s => s.skipped && s.skip_reason === 'oauth_not_advertised');
+      assert.strictEqual(
+        skippedSteps.length,
+        0,
+        'pre-empt must not fire when capabilities advertise an authorization_endpoint'
+      );
+    } finally {
+      await agent.close();
+    }
+  });
 });
 
 describe('comply() HTTPS enforcement', () => {


### PR DESCRIPTION
Closes #1702.

Extends the implicit-requires pattern shipped in #1678 (`webhook_receiver`) to two more requirement surfaces, removing the false-negative step failures per `comply()` run on bearer-only agents like Wonderstruck.

## Part A — `request_signer` requirement (capability-gated)

The signed-requests universal storyboard's own gating spec at `compliance/{version}/universal/signed-requests.yaml` declares:

> Agents that do not advertise support are not tested against this storyboard — absence of advertisement is not a failure, it is a declaration that the agent does not offer verified signed requests.

The runner now enforces that gate:

- Adds `'request_signer'` to `RequirementName` / `KNOWN_REQUIREMENTS` / `REQUIREMENT_TO_SKIP_REASON` (maps to `not_applicable`).
- `detectImplicitRequires` flags any storyboard whose `id === 'signed_requests'` or that contains a `request_signing_probe` step. Authors don't write the tag manually.
- `checkRequires` now accepts the discovered `AgentProfile` and gates on `raw_capabilities.request_signing.supported === true`.

Gating on **the agent's own capability claim** (not a runner opt-out flag) was a deliberate deviation from the issue's wording. An opt-out would silently let signing-claiming sellers slip past compliance. With this design:

- Agent doesn't claim signing → storyboard skips cleanly as `not_applicable` (the case #1702 reports).
- Agent claims signing but hasn't pre-registered the runner's test keypair → storyboard still fails. That's the seller's bug, per the same storyboard's prerequisites section.

**Forward-readiness signal.** The schema (`get-adcp-capabilities-response.json:892`) declares request signing required for spend-committing operations in AdCP 4.0. A 3.0 seller that legitimately skips today would silently break on the 4.0 cut. Until structured notices land (follow-up adcp-client#1704 / adcp#4418), the warning rides in `skip.detail` so adopters at least see the 4.0 signal in the report. Test asserts the 4.0 mention is present so it can't silently drop.

## Part B — pre-emptive `oauth_discovery` cascade-skip

The existing reactive `phaseAbsent` cascade (#677) only triggers on a 404 from `/.well-known/oauth-protected-resource`. Non-404 responses from a bearer-only agent (200-HTML, 405, redirect — the Wonderstruck shape) fell through to validation failures inside an `optional: true` phase.

The runner now pre-empts: when a phase contains a `protected_resource_metadata` or `oauth_auth_server_metadata` probe AND the agent's capabilities lack `account.authorization_endpoint`, `phaseAbsent` flips at phase entry — before any well-known probe fires.

Deliberately **phase-level**, not storyboard-level (which is what #1702 originally proposed). `security_baseline` contains the universal `unauth_rejection` and `mechanism_required` phases that every agent must pass; skipping the whole storyboard would erase that signal. Phase-level skip preserves it.

## Effect on the original Wonderstruck failure set

Cross-referencing the 44 false-negative step failures the issue reported:

| Storyboard | Step | Phase | After this PR |
|---|---|---|---|
| `signed_requests` | all 39 | (whole storyboard) | `not_applicable` ✓ |
| `security_baseline` | `probe_protected_resource` | `oauth_discovery` | phase-skip → `oauth_not_advertised` ✓ |
| `security_baseline` | `probe_auth_server_metadata` | `oauth_discovery` | phase-skip ✓ |
| `security_baseline` | `probe_invalid_oauth_token` | `oauth_discovery` | phase-skip ✓ |
| `security_baseline` | `probe_unauth` | `unauth_rejection` (universal) | **still fails — real Wonderstruck bug** |
| `security_baseline` | `assert_mechanism` | `mechanism_required` (universal) | **still fails — real Wonderstruck bug** |

So **42 of 44 false negatives become clean skips**. The remaining 2 `security_baseline` step failures are not false negatives — they're real seller-side compliance gaps that the universal phases (correctly preserved by Part B) surface. Those fold into the existing Wonderstruck tracking ticket; this PR is doing its job by isolating them from the noise.

## Tests

- `test/lib/storyboard-requires-gate.test.js`: new describe block "Storyboard.requires gate (#1702): implicit request_signer" — 5 tests covering capability absent / capability=false / capability=true / non-`signed_requests` storyboard with a `request_signing_probe` step / unaffected storyboards. Plus an assert on the 4.0 forward-readiness suffix in the skip detail.
- `test/lib/storyboard-security.test.js`: new tests inside the existing `#677` block — caps without `authorization_endpoint` + non-404 PRM pre-empts; caps with `authorization_endpoint` + 500 PRM still probes (no false pre-empt). The pre-empt test asserts both `oauth_discovery` skip AND `unauth_rejection` execution in the same run, locking in the phase-level (not storyboard-level) invariant.

## Test plan

- [x] `npm run build` passes
- [x] `npm run format:check` passes
- [x] `node --test test/lib/storyboard-requires-gate.test.js` — all describe blocks pass (4/4)
- [x] `node --test test/lib/storyboard-security.test.js` — all describe blocks pass (23/23)
- [x] `node --test test/lib/storyboard-*.test.js` — 60/61 pass; the one failure (`storyboard-rejection-hints-e2e.test.js`) reproduces cleanly on origin/main and is unrelated to this change.
- [ ] After merge, re-probing Wonderstruck should show `signed_requests` fully `not_applicable` and `security_baseline`'s `oauth_discovery` phase cleanly skipped, with 2 remaining `unauth_rejection` / `mechanism_required` step failures folded into the existing Wonderstruck tracking ticket as real seller bugs.

## Follow-ups

- adcp-client#1704: structured `notices: RunnerNotice[]` on `ComplianceResult` / `StoryboardResult` to formalize the existing unimplemented "runner SHOULD emit an informational notice" from `signed-requests.yaml:34`, the 4.0 forward-readiness signal currently riding in `skip.detail`, and `legacy_hmac_fallback` ("removed in AdCP 4.0").
- adcontextprotocol/adcp#4418: ask whether `runner-output-contract.yaml` should standardize a `notices` field shape so multiple runners converge on the same advisory surface rather than each baking its own.

Part of the coordinated stance at #1685 (the SDK is a witness, not a translator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)