### PR TITLE
fix(invariant): no_secret_echo only fails on string-valued suspect-named fields (#1713)

### DIFF
--- a/.changeset/no-secret-echo-structured-value-relaxation-1713.md
+++ b/.changeset/no-secret-echo-structured-value-relaxation-1713.md
@@ -1,0 +1,56 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(invariant): no_secret_echo only fails on string-valued suspect-named fields (#1713)
+
+The default `context.no_secret_echo` invariant flagged any response field
+whose name was in `SUSPECT_PROPERTY_NAMES` (`'authorization'`, `'api_key'`,
+`'apikey'`, `'bearer'`, `'x-api-key'`) regardless of the field's value.
+This over-rejected spec-legitimate structured fields — notably the
+`authorization` object on `validation-result.json` (a structured
+authorization-validation payload, not a credential) and any seller-side
+extension fields named `authorization` under
+`sync_accounts_response.accounts[]` (`additionalProperties: true`).
+
+Symptom: BidMachine's `sync_accounts` failures in
+adcontextprotocol/adcp#4419 all surfaced as `context.no_secret_echo`.
+Diagnosis in #4419 pointed at Zod `.strict()` codegen lag, but
+verification of the published SDK tarballs (5.25.1 / 6.12.0 / current)
+shows `SyncAccountsResponseSchema.accounts[]` already uses
+`.passthrough()`. Zod silently accepts the `authorization` field; the
+NAME dragnet in this invariant is the actual rejection.
+
+Fix: narrow `findSecretEcho` so the suspect-name check only fires when
+the field VALUE is a non-empty string. Structured object/array values
+on suspect-named fields pass through to the recursive walk, which still
+scans nested strings against `BEARER_TOKEN_PATTERN` and caller-supplied
+secret literals. The actual leak shapes the invariant was designed to
+catch (bearer tokens, API keys, caller secret echoes) remain caught.
+
+Adds five new test cases covering:
+
+- Suspect name with object value passes (the BidMachine case)
+- Suspect name with array value passes
+- Suspect name with empty string passes (no leak)
+- Suspect name with non-empty string value still fails (existing dragnet)
+- Bearer literal nested inside a structured suspect-named object still
+  fails via the value-scan regression guard
+
+Sequencing relative to other in-flight work:
+
+- adcp-client#1709 (PR #1712, merged) — Zod-reject error attribution.
+  Addresses a different misattribution path (when Zod DOES reject).
+  This fix addresses the case where Zod ACCEPTS but the invariant
+  over-rejects on field name.
+- adcp-client#1707 — dynamic schema fetch + strict→passthrough +
+  codegen regen. Real architectural cleanup; does NOT unblock
+  BidMachine (the published SDK already uses passthrough).
+- adcp-client#1711 (fgranata) — BidMachine's report. The "Zod
+  `.strict()` codegen lag" diagnosis was incorrect for the published
+  SDK; this fix is the actual unblocker. Closes once fgranata retests.
+
+Coordinated stance: adcp-client#1685 (the SDK is a witness, not a
+translator). Same anti-pattern: the SDK fabricated a credential-leak
+signal against a structured non-credential field that the spec legally
+permits.

--- a/src/lib/testing/storyboard/default-invariants.ts
+++ b/src/lib/testing/storyboard/default-invariants.ts
@@ -183,8 +183,27 @@ function findSecretEcho(value: unknown, secrets: Set<string>): string | null {
     }
     if (v !== null && typeof v === 'object') {
       for (const [key, inner] of Object.entries(v as Record<string, unknown>)) {
-        if (SUSPECT_PROPERTY_NAMES.has(key.toLowerCase())) {
-          return `contains suspect property name "${key}"`;
+        // Name-based dragnet. The SUSPECT_PROPERTY_NAMES set catches the
+        // "bare token on a credential-named field" leak shape that the
+        // BEARER_TOKEN_PATTERN value-scan misses (a JWT without `Bearer `
+        // prefix won't match the regex). But the dragnet over-rejects
+        // when the field's VALUE is a structured object or array — those
+        // are spec-legitimate config payloads, not credential echoes.
+        // `compliance/cache/{version}/property/validation-result.json`
+        // declares an `authorization` object field carrying authorization-
+        // validation metadata, not a token; sellers extending
+        // `sync_accounts` via the schema's `additionalProperties: true`
+        // may carry their own structured `authorization` posture. Both
+        // are spec-conformant.
+        //
+        // Gate the name-based fail on `typeof inner === 'string'` and
+        // non-empty so structured values pass through to the recursive
+        // walk below. The recursion still scans nested string values, so
+        // a `Bearer xyz...` literal embedded in a structured object is
+        // still caught by the regex at the top of this loop.
+        // Spec: adcp-client#1713 / adcp#4419.
+        if (SUSPECT_PROPERTY_NAMES.has(key.toLowerCase()) && typeof inner === 'string' && inner.length > 0) {
+          return `contains suspect property name "${key}" with string value`;
         }
         stack.push(inner);
       }

--- a/test/lib/storyboard-default-invariants.test.js
+++ b/test/lib/storyboard-default-invariants.test.js
@@ -856,12 +856,73 @@ describe('default-invariants: context.no_secret_echo (widened whole-body scan)',
     assert.strictEqual(out[0].passed, false);
   });
 
-  test('fails on a suspect property name at any depth', () => {
+  test('fails on a suspect property name with a string value at any depth', () => {
     const c = ctx();
     spec.onStart(c);
     const out = spec.onStep(c, step({ nested: { deeper: { Authorization: 'anything' } } }));
     assert.strictEqual(out[0].passed, false);
     assert.match(out[0].error, /suspect property name "Authorization"/);
+  });
+
+  // adcp-client#1713 / adcp#4419 — name-based dragnet must NOT trip on
+  // structured (object/array) values. BidMachine returns a legitimate
+  // `authorization` field carrying a structured authorization-validation
+  // object (per spec) and was being false-flagged.
+  test('passes when a suspect property name carries an OBJECT value (spec-legit structured config)', () => {
+    const c = ctx();
+    spec.onStart(c);
+    const out = spec.onStep(
+      c,
+      step({
+        accounts: [
+          {
+            brand: 'b',
+            operator: 'o',
+            action: 'created',
+            status: 'active',
+            // Spec-legit structured authorization payload (mirrors the
+            // `authorization` object in validation-result.json).
+            authorization: { type: 'oauth', token_endpoint: 'https://auth.example/oauth/token' },
+          },
+        ],
+      })
+    );
+    assert.strictEqual(
+      out[0].passed,
+      true,
+      `expected pass; got: ${out[0].error || '(no error)'}. Validations:\n${JSON.stringify(out, null, 2)}`
+    );
+  });
+
+  test('passes when a suspect property name carries an ARRAY value', () => {
+    const c = ctx();
+    spec.onStart(c);
+    const out = spec.onStep(c, step({ api_key: [{ scope: 'read' }, { scope: 'write' }] }));
+    assert.strictEqual(out[0].passed, true);
+  });
+
+  test('passes when a suspect property name carries an empty string (no leak)', () => {
+    const c = ctx();
+    spec.onStart(c);
+    const out = spec.onStep(c, step({ authorization: '' }));
+    assert.strictEqual(out[0].passed, true);
+  });
+
+  test('still fails on a nested Bearer-prefixed string inside a structured authorization object', () => {
+    // Regression guard: even though the suspect-name dragnet now ignores
+    // the outer structured object, the recursive walk still scans nested
+    // strings against BEARER_TOKEN_PATTERN. A bearer leak buried inside
+    // a structured object remains caught.
+    const c = ctx();
+    spec.onStart(c);
+    const out = spec.onStep(
+      c,
+      step({
+        authorization: { type: 'oauth', cached_token: 'Bearer eyJabcdefghi1234567890' },
+      })
+    );
+    assert.strictEqual(out[0].passed, false);
+    assert.match(out[0].error, /bearer-token literal/);
   });
 
   test('walks arrays when hunting leaks', () => {


### PR DESCRIPTION
Closes #1713.

## The actual BidMachine root cause

Investigating #1707/#1711 surfaced something unexpected: BidMachine's `sync_accounts` `context.no_secret_echo` failures **aren't** caused by Zod `.strict()` codegen lag. I verified published @adcp/sdk tarballs at 5.25.1, 6.12.0, and current main — every one uses `.passthrough()` on `SyncAccountsResponseSchema.accounts[]`. Zod silently accepts the `authorization` field.

The rejection happens inside `context.no_secret_echo`'s name dragnet at `src/lib/testing/storyboard/default-invariants.ts:184-190`:

```ts
if (v !== null && typeof v === 'object') {
  for (const [key, inner] of Object.entries(v as Record<string, unknown>)) {
    if (SUSPECT_PROPERTY_NAMES.has(key.toLowerCase())) {
      return `contains suspect property name "${key}"`;
    }
    stack.push(inner);
  }
}
```

The dragnet trips on field NAME alone (`authorization`, `api_key`, `apikey`, `bearer`, `x-api-key`) regardless of value. BidMachine's response carries `authorization` with a structured object value (per the spec — `compliance/cache/3.0.11/property/validation-result.json` declares `authorization` as a structured authorization-validation payload, and the `additionalProperties: true` on `sync_accounts_response.accounts[]` permits seller extensions). The structured value isn't a credential leak; the dragnet false-positives.

## The fix

`findSecretEcho` now requires both a suspect name AND a non-empty string value:

```ts
if (
  SUSPECT_PROPERTY_NAMES.has(key.toLowerCase()) &&
  typeof inner === 'string' &&
  inner.length > 0
) {
  return `contains suspect property name "${key}" with string value`;
}
stack.push(inner);
```

Object/array values on suspect-named fields pass through to the recursive walk, which still scans nested strings via `BEARER_TOKEN_PATTERN` and caller-supplied secret literals. The actual leak shapes (bearer tokens at any depth, caller secret echoes, bare credential strings on suspect-named fields) all stay caught.

## Tests

Five new cases in `describe('default-invariants: context.no_secret_echo (widened whole-body scan)')`:

| # | Case | Result |
|---|---|---|
| 1 | Suspect name (`authorization`) carrying an OBJECT value — the BidMachine case | passes ✓ |
| 2 | Suspect name (`api_key`) carrying an ARRAY value | passes ✓ |
| 3 | Suspect name carrying an empty string | passes ✓ |
| 4 | Suspect name carrying a non-empty string — existing dragnet preserved | fails ✓ |
| 5 | Bearer literal nested INSIDE a structured suspect-named object | fails (regression guard) ✓ |

113/113 invariant tests pass.

## Why this matters for the coordinated stance

- adcp-client#1709 (merged via #1712) addresses Zod-reject misattribution (different path — when Zod DOES reject, attribute to `response_schema`).
- adcp-client#1707 — dynamic schema fetch + strict→passthrough + codegen regen. Real architectural cleanup but **does not unblock BidMachine** (verified the published SDK already uses passthrough).
- adcp-client#1711 (fgranata) — BidMachine's report. Their "Zod `.strict()` codegen lag" diagnosis was incorrect for the published SDK; **this PR is the actual unblocker** for the 27-point delta (63/128 comply vs 45/59 CLI). Will close once fgranata retests.

So the order BidMachine cares about:

1. **#1714 (this PR)** — closes BidMachine's immediate symptom.
2. **#1707** — independent architectural cleanup; lower urgency now.

## Test plan

- [x] `npm run build` clean
- [x] `npm run format:check` clean
- [x] `node --test test/lib/storyboard-default-invariants.test.js` — 113/113 pass (5 new + all existing)
- [ ] After merge, BidMachine retest should show `sync_accounts` failures resolved.

Coordinated stance: #1685 (the SDK is a witness, not a translator). Same anti-pattern as #1702 / #1705 / #1712: the SDK fabricated a credential-leak signal against a structured non-credential field the spec legally permits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)