### PR TITLE
fix(runner): attribute Zod schema rejects to response_schema (#1709)

### DIFF
--- a/.changeset/schema-validation-attribution-1709.md
+++ b/.changeset/schema-validation-attribution-1709.md
@@ -1,0 +1,62 @@
+---
+'@adcp/sdk': minor
+---
+
+fix(runner): attribute Zod schema rejects to `response_schema`, short-circuit invariants (#1709)
+
+When the SDK's response unwrapper rejects an agent response against the
+codegen-emitted Zod schema for the tool (e.g. an `additionalProperties:
+true` field the runner's `.strict()` schema doesn't enumerate, like the
+recently-added `authorization` field on `sync_accounts`), the exception
+previously propagated as a generic `Error` with a freeform message.
+The runner's step-execution catch absorbed it into `stepResult.error`
+but never attributed the failure to schema validation in
+`step.validations[]`. Step-scope invariants then ran against the
+malformed payload, and whichever fired first (canonically
+`context.no_secret_echo` — the next assertion in the default-invariant
+queue) became the surfaced failure. BidMachine spent 10+ deploys
+chasing the `no_secret_echo` ghost before the strict-Zod root cause
+surfaced. Full trace: adcontextprotocol/adcp#4419.
+
+Fix:
+
+- New `ResponseSchemaValidationError` typed error class in
+  `src/lib/utils/response-unwrapper.ts`. Carries `toolName`, `issues`
+  (raw Zod issues), and `data` (the rejected payload) for downstream
+  attribution. Stable `name === 'ResponseSchemaValidationError'` so
+  cross-bundle consumers can detect by string match without `instanceof`.
+  Replaces the two generic `new Error('Response validation failed for
+  ${toolName}: ...')` throws in the unwrapper.
+
+- `runStep` in `src/lib/testing/client.ts` now returns
+  `{ result?, step, caughtError? }`. The new `caughtError` is the
+  raw thrown value (typed `unknown`) so callers can pattern-match on
+  typed exceptions. Backwards-compatible — pre-existing callers that
+  consume only `result` and `step` are unaffected.
+
+- Storyboard runner `executeStep` threads `caughtError` from the
+  dispatch fn, and on `ResponseSchemaValidationError` prepends a
+  synthesized `response_schema` ValidationResult to `step.validations`.
+  The synthesized entry carries the structured issues, the failing
+  tool name, an RFC 6901-shaped `json_pointer`, and the rejection
+  message. `extractFailures.find(v => !v.passed)` now picks it up
+  before any inline or invariant entry.
+
+- Step-scope invariants in `executeStoryboardPass` are short-circuited
+  when the synthesized `response_schema` entry is present. Each bypassed
+  invariant emits a single skip marker entry (passed: true) so consumers
+  see WHICH invariants were bypassed and why, but the bypass entries
+  don't crowd out the schema failure in extractFailures.
+
+Sequencing: this PR is the upstream dependency for #1707 (dynamic
+schema fetch + strict→passthrough flip + codegen regen). Lands first
+so any remaining Zod rejects during #1707's rollout produce honest
+signal instead of misattributing to `no_secret_echo`. After both #1709
+and #1707 land, BidMachine's 63/128 comply-vs-45/59 CLI delta
+(adcp#4419) should collapse — fgranata volunteered as the retest
+target on adcp-client#1711.
+
+Coordinated stance: adcp-client#1685 (the SDK is a witness, not a
+translator). Same anti-pattern: the SDK was fabricating a different
+failure (`no_secret_echo`) than what actually went wrong (schema
+rejection); this PR makes it a faithful witness.

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -260,11 +260,29 @@ function raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T
   });
 }
 
+/**
+ * Result of {@link runStep}. The optional `caughtError` carries the raw
+ * thrown value (typed `unknown`, narrow via `instanceof` at the call site)
+ * so callers can pattern-match on typed exceptions like
+ * `ResponseSchemaValidationError` without losing the freeform string
+ * representation on `step.error`. Pre-existing callers that only consume
+ * `result` and `step` are unaffected.
+ *
+ * Spec: adcp-client#1709 (storyboard runner attributes Zod rejects to
+ * the canonical `response_schema` validation entry by detecting the typed
+ * error here).
+ */
+export interface RunStepOutcome<T> {
+  result?: T;
+  step: TestStepResult;
+  caughtError?: unknown;
+}
+
 export async function runStep<T>(
   stepName: string,
   taskName: string | undefined,
   fn: () => Promise<T>
-): Promise<{ result?: T; step: TestStepResult }> {
+): Promise<RunStepOutcome<T>> {
   const start = Date.now();
   try {
     const result = await fn();
@@ -289,6 +307,7 @@ export async function runStep<T>(
         duration_ms: duration,
         error: errorMessage,
       },
+      caughtError: error,
     };
   }
 }

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -32,6 +32,7 @@ import {
 import { PARALLEL_DISPATCH_CONTRACT, runParallelDispatches, validateParallelDispatchSpec } from './parallel-dispatch';
 import { toJsonPointer } from './path';
 import { redactSecrets } from '../../utils/redact-secrets';
+import { ResponseSchemaValidationError } from '../../utils/response-unwrapper';
 import { queryUpstreamTraffic, type ControllerScenario, type UpstreamTrafficSuccess } from '../test-controller';
 import { enrichRequest, hasRequestEnricher } from './request-builder';
 import { resolveAccount, resolveBrand } from '../client';
@@ -2077,6 +2078,21 @@ async function executeStoryboardPass(
       stepResults.push(result);
       priorStepResults.set(step.id, result);
 
+      // Schema-validation short-circuit (adcp-client#1709). When the
+      // response unwrapper rejected the agent's response against the SDK's
+      // Zod schema, the step-execution path synthesized a failing
+      // `response_schema` ValidationResult on `result.validations`.
+      // Running step-scope invariants against a response the SDK has
+      // already declared malformed produces noise — the invariants
+      // can't meaningfully grade a payload that didn't parse. Worse,
+      // before #1709 the invariants' failure entries crowded out the
+      // schema-validation entry in `extractFailures`, masking the root
+      // cause across BidMachine's 10+ deploys (see adcp#4419). Skip the
+      // invariant pass entirely on this step and emit a single skipped
+      // `assertion` entry per invariant so consumers can still see WHICH
+      // invariants were skipped and why.
+      const schemaInvalidResponse = result.validations.some(v => v.check === 'response_schema' && !v.passed);
+
       // Fire per-step assertions. Each result is appended to the step's
       // `validations[]` under `check: "assertion"` so existing UI renders
       // them alongside inline checks, and mirrored into `assertionResults`
@@ -2089,6 +2105,18 @@ async function executeStoryboardPass(
         // suppress a default invariant on a step that deliberately models
         // behavior the invariant would flag (validated at runner start).
         if (stepDisablesAssertion(step.invariants, spec.id)) continue;
+        if (schemaInvalidResponse) {
+          // Emit a skipped marker so the report shows the invariant was
+          // intentionally bypassed (not silently dropped). `passed: true`
+          // keeps it from flipping `result.passed` — the schema-validation
+          // failure already did that.
+          result.validations.push({
+            check: 'assertion',
+            passed: true,
+            description: `${spec.id}: skipped — response failed schema validation (adcp-client#1709)`,
+          });
+          continue;
+        }
         const raw = await spec.onStep(assertionContexts.get(spec.id)!, result);
         for (const r of raw) {
           const full: AssertionResult = { ...r, assertion_id: spec.id, scope: 'step', step_id: step.id };
@@ -3157,6 +3185,11 @@ async function executeStep(
 
   let taskResult: TaskResult | undefined;
   let stepResult: { duration_ms: number; error?: string; passed: boolean };
+  // Raw caught error from the dispatch fn — preserved as `unknown` so the
+  // schema-validation attribution path below can `instanceof` it against
+  // `ResponseSchemaValidationError`. Undefined when the step succeeded or
+  // failed for a non-typed reason. Spec: adcp-client#1709.
+  let caughtError: unknown;
   let httpResult: HttpProbeResult | undefined;
   let responseRecord: RunnerResponseRecord | undefined;
   let a2aEnvelope: A2ATaskEnvelope | undefined;
@@ -3368,6 +3401,7 @@ async function executeStep(
       });
       taskResult = run.result;
       stepResult = run.step;
+      caughtError = run.caughtError;
       if (captureA2a && a2aCaptures) {
         a2aEnvelope = parseLastA2aMessageSendCapture(a2aCaptures);
       }
@@ -3437,10 +3471,10 @@ async function executeStep(
     passed = stepResult.passed && (taskResult?.success ?? false);
   }
 
+  let validations: ValidationResult[] = [];
   // Run validations. Resolve `$context.<key>` placeholders in `value` and
   // `allowed_values` fields so expected values can reference prior steps
   // (e.g., replay tests assert `media_buy_id === $context.initial_media_buy_id`).
-  let validations: ValidationResult[] = [];
   if (step.validations?.length && (taskResult || httpResult)) {
     const resolvedValidations = step.validations.map(v => {
       const resolved = { ...v };
@@ -3543,6 +3577,42 @@ async function executeStep(
         validations.push(...dispatchResults);
       }
     }
+  }
+
+  // Schema-validation attribution (adcp-client#1709). When the response
+  // unwrapper rejected the agent's response against the SDK's Zod schema
+  // for the tool, it threw a typed `ResponseSchemaValidationError` that
+  // surfaced on `caughtError`. Without this attribution, the rejection
+  // would silently propagate into whichever step-scope invariant (e.g.
+  // `context.no_secret_echo`) happened to fire next — the BidMachine
+  // misdiagnosis trace from adcp-client#1709 / adcp#4419 ate 10+ deploys
+  // chasing the wrong cause.
+  //
+  // Synthesize a canonical `response_schema` ValidationResult and prepend
+  // it so `extractFailures.find(v => !v.passed)` resolves it before any
+  // invariant entry. Step-scope invariants downstream of this point will
+  // short-circuit on the schema-invalid response (see the invariant
+  // dispatch loop in `executeStoryboardPass`).
+  if (caughtError instanceof ResponseSchemaValidationError) {
+    const issues = caughtError.issues
+      .slice(0, 5)
+      .map(i => `${i.path.join('.') || '(root)'}: ${i.message}`)
+      .join('; ');
+    const firstIssue = caughtError.issues[0];
+    const jsonPointer = firstIssue ? '/' + firstIssue.path.map(s => String(s)).join('/') : null;
+    const synthSchemaResult: ValidationResult = {
+      check: 'response_schema',
+      passed: false,
+      description: `Response schema validation for ${caughtError.toolName}`,
+      error: issues,
+      json_pointer: jsonPointer,
+      expected: `response schema for ${caughtError.toolName}`,
+      actual: caughtError.issues,
+    };
+    // Prepend so extractFailures picks it up before any inline validation
+    // entry that may also be failing (e.g. `field_present` checks that
+    // legitimately can't observe their target against an unparsed payload).
+    validations = [synthSchemaResult, ...validations];
   }
 
   // Persist the captured A2A envelope keyed by step id so cross-step

--- a/src/lib/utils/response-unwrapper.ts
+++ b/src/lib/utils/response-unwrapper.ts
@@ -16,6 +16,7 @@ const ERROR_CODES = {
   INVALID_RESPONSE: 'invalid_response',
   UNKNOWN: 'unknown',
 } as const;
+
 import type {
   GetProductsResponse,
   ListCreativeFormatsResponse,
@@ -32,6 +33,45 @@ import type {
   ActivateSignalResponse,
 } from '../types/tools.generated';
 import { TOOL_RESPONSE_SCHEMAS } from './response-schemas';
+
+/**
+ * Typed error thrown when the response unwrapper's Zod schema rejects an
+ * agent response. Carries the structured rejection detail so the storyboard
+ * runner can attribute the failure to its canonical `response_schema`
+ * validation entry instead of silently falling through to whichever
+ * step-level invariant fires next (e.g., `context.no_secret_echo`).
+ *
+ * Without this typed boundary, the runner can only catch a generic `Error`
+ * with a freeform message — there's no stable way to distinguish a
+ * schema rejection from a transport error or any other failure. The
+ * misattribution this caused (every BidMachine `sync_accounts` failure
+ * surfaced as `no_secret_echo`, masking the root cause across 10+ deploys)
+ * is the canonical evidence for adcp-client#1709 and the reason this
+ * class exists. The runner pattern-matches `err instanceof
+ * ResponseSchemaValidationError` to synthesize the correct attribution.
+ *
+ * Stable wire surface: `name` is the literal string `'ResponseSchemaValidationError'`
+ * so consumers that can't import the class (cross-bundle, dynamic
+ * `require`) can still recognize it by string comparison.
+ *
+ * Spec: adcp-client#1709.
+ */
+export class ResponseSchemaValidationError extends Error {
+  readonly name = 'ResponseSchemaValidationError';
+  /** The AdCP tool name whose response failed validation (e.g., `'sync_accounts'`). */
+  readonly toolName: string;
+  /** The structured Zod issues from the failed `safeParse`. */
+  readonly issues: z.core.$ZodIssue[];
+  /** The raw response data that failed validation, for diagnostic reporting. */
+  readonly data: unknown;
+
+  constructor(toolName: string, issues: z.core.$ZodIssue[], data: unknown, summaryMessage: string) {
+    super(`Response validation failed for ${toolName}: ${summaryMessage}`);
+    this.toolName = toolName;
+    this.issues = issues;
+    this.data = data;
+  }
+}
 
 /**
  * Union type of all possible AdCP responses
@@ -141,11 +181,11 @@ export function unwrapProtocolResponse(
           const betterErrors = getBestUnionErrors(schema, dataToValidate);
           if (betterErrors && betterErrors.length > 0) {
             const bestMessage = betterErrors.map(e => `${e.path}: ${e.message}`).join('; ');
-            throw new Error(`Response validation failed for ${toolName}: ${bestMessage}`);
+            throw new ResponseSchemaValidationError(toolName, result.error.issues, dataToValidate, bestMessage);
           }
         }
 
-        throw new Error(`Response validation failed for ${toolName}: ${result.error.message}`);
+        throw new ResponseSchemaValidationError(toolName, result.error.issues, dataToValidate, result.error.message);
       }
 
       // Re-attach _message after validation so it's available for text summaries

--- a/test/lib/storyboard-schema-validation-attribution.test.js
+++ b/test/lib/storyboard-schema-validation-attribution.test.js
@@ -1,0 +1,212 @@
+/**
+ * Tests for adcp-client#1709 — Zod-reject error attribution.
+ *
+ * When the SDK's response unwrapper throws `ResponseSchemaValidationError`
+ * (Zod schema rejected the agent's response), the storyboard runner MUST:
+ *
+ *  1. Synthesize a canonical `response_schema` ValidationResult with
+ *     `passed: false` on `step.validations`.
+ *  2. Prepend it so `extractFailures.find(v => !v.passed)` returns it
+ *     before any step-scope invariant entry.
+ *  3. Short-circuit step-scope invariants (e.g. `context.no_secret_echo`)
+ *     so they don't run against a malformed payload. Each skipped invariant
+ *     gets a marker entry naming the bypass reason.
+ *
+ * Without this attribution, the BidMachine misdiagnosis from adcp#4419
+ * recurs: every Zod-reject surfaces as whichever step-scope invariant
+ * happens to fire next (the canonical case: `context.no_secret_echo`),
+ * masking the schema-validation root cause across many deploys.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runStoryboard, runStoryboardStep } = require('../../dist/lib/testing/storyboard/index.js');
+const { ResponseSchemaValidationError } = require('../../dist/lib/utils/response-unwrapper.js');
+
+/**
+ * Build a minimal stub client that throws `ResponseSchemaValidationError`
+ * on the first method call. Simulates the unwrap-layer Zod reject path
+ * — the runner's step execution should attribute the failure correctly
+ * regardless of what triggered the throw.
+ */
+function buildSchemaRejectingClient(toolName = 'get_products') {
+  return {
+    async executeTask(_taskName, _params) {
+      throw new ResponseSchemaValidationError(
+        toolName,
+        [
+          {
+            code: 'unrecognized_keys',
+            path: [],
+            keys: ['authorization'],
+            message: "Unrecognized key(s) in object: 'authorization'",
+          },
+        ],
+        { authorization: 'present', products: [] },
+        "Unrecognized key(s) in object: 'authorization'"
+      );
+    },
+    async getProducts(_params) {
+      throw new ResponseSchemaValidationError(
+        toolName,
+        [
+          {
+            code: 'unrecognized_keys',
+            path: [],
+            keys: ['authorization'],
+            message: "Unrecognized key(s) in object: 'authorization'",
+          },
+        ],
+        { authorization: 'present', products: [] },
+        "Unrecognized key(s) in object: 'authorization'"
+      );
+    },
+    async getAgentInfo() {
+      return { name: 'Schema-rejecting stub', tools: [{ name: 'get_products' }] };
+    },
+  };
+}
+
+const stubProfile = {
+  name: 'Schema-rejecting stub',
+  tools: ['get_products'],
+  raw_capabilities: {},
+};
+
+function buildStoryboard(overrides = {}) {
+  return {
+    id: 'schema_attribution_test',
+    version: '1.0.0',
+    title: 'Schema attribution test',
+    category: 'test',
+    summary: 'Verifies Zod-reject attribution per adcp-client#1709.',
+    narrative: '',
+    agent: { interaction_model: 'sync', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'p1',
+        title: 'Phase 1',
+        steps: [
+          {
+            id: 'fetch_products',
+            title: 'Fetch products (expect schema reject)',
+            task: 'get_products',
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('adcp-client#1709 — Zod-reject error attribution', () => {
+  test('synthesizes response_schema ValidationResult on the step when unwrapper rejects', async () => {
+    const client = buildSchemaRejectingClient('get_products');
+    const result = await runStoryboardStep('https://stub.example/mcp', buildStoryboard(), 'fetch_products', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    const schemaValidation = result.validations.find(v => v.check === 'response_schema');
+    assert.ok(schemaValidation, 'response_schema validation must be present in step.validations');
+    assert.equal(schemaValidation.passed, false);
+    assert.match(schemaValidation.description, /get_products/);
+    assert.match(schemaValidation.error, /authorization/, 'error message names the rejected field');
+  });
+
+  test('response_schema entry is FIRST in step.validations so extractFailures picks it', async () => {
+    const client = buildSchemaRejectingClient('get_products');
+    const result = await runStoryboardStep('https://stub.example/mcp', buildStoryboard(), 'fetch_products', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    const firstFailed = result.validations.find(v => !v.passed);
+    assert.ok(firstFailed, 'expected at least one failed validation');
+    assert.equal(
+      firstFailed.check,
+      'response_schema',
+      'first failed validation must be response_schema, not a step-scope invariant ' +
+        '(the BidMachine misdiagnosis from adcp#4419)'
+    );
+  });
+
+  test('step-scope invariants are short-circuited with skip markers when schema rejects (full-pass)', async () => {
+    // Step-scope invariants only run via `runStoryboard` (the full pass).
+    // `runStoryboardStep` is stateless / LLM-friendly and intentionally
+    // skips storyboard-level invariants by design. So we exercise the
+    // short-circuit through the multi-step pass.
+    const client = buildSchemaRejectingClient('get_products');
+    const result = await runStoryboard('https://stub.example/mcp', buildStoryboard(), {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+      agentTools: stubProfile.tools,
+    });
+    const step = result.phases[0]?.steps?.[0];
+    assert.ok(step, 'step result present');
+
+    // Invariants that ran SHOULD be marked skipped, not have a real
+    // pass/fail verdict. The skip marker carries the invariant id in the
+    // description so consumers see WHICH invariant was bypassed.
+    const invariantSkips = step.validations.filter(
+      v => v.check === 'assertion' && /skipped — response failed schema validation/.test(v.description ?? '')
+    );
+    assert.ok(
+      invariantSkips.length > 0,
+      `expected at least one invariant skip marker, got 0. ` +
+        `validations: ${JSON.stringify(step.validations.map(v => ({ check: v.check, passed: v.passed, description: v.description })))}`
+    );
+
+    // No invariant should be marked as a real failure (passed: false with
+    // a non-skip description). That's the regression #1709 guards.
+    const realInvariantFailures = step.validations.filter(
+      v =>
+        v.check === 'assertion' &&
+        v.passed === false &&
+        !/skipped — response failed schema validation/.test(v.description ?? '')
+    );
+    assert.equal(
+      realInvariantFailures.length,
+      0,
+      `step-scope invariants must not surface as real failures when schema rejected. ` +
+        `got: ${JSON.stringify(realInvariantFailures.map(v => v.description))}`
+    );
+  });
+
+  test('step.passed remains false (schema rejection is a real failure)', async () => {
+    const client = buildSchemaRejectingClient('get_products');
+    const result = await runStoryboardStep('https://stub.example/mcp', buildStoryboard(), 'fetch_products', {
+      protocol: 'mcp',
+      _client: client,
+      _profile: stubProfile,
+    });
+
+    assert.equal(result.passed, false, 'schema rejection must fail the step');
+  });
+});
+
+describe('adcp-client#1709 — ResponseSchemaValidationError class shape', () => {
+  test('carries toolName, issues, and data for diagnostic attribution', () => {
+    const issues = [{ code: 'invalid_type', path: ['x'], message: 'expected string' }];
+    const data = { x: 42 };
+    const err = new ResponseSchemaValidationError('foo_tool', issues, data, 'expected string');
+    assert.ok(err instanceof Error);
+    assert.ok(err instanceof ResponseSchemaValidationError);
+    assert.equal(err.name, 'ResponseSchemaValidationError');
+    assert.equal(err.toolName, 'foo_tool');
+    assert.deepEqual(err.issues, issues);
+    assert.deepEqual(err.data, data);
+    assert.match(err.message, /foo_tool/);
+    assert.match(err.message, /expected string/);
+  });
+
+  test('name field is the literal string so cross-bundle detection works without instanceof', () => {
+    const err = new ResponseSchemaValidationError('x', [], null, 'whatever');
+    assert.equal(err.name, 'ResponseSchemaValidationError', 'stable for string-based detection');
+  });
+});


### PR DESCRIPTION
Closes #1709.

## The bug

When the SDK's response unwrapper rejects an agent response against the codegen-emitted Zod schema for the tool, the exception previously propagated as a generic `Error('Response validation failed for ${toolName}: ...')`. The runner's step-execution catch absorbed it into `stepResult.error` but never attributed the failure to schema validation in `step.validations[]`. Step-scope invariants then ran against the malformed payload, and whichever fired first (canonically `context.no_secret_echo` — the next default-invariant in the registered queue) became the surfaced failure in `extractFailures`.

BidMachine spent 10+ deploys chasing the `no_secret_echo` ghost before the strict-Zod root cause surfaced. Full diagnostic trace at adcontextprotocol/adcp#4419.

## The fix — three layers

**1. Typed error class** (`src/lib/utils/response-unwrapper.ts`).

New `ResponseSchemaValidationError` extends `Error`. Carries:

- `toolName: string` — the AdCP tool whose response failed
- `issues: z.core.$ZodIssue[]` — raw Zod issues for structured attribution
- `data: unknown` — the rejected payload for diagnostic reporting
- Stable `name === 'ResponseSchemaValidationError'` so cross-bundle consumers can detect by string match without `instanceof`

Replaces the two generic `new Error(...)` throws in `unwrapProtocolResponse`.

**2. `runStep` preserves the raw thrown value** (`src/lib/testing/client.ts`).

Return signature widened to `{ result?, step, caughtError? }`. The new `caughtError` is the raw thrown value (typed `unknown`) so callers can pattern-match on typed exceptions. Pre-existing callers consuming only `result` and `step` are unaffected.

**3. Storyboard runner attribution + invariant short-circuit** (`src/lib/testing/storyboard/runner.ts`).

`executeStep` threads `caughtError` from the dispatch fn. When `caughtError instanceof ResponseSchemaValidationError`:

- Synthesizes a `response_schema` ValidationResult with the structured Zod issues, the failing tool name, an RFC 6901-shaped `json_pointer`, and the rejection message.
- Prepends it to `step.validations[]` so `extractFailures.find(v => !v.passed)` resolves it before any inline or invariant entry.

In `executeStoryboardPass`, step-scope invariants short-circuit when the synthesized entry is present. Each bypassed invariant emits a single skip marker (passed: true, `description: '${spec.id}: skipped — response failed schema validation'`) so consumers see WHICH invariants were bypassed and why, without crowding out the schema failure in `extractFailures`.

## Tests

New `test/lib/storyboard-schema-validation-attribution.test.js`:

| # | What it verifies |
|---|---|
| 1 | Synthesized `response_schema` entry present in `step.validations` when unwrapper rejects |
| 2 | `response_schema` is FIRST in `step.validations` so `extractFailures` picks it over invariants |
| 3 | Step-scope invariants short-circuited via skip markers (`runStoryboard` full-pass) |
| 4 | `step.passed === false` (schema rejection is a real failure) |
| 5 | `ResponseSchemaValidationError` class shape carries toolName / issues / data |
| 6 | `name` field is the literal string for cross-bundle detection |

6/6 pass. Sweep of `test/lib/storyboard-*.test.js` covered 50+ tests with no regressions through the in-progress monitor.

## Sequencing

This PR is the upstream dependency for #1707:

| Issue | Status | Sequencing |
|---|---|---|
| #1706 | merged ✓ | sibling drift fix (auto-derived COMPATIBLE_ADCP_VERSIONS) |
| #1705 | merged ✓ | RunnerNotice surface — provides the channel #1707's `schema_version_fetch_failed` advisory needs |
| **#1709** | **this PR** | **upstream of #1707** |
| #1707 | waiting | dynamic schema fetch + strict→passthrough + codegen regen + notice emission |
| #1708 | auto-triage | parity smoke test — sits AFTER #1707 lands |
| #1711 | reporter follow-up | duplicate-by-scope of #1707; closes when #1707 ships |

#1709 lands first so any remaining Zod rejects during #1707's rollout produce honest signal as the strict→passthrough flip reduces reject frequency — instead of misattributing the residual cases.

## Validation hook

fgranata (BidMachine) volunteered as a retest target once #1707 + #1709 land. Current comply-suite score is 63/128 (49%) vs CLI runner 45/59 (76%) — the 27-point delta is the diagnostic signal both fixes should close. Filed under adcp-client#1711.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] `node --test test/lib/storyboard-schema-validation-attribution.test.js` — 6/6 pass
- [x] `node --test test/lib/storyboard-*.test.js` — 50+ tests passing, no regressions
- [ ] After merge, the BidMachine `sync_accounts` failures should attribute to `response_schema` instead of `context.no_secret_echo`; one-step verification once they retest.

Part of the #1685 coordinated stance ("the SDK is a witness, not a translator"). Same anti-pattern as adcp-client#1702 / #1705: the SDK was fabricating a different failure (`no_secret_echo`) than what actually went wrong (schema rejection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)