### PR TITLE
feat(discovery): validateAdAgents with ads.txt MANAGERDOMAIN fallback (#1717)

### DIFF
--- a/.changeset/validate-adagents-managerdomain-fallback-1717.md
+++ b/.changeset/validate-adagents-managerdomain-fallback-1717.md
@@ -1,0 +1,60 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(discovery): `validateAdAgents` with ads.txt `MANAGERDOMAIN` one-hop fallback (#1717)
+
+Implements RFC 4175 / adcontextprotocol/adcp#4175 — new public
+`validateAdAgents(publisherDomain, options?)` helper that resolves a
+publisher's `adagents.json` via:
+
+1. Canonical: `https://{publisher}/.well-known/adagents.json` (direct).
+2. Pointer indirection: if the canonical file carries
+   `authoritative_location` (and no inline `authorized_agents`), follow
+   one redirect — reports `discovery_method: 'authoritative_location'`.
+3. On HTTP **404 only** — parse `https://{publisher}/ads.txt` for a
+   `MANAGERDOMAIN=` directive and attempt
+   `https://{managerdomain}/.well-known/adagents.json` — reports
+   `discovery_method: 'ads_txt_managerdomain'` and populates
+   `manager_domain`.
+
+Per the #4173 resolution of the RFC's open questions:
+
+- Only the IAB directive form `MANAGERDOMAIN=example.com` counts; the
+  comment form `# managerdomain=example.com` is rejected.
+- Duplicate `MANAGERDOMAIN` lines: **last-wins** (rather than the RFC's
+  fail-closed default — IAB-aligned).
+
+Other safety rules carry through from the RFC:
+
+- Fallback fires only on HTTP 404. 5xx / timeouts / invalid JSON / SSRF
+  refusals stay terminal on the direct path.
+- One hop only — the manager-domain file is never recursed into.
+- `publisher → publisher` cycles are rejected.
+- `#noagents` trailing comment on a `MANAGERDOMAIN` line excludes that
+  entry from fallback discovery (publisher-side opt-out).
+- Manager-domain failure (404, parse error, SSRF refusal) is a terminal
+  validation failure, never a silent pass.
+
+### New public API
+
+```ts
+import { validateAdAgents, type DiscoveryMethod, type AdAgentsValidationResult } from '@adcp/sdk';
+
+const result = await validateAdAgents('publisher.example');
+if (result.valid) {
+  console.log(result.discovery_method, result.manager_domain, result.adagents);
+}
+```
+
+Exports added from `@adcp/sdk`:
+
+- `validateAdAgents(domain, options?)` — main entrypoint.
+- `parseManagerDomain(adsTxt)` — directive-only parser, exported for
+  direct unit testing and adopters who want to consume MANAGERDOMAIN
+  outside the validator.
+- Types: `DiscoveryMethod`, `AdAgentsValidationResult`,
+  `ValidateAdAgentsOptions`.
+
+Routes through `ssrfSafeFetch` for DNS-pin / SSRF-policy defense (same
+posture as `PropertyCrawler` and `NetworkConsistencyChecker` post-#1633).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6474,7 +6474,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.0.0"
+        "@adcp/sdk": "^7.1.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -299,9 +299,14 @@ export function parseManagerDomain(adsTxt: string): string | undefined {
     // Directive form only: KEY=VALUE on its own line, key matched
     // case-insensitively. Trailing `, ...` (ads.txt record syntax)
     // isn't valid on a variable line, so we don't tolerate commas.
-    const match = code.match(/^MANAGERDOMAIN\s*=\s*(.+?)\s*$/i);
+    //
+    // Regex shape note: the value is `(.*)` (greedy, no trailing `\s*`)
+    // rather than `(.+?)\s*$` because `code` is already trimmed — the
+    // lazy + trailing-whitespace shape is a polynomial-ReDoS pattern
+    // flagged by CodeQL (uncontrolled input from the network).
+    const match = code.match(/^MANAGERDOMAIN\s*=\s*(.*)$/i);
     if (!match || !match[1]) continue;
-    const value = match[1].trim();
+    const value = match[1];
     if (!isEligibleHostToken(value)) continue;
     if (/\bnoagents\b/i.test(comment)) continue;
     last = value.toLowerCase();

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -144,7 +144,13 @@ export async function validateAdAgents(
           errors: [`authoritative_location must use https://, got: ${target}`],
         };
       }
-      if (target === publisherUrl) {
+      // Normalize before cycle-comparing — string equality misses
+      // trivial bounce variants (trailing slash, `?query`, fragment,
+      // uppercase scheme). Worst case of missing one of these is a
+      // wasted RTT against the publisher's own server, not SSRF
+      // (still routed through `ssrfSafeFetch`), but the right check
+      // is on origin+pathname.
+      if (sameOriginAndPath(target, publisherUrl)) {
         return {
           valid: false,
           publisher_domain: publisher,
@@ -311,6 +317,26 @@ export function parseManagerDomain(adsTxt: string): string | undefined {
     last = value.toLowerCase();
   }
   return last;
+}
+
+/**
+ * URL equality for cycle detection. Compares lowercased origin
+ * (scheme + host + port) and pathname; ignores trailing slashes,
+ * query strings, fragments, and scheme case. Returns false on
+ * unparseable URLs (callers treat unparseable as "not a cycle" so
+ * `ssrfSafeFetch` can produce a cleaner error downstream).
+ */
+function sameOriginAndPath(a: string, b: string): boolean {
+  try {
+    const ua = new URL(a);
+    const ub = new URL(b);
+    if (ua.origin.toLowerCase() !== ub.origin.toLowerCase()) return false;
+    const pathA = ua.pathname.replace(/\/+$/, '');
+    const pathB = ub.pathname.replace(/\/+$/, '');
+    return pathA === pathB;
+  } catch {
+    return false;
+  }
 }
 
 function isEligibleHostToken(value: string): boolean {

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -1,0 +1,409 @@
+/**
+ * `adagents.json` discovery + validation with the ads.txt `MANAGERDOMAIN`
+ * one-hop fallback (adcp#4175 / adcontextprotocol/adcp PR #4173, adcp-client#1717).
+ *
+ * Discovery order:
+ *   1. `https://{publisher}/.well-known/adagents.json` (direct)
+ *      - if the file carries `authoritative_location`, follow one redirect
+ *        and report `discovery_method = 'authoritative_location'`
+ *   2. On HTTP 404 only — fetch `https://{publisher}/ads.txt`, parse the
+ *      `MANAGERDOMAIN=` directive, and attempt
+ *      `https://{managerdomain}/.well-known/adagents.json`.
+ *      Reports `discovery_method = 'ads_txt_managerdomain'` and
+ *      `manager_domain`.
+ *
+ * Per the #4173 resolution of the RFC's open questions:
+ *   - Only the IAB directive form `MANAGERDOMAIN=example.com` counts;
+ *     the comment form `# managerdomain=example.com` is rejected.
+ *   - Duplicate `MANAGERDOMAIN` lines: last-wins (rather than the RFC's
+ *     fail-closed default — IAB-aligned).
+ *
+ * Other safety rules from the RFC carry through:
+ *   - Fallback fires only on 404 (not 5xx / timeout / invalid JSON).
+ *   - Exactly one hop. The manager-domain file is fetched once, never
+ *     recursed into.
+ *   - `publisher → publisher` cycle is rejected.
+ *   - `#noagents` trailing comment on a `MANAGERDOMAIN` line excludes
+ *     that entry from fallback discovery.
+ *   - Manager-domain failure is terminal — never a silent pass.
+ */
+import { createLogger, type LogLevel } from '../utils/logger';
+import { LIBRARY_VERSION } from '../version';
+import { validateUserAgent } from '../utils/validate-user-agent';
+import { ssrfSafeFetch, SsrfRefusedError, decodeBodyAsJsonOrText } from '../net/ssrf-fetch';
+import { isInternalProbesAllowed } from '../utils/probe-policy';
+import type { AdAgentsJson } from './types';
+
+/** How the validator located the authoritative `adagents.json` for a publisher. */
+export type DiscoveryMethod = 'direct' | 'authoritative_location' | 'ads_txt_managerdomain';
+
+export interface AdAgentsValidationResult {
+  /** Whether a valid `adagents.json` was discovered for this publisher. */
+  valid: boolean;
+  /** The publisher domain the caller asked us to validate. */
+  publisher_domain: string;
+  /**
+   * Which discovery path was used. Defaults to `'direct'`: a failure on
+   * the publisher's own `.well-known/adagents.json` reports `'direct'`
+   * even when no file was retrieved. `'authoritative_location'` and
+   * `'ads_txt_managerdomain'` only appear once the validator has
+   * committed to that path (followed the pointer / parsed a directive).
+   */
+  discovery_method: DiscoveryMethod;
+  /**
+   * The manager domain consulted when `discovery_method ===
+   * 'ads_txt_managerdomain'`. Populated even on manager-domain failure
+   * so callers can surface "we tried <manager>" in error reports.
+   */
+  manager_domain?: string;
+  /** URL the `adagents.json` was ultimately loaded from. Omitted when nothing loaded. */
+  resolved_url?: string;
+  /** Parsed authoritative file. Omitted on failure. */
+  adagents?: AdAgentsJson;
+  /** One or more reasons validation failed. Empty when `valid === true`. */
+  errors: string[];
+}
+
+export interface ValidateAdAgentsOptions {
+  /** Per-request timeout in ms (default 10_000). */
+  timeoutMs?: number;
+  /** Optional User-Agent suffix (validated via `validateUserAgent`). */
+  userAgent?: string;
+  /** Logger level (default `'warn'`). */
+  logLevel?: LogLevel;
+  /**
+   * Build the URL for a `domain` + well-known `path` pair. Defaults to
+   * `https://{domain}{path}`. Provide a custom builder to point the
+   * validator at a loopback test server (`http://...`), an internal
+   * mirror, or a CDN-rewriting host.
+   */
+  urlForDomain?: (domain: string, path: string) => string;
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_ADAGENTS_BYTES = 256 * 1024;
+const MAX_ADS_TXT_BYTES = 256 * 1024;
+
+const FETCH_HEADERS = {
+  Accept: 'application/json, text/plain, */*',
+  'Accept-Language': 'en-US,en;q=0.9',
+  'Accept-Encoding': 'gzip, deflate, br',
+};
+
+/**
+ * Validate `adagents.json` for a publisher domain. Implements the
+ * ads.txt `MANAGERDOMAIN` one-hop fallback specified in adcp#4175.
+ */
+export async function validateAdAgents(
+  publisherDomain: string,
+  options: ValidateAdAgentsOptions = {}
+): Promise<AdAgentsValidationResult> {
+  if (!publisherDomain || typeof publisherDomain !== 'string') {
+    throw new Error('publisherDomain must be a non-empty string');
+  }
+  if (options.userAgent) {
+    validateUserAgent(options.userAgent);
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const logger = createLogger({ level: options.logLevel ?? 'warn' }).child('validateAdAgents');
+  const userAgentHeader = `adcp-validate-adagents/${LIBRARY_VERSION} (+https://adcontextprotocol.org)`;
+  const fromHeader = options.userAgent
+    ? `adcp-validate-adagents@adcontextprotocol.org (${options.userAgent}; v${LIBRARY_VERSION})`
+    : `adcp-validate-adagents@adcontextprotocol.org (v${LIBRARY_VERSION})`;
+
+  const publisher = publisherDomain.toLowerCase();
+  const buildUrl = options.urlForDomain ?? ((domain, path) => `https://${domain}${path}`);
+  const publisherUrl = buildUrl(publisher, '/.well-known/adagents.json');
+
+  // Step 1: try the publisher's canonical location.
+  const direct = await fetchJsonOrStatus(publisherUrl, {
+    timeoutMs,
+    maxBodyBytes: MAX_ADAGENTS_BYTES,
+    userAgentHeader,
+    fromHeader,
+  });
+
+  if (direct.kind === 'ok') {
+    const data = direct.data as AdAgentsJson;
+
+    // Handle `authoritative_location` indirection: a pointer file with no
+    // inline `authorized_agents` should be followed exactly once.
+    if (data.authoritative_location && !data.authorized_agents) {
+      const target = data.authoritative_location;
+      // Production: HTTPS-only. Loopback test runs (gated by
+      // ADCP_ALLOW_INTERNAL_PROBES=1) may use `http://` against a
+      // 127.0.0.1 server — the same opt-in that lets `ssrfSafeFetch`
+      // touch loopback in the first place.
+      const allowHttp = isInternalProbesAllowed();
+      if (!target.startsWith('https://') && !(allowHttp && target.startsWith('http://'))) {
+        return {
+          valid: false,
+          publisher_domain: publisher,
+          discovery_method: 'authoritative_location',
+          resolved_url: publisherUrl,
+          errors: [`authoritative_location must use https://, got: ${target}`],
+        };
+      }
+      if (target === publisherUrl) {
+        return {
+          valid: false,
+          publisher_domain: publisher,
+          discovery_method: 'authoritative_location',
+          resolved_url: publisherUrl,
+          errors: ['authoritative_location points back to the publisher (cycle)'],
+        };
+      }
+      const followed = await fetchJsonOrStatus(target, {
+        timeoutMs,
+        maxBodyBytes: MAX_ADAGENTS_BYTES,
+        userAgentHeader,
+        fromHeader,
+      });
+      if (followed.kind !== 'ok') {
+        return {
+          valid: false,
+          publisher_domain: publisher,
+          discovery_method: 'authoritative_location',
+          resolved_url: target,
+          errors: [`authoritative_location fetch failed: ${describeOutcome(followed)}`],
+        };
+      }
+      return {
+        valid: true,
+        publisher_domain: publisher,
+        discovery_method: 'authoritative_location',
+        resolved_url: target,
+        adagents: followed.data as AdAgentsJson,
+        errors: [],
+      };
+    }
+
+    return {
+      valid: true,
+      publisher_domain: publisher,
+      discovery_method: 'direct',
+      resolved_url: publisherUrl,
+      adagents: data,
+      errors: [],
+    };
+  }
+
+  // Step 2: managerdomain fallback only fires on 404. Other failures
+  // (5xx, timeout, malformed JSON, SSRF refusal) are terminal under the
+  // RFC's "Only trigger fallback on 404" rule.
+  if (direct.kind !== 'not_found') {
+    return {
+      valid: false,
+      publisher_domain: publisher,
+      discovery_method: 'direct',
+      errors: [`adagents.json fetch failed: ${describeOutcome(direct)}`],
+    };
+  }
+
+  // Step 3: fetch ads.txt and look for a MANAGERDOMAIN= directive.
+  const adsTxtUrl = buildUrl(publisher, '/ads.txt');
+  const adsTxt = await fetchTextOrStatus(adsTxtUrl, {
+    timeoutMs,
+    maxBodyBytes: MAX_ADS_TXT_BYTES,
+    userAgentHeader,
+    fromHeader,
+  });
+  if (adsTxt.kind !== 'ok') {
+    return {
+      valid: false,
+      publisher_domain: publisher,
+      discovery_method: 'direct',
+      errors: [`adagents.json missing (404) and ads.txt unavailable: ${describeOutcome(adsTxt)}`],
+    };
+  }
+
+  const managerDomain = parseManagerDomain(adsTxt.text);
+  if (!managerDomain) {
+    return {
+      valid: false,
+      publisher_domain: publisher,
+      discovery_method: 'direct',
+      errors: ['adagents.json missing (404) and no eligible MANAGERDOMAIN directive in ads.txt'],
+    };
+  }
+  if (managerDomain === publisher) {
+    return {
+      valid: false,
+      publisher_domain: publisher,
+      discovery_method: 'direct',
+      errors: [`MANAGERDOMAIN references the publisher domain itself (cycle): ${managerDomain}`],
+    };
+  }
+
+  // Step 4: fetch the manager domain's adagents.json. One hop only —
+  // even if this file has its own `authoritative_location`, we do NOT
+  // follow it (the RFC restricts to one hop publisher → managerdomain).
+  const managerUrl = buildUrl(managerDomain, '/.well-known/adagents.json');
+  const manager = await fetchJsonOrStatus(managerUrl, {
+    timeoutMs,
+    maxBodyBytes: MAX_ADAGENTS_BYTES,
+    userAgentHeader,
+    fromHeader,
+  });
+  if (manager.kind !== 'ok') {
+    logger.debug(`Manager domain ${managerDomain} adagents.json fetch failed: ${describeOutcome(manager)}`);
+    return {
+      valid: false,
+      publisher_domain: publisher,
+      discovery_method: 'ads_txt_managerdomain',
+      manager_domain: managerDomain,
+      errors: [`Manager domain adagents.json fetch failed: ${describeOutcome(manager)}`],
+    };
+  }
+
+  return {
+    valid: true,
+    publisher_domain: publisher,
+    discovery_method: 'ads_txt_managerdomain',
+    manager_domain: managerDomain,
+    resolved_url: managerUrl,
+    adagents: manager.data as AdAgentsJson,
+    errors: [],
+  };
+}
+
+/**
+ * Parse a MANAGERDOMAIN directive out of an ads.txt body. Returns the
+ * lowercased host token (last-wins on duplicates) or `undefined` when
+ * no eligible directive is present.
+ *
+ * Eligibility rules (per adcp-client#1717 / adcp#4175 + #4173 resolution):
+ *   - Directive form `MANAGERDOMAIN=<host>` only. Case-insensitive on
+ *     the key; the value preserves no case. Comment-only lines like
+ *     `# managerdomain=...` are rejected.
+ *   - Value must be a host token (no scheme, no path, no whitespace).
+ *   - Trailing inline comment containing `noagents` (case-insensitive)
+ *     opts that entry out of fallback discovery.
+ *   - Duplicate eligible entries: the last one wins.
+ *
+ * Exported for direct unit testing.
+ */
+export function parseManagerDomain(adsTxt: string): string | undefined {
+  if (!adsTxt) return undefined;
+  // Strip BOM if present — common on Windows-authored ads.txt files.
+  const body = adsTxt.replace(/^﻿/, '');
+  let last: string | undefined;
+  for (const rawLine of body.split(/\r?\n/)) {
+    // Split off any inline comment so the directive parser only sees
+    // the code part, but keep the comment text around for the
+    // `#noagents` opt-out check.
+    const hashIdx = rawLine.indexOf('#');
+    const code = (hashIdx === -1 ? rawLine : rawLine.slice(0, hashIdx)).trim();
+    const comment = hashIdx === -1 ? '' : rawLine.slice(hashIdx + 1);
+    if (!code) continue;
+    // Directive form only: KEY=VALUE on its own line, key matched
+    // case-insensitively. Trailing `, ...` (ads.txt record syntax)
+    // isn't valid on a variable line, so we don't tolerate commas.
+    const match = code.match(/^MANAGERDOMAIN\s*=\s*(.+?)\s*$/i);
+    if (!match || !match[1]) continue;
+    const value = match[1].trim();
+    if (!isEligibleHostToken(value)) continue;
+    if (/\bnoagents\b/i.test(comment)) continue;
+    last = value.toLowerCase();
+  }
+  return last;
+}
+
+function isEligibleHostToken(value: string): boolean {
+  if (!value) return false;
+  // Reject anything with whitespace, slashes, or query strings.
+  if (/[\s/?#]/.test(value)) return false;
+  // Reject anything that looks like a URL (`scheme:` prefix). The single
+  // `:` permitted in a host token is the port separator handled below —
+  // so look for the colon-before-slash-or-end shape `scheme:...`.
+  if (/^[a-z][a-z0-9+.-]*:[^0-9]/i.test(value)) return false;
+  // Split off an optional `:port` suffix. Port must be 1–5 digits.
+  const portMatch = value.match(/^(.*?):([0-9]{1,5})$/);
+  const host = portMatch?.[1] ?? value;
+  // Minimal hostname shape — at least one dot, labels per RFC 1035-ish.
+  // Reject `example` (no TLD) and obvious junk like `..` or `-foo.com`.
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i.test(host)) return false;
+  return true;
+}
+
+type FetchFailure =
+  | { kind: 'not_found' }
+  | { kind: 'http_error'; status: number }
+  | { kind: 'transport_error'; message: string }
+  | { kind: 'parse_error'; message: string }
+  | { kind: 'ssrf_refused'; message: string };
+
+type RawFetchOutcome = { kind: 'ok-text'; text: string } | FetchFailure;
+
+type JsonFetchOutcome = { kind: 'ok'; data: unknown } | FetchFailure;
+
+type TextFetchOutcome = { kind: 'ok'; text: string } | FetchFailure;
+
+interface InternalFetchOptions {
+  timeoutMs: number;
+  maxBodyBytes: number;
+  userAgentHeader: string;
+  fromHeader: string;
+}
+
+async function fetchJsonOrStatus(url: string, opts: InternalFetchOptions): Promise<JsonFetchOutcome> {
+  const raw = await rawFetch(url, opts);
+  if (raw.kind !== 'ok-text') return raw;
+  try {
+    return { kind: 'ok', data: JSON.parse(raw.text) };
+  } catch (err) {
+    return { kind: 'parse_error', message: err instanceof Error ? err.message : 'invalid JSON' };
+  }
+}
+
+async function fetchTextOrStatus(url: string, opts: InternalFetchOptions): Promise<TextFetchOutcome> {
+  const raw = await rawFetch(url, opts);
+  if (raw.kind === 'ok-text') return { kind: 'ok', text: raw.text };
+  return raw;
+}
+
+async function rawFetch(url: string, opts: InternalFetchOptions): Promise<RawFetchOutcome> {
+  try {
+    const result = await ssrfSafeFetch(url, {
+      timeoutMs: opts.timeoutMs,
+      allowPrivateIp: isInternalProbesAllowed(),
+      maxBodyBytes: opts.maxBodyBytes,
+      headers: {
+        ...FETCH_HEADERS,
+        'User-Agent': opts.userAgentHeader,
+        From: opts.fromHeader,
+      },
+    });
+    if (result.status === 404) return { kind: 'not_found' };
+    if (result.status < 200 || result.status >= 300) {
+      return { kind: 'http_error', status: result.status };
+    }
+    // Always decode as text — JSON parsing is the caller's choice. This
+    // lets ads.txt and adagents.json share the same fetch primitive.
+    const decoded = decodeBodyAsJsonOrText(result.body, 'text/plain');
+    const text = typeof decoded === 'string' ? decoded : JSON.stringify(decoded);
+    return { kind: 'ok-text', text };
+  } catch (err) {
+    if (err instanceof SsrfRefusedError) {
+      return { kind: 'ssrf_refused', message: err.message };
+    }
+    return { kind: 'transport_error', message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+function describeOutcome(outcome: JsonFetchOutcome | TextFetchOutcome): string {
+  switch (outcome.kind) {
+    case 'not_found':
+      return 'HTTP 404';
+    case 'http_error':
+      return `HTTP ${outcome.status}`;
+    case 'transport_error':
+      return outcome.message;
+    case 'parse_error':
+      return `invalid JSON: ${outcome.message}`;
+    case 'ssrf_refused':
+      return `[SSRF refused] ${outcome.message}`;
+    case 'ok':
+      return 'ok';
+  }
+}

--- a/src/lib/discovery/validate-adagents.ts
+++ b/src/lib/discovery/validate-adagents.ts
@@ -297,16 +297,15 @@ export function parseManagerDomain(adsTxt: string): string | undefined {
     const comment = hashIdx === -1 ? '' : rawLine.slice(hashIdx + 1);
     if (!code) continue;
     // Directive form only: KEY=VALUE on its own line, key matched
-    // case-insensitively. Trailing `, ...` (ads.txt record syntax)
-    // isn't valid on a variable line, so we don't tolerate commas.
-    //
-    // Regex shape note: the value is `(.*)` (greedy, no trailing `\s*`)
-    // rather than `(.+?)\s*$` because `code` is already trimmed — the
-    // lazy + trailing-whitespace shape is a polynomial-ReDoS pattern
-    // flagged by CodeQL (uncontrolled input from the network).
-    const match = code.match(/^MANAGERDOMAIN\s*=\s*(.*)$/i);
-    if (!match || !match[1]) continue;
-    const value = match[1];
+    // case-insensitively. We parse with `indexOf('=')` rather than a
+    // regex because `code` is uncontrolled network input — any regex
+    // shape like `^KEY\s*=\s*(...)$` invites polynomial-ReDoS backtracking
+    // on pathological whitespace-heavy lines (flagged by CodeQL).
+    const eq = code.indexOf('=');
+    if (eq === -1) continue;
+    if (code.slice(0, eq).trim().toLowerCase() !== 'managerdomain') continue;
+    const value = code.slice(eq + 1).trim();
+    if (!value) continue;
     if (!isEligibleHostToken(value)) continue;
     if (/\bnoagents\b/i.test(comment)) continue;
     last = value.toLowerCase();

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -90,6 +90,13 @@ export type {
   PropertyType,
   AdAgentsJson,
 } from './discovery/types';
+export {
+  validateAdAgents,
+  parseManagerDomain,
+  type DiscoveryMethod,
+  type AdAgentsValidationResult,
+  type ValidateAdAgentsOptions,
+} from './discovery/validate-adagents';
 
 // ====== CORE CONVERSATION-AWARE CLIENTS ======
 // New conversation-aware clients with input handler pattern

--- a/test/lib/validate-adagents-cafemedia-fixture.test.js
+++ b/test/lib/validate-adagents-cafemedia-fixture.test.js
@@ -1,0 +1,158 @@
+/**
+ * Regression fixture: Raptive / CafeMedia wire shape as captured on
+ * 2026-05-12.
+ *
+ * Real-world data from probing `ads.cafemedia.com` and `cafemedia.com`
+ * during the rollout of RFC 4175 / adcp-client#1717. Two issues found
+ * with Raptive's current deployment that this fixture pins:
+ *
+ *   1. `ads.cafemedia.com/.well-known/adagents.json` returns **HTTP 403**
+ *      (S3 `AccessDenied` XML) rather than 404. The RFC's fallback
+ *      rule fires only on 404 — so even though `ads.cafemedia.com/ads.txt`
+ *      declares `managerdomain=cafemedia.com`, no conforming validator
+ *      can chase the fallback. Reported upstream at adcontextprotocol/adcp.
+ *
+ *   2. `cafemedia.com/.well-known/adagents.json` returns **HTTP 404**,
+ *      and `cafemedia.com/ads.txt` ALSO declares
+ *      `managerdomain=cafemedia.com` — a self-loop. Our cycle-detection
+ *      branch correctly refuses to chase it.
+ *
+ * This test pins the two outcomes so we catch the day Raptive either
+ * fixes their bucket policy (403→404) or hosts an authoritative
+ * adagents.json on `cafemedia.com`. When that happens, the assertions
+ * will flip and we'll know to update the test (and the upstream issue
+ * can close).
+ */
+
+process.env.ADCP_ALLOW_INTERNAL_PROBES = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { validateAdAgents } = require('../../dist/lib/discovery/validate-adagents.js');
+
+// Captured 2026-05-12 from https://ads.cafemedia.com/ads.txt — only the
+// header + managerdomain + first few records, enough to exercise the
+// directive parser without checking in 5 KB of SSP records.
+const ADS_CAFEMEDIA_ADS_TXT = `#Raptive ads.txt (CafeMedia/AdThrive) v2.70-auto
+managerdomain=cafemedia.com
+contact=info@raptive.com
+google.com, pub-8501674430909082, DIRECT, f08c47fec0942fa0 #video, banner
+google.com, pub-8501674430909082, RESELLER, f08c47fec0942fa0 #video, banner
+`;
+
+// Captured 2026-05-12 from https://cafemedia.com/ads.txt — same shape,
+// self-referencing managerdomain.
+const CAFEMEDIA_ADS_TXT = `# CafeMedia/AdThrive ads.txt v2.60-auto
+managerdomain=cafemedia.com
+contact=info@adthrive.com
+google.com, pub-8501674430909082, DIRECT, f08c47fec0942fa0 #video, banner
+`;
+
+// Real S3 AccessDenied body shape. The HTTP status (403) is the only
+// part the validator inspects, but pinning the body documents what
+// publishers on AWS see by default.
+const S3_ACCESS_DENIED_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>53ZTTYHFDF7PN7GN</RequestId></Error>`;
+
+/**
+ * Stand up two loopback servers that mirror what `ads.cafemedia.com`
+ * and `cafemedia.com` returned on 2026-05-12. Returns a `urlForDomain`
+ * builder + cleanup hook to point the validator at the loopback hosts
+ * while preserving the publisher-domain values the validator sees in
+ * its result and error messages.
+ */
+async function startCafeMediaMirror() {
+  const adsServer = await startServer((req, res) => {
+    if (req.url === '/ads.txt') return respondText(res, 200, ADS_CAFEMEDIA_ADS_TXT);
+    if (req.url === '/.well-known/adagents.json') return respondXml(res, 403, S3_ACCESS_DENIED_XML);
+    respondText(res, 404, 'Not Found');
+  });
+  const managerServer = await startServer((req, res) => {
+    if (req.url === '/ads.txt') return respondText(res, 200, CAFEMEDIA_ADS_TXT);
+    // `/.well-known/adagents.json` falls through to 404 — matching live
+    if (req.url === '/.well-known/adagents.json') return respondText(res, 404, 'Not Found');
+    respondText(res, 404, 'Not Found');
+  });
+
+  const urlForDomain = (domain, path) => {
+    if (domain === 'ads.cafemedia.com') return `http://${adsServer.host}${path}`;
+    if (domain === 'cafemedia.com') return `http://${managerServer.host}${path}`;
+    // Default to publisher's loopback for any unexpected domain — fail
+    // loudly if our fixture-driven code accidentally reaches into the
+    // real internet.
+    throw new Error(`Unexpected domain in CafeMedia fixture: ${domain}`);
+  };
+
+  return {
+    urlForDomain,
+    cleanup: () => Promise.all([adsServer.close(), managerServer.close()]),
+  };
+}
+
+function startServer(handler) {
+  return new Promise(resolve => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ host: `127.0.0.1:${port}`, close: () => new Promise(r => server.close(() => r())) });
+    });
+  });
+}
+
+function respondText(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'text/plain' });
+  res.end(body);
+}
+
+function respondXml(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/xml' });
+  res.end(body);
+}
+
+describe('validateAdAgents — Raptive/CafeMedia wire shape (captured 2026-05-12)', () => {
+  test('ads.cafemedia.com: 403 (S3) on adagents.json must NOT trigger fallback (spec: 404-only)', async () => {
+    const mirror = await startCafeMediaMirror();
+    try {
+      const result = await validateAdAgents('ads.cafemedia.com', { urlForDomain: mirror.urlForDomain });
+      // Spec-correct outcome:
+      // - 403 ≠ 404, so the validator must NOT consult ads.txt at all.
+      // - Even though ads.txt declares `managerdomain=cafemedia.com`,
+      //   the validator stays on the direct path with a terminal 403.
+      // - manager_domain is NOT populated (we never reached the
+      //   fallback decision).
+      assert.strictEqual(result.valid, false);
+      assert.strictEqual(result.discovery_method, 'direct');
+      assert.strictEqual(result.manager_domain, undefined);
+      assert.ok(
+        result.errors.some(e => e.includes('HTTP 403')),
+        `expected error mentioning HTTP 403, got: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await mirror.cleanup();
+    }
+  });
+
+  test('cafemedia.com: 404 → fallback fires → MANAGERDOMAIN points at self → cycle rejected', async () => {
+    const mirror = await startCafeMediaMirror();
+    try {
+      const result = await validateAdAgents('cafemedia.com', { urlForDomain: mirror.urlForDomain });
+      // Spec-correct outcome:
+      // - 404 on adagents.json → ads.txt is consulted.
+      // - ads.txt declares `managerdomain=cafemedia.com` (self).
+      // - Cycle detected — discovery_method stays 'direct' (we never
+      //   commit to the managerdomain hop) and manager_domain is NOT
+      //   populated (no chase happened).
+      assert.strictEqual(result.valid, false);
+      assert.strictEqual(result.discovery_method, 'direct');
+      assert.strictEqual(result.manager_domain, undefined);
+      assert.ok(
+        result.errors.some(e => e.toLowerCase().includes('cycle')),
+        `expected cycle error, got: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await mirror.cleanup();
+    }
+  });
+});

--- a/test/lib/validate-adagents.test.js
+++ b/test/lib/validate-adagents.test.js
@@ -1,0 +1,276 @@
+/**
+ * Tests for `validateAdAgents` — the ads.txt MANAGERDOMAIN one-hop
+ * fallback for `adagents.json` discovery (adcp-client#1717,
+ * adcontextprotocol/adcp#4175 / PR #4173).
+ *
+ * Like discovery-ssrf-policy.test.js, these run against real loopback
+ * HTTP servers — `ssrfSafeFetch` uses undici directly and ignores
+ * `globalThis.fetch` monkey-patches.
+ */
+
+// `ssrfSafeFetch` refuses non-https (loopback HTTP) unless the runtime
+// has opted in to internal probes. Set BEFORE the SDK loads so the
+// probe-policy module reads the env flag at module-init time.
+process.env.ADCP_ALLOW_INTERNAL_PROBES = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+const { validateAdAgents, parseManagerDomain } = require('../../dist/lib/discovery/validate-adagents.js');
+
+/**
+ * Start a loopback HTTP server with a per-path response map.
+ *
+ * @param {Record<string, { status?: number, body?: string, contentType?: string }>} routes
+ *   Map from request path to response config. Unmapped paths → 404.
+ */
+function startRoutedServer(routes) {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const route = routes[req.url];
+      if (!route) {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+        return;
+      }
+      res.writeHead(route.status ?? 200, {
+        'Content-Type': route.contentType ?? 'application/json',
+      });
+      res.end(route.body ?? '');
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({
+        host: `127.0.0.1:${port}`,
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise(r => server.close(() => r())),
+      });
+    });
+  });
+}
+
+function adAgentsJson(agentUrl = 'https://agent.example.com/mcp') {
+  return JSON.stringify({
+    $schema: 'https://adcontextprotocol.org/schemas/v1/adagents.json',
+    authorized_agents: [{ url: agentUrl, authorized_for: 'Programmatic sales' }],
+    properties: [
+      {
+        property_type: 'website',
+        name: 'example.com',
+        identifiers: [{ type: 'domain', value: 'example.com' }],
+      },
+    ],
+  });
+}
+
+describe('parseManagerDomain', () => {
+  test('extracts a single MANAGERDOMAIN= directive (case-insensitive key)', () => {
+    assert.strictEqual(parseManagerDomain('MANAGERDOMAIN=manager.example'), 'manager.example');
+    assert.strictEqual(parseManagerDomain('managerdomain=manager.example'), 'manager.example');
+    assert.strictEqual(parseManagerDomain('ManagerDomain=manager.example'), 'manager.example');
+  });
+
+  test('rejects the comment form `# managerdomain=...`', () => {
+    assert.strictEqual(parseManagerDomain('# managerdomain=manager.example'), undefined);
+    assert.strictEqual(parseManagerDomain('   #managerdomain=manager.example'), undefined);
+  });
+
+  test('last-wins on duplicate MANAGERDOMAIN entries', () => {
+    const adsTxt = ['MANAGERDOMAIN=first.example', 'MANAGERDOMAIN=second.example', 'MANAGERDOMAIN=third.example'].join(
+      '\n'
+    );
+    assert.strictEqual(parseManagerDomain(adsTxt), 'third.example');
+  });
+
+  test('ignores `#noagents` opt-out comment on a MANAGERDOMAIN line', () => {
+    assert.strictEqual(parseManagerDomain('MANAGERDOMAIN=manager.example #noagents'), undefined);
+    assert.strictEqual(parseManagerDomain('MANAGERDOMAIN=manager.example #NoAgents'), undefined);
+    // A noagents entry followed by a clean entry: clean one wins.
+    const adsTxt = ['MANAGERDOMAIN=skip.example #noagents', 'MANAGERDOMAIN=keep.example'].join('\n');
+    assert.strictEqual(parseManagerDomain(adsTxt), 'keep.example');
+  });
+
+  test('rejects URL-shaped values (not host tokens)', () => {
+    assert.strictEqual(parseManagerDomain('MANAGERDOMAIN=https://manager.example'), undefined);
+    assert.strictEqual(parseManagerDomain('MANAGERDOMAIN=//manager.example'), undefined);
+    assert.strictEqual(parseManagerDomain('MANAGERDOMAIN=manager.example/path'), undefined);
+  });
+
+  test('returns undefined when no eligible directive present', () => {
+    assert.strictEqual(parseManagerDomain(''), undefined);
+    assert.strictEqual(parseManagerDomain('# nothing relevant'), undefined);
+    assert.strictEqual(parseManagerDomain('OWNERDOMAIN=example.com'), undefined);
+  });
+
+  test('skips full-line comments and blank lines mixed with directive', () => {
+    const adsTxt = ['# header comment', '', 'OWNERDOMAIN=example.com', 'MANAGERDOMAIN=manager.example', ''].join('\n');
+    assert.strictEqual(parseManagerDomain(adsTxt), 'manager.example');
+  });
+});
+
+describe('validateAdAgents — discovery_method', () => {
+  test("direct path: publisher hosts its own adagents.json → discovery_method 'direct'", async () => {
+    const server = await startRoutedServer({
+      '/.well-known/adagents.json': { body: adAgentsJson() },
+    });
+    try {
+      const result = await validateAdAgents(server.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, true, `expected valid, got errors=${JSON.stringify(result.errors)}`);
+      assert.strictEqual(result.discovery_method, 'direct');
+      assert.strictEqual(result.manager_domain, undefined);
+      assert.ok(result.adagents?.authorized_agents?.length, 'adagents.json should be populated');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("authoritative_location pointer → discovery_method 'authoritative_location'", async () => {
+    // Manager hosts the real file. Publisher hosts a pointer.
+    const manager = await startRoutedServer({
+      '/.well-known/adagents.json': { body: adAgentsJson() },
+    });
+    const publisher = await startRoutedServer({
+      '/.well-known/adagents.json': {
+        body: JSON.stringify({
+          authoritative_location: `http://${manager.host}/.well-known/adagents.json`,
+        }),
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, true, `expected valid, got errors=${JSON.stringify(result.errors)}`);
+      assert.strictEqual(result.discovery_method, 'authoritative_location');
+      assert.ok(result.adagents?.authorized_agents?.length);
+    } finally {
+      await Promise.all([publisher.close(), manager.close()]);
+    }
+  });
+
+  test("managerdomain fallback on 404 → discovery_method 'ads_txt_managerdomain', manager_domain populated", async () => {
+    // Manager hosts adagents.json; publisher only has ads.txt.
+    const manager = await startRoutedServer({
+      '/.well-known/adagents.json': { body: adAgentsJson() },
+    });
+    const publisher = await startRoutedServer({
+      '/ads.txt': {
+        body: `OWNERDOMAIN=example.com\nMANAGERDOMAIN=${manager.host}\n`,
+        contentType: 'text/plain',
+      },
+      // No `/.well-known/adagents.json` route → 404
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, true, `expected valid, got errors=${JSON.stringify(result.errors)}`);
+      assert.strictEqual(result.discovery_method, 'ads_txt_managerdomain');
+      assert.strictEqual(result.manager_domain, manager.host);
+      assert.ok(result.adagents?.authorized_agents?.length);
+    } finally {
+      await Promise.all([publisher.close(), manager.close()]);
+    }
+  });
+
+  test('manager domain 404 → terminal validation failure (not silent pass)', async () => {
+    // Manager 404s on adagents.json. Publisher 404s + has ads.txt
+    // pointing at it. Validator must surface failure, NOT treat as
+    // direct-path missing.
+    const manager = await startRoutedServer({});
+    const publisher = await startRoutedServer({
+      '/ads.txt': {
+        body: `MANAGERDOMAIN=${manager.host}\n`,
+        contentType: 'text/plain',
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.strictEqual(result.discovery_method, 'ads_txt_managerdomain');
+      assert.strictEqual(result.manager_domain, manager.host);
+      assert.ok(result.adagents === undefined);
+      assert.ok(result.errors.length >= 1, 'expected at least one error message');
+    } finally {
+      await Promise.all([publisher.close(), manager.close()]);
+    }
+  });
+
+  test('comment-form `# managerdomain=` in ads.txt is not followed', async () => {
+    // Manager hosts a perfectly valid adagents.json. Publisher's ads.txt
+    // uses the comment form. We must NOT follow it — validation fails.
+    const manager = await startRoutedServer({
+      '/.well-known/adagents.json': { body: adAgentsJson() },
+    });
+    const publisher = await startRoutedServer({
+      '/ads.txt': {
+        body: `# managerdomain=${manager.host}\n`,
+        contentType: 'text/plain',
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.strictEqual(result.discovery_method, 'direct');
+      assert.strictEqual(result.manager_domain, undefined);
+    } finally {
+      await Promise.all([publisher.close(), manager.close()]);
+    }
+  });
+
+  test('duplicate MANAGERDOMAIN lines → last entry wins', async () => {
+    const skip = await startRoutedServer({});
+    const keep = await startRoutedServer({
+      '/.well-known/adagents.json': { body: adAgentsJson('https://keep.example/mcp') },
+    });
+    const publisher = await startRoutedServer({
+      '/ads.txt': {
+        body: `MANAGERDOMAIN=${skip.host}\nMANAGERDOMAIN=${keep.host}\n`,
+        contentType: 'text/plain',
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, true, `expected valid, got errors=${JSON.stringify(result.errors)}`);
+      assert.strictEqual(result.discovery_method, 'ads_txt_managerdomain');
+      assert.strictEqual(result.manager_domain, keep.host);
+      // The agent URL proves we used `keep`, not `skip`.
+      assert.strictEqual(result.adagents?.authorized_agents?.[0]?.url, 'https://keep.example/mcp');
+    } finally {
+      await Promise.all([publisher.close(), skip.close(), keep.close()]);
+    }
+  });
+
+  test('non-404 publisher failure (5xx) does NOT trigger fallback', async () => {
+    const manager = await startRoutedServer({
+      '/.well-known/adagents.json': { body: adAgentsJson() },
+    });
+    const publisher = await startRoutedServer({
+      '/.well-known/adagents.json': { status: 503, body: 'maintenance' },
+      '/ads.txt': {
+        body: `MANAGERDOMAIN=${manager.host}\n`,
+        contentType: 'text/plain',
+      },
+    });
+    try {
+      const result = await validateAdAgents(publisher.host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      // We must stay on the direct path; fallback may only fire on 404.
+      assert.strictEqual(result.discovery_method, 'direct');
+      assert.strictEqual(result.manager_domain, undefined);
+    } finally {
+      await Promise.all([publisher.close(), manager.close()]);
+    }
+  });
+});

--- a/test/lib/validate-adagents.test.js
+++ b/test/lib/validate-adagents.test.js
@@ -250,6 +250,40 @@ describe('validateAdAgents — discovery_method', () => {
     }
   });
 
+  test('authoritative_location bounce variants caught by normalized cycle check', async () => {
+    // Bind the server first so we know its port, then hand-craft a
+    // self-pointer with `?x=1` tacked on. Naive string equality would
+    // miss this (`http://host/path` vs `http://host/path?x=1`).
+    // Origin+path normalization must catch it.
+    const http = require('node:http');
+    const server = http.createServer((req, res) => {
+      if (req.url.startsWith('/.well-known/adagents.json')) {
+        const port = server.address().port;
+        const selfPointer = `http://127.0.0.1:${port}/.well-known/adagents.json?x=1`;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ authoritative_location: selfPointer }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise(r => server.listen(0, '127.0.0.1', r));
+    const host = `127.0.0.1:${server.address().port}`;
+    try {
+      const result = await validateAdAgents(host, {
+        urlForDomain: (domain, path) => `http://${domain}${path}`,
+      });
+      assert.strictEqual(result.valid, false);
+      assert.strictEqual(result.discovery_method, 'authoritative_location');
+      assert.ok(
+        result.errors.some(e => e.toLowerCase().includes('cycle')),
+        `expected cycle error, got: ${JSON.stringify(result.errors)}`
+      );
+    } finally {
+      await new Promise(r => server.close(r));
+    }
+  });
+
   test('non-404 publisher failure (5xx) does NOT trigger fallback', async () => {
     const manager = await startRoutedServer({
       '/.well-known/adagents.json': { body: adAgentsJson() },


### PR DESCRIPTION
## Summary

Implements [adcp-client#1717](https://github.com/adcontextprotocol/adcp-client/issues/1717) — the ads.txt `MANAGERDOMAIN` one-hop fallback for `adagents.json` discovery (RFC adcontextprotocol/adcp#4175 / merged via #4173).

Adds a new public `validateAdAgents(publisherDomain, options?)` helper that resolves `adagents.json` via:

1. **Direct** — `https://{publisher}/.well-known/adagents.json` (`discovery_method: 'direct'`)
2. **Pointer indirection** — if the canonical file carries `authoritative_location` (no inline `authorized_agents`), follow one redirect (`discovery_method: 'authoritative_location'`)
3. **MANAGERDOMAIN fallback** — on HTTP **404 only**, parse `https://{publisher}/ads.txt` for `MANAGERDOMAIN=` and attempt `https://{manager}/.well-known/adagents.json` (`discovery_method: 'ads_txt_managerdomain'` + `manager_domain` populated)

Per the **#4173 resolution** of the RFC's open questions:
- Only the IAB directive form `MANAGERDOMAIN=example.com` counts; the comment form `# managerdomain=example.com` is **rejected**.
- Duplicate `MANAGERDOMAIN` lines: **last-wins** (rather than fail-closed).

Other safety rules from the RFC:
- Fallback fires only on HTTP 404 — 5xx / timeouts / invalid JSON / SSRF refusals stay terminal on the direct path.
- One hop only — the manager-domain file is never recursed into.
- `publisher → publisher` cycles rejected.
- `#noagents` trailing comment on a `MANAGERDOMAIN` line excludes that entry (publisher-side opt-out).
- Manager-domain failure is a terminal validation failure — never a silent pass.

Routes through `ssrfSafeFetch` for DNS-pin / SSRF-policy defence (same posture as `PropertyCrawler` + `NetworkConsistencyChecker` post-#1633).

## New public exports

- `validateAdAgents(domain, options?)` — main entrypoint.
- `parseManagerDomain(adsTxt)` — directive-only parser (exported for unit testing + adopters who consume MANAGERDOMAIN outside the validator).
- Types: `DiscoveryMethod`, `AdAgentsValidationResult`, `ValidateAdAgentsOptions`.

`ValidateAdAgentsOptions.urlForDomain` is a small builder seam that defaults to `https://{domain}{path}` — adopters can point the validator at a loopback test server, an internal mirror, or a CDN-rewriting host. The test suite uses it to drive loopback HTTP fixtures.

## Test plan

- [x] Direct path sets `discovery_method: 'direct'`
- [x] URL-reference path sets `discovery_method: 'authoritative_location'`
- [x] Manager-domain path sets `discovery_method: 'ads_txt_managerdomain'` and populates `manager_domain`
- [x] Comment-form `# managerdomain=` is **not** followed
- [x] Duplicate `MANAGERDOMAIN` lines → last entry wins
- [x] Manager domain 404 → validation failure (not silent pass)
- [x] Non-404 publisher failure (5xx) does **not** trigger fallback
- [x] `#noagents` opt-out excludes that entry; subsequent clean entry still wins
- [x] URL-shaped values (`https://...`, `//...`, `manager.example/path`) rejected as host tokens
- [x] Case-insensitive key match (`MANAGERDOMAIN`, `managerdomain`, `ManagerDomain`)
- [x] Full suite green (`npm test` — 8570 pass, 0 fail, 47 pre-existing skips)
- [x] `npm run format:check` green
- [x] No new lint warnings/errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)