### PR TITLE
fix(ci): run packages/eslint-plugin/ tests as part of root npm test (#1766)

### DIFF
--- a/.changeset/ci-workspace-eslint-plugin.md
+++ b/.changeset/ci-workspace-eslint-plugin.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+fix(ci): run `packages/eslint-plugin/` tests as part of root `npm test` (#1766)
+
+The root `npm test` script now invokes `npm test --workspaces --if-present` after the SDK tests, so CI's `Test & Build` step (which runs `npm test`) exercises the ESLint plugin's rule tests. Plugin tests landed in PR #1762 but weren't running in CI, so plugin regressions could land on main silently.
+
+`--workspaces --if-present` is forward-compatible: any future workspace under `packages/*` that adds a `test` script is automatically picked up. `packages/client-shim` has no `test` script and is skipped (no behavior change there).

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
     "pretest": "npm run schemas:ensure",
-    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js && npm test --workspaces --if-present",
+    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js && npm test --workspace=packages/eslint-plugin --if-present",
     "pretest:lib": "npm run schemas:ensure",
     "test:lib": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/*.test.js",
     "pretest:examples": "npm run build",

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "build:lib": "npm run sync-version && npm run schemas:ensure && tsx scripts/generate-wire-spec-fields.ts && tsc --project tsconfig.lib.json && tsx scripts/copy-schemas-to-dist.ts",
     "build:test-agents": "npm run build:lib && tsc -p test-agents/tsconfig.json --rootDir test-agents",
     "pretest": "npm run schemas:ensure",
-    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js",
+    "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js && npm test --workspaces --if-present",
     "pretest:lib": "npm run schemas:ensure",
     "test:lib": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/*.test.js",
     "pretest:examples": "npm run build",


### PR DESCRIPTION
## Summary

Closes #1766. Chains `npm test --workspaces --if-present` onto the root `test` script so CI's `Test & Build` job (which runs `npm test`) exercises the ESLint plugin's rule tests.

**The gap.** PR #1752 shipped `packages/eslint-plugin/` and PR #1762 added 30 rule tests, but neither wired the plugin's `test` script into root `npm test`. CI's `Test & Build` step ran the SDK tests only — plugin regressions could land on main silently.

**The fix.** Single-line edit to `package.json` `scripts.test`:

```diff
- "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js",
+ "test": "NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/*.test.js test/lib/*.test.js && npm test --workspaces --if-present",
```

`--workspaces --if-present` invokes the `test` script in every workspace that defines one, and silently skips those that don't — forward-compatible for any future workspace.

## Verification

- Plugin standalone: `cd packages/eslint-plugin && npm test` passes 30/30 (3 suites: `no-credential-read-from-args`).
- Root invocation: `npm test --workspaces --if-present` from repo root reaches `@adcp/eslint-plugin`'s `test` script. Verified the npm dispatch picks it up.
- `packages/client-shim/package.json` has no `test` script — `--if-present` correctly skips it (no behavior change there, and if it ever adds tests they'll be auto-covered).
- CI workflow (`.github/workflows/ci.yml`, line 86 in the `Test & Build` job) runs `npm test` directly, so no workflow edit needed.
- `prettier --check` clean on changed files.

## Test plan

- [ ] CI's `Test & Build` job runs both SDK tests and `@adcp/eslint-plugin` tests
- [ ] Future workspace additions with a `test` script are automatically exercised by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)