### PR TITLE
feat(registry): add scope=public option to lookupOperator / lookupPublisher

### DIFF
--- a/.changeset/registry-scope-public.md
+++ b/.changeset/registry-scope-public.md
@@ -1,0 +1,9 @@
+---
+'@adcp/sdk': patch
+---
+
+feat(registry): add `scope=public` option to `lookupOperator` / `lookupPublisher` (#1769)
+
+`RegistryClient.lookupOperator(domain, opts?)` and `RegistryClient.lookupPublisher(domain, opts?)` now accept an optional `{ scope?: 'public' | 'all' }` argument. When `scope: 'public'` is passed, the client appends `?scope=public` so the AAO server returns the anonymous-equivalent view regardless of the caller's API tier — useful for platform integrations using an admin-scoped key that want to render a public picker.
+
+Default behavior (no opts, or `scope: 'all'`) is unchanged: the server honors the caller's tier and includes `members_only` agents when authorized. The publisher endpoint does not vary by tier today; the option is forwarded for symmetry and forward compatibility.

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -389,16 +389,43 @@ export class RegistryClient {
 
   // ====== Operator & Publisher Lookups ======
 
-  /** Look up which agents a domain operates and which publishers trust them. Returns null if not found. */
-  async lookupOperator(domain: string): Promise<OperatorLookupResult | null> {
+  /**
+   * Look up which agents a domain operates and which publishers trust them.
+   * Returns null if not found.
+   *
+   * Pass `{ scope: 'public' }` to surface only agents the profile owner has
+   * made public, regardless of the caller's auth tier. Useful for
+   * anonymous-equivalent picker views where the caller has a member or
+   * admin API key but wants the same result an unauthenticated visitor
+   * would see. Omit `scope` (or pass `'all'`) to honor the caller's
+   * tier (public + members_only + owner's private).
+   */
+  async lookupOperator(
+    domain: string,
+    opts?: { scope?: 'public' | 'all' },
+  ): Promise<OperatorLookupResult | null> {
     if (!domain?.trim()) throw new Error('domain is required');
-    return this.get(`${this.baseUrl}/api/registry/operator?domain=${encodeURIComponent(domain)}`, { nullOn404: true });
+    const params = new URLSearchParams({ domain });
+    if (opts?.scope === 'public') params.set('scope', 'public');
+    return this.get(`${this.baseUrl}/api/registry/operator?${params.toString()}`, { nullOn404: true });
   }
 
-  /** Look up the inventory a domain publishes and which agents it authorizes. Returns null if not found. */
-  async lookupPublisher(domain: string): Promise<PublisherLookupResult | null> {
+  /**
+   * Look up the inventory a domain publishes and which agents it authorizes.
+   * Returns null if not found.
+   *
+   * `scope` is forwarded for symmetry with `lookupOperator`; today the
+   * publisher endpoint does not vary by visibility tier, so the option is
+   * a no-op there but reserved for future visibility-aware filtering.
+   */
+  async lookupPublisher(
+    domain: string,
+    opts?: { scope?: 'public' | 'all' },
+  ): Promise<PublisherLookupResult | null> {
     if (!domain?.trim()) throw new Error('domain is required');
-    return this.get(`${this.baseUrl}/api/registry/publisher?domain=${encodeURIComponent(domain)}`, { nullOn404: true });
+    const params = new URLSearchParams({ domain });
+    if (opts?.scope === 'public') params.set('scope', 'public');
+    return this.get(`${this.baseUrl}/api/registry/publisher?${params.toString()}`, { nullOn404: true });
   }
 
   // ====== Authorization Lookups ======

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -400,10 +400,7 @@ export class RegistryClient {
    * would see. Omit `scope` (or pass `'all'`) to honor the caller's
    * tier (public + members_only + owner's private).
    */
-  async lookupOperator(
-    domain: string,
-    opts?: { scope?: 'public' | 'all' },
-  ): Promise<OperatorLookupResult | null> {
+  async lookupOperator(domain: string, opts?: { scope?: 'public' | 'all' }): Promise<OperatorLookupResult | null> {
     if (!domain?.trim()) throw new Error('domain is required');
     const params = new URLSearchParams({ domain });
     if (opts?.scope === 'public') params.set('scope', 'public');
@@ -418,10 +415,7 @@ export class RegistryClient {
    * publisher endpoint does not vary by visibility tier, so the option is
    * a no-op there but reserved for future visibility-aware filtering.
    */
-  async lookupPublisher(
-    domain: string,
-    opts?: { scope?: 'public' | 'all' },
-  ): Promise<PublisherLookupResult | null> {
+  async lookupPublisher(domain: string, opts?: { scope?: 'public' | 'all' }): Promise<PublisherLookupResult | null> {
     if (!domain?.trim()) throw new Error('domain is required');
     const params = new URLSearchParams({ domain });
     if (opts?.scope === 'public') params.set('scope', 'public');

--- a/test/lib/registry.test.js
+++ b/test/lib/registry.test.js
@@ -2250,6 +2250,44 @@ describe('RegistryClient', () => {
         }
       );
     });
+
+    test('appends scope=public when opts.scope is "public"', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(JSON.stringify(OPERATOR), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.lookupOperator('pubmatic.com', { scope: 'public' });
+      assert.ok(capturedUrl.includes('domain=pubmatic.com'));
+      assert.ok(capturedUrl.includes('scope=public'));
+    });
+
+    test('omits scope param when opts.scope is "all"', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(JSON.stringify(OPERATOR), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.lookupOperator('pubmatic.com', { scope: 'all' });
+      assert.ok(capturedUrl.includes('domain=pubmatic.com'));
+      assert.ok(!capturedUrl.includes('scope='));
+    });
+
+    test('omits scope param when no opts passed', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(JSON.stringify(OPERATOR), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.lookupOperator('pubmatic.com');
+      assert.ok(!capturedUrl.includes('scope='));
+    });
   });
 
   // ============ lookupPublisher ============
@@ -2292,6 +2330,31 @@ describe('RegistryClient', () => {
           return true;
         }
       );
+    });
+
+    test('appends scope=public when opts.scope is "public"', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(JSON.stringify(PUBLISHER), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.lookupPublisher('voxmedia.com', { scope: 'public' });
+      assert.ok(capturedUrl.includes('domain=voxmedia.com'));
+      assert.ok(capturedUrl.includes('scope=public'));
+    });
+
+    test('omits scope param when no opts passed', async () => {
+      let capturedUrl;
+      restore = mockFetch(async url => {
+        capturedUrl = url;
+        return new Response(JSON.stringify(PUBLISHER), { status: 200 });
+      });
+
+      const client = new RegistryClient();
+      await client.lookupPublisher('voxmedia.com');
+      assert.ok(!capturedUrl.includes('scope='));
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds an `opts?: { scope?: 'public' | 'all' }` parameter to `RegistryClient.lookupOperator` and `RegistryClient.lookupPublisher`. When `scope: 'public'` is passed, the client appends `?scope=public` to the request so the AAO server forces the anonymous-equivalent view regardless of the caller's API tier.

## Why

The current AAO operator endpoint includes `members_only` agents whenever the caller's key resolves to an org with API-tier access. That's correct for buyer/seller flows authenticating with their own AAO membership — but breaks for platform integrations holding an admin-scoped API key.

## What changed

- \`lookupOperator(domain, opts?)\` — appends \`&scope=public\` when \`opts.scope === 'public'\`.
- \`lookupPublisher(domain, opts?)\` — same shape for symmetry. Today the publisher endpoint doesn't vary by visibility tier, so the option is a no-op there but reserved for forward compatibility.
- Both default to \`scope=all\` (omitted on the wire) when no opts are passed → fully backwards compatible.

## Server side

Companion PR on adcontextprotocol/adcp adds the server-side enforcement of \`?scope=public\` on \`/registry/operator\`. This SDK PR is safe to merge before the server PR — older AAO servers will ignore the unknown query param and continue to return the current behavior.

## Test plan

- [x] \`npm run build\` — clean, dist regenerated
- [ ] New unit test asserting \`?scope=public\` is appended only when opts.scope === 'public' (follow-up — keeping this PR scoped to the API addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>