### PR TITLE
feat(types): export BrandJson / AdagentsJson from public surface

### DIFF
--- a/.changeset/export-wellknown-types.md
+++ b/.changeset/export-wellknown-types.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Re-export `BrandJson`, `AdagentsJson`, and their Zod schemas (`BrandJsonSchema`, `AdagentsJsonSchema`) from `@adcp/sdk`. Adopters resolving brand.json / adagents.json can now derive types directly from the canonical schemas instead of hand-rolling interfaces that drift from the spec (e.g. `type BrandDefinition = Extract<BrandJson, { brands: unknown[] }>['brands'][number]`). Closes #1739.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1517,6 +1517,24 @@ Variant-specific fields:
 
 **CPV note**: The `parameters.view_threshold` is required and defines what counts as a "view". Use a number for percentage-based thresholds or `{ duration_seconds }` for time-based thresholds.
 
+## Well-Known Files
+
+Inferred types and Zod schemas for the AdCP well-known JSON files. Use these when ingesting `.well-known/brand.json` or `.well-known/adagents.json` instead of hand-rolling interfaces (which drift when the spec bumps).
+
+```typescript
+import { BrandJsonSchema, type BrandJson, type AdagentsJson } from '@adcp/sdk';
+
+// brand.json is a union: redirect | house-redirect | portfolio
+// Narrow with Extract to get just the portfolio shape:
+type BrandPortfolio = Extract<BrandJson, { brands: unknown[] }>;
+type BrandDefinition = BrandPortfolio['brands'][number];
+
+// Parse at the boundary with the Zod schema:
+const brand = BrandJsonSchema.parse(await res.json());
+```
+
+Source of truth: `schemas/cache/{version}/brand.json` and `adagents.json` — regenerate with `npm run generate-wellknown-schemas` when the spec bumps.
+
 ## Key Enums
 
 | Enum | Values |

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -1310,6 +1310,30 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   );
   ln();
 
+  // --- Well-Known Files ---
+  ln(`## Well-Known Files`);
+  ln();
+  ln(
+    `Inferred types and Zod schemas for the AdCP well-known JSON files. Use these when ingesting \`.well-known/brand.json\` or \`.well-known/adagents.json\` instead of hand-rolling interfaces (which drift when the spec bumps).`
+  );
+  ln();
+  ln('```typescript');
+  ln(`import { BrandJsonSchema, type BrandJson, type AdagentsJson } from '@adcp/sdk';`);
+  ln();
+  ln(`// brand.json is a union: redirect | house-redirect | portfolio`);
+  ln(`// Narrow with Extract to get just the portfolio shape:`);
+  ln(`type BrandPortfolio = Extract<BrandJson, { brands: unknown[] }>;`);
+  ln(`type BrandDefinition = BrandPortfolio['brands'][number];`);
+  ln();
+  ln(`// Parse at the boundary with the Zod schema:`);
+  ln(`const brand = BrandJsonSchema.parse(await res.json());`);
+  ln('```');
+  ln();
+  ln(
+    `Source of truth: \`schemas/cache/{version}/brand.json\` and \`adagents.json\` — regenerate with \`npm run generate-wellknown-schemas\` when the spec bumps.`
+  );
+  ln();
+
   // --- Enums ---
   ln(`## Key Enums`);
   ln();

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -338,3 +338,12 @@ export * from './inline-enums.aliases';
 // (adcp#3149 / adcp#3566 canonicalized SCREAMING_SNAKE titles into Title Case).
 // Each alias is `@deprecated`; slated for removal in the next major.
 export * from './error-details.aliases';
+
+// Well-known file shapes (brand.json, adagents.json) inferred from the
+// canonical Zod schemas. Re-exported so adopters can derive types like
+// `BrandDefinition` directly from the spec instead of hand-rolling
+// interfaces that drift across versions. Source of truth is the schema
+// cache (`schemas/cache/{version}/{brand,adagents}.json`) — regenerate
+// with `npm run generate-wellknown-schemas` when the spec bumps.
+export type { BrandJson, AdagentsJson } from './wellknown-schemas.generated';
+export { BrandJsonSchema, AdagentsJsonSchema } from './wellknown-schemas.generated';


### PR DESCRIPTION
## Summary

- Re-export `BrandJson`, `AdagentsJson`, `BrandJsonSchema`, `AdagentsJsonSchema` from `src/lib/types/index.ts` so they flow through the `@adcp/sdk` root entry.
- Closes #1739.

The `wellknown-schemas.generated.ts` module already emits these inferred types from the canonical Zod schemas, but every public entry point omitted them. Consumers wanting a typed brand.json shape had to either deep-import `dist/lib/types/wellknown-schemas.generated` (fragile across SDK versions) or hand-roll an interface that drifts from the spec — exactly what bit `adcontextprotocol/adcp#4512`, where a pre-unify `BrandDefinition` snapshot was missing 13+ fields added by the schema unify commit, causing `/api/brands/resolve` to return an empty `brand_manifest`.

With this PR, server code can derive its types directly from the spec:

```ts
import type { BrandJson } from '@adcp/sdk';
type BrandJsonHousePortfolio = Extract<BrandJson, { brands: unknown[] }>;
export type BrandDefinition = BrandJsonHousePortfolio['brands'][number];
```

## Test plan

- [x] `npm run build` succeeds; `dist/lib/types/index.d.ts` now contains `export type { BrandJson, AdagentsJson }` and the two schema re-exports.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run format:check` clean.
- [ ] CI green on changeset check + build + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)