### PR TITLE
fix(client): pass text/event-stream responses through enforceSizeLimit (#1176)

### DIFF
--- a/.changeset/sse-bypass-size-limit.md
+++ b/.changeset/sse-bypass-size-limit.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(client): pass `text/event-stream` responses through `enforceSizeLimit` (#1176)
+
+The response-body byte cap was designed for one-shot JSON discovery responses
+(`get_adcp_capabilities`, agent-card lookup). SSE responses legitimately stream
+N status frames + a final result frame whose cumulative bytes can exceed any
+reasonable cap, but each frame is bounded by protocol-level framing. Bypass the
+cap for `text/event-stream` (case-insensitive prefix match, covers `; charset=utf-8`
+variants). Adopters can now safely set `maxResponseBytes` on long-lived buyer
+sessions without tearing down legitimate streams.

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -166,12 +166,12 @@ export interface TransportOptions {
    * value set on the client constructor (`SingleAgentClientConfig.transport`).
    *
    * @remarks
-   * **Leave unset for long-lived buyer sessions.** When set, the cap applies
-   * to every fetch in the call's ALS scope — including any side-channel
-   * `GET` the MCP transport opens for server-initiated messages. Long-lived
-   * connections that legitimately stream more cumulative bytes than the cap
-   * will be torn down. The option is intended for one-shot discovery / crawl
-   * paths where the response is bounded by definition.
+   * **Safe to set on all calls.** SSE responses (`text/event-stream`) are
+   * passed through unchanged — a single tool call legitimately emits N status
+   * frames + a final result, bounded by protocol-level framing rather than
+   * cumulative byte counts. The cap applies to one-shot JSON responses
+   * (`get_adcp_capabilities`, agent-card lookup, tool result payloads on
+   * non-streaming transports) where the body is bounded by definition.
    *
    * @remarks
    * Future hardening knobs (DNS-rebind defense, scheme allow-list, request

--- a/src/lib/protocols/responseSizeLimit.ts
+++ b/src/lib/protocols/responseSizeLimit.ts
@@ -100,6 +100,14 @@ export function wrapFetchWithSizeLimit(upstream: typeof fetch): typeof fetch {
 }
 
 function enforceSizeLimit(response: Response, maxBytes: number, url: string): Response {
+  // SSE responses are legitimately unbounded — a single tool call emits N
+  // status frames + a final result. Pass through; the protocol-level framing
+  // terminates the stream, not byte counts. Case-insensitive prefix match
+  // covers `text/event-stream; charset=utf-8` and `Text/Event-Stream` variants.
+  if (response.headers.get('content-type')?.toLowerCase().startsWith('text/event-stream')) {
+    return response;
+  }
+
   // Cheap pre-check: if the server declares a Content-Length over the cap,
   // tear the connection down before reading any of the body. Servers can
   // omit or lie about Content-Length, which is why the streaming counter

--- a/test/unit/response-size-limit.test.js
+++ b/test/unit/response-size-limit.test.js
@@ -215,6 +215,62 @@ describe('responseSizeLimit — wrapFetchWithSizeLimit', () => {
   });
 });
 
+describe('responseSizeLimit — SSE pass-through', () => {
+  it('passes text/event-stream responses through unchanged even when body exceeds the cap', async () => {
+    // SSE responses are legitimately unbounded — a single tool call emits N
+    // status frames + a final result. The cap is intended for one-shot JSON
+    // discovery payloads; applying it to SSE would tear down legitimate
+    // long-lived tool calls mid-stream.
+    const oversized = new Uint8Array(10_000); // 10× the cap
+    const upstream = makeFetch(oversized, { 'content-type': 'text/event-stream' });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    const out = await withResponseSizeLimit(1000, async () => {
+      const response = await wrapped('https://example.invalid/');
+      return new Uint8Array(await response.arrayBuffer());
+    });
+
+    assert.strictEqual(out.byteLength, 10_000);
+  });
+
+  it('passes text/event-stream with charset parameters through (case-insensitive prefix match)', async () => {
+    // Some servers send `text/event-stream; charset=utf-8` or `Text/Event-Stream`.
+    // Lowercase prefix match covers both variants.
+    for (const contentType of [
+      'text/event-stream; charset=utf-8',
+      'Text/Event-Stream',
+      'TEXT/EVENT-STREAM; charset=utf-8',
+    ]) {
+      const oversized = new Uint8Array(10_000);
+      const upstream = makeFetch(oversized, { 'content-type': contentType });
+      const wrapped = wrapFetchWithSizeLimit(upstream);
+
+      const out = await withResponseSizeLimit(1000, async () => {
+        const response = await wrapped('https://example.invalid/');
+        return new Uint8Array(await response.arrayBuffer());
+      });
+
+      assert.strictEqual(out.byteLength, 10_000, `content-type=${contentType} must pass through`);
+    }
+  });
+
+  it('still enforces the cap on application/json responses 10× the cap (regression check)', async () => {
+    // Negative case: the SSE bypass must not accidentally weaken the cap on
+    // the one-shot JSON discovery path it was designed for.
+    const oversized = new Uint8Array(10_000);
+    const upstream = makeFetch(oversized, { 'content-type': 'application/json' });
+    const wrapped = wrapFetchWithSizeLimit(upstream);
+
+    await assert.rejects(
+      withResponseSizeLimit(1000, async () => {
+        const response = await wrapped('https://hostile.invalid/');
+        return response.arrayBuffer();
+      }),
+      err => err instanceof ResponseTooLargeError
+    );
+  });
+});
+
 describe('responseSizeLimit — gzip-bomb defense', () => {
   it("forces Accept-Encoding: identity when the cap is active so the byte counter sees what's on the wire", async () => {
     // Without this, undici's default `Accept-Encoding: gzip, deflate, br`


### PR DESCRIPTION
## Summary

Closes #1176.

`enforceSizeLimit` in `src/lib/protocols/responseSizeLimit.ts` currently applies the byte cap to all responses. SSE responses (`text/event-stream`) legitimately stream N status frames + a final result whose cumulative bytes can exceed any reasonable cap — but each frame is bounded by protocol-level framing, not byte counts. The cap was designed for one-shot JSON discovery (`get_adcp_capabilities`, agent-card lookup), not long-lived event streams.

This change adds an early return at the top of `enforceSizeLimit` that passes SSE responses through unchanged. Case-insensitive prefix match handles `text/event-stream; charset=utf-8` and `Text/Event-Stream` variants.

Also updates the `TransportOptions.maxResponseBytes` TSDoc: the previous "leave unset for long-lived buyer sessions" caveat is no longer accurate once SSE is bypassed — adopters can safely set the cap on all calls.

## Test plan

- [x] New SSE pass-through suite in `test/unit/response-size-limit.test.js`:
  - SSE response with body 10x the cap passes through without throwing
  - `text/event-stream; charset=utf-8` and `Text/Event-Stream` variants pass through
  - `application/json` response 10x the cap still throws `ResponseTooLargeError` (regression check)
- [x] `node --test test/unit/response-size-limit.test.js` — 22/22 pass
- [x] `npm run format:check` clean
- [x] Changeset added (patch)