### PR TITLE
fix(server): tighten IDEMPOTENCY_IN_FLIGHT retry-after hint (closes #1687)

### DIFF
--- a/.changeset/idempotency-in-flight-retry-after-cap.md
+++ b/.changeset/idempotency-in-flight-retry-after-cap.md
@@ -1,0 +1,12 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(server): return IDEMPOTENCY_IN_FLIGHT on in-flight idempotency key (closes #1687)
+
+Tightens the in-flight retry-hint contract on the AdCP-3.1-held `IDEMPOTENCY_IN_FLIGHT` error code:
+
+- `retry_after` is now derived from the in-flight claim's remaining TTL (`expiresAt - now`), capped at 30s. Previously the hint used elapsed time capped at 5s, which meant a freshly-claimed key surfaced `retry_after: 1` and buyers retried instantly. Buyers now wait closer to the expected completion and the hint decays as the claim ages.
+- `error-compliance.ts` exempts the spec-reserved `IDEMPOTENCY_IN_FLIGHT` code from the `X_` vendor-prefix naming-convention check via a new `SPEC_RESERVED_PENDING_CODES` set. Without the exemption, agents emitting the held code would be flagged as non-standard until 3.1 codegen lands the value in `ErrorCodeValues`.
+
+Wire shape is otherwise unchanged: `recovery: 'transient'` plus a numeric `retry_after` hint, behaviorally a no-op for buyer SDKs that already honor transient-retry.

--- a/src/lib/server/idempotency/store.ts
+++ b/src/lib/server/idempotency/store.ts
@@ -162,11 +162,12 @@ export type IdempotencyCheckResult =
       /** A parallel request is currently executing the same key — the caller should retry the check. */
       kind: 'in-flight';
       /**
-       * Suggested retry delay in seconds, derived from how long the first
-       * request has been running. The middleware surfaces this as the
-       * `retry_after` hint on the `IDEMPOTENCY_IN_FLIGHT` response so a
-       * buyer's transient-retry doesn't slam back instantly when the first
-       * call is long-running. Always `>= 1`.
+       * Suggested retry delay in seconds, derived from the remaining TTL on
+       * the first request's in-flight claim (`expiresAt - now`, capped at
+       * `IN_FLIGHT_RETRY_HINT_CAP_SECONDS`). The middleware surfaces this as
+       * the `retry_after` hint on the `IDEMPOTENCY_IN_FLIGHT` response so a
+       * buyer's transient-retry decays toward the expected completion
+       * instead of slamming back instantly. Always `>= 1`.
        */
       retryAfterSeconds: number;
     }
@@ -329,26 +330,23 @@ const TRANSIENT_ERROR_TTL_SECONDS = 10;
 const IN_FLIGHT_HASH = '__adcp_in_flight__';
 /**
  * Soft cap on the retry hint surfaced to buyers on the in-flight branch.
- * Even if the first request still has 100s left on its claim, telling a
- * buyer to wait 100s is worse than the spec's "retry shortly" intent. 5s
- * is a balance — long enough to amortize a slow handler's tail latency,
- * short enough that a healthy seller's fast handlers don't stall buyer
- * retries.
+ * Without a cap, a freshly-claimed key (120s remaining) would tell the buyer
+ * to wait 120s — worse than the spec's "retry shortly" intent and worse than
+ * the buyer's own retry barrier. 30s amortizes a slow handler's tail latency
+ * without stalling buyers behind a fresh long-tail claim.
  */
-const IN_FLIGHT_RETRY_HINT_CAP_SECONDS = 5;
+const IN_FLIGHT_RETRY_HINT_CAP_SECONDS = 30;
 
 /**
- * Derive the buyer-facing `retry_after` hint from how long the first
- * request has been running. Elapsed since claim = `IN_FLIGHT_TTL_SECONDS - (expiresAt - now)`.
- * We assume the first call is roughly halfway done and suggest the buyer
- * retry after an additional `elapsed` seconds, capped at
- * `IN_FLIGHT_RETRY_HINT_CAP_SECONDS`. Always clamped to `>= 1`.
+ * Derive the buyer-facing `retry_after` hint from how much time is left on
+ * the in-flight claim (`expiresAt - now`). A freshly-claimed key surfaces
+ * `IN_FLIGHT_RETRY_HINT_CAP_SECONDS`; the hint decays as the claim ages so
+ * a buyer retrying just before expiry doesn't over-wait. Always clamped to
+ * `>= 1` so a near-expired claim doesn't tell the buyer to retry instantly.
  */
 function inFlightRetryAfter(expiresAt: number, nowSeconds: number): number {
   const remaining = expiresAt - nowSeconds;
-  const elapsed = IN_FLIGHT_TTL_SECONDS - remaining;
-  const hint = Math.max(1, Math.min(IN_FLIGHT_RETRY_HINT_CAP_SECONDS, Math.ceil(elapsed)));
-  return hint;
+  return Math.max(1, Math.min(IN_FLIGHT_RETRY_HINT_CAP_SECONDS, remaining));
 }
 
 /**

--- a/src/lib/testing/scenarios/error-compliance.ts
+++ b/src/lib/testing/scenarios/error-compliance.ts
@@ -13,6 +13,15 @@ import { extractAdcpErrorFromMcp, resolveRecovery } from '../../utils/error-extr
 import type { ExtractedAdcpError } from '../../utils/error-extraction';
 import { isStandardErrorCode } from '../../types/error-codes';
 
+/**
+ * AdCP spec-defined codes that are held for a future wire version and
+ * therefore absent from `ErrorCodeValues` in the current generated enum, but
+ * are explicitly sanctioned by the spec and must not require the `X_` vendor
+ * prefix. Remove a code from this set once it lands in `ErrorCodeValues` via
+ * schema codegen.
+ */
+const SPEC_RESERVED_PENDING_CODES = new Set(['IDEMPOTENCY_IN_FLIGHT']);
+
 /** Raw MCP CallToolResult shape */
 interface RawMcpResponse {
   isError?: boolean;
@@ -294,7 +303,11 @@ export async function testErrorStructure(
     }
 
     // Code is standard?
-    if (!isStandardErrorCode(extracted.code) && !extracted.code.startsWith('X_')) {
+    if (
+      !isStandardErrorCode(extracted.code) &&
+      !extracted.code.startsWith('X_') &&
+      !SPEC_RESERVED_PENDING_CODES.has(extracted.code)
+    ) {
       issues.push(`Non-standard code '${extracted.code}' should use X_ vendor prefix`);
     }
 

--- a/src/lib/testing/storyboard/parallel-dispatch.ts
+++ b/src/lib/testing/storyboard/parallel-dispatch.ts
@@ -37,10 +37,12 @@ export const PARALLEL_DISPATCH_COUNT_MAX = 10;
 /** Default barrier timeout when the storyboard omits `barrier_timeout_ms`. */
 export const PARALLEL_DISPATCH_DEFAULT_BARRIER_MS = 5000;
 /**
- * Per-dispatch retry budget for the in-flight branch. Sized so a slow
- * seller's first request can finish within a 5-second barrier even when
- * the SDK's retry-after hint caps at the store's 5-second hint ceiling —
- * any larger and the barrier timeout would fire first anyway.
+ * Per-dispatch retry budget for the in-flight branch. The outer barrier
+ * (default 5s, configurable) is the real cap — the dispatcher honors the
+ * seller's `retry_after` hint, then clamps every sleep to the remaining
+ * barrier so the budget mostly matters when a misbehaving seller floods
+ * tiny hints. 5 is enough headroom for that case without letting a stuck
+ * seller pin the runner past the barrier.
  */
 const IN_FLIGHT_RETRY_BUDGET = 5;
 /** Floor for the in-flight retry sleep so a misbehaving seller can't busy-loop the runner. */


### PR DESCRIPTION
Closes #1687.

The wire-code swap from `SERVICE_UNAVAILABLE` → `IDEMPOTENCY_IN_FLIGHT` (AdCP rule 9 / 3.1-held) landed in #1692, but two follow-ups from the approved-then-closed #1689 were not carried across to current `main`. This PR brings them over on top of `main`.

## Summary

- **`store.ts` — `retry_after` derivation.** Previously elapsed-time-based with a 5s cap, so a freshly-claimed key surfaced `retry_after: 1` and buyers retried instantly — the exact footgun the original hardcoded `1` introduced. Switched to `expiresAt - now` (remaining TTL) capped at 30s. A fresh claim now hints `30s` and decays as the claim ages.
- **`error-compliance.ts` — `X_`-prefix exemption.** Added `SPEC_RESERVED_PENDING_CODES = new Set(['IDEMPOTENCY_IN_FLIGHT'])` so the spec-reserved (3.1-held) code is not flagged as non-standard by the compliance validator until 3.1 codegen lands the value in `ErrorCodeValues`.
- **`parallel-dispatch.ts` — stale comment fixup.** Comment referenced the old 5s ceiling; updated to reflect that the outer barrier (not the store cap) is the real bound on retry sleeps.
- **Changeset** — `minor` bump on `@adcp/sdk`. Behavioral surface stays `recovery: 'transient'` + numeric `retry_after`, so transient-aware buyer SDKs auto-retry exactly as before; only the hint magnitude changes.

## Context vs prior PR

- #1689 (closed): same approach, approved by code-reviewer and ad-tech-protocol-expert, then closed and became conflicting.
- #1692 (merged): landed the wire-code swap (`SERVICE_UNAVAILABLE` → `IDEMPOTENCY_IN_FLIGHT`), `recovery: 'transient'`, and a 5s elapsed-time hint, but did not adopt the 30s remaining-TTL hint nor the `error-compliance.ts` exemption.

This PR resumes the rest of #1689's approved scope on top of `main`. Per-tool `concurrentRetry: 'reject' | 'wait'` option is explicitly deferred per the issue.

## The six changes called out in the triage

1. ✅ Swap `SERVICE_UNAVAILABLE` → `IDEMPOTENCY_IN_FLIGHT` — already landed in #1692
2. ✅ Derive `retry_after` from `expiresAt - now`, capped at 30s — done here (was 5s elapsed in #1692)
3. ✅ `IdempotencyCheckResult.kind: 'in-flight'` carries a derived hint field — `retryAfterSeconds` field landed in #1692; semantics updated here
4. ✅ `recovery: 'transient'` set explicitly — already landed in #1692
5. ✅ `SPEC_RESERVED_PENDING_CODES` exemption in `error-compliance.ts` — done here
6. ✅ Tests updated — `test/server-idempotency.test.js` already asserts `code === 'IDEMPOTENCY_IN_FLIGHT'`; `retry_after >= 1` assertion is satisfied by the new cap as well

## Test plan

- [x] `npm run format:check` on changed files — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build:lib` — clean
- [x] `NODE_ENV=test node --test test/server-idempotency.test.js` — 38/38 pass
- [x] `NODE_ENV=test node --test test/lib/storyboard-parallel-dispatch.test.js` — 24/24 pass
- [x] `NODE_ENV=test node --test test/lib/idempotency-*.test.js` — 44/44 pass
- [x] `NODE_ENV=test node --test test/server-errors.test.js test/lib/standard-error-codes-drift.test.js test/lib/error-scenarios.test.js test/error-extraction.test.js` — 90/90 pass
- [ ] CI

## Self-review

Ran the code-reviewer and ad-tech-protocol-expert checklists locally (subagent invocation isn't available in this environment):

- **code-reviewer:** behavior change is bounded to one wire field on one error branch; doc comments updated; the stale 5s reference in `parallel-dispatch.ts` is addressed; envelope allowlist already lists `recovery` and `retry_after` for `IDEMPOTENCY_IN_FLIGHT` so no allowlist hole. No new tests added because the existing concurrency assertions already cover the contract that matters (`code === 'IDEMPOTENCY_IN_FLIGHT'`, `recovery === 'transient'`, `retry_after >= 1`); asserting an upper bound would lock the implementation rather than the contract.
- **ad-tech-protocol-expert:** `recovery: 'transient'` + decaying `retry_after` is the AdCP-rule-9 shape; the `expiresAt - now` formula matches the spec's "decaying-hint" guidance noted in the #1689 approval; legacy `SERVICE_UNAVAILABLE` is still accepted by the parallel-dispatch runner for backward compat with SDKs that haven't migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)