### PR TITLE
feat: guard example adapter domains

### DIFF
--- a/.changeset/example-tld-guard.md
+++ b/.changeset/example-tld-guard.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add a server-side guard that fails fast when forked adapter examples still contain `.example` tenant domains outside test or development.

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -60,6 +60,7 @@ import {
   memoryBackend,
   serve,
   verifyApiKey,
+  assertNoExampleTlds,
   type AccountStore,
   type Account,
   type CreativeAdServerPlatform,
@@ -86,6 +87,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${PORT}`;
 
 const KNOWN_PUBLISHERS = ['creative-network.example', 'acmeoutdoor.example', 'pinnacle-agency.example'];
+assertNoExampleTlds(
+  { KNOWN_PUBLISHERS },
+  { allowIn: ['test', 'development'], checklistPath: 'examples/hello_creative_adapter_ad_server.ts' }
+);
 const SANDBOX_ID_PREFIX = 'sandbox_';
 
 // ---------------------------------------------------------------------------

--- a/examples/hello_creative_adapter_template.ts
+++ b/examples/hello_creative_adapter_template.ts
@@ -38,6 +38,7 @@ import {
   memoryBackend,
   AdcpError,
   defineCreativeBuilderPlatform,
+  assertNoExampleTlds,
   type DecisioningPlatform,
   type CreativeBuilderPlatform,
   type BuildCreativeReturn,
@@ -72,6 +73,10 @@ const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${
 // platforms expose a global format catalog or the workspace tied to the API
 // key's principal; the mock fixture keys templates per workspace.
 const DEFAULT_LISTING_WORKSPACE = process.env['DEFAULT_LISTING_WORKSPACE'] ?? 'ws_acme_studio';
+assertNoExampleTlds(
+  { DEFAULT_LISTING_WORKSPACE, PUBLIC_AGENT_URL },
+  { allowIn: ['test', 'development'], checklistPath: 'examples/hello_creative_adapter_template.ts' }
+);
 
 // ---------------------------------------------------------------------------
 // Upstream client — SWAP for production.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -68,6 +68,7 @@ import {
   AdcpError,
   getAccountMode,
   assertMediaBuyTransition,
+  assertNoExampleTlds,
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
@@ -101,6 +102,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${PORT}`;
 
 const KNOWN_PUBLISHERS = ['acmeoutdoor.example', 'pinnacle-agency.example', 'premium-sports.example'];
+assertNoExampleTlds(
+  { KNOWN_PUBLISHERS },
+  { allowIn: ['test', 'development'], checklistPath: 'examples/hello_seller_adapter_guaranteed.ts' }
+);
 
 // SWAP: the seller's minimum committable max_variance_percent — the
 // buyer-vs-seller billing-count delta this seller will tolerate before

--- a/examples/hello_seller_adapter_non_guaranteed.ts
+++ b/examples/hello_seller_adapter_non_guaranteed.ts
@@ -62,6 +62,7 @@ import {
   createMediaBuyStore,
   InMemoryStateStore,
   assertMediaBuyTransition,
+  assertNoExampleTlds,
   type DecisioningPlatform,
   type SalesCorePlatform,
   type SalesIngestionPlatform,
@@ -96,6 +97,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${PORT}`;
 
 const KNOWN_PUBLISHERS = ['remnant-network.example', 'acmeoutdoor.example', 'pinnacle-agency.example'];
+assertNoExampleTlds(
+  { KNOWN_PUBLISHERS },
+  { allowIn: ['test', 'development'], checklistPath: 'examples/hello_seller_adapter_non_guaranteed.ts' }
+);
 
 // TEST-ONLY: id-prefix used by the sandbox arm in `accounts.resolve` so
 // production sellers don't need this; remove the sandbox arm + this

--- a/examples/hello_seller_adapter_social.ts
+++ b/examples/hello_seller_adapter_social.ts
@@ -38,6 +38,7 @@ import {
   AdcpError,
   defineSalesPlatform,
   defineAudiencePlatform,
+  assertNoExampleTlds,
   type DecisioningPlatform,
   type SalesPlatform,
   type AudiencePlatform,
@@ -303,6 +304,10 @@ interface AdvertiserMeta {
 // AdCP-side identifiers from the mock's seed data. SWAP: replace with a
 // real `/advertiser/list` call.
 const KNOWN_ADVERTISERS = ['acmeoutdoor.example', 'summit-media.example'];
+assertNoExampleTlds(
+  { KNOWN_ADVERTISERS },
+  { allowIn: ['test', 'development'], checklistPath: 'examples/hello_seller_adapter_social.ts' }
+);
 
 // Buyer event_source_id → upstream pixel_id translation map. The mock
 // ignores buyer-supplied pixel_id and assigns its own (`px_<uuid>`); buyers

--- a/examples/hello_si_adapter_brand.ts
+++ b/examples/hello_si_adapter_brand.ts
@@ -47,6 +47,7 @@ import {
   createUpstreamHttpClient,
   memoryBackend,
   AdcpError,
+  assertNoExampleTlds,
   type AccountStore,
   type Account,
 } from '@adcp/sdk/server';
@@ -81,6 +82,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 // tenant), so a hardcoded default is fine. Multi-brand deployments derive
 // from `ctx.authInfo` per-API-key binding instead.
 const DEFAULT_LISTING_BRAND = process.env['DEFAULT_LISTING_BRAND'] ?? 'brand_nova_motors';
+assertNoExampleTlds(
+  { DEFAULT_LISTING_BRAND },
+  { allowIn: ['test', 'development'], checklistPath: 'examples/hello_si_adapter_brand.ts' }
+);
 
 // ---------------------------------------------------------------------------
 // Upstream client — SWAP for production.

--- a/src/lib/server/example-tld-guard.ts
+++ b/src/lib/server/example-tld-guard.ts
@@ -1,0 +1,29 @@
+export interface AssertNoExampleTldsOptions {
+  allowIn?: readonly string[];
+  checklistPath?: string;
+  env?: string;
+}
+
+type ExampleTldConstants = Record<string, string | readonly string[] | null | undefined>;
+
+const DEFAULT_ALLOWED_ENVS = ['test', 'development'] as const;
+const EXAMPLE_TLD_PATTERN = /(?:^|[/:@.\s])[\w-]+\.example(?=$|[/:?#\s"'`<>)\],;}])/i;
+
+function valuesFor(value: string | readonly string[] | null | undefined): readonly string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value;
+  return [];
+}
+
+export function assertNoExampleTlds(constants: ExampleTldConstants, opts: AssertNoExampleTldsOptions = {}): void {
+  const env = opts.env ?? process.env.NODE_ENV;
+  const allowIn = opts.allowIn ?? DEFAULT_ALLOWED_ENVS;
+  if (env !== undefined && allowIn.includes(env)) return;
+
+  for (const [key, value] of Object.entries(constants)) {
+    if (valuesFor(value).some(entry => EXAMPLE_TLD_PATTERN.test(entry))) {
+      const checklist = opts.checklistPath ? ` in ${opts.checklistPath}` : '';
+      throw new Error(`Adapter forked without flipping ${key}; see FORK CHECKLIST${checklist}`);
+    }
+  }
+}

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -40,6 +40,9 @@ export type { OperationalPlatform, OperationalContext } from './operational-plat
 export { pickWireSpecFields, scrubExtensions, WIRE_SPEC_FIELDS } from './wire-safe';
 export type { WireSafe, WireSpecRequestName, ScrubExtensionsOptions } from './wire-safe';
 
+export { assertNoExampleTlds } from './example-tld-guard';
+export type { AssertNoExampleTldsOptions } from './example-tld-guard';
+
 export {
   capabilitiesResponse,
   productsResponse,

--- a/test/lib/example-tld-guard.test.js
+++ b/test/lib/example-tld-guard.test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { assertNoExampleTlds } = require('../../dist/lib/server/index.js');
+
+test('assertNoExampleTlds throws for example domains outside allowed envs', () => {
+  assert.throws(
+    () =>
+      assertNoExampleTlds(
+        { KNOWN_PUBLISHERS: ['acmeoutdoor.example', 'seller.example'] },
+        {
+          allowIn: ['test', 'development'],
+          checklistPath: 'examples/hello_seller_adapter_guaranteed.ts',
+          env: 'production',
+        }
+      ),
+    /Adapter forked without flipping KNOWN_PUBLISHERS; see FORK CHECKLIST in examples\/hello_seller_adapter_guaranteed\.ts/
+  );
+});
+
+test('assertNoExampleTlds passes when constants have been flipped', () => {
+  assert.doesNotThrow(() =>
+    assertNoExampleTlds(
+      { KNOWN_PUBLISHERS: ['seller.example.com', 'publisher.test'], API_URL: 'https://seller.test/api' },
+      { allowIn: ['test', 'development'], env: 'production' }
+    )
+  );
+});
+
+test('assertNoExampleTlds is disabled in explicitly allowed envs', () => {
+  assert.doesNotThrow(() =>
+    assertNoExampleTlds(
+      { KNOWN_PUBLISHERS: ['acmeoutdoor.example'] },
+      { allowIn: ['test', 'development'], env: 'development' }
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add `assertNoExampleTlds` to `@adcp/sdk/server` for startup checks outside test/development
- wire the guard into the six checklist-backed adapter examples
- add regression coverage and a patch changeset

Fixes #1747.

## Checks
- `npm run build:lib`
- `node --test test/lib/example-tld-guard.test.js`
- `npm run typecheck:examples`
- `NODE_ENV=test node --test-timeout=180000 --test-force-exit --test-concurrency=1 --test test/examples/hello-seller-adapter-guaranteed.test.js test/examples/hello-seller-adapter-non-guaranteed.test.js test/examples/hello-seller-adapter-social.test.js test/examples/hello-creative-adapter-template.test.js test/examples/hello-creative-adapter-ad-server.test.js test/examples/hello-si-adapter-brand.test.js`
- `npm run test:lib`

Pre-push also ran `npm run format:check`, `npm run typecheck` and `npm run build:lib`.