### PR TITLE
chore(eslint-plugin): bump @adcp/sdk dep range to ^7.3.0

### DIFF
--- a/.changeset/eslint-plugin-sdk-dep-bump.md
+++ b/.changeset/eslint-plugin-sdk-dep-bump.md
@@ -1,0 +1,7 @@
+---
+'@adcp/sdk': patch
+---
+
+chore(eslint-plugin): bump `@adcp/sdk` dep range to `^7.3.0` (#1768)
+
+`packages/eslint-plugin/package.json` declared `"@adcp/sdk": "^7.1.0"` while the CLI workspace already declared `^7.3.0`. The plugin's range now matches so both workspaces resolve against the same minor and lockfile syncs no longer surface an apparent downgrade. No behavior change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6329,7 +6329,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adcp/sdk": "^7.1.0",
+        "@adcp/sdk": "^7.3.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
       "devDependencies": {

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
     "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "dependencies": {
-    "@adcp/sdk": "^7.1.0",
+    "@adcp/sdk": "^7.3.0",
     "@typescript-eslint/utils": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bumps `packages/eslint-plugin/package.json` `@adcp/sdk` dependency range from `^7.1.0` to `^7.3.0` so it matches the CLI workspace.
- Both workspaces now resolve against the same minor; lockfile syncs no longer surface an apparent downgrade (the cause flagged during PR #1764 review).
- Lockfile updated via `npm install`.

Closes #1768.

## Test plan

- [x] `npm run format:check` — clean
- [x] `tsc --noEmit` — passes (pre-push hook)
- [ ] CI green (test, build, changeset check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)