### PR TITLE
docs(signing): note that Authorization is not in SIGNING_RESERVED_HEADERS

### DIFF
--- a/.changeset/signing-fetch-authorization-not-reserved-note.md
+++ b/.changeset/signing-fetch-authorization-not-reserved-note.md
@@ -1,0 +1,29 @@
+---
+'@adcp/sdk': patch
+---
+
+docs(signing): note that Authorization is not in SIGNING_RESERVED_HEADERS (closes #1725)
+
+Add a block comment to `src/lib/signing/fetch.ts` (and the mirrored line in
+`fetch-async.ts`) explaining that `authorization` is intentionally NOT in
+`SIGNING_RESERVED_HEADERS`. AdCP's RFC 9421 profile doesn't cover the
+`Authorization` header (see `MANDATORY_COMPONENTS` in
+`src/lib/signing/types.ts`), so caller-supplied Bearer / RFC 7617 Basic
+headers pass through `createSigningFetch` unmodified.
+
+Surfaces two latent gotchas in the comment so future contributors don't
+have to rediscover them:
+
+1. If a future AdCP profile adds `authorization` to `covered_components`,
+   the canonicalizer must read the FINAL outgoing value (post-`mergeHeaders`
+   injection in `bin/adcp.js` for the CLI Basic-auth path landed in #1719).
+   `createSigningFetch` already reads `init.headers` at fetch time so the
+   architecture survives this — the comment makes that explicit.
+
+2. RFC 9421 §7.5.7 warns about signing over long-lived credentials. Basic
+   credentials don't rotate, so signing over them creates a re-attack
+   surface. Any future `covers_authorization` policy knob needs that
+   security consideration in scope.
+
+Comment-only change. No code, test, or behavior impact. Source: protocol-
+expert review of #1719.

--- a/src/lib/signing/fetch-async.ts
+++ b/src/lib/signing/fetch-async.ts
@@ -5,6 +5,11 @@ import { signRequestAsync } from './signer-async';
 
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
+// Mirrors `fetch.ts`'s SIGNING_RESERVED_HEADERS. `authorization` is intentionally
+// NOT in this set — AdCP's RFC 9421 profile does not cover Authorization, so
+// caller-supplied Bearer / RFC 7617 Basic headers pass through unmodified. See
+// `fetch.ts` for the full rationale and the RFC 9421 §7.5.7 caveat about
+// signing over long-lived credentials.
 const SIGNING_RESERVED_HEADERS = new Set(['signature', 'signature-input', 'content-digest']);
 
 /**

--- a/src/lib/signing/fetch.ts
+++ b/src/lib/signing/fetch.ts
@@ -26,6 +26,17 @@ export type FetchLike = (input: string | URL | Request, init?: RequestInit) => P
  * caller-supplied value gets stripped before signing so a misconfigured
  * custom-headers bag can't silently overwrite (or bypass) the RFC 9421
  * signature output.
+ *
+ * `authorization` is intentionally NOT in this set. AdCP's RFC 9421 profile
+ * does not cover `Authorization` (see `MANDATORY_COMPONENTS` in
+ * `src/lib/signing/types.ts`), so a caller-supplied bearer or RFC 7617 Basic
+ * header passes through unmodified. If a future profile adds `authorization`
+ * to `covered_components`, the canonicalizer must read the FINAL outgoing
+ * value (post-`mergeHeaders` injection in `bin/adcp.js` for the CLI Basic
+ * path) — `createSigningFetch` already does because it reads `init.headers`
+ * at fetch time. Note RFC 9421 §7.5.7 warns about signing over long-lived
+ * credentials (Basic doesn't rotate) — re-attacking the signed credential is
+ * a real risk; a `covers_authorization` policy needs that in scope.
  */
 const SIGNING_RESERVED_HEADERS = new Set(['signature', 'signature-input', 'content-digest']);
 


### PR DESCRIPTION
## Summary

- Closes #1725
- Adds a block comment to `src/lib/signing/fetch.ts` (and the mirrored one-liner in `fetch-async.ts`) noting that `authorization` is intentionally NOT in `SIGNING_RESERVED_HEADERS` — AdCP's RFC 9421 profile doesn't cover the `Authorization` header, so Bearer / RFC 7617 Basic headers pass through `createSigningFetch` unmodified.
- Surfaces the two latent gotchas a future contributor would otherwise have to rediscover: post-`mergeHeaders` injection ordering for the CLI Basic-auth path, and the RFC 9421 §7.5.7 warning about signing over long-lived credentials.

## Why

Follow-up from PR #1719 (`--auth-scheme bearer|basic` for CLI). The protocol-expert review flagged that swapping `Bearer` for `Basic` works today because `Authorization` isn't in the covered-components set, but the architectural contract lives in prose only. Documenting it inline means a future `covers_authorization` policy proposal lands with the right caveats in scope from line one.

## Test plan

- [x] Comment-only change — no code or behavior impact
- [x] `tsc --noEmit` clean
- [x] `prettier --check` clean
- [x] Changeset (`patch`) included so the changeset-check job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)