### PR TITLE
docs(skill): note --auth-scheme basic in call-adcp-agent failure-mode table

### DIFF
--- a/.changeset/eager-shirts-jog.md
+++ b/.changeset/eager-shirts-jog.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs(skill): note --auth-scheme basic in call-adcp-agent failure-mode table (closes #1726). Skills file only — no library / CLI / package release impact.

--- a/skills/call-adcp-agent/SKILL.md
+++ b/skills/call-adcp-agent/SKILL.md
@@ -240,7 +240,7 @@ Quick lookup before reading the full envelope. Match what you see in `adcp_error
 | `recovery: 'transient'` (rate limit, 5xx, timeout) | Server-side, retry-safe | Retry with the **same** `idempotency_key`. |
 | `recovery: 'correctable'` | Buyer-side fix | Read `issues[]`, patch the pointers, resend. Most cases close in one attempt. |
 | `recovery: 'terminal'` (account suspended, payment required, …) | Requires human action | Don't retry. Surface to the user. |
-| HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. |
+| HTTP 401 with `WWW-Authenticate` header | Missing or expired credential | Add `Authorization` per the agent's auth spec; re-auth if applicable. If the challenge `scheme` is `Basic` (gateway-fronted agents — Apigee, Kong, AWS API GW), the SDK / CLI need `auth: { type: 'basic', username, password }` or `--auth user:pass --auth-scheme basic` — `Bearer` will never succeed against that gateway. **Saved aliases**: if registered with `--auth-scheme basic`, the scheme persists in `~/.adcp/config.json` and auto-applies on every later invocation — don't redundantly repeat the flag on each call. |
 
 If your symptom isn't here, fall through to the next section.
 


### PR DESCRIPTION
## Summary

- Closes #1726
- Adds a Basic-auth branch to the HTTP-401 row of the failure-mode table in `skills/call-adcp-agent/SKILL.md` so LLM agents calling AdCP behind an HTTP-Basic gateway (Apigee, Kong, AWS API GW with a BasicAuthentication policy) know to switch schemes instead of retrying Bearer indefinitely.
- Also calls out the saved-alias persistence: aliases registered via `--auth-scheme basic` carry the scheme in `~/.adcp/config.json` and auto-apply, so redundantly repeating the flag on every CLI call is unnecessary.

## Why

Follow-up from PR #1719 (`--auth-scheme bearer|basic` for the CLI). DX-expert review flagged that LLM-driven CLI invocations against the new surface would likely produce `--auth user:pass` and forget the scheme switch (the credential _looks_ like a token), and may also redundantly repeat the flag on every call against a saved basic alias. Skills doc is the right surface to teach both behaviors.

## Test plan

- [x] No library / CLI / changeset impact — `skills/call-adcp-agent/SKILL.md` only.
- [x] Format check clean (file is markdown, no prettier scope).
- [x] Verified the table row still parses as a single GitHub-flavored markdown table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)