### PR TITLE
fix(eslint-plugin): close 3 false-negatives + add additionalPatterns option (#1758)

### DIFF
--- a/.changeset/eslint-plugin-false-negatives.md
+++ b/.changeset/eslint-plugin-false-negatives.md
@@ -1,0 +1,19 @@
+---
+'@adcp/eslint-plugin': patch
+---
+
+fix(eslint-plugin): close destructure / default-param / nested destructure false-negatives + `additionalPatterns` option (#1758)
+
+Three bug-class false-negatives in `no-credential-read-from-args` now fire:
+
+- **Destructure-then-read** — `extractContext(args) { const { access_token } = args; ... }` (added `VariableDeclarator` visitor; recurses through nested `ObjectPattern`s and reports at the source key, not the alias).
+- **AssignmentPattern default-value silently disabled scanning** — `extractContext(args = {}) { args.access_token }` now unwraps `AssignmentPattern.left` in `firstParamIdentifierName`. `extractContext({ access_token } = {})` likewise.
+- **Nested destructure in first param** — `extractContext({ context: { access_token } })` now recurses and reports the full dotted path (`args.context.access_token`). Nested renames (`{ context: { access_token: tok } }`) fire on the source key.
+
+New `additionalPatterns` rule option lets adopters who extend the runtime matcher via `credentialPolicy.patterns.extend(...)` mirror the same strings at lint time. Compiled with the `i` flag and appended to `DEFAULT_CREDENTIAL_PATTERNS`. Fully-replaceable `credentialPolicy.matcher` functions stay a documented gap.
+
+False-positive fix: free-standing `function extractContext(args) { ... }` no longer fires — only object-literal `Property` and class-body `MethodDefinition` method bindings are matched. Class methods still fire (regression-covered).
+
+README adds a `Known gaps` section documenting aliasing / spread / helper-indirection / computed-key / cross-function bypasses that pass the linter by design; runtime `credentialPolicy: 'authInfo-only'` is the security boundary that catches all of them at dispatch.
+
+Test count: 14 → 30.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -56,8 +56,8 @@ const platform = {
 const platform = {
   extractContext(args, ctx) {
     return {
-      accountId: args.account_id,           // non-secret upstream ID
-      token: tokenCache.get(ctx.authInfo),  // secret comes from authInfo
+      accountId: args.account_id, // non-secret upstream ID
+      token: tokenCache.get(ctx.authInfo), // secret comes from authInfo
     };
   },
 };
@@ -72,6 +72,72 @@ Credential-name patterns are imported directly from
 `DEFAULT_CREDENTIAL_PATTERNS`. The runtime guard
 (`credentialPolicy: 'authInfo-only'`) and this rule share one regex set —
 adding a pattern to the SDK surfaces it here automatically.
+
+#### Option: `additionalPatterns`
+
+Adopters who extend the runtime matcher with `credentialPolicy.patterns.extend`
+can mirror the same strings here for lint parity:
+
+```js
+// eslint.config.js
+import adcp from '@adcp/eslint-plugin';
+
+export default [
+  {
+    plugins: { '@adcp': adcp },
+    rules: {
+      '@adcp/no-credential-read-from-args': [
+        'error',
+        { additionalPatterns: ['platform_session_key', 'vendor_bearer'] },
+      ],
+    },
+  },
+];
+```
+
+```ts
+// matching runtime config — keep the two lists in sync
+createAdcpServer({
+  credentialPolicy: {
+    mode: 'authInfo-only',
+    patterns: DEFAULT_CREDENTIAL_PATTERNS.extend(['platform_session_key', 'vendor_bearer']),
+  },
+});
+```
+
+Each entry is compiled as `new RegExp(pattern, 'i')` and appended to
+`DEFAULT_CREDENTIAL_PATTERNS`. A fully-replaceable `credentialPolicy.matcher`
+function has no lint analogue — see [Known gaps](#known-gaps).
+
+## Known gaps
+
+This rule is a code-write-time nudge, not the security boundary. The SDK's
+runtime guard (`credentialPolicy: 'authInfo-only'`) is what enforces the
+contract on the wire. The patterns below intentionally pass the linter
+because catching them at AST time would require cross-function or
+control-flow analysis and the false-positive cost is too high; the
+runtime guard catches all of them at dispatch.
+
+- **Aliasing** — `const a = args; a.access_token` (the rule only scans
+  reads rooted at the `args` parameter name).
+- **Spread** — `const ctx = { ...args }; ctx.access_token` (same — `ctx`
+  isn't `args`).
+- **Helper indirection** — `extractField(args, 'access_token')` (the
+  credential string lives in a sibling-function argument; cross-function
+  scope is out of scope).
+- **Computed access with a non-literal key** — `args[someVar]` (the rule
+  can't statically evaluate the key).
+- **Credential reads inside helper functions called from
+  `extractContext`** — only the body of the flagged method itself is
+  scanned; helpers it calls are not (cross-function scope).
+- **A fully-replaceable `credentialPolicy.matcher`** — function matchers
+  can't be expressed as a regex pattern list, so `additionalPatterns`
+  can't mirror them. If you replace the matcher entirely at runtime,
+  add explicit `additionalPatterns` entries here for the names you want
+  flagged at lint time.
+
+For all of the above, rely on `credentialPolicy: 'authInfo-only'` at the
+request boundary — it doesn't care how the read was spelled in source.
 
 ## Why this exists
 

--- a/packages/eslint-plugin/src/rules/no-credential-read-from-args.ts
+++ b/packages/eslint-plugin/src/rules/no-credential-read-from-args.ts
@@ -31,8 +31,24 @@ const createRule = ESLintUtils.RuleCreator(
 
 type MessageIds = 'credentialReadFromArgs';
 
-function isCredentialName(name: string): boolean {
-  return DEFAULT_CREDENTIAL_PATTERNS.some(rx => rx.test(name));
+type Options = [
+  {
+    additionalPatterns?: string[];
+  }?,
+];
+
+/**
+ * Build the active pattern set from the SDK defaults plus any
+ * adopter-supplied `additionalPatterns`. Adopters using
+ * `credentialPolicy.patterns.extend(...)` at runtime mirror the same
+ * strings here for lint parity. A fully-replaceable
+ * `credentialPolicy.matcher` function has no lint analogue — that's a
+ * known gap documented in the README.
+ */
+function buildPatternMatcher(extra: string[]): (name: string) => boolean {
+  const extraRegexes = extra.map(p => new RegExp(p, 'i'));
+  const patterns = [...DEFAULT_CREDENTIAL_PATTERNS, ...extraRegexes];
+  return (name: string) => patterns.some(rx => rx.test(name));
 }
 
 /**
@@ -76,10 +92,13 @@ function isRootedAtIdentifier(expr: TSESTree.Expression, name: string): boolean 
  * Handles:
  *   - Plain identifier: `(args) => …`
  *   - Typed identifier: `(args: Foo) => …`
- *   - Destructured first param: `({ access_token }) => …` (flagged directly
- *     at the destructure)
+ *   - Default-value: `(args = {}) => …` — unwrap `AssignmentPattern.left`
+ *   - Destructured first param: `({ access_token }) => …` (flagged via
+ *     the destructure scan, not via this name)
+ *   - Destructured with default: `({ access_token } = {}) => …` (same)
  *
- * Returns `null` when the function takes no params; the caller skips.
+ * Returns `null` when the function takes no params or when the first
+ * param has no nameable identifier (pure destructure).
  */
 function firstParamIdentifierName(
   fn: TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration
@@ -87,33 +106,92 @@ function firstParamIdentifierName(
   const first = fn.params[0];
   if (!first) return null;
   if (first.type === AST_NODE_TYPES.Identifier) return first.name;
-  // ObjectPattern / AssignmentPattern wrapping an Identifier — destructure
-  // cases are caught by the ObjectPattern scan below, not here.
+  if (first.type === AST_NODE_TYPES.AssignmentPattern) {
+    const left = first.left;
+    if (left.type === AST_NODE_TYPES.Identifier) return left.name;
+  }
+  // ObjectPattern / ArrayPattern — destructure cases are caught by the
+  // ObjectPattern scan below, not here.
   return null;
 }
 
 /**
- * If the function's first parameter is an ObjectPattern (destructured),
- * return the list of property names destructured. `({ access_token, foo })`
- * → `['access_token', 'foo']`. Used to flag the destructure form, which
- * never reaches a MemberExpression access.
+ * Walk the first parameter's `ObjectPattern` (including when wrapped in
+ * an `AssignmentPattern` for default-value forms like
+ * `({ access_token } = {})`) and collect every destructured key, including
+ * nested patterns. Reports paths like `args.context.access_token` so the
+ * error message reflects the depth of the destructure.
+ *
+ * Recurses through nested `ObjectPattern`s (`{ context: { access_token } }`)
+ * and handles renamed properties (`{ access_token: tok }` — fires on
+ * `access_token`, the source key, not the alias). `RestElement` is
+ * recorded as a binding but never matched against credential patterns:
+ * the post-extraction `rest.access_token` read is an aliasing pattern
+ * documented as out-of-scope.
  */
 function destructuredKeys(
   fn: TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration
-): { name: string; node: TSESTree.Node }[] {
+): { path: string; node: TSESTree.Node }[] {
   const first = fn.params[0];
-  if (!first || first.type !== AST_NODE_TYPES.ObjectPattern) return [];
-  const out: { name: string; node: TSESTree.Node }[] = [];
-  for (const prop of first.properties) {
-    if (prop.type !== AST_NODE_TYPES.Property) continue;
-    const key = prop.key;
-    if (key.type === AST_NODE_TYPES.Identifier) {
-      out.push({ name: key.name, node: key });
-    } else if (key.type === AST_NODE_TYPES.Literal && typeof key.value === 'string') {
-      out.push({ name: key.value, node: key });
-    }
+  if (!first) return [];
+
+  let pattern: TSESTree.Node = first;
+  if (pattern.type === AST_NODE_TYPES.AssignmentPattern) {
+    pattern = pattern.left;
   }
+  if (pattern.type !== AST_NODE_TYPES.ObjectPattern) return [];
+
+  const out: { path: string; node: TSESTree.Node }[] = [];
+  collectObjectPatternKeys(pattern, ['args'], out);
   return out;
+}
+
+/**
+ * Walk an ObjectPattern's properties, recursing into nested
+ * ObjectPatterns. `pathSoFar` accumulates the dotted-path segments used
+ * to render the error message (e.g. `['args', 'context']` →
+ * `args.context.access_token`).
+ */
+function collectObjectPatternKeys(
+  pattern: TSESTree.ObjectPattern,
+  pathSoFar: string[],
+  out: { path: string; node: TSESTree.Node }[]
+): void {
+  for (const prop of pattern.properties) {
+    if (prop.type === AST_NODE_TYPES.RestElement) continue;
+    if (prop.type !== AST_NODE_TYPES.Property) continue;
+
+    const keyName = propertyKeyName(prop.key, prop.computed);
+    if (keyName === null) continue;
+
+    // `prop.value` is the binding target — either an Identifier (plain or
+    // renamed), an ObjectPattern (nested destructure), or an
+    // AssignmentPattern wrapping either of those.
+    let valueNode: TSESTree.Node = prop.value;
+    if (valueNode.type === AST_NODE_TYPES.AssignmentPattern) {
+      valueNode = valueNode.left;
+    }
+
+    if (valueNode.type === AST_NODE_TYPES.ObjectPattern) {
+      collectObjectPatternKeys(valueNode, [...pathSoFar, keyName], out);
+      continue;
+    }
+
+    // Leaf binding — report at the source key (`prop.key`), not the
+    // alias (`prop.value`), so the error highlights the credential name
+    // the buyer would supply, not the local variable name the adopter
+    // chose.
+    out.push({
+      path: [...pathSoFar, keyName].join('.'),
+      node: prop.key,
+    });
+  }
+}
+
+function propertyKeyName(key: TSESTree.PropertyName | TSESTree.Expression, computed: boolean): string | null {
+  if (!computed && key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (key.type === AST_NODE_TYPES.Literal && typeof key.value === 'string') return key.value;
+  return null;
 }
 
 /**
@@ -127,13 +205,17 @@ function destructuredKeys(
  * Cases handled:
  *   - Object property: `{ extractContext: (args) => … }` / `{ extractContext(args) { … } }`
  *   - Class method: `class Foo { extractContext(args) { … } }`
- *   - Function declaration: `function extractContext(args) { … }`
+ *
+ * `FunctionDeclaration`s (`function extractContext(args) { … }`) are
+ * intentionally NOT matched — free-standing functions named
+ * `extractContext` are rare and the false-positive cost outweighs the
+ * duck-typed coverage win.
  */
 function methodNameForFunction(
   fn: TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression | TSESTree.FunctionDeclaration
 ): string | null {
-  if (fn.type === AST_NODE_TYPES.FunctionDeclaration && fn.id) {
-    return fn.id.name;
+  if (fn.type === AST_NODE_TYPES.FunctionDeclaration) {
+    return null;
   }
   const parent = (fn as unknown as { parent?: TSESTree.Node }).parent;
   if (!parent) return null;
@@ -155,7 +237,7 @@ function methodNameForFunction(
   return null;
 }
 
-export default createRule<[], MessageIds>({
+export default createRule<Options, MessageIds>({
   name: 'no-credential-read-from-args',
   meta: {
     type: 'problem',
@@ -167,10 +249,26 @@ export default createRule<[], MessageIds>({
       credentialReadFromArgs:
         'Reading credential-shaped key {{path}} from `args` trusts buyer-supplied identity. Re-derive bearers per request from `ctx.authInfo` + your token cache; embed only non-secret upstream IDs in `args`.',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          additionalPatterns: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+              'Extra regex patterns appended to DEFAULT_CREDENTIAL_PATTERNS. Mirror your credentialPolicy.patterns.extend contents here for lint parity.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
-  defaultOptions: [],
+  defaultOptions: [{}],
   create(context) {
+    const options = context.options[0] ?? {};
+    const isCredentialName = buildPatternMatcher(options.additionalPatterns ?? []);
+
     /**
      * Stack of `{ argsParamName }` frames for the platform methods we're
      * currently inside. The rule fires only when the stack is non-empty.
@@ -187,15 +285,21 @@ export default createRule<[], MessageIds>({
         const argsParamName = firstParamIdentifierName(fn);
         stack.push({ argsParamName });
 
-        // Destructure form: `({ access_token, ... }) => …` — flag at the
-        // destructure site directly. MemberExpression traversal can't see
-        // these because the access never happens.
-        for (const { name, node } of destructuredKeys(fn)) {
-          if (isCredentialName(name)) {
+        // Destructure form: `({ access_token, ... }) => …` (with or
+        // without an `AssignmentPattern` default-value wrapper, and
+        // including nested patterns) — flag at each leaf destructure
+        // site. MemberExpression traversal can't see these because the
+        // access never happens.
+        for (const { path, node } of destructuredKeys(fn)) {
+          // `path` is `args.<...>.<key>`; the leaf segment is the key
+          // whose name decides credential-shape.
+          const segments = path.split('.');
+          const leaf = segments[segments.length - 1];
+          if (leaf && isCredentialName(leaf)) {
             context.report({
               node,
               messageId: 'credentialReadFromArgs',
-              data: { path: `args.${name}` },
+              data: { path },
             });
           }
         }
@@ -223,6 +327,31 @@ export default createRule<[], MessageIds>({
       'FunctionExpression:exit': exitFunction,
       ArrowFunctionExpression: enterFunction,
       'ArrowFunctionExpression:exit': exitFunction,
+
+      VariableDeclarator(node: TSESTree.VariableDeclarator): void {
+        const frame = currentFrame();
+        if (!frame || frame.argsParamName === null) return;
+
+        // Only handle `const { ... } = args` shapes — the args parameter
+        // name has to appear on the right-hand side as an Identifier.
+        if (!node.init || node.init.type !== AST_NODE_TYPES.Identifier) return;
+        if (node.init.name !== frame.argsParamName) return;
+        if (node.id.type !== AST_NODE_TYPES.ObjectPattern) return;
+
+        const out: { path: string; node: TSESTree.Node }[] = [];
+        collectObjectPatternKeys(node.id, [frame.argsParamName], out);
+        for (const entry of out) {
+          const segments = entry.path.split('.');
+          const leaf = segments[segments.length - 1];
+          if (leaf && isCredentialName(leaf)) {
+            context.report({
+              node: entry.node,
+              messageId: 'credentialReadFromArgs',
+              data: { path: entry.path },
+            });
+          }
+        }
+      },
 
       MemberExpression(node: TSESTree.MemberExpression): void {
         const frame = currentFrame();

--- a/packages/eslint-plugin/test/no-credential-read-from-args.test.ts
+++ b/packages/eslint-plugin/test/no-credential-read-from-args.test.ts
@@ -64,6 +64,47 @@ ruleTester.run('no-credential-read-from-args', rule, {
         };
       `,
     },
+    {
+      name: 'free-standing function named extractContext — not a method binding (no false positive)',
+      code: `
+        function extractContext(args) {
+          return args.access_token;
+        }
+      `,
+    },
+    {
+      name: 'spread aliasing is a documented gap and stays valid in lint',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const ctx = { ...args };
+            return ctx.access_token;
+          },
+        };
+      `,
+    },
+    {
+      name: 'plain aliasing is a documented gap and stays valid in lint',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const a = args;
+            return a.access_token;
+          },
+        };
+      `,
+    },
+    {
+      name: 'destructure-then-read of a non-credential key',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const { session_id } = args;
+            return { sessionId: session_id };
+          },
+        };
+      `,
+    },
   ],
   invalid: [
     {
@@ -173,6 +214,145 @@ ruleTester.run('no-credential-read-from-args', rule, {
         };
       `,
       errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'destructure-then-read inside extractContext',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const { access_token } = args;
+            return { token: access_token };
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'destructure-then-read with rename — fires on source key, not alias',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const { access_token: tok } = args;
+            return { token: tok };
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'default-value first param does not silently disable scanning',
+      code: `
+        const platform = {
+          extractContext(args = {}) {
+            return args.access_token;
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'destructure-with-default first param',
+      code: `
+        const platform = {
+          extractContext({ access_token } = {}) {
+            return { token: access_token };
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'nested destructure in first param',
+      code: `
+        const platform = {
+          extractContext({ context: { access_token } }) {
+            return { token: access_token };
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.context.access_token' } }],
+    },
+    {
+      name: 'nested destructure with rename — fires on source key, not alias',
+      code: `
+        const platform = {
+          extractContext({ context: { access_token: tok } }) {
+            return { token: tok };
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.context.access_token' } }],
+    },
+    {
+      name: 'additionalPatterns flags a custom upstream credential name',
+      code: `
+        const platform = {
+          extractContext(args) {
+            return { token: args.platform_session_key };
+          },
+        };
+      `,
+      options: [{ additionalPatterns: ['platform_session_key'] }],
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.platform_session_key' } }],
+    },
+    {
+      name: 'additionalPatterns flags a destructured custom credential name',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const { vendor_bearer } = args;
+            return { token: vendor_bearer };
+          },
+        };
+      `,
+      options: [{ additionalPatterns: ['vendor_bearer'] }],
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.vendor_bearer' } }],
+    },
+    {
+      name: 'destructure-then-read with default value in declarator',
+      code: `
+        const platform = {
+          extractContext(args) {
+            const { access_token = 'fallback' } = args;
+            return { token: access_token };
+          },
+        };
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'class method — destructure-then-read still fires (regression for FunctionDeclaration drop)',
+      code: `
+        class MyPlatform {
+          extractContext(args) {
+            const { access_token } = args;
+            return { token: access_token };
+          }
+        }
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'class method — default-value param still fires',
+      code: `
+        class MyPlatform {
+          extractContext(args = {}) {
+            return { token: args.access_token };
+          }
+        }
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.access_token' } }],
+    },
+    {
+      name: 'class method — nested destructure still fires',
+      code: `
+        class MyPlatform {
+          extractContext({ context: { access_token } }) {
+            return { token: access_token };
+          }
+        }
+      `,
+      errors: [{ messageId: 'credentialReadFromArgs', data: { path: 'args.context.access_token' } }],
     },
   ],
 });


### PR DESCRIPTION
Closes #1758.

## Summary

Closes the three false-negative gaps in `no-credential-read-from-args` (shipped in #1752, on main but not yet released — the existing minor changeset is still pending) and adds an `additionalPatterns` rule option for adopters extending the runtime matcher.

## Bug-class fixes

1. **Destructure-then-read** — `extractContext(args) { const { access_token } = args; ... }` previously passed. New `VariableDeclarator` visitor handles this, recursing through nested `ObjectPattern`s and reporting at the source key (not the alias). Shares `collectObjectPatternKeys` with the first-param destructure scanner so both forms produce identical paths.
2. **`AssignmentPattern` default-value silently disabled scanning** — `extractContext(args = {})` previously made `firstParamIdentifierName` return `null`, which disabled the `MemberExpression` scanner. Now unwraps `AssignmentPattern.left` to recover the identifier name. `extractContext({ access_token } = {})` likewise — `destructuredKeys` unwraps the `AssignmentPattern` wrapper before pattern-walking.
3. **Nested destructure in first param** — `extractContext({ context: { access_token } })` previously only inspected the top-level pattern. `collectObjectPatternKeys` now recurses into nested `ObjectPattern`s and tracks the full path so the error message reads `args.context.access_token`. Nested renames (`{ context: { access_token: tok } }`) fire on the source key. `RestElement` skipped (documented gap).

## False-positive fix

Free-standing `function extractContext(args) { return args.access_token; }` no longer fires. Dropped the `FunctionDeclaration` branch from `methodNameForFunction` — only `Property` (object literals) and `MethodDefinition` (class bodies) are matched. Class methods still fire (three regression tests cover this).

## Rule option

New `additionalPatterns: string[]` option. Each entry compiled as `new RegExp(p, 'i')` and appended to `DEFAULT_CREDENTIAL_PATTERNS`. Adopters mirror their `credentialPolicy.patterns.extend(...)` runtime config for lint parity. Fully-replaceable `credentialPolicy.matcher` functions documented as a known gap (no regex analogue).

## README

Adds `Known gaps` section listing aliasing / spread / helper-indirection / computed-key / cross-function bypasses that pass the linter by design — runtime `credentialPolicy: 'authInfo-only'` is the security boundary. Adds an `additionalPatterns` option example with matching runtime config.

## Test count

14 → 30. New invalid cases: destructure-then-read (incl. rename, with-default, with-leaf-default), default-value param, destructure-with-default first param, nested destructure (plain + rename), `additionalPatterns` (member + destructure), class-method regression for each of the three fixes. New valid cases: free-standing `function extractContext`, spread aliasing, plain aliasing, destructure-then-read of a non-credential key.

## Changeset

`patch` on `@adcp/eslint-plugin`.

## Test plan

- [x] `cd packages/eslint-plugin && npm test` — 30/30 pass
- [x] `cd packages/eslint-plugin && npm run build` — clean
- [x] `npm run format:check` — clean
- [x] All 14 pre-existing tests still pass (verified via test count delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)