### PR TITLE
feat(server): assertNoExampleTlds helper + wire into hello_* examples (#1747)

### DIFF
--- a/.changeset/assert-no-example-tlds-1747.md
+++ b/.changeset/assert-no-example-tlds-1747.md
@@ -1,0 +1,55 @@
+---
+'@adcp/sdk': patch
+---
+
+feat(server): `assertNoExampleTlds` helper + wire into hello\_\* examples (#1747)
+
+Adopters who fork a `hello_*_adapter_*.ts` worked example sometimes ship
+without flipping `KNOWN_PUBLISHERS = ['acmeoutdoor.example', ...]` and
+similar seed constants from the FORK CHECKLIST. The header reminder is
+easy to miss; the result is `.example`-TLD seed data leaking into
+production tenant directories.
+
+`assertNoExampleTlds(constants, opts?)` turns the reminder into a runtime
+assertion. Called at module load with the load-bearing constants, it
+throws a descriptive error before the server starts serving traffic when:
+
+- any string value or string-array element ends with `.example`
+  (case-insensitive), AND
+- `NODE_ENV` is not in the allowlist (default `['test', 'development']`).
+
+Gating uses an exact-match allowlist rather than `NODE_ENV !== 'production'`
+so unset or typo'd `NODE_ENV` fails closed.
+
+Usage:
+
+```ts
+import { assertNoExampleTlds } from '@adcp/sdk/server';
+
+const KNOWN_PUBLISHERS = ['acmeoutdoor.example', 'premium-sports.example'];
+
+// Fail fast when this fork still ships with `.example`-TLD seed data
+// outside of dev/test.
+assertNoExampleTlds({ KNOWN_PUBLISHERS });
+```
+
+Custom allowlist (e.g., to permit a staging environment):
+
+```ts
+assertNoExampleTlds({ KNOWN_PUBLISHERS }, { allowIn: ['test', 'development', 'staging'] });
+```
+
+The helper scans string values and string-array elements; numbers,
+booleans, and nested objects are ignored so adjacent module constants
+can be passed without curating. `.example.com` (RFC 2606 reserved
+second-level domain — legitimate in demo URLs) is NOT flagged; only
+the bare `.example` TLD is the smell we guard against.
+
+Wired into the five worked examples that ship `.example`-TLD seed
+constants:
+
+- `examples/hello_creative_adapter_ad_server.ts` (`KNOWN_PUBLISHERS`)
+- `examples/hello_seller_adapter_guaranteed.ts` (`KNOWN_PUBLISHERS`)
+- `examples/hello_seller_adapter_non_guaranteed.ts` (`KNOWN_PUBLISHERS`)
+- `examples/hello_seller_adapter_proposal_mode.ts` (`KNOWN_PUBLISHERS`)
+- `examples/hello_seller_adapter_social.ts` (`KNOWN_ADVERTISERS`)

--- a/examples/hello_creative_adapter_ad_server.ts
+++ b/examples/hello_creative_adapter_ad_server.ts
@@ -54,6 +54,7 @@
 
 import {
   AdcpError,
+  assertNoExampleTlds,
   createAdcpServerFromPlatform,
   createIdempotencyStore,
   createUpstreamHttpClient,
@@ -87,6 +88,10 @@ const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${
 
 const KNOWN_PUBLISHERS = ['creative-network.example', 'acmeoutdoor.example', 'pinnacle-agency.example'];
 const SANDBOX_ID_PREFIX = 'sandbox_';
+
+// Fail fast if this fork still ships with `.example`-TLD seed data outside
+// of dev/test. See FORK CHECKLIST.
+assertNoExampleTlds({ KNOWN_PUBLISHERS });
 
 // ---------------------------------------------------------------------------
 // Upstream client — SWAP for production.

--- a/examples/hello_seller_adapter_guaranteed.ts
+++ b/examples/hello_seller_adapter_guaranteed.ts
@@ -56,6 +56,7 @@
  */
 
 import {
+  assertNoExampleTlds,
   createAdcpServerFromPlatform,
   createMediaBuyStore,
   createInMemoryTaskRegistry,
@@ -101,6 +102,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${PORT}`;
 
 const KNOWN_PUBLISHERS = ['acmeoutdoor.example', 'pinnacle-agency.example', 'premium-sports.example'];
+
+// Fail fast if this fork still ships with `.example`-TLD seed data outside
+// of dev/test. See FORK CHECKLIST item 2.
+assertNoExampleTlds({ KNOWN_PUBLISHERS });
 
 // SWAP: the seller's minimum committable max_variance_percent — the
 // buyer-vs-seller billing-count delta this seller will tolerate before

--- a/examples/hello_seller_adapter_non_guaranteed.ts
+++ b/examples/hello_seller_adapter_non_guaranteed.ts
@@ -52,6 +52,7 @@
  */
 
 import {
+  assertNoExampleTlds,
   createAdcpServerFromPlatform,
   serve,
   verifyApiKey,
@@ -96,6 +97,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${PORT}`;
 
 const KNOWN_PUBLISHERS = ['remnant-network.example', 'acmeoutdoor.example', 'pinnacle-agency.example'];
+
+// Fail fast if this fork still ships with `.example`-TLD seed data outside
+// of dev/test. See FORK CHECKLIST.
+assertNoExampleTlds({ KNOWN_PUBLISHERS });
 
 // TEST-ONLY: id-prefix used by the sandbox arm in `accounts.resolve` so
 // production sellers don't need this; remove the sandbox arm + this

--- a/examples/hello_seller_adapter_proposal_mode.ts
+++ b/examples/hello_seller_adapter_proposal_mode.ts
@@ -32,6 +32,7 @@
 
 import {
   AdcpError,
+  assertNoExampleTlds,
   createAdcpServerFromPlatform,
   createIdempotencyStore,
   createInMemoryTaskRegistry,
@@ -79,6 +80,10 @@ const ADCP_AUTH_TOKEN = process.env['ADCP_AUTH_TOKEN'] ?? 'sk_harness_do_not_use
 const PUBLIC_AGENT_URL = process.env['PUBLIC_AGENT_URL'] ?? `http://127.0.0.1:${PORT}`;
 
 const KNOWN_PUBLISHERS = ['premium-sports.example', 'acmeoutdoor.example', 'pinnacle-agency.example'];
+
+// Fail fast if this fork still ships with `.example`-TLD seed data outside
+// of dev/test. See FORK CHECKLIST.
+assertNoExampleTlds({ KNOWN_PUBLISHERS });
 
 // ---------------------------------------------------------------------------
 // Upstream client

--- a/examples/hello_seller_adapter_social.ts
+++ b/examples/hello_seller_adapter_social.ts
@@ -29,6 +29,7 @@
  */
 
 import {
+  assertNoExampleTlds,
   createAdcpServerFromPlatform,
   serve,
   verifyApiKey,
@@ -303,6 +304,10 @@ interface AdvertiserMeta {
 // AdCP-side identifiers from the mock's seed data. SWAP: replace with a
 // real `/advertiser/list` call.
 const KNOWN_ADVERTISERS = ['acmeoutdoor.example', 'summit-media.example'];
+
+// Fail fast if this fork still ships with `.example`-TLD seed data outside
+// of dev/test. See FORK CHECKLIST.
+assertNoExampleTlds({ KNOWN_ADVERTISERS });
 
 // Buyer event_source_id → upstream pixel_id translation map. The mock
 // ignores buyer-supplied pixel_id and assigns its own (`px_<uuid>`); buyers

--- a/src/lib/server/assert-no-example-tlds.ts
+++ b/src/lib/server/assert-no-example-tlds.ts
@@ -1,0 +1,78 @@
+/**
+ * Fail-fast startup guard for adopters who fork a `hello_*_adapter_*.ts`
+ * worked example and ship without flipping the seed constants.
+ *
+ * The worked examples wire load-bearing tenant directories like
+ * `KNOWN_PUBLISHERS = ['acmeoutdoor.example', ...]`. The FORK CHECKLIST
+ * header tells adopters to replace those values before deploying, but a
+ * checklist is only as strong as the reader. This helper turns the
+ * reminder into a runtime assertion: if `.example`-TLD strings are still
+ * present at module load and `NODE_ENV` isn't in the dev/test allowlist,
+ * the process exits with a descriptive error before serving traffic.
+ *
+ * Gating uses an explicit `allowIn` allowlist ({ 'test', 'development' }
+ * by default) rather than `NODE_ENV !== 'production'` — unset / typo'd
+ * env values must fail closed, not be treated as "probably dev."
+ */
+
+export interface AssertNoExampleTldsOptions {
+  /**
+   * Skip the assertion when `NODE_ENV` matches one of these values.
+   * Default: `['test', 'development']`.
+   *
+   * The allowlist is exact-match (no startsWith / regex). Unset or
+   * unknown `NODE_ENV` always triggers the assertion.
+   */
+  allowIn?: string[];
+}
+
+/**
+ * Throws if any string in `constants` ends with `.example` (case-insensitive)
+ * when `NODE_ENV` is not in the allowlist. Designed to catch adopters who
+ * fork a `hello_*_adapter` example and ship without flipping the seed
+ * constants in the FORK CHECKLIST.
+ *
+ * Pass the record shape `{ KNOWN_PUBLISHERS, KNOWN_ADVERTISERS, ... }`;
+ * the helper scans string values and string-array elements. Other value
+ * types are ignored (numbers, booleans, nested objects), so it's safe to
+ * pass adjacent module constants without false positives.
+ *
+ * @example
+ *   const KNOWN_PUBLISHERS = ['acmeoutdoor.example', 'premium-sports.example'];
+ *   assertNoExampleTlds({ KNOWN_PUBLISHERS });
+ *   // Throws unless NODE_ENV is 'test' or 'development'.
+ */
+export function assertNoExampleTlds(constants: Record<string, unknown>, opts: AssertNoExampleTldsOptions = {}): void {
+  const allowIn = opts.allowIn ?? ['test', 'development'];
+  const nodeEnv = process.env['NODE_ENV'] ?? '';
+  if (allowIn.includes(nodeEnv)) return;
+
+  const offenders: Array<{ key: string; value: string }> = [];
+  for (const [key, value] of Object.entries(constants)) {
+    if (typeof value === 'string') {
+      if (endsWithExampleTld(value)) {
+        offenders.push({ key, value });
+      }
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (typeof item === 'string' && endsWithExampleTld(item)) {
+          offenders.push({ key, value: item });
+        }
+      }
+    }
+  }
+
+  if (offenders.length === 0) return;
+
+  const detail = offenders.map(o => `  ${o.key}: ${o.value}`).join('\n');
+  throw new Error(
+    `Adapter forked without flipping example constants:\n${detail}\n\n` +
+      `Set NODE_ENV=development or NODE_ENV=test if these are intentional, ` +
+      `or update the constants in your fork. See the FORK CHECKLIST in the ` +
+      `worked example for the full list.`
+  );
+}
+
+function endsWithExampleTld(s: string): boolean {
+  return /\.example$/i.test(s);
+}

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -106,6 +106,9 @@ export {
 export { getAccountMode, isSandboxOrMockAccount, assertSandboxAccount } from './account-mode';
 export type { AccountMode } from './account-mode';
 
+export { assertNoExampleTlds } from './assert-no-example-tlds';
+export type { AssertNoExampleTldsOptions } from './assert-no-example-tlds';
+
 export {
   taskToolResponse,
   registerAdcpTaskTool,

--- a/test/unit/assert-no-example-tlds.test.js
+++ b/test/unit/assert-no-example-tlds.test.js
@@ -1,0 +1,204 @@
+/**
+ * Unit tests for `assertNoExampleTlds` — the fail-fast startup guard
+ * that catches adopters who fork a `hello_*_adapter_*.ts` example and
+ * ship without flipping the `KNOWN_PUBLISHERS = ['*.example', …]` seed
+ * data outside of dev/test.
+ *
+ * The helper is wired into each worked example at module load. These
+ * tests pin the behavior against the compiled `dist/` output so they
+ * exercise what shipped to npm, not the TypeScript source.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+
+const { assertNoExampleTlds } = require('../../dist/lib/server/assert-no-example-tlds');
+
+// NODE_ENV save/restore — the helper reads `process.env.NODE_ENV` at call
+// time, so we mutate the live env and restore the original value (which is
+// almost always 'test' when running `node --test`).
+let originalNodeEnv;
+
+describe('assertNoExampleTlds', () => {
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  describe('default allowlist behavior', () => {
+    it('does not throw when NODE_ENV is "test"', () => {
+      process.env.NODE_ENV = 'test';
+      assert.doesNotThrow(() => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }));
+    });
+
+    it('does not throw when NODE_ENV is "development"', () => {
+      process.env.NODE_ENV = 'development';
+      assert.doesNotThrow(() => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }));
+    });
+
+    it('throws when NODE_ENV is "production"', () => {
+      process.env.NODE_ENV = 'production';
+      assert.throws(
+        () => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+
+    it('throws when NODE_ENV is unset (fails closed)', () => {
+      delete process.env.NODE_ENV;
+      assert.throws(
+        () => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+
+    it('throws when NODE_ENV is empty string', () => {
+      process.env.NODE_ENV = '';
+      assert.throws(
+        () => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+
+    it('throws when NODE_ENV is an unknown value like "staging"', () => {
+      process.env.NODE_ENV = 'staging';
+      assert.throws(
+        () => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+  });
+
+  describe('detection rules', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
+
+    it('throws when a string value ends with .example', () => {
+      assert.throws(
+        () => assertNoExampleTlds({ UPSTREAM_HOST: 'api.acmeoutdoor.example' }),
+        /UPSTREAM_HOST: api\.acmeoutdoor\.example/
+      );
+    });
+
+    it('throws when an array contains a .example entry', () => {
+      assert.throws(
+        () =>
+          assertNoExampleTlds({
+            KNOWN_PUBLISHERS: ['real-publisher.com', 'acmeoutdoor.example'],
+          }),
+        /KNOWN_PUBLISHERS: acmeoutdoor\.example/
+      );
+    });
+
+    it('is case-insensitive (.Example matches)', () => {
+      assert.throws(
+        () => assertNoExampleTlds({ HOST: 'foo.Example' }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+
+    it('does not flag .example.com (real TLD)', () => {
+      // `.example.com` is a real reserved second-level domain (RFC 2606)
+      // that adopters legitimately use in demos. Only the `.example` TLD
+      // is the smell we're guarding against.
+      assert.doesNotThrow(() => assertNoExampleTlds({ PUBLIC_URL: 'https://my-agent.example.com' }));
+    });
+
+    it('does not flag substrings that contain "example" mid-string', () => {
+      assert.doesNotThrow(() => assertNoExampleTlds({ NOTE: 'see example/path/foo' }));
+    });
+
+    it('passes through when no constants match', () => {
+      assert.doesNotThrow(() =>
+        assertNoExampleTlds({
+          KNOWN_PUBLISHERS: ['acmeoutdoor.com', 'premium-sports.io'],
+          UPSTREAM_HOST: 'api.acmeoutdoor.com',
+          PORT: 3000,
+          ENABLED: true,
+        })
+      );
+    });
+
+    it('ignores non-string, non-array values (numbers, booleans, objects)', () => {
+      // Adopters may pass adjacent module constants without curating; the
+      // helper should not throw on types it doesn't know how to scan.
+      assert.doesNotThrow(() =>
+        assertNoExampleTlds({
+          PORT: 3000,
+          ENABLED: true,
+          CONFIG: { upstream: 'https://api.acmeoutdoor.example' }, // nested obj — ignored
+          NULL_VALUE: null,
+          UNDEF_VALUE: undefined,
+        })
+      );
+    });
+
+    it('reports multiple offenders in a single error', () => {
+      try {
+        assertNoExampleTlds({
+          KNOWN_PUBLISHERS: ['acmeoutdoor.example', 'premium-sports.example'],
+          UPSTREAM_HOST: 'api.acmeoutdoor.example',
+        });
+        assert.fail('expected throw');
+      } catch (err) {
+        assert.match(err.message, /KNOWN_PUBLISHERS: acmeoutdoor\.example/);
+        assert.match(err.message, /KNOWN_PUBLISHERS: premium-sports\.example/);
+        assert.match(err.message, /UPSTREAM_HOST: api\.acmeoutdoor\.example/);
+      }
+    });
+
+    it('error message points at FORK CHECKLIST', () => {
+      try {
+        assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] });
+        assert.fail('expected throw');
+      } catch (err) {
+        assert.match(err.message, /FORK CHECKLIST/);
+        assert.match(err.message, /NODE_ENV=development or NODE_ENV=test/);
+      }
+    });
+  });
+
+  describe('custom allowIn allowlist', () => {
+    it('allows callers to add their own environments', () => {
+      process.env.NODE_ENV = 'staging';
+      assert.doesNotThrow(() =>
+        assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }, { allowIn: ['staging'] })
+      );
+    });
+
+    it('custom allowlist replaces the default (test no longer allowed)', () => {
+      process.env.NODE_ENV = 'test';
+      assert.throws(
+        () => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }, { allowIn: ['staging'] }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+
+    it('empty allowlist means assertion always runs', () => {
+      process.env.NODE_ENV = 'development';
+      assert.throws(
+        () => assertNoExampleTlds({ KNOWN_PUBLISHERS: ['acmeoutdoor.example'] }, { allowIn: [] }),
+        /Adapter forked without flipping example constants/
+      );
+    });
+  });
+
+  describe('exported from @adcp/sdk/server', () => {
+    it('is re-exported from the server barrel', () => {
+      const serverBarrel = require('../../dist/lib/server');
+      assert.strictEqual(
+        typeof serverBarrel.assertNoExampleTlds,
+        'function',
+        'assertNoExampleTlds must be re-exported from @adcp/sdk/server'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1747.

Adopters who fork a `hello_*_adapter_*.ts` worked example sometimes ship without flipping `KNOWN_PUBLISHERS = ['acmeoutdoor.example', ...]` and similar seed constants from the FORK CHECKLIST. The header reminder is easy to miss; the result is `.example`-TLD seed data leaking into production tenant directories.

- New `assertNoExampleTlds(constants, opts?)` helper in `src/lib/server/assert-no-example-tlds.ts`, exported from `@adcp/sdk/server`. Throws at module load when any string value or string-array element ends with `.example` (case-insensitive) and `NODE_ENV` is not in the allowlist (default `['test', 'development']`).
- Gating uses an exact-match allowlist (per `feedback_node_env_allowlist`) rather than `NODE_ENV !== 'production'` so unset / typo'd `NODE_ENV` fails closed.
- Wired into the five examples that ship `.example`-TLD seed constants: `hello_creative_adapter_ad_server.ts`, `hello_seller_adapter_guaranteed.ts`, `hello_seller_adapter_non_guaranteed.ts`, `hello_seller_adapter_proposal_mode.ts`, `hello_seller_adapter_social.ts`. (`hello_creative_adapter_template.ts` has no such constants.)
- `.example.com` (RFC 2606 reserved second-level domain) is NOT flagged; only the bare `.example` TLD is the smell.

## Test plan

- [x] `test/unit/assert-no-example-tlds.test.js` — 19 unit tests pin: NODE_ENV gating (test/dev pass, production/unset/empty/staging throw), array + scalar detection, case-insensitive match, `.example.com` exclusion, multi-offender reporting, custom `allowIn`, server-barrel re-export.
- [x] `test/examples/hello-seller-adapter-{guaranteed,non-guaranteed,proposal-mode,social}.test.js` + `hello-creative-adapter-ad-server.test.js` — all four wired-example storyboards pass under `NODE_ENV=test` (the test runner's default), proving the guard doesn't false-positive at module load.
- [x] `npm run format:check` clean.
- [ ] CI: full test suite + changeset check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)