### PR TITLE
docs(client): note hostile-peer SSE bypass on `maxResponseBytes` (#1757)

### DIFF
--- a/.changeset/max-response-bytes-sse-hostile-peer-note.md
+++ b/.changeset/max-response-bytes-sse-hostile-peer-note.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+docs(client): note hostile-peer SSE bypass on `maxResponseBytes` (#1757)

--- a/src/lib/protocols/index.ts
+++ b/src/lib/protocols/index.ts
@@ -174,6 +174,16 @@ export interface TransportOptions {
    * non-streaming transports) where the body is bounded by definition.
    *
    * @remarks
+   * **Hostile-peer note:** A peer can opt itself out of this cap by responding
+   * with `Content-Type: text/event-stream`. SSE is bypassed because cumulative
+   * event-frame bytes are unbounded by spec — MCP and A2A both stream tool
+   * responses this way. The MCP/A2A SDKs consume SSE incrementally and frame
+   * termination bounds memory in practice, so this is not a memory-bomb risk
+   * for well-formed transports. Adopters relying on `maxResponseBytes` as a
+   * hostile-server defense should treat it as best-effort for non-SSE
+   * responses only.
+   *
+   * @remarks
    * Future hardening knobs (DNS-rebind defense, scheme allow-list, request
    * timeout overrides) will land here as additional fields rather than
    * forcing callers to compose their own `fetch` — wrap order with the SDK's


### PR DESCRIPTION
## Summary

Closes #1757.

Appends a hostile-peer caveat to the `TransportOptions.maxResponseBytes` TSDoc in `src/lib/protocols/index.ts`. The existing `@remarks` block already documents the SSE pass-through as a feature (so legitimate long-lived buyer sessions aren't torn down). This adds a second `@remarks` block immediately after it, naming the corollary: a peer can opt itself out of the cap by responding with `Content-Type: text/event-stream`.

Why this matters: MCP and A2A both stream tool responses as SSE, and cumulative event-frame bytes are unbounded by spec. The MCP/A2A SDKs consume SSE incrementally and frame termination bounds memory in practice, so this is not a memory-bomb risk for well-formed transports — but adopters relying on `maxResponseBytes` as a hostile-server defense should treat it as best-effort for non-SSE responses only.

Docs-only. No behavior change. Patch changeset per CLAUDE.md changeset conventions (library TSDoc ships in the published package).

Context:
- #1757 — this issue.
- #1750 — the SSE bypass fix that made this caveat necessary.
- #1176 — original `maxResponseBytes` issue.

## Test plan

- [x] `npm run format:check` clean.
- [x] `npm run typecheck` clean.
- [ ] CI green on the patch changeset.