### PR TITLE
feat(agents): Phase 3 — weekly sync workflow from adcp

### DIFF
--- a/.changeset/phase-3-sync-workflow.md
+++ b/.changeset/phase-3-sync-workflow.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add Phase 3 cross-repo sync workflow (`.github/workflows/sync-agent-roles.yml`) — weekly job that pulls `.agents/roles/` from `adcontextprotocol/adcp` and opens a PR if there's drift.

--- a/.github/workflows/sync-agent-roles.yml
+++ b/.github/workflows/sync-agent-roles.yml
@@ -1,0 +1,86 @@
+name: Sync agent roles from adcp
+
+# Mirrors `.agents/roles/` + `scripts/import-claude-agents.mjs` from
+# the canonical source in adcontextprotocol/adcp. Opens a PR if drift
+# is detected. Runs weekly on Mondays and on-demand.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'  # Mondays, 06:17 UTC (off-peak)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Fetch canonical .agents/roles/ and sync script from adcp
+        run: |
+          set -euo pipefail
+          tmp=$(mktemp -d)
+          curl -fsSL https://github.com/adcontextprotocol/adcp/archive/refs/heads/main.tar.gz \
+            | tar -xz -C "$tmp" --strip-components=1 \
+                adcp-main/.agents/roles \
+                adcp-main/scripts/import-claude-agents.mjs
+          rm -rf .agents/roles
+          mkdir -p .agents scripts
+          cp -r "$tmp/.agents/roles" .agents/roles
+          cp "$tmp/scripts/import-claude-agents.mjs" scripts/import-claude-agents.mjs
+          rm -rf "$tmp"
+
+      - name: Regenerate .claude/agents/ from synced roles
+        run: node scripts/import-claude-agents.mjs
+
+      - name: Detect drift
+        id: diff
+        run: |
+          if git diff --quiet HEAD; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No drift — nothing to sync."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Drift detected:"
+            git diff --stat HEAD
+          fi
+
+      - name: Add empty changeset (repos that use changesets)
+        if: steps.diff.outputs.changed == 'true' && hashFiles('.changeset/config.json') != ''
+        run: |
+          mkdir -p .changeset
+          cat > .changeset/sync-agent-roles.md <<'EOF'
+          ---
+          ---
+
+          Sync `.agents/roles/` from canonical source in `adcontextprotocol/adcp`.
+          EOF
+
+      - uses: peter-evans/create-pull-request@v7
+        if: steps.diff.outputs.changed == 'true'
+        with:
+          branch: claude-routine/sync-agent-roles
+          base: main
+          title: 'chore(agents): sync .agents/roles/ from adcp'
+          commit-message: 'chore(agents): sync .agents/roles/ from adcp'
+          delete-branch: true
+          body: |
+            Automated weekly sync from `adcontextprotocol/adcp:.agents/roles/`
+            and `scripts/import-claude-agents.mjs`.
+
+            Run by `.github/workflows/sync-agent-roles.yml`.
+
+            **CI note:** PRs opened by GitHub Actions' default `GITHUB_TOKEN`
+            don't trigger downstream `pull_request` workflows. The same job
+            re-ran `node scripts/import-claude-agents.mjs` before opening
+            this PR, so `.claude/agents/` already matches the synced source.
+            To force a fresh CI run, close and reopen this PR, or push an
+            empty commit.


### PR DESCRIPTION
## Summary

Phase 3 of the agent-roles unification (Phase 1: [adcp#4500](https://github.com/adcontextprotocol/adcp/pull/4500), Phase 2: this repo's prior adoption PR).

Adds `.github/workflows/sync-agent-roles.yml` — a weekly job that:

1. Fetches `.agents/roles/` and `scripts/import-claude-agents.mjs` from `adcontextprotocol/adcp:main`
2. Regenerates `.claude/agents/` locally via the synced script
3. Opens a PR titled `chore(agents): sync .agents/roles/ from adcp` if anything drifted

`adcp` is now the canonical source of truth across all 5 AdCP repos. Edit roles once in adcp; this workflow propagates to consumers automatically.

## Schedule

- **Cron**: every Monday at 06:17 UTC
- **Manual**: workflow_dispatch (run from Actions tab anytime)

## Caveats

- PRs opened by GitHub Actions' default `GITHUB_TOKEN` don't trigger downstream `pull_request` workflows. The sync job re-runs the import script itself before opening the PR, so by construction `.claude/agents/` already matches the synced source. To force a fresh CI run on a sync PR, close-and-reopen or push an empty commit.
- If a repo grows divergence that needs to be preserved (a role with repo-specific tuning), this workflow will overwrite it. Phase 4 (if ever needed) would add per-repo override support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)