### PR TITLE
chore: transfer CODEOWNERS rules to @adcontextprotocol/maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,9 @@
 # approves. Prevents prompt-injection rewrites of agent behavior,
 # workflow hijacking, or dep-chain tampering from ever reaching main.
 
-/.agents/                   @bokelley
-/.github/                   @bokelley
-/.github/workflows/         @bokelley
-/.changeset/                @bokelley
-/package.json               @bokelley
-/package-lock.json          @bokelley
+/.agents/                   @adcontextprotocol/maintainers
+/.github/                   @adcontextprotocol/maintainers
+/.github/workflows/         @adcontextprotocol/maintainers
+/.changeset/                @adcontextprotocol/maintainers
+/package.json               @adcontextprotocol/maintainers
+/package-lock.json          @adcontextprotocol/maintainers


### PR DESCRIPTION
## Summary
- Replaces `@bokelley` with `@adcontextprotocol/maintainers` across all CODEOWNERS path rules so required-review responsibility lives with the team rather than a single user.

## Test plan
- [ ] GitHub recognizes `@adcontextprotocol/maintainers` as a valid reviewer on PRs touching `/.agents/`, `/.github/`, `/.github/workflows/`, `/.changeset/`, `/package.json`, `/package-lock.json`.
- [ ] Confirm the team has at least Write access to the repo so CODEOWNERS rules apply.