### PR TITLE
fix(client): route synthetic-v2 sellers through v2 adapter instead of refusing

### DIFF
--- a/.changeset/synthetic-v2-routes-as-v2.md
+++ b/.changeset/synthetic-v2-routes-as-v2.md
@@ -1,0 +1,13 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(client): route synthetic-v2 sellers through the v2 adapter instead of refusing the dispatch
+
+`requireSupportedMajor` (called by `requireV3ForMutations: true` before every mutating task) used to throw `VersionUnsupportedError(reason: 'synthetic')` when a seller's capabilities were synthesized from `tools/list` and the synthesized version was `'v2'` (no `get_adcp_capabilities` tool present). The throw blocked legitimate buyers from calling sellers that simply hadn't implemented the v3 discovery tool.
+
+A compliant v3 seller would declare itself via `get_adcp_capabilities`. Absence of that declaration is now read as v2: the SDK emits a one-time per-client warning (`maybeWarnSyntheticV2`) explaining the routing decision and dispatches through the v2 wire-shape adapter. Idempotency-TTL guarantees remain unknown for these sellers — BYOK retry callers should treat them as such.
+
+Synthetic-v3 behavior is unchanged (still accepts with `maybeWarnSyntheticV3`). Real declared-v2 sellers and real-v3-missing-idempotency-TTL sellers are still refused with their respective `VersionUnsupportedError` reasons.
+
+The `'synthetic'` member of `VersionUnsupportedReason` is retained for backwards compatibility with consumers that pattern-match on the union; no SDK call site throws it anymore.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adcp/sdk",
-  "version": "7.1.0",
+  "version": "7.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@adcp/sdk",
-      "version": "7.1.0",
+      "version": "7.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         ".",
@@ -6318,7 +6318,7 @@
       "version": "6.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.1.0"
+        "@adcp/sdk": "^7.3.0"
       },
       "bin": {
         "adcp": "bin/adcp.js"
@@ -6329,7 +6329,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.3.0",
+        "@adcp/sdk": "^7.1.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
       "devDependencies": {

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -404,6 +404,7 @@ export class SingleAgentClient {
   private cachedToolSchemas?: Map<string, Record<string, unknown>>; // inputSchema.properties per tool name
   private _v2WarningFired = false; // Gate: emit the v2-sunset warning once per client instance
   private _syntheticV3WarningFired = false; // Gate: emit the synthetic-v3 warning once per client instance
+  private _syntheticV2WarningFired = false; // Gate: emit the synthetic-v2 warning once per client instance
   private readonly resolvedAdcpVersion: string;
 
   constructor(
@@ -2999,6 +3000,27 @@ export class SingleAgentClient {
   }
 
   /**
+   * Warn once per client when `requireSupportedMajor` routes a synthetic-v2
+   * seller through the v2 adapter — the agent did not expose
+   * `get_adcp_capabilities`, so the version was inferred from `tools/list`.
+   * A compliant v3 seller would declare itself; absence of a declaration is
+   * read as v2. Idempotency-TTL guarantees are unknown for these sellers,
+   * so BYOK retry callers should treat them as such.
+   *
+   * One-shot via `_syntheticV2WarningFired` (matches `maybeWarnV2Sunset`
+   * cadence).
+   */
+  private maybeWarnSyntheticV2(): void {
+    if (this._syntheticV2WarningFired) return;
+    this._syntheticV2WarningFired = true;
+    console.warn(
+      `[adcp] Warning: agent ${this.agent.agent_uri} does not expose get_adcp_capabilities. ` +
+        `Routing as v2 (synthetic) — idempotency-TTL guarantee is unknown. ` +
+        `Ask the agent operator to declare v3 via get_adcp_capabilities if v3 routing is intended.`
+    );
+  }
+
+  /**
    * Detect server AdCP version
    *
    * @returns 'v2' or 'v3' based on server capabilities
@@ -3100,19 +3122,24 @@ export class SingleAgentClient {
    * is pinned to (per `getAdcpVersion()`).
    *
    * A self-reported `version: 'v3'` is not enough — a hostile or
-   * misconfigured seller can just string-claim the version. The guard
-   * requires:
+   * misconfigured seller can just string-claim the version. For sellers
+   * that return an authoritative `get_adcp_capabilities` response, the
+   * guard requires:
    *
    *   1. `capabilities.majorVersions.includes(<this client's major>)`
    *   2. `capabilities.idempotency.replayTtlSeconds` present (spec-required
-   *      for real major-3+ sellers; synthetic capabilities don't get this
-   *      free)
-   *   3. capabilities were not synthesized from a tool list
+   *      for real major-3+ sellers)
+   *
+   * Sellers whose capabilities are synthesized from `tools/list` (no
+   * authoritative `get_adcp_capabilities` response) are treated as v2: a
+   * compliant v3 seller would declare itself, so absence of a declaration
+   * is taken as evidence of v2. The dispatcher routes the request through
+   * the v2 wire-shape adapter. A one-time warning surfaces the routing
+   * decision so adopters can audit it; retry-safety (idempotency TTL) is
+   * unknown for these sellers and BYOK callers should treat them as such.
    *
    * Per-client `allowV2: true` or, when that's undefined,
-   * `ADCP_ALLOW_V2=1` in the environment bypasses the check (the v2 escape
-   * hatch is named for the original v2/v3 split; it's the generic
-   * "skip the major-version guard" knob).
+   * `ADCP_ALLOW_V2=1` in the environment bypasses the guard entirely.
    *
    * Throws `VersionUnsupportedError` with the specific reason on failure.
    */
@@ -3120,25 +3147,18 @@ export class SingleAgentClient {
     if (this.isV2Allowed()) return;
     const capabilities = await this.getCapabilities();
 
-    // Synthetic + v2: no `get_adcp_capabilities` tool — we can't confirm the
-    // agent supports our version, throw so the caller fails loud rather than
-    // silently sending v2-adapted requests to an unknown agent.
-    // Synthetic + v3: the tool was present but the call failed — the agent
-    // is verifiably v3 (it advertises the v3-only discovery tool). Skip the
-    // detail-level checks (supportedVersions, majorVersions, idempotency
-    // TTL) since we couldn't read those fields; we know the spec requires
-    // v3 to support idempotency, just can't confirm the TTL until the
-    // capabilities endpoint is fixed (#1217).
-    if (capabilities._synthetic && capabilities.version !== 'v3') {
-      throw new VersionUnsupportedError(taskType, 'synthetic', capabilities.version, this.agent.agent_uri);
-    }
+    // Synthetic capabilities — no authoritative `get_adcp_capabilities`
+    // response, so the version + idempotency-TTL fields couldn't be read.
+    // Route as the synthesized version (v2 when the v3 discovery tool is
+    // absent from tools/list, v3 when the tool is present but the call
+    // failed). Emit a one-time per-client warning so adopters can audit
+    // the routing decision and the skipped TTL guarantee.
     if (capabilities._synthetic) {
-      // Synthetic v3 — silent passage of the version + idempotency-TTL
-      // checks. Adopters who called `requireSupportedMajor` precisely
-      // because they need TTL guarantees deserve to know the check was
-      // skipped. Emit a one-time warning per client (matches the
-      // `maybeWarnV2Sunset` cadence so we don't spam every call).
-      this.maybeWarnSyntheticV3();
+      if (capabilities.version === 'v3') {
+        this.maybeWarnSyntheticV3();
+      } else {
+        this.maybeWarnSyntheticV2();
+      }
       return;
     }
     // Prefer release-precision matching when the seller advertises

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -460,8 +460,10 @@ export class ResponseTooLargeError extends ADCPError {
  * - `version`: seller's `major_versions` does not include 3
  * - `idempotency`: seller reports v3 but omits the required
  *   `adcp.idempotency.replay_ttl_seconds` declaration
- * - `synthetic`: capabilities were synthesized from a tool list (no
- *   `get_adcp_capabilities` response) so the v3 claim is unverifiable
+ * - `synthetic`: retained for backwards compatibility with consumers that
+ *   pattern-match on the union. Sellers whose capabilities are synthesized
+ *   from `tools/list` are now routed through the v2 adapter rather than
+ *   refused, so the SDK no longer throws this reason.
  */
 export type VersionUnsupportedReason = 'version' | 'idempotency' | 'synthetic';
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -4,7 +4,7 @@
 /**
  * AdCP SDK library version
  */
-export const LIBRARY_VERSION = '7.1.0';
+export const LIBRARY_VERSION = '7.3.0';
 
 /**
  * AdCP specification version this library is built for
@@ -59,10 +59,10 @@ export type AdcpVersion = (typeof COMPATIBLE_ADCP_VERSIONS)[number];
  * Full version information
  */
 export const VERSION_INFO = {
-  library: '7.1.0',
+  library: '7.3.0',
   adcp: '3.0.11',
   compatibleVersions: COMPATIBLE_ADCP_VERSIONS,
-  generatedAt: '2026-05-12T14:47:55.363Z',
+  generatedAt: '2026-05-14T22:16:11.218Z',
 } as const;
 
 /**

--- a/test/lib/synthetic-v3-fallback.test.js
+++ b/test/lib/synthetic-v3-fallback.test.js
@@ -67,13 +67,15 @@ describe('SingleAgentClient.requireSupportedMajor with synthetic capabilities (i
     // No throw = pass.
   });
 
-  it('still throws VersionUnsupportedError on synthetic v2 capabilities (no v3 tool present)', async () => {
-    // No get_adcp_capabilities in tool list → agent is verifiably v2 →
-    // version-compat throws (preserves pre-#1217 safety behavior).
+  it('accepts synthetic v2 capabilities (no get_adcp_capabilities — routed as v2)', async () => {
+    // No get_adcp_capabilities in tool list → a compliant v3 seller would
+    // declare itself, so absence of declaration is read as v2 → request is
+    // routed through the v2 wire-shape adapter rather than refused.
     const client = new SingleAgentClient(stubAgent);
     client.cachedCapabilities = buildSyntheticCapabilities([{ name: 'list_signals' }]);
 
-    await assert.rejects(() => client.requireSupportedMajor('test'), VersionUnsupportedError);
+    await client.requireSupportedMajor('test');
+    // No throw = pass.
   });
 
   it('skips idempotency-TTL check on synthetic v3 (TTL is unknowable until caps endpoint is fixed)', async () => {
@@ -162,6 +164,24 @@ describe('SingleAgentClient.maybeWarnSyntheticV3 — one-time warning when check
 
       const synthV3Warns = warn.calls.filter(c => c.includes('synthetic'));
       assert.equal(synthV3Warns.length, 0, 'real v3 caps must not trigger the synthetic-v3 warning');
+    } finally {
+      warn.restore();
+    }
+  });
+
+  it('emits exactly one warning when requireSupportedMajor routes synthetic v2', async () => {
+    const warn = captureWarnings();
+    try {
+      const client = new SingleAgentClient(stubAgent);
+      client.cachedCapabilities = buildSyntheticCapabilities([{ name: 'list_signals' }]);
+
+      await client.requireSupportedMajor('test');
+      await client.requireSupportedMajor('test');
+      await client.requireSupportedMajor('test');
+
+      const synthV2Warns = warn.calls.filter(c => c.includes('does not expose get_adcp_capabilities'));
+      assert.equal(synthV2Warns.length, 1, 'synthetic-v2 warning must fire once per client');
+      assert.match(synthV2Warns[0], /Routing as v2/);
     } finally {
       warn.restore();
     }

--- a/test/lib/v3-guard.test.js
+++ b/test/lib/v3-guard.test.js
@@ -71,19 +71,18 @@ describe('SingleAgentClient.requireV3 — corroborated check', () => {
     // No throw = pass.
   });
 
-  test('still rejects synthetic v2 capabilities (no v3-only tool in tools/list)', async () => {
-    // The synthetic-v3 escape hatch is gated on version === 'v3'. A synthetic
-    // v2 capabilities object (no get_adcp_capabilities tool present) still
-    // fails loudly — that's the case we genuinely don't know the version for.
+  test('accepts synthetic v2 capabilities (no get_adcp_capabilities — routed as v2)', async () => {
+    // A compliant v3 seller would declare itself via get_adcp_capabilities.
+    // Absence of that declaration is read as v2 and routed through the v2
+    // adapter rather than refused. A one-time warning surfaces the routing
+    // decision; idempotency-TTL guarantees are unknown for these sellers.
     const client = clientWithCapabilities({
       version: 'v2',
       majorVersions: [2],
       _synthetic: true,
     });
-    await assert.rejects(
-      () => client.requireV3('sync_creatives'),
-      err => err instanceof VersionUnsupportedError && err.reason === 'synthetic'
-    );
+    await client.requireV3('sync_creatives');
+    // No throw = pass.
   });
 
   test('rejects v2-only seller', async () => {


### PR DESCRIPTION
## Summary

- `requireSupportedMajor` previously threw `VersionUnsupportedError(reason: 'synthetic')` when capabilities were synthesized from `tools/list` and the inferred version was `'v2'`. That blocked buyers from calling sellers that simply hadn't implemented `get_adcp_capabilities`. The SDK now routes those requests through the v2 wire-shape adapter and emits a one-time per-client warning via `maybeWarnSyntheticV2` so adopters can audit the routing decision; idempotency-TTL guarantees remain unknown for these sellers and BYOK retry callers should treat them as such.
- Synthetic-v3 behavior, real declared-v2 sellers, and real-v3-missing-idempotency-TTL sellers are unchanged. The `'synthetic'` member of `VersionUnsupportedReason` is retained for back-compat with consumers that pattern-match the union, but no SDK call site throws it anymore.
- Tests in `synthetic-v3-fallback.test.js` and `v3-guard.test.js` flipped from rejecting synthetic-v2 to accepting it (plus a new one-shot warning assertion). Patch changeset included. `version.ts` and `package-lock.json` are catch-up sync to `package.json` 7.3.0 via `sync-version`.

## Test plan

- [ ] `npm test` covers the updated synthetic-v2 / synthetic-v3 / v3-guard suites