### PR TITLE
docs(llms): add Transport auth section clarifying operator-private posture

### DIFF
--- a/.changeset/docs-llms-transport-auth-operator-private.md
+++ b/.changeset/docs-llms-transport-auth-operator-private.md
@@ -1,0 +1,28 @@
+---
+'@adcp/sdk': patch
+---
+
+docs(llms): add Transport auth section clarifying operator-private posture (closes #1724)
+
+Add a "Transport auth" section to `docs/llms.txt` (immediately after Quick
+Start) clarifying that AdCP is auth-scheme-agnostic at the transport
+layer. The protocol carries JSON-RPC over HTTP; how the outer envelope
+is gated is an operator-private deployment choice — bearer, OAuth, mTLS,
+AWS SigV4 at the edge, IP allow-lists, or RFC 7617 HTTP Basic for
+gateway-fronted agents (Apigee, Kong, AWS API Gateway, nginx
+auth_basic). `get_adcp_capabilities` does NOT advertise accepted auth
+schemes; coupling the protocol to infrastructure permutations would
+invite "auth_methods" PRs every time someone adds a new gateway shape.
+
+Calls out the discovery vector explicitly: `WWW-Authenticate` (RFC 9110
+§11.6.1) and PRM (RFC 9728), already consumed by
+`src/lib/auth/oauth/diagnose.ts`. Basic-fronted agents emit
+`WWW-Authenticate: Basic realm="…"` on a 401; consumers should branch on
+the challenge scheme rather than retrying Bearer indefinitely.
+
+Closes the documentation gap surfaced by the protocol-expert review of
+PR #1719 (`--auth-scheme bearer|basic` for the CLI). Pre-empts the
+"should we add `auth_methods` to capabilities?" PR that someone will
+eventually open.
+
+Doc-only change. No code or behavior impact.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,7 +1,7 @@
 # AdCP Type Summary
 
-> Generated at: 2026-05-08
-> @adcp/sdk v6.11.0
+> Generated at: 2026-05-12
+> @adcp/sdk v7.1.0
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,7 +1,7 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-05-08
-> Library: @adcp/sdk v6.11.0
+> Generated at: 2026-05-12
+> Library: @adcp/sdk v7.1.0
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
 > Note: the `Library` stamp reflects the package.json version at doc-generation time. The narrative below describes the surface that lands on the next-published minor — including any 6.7 helpers documented here ahead of the release tag.
@@ -96,6 +96,14 @@ const buy = await agent.createMediaBuy({
   packages: [{ buyer_ref: 'pkg-1', product_id: 'prod_1', pricing_option_id: 'cpm_1', budget: 5000 }],
 });
 ```
+
+## Transport auth
+
+AdCP is auth-scheme-agnostic at the transport layer. The protocol carries JSON-RPC over HTTP; how the outer envelope is gated is an operator-private deployment choice — bearer tokens, OAuth, mTLS, AWS SigV4 at the edge, an IP allow-list, or RFC 7617 HTTP Basic when the agent sits behind an API gateway with a BasicAuthentication policy (Apigee, Kong, AWS API Gateway, nginx `auth_basic`) are all valid. `get_adcp_capabilities` does NOT advertise the accepted auth schemes; encoding every gateway permutation in the capability payload would couple the protocol to infrastructure choices that change between deployments.
+
+Auth-scheme discovery, when needed, flows through `WWW-Authenticate` (RFC 9110 §11.6.1) and Protected Resource Metadata (RFC 9728) — both consumed by the SDK's auth-diagnostics path. Basic-fronted agents emit `WWW-Authenticate: Basic realm="…"` on a 401; consumers (SDK callers, the CLI's 401-bounce path, LLM agents) should branch on the challenge scheme rather than retrying Bearer indefinitely.
+
+The TypeScript SDK speaks both schemes today. Programmatically: `createTestClient({ auth: { type: 'basic', username, password } })` (RFC 7617) and `createTestClient({ auth: { type: 'bearer', token } })`. From the CLI: `--auth-scheme basic` opts into Basic and `--auth <user:pass>` carries the credential; the default `bearer` remains unchanged.
 
 ## Error Handling
 

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -637,6 +637,26 @@ function generateLlmsTxt(
   ln('```');
   ln();
 
+  // --- Transport auth ---
+  // Clarifies the operator-private posture and points at the right discovery
+  // vector (WWW-Authenticate / PRM) so future "should we add auth_methods to
+  // capabilities?" proposals land with the precedent already documented.
+  // Closes #1724.
+  ln(`## Transport auth`);
+  ln();
+  ln(
+    `AdCP is auth-scheme-agnostic at the transport layer. The protocol carries JSON-RPC over HTTP; how the outer envelope is gated is an operator-private deployment choice — bearer tokens, OAuth, mTLS, AWS SigV4 at the edge, an IP allow-list, or RFC 7617 HTTP Basic when the agent sits behind an API gateway with a BasicAuthentication policy (Apigee, Kong, AWS API Gateway, nginx \`auth_basic\`) are all valid. \`get_adcp_capabilities\` does NOT advertise the accepted auth schemes; encoding every gateway permutation in the capability payload would couple the protocol to infrastructure choices that change between deployments.`
+  );
+  ln();
+  ln(
+    `Auth-scheme discovery, when needed, flows through \`WWW-Authenticate\` (RFC 9110 §11.6.1) and Protected Resource Metadata (RFC 9728) — both consumed by the SDK's auth-diagnostics path. Basic-fronted agents emit \`WWW-Authenticate: Basic realm="…"\` on a 401; consumers (SDK callers, the CLI's 401-bounce path, LLM agents) should branch on the challenge scheme rather than retrying Bearer indefinitely.`
+  );
+  ln();
+  ln(
+    `The TypeScript SDK speaks both schemes today. Programmatically: \`createTestClient({ auth: { type: 'basic', username, password } })\` (RFC 7617) and \`createTestClient({ auth: { type: 'bearer', token } })\`. From the CLI: \`--auth-scheme basic\` opts into Basic and \`--auth <user:pass>\` carries the credential; the default \`bearer\` remains unchanged.`
+  );
+  ln();
+
   // --- Error Handling ---
   ln(`## Error Handling`);
   ln();


### PR DESCRIPTION
## Summary

- Closes #1724
- Adds a "Transport auth" section to `docs/llms.txt` (immediately after Quick Start) clarifying that AdCP is auth-scheme-agnostic at the transport layer. `get_adcp_capabilities` does NOT advertise accepted auth schemes; how the outer envelope is gated is an operator-private deployment choice.
- Calls out the discovery vector: `WWW-Authenticate` (RFC 9110 §11.6.1) and PRM (RFC 9728), already consumed by `src/lib/auth/oauth/diagnose.ts`. Basic-fronted agents emit `WWW-Authenticate: Basic realm="…"` on a 401 — consumers should branch on the challenge scheme rather than retrying Bearer.

## Why

Follow-up from PR #1719 (`--auth-scheme bearer|basic` for CLI). The protocol-expert review flagged that adding first-class Basic support to the SDK / CLI may prompt a future PR proposing `auth_methods: ['bearer','basic']` in capabilities. That would couple AdCP to one infrastructure choice and invite encoding every gateway permutation (mTLS, IP allow-list, Cloudflare Access JWT, AWS SigV4). The right discovery vector is already `WWW-Authenticate` + PRM. Documenting this posture explicitly pre-empts the speculative PR.

## Test plan

- [x] Doc-only change — no code or behavior impact
- [x] Changeset (`patch`) included
- [x] Markdown renders correctly in the GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)