### PR TITLE
feat(testing): per-tool seeded callbacks on `TestControllerBridge` for platform-proxy sellers (closes #1002)

### DIFF
--- a/.changeset/test-controller-bridge-per-tool.md
+++ b/.changeset/test-controller-bridge-per-tool.md
@@ -1,0 +1,19 @@
+---
+'@adcp/sdk': minor
+---
+
+feat(testing): per-tool seeded callbacks on `TestControllerBridge` for platform-proxy sellers (closes #1002)
+
+`TestControllerBridge` previously exposed only `getSeededProducts`, leaving platform-proxy sellers (DSPs, walled gardens, retail-media networks) without a way to feed seeded fixtures into the read path of every other read tool — storyboard seeds against `seed_creative` / `seed_media_buy` were dead writes when the adapter proxied to upstream APIs.
+
+Extends `TestControllerBridge<TAccount>` with five opt-in callbacks mirroring `getSeededProducts` (post-handler merge, sandbox + resolved-account + controller-present gating, warn-and-drop validation, never throws):
+
+- `getSeededCreatives(ctx)` → merged into `list_creatives` (dedup by `creative_id`)
+- `getSeededMediaBuys(ctx)` → merged into `get_media_buys` (dedup by `media_buy_id`)
+- `getSeededAccounts(ctx)` → merged into `list_accounts` (dedup by `account_id`)
+- `getSeededAccountFinancials(ctx)` → replaces `get_account_financials` envelope when seeded `account.account_id` matches the request (singleton response, replace semantics)
+- `getSeededCreativeFormats(ctx)` → merged into `list_creative_formats` (dedup by canonical `format_id.agent_url|format_id.id`)
+
+`BridgeFromSessionStoreOptions` gains matching `selectSeeded*` selectors so adopters wiring storyboards via the session-store pattern get all bridges in one helper. Per-tool callbacks are omitted from the returned bridge when no selector is provided.
+
+Production traffic is unchanged: bridges run only on sandbox-flagged requests against a registered controller.

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -235,6 +235,41 @@ Omit adapters you don't support — they auto-return `UNKNOWN_SCENARIO`. Throw `
 
 For domain state that carries internal structure (packages, revision, history) read by production tools, use `registerTestController(server, store)` — flat store surface, session-scoped factory. See `examples/seller-test-controller.ts`. Pick by state shape, not by helper tier — both sit on the same primitives and both auto-emit the capability block.
 
+### Platform-proxy sellers (state-of-record lives upstream)
+
+Sellers whose read path proxies to upstream platforms (`snapClient.getCreatives(...)`, `metaClient.getMediaBuy(...)`) don't read seeded fixtures from their own data layer — controller-seeded state is a dead write. Wire `TestControllerBridge` to feed those fixtures back into the read path on sandbox requests, without stubbing 13 upstream clients per adapter.
+
+```typescript
+import { createAdcpServer, bridgeFromSessionStore } from '@adcp/sdk/server';
+
+const server = createAdcpServer({
+  // ... usual config + per-adapter handlers ...
+  testController: bridgeFromSessionStore({
+    loadSession: input => sessionStore.load(sessionKey(input)),
+
+    // Each selector is opt-in by presence — wire the ones whose storyboards
+    // your specialism gates on. Returned entries are validated (warn-and-drop
+    // on shape errors, never throw) and merged into the matching tool's
+    // response on sandbox requests only.
+    selectSeededProducts:          s => s.seededProducts,          // get_products
+    selectSeededCreatives:         s => s.seededCreatives,         // list_creatives
+    selectSeededMediaBuys:         s => s.seededMediaBuys,         // get_media_buys
+    selectSeededAccounts:          s => s.seededAccounts,          // list_accounts
+    selectSeededAccountFinancials: s => s.seededFinancials,        // get_account_financials
+    selectSeededCreativeFormats:   s => s.seededFormats,           // list_creative_formats
+  }),
+});
+```
+
+Bridge contract:
+
+- **Triply gated.** Bridge runs only when the bridge is registered, the request carries a sandbox marker (`account.sandbox === true` or `context.sandbox === true`), and — if `resolveAccount` produced a record — that record is `sandbox: true` too. Production traffic untouched.
+- **Post-handler merge.** The adapter's real handler runs first (so a broken `snapClient.getCreatives()` still fails the conformance gate — the bridge supplements, it does not replace adapter behavior). Seeded entries append; on id collision the seeded fixture wins.
+- **Singleton exception.** `get_account_financials` returns one account's envelope, so the bridge picks the seeded fixture whose `account.account_id` matches the request's `account.account_id` and REPLACES the handler envelope for that account. Other accounts pass through unchanged.
+- **Validation drops invalid fixtures.** Entries missing the dedup id (`creative_id`, `media_buy_id`, `account_id`, `account.account_id`, `format_id.{agent_url,id}`) are warn-and-dropped, not thrown — a broken test fixture shouldn't tank the request under test.
+
+Plain hand-rolled `TestControllerBridge` (no session store) is also supported — wire `getSeededProducts` / `getSeededCreatives` / etc. directly. See `src/lib/server/test-controller-bridge.ts` for the interface.
+
 ---
 
 ## Schema-driven validation (catch field drift at dev time)

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -130,7 +130,17 @@ import { createExpressVerifier, type ExpressLike } from '../signing/middleware';
 import {
   isSandboxRequest as isSandboxRequestForSeeding,
   mergeSeededProductsIntoResponse,
+  mergeSeededCreativesIntoResponse,
+  mergeSeededMediaBuysIntoResponse,
+  mergeSeededAccountsIntoResponse,
+  mergeSeededCreativeFormatsIntoResponse,
+  replaceAccountFinancialsIfSeeded,
   filterValidSeededProducts,
+  filterValidSeededCreatives,
+  filterValidSeededMediaBuys,
+  filterValidSeededAccounts,
+  filterValidSeededAccountFinancials,
+  filterValidSeededCreativeFormats,
   type TestControllerBridge,
   type TestControllerBridgeContext,
 } from './test-controller-bridge';
@@ -3866,52 +3876,175 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
             formatted = wrap(result);
           }
 
-          // --- Test-controller bridge: augment get_products with seeded fixtures. ---
-          // Only runs when the seller opted in via `testController.getSeededProducts`
-          // AND the request carries a sandbox marker (account.sandbox === true or
-          // context.sandbox === true). When `resolveAccount` returned a concrete
-          // account, we additionally require `ctx.account.sandbox === true` so a
-          // request that happens to include `account.sandbox: true` can't leak
-          // fixtures into a non-sandbox resolved account (belt-and-suspenders).
-          // Seeded products append to whatever the handler returned; `product_id`
-          // collisions resolve with the seeded entry winning, so storyboards that
-          // override default inventory see their fixture.
+          // --- Test-controller bridge: augment read-side tools with seeded fixtures. ---
+          // Each per-tool callback (`getSeededProducts`, `getSeededCreatives`, ...)
+          // is opt-in by presence on the bridge interface. All callbacks share the
+          // same triply-gated contract:
+          //   1. The bridge is registered AND has the matching callback;
+          //   2. The handler returned a success envelope (not an `adcp_error`);
+          //   3. The request carries a sandbox marker (account.sandbox === true or
+          //      context.sandbox === true) AND, if `resolveAccount` produced a
+          //      record, that record is flagged `sandbox: true` too.
+          // For array-collection tools, seeded entries append to the handler's
+          // response with seeded winning on id collision (same as `getSeededProducts`).
+          // `get_account_financials` is the exception — singleton response, so the
+          // seeded entry REPLACES the handler payload when its `account.account_id`
+          // matches the request's `account.account_id`.
           if (
-            toolName === 'get_products' &&
-            testControllerBridge?.getSeededProducts &&
+            testControllerBridge &&
             !isErrorResponse(formatted) &&
             isSandboxRequestForSeeding(params) &&
-            // If resolveAccount produced a record, require it to be flagged
-            // sandbox too. If no account was resolved, the request-signal
-            // check above is the only line of defense — keep that contract.
             (ctx.account === undefined ||
               (typeof ctx.account === 'object' &&
                 ctx.account !== null &&
                 (ctx.account as { sandbox?: unknown }).sandbox === true))
           ) {
-            try {
-              const bridgeCtx: TestControllerBridgeContext<TAccount> = { input: params };
-              if (ctx.account !== undefined) bridgeCtx.account = ctx.account;
-              const rawSeeded = await testControllerBridge.getSeededProducts(bridgeCtx);
-              const seeded = filterValidSeededProducts(rawSeeded, logger);
-              if (seeded.length > 0) {
-                const sc = formatted.structuredContent as
-                  | import('../types/tools.generated').GetProductsResponse
-                  | undefined;
-                if (sc && typeof sc === 'object') {
-                  const merged = mergeSeededProductsIntoResponse(sc, seeded);
-                  formatted = wrap(merged);
+            const bridgeCtx: TestControllerBridgeContext<TAccount> = { input: params };
+            if (ctx.account !== undefined) bridgeCtx.account = ctx.account;
+
+            // get_products
+            if (toolName === 'get_products' && testControllerBridge.getSeededProducts) {
+              try {
+                const rawSeeded = await testControllerBridge.getSeededProducts(bridgeCtx);
+                const seeded = filterValidSeededProducts(rawSeeded, logger);
+                if (seeded.length > 0) {
+                  const sc = formatted.structuredContent as
+                    | import('../types/tools.generated').GetProductsResponse
+                    | undefined;
+                  if (sc && typeof sc === 'object') {
+                    const merged = mergeSeededProductsIntoResponse(sc, seeded);
+                    formatted = wrap(merged);
+                  }
                 }
+              } catch (err) {
+                // Bridge failures are sandbox-only by construction, so logging +
+                // returning the handler's response is the right default — a broken
+                // test fixture shouldn't tank the request under test.
+                const reason = err instanceof Error ? err.message : String(err);
+                logger.warn('testController.getSeededProducts failed; returning handler response unchanged', {
+                  tool: toolName,
+                  error: reason,
+                });
               }
-            } catch (err) {
-              // Bridge failures are sandbox-only by construction, so logging +
-              // returning the handler's response is the right default — a broken
-              // test fixture shouldn't tank the request under test.
-              const reason = err instanceof Error ? err.message : String(err);
-              logger.warn('testController.getSeededProducts failed; returning handler response unchanged', {
-                tool: toolName,
-                error: reason,
-              });
+            }
+
+            // list_creatives
+            else if (toolName === 'list_creatives' && testControllerBridge.getSeededCreatives) {
+              try {
+                const rawSeeded = await testControllerBridge.getSeededCreatives(bridgeCtx);
+                const seeded = filterValidSeededCreatives(rawSeeded, logger);
+                if (seeded.length > 0) {
+                  const sc = formatted.structuredContent as
+                    | import('../types/tools.generated').ListCreativesResponse
+                    | undefined;
+                  if (sc && typeof sc === 'object') {
+                    const merged = mergeSeededCreativesIntoResponse(sc, seeded);
+                    formatted = wrap(merged);
+                  }
+                }
+              } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                logger.warn('testController.getSeededCreatives failed; returning handler response unchanged', {
+                  tool: toolName,
+                  error: reason,
+                });
+              }
+            }
+
+            // get_media_buys
+            else if (toolName === 'get_media_buys' && testControllerBridge.getSeededMediaBuys) {
+              try {
+                const rawSeeded = await testControllerBridge.getSeededMediaBuys(bridgeCtx);
+                const seeded = filterValidSeededMediaBuys(rawSeeded, logger);
+                if (seeded.length > 0) {
+                  const sc = formatted.structuredContent as
+                    | import('../types/tools.generated').GetMediaBuysResponse
+                    | undefined;
+                  if (sc && typeof sc === 'object') {
+                    const merged = mergeSeededMediaBuysIntoResponse(sc, seeded);
+                    formatted = wrap(merged);
+                  }
+                }
+              } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                logger.warn('testController.getSeededMediaBuys failed; returning handler response unchanged', {
+                  tool: toolName,
+                  error: reason,
+                });
+              }
+            }
+
+            // list_accounts
+            else if (toolName === 'list_accounts' && testControllerBridge.getSeededAccounts) {
+              try {
+                const rawSeeded = await testControllerBridge.getSeededAccounts(bridgeCtx);
+                const seeded = filterValidSeededAccounts(rawSeeded, logger);
+                if (seeded.length > 0) {
+                  const sc = formatted.structuredContent as
+                    | import('../types/tools.generated').ListAccountsResponse
+                    | undefined;
+                  if (sc && typeof sc === 'object') {
+                    const merged = mergeSeededAccountsIntoResponse(sc, seeded);
+                    formatted = wrap(merged);
+                  }
+                }
+              } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                logger.warn('testController.getSeededAccounts failed; returning handler response unchanged', {
+                  tool: toolName,
+                  error: reason,
+                });
+              }
+            }
+
+            // get_account_financials (singleton — replace, not append)
+            else if (toolName === 'get_account_financials' && testControllerBridge.getSeededAccountFinancials) {
+              try {
+                const rawSeeded = await testControllerBridge.getSeededAccountFinancials(bridgeCtx);
+                const seeded = filterValidSeededAccountFinancials(rawSeeded, logger);
+                if (seeded.length > 0) {
+                  const sc = formatted.structuredContent as
+                    | import('../types/tools.generated').GetAccountFinancialsResponse
+                    | undefined;
+                  if (sc && typeof sc === 'object') {
+                    const merged = replaceAccountFinancialsIfSeeded(
+                      params as import('../types/tools.generated').GetAccountFinancialsRequest,
+                      sc,
+                      seeded
+                    );
+                    if (merged !== sc) formatted = wrap(merged);
+                  }
+                }
+              } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                logger.warn('testController.getSeededAccountFinancials failed; returning handler response unchanged', {
+                  tool: toolName,
+                  error: reason,
+                });
+              }
+            }
+
+            // list_creative_formats
+            else if (toolName === 'list_creative_formats' && testControllerBridge.getSeededCreativeFormats) {
+              try {
+                const rawSeeded = await testControllerBridge.getSeededCreativeFormats(bridgeCtx);
+                const seeded = filterValidSeededCreativeFormats(rawSeeded, logger);
+                if (seeded.length > 0) {
+                  const sc = formatted.structuredContent as
+                    | import('../types/tools.generated').ListCreativeFormatsResponse
+                    | undefined;
+                  if (sc && typeof sc === 'object') {
+                    const merged = mergeSeededCreativeFormatsIntoResponse(sc, seeded);
+                    formatted = wrap(merged);
+                  }
+                }
+              } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                logger.warn('testController.getSeededCreativeFormats failed; returning handler response unchanged', {
+                  tool: toolName,
+                  error: reason,
+                });
+              }
             }
           }
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -4007,10 +4007,20 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                     | import('../types/tools.generated').GetAccountFinancialsResponse
                     | undefined;
                   if (sc && typeof sc === 'object') {
+                    // Brand+operator `AccountReference` variants don't carry
+                    // `account_id` on the wire — the framework's resolved
+                    // account does, so prefer it for the match key.
+                    const resolvedAccountId =
+                      ctx.account && typeof ctx.account === 'object' && !Array.isArray(ctx.account)
+                        ? ((ctx.account as { account_id?: unknown }).account_id as string | undefined)
+                        : undefined;
                     const merged = replaceAccountFinancialsIfSeeded(
                       params as import('../types/tools.generated').GetAccountFinancialsRequest,
                       sc,
-                      seeded
+                      seeded,
+                      typeof resolvedAccountId === 'string' && resolvedAccountId.length > 0
+                        ? resolvedAccountId
+                        : undefined
                     );
                     if (merged !== sc) formatted = wrap(merged);
                   }

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -294,6 +294,17 @@ export {
   isSandboxRequest,
   mergeSeededProductsIntoResponse,
   filterValidSeededProducts,
+  filterValidSeededCreatives,
+  filterValidSeededMediaBuys,
+  filterValidSeededAccounts,
+  filterValidSeededAccountFinancials,
+  filterValidSeededCreativeFormats,
+  mergeSeededCreativesIntoResponse,
+  mergeSeededMediaBuysIntoResponse,
+  mergeSeededAccountsIntoResponse,
+  mergeSeededCreativeFormatsIntoResponse,
+  pickSeededAccountFinancialsForRequest,
+  replaceAccountFinancialsIfSeeded,
   bridgeFromTestControllerStore,
   bridgeFromSessionStore,
 } from './test-controller-bridge';
@@ -301,6 +312,9 @@ export type {
   TestControllerBridge,
   TestControllerBridgeContext,
   BridgeFromSessionStoreOptions,
+  SeededCreative,
+  SeededMediaBuy,
+  SeededAccountFinancials,
 } from './test-controller-bridge';
 
 export {

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -19,8 +19,42 @@
  * store is in-memory, Postgres, Redis, or a mock.
  */
 
-import type { Product, GetProductsResponse } from '../types/tools.generated';
+import type {
+  Product,
+  GetProductsResponse,
+  Account,
+  ListAccountsResponse,
+  ListCreativesResponse,
+  GetMediaBuysResponse,
+  ListCreativeFormatsResponse,
+  Format,
+  GetAccountFinancialsResponse,
+  GetAccountFinancialsSuccess,
+  GetAccountFinancialsRequest,
+} from '../types/tools.generated';
 import { mergeSeedProduct } from '../testing/seed-merge';
+
+/**
+ * Seeded creative entry — the inline element type of `ListCreativesResponse.creatives`.
+ * Derived via lookup so it stays in lockstep with the generated wire schema.
+ */
+export type SeededCreative = ListCreativesResponse['creatives'][number];
+
+/**
+ * Seeded media-buy entry — the inline element type of `GetMediaBuysResponse.media_buys`.
+ * Derived via lookup so it stays in lockstep with the generated wire schema.
+ */
+export type SeededMediaBuy = GetMediaBuysResponse['media_buys'][number];
+
+/**
+ * Seeded account-financials entry. The `get_account_financials` response is a
+ * singleton (one account, one envelope), so the bridge callback returns an
+ * array keyed by `account.account_id` and the framework picks the entry
+ * matching the request's `account` reference — replacing the handler response
+ * for that account when matched. Storyboards seeding financials for an account
+ * under test see their fixture; un-seeded accounts pass through to the handler.
+ */
+export type SeededAccountFinancials = GetAccountFinancialsSuccess;
 
 /**
  * Context passed to {@link TestControllerBridge.getSeededProducts}.
@@ -58,6 +92,61 @@ export interface TestControllerBridge<TAccount = unknown> {
    * bridge when it has a resolved non-sandbox account, belt-and-suspenders).
    */
   getSeededProducts?: (ctx: TestControllerBridgeContext<TAccount>) => Promise<Product[]> | Product[];
+
+  /**
+   * Retrieve seeded creatives for the current request. Returned entries are
+   * appended to the handler's `list_creatives` response (`creatives` array);
+   * on `creative_id` collision the seeded entry wins. Empty array (or
+   * `undefined`) when nothing is seeded. Same sandbox gating contract as
+   * {@link TestControllerBridge.getSeededProducts}.
+   */
+  getSeededCreatives?: (ctx: TestControllerBridgeContext<TAccount>) => Promise<SeededCreative[]> | SeededCreative[];
+
+  /**
+   * Retrieve seeded media buys for the current request. Returned entries are
+   * appended to the handler's `get_media_buys` response (`media_buys` array);
+   * on `media_buy_id` collision the seeded entry wins. Same sandbox gating
+   * contract as {@link TestControllerBridge.getSeededProducts}.
+   */
+  getSeededMediaBuys?: (ctx: TestControllerBridgeContext<TAccount>) => Promise<SeededMediaBuy[]> | SeededMediaBuy[];
+
+  /**
+   * Retrieve seeded accounts for the current request. Returned entries are
+   * appended to the handler's `list_accounts` response (`accounts` array);
+   * on `account_id` collision the seeded entry wins. Same sandbox gating
+   * contract as {@link TestControllerBridge.getSeededProducts}.
+   */
+  getSeededAccounts?: (ctx: TestControllerBridgeContext<TAccount>) => Promise<Account[]> | Account[];
+
+  /**
+   * Retrieve seeded account-financials records. Unlike the other seeded
+   * collections, `get_account_financials` returns a singleton response —
+   * one account, one envelope. The bridge callback returns an array of
+   * seeded records keyed by `account.account_id`; the framework picks the
+   * entry whose `account_id` matches the request's `account` reference and
+   * REPLACES the handler response with that fixture. When no seeded entry
+   * matches, the handler response passes through unchanged.
+   *
+   * Same sandbox gating contract as {@link TestControllerBridge.getSeededProducts}.
+   */
+  getSeededAccountFinancials?: (
+    ctx: TestControllerBridgeContext<TAccount>
+  ) => Promise<SeededAccountFinancials[]> | SeededAccountFinancials[];
+
+  /**
+   * Retrieve seeded creative formats. Returned entries are appended to the
+   * handler's `list_creative_formats` response (`formats` array); on
+   * collision (matched by canonical `format_id.agent_url` + `format_id.id`)
+   * the seeded entry wins. Same sandbox gating contract as
+   * {@link TestControllerBridge.getSeededProducts}.
+   *
+   * Composes with `SalesPlatform.listCreativeFormats` /
+   * `CreativeBuilderPlatform.listCreativeFormats` — the adapter handler
+   * runs first, then this bridge supplements. Not a replacement for those
+   * handler-side hooks; storyboards use this seam to inject test-only
+   * formats without rewriting the adapter.
+   */
+  getSeededCreativeFormats?: (ctx: TestControllerBridgeContext<TAccount>) => Promise<Format[]> | Format[];
 }
 
 /**
@@ -161,6 +250,335 @@ export function filterValidSeededProducts(
   return valid;
 }
 
+// ---------------------------------------------------------------------------
+// Per-tool validation + merge helpers
+//
+// Each helper pair (`filterValidSeededXxx` + `mergeSeededXxxIntoResponse`)
+// mirrors the `filterValidSeededProducts` + `mergeSeededProductsIntoResponse`
+// shape. The semantics are identical: validate-and-drop on the input side,
+// dedupe-and-stamp-sandbox on the merge side. Symmetry is the point — adopters
+// who understand the products seam should be able to read the others at a
+// glance.
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate seeded creatives. Drops entries that are not plain objects or are
+ * missing a non-empty string `creative_id` — matches the products contract
+ * (a missing identifier collides on `undefined === undefined` when deduping).
+ */
+export function filterValidSeededCreatives(
+  raw: unknown,
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void }
+): SeededCreative[] {
+  return filterValidById<SeededCreative>(raw, 'creative_id', 'getSeededCreatives', logger);
+}
+
+/**
+ * Validate seeded media buys. Drops entries missing a non-empty string
+ * `media_buy_id`.
+ */
+export function filterValidSeededMediaBuys(
+  raw: unknown,
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void }
+): SeededMediaBuy[] {
+  return filterValidById<SeededMediaBuy>(raw, 'media_buy_id', 'getSeededMediaBuys', logger);
+}
+
+/**
+ * Validate seeded accounts. Drops entries missing a non-empty string `account_id`.
+ */
+export function filterValidSeededAccounts(
+  raw: unknown,
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void }
+): Account[] {
+  return filterValidById<Account>(raw, 'account_id', 'getSeededAccounts', logger);
+}
+
+/**
+ * Validate seeded account-financials records. Drops entries whose `account`
+ * field is not a `{ account_id: string }`-shaped object (`AccountReference`
+ * carries `account_id` on the operator-resolved variant; the bridge keys on
+ * that field to match against the request's account).
+ */
+export function filterValidSeededAccountFinancials(
+  raw: unknown,
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void }
+): SeededAccountFinancials[] {
+  if (!Array.isArray(raw)) {
+    logger?.warn('testController.getSeededAccountFinancials did not return an array; skipping bridge', {
+      received: typeof raw,
+    });
+    return [];
+  }
+  const valid: SeededAccountFinancials[] = [];
+  raw.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      logger?.warn('testController.getSeededAccountFinancials entry is not an object; dropping', { index });
+      return;
+    }
+    const account = (entry as { account?: unknown }).account;
+    const accountId =
+      account && typeof account === 'object' && !Array.isArray(account)
+        ? (account as { account_id?: unknown }).account_id
+        : undefined;
+    if (typeof accountId !== 'string' || accountId.length === 0) {
+      logger?.warn('testController.getSeededAccountFinancials entry missing account.account_id; dropping', { index });
+      return;
+    }
+    valid.push(entry as SeededAccountFinancials);
+  });
+  return valid;
+}
+
+/**
+ * Validate seeded creative formats. Drops entries whose `format_id` is not a
+ * `{ agent_url: string, id: string }`-shaped object — both fields are
+ * required to dedupe (and to canonicalize per the URL canonicalization rules
+ * in the AdCP spec).
+ */
+export function filterValidSeededCreativeFormats(
+  raw: unknown,
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void }
+): Format[] {
+  if (!Array.isArray(raw)) {
+    logger?.warn('testController.getSeededCreativeFormats did not return an array; skipping bridge', {
+      received: typeof raw,
+    });
+    return [];
+  }
+  const valid: Format[] = [];
+  raw.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      logger?.warn('testController.getSeededCreativeFormats entry is not an object; dropping', { index });
+      return;
+    }
+    const formatId = (entry as { format_id?: unknown }).format_id;
+    if (!formatId || typeof formatId !== 'object' || Array.isArray(formatId)) {
+      logger?.warn('testController.getSeededCreativeFormats entry missing format_id; dropping', { index });
+      return;
+    }
+    const agentUrl = (formatId as { agent_url?: unknown }).agent_url;
+    const id = (formatId as { id?: unknown }).id;
+    if (typeof agentUrl !== 'string' || agentUrl.length === 0 || typeof id !== 'string' || id.length === 0) {
+      logger?.warn(
+        'testController.getSeededCreativeFormats entry has incomplete format_id (agent_url and id required); dropping',
+        { index }
+      );
+      return;
+    }
+    valid.push(entry as Format);
+  });
+  return valid;
+}
+
+/**
+ * Shared by-`id` validator for collections whose entries dedupe on a single
+ * top-level string field (creatives → `creative_id`, media buys →
+ * `media_buy_id`, accounts → `account_id`). Mirrors
+ * {@link filterValidSeededProducts} exactly; factored only because the three
+ * shapes share the same single-string-key contract.
+ */
+function filterValidById<T>(
+  raw: unknown,
+  idField: string,
+  callbackName: string,
+  logger?: { warn: (message: string, meta?: Record<string, unknown>) => void }
+): T[] {
+  if (!Array.isArray(raw)) {
+    logger?.warn(`testController.${callbackName} did not return an array; skipping bridge`, {
+      received: typeof raw,
+    });
+    return [];
+  }
+  const valid: T[] = [];
+  raw.forEach((entry, index) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      logger?.warn(`testController.${callbackName} entry is not an object; dropping`, { index });
+      return;
+    }
+    const id = (entry as Record<string, unknown>)[idField];
+    if (typeof id !== 'string' || id.length === 0) {
+      logger?.warn(`testController.${callbackName} entry missing ${idField}; dropping`, { index });
+      return;
+    }
+    valid.push(entry as T);
+  });
+  return valid;
+}
+
+/**
+ * Merge seeded creatives into a `list_creatives` response. Existing creatives
+ * come first; seeded entries append after deduping by `creative_id`. On
+ * collision the seeded entry wins. Stamps `sandbox: true` unless the handler
+ * explicitly declared `sandbox: false`. Returns a NEW response object.
+ */
+export function mergeSeededCreativesIntoResponse(
+  response: ListCreativesResponse,
+  seeded: readonly SeededCreative[]
+): ListCreativesResponse {
+  if (!seeded.length) return response;
+  const seededIds = new Set<string>();
+  for (const c of seeded) seededIds.add(c.creative_id);
+  const existing = Array.isArray(response.creatives) ? response.creatives : [];
+  const retained = existing.filter(c => !seededIds.has(c?.creative_id));
+  const merged: ListCreativesResponse = {
+    ...response,
+    creatives: [...retained, ...seeded],
+  };
+  if ((response as { sandbox?: unknown }).sandbox !== false) {
+    (merged as { sandbox?: boolean }).sandbox = true;
+  }
+  return merged;
+}
+
+/**
+ * Merge seeded media buys into a `get_media_buys` response. Existing media
+ * buys come first; seeded entries append after deduping by `media_buy_id`.
+ * On collision the seeded entry wins. Returns a NEW response object.
+ */
+export function mergeSeededMediaBuysIntoResponse(
+  response: GetMediaBuysResponse,
+  seeded: readonly SeededMediaBuy[]
+): GetMediaBuysResponse {
+  if (!seeded.length) return response;
+  const seededIds = new Set<string>();
+  for (const mb of seeded) seededIds.add(mb.media_buy_id);
+  const existing = Array.isArray(response.media_buys) ? response.media_buys : [];
+  const retained = existing.filter(mb => !seededIds.has(mb?.media_buy_id));
+  const merged: GetMediaBuysResponse = {
+    ...response,
+    media_buys: [...retained, ...seeded],
+  };
+  if ((response as { sandbox?: unknown }).sandbox !== false) {
+    (merged as { sandbox?: boolean }).sandbox = true;
+  }
+  return merged;
+}
+
+/**
+ * Merge seeded accounts into a `list_accounts` response. Existing accounts
+ * come first; seeded entries append after deduping by `account_id`. On
+ * collision the seeded entry wins. Returns a NEW response object.
+ */
+export function mergeSeededAccountsIntoResponse(
+  response: ListAccountsResponse,
+  seeded: readonly Account[]
+): ListAccountsResponse {
+  if (!seeded.length) return response;
+  const seededIds = new Set<string>();
+  for (const a of seeded) seededIds.add(a.account_id);
+  const existing = Array.isArray(response.accounts) ? response.accounts : [];
+  const retained = existing.filter(a => !seededIds.has(a?.account_id));
+  const merged: ListAccountsResponse = {
+    ...response,
+    accounts: [...retained, ...seeded],
+  };
+  if ((response as { sandbox?: unknown }).sandbox !== false) {
+    (merged as { sandbox?: boolean }).sandbox = true;
+  }
+  return merged;
+}
+
+/**
+ * Extract `account_id` from a `get_account_financials` request's `account`
+ * reference. `AccountReference` is a discriminated union — the
+ * operator-resolved variant carries `account_id` directly, brand+operator
+ * variants do not. Returns `undefined` for variants that don't carry an
+ * `account_id` (those requests can't match a seeded fixture by id and pass
+ * through to the handler).
+ */
+function readRequestAccountId(req: Record<string, unknown> | undefined): string | undefined {
+  const account = req?.account;
+  if (!account || typeof account !== 'object' || Array.isArray(account)) return undefined;
+  const id = (account as { account_id?: unknown }).account_id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
+/**
+ * Pick a seeded `get_account_financials` fixture matching the request's
+ * `account.account_id`. Unlike the array-collection helpers, this returns
+ * the SINGLE matched envelope or `undefined` — `get_account_financials` is
+ * a singleton response and "merge" reduces to "replace if the request's
+ * account matches a seeded fixture".
+ */
+export function pickSeededAccountFinancialsForRequest(
+  request: GetAccountFinancialsRequest | Record<string, unknown>,
+  seeded: readonly SeededAccountFinancials[]
+): SeededAccountFinancials | undefined {
+  if (!seeded.length) return undefined;
+  const requestedId = readRequestAccountId(request as Record<string, unknown>);
+  if (requestedId == null) return undefined;
+  for (const entry of seeded) {
+    const id = (entry.account as { account_id?: unknown } | undefined)?.account_id;
+    if (typeof id === 'string' && id === requestedId) return entry;
+  }
+  return undefined;
+}
+
+/**
+ * Replace a `get_account_financials` response when a seeded fixture matches
+ * the request's account. Returns the seeded fixture (preserving any
+ * `context` / `ext` from the handler response is intentionally NOT done —
+ * the seeded envelope is authoritative for the seeded account, including
+ * its own `context` / `ext` if the fixture set them). When no fixture
+ * matches, returns the handler response unchanged.
+ */
+export function replaceAccountFinancialsIfSeeded(
+  request: GetAccountFinancialsRequest | Record<string, unknown>,
+  response: GetAccountFinancialsResponse,
+  seeded: readonly SeededAccountFinancials[]
+): GetAccountFinancialsResponse {
+  const picked = pickSeededAccountFinancialsForRequest(request, seeded);
+  return picked ?? response;
+}
+
+/**
+ * Canonical dedup key for a `Format` — `${agent_url}|${id}`. Matches the AdCP
+ * format-id contract: two formats from the same agent with the same id are
+ * the same format, regardless of parameterized dimension / duration. Fixtures
+ * that seed multiple parameterized variants of the same template should use
+ * distinct `id` values per variant.
+ */
+function formatDedupKey(f: Format): string | undefined {
+  const fid = f.format_id;
+  if (!fid || typeof fid !== 'object') return undefined;
+  const agentUrl = (fid as { agent_url?: unknown }).agent_url;
+  const id = (fid as { id?: unknown }).id;
+  if (typeof agentUrl !== 'string' || typeof id !== 'string') return undefined;
+  return `${agentUrl}|${id}`;
+}
+
+/**
+ * Merge seeded creative formats into a `list_creative_formats` response.
+ * Existing formats come first; seeded entries append after deduping by
+ * canonical `${agent_url}|${id}`. On collision the seeded entry wins.
+ * Returns a NEW response object.
+ */
+export function mergeSeededCreativeFormatsIntoResponse(
+  response: ListCreativeFormatsResponse,
+  seeded: readonly Format[]
+): ListCreativeFormatsResponse {
+  if (!seeded.length) return response;
+  const seededKeys = new Set<string>();
+  for (const f of seeded) {
+    const key = formatDedupKey(f);
+    if (key != null) seededKeys.add(key);
+  }
+  const existing = Array.isArray(response.formats) ? response.formats : [];
+  const retained = existing.filter(f => {
+    const key = formatDedupKey(f);
+    return key == null || !seededKeys.has(key);
+  });
+  const merged: ListCreativeFormatsResponse = {
+    ...response,
+    formats: [...retained, ...seeded],
+  };
+  if (response.sandbox !== false) {
+    merged.sandbox = true;
+  }
+  return merged;
+}
+
 /**
  * Bridge the default test-controller store (a `Map<string, unknown>` that
  * holds seeded fixtures by `product_id`, populated by `seed_product` scenarios)
@@ -251,6 +669,55 @@ export interface BridgeFromSessionStoreOptions<TSession> {
    * / pricing / property fields the response schema requires.
    */
   productDefaults?: Partial<Product>;
+
+  /**
+   * Extract seeded creatives from a resolved session. The returned entries
+   * are passed through `filterValidSeededCreatives` and merged into
+   * `list_creatives` responses on sandbox requests. Each entry MUST carry a
+   * non-empty string `creative_id`. Return `null` / `undefined` when the
+   * session has no seeded creatives.
+   */
+  selectSeededCreatives?: (
+    session: TSession
+  ) => Iterable<SeededCreative> | Promise<Iterable<SeededCreative> | null | undefined> | null | undefined;
+
+  /**
+   * Extract seeded media buys from a resolved session. Each entry MUST carry
+   * a non-empty string `media_buy_id`.
+   */
+  selectSeededMediaBuys?: (
+    session: TSession
+  ) => Iterable<SeededMediaBuy> | Promise<Iterable<SeededMediaBuy> | null | undefined> | null | undefined;
+
+  /**
+   * Extract seeded accounts from a resolved session. Each entry MUST carry
+   * a non-empty string `account_id`.
+   */
+  selectSeededAccounts?: (
+    session: TSession
+  ) => Iterable<Account> | Promise<Iterable<Account> | null | undefined> | null | undefined;
+
+  /**
+   * Extract seeded account-financials envelopes from a resolved session.
+   * Each entry MUST carry `account.account_id`. The framework picks the
+   * fixture matching the request's `account` reference (singleton replace,
+   * not append — see {@link TestControllerBridge.getSeededAccountFinancials}).
+   */
+  selectSeededAccountFinancials?: (
+    session: TSession
+  ) =>
+    | Iterable<SeededAccountFinancials>
+    | Promise<Iterable<SeededAccountFinancials> | null | undefined>
+    | null
+    | undefined;
+
+  /**
+   * Extract seeded creative formats from a resolved session. Each entry MUST
+   * carry a `format_id.agent_url` + `format_id.id` (both non-empty strings).
+   */
+  selectSeededCreativeFormats?: (
+    session: TSession
+  ) => Iterable<Format> | Promise<Iterable<Format> | null | undefined> | null | undefined;
 }
 
 /**
@@ -283,8 +750,24 @@ export interface BridgeFromSessionStoreOptions<TSession> {
 export function bridgeFromSessionStore<TSession, TAccount = unknown>(
   opts: BridgeFromSessionStoreOptions<TSession>
 ): TestControllerBridge<TAccount> {
-  const { loadSession, selectSeededProducts, productDefaults = {} } = opts;
-  return {
+  const {
+    loadSession,
+    selectSeededProducts,
+    productDefaults = {},
+    selectSeededCreatives,
+    selectSeededMediaBuys,
+    selectSeededAccounts,
+    selectSeededAccountFinancials,
+    selectSeededCreativeFormats,
+  } = opts;
+
+  // Each per-tool callback resolves the session per-request (no memoisation —
+  // same contract as the original `getSeededProducts` path) and awaits the
+  // selector so callers can lazy-load seed collections on the selector path.
+  // Selectors are wired only when the adopter provided them; absent selectors
+  // leave the bridge callback omitted (opt-in by presence on the bridge
+  // interface, same shape as `getSeededProducts`).
+  const bridge: TestControllerBridge<TAccount> = {
     getSeededProducts: async ctx => {
       const session = await loadSession(ctx.input);
       const entries = await selectSeededProducts(session);
@@ -300,4 +783,42 @@ export function bridgeFromSessionStore<TSession, TAccount = unknown>(
       return out;
     },
   };
+
+  if (selectSeededCreatives) {
+    bridge.getSeededCreatives = async ctx => {
+      const session = await loadSession(ctx.input);
+      const entries = await selectSeededCreatives(session);
+      return entries ? Array.from(entries) : [];
+    };
+  }
+  if (selectSeededMediaBuys) {
+    bridge.getSeededMediaBuys = async ctx => {
+      const session = await loadSession(ctx.input);
+      const entries = await selectSeededMediaBuys(session);
+      return entries ? Array.from(entries) : [];
+    };
+  }
+  if (selectSeededAccounts) {
+    bridge.getSeededAccounts = async ctx => {
+      const session = await loadSession(ctx.input);
+      const entries = await selectSeededAccounts(session);
+      return entries ? Array.from(entries) : [];
+    };
+  }
+  if (selectSeededAccountFinancials) {
+    bridge.getSeededAccountFinancials = async ctx => {
+      const session = await loadSession(ctx.input);
+      const entries = await selectSeededAccountFinancials(session);
+      return entries ? Array.from(entries) : [];
+    };
+  }
+  if (selectSeededCreativeFormats) {
+    bridge.getSeededCreativeFormats = async ctx => {
+      const session = await loadSession(ctx.input);
+      const entries = await selectSeededCreativeFormats(session);
+      return entries ? Array.from(entries) : [];
+    };
+  }
+
+  return bridge;
 }

--- a/src/lib/server/test-controller-bridge.ts
+++ b/src/lib/server/test-controller-bridge.ts
@@ -123,9 +123,17 @@ export interface TestControllerBridge<TAccount = unknown> {
    * collections, `get_account_financials` returns a singleton response —
    * one account, one envelope. The bridge callback returns an array of
    * seeded records keyed by `account.account_id`; the framework picks the
-   * entry whose `account_id` matches the request's `account` reference and
-   * REPLACES the handler response with that fixture. When no seeded entry
-   * matches, the handler response passes through unchanged.
+   * entry whose `account_id` matches the resolved request account and
+   * replaces the handler response's financials payload with that fixture.
+   * Framework-managed `context` and `ext` from the handler response are
+   * PRESERVED across the replace — the seeded fixture is authoritative on
+   * the financials body (spend / period / account / currency / ...) but not
+   * on the response envelope (the fixture can't know the current request's
+   * `request_id` / `adcp_version` echo).
+   *
+   * When no seeded entry matches, the handler response passes through
+   * unchanged. Duplicate seeded entries with the same `account.account_id`
+   * are warn-and-dropped during validation (first occurrence wins).
    *
    * Same sandbox gating contract as {@link TestControllerBridge.getSeededProducts}.
    */
@@ -299,6 +307,13 @@ export function filterValidSeededAccounts(
  * field is not a `{ account_id: string }`-shaped object (`AccountReference`
  * carries `account_id` on the operator-resolved variant; the bridge keys on
  * that field to match against the request's account).
+ *
+ * Also drops duplicate entries by `account.account_id` (first occurrence
+ * wins, matching the array-collection helpers' on-collision-seeded-wins
+ * contract — the "first" seeded entry in iteration order is authoritative).
+ * A fixture array with two entries for the same `account_id` is almost
+ * always a seed-store bug; warn-and-drop surfaces it instead of silently
+ * picking whichever happened to come first in iteration order.
  */
 export function filterValidSeededAccountFinancials(
   raw: unknown,
@@ -311,6 +326,7 @@ export function filterValidSeededAccountFinancials(
     return [];
   }
   const valid: SeededAccountFinancials[] = [];
+  const seenAccountIds = new Set<string>();
   raw.forEach((entry, index) => {
     if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
       logger?.warn('testController.getSeededAccountFinancials entry is not an object; dropping', { index });
@@ -325,6 +341,14 @@ export function filterValidSeededAccountFinancials(
       logger?.warn('testController.getSeededAccountFinancials entry missing account.account_id; dropping', { index });
       return;
     }
+    if (seenAccountIds.has(accountId)) {
+      logger?.warn(
+        'testController.getSeededAccountFinancials duplicate account.account_id; dropping (first occurrence wins)',
+        { index, account_id: accountId }
+      );
+      return;
+    }
+    seenAccountIds.add(accountId);
     valid.push(entry as SeededAccountFinancials);
   });
   return valid;
@@ -411,6 +435,13 @@ function filterValidById<T>(
  * come first; seeded entries append after deduping by `creative_id`. On
  * collision the seeded entry wins. Stamps `sandbox: true` unless the handler
  * explicitly declared `sandbox: false`. Returns a NEW response object.
+ *
+ * Also updates `query_summary.returned` to match the final array length and
+ * `query_summary.total_matching` to `handler.total_matching + (seeded entries
+ * that did NOT collide with the handler set)`. Storyboards that assert on
+ * counts see the merged totals, not the handler's pre-merge counts. Mirror
+ * field on `pagination.total_count` is updated by the same delta when the
+ * handler set it.
  */
 export function mergeSeededCreativesIntoResponse(
   response: ListCreativesResponse,
@@ -420,13 +451,42 @@ export function mergeSeededCreativesIntoResponse(
   const seededIds = new Set<string>();
   for (const c of seeded) seededIds.add(c.creative_id);
   const existing = Array.isArray(response.creatives) ? response.creatives : [];
+  const existingIds = new Set<string>();
+  for (const c of existing) {
+    if (c && typeof c.creative_id === 'string') existingIds.add(c.creative_id);
+  }
   const retained = existing.filter(c => !seededIds.has(c?.creative_id));
+  const finalCreatives = [...retained, ...seeded];
+  // New entries = seeded that did NOT collide with the handler's set. Collisions
+  // replace in-place; the merged total_matching shouldn't grow on those.
+  let newCount = 0;
+  for (const c of seeded) if (!existingIds.has(c.creative_id)) newCount += 1;
   const merged: ListCreativesResponse = {
     ...response,
-    creatives: [...retained, ...seeded],
+    creatives: finalCreatives,
   };
   if ((response as { sandbox?: unknown }).sandbox !== false) {
     (merged as { sandbox?: boolean }).sandbox = true;
+  }
+  // query_summary is required on list_creatives per AdCP 3.0.11. Update the
+  // counts if the handler provided them; leave the rest of the block
+  // (filters_applied, etc.) untouched.
+  const qs = (response as { query_summary?: { total_matching?: unknown; returned?: unknown } }).query_summary;
+  if (qs && typeof qs === 'object') {
+    const baseTotal = typeof qs.total_matching === 'number' ? qs.total_matching : existing.length;
+    (merged as { query_summary?: unknown }).query_summary = {
+      ...qs,
+      total_matching: baseTotal + newCount,
+      returned: finalCreatives.length,
+    };
+  }
+  // pagination.total_count is optional; only update when the handler provided it.
+  const pagination = (response as { pagination?: { total_count?: unknown } }).pagination;
+  if (pagination && typeof pagination === 'object' && typeof pagination.total_count === 'number') {
+    (merged as { pagination?: unknown }).pagination = {
+      ...pagination,
+      total_count: pagination.total_count + newCount,
+    };
   }
   return merged;
 }
@@ -435,6 +495,13 @@ export function mergeSeededCreativesIntoResponse(
  * Merge seeded media buys into a `get_media_buys` response. Existing media
  * buys come first; seeded entries append after deduping by `media_buy_id`.
  * On collision the seeded entry wins. Returns a NEW response object.
+ *
+ * `get_media_buys` does NOT carry a `query_summary` block (per AdCP 3.0.11);
+ * it exposes its count via `pagination.total_count` (optional). When the
+ * handler set `pagination.total_count`, it's incremented by the count of
+ * new (non-colliding) seeded entries so the merged response stays
+ * internally consistent. Handlers that left `total_count` off pass through
+ * unchanged.
  */
 export function mergeSeededMediaBuysIntoResponse(
   response: GetMediaBuysResponse,
@@ -444,13 +511,26 @@ export function mergeSeededMediaBuysIntoResponse(
   const seededIds = new Set<string>();
   for (const mb of seeded) seededIds.add(mb.media_buy_id);
   const existing = Array.isArray(response.media_buys) ? response.media_buys : [];
+  const existingIds = new Set<string>();
+  for (const mb of existing) {
+    if (mb && typeof mb.media_buy_id === 'string') existingIds.add(mb.media_buy_id);
+  }
   const retained = existing.filter(mb => !seededIds.has(mb?.media_buy_id));
+  let newCount = 0;
+  for (const mb of seeded) if (!existingIds.has(mb.media_buy_id)) newCount += 1;
   const merged: GetMediaBuysResponse = {
     ...response,
     media_buys: [...retained, ...seeded],
   };
   if ((response as { sandbox?: unknown }).sandbox !== false) {
     (merged as { sandbox?: boolean }).sandbox = true;
+  }
+  const pagination = (response as { pagination?: { total_count?: unknown } }).pagination;
+  if (pagination && typeof pagination === 'object' && typeof pagination.total_count === 'number') {
+    (merged as { pagination?: unknown }).pagination = {
+      ...pagination,
+      total_count: pagination.total_count + newCount,
+    };
   }
   return merged;
 }
@@ -459,6 +539,10 @@ export function mergeSeededMediaBuysIntoResponse(
  * Merge seeded accounts into a `list_accounts` response. Existing accounts
  * come first; seeded entries append after deduping by `account_id`. On
  * collision the seeded entry wins. Returns a NEW response object.
+ *
+ * `list_accounts` exposes its count via `pagination.total_count` (optional,
+ * same as `get_media_buys`). When the handler set it, it's incremented by
+ * the count of new (non-colliding) seeded entries.
  */
 export function mergeSeededAccountsIntoResponse(
   response: ListAccountsResponse,
@@ -468,13 +552,26 @@ export function mergeSeededAccountsIntoResponse(
   const seededIds = new Set<string>();
   for (const a of seeded) seededIds.add(a.account_id);
   const existing = Array.isArray(response.accounts) ? response.accounts : [];
+  const existingIds = new Set<string>();
+  for (const a of existing) {
+    if (a && typeof a.account_id === 'string') existingIds.add(a.account_id);
+  }
   const retained = existing.filter(a => !seededIds.has(a?.account_id));
+  let newCount = 0;
+  for (const a of seeded) if (!existingIds.has(a.account_id)) newCount += 1;
   const merged: ListAccountsResponse = {
     ...response,
     accounts: [...retained, ...seeded],
   };
   if ((response as { sandbox?: unknown }).sandbox !== false) {
     (merged as { sandbox?: boolean }).sandbox = true;
+  }
+  const pagination = (response as { pagination?: { total_count?: unknown } }).pagination;
+  if (pagination && typeof pagination === 'object' && typeof pagination.total_count === 'number') {
+    (merged as { pagination?: unknown }).pagination = {
+      ...pagination,
+      total_count: pagination.total_count + newCount,
+    };
   }
   return merged;
 }
@@ -496,17 +593,32 @@ function readRequestAccountId(req: Record<string, unknown> | undefined): string 
 
 /**
  * Pick a seeded `get_account_financials` fixture matching the request's
- * `account.account_id`. Unlike the array-collection helpers, this returns
- * the SINGLE matched envelope or `undefined` — `get_account_financials` is
- * a singleton response and "merge" reduces to "replace if the request's
- * account matches a seeded fixture".
+ * account. Unlike the array-collection helpers, this returns the SINGLE
+ * matched envelope or `undefined` — `get_account_financials` is a singleton
+ * response and "merge" reduces to "replace if the request's account matches
+ * a seeded fixture".
+ *
+ * Matching honors both the raw request and the resolved account from
+ * `resolveAccount`. `AccountReference` is a discriminated union — the
+ * operator-resolved variant carries `account_id` on the request, but the
+ * brand+operator variants do not. When the framework has already resolved
+ * the request to an account, prefer that resolved id so seeded fixtures
+ * find their match regardless of which `AccountReference` variant the
+ * buyer sent.
+ *
+ * @param resolvedAccountId - The `account_id` from `ctx.account` after
+ *   `resolveAccount` ran. Pass `undefined` when no account was resolved
+ *   (singleton-tenant adopters) — the function falls back to the request's
+ *   `account.account_id` field, which preserves the original semantics for
+ *   adopters who don't wire `resolveAccount`.
  */
 export function pickSeededAccountFinancialsForRequest(
   request: GetAccountFinancialsRequest | Record<string, unknown>,
-  seeded: readonly SeededAccountFinancials[]
+  seeded: readonly SeededAccountFinancials[],
+  resolvedAccountId?: string
 ): SeededAccountFinancials | undefined {
   if (!seeded.length) return undefined;
-  const requestedId = readRequestAccountId(request as Record<string, unknown>);
+  const requestedId = resolvedAccountId ?? readRequestAccountId(request as Record<string, unknown>);
   if (requestedId == null) return undefined;
   for (const entry of seeded) {
     const id = (entry.account as { account_id?: unknown } | undefined)?.account_id;
@@ -517,19 +629,38 @@ export function pickSeededAccountFinancialsForRequest(
 
 /**
  * Replace a `get_account_financials` response when a seeded fixture matches
- * the request's account. Returns the seeded fixture (preserving any
- * `context` / `ext` from the handler response is intentionally NOT done —
- * the seeded envelope is authoritative for the seeded account, including
- * its own `context` / `ext` if the fixture set them). When no fixture
- * matches, returns the handler response unchanged.
+ * the request's account. The seeded fixture is authoritative on the
+ * financials payload (spend, period, account, currency, ...). The handler's
+ * `context` and `ext` are framework-managed (`context` echoes
+ * `adcp_version` / `request_id`; `ext` carries adopter passthrough) and
+ * MUST be preserved across the replace — wire-correct context echo is the
+ * framework's responsibility, not the seed fixture's.
+ *
+ * When no fixture matches, returns the handler response unchanged.
+ *
+ * @param resolvedAccountId - Optional resolved `account_id` from
+ *   `ctx.account`; passed through to {@link pickSeededAccountFinancialsForRequest}.
  */
 export function replaceAccountFinancialsIfSeeded(
   request: GetAccountFinancialsRequest | Record<string, unknown>,
   response: GetAccountFinancialsResponse,
-  seeded: readonly SeededAccountFinancials[]
+  seeded: readonly SeededAccountFinancials[],
+  resolvedAccountId?: string
 ): GetAccountFinancialsResponse {
-  const picked = pickSeededAccountFinancialsForRequest(request, seeded);
-  return picked ?? response;
+  const picked = pickSeededAccountFinancialsForRequest(request, seeded, resolvedAccountId);
+  if (!picked) return response;
+  // Preserve framework-managed envelope fields from the handler response;
+  // seeded fixture owns the financials body. Pull `context` / `ext` off the
+  // handler response (when present) and re-stamp them on top of the seeded
+  // payload — the fixture's own `context` / `ext` (if any) lose to the
+  // handler's, which is correct: a seeded snapshot can't know the current
+  // request's `request_id` / `adcp_version` echo.
+  const handlerContext = (response as { context?: unknown }).context;
+  const handlerExt = (response as { ext?: unknown }).ext;
+  const merged: GetAccountFinancialsResponse = { ...picked };
+  if (handlerContext !== undefined) (merged as { context?: unknown }).context = handlerContext;
+  if (handlerExt !== undefined) (merged as { ext?: unknown }).ext = handlerExt;
+  return merged;
 }
 
 /**

--- a/src/lib/testing/index.ts
+++ b/src/lib/testing/index.ts
@@ -186,11 +186,25 @@ export {
   mergeSeedMediaBuy,
 } from './seed-merge';
 
-// Test-controller bridge: seeded `get_products` augmentation on sandbox requests.
+// Test-controller bridge: seeded augmentation of read-side responses on sandbox
+// requests. Per-tool callbacks (`getSeededProducts`, `getSeededCreatives`,
+// `getSeededMediaBuys`, `getSeededAccounts`, `getSeededAccountFinancials`,
+// `getSeededCreativeFormats`) opt in by presence — see TestControllerBridge.
 export {
   isSandboxRequest,
   mergeSeededProductsIntoResponse,
   filterValidSeededProducts,
+  filterValidSeededCreatives,
+  filterValidSeededMediaBuys,
+  filterValidSeededAccounts,
+  filterValidSeededAccountFinancials,
+  filterValidSeededCreativeFormats,
+  mergeSeededCreativesIntoResponse,
+  mergeSeededMediaBuysIntoResponse,
+  mergeSeededAccountsIntoResponse,
+  mergeSeededCreativeFormatsIntoResponse,
+  pickSeededAccountFinancialsForRequest,
+  replaceAccountFinancialsIfSeeded,
   bridgeFromTestControllerStore,
   bridgeFromSessionStore,
 } from '../server/test-controller-bridge';
@@ -198,6 +212,9 @@ export type {
   TestControllerBridge,
   TestControllerBridgeContext,
   BridgeFromSessionStoreOptions,
+  SeededCreative,
+  SeededMediaBuy,
+  SeededAccountFinancials,
 } from '../server/test-controller-bridge';
 
 // One-call harness for server-side agents — composes serve() +

--- a/test/lib/seed-per-tool-wiring.test.js
+++ b/test/lib/seed-per-tool-wiring.test.js
@@ -672,3 +672,319 @@ describe('bridgeFromSessionStore — per-tool selectors', () => {
     assert.equal(bridge.getSeededCreativeFormats, undefined);
   });
 });
+
+// ---------------------------------------------------------------------------
+// get_account_financials — brand+operator AccountReference resolution
+//
+// AccountReference is a discriminated union. The brand+operator variants
+// don't carry `account_id` on the wire — `resolveAccount` produces a
+// resolved record with `account_id`, and the bridge MUST key on the
+// resolved id, not the (absent) request field.
+// ---------------------------------------------------------------------------
+
+describe('get_account_financials — brand+operator account reference resolution', () => {
+  it('matches seeded fixture against resolved ctx.account.account_id on brand+operator requests', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      resolveAccount: async () => ({ account_id: 'resolved-acct-7', sandbox: true }),
+      accounts: {
+        getAccountFinancials: async () => ({
+          account: { account_id: 'resolved-acct-7' },
+          currency: 'USD',
+          period: { start: '2025-01-01', end: '2025-01-31' },
+          timezone: 'UTC',
+          spend: { total_spend: 1 },
+        }),
+      },
+      testController: {
+        getSeededAccountFinancials: () => [
+          {
+            account: { account_id: 'resolved-acct-7' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 4242 },
+          },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { brand: { domain: 'example.com' }, operator: 'example.com', sandbox: true },
+    });
+    assert.equal(res.structuredContent.spend.total_spend, 4242, 'seeded fixture should replace via resolved id');
+  });
+
+  it('passes handler envelope through unchanged when no seeded fixture matches the resolved id', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      resolveAccount: async () => ({ account_id: 'resolved-acct-8', sandbox: true }),
+      accounts: {
+        getAccountFinancials: async () => ({
+          account: { account_id: 'resolved-acct-8' },
+          currency: 'USD',
+          period: { start: '2025-01-01', end: '2025-01-31' },
+          timezone: 'UTC',
+          spend: { total_spend: 17 },
+        }),
+      },
+      testController: {
+        getSeededAccountFinancials: () => [
+          {
+            account: { account_id: 'some-other-account' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 999 },
+          },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { brand: { domain: 'example.com' }, operator: 'example.com', sandbox: true },
+    });
+    assert.equal(res.structuredContent.spend.total_spend, 17, 'handler response should pass through unchanged');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_account_financials — preserve handler context/ext on singleton replace
+// ---------------------------------------------------------------------------
+
+describe('get_account_financials — handler context/ext preserved on singleton replace', () => {
+  it('preserves handler.context and handler.ext when replacing with seeded financials', async () => {
+    const handlerEnvelope = {
+      context: { adcp_version: '3.0.11', request_id: 'req-xyz' },
+      ext: { audit: { trace_id: 'trace-1' } },
+      account: { account_id: 'acct-ctx' },
+      currency: 'USD',
+      period: { start: '2025-01-01', end: '2025-01-31' },
+      timezone: 'UTC',
+      spend: { total_spend: 1 },
+    };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: { getAccountFinancials: async () => handlerEnvelope },
+      testController: {
+        getSeededAccountFinancials: () => [
+          {
+            // Seeded fixture has NO context / ext. Replace must preserve
+            // the handler's context echo, not produce a fixture envelope
+            // missing it.
+            account: { account_id: 'acct-ctx' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 7777 },
+          },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { account_id: 'acct-ctx', sandbox: true },
+    });
+    assert.equal(res.structuredContent.spend.total_spend, 7777, 'financials replaced by seeded fixture');
+    assert.deepEqual(
+      res.structuredContent.context,
+      { adcp_version: '3.0.11', request_id: 'req-xyz' },
+      'handler context preserved across replace'
+    );
+    assert.deepEqual(
+      res.structuredContent.ext,
+      { audit: { trace_id: 'trace-1' } },
+      'handler ext preserved across replace'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_account_financials — duplicate seeded account_ids warn-and-drop
+// ---------------------------------------------------------------------------
+
+describe('get_account_financials — duplicate seeded account_ids', () => {
+  it('warns and drops duplicate seeded entries by account.account_id (first wins)', async () => {
+    const warnings = [];
+    const logger = {
+      info: () => {},
+      warn: (message, meta) => warnings.push({ message, meta }),
+      error: () => {},
+      debug: () => {},
+    };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      logger,
+      accounts: {
+        getAccountFinancials: async () => ({
+          account: { account_id: 'dup-acct' },
+          currency: 'USD',
+          period: { start: '2025-01-01', end: '2025-01-31' },
+          timezone: 'UTC',
+          spend: { total_spend: 1 },
+        }),
+      },
+      testController: {
+        getSeededAccountFinancials: () => [
+          {
+            account: { account_id: 'dup-acct' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 100 },
+          },
+          {
+            account: { account_id: 'dup-acct' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 200 },
+          },
+          {
+            account: { account_id: 'other-acct' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 300 },
+          },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { account_id: 'dup-acct', sandbox: true },
+    });
+    // First seeded fixture (total_spend: 100) wins; the duplicate (total_spend: 200) is dropped.
+    assert.equal(res.structuredContent.spend.total_spend, 100);
+    const dupWarn = warnings.find(w => /duplicate account.account_id/.test(w.message));
+    assert.ok(dupWarn, 'should have logged a duplicate-drop warning');
+    assert.equal(dupWarn.meta.account_id, 'dup-acct');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list_creatives — query_summary count update on merge
+// ---------------------------------------------------------------------------
+
+describe('list_creatives — query_summary count updates on merge', () => {
+  it('updates returned and total_matching when new seeded entries append', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: {
+        listCreatives: async () => ({
+          query_summary: { total_matching: 50, returned: 2 },
+          pagination: { has_more: true, total_count: 50 },
+          creatives: [
+            { creative_id: 'h-1', name: 'A' },
+            { creative_id: 'h-2', name: 'B' },
+          ],
+        }),
+      },
+      testController: {
+        getSeededCreatives: () => [
+          { creative_id: 's-1', name: 'X' },
+          { creative_id: 's-2', name: 'Y' },
+          { creative_id: 's-3', name: 'Z' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    assert.equal(res.structuredContent.creatives.length, 5);
+    assert.equal(res.structuredContent.query_summary.returned, 5, 'returned == final array length');
+    assert.equal(res.structuredContent.query_summary.total_matching, 53, 'total_matching += new seeded count');
+    // pagination.total_count mirrors the delta when the handler set it.
+    assert.equal(res.structuredContent.pagination.total_count, 53);
+  });
+
+  it('does not inflate counts on id collision (dedupe wins, no drift)', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: {
+        listCreatives: async () => ({
+          query_summary: { total_matching: 10, returned: 3 },
+          pagination: { has_more: false, total_count: 10 },
+          creatives: [
+            { creative_id: 'shared-1', name: 'A' },
+            { creative_id: 'shared-2', name: 'B' },
+            { creative_id: 'h-only', name: 'C' },
+          ],
+        }),
+      },
+      testController: {
+        getSeededCreatives: () => [
+          { creative_id: 'shared-1', name: 'A-seeded' },
+          { creative_id: 'shared-2', name: 'B-seeded' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    assert.equal(res.structuredContent.creatives.length, 3, 'array length unchanged on full collision');
+    assert.equal(res.structuredContent.query_summary.returned, 3);
+    assert.equal(
+      res.structuredContent.query_summary.total_matching,
+      10,
+      'no drift; collided entries do not grow total'
+    );
+    assert.equal(res.structuredContent.pagination.total_count, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// get_media_buys — pagination.total_count update on merge
+// ---------------------------------------------------------------------------
+
+describe('get_media_buys — pagination.total_count updates on merge', () => {
+  it('updates pagination.total_count when new seeded entries append', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        getMediaBuys: async () => ({
+          pagination: { has_more: true, total_count: 50 },
+          media_buys: [
+            { media_buy_id: 'h-1', status: 'active', currency: 'USD' },
+            { media_buy_id: 'h-2', status: 'active', currency: 'USD' },
+          ],
+        }),
+      },
+      testController: {
+        getSeededMediaBuys: () => [
+          { media_buy_id: 's-1', status: 'active', currency: 'USD' },
+          { media_buy_id: 's-2', status: 'active', currency: 'USD' },
+          { media_buy_id: 's-3', status: 'active', currency: 'USD' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_media_buys', { account: SANDBOX_ACCOUNT });
+    assert.equal(res.structuredContent.media_buys.length, 5);
+    assert.equal(res.structuredContent.pagination.total_count, 53);
+  });
+
+  it('does not inflate pagination.total_count on full id collision', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        getMediaBuys: async () => ({
+          pagination: { has_more: false, total_count: 10 },
+          media_buys: [
+            { media_buy_id: 'shared-1', status: 'active', currency: 'USD' },
+            { media_buy_id: 'shared-2', status: 'active', currency: 'USD' },
+            { media_buy_id: 'h-only', status: 'active', currency: 'USD' },
+          ],
+        }),
+      },
+      testController: {
+        getSeededMediaBuys: () => [
+          { media_buy_id: 'shared-1', status: 'completed', currency: 'USD' },
+          { media_buy_id: 'shared-2', status: 'completed', currency: 'USD' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_media_buys', { account: SANDBOX_ACCOUNT });
+    assert.equal(res.structuredContent.media_buys.length, 3);
+    assert.equal(res.structuredContent.pagination.total_count, 10);
+  });
+});

--- a/test/lib/seed-per-tool-wiring.test.js
+++ b/test/lib/seed-per-tool-wiring.test.js
@@ -1,0 +1,674 @@
+/**
+ * Wiring tests for the per-tool `TestControllerBridge` callbacks added for
+ * platform-proxy sellers (adcp-client#1002). Each callback mirrors the
+ * `getSeededProducts` contract — opt-in by presence, post-handler merge,
+ * gated on sandbox + resolved-account + controller-present.
+ *
+ * Each suite below verifies: seeded-only path, handler-only path, merge
+ * path (order matches `getSeededProducts` — handler entries first, seeded
+ * append), sandbox-gating refusal, validation drop. Schema validation is
+ * opted off so fixtures can stay minimal (just the id field + a name) and
+ * the tests focus on merge semantics, not response-shape coverage.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createAdcpServer: _createAdcpServer } = require('../../dist/lib/server/create-adcp-server');
+const { bridgeFromSessionStore } = require('../../dist/lib/server/index.js');
+
+function createAdcpServer(config) {
+  return _createAdcpServer({
+    ...config,
+    validation: { requests: 'off', responses: 'off', ...(config?.validation ?? {}) },
+  });
+}
+
+function dispatch(server, name, args) {
+  return server.dispatchTestRequest({
+    method: 'tools/call',
+    params: { name, arguments: args },
+  });
+}
+
+const SANDBOX_ACCOUNT = { brand: { domain: 'example.com' }, operator: 'example.com', sandbox: true };
+
+// ---------------------------------------------------------------------------
+// getSeededCreatives — list_creatives
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — getSeededCreatives wiring (list_creatives)', () => {
+  function handlerWith(creatives) {
+    return async () => ({
+      query_summary: { total_matching: creatives.length, returned: creatives.length },
+      pagination: { limit: 50, offset: 0, has_more: false },
+      creatives,
+    });
+  }
+
+  it('appends seeded creatives to handler output on sandbox requests', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: {
+        listCreatives: handlerWith([{ creative_id: 'handler-1', name: 'Handler' }]),
+      },
+      testController: {
+        getSeededCreatives: () => [
+          { creative_id: 'seed-1', name: 'Seeded 1' },
+          { creative_id: 'seed-2', name: 'Seeded 2' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    const ids = res.structuredContent.creatives.map(c => c.creative_id);
+    assert.deepEqual(ids, ['handler-1', 'seed-1', 'seed-2']);
+    assert.equal(res.structuredContent.sandbox, true);
+  });
+
+  it('returns handler-only entries when getSeededCreatives is omitted', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: {
+        listCreatives: handlerWith([
+          { creative_id: 'h-1', name: 'A' },
+          { creative_id: 'h-2', name: 'B' },
+          { creative_id: 'h-3', name: 'C' },
+        ]),
+      },
+      testController: {},
+    });
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.creatives.map(c => c.creative_id),
+      ['h-1', 'h-2', 'h-3']
+    );
+  });
+
+  it('returns seeded-only entries when handler returned empty', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: { listCreatives: handlerWith([]) },
+      testController: {
+        getSeededCreatives: () => [
+          { creative_id: 's-1', name: 'A' },
+          { creative_id: 's-2', name: 'B' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.creatives.map(c => c.creative_id),
+      ['s-1', 's-2']
+    );
+  });
+
+  it('does not call the bridge on non-sandbox requests', async () => {
+    let bridgeCalled = false;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: { listCreatives: handlerWith([{ creative_id: 'h-1', name: 'A' }]) },
+      testController: {
+        getSeededCreatives: () => {
+          bridgeCalled = true;
+          return [{ creative_id: 's-1', name: 'Seed' }];
+        },
+      },
+    });
+    const res = await dispatch(server, 'list_creatives', {
+      account: { brand: { domain: 'example.com' }, operator: 'example.com' /* no sandbox */ },
+    });
+    assert.equal(bridgeCalled, false);
+    assert.deepEqual(
+      res.structuredContent.creatives.map(c => c.creative_id),
+      ['h-1']
+    );
+  });
+
+  it('drops seeded entries missing creative_id and keeps valid ones', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      creative: { listCreatives: handlerWith([]) },
+      testController: {
+        getSeededCreatives: () => [
+          { creative_id: 'ok-1', name: 'A' },
+          { name: 'no id' },
+          { creative_id: '', name: 'empty id' },
+          { creative_id: 'ok-2', name: 'B' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creatives', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.creatives.map(c => c.creative_id),
+      ['ok-1', 'ok-2']
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSeededMediaBuys — get_media_buys
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — getSeededMediaBuys wiring (get_media_buys)', () => {
+  function handlerWith(buys) {
+    return async () => ({ media_buys: buys });
+  }
+
+  it('appends seeded media buys to handler output on sandbox requests', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        getMediaBuys: handlerWith([{ media_buy_id: 'h-1', status: 'active', currency: 'USD' }]),
+      },
+      testController: {
+        getSeededMediaBuys: () => [
+          { media_buy_id: 's-1', status: 'active', currency: 'USD' },
+          { media_buy_id: 's-2', status: 'completed', currency: 'USD' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_media_buys', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.media_buys.map(b => b.media_buy_id),
+      ['h-1', 's-1', 's-2']
+    );
+  });
+
+  it('seeded wins on media_buy_id collision', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        getMediaBuys: handlerWith([
+          { media_buy_id: 'shared', status: 'active', currency: 'USD' },
+          { media_buy_id: 'h-only', status: 'active', currency: 'USD' },
+        ]),
+      },
+      testController: {
+        getSeededMediaBuys: () => [{ media_buy_id: 'shared', status: 'completed', currency: 'USD' }],
+      },
+    });
+    const res = await dispatch(server, 'get_media_buys', { account: SANDBOX_ACCOUNT });
+    const byId = Object.fromEntries(res.structuredContent.media_buys.map(b => [b.media_buy_id, b.status]));
+    assert.equal(byId.shared, 'completed', 'seeded wins on collision');
+    assert.equal(byId['h-only'], 'active');
+  });
+
+  it('handler-only when bridge omitted', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { getMediaBuys: handlerWith([{ media_buy_id: 'h-1', status: 'active', currency: 'USD' }]) },
+      testController: {},
+    });
+    const res = await dispatch(server, 'get_media_buys', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.media_buys.map(b => b.media_buy_id),
+      ['h-1']
+    );
+  });
+
+  it('skipped on non-sandbox requests', async () => {
+    let called = false;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { getMediaBuys: handlerWith([]) },
+      testController: {
+        getSeededMediaBuys: () => {
+          called = true;
+          return [{ media_buy_id: 's-1', status: 'active', currency: 'USD' }];
+        },
+      },
+    });
+    const res = await dispatch(server, 'get_media_buys', {
+      account: { brand: { domain: 'example.com' }, operator: 'example.com' },
+    });
+    assert.equal(called, false);
+    assert.deepEqual(res.structuredContent.media_buys, []);
+  });
+
+  it('drops seeded entries missing media_buy_id', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { getMediaBuys: handlerWith([]) },
+      testController: {
+        getSeededMediaBuys: () => [
+          { media_buy_id: 'ok-1', status: 'active', currency: 'USD' },
+          { status: 'active', currency: 'USD' },
+          { media_buy_id: '', status: 'active', currency: 'USD' },
+          { media_buy_id: 'ok-2', status: 'active', currency: 'USD' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_media_buys', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.media_buys.map(b => b.media_buy_id),
+      ['ok-1', 'ok-2']
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSeededAccounts — list_accounts
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — getSeededAccounts wiring (list_accounts)', () => {
+  function handlerWith(accounts) {
+    return async () => ({ accounts });
+  }
+
+  it('appends seeded accounts to handler output on sandbox requests', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: {
+        listAccounts: handlerWith([{ account_id: 'h-1', name: 'Handler', status: 'active' }]),
+      },
+      testController: {
+        getSeededAccounts: () => [{ account_id: 's-1', name: 'Seed', status: 'active' }],
+      },
+    });
+    const res = await dispatch(server, 'list_accounts', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.accounts.map(a => a.account_id),
+      ['h-1', 's-1']
+    );
+  });
+
+  it('drops seeded entries missing account_id', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: { listAccounts: handlerWith([]) },
+      testController: {
+        getSeededAccounts: () => [
+          { account_id: 'ok-1', name: 'A', status: 'active' },
+          { name: 'no id', status: 'active' },
+          { account_id: 'ok-2', name: 'B', status: 'active' },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_accounts', { account: SANDBOX_ACCOUNT });
+    assert.deepEqual(
+      res.structuredContent.accounts.map(a => a.account_id),
+      ['ok-1', 'ok-2']
+    );
+  });
+
+  it('skipped on non-sandbox requests', async () => {
+    let called = false;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: { listAccounts: handlerWith([{ account_id: 'h-1', name: 'A', status: 'active' }]) },
+      testController: {
+        getSeededAccounts: () => {
+          called = true;
+          return [{ account_id: 's-1', name: 'A', status: 'active' }];
+        },
+      },
+    });
+    const res = await dispatch(server, 'list_accounts', {
+      account: { brand: { domain: 'example.com' }, operator: 'example.com' },
+    });
+    assert.equal(called, false);
+    assert.deepEqual(
+      res.structuredContent.accounts.map(a => a.account_id),
+      ['h-1']
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSeededAccountFinancials — get_account_financials (singleton replace)
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — getSeededAccountFinancials wiring (get_account_financials)', () => {
+  // Note: get_account_financials returns a SINGLE envelope. The bridge picks
+  // the seeded fixture whose `account.account_id` matches the request's
+  // `account.account_id` and REPLACES the handler envelope for that account.
+  // No match → handler response passes through.
+  function handlerStub(result) {
+    return async () => result;
+  }
+
+  it('replaces handler response when seeded fixture matches request account_id', async () => {
+    const seededEnvelope = {
+      account: { account_id: 'acct-1' },
+      currency: 'USD',
+      period: { start: '2025-01-01', end: '2025-01-31' },
+      timezone: 'UTC',
+      spend: { total_spend: 999, media_buy_count: 5 },
+    };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: {
+        getAccountFinancials: handlerStub({
+          account: { account_id: 'acct-1' },
+          currency: 'USD',
+          period: { start: '2025-01-01', end: '2025-01-31' },
+          timezone: 'UTC',
+          spend: { total_spend: 1, media_buy_count: 1 },
+        }),
+      },
+      testController: {
+        getSeededAccountFinancials: () => [seededEnvelope],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { account_id: 'acct-1', sandbox: true },
+    });
+    assert.equal(res.structuredContent.spend.total_spend, 999);
+  });
+
+  it('passes through handler response when no seeded fixture matches', async () => {
+    const handlerEnvelope = {
+      account: { account_id: 'acct-2' },
+      currency: 'USD',
+      period: { start: '2025-01-01', end: '2025-01-31' },
+      timezone: 'UTC',
+      spend: { total_spend: 42 },
+    };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: { getAccountFinancials: handlerStub(handlerEnvelope) },
+      testController: {
+        getSeededAccountFinancials: () => [
+          {
+            account: { account_id: 'other-account' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+          },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { account_id: 'acct-2', sandbox: true },
+    });
+    assert.equal(res.structuredContent.spend.total_spend, 42);
+  });
+
+  it('drops seeded entries missing account.account_id', async () => {
+    let pickedReplaced = false;
+    const handlerEnvelope = {
+      account: { account_id: 'acct-3' },
+      currency: 'USD',
+      period: { start: '2025-01-01', end: '2025-01-31' },
+      timezone: 'UTC',
+      spend: { total_spend: 7 },
+    };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: { getAccountFinancials: handlerStub(handlerEnvelope) },
+      testController: {
+        getSeededAccountFinancials: () => [
+          {
+            /* no account field — dropped */
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+          },
+          {
+            account: { account_id: 'acct-3' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+            spend: { total_spend: 555 },
+          },
+        ],
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { account_id: 'acct-3', sandbox: true },
+    });
+    // Valid seeded fixture (acct-3) replaced the handler response.
+    assert.equal(res.structuredContent.spend.total_spend, 555);
+    pickedReplaced = true;
+    assert.ok(pickedReplaced);
+  });
+
+  it('skipped on non-sandbox requests', async () => {
+    let called = false;
+    const handlerEnvelope = {
+      account: { account_id: 'acct-4' },
+      currency: 'USD',
+      period: { start: '2025-01-01', end: '2025-01-31' },
+      timezone: 'UTC',
+      spend: { total_spend: 11 },
+    };
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      accounts: { getAccountFinancials: handlerStub(handlerEnvelope) },
+      testController: {
+        getSeededAccountFinancials: () => {
+          called = true;
+          return [
+            {
+              account: { account_id: 'acct-4' },
+              currency: 'USD',
+              period: { start: '2025-01-01', end: '2025-01-31' },
+              timezone: 'UTC',
+              spend: { total_spend: 999 },
+            },
+          ];
+        },
+      },
+    });
+    const res = await dispatch(server, 'get_account_financials', {
+      account: { account_id: 'acct-4' /* no sandbox */ },
+    });
+    assert.equal(called, false);
+    assert.equal(res.structuredContent.spend.total_spend, 11);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSeededCreativeFormats — list_creative_formats
+// ---------------------------------------------------------------------------
+
+describe('createAdcpServer — getSeededCreativeFormats wiring (list_creative_formats)', () => {
+  function handlerWith(formats) {
+    return async () => ({ formats });
+  }
+
+  function makeFormat(agentUrl, id, overrides = {}) {
+    return {
+      format_id: { agent_url: agentUrl, id },
+      name: `Format ${id}`,
+      ...overrides,
+    };
+  }
+
+  it('appends seeded formats to handler output on sandbox requests', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        listCreativeFormats: handlerWith([makeFormat('https://h.example', 'h-1')]),
+      },
+      testController: {
+        getSeededCreativeFormats: () => [
+          makeFormat('https://s.example', 's-1'),
+          makeFormat('https://s.example', 's-2'),
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creative_formats', { context: { sandbox: true } });
+    const ids = res.structuredContent.formats.map(f => f.format_id.id);
+    assert.deepEqual(ids, ['h-1', 's-1', 's-2']);
+    assert.equal(res.structuredContent.sandbox, true);
+  });
+
+  it('seeded wins on (agent_url|id) collision', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: {
+        listCreativeFormats: handlerWith([
+          makeFormat('https://x.example', 'shared', { name: 'Handler shared' }),
+          makeFormat('https://x.example', 'h-only', { name: 'Handler only' }),
+        ]),
+      },
+      testController: {
+        getSeededCreativeFormats: () => [makeFormat('https://x.example', 'shared', { name: 'Seeded shared' })],
+      },
+    });
+    const res = await dispatch(server, 'list_creative_formats', { context: { sandbox: true } });
+    const byId = Object.fromEntries(res.structuredContent.formats.map(f => [f.format_id.id, f.name]));
+    assert.equal(byId.shared, 'Seeded shared');
+    assert.equal(byId['h-only'], 'Handler only');
+  });
+
+  it('drops seeded entries with incomplete format_id', async () => {
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { listCreativeFormats: handlerWith([]) },
+      testController: {
+        getSeededCreativeFormats: () => [
+          makeFormat('https://x.example', 'ok-1'),
+          { name: 'no format_id' },
+          { format_id: { agent_url: '', id: 'empty-url' }, name: 'bad' },
+          { format_id: { agent_url: 'https://x.example' /* no id */ }, name: 'bad' },
+          makeFormat('https://x.example', 'ok-2'),
+        ],
+      },
+    });
+    const res = await dispatch(server, 'list_creative_formats', { context: { sandbox: true } });
+    assert.deepEqual(
+      res.structuredContent.formats.map(f => f.format_id.id),
+      ['ok-1', 'ok-2']
+    );
+  });
+
+  it('skipped on non-sandbox requests', async () => {
+    let called = false;
+    const server = createAdcpServer({
+      name: 'Test',
+      version: '1.0.0',
+      mediaBuy: { listCreativeFormats: handlerWith([makeFormat('https://x.example', 'h-1')]) },
+      testController: {
+        getSeededCreativeFormats: () => {
+          called = true;
+          return [makeFormat('https://x.example', 's-1')];
+        },
+      },
+    });
+    const res = await dispatch(server, 'list_creative_formats', {});
+    assert.equal(called, false);
+    assert.deepEqual(
+      res.structuredContent.formats.map(f => f.format_id.id),
+      ['h-1']
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bridgeFromSessionStore — per-tool selectors
+// ---------------------------------------------------------------------------
+
+describe('bridgeFromSessionStore — per-tool selectors', () => {
+  it('wires getSeededCreatives from selectSeededCreatives', async () => {
+    const bridge = bridgeFromSessionStore({
+      loadSession: () => ({
+        creatives: [{ creative_id: 'sc-1', name: 'A' }],
+      }),
+      selectSeededProducts: () => undefined,
+      selectSeededCreatives: session => session.creatives,
+    });
+    const out = await bridge.getSeededCreatives({ input: {} });
+    assert.deepEqual(
+      out.map(c => c.creative_id),
+      ['sc-1']
+    );
+  });
+
+  it('wires getSeededMediaBuys from selectSeededMediaBuys', async () => {
+    const bridge = bridgeFromSessionStore({
+      loadSession: () => ({
+        buys: [{ media_buy_id: 'mb-1', status: 'active', currency: 'USD' }],
+      }),
+      selectSeededProducts: () => undefined,
+      selectSeededMediaBuys: session => session.buys,
+    });
+    const out = await bridge.getSeededMediaBuys({ input: {} });
+    assert.deepEqual(
+      out.map(b => b.media_buy_id),
+      ['mb-1']
+    );
+  });
+
+  it('wires getSeededAccounts from selectSeededAccounts', async () => {
+    const bridge = bridgeFromSessionStore({
+      loadSession: () => ({ accounts: [{ account_id: 'a-1', name: 'A', status: 'active' }] }),
+      selectSeededProducts: () => undefined,
+      selectSeededAccounts: session => session.accounts,
+    });
+    const out = await bridge.getSeededAccounts({ input: {} });
+    assert.deepEqual(
+      out.map(a => a.account_id),
+      ['a-1']
+    );
+  });
+
+  it('wires getSeededAccountFinancials from selectSeededAccountFinancials', async () => {
+    const bridge = bridgeFromSessionStore({
+      loadSession: () => ({
+        fins: [
+          {
+            account: { account_id: 'a-1' },
+            currency: 'USD',
+            period: { start: '2025-01-01', end: '2025-01-31' },
+            timezone: 'UTC',
+          },
+        ],
+      }),
+      selectSeededProducts: () => undefined,
+      selectSeededAccountFinancials: session => session.fins,
+    });
+    const out = await bridge.getSeededAccountFinancials({ input: {} });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].account.account_id, 'a-1');
+  });
+
+  it('wires getSeededCreativeFormats from selectSeededCreativeFormats', async () => {
+    const bridge = bridgeFromSessionStore({
+      loadSession: () => ({
+        formats: [{ format_id: { agent_url: 'https://x.example', id: 'f-1' }, name: 'A' }],
+      }),
+      selectSeededProducts: () => undefined,
+      selectSeededCreativeFormats: session => session.formats,
+    });
+    const out = await bridge.getSeededCreativeFormats({ input: {} });
+    assert.deepEqual(
+      out.map(f => f.format_id.id),
+      ['f-1']
+    );
+  });
+
+  it('omits per-tool callbacks when no selector is provided', async () => {
+    const bridge = bridgeFromSessionStore({
+      loadSession: () => ({}),
+      selectSeededProducts: () => undefined,
+    });
+    assert.equal(typeof bridge.getSeededProducts, 'function');
+    assert.equal(bridge.getSeededCreatives, undefined);
+    assert.equal(bridge.getSeededMediaBuys, undefined);
+    assert.equal(bridge.getSeededAccounts, undefined);
+    assert.equal(bridge.getSeededAccountFinancials, undefined);
+    assert.equal(bridge.getSeededCreativeFormats, undefined);
+  });
+});


### PR DESCRIPTION
Closes #1002.

## Context

Platform-proxy sellers (DSPs, walled gardens, retail-media networks) run adapters that proxy AdCP tool calls to upstream platforms — state of record lives upstream, not in the seller's data layer. Today `TestControllerBridge` only exposes `getSeededProducts`, so storyboard seeds against every other read tool (`seed_creative`, `seed_media_buy`, etc.) are dead writes; without per-platform upstream-client stubs (~150–300 LOC × 13 platforms in Scope3's case), conformance runs either need real upstream OAuth or skip those steps.

This PR extends the same bridge pattern across the read-side tool surface so a platform-proxy seller wires one `TestControllerBridge` (typically via `bridgeFromSessionStore`) and the framework feeds seeded fixtures into the read path on sandbox requests — without bypassing adapter code (that was the rejected Option A from the triage on #1002; this is Option B).

cc Scope3 (per #1002).

## Summary

Five new opt-in callbacks on `TestControllerBridge<TAccount>`, all mirroring `getSeededProducts` exactly (post-handler merge, opt-in by presence, gated on sandbox + resolved-account + controller-present, warn-and-drop validation):

| Callback                          | Tool                      | Semantics                                                                     | Dedup key                                              |
| --------------------------------- | ------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------ |
| `getSeededCreatives`              | `list_creatives`          | append; seeded wins on collision                                              | `creative_id`                                          |
| `getSeededMediaBuys`              | `get_media_buys`          | append; seeded wins on collision                                              | `media_buy_id`                                         |
| `getSeededAccounts`               | `list_accounts`           | append; seeded wins on collision                                              | `account_id`                                           |
| `getSeededAccountFinancials`      | `get_account_financials`  | **singleton replace** — pick fixture matching request's `account.account_id`  | `account.account_id`                                   |
| `getSeededCreativeFormats`        | `list_creative_formats`   | append; seeded wins on collision                                              | canonical `format_id.agent_url\|format_id.id`          |

`bridgeFromSessionStore` gets matching `selectSeeded*` selectors so adopters wiring storyboards via the session-store pattern get all bridges in one helper. Per-tool callbacks are omitted from the returned bridge when no selector is provided.

Production traffic is unchanged: bridges run only on sandbox-flagged requests (`account.sandbox === true` or `context.sandbox === true`) against a registered controller, with the additional resolved-account `sandbox: true` cross-check when `resolveAccount` is wired.

### Notes on shape

- `get_account_financials` is the singleton exception — it returns one account's envelope, so "merge" reduces to "replace if the request's `account.account_id` matches a seeded fixture". The bridge interface and validation pattern still mirror the others.
- `list_creative_formats` composes with `SalesPlatform.listCreativeFormats` / `CreativeBuilderPlatform.listCreativeFormats` — the adapter handler runs first, then this bridge supplements. Not a replacement for those handler-side hooks; storyboards use the bridge to inject test-only formats.
- Type derivation: seeded entry types are derived via lookup (`ListCreativesResponse['creatives'][number]`, etc.) so they stay in lockstep with the generated wire schema. The named entity types `Account` and `Format` are imported directly. `SeededCreative`, `SeededMediaBuy`, `SeededAccountFinancials` are exported from `@adcp/sdk/server` and `@adcp/sdk/testing`.

## Test plan

- [x] `test/lib/seed-per-tool-wiring.test.js` — 27 new tests covering, per callback: seeded-only path, handler-only path, merge path (handler entries first, seeded append, seeded wins on collision), sandbox-gating refusal, validation drop.
- [x] `test/lib/test-controller-bridge.test.js` and `test/lib/seed-get-products-wiring.test.js` still pass (no regression in `getSeededProducts` precedent).
- [x] `bridgeFromSessionStore` per-tool selector wiring — 6 tests covering each new selector and the "no selector → no callback" omission.
- [x] Full test suite: 8638 tests pass / 0 fail / 3 skipped.
- [x] `npm run format:check` clean.
- [x] `npm run build` clean.

## Migration

None — additive. Existing `testController: { getSeededProducts }` adopters are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)